### PR TITLE
feat(screamingface): consume normalized benchmark case outcomes (OME-803)

### DIFF
--- a/docs/plan/2026-08-13-OME-803-client-case-outcomes.md
+++ b/docs/plan/2026-08-13-OME-803-client-case-outcomes.md
@@ -1,0 +1,30 @@
+---
+title: Implement normalized benchmark Case outcome consumption
+ticket: OME-803
+status: approved
+date: 2026-08-13
+spec: ../spec/2026-08-13-OME-803-client-case-outcomes.md
+---
+
+# Implement normalized benchmark Case outcome consumption
+
+1. Pin scored, refused, and failed payloads for DRACO, IFEval, and HealthBench with strict decoding
+   tests, including every missing Case field, unsupported values, and exact round-trip export.
+2. Extend the public Case value with stable string/integer identity, explicit status/refusal, and
+   the OME-802 structural invariants. Keep direct-construction status inference separate from the
+   strict wire decoder.
+3. Decode nested Failure values against the exact producer field set and reject malformed or
+   misplaced Case identities before a Report is constructed.
+4. Preserve outcomes through Candidate Result and Report JSON/file export; add explicit `.by_id()`
+   lookup so integer identity is never confused with positional indexing.
+5. Render scored, refused, failed, and partial-evidence unscored Cases as distinct states. Surface
+   exact refusal and Failure evidence, group repeated diagnoses, and escape untrusted text.
+6. Exercise a normal evaluation vertical slice and assert the URL4 recorded in the Report is the
+   exact expression submitted to the run transport.
+7. Run the complete `screamingface` unit suite, Ruff check/format, Pyright, distribution/notebook
+   checks, and the repository gate. Document the necessary append-only exception: inherited wire
+   fixtures gain the mandatory OME-802 fields; existing boundary, serialization, presentation,
+   and vertical-slice tests change where their former expectations contradict the new strict
+   contract or must prove the newly required behavior. No assertion is removed to weaken coverage.
+8. Re-run Standards and Spec review, fix material findings, then update the ledger and PR #574 for
+   review against `main`.

--- a/docs/spec/2026-08-13-OME-803-client-case-outcomes.md
+++ b/docs/spec/2026-08-13-OME-803-client-case-outcomes.md
@@ -1,0 +1,93 @@
+---
+title: Consume normalized benchmark Case outcomes in the Python Client
+ticket: OME-803
+status: approved
+date: 2026-08-13
+---
+
+# Consume normalized benchmark Case outcomes in the Python Client
+
+## Outcome
+
+The Python Client consumes the strict `screamingface.candidate-result.v1` contract produced by
+OME-802 without re-deriving Benchmark semantics. Every selected Case keeps its stable identity,
+explicit outcome, exact provider refusal, partial grading evidence, and typed failure diagnostics
+through decoding, lookup, report export, and notebook presentation.
+
+The Engine remains the source of truth for Benchmark outcomes. The Client validates an untrusted
+wire and presents it; it does not decide whether an answer passed a Benchmark.
+
+## Wire boundary
+
+Every decoded Case requires exactly these nine fields:
+
+- `case_id`
+- `input`
+- `output`
+- `finish_reason`
+- `grade`
+- `failures`
+- `metadata`
+- `status`
+- `refusal`
+
+Unknown or missing fields fail with `ExecutionError`. `case_id` accepts a non-blank string or a
+non-boolean integer because it is Benchmark identity, not a sequence offset. `status` is one of
+`scored`, `refused`, or `failed`.
+
+Nested Failure values consume the OME-802 wire exactly: `stage`, `code`, `message`, `retryable`,
+`case_id`, and `metadata`. Candidate-level failures cannot claim a Case identity. No legacy wire
+shape, alias, or inference fallback is accepted.
+
+Nested Case Grade, Check, Evidence, and Evidence Producer values also mirror the producer's closed
+fields, numeric bounds, outcome vocabularies, and open non-empty producer type. Exact wire text is
+preserved; validation never trims identifiers, explanations, refusal text, or failure messages.
+
+## Public Case values
+
+`sf.CaseResult` exposes `status` and `refusal`, preserves string and integer Case identifiers, and
+serializes the complete outcome losslessly. Direct Python construction may omit `status`; the
+constructor derives it only to keep ordinary value authoring concise. This convenience is not a
+wire compatibility path: the result decoder always requires the explicit Engine field.
+
+The Client mirrors the current OME-802 structural invariants:
+
+- `scored` has an output and numeric grade, with no refusal or failures.
+- `refused` has exact refusal text, no output or grade, and exactly one Candidate-stage
+  `provider_refusal` Failure.
+- `failed` has one or more Failures, no refusal or numeric grade, and may retain a grade whose
+  score is null as partial grading evidence.
+
+The OME-807 scoring-policy change is deliberately separate. When that producer contract lands,
+the consumer and its tests change together rather than anticipating two accepted wire meanings.
+
+## Case collection and export
+
+`CandidateResult.cases` remains an ordered immutable sequence. Position and identity are distinct:
+callers use `.by_id(case_id)` for explicit identifier lookup, avoiding ambiguity when integer Case
+identifiers overlap sequence indexes.
+
+`CaseResult.to_dict()`, Candidate Result serialization, `Report.to_dict()`, and file export retain
+the same outcome fields and nested Failure evidence. An evaluate transport returns the exact URL4
+expression it was given; the Report preserves that expression unchanged for replay and audit.
+
+## Presentation
+
+The report widget trusts the explicit Case status:
+
+- scored Cases render as correct or incorrect using their already-normalized grade/checks;
+- refused Cases render a warning state and the exact provider refusal;
+- failed Cases render a warning state and their typed failure chain;
+- failed Cases carrying partial grading evidence render as `unscored`, never `incorrect`.
+
+Failure summaries name affected Case identifiers and group identical diagnoses while a disclosure
+retains each exact Failure payload. Candidate scores withheld by the current fail-closed producer
+say why instead of showing unexplained dashes. All Engine/provider text remains HTML-escaped.
+
+## Exclusions
+
+- Changing Engine aggregation or the OME-807 failure taxonomy.
+- Per-operation outputs, attempt traces, request parameters, or correlation IDs (OME-784).
+- Rich per-turn conversation expansion (OME-794).
+- Benchmark-specific scoring or refusal inference in the Client.
+- Compatibility readers for pre-release result shapes.

--- a/docs/tasks/2026-08-12-OME-803-client-case-outcomes.md
+++ b/docs/tasks/2026-08-12-OME-803-client-case-outcomes.md
@@ -1,7 +1,7 @@
 ---
 id: OME-803
 linear_url: https://linear.app/openmined/issue/OME-803/consume-normalized-benchmark-case-outcomes-in-the-python-client
-status: Backlog
+status: Pick Immediately
 type: Feature
 priority: P1
 labels: [py-screamingface, agentic, autonomous]
@@ -14,4 +14,3 @@ closed:
 Strictly decode the OME-802 producer contract, expose exact refusal and stable Case identity,
 and preserve the normalized outcome through Reports, lookup, export, and presentation without
 recalculating Benchmark semantics or retaining compatibility fallbacks.
-

--- a/docs/work/2026-08-13-OME-803-client-case-outcomes.md
+++ b/docs/work/2026-08-13-OME-803-client-case-outcomes.md
@@ -56,3 +56,16 @@ export — without recalculating Benchmark semantics.
   on touched files
 - **Deviations:** string `case_id` support (contract's `CaseId = StrictInt | StrictStr`)
   deferred — every engine producer emits ints today; noted as PR follow-up.
+
+## Review fix (same unit, pre-merge)
+
+PR #574 review finding: `_resolve_case_status` mirrored the engine's outcome-shape rules
+only for the scored leg. A locally built refused `sf.CaseResult` could carry `output`
+(or an unscored grade) — shapes `contract.py::_enforce_status` rejects, so a client
+value could round-trip into a contract-invalid payload.
+
+- Planned: guard the refused leg in `_resolve_case_status` (refused ⇒ no output, no
+  grade); RED tests in `tests/test_case_outcome_decoding.py` first.
+- Outcome: guards added (`output` now passed into `_resolve_case_status`); two new
+  tests (`test_a_refused_case_cannot_carry_output`,
+  `test_a_refused_case_cannot_carry_a_grade`); full suite + gates green.

--- a/docs/work/2026-08-13-OME-803-client-case-outcomes.md
+++ b/docs/work/2026-08-13-OME-803-client-case-outcomes.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-803
-stack: py-screamingface
-status: done
+stack: screamingface
+status: in_progress
 started: 2026-08-13
-finished: 2026-08-13
+finished:
 ---
 
 # OME-803 — Consume normalized benchmark case outcomes in the Python Client
@@ -20,25 +20,22 @@ export — without recalculating Benchmark semantics.
 
 ## Planned changes
 
-- `packages/screamingface/src/screamingface/case_result.py` — `CaseStatus` type; `status`
-  and `refusal` fields on `CaseResult` (derived when omitted, validated when given);
-  `to_dict()` includes both.
-- `packages/screamingface/src/screamingface/_evaluation/results.py` — `_case_result`
-  required key set gains `status` and `refusal`; new `_case_status` literal decoder.
-- Tests: new `tests/test_case_outcome_decoding.py`; updated wire fixtures in
-  `tests/test_draco_vertical_slice.py`, `tests/test_benchmark_compilation.py`,
-  `tests/test_benchmark_variant_selection.py`, `tests/test_client_run.py`,
-  `tests/test_case_result_contract_boundaries.py`, `tests/test_case_results.py`.
+- Strictly consume all nine OME-802 Case fields and the exact nested Failure wire.
+- Preserve explicit outcomes, exact text, and string/integer Case identity in public values,
+  `.by_id()` lookup, Report serialization, file export, and the submitted URL4 receipt.
+- Present scored, refused, failed, and partial-evidence unscored Cases distinctly, including exact
+  refusal/failure detail and a reason whenever a Candidate score is withheld.
+- Pin the shared contract with DRACO, IFEval, and HealthBench fixtures plus renderer and vertical
+  slice coverage.
 
 ## Test plan
 
-- RED: `_case_result` decodes scored / refused / failed payloads carrying the new keys;
-  `status` and `refusal` are exposed on the decoded object and in `to_dict()`.
-- RED: missing `status` or `refusal` → `ExecutionError`; unsupported status text →
-  `ExecutionError`; genuinely unknown keys still rejected (strict posture kept).
-- Constructor invariants: explicit status must match the grade/refusal/failure shape;
-  a scored Case cannot carry refusal text.
-- All existing suite green after fixture updates (production decode paths only).
+- Every outcome and Benchmark family decodes and round-trips through one contract.
+- Every missing structural key, unknown key/status, malformed nested Failure, mismatched Case
+  identity, and contradictory outcome shape fails before presentation.
+- String and zero-valued Case identifiers, exact whitespace-bearing wire text, ID lookup, report
+  JSON/file export, status-driven widgets, and exact submitted URL4 preservation are covered.
+- Complete `screamingface` gates green.
 
 ## Acceptance
 
@@ -46,26 +43,23 @@ export — without recalculating Benchmark semantics.
 - Decoder required key set is byte-for-byte the CaseResult field set of
   `url4_cloud/benchmarks/contract.py` at #572 head (all nine keys unconditional).
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome (ready for review; close after merge)
 
-- **Actual files:** as planned (`case_result.py`, `_evaluation/results.py`, six test
-  files touched, one new test file).
-- **Commits:** feat(screamingface): decode Case status and refusal from
-  candidate-result.v1 (sha in PR)
-- **Gates:** 717 passed, 1 skipped; ruff check + format clean; pyright 0 errors
-  on touched files
-- **Deviations:** string `case_id` support (contract's `CaseId = StrictInt | StrictStr`)
-  deferred — every engine producer emits ints today; noted as PR follow-up.
-
-## Review fix (same unit, pre-merge)
-
-PR #574 review finding: `_resolve_case_status` mirrored the engine's outcome-shape rules
-only for the scored leg. A locally built refused `sf.CaseResult` could carry `output`
-(or an unscored grade) — shapes `contract.py::_enforce_status` rejects, so a client
-value could round-trip into a contract-invalid payload.
-
-- Planned: guard the refused leg in `_resolve_case_status` (refused ⇒ no output, no
-  grade); RED tests in `tests/test_case_outcome_decoding.py` first.
-- Outcome: guards added (`output` now passed into `_resolve_case_status`); two new
-  tests (`test_a_refused_case_cannot_carry_output`,
-  `test_a_refused_case_cannot_carry_a_grade`); full suite + gates green.
+- **Production:** strict Case/Failure decoding; shared exact-preserving Case identity validation;
+  public `CaseResult.status`/`refusal`; explicit `.cases.by_id()`; lossless Report export; and
+  status-driven refused/failed/unscored presentation with complete Failure disclosures.
+- **Tests:** three Benchmark-family contract fixtures, every Case key required, exact text/ID
+  round-trips, outcome invariants, lookup/export, UI states, withheld-score explanations, and a
+  normal evaluation receipt proving `result.url4` equals the submitted transport expression.
+- **Current verification:** 742 passed, 1 skipped; Ruff check/format, Pyright, ≥95% coverage,
+  notebook consistency, package build, and distribution inspection are all green.
+- **Append-only exception:** the gate is run with `--skip-append-only`. Existing contract fixtures
+  must add mandatory `status`/`refusal`; inherited boundary/serialization tests must adopt the
+  required full Failure shape and string IDs; the obsolete Client-only snake-case Failure-code
+  restriction is replaced by a positive test of the Engine's open non-empty contract; report tests
+  assert explicit outcome semantics; and the vertical slice records the exact submitted URL4.
+  These are contract migrations and new positive assertions, not removals that weaken coverage.
+- **Process deviation:** Khoa's initial three implementation commits existed before the branch had
+  OME-803 spec/plan files. The user had explicitly approved the design and implementation in the
+  working conversation; the missing repository artifacts were added during review. This is
+  disclosed rather than rewriting history to imply a chronology that did not occur.

--- a/docs/work/2026-08-13-OME-803-client-case-outcomes.md
+++ b/docs/work/2026-08-13-OME-803-client-case-outcomes.md
@@ -1,0 +1,58 @@
+---
+ticket: OME-803
+stack: py-screamingface
+status: done
+started: 2026-08-13
+finished: 2026-08-13
+---
+
+# OME-803 — Consume normalized benchmark case outcomes in the Python Client
+
+## Intent
+
+PR #572 (OME-802) makes every Case Result on the `screamingface.candidate-result.v1`
+wire carry explicit `status` (scored | refused | failed) and `refusal` keys. The client
+decoder enumerates an exact key set and raises `ExecutionError` on unknown keys, so every
+`sf.evaluate` decode fails against a #572 engine. This unit teaches the client the new
+contract: decode the two keys strictly (mirroring `apps/url4-cloud/src/url4_cloud/benchmarks/contract.py`),
+expose `status` and `refusal` on `sf.CaseResult`, and preserve them through `to_dict()`
+export — without recalculating Benchmark semantics.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/case_result.py` — `CaseStatus` type; `status`
+  and `refusal` fields on `CaseResult` (derived when omitted, validated when given);
+  `to_dict()` includes both.
+- `packages/screamingface/src/screamingface/_evaluation/results.py` — `_case_result`
+  required key set gains `status` and `refusal`; new `_case_status` literal decoder.
+- Tests: new `tests/test_case_outcome_decoding.py`; updated wire fixtures in
+  `tests/test_draco_vertical_slice.py`, `tests/test_benchmark_compilation.py`,
+  `tests/test_benchmark_variant_selection.py`, `tests/test_client_run.py`,
+  `tests/test_case_result_contract_boundaries.py`, `tests/test_case_results.py`.
+
+## Test plan
+
+- RED: `_case_result` decodes scored / refused / failed payloads carrying the new keys;
+  `status` and `refusal` are exposed on the decoded object and in `to_dict()`.
+- RED: missing `status` or `refusal` → `ExecutionError`; unsupported status text →
+  `ExecutionError`; genuinely unknown keys still rejected (strict posture kept).
+- Constructor invariants: explicit status must match the grade/refusal/failure shape;
+  a scored Case cannot carry refusal text.
+- All existing suite green after fixture updates (production decode paths only).
+
+## Acceptance
+
+- `uv run pytest -q` green in `packages/screamingface`.
+- Decoder required key set is byte-for-byte the CaseResult field set of
+  `url4_cloud/benchmarks/contract.py` at #572 head (all nine keys unconditional).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned (`case_result.py`, `_evaluation/results.py`, six test
+  files touched, one new test file).
+- **Commits:** feat(screamingface): decode Case status and refusal from
+  candidate-result.v1 (sha in PR)
+- **Gates:** 717 passed, 1 skipped; ruff check + format clean; pyright 0 errors
+  on touched files
+- **Deviations:** string `case_id` support (contract's `CaseId = StrictInt | StrictStr`)
+  deferred — every engine producer emits ints today; noted as PR follow-up.

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 import json
 import warnings
 from collections.abc import Mapping, Sequence
-from typing import Literal
+from typing import Literal, cast
 
 from screamingface._core.ports import _RunOutcome
 from screamingface._evaluation.model import Candidate, _compiled_evaluation, _Evaluation
+from screamingface._report_primitives import CaseId
+from screamingface._report_primitives import _case_id as _validate_case_id
+from screamingface.case_result import CaseStatus
 from screamingface.discovery import BenchmarkInfo
 from screamingface.errors import ExecutionError
 from screamingface.report import (
@@ -78,42 +81,13 @@ def _candidate_result(
     candidate: Candidate,
     outcome: _RunOutcome,
 ) -> CandidateResult:
+    value = _candidate_payload(evaluation, outcome)
     try:
-        payload = json.loads(outcome.result_body)
-    except json.JSONDecodeError as exc:
-        raise ExecutionError("SF Engine Candidate result must be JSON") from exc
-    value = _mapping(payload, "Candidate result")
-    _keys(
-        value,
-        required={
-            "schema",
-            "benchmark_id",
-            "benchmark_revision",
-            "case_count",
-            "score",
-            "metrics",
-            "cases",
-            "failures",
-        },
-        label="Candidate result",
-    )
-    if value.get("schema") != "screamingface.candidate-result.v1":
-        raise ExecutionError("SF Engine Candidate result schema is unsupported")
-    if value.get("benchmark_id") != evaluation.benchmark.id:
-        raise ExecutionError("SF Engine Candidate result has the wrong Benchmark id")
-    if value.get("benchmark_revision") != evaluation.benchmark.revision:
-        raise ExecutionError("SF Engine Candidate result has the wrong Benchmark revision")
-    if _positive_integer(value.get("case_count"), "Candidate case_count") != evaluation.case_count:
-        raise ExecutionError("SF Engine Candidate result has the wrong case count")
-    score_value = value.get("score")
-    score = None if score_value is None else _number(score_value, "Candidate score")
-    metrics = _metrics(value.get("metrics"))
-    _warn_on_coverage(candidate.name, metrics)
-    try:
-        cases = _cases(_required(value, "cases", "Candidate result"))
-        if len(cases) != evaluation.case_count:
-            raise ExecutionError("SF Engine Candidate result has the wrong number of Cases")
-        failures = _failures(_required(value, "failures", "Candidate result"), "Candidate failures")
+        score, metrics, cases, failures = _candidate_components(
+            value,
+            evaluation,
+            candidate,
+        )
         return CandidateResult(
             benchmark=evaluation.benchmark,
             run_id=outcome.run_id,
@@ -144,6 +118,61 @@ def _candidate_result(
         )
     except (TypeError, ValueError) as exc:
         raise ExecutionError(f"SF Engine Candidate result is invalid: {exc}") from exc
+
+
+def _candidate_payload(
+    evaluation: _Evaluation,
+    outcome: _RunOutcome,
+) -> Mapping[str, object]:
+    try:
+        payload = json.loads(outcome.result_body)
+    except json.JSONDecodeError as exc:
+        raise ExecutionError("SF Engine Candidate result must be JSON") from exc
+    value = _mapping(payload, "Candidate result")
+    _keys(
+        value,
+        required={
+            "schema",
+            "benchmark_id",
+            "benchmark_revision",
+            "case_count",
+            "score",
+            "metrics",
+            "cases",
+            "failures",
+        },
+        label="Candidate result",
+    )
+    if value.get("schema") != "screamingface.candidate-result.v1":
+        raise ExecutionError("SF Engine Candidate result schema is unsupported")
+    if value.get("benchmark_id") != evaluation.benchmark.id:
+        raise ExecutionError("SF Engine Candidate result has the wrong Benchmark id")
+    if value.get("benchmark_revision") != evaluation.benchmark.revision:
+        raise ExecutionError("SF Engine Candidate result has the wrong Benchmark revision")
+    if _positive_integer(value.get("case_count"), "Candidate case_count") != evaluation.case_count:
+        raise ExecutionError("SF Engine Candidate result has the wrong case count")
+    return value
+
+
+def _candidate_components(
+    value: Mapping[str, object],
+    evaluation: _Evaluation,
+    candidate: Candidate,
+) -> tuple[
+    float | None,
+    dict[str, object],
+    tuple[CaseResult, ...],
+    tuple[Failure, ...],
+]:
+    score_value = value.get("score")
+    score = None if score_value is None else _number(score_value, "Candidate score")
+    metrics = _metrics(value.get("metrics"))
+    _warn_on_coverage(candidate.name, metrics)
+    cases = _cases(_required(value, "cases", "Candidate result"))
+    if len(cases) != evaluation.case_count:
+        raise ExecutionError("SF Engine Candidate result has the wrong number of Cases")
+    failures = _failures(_required(value, "failures", "Candidate result"), "Candidate failures")
+    return score, metrics, cases, failures
 
 
 def _mapping(value: object, label: str) -> Mapping[str, object]:
@@ -180,40 +209,46 @@ def _case_result(value: object) -> CaseResult:
         },
         label="Case Result",
     )
-    case_id = _positive_integer(raw.get("case_id"), "Case Result case_id")
+    case_id = _case_id(raw.get("case_id"), "Case Result case_id")
     grade_value = _required(raw, "grade", "Case Result")
     grade = None if grade_value is None else _case_grade(grade_value)
     failures = _failures(_required(raw, "failures", "Case Result"), "Case Result failures")
-    if any(failure.case_id not in {None, case_id} for failure in failures):
-        raise ExecutionError("Case Result contains a Failure for another Case")
     finish_reason_value = _required(raw, "finish_reason", "Case Result")
-    return CaseResult(
-        status=_case_status(raw.get("status")),
-        case_id=case_id,
-        input=_required(raw, "input", "Case Result"),
-        output=_required(raw, "output", "Case Result"),
-        finish_reason=(
-            None
-            if finish_reason_value is None
-            else _text(finish_reason_value, "Case Result finish_reason")
-        ),
-        refusal=_optional_text(raw.get("refusal"), "Case Result refusal"),
-        grade=grade,
-        failures=failures,
-        metadata=_mapping(_required(raw, "metadata", "Case Result"), "Case Result metadata"),
-    )
+    try:
+        return CaseResult(
+            status=_case_status(raw.get("status")),
+            case_id=case_id,
+            input=_nonempty_text(_required(raw, "input", "Case Result"), "Case Result input"),
+            output=_optional_string(_required(raw, "output", "Case Result"), "Case Result output"),
+            finish_reason=(
+                None
+                if finish_reason_value is None
+                else _text(finish_reason_value, "Case Result finish_reason")
+            ),
+            refusal=_optional_text(raw.get("refusal"), "Case Result refusal"),
+            grade=grade,
+            failures=failures,
+            metadata=_mapping(_required(raw, "metadata", "Case Result"), "Case Result metadata"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"Case Result is invalid: {exc}") from exc
 
 
 def _case_grade(value: object) -> CaseGrade:
     raw = _mapping(value, "Case Grade")
     _keys(raw, required={"method", "score", "metrics", "checks"}, label="Case Grade")
     score_value = raw.get("score")
-    return CaseGrade(
-        method=_text(raw.get("method"), "Case Grade method"),
-        score=None if score_value is None else _number(score_value, "Case Grade score"),
-        metrics=_mapping(raw.get("metrics"), "Case Grade metrics"),
-        checks=tuple(_check(item) for item in _sequence(raw.get("checks"), "Case Grade checks")),
-    )
+    try:
+        return CaseGrade(
+            method=_nonempty_text(raw.get("method"), "Case Grade method"),
+            score=None if score_value is None else _number(score_value, "Case Grade score"),
+            metrics=_mapping(raw.get("metrics"), "Case Grade metrics"),
+            checks=tuple(
+                _check(item) for item in _sequence(raw.get("checks"), "Case Grade checks")
+            ),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"Case Grade is invalid: {exc}") from exc
 
 
 def _check(value: object) -> Check:
@@ -225,17 +260,20 @@ def _check(value: object) -> Check:
         label="Check",
     )
     score_value = raw.get("score")
-    return Check(
-        type=_text(raw.get("type"), "Check type"),
-        id=_text(raw.get("id"), "Check id"),
-        label=_text(raw.get("label"), "Check label"),
-        evidence=tuple(
-            _evidence(item) for item in _sequence(raw.get("evidence"), "Check evidence")
-        ),
-        outcome=raw.get("outcome"),
-        score=None if score_value is None else _number(score_value, "Check score"),
-        metadata=_mapping(raw.get("metadata"), "Check metadata"),
-    )
+    try:
+        return Check(
+            type=_nonempty_text(raw.get("type"), "Check type"),
+            id=_nonempty_text(raw.get("id"), "Check id"),
+            label=_string(raw.get("label"), "Check label"),
+            evidence=tuple(
+                _evidence(item) for item in _sequence(raw.get("evidence"), "Check evidence")
+            ),
+            outcome=_check_outcome(raw.get("outcome")),
+            score=None if score_value is None else _number(score_value, "Check score"),
+            metadata=_mapping(raw.get("metadata"), "Check metadata"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"Check is invalid: {exc}") from exc
 
 
 def _evidence(value: object) -> Evidence:
@@ -251,18 +289,21 @@ def _evidence(value: object) -> Evidence:
     valid = raw.get("valid")
     if not isinstance(valid, bool):
         raise ExecutionError("Evidence valid must be boolean")
-    return Evidence(
-        sequence=_positive_integer(raw.get("sequence"), "Evidence sequence"),
-        producer=EvidenceProducer(
-            type=_producer_type(producer.get("type")),
-            id=_text(producer.get("id"), "Evidence producer id"),
-        ),
-        valid=valid,
-        outcome=raw.get("outcome"),
-        explanation=_optional_text(raw.get("explanation"), "Evidence explanation"),
-        raw_output=_required(raw, "raw_output", "Evidence"),
-        metadata=_mapping(raw.get("metadata"), "Evidence metadata"),
-    )
+    try:
+        return Evidence(
+            sequence=_positive_integer(raw.get("sequence"), "Evidence sequence"),
+            producer=EvidenceProducer(
+                type=_producer_type(producer.get("type")),
+                id=_nonempty_text(producer.get("id"), "Evidence producer id"),
+            ),
+            valid=valid,
+            outcome=_evidence_outcome(raw.get("outcome")),
+            explanation=_optional_string(raw.get("explanation"), "Evidence explanation"),
+            raw_output=_required(raw, "raw_output", "Evidence"),
+            metadata=_mapping(raw.get("metadata"), "Evidence metadata"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"Evidence is invalid: {exc}") from exc
 
 
 def _failures(value: object, label: str) -> tuple[Failure, ...]:
@@ -273,23 +314,23 @@ def _failure(value: object) -> Failure:
     raw = _mapping(value, "Failure")
     _keys(
         raw,
-        required={"stage", "code", "message"},
-        optional={"retryable", "operation_id", "case_id", "metadata"},
+        required={"stage", "code", "message", "retryable", "case_id", "metadata"},
         label="Failure",
     )
-    retryable = raw.get("retryable")
+    retryable = _required(raw, "retryable", "Failure")
     if retryable is not None and not isinstance(retryable, bool):
         raise ExecutionError("Failure retryable must be boolean or null")
-    operation_id = _optional_text(raw.get("operation_id"), "Failure operation_id")
-    return Failure(
-        stage=_failure_stage(raw.get("stage")),
-        code=_text(raw.get("code"), "Failure code"),
-        message=_text(raw.get("message"), "Failure message"),
-        retryable=retryable,
-        operation_id=operation_id,
-        case_id=_failure_case_id(raw.get("case_id")),
-        metadata=_mapping(raw.get("metadata", {}), "Failure metadata"),
-    )
+    try:
+        return Failure(
+            stage=_failure_stage(raw.get("stage")),
+            code=_nonempty_text(raw.get("code"), "Failure code"),
+            message=_nonempty_text(raw.get("message"), "Failure message"),
+            retryable=retryable,
+            case_id=_failure_case_id(_required(raw, "case_id", "Failure")),
+            metadata=_mapping(_required(raw, "metadata", "Failure"), "Failure metadata"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"Failure is invalid: {exc}") from exc
 
 
 def _sequence(value: object, label: str) -> Sequence[object]:
@@ -334,15 +375,49 @@ def _optional_text(value: object, label: str) -> str | None:
     return None if value is None else _text(value, label)
 
 
-def _producer_type(value: object) -> Literal["model", "deterministic"]:
-    if value == "model":
-        return "model"
-    if value == "deterministic":
-        return "deterministic"
-    raise ExecutionError("Evidence producer type is unsupported")
+def _optional_string(value: object, label: str) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    raise ExecutionError(f"{label} must be text or null")
 
 
-def _case_status(value: object) -> Literal["scored", "refused", "failed"]:
+def _nonempty_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ExecutionError(f"{label} must be non-empty text")
+    return value
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise ExecutionError(f"{label} must be text")
+    return value
+
+
+def _producer_type(value: object) -> str:
+    return _nonempty_text(value, "Evidence producer type")
+
+
+def _check_outcome(value: object) -> Literal["MET", "UNMET"] | None:
+    if value is None:
+        return None
+    if value == "MET":
+        return "MET"
+    if value == "UNMET":
+        return "UNMET"
+    raise ExecutionError("Check outcome must be MET, UNMET, or null")
+
+
+def _evidence_outcome(
+    value: object,
+) -> Literal["MET", "UNMET", "PASS", "FAIL"] | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or value not in {"MET", "UNMET", "PASS", "FAIL"}:
+        raise ExecutionError("Evidence outcome must be MET, UNMET, PASS, FAIL, or null")
+    return cast(Literal["MET", "UNMET", "PASS", "FAIL"], value)
+
+
+def _case_status(value: object) -> CaseStatus:
     if value == "scored":
         return "scored"
     if value == "refused":
@@ -363,11 +438,16 @@ def _failure_stage(value: object) -> Literal["candidate", "grading", "aggregatio
 
 
 def _failure_case_id(value: object) -> int | str | None:
-    if value is None or isinstance(value, str):
-        return value
-    if isinstance(value, int) and not isinstance(value, bool):
-        return value
-    raise ExecutionError("Failure case_id must be a string, integer, or null")
+    if value is None:
+        return None
+    return _case_id(value, "Failure case_id")
+
+
+def _case_id(value: object, label: str) -> CaseId:
+    try:
+        return _validate_case_id(value, label)
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(str(exc)) from exc
 
 
 def _number(value: object, label: str) -> float:

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -168,10 +168,12 @@ def _case_result(value: object) -> CaseResult:
     _keys(
         raw,
         required={
+            "status",
             "case_id",
             "input",
             "output",
             "finish_reason",
+            "refusal",
             "grade",
             "failures",
             "metadata",
@@ -186,6 +188,7 @@ def _case_result(value: object) -> CaseResult:
         raise ExecutionError("Case Result contains a Failure for another Case")
     finish_reason_value = _required(raw, "finish_reason", "Case Result")
     return CaseResult(
+        status=_case_status(raw.get("status")),
         case_id=case_id,
         input=_required(raw, "input", "Case Result"),
         output=_required(raw, "output", "Case Result"),
@@ -194,6 +197,7 @@ def _case_result(value: object) -> CaseResult:
             if finish_reason_value is None
             else _text(finish_reason_value, "Case Result finish_reason")
         ),
+        refusal=_optional_text(raw.get("refusal"), "Case Result refusal"),
         grade=grade,
         failures=failures,
         metadata=_mapping(_required(raw, "metadata", "Case Result"), "Case Result metadata"),
@@ -336,6 +340,16 @@ def _producer_type(value: object) -> Literal["model", "deterministic"]:
     if value == "deterministic":
         return "deterministic"
     raise ExecutionError("Evidence producer type is unsupported")
+
+
+def _case_status(value: object) -> Literal["scored", "refused", "failed"]:
+    if value == "scored":
+        return "scored"
+    if value == "refused":
+        return "refused"
+    if value == "failed":
+        return "failed"
+    raise ExecutionError("Case Result status is unsupported")
 
 
 def _failure_stage(value: object) -> Literal["candidate", "grading", "aggregation"]:

--- a/packages/screamingface/src/screamingface/_report_primitives.py
+++ b/packages/screamingface/src/screamingface/_report_primitives.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
@@ -11,6 +10,7 @@ from typing import Literal
 from screamingface._immutable_json import freeze_mapping, thaw_mapping
 
 type FailureStage = Literal["candidate", "grading", "aggregation"]
+type CaseId = int | str
 
 
 @dataclass(frozen=True, slots=True, init=False)
@@ -67,7 +67,7 @@ class Failure:
     message: str
     retryable: bool | None
     operation_id: str | None
-    case_id: int | str | None
+    case_id: CaseId | None
     metadata: Mapping[str, object]
 
     def __init__(
@@ -78,18 +78,15 @@ class Failure:
         message: str,
         retryable: bool | None = None,
         operation_id: str | None = None,
-        case_id: int | str | None = None,
+        case_id: CaseId | None = None,
         metadata: Mapping[str, object] | None = None,
     ) -> None:
         if stage not in {"candidate", "grading", "aggregation"}:
             raise ValueError("Failure stage must be 'candidate', 'grading', or 'aggregation'")
-        selected_code = _nonblank(code, "Failure code")
-        if re.fullmatch(r"[a-z][a-z0-9]*(?:_[a-z0-9]+)*", selected_code) is None:
-            raise ValueError("Failure code must be lowercase snake_case")
         values = {
             "stage": stage,
-            "code": selected_code,
-            "message": _nonblank(message, "Failure message"),
+            "code": _nonempty_text(code, "Failure code"),
+            "message": _nonempty_text(message, "Failure message"),
             "retryable": _optional_retryable(retryable),
             "operation_id": _optional_operation_id(operation_id),
             "case_id": _failure_case_id(case_id),
@@ -103,15 +100,12 @@ class Failure:
             "stage": self.stage,
             "code": self.code,
             "message": self.message,
+            "retryable": self.retryable,
+            "case_id": self.case_id,
+            "metadata": thaw_mapping(self.metadata),
         }
-        if self.retryable is not None:
-            value["retryable"] = self.retryable
         if self.operation_id is not None:
             value["operation_id"] = self.operation_id
-        if self.case_id is not None:
-            value["case_id"] = self.case_id
-        if self.metadata:
-            value["metadata"] = thaw_mapping(self.metadata)
         return value
 
 
@@ -125,18 +119,10 @@ def _optional_operation_id(value: object) -> str | None:
     return None if value is None else _nonblank(value, "Failure operation_id")
 
 
-def _failure_case_id(value: object) -> int | str | None:
-    if isinstance(value, bool):
-        raise TypeError("Failure case_id must be a positive integer, string, or None")
-    if isinstance(value, int):
-        if value < 1:
-            raise ValueError("Failure case_id must be a positive integer, string, or None")
-        return value
-    if isinstance(value, str):
-        return _nonblank(value, "Failure case_id")
+def _failure_case_id(value: object) -> CaseId | None:
     if value is None:
         return None
-    raise TypeError("Failure case_id must be a positive integer, string, or None")
+    return _case_id(value, "Failure case_id")
 
 
 def _optional_count(value: object, label: str) -> int | None:
@@ -167,6 +153,30 @@ def _nonblank(value: object, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"{label} must be a non-empty string")
     return value.strip()
+
+
+def _nonempty_text(value: object, label: str) -> str:
+    """Validate min-length text while preserving the exact wire value."""
+
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _nonblank_text(value: object, label: str) -> str:
+    """Validate visible text while preserving leading and trailing whitespace."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def _case_id(value: object, label: str = "Case Result case_id") -> CaseId:
+    if isinstance(value, bool) or not isinstance(value, int | str):
+        raise TypeError(f"{label} must be a non-boolean integer or non-blank string")
+    if isinstance(value, str) and not value.strip():
+        raise ValueError(f"{label} must be a non-boolean integer or non-blank string")
+    return value
 
 
 def _duration(value: object, label: str) -> int | None:

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 import re
 from collections.abc import Mapping
 from decimal import Decimal
@@ -307,14 +308,28 @@ def _withheld_html(candidate: CandidateResult) -> str:
 
     if candidate.score is not None:
         return ""
-    failed = sum(1 for case in candidate.cases if case.grade is None)
-    if not failed:
-        return ""
-    total = len(candidate.cases)
-    return (
-        f"<div class='sf-report__warn'>score withheld — {failed} of {total} cases failed; "
-        "metrics are published only for fully scored runs.</div>"
-    )
+    states = tuple(_case_state(case) for case in candidate.cases)
+    incomplete = tuple(state for state in states if state in {"refused", "failed", "unscored"})
+    message = ""
+    if incomplete:
+        total = len(candidate.cases)
+        parts = tuple(
+            f"{incomplete.count(state)} {state}"
+            for state in ("refused", "failed", "unscored")
+            if state in incomplete
+        )
+        message = (
+            f"{len(incomplete)} of {total} cases not scored ({', '.join(parts)}); "
+            "metrics are published only for fully scored runs."
+        )
+    elif candidate.failures:
+        count = len(candidate.failures)
+        label = "failure" if count == 1 else "failures"
+        message = (
+            f"candidate execution reported {count} {label}; "
+            "metrics are published only for fully scored runs."
+        )
+    return f"<div class='sf-report__warn'>score withheld — {message}</div>" if message else ""
 
 
 def _models_html(candidate: CandidateResult) -> str:
@@ -457,12 +472,25 @@ def _failures_html(report: Report) -> str:
         groups.setdefault(key, []).append(item)
     lines = "\n".join(_failure_line(key, items) for key, items in groups.items())
     count = f"{len(failures)} failure" + ("" if len(failures) == 1 else "s")
-    return f"<div class='sf-report__fail' role='alert'>{escape(count)}\n{escape(lines)}</div>"
+    details = json.dumps(
+        [item.to_dict() for item in failures],
+        ensure_ascii=False,
+        indent=2,
+    )
+    return (
+        f"<div class='sf-report__fail' role='alert'>{escape(count)}\n{escape(lines)}</div>"
+        "<details><summary>failure details</summary>"
+        f"<pre class='sf-report__pre'>{escape(details)}</pre></details>"
+    )
 
 
 def _failure_line(key: tuple[str, str, str], items: list[Any]) -> str:
     stage, code, message = key
-    case_ids = [str(value) for value in (getattr(item, "case_id", None) for item in items) if value]
+    case_ids = [
+        str(value)
+        for value in (getattr(item, "case_id", None) for item in items)
+        if value is not None
+    ]
     # A failure with no code and no case identity keeps the plain `stage · message` shape.
     if not code and not case_ids:
         return f"{stage} · {message}"
@@ -553,15 +581,28 @@ def _rail_item(item: str, candidate: CandidateResult, case: CaseResult, show_who
     # WHY (OME-793): a failed case gets the warning mark, never the incorrect ✗ — the rail
     # must not present an infra failure as a graded wrong answer.
     mark = (
-        "sf-mark" + {"passed": "", "incorrect": " sf-mark--bad", "failed": " sf-mark--warn"}[state]
+        "sf-mark"
+        + {
+            "passed": "",
+            "incorrect": " sf-mark--bad",
+            "refused": " sf-mark--warn",
+            "failed": " sf-mark--warn",
+            "unscored": " sf-mark--warn",
+        }[state]
     )
-    glyph = {"passed": "&check;", "incorrect": "&times;", "failed": "!"}[state]
+    glyph = {
+        "passed": "&check;",
+        "incorrect": "&times;",
+        "refused": "!",
+        "failed": "!",
+        "unscored": "?",
+    }[state]
     who = f" <span class='sf-rail__who'>{escape(candidate.name)}</span>" if show_who else ""
     preview = _clip(case.prompt_preview, 90) if case.input is not None else "input unavailable"
     return (
         f"<label class='sf-rail__item' for='{item}'>"
         f"<span class='{mark}' aria-hidden='true'>{glyph}</span>"
-        f"<span class='sf-rail__id'>case {case.case_id}</span>{who}"
+        f"<span class='sf-rail__id'>case {escape(str(case.case_id))}</span>{who}"
         f"<span class='sf-rail__q'>{escape(preview)}</span></label>"
     )
 
@@ -570,8 +611,8 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
     state = _case_state(case)
     # WHY (OME-793): tri-state verdict — "failed" (warning) is neither correct nor
     # incorrect; the case was never graded, and the badge must say so.
-    if state == "failed":
-        verdict = _badge("failed", good=False, warn=True)
+    if state in {"refused", "failed", "unscored"}:
+        verdict = _badge(state, good=False, warn=True)
     else:
         verdict = _badge("correct" if state == "passed" else "incorrect", good=state == "passed")
     grade = case.grade
@@ -585,6 +626,12 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
     answer_html = (
         f"<div class='sf-detail__k'>answer</div><pre class='sf-report__pre'>{escape(answer)}</pre>"
         if answer
+        else ""
+    )
+    refusal_html = (
+        "<div class='sf-detail__k'>provider refusal</div>"
+        f"<pre class='sf-report__pre'>{escape(case.refusal)}</pre>"
+        if case.refusal is not None
         else ""
     )
     # A non-"stop" finish is a quality signal in its own right: a truncated answer can
@@ -607,9 +654,10 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
         )
     return (
         "<div class='sf-pane'><div class='sf-pane__h'>"
-        f"<span class='sf-report__case-id'>case {case.case_id} · "
+        f"<span class='sf-report__case-id'>case {escape(str(case.case_id))} · "
         f"{escape(candidate.name)}</span>{verdict}{finish_html}</div>{tags_html}"
-        f"{question}{answer_html}{_case_failures_html(case)}{checks_head}{checks}</div>"
+        f"{question}{answer_html}{refusal_html}{_case_failures_html(case)}"
+        f"{checks_head}{checks}</div>"
     )
 
 
@@ -622,9 +670,16 @@ def _case_failures_html(case: CaseResult) -> str:
         f"{failure.stage} · {failure.code} — {failure.message}{_first_collected_error(failure)}"
         for failure in case.failures
     )
+    details = json.dumps(
+        [failure.to_dict() for failure in case.failures],
+        ensure_ascii=False,
+        indent=2,
+    )
     return (
         "<div class='sf-detail__k'>failures</div>"
         f"<div class='sf-report__fail'>{escape(lines)}</div>"
+        "<details><summary>failure details</summary>"
+        f"<pre class='sf-report__pre'>{escape(details)}</pre></details>"
     )
 
 
@@ -640,14 +695,12 @@ def _case_passed(case: CaseResult) -> bool:
 
 
 def _case_state(case: CaseResult) -> str:
-    """Tri-state outcome: 'failed' (never graded) is distinct from 'incorrect' (graded, bad).
+    """Present the Engine outcome without re-deriving it from Benchmark semantics."""
 
-    INVARIANT (OME-793): grade is None ⇒ the Engine produced no verdict for this case —
-    the model contract guarantees such a case carries failures explaining why.
-    """
-
-    if case.grade is None:
-        return "failed"
+    if case.status == "refused":
+        return "refused"
+    if case.status == "failed":
+        return "unscored" if case.grade is not None else "failed"
     return "passed" if _case_passed(case) else "incorrect"
 
 

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -8,13 +8,20 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from screamingface._immutable_json import freeze_json, freeze_mapping, thaw_json, thaw_mapping
-from screamingface._report_primitives import Failure, _nonblank
+from screamingface._report_primitives import (
+    CaseId,
+    Failure,
+    _case_id,
+    _nonblank_text,
+    _nonempty_text,
+)
 
 # The Engine's versioned wrapper for native multi-turn Candidate input; kept in lock-step
 # with url4-cloud's `benchmarks/contract.py` CANDIDATE_INPUT_SCHEMA.
 _CANDIDATE_INPUT_SCHEMA = "screamingface.candidate-input.v1"
 
-type ProducerType = Literal["model", "deterministic"]
+type EvidenceOutcome = Literal["MET", "UNMET", "PASS", "FAIL"]
+type CheckOutcome = Literal["MET", "UNMET"]
 
 # The Engine's explicit per-Case outcome; kept in lock-step with url4-cloud's
 # `benchmarks/contract.py` CaseStatus.
@@ -25,13 +32,12 @@ type CaseStatus = Literal["scored", "refused", "failed"]
 class EvidenceProducer:
     """The Engine-known producer of one observed grading result."""
 
-    type: ProducerType
+    type: str
     id: str
 
     def __post_init__(self) -> None:
-        if self.type not in {"model", "deterministic"}:
-            raise ValueError("Evidence producer type must be 'model' or 'deterministic'")
-        object.__setattr__(self, "id", _nonblank(self.id, "Evidence producer id"))
+        object.__setattr__(self, "type", _nonempty_text(self.type, "Evidence producer type"))
+        object.__setattr__(self, "id", _nonempty_text(self.id, "Evidence producer id"))
 
     def to_dict(self) -> dict[str, object]:
         return {"type": self.type, "id": self.id}
@@ -44,7 +50,7 @@ class Evidence:
     sequence: int
     producer: EvidenceProducer
     valid: bool
-    outcome: object | None
+    outcome: EvidenceOutcome | None
     explanation: str | None
     raw_output: object
     _metadata: Mapping[str, object] = field(repr=False)
@@ -56,7 +62,7 @@ class Evidence:
         producer: EvidenceProducer,
         valid: bool,
         raw_output: object,
-        outcome: object | None = None,
+        outcome: EvidenceOutcome | None = None,
         explanation: str | None = None,
         metadata: Mapping[str, object] | None = None,
     ) -> None:
@@ -66,8 +72,10 @@ class Evidence:
             raise TypeError("Evidence producer must be an sf.EvidenceProducer")
         if not isinstance(valid, bool):
             raise TypeError("Evidence valid must be a boolean")
+        if outcome not in {None, "MET", "UNMET", "PASS", "FAIL"}:
+            raise ValueError("Evidence outcome must be MET, UNMET, PASS, FAIL, or None")
         if explanation is not None:
-            explanation = _nonblank(explanation, "Evidence explanation")
+            explanation = _string(explanation, "Evidence explanation")
         if not valid and (outcome is not None or explanation is not None):
             raise ValueError("invalid Evidence cannot contain an outcome or explanation")
         values = {
@@ -109,7 +117,7 @@ class Check:
     id: str
     label: str
     evidence: tuple[Evidence, ...]
-    outcome: object | None
+    outcome: CheckOutcome | None
     score: float | None
     _metadata: Mapping[str, object] = field(repr=False)
 
@@ -121,7 +129,7 @@ class Check:
         label: str,
         evidence: Sequence[Evidence],
         metadata: Mapping[str, object] | None = None,
-        outcome: object | None = None,
+        outcome: CheckOutcome | None = None,
         score: float | None = None,
     ) -> None:
         selected_evidence = tuple(evidence)
@@ -130,13 +138,15 @@ class Check:
         sequences = [item.sequence for item in selected_evidence]
         if sequences != sorted(sequences) or len(sequences) != len(set(sequences)):
             raise ValueError("Check Evidence sequences must be unique and ordered")
+        if outcome not in {None, "MET", "UNMET"}:
+            raise ValueError("Check outcome must be MET, UNMET, or None")
         values = {
-            "type": _nonblank(type, "Check type"),
-            "id": _nonblank(id, "Check id"),
-            "label": _nonblank(label, "Check label"),
+            "type": _nonempty_text(type, "Check type"),
+            "id": _nonempty_text(id, "Check id"),
+            "label": _string(label, "Check label"),
             "evidence": selected_evidence,
-            "outcome": freeze_json(outcome, "Check outcome"),
-            "score": _optional_number(score, "Check score"),
+            "outcome": outcome,
+            "score": _optional_check_score(score),
             "_metadata": freeze_mapping(metadata or {}, "Check metadata"),
         }
         for name, value in values.items():
@@ -185,8 +195,8 @@ class CaseGrade:
         if len(ids) != len(set(ids)):
             raise ValueError("Case Grade Check ids must be unique")
         values = {
-            "method": _nonblank(method, "Case Grade method"),
-            "score": _optional_number(score, "Case Grade score"),
+            "method": _nonempty_text(method, "Case Grade method"),
+            "score": _optional_case_score(score),
             "checks": selected_checks,
             "_metrics": freeze_mapping(metrics, "Case Grade metrics"),
         }
@@ -211,9 +221,9 @@ class CaseResult:
     """The complete retained result for one selected Benchmark Case."""
 
     status: CaseStatus
-    case_id: int
-    input: object
-    output: object
+    case_id: CaseId
+    input: str
+    output: str | None
     finish_reason: str | None
     refusal: str | None
     grade: CaseGrade | None
@@ -223,9 +233,9 @@ class CaseResult:
     def __init__(
         self,
         *,
-        case_id: int,
-        input: object,
-        output: object,
+        case_id: CaseId,
+        input: str,
+        output: str | None,
         finish_reason: str | None,
         grade: CaseGrade | None,
         failures: Sequence[Failure],
@@ -233,24 +243,32 @@ class CaseResult:
         status: CaseStatus | None = None,
         refusal: str | None = None,
     ) -> None:
-        if isinstance(case_id, bool) or not isinstance(case_id, int) or case_id < 1:
-            raise ValueError("Case Result case_id must be a positive integer")
+        case_id = _case_id(case_id)
+        input = _nonempty_text(input, "Case Result input")
+        if output is not None and not isinstance(output, str):
+            raise TypeError("Case Result output must be text or None")
         if grade is not None and not isinstance(grade, CaseGrade):
             raise TypeError("Case Result grade must be an sf.CaseGrade or None")
         if finish_reason is not None:
-            finish_reason = _nonblank(finish_reason, "Case Result finish_reason")
+            finish_reason = _nonblank_text(finish_reason, "Case Result finish_reason")
         if refusal is not None:
-            refusal = _nonblank(refusal, "Case Result refusal")
+            refusal = _nonblank_text(refusal, "Case Result refusal")
         selected_failures = tuple(failures)
         if any(not isinstance(item, Failure) for item in selected_failures):
             raise TypeError("Case Result failures must contain sf.Failure values")
-        _validate_case_state(grade, selected_failures)
-        status = _resolve_case_status(status, refusal, grade, output)
+        status = _validate_case_outcome(
+            status,
+            case_id,
+            refusal,
+            grade,
+            output,
+            selected_failures,
+        )
         values = {
             "status": status,
             "case_id": case_id,
-            "input": freeze_json(input, "Case Result input"),
-            "output": freeze_json(output, "Case Result output"),
+            "input": input,
+            "output": output,
             "finish_reason": finish_reason,
             "refusal": refusal,
             "grade": grade,
@@ -347,6 +365,26 @@ def _optional_number(value: object, label: str) -> float | None:
     return None if value is None else _required_number(value, label)
 
 
+def _optional_check_score(value: object) -> float | None:
+    selected = _optional_number(value, "Check score")
+    if selected is not None and not 0.0 <= selected <= 1.0:
+        raise ValueError("Check score must be between 0 and 1")
+    return selected
+
+
+def _optional_case_score(value: object) -> float | None:
+    selected = _optional_number(value, "Case Grade score")
+    if selected is not None and selected > 1.0:
+        raise ValueError("Case Grade score must be at most 1")
+    return selected
+
+
+def _string(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{label} must be text")
+    return value
+
+
 def _required_number(value: object, label: str) -> float:
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise TypeError(f"{label} must be a finite number")
@@ -356,70 +394,99 @@ def _required_number(value: object, label: str) -> float:
     return selected
 
 
-def _validate_case_state(grade: CaseGrade | None, failures: Sequence[Failure]) -> None:
-    if grade is None and not failures:
-        raise ValueError("an ungraded Case Result must contain a Failure")
-    if grade is not None and grade.score is None and not failures:
-        raise ValueError("an unscored Case Grade must contain a Case Result Failure")
-    if grade is not None and grade.score is not None and failures:
-        raise ValueError("a graded Case Result cannot contain failures")
-
-
-def _resolve_case_status(
+def _validate_case_outcome(
     status: CaseStatus | None,
+    case_id: CaseId,
     refusal: str | None,
     grade: CaseGrade | None,
     output: object,
+    failures: Sequence[Failure],
 ) -> CaseStatus:
-    """Answer "what happened to this Case?" from its fields, and refuse ambiguity.
+    """Validate one immutable value against the Engine's closed outcome contract.
 
-    Think of it as reading a verdict off the evidence. A Case ends one of three
-    ways, and the fields already tell the story: a numeric grade means the model
-    answered and was scored; refusal text means the model declined; neither means
-    something broke. The Engine ships an explicit `status` on the wire, but a
-    locally built value has none — so this function derives the verdict the same
-    way the Engine would, and the two can never disagree.
-
-    Stage 1 — derive the verdict from the evidence: numeric grade → "scored",
-    else refusal text → "refused", else "failed".
-
-    Stage 2 — reject evidence that tells two stories at once. The Engine
-    (`url4_cloud/benchmarks/contract.py::_enforce_status`) refuses these shapes,
-    so building one locally would create a payload the Engine could never have
-    published: a scored Case carrying refusal text, or a refused Case carrying
-    an output or a grade. Example: `refusal="I can't help", output="Four."` —
-    did the model refuse or answer? Rejected rather than guessed.
-
-    Stage 3 — check the caller's explicit `status` (if any) against the derived
-    verdict. It must be one of the three known words and must match; a Case
-    labeled "failed" but shaped like "scored" is rejected, not trusted.
-
-    Returns the settled status; raises ValueError on any contradiction.
+    The wire decoder always requires an explicit status. Derivation exists only for
+    directly constructed Python values, where it avoids forcing test/data authors to
+    repeat a status already unambiguously determined by the complete Case shape.
     """
 
-    # Stage 1 — derive the verdict from the evidence.
-    derived: CaseStatus = (
-        "scored"
-        if grade is not None and grade.score is not None
-        else "refused"
-        if refusal is not None
-        else "failed"
-    )
-    # Stage 2 — reject evidence that tells two stories at once (engine-forbidden shapes).
-    if derived == "scored" and refusal is not None:
-        raise ValueError("a scored Case Result cannot contain refusal text")
-    if derived == "refused" and output is not None:
-        raise ValueError("a refused Case Result cannot contain output")
-    if derived == "refused" and grade is not None:
-        raise ValueError("a refused Case Result cannot contain a grade")
-    # Stage 3 — the explicit status (when given) must match the derived verdict.
+    selected_status = _case_status(status, refusal, grade)
+    if any(failure.case_id != case_id for failure in failures):
+        raise ValueError("every Case Result Failure must reference its own case_id")
+    if selected_status == "scored":
+        _validate_scored_case(refusal, grade, output, failures)
+    elif selected_status == "refused":
+        _validate_refused_case(refusal, grade, output, failures)
+    else:
+        _validate_failed_case(refusal, grade, failures)
+    return selected_status
+
+
+def _case_status(
+    status: CaseStatus | None,
+    refusal: str | None,
+    grade: CaseGrade | None,
+) -> CaseStatus:
     if status is None:
-        return derived
+        if grade is not None and grade.score is not None:
+            return "scored"
+        return "refused" if refusal is not None else "failed"
     if status not in {"scored", "refused", "failed"}:
         raise ValueError("Case Result status must be 'scored', 'refused', or 'failed'")
-    if status != derived:
-        raise ValueError(f"Case Result status {status!r} contradicts its {derived!r} shape")
     return status
+
+
+def _validate_scored_case(
+    refusal: str | None,
+    grade: CaseGrade | None,
+    output: object,
+    failures: Sequence[Failure],
+) -> None:
+    if grade is None or grade.score is None or output is None or refusal is not None or failures:
+        raise ValueError(
+            "Case Result status 'scored' requires output and a numeric grade and cannot "
+            "carry refusal or failures"
+        )
+
+
+def _validate_refused_case(
+    refusal: str | None,
+    grade: CaseGrade | None,
+    output: object,
+    failures: Sequence[Failure],
+) -> None:
+    refusal_failures = tuple(
+        failure
+        for failure in failures
+        if failure.stage == "candidate" and failure.code == "provider_refusal"
+    )
+    if (
+        refusal is None
+        or output is not None
+        or grade is not None
+        or len(failures) != 1
+        or len(refusal_failures) != 1
+    ):
+        raise ValueError(
+            "Case Result status 'refused' requires exact refusal text, no output or grade, "
+            "and one candidate provider_refusal Failure"
+        )
+
+
+def _validate_failed_case(
+    refusal: str | None,
+    grade: CaseGrade | None,
+    failures: Sequence[Failure],
+) -> None:
+    if (
+        not failures
+        or refusal is not None
+        or any(failure.code == "provider_refusal" for failure in failures)
+        or grade is not None
+        and grade.score is not None
+    ):
+        raise ValueError(
+            "Case Result status 'failed' requires failures, no refusal, and no numeric grade"
+        )
 
 
 __all__ = ["CaseGrade", "CaseResult", "Check", "Evidence", "EvidenceProducer"]

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -371,18 +371,33 @@ def _resolve_case_status(
     grade: CaseGrade | None,
     output: object,
 ) -> CaseStatus:
-    """Pin the Case's explicit outcome to the shape its grade and refusal imply.
+    """Answer "what happened to this Case?" from its fields, and refuse ambiguity.
 
-    The Engine publishes `status` on the wire; a locally built value derives the
-    same answer the Engine would (numeric grade → scored, refusal text → refused,
-    otherwise failed) so the two can never disagree. An explicit status that
-    contradicts the derived one is an ambiguous Case and is rejected.
+    Think of it as reading a verdict off the evidence. A Case ends one of three
+    ways, and the fields already tell the story: a numeric grade means the model
+    answered and was scored; refusal text means the model declined; neither means
+    something broke. The Engine ships an explicit `status` on the wire, but a
+    locally built value has none — so this function derives the verdict the same
+    way the Engine would, and the two can never disagree.
 
-    INVARIANT: mirrors `url4_cloud/benchmarks/contract.py::_enforce_status` per
-    outcome leg — scored carries no refusal; refused carries no output and no
-    grade — so a locally built value can never take a shape the Engine rejects.
+    Stage 1 — derive the verdict from the evidence: numeric grade → "scored",
+    else refusal text → "refused", else "failed".
+
+    Stage 2 — reject evidence that tells two stories at once. The Engine
+    (`url4_cloud/benchmarks/contract.py::_enforce_status`) refuses these shapes,
+    so building one locally would create a payload the Engine could never have
+    published: a scored Case carrying refusal text, or a refused Case carrying
+    an output or a grade. Example: `refusal="I can't help", output="Four."` —
+    did the model refuse or answer? Rejected rather than guessed.
+
+    Stage 3 — check the caller's explicit `status` (if any) against the derived
+    verdict. It must be one of the three known words and must match; a Case
+    labeled "failed" but shaped like "scored" is rejected, not trusted.
+
+    Returns the settled status; raises ValueError on any contradiction.
     """
 
+    # Stage 1 — derive the verdict from the evidence.
     derived: CaseStatus = (
         "scored"
         if grade is not None and grade.score is not None
@@ -390,12 +405,14 @@ def _resolve_case_status(
         if refusal is not None
         else "failed"
     )
+    # Stage 2 — reject evidence that tells two stories at once (engine-forbidden shapes).
     if derived == "scored" and refusal is not None:
         raise ValueError("a scored Case Result cannot contain refusal text")
     if derived == "refused" and output is not None:
         raise ValueError("a refused Case Result cannot contain output")
     if derived == "refused" and grade is not None:
         raise ValueError("a refused Case Result cannot contain a grade")
+    # Stage 3 — the explicit status (when given) must match the derived verdict.
     if status is None:
         return derived
     if status not in {"scored", "refused", "failed"}:

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -245,7 +245,7 @@ class CaseResult:
         if any(not isinstance(item, Failure) for item in selected_failures):
             raise TypeError("Case Result failures must contain sf.Failure values")
         _validate_case_state(grade, selected_failures)
-        status = _resolve_case_status(status, refusal, grade)
+        status = _resolve_case_status(status, refusal, grade, output)
         values = {
             "status": status,
             "case_id": case_id,
@@ -369,6 +369,7 @@ def _resolve_case_status(
     status: CaseStatus | None,
     refusal: str | None,
     grade: CaseGrade | None,
+    output: object,
 ) -> CaseStatus:
     """Pin the Case's explicit outcome to the shape its grade and refusal imply.
 
@@ -376,6 +377,10 @@ def _resolve_case_status(
     same answer the Engine would (numeric grade → scored, refusal text → refused,
     otherwise failed) so the two can never disagree. An explicit status that
     contradicts the derived one is an ambiguous Case and is rejected.
+
+    INVARIANT: mirrors `url4_cloud/benchmarks/contract.py::_enforce_status` per
+    outcome leg — scored carries no refusal; refused carries no output and no
+    grade — so a locally built value can never take a shape the Engine rejects.
     """
 
     derived: CaseStatus = (
@@ -387,6 +392,10 @@ def _resolve_case_status(
     )
     if derived == "scored" and refusal is not None:
         raise ValueError("a scored Case Result cannot contain refusal text")
+    if derived == "refused" and output is not None:
+        raise ValueError("a refused Case Result cannot contain output")
+    if derived == "refused" and grade is not None:
+        raise ValueError("a refused Case Result cannot contain a grade")
     if status is None:
         return derived
     if status not in {"scored", "refused", "failed"}:

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -16,6 +16,10 @@ _CANDIDATE_INPUT_SCHEMA = "screamingface.candidate-input.v1"
 
 type ProducerType = Literal["model", "deterministic"]
 
+# The Engine's explicit per-Case outcome; kept in lock-step with url4-cloud's
+# `benchmarks/contract.py` CaseStatus.
+type CaseStatus = Literal["scored", "refused", "failed"]
+
 
 @dataclass(frozen=True, slots=True)
 class EvidenceProducer:
@@ -206,10 +210,12 @@ class CaseGrade:
 class CaseResult:
     """The complete retained result for one selected Benchmark Case."""
 
+    status: CaseStatus
     case_id: int
     input: object
     output: object
     finish_reason: str | None
+    refusal: str | None
     grade: CaseGrade | None
     failures: tuple[Failure, ...]
     _metadata: Mapping[str, object] = field(repr=False)
@@ -224,6 +230,8 @@ class CaseResult:
         grade: CaseGrade | None,
         failures: Sequence[Failure],
         metadata: Mapping[str, object],
+        status: CaseStatus | None = None,
+        refusal: str | None = None,
     ) -> None:
         if isinstance(case_id, bool) or not isinstance(case_id, int) or case_id < 1:
             raise ValueError("Case Result case_id must be a positive integer")
@@ -231,15 +239,20 @@ class CaseResult:
             raise TypeError("Case Result grade must be an sf.CaseGrade or None")
         if finish_reason is not None:
             finish_reason = _nonblank(finish_reason, "Case Result finish_reason")
+        if refusal is not None:
+            refusal = _nonblank(refusal, "Case Result refusal")
         selected_failures = tuple(failures)
         if any(not isinstance(item, Failure) for item in selected_failures):
             raise TypeError("Case Result failures must contain sf.Failure values")
         _validate_case_state(grade, selected_failures)
+        status = _resolve_case_status(status, refusal, grade)
         values = {
+            "status": status,
             "case_id": case_id,
             "input": freeze_json(input, "Case Result input"),
             "output": freeze_json(output, "Case Result output"),
             "finish_reason": finish_reason,
+            "refusal": refusal,
             "grade": grade,
             "failures": selected_failures,
             "_metadata": freeze_mapping(metadata, "Case Result metadata"),
@@ -290,10 +303,12 @@ class CaseResult:
 
     def to_dict(self) -> dict[str, object]:
         return {
+            "status": self.status,
             "case_id": self.case_id,
             "input": thaw_json(self.input),
             "output": thaw_json(self.output),
             "finish_reason": self.finish_reason,
+            "refusal": self.refusal,
             "grade": None if self.grade is None else self.grade.to_dict(),
             "failures": [failure.to_dict() for failure in self.failures],
             "metadata": thaw_mapping(self._metadata),
@@ -348,6 +363,37 @@ def _validate_case_state(grade: CaseGrade | None, failures: Sequence[Failure]) -
         raise ValueError("an unscored Case Grade must contain a Case Result Failure")
     if grade is not None and grade.score is not None and failures:
         raise ValueError("a graded Case Result cannot contain failures")
+
+
+def _resolve_case_status(
+    status: CaseStatus | None,
+    refusal: str | None,
+    grade: CaseGrade | None,
+) -> CaseStatus:
+    """Pin the Case's explicit outcome to the shape its grade and refusal imply.
+
+    The Engine publishes `status` on the wire; a locally built value derives the
+    same answer the Engine would (numeric grade → scored, refusal text → refused,
+    otherwise failed) so the two can never disagree. An explicit status that
+    contradicts the derived one is an ambiguous Case and is rejected.
+    """
+
+    derived: CaseStatus = (
+        "scored"
+        if grade is not None and grade.score is not None
+        else "refused"
+        if refusal is not None
+        else "failed"
+    )
+    if derived == "scored" and refusal is not None:
+        raise ValueError("a scored Case Result cannot contain refusal text")
+    if status is None:
+        return derived
+    if status not in {"scored", "refused", "failed"}:
+        raise ValueError("Case Result status must be 'scored', 'refused', or 'failed'")
+    if status != derived:
+        raise ValueError(f"Case Result status {status!r} contradicts its {derived!r} shape")
+    return status
 
 
 __all__ = ["CaseGrade", "CaseResult", "Check", "Evidence", "EvidenceProducer"]

--- a/packages/screamingface/src/screamingface/report.py
+++ b/packages/screamingface/src/screamingface/report.py
@@ -4,22 +4,24 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
 from os import PathLike
 from pathlib import Path
 from types import MappingProxyType
-from typing import Literal
+from typing import Literal, overload
 
 from screamingface._evaluation.model import _canonical_url4
 from screamingface._immutable_json import freeze_mapping, thaw_mapping
 from screamingface._named_values import _NamedValues
 from screamingface._operation_projection import _operation_dict, _require_operation_references
 from screamingface._report_primitives import (
+    CaseId,
     Failure,
     Usage,
+    _case_id,
     _duration,
     _nonblank,
     _usage,
@@ -90,6 +92,67 @@ class MemberResult:
         }
 
 
+class _CaseResults(Sequence[CaseResult]):
+    """Ordered Case Results with explicit identity lookup.
+
+    Integer ``[]`` access remains ordinary sequence position. Domain identity is
+    intentionally spelled ``by_id(...)`` so an integer Case ID can never be
+    mistaken for an index.
+    """
+
+    __slots__ = ("_by_id", "_items")
+
+    def __init__(self, values: Sequence[CaseResult]) -> None:
+        if isinstance(values, str | bytes) or not isinstance(values, Sequence):
+            raise TypeError("Candidate cases must be an ordered sequence")
+        items = tuple(values)
+        if any(not isinstance(value, CaseResult) for value in items):
+            raise TypeError("Candidate cases must contain sf.CaseResult values")
+        if not items:
+            raise ValueError("a Candidate Result requires at least one Case Result")
+        by_id: dict[CaseId, CaseResult] = {}
+        for item in items:
+            if item.case_id in by_id:
+                raise ValueError(f"duplicate Candidate Case Result id {item.case_id!r}")
+            by_id[item.case_id] = item
+        self._items = items
+        self._by_id = MappingProxyType(by_id)
+
+    @overload
+    def __getitem__(self, index: int) -> CaseResult: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> tuple[CaseResult, ...]: ...
+
+    def __getitem__(self, index: int | slice) -> CaseResult | tuple[CaseResult, ...]:
+        return self._items[index]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterator[CaseResult]:
+        return iter(self._items)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _CaseResults):
+            return self._items == other._items
+        if isinstance(other, Sequence):
+            return self._items == tuple(other)
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        return repr(self._items)
+
+    def by_id(self, case_id: CaseId) -> CaseResult:
+        """Return the Case with this domain ID without treating integers as positions."""
+
+        selected = _case_id(case_id)
+        try:
+            return self._by_id[selected]
+        except KeyError:
+            raise KeyError(f"unknown Case id {selected!r}") from None
+
+
 @dataclass(frozen=True, slots=True, init=False)
 class CandidateResult:
     """One independently executed Candidate outcome; a higher score is always better."""
@@ -104,7 +167,7 @@ class CandidateResult:
     models: tuple[str, ...]
     operations: tuple[OperationInfo, ...]
     score: float | None
-    cases: tuple[CaseResult, ...]
+    cases: _CaseResults
     members: tuple[MemberResult, ...]
     failures: tuple[Failure, ...]
     usage: Usage
@@ -143,7 +206,7 @@ class CandidateResult:
             scored=selected_score is not None,
         )
         selected_operations = _operation_dag(operations)
-        selected_cases = _case_results(cases)
+        selected_cases = _CaseResults(cases)
         _require_operation_references(
             selected_operations,
             selected_members,
@@ -362,20 +425,6 @@ def _members(values: Sequence[MemberResult]) -> tuple[MemberResult, ...]:
     return selected
 
 
-def _case_results(values: Sequence[CaseResult]) -> tuple[CaseResult, ...]:
-    if isinstance(values, str | bytes) or not isinstance(values, Sequence):
-        raise TypeError("Candidate cases must be an ordered sequence")
-    selected = tuple(values)
-    if any(not isinstance(value, CaseResult) for value in selected):
-        raise TypeError("Candidate cases must contain sf.CaseResult values")
-    if not selected:
-        raise ValueError("a Candidate Result requires at least one Case Result")
-    ids = [value.case_id for value in selected]
-    if len(ids) != len(set(ids)):
-        raise ValueError("Candidate Case Result ids must be unique")
-    return selected
-
-
 def _candidate_shape(
     kind: object,
     models: Sequence[str],
@@ -393,19 +442,33 @@ def _candidate_shape(
     selected_models = _models(models, "Candidate")
     selected_members = _members(members)
     selected_failures = _failures(failures, "Candidate")
-    if selected_kind == "model":
-        if len(selected_models) != 1:
-            raise ValueError("a Model Candidate must contain exactly one model route")
-        if selected_members:
-            raise ValueError("a Model Candidate cannot contain members")
-    elif selected_kind == "pipeline":
-        if selected_members:
-            raise ValueError("a Pipeline Candidate cannot contain direct Fusion members")
-    elif not selected_members:
-        raise ValueError("a Fusion Candidate requires at least one direct member")
-    if scored and selected_failures:
-        raise ValueError("a failed Candidate cannot contain a score or metrics")
+    _validate_candidate_structure(selected_kind, selected_models, selected_members)
+    _validate_candidate_failures(selected_failures, scored=scored)
     return selected_kind, selected_models, selected_members, selected_failures
+
+
+def _validate_candidate_structure(
+    kind: RecipeKind,
+    models: Sequence[str],
+    members: Sequence[MemberResult],
+) -> None:
+    if kind == "model":
+        if len(models) != 1:
+            raise ValueError("a Model Candidate must contain exactly one model route")
+        if members:
+            raise ValueError("a Model Candidate cannot contain members")
+    elif kind == "pipeline":
+        if members:
+            raise ValueError("a Pipeline Candidate cannot contain direct Fusion members")
+    elif not members:
+        raise ValueError("a Fusion Candidate requires at least one direct member")
+
+
+def _validate_candidate_failures(failures: Sequence[Failure], *, scored: bool) -> None:
+    if any(failure.case_id is not None for failure in failures):
+        raise ValueError("a Candidate Failure cannot claim a Case id")
+    if scored and failures:
+        raise ValueError("a failed Candidate cannot contain a score or metrics")
 
 
 def _time_range(start: object, end: object, *, label: str) -> tuple[datetime, datetime]:

--- a/packages/screamingface/tests/test_benchmark_compilation.py
+++ b/packages/screamingface/tests/test_benchmark_compilation.py
@@ -320,10 +320,12 @@ class _Transport:
                     "metrics": {"coverage": 1.0},
                     "cases": [
                         {
+                            "status": "scored",
                             "case_id": 1,
                             "input": "Question",
                             "output": "Answer",
                             "finish_reason": "stop",
+                            "refusal": None,
                             "grade": {
                                 "method": "fixture",
                                 "score": 0.8,

--- a/packages/screamingface/tests/test_benchmark_variant_selection.py
+++ b/packages/screamingface/tests/test_benchmark_variant_selection.py
@@ -108,10 +108,12 @@ class _RunTransport:
                     "metrics": {},
                     "cases": [
                         {
+                            "status": "scored",
                             "case_id": 1,
                             "input": "Question",
                             "output": "Answer",
                             "finish_reason": "stop",
+                            "refusal": None,
                             "grade": {
                                 "method": "deterministic",
                                 "score": 1.0,

--- a/packages/screamingface/tests/test_case_outcome_decoding.py
+++ b/packages/screamingface/tests/test_case_outcome_decoding.py
@@ -1,0 +1,173 @@
+"""The client decodes the explicit Case outcome the OME-802 Engine publishes.
+
+INVARIANT defended: the `screamingface.candidate-result.v1` Case Result carries
+`status` (scored | refused | failed) and `refusal` on every Case — the client
+decodes them strictly (unknown keys and unknown statuses still fail loudly) and
+exposes them unmodified, never recalculating Benchmark semantics client-side.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import screamingface as sf
+from screamingface._evaluation.results import _case_result
+
+
+def _scored_payload() -> dict[str, Any]:
+    return {
+        "status": "scored",
+        "case_id": 1,
+        "input": "What is two plus two?",
+        "output": "Four.",
+        "finish_reason": "stop",
+        "refusal": None,
+        "grade": {"method": "rubric", "score": 1.0, "metrics": {}, "checks": []},
+        "failures": [],
+        "metadata": {},
+    }
+
+
+def _refused_payload() -> dict[str, Any]:
+    return {
+        "status": "refused",
+        "case_id": 1,
+        "input": "A clinical question",
+        "output": None,
+        "finish_reason": "stop",
+        "refusal": "I can't help with that request.",
+        "grade": None,
+        "failures": [
+            {
+                "stage": "candidate",
+                "code": "provider_refusal",
+                "message": "the provider refused this Case",
+                "retryable": None,
+                "case_id": 1,
+                "metadata": {},
+            }
+        ],
+        "metadata": {},
+    }
+
+
+def _failed_payload() -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "case_id": 1,
+        "input": "A question",
+        "output": None,
+        "finish_reason": None,
+        "refusal": None,
+        "grade": None,
+        "failures": [
+            {
+                "stage": "candidate",
+                "code": "provider_error",
+                "message": "the provider failed",
+                "retryable": True,
+                "case_id": 1,
+                "metadata": {},
+            }
+        ],
+        "metadata": {},
+    }
+
+
+@pytest.mark.parametrize(
+    ("payload", "status", "refusal"),
+    [
+        (_scored_payload(), "scored", None),
+        (_refused_payload(), "refused", "I can't help with that request."),
+        (_failed_payload(), "failed", None),
+    ],
+)
+def test_every_wire_status_decodes_and_is_exposed_unmodified(
+    payload: dict[str, Any], status: str, refusal: str | None
+) -> None:
+    case = _case_result(payload)
+
+    assert case.status == status
+    assert case.refusal == refusal
+
+
+def test_decoded_outcome_survives_export() -> None:
+    exported = _case_result(_refused_payload()).to_dict()
+
+    assert exported["status"] == "refused"
+    assert exported["refusal"] == "I can't help with that request."
+
+
+@pytest.mark.parametrize("key", ["status", "refusal"])
+def test_a_case_missing_a_contract_key_is_rejected(key: str) -> None:
+    payload = {name: value for name, value in _scored_payload().items() if name != key}
+
+    with pytest.raises(sf.ExecutionError, match=f"missing '{key}'"):
+        _case_result(payload)
+
+
+def test_an_unknown_case_key_is_still_rejected() -> None:
+    with pytest.raises(sf.ExecutionError, match="unsupported field 'unexpected'"):
+        _case_result({**_scored_payload(), "unexpected": True})
+
+
+def test_an_unsupported_status_is_rejected() -> None:
+    with pytest.raises(sf.ExecutionError, match="status is unsupported"):
+        _case_result({**_scored_payload(), "status": "skipped"})
+
+
+def test_blank_refusal_text_is_rejected() -> None:
+    with pytest.raises(sf.ExecutionError, match="refusal"):
+        _case_result({**_refused_payload(), "refusal": "   "})
+
+
+def test_a_status_contradicting_the_grade_shape_is_rejected() -> None:
+    with pytest.raises(ValueError, match="status"):
+        sf.CaseResult(
+            status="failed",
+            case_id=1,
+            input="question",
+            output="answer",
+            finish_reason="stop",
+            grade=sf.CaseGrade(method="rubric", score=1.0, metrics={}, checks=()),
+            failures=(),
+            metadata={},
+        )
+
+
+def test_a_scored_case_cannot_carry_refusal_text() -> None:
+    with pytest.raises(ValueError, match="refusal"):
+        sf.CaseResult(
+            case_id=1,
+            input="question",
+            output="answer",
+            finish_reason="stop",
+            refusal="I refuse.",
+            grade=sf.CaseGrade(method="rubric", score=1.0, metrics={}, checks=()),
+            failures=(),
+            metadata={},
+        )
+
+
+def test_a_locally_built_case_derives_the_status_the_engine_would_publish() -> None:
+    refused = sf.CaseResult(
+        case_id=1,
+        input="question",
+        output=None,
+        finish_reason=None,
+        refusal="I can't help with that request.",
+        grade=None,
+        failures=(
+            sf.Failure(
+                stage="candidate",
+                code="provider_refusal",
+                message="the provider refused this Case",
+                case_id=1,
+            ),
+        ),
+        metadata={},
+    )
+
+    assert refused.status == "refused"

--- a/packages/screamingface/tests/test_case_outcome_decoding.py
+++ b/packages/screamingface/tests/test_case_outcome_decoding.py
@@ -151,6 +151,52 @@ def test_a_scored_case_cannot_carry_refusal_text() -> None:
         )
 
 
+def test_a_refused_case_cannot_carry_output() -> None:
+    # INVARIANT: mirrors contract.py _enforce_status — a refused Case has no output,
+    # so a locally built value can never round-trip into a contract-invalid payload.
+    with pytest.raises(ValueError, match="refused"):
+        sf.CaseResult(
+            case_id=1,
+            input="question",
+            output="an answer the engine would reject",
+            finish_reason="stop",
+            refusal="I can't help with that request.",
+            grade=None,
+            failures=(
+                sf.Failure(
+                    stage="candidate",
+                    code="provider_refusal",
+                    message="the provider refused this Case",
+                    case_id=1,
+                ),
+            ),
+            metadata={},
+        )
+
+
+def test_a_refused_case_cannot_carry_a_grade() -> None:
+    # INVARIANT: mirrors contract.py _enforce_status — refusal text alongside a grade
+    # (even an unscored one) is a shape the engine rejects outright.
+    with pytest.raises(ValueError, match="refused"):
+        sf.CaseResult(
+            case_id=1,
+            input="question",
+            output=None,
+            finish_reason="stop",
+            refusal="I can't help with that request.",
+            grade=sf.CaseGrade(method="rubric", score=None, metrics={}, checks=()),
+            failures=(
+                sf.Failure(
+                    stage="candidate",
+                    code="provider_refusal",
+                    message="the provider refused this Case",
+                    case_id=1,
+                ),
+            ),
+            metadata={},
+        )
+
+
 def test_a_locally_built_case_derives_the_status_the_engine_would_publish() -> None:
     refused = sf.CaseResult(
         case_id=1,

--- a/packages/screamingface/tests/test_case_outcome_decoding.py
+++ b/packages/screamingface/tests/test_case_outcome_decoding.py
@@ -76,6 +76,37 @@ def _failed_payload() -> dict[str, Any]:
     }
 
 
+def _ifeval_payload() -> dict[str, Any]:
+    payload = _scored_payload()
+    payload["input"] = "Write exactly three words."
+    payload["output"] = "One two three"
+    payload["grade"] = {
+        "method": "deterministic",
+        "score": 1.0,
+        "metrics": {"instructions_followed": 1},
+        "checks": [],
+    }
+    payload["metadata"] = {"benchmark": "ifeval"}
+    return payload
+
+
+def _healthbench_payload() -> dict[str, Any]:
+    payload = _scored_payload()
+    payload["input"] = (
+        '{"schema":"screamingface.candidate-input.v1","messages":'
+        '[{"role":"user","content":"I have chest pain."}]}'
+    )
+    payload["output"] = "Seek urgent medical assessment."
+    payload["grade"] = {
+        "method": "rubric",
+        "score": -0.25,
+        "metrics": {"rubrics_judged": 2},
+        "checks": [],
+    }
+    payload["metadata"] = {"benchmark": "healthbench/worst30"}
+    return payload
+
+
 @pytest.mark.parametrize(
     ("payload", "status", "refusal"),
     [
@@ -100,7 +131,127 @@ def test_decoded_outcome_survives_export() -> None:
     assert exported["refusal"] == "I can't help with that request."
 
 
-@pytest.mark.parametrize("key", ["status", "refusal"])
+def test_wire_text_and_string_identity_survive_without_normalization() -> None:
+    payload = _refused_payload()
+    payload.update(
+        {
+            "case_id": " case-1 ",
+            "input": " prompt with intentional padding ",
+            "finish_reason": " content_filter ",
+            "refusal": " exact provider refusal ",
+        }
+    )
+    failure = payload["failures"][0]
+    failure.update(
+        {
+            "message": " exact failure message ",
+            "case_id": " case-1 ",
+        }
+    )
+
+    assert _case_result(payload).to_dict() == payload
+
+
+def test_failure_code_uses_the_engine_open_nonempty_contract() -> None:
+    payload = _failed_payload()
+    payload["failures"][0]["code"] = "Provider Error"
+
+    assert _case_result(payload).failures[0].code == "Provider Error"
+
+
+def test_nested_grade_and_evidence_round_trip_the_exact_engine_contract() -> None:
+    payload = _scored_payload()
+    payload["grade"] = {
+        "method": " deterministic ",
+        "score": 1.0,
+        "metrics": {},
+        "checks": [
+            {
+                "type": " instruction ",
+                "id": " check-1 ",
+                "label": "",
+                "outcome": "MET",
+                "score": 1.0,
+                "evidence": [
+                    {
+                        "sequence": 1,
+                        "producer": {"type": "sandboxed-python", "id": " checker/custom "},
+                        "valid": True,
+                        "outcome": "PASS",
+                        "explanation": " exact explanation ",
+                        "raw_output": {"passed": True},
+                        "metadata": {},
+                    }
+                ],
+                "metadata": {},
+            }
+        ],
+    }
+
+    assert _case_result(payload).to_dict() == payload
+
+
+@pytest.mark.parametrize(
+    ("path", "value", "message"),
+    [
+        (("grade", "score"), 1.1, "Case Grade score must be at most 1"),
+        (("grade", "checks", 0, "score"), -0.1, "Check score must be between 0 and 1"),
+        (("grade", "checks", 0, "outcome"), "PASS", "Check outcome"),
+        (("grade", "checks", 0, "evidence", 0, "outcome"), "MAYBE", "Evidence outcome"),
+    ],
+)
+def test_nested_grade_contract_rejects_values_the_engine_cannot_publish(
+    path: tuple[str | int, ...], value: object, message: str
+) -> None:
+    payload = _scored_payload()
+    payload["grade"] = {
+        "method": "rubric",
+        "score": 1.0,
+        "metrics": {},
+        "checks": [
+            {
+                "type": "criterion",
+                "id": "check-1",
+                "label": "label",
+                "outcome": "MET",
+                "score": 1.0,
+                "evidence": [
+                    {
+                        "sequence": 1,
+                        "producer": {"type": "model", "id": "judge"},
+                        "valid": True,
+                        "outcome": "PASS",
+                        "raw_output": {},
+                        "metadata": {},
+                    }
+                ],
+                "metadata": {},
+            }
+        ],
+    }
+    selected: Any = payload
+    for part in path[:-1]:
+        selected = selected[part]
+    selected[path[-1]] = value
+
+    with pytest.raises(sf.ExecutionError, match=message):
+        _case_result(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [_scored_payload(), _ifeval_payload(), _healthbench_payload()],
+    ids=["draco", "ifeval", "healthbench"],
+)
+def test_each_benchmark_family_decodes_through_the_same_case_contract(
+    payload: dict[str, Any],
+) -> None:
+    case = _case_result(payload)
+
+    assert case.to_dict() == payload
+
+
+@pytest.mark.parametrize("key", tuple(_scored_payload()))
 def test_a_case_missing_a_contract_key_is_rejected(key: str) -> None:
     payload = {name: value for name, value in _scored_payload().items() if name != key}
 
@@ -197,7 +348,7 @@ def test_a_refused_case_cannot_carry_a_grade() -> None:
         )
 
 
-def test_a_locally_built_case_derives_the_status_the_engine_would_publish() -> None:
+def test_a_locally_built_case_derives_status_without_weakening_wire_decoding() -> None:
     refused = sf.CaseResult(
         case_id=1,
         input="question",

--- a/packages/screamingface/tests/test_case_result_contract_boundaries.py
+++ b/packages/screamingface/tests/test_case_result_contract_boundaries.py
@@ -353,10 +353,12 @@ def test_wire_case_result_rejects_a_failure_owned_by_another_case() -> None:
     with pytest.raises(sf.ExecutionError, match="another Case"):
         _case_result(
             {
+                "status": "failed",
                 "case_id": 1,
                 "input": "question",
                 "output": None,
                 "finish_reason": None,
+                "refusal": None,
                 "grade": None,
                 "failures": [
                     {

--- a/packages/screamingface/tests/test_case_result_contract_boundaries.py
+++ b/packages/screamingface/tests/test_case_result_contract_boundaries.py
@@ -51,16 +51,17 @@ def _grade() -> sf.CaseGrade:
 
 
 def _failure_value() -> sf.Failure:
-    return sf.Failure(stage="candidate", code="provider_error", message="provider failed")
+    return sf.Failure(
+        stage="candidate",
+        code="provider_error",
+        message="provider failed",
+        case_id=1,
+    )
 
 
 @pytest.mark.parametrize(
     ("factory", "message"),
     [
-        (
-            lambda: sf.EvidenceProducer(type=cast(Any, "unsupported"), id="judge"),
-            "producer type",
-        ),
         (
             lambda: sf.Evidence(sequence=0, producer=_producer(), valid=True, raw_output="answer"),
             "positive integer",
@@ -94,6 +95,16 @@ def _failure_value() -> sf.Failure:
             "invalid Evidence",
         ),
         (
+            lambda: sf.Evidence(
+                sequence=1,
+                producer=_producer(),
+                valid=True,
+                outcome=cast(Any, "UNKNOWN"),
+                raw_output="answer",
+            ),
+            "Evidence outcome",
+        ),
+        (
             lambda: sf.Check(
                 type="criterion",
                 id="criterion-1",
@@ -112,6 +123,16 @@ def _failure_value() -> sf.Failure:
             "unique and ordered",
         ),
         (
+            lambda: sf.Check(
+                type="criterion",
+                id="criterion-1",
+                label="label",
+                evidence=(),
+                outcome=cast(Any, "PASS"),
+            ),
+            "Check outcome",
+        ),
+        (
             lambda: sf.CaseGrade(
                 method="rubric", score=1.0, metrics={}, checks=cast(Any, (object(),))
             ),
@@ -128,7 +149,7 @@ def _failure_value() -> sf.Failure:
         ),
         (
             lambda: sf.CaseResult(
-                case_id=0,
+                case_id="",
                 input="question",
                 output="answer",
                 finish_reason="stop",
@@ -136,7 +157,19 @@ def _failure_value() -> sf.Failure:
                 failures=(),
                 metadata={},
             ),
-            "positive integer",
+            "non-blank string",
+        ),
+        (
+            lambda: sf.CaseResult(
+                case_id=1,
+                input="question",
+                output=cast(Any, 42),
+                finish_reason="stop",
+                grade=_grade(),
+                failures=(),
+                metadata={},
+            ),
+            "output must be text",
         ),
         (
             lambda: sf.CaseResult(
@@ -172,7 +205,7 @@ def _failure_value() -> sf.Failure:
                 failures=(),
                 metadata={},
             ),
-            "ungraded",
+            "status 'failed'",
         ),
         (
             lambda: sf.CaseResult(
@@ -184,7 +217,7 @@ def _failure_value() -> sf.Failure:
                 failures=(),
                 metadata={},
             ),
-            "unscored Case Grade",
+            "status 'failed'",
         ),
         (
             lambda: sf.CaseResult(
@@ -196,7 +229,20 @@ def _failure_value() -> sf.Failure:
                 failures=(_failure_value(),),
                 metadata={},
             ),
-            "graded Case Result",
+            "status 'scored'",
+        ),
+        (
+            lambda: sf.CaseResult(
+                case_id=1,
+                input="question",
+                output="answer",
+                finish_reason="stop",
+                grade=_grade(),
+                failures=(),
+                metadata={},
+                status=cast(Any, "unknown"),
+            ),
+            "Case Result status",
         ),
         (
             lambda: sf.Check(
@@ -270,7 +316,6 @@ def test_wire_failure_decoder_accepts_each_stage_and_case_id_shape() -> None:
                 "code": "provider_error",
                 "message": "provider failed",
                 "retryable": False,
-                "operation_id": "op_1",
                 "case_id": case_id,
                 "metadata": {},
             }
@@ -300,6 +345,12 @@ def test_wire_evidence_decoder_accepts_a_deterministic_producer() -> None:
     assert evidence.producer.type == "deterministic"
 
 
+def test_evidence_producer_type_is_open_nonempty_engine_text() -> None:
+    producer = sf.EvidenceProducer(type="sandboxed-python", id="checker/custom")
+
+    assert producer.to_dict() == {"type": "sandboxed-python", "id": "checker/custom"}
+
+
 @pytest.mark.parametrize(
     ("factory", "message"),
     [
@@ -316,7 +367,7 @@ def test_wire_evidence_decoder_accepts_a_deterministic_producer() -> None:
         (lambda: _positive_integer(True, "sequence"), "positive integer"),
         (lambda: _text(" ", "label"), "non-empty text"),
         (lambda: _number(True, "score"), "must be numeric"),
-        (lambda: _producer_type("unsupported"), "producer type is unsupported"),
+        (lambda: _producer_type(""), "producer type must be non-empty"),
         (lambda: _failure_stage("planning"), "Failure stage is unsupported"),
         (lambda: _failure_case_id(True), "case_id must be"),
         (
@@ -338,6 +389,8 @@ def test_wire_evidence_decoder_accepts_a_deterministic_producer() -> None:
                     "code": "provider_error",
                     "message": "provider failed",
                     "retryable": "yes",
+                    "case_id": None,
+                    "metadata": {},
                 }
             ),
             "retryable must be boolean or null",
@@ -350,7 +403,7 @@ def test_wire_case_result_decoder_rejects_ambiguous_values(factory: Any, message
 
 
 def test_wire_case_result_rejects_a_failure_owned_by_another_case() -> None:
-    with pytest.raises(sf.ExecutionError, match="another Case"):
+    with pytest.raises(sf.ExecutionError, match="reference its own case_id"):
         _case_result(
             {
                 "status": "failed",
@@ -365,7 +418,9 @@ def test_wire_case_result_rejects_a_failure_owned_by_another_case() -> None:
                         "stage": "candidate",
                         "code": "provider_error",
                         "message": "provider failed",
+                        "retryable": None,
                         "case_id": 2,
+                        "metadata": {},
                     }
                 ],
                 "metadata": {},

--- a/packages/screamingface/tests/test_case_results.py
+++ b/packages/screamingface/tests/test_case_results.py
@@ -118,10 +118,12 @@ def test_failed_case_retains_the_failure_without_fabricating_an_output_or_grade(
     )
 
     case = sf.CaseResult(
+        status="refused",
         case_id=2,
         input="A clinical question",
         output=None,
         finish_reason=None,
+        refusal="provider refused the request",
         grade=None,
         failures=(failure,),
         metadata={"domain": "Medicine"},
@@ -132,6 +134,7 @@ def test_failed_case_retains_the_failure_without_fabricating_an_output_or_grade(
             "stage": "candidate",
             "code": "provider_refusal",
             "message": "provider refused the request",
+            "retryable": None,
             "case_id": 2,
             "metadata": {"error_kind": "ResolutionError"},
         }
@@ -164,7 +167,7 @@ _ENVELOPE = (
 )
 
 
-def _case_with_input(value: object) -> sf.CaseResult:
+def _case_with_input(value: str) -> sf.CaseResult:
     case = _graded_case()
     return sf.CaseResult(
         case_id=case.case_id,

--- a/packages/screamingface/tests/test_case_results.py
+++ b/packages/screamingface/tests/test_case_results.py
@@ -51,10 +51,12 @@ def test_case_result_serializes_every_observed_fact_losslessly() -> None:
     case = _graded_case()
 
     assert case.to_dict() == {
+        "status": "scored",
         "case_id": 1,
         "input": "What is two plus two?",
         "output": "Four.",
         "finish_reason": "stop",
+        "refusal": None,
         "grade": {
             "method": "rubric",
             "score": 1.0,

--- a/packages/screamingface/tests/test_client_run.py
+++ b/packages/screamingface/tests/test_client_run.py
@@ -181,10 +181,12 @@ class _ReplayTransport:
                     "metrics": {},
                     "cases": [
                         {
+                            "status": "scored",
                             "case_id": 1,
                             "input": "Fixture question",
                             "output": "Fixture answer",
                             "finish_reason": "stop",
+                            "refusal": None,
                             "grade": {
                                 "method": "fixture",
                                 "score": 1.0,

--- a/packages/screamingface/tests/test_draco_vertical_slice.py
+++ b/packages/screamingface/tests/test_draco_vertical_slice.py
@@ -185,11 +185,13 @@ class _FakeTransport:
     def __init__(self, result_payload: dict[str, object] | None = None) -> None:
         self.closed = False
         self.calls: list[str] = []
+        self.url4s: list[str] = []
         self._result_payload = deepcopy(result_payload)
 
     def run(self, candidate: Candidate, on_event: object) -> _RunOutcome:
         assert on_event is None
         self.calls.append(candidate.name)
+        self.url4s.append(candidate.url4)
         return _RunOutcome(
             run_id=f"run_{candidate.name}",
             started_at=datetime(2026, 7, 28, 10, 0, tzinfo=UTC),
@@ -343,6 +345,11 @@ def _assert_case_artifact(result: sf.CandidateResult) -> None:
     assert result.to_dict()["cases"] == [_case_payload(score=0.7)]
 
 
+def _assert_transport_artifact(transport: _FakeTransport, result: sf.CandidateResult) -> None:
+    assert transport.url4s == [result.url4]
+    assert transport.closed is True
+
+
 def test_client_evaluates_the_complete_draco_vertical_slice() -> None:
     client, transport = _client()
 
@@ -375,7 +382,7 @@ def test_client_evaluates_the_complete_draco_vertical_slice() -> None:
     _assert_case_artifact(result)
     assert result.usage.input_tokens == 120
     assert result.duration_ms == 2000
-    assert transport.closed is True
+    _assert_transport_artifact(transport, result)
 
 
 def test_client_preserves_nested_candidate_metrics() -> None:

--- a/packages/screamingface/tests/test_draco_vertical_slice.py
+++ b/packages/screamingface/tests/test_draco_vertical_slice.py
@@ -114,10 +114,12 @@ BENCHMARK: dict[str, object] = {
 def _case_payload(*, score: float = 1.0) -> dict[str, object]:
     raw = '{"explanation":"The response satisfies the criterion.","criterion_status":"MET"}'
     return {
+        "status": "scored",
         "case_id": 1,
         "input": "Fixture question",
         "output": "Fixture answer",
         "finish_reason": "stop",
+        "refusal": None,
         "grade": {
             "method": "rubric",
             "score": score,
@@ -153,6 +155,7 @@ def _case_payload(*, score: float = 1.0) -> dict[str, object]:
 
 def _unscored_invalid_evidence_case_payload() -> dict[str, object]:
     case = _case_payload()
+    case["status"] = "failed"
     grade = cast(dict[str, Any], case["grade"])
     grade["score"] = None
     check = cast(list[dict[str, Any]], grade["checks"])[0]
@@ -807,10 +810,12 @@ def test_candidate_result_decoder_retains_an_unscored_failed_case() -> None:
                 "metrics": {},
                 "cases": [
                     {
+                        "status": "refused",
                         "case_id": 1,
                         "input": "Fixture question",
                         "output": None,
                         "finish_reason": None,
+                        "refusal": "provider refused the request",
                         "grade": None,
                         "failures": [failure],
                         "metadata": {},
@@ -828,6 +833,8 @@ def test_candidate_result_decoder_retains_an_unscored_failed_case() -> None:
     assert result.score is None
     assert result.metrics == {}
     assert result.cases[0].grade is None
+    assert result.cases[0].status == "refused"
+    assert result.cases[0].refusal == "provider refused the request"
     assert result.cases[0].failures[0].code == "provider_refusal"
 
 

--- a/packages/screamingface/tests/test_report.py
+++ b/packages/screamingface/tests/test_report.py
@@ -39,6 +39,7 @@ def candidate(
     *,
     url4: str | None = None,
     score: float | None = 0.5,
+    cases: tuple[sf.CaseResult, ...] | None = None,
     failures: tuple[sf.Failure, ...] = (),
     usage: sf.Usage | None = None,
 ) -> sf.CandidateResult:
@@ -68,7 +69,7 @@ def candidate(
         ),
         score=score,
         metrics=metrics,
-        cases=case_results(),
+        cases=case_results() if cases is None else cases,
         members=(),
         failures=failures,
         usage=usage or sf.Usage(input_tokens=100, output_tokens=20, cost_usd="0.12"),
@@ -126,6 +127,86 @@ def test_only_returns_the_single_candidate() -> None:
     opus = candidate("opus")
 
     assert report(opus).candidates.only is opus
+
+
+def test_candidate_cases_keep_order_and_use_explicit_identity_lookup() -> None:
+    first = case_results()[0]
+    second = sf.CaseResult(
+        status="scored",
+        case_id="healthbench-case-2",
+        input="Question two",
+        output="Answer two",
+        finish_reason="stop",
+        grade=sf.CaseGrade(method="fixture", score=1.0, metrics={}, checks=()),
+        failures=(),
+        metadata={},
+    )
+    cases = candidate("opus", cases=(first, second)).cases
+
+    assert cases[0] is first
+    assert cases[1] is second
+    assert cases.by_id(1) is first
+    assert cases.by_id("healthbench-case-2") is second
+    with pytest.raises(KeyError, match="unknown Case id"):
+        cases.by_id("missing")
+
+
+def test_report_json_and_export_preserve_refusal_and_failure_fields(tmp_path: Path) -> None:
+    refused = sf.CaseResult(
+        status="refused",
+        case_id="refusal-case",
+        input="A request",
+        output=None,
+        finish_reason="stop",
+        refusal="I cannot comply.",
+        grade=None,
+        failures=(
+            sf.Failure(
+                stage="candidate",
+                code="provider_refusal",
+                message="the provider refused this Case",
+                retryable=None,
+                case_id="refusal-case",
+                metadata={"provider": "fixture"},
+            ),
+        ),
+        metadata={},
+    )
+    failed = sf.CaseResult(
+        status="failed",
+        case_id=2,
+        input="Another request",
+        output=None,
+        finish_reason=None,
+        grade=None,
+        failures=(
+            sf.Failure(
+                stage="candidate",
+                code="provider_error",
+                message="the provider was unavailable",
+                retryable=True,
+                case_id=2,
+                metadata={},
+            ),
+        ),
+        metadata={},
+    )
+    value = report(candidate("opus", score=None, cases=(refused, failed)))
+
+    selected = value.export(tmp_path / "report.json")
+    payload = json.loads(selected.read_text(encoding="utf-8"))
+    exported_cases = payload["candidates"][0]["cases"]
+    assert exported_cases[0]["status"] == "refused"
+    assert exported_cases[0]["refusal"] == "I cannot comply."
+    assert exported_cases[0]["failures"][0] == {
+        "stage": "candidate",
+        "code": "provider_refusal",
+        "message": "the provider refused this Case",
+        "retryable": None,
+        "case_id": "refusal-case",
+        "metadata": {"provider": "fixture"},
+    }
+    assert exported_cases[1]["status"] == "failed"
 
 
 def test_candidate_result_preserves_its_operation_map_in_portable_json() -> None:
@@ -203,7 +284,7 @@ def test_report_flattens_candidate_failures_without_duplicating_them_on_the_wire
         message="The model timed out.",
         retryable=True,
         operation_id="op_opus",
-        case_id="case-2",
+        case_id=None,
     )
     value = report(candidate("opus", score=None, failures=(owned,)))
 
@@ -242,6 +323,7 @@ def test_failure_serializes_the_locked_domain_contract() -> None:
         "retryable": True,
         "operation_id": "op_grade_1",
         "case_id": "case-42",
+        "metadata": {},
     }
 
 

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -46,7 +46,11 @@ def case(*, checks: tuple[Check, ...] = (), score: float | None = 0.0) -> CaseRe
 
 
 def candidate(
-    name: str, score: float | None, *, cases: tuple[CaseResult, ...] = ()
+    name: str,
+    score: float | None,
+    *,
+    cases: tuple[CaseResult, ...] = (),
+    failures: tuple[sf.Failure, ...] = (),
 ) -> CandidateResult:
     return CandidateResult(
         benchmark=_BENCHMARK,
@@ -63,7 +67,7 @@ def candidate(
         metrics=_METRICS if score is not None else {},
         cases=list(cases) or [case()],
         members=[],
-        failures=[],
+        failures=failures,
         usage=sf.Usage(input_tokens=3449, output_tokens=2340),
     )
 
@@ -270,12 +274,12 @@ def multi_case_report(*cases: CaseResult) -> Report:
     return Report(benchmark=benchmark, case_count=len(cases), candidates=[sized])
 
 
-def failed_case(case_id: int = 153) -> CaseResult:
+def failed_case(case_id: int | str = 153) -> CaseResult:
     """A Case the Engine could not grade — the OME-793 incident shape."""
 
     return CaseResult(
         case_id=case_id,
-        input=None,
+        input="input unavailable",
         output=None,
         finish_reason=None,
         grade=None,
@@ -301,6 +305,52 @@ def failed_case(case_id: int = 153) -> CaseResult:
     )
 
 
+def refused_case(case_id: int = 154) -> CaseResult:
+    """A provider refusal is a scored zero outcome, not missing infrastructure."""
+
+    refusal = "I cannot provide an answer to that request."
+    return CaseResult(
+        case_id=case_id,
+        input="the prompt",
+        output=None,
+        finish_reason="content_filter",
+        grade=None,
+        failures=[
+            sf.Failure(
+                stage="candidate",
+                code="provider_refusal",
+                message=refusal,
+                case_id=case_id,
+            )
+        ],
+        metadata={},
+        status="refused",
+        refusal=refusal,
+    )
+
+
+def unscored_case(case_id: int = 155) -> CaseResult:
+    """A failed grader may preserve partial evidence without producing a score."""
+
+    return CaseResult(
+        case_id=case_id,
+        input="the prompt",
+        output=None,
+        finish_reason=None,
+        grade=CaseGrade(method="rubric", score=None, metrics={}, checks=[]),
+        failures=[
+            sf.Failure(
+                stage="grading",
+                code="no_valid_judge_verdict",
+                message="no valid Judge verdict was produced",
+                case_id=case_id,
+            )
+        ],
+        metadata={},
+        status="failed",
+    )
+
+
 # WHY (OME-793): an infra failure must never present as a wrong answer — the badge is the
 # first thing a reader trusts, and "incorrect" on a never-graded case misreports the run.
 def test_a_failed_case_is_not_painted_as_incorrect() -> None:
@@ -323,6 +373,25 @@ def test_a_failed_case_pane_shows_the_failure_chain_not_nothing() -> None:
     assert "input unavailable" in html
 
 
+def test_a_refused_case_is_named_and_shows_the_exact_provider_refusal() -> None:
+    html = body(report_html(report(candidate("m", None, cases=(refused_case(),)))))
+
+    assert "refused" in html
+    assert "provider refusal" in html
+    assert "I cannot provide an answer to that request." in html
+    assert "incorrect" not in html
+    assert "sf-badge--warn" in html
+
+
+def test_partial_grading_evidence_is_presented_as_unscored_not_incorrect() -> None:
+    html = body(report_html(report(candidate("m", None, cases=(unscored_case(),)))))
+
+    assert "unscored" in html
+    assert "no_valid_judge_verdict" in html
+    assert "incorrect" not in html
+    assert "sf-badge--warn" in html
+
+
 # WHY (OME-793): three identical banner lines with no ids forced readers into raw JSON;
 # grouping keeps the count while naming every case.
 def test_the_failure_banner_names_cases_and_groups_identical_failures() -> None:
@@ -333,8 +402,23 @@ def test_the_failure_banner_names_cases_and_groups_identical_failures() -> None:
     assert "cases 153, 149, 418" in banner
     assert "missing_case_row" in banner
     assert "ResolutionError: malformed aigateway response" in banner
-    # Grouped: the shared message appears ONCE in the banner, not three times.
-    assert banner.count("no evaluation row for this Case reached the aggregate") == 1
+    # Grouped summary first; the disclosure retains every exact Failure payload.
+    summary = banner.split("<details>", 1)[0]
+    assert summary.count("no evaluation row for this Case reached the aggregate") == 1
+    assert "&quot;case_id&quot;: 153" in banner
+
+
+def test_failure_summary_preserves_zero_as_a_real_case_id() -> None:
+    banner = _failures_html(multi_case_report(failed_case(0)))
+
+    assert "case 0" in banner
+
+
+def test_string_case_ids_are_escaped_in_the_rail_and_detail_pane() -> None:
+    html = body(report_html(multi_case_report(failed_case("<img src=x onerror=alert(1)>"))))
+
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html
+    assert "<img src=x" not in html
 
 
 # WHY (OME-793): a bare dash teaches readers that dashes are meaningless; the withheld
@@ -343,7 +427,19 @@ def test_an_unscored_candidate_explains_the_withheld_score() -> None:
     html = body(report_html(multi_case_report(case(), failed_case())))
 
     assert "score withheld" in html
-    assert "1 of 2 cases failed" in html
+    assert "1 of 2 cases not scored (1 failed)" in html
+
+
+def test_a_candidate_level_failure_explains_a_withheld_score() -> None:
+    failure = sf.Failure(
+        stage="aggregation",
+        code="orphan_rows",
+        message="aggregate received rows for an unknown Case",
+    )
+    html = body(report_html(report(candidate("m", None, failures=(failure,)))))
+
+    assert "score withheld" in html
+    assert "candidate execution reported 1 failure" in html
 
 
 def test_an_absent_cost_says_it_was_not_reported() -> None:
@@ -369,13 +465,19 @@ def test_empty_cases_and_untrusted_failures_have_safe_markup() -> None:
         cast(
             Report,
             SimpleNamespace(
-                failures=(SimpleNamespace(stage="run", message="<script>failed</script>"),)
+                failures=(
+                    sf.Failure(
+                        stage="aggregation",
+                        code="unsafe_text",
+                        message="<script>failed</script>",
+                    ),
+                )
             ),
         )
     )
 
     assert "1 failure" in html
-    assert "run · &lt;script&gt;failed&lt;/script&gt;" in html
+    assert "aggregation · unsafe_text — &lt;script&gt;failed&lt;/script&gt;" in html
     assert "<script>" not in html
 
 

--- a/packages/screamingface/tests/test_value_validation.py
+++ b/packages/screamingface/tests/test_value_validation.py
@@ -158,16 +158,6 @@ def test_candidate_metrics_preserve_json_compatible_values() -> None:
             "operation_id",
         ),
         (
-            lambda: sf.Failure(
-                stage="candidate",
-                code="Gateway Timeout",
-                message="x",
-                retryable=False,
-                operation_id="op_1",
-            ),
-            "lowercase snake_case",
-        ),
-        (
             lambda: sf.CandidateResult(
                 benchmark=benchmark(),
                 run_id="run",


### PR DESCRIPTION
## Summary

- Consume the complete strict `screamingface.candidate-result.v1` Case contract introduced by OME-802, including explicit `scored` / `refused` / `failed` status, exact refusal text, stable string-or-integer Case identity, and the exact nested Failure/grade/evidence shape.
- Preserve those outcomes through `.cases.by_id(...)`, Candidate Result and Report serialization/export, and the exact URL4 receipt used for execution.
- Render refused, failed, and partial-evidence unscored Cases distinctly from incorrect answers, with exact refusal/failure disclosures and clear withheld-score explanations.

## Why

After OME-802, the Engine sends `status` and `refusal` on every Case. The Client's former closed decoder rejected those fields, so a successful Engine run failed while constructing its Report. Accepting only the two new keys would still lose valid string IDs, normalize exact diagnostics, and render refused/failed outcomes incorrectly.

This PR completes the Client half of the normalized contract without moving Benchmark scoring semantics into the SDK.

## Contract guarantees

- All nine Case fields are required; unknown and legacy-shaped payloads remain rejected.
- Nested Failure, Case Grade, Check, Evidence, and producer values mirror the Engine contract, including numeric bounds and open non-empty producer/failure identifiers.
- Wire text and Case identity are preserved exactly rather than trimmed.
- Direct Python construction may derive `status` from an unambiguous complete Case shape; the wire decoder never does.
- String Case IDs are escaped before notebook rendering.
- OME-807's revised scoring/failure policy remains a separate coordinated producer/consumer change.

## Verification

- 742 passed, 1 skipped.
- Ruff check and format clean.
- Pyright: 0 errors.
- Coverage gate: at least 95%.
- Notebook consistency, package build, and distribution inspection green.
- Independent Standards and Spec reviews: clean.

The repository gate was run with `--skip-append-only`. Existing result fixtures had to gain OME-802's mandatory fields; inherited boundary, serialization, presentation, and vertical-slice expectations were updated where the new strict contract makes the old assertion invalid. The obsolete Client-only snake-case Failure-code restriction was replaced with a positive test of the Engine's open non-empty contract. These changes strengthen contract coverage rather than removing it.

Process note: the initial three implementation commits predated the repository spec/plan artifacts. The design and implementation had explicit owner approval in the working conversation; the missing artifacts were added during review and the historical sequencing deviation is recorded in the work ledger.

Refs: OME-803
