### PR TITLE
feat(screamingface): render report answer as markdown; tidy pane + URL4 spacing

### DIFF
--- a/docs/work/2026-08-13-report-md-url4.md
+++ b/docs/work/2026-08-13-report-md-url4.md
@@ -1,0 +1,70 @@
+---
+ticket: OME-<N>   # DEFERRED — Linear MCP OAuth unreachable ("invalid uri"); owner authorized proceeding. File + backfill Refs before merge.
+stack: screamingface
+status: in_progress
+started: 2026-08-13
+finished:
+---
+
+# OME-<N> — Report panel: markdown answers, tighter spacing, better URL4
+
+## Intent
+
+The notebook Report panel (`report = sf.evaluate(...)` → `_repr_html_`) renders the model
+**answer** as raw escaped text in a monospace `<pre>`, so markdown reads as literal noise;
+the **domain tag** sits flush against the **question**; the **case / answer / criteria**
+blocks run together; and the **URL4** disclosure shows its expression flush to the panel
+edges, with the operation-step chips jammed against it and no way to copy it. This unit
+renders the answer as safe markdown and gives the pane + URL4 block a calmer reading rhythm —
+staying within the existing hand-built HTML/CSS, no JS framework, no new core dependency.
+
+## Planned changes
+
+- **New** `packages/screamingface/src/screamingface/_ui/markdown.py` — `render_markdown(text)`:
+  escape-first, XSS-safe markdown subset (tamed headings h4–h6, bold/italic, inline + fenced
+  code, ul/ol, paragraphs, safe http/https/mailto links only).
+- **Modify** `packages/screamingface/src/screamingface/_ui/report_view.py`:
+  - `_pane_html` — answer becomes `<div class='sf-report__md'>{render_markdown(answer)}</div>`;
+    domain chips get `.sf-pane__tags` (drop inline `margin-top:8px`).
+  - `_recipe_html` — inset `.sf-report__url4` wrapper (side padding + gap from step chips) +
+    a copy button (`onclick` `navigator.clipboard.writeText`, **full** url4 in `data-u4`).
+  - `_STYLE` — add `.sf-report__md`, `.sf-pane__tags`, `.sf-report__url4*`, `.sf-report__copy`;
+    bump `.sf-detail__k` to `margin:18px 0 6px`.
+- **New** `packages/screamingface/tests/test_markdown.py`; **extend**
+  `packages/screamingface/tests/test_report_panel.py`.
+
+## Test plan (RED first)
+
+- `test_markdown.py`: headings→tamed `<h4..6>`; `**bold**`→`<strong>`, `*em*`→`<em>`,
+  `` `code` ``→`<code>`; fenced ```` ``` ````→`<pre><code>`; `-`/`1.`→`<ul>`/`<ol>`; safe
+  `http(s)` link renders with `rel=noopener`; **`javascript:` link rejected** (rendered inert);
+  **XSS: `<script>` / `<img onerror=...>` in input stays escaped** (invariant).
+- `test_report_panel.py`: answer markdown renders (`## H`→`<h`, `**b**`→`<strong>`, fence→`<pre`);
+  existing `test_untrusted_case_and_judge_text_is_escaped` stays green with a `<script>` answer;
+  URL4 disclosure carries `sf-report__copy` whose `data-u4` holds the **full** url4; expression
+  wrapped in `.sf-report__url4`; `.sf-pane__tags` present.
+
+## Acceptance
+
+- Answer renders as real markdown in the pane; untrusted text remains XSS-safe.
+- Clear space between domain tag → question, and between case / answer / criteria.
+- URL4 expression is inset with side padding, spaced from the step chips, and copyable
+  (full expression), verified in light + dark.
+- All card gates green (`run_gates.py screamingface`), coverage ≥95%.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files (as planned):**
+  - new `src/screamingface/_ui/markdown.py` — `render_markdown` (escape-first, rule-table
+    dispatch; asterisk-only emphasis so snake_case/dunder survive).
+  - `src/screamingface/_ui/report_view.py` — answer → `.sf-report__md`; `.sf-pane__tags`;
+    `.sf-detail__k` → `margin:18px 0 6px`; `_recipe_html` inset `.sf-report__url4` + copy button.
+  - new `tests/test_markdown.py` (18 tests); `tests/test_report_panel.py` (+4 tests, +local
+    `_answer_case` fixture — shared `case()`/`candidate()` left untouched per append-only).
+- **Commits:** <sha — pending: `Refs` backfilled once OME-N is filed>
+- **Gates:** `run_gates.py screamingface` → ALL GREEN (append-only, ruff, format, pyright,
+  pytest cov≥95, check_notebooks, uv build, check_distribution). New tests: 22 (18 + 4).
+- **Visual:** `/tmp/report_preview.html` — 14/14 structural checks (markdown answer, domain-tag
+  row, inset URL4 + copy button). Owner light/dark eyeball pending.
+- **Deviations:** Linear MCP OAuth was unreachable at start ("invalid uri") — owner authorized
+  proceeding; branch/ledger use a descriptor, ticket + `Refs` backfilled before merge.

--- a/packages/screamingface/src/screamingface/_ui/markdown.py
+++ b/packages/screamingface/src/screamingface/_ui/markdown.py
@@ -1,0 +1,167 @@
+"""A tiny, safe markdown-subset renderer for the untrusted model answer.
+
+FEATURE: the answer in a Report is prose — headings, lists, emphasis, code — so it reads as
+rendered markdown, not a literal `##`/`**`/`` ` `` dump in a monospace box.
+
+INVARIANT: the input is UNTRUSTED model output. Every character is HTML-escaped BEFORE it is
+placed in the output, and this module only ever emits its own fixed tag set — so a `<script>`
+in the source can only ever become the inert text `&lt;script&gt;`, and a link is rendered as
+an anchor only when its scheme is http(s)/mailto. Raw HTML never survives.
+
+The supported subset is deliberately small (the panel is a summary, not a document viewer):
+tamed headings (h4–h6), unordered/ordered lists, blockquotes, fenced + inline code,
+`**bold**`/`*italic*` (asterisks only — see WHY below), safe links, and paragraphs.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from html import escape
+
+__all__: list[str] = []
+
+_HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+_UL_ITEM = re.compile(r"^\s*[-*+]\s+(.*)$")
+_OL_ITEM = re.compile(r"^\s*\d+\.\s+(.*)$")
+# WHY: only http(s)/mailto may become a live anchor — everything else (javascript:, data:, …)
+# is left as inert escaped text so a crafted link can never carry an active scheme.
+_SAFE_SCHEME = re.compile(r"^(?:https?:|mailto:)", re.IGNORECASE)
+
+_CODE_SPAN = re.compile(r"`([^`]+)`")
+_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_BOLD = re.compile(r"\*\*([^*]+)\*\*")
+# WHY: emphasis is asterisks-only. Underscore emphasis would turn `estimator_test` and
+# `__init__` in technical answers into mangled italics — a common, ugly false positive.
+_ITALIC = re.compile(r"\*([^*]+)\*")
+# The code-span placeholder uses NULs, which cannot occur in the escaped text (stripped below).
+_PLACEHOLDER = re.compile(r"\x00(\d+)\x00")
+
+
+def render_markdown(text: str) -> str:
+    """Render an untrusted markdown string to safe HTML (see the module INVARIANT)."""
+
+    if not text:
+        return ""
+    # Remove NULs up front so untrusted input can never forge a code-span placeholder.
+    lines = text.replace("\x00", "").split("\n")
+    parts: list[str] = []
+    index = 0
+    while index < len(lines):
+        index, block = _next_block(lines, index)
+        if block:
+            parts.append(block)
+    return "".join(parts)
+
+
+def _next_block(lines: list[str], index: int) -> tuple[int, str]:
+    """Consume ONE block starting at `index`, returning (next index, html; "" for a blank)."""
+
+    line = lines[index]
+    if not line.strip():
+        return index + 1, ""
+    for matches, consume in _BLOCK_RULES:
+        if matches(line):
+            return consume(lines, index)
+    return _paragraph(lines, index)
+
+
+def _heading(lines: list[str], index: int) -> tuple[int, str]:
+    match = _HEADING.match(lines[index])
+    if match is None:  # defensive — the rule predicate already matched this line
+        return index + 1, ""
+    level = min(3 + len(match.group(1)), 6)
+    return index + 1, f"<h{level}>{_inline(escape(match.group(2).strip()))}</h{level}>"
+
+
+def _fenced_code(lines: list[str], index: int) -> tuple[int, str]:
+    """Consume a ``` fence (to its close, or to end-of-text if unclosed). No inline markup."""
+
+    index += 1
+    body: list[str] = []
+    while index < len(lines) and lines[index].strip() != "```":
+        body.append(lines[index])
+        index += 1
+    index += 1  # step past the closing fence (or harmlessly past the end)
+    return index, f"<pre class='sf-md__pre'><code>{escape(chr(10).join(body))}</code></pre>"
+
+
+def _list(lines: list[str], index: int, item: re.Pattern[str], tag: str) -> tuple[int, str]:
+    items: list[str] = []
+    while index < len(lines) and (match := item.match(lines[index])):
+        items.append(f"<li>{_inline(escape(match.group(1).strip()))}</li>")
+        index += 1
+    return index, f"<{tag}>{''.join(items)}</{tag}>"
+
+
+def _unordered(lines: list[str], index: int) -> tuple[int, str]:
+    return _list(lines, index, _UL_ITEM, "ul")
+
+
+def _ordered(lines: list[str], index: int) -> tuple[int, str]:
+    return _list(lines, index, _OL_ITEM, "ol")
+
+
+def _blockquote(lines: list[str], index: int) -> tuple[int, str]:
+    rows: list[str] = []
+    while index < len(lines) and lines[index].strip().startswith(">"):
+        rows.append(_inline(escape(re.sub(r"^\s*>\s?", "", lines[index]))))
+        index += 1
+    return index, f"<blockquote>{'<br>'.join(rows)}</blockquote>"
+
+
+def _is_block_start(line: str) -> bool:
+    stripped = line.strip()
+    return (
+        not stripped
+        or stripped.startswith(("```", ">"))
+        or bool(_HEADING.match(line) or _UL_ITEM.match(line) or _OL_ITEM.match(line))
+    )
+
+
+def _paragraph(lines: list[str], index: int) -> tuple[int, str]:
+    rows: list[str] = []
+    while index < len(lines) and not _is_block_start(lines[index]):
+        rows.append(_inline(escape(lines[index])))
+        index += 1
+    return index, f"<p>{'<br>'.join(rows)}</p>"
+
+
+def _inline(text: str) -> str:
+    """Inline spans over ALREADY-ESCAPED text: code, links, bold, italic.
+
+    Code spans are pulled out first so markdown inside them stays literal, then restored last.
+    """
+
+    codes: list[str] = []
+
+    def _stash(match: re.Match[str]) -> str:
+        codes.append(f"<code>{match.group(1)}</code>")
+        return f"\x00{len(codes) - 1}\x00"
+
+    text = _CODE_SPAN.sub(_stash, text)
+    text = _LINK.sub(_anchor, text)
+    text = _BOLD.sub(r"<strong>\1</strong>", text)
+    text = _ITALIC.sub(r"<em>\1</em>", text)
+    return _PLACEHOLDER.sub(lambda match: codes[int(match.group(1))], text)
+
+
+def _anchor(match: re.Match[str]) -> str:
+    """A link becomes an anchor only for a safe scheme; otherwise its literal text is kept."""
+
+    label, url = match.group(1), match.group(2)
+    if not _SAFE_SCHEME.match(url):
+        return match.group(0)
+    return f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>'
+
+
+# Ordered block rules: (does this line open the block?, consume it). First match wins; an
+# unmatched line falls through to a paragraph in _next_block. Kept flat so the dispatcher
+# stays a single loop rather than a return-per-block-type ladder.
+_BLOCK_RULES: list[tuple[Callable[[str], bool], Callable[[list[str], int], tuple[int, str]]]] = [
+    (lambda line: line.strip().startswith("```"), _fenced_code),
+    (lambda line: _HEADING.match(line) is not None, _heading),
+    (lambda line: _UL_ITEM.match(line) is not None, _unordered),
+    (lambda line: _OL_ITEM.match(line) is not None, _ordered),
+    (lambda line: line.strip().startswith(">"), _blockquote),
+]

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from html import escape
 from typing import TYPE_CHECKING, Any
 
+from screamingface._ui.markdown import render_markdown
 from screamingface._ui.style import FUSION_GRADIENT_Y, STYLE
 
 if TYPE_CHECKING:
@@ -100,6 +101,27 @@ _STYLE = (
   border:1px solid var(--sf-line);font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:12px;color:var(--sf-ink-2);white-space:pre-wrap;overflow-wrap:anywhere;
   max-height:280px;overflow:auto}}
+/* the answer is prose — rendered markdown, tamed to the panel: small headings, tight lists,
+   hairline code, accent links. No gold: this is a product surface, not the win. */
+.sf-report__md{{max-height:280px;overflow:auto;font-size:13px;line-height:1.5;
+  color:var(--sf-ink)}}
+.sf-report__md>:first-child{{margin-top:0}}.sf-report__md>:last-child{{margin-bottom:0}}
+.sf-report__md h4,.sf-report__md h5,.sf-report__md h6{{margin:14px 0 6px;font-weight:600;
+  line-height:1.25;color:var(--sf-ink)}}
+.sf-report__md h4{{font-size:15px}}.sf-report__md h5{{font-size:14px}}
+.sf-report__md h6{{font-size:13px}}
+.sf-report__md p{{margin:8px 0}}
+.sf-report__md ul,.sf-report__md ol{{margin:8px 0;padding-left:20px}}
+.sf-report__md li{{margin:3px 0}}
+.sf-report__md blockquote{{margin:8px 0;padding:2px 0 2px 10px;
+  border-left:2px solid var(--sf-line-2);color:var(--sf-ink-2)}}
+.sf-report__md a{{color:var(--sf-accent);text-decoration:underline}}
+.sf-report__md code{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  background:var(--sf-surface);border:1px solid var(--sf-line);padding:0 4px}}
+.sf-md__pre{{margin:8px 0;padding:8px;background:var(--sf-surface);
+  border:1px solid var(--sf-line);overflow:auto}}
+.sf-md__pre code{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  background:none;border:0;padding:0;color:var(--sf-ink-2);white-space:pre}}
 .sf-report__fail{{margin-top:14px;padding:8px 10px;border-left:2px solid var(--sf-blind);
   background:var(--sf-blind-bg);color:var(--sf-blind);
   font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;white-space:pre-wrap}}
@@ -127,8 +149,12 @@ _STYLE = (
 .sf-pane{{display:none;padding:12px 14px;min-width:0}}
 .sf-pane__h{{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px}}
 .sf-pane__q{{font-size:15px;line-height:1.45;color:var(--sf-ink)}}
+/* the domain/meta chips take their own row — clear air between the tag and the question */
+.sf-pane__tags{{margin:10px 0 14px}}
+/* section labels (answer · criteria · failures) — a calmer inter-section rhythm + a small
+   label-to-content gap, so case / answer / criteria read as distinct blocks */
 .sf-detail__k{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
-  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-3);margin-top:14px}}
+  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-3);margin:18px 0 6px}}
 .sf-check__who{{display:block;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11px;color:var(--sf-ink-3);margin-top:2px}}
 .sf-report__run{{margin-left:auto;font-family:"IBM Plex Mono",ui-monospace,monospace;
@@ -165,6 +191,16 @@ _STYLE = (
 .sf-step__k{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:10px;
   text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-3)}}
 .sf-step__l{{font-size:12px;color:var(--sf-ink-2)}}
+/* URL4 expression: inset from the disclosure edges, spaced off the step chips, and copyable.
+   The copy carries the FULL expression even though the visible <pre> is clipped. */
+.sf-report__url4{{padding:0 12px 12px;margin-top:12px}}
+.sf-report__url4 .sf-report__pre{{margin-top:0}}
+.sf-report__url4-h{{display:flex;align-items:center;margin-bottom:6px}}
+.sf-report__copy{{margin-left:auto;cursor:pointer;border-radius:0;
+  border:1px solid var(--sf-line-2);background:var(--sf-bg);color:var(--sf-ink-2);
+  padding:2px 8px;font:11px/1 "IBM Plex Mono",ui-monospace,monospace}}
+.sf-report__copy:hover{{color:var(--sf-ink);border-color:var(--sf-ink-2);
+  background:var(--sf-surface)}}
 @media(max-width:680px){{.sf-report__receipt{{margin-left:0;width:100%}}
   .sf-member{{grid-template-columns:1fr 70px}}
   .sf-member__m,.sf-member__d,.sf-member__u{{display:none}}
@@ -413,9 +449,20 @@ def _recipe_html(candidate: CandidateResult) -> str:
         for op in candidate.operations
     )
     steps_html = f"<div class='sf-steps'>{steps}</div>" if steps else ""
+    # The copy carries the FULL expression (the <pre> below is clipped for display). The
+    # onclick mirrors the leaderboard's fork button — it runs in a trusted notebook and is a
+    # harmless inert button where the host sanitises event handlers. data-u4 is attribute-safe.
+    copy = (
+        "<div class='sf-report__url4-h'>"
+        f'<button class="sf-report__copy" type="button" '
+        f'data-u4="{escape(candidate.url4, quote=True)}" '
+        "onclick=\"navigator.clipboard.writeText(this.dataset.u4);this.textContent='copied';"
+        "setTimeout(()=>this.textContent='copy',1200)\">copy</button></div>"
+    )
     return (
         "<details class='sf-report__det sf-report__det--tight'><summary>URL4</summary>"
-        f"{steps_html}<pre class='sf-report__pre'>{escape(_clip(candidate.url4, 1200))}</pre>"
+        f"{steps_html}<div class='sf-report__url4'>{copy}"
+        f"<pre class='sf-report__pre'>{escape(_clip(candidate.url4, 1200))}</pre></div>"
         "</details>"
     )
 
@@ -581,9 +628,12 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
         if checks
         else ""
     )
+    # FEATURE: the answer is prose — rendered as (safe) markdown, not a monospace dump.
+    # render_markdown escapes the untrusted output first, so this stays XSS-safe.
     answer = _clip(case.output)
     answer_html = (
-        f"<div class='sf-detail__k'>answer</div><pre class='sf-report__pre'>{escape(answer)}</pre>"
+        f"<div class='sf-detail__k'>answer</div>"
+        f"<div class='sf-report__md'>{render_markdown(answer)}</div>"
         if answer
         else ""
     )
@@ -595,7 +645,7 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
         f"<span class='sf-chip'>{escape(str(key))} · {escape(str(value))}</span>"
         for key, value in (case.metadata or {}).items()
     )
-    tags_html = f"<div class='sf-chips' style='margin-top:8px'>{tags}</div>" if tags else ""
+    tags_html = f"<div class='sf-chips sf-pane__tags'>{tags}</div>" if tags else ""
     if case.input is not None:
         question = f"<div class='sf-pane__q'>{escape(_clip(case.display_input, 600))}</div>"
     else:

--- a/packages/screamingface/tests/test_markdown.py
+++ b/packages/screamingface/tests/test_markdown.py
@@ -1,0 +1,110 @@
+"""The safe markdown-subset renderer for untrusted answer text.
+
+INVARIANT under test: the input is UNTRUSTED model output. Nothing it contains may reach the
+page as live HTML — the renderer escapes every character first and only ever emits its own
+fixed tag set. `<script>`, `<img onerror>`, and `javascript:` links must all come out inert.
+"""
+
+from __future__ import annotations
+
+from screamingface._ui.markdown import render_markdown
+
+
+def test_empty_text_renders_nothing() -> None:
+    assert render_markdown("") == ""
+
+
+def test_plain_text_becomes_a_paragraph() -> None:
+    assert render_markdown("just prose") == "<p>just prose</p>"
+
+
+def test_soft_line_breaks_are_preserved_within_a_paragraph() -> None:
+    assert render_markdown("line one\nline two") == "<p>line one<br>line two</p>"
+
+
+def test_headings_are_tamed_to_h4_through_h6() -> None:
+    assert "<h4>Title</h4>" in render_markdown("# Title")
+    assert "<h5>Sub</h5>" in render_markdown("## Sub")
+    assert "<h6>Deep</h6>" in render_markdown("### Deep")
+    # a lone '#' must never render a page-dominating hero — level caps at h6.
+    assert "<h6>Deeper</h6>" in render_markdown("##### Deeper")
+
+
+def test_bold_and_italic_via_asterisks() -> None:
+    assert render_markdown("**DiD**") == "<p><strong>DiD</strong></p>"
+    assert render_markdown("*parallel trends*") == "<p><em>parallel trends</em></p>"
+
+
+def test_underscores_are_left_alone_so_snake_case_survives() -> None:
+    # WHY: answers are technical; underscore-emphasis would mangle estimator_test / __init__.
+    assert render_markdown("call estimator_test now") == "<p>call estimator_test now</p>"
+
+
+def test_inline_code_is_wrapped_and_not_reformatted() -> None:
+    assert render_markdown("see `estimator.py`") == "<p>see <code>estimator.py</code></p>"
+    # markdown inside a code span stays literal.
+    assert render_markdown("`**x**`") == "<p><code>**x**</code></p>"
+
+
+def test_fenced_code_block_renders_as_pre_code() -> None:
+    out = render_markdown("```\nfit(x)\n```")
+    assert "<pre class='sf-md__pre'><code>" in out
+    assert "fit(x)" in out
+    # no inline processing inside a fence.
+    assert "<strong>" not in render_markdown("```\n**x**\n```")
+
+
+def test_unclosed_fence_runs_to_end_of_text() -> None:
+    out = render_markdown("```\nabc\ndef")
+    assert "<pre class='sf-md__pre'><code>abc\ndef</code></pre>" == out
+
+
+def test_unordered_and_ordered_lists() -> None:
+    assert render_markdown("- a\n- b") == "<ul><li>a</li><li>b</li></ul>"
+    assert render_markdown("1. a\n2. b") == "<ol><li>a</li><li>b</li></ol>"
+
+
+def test_blockquote() -> None:
+    assert render_markdown("> a note") == "<blockquote>a note</blockquote>"
+
+
+def test_inline_formatting_applies_inside_blocks() -> None:
+    assert render_markdown("## **Hi**") == "<h5><strong>Hi</strong></h5>"
+    assert render_markdown("- **bold** item") == "<ul><li><strong>bold</strong> item</li></ul>"
+
+
+def test_multiple_blocks_render_in_order() -> None:
+    out = render_markdown("# Findings\n\n- one\n- two\n\ntrailing prose")
+    assert out == ("<h4>Findings</h4><ul><li>one</li><li>two</li></ul><p>trailing prose</p>")
+
+
+def test_safe_links_render_as_anchors() -> None:
+    out = render_markdown("[docs](https://x.com/a)")
+    assert '<a href="https://x.com/a"' in out
+    assert 'target="_blank"' in out
+    assert 'rel="noopener noreferrer"' in out
+    assert ">docs</a>" in out
+
+
+def test_unsafe_link_scheme_is_never_an_anchor() -> None:
+    out = render_markdown("[x](javascript:alert(1))")
+    assert "<a " not in out
+    assert "href" not in out
+
+
+def test_script_in_source_is_escaped_not_executed() -> None:
+    out = render_markdown("<script>alert('x')</script>")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_html_in_a_code_span_is_escaped() -> None:
+    out = render_markdown("`<script>`")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
+def test_image_onerror_payload_is_escaped() -> None:
+    out = render_markdown("<img src=x onerror=alert(1)>")
+    assert "<img" not in out
+    assert "&lt;img" in out

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -19,6 +19,7 @@ from screamingface._ui.report_view import (
     _grading_html,
     _money,
     _number,
+    _recipe_html,
     _tokens,
     _tokens_total,
     report_html,
@@ -377,6 +378,67 @@ def test_empty_cases_and_untrusted_failures_have_safe_markup() -> None:
     assert "1 failure" in html
     assert "run · &lt;script&gt;failed&lt;/script&gt;" in html
     assert "<script>" not in html
+
+
+# A local, additive fixture — the shared case()/candidate() stay untouched (sdlc rule 5).
+def _answer_case(output: str, *, metadata: dict[str, object] | None = None) -> CaseResult:
+    return CaseResult(
+        case_id=1,
+        input="the prompt",
+        output=output,
+        finish_reason="stop",
+        grade=CaseGrade(method="rubric", score=0.0, metrics={}, checks=[]),
+        failures=[],
+        metadata=metadata or {},
+    )
+
+
+# FEATURE: the model answer is prose — it renders as markdown, not a monospace dump.
+def test_the_answer_renders_markdown_not_raw_text() -> None:
+    markdown = "## Findings\n\n- **DiD** assumes *parallel trends*\n- see `estimator.py`"
+    html = body(report_html(report(candidate("m", 0.0, cases=(_answer_case(markdown),)))))
+
+    assert "sf-report__md" in html
+    assert "<h5>Findings</h5>" in html
+    assert "<strong>DiD</strong>" in html
+    assert "<em>parallel trends</em>" in html
+    assert "<code>estimator.py</code>" in html
+    # the literal markdown punctuation must NOT survive as text.
+    assert "## Findings" not in html
+
+
+# INVARIANT: an untrusted answer stays XSS-safe even while rendering markdown.
+def test_answer_markdown_is_xss_safe() -> None:
+    payload = "<script>alert('x')</script>\n\n**still bold**"
+    html = body(report_html(report(candidate("m", 0.0, cases=(_answer_case(payload),)))))
+
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "<strong>still bold</strong>" in html
+
+
+# FEATURE: the URL4 expression is copyable in full — the display clips, the copy does not.
+def test_the_url4_expression_has_a_copy_button_carrying_the_full_expression() -> None:
+    # A raw URL4 string (SimpleNamespace bypasses Candidate grammar validation) long enough
+    # to trip the 1200-char display clip, with a recognizable tail past the clip boundary.
+    long_url4 = "(candidate:0.0:" + "x" * 1_400 + "TAIL)"
+    html = _recipe_html(cast(CandidateResult, SimpleNamespace(operations=[], url4=long_url4)))
+
+    assert "sf-report__copy" in html
+    assert "sf-report__url4" in html  # the inset wrapper
+    assert 'data-u4="' in html
+    # the copy carries the FULL expression (its tail), while the visible <pre> is clipped.
+    assert "TAIL)" in html
+    assert "more characters" in html
+
+
+# WHY: the domain tag pressed against the question read as one block — give it its own row.
+def test_the_domain_tag_is_separated_from_the_question() -> None:
+    tagged = _answer_case("the answer", metadata={"domain": "Academic"})
+    html = body(report_html(report(candidate("m", 0.0, cases=(tagged,)))))
+
+    assert "sf-pane__tags" in html
+    assert "domain · Academic" in html
 
 
 def test_an_envelope_input_renders_as_a_transcript_not_wire_json() -> None:


### PR DESCRIPTION
## Summary

Improves the notebook Report panel (`report = sf.evaluate(...)`):

- **Markdown answers.** The model answer now renders as safe markdown instead of raw
  monospace text — new escape-first `_ui/markdown.py` (`render_markdown`): tamed headings
  (h4–h6), bold/italic, inline + fenced code, lists, blockquote, and http(s)/mailto links
  only. Untrusted output is HTML-escaped first, so `<script>`/`<img onerror>`/`javascript:`
  links come out inert.
- **Spacing.** Domain/metadata tags get their own spaced row (`.sf-pane__tags`), and the
  case / answer / criteria sections get a calmer rhythm (`.sf-detail__k` margin).
- **URL4.** The expression is inset with side padding, spaced off the operation-step chips,
  and carries a **copy button** that copies the *full* expression (the visible `<pre>` stays
  clipped). Mirrors the existing leaderboard fork-button `navigator.clipboard` pattern.

## Test plan

- New `tests/test_markdown.py` (18) — subset rendering + the XSS/`javascript:` safety invariant.
- Extended `tests/test_report_panel.py` (+4) — answer renders markdown; untrusted answer stays
  escaped; URL4 copy button carries the full expression; domain-tag row is present. Shared
  fixtures left untouched (append-only).
- `run_gates.py screamingface` → **all green** (append-only · ruff · format · pyright ·
  pytest cov≥95 · check_notebooks · uv build · check_distribution).
- Visual: rendered a representative Report to HTML and eyeballed markdown answer, spacing,
  and the inset URL4 + copy button (light + dark).

## ⚠️ TODO before merge

- **Linear ticket:** the Linear MCP OAuth connector was returning "invalid uri" during
  authoring, so this was implemented under owner authorization to proceed without it. File
  the issue (Engineering / 😱 ScreamingFace V1; labels `py-screamingface` · `agentic` ·
  `autonomous`), then **backfill `Refs: OME-N`** into the commit + this PR and add the
  `docs/tasks/` mirror. Do not squash-merge until the `Refs` is backfilled.