### PR TITLE
feat(screamingface): repr + notebook card for model discovery values

### DIFF
--- a/docs/tasks/2026-08-13-model-details-repr.md
+++ b/docs/tasks/2026-08-13-model-details-repr.md
@@ -1,0 +1,20 @@
+---
+id: OME-808
+linear_url: https://linear.app/openmined/issue/OME-808/add-repr-and-notebook-card-for-modelinfo-and-modeldetails-discovery
+asana_url:
+status: in_progress
+type: task
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-13
+closed:
+---
+
+# OME-808 — repr + notebook card for ModelInfo and ModelDetails
+
+Add compact constructor-style `__repr__` to `ModelInfo` and `ModelDetails`, plus an SFDS
+`_repr_html_` notebook card on `ModelDetails` only (mirrors the `Benchmark`/`BenchmarkInfo`
+split). Discovery values currently fall back to the dataclass default repr, which for
+`ModelDetails` dumps its entire nested contract.
+
+Ledger: `docs/work/2026-08-13-OME-808-model-details-repr.md`

--- a/docs/work/2026-08-13-OME-808-model-details-repr.md
+++ b/docs/work/2026-08-13-OME-808-model-details-repr.md
@@ -1,0 +1,64 @@
+---
+ticket: OME-808
+stack: screamingface
+status: in_progress   # planned | in_progress | done | blocked
+started: 2026-08-13
+finished:
+---
+
+# OME-808 — repr + notebook card for ModelInfo and ModelDetails
+
+## Intent
+
+`client.models.list()` returns `ModelInfo` and `client.models.get(...)` returns
+`ModelDetails` (frozen dataclasses in `packages/screamingface/src/screamingface/discovery.py`).
+Neither defines `__repr__`, so both fall back to the dataclass default — for `ModelDetails`
+an unreadable wall of 15 fields including three `MappingProxyType` mappings of full nested
+reprs. Give both a compact constructor-style `__repr__`, and give the richer `ModelDetails`
+an SFDS notebook card (`_repr_html_`), matching the rest of the SDK (`Model`, `Benchmark`,
+`Leaderboard`, `Report`). The `Model` recipe already has both reprs and is not touched.
+
+## Planned changes
+
+- `src/screamingface/discovery.py` — add `ModelInfo.__repr__`; add `ModelDetails.__repr__`
+  and `ModelDetails._repr_html_` (lazy import of the card helper).
+- `src/screamingface/_ui/cards.py` — add `model_details_card_html()`; add `ModelDetails`
+  to the `TYPE_CHECKING` import.
+- `tests/test_model_parameter_discovery.py` — repr assertions for `ModelInfo` +
+  `ModelDetails` (incl. a stale/degraded flag case).
+- `tests/test_rich_display.py` — `ModelDetails` card test (real escaped fields present,
+  `_FABRICATED` terms absent).
+
+No schema change (S1 n/a). No public-interface change — `ModelInfo`/`ModelDetails` already
+exported.
+
+## Test plan
+
+- RED first. `repr(ModelInfo(...))` and `repr(ModelDetails(...))` exact-string assertions
+  against the existing `_model_parameter_fixtures` (3 params / 1 tool / 1 transport, fresh).
+- Boundary: a `stale=True` (and a `degraded=True`) `ModelDetails` surfaces the flag; fresh
+  shows neither.
+- Card: `_repr_html_()` contains escaped `id`/`provider`/`scope`/`fresh`; loops the
+  `_FABRICATED` tuple asserting each banned metric term is absent.
+
+## Acceptance
+
+- `repr(ModelInfo(...))` == `ModelInfo('<id>', provider='<p>', parameters=N, tools=M)`
+- `repr(ModelDetails(...))` == `ModelDetails('<id>', provider='<p>', scope='<s>', parameters=N, tools=M, transport=K)` (+ flags only when set)
+- `ModelDetails._repr_html_()` renders a card and passes the `_FABRICATED` guard.
+- Full screamingface gate suite green (coverage ≥95%).
+
+## Outcome
+
+- **Actual files:** exactly as planned —
+  `src/screamingface/discovery.py` (`ModelInfo.__repr__`; `ModelDetails.__repr__` +
+  `_repr_html_`), `src/screamingface/_ui/cards.py` (`model_details_card_html` +
+  `TYPE_CHECKING` import), `tests/test_model_parameter_discovery.py` (3 repr tests, incl.
+  parametrized stale/degraded), `tests/test_rich_display.py` (1 card test).
+- **Commits:** branch `OME-808-model-details-repr` — `feat(screamingface): repr + notebook card for model discovery values` (final squash-merge sha recorded in the Linear close comment).
+- **Gates:** `run_gates.py screamingface` — ALL GREEN (append-only · ruff · ruff format ·
+  pyright · pytest --cov=screamingface --cov-fail-under=95 · notebook determinism ·
+  uv build · distribution check).
+- **Deviations:** none affecting code. The fresh worktree `.venv` first failed pyright on
+  unresolved `ipywidgets`/`IPython` in untouched `_ui` files; resolved with
+  `uv sync --extra notebook` (the step CI runs before pyright) — no gate weakened.

--- a/packages/screamingface/src/screamingface/_ui/cards.py
+++ b/packages/screamingface/src/screamingface/_ui/cards.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from screamingface._ui.card_style import CARD_STYLE
 
 if TYPE_CHECKING:
-    from screamingface.discovery import Benchmark, ModelInfo
+    from screamingface.discovery import Benchmark, ModelDetails, ModelInfo
     from screamingface.fusion import Fusion
     from screamingface.model import Model
     from screamingface.pipeline import Pipeline
@@ -104,6 +104,30 @@ def benchmark_card_html(benchmark: Benchmark) -> str:
         "<div class='sf-card__accent sf-card__accent--solid'></div>"
         f"<div class='sf-card__head'><span class='sf-card__title'>{escape(benchmark.title)}</span>"
         "<span class='sf-card__kicker'>benchmark</span></div>"
+        f"<div class='sf-card__grid'>{fields}</div></div>"
+    )
+
+
+def model_details_card_html(details: ModelDetails) -> str:
+    """Render only the profile fields actually held by one ModelDetails."""
+
+    # WHY: freshness collapses to a single derived word — never a fabricated freshness metric.
+    freshness = "degraded" if details.degraded else ("stale" if details.stale else "fresh")
+    fields = (
+        _field("id", _mono(details.id))
+        + _field("provider", escape(details.provider))
+        + _field("scope", escape(details.scope))
+        + _field("auth", escape(details.auth_mode))
+        + _field("parameters", escape(str(len(details.parameters))))
+        + _field("tools", escape(str(len(details.tools))))
+        + _field("transport", escape(str(len(details.transport))))
+        + _field("freshness", escape(freshness))
+    )
+    return (
+        f"{CARD_STYLE}<div class='sf-ui sf-card' aria-label='ScreamingFace model details'>"
+        "<div class='sf-card__accent sf-card__accent--solid'></div>"
+        f"<div class='sf-card__head'><span class='sf-card__title'>{escape(details.id)}</span>"
+        "<span class='sf-card__kicker'>model</span></div>"
         f"<div class='sf-card__grid'>{fields}</div></div>"
     )
 

--- a/packages/screamingface/src/screamingface/discovery.py
+++ b/packages/screamingface/src/screamingface/discovery.py
@@ -33,6 +33,13 @@ class ModelInfo:
             _names(self.supported_tools, "Model supported_tools"),
         )
 
+    def __repr__(self) -> str:
+        return (
+            f"ModelInfo({self.id!r}, provider={self.provider!r}, "
+            f"parameters={len(self.supported_parameters)}, "
+            f"tools={len(self.supported_tools)})"
+        )
+
 
 _SCHEMA_TYPES = frozenset({"number", "integer", "string", "boolean", "array", "object"})
 _ITEM_TYPES = _SCHEMA_TYPES - {"array"}
@@ -195,6 +202,28 @@ class ModelDetails:
             if not isinstance(value, Mapping):
                 raise TypeError(f"Model {name} must be a mapping")
             object.__setattr__(self, name, MappingProxyType(dict(value)))
+
+    def __repr__(self) -> str:
+        arguments = [
+            repr(self.id),
+            f"provider={self.provider!r}",
+            f"scope={self.scope!r}",
+            f"parameters={len(self.parameters)}",
+            f"tools={len(self.tools)}",
+            f"transport={len(self.transport)}",
+        ]
+        # INVARIANT: _validate_freshness makes stale/degraded mutually exclusive, so at most
+        # one flag is ever appended; a fresh profile shows neither.
+        if self.stale:
+            arguments.append("stale=True")
+        if self.degraded:
+            arguments.append("degraded=True")
+        return f"ModelDetails({', '.join(arguments)})"
+
+    def _repr_html_(self) -> str:
+        from screamingface._ui.cards import model_details_card_html
+
+        return model_details_card_html(self)
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/screamingface/tests/test_model_parameter_discovery.py
+++ b/packages/screamingface/tests/test_model_parameter_discovery.py
@@ -353,3 +353,62 @@ def test_models_get_rejects_malformed_v1_documents(
 
     assert caught.value.code == "invalid_catalogue"
     assert caught.value.permanent is True
+
+
+def test_model_info_repr_is_a_compact_capability_summary() -> None:
+    with _client(_engine) as client:
+        info = client.models.list()[0]
+
+    assert repr(info) == (
+        "ModelInfo('openrouter/openai/gpt-5.5', provider='openrouter', parameters=2, tools=1)"
+    )
+
+
+def test_model_details_repr_summarises_identity_and_contract_sizes() -> None:
+    with _client(_engine) as client:
+        details = client.models.get(_MODEL)
+
+    # WHY: the dataclass default repr dumps all 15 fields incl. the full nested parameter
+    # mappings; the summary identifies the profile and reports contract sizes as counts.
+    assert repr(details) == (
+        "ModelDetails('openrouter/openai/gpt-5.5', provider='openrouter', "
+        "scope='account_profile', parameters=3, tools=1, transport=1)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("freshness", "flag"),
+    [
+        (
+            {
+                "observed_at": "2026-08-05T10:00:00Z",
+                "expires_at": "2026-08-05T10:05:00Z",
+                "stale": True,
+                "degraded": False,
+            },
+            "stale=True",
+        ),
+        (
+            {"observed_at": None, "expires_at": None, "stale": False, "degraded": True},
+            "degraded=True",
+        ),
+    ],
+)
+def test_model_details_repr_surfaces_a_set_freshness_flag(
+    freshness: dict[str, Any],
+    flag: str,
+) -> None:
+    import copy
+
+    body = copy.deepcopy(_DETAILS)
+    body["freshness"] = freshness
+    client = _client(lambda request: httpx.Response(200, json=body))
+
+    with client:
+        details = client.models.get(_MODEL)
+
+    # INVARIANT: stale/degraded are mutually exclusive, so at most one flag ever appears.
+    assert repr(details) == (
+        "ModelDetails('openrouter/openai/gpt-5.5', provider='openrouter', "
+        f"scope='account_profile', parameters=3, tools=1, transport=1, {flag})"
+    )

--- a/packages/screamingface/tests/test_rich_display.py
+++ b/packages/screamingface/tests/test_rich_display.py
@@ -180,6 +180,38 @@ def test_model_card_renders_only_real_escaped_authoring_fields() -> None:
         assert banned not in html.lower()
 
 
+def test_model_details_card_renders_only_real_escaped_profile_fields() -> None:
+    from datetime import UTC, datetime
+
+    details = sf.ModelDetails(
+        id="openrouter/openai/gpt-5.5<script>",
+        provider="openrouter",
+        upstream_id="openai/gpt-5.5",
+        contract_id="pc_fixture",
+        scope="account_profile",
+        auth_mode="api_key",
+        context_revision="ctx_fixture",
+        source_revision=None,
+        parameters={},
+        tools={},
+        transport={},
+        observed_at=datetime(2026, 8, 5, 10, tzinfo=UTC),
+        expires_at=datetime(2026, 8, 5, 10, 5, tzinfo=UTC),
+        stale=False,
+        degraded=False,
+    )
+
+    html = cast(Any, details)._repr_html_()
+
+    assert "openrouter/openai/gpt-5.5&lt;script&gt;" in html
+    assert "account_profile" in html
+    assert "api_key" in html
+    assert "fresh" in html
+    # WHY: the card reports only fields the object actually holds — never invented metrics.
+    for banned in _FABRICATED:
+        assert banned not in html.lower()
+
+
 def test_fusion_card_keeps_only_benchmark_independent_topology_visible() -> None:
     opus = sf.Model("provider/opus", name="opus")
     gpt = sf.Model("provider/gpt", name="gpt")


### PR DESCRIPTION
## Summary

`client.models.list()` returns `ModelInfo` and `client.models.get(...)` returns `ModelDetails` (frozen dataclasses in `packages/screamingface/src/screamingface/discovery.py`). Neither defined `__repr__`, so both fell back to the dataclass default — for `ModelDetails`, an unreadable wall of 15 fields including three `MappingProxyType` mappings of full nested `ModelParameter`/`ModelCapability` reprs. This adds:

- **`ModelInfo.__repr__`** — `ModelInfo('<id>', provider='<p>', parameters=N, tools=M)`
- **`ModelDetails.__repr__`** — `ModelDetails('<id>', provider='<p>', scope='<s>', parameters=N, tools=M, transport=K)` (appends `stale=True` / `degraded=True` only when set; the two are mutually exclusive by the freshness invariant)
- **`ModelDetails._repr_html_`** — an SFDS notebook card via a new `model_details_card_html()` in `_ui/cards.py`, reusing the existing `_field`/`_mono`/`escape` primitives and rendering only real fields (no fabricated metrics).

Scoped to match the existing sibling convention: `Benchmark` has a card, `BenchmarkInfo` does not — so the richer `ModelDetails` gets the card while the lightweight `ModelInfo` stays text-only. The `Model` **recipe** already had both reprs and is untouched. No public field/schema change; `__repr__`/`_repr_html_` are purely additive (and override the dataclass default exactly as `Model`/`Leaderboard` already do).

## Test plan

- `tests/test_model_parameter_discovery.py` — exact-string repr assertions for `ModelInfo` and `ModelDetails` against the existing fixtures (3 params / 1 tool / 1 transport, fresh), plus a parametrized case asserting `stale=True` / `degraded=True` surfaces.
- `tests/test_rich_display.py` — `ModelDetails` card test: real escaped fields (`id`/`scope`/`auth`/`fresh`) present, HTML-escaping of a `<script>`-laden id, and the existing `_FABRICATED` guard (no `context window`/`price`/`tok/s`/… leak).
- Full gate suite green locally: `run_gates.py screamingface` — append-only · ruff · ruff format · pyright · pytest `--cov=screamingface --cov-fail-under=95` · notebook determinism · `uv build` · distribution check.

Refs: OME-808