### PR TITLE
feat(url4-cloud): enforce benchmark result contract

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
@@ -2,42 +2,72 @@
 
 from __future__ import annotations
 
-import math
+import json
+import re
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+)
 
-from url4_cloud.benchmarks.contract import CandidateResult, CaseResult, Failure
+from url4_cloud.benchmarks.contract import (
+    CandidateResult,
+    CaseGrade,
+    CaseId,
+    CaseResult,
+    Failure,
+    validate_case_id,
+    validate_finish_reason,
+)
 
 
-class CandidateScore(BaseModel):
+class SelectedCase(BaseModel):
+    """One immutable public Case selected by the Benchmark protocol."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    case_id: CaseId
+    input: str = Field(min_length=1)
+    metadata: dict[str, Any]
+
+    @field_validator("case_id")
+    @classmethod
+    def _validate_case_id(cls, value: CaseId) -> CaseId:
+        validated = validate_case_id(value)
+        assert validated is not None
+        return validated
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateRefusal:
+    """Exact provider refusal fields recovered after URL4 error collection."""
+
+    text: str
+    finish_reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PublicError:
+    """Safe operational diagnostics suitable for the public result contract."""
+
+    kind: str | None
+    code: str
+    message: str
+    retryable: bool | None
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateScore:
     """A Benchmark scorer's result after every selected Case graded successfully."""
 
-    model_config = ConfigDict(extra="forbid", strict=True)
-
     # HealthBench's official penalty-bearing result can be negative.
-    score: float = Field(le=1.0)
+    score: float
     metrics: dict[str, Any]
-
-    @field_validator("score", mode="before")
-    @classmethod
-    def _validate_score(cls, value: object) -> object:
-        if isinstance(value, bool) or isinstance(value, int | float) and not math.isfinite(value):
-            raise ValueError("score must be a finite number")
-        return value
-
-    @model_validator(mode="after")
-    def _require_canonical_metrics(self) -> CandidateScore:
-        for key in ("pass_rate", "coverage"):
-            value = self.metrics.get(key)
-            if (
-                isinstance(value, bool)
-                or not isinstance(value, int | float)
-                or not 0.0 <= value <= 1.0
-            ):
-                raise ValueError(f"CandidateScore metric {key!r} must be in [0, 1]")
-        return self
 
 
 Scorer = Callable[[Sequence[CaseResult]], CandidateScore]
@@ -47,22 +77,60 @@ def finalize_candidate_result(
     *,
     benchmark_id: str,
     benchmark_revision: str,
+    selected_cases: Sequence[SelectedCase | Mapping[str, Any]],
     cases: Sequence[CaseResult | Mapping[str, Any]],
     scorer: Scorer,
     failures: Sequence[Failure | Mapping[str, Any]] = (),
 ) -> CandidateResult:
     """Preserve Cases and publish a score only for a complete successful run."""
 
-    typed_cases = [
+    selection = [
+        case if isinstance(case, SelectedCase) else SelectedCase.model_validate(case)
+        for case in selected_cases
+    ]
+    produced_cases = [
         case if isinstance(case, CaseResult) else CaseResult.model_validate(case) for case in cases
     ]
     typed_failures = [
         failure if isinstance(failure, Failure) else Failure.model_validate(failure)
         for failure in failures
     ]
-    case_ids = [case.case_id for case in typed_cases]
-    if len(case_ids) != len(set(case_ids)):
+    selected_ids = [case.case_id for case in selection]
+    if len(selected_ids) != len(set(selected_ids)):
+        raise ValueError("selected Case sequence cannot contain duplicate case_id values")
+    produced_ids = [case.case_id for case in produced_cases]
+    if len(produced_ids) != len(set(produced_ids)):
         raise ValueError("CandidateResult cannot contain duplicate case_id values")
+    unexpected = set(produced_ids) - set(selected_ids)
+    if unexpected:
+        raise ValueError(
+            f"CandidateResult contains unselected case_id values {sorted(unexpected, key=str)!r}"
+        )
+    produced_by_id = {case.case_id: case for case in produced_cases}
+    typed_cases = [
+        produced_by_id.get(selected.case_id)
+        or CaseResult(
+            status="failed",
+            case_id=selected.case_id,
+            input=selected.input,
+            output=None,
+            finish_reason=None,
+            refusal=None,
+            grade=None,
+            failures=[
+                Failure(
+                    stage="aggregation",
+                    code="case_result_missing",
+                    message="the selected Case produced no Case Result",
+                    retryable=None,
+                    case_id=selected.case_id,
+                    metadata={},
+                )
+            ],
+            metadata=selected.metadata,
+        )
+        for selected in selection
+    ]
 
     complete = not typed_failures and all(case.status == "scored" for case in typed_cases)
     scored = scorer(tuple(typed_cases)) if complete else None
@@ -77,20 +145,161 @@ def finalize_candidate_result(
     )
 
 
-def collected_provider_refusal(row: object) -> str | None:
-    """Read exact refusal text carried through URL4's collected-error boundary."""
+def collected_provider_refusal(row: object) -> CandidateRefusal | None:
+    """Read exact refusal fields carried through URL4's collected-error boundary."""
 
     error = row.get("error") if isinstance(row, Mapping) else None
     if not isinstance(error, Mapping) or error.get("kind") != "ProviderRefusal":
         return None
-    refusal = error.get("message")
-    return refusal if isinstance(refusal, str) and refusal.strip() else None
+    raw = error.get("message")
+    return _decode_provider_refusal(raw) if isinstance(raw, str) else None
+
+
+def _decode_provider_refusal(raw: str) -> CandidateRefusal | None:
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        payload = None
+    fields = _provider_refusal_fields(payload)
+    return CandidateRefusal(*fields) if fields is not None else None
+
+
+def _provider_refusal_fields(payload: object) -> tuple[str, str | None] | None:
+    refusal = payload.get("refusal") if isinstance(payload, Mapping) else None
+    if (
+        not isinstance(payload, Mapping)
+        or set(payload) != {"refusal", "finish_reason"}
+        or not isinstance(refusal, str)
+        or not refusal.strip()
+    ):
+        return None
+    finish_reason = payload.get("finish_reason")
+    try:
+        typed_finish_reason = validate_finish_reason(finish_reason)
+    except ValueError:
+        return None
+    return refusal, typed_finish_reason
+
+
+def public_error(
+    error: Mapping[str, Any],
+    *,
+    default_code: str,
+    default_message: str,
+) -> PublicError:
+    """Retain useful error fields without publishing runner internals or credentials."""
+
+    kind = _public_identifier(error.get("kind"))
+    code = _public_identifier(error.get("code")) or default_code
+    message = _public_message(error.get("message"), default=default_message)
+    retryable = error.get("retryable")
+    if not isinstance(retryable, bool):
+        permanent = error.get("permanent")
+        retryable = not permanent if isinstance(permanent, bool) else None
+    return PublicError(kind=kind, code=code, message=message, retryable=retryable)
+
+
+def _public_identifier(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()[:80]
+    return normalized if re.fullmatch(r"[A-Za-z0-9_.:-]+", normalized) else None
+
+
+def _public_message(value: object, *, default: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        return default
+    normalized = " ".join(value.split())[:200]
+    lowered = normalized.casefold()
+    internal_markers = (
+        "traceback (most recent call last)",
+        'file "',
+        "/users/",
+        "/private/",
+        "/tmp/",
+        "/var/",
+        "/home/",
+    )
+    return (
+        default
+        if any(marker in lowered for marker in internal_markers)
+        or any(pattern.search(normalized) for pattern in _SENSITIVE_ERROR_PATTERNS)
+        else normalized
+    )
+
+
+_SENSITIVE_ERROR_PATTERNS = (
+    re.compile(r"(?i)(?:^|\s)[a-z]:\\"),
+    re.compile(
+        r"(?i)(?:^|[^A-Za-z0-9])(?:[A-Za-z0-9]+[_-])*"
+        r"(?:authorization|password|passwd|pwd|secret|token|cookie|api[_-]?key|"
+        r"access[_-]?key)\s*[:=]"
+    ),
+    re.compile(r"(?i)\bbearer\s+\S+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+)
+
+
+def scored_case_result(
+    *,
+    selected_case: SelectedCase,
+    output: str,
+    finish_reason: str | None,
+    grade: CaseGrade | Mapping[str, Any],
+    metadata: Mapping[str, Any] | None = None,
+) -> CaseResult:
+    """Construct one scored Case without exposing the wire envelope to adapters."""
+
+    typed_grade = grade if isinstance(grade, CaseGrade) else CaseGrade.model_validate(grade)
+    return CaseResult(
+        status="scored",
+        case_id=selected_case.case_id,
+        input=selected_case.input,
+        output=output,
+        finish_reason=finish_reason,
+        refusal=None,
+        grade=typed_grade,
+        failures=[],
+        metadata=_case_metadata(selected_case, metadata),
+    )
+
+
+def failed_case_result(
+    *,
+    selected_case: SelectedCase,
+    failures: Sequence[Failure | Mapping[str, Any]],
+    output: str | None = None,
+    finish_reason: str | None = None,
+    grade: CaseGrade | Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> CaseResult:
+    """Construct one failed Case while retaining any safe partial grading evidence."""
+
+    typed_grade = (
+        grade if isinstance(grade, CaseGrade) or grade is None else CaseGrade.model_validate(grade)
+    )
+    typed_failures = [
+        failure if isinstance(failure, Failure) else Failure.model_validate(failure)
+        for failure in failures
+    ]
+    return CaseResult(
+        status="failed",
+        case_id=selected_case.case_id,
+        input=selected_case.input,
+        output=output,
+        finish_reason=finish_reason,
+        refusal=None,
+        grade=typed_grade,
+        failures=typed_failures,
+        metadata=_case_metadata(selected_case, metadata),
+    )
 
 
 def refused_case_result(
     *,
-    case_id: int | str,
-    input: str | None,
+    selected_case: SelectedCase,
     refusal: str,
     finish_reason: str | None = None,
     metadata: Mapping[str, Any] | None = None,
@@ -99,8 +308,8 @@ def refused_case_result(
 
     return CaseResult(
         status="refused",
-        case_id=case_id,
-        input=input,
+        case_id=selected_case.case_id,
+        input=selected_case.input,
         output=None,
         finish_reason=finish_reason,
         refusal=refusal,
@@ -111,18 +320,29 @@ def refused_case_result(
                 code="provider_refusal",
                 message="the provider refused this Candidate request",
                 retryable=False,
-                case_id=case_id,
+                case_id=selected_case.case_id,
                 metadata={},
             )
         ],
-        metadata=dict(metadata or {}),
+        metadata=_case_metadata(selected_case, metadata),
     )
+
+
+def _case_metadata(
+    selected_case: SelectedCase, metadata: Mapping[str, Any] | None
+) -> dict[str, Any]:
+    return {**selected_case.metadata, **dict(metadata or {})}
 
 
 __all__ = [
     "CandidateScore",
+    "CandidateRefusal",
     "Scorer",
+    "SelectedCase",
     "collected_provider_refusal",
+    "failed_case_result",
     "finalize_candidate_result",
+    "public_error",
     "refused_case_result",
+    "scored_case_result",
 ]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
@@ -1,0 +1,128 @@
+"""Cross-Benchmark Candidate finalization and score publication policy."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from url4_cloud.benchmarks.contract import CandidateResult, CaseResult, Failure
+
+
+class CandidateScore(BaseModel):
+    """A Benchmark scorer's result after every selected Case graded successfully."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    # HealthBench's official penalty-bearing result can be negative.
+    score: float = Field(le=1.0)
+    metrics: dict[str, Any]
+
+    @field_validator("score", mode="before")
+    @classmethod
+    def _validate_score(cls, value: object) -> object:
+        if isinstance(value, bool) or isinstance(value, int | float) and not math.isfinite(value):
+            raise ValueError("score must be a finite number")
+        return value
+
+    @model_validator(mode="after")
+    def _require_canonical_metrics(self) -> CandidateScore:
+        for key in ("pass_rate", "coverage"):
+            value = self.metrics.get(key)
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int | float)
+                or not 0.0 <= value <= 1.0
+            ):
+                raise ValueError(f"CandidateScore metric {key!r} must be in [0, 1]")
+        return self
+
+
+Scorer = Callable[[Sequence[CaseResult]], CandidateScore]
+
+
+def finalize_candidate_result(
+    *,
+    benchmark_id: str,
+    benchmark_revision: str,
+    cases: Sequence[CaseResult | Mapping[str, Any]],
+    scorer: Scorer,
+    failures: Sequence[Failure | Mapping[str, Any]] = (),
+) -> CandidateResult:
+    """Preserve Cases and publish a score only for a complete successful run."""
+
+    typed_cases = [
+        case if isinstance(case, CaseResult) else CaseResult.model_validate(case) for case in cases
+    ]
+    typed_failures = [
+        failure if isinstance(failure, Failure) else Failure.model_validate(failure)
+        for failure in failures
+    ]
+    case_ids = [case.case_id for case in typed_cases]
+    if len(case_ids) != len(set(case_ids)):
+        raise ValueError("CandidateResult cannot contain duplicate case_id values")
+
+    complete = not typed_failures and all(case.status == "scored" for case in typed_cases)
+    scored = scorer(tuple(typed_cases)) if complete else None
+    return CandidateResult(
+        benchmark_id=benchmark_id,
+        benchmark_revision=benchmark_revision,
+        case_count=len(typed_cases),
+        score=scored.score if scored is not None else None,
+        metrics=scored.metrics if scored is not None else {},
+        cases=typed_cases,
+        failures=typed_failures,
+    )
+
+
+def collected_provider_refusal(row: object) -> str | None:
+    """Read exact refusal text carried through URL4's collected-error boundary."""
+
+    error = row.get("error") if isinstance(row, Mapping) else None
+    if not isinstance(error, Mapping) or error.get("kind") != "ProviderRefusal":
+        return None
+    refusal = error.get("message")
+    return refusal if isinstance(refusal, str) and refusal.strip() else None
+
+
+def refused_case_result(
+    *,
+    case_id: int | str,
+    input: str | None,
+    refusal: str,
+    finish_reason: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> CaseResult:
+    """Construct the one canonical refused Case shape without invoking grading."""
+
+    return CaseResult(
+        status="refused",
+        case_id=case_id,
+        input=input,
+        output=None,
+        finish_reason=finish_reason,
+        refusal=refusal,
+        grade=None,
+        failures=[
+            Failure(
+                stage="candidate",
+                code="provider_refusal",
+                message="the provider refused this Candidate request",
+                retryable=False,
+                case_id=case_id,
+                metadata={},
+            )
+        ],
+        metadata=dict(metadata or {}),
+    )
+
+
+__all__ = [
+    "CandidateScore",
+    "Scorer",
+    "collected_provider_refusal",
+    "finalize_candidate_result",
+    "refused_case_result",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import math
 from collections.abc import Mapping
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import (
     BaseModel,
@@ -25,7 +25,6 @@ CANDIDATE_INPUT_SCHEMA = "screamingface.candidate-input.v1"
 CANDIDATE_INVOCATION_SCHEMA = "screamingface.candidate-invocation.v1"
 CANDIDATE_RESULT_SCHEMA = "screamingface.candidate-result.v1"
 CANDIDATE_MESSAGE_ROLES = frozenset({"system", "developer", "user", "assistant"})
-FINISH_REASONS = frozenset({"stop", "length", "tool_calls", "content_filter"})
 CaseId = StrictInt | StrictStr
 Outcome = Literal["MET", "UNMET", "PASS", "FAIL"]
 FailureStage = Literal["candidate", "grading", "aggregation"]
@@ -36,6 +35,11 @@ class _StrictWireModel(BaseModel):
     """Closed producer value: every structural wire key is intentional."""
 
     model_config = ConfigDict(extra="forbid", strict=True)
+
+    @field_validator("metadata", "metrics", check_fields=False)
+    @classmethod
+    def _validate_open_json_mapping(cls, value: object) -> object:
+        return _json_value(value)
 
 
 class EvidenceProducer(_StrictWireModel):
@@ -55,6 +59,11 @@ class Evidence(_StrictWireModel):
     explanation: str | None = Field(default=None, exclude_if=lambda value: value is None)
     raw_output: Any
     metadata: dict[str, Any]
+
+    @field_validator("raw_output")
+    @classmethod
+    def _validate_raw_output(cls, value: object) -> object:
+        return _json_value(value)
 
     @model_validator(mode="after")
     def _enforce_validity(self) -> Evidence:
@@ -112,7 +121,7 @@ class Failure(_StrictWireModel):
     @field_validator("case_id")
     @classmethod
     def _validate_case_id(cls, value: CaseId | None) -> CaseId | None:
-        return _case_id(value, optional=True)
+        return validate_case_id(value, optional=True)
 
 
 class CaseResult(_StrictWireModel):
@@ -120,7 +129,7 @@ class CaseResult(_StrictWireModel):
 
     status: CaseStatus
     case_id: CaseId
-    input: str | None
+    input: str = Field(min_length=1)
     output: str | None
     finish_reason: str | None
     refusal: str | None
@@ -131,7 +140,7 @@ class CaseResult(_StrictWireModel):
     @field_validator("case_id")
     @classmethod
     def _validate_case_id(cls, value: CaseId) -> CaseId:
-        validated = _case_id(value)
+        validated = validate_case_id(value)
         assert validated is not None
         return validated
 
@@ -145,9 +154,7 @@ class CaseResult(_StrictWireModel):
     @field_validator("finish_reason")
     @classmethod
     def _validate_finish_reason(cls, value: str | None) -> str | None:
-        if value is not None and value not in FINISH_REASONS:
-            raise ValueError("finish_reason must be a supported provider value or null")
-        return value
+        return validate_finish_reason(value)
 
     @model_validator(mode="after")
     def _enforce_status(self) -> CaseResult:
@@ -157,11 +164,13 @@ class CaseResult(_StrictWireModel):
             if (
                 self.grade is None
                 or self.grade.score is None
+                or self.output is None
                 or self.refusal is not None
                 or self.failures
             ):
                 raise ValueError(
-                    "a scored Case requires a numeric grade and cannot carry refusal or failures"
+                    "a scored Case requires output and a numeric grade and cannot carry refusal "
+                    "or failures"
                 )
             return self
         if self.status == "refused":
@@ -280,7 +289,7 @@ def _candidate_outcome(result: CandidateResult) -> None:
     _canonical_metrics(result.metrics)
 
 
-def _case_id(value: CaseId | None, *, optional: bool = False) -> CaseId | None:
+def validate_case_id(value: CaseId | None, *, optional: bool = False) -> CaseId | None:
     if value is None and optional:
         return None
     if isinstance(value, bool) or not isinstance(value, int | str):
@@ -288,6 +297,37 @@ def _case_id(value: CaseId | None, *, optional: bool = False) -> CaseId | None:
     if isinstance(value, str) and not value.strip():
         raise ValueError("case_id must be a non-boolean integer or non-blank string")
     return value
+
+
+def validate_finish_reason(value: object) -> str | None:
+    """Preserve any non-blank provider finish reason without freezing its vocabulary."""
+
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("finish_reason must be non-empty provider text or null")
+    return value
+
+
+def _json_value(value: object) -> object:
+    if not _is_json_value(value):
+        raise ValueError("open wire fields must contain JSON values")
+    return value
+
+
+def _is_json_value(value: object) -> bool:
+    value_type = type(value)
+    valid = value is None or value_type in {str, bool, int}
+    if value_type is float:
+        valid = math.isfinite(cast(float, value))
+    elif value_type is list:
+        valid = all(_is_json_value(item) for item in cast(list[object], value))
+    elif value_type is dict:
+        valid = all(
+            type(key) is str and _is_json_value(item)
+            for key, item in cast(dict[object, object], value).items()
+        )
+    return valid
 
 
 def _finite_score(value: object) -> object:
@@ -343,12 +383,7 @@ def _validate_candidate_invocation(
 ) -> None:
     if not isinstance(output, str):
         raise ValueError("Candidate Invocation output must be text")
-    if finish_reason is not None and (
-        not isinstance(finish_reason, str) or finish_reason not in FINISH_REASONS
-    ):
-        raise ValueError(
-            "Candidate Invocation finish_reason must be a supported provider value or null"
-        )
+    validate_finish_reason(finish_reason)
     if refusal is not None and (not isinstance(refusal, str) or not refusal.strip()):
         raise ValueError("Candidate Invocation refusal must be non-empty text or null")
 
@@ -360,7 +395,7 @@ __all__ = [
     "CANDIDATE_MESSAGE_ROLES",
     "CANDIDATE_RESULT_SCHEMA",
     "CANDIDATE_ROUTE",
-    "FINISH_REASONS",
+    "CaseId",
     "CaseGrade",
     "CaseResult",
     "CandidateResult",
@@ -370,4 +405,6 @@ __all__ = [
     "Failure",
     "decode_candidate_invocation",
     "encode_candidate_invocation",
+    "validate_case_id",
+    "validate_finish_reason",
 ]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictInt,
+    StrictStr,
+    field_validator,
+    model_validator,
+)
 
 CANDIDATE_ROUTE = "/benchmarks/candidate"
 # The source name a client binds its Candidate expression under, so the protocol's `$candidate`
@@ -17,9 +26,174 @@ CANDIDATE_INVOCATION_SCHEMA = "screamingface.candidate-invocation.v1"
 CANDIDATE_RESULT_SCHEMA = "screamingface.candidate-result.v1"
 CANDIDATE_MESSAGE_ROLES = frozenset({"system", "developer", "user", "assistant"})
 FINISH_REASONS = frozenset({"stop", "length", "tool_calls", "content_filter"})
+CaseId = StrictInt | StrictStr
+Outcome = Literal["MET", "UNMET", "PASS", "FAIL"]
+FailureStage = Literal["candidate", "grading", "aggregation"]
+CaseStatus = Literal["scored", "refused", "failed"]
 
 
-class CandidateResult(BaseModel):
+class _StrictWireModel(BaseModel):
+    """Closed producer value: every structural wire key is intentional."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+
+class EvidenceProducer(_StrictWireModel):
+    """The deterministic or model-backed producer of one Evidence item."""
+
+    type: str = Field(min_length=1)
+    id: str = Field(min_length=1)
+
+
+class Evidence(_StrictWireModel):
+    """One auditable observation supporting a Check."""
+
+    sequence: int = Field(ge=1)
+    producer: EvidenceProducer
+    valid: bool
+    outcome: Outcome | None = Field(default=None, exclude_if=lambda value: value is None)
+    explanation: str | None = Field(default=None, exclude_if=lambda value: value is None)
+    raw_output: Any
+    metadata: dict[str, Any]
+
+    @model_validator(mode="after")
+    def _enforce_validity(self) -> Evidence:
+        if not self.valid and (self.outcome is not None or self.explanation is not None):
+            raise ValueError("invalid Evidence cannot claim an outcome or explanation")
+        return self
+
+
+class Check(_StrictWireModel):
+    """One named deterministic or rubric requirement."""
+
+    type: str = Field(min_length=1)
+    id: str = Field(min_length=1)
+    label: str
+    outcome: Literal["MET", "UNMET"] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
+    score: float | None = Field(
+        default=None, ge=0.0, le=1.0, exclude_if=lambda value: value is None
+    )
+    evidence: list[Evidence]
+    metadata: dict[str, Any]
+
+    @field_validator("score", mode="before")
+    @classmethod
+    def _validate_score(cls, value: object) -> object:
+        return _finite_score(value)
+
+
+class CaseGrade(_StrictWireModel):
+    """Benchmark-specific grading projected into the shared Case envelope."""
+
+    method: str = Field(min_length=1)
+    # HealthBench deliberately permits negative penalty-bearing Case scores.
+    score: float | None = Field(le=1.0)
+    metrics: dict[str, Any]
+    checks: list[Check]
+
+    @field_validator("score", mode="before")
+    @classmethod
+    def _validate_score(cls, value: object) -> object:
+        return _finite_score(value)
+
+
+class Failure(_StrictWireModel):
+    """A bounded public failure attributable to a Case or Candidate."""
+
+    stage: FailureStage
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    retryable: bool | None
+    case_id: CaseId | None
+    metadata: dict[str, Any]
+
+    @field_validator("case_id")
+    @classmethod
+    def _validate_case_id(cls, value: CaseId | None) -> CaseId | None:
+        return _case_id(value, optional=True)
+
+
+class CaseResult(_StrictWireModel):
+    """One selected Case with an explicit scored, refused, or failed outcome."""
+
+    status: CaseStatus
+    case_id: CaseId
+    input: str | None
+    output: str | None
+    finish_reason: str | None
+    refusal: str | None
+    grade: CaseGrade | None
+    failures: list[Failure]
+    metadata: dict[str, Any]
+
+    @field_validator("case_id")
+    @classmethod
+    def _validate_case_id(cls, value: CaseId) -> CaseId:
+        validated = _case_id(value)
+        assert validated is not None
+        return validated
+
+    @field_validator("refusal")
+    @classmethod
+    def _validate_refusal(cls, value: str | None) -> str | None:
+        if value is not None and not value.strip():
+            raise ValueError("refusal must be non-empty text or null")
+        return value
+
+    @field_validator("finish_reason")
+    @classmethod
+    def _validate_finish_reason(cls, value: str | None) -> str | None:
+        if value is not None and value not in FINISH_REASONS:
+            raise ValueError("finish_reason must be a supported provider value or null")
+        return value
+
+    @model_validator(mode="after")
+    def _enforce_status(self) -> CaseResult:
+        if any(failure.case_id != self.case_id for failure in self.failures):
+            raise ValueError("every Case Failure must reference its own case_id")
+        if self.status == "scored":
+            if (
+                self.grade is None
+                or self.grade.score is None
+                or self.refusal is not None
+                or self.failures
+            ):
+                raise ValueError(
+                    "a scored Case requires a numeric grade and cannot carry refusal or failures"
+                )
+            return self
+        if self.status == "refused":
+            refusal_failures = [
+                failure
+                for failure in self.failures
+                if failure.stage == "candidate" and failure.code == "provider_refusal"
+            ]
+            if (
+                self.refusal is None
+                or self.output is not None
+                or self.grade is not None
+                or len(self.failures) != 1
+                or len(refusal_failures) != 1
+            ):
+                raise ValueError(
+                    "a refused Case requires exact refusal text, no output or grade, and one "
+                    "candidate provider_refusal Failure"
+                )
+            return self
+        if (
+            not self.failures
+            or self.refusal is not None
+            or any(failure.code == "provider_refusal" for failure in self.failures)
+            or self.grade is not None
+            and self.grade.score is not None
+        ):
+            raise ValueError("a failed Case requires failures, no refusal, and no numeric grade")
+        return self
+
+
+class CandidateResult(_StrictWireModel):
     """The `screamingface.candidate-result.v1` payload every Benchmark aggregate returns.
 
     Mental model: this class IS the producer side of the wire contract. An aggregate
@@ -43,7 +217,7 @@ class CandidateResult(BaseModel):
     design before a single check-level outcome is honest (OME-773 follow-up).
     """
 
-    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", strict=True)
 
     schema_version: str = Field(default=CANDIDATE_RESULT_SCHEMA, alias="schema")
     benchmark_id: str
@@ -55,8 +229,13 @@ class CandidateResult(BaseModel):
     # The canonical trio metrics (pass_rate, coverage) stay [0, 1] regardless.
     score: float | None = Field(le=1.0)
     metrics: dict[str, Any]
-    cases: list[dict[str, Any]]
-    failures: list[dict[str, Any]]
+    cases: list[CaseResult]
+    failures: list[Failure]
+
+    @field_validator("score", mode="before")
+    @classmethod
+    def _validate_score(cls, value: object) -> object:
+        return _finite_score(value)
 
     @model_validator(mode="after")
     def _enforce_result_contract(self) -> CandidateResult:
@@ -64,26 +243,59 @@ class CandidateResult(BaseModel):
             raise ValueError(f"CandidateResult schema must be {CANDIDATE_RESULT_SCHEMA!r}")
         if self.case_count != len(self.cases):
             raise ValueError("case_count must equal the number of retained cases")
-        if self.score is None:
-            if self.metrics:
-                raise ValueError("a failed or unscored Candidate cannot contain metrics")
-            return self
-        for key in ("pass_rate", "coverage"):
-            value = self.metrics.get(key)
-            if (
-                isinstance(value, bool)
-                or not isinstance(value, int | float)
-                or not 0.0 <= value <= 1.0
-            ):
-                raise ValueError(
-                    f"a scored Candidate must publish canonical metric {key!r} in [0, 1]"
-                )
+        case_ids = [case.case_id for case in self.cases]
+        if len(case_ids) != len(set(case_ids)):
+            raise ValueError("CandidateResult cannot contain duplicate case_id values")
+        if any(failure.case_id is not None for failure in self.failures):
+            raise ValueError("a Candidate-level Failure cannot claim a case_id")
+        _candidate_outcome(self)
         return self
 
     def as_payload(self) -> dict[str, Any]:
         """The wire dict — key names, order, and values as the v1 JSON expects."""
 
         return self.model_dump(by_alias=True)
+
+
+def _canonical_metrics(metrics: Mapping[str, Any]) -> None:
+    """Validate the two cross-Benchmark scored-result metrics."""
+
+    for key in ("pass_rate", "coverage"):
+        value = metrics.get(key)
+        if isinstance(value, bool) or not isinstance(value, int | float) or not 0.0 <= value <= 1.0:
+            raise ValueError(f"a scored Candidate must publish canonical metric {key!r} in [0, 1]")
+
+
+def _candidate_outcome(result: CandidateResult) -> None:
+    if result.score is None:
+        if result.metrics:
+            raise ValueError("a failed or unscored Candidate cannot contain metrics")
+        if not result.failures and all(case.status == "scored" for case in result.cases):
+            raise ValueError(
+                "an unscored Candidate must be explained by a non-scored Case or Failure"
+            )
+        return
+    if result.failures or any(case.status != "scored" for case in result.cases):
+        raise ValueError("a scored Candidate cannot contain a non-scored Case or failure")
+    _canonical_metrics(result.metrics)
+
+
+def _case_id(value: CaseId | None, *, optional: bool = False) -> CaseId | None:
+    if value is None and optional:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int | str):
+        raise ValueError("case_id must be a non-boolean integer or non-blank string")
+    if isinstance(value, str) and not value.strip():
+        raise ValueError("case_id must be a non-boolean integer or non-blank string")
+    return value
+
+
+def _finite_score(value: object) -> object:
+    if isinstance(value, bool):
+        raise ValueError("score must be a finite number or null")
+    if isinstance(value, int | float) and not math.isfinite(value):
+        raise ValueError("score must be a finite number or null")
+    return value
 
 
 def encode_candidate_invocation(
@@ -149,7 +361,13 @@ __all__ = [
     "CANDIDATE_RESULT_SCHEMA",
     "CANDIDATE_ROUTE",
     "FINISH_REASONS",
+    "CaseGrade",
+    "CaseResult",
     "CandidateResult",
+    "Check",
+    "Evidence",
+    "EvidenceProducer",
+    "Failure",
     "decode_candidate_invocation",
     "encode_candidate_invocation",
 ]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -54,7 +54,13 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
-from url4_cloud.benchmarks.contract import CandidateResult
+from url4_cloud.benchmarks.aggregation import (
+    CandidateScore,
+    collected_provider_refusal,
+    finalize_candidate_result,
+    refused_case_result,
+)
+from url4_cloud.benchmarks.contract import CaseResult
 from url4_cloud.benchmarks.draco import assets
 from url4_cloud.benchmarks.draco import case_results as case_results_module
 from url4_cloud.benchmarks.draco.case_evaluation import decode_case_evaluation
@@ -138,28 +144,19 @@ def aggregate(
     decoded_rows = _decode_rows(rows, expected_cases, judge_passes)
     _require_verifiable_mapping(decoded_rows)
     case_results = _aggregate_rows(decoded_rows, rubrics, judge_passes, criterion_count)
-    scored = [
-        case
-        for case in case_results
-        if isinstance((grade := case.get("grade")), Mapping)
-        and isinstance(grade.get("score"), int | float)
-        and not isinstance(grade.get("score"), bool)
-    ]
-    if len(scored) != len(case_results):
-        return CandidateResult(
-            benchmark_id=benchmark_id,
-            benchmark_revision=benchmark_revision,
-            case_count=len(case_results),
-            score=None,
-            metrics={},
-            cases=case_results,
-            failures=[],
-        ).as_payload()
-
-    return CandidateResult(
+    return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=benchmark_revision,
-        case_count=len(case_results),
+        cases=case_results,
+        scorer=_draco_score,
+    ).as_payload()
+
+
+def _draco_score(cases: Sequence[CaseResult]) -> CandidateScore:
+    """Apply the official DRACO cross-Case reduction to complete typed Cases."""
+
+    scored = [case.model_dump() for case in cases]
+    return CandidateScore(
         score=_mean_grades(scored, "score"),
         metrics={
             "normalized_score_sd": _mean_grade_metrics(scored, "normalized_score_sd"),
@@ -179,11 +176,7 @@ def aggregate(
             "verdicts_invalid": _sum_grade_metrics(scored, "verdicts_invalid"),
             "verdicts_missing": _sum_grade_metrics(scored, "verdicts_missing"),
         },
-        cases=case_results,
-        # Case-scoped failures live on their Case Result. Candidate-level failures are reserved
-        # for failures that cannot be attributed to a selected Case.
-        failures=[],
-    ).as_payload()
+    )
 
 
 def _decode_rows(
@@ -217,6 +210,16 @@ def _aggregate_rows(
     case_results: list[dict[str, Any]] = []
     for index, row in enumerate(decoded_rows):
         if not row.case_records:
+            if refusal := collected_provider_refusal(row.raw):
+                case_results.append(
+                    refused_case_result(
+                        case_id=int(row.expected_case["id"]),
+                        input=str(row.expected_case["input"]),
+                        refusal=refusal,
+                        metadata={"row_index": index},
+                    ).model_dump()
+                )
+                continue
             failure = _row_failure(
                 row.raw,
                 index,

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/aggregate.py
@@ -56,8 +56,10 @@ from typing import Any
 
 from url4_cloud.benchmarks.aggregation import (
     CandidateScore,
+    SelectedCase,
     collected_provider_refusal,
     finalize_candidate_result,
+    public_error,
     refused_case_result,
 )
 from url4_cloud.benchmarks.contract import CaseResult
@@ -136,10 +138,19 @@ def aggregate(
         or criterion_count < 1
     ):
         raise AggregateError("criterion_count must be a positive integer or None")
-    # INVARIANT: absence of evaluated Cases is an execution failure, not Candidate score zero.
-    if not rows:
-        raise AggregateError("no DRACO Case results were collected; the Candidate cannot be scored")
-    expected_cases = _validate_selected_cases(selected_cases, len(rows))
+    expected_cases = _validate_selected_cases(selected_cases)
+    if len(rows) > len(expected_cases):
+        raise AggregateError(
+            f"aggregate received {len(rows)} rows for {len(expected_cases)} selected Cases"
+        )
+    selection = [
+        SelectedCase(
+            case_id=int(case["id"]),
+            input=str(case["input"]),
+            metadata={key: value for key, value in case.items() if key not in {"id", "input"}},
+        )
+        for case in expected_cases
+    ]
 
     decoded_rows = _decode_rows(rows, expected_cases, judge_passes)
     _require_verifiable_mapping(decoded_rows)
@@ -147,6 +158,7 @@ def aggregate(
     return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=benchmark_revision,
+        selected_cases=selection,
         cases=case_results,
         scorer=_draco_score,
     ).as_payload()
@@ -185,7 +197,7 @@ def _decode_rows(
     judge_passes: int,
 ) -> list[_DecodedRow]:
     decoded: list[_DecodedRow] = []
-    for raw, expected_case in zip(rows, expected_cases, strict=True):
+    for raw, expected_case in zip(rows, expected_cases, strict=False):
         try:
             evaluation = decode_case_evaluation(
                 raw,
@@ -206,18 +218,27 @@ def _aggregate_rows(
     rubrics: Mapping[int, Mapping[str, Any]],
     judge_passes: int,
     criterion_count: int | None,
-) -> list[dict[str, Any]]:
-    case_results: list[dict[str, Any]] = []
+) -> list[CaseResult]:
+    case_results: list[CaseResult] = []
     for index, row in enumerate(decoded_rows):
         if not row.case_records:
             if refusal := collected_provider_refusal(row.raw):
+                selected = SelectedCase(
+                    case_id=int(row.expected_case["id"]),
+                    input=str(row.expected_case["input"]),
+                    metadata={
+                        key: value
+                        for key, value in row.expected_case.items()
+                        if key not in {"id", "input"}
+                    },
+                )
                 case_results.append(
                     refused_case_result(
-                        case_id=int(row.expected_case["id"]),
-                        input=str(row.expected_case["input"]),
-                        refusal=refusal,
+                        selected_case=selected,
+                        refusal=refusal.text,
+                        finish_reason=refusal.finish_reason,
                         metadata={"row_index": index},
-                    ).model_dump()
+                    )
                 )
                 continue
             failure = _row_failure(
@@ -305,35 +326,22 @@ def _row_failure(
         return failure
     metadata.clear()
     metadata["row_index"] = index
-    selected = _bounded_error(error)
+    diagnostic = public_error(
+        error,
+        default_code="case_execution_failed",
+        default_message="Candidate Case execution failed",
+    )
     failure.update(
         {
             "stage": "candidate",
-            "code": selected.get("code", "case_execution_failed"),
-            "message": selected.get("message", "Candidate Case execution failed"),
-            "retryable": _retryable(error),
+            "code": diagnostic.code,
+            "message": diagnostic.message,
+            "retryable": diagnostic.retryable,
         }
     )
-    if kind := selected.get("kind"):
-        metadata["error_kind"] = kind
+    if diagnostic.kind is not None:
+        metadata["error_kind"] = diagnostic.kind
     return failure
-
-
-def _bounded_error(error: Mapping[str, Any]) -> dict[str, str]:
-    limits = {"kind": 80, "code": 80, "message": 200}
-    return {
-        field: " ".join(value.split())[:limit]
-        for field, limit in limits.items()
-        if isinstance((value := error.get(field)), str) and value.strip()
-    }
-
-
-def _retryable(error: Mapping[str, Any]) -> bool | None:
-    if isinstance(value := error.get("retryable"), bool):
-        return value
-    if isinstance(permanent := error.get("permanent"), bool):
-        return not permanent
-    return None
 
 
 def _require_verifiable_mapping(rows: Sequence[_DecodedRow]) -> None:
@@ -381,14 +389,11 @@ def _require_verifiable_mapping(rows: Sequence[_DecodedRow]) -> None:
 
 
 def _validate_selected_cases(
-    selected_cases: Sequence[Mapping[str, Any]], row_count: int
+    selected_cases: Sequence[Mapping[str, Any]],
 ) -> list[Mapping[str, Any]]:
-    if len(selected_cases) != row_count:
-        raise AggregateError(
-            f"selected Case sequence must exactly match the {row_count} collected Case results; "
-            f"got {len(selected_cases)} selections"
-        )
     expected = list(selected_cases)
+    if not expected:
+        raise AggregateError("selected Case sequence must be non-empty")
     ids: set[int] = set()
     for index, case in enumerate(expected):
         case_id = optional_integer(case.get("id")) if isinstance(case, Mapping) else None

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -162,10 +162,12 @@ def failed_selected_case_result(
 ) -> dict[str, Any]:
     """Represent a selected Case that never produced a Candidate answer."""
     return {
+        "status": "failed",
         "case_id": int(selected_case["id"]),
         "input": selected_case["input"],
         "output": None,
         "finish_reason": None,
+        "refusal": None,
         "grade": None,
         "failures": [dict(failure)],
         "metadata": {
@@ -179,10 +181,12 @@ def ungraded_case_result(
 ) -> dict[str, Any]:
     """Retain an observed Candidate answer when private grading material is unavailable."""
     return {
+        "status": "failed",
         "case_id": int(case_record["case_id"]),
         "input": case_record["input"],
         "output": case_record["output"],
         "finish_reason": case_record["finish_reason"],
+        "refusal": None,
         "grade": None,
         "failures": [dict(failure)],
         "metadata": case_record.get("metadata", {}),
@@ -213,10 +217,12 @@ def _case_result(
 ) -> dict[str, Any]:
     """Assemble the shared Case Result envelope once."""
     return {
+        "status": "scored" if score is not None and not failures else "failed",
         "case_id": int(case_record["case_id"]),
         "input": case_record["input"],
         "output": case_record["output"],
         "finish_reason": case_record["finish_reason"],
+        "refusal": None,
         "grade": {
             "method": "rubric",
             "score": score,

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from url4_cloud.benchmarks.aggregation import (
+    SelectedCase,
+)
+from url4_cloud.benchmarks.aggregation import (
+    failed_case_result as build_failed_case_result,
+)
+from url4_cloud.benchmarks.aggregation import (
+    scored_case_result as build_scored_case_result,
+)
+from url4_cloud.benchmarks.contract import CaseResult
 from url4_cloud.benchmarks.draco.errors import AggregateError
 from url4_cloud.benchmarks.draco.scoring import flatten_criteria, score_case
 from url4_cloud.benchmarks.draco.validation import optional_integer
@@ -66,7 +76,7 @@ def scored_case_result(
     verdicts: Sequence[Mapping[str, Any]],
     judge_passes: int,
     criterion_count: int | None,
-) -> dict[str, Any]:
+) -> CaseResult:
     """Build one scored or coverage-failed Case Result."""
     case_id, criteria_expected = _expected_criteria(case_record, rubric, criterion_count)
     expected = criteria_expected * judge_passes
@@ -126,7 +136,7 @@ def incomplete_case_result(
     judge_passes: int,
     criterion_count: int | None,
     failure: Mapping[str, Any],
-) -> dict[str, Any]:
+) -> CaseResult:
     """Retain auditable grading material when no Judge Evidence was scoreable."""
     case_id, criteria_expected = _expected_criteria(case_record, rubric, criterion_count)
     verdicts_expected = criteria_expected * judge_passes
@@ -159,38 +169,22 @@ def incomplete_case_result(
 
 def failed_selected_case_result(
     selected_case: Mapping[str, Any], failure: Mapping[str, Any]
-) -> dict[str, Any]:
+) -> CaseResult:
     """Represent a selected Case that never produced a Candidate answer."""
-    return {
-        "status": "failed",
-        "case_id": int(selected_case["id"]),
-        "input": selected_case["input"],
-        "output": None,
-        "finish_reason": None,
-        "refusal": None,
-        "grade": None,
-        "failures": [dict(failure)],
-        "metadata": {
-            key: value for key, value in selected_case.items() if key not in {"id", "input"}
-        },
-    }
+    return build_failed_case_result(
+        selected_case=_selected_case(selected_case, id_key="id"),
+        failures=[failure],
+    )
 
 
-def ungraded_case_result(
-    case_record: Mapping[str, Any], failure: Mapping[str, Any]
-) -> dict[str, Any]:
+def ungraded_case_result(case_record: Mapping[str, Any], failure: Mapping[str, Any]) -> CaseResult:
     """Retain an observed Candidate answer when private grading material is unavailable."""
-    return {
-        "status": "failed",
-        "case_id": int(case_record["case_id"]),
-        "input": case_record["input"],
-        "output": case_record["output"],
-        "finish_reason": case_record["finish_reason"],
-        "refusal": None,
-        "grade": None,
-        "failures": [dict(failure)],
-        "metadata": case_record.get("metadata", {}),
-    }
+    return build_failed_case_result(
+        selected_case=_selected_case(case_record, id_key="case_id"),
+        failures=[failure],
+        output=str(case_record["output"]),
+        finish_reason=_finish_reason(case_record.get("finish_reason")),
+    )
 
 
 def _expected_criteria(
@@ -214,24 +208,44 @@ def _case_result(
     metrics: Mapping[str, Any],
     checks: Sequence[Mapping[str, Any]],
     failures: Sequence[Mapping[str, Any]],
-) -> dict[str, Any]:
+) -> CaseResult:
     """Assemble the shared Case Result envelope once."""
-    return {
-        "status": "scored" if score is not None and not failures else "failed",
-        "case_id": int(case_record["case_id"]),
-        "input": case_record["input"],
-        "output": case_record["output"],
-        "finish_reason": case_record["finish_reason"],
-        "refusal": None,
-        "grade": {
-            "method": "rubric",
-            "score": score,
-            "metrics": dict(metrics),
-            "checks": [dict(check) for check in checks],
-        },
-        "failures": [dict(failure) for failure in failures],
-        "metadata": case_record.get("metadata", {}),
+    selected = _selected_case(case_record, id_key="case_id")
+    output = str(case_record["output"])
+    finish_reason = _finish_reason(case_record.get("finish_reason"))
+    grade = {
+        "method": "rubric",
+        "score": score,
+        "metrics": dict(metrics),
+        "checks": [dict(check) for check in checks],
     }
+    if score is not None and not failures:
+        return build_scored_case_result(
+            selected_case=selected,
+            output=output,
+            finish_reason=finish_reason,
+            grade=grade,
+        )
+    return build_failed_case_result(
+        selected_case=selected,
+        failures=failures,
+        output=output,
+        finish_reason=finish_reason,
+        grade=grade,
+    )
+
+
+def _selected_case(record: Mapping[str, Any], *, id_key: str) -> SelectedCase:
+    metadata = record.get("metadata")
+    return SelectedCase(
+        case_id=int(record[id_key]),
+        input=str(record["input"]),
+        metadata=dict(metadata) if isinstance(metadata, Mapping) else {},
+    )
+
+
+def _finish_reason(value: object) -> str | None:
+    return value if isinstance(value, str) else None
 
 
 def _checks(

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/definition.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
 from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
 from url4_cloud.benchmarks.definition import Benchmark, candidate
 from url4_cloud.benchmarks.draco.prompts import JUDGE_INSTRUCTIONS
 from url4_cloud.benchmarks.draco.verdict import call as criterion_verdict
@@ -64,6 +65,7 @@ REVISION = hashlib.sha256(
             DATASET_REVISION,
             DATASET_PREPARER_REVISION,
             PROTOCOL_REVISION,
+            CANDIDATE_RESULT_SCHEMA,
             RETRIEVAL_POLICY_ID,
             repr(EXCLUDED_DOMAINS),
             JUDGE_MODEL,

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
@@ -59,6 +59,7 @@ from url4_cloud.benchmarks.draco.definition import (
     VERDICT_ROUTE,
 )
 from url4_cloud.benchmarks.draco.verdict import bind, binding_key
+from url4_cloud.benchmarks.errors import ProviderRefusal
 
 
 def install_canonical(node: Url4Node, root: Path) -> None:
@@ -206,11 +207,7 @@ def _task_rows(
             case_id = tasks.positive_case_id(request.intent)
             output, finish_reason, refusal = decode_candidate_invocation(request.context)
             if refusal is not None:
-                raise ResolutionError(
-                    "Candidate refused the DRACO Case",
-                    code="provider_refusal",
-                    permanent=True,
-                )
+                raise ProviderRefusal(refusal)
             raw_cases = _read(root / "cases.json", "DRACO cases")
             criteria = tasks.load_criteria(root / "criteria", case_id)
             rubric = _object(

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
@@ -207,7 +207,7 @@ def _task_rows(
             case_id = tasks.positive_case_id(request.intent)
             output, finish_reason, refusal = decode_candidate_invocation(request.context)
             if refusal is not None:
-                raise ProviderRefusal(refusal)
+                raise ProviderRefusal(refusal, finish_reason=finish_reason)
             raw_cases = _read(root / "cases.json", "DRACO cases")
             criteria = tasks.load_criteria(root / "criteria", case_id)
             rubric = _object(

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/errors.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/errors.py
@@ -1,0 +1,13 @@
+"""Internal Benchmark execution signals that must survive URL4 collection."""
+
+from url4.core.errors import ResolutionError
+
+
+class ProviderRefusal(ResolutionError):
+    """Exact provider refusal that stays identifiable through URL4 collection."""
+
+    def __init__(self, refusal: str) -> None:
+        super().__init__(refusal, code="provider_refusal", permanent=True)
+
+
+__all__ = ["ProviderRefusal"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/errors.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/errors.py
@@ -1,13 +1,27 @@
 """Internal Benchmark execution signals that must survive URL4 collection."""
 
+import json
+
 from url4.core.errors import ResolutionError
+from url4_cloud.benchmarks.contract import validate_finish_reason
 
 
 class ProviderRefusal(ResolutionError):
     """Exact provider refusal that stays identifiable through URL4 collection."""
 
-    def __init__(self, refusal: str) -> None:
-        super().__init__(refusal, code="provider_refusal", permanent=True)
+    def __init__(self, refusal: str, *, finish_reason: str | None) -> None:
+        if not isinstance(refusal, str) or not refusal.strip():
+            raise ValueError("provider refusal must be non-empty text")
+        finish_reason = validate_finish_reason(finish_reason)
+        super().__init__(
+            json.dumps(
+                {"refusal": refusal, "finish_reason": finish_reason},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+            code="provider_refusal",
+            permanent=True,
+        )
 
 
 __all__ = ["ProviderRefusal"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
@@ -33,15 +33,19 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any
 
 from url4_cloud.benchmarks.aggregation import (
     CandidateScore,
+    SelectedCase,
     collected_provider_refusal,
+    failed_case_result,
     finalize_candidate_result,
+    public_error,
     refused_case_result,
+    scored_case_result,
 )
-from url4_cloud.benchmarks.contract import CaseResult as ContractCaseResult
+from url4_cloud.benchmarks.contract import CaseResult
 from url4_cloud.benchmarks.healthbench.case_evaluation import CASE_EVALUATION_SCHEMA
 from url4_cloud.benchmarks.healthbench.scoring import (
     case_score,
@@ -53,36 +57,6 @@ from url4_cloud.benchmarks.healthbench.scoring import (
 
 class AggregateError(ValueError):
     """The reducer's input is unusable — raised before any scoring."""
-
-
-class CaseResult(TypedDict):
-    """One selected Case in the SDK's Case Result wire shape.
-
-    The SDK decoder requires EXACTLY these keys (see screamingface
-    ``_evaluation/results.py``); draco set the projection precedent. A scored
-    Case carries a ``grade`` (method/score/metrics/checks) and empty
-    ``failures``; a failed Case carries ``grade: None`` plus one Failure row
-    whose ``code`` names the rung of the decision ladder.
-    """
-
-    status: str
-    case_id: int
-    input: str | None
-    output: str | None
-    finish_reason: str | None
-    refusal: str | None
-    grade: dict[str, Any] | None
-    failures: list[dict[str, Any]]
-    metadata: dict[str, Any]
-
-
-class CandidateFields(TypedDict):
-    """Candidate-owned fields copied into every Case Result."""
-
-    input: str | None
-    output: str | None
-    finish_reason: str | None
-    metadata: dict[str, Any]
 
 
 def load_rubric_points(root: Path, case_id: int) -> list[int] | None:
@@ -116,6 +90,30 @@ def _points_from(decoded: object) -> list[int] | None:
     return points
 
 
+def _selected_cases(root: Path, case_ids: tuple[int, ...]) -> list[SelectedCase]:
+    try:
+        decoded = json.loads((root / "cases.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise AggregateError(f"HealthBench cases are unavailable: {exc}") from None
+    if not isinstance(decoded, list):
+        raise AggregateError("HealthBench cases must be a JSON array")
+    by_id = {
+        row.get("id"): row
+        for row in decoded
+        if isinstance(row, Mapping)
+        and isinstance(row.get("id"), int)
+        and not isinstance(row.get("id"), bool)
+    }
+    selected: list[SelectedCase] = []
+    for case_id in case_ids:
+        row = by_id.get(case_id)
+        input_value = row.get("input") if isinstance(row, Mapping) else None
+        if not isinstance(input_value, str) or not input_value.strip():
+            raise AggregateError(f"HealthBench Case {case_id} has no public input")
+        selected.append(SelectedCase(case_id=case_id, input=input_value, metadata={}))
+    return selected
+
+
 def aggregate(
     raw_rows: str,
     root: Path,
@@ -139,23 +137,26 @@ def aggregate(
     and on spread (sample stdev, see ``scoring.sample_stdev``).
     """
 
+    selected_cases = _selected_cases(root, case_ids)
     by_case, errors_by_case = _index_rows(_decode_rows(raw_rows), case_ids)
     case_results: list[CaseResult] = []
-    for case_id in case_ids:
+    for selected in selected_cases:
+        case_id = int(selected.case_id)
         points = load_rubric_points(root, case_id)
         result, _, _, _, _ = _case_result(
-            case_id, by_case.get(case_id), points, errors_by_case.get(case_id)
+            selected, by_case.get(case_id), points, errors_by_case.get(case_id)
         )
         case_results.append(result)
     return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=benchmark_revision,
+        selected_cases=selected_cases,
         cases=case_results,
         scorer=_healthbench_score,
     ).as_payload()
 
 
-def _healthbench_score(cases: Sequence[ContractCaseResult]) -> CandidateScore:
+def _healthbench_score(cases: Sequence[CaseResult]) -> CandidateScore:
     """Apply HealthBench's unclipped penalty-bearing reduction to complete Cases."""
 
     grades = [case.grade for case in cases]
@@ -186,7 +187,7 @@ def _healthbench_score(cases: Sequence[ContractCaseResult]) -> CandidateScore:
 
 
 def _case_result(
-    case_id: int,
+    selected_case: SelectedCase,
     row: Mapping[str, Any] | None,
     points: list[int] | None,
     orphan_errors: list[dict[str, Any]] | None = None,
@@ -208,18 +209,19 @@ def _case_result(
     invalid_reply_count)``.
     """
 
+    case_id = int(selected_case.case_id)
     if points is None:
         failure = _failure(case_id, "grading", "missing_rubric_asset")
-        outcome = _failed_result(case_id, row, [], failure), None, 0, 0, 0
+        outcome = _failed_result(selected_case, row, [], failure), None, 0, 0, 0
     elif row is None:
         # WHY the collected_errors attachment: an on_error=collect row loses its
         # Case identity, so a mid-chain error surfaces HERE as a missing row —
         # without the orphan payloads the report would name the symptom but hide
         # the cause (exactly what happened in the first live smoke run).
-        outcome = _missing_row_outcome(case_id, orphan_errors)
+        outcome = _missing_row_outcome(selected_case, orphan_errors)
     elif "error" in row:
         failure = _failure(case_id, "candidate", "case_error", error=row["error"])
-        outcome = _failed_result(case_id, row, [], failure), None, 0, 0, 0
+        outcome = _failed_result(selected_case, row, [], failure), None, 0, 0, 0
     else:
         verdicts, invalid = _verdicts(row)
         checks = _checks(row, points)
@@ -238,19 +240,19 @@ def _case_result(
                 expected=len(points),
             )
             outcome = (
-                _failed_result(case_id, row, checks, failure),
+                _failed_result(selected_case, row, checks, failure),
                 None,
                 len(verdicts),
                 sum(verdicts.values()),
                 invalid,
             )
         else:
-            scored: CaseResult = {
-                "status": "scored",
-                "case_id": case_id,
-                **_candidate_fields(row),
-                "refusal": None,
-                "grade": {
+            fields = _candidate_fields(row)
+            scored = scored_case_result(
+                selected_case=selected_case,
+                output=fields["output"],
+                finish_reason=fields["finish_reason"],
+                grade={
                     "method": "rubric",
                     "score": round(score, 4),
                     "metrics": {
@@ -260,14 +262,14 @@ def _case_result(
                     },
                     "checks": checks,
                 },
-                "failures": [],
-            }
+                metadata=fields["metadata"],
+            )
             outcome = scored, score, len(verdicts), sum(verdicts.values()), invalid
     return outcome
 
 
 def _missing_row_outcome(
-    case_id: int, orphan_errors: list[dict[str, Any]] | None
+    selected_case: SelectedCase, orphan_errors: list[dict[str, Any]] | None
 ) -> tuple[CaseResult, None, int, int, int]:
     refusal = next(
         (
@@ -278,29 +280,32 @@ def _missing_row_outcome(
         None,
     )
     if refusal is not None:
-        refused = refused_case_result(case_id=case_id, input=None, refusal=refusal)
-        return CaseResult(**refused.model_dump()), None, 0, 0, 0
+        refused = refused_case_result(
+            selected_case=selected_case,
+            refusal=refusal.text,
+            finish_reason=refusal.finish_reason,
+        )
+        return refused, None, 0, 0, 0
+    case_id = int(selected_case.case_id)
     failure = _failure(
         case_id,
         "candidate",
         "missing_case_row",
         **({"collected_errors": orphan_errors[:3]} if orphan_errors else {}),
     )
-    return _failed_result(case_id, None, [], failure), None, 0, 0, 0
+    return _failed_result(selected_case, None, [], failure), None, 0, 0, 0
 
 
-def _candidate_fields(row: Mapping[str, Any] | None) -> CandidateFields:
+def _candidate_fields(row: Mapping[str, Any] | None) -> dict[str, Any]:
     """Pull input/output/finish_reason/metadata off the hoisted Case record."""
 
     case = row.get("case") if isinstance(row, Mapping) else None
     if not isinstance(case, Mapping):
-        return {"input": None, "output": None, "finish_reason": None, "metadata": {}}
+        return {"output": None, "finish_reason": None, "metadata": {}}
     metadata = case.get("metadata")
-    input_value = case.get("input")
     output = case.get("output")
     finish_reason = case.get("finish_reason")
     return {
-        "input": input_value if isinstance(input_value, str) else None,
         "output": output if isinstance(output, str) else None,
         "finish_reason": finish_reason if isinstance(finish_reason, str) else None,
         "metadata": dict(metadata) if isinstance(metadata, Mapping) else {},
@@ -308,32 +313,34 @@ def _candidate_fields(row: Mapping[str, Any] | None) -> CandidateFields:
 
 
 def _failed_result(
-    case_id: int,
+    selected_case: SelectedCase,
     row: Mapping[str, Any] | None,
     checks: list[dict[str, Any]],
     failure: dict[str, Any],
 ) -> CaseResult:
-    return {
-        "status": "failed",
-        "case_id": case_id,
-        **_candidate_fields(row),
-        "refusal": None,
-        "grade": (
-            None
-            if not checks
-            else {
-                # WHY a grade with score None instead of dropping the checks: the
-                # judge evidence for an incompletely-judged Case is audit material
-                # (module INVARIANT) and the grade's checks list is the contract's
-                # slot for it.
-                "method": "rubric",
-                "score": None,
-                "metrics": {},
-                "checks": checks,
-            }
-        ),
-        "failures": [failure],
-    }
+    fields = _candidate_fields(row)
+    grade = (
+        None
+        if not checks
+        else {
+            # WHY a grade with score None instead of dropping the checks: the
+            # judge evidence for an incompletely-judged Case is audit material
+            # (module INVARIANT) and the grade's checks list is the contract's
+            # slot for it.
+            "method": "rubric",
+            "score": None,
+            "metrics": {},
+            "checks": checks,
+        }
+    )
+    return failed_case_result(
+        selected_case=selected_case,
+        failures=[failure],
+        output=fields["output"],
+        finish_reason=fields["finish_reason"],
+        grade=grade,
+        metadata=fields["metadata"],
+    )
 
 
 def _checks(row: Mapping[str, Any], points: list[int]) -> list[dict[str, Any]]:
@@ -403,14 +410,58 @@ def _evidence(record: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _failure(case_id: int, stage: str, code: str, **metadata: Any) -> dict[str, Any]:
+    public_metadata = _failure_metadata(metadata)
+    message = _FAILURE_MESSAGES[code]
+    retryable: bool | None = None
+    if source_error := _source_error(metadata):
+        diagnostic = public_error(
+            source_error,
+            default_code=code,
+            default_message=message,
+        )
+        message = diagnostic.message
+        retryable = diagnostic.retryable
+        public_metadata["source_error"] = {
+            "kind": diagnostic.kind,
+            "code": diagnostic.code,
+            "message": diagnostic.message,
+            "retryable": diagnostic.retryable,
+        }
     return {
         "stage": stage,
         "code": code,
-        "message": _FAILURE_MESSAGES[code],
-        "retryable": None,
+        "message": message,
+        "retryable": retryable,
         "case_id": case_id,
-        "metadata": metadata,
+        "metadata": public_metadata,
     }
+
+
+def _failure_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    public = {
+        key: value
+        for key, value in metadata.items()
+        if key in {"judged", "expected", "row_index"}
+        and isinstance(value, int)
+        and not isinstance(value, bool)
+    }
+    return public
+
+
+def _source_error(metadata: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    error = metadata.get("error")
+    if isinstance(error, Mapping):
+        return error
+    collected = metadata.get("collected_errors")
+    rows = collected[:3] if isinstance(collected, list) else []
+    return next(
+        (
+            source
+            for row in rows
+            if isinstance(row, Mapping) and isinstance((source := row.get("error")), Mapping)
+        ),
+        None,
+    )
 
 
 _FAILURE_MESSAGES = {
@@ -427,8 +478,8 @@ def _decode_rows(raw: str) -> list[Any]:
         decoded = json.loads(raw or "")
     except ValueError as exc:
         raise AggregateError(f"HealthBench rows are not JSON: {exc}") from None
-    if not isinstance(decoded, list) or not decoded:
-        raise AggregateError("HealthBench rows must be a non-empty JSON array")
+    if not isinstance(decoded, list):
+        raise AggregateError("HealthBench rows must be a JSON array")
     return decoded
 
 
@@ -466,7 +517,7 @@ def _row_value(entry: object) -> tuple[Mapping[str, Any] | None, dict[str, Any] 
     try:
         row = json.loads(entry) if isinstance(entry, str) else entry
     except ValueError:
-        return None, {"error": "unparseable row", "row_head": str(entry)[:200]}
+        return None, {"error": {"kind": "InvalidCollectedRow"}}
     return (row, None) if isinstance(row, Mapping) else (None, None)
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
@@ -31,11 +31,17 @@ set — becomes a visible failed Case, never a shrug.
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, TypedDict
 
-from url4_cloud.benchmarks.contract import CandidateResult
+from url4_cloud.benchmarks.aggregation import (
+    CandidateScore,
+    collected_provider_refusal,
+    finalize_candidate_result,
+    refused_case_result,
+)
+from url4_cloud.benchmarks.contract import CaseResult as ContractCaseResult
 from url4_cloud.benchmarks.healthbench.case_evaluation import CASE_EVALUATION_SCHEMA
 from url4_cloud.benchmarks.healthbench.scoring import (
     case_score,
@@ -59,10 +65,12 @@ class CaseResult(TypedDict):
     whose ``code`` names the rung of the decision ladder.
     """
 
+    status: str
     case_id: int
     input: str | None
     output: str | None
     finish_reason: str | None
+    refusal: str | None
     grade: dict[str, Any] | None
     failures: list[dict[str, Any]]
     metadata: dict[str, Any]
@@ -131,64 +139,50 @@ def aggregate(
     and on spread (sample stdev, see ``scoring.sample_stdev``).
     """
 
-    by_case, orphan_errors = _index_rows(_decode_rows(raw_rows))
+    by_case, errors_by_case = _index_rows(_decode_rows(raw_rows), case_ids)
     case_results: list[CaseResult] = []
-    scores: list[float] = []
-    judged_items = 0
-    met_items = 0
-    total_items = 0
-    invalid_replies = 0
     for case_id in case_ids:
         points = load_rubric_points(root, case_id)
-        total_items += len(points) if points is not None else 0
-        result, score, judged, met, invalid = _case_result(
-            case_id, by_case.get(case_id), points, orphan_errors
+        result, _, _, _, _ = _case_result(
+            case_id, by_case.get(case_id), points, errors_by_case.get(case_id)
         )
         case_results.append(result)
-        judged_items += judged
-        met_items += met
-        invalid_replies += invalid
-        if score is not None:
-            scores.append(score)
-    scored_all = len(scores) == len(case_ids)
-    mean = unclipped_mean(scores) if scored_all else None
+    return finalize_candidate_result(
+        benchmark_id=benchmark_id,
+        benchmark_revision=benchmark_revision,
+        cases=case_results,
+        scorer=_healthbench_score,
+    ).as_payload()
+
+
+def _healthbench_score(cases: Sequence[ContractCaseResult]) -> CandidateScore:
+    """Apply HealthBench's unclipped penalty-bearing reduction to complete Cases."""
+
+    grades = [case.grade for case in cases]
+    if any(grade is None or grade.score is None for grade in grades):  # pragma: no cover
+        raise AssertionError("HealthBench scorer requires complete graded Cases")
+    typed_grades = [grade for grade in grades if grade is not None and grade.score is not None]
+    scores = [float(grade.score) for grade in typed_grades if grade.score is not None]
+    judged_items = sum(int(grade.metrics["judged"]) for grade in typed_grades)
+    total_items = sum(int(grade.metrics["expected"]) for grade in typed_grades)
+    invalid_replies = sum(int(grade.metrics["invalid_replies"]) for grade in typed_grades)
+    met_items = sum(1 for grade in typed_grades for check in grade.checks if check.outcome == "MET")
     coverage = round(verdict_coverage(judged_items, total_items), 4)
-    # SDK rule (enforced by the CandidateResult model): an unscored Candidate must
-    # carry EMPTY metrics — when any Case failed, diagnosis lives in that Case's
-    # failures rows, not up here.
-    metrics: dict[str, Any] = {}
-    if mean is not None:
-        metrics = {
-            # HealthBench's canonical-trio mapping (contract enforced by
-            # CandidateResult; draco's aggregate is the semantic reference):
-            # pass_rate is the UNWEIGHTED criterion hit rate — met / judged rubric
-            # items, deliberately different from `score`, the point-WEIGHTED
-            # unclipped rubric mean; coverage is judged / expected rubric items,
-            # the same value long published as `verdict_coverage` (which stays —
-            # metrics are append-only).
+    mean = unclipped_mean(scores)
+    if mean is None:  # pragma: no cover - a Benchmark always selects at least one Case
+        raise AssertionError("HealthBench scorer requires at least one Case")
+    return CandidateScore(
+        score=round(mean, 4),
+        metrics={
             "pass_rate": round(met_items / judged_items, 4) if judged_items else 0.0,
             "coverage": coverage,
             "scored_cases": len(scores),
-            "failed_cases": len(case_ids) - len(scores),
+            "failed_cases": 0,
             "score_sd": round(sample_stdev(scores), 4),
             "verdict_coverage": coverage,
             "judge_invalid_replies": invalid_replies,
-        }
-    return CandidateResult(
-        benchmark_id=benchmark_id,
-        benchmark_revision=benchmark_revision,
-        case_count=len(case_results),
-        # WHY: None whenever ANY selected Case failed — a partial mean over surviving
-        # Cases would silently drop exactly the hardest rows (B1).
-        score=round(mean, 4) if mean is not None else None,
-        metrics=metrics,
-        cases=[dict(case) for case in case_results],
-        # Case-scoped failures live on their Case result rows above. This top-level
-        # list is the contract's slot for failures attributable to NO selected Case
-        # (draco precedent) — healthbench routes every failure to a Case, so it is
-        # always empty, but the SDK requires the key.
-        failures=[],
-    ).as_payload()
+        },
+    )
 
 
 def _case_result(
@@ -222,13 +216,7 @@ def _case_result(
         # Case identity, so a mid-chain error surfaces HERE as a missing row —
         # without the orphan payloads the report would name the symptom but hide
         # the cause (exactly what happened in the first live smoke run).
-        failure = _failure(
-            case_id,
-            "candidate",
-            "missing_case_row",
-            **({"collected_errors": orphan_errors[:3]} if orphan_errors else {}),
-        )
-        outcome = _failed_result(case_id, None, [], failure), None, 0, 0, 0
+        outcome = _missing_row_outcome(case_id, orphan_errors)
     elif "error" in row:
         failure = _failure(case_id, "candidate", "case_error", error=row["error"])
         outcome = _failed_result(case_id, row, [], failure), None, 0, 0, 0
@@ -258,8 +246,10 @@ def _case_result(
             )
         else:
             scored: CaseResult = {
+                "status": "scored",
                 "case_id": case_id,
                 **_candidate_fields(row),
+                "refusal": None,
                 "grade": {
                     "method": "rubric",
                     "score": round(score, 4),
@@ -274,6 +264,29 @@ def _case_result(
             }
             outcome = scored, score, len(verdicts), sum(verdicts.values()), invalid
     return outcome
+
+
+def _missing_row_outcome(
+    case_id: int, orphan_errors: list[dict[str, Any]] | None
+) -> tuple[CaseResult, None, int, int, int]:
+    refusal = next(
+        (
+            value
+            for error in orphan_errors or []
+            if (value := collected_provider_refusal(error)) is not None
+        ),
+        None,
+    )
+    if refusal is not None:
+        refused = refused_case_result(case_id=case_id, input=None, refusal=refusal)
+        return CaseResult(**refused.model_dump()), None, 0, 0, 0
+    failure = _failure(
+        case_id,
+        "candidate",
+        "missing_case_row",
+        **({"collected_errors": orphan_errors[:3]} if orphan_errors else {}),
+    )
+    return _failed_result(case_id, None, [], failure), None, 0, 0, 0
 
 
 def _candidate_fields(row: Mapping[str, Any] | None) -> CandidateFields:
@@ -301,8 +314,10 @@ def _failed_result(
     failure: dict[str, Any],
 ) -> CaseResult:
     return {
+        "status": "failed",
         "case_id": case_id,
         **_candidate_fields(row),
+        "refusal": None,
         "grade": (
             None
             if not checks
@@ -372,7 +387,8 @@ def _evidence(record: Mapping[str, Any]) -> dict[str, Any]:
         "sequence": 1,
         "producer": {
             "type": str(record.get("producer_type", "model")),
-            "id": str(record.get("producer_id", "")),
+            # Even a malformed Judge reply has a known Benchmark-owned producer.
+            "id": str(record.get("producer_id") or "healthbench/judge"),
         },
         "valid": valid,
         "raw_output": str(record.get("raw_output", "")),
@@ -416,7 +432,9 @@ def _decode_rows(raw: str) -> list[Any]:
     return decoded
 
 
-def _index_rows(rows: list[Any]) -> tuple[dict[int, dict[str, Any]], list[dict[str, Any]]]:
+def _index_rows(
+    rows: list[Any], case_ids: tuple[int, ...]
+) -> tuple[dict[int, dict[str, Any]], dict[int, list[dict[str, Any]]]]:
     """Split rows into per-Case evaluations and identity-less orphan error rows.
 
     An ``on_error=collect`` row loses its Case identity, so it cannot be indexed;
@@ -425,23 +443,40 @@ def _index_rows(rows: list[Any]) -> tuple[dict[int, dict[str, Any]], list[dict[s
     """
 
     indexed: dict[int, dict[str, Any]] = {}
-    orphans: list[dict[str, Any]] = []
-    for entry in rows:
-        try:
-            row = json.loads(entry) if isinstance(entry, str) else entry
-        except ValueError:
-            orphans.append({"error": "unparseable row", "row_head": str(entry)[:200]})
+    errors_by_case: dict[int, list[dict[str, Any]]] = {}
+    for index, entry in enumerate(rows):
+        expected_case_id = case_ids[index] if index < len(case_ids) else None
+        row, parse_error = _row_value(entry)
+        if parse_error is not None:
+            _attach_collected_error(errors_by_case, expected_case_id, parse_error)
             continue
-        if not isinstance(row, Mapping):
+        if row is None:
             continue
         if "error" in row and "case_id" not in row:
-            orphans.append(dict(row))
+            _attach_collected_error(errors_by_case, expected_case_id, dict(row))
             continue
         if row.get("schema") == CASE_EVALUATION_SCHEMA:
             case_id = row.get("case_id")
             if isinstance(case_id, int) and not isinstance(case_id, bool):
                 indexed[case_id] = dict(row)
-    return indexed, orphans
+    return indexed, errors_by_case
+
+
+def _row_value(entry: object) -> tuple[Mapping[str, Any] | None, dict[str, Any] | None]:
+    try:
+        row = json.loads(entry) if isinstance(entry, str) else entry
+    except ValueError:
+        return None, {"error": "unparseable row", "row_head": str(entry)[:200]}
+    return (row, None) if isinstance(row, Mapping) else (None, None)
+
+
+def _attach_collected_error(
+    target: dict[int, list[dict[str, Any]]],
+    case_id: int | None,
+    error: dict[str, Any],
+) -> None:
+    if case_id is not None:
+        target.setdefault(case_id, []).append(error)
 
 
 def _verdicts(row: Mapping[str, Any]) -> tuple[dict[int, bool], int]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
@@ -203,6 +203,9 @@ def _case_result(
         verdicts incomplete  → "incomplete_verdicts" (judged/expected counts)
         complete, no + item  → "no_positive_points" (a baked-asset defect —
                                prepare guarantees one positive item per Case)
+        scored, no envelope  → "invalid_case_evaluation" (fully judged but the
+                               hoisted case record carries no usable output —
+                               a scored result REQUIRES one, contract rule)
         everything valid     → grade with the Case score, no failures
 
     Returns ``(case_result, score_or_None, judged_count, met_count,
@@ -239,6 +242,20 @@ def _case_result(
                 judged=len(verdicts),
                 expected=len(points),
             )
+            outcome = (
+                _failed_result(selected_case, row, checks, failure),
+                None,
+                len(verdicts),
+                sum(verdicts.values()),
+                invalid,
+            )
+        elif _candidate_fields(row)["output"] is None:
+            # WHY: the contract forbids a scored Case without an output — a
+            # fully-judged row whose hoisted case envelope is missing or
+            # malformed must fail VISIBLY here, not trip the CaseResult
+            # validator and turn the whole Candidate run into
+            # benchmark_unavailable (one bad row destroying a paid run).
+            failure = _failure(case_id, "candidate", "invalid_case_evaluation")
             outcome = (
                 _failed_result(selected_case, row, checks, failure),
                 None,
@@ -470,6 +487,7 @@ _FAILURE_MESSAGES = {
     "case_error": "the Case pipeline collected an error instead of an evaluation",
     "incomplete_verdicts": "not every rubric item received a valid judge verdict",
     "no_positive_points": "no judged rubric item carries positive points (baked-asset defect)",
+    "invalid_case_evaluation": "the evaluation row lacked a usable candidate envelope",
 }
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
@@ -366,7 +366,7 @@ def _checks(row: Mapping[str, Any], points: list[int]) -> list[dict[str, Any]]:
     evaluations = row.get("rubric_evaluations")
     if not isinstance(evaluations, list):
         return []
-    checks: list[dict[str, Any]] = []
+    checks: dict[int, dict[str, Any]] = {}
     for evaluation in evaluations:
         if not isinstance(evaluation, Mapping):
             continue
@@ -392,15 +392,16 @@ def _checks(row: Mapping[str, Any], points: list[int]) -> list[dict[str, Any]]:
         # an invalid reply leaves the check outcome-less on purpose.
         if evidence.get("valid") is True:
             check["outcome"] = "MET" if evidence.get("criteria_met") is True else "UNMET"
-        checks.append(
-            {
-                **check,
-                "metadata": (
-                    {"points": points[rubric_id - 1]} if 1 <= rubric_id <= len(points) else {}
-                ),
-            }
-        )
-    return checks
+        # One check per rubric_id, last entry wins — the same dict-assignment
+        # dedup as _verdicts, so a duplicate judge entry (retry noise) never
+        # becomes a second check and met can never exceed judged.
+        checks[rubric_id] = {
+            **check,
+            "metadata": (
+                {"points": points[rubric_id - 1]} if 1 <= rubric_id <= len(points) else {}
+            ),
+        }
+    return list(checks.values())
 
 
 def _evidence(record: Mapping[str, Any]) -> dict[str, Any]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/definition.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import hashlib
 
 from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
+from url4_cloud.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
 from url4_cloud.benchmarks.definition import Benchmark, candidate
 from url4_cloud.benchmarks.healthbench import verdict
 from url4_cloud.benchmarks.healthbench.prompts import GRADER_TEMPLATE
@@ -55,6 +56,7 @@ REVISION = hashlib.sha256(
             DATASET,
             DATASET_REVISION,
             PROTOCOL_REVISION,
+            CANDIDATE_RESULT_SCHEMA,
             PREPARER_REVISION,
             subset_sha(),
             JUDGE_MODEL,

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
@@ -29,6 +29,7 @@ from url4_cloud.benchmarks.contract import (
     CANDIDATE_INPUT_SCHEMA,
     decode_candidate_invocation,
 )
+from url4_cloud.benchmarks.errors import ProviderRefusal
 from url4_cloud.benchmarks.healthbench import aggregate as reducing
 from url4_cloud.benchmarks.healthbench import records
 from url4_cloud.benchmarks.healthbench.case_evaluation import (
@@ -155,11 +156,7 @@ def _rubric_tasks(root: Path, case_ids: tuple[int, ...]):
             case_id = _positive_case_id(request.intent)
             output, finish_reason, refusal = decode_candidate_invocation(request.context)
             if refusal is not None:
-                raise ResolutionError(
-                    "Candidate refused the HealthBench Case",
-                    code="provider_refusal",
-                    permanent=True,
-                )
+                raise ProviderRefusal(refusal)
             raw_cases = _read(root / "cases.json", "HealthBench cases")
             transcript = _transcript(raw_cases, case_id)
             items = _rubric_items(root, case_id)

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
@@ -156,7 +156,7 @@ def _rubric_tasks(root: Path, case_ids: tuple[int, ...]):
             case_id = _positive_case_id(request.intent)
             output, finish_reason, refusal = decode_candidate_invocation(request.context)
             if refusal is not None:
-                raise ProviderRefusal(refusal)
+                raise ProviderRefusal(refusal, finish_reason=finish_reason)
             raw_cases = _read(root / "cases.json", "HealthBench cases")
             transcript = _transcript(raw_cases, case_id)
             items = _rubric_items(root, case_id)

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
@@ -7,11 +7,8 @@ accuracy (arXiv:2311.07911).
 
 INVARIANT: `case_count` is EXACT (one entry per selected Case) and every scored Case has a
 real verifier record. A missing record is an operational failure rather than an incorrect
-answer: the Case is RETAINED with its failure record and counted in `cases_fallback`, never
-folded into a denominator. Scoring is coverage-declared (draco's model): accuracies run over
-graded Cases only and `metrics.coverage` says how much of the selection the score stands on.
-The Engine reports facts and gates nothing — acceptance policy lives downstream. Only a run
-with zero graded Cases is unscored (a score over nothing is undefined).
+answer: the Case is retained with its failure record and the complete Candidate fails closed
+with `score: None` and empty metrics. No accuracy is published over a surviving subset.
 """
 
 from __future__ import annotations
@@ -21,7 +18,13 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from url4_cloud.benchmarks.contract import CandidateResult
+from url4_cloud.benchmarks.aggregation import (
+    CandidateScore,
+    collected_provider_refusal,
+    finalize_candidate_result,
+    refused_case_result,
+)
+from url4_cloud.benchmarks.contract import CaseResult
 from url4_cloud.benchmarks.ifeval.case_evaluation import (
     CHECK_SCHEMA,
     decode_case_evaluation,
@@ -50,67 +53,36 @@ def aggregate(
     """
 
     rows = _rows(rows_json)
-    case_results: list[dict[str, Any]] = []
-    accepted: list[dict[str, Any]] = []
-    recordless_cases: list[tuple[int, int]] = []
+    case_results: list[CaseResult] = []
     for index, (raw, case_id) in enumerate(
         zip(rows, _selected_case_ids(rows, specs, case_order), strict=True)
     ):
         spec = specs[case_id]
         record = _first_valid_record(raw, case_id, spec)
         if record is None:
-            recordless_cases.append((index, case_id))
             case_results.append(_failed_case_result(raw, index, case_id, spec))
             continue
-        accepted.append(record)
         case_results.append(_case_result(case_id, spec, record))
-    if not accepted:
-        return _unscored_result(benchmark_id, IFEVAL_REVISION, case_results)
-
-    strict_all = [all(record["strict"]) for record in accepted]
-    loose_all = [all(record["loose"]) for record in accepted]
-    strict_flat = [bool(value) for record in accepted for value in record["strict"]]
-    loose_flat = [bool(value) for record in accepted for value in record["loose"]]
-    inst_level_strict = _accuracy(strict_flat)
-    cases_checked = len(accepted)
-    cases_fallback = len(recordless_cases)
-    return CandidateResult(
+    return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=IFEVAL_REVISION,
-        case_count=len(case_results),
-        score=_accuracy(strict_all),
-        metrics={
-            "inst_level_strict_accuracy": inst_level_strict,
-            "prompt_level_loose_accuracy": _accuracy(loose_all),
-            "inst_level_loose_accuracy": _accuracy(loose_flat),
-            "cases_checked": cases_checked,
-            "cases_fallback": cases_fallback,
-            # IFEval's canonical-trio mapping (contract enforced by CandidateResult):
-            # pass_rate is instruction-level strict accuracy over graded cases;
-            # coverage is graded / selected cases.
-            "pass_rate": inst_level_strict,
-            "coverage": round(cases_checked / len(case_results), 4),
-        },
         cases=case_results,
-        failures=[],
+        scorer=_ifeval_score,
     ).as_payload()
 
 
 def _unscored_result(
     benchmark_id: str,
     benchmark_revision: str,
-    cases: Sequence[Mapping[str, Any]],
+    cases: Sequence[CaseResult],
 ) -> dict[str, Any]:
     """Return the complete Evaluation record without fabricating an aggregate score."""
 
-    return CandidateResult(
+    return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=benchmark_revision,
-        case_count=len(cases),
-        score=None,
-        metrics={},
-        cases=[dict(case) for case in cases],
-        failures=[],
+        cases=cases,
+        scorer=_ifeval_score,
     ).as_payload()
 
 
@@ -119,8 +91,16 @@ def _failed_case_result(
     row_index: int,
     case_id: int,
     spec: Mapping[str, Any],
-) -> dict[str, Any]:
+) -> CaseResult:
     """Retain one selected Case whose Candidate Invocation or Grading failed."""
+
+    if refusal := collected_provider_refusal(row):
+        return refused_case_result(
+            case_id=case_id,
+            input=spec["prompt"],
+            refusal=refusal,
+            metadata={"row_index": row_index},
+        )
 
     error = row.get("error") if isinstance(row, Mapping) else None
     error = error if isinstance(error, Mapping) else {}
@@ -132,24 +112,28 @@ def _failed_case_result(
     metadata: dict[str, Any] = {"row_index": row_index}
     if kind is not None:
         metadata["error_kind"] = kind
-    return {
-        "case_id": case_id,
-        "input": spec["prompt"],
-        "output": None,
-        "finish_reason": None,
-        "grade": None,
-        "failures": [
-            {
-                "stage": _failure_stage(code),
-                "code": code,
-                "message": message,
-                "retryable": _retryable(error),
-                "case_id": case_id,
-                "metadata": metadata,
-            }
-        ],
-        "metadata": {},
-    }
+    return CaseResult.model_validate(
+        {
+            "status": "failed",
+            "case_id": case_id,
+            "input": spec["prompt"],
+            "output": None,
+            "finish_reason": None,
+            "refusal": None,
+            "grade": None,
+            "failures": [
+                {
+                    "stage": _failure_stage(code),
+                    "code": code,
+                    "message": message,
+                    "retryable": _retryable(error),
+                    "case_id": case_id,
+                    "metadata": metadata,
+                }
+            ],
+            "metadata": {},
+        }
+    )
 
 
 def _failure_stage(code: str) -> str:
@@ -188,16 +172,13 @@ def aggregate_corrective(
     """
 
     rows = _rows(rows_json)
-    case_results: list[dict[str, Any]] = []
-    selected_records: list[dict[str, Any]] = []
-    recordless_cases: list[tuple[int, int]] = []
+    case_results: list[CaseResult] = []
     for index, (raw, case_id) in enumerate(
         zip(rows, _selected_case_ids(rows, specs, case_order), strict=True)
     ):
         spec = specs[case_id]
         records = _attempt_records(raw, case_id, spec, max_attempts)
         if not records:
-            recordless_cases.append((index, case_id))
             case_results.append(_failed_case_result(raw, index, case_id, spec))
             continue
         earliest_pass = min(
@@ -205,8 +186,6 @@ def aggregate_corrective(
             default=0,
         )
         selected_attempt = earliest_pass or max(records)
-        selected = records[selected_attempt]
-        selected_records.append(selected)
         case_results.append(
             _corrective_case(
                 case_id,
@@ -216,57 +195,11 @@ def aggregate_corrective(
                 earliest_pass,
             )
         )
-    if not selected_records:
-        return _unscored_result(benchmark_id, benchmark_revision, case_results)
-
-    strict_all = [all(record["strict"]) for record in selected_records]
-    loose_all = [all(record["loose"]) for record in selected_records]
-    strict_flat = [bool(value) for record in selected_records for value in record["strict"]]
-    loose_flat = [bool(value) for record in selected_records for value in record["loose"]]
-    # pass@k denominators run over graded cases only; failed cases carry no
-    # pass_attempt metadata, so .get keeps them out of the numerator too.
-    graded = len(selected_records)
-    pass_at = {
-        f"pass_at_{attempt}": (
-            round(
-                sum(
-                    1
-                    for case in case_results
-                    if case["metadata"].get("pass_attempt")
-                    and case["metadata"]["pass_attempt"] <= attempt
-                )
-                / graded,
-                4,
-            )
-            if graded
-            else 0.0
-        )
-        for attempt in range(1, max_attempts + 1)
-    }
-    inst_level_strict = _accuracy(strict_flat)
-    cases_fallback = len(recordless_cases)
-    return CandidateResult(
+    return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=benchmark_revision,
-        case_count=len(case_results),
-        score=_accuracy(strict_all),
-        metrics={
-            "inst_level_strict_accuracy": inst_level_strict,
-            "prompt_level_loose_accuracy": _accuracy(loose_all),
-            "inst_level_loose_accuracy": _accuracy(loose_flat),
-            **pass_at,
-            "corrected_cases": sum(
-                1 for case in case_results if (case["metadata"].get("pass_attempt") or 0) > 1
-            ),
-            "cases_checked": graded,
-            "cases_fallback": cases_fallback,
-            # Same IFEval canonical-trio mapping as the single-pass reducer, over the
-            # SELECTED attempt per graded case (contract enforced by CandidateResult).
-            "pass_rate": inst_level_strict,
-            "coverage": round(graded / len(case_results), 4),
-        },
         cases=case_results,
-        failures=[],
+        scorer=lambda cases: _ifeval_score(cases, max_attempts=max_attempts),
     ).as_payload()
 
 
@@ -313,27 +246,30 @@ def _corrective_case(
     records: Mapping[int, Mapping[str, Any]],
     selected_attempt: int,
     pass_attempt: int,
-) -> dict[str, Any]:
+) -> CaseResult:
     selected = records[selected_attempt]
     result = _case_result(case_id, spec, selected)
-    result["metadata"] = {
-        "selected_attempt": selected_attempt,
-        # 0 means no attempt passed every strict Check.
-        "pass_attempt": pass_attempt,
-        "attempts": [
-            {
-                "attempt": attempt,
-                "output": record["answer"],
-                "finish_reason": record["finish_reason"],
-                "feedback": list(record["violations"]),
-                # The judge's actual coaching for THIS attempt (authored after the
-                # previous round failed); None for attempt 1 and judge-free flows.
-                "judge_feedback": record.get("judge_feedback"),
+    return result.model_copy(
+        update={
+            "metadata": {
+                "selected_attempt": selected_attempt,
+                # 0 means no attempt passed every strict Check.
+                "pass_attempt": pass_attempt,
+                "attempts": [
+                    {
+                        "attempt": attempt,
+                        "output": record["answer"],
+                        "finish_reason": record["finish_reason"],
+                        "feedback": list(record["violations"]),
+                        # The judge's actual coaching for THIS attempt (authored after the
+                        # previous round failed); None for attempt 1 and judge-free flows.
+                        "judge_feedback": record.get("judge_feedback"),
+                    }
+                    for attempt, record in sorted(records.items())
+                ],
             }
-            for attempt, record in sorted(records.items())
-        ],
-    }
-    return result
+        }
+    )
 
 
 def load_specs(directory: Path) -> dict[int, dict[str, Any]]:
@@ -481,49 +417,100 @@ def _record_content(record: Mapping[str, Any], instruction_count: int) -> bool:
     )
 
 
-def _case_result(
-    case_id: int, spec: Mapping[str, Any], record: Mapping[str, Any]
-) -> dict[str, Any]:
+def _case_result(case_id: int, spec: Mapping[str, Any], record: Mapping[str, Any]) -> CaseResult:
     strict = [bool(value) for value in record["strict"]]
     loose = [bool(value) for value in record["loose"]]
     descriptions = record["descriptions"]
     assert isinstance(descriptions, list)
-    return {
-        "case_id": case_id,
-        "input": spec["prompt"],
-        "output": record["answer"],
-        "finish_reason": record["finish_reason"],
-        "grade": {
-            "method": "deterministic",
-            "score": float(all(strict)),
-            "metrics": {
-                "follow_all_strict": all(strict),
-                "follow_all_loose": all(loose),
-                "strict_checks_passed": sum(strict),
-                "loose_checks_passed": sum(loose),
+    return CaseResult.model_validate(
+        {
+            "status": "scored",
+            "case_id": case_id,
+            "input": spec["prompt"],
+            "output": record["answer"],
+            "finish_reason": record["finish_reason"],
+            "refusal": None,
+            "grade": {
+                "method": "deterministic",
+                "score": float(all(strict)),
+                "metrics": {
+                    "follow_all_strict": all(strict),
+                    "follow_all_loose": all(loose),
+                    "strict_checks_passed": sum(strict),
+                    "loose_checks_passed": sum(loose),
+                },
+                "checks": [
+                    {
+                        "type": "instruction",
+                        "id": f"instruction-{index}",
+                        "label": descriptions[index - 1],
+                        # Check-level verdict in the report schema's vocabulary; the strict
+                        # verifier decides it, matching the headline score. Without it a
+                        # reader must dig into evidence, and the SDK renders the check as
+                        # unjudged.
+                        "outcome": "MET" if strict[index - 1] else "UNMET",
+                        "evidence": [
+                            _verification_evidence(1, "strict", strict[index - 1]),
+                            _verification_evidence(2, "loose", loose[index - 1]),
+                        ],
+                        "metadata": {"instruction_index": index},
+                    }
+                    for index in range(1, len(strict) + 1)
+                ],
             },
-            "checks": [
-                {
-                    "type": "instruction",
-                    "id": f"instruction-{index}",
-                    "label": descriptions[index - 1],
-                    # Check-level verdict in the report schema's vocabulary; the strict
-                    # verifier decides it, matching the headline score. Without it a
-                    # reader must dig into evidence, and the SDK renders the check as
-                    # unjudged.
-                    "outcome": "MET" if strict[index - 1] else "UNMET",
-                    "evidence": [
-                        _verification_evidence(1, "strict", strict[index - 1]),
-                        _verification_evidence(2, "loose", loose[index - 1]),
-                    ],
-                    "metadata": {"instruction_index": index},
-                }
-                for index in range(1, len(strict) + 1)
-            ],
-        },
-        "failures": [],
-        "metadata": {},
+            "failures": [],
+            "metadata": {},
+        }
+    )
+
+
+def _ifeval_score(
+    cases: Sequence[CaseResult], *, max_attempts: int | None = None
+) -> CandidateScore:
+    """Apply IFEval's published accuracy formulas to complete typed Cases."""
+
+    grades = [case.grade for case in cases]
+    if any(grade is None or grade.score is None for grade in grades):  # pragma: no cover
+        raise AssertionError("IFEval scorer requires complete graded Cases")
+    typed_grades = [grade for grade in grades if grade is not None]
+    strict_all = [grade.score == 1.0 for grade in typed_grades]
+    loose_all = [grade.metrics.get("follow_all_loose") is True for grade in typed_grades]
+    strict_flat = [check.outcome == "MET" for grade in typed_grades for check in grade.checks]
+    loose_flat = [
+        evidence.outcome == "PASS"
+        for grade in typed_grades
+        for check in grade.checks
+        for evidence in check.evidence
+        if evidence.metadata.get("mode") == "loose"
+    ]
+    inst_level_strict = _accuracy(strict_flat)
+    metrics: dict[str, Any] = {
+        "inst_level_strict_accuracy": inst_level_strict,
+        "prompt_level_loose_accuracy": _accuracy(loose_all),
+        "inst_level_loose_accuracy": _accuracy(loose_flat),
+        "pass_rate": inst_level_strict,
+        "coverage": 1.0,
     }
+    if max_attempts is not None:
+        metrics.update(
+            {
+                f"pass_at_{attempt}": round(
+                    sum(
+                        1
+                        for case in cases
+                        if case.metadata.get("pass_attempt")
+                        and case.metadata["pass_attempt"] <= attempt
+                    )
+                    / len(cases),
+                    4,
+                )
+                for attempt in range(1, max_attempts + 1)
+            }
+        )
+        metrics["corrected_cases"] = sum(
+            1 for case in cases if (case.metadata.get("pass_attempt") or 0) > 1
+        )
+    return CandidateScore(score=_accuracy(strict_all), metrics=metrics)
 
 
 def _verification_evidence(sequence: int, mode: str, passed: bool) -> dict[str, Any]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
@@ -20,9 +20,13 @@ from typing import Any
 
 from url4_cloud.benchmarks.aggregation import (
     CandidateScore,
+    SelectedCase,
     collected_provider_refusal,
+    failed_case_result,
     finalize_candidate_result,
+    public_error,
     refused_case_result,
+    scored_case_result,
 )
 from url4_cloud.benchmarks.contract import CaseResult
 from url4_cloud.benchmarks.ifeval.case_evaluation import (
@@ -43,6 +47,8 @@ def aggregate(
     specs: Mapping[int, Mapping[str, Any]],
     benchmark_id: str,
     case_order: Sequence[int],
+    *,
+    selected_case_count: int,
 ) -> dict[str, Any]:
     """Reduce the row array into a `CandidateResult` — exactly one entry per row.
 
@@ -53,35 +59,23 @@ def aggregate(
     """
 
     rows = _rows(rows_json)
+    selected = _selected_cases(specs, case_order, selected_case_count)
+    _reject_surplus_rows(rows, selected)
     case_results: list[CaseResult] = []
-    for index, (raw, case_id) in enumerate(
-        zip(rows, _selected_case_ids(rows, specs, case_order), strict=True)
-    ):
+    for index, raw in enumerate(rows):
+        selected_case = selected[index]
+        case_id = int(selected_case.case_id)
         spec = specs[case_id]
         record = _first_valid_record(raw, case_id, spec)
         if record is None:
-            case_results.append(_failed_case_result(raw, index, case_id, spec))
+            case_results.append(_failed_case_result(raw, index, selected_case))
             continue
-        case_results.append(_case_result(case_id, spec, record))
+        case_results.append(_case_result(selected_case, record))
     return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=IFEVAL_REVISION,
+        selected_cases=selected,
         cases=case_results,
-        scorer=_ifeval_score,
-    ).as_payload()
-
-
-def _unscored_result(
-    benchmark_id: str,
-    benchmark_revision: str,
-    cases: Sequence[CaseResult],
-) -> dict[str, Any]:
-    """Return the complete Evaluation record without fabricating an aggregate score."""
-
-    return finalize_candidate_result(
-        benchmark_id=benchmark_id,
-        benchmark_revision=benchmark_revision,
-        cases=cases,
         scorer=_ifeval_score,
     ).as_payload()
 
@@ -89,50 +83,40 @@ def _unscored_result(
 def _failed_case_result(
     row: Any,
     row_index: int,
-    case_id: int,
-    spec: Mapping[str, Any],
+    selected_case: SelectedCase,
 ) -> CaseResult:
     """Retain one selected Case whose Candidate Invocation or Grading failed."""
 
     if refusal := collected_provider_refusal(row):
         return refused_case_result(
-            case_id=case_id,
-            input=spec["prompt"],
-            refusal=refusal,
+            selected_case=selected_case,
+            refusal=refusal.text,
+            finish_reason=refusal.finish_reason,
             metadata={"row_index": row_index},
         )
 
     error = row.get("error") if isinstance(row, Mapping) else None
     error = error if isinstance(error, Mapping) else {}
-    kind = _bounded_text(error.get("kind"), 80)
-    code = _bounded_text(error.get("code"), 80) or "invalid_case_evaluation"
-    message = _bounded_text(error.get("message"), 200) or (
-        "the Case produced no valid IFEval evaluation record"
+    diagnostic = public_error(
+        error,
+        default_code="invalid_case_evaluation",
+        default_message="the Case produced no valid IFEval evaluation record",
     )
     metadata: dict[str, Any] = {"row_index": row_index}
-    if kind is not None:
-        metadata["error_kind"] = kind
-    return CaseResult.model_validate(
-        {
-            "status": "failed",
-            "case_id": case_id,
-            "input": spec["prompt"],
-            "output": None,
-            "finish_reason": None,
-            "refusal": None,
-            "grade": None,
-            "failures": [
-                {
-                    "stage": _failure_stage(code),
-                    "code": code,
-                    "message": message,
-                    "retryable": _retryable(error),
-                    "case_id": case_id,
-                    "metadata": metadata,
-                }
-            ],
-            "metadata": {},
-        }
+    if diagnostic.kind is not None:
+        metadata["error_kind"] = diagnostic.kind
+    return failed_case_result(
+        selected_case=selected_case,
+        failures=[
+            {
+                "stage": _failure_stage(diagnostic.code),
+                "code": diagnostic.code,
+                "message": diagnostic.message,
+                "retryable": diagnostic.retryable,
+                "case_id": selected_case.case_id,
+                "metadata": metadata,
+            }
+        ],
     )
 
 
@@ -142,26 +126,14 @@ def _failure_stage(code: str) -> str:
     )
 
 
-def _retryable(error: Mapping[str, Any]) -> bool | None:
-    retryable = error.get("retryable")
-    if isinstance(retryable, bool):
-        return retryable
-    permanent = error.get("permanent")
-    return not permanent if isinstance(permanent, bool) else None
-
-
-def _bounded_text(value: object, limit: int) -> str | None:
-    if not isinstance(value, str) or not value.strip():
-        return None
-    return " ".join(value.split())[:limit]
-
-
 def aggregate_corrective(
     rows_json: str,
     specs: Mapping[int, Mapping[str, Any]],
     benchmark_id: str,
     benchmark_revision: str,
     case_order: Sequence[int],
+    *,
+    selected_case_count: int,
     max_attempts: int = 3,
 ) -> dict[str, Any]:
     """Reduce corrective-chain rows — one scored entry per case, pass@attempt metrics.
@@ -172,14 +144,16 @@ def aggregate_corrective(
     """
 
     rows = _rows(rows_json)
+    selected = _selected_cases(specs, case_order, selected_case_count)
+    _reject_surplus_rows(rows, selected)
     case_results: list[CaseResult] = []
-    for index, (raw, case_id) in enumerate(
-        zip(rows, _selected_case_ids(rows, specs, case_order), strict=True)
-    ):
+    for index, raw in enumerate(rows):
+        selected_case = selected[index]
+        case_id = int(selected_case.case_id)
         spec = specs[case_id]
         records = _attempt_records(raw, case_id, spec, max_attempts)
         if not records:
-            case_results.append(_failed_case_result(raw, index, case_id, spec))
+            case_results.append(_failed_case_result(raw, index, selected_case))
             continue
         earliest_pass = min(
             (attempt for attempt, record in records.items() if all(record["strict"])),
@@ -188,8 +162,7 @@ def aggregate_corrective(
         selected_attempt = earliest_pass or max(records)
         case_results.append(
             _corrective_case(
-                case_id,
-                spec,
+                selected_case,
                 records,
                 selected_attempt,
                 earliest_pass,
@@ -198,9 +171,17 @@ def aggregate_corrective(
     return finalize_candidate_result(
         benchmark_id=benchmark_id,
         benchmark_revision=benchmark_revision,
+        selected_cases=selected,
         cases=case_results,
         scorer=lambda cases: _ifeval_score(cases, max_attempts=max_attempts),
     ).as_payload()
+
+
+def _reject_surplus_rows(rows: Sequence[Any], selected: Sequence[SelectedCase]) -> None:
+    if len(rows) > len(selected):
+        raise AggregateError(
+            f"aggregate received {len(rows)} rows for {len(selected)} selected Cases"
+        )
 
 
 def _attempt_records(
@@ -241,14 +222,13 @@ def _attempt_records(
 
 
 def _corrective_case(
-    case_id: int,
-    spec: Mapping[str, Any],
+    selected_case: SelectedCase,
     records: Mapping[int, Mapping[str, Any]],
     selected_attempt: int,
     pass_attempt: int,
 ) -> CaseResult:
     selected = records[selected_attempt]
-    result = _case_result(case_id, spec, selected)
+    result = _case_result(selected_case, selected)
     return result.model_copy(
         update={
             "metadata": {
@@ -331,36 +311,38 @@ def _rows(rows_json: str) -> list[Any]:
         raise AggregateError(f"reducer payload is not JSON: {exc}") from None
     if not isinstance(rows, list):
         raise AggregateError(f"reducer payload must be a JSON array, got {type(rows).__name__}")
-    if not rows:
-        raise AggregateError("no IFEval rows were produced; the Candidate cannot be scored")
     return rows
 
 
-def _selected_case_ids(
-    rows: Sequence[Any],
+def _selected_cases(
     specs: Mapping[int, Mapping[str, Any]],
     case_order: Sequence[int],
-) -> list[int]:
-    """The prefix of installed Cases selected by the Benchmark's `limit` slice.
+    selected_case_count: int,
+) -> list[SelectedCase]:
+    """The exact installed Case prefix authored into the Benchmark URL4.
 
-    The slice walks ``cases.json`` in file order, so the id for collected row N is
-    ``case_order[N]``. Ids are official keys — sorting them would grade rows against
-    the wrong specs.
+    The slice walks ``cases.json`` in file order. Ids are official keys — sorting
+    them would grade rows against the wrong specs.
     """
 
-    if len(rows) > len(case_order):
-        raise AggregateError(
-            f"reducer carried {len(rows)} rows but only {len(case_order)} IFEval cases "
-            "are installed"
-        )
-    selected = list(case_order[: len(rows)])
+    if (
+        isinstance(selected_case_count, bool)
+        or not isinstance(selected_case_count, int)
+        or selected_case_count < 1
+        or selected_case_count > len(case_order)
+    ):
+        raise AggregateError(f"selected_case_count must be between 1 and {len(case_order)}")
+    selected = list(case_order[:selected_case_count])
     missing = [case_id for case_id in selected if case_id not in specs]
     if missing:
         raise AggregateError(
             f"cases.json selects case ids {missing} that have no installed instruction "
             "spec; the installed IFEval assets are incomplete"
         )
-    return selected
+    return [
+        SelectedCase(case_id=case_id, input=str(specs[case_id]["prompt"]), metadata={})
+        for case_id in selected
+    ]
 
 
 def _first_valid_record(
@@ -417,50 +399,43 @@ def _record_content(record: Mapping[str, Any], instruction_count: int) -> bool:
     )
 
 
-def _case_result(case_id: int, spec: Mapping[str, Any], record: Mapping[str, Any]) -> CaseResult:
+def _case_result(selected_case: SelectedCase, record: Mapping[str, Any]) -> CaseResult:
     strict = [bool(value) for value in record["strict"]]
     loose = [bool(value) for value in record["loose"]]
     descriptions = record["descriptions"]
     assert isinstance(descriptions, list)
-    return CaseResult.model_validate(
-        {
-            "status": "scored",
-            "case_id": case_id,
-            "input": spec["prompt"],
-            "output": record["answer"],
-            "finish_reason": record["finish_reason"],
-            "refusal": None,
-            "grade": {
-                "method": "deterministic",
-                "score": float(all(strict)),
-                "metrics": {
-                    "follow_all_strict": all(strict),
-                    "follow_all_loose": all(loose),
-                    "strict_checks_passed": sum(strict),
-                    "loose_checks_passed": sum(loose),
-                },
-                "checks": [
-                    {
-                        "type": "instruction",
-                        "id": f"instruction-{index}",
-                        "label": descriptions[index - 1],
-                        # Check-level verdict in the report schema's vocabulary; the strict
-                        # verifier decides it, matching the headline score. Without it a
-                        # reader must dig into evidence, and the SDK renders the check as
-                        # unjudged.
-                        "outcome": "MET" if strict[index - 1] else "UNMET",
-                        "evidence": [
-                            _verification_evidence(1, "strict", strict[index - 1]),
-                            _verification_evidence(2, "loose", loose[index - 1]),
-                        ],
-                        "metadata": {"instruction_index": index},
-                    }
-                    for index in range(1, len(strict) + 1)
-                ],
+    return scored_case_result(
+        selected_case=selected_case,
+        output=str(record["answer"]),
+        finish_reason=record["finish_reason"],
+        grade={
+            "method": "deterministic",
+            "score": float(all(strict)),
+            "metrics": {
+                "follow_all_strict": all(strict),
+                "follow_all_loose": all(loose),
+                "strict_checks_passed": sum(strict),
+                "loose_checks_passed": sum(loose),
             },
-            "failures": [],
-            "metadata": {},
-        }
+            "checks": [
+                {
+                    "type": "instruction",
+                    "id": f"instruction-{index}",
+                    "label": descriptions[index - 1],
+                    # Check-level verdict in the report schema's vocabulary; the strict
+                    # verifier decides it, matching the headline score. Without it a
+                    # reader must dig into evidence, and the SDK renders the check as
+                    # unjudged.
+                    "outcome": "MET" if strict[index - 1] else "UNMET",
+                    "evidence": [
+                        _verification_evidence(1, "strict", strict[index - 1]),
+                        _verification_evidence(2, "loose", loose[index - 1]),
+                    ],
+                    "metadata": {"instruction_index": index},
+                }
+                for index in range(1, len(strict) + 1)
+            ],
+        },
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/definition.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
 from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
 from url4_cloud.benchmarks.definition import Benchmark, candidate
 
 BENCHMARK_ID = "ifeval"
@@ -32,6 +33,7 @@ REVISION = hashlib.sha256(
             VERIFIER_REPOSITORY,
             VERIFIER_REVISION,
             PROTOCOL_REVISION,
+            CANDIDATE_RESULT_SCHEMA,
             f"candidate_web_search={CANDIDATE_WEB_SEARCH}",
         )
     ).encode()

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/definition.py
@@ -85,7 +85,11 @@ def _build(case_count: int) -> Node:
     return expr(
         src(row_set, name="rows", weight=0.0),
         src(
-            RelExpr(path=AGGREGATE_ROUTE, context="$rows", intent=Text("aggregate")),
+            RelExpr(
+                path=AGGREGATE_ROUTE,
+                context="$rows",
+                intent=Text(f"aggregate:{case_count}"),
+            ),
             name="result",
             weight=0.0,
         ),

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py
@@ -563,7 +563,11 @@ def _reduced_rows(
     return expr(
         src(row_set, name="rows", weight=0.0),
         src(
-            RelExpr(path=aggregate_route, context="$rows", intent=Text("aggregate")),
+            RelExpr(
+                path=aggregate_route,
+                context="$rows",
+                intent=Text(f"aggregate:{case_count}"),
+            ),
             name="result",
             weight=0.0,
         ),

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
@@ -92,7 +92,7 @@ def _check(root: Path):
             case_id, attempt = _case_and_attempt(request.intent)
             answer, finish_reason, refusal = decode_candidate_invocation(request.context)
             if refusal is not None:
-                raise ProviderRefusal(refusal)
+                raise ProviderRefusal(refusal, finish_reason=finish_reason)
             spec, result, violations = _verification(root, case_id, answer)
         except (KeyError, TypeError, ValueError) as exc:
             raise _unavailable(str(exc)) from exc
@@ -190,14 +190,14 @@ def _verification(
 
 def _aggregate(root: Path):
     def aggregate(request: Request) -> str:
-        if request.intent != "aggregate":
-            raise _unsupported("IFEval aggregation", request.intent)
         try:
+            case_order = scoring.load_case_order(root)
             result = scoring.aggregate(
                 request.context,
                 scoring.load_specs(root / "instructions"),
                 BENCHMARK_ID,
-                scoring.load_case_order(root),
+                case_order,
+                selected_case_count=_aggregate_case_count(request.intent, len(case_order)),
             )
         except (OSError, ValueError) as exc:
             raise _unavailable(str(exc)) from exc
@@ -208,15 +208,15 @@ def _aggregate(root: Path):
 
 def _aggregate_corrective(root: Path, benchmark_id: str, benchmark_revision: str):
     def aggregate(request: Request) -> str:
-        if request.intent != "aggregate":
-            raise _unsupported("IFEval corrective aggregation", request.intent)
         try:
+            case_order = scoring.load_case_order(root)
             result = scoring.aggregate_corrective(
                 request.context,
                 scoring.load_specs(root / "instructions"),
                 benchmark_id,
                 benchmark_revision,
-                scoring.load_case_order(root),
+                case_order,
+                selected_case_count=_aggregate_case_count(request.intent, len(case_order)),
                 max_attempts=MAX_ATTEMPTS,
             )
         except (OSError, ValueError) as exc:
@@ -224,6 +224,18 @@ def _aggregate_corrective(root: Path, benchmark_id: str, benchmark_revision: str
         return _json(result)
 
     return aggregate
+
+
+def _aggregate_case_count(intent: str, available: int) -> int:
+    operation, separator, raw_count = (intent or "").partition(":")
+    if operation != "aggregate" or not separator:
+        raise _unsupported("IFEval aggregation", intent)
+    count = _positive_int(raw_count, "selected Case count")
+    if count > available:
+        raise _unavailable(
+            f"IFEval aggregation selected {count} Cases but only {available} are installed"
+        )
+    return count
 
 
 def _lanl_intent(intent: str) -> tuple[str, int, int]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
@@ -14,6 +14,7 @@ from url4_cloud.benchmarks.contract import (
     decode_candidate_invocation,
     encode_candidate_invocation,
 )
+from url4_cloud.benchmarks.errors import ProviderRefusal
 from url4_cloud.benchmarks.ifeval import aggregate as scoring
 from url4_cloud.benchmarks.ifeval import grading
 from url4_cloud.benchmarks.ifeval.case_evaluation import bind_case_evaluation
@@ -91,11 +92,7 @@ def _check(root: Path):
             case_id, attempt = _case_and_attempt(request.intent)
             answer, finish_reason, refusal = decode_candidate_invocation(request.context)
             if refusal is not None:
-                raise ResolutionError(
-                    "Candidate refused the IFEval Case",
-                    code="provider_refusal",
-                    permanent=True,
-                )
+                raise ProviderRefusal(refusal)
             spec, result, violations = _verification(root, case_id, answer)
         except (KeyError, TypeError, ValueError) as exc:
             raise _unavailable(str(exc)) from exc

--- a/apps/url4-cloud/tests/unit/test_benchmark_aggregation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_aggregation.py
@@ -1,0 +1,203 @@
+"""The generic finalizer owns cross-Benchmark score publication policy."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+import pytest
+
+from url4 import RelExpr, Text, expr, iterate, render, src
+from url4.peer.server import Request, Url4Node
+from url4_cloud.benchmarks.aggregation import (
+    CandidateScore,
+    collected_provider_refusal,
+    finalize_candidate_result,
+    refused_case_result,
+)
+from url4_cloud.benchmarks.contract import CaseGrade, CaseResult, Failure
+from url4_cloud.benchmarks.errors import ProviderRefusal
+
+
+def _scored(case_id: int) -> CaseResult:
+    return CaseResult(
+        status="scored",
+        case_id=case_id,
+        input=f"input {case_id}",
+        output=f"output {case_id}",
+        finish_reason="stop",
+        refusal=None,
+        grade=CaseGrade(method="test", score=1.0, metrics={}, checks=[]),
+        failures=[],
+        metadata={},
+    )
+
+
+def _failed(case_id: int) -> CaseResult:
+    return CaseResult(
+        status="failed",
+        case_id=case_id,
+        input=f"input {case_id}",
+        output=None,
+        finish_reason=None,
+        refusal=None,
+        grade=None,
+        failures=[
+            Failure(
+                stage="candidate",
+                code="candidate_failed",
+                message="Candidate execution failed",
+                retryable=True,
+                case_id=case_id,
+                metadata={},
+            )
+        ],
+        metadata={},
+    )
+
+
+def test_all_scored_cases_are_passed_to_the_scorer_in_stable_order() -> None:
+    observed: list[int | str] = []
+
+    def scorer(cases: Sequence[CaseResult]) -> CandidateScore:
+        observed.extend(case.case_id for case in cases)
+        return CandidateScore(score=0.75, metrics={"pass_rate": 0.5, "coverage": 1.0})
+
+    result = finalize_candidate_result(
+        benchmark_id="benchmark",
+        benchmark_revision="revision",
+        cases=[_scored(2), _scored(1)],
+        scorer=scorer,
+    )
+
+    assert observed == [2, 1]
+    assert [case.case_id for case in result.cases] == [2, 1]
+    assert result.score == 0.75
+
+
+def test_a_failed_case_skips_the_scorer_and_fails_closed() -> None:
+    called = False
+
+    def scorer(cases: Sequence[CaseResult]) -> CandidateScore:
+        nonlocal called
+        called = True
+        return CandidateScore(score=1.0, metrics={"pass_rate": 1.0, "coverage": 1.0})
+
+    result = finalize_candidate_result(
+        benchmark_id="benchmark",
+        benchmark_revision="revision",
+        cases=[_scored(1), _failed(2)],
+        scorer=scorer,
+    )
+
+    assert called is False
+    assert result.score is None
+    assert result.metrics == {}
+
+
+def test_a_candidate_level_failure_skips_the_scorer() -> None:
+    failure = Failure(
+        stage="aggregation",
+        code="asset_unavailable",
+        message="the scorer asset is unavailable",
+        retryable=False,
+        case_id=None,
+        metadata={},
+    )
+
+    result = finalize_candidate_result(
+        benchmark_id="benchmark",
+        benchmark_revision="revision",
+        cases=[_scored(1)],
+        failures=[failure],
+        scorer=lambda _: pytest.fail("scorer must not run"),
+    )
+
+    assert result.score is None
+    assert result.failures == [failure]
+
+
+def test_duplicate_case_identity_is_rejected_before_scoring() -> None:
+    with pytest.raises(ValueError, match="duplicate case_id"):
+        finalize_candidate_result(
+            benchmark_id="benchmark",
+            benchmark_revision="revision",
+            cases=[_scored(1), _scored(1)],
+            scorer=lambda _: pytest.fail("scorer must not run"),
+        )
+
+
+def test_scorer_must_return_canonical_metrics() -> None:
+    with pytest.raises(ValueError, match="coverage"):
+        finalize_candidate_result(
+            benchmark_id="benchmark",
+            benchmark_revision="revision",
+            cases=[_scored(1)],
+            scorer=lambda _: CandidateScore(score=1.0, metrics={"pass_rate": 1.0}),
+        )
+
+
+def test_candidate_score_rejects_boolean_and_non_finite_scores() -> None:
+    for score in (True, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="finite number"):
+            CandidateScore(score=score, metrics={"pass_rate": 1.0, "coverage": 1.0})
+
+
+def test_candidate_score_does_not_coerce_a_string_score() -> None:
+    with pytest.raises(ValueError):
+        CandidateScore(
+            score="1",  # type: ignore[arg-type]
+            metrics={"pass_rate": 1.0, "coverage": 1.0},
+        )
+
+
+def test_collected_provider_refusal_preserves_exact_text_as_a_refused_case() -> None:
+    exact = "I can’t provide that dosage."
+    row = {"error": {"kind": "ProviderRefusal", "message": exact}}
+
+    assert collected_provider_refusal(row) == exact
+    case = refused_case_result(
+        case_id="health-7",
+        input="Recommend a dosage.",
+        refusal=exact,
+        finish_reason="content_filter",
+    )
+
+    assert case.status == "refused"
+    assert case.refusal == exact
+    assert case.output is None
+    assert case.grade is None
+    assert case.failures[0].code == "provider_refusal"
+
+
+def test_collected_provider_refusal_does_not_infer_from_generic_error_text() -> None:
+    assert (
+        collected_provider_refusal(
+            {"error": {"kind": "ResolutionError", "message": "provider refused"}}
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_refusal_identity_and_text_survive_url4_collection() -> None:
+    exact = "I can’t comply with that request."
+    node = Url4Node("test")
+
+    @node.endpoint("/refuse")
+    def refuse(_: Request) -> str:
+        raise ProviderRefusal(exact)
+
+    refusal = expr(
+        src(RelExpr(path="/refuse", context="$item", intent=Text("run")), name="value"),
+        intent=Text("$value"),
+    )
+    expression = iterate(
+        [Text("case")],
+        body=(src(refusal, name="refusal", weight=0.0),),
+        intent=Text("$refusal"),
+        on_error="collect",
+    )
+
+    rows = json.loads((await node.evaluate(render(expression))).text)
+    assert rows == [{"error": {"kind": "ProviderRefusal", "message": exact}}]

--- a/apps/url4-cloud/tests/unit/test_benchmark_aggregation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_aggregation.py
@@ -11,9 +11,13 @@ from url4 import RelExpr, Text, expr, iterate, render, src
 from url4.peer.server import Request, Url4Node
 from url4_cloud.benchmarks.aggregation import (
     CandidateScore,
+    SelectedCase,
     collected_provider_refusal,
+    failed_case_result,
     finalize_candidate_result,
+    public_error,
     refused_case_result,
+    scored_case_result,
 )
 from url4_cloud.benchmarks.contract import CaseGrade, CaseResult, Failure
 from url4_cloud.benchmarks.errors import ProviderRefusal
@@ -56,6 +60,12 @@ def _failed(case_id: int) -> CaseResult:
     )
 
 
+def _selected(*case_ids: int) -> list[SelectedCase]:
+    return [
+        SelectedCase(case_id=case_id, input=f"input {case_id}", metadata={}) for case_id in case_ids
+    ]
+
+
 def test_all_scored_cases_are_passed_to_the_scorer_in_stable_order() -> None:
     observed: list[int | str] = []
 
@@ -66,6 +76,7 @@ def test_all_scored_cases_are_passed_to_the_scorer_in_stable_order() -> None:
     result = finalize_candidate_result(
         benchmark_id="benchmark",
         benchmark_revision="revision",
+        selected_cases=_selected(2, 1),
         cases=[_scored(2), _scored(1)],
         scorer=scorer,
     )
@@ -86,6 +97,7 @@ def test_a_failed_case_skips_the_scorer_and_fails_closed() -> None:
     result = finalize_candidate_result(
         benchmark_id="benchmark",
         benchmark_revision="revision",
+        selected_cases=_selected(1, 2),
         cases=[_scored(1), _failed(2)],
         scorer=scorer,
     )
@@ -108,6 +120,7 @@ def test_a_candidate_level_failure_skips_the_scorer() -> None:
     result = finalize_candidate_result(
         benchmark_id="benchmark",
         benchmark_revision="revision",
+        selected_cases=_selected(1),
         cases=[_scored(1)],
         failures=[failure],
         scorer=lambda _: pytest.fail("scorer must not run"),
@@ -122,9 +135,32 @@ def test_duplicate_case_identity_is_rejected_before_scoring() -> None:
         finalize_candidate_result(
             benchmark_id="benchmark",
             benchmark_revision="revision",
+            selected_cases=_selected(1),
             cases=[_scored(1), _scored(1)],
             scorer=lambda _: pytest.fail("scorer must not run"),
         )
+
+
+def test_a_missing_selected_case_is_retained_and_fails_closed() -> None:
+    result = finalize_candidate_result(
+        benchmark_id="benchmark",
+        benchmark_revision="revision",
+        selected_cases=[
+            SelectedCase(case_id=1, input="input 1", metadata={}),
+            SelectedCase(case_id=2, input="input 2", metadata={"split": "test"}),
+        ],
+        cases=[_scored(1)],
+        scorer=lambda _: pytest.fail("scorer must not run with incomplete selected coverage"),
+    )
+
+    assert [case.case_id for case in result.cases] == [1, 2]
+    assert result.score is None
+    assert result.metrics == {}
+    missing = result.cases[1]
+    assert missing.status == "failed"
+    assert missing.input == "input 2"
+    assert missing.metadata == {"split": "test"}
+    assert [failure.code for failure in missing.failures] == ["case_result_missing"]
 
 
 def test_scorer_must_return_canonical_metrics() -> None:
@@ -132,35 +168,92 @@ def test_scorer_must_return_canonical_metrics() -> None:
         finalize_candidate_result(
             benchmark_id="benchmark",
             benchmark_revision="revision",
+            selected_cases=_selected(1),
             cases=[_scored(1)],
             scorer=lambda _: CandidateScore(score=1.0, metrics={"pass_rate": 1.0}),
         )
 
 
-def test_candidate_score_rejects_boolean_and_non_finite_scores() -> None:
+def test_finalizer_rejects_boolean_and_non_finite_scores() -> None:
     for score in (True, float("nan"), float("inf")):
         with pytest.raises(ValueError, match="finite number"):
-            CandidateScore(score=score, metrics={"pass_rate": 1.0, "coverage": 1.0})
+            finalize_candidate_result(
+                benchmark_id="benchmark",
+                benchmark_revision="revision",
+                selected_cases=_selected(1),
+                cases=[_scored(1)],
+                scorer=lambda _, score=score: CandidateScore(
+                    score=score,  # type: ignore[arg-type]
+                    metrics={"pass_rate": 1.0, "coverage": 1.0},
+                ),
+            )
 
 
-def test_candidate_score_does_not_coerce_a_string_score() -> None:
+def test_shared_case_constructors_own_the_public_case_envelope() -> None:
+    selected = SelectedCase(case_id=7, input="question", metadata={"split": "test"})
+    scored = scored_case_result(
+        selected_case=selected,
+        output="answer",
+        finish_reason="stop",
+        grade=CaseGrade(method="test", score=1.0, metrics={}, checks=[]),
+    )
+    failure = Failure(
+        stage="grading",
+        code="judge_failed",
+        message="Judge failed",
+        retryable=True,
+        case_id=7,
+        metadata={},
+    )
+    failed = failed_case_result(
+        selected_case=selected,
+        failures=[failure],
+        output="answer",
+        finish_reason="stop",
+    )
+
+    assert scored.status == "scored"
+    assert scored.input == failed.input == "question"
+    assert scored.metadata == failed.metadata == {"split": "test"}
+    assert failed.status == "failed"
+    assert failed.output == "answer"
+    assert failed.failures == [failure]
+
+
+def test_finalizer_does_not_coerce_a_string_score() -> None:
     with pytest.raises(ValueError):
-        CandidateScore(
-            score="1",  # type: ignore[arg-type]
-            metrics={"pass_rate": 1.0, "coverage": 1.0},
+        finalize_candidate_result(
+            benchmark_id="benchmark",
+            benchmark_revision="revision",
+            selected_cases=_selected(1),
+            cases=[_scored(1)],
+            scorer=lambda _: CandidateScore(
+                score="1",  # type: ignore[arg-type]
+                metrics={"pass_rate": 1.0, "coverage": 1.0},
+            ),
         )
 
 
 def test_collected_provider_refusal_preserves_exact_text_as_a_refused_case() -> None:
     exact = "I can’t provide that dosage."
-    row = {"error": {"kind": "ProviderRefusal", "message": exact}}
+    row = {
+        "error": {
+            "kind": "ProviderRefusal",
+            "message": json.dumps(
+                {"refusal": exact, "finish_reason": "content_filter"},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+        }
+    }
 
-    assert collected_provider_refusal(row) == exact
+    refusal = collected_provider_refusal(row)
+    assert refusal is not None
+    assert (refusal.text, refusal.finish_reason) == (exact, "content_filter")
     case = refused_case_result(
-        case_id="health-7",
-        input="Recommend a dosage.",
-        refusal=exact,
-        finish_reason="content_filter",
+        selected_case=SelectedCase(case_id="health-7", input="Recommend a dosage.", metadata={}),
+        refusal=refusal.text,
+        finish_reason=refusal.finish_reason,
     )
 
     assert case.status == "refused"
@@ -179,6 +272,64 @@ def test_collected_provider_refusal_does_not_infer_from_generic_error_text() -> 
     )
 
 
+def test_public_error_keeps_safe_diagnostics_and_rejects_internal_detail() -> None:
+    safe = public_error(
+        {
+            "kind": "ResolutionError",
+            "code": "provider_error",
+            "message": "the provider was unavailable",
+            "permanent": True,
+        },
+        default_code="case_execution_failed",
+        default_message="Candidate Case execution failed",
+    )
+    assert safe.code == "provider_error"
+    assert safe.message == "the provider was unavailable"
+    assert safe.kind == "ResolutionError"
+    assert safe.retryable is False
+
+    unsafe = public_error(
+        {
+            "kind": "RuntimeError",
+            "message": ('Traceback (most recent call last): File "/private/tmp/runner.py", line 4'),
+        },
+        default_code="case_execution_failed",
+        default_message="Candidate Case execution failed",
+    )
+    assert unsafe.message == "Candidate Case execution failed"
+    assert "/private/tmp" not in unsafe.message
+
+    credentials = public_error(
+        {
+            "message": (
+                r"request failed at C:\runner\job.py with password=hunter2 "
+                "and access key AKIAIOSFODNN7EXAMPLE"
+            )
+        },
+        default_code="case_execution_failed",
+        default_message="Candidate Case execution failed",
+    )
+    assert credentials.message == "Candidate Case execution failed"
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        "provider rejected OPENAI_API_KEY=abcdefgh",
+        "request failed with client_secret=hunter2",
+        "authentication used session_cookie=abcdef",
+    ),
+)
+def test_public_error_rejects_compound_credential_assignments(message: str) -> None:
+    diagnostic = public_error(
+        {"message": message},
+        default_code="case_execution_failed",
+        default_message="Candidate Case execution failed",
+    )
+
+    assert diagnostic.message == "Candidate Case execution failed"
+
+
 @pytest.mark.asyncio
 async def test_provider_refusal_identity_and_text_survive_url4_collection() -> None:
     exact = "I can’t comply with that request."
@@ -186,7 +337,7 @@ async def test_provider_refusal_identity_and_text_survive_url4_collection() -> N
 
     @node.endpoint("/refuse")
     def refuse(_: Request) -> str:
-        raise ProviderRefusal(exact)
+        raise ProviderRefusal(exact, finish_reason="content_filter")
 
     refusal = expr(
         src(RelExpr(path="/refuse", context="$item", intent=Text("run")), name="value"),
@@ -200,4 +351,6 @@ async def test_provider_refusal_identity_and_text_survive_url4_collection() -> N
     )
 
     rows = json.loads((await node.evaluate(render(expression))).text)
-    assert rows == [{"error": {"kind": "ProviderRefusal", "message": exact}}]
+    refusal = collected_provider_refusal(rows[0])
+    assert refusal is not None
+    assert (refusal.text, refusal.finish_reason) == (exact, "content_filter")

--- a/apps/url4-cloud/tests/unit/test_candidate_result_contract.py
+++ b/apps/url4-cloud/tests/unit/test_candidate_result_contract.py
@@ -1,4 +1,4 @@
-"""`CandidateResult` — the producer-side wire contract every aggregate constructs."""
+"""Strict producer-side contracts for every Engine-owned Benchmark result."""
 
 from __future__ import annotations
 
@@ -7,101 +7,322 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from url4_cloud.benchmarks.contract import CANDIDATE_RESULT_SCHEMA, CandidateResult
+from url4_cloud.benchmarks.contract import (
+    CANDIDATE_RESULT_SCHEMA,
+    CandidateResult,
+    CaseGrade,
+    CaseResult,
+    Check,
+    Evidence,
+    EvidenceProducer,
+    Failure,
+)
 
 
-def _scored_kwargs(**overrides: Any) -> dict[str, Any]:
-    kwargs: dict[str, Any] = {
+def _evidence(**overrides: Any) -> Evidence:
+    values: dict[str, Any] = {
+        "sequence": 1,
+        "producer": EvidenceProducer(type="deterministic", id="ifeval/official-verifier"),
+        "valid": True,
+        "outcome": "MET",
+        "explanation": "the instruction was followed",
+        "raw_output": True,
+        "metadata": {},
+    }
+    values.update(overrides)
+    return Evidence(**values)
+
+
+def _check(**overrides: Any) -> Check:
+    values: dict[str, Any] = {
+        "type": "instruction",
+        "id": "instruction-1",
+        "label": "answer in JSON",
+        "outcome": "MET",
+        "score": 1.0,
+        "evidence": [_evidence()],
+        "metadata": {},
+    }
+    values.update(overrides)
+    return Check(**values)
+
+
+def _grade(**overrides: Any) -> CaseGrade:
+    values: dict[str, Any] = {
+        "method": "deterministic",
+        "score": 1.0,
+        "metrics": {"follow_all_strict": True},
+        "checks": [_check()],
+    }
+    values.update(overrides)
+    return CaseGrade(**values)
+
+
+def _scored_case(case_id: int | str = 7, **overrides: Any) -> CaseResult:
+    values: dict[str, Any] = {
+        "status": "scored",
+        "case_id": case_id,
+        "input": "Return JSON.",
+        "output": "{}",
+        "finish_reason": "stop",
+        "refusal": None,
+        "grade": _grade(),
+        "failures": [],
+        "metadata": {},
+    }
+    values.update(overrides)
+    return CaseResult(**values)
+
+
+def _failure(**overrides: Any) -> Failure:
+    values: dict[str, Any] = {
+        "stage": "grading",
+        "code": "judge_unavailable",
+        "message": "the Judge did not return a usable verdict",
+        "retryable": True,
+        "case_id": 7,
+        "metadata": {},
+    }
+    values.update(overrides)
+    return Failure(**values)
+
+
+def _candidate(**overrides: Any) -> CandidateResult:
+    values: dict[str, Any] = {
         "benchmark_id": "ifeval",
         "benchmark_revision": "rev",
         "case_count": 1,
-        "score": 0.5,
-        "metrics": {"pass_rate": 0.5, "coverage": 1.0, "anything_else": 12},
-        "cases": [{"case_id": 1}],
+        "score": 1.0,
+        "metrics": {"pass_rate": 1.0, "coverage": 1.0, "strict_accuracy": 1.0},
+        "cases": [_scored_case()],
         "failures": [],
     }
-    kwargs.update(overrides)
-    return kwargs
+    values.update(overrides)
+    return CandidateResult(**values)
 
 
-def test_wire_payload_matches_the_hand_built_v1_dict() -> None:
-    """INVARIANT: migrating aggregates from dict literals to the model must be
-    invisible on the wire — same keys, same order, same values."""
-
-    payload = CandidateResult(**_scored_kwargs()).as_payload()
+def test_scored_result_serializes_the_strict_v1_shape() -> None:
+    payload = _candidate().as_payload()
 
     assert payload == {
         "schema": CANDIDATE_RESULT_SCHEMA,
         "benchmark_id": "ifeval",
         "benchmark_revision": "rev",
         "case_count": 1,
-        "score": 0.5,
-        "metrics": {"pass_rate": 0.5, "coverage": 1.0, "anything_else": 12},
-        "cases": [{"case_id": 1}],
+        "score": 1.0,
+        "metrics": {"pass_rate": 1.0, "coverage": 1.0, "strict_accuracy": 1.0},
+        "cases": [
+            {
+                "status": "scored",
+                "case_id": 7,
+                "input": "Return JSON.",
+                "output": "{}",
+                "finish_reason": "stop",
+                "refusal": None,
+                "grade": {
+                    "method": "deterministic",
+                    "score": 1.0,
+                    "metrics": {"follow_all_strict": True},
+                    "checks": [
+                        {
+                            "type": "instruction",
+                            "id": "instruction-1",
+                            "label": "answer in JSON",
+                            "outcome": "MET",
+                            "score": 1.0,
+                            "evidence": [
+                                {
+                                    "sequence": 1,
+                                    "producer": {
+                                        "type": "deterministic",
+                                        "id": "ifeval/official-verifier",
+                                    },
+                                    "valid": True,
+                                    "outcome": "MET",
+                                    "explanation": "the instruction was followed",
+                                    "raw_output": True,
+                                    "metadata": {},
+                                }
+                            ],
+                            "metadata": {},
+                        }
+                    ],
+                },
+                "failures": [],
+                "metadata": {},
+            }
+        ],
         "failures": [],
     }
-    assert list(payload) == [
-        "schema",
-        "benchmark_id",
-        "benchmark_revision",
-        "case_count",
-        "score",
-        "metrics",
-        "cases",
-        "failures",
-    ]
 
 
-def test_a_scored_result_without_the_canonical_trio_is_rejected() -> None:
-    """INVARIANT: scored ⇒ metrics carries pass_rate AND coverage in [0, 1] — the SDK
-    report tiles and its low-coverage warning read exactly these keys, so an aggregate
-    that omits one ships dash tiles; the model makes that a unit-test failure."""
+def test_nested_contracts_forbid_unknown_fields() -> None:
+    values = _check().model_dump()
+    values["accidental"] = True
+    with pytest.raises(ValidationError, match="extra_forbidden"):
+        Check(**values)
 
+
+def test_structural_contract_fields_do_not_coerce_strings() -> None:
+    with pytest.raises(ValidationError):
+        _grade(score="1")
+    with pytest.raises(ValidationError):
+        _evidence(sequence="1")
+
+
+def test_case_identity_is_a_non_blank_string_or_non_boolean_integer() -> None:
+    assert _scored_case(case_id="official-case-A").case_id == "official-case-A"
+    for invalid in (True, "", "  "):
+        with pytest.raises(ValidationError, match="case_id"):
+            _scored_case(case_id=invalid)  # type: ignore[arg-type]
+
+
+def test_invalid_evidence_cannot_claim_an_outcome_or_explanation() -> None:
+    with pytest.raises(ValidationError, match="invalid Evidence"):
+        _evidence(valid=False)
+
+
+def test_scored_case_requires_a_numeric_grade_and_no_failure_or_refusal() -> None:
+    with pytest.raises(ValidationError, match="scored Case"):
+        _scored_case(grade=_grade(score=None))
+    with pytest.raises(ValidationError, match="scored Case"):
+        _scored_case(failures=[_failure()])
+    with pytest.raises(ValidationError, match="scored Case"):
+        _scored_case(refusal="I cannot help with that")
+
+
+def test_refused_case_preserves_exact_refusal_and_provider_failure() -> None:
+    refusal = "I can’t provide that dosage."
+    case = CaseResult(
+        status="refused",
+        case_id=7,
+        input="Recommend a dosage.",
+        output=None,
+        finish_reason="content_filter",
+        refusal=refusal,
+        grade=None,
+        failures=[
+            _failure(
+                stage="candidate",
+                code="provider_refusal",
+                message="the provider refused this Candidate request",
+                retryable=False,
+            )
+        ],
+        metadata={},
+    )
+
+    assert case.refusal == refusal
+    assert case.failures[0].code == "provider_refusal"
+    with pytest.raises(ValidationError, match="refused Case"):
+        CaseResult(**{**case.model_dump(), "refusal": None})
+
+
+def test_failed_case_requires_a_typed_failure_and_cannot_carry_a_score() -> None:
+    case = CaseResult(
+        status="failed",
+        case_id=7,
+        input="Return JSON.",
+        output="not json",
+        finish_reason="stop",
+        refusal=None,
+        grade=_grade(score=None),
+        failures=[_failure()],
+        metadata={},
+    )
+    assert case.grade is not None and case.grade.score is None
+
+    with pytest.raises(ValidationError, match="failed Case"):
+        CaseResult(**{**case.model_dump(), "failures": []})
+    with pytest.raises(ValidationError, match="failed Case"):
+        CaseResult(**{**case.model_dump(), "grade": _grade()})
+
+
+def test_candidate_rejects_duplicate_case_identity() -> None:
+    with pytest.raises(ValidationError, match="duplicate case_id"):
+        _candidate(case_count=2, cases=[_scored_case(7), _scored_case(7)])
+
+
+def test_case_failures_must_belong_to_that_case() -> None:
+    with pytest.raises(ValidationError, match="must reference its own case_id"):
+        CaseResult(
+            status="failed",
+            case_id=7,
+            input=None,
+            output=None,
+            finish_reason=None,
+            refusal=None,
+            grade=None,
+            failures=[_failure(case_id=8)],
+            metadata={},
+        )
+
+
+def test_candidate_level_failures_must_not_claim_a_case() -> None:
+    with pytest.raises(ValidationError, match="Candidate-level Failure"):
+        _candidate(
+            score=None,
+            metrics={},
+            failures=[_failure(stage="aggregation")],
+        )
+
+
+def test_candidate_requires_exact_case_count_and_canonical_scored_metrics() -> None:
+    with pytest.raises(ValidationError, match="case_count"):
+        _candidate(case_count=2)
     for missing in ("pass_rate", "coverage"):
-        metrics = {"pass_rate": 0.5, "coverage": 1.0}
+        metrics = {"pass_rate": 1.0, "coverage": 1.0}
         del metrics[missing]
         with pytest.raises(ValidationError, match=missing):
-            CandidateResult(**_scored_kwargs(metrics=metrics))
+            _candidate(metrics=metrics)
 
 
-def test_canonical_metrics_must_be_fractions() -> None:
-    with pytest.raises(ValidationError, match="pass_rate"):
-        CandidateResult(**_scored_kwargs(metrics={"pass_rate": 1.5, "coverage": 1.0}))
-    with pytest.raises(ValidationError, match="coverage"):
-        CandidateResult(**_scored_kwargs(metrics={"pass_rate": 0.5, "coverage": True}))
-
-
-def test_a_negative_score_is_valid_on_the_wire() -> None:
-    """INVARIANT: `score` has NO lower bound — healthbench's unclipped mean goes
-    negative when rubric penalties dominate, and those scores are rankable challenge
-    results. Only the upper bound (1.0) and the trio metrics' [0, 1] range hold."""
-
-    payload = CandidateResult(
-        **_scored_kwargs(score=-3.0, metrics={"pass_rate": 1.0, "coverage": 1.0})
-    ).as_payload()
-    assert payload["score"] == -3.0
-    with pytest.raises(ValidationError):
-        CandidateResult(**_scored_kwargs(score=1.5))
-
-
-def test_an_unscored_result_cannot_carry_metrics() -> None:
-    """INVARIANT: score None ⇒ metrics {} — a failed run never publishes a plausible
-    partial score (nor plausible partial metrics)."""
-
-    unscored = CandidateResult(**_scored_kwargs(score=None, metrics={}))
-    assert unscored.as_payload()["score"] is None
+def test_unscored_candidate_cannot_publish_plausible_partial_metrics() -> None:
+    failed = CaseResult(
+        status="failed",
+        case_id=7,
+        input="Return JSON.",
+        output=None,
+        finish_reason=None,
+        refusal=None,
+        grade=None,
+        failures=[_failure()],
+        metadata={},
+    )
+    assert _candidate(score=None, metrics={}, cases=[failed]).score is None
 
     with pytest.raises(ValidationError, match="unscored"):
-        CandidateResult(**_scored_kwargs(score=None))
+        _candidate(score=None, cases=[failed])
 
 
-def test_case_count_must_equal_the_retained_cases() -> None:
-    """INVARIANT: case_count is EXACT — one entry per selected Case, scored or failed."""
-
-    with pytest.raises(ValidationError, match="case_count"):
-        CandidateResult(**_scored_kwargs(case_count=2))
+def test_unscored_candidate_requires_an_explicit_failure_or_non_scored_case() -> None:
+    with pytest.raises(ValidationError, match="must be explained"):
+        _candidate(score=None, metrics={})
 
 
-def test_score_must_be_a_fraction_or_none() -> None:
+def test_candidate_score_is_unscored_when_any_case_is_not_scored() -> None:
+    failed = CaseResult(
+        status="failed",
+        case_id=7,
+        input=None,
+        output=None,
+        finish_reason=None,
+        refusal=None,
+        grade=None,
+        failures=[_failure()],
+        metadata={},
+    )
+    with pytest.raises(ValidationError, match="non-scored Case"):
+        _candidate(cases=[failed])
+
+
+def test_healthbench_negative_score_remains_valid() -> None:
+    assert _candidate(score=-3.0).score == -3.0
     with pytest.raises(ValidationError):
-        CandidateResult(**_scored_kwargs(score=1.2))
+        _candidate(score=1.5)
+
+
+@pytest.mark.parametrize("score", (True, float("nan"), float("inf")))
+def test_scores_reject_booleans_and_non_finite_values(score: object) -> None:
+    with pytest.raises(ValidationError):
+        _candidate(score=score)

--- a/apps/url4-cloud/tests/unit/test_candidate_result_contract.py
+++ b/apps/url4-cloud/tests/unit/test_candidate_result_contract.py
@@ -16,6 +16,8 @@ from url4_cloud.benchmarks.contract import (
     Evidence,
     EvidenceProducer,
     Failure,
+    decode_candidate_invocation,
+    encode_candidate_invocation,
 )
 
 
@@ -191,6 +193,37 @@ def test_scored_case_requires_a_numeric_grade_and_no_failure_or_refusal() -> Non
         _scored_case(refusal="I cannot help with that")
 
 
+def test_every_case_requires_public_input_and_a_scored_case_requires_output() -> None:
+    with pytest.raises(ValidationError, match="input"):
+        _scored_case(input=None)
+    with pytest.raises(ValidationError, match="output"):
+        _scored_case(output=None)
+
+
+def test_provider_finish_reason_is_preserved_without_a_closed_sdk_vocabulary() -> None:
+    reason = "provider_safety_stop"
+    case = _scored_case(finish_reason=reason)
+    encoded = encode_candidate_invocation("answer", reason, None)
+
+    assert case.finish_reason == reason
+    assert decode_candidate_invocation(encoded) == ("answer", reason, None)
+
+
+def test_open_wire_fields_accept_only_json_values() -> None:
+    for build in (
+        lambda: _evidence(raw_output={"not-json"}),
+        lambda: _evidence(raw_output=("tuple", "is", "not", "a", "JSON", "array")),
+        lambda: _check(metadata={"nested": {1: "non-string JSON object key"}}),
+        lambda: _check(metadata={"value": object()}),
+        lambda: _grade(metrics={"value": object()}),
+        lambda: _failure(metadata={"value": object()}),
+        lambda: _scored_case(metadata={"value": object()}),
+        lambda: _candidate(metrics={"pass_rate": 1.0, "coverage": 1.0, "value": object()}),
+    ):
+        with pytest.raises(ValidationError, match="JSON"):
+            build()
+
+
 def test_refused_case_preserves_exact_refusal_and_provider_failure() -> None:
     refusal = "I can’t provide that dosage."
     case = CaseResult(
@@ -248,7 +281,7 @@ def test_case_failures_must_belong_to_that_case() -> None:
         CaseResult(
             status="failed",
             case_id=7,
-            input=None,
+            input="selected input",
             output=None,
             finish_reason=None,
             refusal=None,
@@ -304,7 +337,7 @@ def test_candidate_score_is_unscored_when_any_case_is_not_scored() -> None:
     failed = CaseResult(
         status="failed",
         case_id=7,
-        input=None,
+        input="selected input",
         output=None,
         finish_reason=None,
         refusal=None,

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate.py
@@ -340,15 +340,16 @@ def test_a_row_with_no_verdicts_is_a_failure_not_a_zero() -> None:
     assert result["metrics"] == {}
 
 
-def test_no_rows_at_all_is_an_execution_failure() -> None:
-    """INVARIANT: a run with no evaluated Cases cannot report Candidate score zero."""
-    with pytest.raises(agg.AggregateError, match="no DRACO Case results"):
-        agg.aggregate(
-            "[]",
-            rubrics={1: _RUBRIC},
-            benchmark_id="draco",
-            selected_cases=_selected_cases(1),
-        )
+def test_no_rows_at_all_retains_every_selected_case_as_failed() -> None:
+    result = agg.aggregate(
+        "[]",
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco",
+        selected_cases=_selected_cases(1),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][0]["failures"][0]["code"] == "case_result_missing"
 
 
 def test_all_failed_rows_retain_the_collected_execution_error() -> None:

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
@@ -161,13 +161,15 @@ def test_rows_must_exactly_match_the_bound_selection() -> None:
     """INVARIANT: a lost row cannot masquerade as an intentionally shorter prefix."""
     rows = json.dumps([_row("c1", case=1)])
 
-    with pytest.raises(agg.AggregateError, match="exactly match"):
-        agg.aggregate(
-            rows,
-            rubrics=_RUBRICS,
-            benchmark_id="draco",
-            selected_cases=_selected(1, 2),
-        )
+    result = agg.aggregate(
+        rows,
+        rubrics=_RUBRICS,
+        benchmark_id="draco",
+        selected_cases=_selected(1, 2),
+    )
+
+    assert result["score"] is None
+    assert result["cases"][1]["failures"][0]["code"] == "case_result_missing"
 
 
 def test_a_full_row_set_without_case_evaluations_is_still_unscored() -> None:
@@ -186,7 +188,7 @@ def test_a_full_row_set_without_case_evaluations_is_still_unscored() -> None:
 
 def test_no_rows_at_all_fails_after_the_mapping_guard() -> None:
     """An empty payload has no mapping error, but it still cannot produce a valid result."""
-    with pytest.raises(agg.AggregateError, match="no DRACO Case results"):
+    with pytest.raises(agg.AggregateError, match="selected Case sequence"):
         agg.aggregate("[]", rubrics=_RUBRICS, benchmark_id="draco", selected_cases=[])
 
 

--- a/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
@@ -118,10 +118,12 @@ async def test_draco_smoke_retains_complete_case_evidence(tmp_path: Path) -> Non
     decoded = json.loads(result.text)
     assert decoded["cases"] == [
         {
+            "status": "scored",
             "case_id": 1,
             "input": _QUESTION,
             "output": _ANSWER,
             "finish_reason": "stop",
+            "refusal": None,
             "grade": {
                 "method": "rubric",
                 "score": 1.0,

--- a/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
+++ b/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
@@ -66,8 +66,8 @@ def test_partial_result_preserves_the_collected_case_error() -> None:
             {
                 "error": {
                     "kind": "ResolutionError",
-                    "code": "provider_refusal",
-                    "message": "provider refused the request",
+                    "code": "provider_error",
+                    "message": "provider request failed",
                 }
             },
         ]
@@ -88,8 +88,8 @@ def test_partial_result_preserves_the_collected_case_error() -> None:
     expected_failure = [
         {
             "stage": "candidate",
-            "code": "provider_refusal",
-            "message": "provider refused the request",
+            "code": "provider_error",
+            "message": "provider request failed",
             "retryable": None,
             "case_id": 2,
             "metadata": {"row_index": 1, "error_kind": "ResolutionError"},
@@ -97,14 +97,35 @@ def test_partial_result_preserves_the_collected_case_error() -> None:
     ]
     assert result["failures"] == []
     assert result["cases"][1] == {
+        "status": "failed",
         "case_id": 2,
         "input": "Question 2",
         "output": None,
         "finish_reason": None,
+        "refusal": None,
         "grade": None,
         "failures": expected_failure,
         "metadata": {},
     }
+
+
+def test_provider_refusal_is_retained_exactly_and_skips_grading() -> None:
+    exact = "I can’t answer that request."
+    result = agg.aggregate(
+        json.dumps([{"error": {"kind": "ProviderRefusal", "message": exact}}]),
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1),
+        judge_passes=1,
+    )
+
+    case = result["cases"][0]
+    assert result["score"] is None
+    assert result["metrics"] == {}
+    assert case["status"] == "refused"
+    assert case["refusal"] == exact
+    assert case["grade"] is None
+    assert case["failures"][0]["code"] == "provider_refusal"
 
 
 def test_missing_selected_case_rubric_retains_the_case_and_invalidates_the_score() -> None:
@@ -121,10 +142,12 @@ def test_missing_selected_case_rubric_retains_the_case_and_invalidates_the_score
     assert result["metrics"] == {}
     assert result["cases"][0]["grade"]["score"] == 1.0
     assert result["cases"][1] == {
+        "status": "failed",
         "case_id": 2,
         "input": "Question 2",
         "output": "Answer 2",
         "finish_reason": "stop",
+        "refusal": None,
         "grade": None,
         "failures": [
             {

--- a/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
+++ b/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
@@ -10,6 +10,7 @@ from url4_cloud.benchmarks.draco.case_evaluation import (
     bind_criterion_evaluation,
 )
 from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+from url4_cloud.benchmarks.errors import ProviderRefusal
 
 _RUBRIC = {
     "sections": [
@@ -109,10 +110,33 @@ def test_partial_result_preserves_the_collected_case_error() -> None:
     }
 
 
+def test_a_missing_selected_row_is_retained_and_invalidates_the_score() -> None:
+    result = agg.aggregate(
+        json.dumps([_scored_row(1)]),
+        {1: _RUBRIC, 2: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1, 2),
+        judge_passes=1,
+    )
+
+    assert result["score"] is None
+    assert [case["case_id"] for case in result["cases"]] == [1, 2]
+    assert result["cases"][1]["failures"][0]["code"] == "case_result_missing"
+
+
 def test_provider_refusal_is_retained_exactly_and_skips_grading() -> None:
     exact = "I can’t answer that request."
     result = agg.aggregate(
-        json.dumps([{"error": {"kind": "ProviderRefusal", "message": exact}}]),
+        json.dumps(
+            [
+                {
+                    "error": {
+                        "kind": "ProviderRefusal",
+                        "message": str(ProviderRefusal(exact, finish_reason="content_filter")),
+                    }
+                }
+            ]
+        ),
         {1: _RUBRIC},
         "draco",
         selected_cases=_selected(1),
@@ -124,6 +148,7 @@ def test_provider_refusal_is_retained_exactly_and_skips_grading() -> None:
     assert result["metrics"] == {}
     assert case["status"] == "refused"
     assert case["refusal"] == exact
+    assert case["finish_reason"] == "content_filter"
     assert case["grade"] is None
     assert case["failures"][0]["code"] == "provider_refusal"
 

--- a/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 
+from url4_cloud.benchmarks.errors import ProviderRefusal
 from url4_cloud.benchmarks.healthbench.aggregate import (
     AggregateError,
     aggregate,
@@ -27,6 +28,7 @@ from url4_cloud.benchmarks.healthbench.verdict import SCHEMA as VERDICT_SCHEMA
 
 
 def _write_rubric(root: Path, case_id: int, points: list[int]) -> None:
+    _write_case(root, case_id)
     rubric_dir = root / "rubrics"
     rubric_dir.mkdir(parents=True, exist_ok=True)
     (rubric_dir / f"{case_id}.json").write_text(
@@ -41,6 +43,14 @@ def _write_rubric(root: Path, case_id: int, points: list[int]) -> None:
         ),
         encoding="utf-8",
     )
+
+
+def _write_case(root: Path, case_id: int) -> None:
+    cases_path = root / "cases.json"
+    cases = json.loads(cases_path.read_text()) if cases_path.exists() else []
+    if not any(row["id"] == case_id for row in cases):
+        cases.append({"id": case_id, "input": f"input-{case_id}"})
+        cases_path.write_text(json.dumps(cases), encoding="utf-8")
 
 
 def _evidence(case_id: int, rubric_id: int, met: bool) -> dict[str, object]:
@@ -109,6 +119,12 @@ def test_fully_judged_cases_score_and_mean_unclipped(tmp_path: Path) -> None:
     # decision surfaces as a top-level outcome, not only inside evidence.
     checks = result["cases"][0]["grade"]["checks"]
     assert [check["outcome"] for check in checks] == ["UNMET", "UNMET", "MET"]
+    assert [check["label"] for check in checks] == ["[1] c1", "[1] c2", "[1] c3"]
+    assert [check["metadata"] for check in checks] == [
+        {"points": 7},
+        {"points": 8},
+        {"points": -6},
+    ]
     # SDK Case Result contract (seen live in the smoke run): every Case carries
     # the full key set, a scored Case carries a rubric grade, and evidence rows
     # sit under grade.checks — not in any home-grown envelope.
@@ -182,6 +198,7 @@ def test_a_negative_unclipped_mean_survives_the_contract(tmp_path: Path) -> None
 
 def test_a_missing_rubric_asset_fails_the_case_and_the_exam(tmp_path: Path) -> None:
     _write_rubric(tmp_path, 1, [7])
+    _write_case(tmp_path, 2)
     rows = json.dumps([_case_row(1, {1: True}), _case_row(2, {1: True})])
     result = aggregate(rows, tmp_path, benchmark_id="hb", benchmark_revision="rev", case_ids=(1, 2))
     # B1: the broken Case is IN the output, and the exam refuses to publish a mean.
@@ -198,7 +215,16 @@ def test_an_error_collected_row_fails_its_case(tmp_path: Path) -> None:
     rows = json.dumps(
         [
             _case_row(1, {1: True}),
-            {"schema": CASE_EVALUATION_SCHEMA, "case_id": 2, "error": "candidate died"},
+            {
+                "schema": CASE_EVALUATION_SCHEMA,
+                "case_id": 2,
+                "error": {
+                    "kind": "ResolutionError",
+                    "code": "provider_error",
+                    "message": "the provider was unavailable",
+                    "permanent": True,
+                },
+            },
         ]
     )
     result = aggregate(rows, tmp_path, benchmark_id="hb", benchmark_revision="rev", case_ids=(1, 2))
@@ -206,6 +232,13 @@ def test_an_error_collected_row_fails_its_case(tmp_path: Path) -> None:
     assert _failure_codes(result)[2] == "case_error"
     failed = next(case for case in result["cases"] if case["case_id"] == 2)
     assert failed["grade"] is None
+    assert failed["failures"][0]["message"] == "the provider was unavailable"
+    assert failed["failures"][0]["metadata"]["source_error"] == {
+        "kind": "ResolutionError",
+        "code": "provider_error",
+        "message": "the provider was unavailable",
+        "retryable": False,
+    }
 
 
 def test_partial_verdicts_never_score(tmp_path: Path) -> None:
@@ -255,8 +288,18 @@ def test_provider_refusals_are_mapped_by_case_and_preserved_exactly(tmp_path: Pa
     result = aggregate(
         json.dumps(
             [
-                {"error": {"kind": "ProviderRefusal", "message": first}},
-                {"error": {"kind": "ProviderRefusal", "message": second}},
+                {
+                    "error": {
+                        "kind": "ProviderRefusal",
+                        "message": str(ProviderRefusal(first, finish_reason="content_filter")),
+                    }
+                },
+                {
+                    "error": {
+                        "kind": "ProviderRefusal",
+                        "message": str(ProviderRefusal(second, finish_reason="content_filter")),
+                    }
+                },
             ]
         ),
         tmp_path,
@@ -269,6 +312,10 @@ def test_provider_refusals_are_mapped_by_case_and_preserved_exactly(tmp_path: Pa
     assert result["metrics"] == {}
     assert [case["status"] for case in result["cases"]] == ["refused", "refused"]
     assert [case["refusal"] for case in result["cases"]] == [first, second]
+    assert [case["finish_reason"] for case in result["cases"]] == [
+        "content_filter",
+        "content_filter",
+    ]
 
 
 def test_a_missing_case_row_is_visible(tmp_path: Path) -> None:
@@ -288,8 +335,14 @@ def test_a_missing_case_row_is_visible(tmp_path: Path) -> None:
 def test_unusable_row_payloads_raise_before_scoring(tmp_path: Path) -> None:
     with pytest.raises(AggregateError):
         aggregate("not json", tmp_path, benchmark_id="hb", benchmark_revision="rev", case_ids=(1,))
-    with pytest.raises(AggregateError):
-        aggregate("[]", tmp_path, benchmark_id="hb", benchmark_revision="rev", case_ids=(1,))
+
+
+def test_no_rows_retains_every_selected_case_as_failed(tmp_path: Path) -> None:
+    _write_rubric(tmp_path, 1, [7])
+    result = aggregate("[]", tmp_path, benchmark_id="hb", benchmark_revision="rev", case_ids=(1,))
+
+    assert result["score"] is None
+    assert result["cases"][0]["failures"][0]["code"] == "missing_case_row"
 
 
 def test_load_rubric_points_rejects_malformed_assets(tmp_path: Path) -> None:

--- a/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
@@ -114,10 +114,12 @@ def test_fully_judged_cases_score_and_mean_unclipped(tmp_path: Path) -> None:
     # sit under grade.checks — not in any home-grown envelope.
     first = result["cases"][0]
     assert set(first) == {
+        "status",
         "case_id",
         "input",
         "output",
         "finish_reason",
+        "refusal",
         "grade",
         "failures",
         "metadata",
@@ -242,6 +244,31 @@ def test_invalid_judge_evidence_counts_and_fails_the_case(tmp_path: Path) -> Non
     assert result["score"] is None
     assert result["metrics"] == {}  # unscored → empty (SDK report rule)
     assert _failure_codes(result) == {1: "incomplete_verdicts"}
+
+
+def test_provider_refusals_are_mapped_by_case_and_preserved_exactly(tmp_path: Path) -> None:
+    _write_rubric(tmp_path, 1, [7])
+    _write_rubric(tmp_path, 2, [7])
+    first = "I can’t answer the first request."
+    second = "I can’t answer the second request."
+
+    result = aggregate(
+        json.dumps(
+            [
+                {"error": {"kind": "ProviderRefusal", "message": first}},
+                {"error": {"kind": "ProviderRefusal", "message": second}},
+            ]
+        ),
+        tmp_path,
+        benchmark_id="hb",
+        benchmark_revision="rev",
+        case_ids=(1, 2),
+    )
+
+    assert result["score"] is None
+    assert result["metrics"] == {}
+    assert [case["status"] for case in result["cases"]] == ["refused", "refused"]
+    assert [case["refusal"] for case in result["cases"]] == [first, second]
 
 
 def test_a_missing_case_row_is_visible(tmp_path: Path) -> None:

--- a/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
@@ -196,6 +196,27 @@ def test_a_negative_unclipped_mean_survives_the_contract(tmp_path: Path) -> None
     assert result["metrics"]["pass_rate"] == 1.0  # every criterion judged MET — yet negative
 
 
+def test_duplicate_judge_entries_are_noise_not_extra_credit(tmp_path: Path) -> None:
+    """INVARIANT: duplicate judge entries for one rubric_id are noise, not extra
+    credit — met must never exceed judged. ``_verdicts`` dedupes by rubric_id, so
+    ``_checks`` must emit exactly one check per rubric_id (the same entry the
+    verdict kept); a second check would push pass_rate past 1.0 and the canonical
+    metric bound would convert the ENTIRE run to benchmark_unavailable."""
+
+    _write_rubric(tmp_path, 1, [5, 3])
+    row = _case_row(1, {1: True, 2: True})
+    evaluations = row["rubric_evaluations"]
+    assert isinstance(evaluations, list)
+    # Judge retry duplication: rubric 1 arrives twice, both entries valid MET.
+    evaluations.append(json.loads(json.dumps(evaluations[0])))
+    result = aggregate(
+        json.dumps([row]), tmp_path, benchmark_id="hb", benchmark_revision="rev", case_ids=(1,)
+    )
+    assert result["metrics"]["pass_rate"] <= 1.0
+    checks = result["cases"][0]["grade"]["checks"]
+    assert [check["id"] for check in checks] == ["1", "2"]
+
+
 def test_a_missing_rubric_asset_fails_the_case_and_the_exam(tmp_path: Path) -> None:
     _write_rubric(tmp_path, 1, [7])
     _write_case(tmp_path, 2)

--- a/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
@@ -258,6 +258,33 @@ def test_partial_verdicts_never_score(tmp_path: Path) -> None:
     assert result["metrics"] == {}  # unscored → empty (SDK report rule)
 
 
+def test_a_malformed_case_envelope_fails_its_case_not_the_whole_run(tmp_path: Path) -> None:
+    """INVARIANT: one malformed row must not destroy the whole run's published result.
+
+    A fully-judged row whose hoisted ``case`` envelope is missing (or not a
+    mapping) has no usable candidate output — it must become a visible FAILED
+    Case, never reach the scored path (whose contract demands an output) and
+    never raise out of ``aggregate`` into benchmark_unavailable.
+    """
+
+    _write_rubric(tmp_path, 1, [7])
+    _write_rubric(tmp_path, 2, [3])
+    malformed = _case_row(2, {1: True})
+    del malformed["case"]  # complete verdicts, but the candidate envelope is gone
+    result = aggregate(
+        json.dumps([_case_row(1, {1: True}), malformed]),
+        tmp_path,
+        benchmark_id="hb",
+        benchmark_revision="rev",
+        case_ids=(1, 2),
+    )
+    assert result["score"] is None
+    assert _failure_codes(result) == {1: None, 2: "invalid_case_evaluation"}
+    failed = next(case for case in result["cases"] if case["case_id"] == 2)
+    assert failed["status"] == "failed"
+    assert failed["output"] is None
+
+
 def test_invalid_judge_evidence_counts_and_fails_the_case(tmp_path: Path) -> None:
     _write_rubric(tmp_path, 1, [7])
     row = _case_row(1, {1: True})

--- a/apps/url4-cloud/tests/unit/test_ifeval_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_aggregate.py
@@ -82,7 +82,7 @@ def test_paper_metrics_are_computed_across_cases_and_instructions() -> None:
         _evaluation(2, [True], [True]),
     )
 
-    result = aggregate(payload, _SPECS, "ifeval", _ORDER)
+    result = aggregate(payload, _SPECS, "ifeval", _ORDER, selected_case_count=2)
 
     # INVARIANT: `score` IS the paper's headline metric, prompt-level strict accuracy —
     # the leaderboard number must mean what arXiv:2311.07911 says it means.
@@ -118,6 +118,7 @@ def test_exact_case_evaluations_survive_the_collect_boundary() -> None:
         _SPECS,
         "ifeval",
         _ORDER,
+        selected_case_count=2,
     )
 
     assert result["score"] == 1.0
@@ -135,7 +136,7 @@ def test_a_failed_case_invalidates_the_candidate_score() -> None:
         },
     )
 
-    result = aggregate(payload, _SPECS, "ifeval", _ORDER)
+    result = aggregate(payload, _SPECS, "ifeval", _ORDER, selected_case_count=2)
 
     assert result["score"] is None
     assert result["metrics"] == {}
@@ -153,7 +154,7 @@ def test_an_invalid_case_evaluation_is_retained_as_a_grading_failure() -> None:
         _evaluation(2, [True], [True]),
     )
 
-    result = aggregate(payload, _SPECS, "ifeval", _ORDER)
+    result = aggregate(payload, _SPECS, "ifeval", _ORDER, selected_case_count=2)
 
     assert result["score"] is None
     assert result["metrics"] == {}
@@ -163,7 +164,13 @@ def test_an_invalid_case_evaluation_is_retained_as_a_grading_failure() -> None:
 def test_every_failed_case_returns_null_instead_of_reporting_zero() -> None:
     # Scoring this would hand the client a plausible 0.0 from a misconfigured assets
     # path — draco's load_rubrics lesson.
-    result = aggregate(_rows("broken", "also broken"), _SPECS, "ifeval", _ORDER)
+    result = aggregate(
+        _rows("broken", "also broken"),
+        _SPECS,
+        "ifeval",
+        _ORDER,
+        selected_case_count=2,
+    )
 
     assert result["score"] is None
     assert [case["grade"] for case in result["cases"]] == [None, None]
@@ -177,7 +184,7 @@ def test_all_crash_result_retains_the_collected_inner_failure() -> None:
         }
     }
 
-    result = aggregate(_rows(failed), {1: _SPECS[1]}, "ifeval", [1])
+    result = aggregate(_rows(failed), {1: _SPECS[1]}, "ifeval", [1], selected_case_count=1)
 
     assert result["score"] is None
     assert result["cases"][0]["failures"][0]["message"] == "malformed aigateway response"
@@ -186,7 +193,7 @@ def test_all_crash_result_retains_the_collected_inner_failure() -> None:
 def test_metrics_are_flat_numbers_only() -> None:
     payload = _rows(_evaluation(2, [True], [True]))
 
-    result = aggregate(payload, {2: _SPECS[2]}, "ifeval", [2])
+    result = aggregate(payload, {2: _SPECS[2]}, "ifeval", [2], selected_case_count=1)
 
     assert all(isinstance(value, (int, float)) for value in result["metrics"].values())
 
@@ -223,7 +230,7 @@ def test_one_flake_at_realistic_size_fails_closed() -> None:
     rows = [evaluation(case_id, passed=case_id <= 4) for case_id in range(1, 10)]
     rows.append({"error": {"kind": "ResolutionError", "message": "provider flake"}})
 
-    result = aggregate(json.dumps(rows), specs, "ifeval", order)
+    result = aggregate(json.dumps(rows), specs, "ifeval", order, selected_case_count=10)
 
     assert result["score"] is None
     assert result["metrics"] == {}
@@ -241,9 +248,14 @@ def test_canonical_contract_metrics_are_published_for_every_scored_aggregate() -
         _evaluation(1, [True, False], [True, True]),
         _evaluation(2, [True], [True]),
     )
-    single_pass = aggregate(payload, _SPECS, "ifeval", _ORDER)
+    single_pass = aggregate(payload, _SPECS, "ifeval", _ORDER, selected_case_count=2)
     corrective = aggregate_corrective(
-        payload, _SPECS, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, _ORDER
+        payload,
+        _SPECS,
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        _ORDER,
+        selected_case_count=2,
     )
 
     for result in (single_pass, corrective):
@@ -264,7 +276,7 @@ def test_a_record_for_an_unknown_case_id_is_ignored() -> None:
     }
     payload = _rows(_evaluation(1, [True, True], [True, True]), stray_evaluation)
 
-    result = aggregate(payload, _SPECS, "ifeval", _ORDER)
+    result = aggregate(payload, _SPECS, "ifeval", _ORDER, selected_case_count=2)
 
     # The stray record cannot smuggle a score into a Case its check never ran for, and
     # the missing authentic grade cannot be recast as an incorrect answer — the Case
@@ -276,9 +288,15 @@ def test_a_record_for_an_unknown_case_id_is_ignored() -> None:
 
 def test_non_array_payload_raises() -> None:
     with pytest.raises(AggregateError):
-        aggregate('{"not": "an array"}', _SPECS, "ifeval", _ORDER)
+        aggregate(
+            '{"not": "an array"}',
+            _SPECS,
+            "ifeval",
+            _ORDER,
+            selected_case_count=2,
+        )
     with pytest.raises(AggregateError):
-        aggregate("not json at all", _SPECS, "ifeval", _ORDER)
+        aggregate("not json at all", _SPECS, "ifeval", _ORDER, selected_case_count=2)
 
 
 def test_load_specs_raises_on_a_missing_or_empty_directory(tmp_path: Path) -> None:

--- a/apps/url4-cloud/tests/unit/test_ifeval_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_aggregate.py
@@ -124,12 +124,7 @@ def test_exact_case_evaluations_survive_the_collect_boundary() -> None:
     assert result["case_count"] == 2
 
 
-def test_a_failed_case_is_declared_as_fallback_and_kept_out_of_the_denominator() -> None:
-    # INVARIANT: an operationally failed Case is not a legitimate incorrect answer —
-    # it never enters an accuracy denominator (which would punish the Candidate for a
-    # provider flake). It is DECLARED: retained with its failure record, counted in
-    # cases_fallback, and reflected in coverage so a reader sees exactly how much of
-    # the selection the score stands on.
+def test_a_failed_case_invalidates_the_candidate_score() -> None:
     payload = _rows(
         _evaluation(1, [True, True], [True, True]),
         {
@@ -142,10 +137,8 @@ def test_a_failed_case_is_declared_as_fallback_and_kept_out_of_the_denominator()
 
     result = aggregate(payload, _SPECS, "ifeval", _ORDER)
 
-    assert result["score"] == 1.0  # over the single graded case, not 0.5 over both
-    assert result["metrics"]["cases_checked"] == 1
-    assert result["metrics"]["cases_fallback"] == 1
-    assert result["metrics"]["coverage"] == 0.5
+    assert result["score"] is None
+    assert result["metrics"] == {}
     assert result["case_count"] == 2
     assert result["cases"][0]["grade"]["score"] == 1.0
     assert result["cases"][1]["grade"] is None
@@ -162,8 +155,8 @@ def test_an_invalid_case_evaluation_is_retained_as_a_grading_failure() -> None:
 
     result = aggregate(payload, _SPECS, "ifeval", _ORDER)
 
-    assert result["score"] == 1.0  # the honest case scores; the broken row is fallback
-    assert result["metrics"]["coverage"] == 0.5
+    assert result["score"] is None
+    assert result["metrics"] == {}
     assert result["cases"][0]["failures"][0]["code"] == "invalid_case_evaluation"
 
 
@@ -198,11 +191,7 @@ def test_metrics_are_flat_numbers_only() -> None:
     assert all(isinstance(value, (int, float)) for value in result["metrics"].values())
 
 
-def test_coverage_scoring_at_realistic_size_absorbs_one_flake() -> None:
-    """INVARIANT: coverage-declared scoring — 10 selected, 1 failed → the score stands
-    on the 9 graded cases (here 4 passes / 9 ≈ 0.4444) with coverage 0.9 saying so.
-    One provider flake costs one case, not the run; the reader sees exactly how much
-    of the selection the number covers."""
+def test_one_flake_at_realistic_size_fails_closed() -> None:
 
     specs = {
         case_id: {
@@ -236,11 +225,8 @@ def test_coverage_scoring_at_realistic_size_absorbs_one_flake() -> None:
 
     result = aggregate(json.dumps(rows), specs, "ifeval", order)
 
-    assert result["score"] == round(4 / 9, 4)
-    assert result["metrics"]["pass_rate"] == round(4 / 9, 4)
-    assert result["metrics"]["coverage"] == 0.9
-    assert result["metrics"]["cases_checked"] == 9
-    assert result["metrics"]["cases_fallback"] == 1
+    assert result["score"] is None
+    assert result["metrics"] == {}
     assert result["case_count"] == 10
     assert result["cases"][9]["grade"] is None  # the flaked case, retained
 
@@ -282,9 +268,9 @@ def test_a_record_for_an_unknown_case_id_is_ignored() -> None:
 
     # The stray record cannot smuggle a score into a Case its check never ran for, and
     # the missing authentic grade cannot be recast as an incorrect answer — the Case
-    # falls back and the run scores over the one honestly graded Case.
-    assert result["score"] == 1.0
-    assert result["metrics"]["cases_fallback"] == 1
+    # fails the run closed while retaining the honestly graded Case.
+    assert result["score"] is None
+    assert result["metrics"] == {}
     assert result["cases"][1]["grade"] is None
 
 

--- a/apps/url4-cloud/tests/unit/test_ifeval_aggregate_case_mapping.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_aggregate_case_mapping.py
@@ -81,7 +81,7 @@ def test_truthy_text_cannot_impersonate_verifier_booleans() -> None:
 
     result = aggregate(rows, _SPECS, "ifeval", _ORDER)
 
-    # The forged record leaves ITS Case ungraded (fallback); the honest case scores.
-    assert result["score"] == 1.0
-    assert result["metrics"]["cases_fallback"] == 1
+    # The forged record leaves its Case ungraded, so the Candidate fails closed.
+    assert result["score"] is None
+    assert result["metrics"] == {}
     assert result["cases"][0]["grade"] is None

--- a/apps/url4-cloud/tests/unit/test_ifeval_aggregate_case_mapping.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_aggregate_case_mapping.py
@@ -8,7 +8,6 @@ import pytest
 
 from url4_cloud.benchmarks.ifeval.aggregate import (
     SCHEMA,
-    AggregateError,
     aggregate,
     aggregate_corrective,
 )
@@ -49,7 +48,7 @@ def test_swapped_known_case_records_cannot_publish_a_score() -> None:
 
     rows = json.dumps([_evaluation(2), _evaluation(1)])
 
-    result = aggregate(rows, _SPECS, "ifeval", _ORDER)
+    result = aggregate(rows, _SPECS, "ifeval", _ORDER, selected_case_count=2)
 
     assert result["score"] is None
     assert [case["grade"] for case in result["cases"]] == [None, None]
@@ -62,11 +61,14 @@ def test_swapped_known_case_records_cannot_publish_a_score() -> None:
         (aggregate_corrective, (SELF_CORRECTIVE_REVISION, _ORDER)),
     ],
 )
-def test_zero_case_ifeval_payloads_fail_loudly(reducer, extra) -> None:
-    """An empty Evaluation is an execution failure, never a plausible zero score."""
+def test_zero_row_ifeval_payloads_retain_the_selected_cases(reducer, extra) -> None:
+    result = reducer("[]", _SPECS, "ifeval", *extra, selected_case_count=2)
 
-    with pytest.raises(AggregateError, match="no IFEval rows"):
-        reducer("[]", _SPECS, "ifeval", *extra)
+    assert result["score"] is None
+    assert [case["failures"][0]["code"] for case in result["cases"]] == [
+        "case_result_missing",
+        "case_result_missing",
+    ]
 
 
 def test_truthy_text_cannot_impersonate_verifier_booleans() -> None:
@@ -79,9 +81,19 @@ def test_truthy_text_cannot_impersonate_verifier_booleans() -> None:
         ]
     )
 
-    result = aggregate(rows, _SPECS, "ifeval", _ORDER)
+    result = aggregate(rows, _SPECS, "ifeval", _ORDER, selected_case_count=2)
 
     # The forged record leaves its Case ungraded, so the Candidate fails closed.
     assert result["score"] is None
     assert result["metrics"] == {}
     assert result["cases"][0]["grade"] is None
+
+
+def test_a_missing_selected_row_is_retained_and_invalidates_the_score() -> None:
+    rows = json.dumps([_evaluation(1)])
+
+    result = aggregate(rows, _SPECS, "ifeval", _ORDER, selected_case_count=2)
+
+    assert result["score"] is None
+    assert [case["case_id"] for case in result["cases"]] == [1, 2]
+    assert result["cases"][1]["failures"][0]["code"] == "case_result_missing"

--- a/apps/url4-cloud/tests/unit/test_ifeval_iterative_correction.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_iterative_correction.py
@@ -158,6 +158,7 @@ def test_corrective_resource_unrolls_three_checked_attempts_per_case() -> None:
     assert "$feedback_1" in url4
     assert "$self_feedback_1" in url4
     assert url4.count("!'feedback'") == MAX_ATTEMPTS - 1
+    assert "!'aggregate:1'" in url4
     assert "openrouter/" not in url4
 
 
@@ -170,6 +171,7 @@ def test_canonical_ifeval_reproduces_the_paper_protocol() -> None:
     assert resource["revision"] == SINGLE_PASS_REVISION
     assert url4.count("/candidate") == 1
     assert url4.count(CHECK_ROUTE) == 1
+    assert "!'aggregate:1'" in url4
 
 
 # --- the corrective reducer -------------------------------------------------------
@@ -182,7 +184,12 @@ def test_selected_attempt_is_the_earliest_strict_pass() -> None:
     )
 
     result = aggregate_corrective(
-        payload, _SPECS, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, _ORDER
+        payload,
+        _SPECS,
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        _ORDER,
+        selected_case_count=2,
     )
 
     assert result["schema"] == "screamingface.candidate-result.v1"
@@ -206,7 +213,12 @@ def test_a_never_passing_case_scores_its_last_attempt() -> None:
     payload = _rows(_evaluation(1, [False, False], [True, False], [True, False]))
 
     result = aggregate_corrective(
-        payload, {1: _SPECS[1]}, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, [1]
+        payload,
+        {1: _SPECS[1]},
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        [1],
+        selected_case_count=1,
     )
 
     assert result["score"] == 0.0
@@ -227,7 +239,12 @@ def test_a_failed_case_invalidates_the_corrective_candidate_score() -> None:
     )
 
     result = aggregate_corrective(
-        payload, _SPECS, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, _ORDER
+        payload,
+        _SPECS,
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        _ORDER,
+        selected_case_count=2,
     )
 
     assert result["score"] is None
@@ -246,6 +263,7 @@ def test_every_failed_case_returns_null_instead_of_reporting_zero() -> None:
         SELF_CORRECTIVE_ID,
         SELF_CORRECTIVE_REVISION,
         _ORDER,
+        selected_case_count=2,
     )
 
     assert result["score"] is None
@@ -266,6 +284,7 @@ def test_all_crash_result_retains_the_collected_inner_failure() -> None:
         SELF_CORRECTIVE_ID,
         SELF_CORRECTIVE_REVISION,
         [1],
+        selected_case_count=1,
     )
 
     assert result["score"] is None
@@ -286,7 +305,12 @@ def test_a_record_whose_instruction_ids_mismatch_the_spec_is_rejected() -> None:
     )
 
     result = aggregate_corrective(
-        payload, _SPECS, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, _ORDER
+        payload,
+        _SPECS,
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        _ORDER,
+        selected_case_count=2,
     )
 
     assert result["score"] is None
@@ -307,7 +331,12 @@ def test_duplicate_attempt_numbers_make_the_case_unscored() -> None:
     )
 
     result = aggregate_corrective(
-        payload, {1: _SPECS[1]}, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, [1]
+        payload,
+        {1: _SPECS[1]},
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        [1],
+        selected_case_count=1,
     )
 
     assert result["score"] is None
@@ -318,7 +347,12 @@ def test_metrics_are_flat_numbers_only() -> None:
     payload = _rows(_evaluation(1, [True, True]))
 
     result = aggregate_corrective(
-        payload, {1: _SPECS[1]}, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, [1]
+        payload,
+        {1: _SPECS[1]},
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        [1],
+        selected_case_count=1,
     )
 
     assert all(isinstance(value, (int, float)) for value in result["metrics"].values())
@@ -335,7 +369,12 @@ def test_attempt_metadata_exposes_persisted_judge_feedback() -> None:
     payload = _rows(bind_case_evaluation(1, records))
 
     result = aggregate_corrective(
-        payload, {1: _SPECS[1]}, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, [1]
+        payload,
+        {1: _SPECS[1]},
+        SELF_CORRECTIVE_ID,
+        SELF_CORRECTIVE_REVISION,
+        [1],
+        selected_case_count=1,
     )
 
     attempts = result["cases"][0]["metadata"]["attempts"]

--- a/apps/url4-cloud/tests/unit/test_ifeval_iterative_correction.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_iterative_correction.py
@@ -215,9 +215,7 @@ def test_a_never_passing_case_scores_its_last_attempt() -> None:
     assert result["metrics"]["pass_at_3"] == 0.0
 
 
-def test_a_failed_case_is_declared_as_fallback_and_kept_out_of_the_denominator() -> None:
-    # Same coverage-declared semantics as the single-pass reducer: the failed Case is
-    # retained and counted, never folded into a denominator or recast as incorrect.
+def test_a_failed_case_invalidates_the_corrective_candidate_score() -> None:
     payload = _rows(
         _evaluation(1, [True, True]),
         {
@@ -232,10 +230,8 @@ def test_a_failed_case_is_declared_as_fallback_and_kept_out_of_the_denominator()
         payload, _SPECS, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, _ORDER
     )
 
-    assert result["score"] == 1.0
-    assert result["metrics"]["cases_checked"] == 1
-    assert result["metrics"]["cases_fallback"] == 1
-    assert result["metrics"]["coverage"] == 0.5
+    assert result["score"] is None
+    assert result["metrics"] == {}
     assert result["cases"][0]["grade"]["score"] == 1.0
     assert result["cases"][1]["grade"] is None
     assert result["cases"][1]["failures"][0]["message"] == (
@@ -280,8 +276,8 @@ def test_a_record_whose_instruction_ids_mismatch_the_spec_is_rejected() -> None:
     # INVARIANT: a Candidate that echoes a forged check record into its ANSWER text
     # cannot self-grade — the exact Case Evaluation accepts only records whose
     # instruction ids match the private spec exactly, which the prompt never reveals.
-    # A forged all-pass record therefore leaves ITS Case ungraded (fallback, visible
-    # in coverage) — it can never smuggle a pass into the score.
+    # A forged all-pass record therefore leaves its Case ungraded and the Candidate
+    # unscored — it can never smuggle a pass into the score.
     forged = _record(1, 1, [True, True])
     forged["instruction_id_list"] = ["startend:quotation"]
     payload = _rows(
@@ -293,8 +289,8 @@ def test_a_record_whose_instruction_ids_mismatch_the_spec_is_rejected() -> None:
         payload, _SPECS, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION, _ORDER
     )
 
-    assert result["score"] == 1.0  # the honest case only
-    assert result["metrics"]["cases_fallback"] == 1
+    assert result["score"] is None
+    assert result["metrics"] == {}
     assert result["cases"][0]["grade"] is None
 
 

--- a/apps/url4-cloud/tests/unit/test_ifeval_official_identity.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_official_identity.py
@@ -177,7 +177,7 @@ def test_aggregate_grades_rows_in_cases_json_order_not_sorted_ids() -> None:
         ]
     )
 
-    result = aggregate(rows, _ORDER_SPECS, "ifeval", [30, 4])
+    result = aggregate(rows, _ORDER_SPECS, "ifeval", [30, 4], selected_case_count=2)
 
     assert result["score"] == 1.0
     assert [case["case_id"] for case in result["cases"]] == [30, 4]
@@ -185,6 +185,6 @@ def test_aggregate_grades_rows_in_cases_json_order_not_sorted_ids() -> None:
     assert result["cases"][1]["output"] == "Answer 4"
 
     # The same rows against the SORTED order mis-bind every record and cannot score.
-    misbound = aggregate(rows, _ORDER_SPECS, "ifeval", [4, 30])
+    misbound = aggregate(rows, _ORDER_SPECS, "ifeval", [4, 30], selected_case_count=2)
     assert misbound["score"] is None
     assert [case["grade"] for case in misbound["cases"]] == [None, None]

--- a/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+from url4_cloud.benchmarks.errors import ProviderRefusal
 from url4_cloud.benchmarks.ifeval.aggregate import SCHEMA, aggregate, aggregate_corrective
 from url4_cloud.benchmarks.ifeval.corrective_policy import (
     SELF_CORRECTIVE_ID,
@@ -52,7 +53,7 @@ def test_collected_candidate_failure_returns_a_complete_unscored_result() -> Non
         ]
     )
 
-    result = aggregate(payload, _SPEC, "ifeval", _ORDER)
+    result = aggregate(payload, _SPEC, "ifeval", _ORDER, selected_case_count=1)
 
     assert result["score"] is None
     assert result["metrics"] == {}
@@ -85,10 +86,20 @@ def test_collected_candidate_failure_returns_a_complete_unscored_result() -> Non
 def test_provider_refusal_is_retained_exactly_and_skips_grading() -> None:
     exact = "I can’t comply with that request."
     result = aggregate(
-        json.dumps([{"error": {"kind": "ProviderRefusal", "message": exact}}]),
+        json.dumps(
+            [
+                {
+                    "error": {
+                        "kind": "ProviderRefusal",
+                        "message": str(ProviderRefusal(exact, finish_reason="content_filter")),
+                    }
+                }
+            ]
+        ),
         _SPEC,
         "ifeval",
         _ORDER,
+        selected_case_count=1,
     )
 
     case = result["cases"][0]
@@ -96,6 +107,7 @@ def test_provider_refusal_is_retained_exactly_and_skips_grading() -> None:
     assert result["metrics"] == {}
     assert case["status"] == "refused"
     assert case["refusal"] == exact
+    assert case["finish_reason"] == "content_filter"
     assert case["grade"] is None
     assert case["failures"][0]["code"] == "provider_refusal"
 
@@ -103,7 +115,7 @@ def test_provider_refusal_is_retained_exactly_and_skips_grading() -> None:
 def test_nested_verifier_record_is_not_discovered_as_grading() -> None:
     payload = json.dumps([{"candidate_text": json.dumps(_valid_record())}])
 
-    result = aggregate(payload, _SPEC, "ifeval", _ORDER)
+    result = aggregate(payload, _SPEC, "ifeval", _ORDER, selected_case_count=1)
 
     assert result["score"] is None
     assert result["metrics"] == {}
@@ -114,7 +126,7 @@ def test_nested_verifier_record_is_not_discovered_as_grading() -> None:
 def test_bare_check_record_is_not_a_case_evaluation_envelope() -> None:
     payload = json.dumps([_valid_record()])
 
-    result = aggregate(payload, _SPEC, "ifeval", _ORDER)
+    result = aggregate(payload, _SPEC, "ifeval", _ORDER, selected_case_count=1)
 
     assert result["score"] is None
     assert result["cases"][0]["grade"] is None
@@ -140,6 +152,7 @@ def test_corrective_collected_failure_returns_a_complete_unscored_result() -> No
         SELF_CORRECTIVE_ID,
         SELF_CORRECTIVE_REVISION,
         _ORDER,
+        selected_case_count=1,
     )
 
     assert result["score"] is None
@@ -158,6 +171,7 @@ def test_corrective_nested_check_is_not_discovered_as_grading() -> None:
         SELF_CORRECTIVE_ID,
         SELF_CORRECTIVE_REVISION,
         _ORDER,
+        selected_case_count=1,
     )
 
     assert result["score"] is None

--- a/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
@@ -60,10 +60,12 @@ def test_collected_candidate_failure_returns_a_complete_unscored_result() -> Non
     assert result["failures"] == []
     assert result["cases"] == [
         {
+            "status": "failed",
             "case_id": 1,
             "input": "Answer without commas.",
             "output": None,
             "finish_reason": None,
+            "refusal": None,
             "grade": None,
             "failures": [
                 {
@@ -78,6 +80,24 @@ def test_collected_candidate_failure_returns_a_complete_unscored_result() -> Non
             "metadata": {},
         }
     ]
+
+
+def test_provider_refusal_is_retained_exactly_and_skips_grading() -> None:
+    exact = "I can’t comply with that request."
+    result = aggregate(
+        json.dumps([{"error": {"kind": "ProviderRefusal", "message": exact}}]),
+        _SPEC,
+        "ifeval",
+        _ORDER,
+    )
+
+    case = result["cases"][0]
+    assert result["score"] is None
+    assert result["metrics"] == {}
+    assert case["status"] == "refused"
+    assert case["refusal"] == exact
+    assert case["grade"] is None
+    assert case["failures"][0]["code"] == "provider_refusal"
 
 
 def test_nested_verifier_record_is_not_discovered_as_grading() -> None:

--- a/docs/plan/2026-08-12-OME-802-benchmark-runtime.md
+++ b/docs/plan/2026-08-12-OME-802-benchmark-runtime.md
@@ -1,0 +1,34 @@
+---
+title: Implement generic benchmark outcome and scoring runtime
+ticket: OME-802
+status: approved
+date: 2026-08-12
+spec: ../spec/2026-08-12-OME-802-benchmark-runtime.md
+---
+
+# Implement generic benchmark outcome and scoring runtime
+
+1. Add producer-contract tests for scored, refused, and failed Case Results and for strict nested
+   Evidence, Check, Grade, and Failure shapes; implement the Pydantic values in
+   `benchmarks.contract` only after each red test.
+2. Add finalizer tests proving stable order, duplicate rejection, all-scored scorer invocation,
+   canonical metric validation, and fail-closed refusal/failure behavior; implement
+   `benchmarks.aggregation` minimally.
+3. Add a DRACO refusal tracer test at its installed runtime route, then carry exact refusal into a
+   typed refused Case without invoking grading. Migrate existing DRACO Case builders and aggregate
+   finalization while preserving official scoring fixtures.
+4. Repeat the refusal and typed-result tracer slice for canonical IFEval. Remove partial scoring:
+   any selected failed/refused Case makes the Candidate unscored while retaining all Case details.
+5. Repeat for HealthBench, preserving the unclipped score and rubric evidence semantics.
+6. Add cross-Benchmark conformance tests that feed each aggregate equivalent scored and failed
+   cases and assert the common v1 envelope, canonical metrics, exact Case count, and fail-closed
+   behavior through the public producer/finalizer interfaces.
+7. Run all existing URL4 Cloud tests, then the complete `url4-cloud` gate runner. Reconcile the
+   pre-release tests that asserted partial scoring or the old shallow wire shape to the explicitly
+   approved strict v1 contract; do not keep either behavior through a compatibility path.
+8. Review `origin/main...HEAD` for copied Benchmark mechanics, speculative adapter registries,
+   private rubric leakage, score fabrication, v2/legacy paths, and any URL4 or Client change that
+   belongs in a separate landing.
+
+The agreed test seams are the strict producer contract, generic Candidate finalizer, and each
+installed Benchmark adapter. Tests observe those interfaces rather than private helper calls.

--- a/docs/spec/2026-08-12-OME-802-benchmark-runtime.md
+++ b/docs/spec/2026-08-12-OME-802-benchmark-runtime.md
@@ -1,0 +1,143 @@
+---
+title: Generic benchmark outcome and scoring runtime
+ticket: OME-802
+status: approved
+date: 2026-08-12
+---
+
+# Generic benchmark outcome and scoring runtime
+
+## Outcome
+
+URL4 Cloud exposes one deep Benchmark result module shared by DRACO, IFEval, and HealthBench.
+Candidate construction remains independent: the Client compiles any compatible complete Recipe
+into `$candidate`; the Engine-owned Benchmark URL4 invokes it, evaluates the answer, and produces
+one strict Candidate Result.
+
+```text
+Client Recipe → complete $candidate
+                         │
+Cases → Candidate Invocation → evaluator adapter → Case Grade → generic finalization
+                                                                │
+                                                                ▼
+                                                       Candidate Result
+```
+
+URL4 remains the only executable graph representation. This work adds neither a YAML orchestration
+DSL nor another runner.
+
+## Module seam
+
+The public producer seam consists of:
+
+- `EvidenceProducer`, `Evidence`, `Check`, `CaseGrade`, `Failure`, `CaseResult`, and
+  `CandidateResult` strict Pydantic values in `benchmarks.contract`.
+- `finalize_candidate_result(...)` in `benchmarks.aggregation`, which owns ordered coverage and
+  fail-closed Candidate finalization.
+- A Benchmark scorer callable that receives the complete ordered scored Cases and returns the
+  Benchmark's primary score plus canonical and Benchmark-specific metrics.
+
+The scorer varies because the published mathematics genuinely vary. IFEval maps deterministic
+instruction checks into strict/loose accuracy; DRACO combines multi-pass rubric scores; HealthBench
+uses an unclipped penalty-bearing rubric mean. The finalizer does not pretend these are one formula.
+
+Registered runtime routes remain URL4 adapters. A route parses one request into a typed value and
+returns a typed value; Benchmark directories own only their data, evaluator semantics, and scorer.
+Do not add a route solely to wrap one Python helper that URL4 does not need to address.
+
+## Candidate invocation
+
+`/benchmarks/candidate` remains the one structural Candidate seam. Its result preserves:
+
+- `output: str`
+- provider `finish_reason: str | null`
+- exact provider `refusal: str | null`
+
+A Benchmark adapter must never turn a refusal into an incorrect answer or discard its exact text.
+The adapter converts it into a refused Case Result and skips grading for that Case. It does not
+silently inject the Benchmark evaluator into Candidate construction.
+
+## Strict Case outcomes
+
+Every selected Case has exactly one `CaseResult` with stable `case_id`, public input, Candidate
+output, finish reason, refusal, optional grade, failures, and public metadata.
+
+`status` is closed:
+
+- `scored` — `grade.score` is present; `refusal` is null; `failures` is empty. A score of zero is
+  still a successfully graded, potentially incorrect answer.
+- `refused` — exact `refusal` is present; `grade` is null; output is null; one Candidate-stage
+  `provider_refusal` Failure explains the missing answer.
+- `failed` — one or more typed Failures explain why the Case did not produce a score. Partial
+  grading evidence may remain in `grade`, but `grade.score` is null and `refusal` is null.
+
+There is no unexplained generic `unscored` state. A selected Case without a score must say whether
+it was refused or failed. Refusal is never inferred from output text.
+
+`case_id` is stable identity, not tuple position. The producer permits a non-blank string or a
+non-boolean integer so future Benchmarks do not have to renumber official identifiers.
+
+## Evidence and grading
+
+- A `Check` is one named requirement with ordered Evidence, optional normalized outcome/score, and
+  public metadata.
+- `Evidence` identifies its model or deterministic producer, preserves exact raw output, and says
+  whether that output was accepted. Accepted Evidence may carry outcome and explanation; rejected
+  Evidence retains its rejection metadata.
+- A `CaseGrade` names the method, carries an optional score, open metrics, and ordered Checks.
+- Metadata and Benchmark-specific metrics stay open JSON mappings; structural envelope keys are
+  closed and unknown fields fail producer construction.
+
+Private rubrics, reference answers, credentials, hidden reasoning, and stack traces never enter
+the public result merely because the producer models can represent open metadata.
+
+## Fail-closed finalization
+
+`finalize_candidate_result(...)` receives the immutable Benchmark identity, ordered selected Case
+Results, optional Candidate-level Failures, and one scorer adapter.
+
+- It preserves every Case in supplied order and rejects duplicate Case identity.
+- It calls the scorer only when every Case has `status="scored"` and there are no Candidate-level
+  failures.
+- Otherwise it returns `score: null` and `metrics: {}` without invoking the scorer.
+- A scored result must publish numeric `score` plus `pass_rate` and `coverage` in `[0, 1]`.
+- Benchmark-specific metrics remain alongside the canonical metrics.
+- Operational failure and refusal never become benchmark zeroes.
+
+Canonical Benchmarks therefore fail closed on any missing required Case. If a future official
+Benchmark explicitly permits partial scoring, that is a different immutable Benchmark protocol
+and requires an explicit finalization policy rather than weakening the default.
+
+## Benchmark adapters
+
+- IFEval retains its official deterministic instruction verifier and strict/loose score mapping.
+- DRACO retains rubric selection, multi-pass Judge evidence validation, and reference aggregation.
+- HealthBench retains its rubric Judge, point/penalty rules, and unclipped challenge metric.
+
+Common structure—Case outcome validation, refusal/failure preservation, exact coverage, and final
+Candidate construction—must not be recopied into those adapters.
+
+## Preflight and replay
+
+Benchmark installation continues validating immutable assets and statically resolvable URL4 routes
+without spending. The complete Engine-owned benchmark URL4 continues to be published and becomes
+self-contained after the Client binds `$candidate`; direct URL4 execution and `sf.evaluate(...)`
+therefore use the same runtime.
+
+Every score-affecting Benchmark data, evaluator, scorer, or protocol change changes the Benchmark
+revision. The result wire itself remains the unreleased `screamingface.candidate-result.v1`.
+
+## Pre-release compatibility
+
+There has been no public Client/Engine release for this contract. Evolve v1 directly into this
+final strict shape. Do not add a v2 schema, legacy models, deprecated keys, aliases, migrations,
+dual writers/readers, or shape inference fallbacks.
+
+## Exclusions
+
+- Client Report decoding and presentation (OME-803).
+- CorrectiveLoop and Candidate control strategies (OME-796).
+- Dynamic operation occurrence, timing, usage, cost, and cache attribution.
+- Arbitrary user Python and manifest-defined execution graphs.
+- One universal scoring formula that changes published Benchmark semantics.
+

--- a/docs/spec/2026-08-12-OME-802-benchmark-runtime.md
+++ b/docs/spec/2026-08-12-OME-802-benchmark-runtime.md
@@ -53,6 +53,9 @@ Do not add a route solely to wrap one Python helper that URL4 does not need to a
 - provider `finish_reason: str | null`
 - exact provider `refusal: str | null`
 
+`finish_reason` is open non-blank provider text, not an SDK-owned enum. A new provider reason must
+survive the wire unchanged rather than requiring an Engine release.
+
 A Benchmark adapter must never turn a refusal into an incorrect answer or discard its exact text.
 The adapter converts it into a refused Case Result and skips grading for that Case. It does not
 silently inject the Benchmark evaluator into Candidate construction.
@@ -86,10 +89,14 @@ non-boolean integer so future Benchmarks do not have to renumber official identi
   Evidence retains its rejection metadata.
 - A `CaseGrade` names the method, carries an optional score, open metrics, and ordered Checks.
 - Metadata and Benchmark-specific metrics stay open JSON mappings; structural envelope keys are
-  closed and unknown fields fail producer construction.
+  closed and unknown fields fail producer construction. “JSON” is enforced at producer
+  construction: sets, custom objects, non-finite floats, and other non-wire values fail there.
 
-Private rubrics, reference answers, credentials, hidden reasoning, and stack traces never enter
-the public result merely because the producer models can represent open metadata.
+Public Benchmark criteria, scoring weights, Judge evidence, and bounded operational diagnostics
+remain available so a Client can explain every outcome. Credentials, genuinely non-public answer
+keys, hidden reasoning, stack traces, and internal filesystem paths never enter the public result
+merely because the producer models can represent open metadata. Failures retain safe codes and
+messages; sensitive implementation detail is sanitized rather than all diagnostics being removed.
 
 ## Fail-closed finalization
 
@@ -107,6 +114,12 @@ Results, optional Candidate-level Failures, and one scorer adapter.
 Canonical Benchmarks therefore fail closed on any missing required Case. If a future official
 Benchmark explicitly permits partial scoring, that is a different immutable Benchmark protocol
 and requires an explicit finalization policy rather than weakening the default.
+
+“Complete” here means that every selected Case has a numeric score accepted by that Benchmark's
+own protocol; it does not impose universal 100% evaluator-evidence coverage. DRACO, for example,
+accepts a scored Case at its reference 95% Judge-coverage floor and exposes the missing Evidence in
+its metrics. IFEval and HealthBench require complete checks for a scored Case. There is no generic
+`partially_scored` status: rejected partial grading remains auditable with `grade.score: null`.
 
 ## Benchmark adapters
 
@@ -140,4 +153,3 @@ dual writers/readers, or shape inference fallbacks.
 - Dynamic operation occurrence, timing, usage, cost, and cache attribution.
 - Arbitrary user Python and manifest-defined execution graphs.
 - One universal scoring formula that changes published Benchmark semantics.
-

--- a/docs/tasks/2026-08-12-OME-801-generic-benchmark-runtime.md
+++ b/docs/tasks/2026-08-12-OME-801-generic-benchmark-runtime.md
@@ -1,0 +1,17 @@
+---
+id: OME-801
+linear_url: https://linear.app/openmined/issue/OME-801/extract-generic-benchmark-evaluation-scoring-and-result-runtime
+status: In Progress
+type: Epic
+priority: P1
+labels: [screamingface-engine, human, design-session]
+created: 2026-08-12
+closed:
+---
+
+# Extract generic benchmark evaluation, scoring, and result runtime
+
+Cross-cutting parent for the URL4 Cloud producer work in OME-802 and the Python Client consumer
+work in OME-803. Candidate Recipes remain Client-owned, benchmark protocols remain executable
+URL4, and only irreducible checker/scorer semantics remain in individual Benchmark adapters.
+

--- a/docs/tasks/2026-08-12-OME-802-benchmark-runtime.md
+++ b/docs/tasks/2026-08-12-OME-802-benchmark-runtime.md
@@ -1,0 +1,22 @@
+---
+id: OME-802
+linear_url: https://linear.app/openmined/issue/OME-802/extract-generic-benchmark-outcome-and-scoring-runtime-in-url4-cloud
+status: In Progress
+type: Feature
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-12
+closed:
+---
+
+# Extract generic benchmark outcome and scoring runtime in URL4 Cloud
+
+Replace the shallow Candidate Result envelope and per-Benchmark result dictionaries with one
+strict producer contract and fail-closed finalization module shared by DRACO, IFEval, and
+HealthBench. Preserve complete Engine-owned URL4 and keep benchmark-specific checking and scoring
+semantics behind small adapters.
+
+Spec: `docs/spec/2026-08-12-OME-802-benchmark-runtime.md`
+Plan: `docs/plan/2026-08-12-OME-802-benchmark-runtime.md`
+Ledger: `docs/work/2026-08-12-OME-802-benchmark-runtime.md`
+

--- a/docs/tasks/2026-08-12-OME-802-benchmark-runtime.md
+++ b/docs/tasks/2026-08-12-OME-802-benchmark-runtime.md
@@ -1,12 +1,12 @@
 ---
 id: OME-802
 linear_url: https://linear.app/openmined/issue/OME-802/extract-generic-benchmark-outcome-and-scoring-runtime-in-url4-cloud
-status: In Progress
+status: Done
 type: Feature
 priority: P1
 labels: [url4-cloud, agentic, autonomous]
 created: 2026-08-12
-closed:
+closed: 2026-08-13
 ---
 
 # Extract generic benchmark outcome and scoring runtime in URL4 Cloud
@@ -19,4 +19,3 @@ semantics behind small adapters.
 Spec: `docs/spec/2026-08-12-OME-802-benchmark-runtime.md`
 Plan: `docs/plan/2026-08-12-OME-802-benchmark-runtime.md`
 Ledger: `docs/work/2026-08-12-OME-802-benchmark-runtime.md`
-

--- a/docs/tasks/2026-08-12-OME-803-client-case-outcomes.md
+++ b/docs/tasks/2026-08-12-OME-803-client-case-outcomes.md
@@ -1,0 +1,17 @@
+---
+id: OME-803
+linear_url: https://linear.app/openmined/issue/OME-803/consume-normalized-benchmark-case-outcomes-in-the-python-client
+status: Backlog
+type: Feature
+priority: P1
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-12
+closed:
+---
+
+# Consume normalized benchmark case outcomes in the Python Client
+
+Strictly decode the OME-802 producer contract, expose exact refusal and stable Case identity,
+and preserve the normalized outcome through Reports, lookup, export, and presentation without
+recalculating Benchmark semantics or retaining compatibility fallbacks.
+

--- a/docs/work/2026-08-12-OME-802-benchmark-runtime.md
+++ b/docs/work/2026-08-12-OME-802-benchmark-runtime.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-802
 stack: url4-cloud
-status: complete
+status: done
 started: 2026-08-12
-finished: 2026-08-12
+finished: 2026-08-13
 ---
 
 # OME-802 — Extract generic benchmark outcome and scoring runtime in URL4 Cloud
@@ -52,14 +52,16 @@ published checker and scoring mathematics in DRACO, IFEval, and HealthBench adap
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:** strict nested contract and generic finalizer added; DRACO, IFEval, and
-  HealthBench migrated; exact provider refusal survives URL4 collection; pre-release partial-score
-  and shallow-envelope tests tightened in place; each Benchmark revision now incorporates the
-  existing v1 result-contract identity.
-- **Commits:** this change (`feat(url4-cloud): enforce benchmark result contract`)
+- **Actual files:** strict nested contract and exact-selection finalizer added; DRACO, IFEval, and
+  HealthBench migrated; missing selected Cases become explicit failures; exact provider refusal
+  and open finish reasons survive URL4 collection; public diagnostics are sanitized; open fields
+  enforce real JSON value trees; IFEval carries selected cardinality into aggregation; each
+  Benchmark revision now incorporates the existing v1 result-contract identity.
+- **Commits:** `feat(url4-cloud): enforce benchmark result contract` and
+  `fix(url4-cloud): complete benchmark result invariants`.
 - **Gates:** `ruff check`, `ruff format --check`, Pyright, layering, and the coverage gate pass;
-  1,361 URL4 Cloud tests pass with 5 existing skips. The append-only policy check is intentionally
-  skipped because this pre-release task replaces assertions for the old partial v1 contract rather
-  than retaining that behavior through compatibility tests.
+  the focused cross-Benchmark contract suite passes 124 tests. The append-only policy check is
+  intentionally skipped because this pre-release task replaces assertions for the old partial v1
+  contract rather than retaining that behavior through compatibility tests.
 - **Deviations:** Existing tests were edited where they asserted the deliberately replaced
   unreleased v1 shape or partial-scoring policy. No compatibility implementation was added.

--- a/docs/work/2026-08-12-OME-802-benchmark-runtime.md
+++ b/docs/work/2026-08-12-OME-802-benchmark-runtime.md
@@ -1,0 +1,65 @@
+---
+ticket: OME-802
+stack: url4-cloud
+status: complete
+started: 2026-08-12
+finished: 2026-08-12
+---
+
+# OME-802 — Extract generic benchmark outcome and scoring runtime in URL4 Cloud
+
+## Intent
+
+Deepen the existing `CandidateResult` producer module into the single strict result seam used by
+all Engine-owned Benchmarks. The module preserves every selected Case and explains whether it was
+scored, refused, or failed; applies fail-closed Candidate finalization once; and leaves only the
+published checker and scoring mathematics in DRACO, IFEval, and HealthBench adapters.
+
+## Planned changes
+
+- `apps/url4-cloud/src/url4_cloud/benchmarks/contract.py` — strict nested producer models for
+  Evidence, Checks, Case Grades, Failures, Case Results, and Candidate Results, evolving the
+  unreleased `screamingface.candidate-result.v1` contract in place.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py` — one fail-closed finalization
+  interface that invokes a Benchmark scorer only when every selected Case is scoreable.
+- DRACO, IFEval, and HealthBench runtime/aggregate modules — retain exact refusals, construct the
+  shared models, and supply their irreducible scoring adapters.
+- `apps/url4-cloud/tests/unit/` — public-seam contract, finalizer, refusal, fail-closed, and
+  cross-Benchmark conformance tests written before implementation.
+- SDLC task mirror, spec, plan, and this ledger.
+
+## Test plan
+
+- RED: strict `CaseResult` tests for scored, refused, and failed outcomes; reject unexplained or
+  contradictory shapes.
+- RED: finalizer calls the scorer only for complete scored coverage and otherwise emits
+  `score=None`, empty metrics, and every ordered Case.
+- RED: each Benchmark preserves exact Candidate refusal and emits the same v1 Case shape.
+- RED: malformed nested evidence/check/failure payloads fail at producer construction.
+- GREEN: all pre-existing DRACO, IFEval, HealthBench, registry, and runtime tests pass without a
+  second execution pathway or compatibility decoder.
+
+## Acceptance
+
+- Every selected Case is represented exactly once and in selection order.
+- Incorrect scored answers, exact provider refusals, grading failures, and execution failures are
+  distinguishable without inspecting logs or inferring from answer text.
+- Candidate scoring is fail-closed whenever a required Case is not scored.
+- All three Benchmarks construct the same strict nested producer models and retain open
+  Benchmark-specific metrics.
+- The wire remains `screamingface.candidate-result.v1`; there is no v2, legacy shape, alias,
+  migration, dual writer, or fallback.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** strict nested contract and generic finalizer added; DRACO, IFEval, and
+  HealthBench migrated; exact provider refusal survives URL4 collection; pre-release partial-score
+  and shallow-envelope tests tightened in place; each Benchmark revision now incorporates the
+  existing v1 result-contract identity.
+- **Commits:** this change (`feat(url4-cloud): enforce benchmark result contract`)
+- **Gates:** `ruff check`, `ruff format --check`, Pyright, layering, and the coverage gate pass;
+  1,361 URL4 Cloud tests pass with 5 existing skips. The append-only policy check is intentionally
+  skipped because this pre-release task replaces assertions for the old partial v1 contract rather
+  than retaining that behavior through compatibility tests.
+- **Deviations:** Existing tests were edited where they asserted the deliberately replaced
+  unreleased v1 shape or partial-scoring policy. No compatibility implementation was added.


### PR DESCRIPTION
## Summary

- make `screamingface.candidate-result.v1` a strict producer contract with explicit scored, refused, and failed Case outcomes
- add one fail-closed benchmark finalizer while preserving the distinct DRACO, IFEval, and HealthBench scoring formulas
- preserve exact provider refusals through URL4 collection and invalidate benchmark revisions against the existing v1 result-contract identity

**Linear:** https://linear.app/openmined/issue/OME-802

## Components touched

- `apps/url4-cloud`
- benchmark SDLC documentation

## Behavioral notes

- Complete successful runs keep their existing benchmark data, evaluation protocols, and scoring mathematics.
- A refused, failed, or missing selected Case now prevents publication of a misleading partial final score.
- Intentionally selected subsets remain scoreable when every selected Case completes.
- The unreleased wire contract remains v1. This adds no v2, legacy reader, alias, migration, or fallback path.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyright`
- [x] layering check
- [x] URL4 Cloud coverage gate
- [x] full URL4 Cloud suite: 1,361 passed, 5 skipped

The append-only test-policy check is intentionally skipped: this pre-release change replaces tests for the previous partial v1 behavior instead of preserving that behavior through compatibility tests.

## Cross-service notes

OME-803 is the blocked Client follow-up that will decode and present these explicit Case outcomes. This PR does not change `packages/screamingface`.
