### PR TITLE
refactor(url4-cloud): extract benchmark evaluation capabilities

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/definition.py
@@ -11,6 +11,10 @@ from url4_cloud.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
 from url4_cloud.benchmarks.definition import Benchmark, candidate
 from url4_cloud.benchmarks.draco.prompts import JUDGE_INSTRUCTIONS
 from url4_cloud.benchmarks.draco.verdict import call as criterion_verdict
+from url4_cloud.benchmarks.protocol import (
+    EVALUATION_PROTOCOL_REVISION,
+    build_evaluation_protocol,
+)
 
 BENCHMARK_ID = "draco"
 CASE_COUNT = 100
@@ -65,6 +69,7 @@ REVISION = hashlib.sha256(
             DATASET_REVISION,
             DATASET_PREPARER_REVISION,
             PROTOCOL_REVISION,
+            EVALUATION_PROTOCOL_REVISION,
             CANDIDATE_RESULT_SCHEMA,
             RETRIEVAL_POLICY_ID,
             repr(EXCLUDED_DOMAINS),
@@ -258,36 +263,13 @@ def _build_protocol(
         ),
         intent=Text("$case_evaluation"),
     )
-    rows = iterate(
-        cases_route,
-        body=(src(case_evaluation, name="graded", weight=0.0),),
-        intent=Text("$graded"),
-        slice=None if case_count == CASE_COUNT else (0, case_count),
-        on_error="collect",
+    return build_evaluation_protocol(
+        cases_route=cases_route,
+        case_evaluation=case_evaluation,
+        selected_case_count=case_count,
+        available_case_count=CASE_COUNT,
+        aggregate_route=aggregate_route,
     )
-    row_set = expr(
-        src(rows, name="selected_rows", weight=0.0),
-        intent=Text("$selected_rows"),
-    )
-    node = expr(
-        src(row_set, name="rows", weight=0.0),
-        src(
-            RelExpr(
-                path=aggregate_route,
-                # The complete row collection is the wide channel. Keeping it in context means
-                # an in-process handler receives it directly and a subprocess adapter would pipe
-                # it over stdin; it can never hit the operating system's argv size limit.
-                context="$rows",
-                # INVARIANT: the reducer receives the selection bound authored into this exact
-                # protocol. It must not infer intent from however many rows happened to survive.
-                intent=Text(f"aggregate:{case_count}"),
-            ),
-            name="result",
-            weight=0.0,
-        ),
-        intent=Text("$result"),
-    )
-    return node
 
 
 def _install_canonical(node: Url4Node, assets: Path) -> None:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
@@ -10,9 +10,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
-from url4_cloud.benchmarks.contract import decode_candidate_invocation
 from url4_cloud.benchmarks.draco import aggregate as scoring
 from url4_cloud.benchmarks.draco import assets as protocol_assets
 from url4_cloud.benchmarks.draco import records, tasks
@@ -59,7 +57,14 @@ from url4_cloud.benchmarks.draco.definition import (
     VERDICT_ROUTE,
 )
 from url4_cloud.benchmarks.draco.verdict import bind, binding_key
-from url4_cloud.benchmarks.errors import ProviderRefusal
+from url4_cloud.benchmarks.evaluation import (
+    aggregate_endpoint,
+    candidate_answer,
+    case_evaluation_endpoint,
+    compact_json,
+    json_object,
+)
+from url4_cloud.benchmarks.evaluation import benchmark_unavailable as _unavailable
 
 
 def install_canonical(node: Url4Node, root: Path) -> None:
@@ -156,15 +161,25 @@ def _install_protocol(
     node.endpoint(tasks_route)(_task_rows(root, criterion_count, criterion_selection))
     node.endpoint(verdict_route)(_criterion_verdict)
     node.endpoint(criterion_evaluation_route)(_criterion_evaluation(judge_passes))
-    node.endpoint(case_evaluation_route)(_case_evaluation)
+    node.endpoint(case_evaluation_route)(
+        case_evaluation_endpoint(
+            label="DRACO Case evaluation",
+            item_name="Criterion evaluation",
+            bind=bind_case_evaluation,
+        )
+    )
     node.endpoint(aggregate_route)(
-        _aggregate(
-            benchmark_id,
-            benchmark_revision,
-            judge_passes,
-            criterion_count,
-            selected_cases,
-            rubrics,
+        aggregate_endpoint(
+            label="DRACO",
+            available_case_count=len(selected_cases),
+            aggregate=_aggregate(
+                benchmark_id,
+                benchmark_revision,
+                judge_passes,
+                criterion_count,
+                selected_cases,
+                rubrics,
+            ),
         )
     )
 
@@ -205,12 +220,11 @@ def _task_rows(
     def task_rows(request: Request) -> str:
         try:
             case_id = tasks.positive_case_id(request.intent)
-            output, finish_reason, refusal = decode_candidate_invocation(request.context)
-            if refusal is not None:
-                raise ProviderRefusal(refusal, finish_reason=finish_reason)
+            answer = candidate_answer(request.context)
+            output, finish_reason = answer.output, answer.finish_reason
             raw_cases = _read(root / "cases.json", "DRACO cases")
             criteria = tasks.load_criteria(root / "criteria", case_id)
-            rubric = _object(
+            rubric = json_object(
                 _read(root / "rubrics" / f"{case_id}.json", f"DRACO Case {case_id} rubric"),
                 f"DRACO Case {case_id} rubric",
             )
@@ -251,7 +265,7 @@ def _task_rows(
                 )
         except (OSError, ValueError) as exc:
             raise _unavailable(str(exc)) from exc
-        return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+        return compact_json(result)
 
     return task_rows
 
@@ -268,14 +282,14 @@ def _criterion_verdict(request: Request) -> str:
         )
     except ValueError as exc:
         raise _unavailable(str(exc)) from exc
-    return json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+    return compact_json(record)
 
 
 def _criterion_evaluation(judge_passes: int):
     def criterion_evaluation(request: Request) -> str:
         try:
             case_id = tasks.positive_case_id(request.intent)
-            payload = _object(request.context, "DRACO Criterion evaluation")
+            payload = json_object(request.context, "DRACO Criterion evaluation")
             expected = (
                 "case",
                 "check",
@@ -286,11 +300,11 @@ def _criterion_evaluation(judge_passes: int):
                     "DRACO Criterion evaluation fields must be case, check, and consecutive "
                     "evidence_1..evidence_N"
                 )
-            raw_case = _embedded_object(payload["case"], "Case record")
+            raw_case = json_object(payload["case"], "Case record")
             case_record = raw_case or None
-            check_record = _embedded_object(payload["check"], "Check record")
+            check_record = json_object(payload["check"], "Check record")
             evidence = [
-                _embedded_object(payload[field], field)
+                json_object(payload[field], field)
                 for field in expected
                 if field.startswith("evidence_")
             ]
@@ -302,39 +316,9 @@ def _criterion_evaluation(judge_passes: int):
             )
         except (TypeError, ValueError) as exc:
             raise _unavailable(str(exc)) from exc
-        return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+        return compact_json(result)
 
     return criterion_evaluation
-
-
-def _case_evaluation(request: Request) -> str:
-    try:
-        case_id = tasks.positive_case_id(request.intent)
-        raw = json.loads(request.context)
-        if not isinstance(raw, list) or not raw:
-            raise ValueError("DRACO Case evaluation must be a non-empty JSON array")
-        criteria = [
-            _embedded_object(item, f"Criterion evaluation {index}")
-            for index, item in enumerate(raw, start=1)
-        ]
-        result = bind_case_evaluation(case_id, criteria)
-    except (TypeError, ValueError) as exc:
-        raise _unavailable(str(exc)) from exc
-    return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
-
-
-def _object(value: str, label: str) -> dict[str, object]:
-    decoded = json.loads(value)
-    if not isinstance(decoded, dict):
-        raise ValueError(f"{label} must be a JSON object")
-    return decoded
-
-
-def _embedded_object(value: object, label: str) -> dict[str, object]:
-    decoded = json.loads(value) if isinstance(value, str) else value
-    if not isinstance(decoded, dict):
-        raise ValueError(f"{label} must decode to an object")
-    return decoded
 
 
 def _aggregate(
@@ -345,50 +329,28 @@ def _aggregate(
     selected_cases: list[dict[str, object]],
     rubrics: dict[int, dict[str, Any]],
 ):
-    def aggregate(request: Request) -> str:
-        if not request.intent.startswith("aggregate:"):
-            raise ResolutionError(
-                f"unsupported DRACO operation {request.intent!r}",
-                code="benchmark_operation_unsupported",
-                permanent=True,
-            )
-        try:
-            selected_count = _selected_count(request.intent, len(selected_cases))
-            result = scoring.aggregate(
-                request.context,
-                rubrics,
-                benchmark_id,
-                selected_cases=selected_cases[:selected_count],
-                judge_passes=judge_passes,
-                benchmark_revision=benchmark_revision,
-                criterion_count=criterion_count,
-            )
-        except (OSError, ValueError) as exc:
-            raise _unavailable(str(exc)) from exc
-        return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+    def aggregate(case_evaluations: str, selected_case_count: int) -> dict[str, Any]:
+        return scoring.aggregate(
+            case_evaluations,
+            rubrics,
+            benchmark_id,
+            selected_cases=selected_cases[:selected_case_count],
+            judge_passes=judge_passes,
+            benchmark_revision=benchmark_revision,
+            criterion_count=criterion_count,
+        )
 
     return aggregate
 
 
-def _selected_count(intent: str, available: int) -> int:
-    raw = intent.removeprefix("aggregate:")
-    try:
-        selected = int(raw)
-    except ValueError:
-        raise ValueError("DRACO aggregate selection must be a positive integer") from None
-    if selected < 1 or selected > available:
-        raise ValueError(f"DRACO aggregate selection must be between 1 and {available}")
-    return selected
-
-
 def _select_cases(raw: str, case_ids: tuple[int, ...] | None) -> list[dict[str, object]]:
     try:
-        rows = json.loads(raw)
-        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+        cases = json.loads(raw)
+        if not isinstance(cases, list) or not all(isinstance(case, dict) for case in cases):
             raise ValueError("expected a JSON array of objects")
         if case_ids is None:
-            return rows
-        by_id = {row["id"]: row for row in rows}
+            return cases
+        by_id = {case["id"]: case for case in cases}
         return [by_id[case_id] for case_id in case_ids]
     except (KeyError, TypeError, ValueError) as exc:
         raise _unavailable(f"could not select DRACO cases {case_ids}: {exc}") from exc
@@ -399,14 +361,6 @@ def _read(path: Path, label: str) -> str:
         return path.read_text(encoding="utf-8")
     except OSError as exc:
         raise _unavailable(f"could not read {label} at {str(path)!r}: {exc}") from exc
-
-
-def _unavailable(detail: str) -> ResolutionError:
-    return ResolutionError(
-        detail,
-        code="benchmark_unavailable",
-        permanent=True,
-    )
 
 
 __all__ = ["install_canonical", "install_lite", "install_smoke"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/evaluation.py
@@ -1,0 +1,182 @@
+"""Installed URL4 evaluation capabilities shared by Engine-owned Benchmarks."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from url4.core.errors import ResolutionError
+from url4.peer.server import Request
+from url4_cloud.benchmarks.contract import decode_candidate_invocation
+from url4_cloud.benchmarks.errors import ProviderRefusal
+
+JsonObject = dict[str, Any]
+CaseEvaluationBinder = Callable[[int, list[JsonObject]], JsonObject]
+AggregateAdapter = Callable[[str, int], JsonObject]
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateAnswer:
+    """One non-refused Candidate Invocation ready for Benchmark evaluation."""
+
+    output: str
+    finish_reason: str | None
+
+
+def candidate_answer(value: str) -> CandidateAnswer:
+    """Decode one invocation and stop grading immediately on exact provider refusal."""
+
+    output, finish_reason, refusal = decode_candidate_invocation(value)
+    if refusal is not None:
+        raise ProviderRefusal(refusal, finish_reason=finish_reason)
+    return CandidateAnswer(output=output, finish_reason=finish_reason)
+
+
+def case_evaluation_endpoint(
+    *,
+    label: str,
+    item_name: str,
+    bind: CaseEvaluationBinder,
+    error_context_head: int | None = None,
+) -> Callable[[Request], str]:
+    """Adapt one non-empty collection of evaluator records into a Case envelope route."""
+
+    def endpoint(request: Request) -> str:
+        try:
+            case_id = positive_case_id(request.intent)
+            raw_items = json_array(request.context, label)
+            if not raw_items:
+                raise ValueError(f"{label} must be a non-empty JSON array")
+            items = [
+                json_object(item, f"{item_name} {index}")
+                for index, item in enumerate(raw_items, start=1)
+            ]
+            result = bind(case_id, items)
+        except (OSError, TypeError, ValueError) as exc:
+            detail = str(exc)
+            if error_context_head is not None:
+                detail += f"; context head: {request.context[:error_context_head]!r}"
+            raise benchmark_unavailable(detail) from exc
+        return compact_json(result)
+
+    return endpoint
+
+
+def aggregate_endpoint(
+    *,
+    label: str,
+    available_case_count: int,
+    aggregate: AggregateAdapter,
+) -> Callable[[Request], str]:
+    """Adapt ordered Case evaluations and their exact selection into Aggregation."""
+
+    positive_count(available_case_count, "available_case_count")
+
+    def endpoint(request: Request) -> str:
+        selected_case_count = _aggregate_selection(request.intent, available_case_count, label)
+        try:
+            result = aggregate(request.context, selected_case_count)
+        except (OSError, ValueError) as exc:
+            raise benchmark_unavailable(str(exc)) from exc
+        return compact_json(result)
+
+    return endpoint
+
+
+def positive_case_id(value: object) -> int:
+    """One shared definition of the positive integer Case identity used by built-ins."""
+
+    if isinstance(value, bool) or not isinstance(value, int | str):
+        raise ValueError("case_id must be a positive integer")
+    try:
+        selected = int(value)
+    except ValueError:
+        raise ValueError("case_id must be a positive integer") from None
+    if selected < 1:
+        raise ValueError("case_id must be a positive integer")
+    return selected
+
+
+def json_object(value: object, label: str) -> JsonObject:
+    """Decode a URL4 value that must be one JSON object."""
+
+    decoded = _decode_json(value, label)
+    if not isinstance(decoded, dict):
+        raise benchmark_unavailable(f"{label} must be a JSON object")
+    return decoded
+
+
+def json_array(value: object, label: str) -> list[object]:
+    """Decode a URL4 value that must be one JSON array."""
+
+    decoded = _decode_json(value, label)
+    if not isinstance(decoded, list):
+        raise benchmark_unavailable(f"{label} must be a JSON array")
+    return decoded
+
+
+def _decode_json(value: object, label: str) -> object:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except ValueError as exc:
+        raise benchmark_unavailable(f"{label} must be JSON: {exc}") from exc
+
+
+def compact_json(value: object) -> str:
+    """Encode a deterministic endpoint result without ASCII loss or padding."""
+
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def benchmark_unavailable(detail: str) -> ResolutionError:
+    """The bounded public failure for unavailable Benchmark assets or adapters."""
+
+    return ResolutionError(detail, code="benchmark_unavailable", permanent=True)
+
+
+def _aggregate_selection(intent: str, available: int, label: str) -> int:
+    operation, separator, raw_count = intent.partition(":")
+    if operation != "aggregate" or not separator:
+        raise _unsupported(label, intent)
+    try:
+        selected_case_count = int(raw_count)
+        positive_count(selected_case_count, "selected_case_count")
+    except ValueError as exc:
+        raise benchmark_unavailable(str(exc)) from exc
+    if selected_case_count > available:
+        raise benchmark_unavailable(
+            f"selected_case_count cannot exceed available_case_count ({available})"
+        )
+    return selected_case_count
+
+
+def _unsupported(label: str, intent: str) -> ResolutionError:
+    return ResolutionError(
+        f"unsupported {label} operation {intent!r}",
+        code="benchmark_operation_unsupported",
+        permanent=True,
+    )
+
+
+def positive_count(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+__all__ = [
+    "CandidateAnswer",
+    "aggregate_endpoint",
+    "benchmark_unavailable",
+    "candidate_answer",
+    "case_evaluation_endpoint",
+    "compact_json",
+    "json_array",
+    "json_object",
+    "positive_case_id",
+    "positive_count",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/definition.py
@@ -22,6 +22,10 @@ from url4_cloud.benchmarks.definition import Benchmark, candidate
 from url4_cloud.benchmarks.healthbench import verdict
 from url4_cloud.benchmarks.healthbench.prompts import GRADER_TEMPLATE
 from url4_cloud.benchmarks.healthbench.subset import WORST30_CASE_IDS, subset_sha
+from url4_cloud.benchmarks.protocol import (
+    EVALUATION_PROTOCOL_REVISION,
+    build_evaluation_protocol,
+)
 
 BENCHMARK_ID = "healthbench/worst30"
 CASE_COUNT = len(WORST30_CASE_IDS)
@@ -56,6 +60,7 @@ REVISION = hashlib.sha256(
             DATASET,
             DATASET_REVISION,
             PROTOCOL_REVISION,
+            EVALUATION_PROTOCOL_REVISION,
             CANDIDATE_RESULT_SCHEMA,
             PREPARER_REVISION,
             subset_sha(),
@@ -199,40 +204,12 @@ def _build_protocol(
         ),
         intent=Text("$case_evaluation"),
     )
-    # Stage 1 — the outer loop: one graded row per Case; errors collect, not abort.
-    rows = iterate(
-        cases_route,
-        body=(src(case_evaluation, name="graded", weight=0.0),),
-        intent=Text("$graded"),
-        # Partial run (limit=N) takes the first N Cases; full run takes them all.
-        slice=None if case_count == total else (0, case_count),
-        on_error="collect",
-    )
-    # Materialize the row collection so the aggregate sees one value, not a stream.
-    row_set = expr(
-        src(rows, name="selected_rows", weight=0.0),
-        intent=Text("$selected_rows"),
-    )
-    # Stage 4b — the final aggregate: all Case rows → the challenge metric.
-    return expr(
-        src(row_set, name="rows", weight=0.0),
-        src(
-            RelExpr(
-                path=aggregate_route,
-                # Rows travel as CONTEXT (never argv) so a subprocess adapter would
-                # pipe them over stdin and the OS argv limit can never truncate them.
-                context="$rows",
-                # WHY the count in the intent: with ``limit=N`` the SDK compiles a
-                # SLICED expression, but the aggregate handler was installed with
-                # the full case list — the intent is the only channel that tells
-                # the reducer which prefix was actually selected, so it can score
-                # exactly those Cases and emit case_count == N.
-                intent=Text(f"aggregate:{case_count}"),
-            ),
-            name="result",
-            weight=0.0,
-        ),
-        intent=Text("$result"),
+    return build_evaluation_protocol(
+        cases_route=cases_route,
+        case_evaluation=case_evaluation,
+        selected_case_count=case_count,
+        available_case_count=total,
+        aggregate_route=aggregate_route,
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
@@ -9,7 +9,7 @@ recipe can actually resolve. Data flows through them in exam order:
                          one fully-built judge prompt per rubric item
     /rubric-verdict    → parse one judge reply into a verdict (or raise → retry)
     /rubric-evaluation → staple {case, rubric, verdict} into one row
-    /case-evaluation   → collect a Case's rows into its per-Case artifact
+    /case-evaluation   → collect a Case's rubric evaluations into its Case Evaluation
     /aggregate         → reduce all Case artifacts into the final score
 
 Everything here is deterministic — the model calls live in the expression, not in
@@ -25,11 +25,16 @@ from typing import Any
 
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
-from url4_cloud.benchmarks.contract import (
-    CANDIDATE_INPUT_SCHEMA,
-    decode_candidate_invocation,
+from url4_cloud.benchmarks.contract import CANDIDATE_INPUT_SCHEMA
+from url4_cloud.benchmarks.evaluation import (
+    aggregate_endpoint,
+    candidate_answer,
+    case_evaluation_endpoint,
+    compact_json,
+    json_object,
+    positive_case_id,
 )
-from url4_cloud.benchmarks.errors import ProviderRefusal
+from url4_cloud.benchmarks.evaluation import benchmark_unavailable as _unavailable
 from url4_cloud.benchmarks.healthbench import aggregate as reducing
 from url4_cloud.benchmarks.healthbench import records
 from url4_cloud.benchmarks.healthbench.case_evaluation import (
@@ -96,8 +101,23 @@ def _install_protocol_once(
         (tasks_route, _rubric_tasks(root, case_ids)),
         (verdict_route, _rubric_verdict),
         (rubric_evaluation_route, _rubric_evaluation),
-        (case_evaluation_route, _case_evaluation),
-        (aggregate_route, _aggregate(root, benchmark_id, benchmark_revision, case_ids)),
+        (
+            case_evaluation_route,
+            case_evaluation_endpoint(
+                label="HealthBench Case evaluation",
+                item_name="Rubric evaluation",
+                bind=bind_case_evaluation,
+                error_context_head=300,
+            ),
+        ),
+        (
+            aggregate_route,
+            aggregate_endpoint(
+                label="HealthBench",
+                available_case_count=len(case_ids),
+                aggregate=_aggregate(root, benchmark_id, benchmark_revision, case_ids),
+            ),
+        ),
     )
     for route, handler in endpoints:
         if route not in routes:
@@ -119,8 +139,8 @@ def preflight(root: Path, case_ids: tuple[int, ...]) -> None:
         problems.append(f"cases.json missing under {root}")
     else:
         try:
-            rows = json.loads((root / "cases.json").read_text(encoding="utf-8"))
-            present = {row.get("id") for row in rows if isinstance(row, Mapping)}
+            cases = json.loads((root / "cases.json").read_text(encoding="utf-8"))
+            present = {case.get("id") for case in cases if isinstance(case, Mapping)}
             missing = [case_id for case_id in case_ids if case_id not in present]
             if missing:
                 problems.append(f"cases.json lacks selected cases {missing[:5]}")
@@ -153,23 +173,22 @@ def _rubric_tasks(root: Path, case_ids: tuple[int, ...]):
     # (https://github.com/openai/simple-evals/blob/main/healthbench_eval.py).
     def rubric_tasks(request: Request) -> str:
         try:
-            case_id = _positive_case_id(request.intent)
-            output, finish_reason, refusal = decode_candidate_invocation(request.context)
-            if refusal is not None:
-                raise ProviderRefusal(refusal, finish_reason=finish_reason)
+            case_id = positive_case_id(request.intent)
+            answer = candidate_answer(request.context)
+            output, finish_reason = answer.output, answer.finish_reason
             raw_cases = _read(root / "cases.json", "HealthBench cases")
             transcript = _transcript(raw_cases, case_id)
             items = _rubric_items(root, case_id)
             case_record = records.bind_case(
                 raw_cases, case_id=case_id, output=output, finish_reason=finish_reason
             )
-            rows: list[dict[str, str]] = []
+            tasks: list[dict[str, str]] = []
             for item in items:
                 rendered = render_rubric_item(item["points"], item["criterion"])
                 rubric_record = records.bind_rubric_item(
                     rendered, case_id=case_id, rubric_id=item["rubric_id"]
                 )
-                rows.append(
+                tasks.append(
                     {
                         "case_id": str(case_id),
                         "rubric_id": str(item["rubric_id"]),
@@ -182,7 +201,7 @@ def _rubric_tasks(root: Path, case_ids: tuple[int, ...]):
                         # hoists it back to one record per Case.
                         "case_record": (
                             json.dumps(case_record, ensure_ascii=False, separators=(",", ":"))
-                            if not rows
+                            if not tasks
                             else "{}"
                         ),
                         "rubric_record": json.dumps(
@@ -192,7 +211,7 @@ def _rubric_tasks(root: Path, case_ids: tuple[int, ...]):
                 )
         except (OSError, ValueError) as exc:
             raise _unavailable(str(exc)) from exc
-        return json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
+        return compact_json(tasks)
 
     return rubric_tasks
 
@@ -227,48 +246,27 @@ def _rubric_verdict(request: Request) -> str:
             code="judge_reply_invalid",
             permanent=False,
         )
-    return json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+    return compact_json(record)
 
 
 def _rubric_evaluation(request: Request) -> str:
     try:
-        case_id = _positive_case_id(request.intent)
-        payload = _object(request.context, "HealthBench rubric evaluation")
+        case_id = positive_case_id(request.intent)
+        payload = json_object(request.context, "HealthBench rubric evaluation")
         # Exact keys in exact order — the payload comes from OUR expression's struct()
         # (definition.py), so any drift means the expression and runtime disagree.
         if tuple(payload) != ("case", "rubric", "evidence"):
             raise ValueError("HealthBench rubric evaluation fields must be case, rubric, evidence")
-        raw_case = _embedded_object(payload["case"], "Case record")
+        raw_case = json_object(payload["case"], "Case record")
         result = bind_rubric_evaluation(
             case_id,
             raw_case or None,
-            _embedded_object(payload["rubric"], "Rubric record"),
-            _embedded_object(payload["evidence"], "Rubric verdict"),
+            json_object(payload["rubric"], "Rubric record"),
+            json_object(payload["evidence"], "Rubric verdict"),
         )
     except (TypeError, ValueError) as exc:
         raise _unavailable(str(exc)) from exc
-    return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
-
-
-def _case_evaluation(request: Request) -> str:
-    try:
-        case_id = _positive_case_id(request.intent)
-        raw = json.loads(request.context)
-        if not isinstance(raw, list) or not raw:
-            raise ValueError("HealthBench Case evaluation must be a non-empty JSON array")
-        evaluations = [
-            _embedded_object(item, f"Rubric evaluation {index}")
-            for index, item in enumerate(raw, start=1)
-        ]
-        result = bind_case_evaluation(case_id, evaluations)
-    except (TypeError, ValueError) as exc:
-        # WHY the context head in the error: this route sits on the resolver seam —
-        # its context is whatever the runner rendered for the rubric_rows collection.
-        # A live failure here (2026-08-06 smoke run) was undiagnosable without seeing
-        # the actual payload, and this error IS the audit record that reaches the
-        # report via on_error=collect.
-        raise _unavailable(f"{exc}; context head: {request.context[:300]!r}") from exc
-    return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+    return compact_json(result)
 
 
 def _aggregate(
@@ -277,37 +275,14 @@ def _aggregate(
     benchmark_revision: str,
     case_ids: tuple[int, ...],
 ):
-    def aggregate_handler(request: Request) -> str:
-        # Intent is "aggregate:<selected>" — the expression tells the reducer how
-        # many Cases the run actually selected (a `limit=N` run slices the Case
-        # loop, and scoring the full installed list would fail every un-run Case).
-        operation, _, raw_count = request.intent.partition(":")
-        if operation != "aggregate" or not raw_count.isdigit():
-            raise ResolutionError(
-                f"unsupported HealthBench operation {request.intent!r}",
-                code="benchmark_operation_unsupported",
-                permanent=True,
-            )
-        selected = int(raw_count)
-        if not 1 <= selected <= len(case_ids):
-            raise ResolutionError(
-                f"HealthBench aggregate selection {selected} is outside 1..{len(case_ids)}",
-                code="benchmark_operation_unsupported",
-                permanent=True,
-            )
-        try:
-            result = reducing.aggregate(
-                request.context,
-                root,
-                benchmark_id=benchmark_id,
-                benchmark_revision=benchmark_revision,
-                # The slice in the expression is (0, selected) over this same
-                # ordering, so the selected prefix IS the run's Case list.
-                case_ids=case_ids[:selected],
-            )
-        except (OSError, ValueError) as exc:
-            raise _unavailable(str(exc)) from exc
-        return json.dumps(result, ensure_ascii=False, separators=(",", ":"))
+    def aggregate_handler(case_evaluations: str, selected_case_count: int) -> dict[str, Any]:
+        return reducing.aggregate(
+            case_evaluations,
+            root,
+            benchmark_id=benchmark_id,
+            benchmark_revision=benchmark_revision,
+            case_ids=case_ids[:selected_case_count],
+        )
 
     return aggregate_handler
 
@@ -350,41 +325,15 @@ def _rubric_items(root: Path, case_id: int) -> list[dict[str, Any]]:
     return items
 
 
-def _positive_case_id(value: object) -> int:
-    if isinstance(value, bool) or not isinstance(value, (int, str)):
-        raise ValueError("case_id must be a positive integer")
-    try:
-        selected = int(value)
-    except ValueError:
-        raise ValueError("case_id must be a positive integer") from None
-    if selected < 1:
-        raise ValueError("case_id must be a positive integer")
-    return selected
-
-
 def _select_cases(raw: str, case_ids: tuple[int, ...]) -> list[dict[str, object]]:
     try:
-        rows = json.loads(raw)
-        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+        cases = json.loads(raw)
+        if not isinstance(cases, list) or not all(isinstance(case, dict) for case in cases):
             raise ValueError("expected a JSON array of objects")
-        by_id = {row["id"]: row for row in rows}
+        by_id = {case["id"]: case for case in cases}
         return [by_id[case_id] for case_id in case_ids]
     except (KeyError, TypeError, ValueError) as exc:
         raise _unavailable(f"could not select HealthBench cases {case_ids}: {exc}") from exc
-
-
-def _object(value: str, label: str) -> dict[str, object]:
-    decoded = json.loads(value)
-    if not isinstance(decoded, dict):
-        raise ValueError(f"{label} must be a JSON object")
-    return decoded
-
-
-def _embedded_object(value: object, label: str) -> dict[str, object]:
-    decoded = json.loads(value) if isinstance(value, str) else value
-    if not isinstance(decoded, dict):
-        raise ValueError(f"{label} must decode to an object")
-    return decoded
 
 
 def _read(path: Path, label: str) -> str:
@@ -392,14 +341,6 @@ def _read(path: Path, label: str) -> str:
         return path.read_text(encoding="utf-8")
     except OSError as exc:
         raise _unavailable(f"could not read {label} at {str(path)!r}: {exc}") from exc
-
-
-def _unavailable(detail: str) -> ResolutionError:
-    return ResolutionError(
-        detail,
-        code="benchmark_unavailable",
-        permanent=True,
-    )
 
 
 __all__ = ["install", "preflight"]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/definition.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/definition.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import hashlib
 from pathlib import Path
 
-from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
+from url4 import Node, RelExpr, Text, expr, render, src, struct
 from url4.peer.server import Url4Node
 from url4_cloud.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
 from url4_cloud.benchmarks.definition import Benchmark, candidate
+from url4_cloud.benchmarks.protocol import (
+    EVALUATION_PROTOCOL_REVISION,
+    build_evaluation_protocol,
+)
 
 BENCHMARK_ID = "ifeval"
 CASE_COUNT = 541
@@ -33,6 +37,7 @@ REVISION = hashlib.sha256(
             VERIFIER_REPOSITORY,
             VERIFIER_REVISION,
             PROTOCOL_REVISION,
+            EVALUATION_PROTOCOL_REVISION,
             CANDIDATE_RESULT_SCHEMA,
             f"candidate_web_search={CANDIDATE_WEB_SEARCH}",
         )
@@ -71,29 +76,12 @@ def _build(case_count: int) -> Node:
         ),
         intent=Text("$case_evaluation"),
     )
-    rows = iterate(
-        CASES_ROUTE,
-        body=(src(checked, name="checked", weight=0.0),),
-        intent=Text("$checked"),
-        slice=None if case_count == CASE_COUNT else (0, case_count),
-        on_error="collect",
-    )
-    row_set = expr(
-        src(rows, name="selected_rows", weight=0.0),
-        intent=Text("$selected_rows"),
-    )
-    return expr(
-        src(row_set, name="rows", weight=0.0),
-        src(
-            RelExpr(
-                path=AGGREGATE_ROUTE,
-                context="$rows",
-                intent=Text(f"aggregate:{case_count}"),
-            ),
-            name="result",
-            weight=0.0,
-        ),
-        intent=Text("$result"),
+    return build_evaluation_protocol(
+        cases_route=CASES_ROUTE,
+        case_evaluation=checked,
+        selected_case_count=case_count,
+        available_case_count=CASE_COUNT,
+        aggregate_route=AGGREGATE_ROUTE,
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py
@@ -70,6 +70,7 @@ from url4_cloud.benchmarks.ifeval.definition import (
     CHECK_ROUTE,
     install_ifeval,
 )
+from url4_cloud.benchmarks.protocol import build_evaluation_protocol
 
 
 def _solo_attempt_input(attempt: int) -> str:
@@ -548,30 +549,13 @@ def _reduced_rows(
     # INVARIANT: both shapes emit exactly one exact Case Evaluation per row (solo packs
     # attempt-tagged check records; lanl packs the gated chain via its envelope route),
     # so the Aggregator never has to discover grading records inside arbitrary text.
-    rows = iterate(
-        CASES_ROUTE,
-        body=(src(checked, name="checked", weight=0.0),),
-        intent=Text("$checked"),
-        slice=None if case_count == CASE_COUNT else (0, case_count),
-        on_error="collect",
-    )
-    row_set = expr(
-        *row_bindings,
-        src(rows, name="selected_rows", weight=0.0),
-        intent=Text("$selected_rows"),
-    )
-    return expr(
-        src(row_set, name="rows", weight=0.0),
-        src(
-            RelExpr(
-                path=aggregate_route,
-                context="$rows",
-                intent=Text(f"aggregate:{case_count}"),
-            ),
-            name="result",
-            weight=0.0,
-        ),
-        intent=Text("$result"),
+    return build_evaluation_protocol(
+        cases_route=CASES_ROUTE,
+        case_evaluation=checked,
+        selected_case_count=case_count,
+        available_case_count=CASE_COUNT,
+        aggregate_route=aggregate_route,
+        bindings=row_bindings,
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
@@ -14,7 +14,14 @@ from url4_cloud.benchmarks.contract import (
     decode_candidate_invocation,
     encode_candidate_invocation,
 )
-from url4_cloud.benchmarks.errors import ProviderRefusal
+from url4_cloud.benchmarks.evaluation import (
+    aggregate_endpoint,
+    candidate_answer,
+    compact_json,
+    json_array,
+    json_object,
+)
+from url4_cloud.benchmarks.evaluation import benchmark_unavailable as _unavailable
 from url4_cloud.benchmarks.ifeval import aggregate as scoring
 from url4_cloud.benchmarks.ifeval import grading
 from url4_cloud.benchmarks.ifeval.case_evaluation import bind_case_evaluation
@@ -39,6 +46,7 @@ from url4_cloud.benchmarks.ifeval.corrective_policy import (
 from url4_cloud.benchmarks.ifeval.definition import (
     AGGREGATE_ROUTE,
     BENCHMARK_ID,
+    CASE_COUNT,
     CASE_EVALUATION_ROUTE,
     CASES_ROUTE,
     CHECK_ROUTE,
@@ -54,17 +62,32 @@ def install(node: Url4Node, root: Path) -> None:
     endpoints = (
         (CHECK_ROUTE, _check(root)),
         (CASE_EVALUATION_ROUTE, _case_evaluation),
-        (AGGREGATE_ROUTE, _aggregate(root)),
+        (
+            AGGREGATE_ROUTE,
+            aggregate_endpoint(
+                label="IFEval aggregation",
+                available_case_count=CASE_COUNT,
+                aggregate=_aggregate(root),
+            ),
+        ),
         (
             SELF_AGGREGATE_ROUTE,
-            _aggregate_corrective(root, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION),
+            aggregate_endpoint(
+                label="IFEval corrective aggregation",
+                available_case_count=CASE_COUNT,
+                aggregate=_aggregate_corrective(root, SELF_CORRECTIVE_ID, SELF_CORRECTIVE_REVISION),
+            ),
         ),
         (RESOLVE_CANDIDATE_ROUTE, _resolve_candidate),
         (MEMBER_RECORD_ROUTE, _member_record),
         (MEMBER_ANSWER_ROUTE, _member_answer),
         (
             LANL_AGGREGATE_ROUTE,
-            _aggregate_corrective(root, LANL_ENSEMBLE_ID, LANL_ENSEMBLE_REVISION),
+            aggregate_endpoint(
+                label="IFEval corrective aggregation",
+                available_case_count=CASE_COUNT,
+                aggregate=_aggregate_corrective(root, LANL_ENSEMBLE_ID, LANL_ENSEMBLE_REVISION),
+            ),
         ),
         (LANL_GATE_ROUTE, _lanl_gate(root)),
         (LANL_SELECT_ROUTE, _lanl_select(root)),
@@ -90,10 +113,8 @@ def _check(root: Path):
             return _feedback(request.context)
         try:
             case_id, attempt = _case_and_attempt(request.intent)
-            answer, finish_reason, refusal = decode_candidate_invocation(request.context)
-            if refusal is not None:
-                raise ProviderRefusal(refusal, finish_reason=finish_reason)
-            spec, result, violations = _verification(root, case_id, answer)
+            candidate = candidate_answer(request.context)
+            spec, result, violations = _verification(root, case_id, candidate.output)
         except (KeyError, TypeError, ValueError) as exc:
             raise _unavailable(str(exc)) from exc
         record = {
@@ -101,8 +122,8 @@ def _check(root: Path):
             "case_id": case_id,
             "attempt": attempt,
             "valid": True,
-            "answer": answer,
-            "finish_reason": finish_reason,
+            "answer": candidate.output,
+            "finish_reason": candidate.finish_reason,
             "instruction_id_list": spec["instruction_id_list"],
             "descriptions": grading.describe_instructions(
                 instruction_id_list=spec["instruction_id_list"],
@@ -114,7 +135,7 @@ def _check(root: Path):
             # Violations remain ordinary fields inside the exact Case Evaluation.
             "violations": violations,
         }
-        return _json(record)
+        return compact_json(record)
 
     return check
 
@@ -143,7 +164,7 @@ def _case_evaluation(request: Request) -> str:
 
     try:
         case_id = _positive_int(request.intent, "case id")
-        payload = _json_payload(request.context, "Case evaluation")
+        payload = json_object(request.context, "Case evaluation")
         expected = tuple(f"attempt_{index}" for index in range(1, len(payload) + 1))
         if not expected or tuple(payload) != expected:
             raise ValueError(
@@ -161,7 +182,7 @@ def _case_evaluation(request: Request) -> str:
         result = bind_case_evaluation(case_id, attempts)
     except (TypeError, ValueError) as exc:
         raise _unavailable(str(exc)) from exc
-    return _json(result)
+    return compact_json(result)
 
 
 def _verification(
@@ -189,53 +210,33 @@ def _verification(
 
 
 def _aggregate(root: Path):
-    def aggregate(request: Request) -> str:
-        try:
-            case_order = scoring.load_case_order(root)
-            result = scoring.aggregate(
-                request.context,
-                scoring.load_specs(root / "instructions"),
-                BENCHMARK_ID,
-                case_order,
-                selected_case_count=_aggregate_case_count(request.intent, len(case_order)),
-            )
-        except (OSError, ValueError) as exc:
-            raise _unavailable(str(exc)) from exc
-        return _json(result)
+    def aggregate(case_evaluations: str, selected_case_count: int) -> dict[str, Any]:
+        case_order = scoring.load_case_order(root)
+        return scoring.aggregate(
+            case_evaluations,
+            scoring.load_specs(root / "instructions"),
+            BENCHMARK_ID,
+            case_order,
+            selected_case_count=selected_case_count,
+        )
 
     return aggregate
 
 
 def _aggregate_corrective(root: Path, benchmark_id: str, benchmark_revision: str):
-    def aggregate(request: Request) -> str:
-        try:
-            case_order = scoring.load_case_order(root)
-            result = scoring.aggregate_corrective(
-                request.context,
-                scoring.load_specs(root / "instructions"),
-                benchmark_id,
-                benchmark_revision,
-                case_order,
-                selected_case_count=_aggregate_case_count(request.intent, len(case_order)),
-                max_attempts=MAX_ATTEMPTS,
-            )
-        except (OSError, ValueError) as exc:
-            raise _unavailable(str(exc)) from exc
-        return _json(result)
+    def aggregate(case_evaluations: str, selected_case_count: int) -> dict[str, Any]:
+        case_order = scoring.load_case_order(root)
+        return scoring.aggregate_corrective(
+            case_evaluations,
+            scoring.load_specs(root / "instructions"),
+            benchmark_id,
+            benchmark_revision,
+            case_order,
+            selected_case_count=selected_case_count,
+            max_attempts=MAX_ATTEMPTS,
+        )
 
     return aggregate
-
-
-def _aggregate_case_count(intent: str, available: int) -> int:
-    operation, separator, raw_count = (intent or "").partition(":")
-    if operation != "aggregate" or not separator:
-        raise _unsupported("IFEval aggregation", intent)
-    count = _positive_int(raw_count, "selected Case count")
-    if count > available:
-        raise _unavailable(
-            f"IFEval aggregation selected {count} Cases but only {available} are installed"
-        )
-    return count
 
 
 def _lanl_intent(intent: str) -> tuple[str, int, int]:
@@ -247,7 +248,7 @@ def _lanl_intent(intent: str) -> tuple[str, int, int]:
 
 
 def _lanl_members(value: object, label: str) -> list[dict[str, Any]]:
-    raw = _json_array(value, label)
+    raw = json_array(value, label)
     members = [_attempt_member(_member(item, index), index) for index, item in enumerate(raw)]
     if not MIN_MEMBERS <= len(members) <= MAX_MEMBERS:
         raise _unavailable(f"{label} must carry {MIN_MEMBERS}..{MAX_MEMBERS} member answers")
@@ -294,7 +295,7 @@ def _lanl_gate(root: Path):
         if kind == "continue":
             proceed = not passers and attempt < MAX_ATTEMPTS
             payload = [{"case_id": case_id, "attempt": attempt + 1}] if proceed else []
-            return _json(payload)
+            return compact_json(payload)
         if len(passers) >= 2:
             pool = passers
         elif not passers and attempt == MAX_ATTEMPTS:
@@ -308,8 +309,8 @@ def _lanl_gate(root: Path):
         else:
             pool = []
         if not pool:
-            return _json([])
-        return _json(
+            return compact_json([])
+        return compact_json(
             [
                 {
                     "case_id": case_id,
@@ -340,7 +341,7 @@ def _lanl_select(root: Path):
 
     def select(request: Request) -> str:
         case_id, _attempt = _case_and_attempt(request.intent)
-        payload = _json_payload(request.context, "lanl selection")
+        payload = json_object(request.context, "lanl selection")
         if set(payload) != {"round", "tie"}:
             raise _unavailable("lanl selection payload must carry exactly round and tie")
         members = _lanl_members(payload["round"], "selection round")
@@ -366,7 +367,7 @@ def _lanl_select(root: Path):
 def _tie_letter(value: object, members: list[dict[str, Any]]) -> str | None:
     """The judge's letter from the 0-or-1-item tie-pick collection, if any."""
 
-    items = _json_array(value, "tie picks") if value not in (None, "") else []
+    items = json_array(value, "tie picks") if value not in (None, "") else []
     if not items:
         return None
     reply = items[0]
@@ -400,13 +401,13 @@ def _lanl_envelope(request: Request) -> str:
 
     try:
         case_id = _positive_int(request.intent, "case id")
-        payload = _json_payload(request.context, "lanl case evaluation")
+        payload = json_object(request.context, "lanl case evaluation")
         if set(payload) != {"attempt_1", "next"}:
             raise ValueError("lanl case evaluation must carry exactly attempt_1 and next")
         attempts = [_decoded_check(payload["attempt_1"], "attempt_1")]
         next_value: object = payload["next"]
         while True:
-            items = _json_array(next_value, "lanl continuation") if next_value != "" else []
+            items = json_array(next_value, "lanl continuation") if next_value != "" else []
             if not items:
                 break
             if len(items) != 1:
@@ -416,7 +417,7 @@ def _lanl_envelope(request: Request) -> str:
         result = bind_case_evaluation(case_id, attempts)
     except (TypeError, ValueError) as exc:
         raise _unavailable(str(exc)) from exc
-    return _json(result)
+    return compact_json(result)
 
 
 def _continuation_outcome(outcome: object) -> tuple[dict[str, Any], object]:
@@ -457,7 +458,7 @@ def _resolve_candidate(request: Request) -> str:
     """Validate raw Fusion bindings before any LANL member invocation."""
 
     value = _bound_members(request)
-    return _json(_resolved_members(value))
+    return compact_json(_resolved_members(value))
 
 
 def _bound_members(request: Request) -> dict[str, object]:
@@ -543,25 +544,12 @@ def _direct_model_call(parsed: Expression, label: str) -> RelExpr:
     return call
 
 
-def _json_array(value: object, label: str) -> list[object]:
-    """Decode arrays carried as JSON text through URL4's scalar struct fields."""
-
-    if isinstance(value, str):
-        try:
-            value = json.loads(value)
-        except ValueError as exc:
-            raise _unavailable(f"{label} must be JSON: {exc}") from exc
-    if not isinstance(value, list):
-        raise _unavailable(f"{label} must be an array")
-    return value
-
-
 def _member_record(request: Request) -> str:
     """Return one validated attempt record for the next URL4 round."""
 
     if request.intent != "record":
         raise _unsupported("IFEval member record", request.intent)
-    return _json(_attempt_member(_json_payload(request.context, "member record"), 0))
+    return compact_json(_attempt_member(json_object(request.context, "member record"), 0))
 
 
 def _member_answer(request: Request) -> str:
@@ -569,7 +557,7 @@ def _member_answer(request: Request) -> str:
 
     members = [
         _member(value, index)
-        for index, value in enumerate(_json_array(request.context, "Candidate member round"))
+        for index, value in enumerate(json_array(request.context, "Candidate member round"))
     ]
     for member in members:
         if member["key"] == request.intent:
@@ -643,16 +631,6 @@ def _judge_letter(reply: object, selected: Mapping[str, object]) -> str | None:
     return token if len(token) == 1 and token in selected else None
 
 
-def _json_payload(context: str, label: str) -> dict[str, object]:
-    try:
-        payload = json.loads(context or "")
-    except ValueError as exc:
-        raise _unavailable(f"{label} input must be JSON: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise _unavailable(f"{label} input must be a JSON object")
-    return payload
-
-
 def _case_and_attempt(value: str) -> tuple[int, int]:
     case_part, _, attempt_part = (value or "").partition(":")
     case_id = _positive_int(case_part, "case id")
@@ -661,7 +639,7 @@ def _case_and_attempt(value: str) -> tuple[int, int]:
 
 
 def _positive_int(value: object, label: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, (int, str)):
+    if isinstance(value, bool) or not isinstance(value, int | str):
         raise ValueError(f"IFEval {label} must be an integer, got {value!r}")
     try:
         selected = int(value)
@@ -670,10 +648,6 @@ def _positive_int(value: object, label: str) -> int:
     if selected < 1:
         raise ValueError(f"IFEval {label} must be positive, got {selected}")
     return selected
-
-
-def _json(value: object) -> str:
-    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
 
 
 def _unsupported(label: str, intent: str) -> ResolutionError:
@@ -689,10 +663,6 @@ def _read(path: Path, label: str) -> str:
         return path.read_text(encoding="utf-8")
     except OSError as exc:
         raise _unavailable(f"could not read {label} at {str(path)!r}: {exc}") from exc
-
-
-def _unavailable(detail: str) -> ResolutionError:
-    return ResolutionError(detail, code="benchmark_unavailable", permanent=True)
 
 
 def _candidate_invalid(detail: str) -> ResolutionError:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/protocol.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/protocol.py
@@ -1,0 +1,66 @@
+"""URL4 composition capabilities shared by Engine-owned Benchmarks."""
+
+from __future__ import annotations
+
+from url4 import Node, RelExpr, Text, expr, iterate, src
+from url4_cloud.benchmarks.evaluation import positive_count
+
+EVALUATION_PROTOCOL_REVISION = "ordered-case-evaluation-v1"
+
+
+def build_evaluation_protocol(
+    *,
+    cases_route: str,
+    case_evaluation: Node,
+    selected_case_count: int,
+    available_case_count: int,
+    aggregate_route: str,
+    bindings: tuple[Node, ...] = (),
+) -> Node:
+    """Compose ordered Case evaluation and fail-closed Aggregation around one Case node."""
+
+    _route(cases_route, "cases_route")
+    _route(aggregate_route, "aggregate_route")
+    positive_count(available_case_count, "available_case_count")
+    positive_count(selected_case_count, "selected_case_count")
+    if selected_case_count > available_case_count:
+        raise ValueError("selected_case_count cannot exceed available_case_count")
+    if not isinstance(case_evaluation, Node):
+        raise TypeError("case_evaluation must be a URL4 Node")
+    if any(not isinstance(binding, Node) for binding in bindings):
+        raise TypeError("bindings must contain only URL4 Nodes")
+
+    case_evaluations = iterate(
+        cases_route,
+        body=(src(case_evaluation, name="evaluated", weight=0.0),),
+        intent=Text("$evaluated"),
+        slice=(None if selected_case_count == available_case_count else (0, selected_case_count)),
+        on_error="collect",
+    )
+    selected_case_evaluations = expr(
+        *bindings,
+        src(case_evaluations, name="selected_case_evaluations", weight=0.0),
+        intent=Text("$selected_case_evaluations"),
+    )
+    return expr(
+        src(selected_case_evaluations, name="case_evaluations", weight=0.0),
+        src(
+            RelExpr(
+                path=aggregate_route,
+                context="$case_evaluations",
+                intent=Text(f"aggregate:{selected_case_count}"),
+            ),
+            name="result",
+            weight=0.0,
+        ),
+        intent=Text("$result"),
+    )
+
+
+def _route(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.startswith("/"):
+        raise ValueError(f"{label} must be an absolute URL4 path")
+    return value
+
+
+__all__ = ["EVALUATION_PROTOCOL_REVISION", "build_evaluation_protocol"]

--- a/apps/url4-cloud/tests/unit/test_benchmark_evaluation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_evaluation.py
@@ -1,0 +1,105 @@
+"""Installed evaluation capabilities adapt distinct Benchmark semantics to URL4 routes."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from url4 import RelExpr, Text, render
+from url4.core.errors import ResolutionError
+from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.contract import encode_candidate_invocation
+from url4_cloud.benchmarks.errors import ProviderRefusal
+from url4_cloud.benchmarks.evaluation import (
+    aggregate_endpoint,
+    candidate_answer,
+    case_evaluation_endpoint,
+)
+
+
+def _call(path: str, context: str, intent: str) -> str:
+    return render(RelExpr(path=path, context=context, intent=Text(intent)))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route", "item_name", "marker"),
+    (
+        ("/draco/case", "Criterion evaluation", "criterion"),
+        ("/healthbench/case", "Rubric evaluation", "rubric"),
+    ),
+)
+async def test_case_evaluation_endpoint_adapts_two_benchmark_binders(
+    route: str,
+    item_name: str,
+    marker: str,
+) -> None:
+    node = Url4Node("case-evaluation")
+
+    def bind(case_id: int, items: list[dict[str, object]]) -> dict[str, object]:
+        return {"case_id": case_id, "kind": marker, "items": items}
+
+    node.endpoint(route)(
+        case_evaluation_endpoint(
+            label=f"{marker} Case evaluation",
+            item_name=item_name,
+            bind=bind,
+        )
+    )
+    context = json.dumps([json.dumps({"value": 1}), {"value": 2}])
+
+    result = json.loads((await node.evaluate(_call(route, context, "7"))).text)
+
+    assert result == {
+        "case_id": 7,
+        "kind": marker,
+        "items": [{"value": 1}, {"value": 2}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_aggregate_endpoint_validates_selection_and_passes_case_evaluations_as_context() -> (
+    None
+):
+    node = Url4Node("aggregate")
+
+    def aggregate(case_evaluations: str, selected_case_count: int) -> dict[str, object]:
+        return {
+            "selected_case_count": selected_case_count,
+            "case_evaluations": json.loads(case_evaluations),
+        }
+
+    node.endpoint("/benchmark/aggregate")(
+        aggregate_endpoint(label="Example", available_case_count=3, aggregate=aggregate)
+    )
+
+    result = json.loads(
+        (await node.evaluate(_call("/benchmark/aggregate", '[{"case_id":1}]', "aggregate:1"))).text
+    )
+    assert result == {
+        "selected_case_count": 1,
+        "case_evaluations": [{"case_id": 1}],
+    }
+
+    for intent in ("aggregate:0", "aggregate:4", "aggregate:invalid", "aggregate:²"):
+        with pytest.raises(ResolutionError) as caught:
+            await node.evaluate(_call("/benchmark/aggregate", "[]", intent))
+        assert caught.value.code == "benchmark_unavailable"
+
+    with pytest.raises(ResolutionError) as caught:
+        await node.evaluate(_call("/benchmark/aggregate", "[]", "summarize:1"))
+    assert caught.value.code == "benchmark_operation_unsupported"
+
+
+def test_candidate_answer_preserves_completion_and_raises_exact_refusal() -> None:
+    answer = candidate_answer(encode_candidate_invocation("answer", "length", None))
+    assert (answer.output, answer.finish_reason) == ("answer", "length")
+
+    with pytest.raises(ProviderRefusal, match="exact refusal") as caught:
+        candidate_answer(encode_candidate_invocation("", "content_filter", "exact refusal"))
+
+    assert json.loads(str(caught.value)) == {
+        "refusal": "exact refusal",
+        "finish_reason": "content_filter",
+    }

--- a/apps/url4-cloud/tests/unit/test_benchmark_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_protocol.py
@@ -1,0 +1,135 @@
+"""The shared Benchmark protocol owns the outer Case-to-Aggregation lifecycle."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from url4 import RelExpr, Text, render, src
+from url4.core.errors import ResolutionError
+from url4.peer.server import Request, Url4Node
+from url4_cloud.benchmarks.definition import Benchmark
+from url4_cloud.benchmarks.draco.definition import DRACO
+from url4_cloud.benchmarks.healthbench.definition import HEALTHBENCH_WORST30
+from url4_cloud.benchmarks.ifeval.definition import IFEVAL
+from url4_cloud.benchmarks.protocol import build_evaluation_protocol
+
+
+@pytest.mark.asyncio
+async def test_protocol_preserves_selected_order_and_collects_a_case_failure() -> None:
+    node = Url4Node("benchmark-protocol")
+    node.data(
+        "/example/cases",
+        json.dumps(
+            [
+                {"id": 11, "input": "first"},
+                {"id": 22, "input": "second"},
+                {"id": 33, "input": "unselected"},
+            ]
+        ),
+        media_type="application/json",
+    )
+
+    @node.endpoint("/example/evaluate-case")
+    def evaluate_case(request: Request) -> str:
+        if request.intent == "22":
+            raise ResolutionError("candidate failed", code="candidate_failed", permanent=True)
+        return json.dumps({"case_id": int(request.intent), "output": request.context})
+
+    @node.endpoint("/example/aggregate")
+    def aggregate(request: Request) -> str:
+        return json.dumps(
+            {
+                "intent": request.intent,
+                "case_evaluations": json.loads(request.context),
+            }
+        )
+
+    protocol = build_evaluation_protocol(
+        cases_route="/example/cases",
+        case_evaluation=RelExpr(
+            path="/example/evaluate-case",
+            context="$item.input",
+            intent=Text("$item.id"),
+        ),
+        selected_case_count=2,
+        available_case_count=3,
+        aggregate_route="/example/aggregate",
+    )
+
+    result = json.loads((await node.evaluate(render(protocol))).text)
+
+    assert result == {
+        "intent": "aggregate:2",
+        "case_evaluations": [
+            {"case_id": 11, "output": "first"},
+            {"error": {"kind": "ResolutionError", "message": "candidate failed"}},
+        ],
+    }
+
+
+def test_protocol_rejects_an_impossible_case_selection() -> None:
+    with pytest.raises(ValueError, match="selected_case_count"):
+        build_evaluation_protocol(
+            cases_route="/example/cases",
+            case_evaluation=RelExpr(path="/example/evaluate-case"),
+            selected_case_count=4,
+            available_case_count=3,
+            aggregate_route="/example/aggregate",
+        )
+
+
+@pytest.mark.parametrize(
+    ("benchmark", "expected_sha256"),
+    (
+        (DRACO, "559bbcacbf7da44ccc811e205ab2c20ceb232f1ba126922f7d053741b3bd3de0"),
+        (IFEVAL, "f8be102aafa71f04939f6d8751b0c8fc20a694a233caea7317176f1827bbed41"),
+        (
+            HEALTHBENCH_WORST30,
+            "135511db8df1d16d1d1eea6ea90afc1881452b061922d9586bab770a6344f220",
+        ),
+    ),
+)
+def test_canonical_benchmark_url4_is_pinned_byte_for_byte(
+    benchmark: Benchmark, expected_sha256: str
+) -> None:
+    url4 = render(benchmark.build(benchmark.case_count))
+
+    assert hashlib.sha256(url4.encode()).hexdigest() == expected_sha256
+
+
+def test_canonical_ifeval_binds_the_exact_selected_count_for_aggregation() -> None:
+    assert "!'aggregate:2'" in render(IFEVAL.build(2))
+
+
+@pytest.mark.asyncio
+async def test_protocol_resolves_shared_bindings_before_case_iteration() -> None:
+    node = Url4Node("benchmark-bindings")
+    node.data(
+        "/example/cases",
+        json.dumps([{"id": 1, "input": "case"}]),
+        media_type="application/json",
+    )
+
+    @node.endpoint("/example/evaluate-case")
+    def evaluate_case(request: Request) -> str:
+        return request.context
+
+    @node.endpoint("/example/aggregate")
+    def aggregate(request: Request) -> str:
+        return request.context
+
+    protocol = build_evaluation_protocol(
+        cases_route="/example/cases",
+        case_evaluation=RelExpr(
+            path="/example/evaluate-case", context="$shared", intent=Text("$item.id")
+        ),
+        selected_case_count=1,
+        available_case_count=1,
+        aggregate_route="/example/aggregate",
+        bindings=(src(Text("resolved-once"), name="shared", weight=0.0),),
+    )
+
+    assert json.loads((await node.evaluate(render(protocol))).text) == ["resolved-once"]

--- a/docs/plan/2026-08-12-OME-804-generic-benchmark-evaluation.md
+++ b/docs/plan/2026-08-12-OME-804-generic-benchmark-evaluation.md
@@ -1,0 +1,31 @@
+---
+title: Implement generic benchmark evaluation capabilities
+ticket: OME-804
+status: approved
+date: 2026-08-12
+spec: ../spec/2026-08-12-OME-804-generic-benchmark-evaluation.md
+---
+
+# Implement generic benchmark evaluation capabilities
+
+The agreed test seams are the rendered/installed Benchmark protocol and its typed Candidate
+Result. Tests do not assert private helper calls or internal module layout.
+
+1. Pin the existing rendered canonical URL4 and installed successful/refused/failed outcomes for
+   DRACO, IFEval, and HealthBench with independent literals or existing official fixtures.
+2. Add one failing tracer test for a shared outer Case-evaluation protocol: ordered selection,
+   collected Case failure, context-carried Case evaluations, and exact aggregate selection.
+3. Implement the smallest URL4 AST combinator that passes that test; migrate canonical IFEval,
+   then DRACO and HealthBench, preserving each supplied per-Case evaluator node.
+4. Add a failing tracer test for the shared installed runtime envelope using two genuinely
+   different adapters. Extract only common Candidate Invocation, JSON, Case collection, and
+   aggregate mechanics demonstrated by those adapters.
+5. Migrate DRACO and HealthBench Judge-based routes, then IFEval deterministic routes, one vertical
+   slice at a time. After each migration run its existing protocol and scoring fixtures.
+6. Delete replaced shallow helpers and their implementation-coupled tests only after equivalent
+   behavior is covered through the installed Benchmark seam.
+7. Bump every Benchmark revision whose rendered URL4 or score-affecting runtime identity changes;
+   keep the result and internal record schemas at their existing v1 identities.
+8. Run the complete URL4 Cloud gate, inspect the final diff for Benchmark-semantic movement,
+   speculative registries, DSL-like configuration, private rubric leakage, and compatibility
+   paths.

--- a/docs/spec/2026-08-12-OME-804-generic-benchmark-evaluation.md
+++ b/docs/spec/2026-08-12-OME-804-generic-benchmark-evaluation.md
@@ -1,0 +1,101 @@
+---
+title: Generic benchmark evaluation capabilities
+ticket: OME-804
+status: approved
+date: 2026-08-12
+---
+
+# Generic benchmark evaluation capabilities
+
+## Outcome
+
+URL4 Cloud exposes a small set of deep Benchmark Evaluation modules. A Benchmark definition
+supplies its irreducible evaluator graph and scoring adapter; the shared modules own the repeated
+outer lifecycle:
+
+```text
+selected Cases
+→ complete $candidate invocation
+→ Benchmark evaluator adapter
+→ typed Case Result
+→ fail-closed Aggregation
+→ Candidate Result
+```
+
+URL4 remains the only executable graph. The Client binds one complete Candidate Recipe at
+`$candidate`; neither the Benchmark card nor the Client re-describes Evaluation in another DSL.
+
+## Interfaces and seams
+
+### Protocol composition
+
+One URL4 AST combinator owns the mechanics common to every Benchmark:
+
+- iterate the immutable Case collection in selection order;
+- evaluate one supplied Case graph;
+- collect Case-scoped resolution failures rather than aborting the collection;
+- materialize the ordered Case evaluations;
+- pass them through context to the aggregate route;
+- bind the exact selected count in the aggregate intent.
+
+The combinator accepts a complete per-Case `Node`; it does not know whether that node performs a
+deterministic check, one Judge call, multiple rubric passes, or a corrective strategy. This makes
+it a URL4 composition capability, not a benchmark-manifest DSL.
+
+### Installed runtime
+
+Shared runtime functions own only mechanics proven identical across at least two Benchmarks:
+
+- strict JSON object/array decoding and compact encoding;
+- positive Case identity and selected-count validation;
+- preservation of selected Case order so Benchmark result adapters can attach identity-less
+  collected failures to the exact selected Case;
+- Candidate Invocation decoding with exact refusal propagation;
+- standard Case-evaluation collection and Aggregation endpoint envelopes;
+- conversion of local asset/adapter errors into bounded `benchmark_unavailable` failures.
+
+Benchmark adapters remain ordinary callables registered on revision-pinned routes. The runtime
+does not add a generic registry whose only implementation is one Benchmark.
+
+### Evaluator adapters
+
+The real evaluator seam is one complete per-Case URL4 node plus its installed routes:
+
+- IFEval supplies deterministic instruction verification.
+- DRACO supplies multi-pass criterion Judging and evidence-to-credit logic.
+- HealthBench supplies per-rubric-item Judging and penalty-bearing credit logic.
+
+These are distinct adapters because they genuinely vary. Shared endpoint envelopes may be
+extracted; evaluator semantics, schemas, prompts, retry policy, and scoring remain local.
+
+## Behavioral invariants
+
+- Each selected Case invokes the complete Candidate according to the immutable Benchmark
+  protocol and appears exactly once in the final ordered result.
+- Candidate output, finish reason, refusal, and Candidate Invocation failure remain distinguishable.
+- Operational failure never becomes an incorrect answer or a numeric zero.
+- The scorer runs only when the Benchmark's selected Case coverage is complete, as established by
+  OME-802.
+- Direct URL4 evaluation and `sf.evaluate(...)` resolve the same expression.
+- A structural extraction that changes rendered URL4 changes the immutable Benchmark revision,
+  even when score mathematics are unchanged.
+
+## Benchmark-specific remainder
+
+Each Benchmark directory may retain files for immutable data preparation, evaluator semantics,
+prompts, evidence validation, scoring mathematics, and thin registration. File-count reduction is
+not itself the objective: shared knowledge and mechanics must move to the deep module, while
+genuinely different research protocols remain obvious and local.
+
+## Compatibility
+
+This is unreleased v1. Do not add legacy routes, aliases, dual builders, old-shape readers,
+migrations, fallbacks, or new schema versions. Existing successful-result semantics are preserved
+and structurally changed Benchmark URL4 receives a new immutable revision.
+
+## Exclusions
+
+- Client Report consumption and widgets (OME-803).
+- Pipeline or CorrectiveLoop Candidate construction (OME-796 and its dependencies).
+- Arbitrary user Python or manifest-authored execution graphs.
+- Timing, usage, cost, cache, and dynamic operation-occurrence attribution.

--- a/docs/tasks/2026-08-12-OME-804-generic-benchmark-evaluation.md
+++ b/docs/tasks/2026-08-12-OME-804-generic-benchmark-evaluation.md
@@ -1,0 +1,33 @@
+---
+title: Extract generic benchmark evaluation capabilities in URL4 Cloud
+ticket: OME-804
+status: Done
+date: 2026-08-12
+closed: 2026-08-13
+parent: OME-801
+blocked-by: OME-802
+---
+
+# OME-804 — Extract generic benchmark evaluation capabilities in URL4 Cloud
+
+## Goal
+
+Deepen the URL4 Cloud Benchmark module so DRACO, IFEval, and HealthBench compose the same
+Case-selection, Candidate-invocation, error-collection, Case-evaluation, and Aggregation
+capabilities while retaining their irreducible data, evaluator, prompt, and scoring semantics.
+
+## Delivery
+
+Development occurs on `OME-804-benchmark-execution`, rebased onto `origin/main` after prerequisite
+OME-802 PR #572 merged. The branch contains one OME-804 commit above that merged prerequisite and
+is delivered as one ordinary, unstacked PR.
+
+## Acceptance
+
+- The complete installed Benchmark URL4 remains the Evaluation and test seam.
+- Successful protocol behavior remains pinned by independent DRACO, IFEval, and HealthBench
+  fixtures.
+- Shared mechanics live outside Benchmark-specific directories.
+- Benchmark-owned checker, Judge, prompts, grading, and score mathematics remain local.
+- No manifest DSL, second runner, arbitrary Python, compatibility fallback, or schema version is
+  introduced.

--- a/docs/work/2026-08-12-OME-804-benchmark-evaluation.md
+++ b/docs/work/2026-08-12-OME-804-benchmark-evaluation.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-804
+stack: url4-cloud
+status: done
+started: 2026-08-12
+finished: 2026-08-13
+---
+
+# OME-804 — Extract generic benchmark evaluation capabilities in URL4 Cloud
+
+## Intent
+
+Move repeated Benchmark Evaluation mechanics behind a small URL4 composition/runtime interface so
+future Benchmarks reuse trusted Engine capabilities while DRACO, IFEval, and HealthBench retain
+their published evaluator and scoring semantics.
+
+## Planned changes
+
+- `apps/url4-cloud/src/url4_cloud/benchmarks/` — shared protocol and runtime capabilities.
+- DRACO, IFEval, and HealthBench definitions/runtime adapters — compose those capabilities and
+  delete replaced plumbing.
+- `apps/url4-cloud/tests/` — public-seam tracer and cross-Benchmark conformance coverage.
+- OME-804 task mirror, spec, plan, and this work ledger.
+
+## Test plan
+
+- RED: shared outer protocol preserves selection order, collected failure, and aggregate intent.
+- RED: two distinct installed evaluator adapters pass through the same runtime envelope.
+- Existing Benchmark fixtures pin Candidate inputs, Judge/check behavior, evidence, Case scores,
+  aggregate metrics, and direct URL4 replay throughout migration.
+- Full URL4 Cloud gates and coverage run after the final slice.
+
+## Acceptance
+
+- Generic mechanics live once outside Benchmark-specific directories.
+- Each Benchmark retains only its irreducible protocol semantics and thin adapters.
+- Existing successful and failure outcomes remain equivalent through the public seam.
+- No alternate runner, manifest DSL, version proliferation, or compatibility path is introduced.
+
+## Outcome
+
+- **Actual files:** Added shared `benchmarks/protocol.py` and `benchmarks/evaluation.py`, migrated
+  the DRACO, IFEval (canonical and corrective), and HealthBench definitions/runtime adapters,
+  added two cross-Benchmark public-seam test modules, and recorded the OME-804 task/spec/plan.
+- **Commits:** One OME-804 implementation commit follows merged prerequisite PR #572; Khoa's two
+  HealthBench fixes remain in `main` ancestry rather than being duplicated in this branch.
+- **Gates:** `python3 .claude/scripts/run_gates.py url4-cloud --base origin/main` — all gates green
+  (append-only tests, Ruff lint/format, Pyright, layering, and the full pytest coverage suite).
+- **Review:** Independent Standards and Spec reviews are clean. Exact canonical URL4 is pinned for
+  all three Benchmark families, malformed aggregate bounds fail with bounded public errors, and
+  shared JSON, Case Evaluation, Candidate Invocation, and Aggregation mechanics live in the common
+  runtime.
+- **Deviations:** No generic evaluator registry was introduced. Existing evidence showed that the
+  complete per-Case URL4 node and its revision-pinned installed routes already form the deeper
+  evaluator seam; Benchmark-specific checking, prompts, retries, evidence validation, and score
+  mathematics remain local.


### PR DESCRIPTION
## Summary

- extract the repeated Benchmark Evaluation lifecycle into shared URL4 protocol and installed-runtime capabilities
- migrate DRACO, IFEval, and HealthBench onto the shared Case-selection, Candidate Invocation, Case Evaluation, and Aggregation seams
- retain each Benchmark's irreducible cases, checking/Judge behavior, prompts, evidence rules, retries, and scoring mathematics

**Linear:** https://linear.app/openmined/issue/OME-804

## Components touched

- `apps/url4-cloud`
- benchmark SDLC documentation

## Behavioral notes

- URL4 remains the only executable graph; this introduces no manifest DSL, second runner, arbitrary Python pathway, compatibility fallback, or schema version.
- Candidate construction remains independent of Benchmark evaluation through the existing complete `$candidate` seam.
- Exact provider refusal and finish-reason data from OME-802 remain preserved.
- All structurally changed Benchmark URL4 expressions receive new immutable revisions.
- Khoa's HealthBench malformed-evaluation and duplicate-rubric fixes are already present through merged prerequisite PR #572 and are not duplicated in this branch.

## Test plan

- [x] append-only test check against `origin/main`
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run pyright`
- [x] layering check
- [x] full URL4 Cloud pytest coverage gate
- [x] independent Standards review
- [x] independent Spec review

## Cross-service notes

OME-803 is the Client follow-up that consumes the normalized OME-802 Case outcomes. OME-796 covers Client-owned corrective Candidate construction; strategy-only Benchmark variants can move to Client recipes after that capability exists. This PR does not change `packages/screamingface`.
