### PR TITLE
docs(public-docs): sync recipe pages with the shipped screamingface API

### DIFF
--- a/docs/tasks/2026-08-13-public-docs-api-sync-epic.md
+++ b/docs/tasks/2026-08-13-public-docs-api-sync-epic.md
@@ -1,0 +1,26 @@
+---
+id: OME-810
+linear_url: https://linear.app/openmined/issue/OME-810/public-docs-v1-bring-api-docs-back-in-sync-with-the-screamingface
+status: in_progress
+type: task
+priority: P1
+labels: [repo, agentic, autonomous, task]
+created: 2026-08-13
+closed:
+---
+
+Epic: bring `public-docs/` back in sync with the shipped `packages/screamingface` public API. The
+API reference and Fusions guide describe removed symbols (`Fusion(reducer=...)`, `sf.reducers.*`,
+`sf.CorrectiveEnsemble`) and omit `Pipeline`; documented examples raise on copy-paste because
+`synthesizer` is now required.
+
+Four workstreams, one sub-issue each:
+
+- OME-811 (WS1, High) — recipe correctness: RecipesPage, FusionsPage, new Pipelines guide.
+- OME-812 (WS2) — new API pages: Leaderboards, Errors, Events, Url4.
+- OME-813 (WS3) — new/expanded guides: Leaderboards (incl. the `sf.Url4(...)` copy-and-edit loop),
+  Errors, Events.
+- OME-814 (WS4, blocked-by 811/812/813) — nav + version footer + global stale-term sweep + repr
+  audit + GitHub-link refresh.
+
+Plan: `.claude/plans/can-you-generate-me-effervescent-crane.md`. Prior art: OME-667, OME-668, OME-672.

--- a/docs/tasks/2026-08-13-public-docs-recipe-fix.md
+++ b/docs/tasks/2026-08-13-public-docs-recipe-fix.md
@@ -1,0 +1,21 @@
+---
+id: OME-811
+linear_url: https://linear.app/openmined/issue/OME-811/fix-broken-recipe-docs-synthesizer-drop-correctiveensemble-add
+status: in_progress
+type: task
+priority: P1
+labels: [repo, agentic, autonomous, task]
+created: 2026-08-13
+closed:
+---
+
+WS1 of OME-810. Fix the `public-docs/` pages that are factually wrong today and add the missing
+serial-composition story:
+
+- `src/pages/sf-client/api/RecipesPage.vue` — `reducer`→`synthesizer` (required), drop
+  `CorrectiveEnsemble`, add `Pipeline` section.
+- `src/pages/sf-client/guides/FusionsPage.vue` — `reducer`→`synthesizer` throughout.
+- NEW `src/pages/sf-client/guides/PipelinesPage.vue` — serial + recursive composition; wired into
+  `src/navigation/sf-client.ts` + `src/router/index.ts`.
+
+Ledger: `docs/work/2026-08-13-OME-811-public-docs-recipe-fix.md`.

--- a/docs/work/2026-08-13-OME-811-public-docs-recipe-fix.md
+++ b/docs/work/2026-08-13-OME-811-public-docs-recipe-fix.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-811
+stack: repo
+status: in_progress
+started: 2026-08-13
+finished:
+---
+
+# OME-811 — Fix broken Recipe docs: synthesizer, drop CorrectiveEnsemble, add Pipeline
+
+## Intent
+
+The `public-docs/` API reference and Fusions guide describe a `screamingface` Recipe API that no
+longer exists: `Fusion(reducer=...)`, `sf.reducers.*`, and `sf.CorrectiveEnsemble` are gone, and
+`Pipeline` (serial + recursive composition) is undocumented. Because `synthesizer` is now a required
+argument, the docs' own `sf.Fusion([opus, gpt])` example raises on copy-paste. This unit (WS1 of the
+OME-810 epic) makes the recipe pages accurate to the shipped package and adds the missing serial-
+composition story.
+
+## Planned changes
+
+- `public-docs/src/pages/sf-client/api/RecipesPage.vue` — `reducer`→`synthesizer` (required);
+  delete `CorrectiveEnsemble` section; add `Pipeline` section (`.then()`, flatten-vs-nest); refresh
+  intro/description; verify `Model` default-params claim vs `_evaluation/policy.py`.
+- `public-docs/src/pages/sf-client/guides/FusionsPage.vue` — `reducer`→`synthesizer` throughout
+  (SVG caption, Main-APIs table, reprs, examples, `/learn/engine` link, corrective note).
+- NEW `public-docs/src/pages/sf-client/guides/PipelinesPage.vue` — serial + recursive composition.
+- `public-docs/src/navigation/sf-client.ts` + `public-docs/src/router/index.ts` — register the new
+  Pipelines guide (minimal WS4 slice needed to ship WS1).
+
+## Test plan
+
+`public-docs/` is a Vue SPA with no unit-test suite; the gate is type-check + build + accuracy greps.
+
+- `cd public-docs && npm run type-check && npm run build` — both green.
+- `grep -rE 'reducer|CorrectiveEnsemble|MajorityVote|sf\.reducers'` over the two edited recipe pages
+  → no hits.
+- Every recipe signature/repr in the edited pages matches
+  `packages/screamingface/src/screamingface/{model,fusion,pipeline}.py` and
+  `tests/test_pipeline_recipes.py`.
+- Every `sf.*` symbol referenced appears in `src/screamingface/__init__.py::__all__`.
+
+## Acceptance
+
+- The three recipe pages (Recipes API, Fusions guide, new Pipelines guide) are accurate to the
+  current API; no reference to removed symbols remains on them; build + type-check green; new guide
+  wired into sidebar + prev/next.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `api/RecipesPage.vue` (rewrite), `guides/FusionsPage.vue`
+  (rewrite), NEW `guides/PipelinesPage.vue`, `navigation/sf-client.ts` + `router/index.ts`
+  (wire the Pipelines guide). No other page touched.
+- **Commits:** <sha — filled at commit>
+- **Gates:** `npx oxlint .` PASS · `npx eslint .` PASS · `npm run type-check` PASS ·
+  `npm run build` PASS (type-check + vite, PipelinesPage/FusionsPage/RecipesPage all built).
+  Scoped stale-term grep over the three recipe pages: clean except one deliberate mention
+  ("there is no `reducer` attribute", matching the source test `not hasattr(fusion, "reducer")`).
+- **Deviations:**
+  - The source contract had drifted further than the plan named. Corrected against
+    `model.py`/`fusion.py`/`pipeline.py` + `tests/test_recipes.py`/`test_pipeline_recipes.py`:
+    (a) recipes compare **by value** and are unhashable — the old "compare by identity → False"
+    cell was wrong; (b) a Fusion needs **≥1** member, not ≥2; (c) there is **no** construction-time
+    duplicate-member-name check; (d) a Model applies **no default `params`** (only a default
+    prompt) — the old `reasoning="low"` / `max_output_tokens=4096` claim was removed.
+  - `npm run format` (prettier) reformatted 11 pre-existing files unrelated to WS1; reverted them
+    — CI does not gate prettier (only oxlint/eslint/build), so this is pre-existing drift for a
+    later pass, not this ticket.
+  - Refreshed the stale `OME-605-…` GitHub link on the Fusions page to `main` (the page was being
+    rewritten anyway). Remaining stale-term hits live on `QuickstartPage.vue` and `Url4Page.vue`
+    (WS3/WS4, tracked in OME-813/OME-814).

--- a/public-docs/CLAUDE.md
+++ b/public-docs/CLAUDE.md
@@ -56,18 +56,29 @@ There is no automated test setup in this project.
 | `/sf-client/guides/connections` | `src/pages/sf-client/guides/ConnectionsPage.vue` |
 | `/sf-client/guides/models` | `src/pages/sf-client/guides/ModelsPage.vue` |
 | `/sf-client/guides/fusions` | `src/pages/sf-client/guides/FusionsPage.vue` |
+| `/sf-client/guides/pipelines` | `src/pages/sf-client/guides/PipelinesPage.vue` |
 | `/sf-client/guides/benchmarks` | `src/pages/sf-client/guides/BenchmarksPage.vue` |
 | `/sf-client/guides/running-an-evaluation` | `src/pages/sf-client/guides/EvaluationPage.vue` |
+| `/sf-client/guides/leaderboards` | `src/pages/sf-client/guides/LeaderboardsPage.vue` |
 | `/sf-client/guides/reproduce-and-share` | `src/pages/sf-client/guides/Url4Page.vue` |
 | `/sf-client/api/recipes` | `src/pages/sf-client/api/RecipesPage.vue` |
 | `/sf-client/api/benchmarks` | `src/pages/sf-client/api/BenchmarksPage.vue` |
 | `/sf-client/api/reports` | `src/pages/sf-client/api/ReportsPage.vue` |
 | `/sf-client/api/clients` | `src/pages/sf-client/api/ClientsPage.vue` |
-| `/sdk` | `src/pages/sdk/Index.vue` |
+| `/learn` | `src/pages/learn/ArchitecturePage.vue` |
+| `/learn/url4` | `src/pages/learn/Url4Page.vue` |
+| `/learn/url4-sdk` | `src/pages/learn/Url4SdkPage.vue` |
+| `/learn/engine` | `src/pages/learn/EnginePage.vue` |
+| `/learn/caching` | `src/pages/learn/CachingPage.vue` |
+| `/learn/ai-gateway` | `src/pages/learn/GatewayPage.vue` |
+| `/learn/leaderboard` | `src/pages/learn/LeaderboardPage.vue` |
 
 Note that `BenchmarksPage.vue` exists twice — under `guides/` (how to choose a
 benchmark) and under `api/` (the `Benchmark` type). The route names
-disambiguate them.
+disambiguate them. The same applies to `Url4Page.vue` (`learn/` = the protocol,
+`sf-client/guides/` = reproduce & share) and to the leaderboard pages:
+`learn/LeaderboardPage.vue` is the concept, `sf-client/guides/LeaderboardsPage.vue`
+is the `sf.leaderboards` API walkthrough.
 
 ### NotebookViewer
 

--- a/public-docs/src/components/nb/EvaluationReport.vue
+++ b/public-docs/src/components/nb/EvaluationReport.vue
@@ -12,7 +12,7 @@ const props = withDefaults(
   defineProps<{
     /** e.g. "16 candidates" */
     title: string
-    /** e.g. "draco-lite@1" */
+    /** e.g. "draco/lite" */
     benchmark?: string
     phase?: RunPhase
     /** e.g. "4M 51S" */

--- a/public-docs/src/navigation/learn.ts
+++ b/public-docs/src/navigation/learn.ts
@@ -13,6 +13,7 @@ export const learnNavigation: NavEntry[] = [
       { title: 'ScreamingFace Engine', path: '/learn/engine' },
       { title: 'Caching and compute', path: '/learn/caching' },
       { title: 'AI gateway', path: '/learn/ai-gateway' },
+      { title: 'Leaderboard', path: '/learn/leaderboard' },
     ],
   },
 ]

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -6,8 +6,8 @@ import type { NavEntry } from '@/composables/useDocNavigation'
 // nothing else changes.
 export const sfClientVersion = {
   prefix: 'Based on state at commit',
-  label: 'e387aefd',
-  url: 'https://github.com/OpenMined/screamingface/commit/e387aefd311b1f4f057a0858fdf4c363f145bddb',
+  label: 'b698fcff',
+  url: 'https://github.com/OpenMined/screamingface/commit/b698fcffd20d3dbe19c17a7b6654e302adeaf6ee',
 }
 
 // ScreamingFace Client sidebar (OME-666). A group labels its children and is
@@ -37,6 +37,7 @@ export const sfClientNavigation: NavEntry[] = [
       },
       { title: 'Benchmarks', path: '/sf-client/guides/benchmarks' },
       { title: 'Running an evaluation', path: '/sf-client/guides/running-an-evaluation' },
+      { title: 'Leaderboards', path: '/sf-client/guides/leaderboards' },
       { title: 'Reproduce & share (URL4)', path: '/sf-client/guides/reproduce-and-share' },
     ],
   },

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -32,6 +32,7 @@ export const sfClientNavigation: NavEntry[] = [
         children: [
           { title: 'Models', path: '/sf-client/guides/models' },
           { title: 'Fusions', path: '/sf-client/guides/fusions' },
+          { title: 'Pipelines', path: '/sf-client/guides/pipelines' },
         ],
       },
       { title: 'Benchmarks', path: '/sf-client/guides/benchmarks' },

--- a/public-docs/src/pages/HomePage.vue
+++ b/public-docs/src/pages/HomePage.vue
@@ -27,7 +27,7 @@ const docs = [
     title: 'Learn more',
     to: '/learn',
     kicker: 'concepts',
-    desc: 'Architecture, the url4 protocol, the ScreamingFace Engine, and the url4 SDK.',
+    desc: 'Architecture, the url4 protocol and SDK, the engine and its trust boundary, caching, and the leaderboard.',
   },
 ]
 
@@ -44,9 +44,9 @@ const GITHUB = 'https://github.com/OpenMined'
         <span class="hero__title-2">Reproduce every run from one line.</span>
       </h1>
       <p class="lead">
-        ScreamingFace is an open toolkit for composing model <em>fusions</em> that outperform any
-        single model. Push the frontier together, in the open, while every result stays trivial to
-        reproduce for everyone.
+        ScreamingFace is an open toolkit for composing model <em>fusions</em>: several models
+        answering together, graded against a real research benchmark. Every run reproduces from a
+        single line, on your own keys.
       </p>
 
       <div class="actions">

--- a/public-docs/src/pages/learn/ArchitecturePage.vue
+++ b/public-docs/src/pages/learn/ArchitecturePage.vue
@@ -43,11 +43,11 @@ const components = [
 
     <ul>
       <li>
-        <RouterLink to="/learn/url4"><strong>url4: the protocol.</strong></RouterLink> A url4 string
-        names some sources and an intent, and compiles to a typed graph of operations: it can fetch
-        data, call models or run code, fan those out, and reduce the results to one answer. A source
-        can itself be another url4, so the format is recursive and composes into arbitrarily large
-        pipelines.
+        <RouterLink to="/learn/url4"><strong>url4: the protocol.</strong></RouterLink> One line
+        naming some sources and an intent, which compiles to a typed graph of operations. It can
+        fetch data, call models, run code, fan those out, and reduce the results to one answer. A
+        source can itself be another url4, so expressions nest into arbitrarily large systems. This
+        is the artifact everything else passes around.
       </li>
       <li>
         <RouterLink to="/learn/engine"
@@ -74,10 +74,13 @@ const components = [
       </li>
       -->
       <li>
+        <RouterLink to="/learn/leaderboard"><strong>The Leaderboard.</strong></RouterLink> Where
+        results go public, after an independent re-run rather than on the submitter's word. Each
+        entry keeps the url4 that produced it, so a rank can always be checked. The board itself is
+        at
         <a href="https://leaderboard.screamingface.ai" target="_blank" rel="noopener"
-          ><strong>The Leaderboard.</strong></a
-        >
-        Where verified, reproducible results are published.
+          >leaderboard.screamingface.ai</a
+        >.
       </li>
     </ul>
 

--- a/public-docs/src/pages/learn/CachingPage.vue
+++ b/public-docs/src/pages/learn/CachingPage.vue
@@ -30,8 +30,9 @@ import { learnNavigation as navigation } from '@/navigation/learn'
         a fusion that reuses its members is far cheaper than the number of candidates suggests.
       </li>
       <li>
-        <strong>Across runs:</strong> re-running an evaluation only pays for calls that are new. If
-        a run fails partway, restarting it charges you only for the work that had not completed.
+        <strong>Across runs:</strong> re-running an evaluation pays only for the calls that are new
+        to it. A run that failed partway is worth restarting, because the calls that already
+        completed come back from the cache instead of being bought twice.
       </li>
     </ul>
 
@@ -52,14 +53,14 @@ import { learnNavigation as navigation } from '@/navigation/learn'
     </p>
 
     <p>
-      The shared cache also propagates to <strong>local</strong> engines: entries from the hosted
-      cache are uploaded into your local cache, so a run the community has already paid for is a
-      cache hit on your own machine too, even when you run everything yourself.
+      The shared cache belongs to the hosted engine. A local engine keeps its own cache, which makes
+      your reruns cheap but starts empty and stays yours. Running everything yourself means giving
+      up the community's hits, and that is the real trade against the local path's independence.
     </p>
 
     <h2>Where the compute comes from</h2>
 
-    <p>There are two ways to run, and they differ only in who supplies the compute.</p>
+    <p>There are two ways to run. They differ in who supplies the compute and which cache you draw from.</p>
 
     <ul>
       <li>
@@ -68,7 +69,7 @@ import { learnNavigation as navigation } from '@/navigation/learn'
       </li>
       <li>
         <strong>Hosted.</strong> Use an engine we operate. It carries the shared cache, and we
-        provide subsidized compute to chosen cohorts so that verifying and exploring stays cheap.
+        subsidize compute for chosen cohorts so that verifying and exploring stays cheap.
       </li>
     </ul>
 
@@ -90,17 +91,6 @@ import { learnNavigation as navigation } from '@/navigation/learn'
             orient="auto"
           >
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
-          </marker>
-          <marker
-            id="cc-arrow-a"
-            viewBox="0 0 8 8"
-            refX="7"
-            refY="4"
-            markerWidth="6"
-            markerHeight="6"
-            orient="auto"
-          >
-            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--accent)" />
           </marker>
         </defs>
         <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#cc-arrow)">
@@ -145,24 +135,6 @@ import { learnNavigation as navigation } from '@/navigation/learn'
           <text x="140" y="147">your machine · your keys</text>
           <text x="540" y="147">we run it · subsidized</text>
         </g>
-        <path
-          d="M444 214 H210"
-          style="stroke: var(--accent); stroke-width: 1.25; fill: none; stroke-dasharray: 5 3"
-          marker-end="url(#cc-arrow-a)"
-        />
-        <text
-          x="327"
-          y="205"
-          text-anchor="middle"
-          style="
-            fill: var(--accent);
-            font-size: 10px;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-          "
-        >
-          propagates to local
-        </text>
       </svg>
       <figcaption
         style="
@@ -174,8 +146,8 @@ import { learnNavigation as navigation } from '@/navigation/learn'
           margin-top: var(--space-3);
         "
       >
-        Same protocol, two engines; the hosted engine's shared community cache propagates into your
-        local cache, so prior runs stay cache hits on your own machine.
+        Same protocol, two engines. A local engine keeps its own cache; the hosted engine carries
+        the shared community cache.
       </figcaption>
     </figure>
 

--- a/public-docs/src/pages/learn/EnginePage.vue
+++ b/public-docs/src/pages/learn/EnginePage.vue
@@ -23,10 +23,16 @@ const health = `curl http://127.0.0.1:9108/healthz`
       The Engine is the runtime that runs
       <RouterLink to="/learn/url4">url4</RouterLink> expressions. The
       <RouterLink to="/sf-client">Client</RouterLink> never calls a model provider itself. It hands
-      a url4 expression to an Engine, and the Engine does the work: it schedules the graph, reaches
-      the providers, and streams back usage and the result. Because it sits between you and the
-      providers, it is also the system's <strong>trust boundary</strong>: the one place that holds
-      your keys.
+      a url4 expression to an Engine. The Engine does the work: schedules the graph, reaches the
+      providers, and streams back usage and the result. Because it sits between you and the
+      providers, it is also the system's <strong>trust boundary</strong>, the one place that holds
+      both your credentials and the benchmark answer keys.
+    </p>
+
+    <p>
+      You mostly will not touch it directly. The
+      <RouterLink to="/sf-client">Client</RouterLink> talks to it for you, and the only decision
+      that usually matters is which Engine to point at.
     </p>
 
     <h2>How it executes</h2>
@@ -35,9 +41,9 @@ const health = `curl http://127.0.0.1:9108/healthz`
       At its core is a <strong>demand-driven, memoized DAG executor</strong>. Demand-driven means it
       works backwards from the result, so it only runs the nodes that result actually needs. Memoized
       means a value shared by several branches is computed exactly once, not repeated. Independent
-      nodes run at the same time; the first failure cancels the others rather than letting a broken
-      run drift on, and the number of calls running at once is capped so a wide fan-out can't
-      overwhelm the providers.
+      nodes run at the same time. The first failure cancels the others rather than letting a broken
+      run drift on. The number of calls running at once is capped so a wide fan-out can't overwhelm
+      the providers.
     </p>
 
     <p>
@@ -55,10 +61,17 @@ const health = `curl http://127.0.0.1:9108/healthz`
 
     <p>
       The Engine holds what must not leak. Provider credentials are handed to it once and stored
-      encrypted at rest (AES-256-GCM) by the AI gateway's credential store; they are never returned
-      to the client. Benchmark answer keys and grading stay engine-side too. Prompts go out to the
-      models, but the answers and grading rules do not. That separation is what makes a verified
-      result meaningful rather than self-reported.
+      encrypted at rest (AES-256-GCM) by the AI gateway's credential store, and are never returned
+      to the client. Benchmark answer keys, rubrics, and grading stay engine-side. That separation
+      is what makes a score mean something: the code being graded cannot read the answers it is
+      being graded against, and neither can the person who wrote it.
+    </p>
+
+    <p>
+      Be clear about the direction this runs, though. The boundary protects the answer keys and your
+      credentials, not the content of your prompts. Whatever you put into a prompt is sent to the
+      model provider you chose, exactly as any other API call would send it. If you are evaluating
+      against sensitive material, that material reaches the provider.
     </p>
 
     <ul>
@@ -81,8 +94,8 @@ const health = `curl http://127.0.0.1:9108/healthz`
     <h2>Running one</h2>
 
     <p>
-      Point the Client at an Engine with one call. The Client's local default is
-      <code>http://127.0.0.1:9108</code>, so you can omit the argument while working locally:
+      Point the Client at an Engine with one call. Its default is a hosted Engine, so a local one is
+      always named explicitly:
     </p>
 
     <CodeBlock :code="point" language="python" />
@@ -95,16 +108,16 @@ const health = `curl http://127.0.0.1:9108/healthz`
       The same Engine runs three ways: <strong>bundled</strong> invisibly inside the Client and
       <RouterLink to="/learn/url4-sdk">SDK</RouterLink>, <strong>self-hosted</strong> for a team
       that wants the whole system inside its own walls, or <strong>hosted</strong> for shared,
-      subsidised capacity that we run. The cloud deployment (Kubernetes Jobs, a streaming event bus,
+      subsidized capacity that we run. The cloud deployment (Kubernetes Jobs, a streaming event bus,
       a Helm chart) lives in
       <a :href="`${GH_TREE}/apps/url4-cloud`" target="_blank" rel="noopener"
         ><code>apps/url4-cloud</code></a
-      >; a local run needs none of it.
+      >. A local run needs none of it.
     </p>
 
     <blockquote>
-      The Engine is not a router. A router picks one model per call, the Engine composes many into a
-      graph. It is not open compute either: hosted capacity is subsidised for chosen cohorts, and
+      The Engine is not a router. A router picks one model per call. The Engine composes many into a
+      graph. It is not open compute either: hosted capacity is subsidized for chosen cohorts, and
       self-hosting is on your own hardware.
     </blockquote>
 

--- a/public-docs/src/pages/learn/EnginePage.vue
+++ b/public-docs/src/pages/learn/EnginePage.vue
@@ -10,7 +10,11 @@ const point = `import screamingface as sf
 
 sf.configure(engine_url="http://127.0.0.1:9108")   # the Client talks only to an Engine`
 
-const health = `curl http://127.0.0.1:9108/healthz`
+const runLocal = `pip install "screamingface[runtime]"
+screamingface prepare draco   # benchmark data, once
+screamingface up              # engine, gateway, scoreboard on loopback`
+
+const health = `screamingface status`
 </script>
 
 <template>
@@ -39,11 +43,11 @@ const health = `curl http://127.0.0.1:9108/healthz`
 
     <p>
       At its core is a <strong>demand-driven, memoized DAG executor</strong>. Demand-driven means it
-      works backwards from the result, so it only runs the nodes that result actually needs. Memoized
-      means a value shared by several branches is computed exactly once, not repeated. Independent
-      nodes run at the same time. The first failure cancels the others rather than letting a broken
-      run drift on. The number of calls running at once is capped so a wide fan-out can't overwhelm
-      the providers.
+      works backwards from the result, so it only runs the nodes that result actually needs.
+      Memoized means a value shared by several branches is computed exactly once, not repeated.
+      Independent nodes run at the same time. The first failure cancels the others rather than
+      letting a broken run drift on. The number of calls running at once is capped so a wide fan-out
+      can't overwhelm the providers.
     </p>
 
     <p>
@@ -94,15 +98,28 @@ const health = `curl http://127.0.0.1:9108/healthz`
     <h2>Running one</h2>
 
     <p>
+      Your own Engine ships in the client package, behind the <code>runtime</code> extra. Three
+      commands install it, fetch the benchmark data it reads from disk, and start it:
+    </p>
+
+    <CodeBlock :code="runLocal" language="bash" />
+
+    <p>
+      That serves the Engine on <code>127.0.0.1:9108</code>, alongside the gateway that holds your
+      provider keys and a local scoreboard. <code>screamingface status</code> reports each of the
+      three, and <code>screamingface down</code> stops them. The
+      <RouterLink to="/sf-client/installation">Installation</RouterLink> guide covers the rest,
+      including when a local Engine needs its own web-search key.
+    </p>
+
+    <CodeBlock :code="health" language="bash" />
+
+    <p>
       Point the Client at an Engine with one call. Its default is a hosted Engine, so a local one is
       always named explicitly:
     </p>
 
     <CodeBlock :code="point" language="python" />
-
-    <p>A health check confirms it is up before you spend anything:</p>
-
-    <CodeBlock :code="health" language="bash" />
 
     <p>
       The same Engine runs three ways: <strong>bundled</strong> invisibly inside the Client and

--- a/public-docs/src/pages/learn/LeaderboardPage.vue
+++ b/public-docs/src/pages/learn/LeaderboardPage.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import { learnNavigation as navigation } from '@/navigation/learn'
+
+const GH_TREE = 'https://github.com/OpenMined/screamingface/tree/main'
+
+const read = `import screamingface as sf
+
+sf.leaderboards.list()                      # benchmarks with a public board
+
+board = sf.leaderboards.get("draco", top=10)
+for entry in board.entries:
+    print(entry.rank, entry.accuracy, entry.verified_by_openmined)
+
+board.baselines                             # single-model numbers, for comparison`
+
+const publish = `score = sf.leaderboards.submit(report.candidates.only)
+score.id                                    # the stable id of this submission
+sf.leaderboards.get_score(score.id)         # read it back later`
+
+const remix = `entry = board.entries[0]
+
+entry.url4.to_python()   # the winning recipe as editable code, no spend
+sf.evaluate(entry.url4)  # or replay it verbatim, benchmark included`
+</script>
+
+<template>
+  <DocLayout
+    title="Leaderboard"
+    description="The public board where ensemble results are ranked after an independent re-run, and where every entry carries the recipe that produced it."
+    :navigation="navigation"
+  >
+    <p>
+      The <strong>Leaderboard</strong> is where results go public. It ranks ensemble runs against
+      research benchmarks, and a result only counts once it has been re-run independently. Every
+      entry shows what it scored, what it cost to get there, and the
+      <RouterLink to="/learn/url4">url4</RouterLink> expression that produced it, which is what you
+      would use to run the same evaluation and check the number against your own result.
+    </p>
+
+    <p>
+      Published model numbers usually originate with the party that benefits from them, and are
+      reported rather than demonstrated. The board is organized around the opposite arrangement: a
+      rank is a claim someone else has already reproduced, and that you can reproduce again.
+    </p>
+
+    <h2>How a rank happens</h2>
+
+    <p>
+      A submission carries the benchmark, the recipe's url4, the result, and the providers the run
+      used. It then goes through four steps before it appears:
+    </p>
+
+    <ul>
+      <li>
+        <strong>Validation.</strong> The claimed accuracy has to match the submitted
+        <code>correct</code> over <code>total</code>, within a tolerance of <code>0.01</code>. A
+        number that does not reconcile with its own case counts is rejected.
+      </li>
+      <li>
+        <strong>Deduplication.</strong> Each submission is hashed over its recipe identity, meaning
+        the benchmark, the spec, the expression, the result, and the providers. Identical content
+        lands on the same entry rather than a second one. A resubmission inside a 24-hour
+        idempotency window replays the original instead of creating a duplicate.
+      </li>
+      <li>
+        <strong>Independent re-run.</strong> OpenMined re-runs the submission. Entries that survive
+        carry <code>verified_by_openmined</code>, which is the flag worth reading before you trust a
+        row.
+      </li>
+      <li>
+        <strong>Ranking.</strong> The board keeps the best result per spec, ties broken by recency,
+        and orders by accuracy. One recipe cannot crowd the board with near-identical attempts.
+      </li>
+    </ul>
+
+    <h2>The line to beat</h2>
+
+    <p>
+      Single-model results imported from public sources sit on the same board as the ensembles, as
+      <strong>baselines</strong>. They are what makes a fusion's gain legible: a composed system is
+      only interesting if it beats the models it is composed from, and the comparison should use
+      numbers the field already accepts. Each baseline records where it came from, so you can go
+      read the original.
+    </p>
+
+    <h2>The recipe is the reward</h2>
+
+    <p>
+      A rank on its own would only settle who is ahead. What makes the board compound is that the
+      recipe travels with it: every entry stores its url4, so the ordinary way to enter is to start
+      from whatever is currently winning, change one part of it, and run it again. Prior results
+      become the starting position rather than a blank file.
+    </p>
+
+    <p>
+      Because reruns mostly land on the
+      <RouterLink to="/learn/caching">cache</RouterLink>, starting from someone else's result is
+      usually far cheaper than the original run was.
+    </p>
+
+    <h2>From the client</h2>
+
+    <p>
+      The <RouterLink to="/sf-client">Client</RouterLink> reads and writes the board directly. To
+      browse it:
+    </p>
+
+    <CodeBlock :code="read" language="python" />
+
+    <p>To publish a result you ran yourself:</p>
+
+    <CodeBlock :code="publish" language="python" />
+
+    <p>
+      <code>submit()</code> takes a candidate out of a
+      <RouterLink to="/sf-client/api/reports">Report</RouterLink>, so you can only publish something
+      you actually evaluated. To start from an existing entry instead, read its url4 back as code,
+      or hand it straight to the engine:
+    </p>
+
+    <CodeBlock :code="remix" language="python" />
+
+    <h2>Known limits</h2>
+
+    <p>
+      Evaluation is nondeterministic. The same recipe run twice will not return the same number to
+      the decimal, so ranks that sit close together are best read as tied rather than ordered. Treat
+      a single run as one sample, not a settled result.
+    </p>
+
+    <blockquote>
+      The board is not a vote and not a vendor chart. Rankings come from graded benchmark runs
+      behind the <RouterLink to="/learn/engine">Engine</RouterLink>'s trust boundary, where the
+      answer keys stay, and no rank can be bought or self-reported.
+    </blockquote>
+
+    <h2>Where the code lives</h2>
+
+    <p>
+      The board is
+      <a :href="`${GH_TREE}/apps/scoreboard`" target="_blank" rel="noopener"
+        ><code>apps/scoreboard</code></a
+      >: the submission and ranking API, the baseline registry, and the public portal. Submissions
+      arrive at <code>POST /v1/scores</code>; the portal reads
+      <code>GET /v1/leaderboard/{benchmark_id}</code>, with per-spec history under
+      <code>/history</code>.
+    </p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/learn/Url4Page.vue
+++ b/public-docs/src/pages/learn/Url4Page.vue
@@ -26,15 +26,25 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
     :navigation="navigation"
   >
     <p>
-      <strong>url4</strong> is a grammar and a protocol for saying <em>given these sources, do this</em>. It
-      packages a set of sources, an intent, and the metadata to run them into a single line of text:
-      <code>(data)!intent</code>. That line is also an <strong>address</strong>: hand it to the
-      <RouterLink to="/learn/engine">Engine</RouterLink> and it resolves. So everything you build in
-      the <RouterLink to="/sf-client">Client</RouterLink>, a single model, a
-      <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>, or a whole benchmark run,
-      compiles to one url4 string. You can log it, diff it, share it, reproduce it, and call it again
-      exactly like a single model. That reuse is the point: a Fusion you like is not a one-off, its
-      url4 is a callable, reproducible artifact you can drop into any workflow.
+      <strong>url4</strong> is a grammar and a protocol for saying
+      <em>given these sources, do this</em>. It packs the sources, the intent, and everything needed
+      to run them into one line of text: <code>(data)!intent</code>.
+    </p>
+
+    <p>
+      Everything you build in the <RouterLink to="/sf-client">Client</RouterLink> compiles to one of
+      these, whether it is a single model, a
+      <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>, or a whole benchmark run. The
+      line is also an <strong>address</strong>: hand it to the
+      <RouterLink to="/learn/engine">Engine</RouterLink> and it resolves, the way a URL resolves.
+    </p>
+
+    <p>
+      That is what makes a composed system shareable at all. A model is easy to pass around because
+      it is a thing with a name; an ensemble usually is not, because it lives as glue code in
+      somebody's notebook. url4 gives it a name you can copy. A Fusion you like stops being a
+      one-off and becomes an artifact you can log, diff, publish, and call again like any single
+      model.
     </p>
 
     <h2>Two layers</h2>
@@ -89,16 +99,17 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
     <h2>How it runs</h2>
 
     <p>
-      A url4 string is parsed by a recursive-descent parser into a frozen syntax tree, then lowered
-      to a <strong>typed DAG</strong>. Independent nodes run in parallel; named and positional
-      references become the edges between them; iteration compiles to map nodes and a reduce. The
-      graph is demand-driven, so only the nodes a result depends on are ever scheduled.
+      Parsing a url4 string produces a syntax tree, which is then lowered to a
+      <strong>typed DAG</strong>. Independent nodes run in parallel, and the references you wrote
+      (<code>$a</code>, <code>$1</code>) become the edges between them. The graph is demand-driven,
+      so only the nodes your result actually depends on get scheduled.
     </p>
 
     <p>
-      The text form and the tree are two views of the same thing: rendering a tree back to text is
-      the certified inverse of parsing it, so <code>url4.build(url4.render(node))</code> returns the
-      original tree. That round-trip is what lets a run be logged, shared, and replayed exactly.
+      Text and tree are two views of the same thing, and converting between them loses nothing in
+      either direction: <code>url4.build(url4.render(node))</code> gives back the tree you started
+      with. That guarantee is what lets a run be logged, shared, and replayed exactly rather than
+      approximately.
     </p>
 
     <CodeBlock :code="roundtrip" language="python" />
@@ -107,31 +118,36 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
 
     <p>
       Because the whole request lives in one URI, the Engine treats a url4 expression the way
-      <code>http</code> treats a URL: as an address it resolves. The call is idempotent and
-      cacheable, since the same expression always describes the same work, and that is exactly what
-      lets you <em>reuse</em> it. Save a Fusion's url4, hand it to an
-      <RouterLink to="/learn/engine">Engine</RouterLink>, and it runs like any other model call. A
-      source inside one expression can be the result of another expression on another node, so
-      fusions compose into larger pipelines without anyone unpacking them.
+      <code>http</code> treats a URL: as an address it resolves. The same expression always
+      describes the same work, which makes the call cacheable and safe to repeat. Save a Fusion's
+      url4, hand it to an <RouterLink to="/learn/engine">Engine</RouterLink>, and it runs like any
+      other model call. A source inside one expression can be the result of another expression on
+      another node, so fusions nest into larger systems without anyone having to unpack them.
     </p>
 
     <p>
-      This is why the request is a URI and not out-of-band configuration. Standard HTTP
-      infrastructure, gateways, caches, and logs, can route and trace the request without
-      understanding the grammar, and the attribution and governance metadata travels
-      <em>with</em> the request rather than alongside it. To serve and call a url4 node yourself,
-      see the <RouterLink to="/learn/url4-sdk">url4 SDK</RouterLink>, which exposes the same shape
-      the Engine does.
+      Putting the request in the URI rather than in out-of-band configuration has a practical
+      payoff: ordinary HTTP infrastructure such as gateways, caches, and logs can route and trace it
+      without understanding the grammar, and attribution metadata travels <em>with</em> the request
+      instead of beside it. To serve and call a url4 node yourself, see the
+      <RouterLink to="/learn/url4-sdk">url4 SDK</RouterLink>, which exposes the same shape the
+      Engine does.
     </p>
 
     <h2>Why it exists</h2>
 
     <p>
-      Every run compiles to one canonical url4 string: loggable, inspectable, and re-runnable. It is
-      the audit trail: import a url4 and you hold the whole system and its benchmark run, not a
-      description of it. Model outputs still vary between runs, so the numbers will not match to the
-      decimal; the expression pins down the <em>definition</em> of the run, not its results.
-      Stability is the promise: a url4 written today is meant to run tomorrow.
+      Every run compiles to one canonical url4 string, and that string is the audit trail. Import it
+      and you hold the system itself along with its benchmark run, not a description of either. It
+      is also what the <RouterLink to="/learn/leaderboard">Leaderboard</RouterLink> stores next to a
+      rank, which is how a published result stays checkable.
+    </p>
+
+    <p>
+      Be careful about what it pins down, though. Model outputs vary between runs, so replaying an
+      expression will not reproduce the numbers to the decimal. What the expression fixes is the
+      <em>definition</em> of the run, not its results. Stability is the promise on top of that: a
+      url4 written today is meant to run tomorrow.
     </p>
 
     <blockquote>

--- a/public-docs/src/pages/learn/Url4SdkPage.vue
+++ b/public-docs/src/pages/learn/Url4SdkPage.vue
@@ -37,10 +37,11 @@ result = url4.evaluate_sync("(https://a, https://b)!'summarize both'", io=io)
 print(result.text)      # the reduced answer
 print(result.request)   # the canonical url4 that actually ran`
 
-const serve = `from url4 import Url4Node
+const serve = `# Serving needs the server extra: pip install "url4[server]"
+from url4 import Url4Node
 
 node = Url4Node("demo")
-node.serve(port=9108)   # an HTTP node other expressions can call`
+node.serve()   # 127.0.0.1:4404 by default, an HTTP node other expressions can call`
 
 const cli = `url4 eval "(https://a, https://b)!'summarize both'"
 url4 serve`
@@ -98,7 +99,9 @@ url4 serve`
 
     <p>
       A url4 node can also be served over HTTP, so other expressions can call it as a source. This
-      is the same shape the <RouterLink to="/learn/engine">Engine</RouterLink> exposes:
+      is the same shape the <RouterLink to="/learn/engine">Engine</RouterLink> exposes. Serving
+      needs uvicorn, which comes with the <code>url4[server]</code> extra rather than the base
+      install:
     </p>
 
     <CodeBlock :code="serve" language="python" />

--- a/public-docs/src/pages/sf-client/Index.vue
+++ b/public-docs/src/pages/sf-client/Index.vue
@@ -17,7 +17,7 @@ sf.configure(engine_url="${SF_ENGINE_URL}")
 
 gpt = sf.Model("openrouter/openai/gpt-5.5")
 flash = sf.Model("openrouter/google/gemini-3-flash-preview")
-fusion = sf.Fusion([gpt, flash])
+fusion = sf.Fusion([gpt, flash], synthesizer="openrouter/openai/gpt-5.5")
 
 # Score the solo model beside the fusion, on the same cases.
 report = sf.evaluate([gpt, fusion], benchmark="ifeval", limit=3)
@@ -34,82 +34,106 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     :version="version"
   >
     <p>
-      ScreamingFace is an open-source Python client for building <strong>fusions</strong>: several
-      models answering the same question, combined into one. You compose a fusion from providers you
-      already have keys for, evaluate it against a real benchmark, and read how it did, in a
-      notebook.
+      ScreamingFace is an open-source Python client for composing model ensembles, which it calls
+      <strong>fusions</strong>, and evaluating them against research benchmarks. You build a fusion
+      from providers you already hold keys for, evaluate it, and read back a score together with
+      what the run cost. The benchmark answer keys and the grading stay on the engine, so the code
+      being scored is never the code doing the scoring.
     </p>
 
     <p>
-      Why bother? A fusion can score higher than any single model in it. In a reproduction of the
-      <strong>DRACO</strong> deep-research benchmark, the strongest fusion reached
-      <strong>68.6%</strong> against <strong>60.2%</strong> for the best single model, a
-      <strong>+8.4-point</strong> gain, and five separate fusions beat every individual model (<a
+      The reason to compose at all is that a fusion can score higher than any of the models inside
+      it. In a reproduction of the <strong>DRACO</strong> deep-research benchmark, the strongest
+      fusion reached <strong>68.6%</strong> where the best single model reached
+      <strong>60.2%</strong>, and five separate fusions beat every individual model (<a
         href="https://andrewtrask.substack.com/p/6-weeks-ago-frontier-ai-labs-lost"
         target="_blank"
         rel="noopener"
         >published results</a
-      >). The effect appears in the literature too, such as
+      >). The effect is reported elsewhere as well, for instance in
       <em>Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles</em> (Skurikhin
-      et al., Los Alamos). It is not magic: the gains come from genuine diversity between models,
-      and it can bring visible improvements and significant cost reductions.
+      et al., Los Alamos). It appears to come from genuine diversity between the models rather than
+      from any single one of them.
     </p>
 
-    <h2>How the stack helps you</h2>
+    <p>
+      Evaluation is nondeterministic, so a single comparison is one sample rather than a settled
+      result. The point of the tooling is that you can re-run any of this yourself and see what you
+      get.
+    </p>
+
+    <h2>What the client gives you</h2>
 
     <ul>
       <li>
-        <strong>One interface, every provider.</strong> Bring your own keys and compose across open
-        and closed models.
+        <strong>Grading you did not perform yourself.</strong> Benchmark answer keys, rubrics, and
+        judges live on the engine and are never returned to the client, so a score does not rest on
+        trusting whoever produced it.
       </li>
       <li>
-        <strong>Honest measurement.</strong> Every run reports accuracy alongside its tokens, cost,
-        and time, graded against a fixed benchmark so the comparison is fair.
+        <strong>A reproducible artifact for every run.</strong> Each evaluation compiles to one
+        <RouterLink to="/learn/url4">url4</RouterLink> expression recording the models, their
+        parameters, and the benchmark revision that was used. Anyone holding it can run the same
+        evaluation.
       </li>
       <li>
-        <strong>Reproducible from one line.</strong> Every run compiles to a single
-        <RouterLink to="/learn/url4">url4</RouterLink> expression you can share.
+        <strong>Your own providers.</strong> You connect the API keys you already have, and calls
+        are billed to your own accounts rather than resold to you.
       </li>
       <li>
-        <strong>Cheap to repeat.</strong> Calls are cached, and a shared community cache makes
-        re-running prior work nearly free.
+        <strong>Exploration you pay for once.</strong> Every model response is
+        <RouterLink to="/learn/caching">cached</RouterLink> against its exact request, so comparing
+        many fusion candidates over one benchmark is billed only for the calls that have not been
+        made before. A model shared between two candidates answers once, and swapping a single
+        member re-uses what the others already produced.
       </li>
       <li>
-        <strong>Build on what others did.</strong> Because anyone can reproduce a published run from
-        its url4, you can start from someone else's result, iterate on it, and push the frontier
-        further.
+        <strong>Cost reported alongside accuracy.</strong> Tokens, spend, and duration stream while
+        the run is in progress and are totalled per model and per fusion, so the price of a gain is
+        visible at the same time as the gain.
+      </li>
+      <li>
+        <strong>Earlier work you can build on.</strong> Recipes published to the leaderboard can be
+        imported, modified, and re-run, and on a hosted engine the cache is shared across the
+        community, so repeating someone else's run usually costs a fraction of the original.
       </li>
     </ul>
 
     <h2>What url4 is</h2>
 
     <p>
-      A <strong>url4</strong> is a one-line, human-readable expression that captures a whole run:
-      the models, how they combine, and the benchmark, in a single shareable string. Hand someone
-      the url4 and they reproduce the exact result. It is the receipt for a run.
+      A <strong>url4</strong> is a single-line expression describing a composed system: which models
+      take part, how their answers are combined, and what each one is asked to do. It serves as both
+      the record of what ran and the instruction for running it again, which is what lets a
+      published result carry its own method instead of describing it in prose.
     </p>
 
     <h2>Two ways to run</h2>
 
     <p>
-      You point the client at an <RouterLink to="/learn/engine">engine</RouterLink>, the runtime
-      that does the work. There are two ways to get one:
+      The client never calls a model provider itself. It sends work to an
+      <RouterLink to="/learn/engine">engine</RouterLink>, which holds the credentials and the
+      benchmark answer keys and performs the grading. You can point it at either of two, and the
+      choice is a genuine trade rather than a formality.
     </p>
 
     <ul>
       <li>
-        <strong>Local.</strong> Run the engine on your own machine, on your own keys. There is no
-        middleman on the local path.
+        <strong>A local engine</strong> ships with the toolkit and runs on your own machine, using
+        your keys and its own cache. Nothing is hosted and no third party sits between you and your
+        providers, but the cache starts empty and you supply the compute.
       </li>
       <li>
-        <strong>Hosted.</strong> Use an engine we operate, which adds subsidized compute for chosen
-        cohorts and the shared cache.
+        <strong>A hosted engine</strong> runs the same software as a service, which adds the shared
+        community cache and subsidized compute for selected cohorts. In exchange, your prompts and
+        your stored credentials are handled by an engine we operate.
       </li>
     </ul>
 
     <p>
-      The client code is the same either way; only the engine URL changes. The
-      <RouterLink to="/sf-client/installation">Installation</RouterLink> guide covers both.
+      Client code is identical either way and only the engine URL differs, so the decision is
+      reversible. The <RouterLink to="/sf-client/installation">Installation</RouterLink> guide
+      covers both.
     </p>
 
     <h2>The smallest example</h2>
@@ -119,18 +143,19 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     </div>
 
     <p>
-      <code>score</code> is each candidate's accuracy on the same cases, and higher is always
-      better. There is no separate baseline or gain. The comparison <em>is</em> putting the solo
-      model and the fusion in one run and reading both numbers.
+      <code>score</code> is each candidate's accuracy over the same cases, where higher is better.
+      The report carries no baseline or gain field, because the comparison is simply that you ran
+      the solo model and the fusion in one call and can read both numbers.
     </p>
 
     <h2>How it works</h2>
 
     <p>
-      The client talks only to the <strong>ScreamingFace Engine</strong>, never to model providers
-      directly. Each evaluation compiles to one <strong>url4</strong> expression, and that
-      expression is the contract between them: the engine resolves it, and anyone holding it can
-      reproduce the run.
+      The client compiles your recipe into one <strong>url4</strong> expression and hands it to the
+      <strong>engine</strong>. The engine resolves that expression, calls each model, applies the
+      benchmark's grader, and streams usage back while the run proceeds. What returns is the set of
+      scores, any failures, and the total cost. Because the url4 travels with the result, someone
+      else can repeat the evaluation and compare what they get against what you reported.
     </p>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -16,7 +16,7 @@ const pypiTerminal = `uv pip install "screamingface[notebook]"`
 
 const verify = `import screamingface as sf
 
-len(sf.__all__)   # 36`
+len(sf.__all__)   # 53`
 
 const point = `import screamingface as sf
 
@@ -193,8 +193,8 @@ const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;p
     </div>
 
     <p>
-      That is the whole hosted path. Go and run the
-      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink>.
+      That is the whole hosted path, and it is enough to start running evaluations. The
+      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> takes it from here.
     </p>
 
     <h2>Frequently Asked Questions</h2>

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -13,6 +13,7 @@ import {
 
 const pypiNotebook = `!pip install "screamingface[notebook]"`
 const pypiTerminal = `uv pip install "screamingface[notebook]"`
+const pypiRuntime = `pip install "screamingface[runtime,notebook]"`
 
 const verify = `import screamingface as sf
 
@@ -28,29 +29,36 @@ client.authenticated    # True once the token arrives`
 
 const connectCode = `sf.connect()   # the provider panel`
 
-const gateway = `cd apps/aigateway
-uv sync
-uv run aigateway migrate
+const prepare = `$ screamingface prepare draco
+Benchmark assets ready at /Users/you/.screamingface/benchmark-assets`
 
-AIGW_AUTH_MODE=disabled AIGW_OPENROUTER_ENABLED=true \\
-  uv run uvicorn aigateway.main:app --port 9105`
+const up = `$ screamingface up
+ScreamingFace is ready.
+  Gateway    http://127.0.0.1:9105
+  Scoreboard http://127.0.0.1:9106
+  Engine     http://127.0.0.1:9108
+  Logs       /Users/you/.screamingface/runtime.log`
 
-const assets = `cd apps/url4-cloud
-uv sync
-uv run --with datasets python -m url4_cloud.benchmarks.ifeval.prepare \\
-  --out /tmp/screamingface-benchmark-assets/ifeval`
+const status = `$ screamingface status
+ScreamingFace: running
+  gateway    UP    http://127.0.0.1:9105
+  scoreboard UP    http://127.0.0.1:9106
+  engine     UP    http://127.0.0.1:9108
+  logs       /Users/you/.screamingface/runtime.log`
 
-const engine = `URL4_BENCHMARK_ASSETS=/tmp/screamingface-benchmark-assets \\
-  uv run url4-cloud serve --local`
+const down = `screamingface down`
+const logs = `screamingface logs --tail 50`
+
+const tavily = `export TAVILY_API_KEY="tvly-..."
+screamingface up`
+
+const searchCheck = `gpt = sf.models.get("openrouter/openai/gpt-5.5")
+"web_search" in gpt.tools   # True when the provider searches for itself`
 
 const localPoint = `sf.configure(engine_url="http://127.0.0.1:9108")`
 
-const health = `curl -sf http://localhost:9105/healthz      # {"status":"ok"}
-curl -s  http://localhost:9108/v1/benchmarks   # draco, ifeval`
-
-const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;print(certifi.where())") \\
-  uv run --with datasets python -m url4_cloud.benchmarks.ifeval.prepare \\
-  --out /tmp/screamingface-benchmark-assets/ifeval`
+const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())") \\
+  screamingface prepare draco`
 </script>
 
 <template>
@@ -68,10 +76,13 @@ const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;p
         always needs an engine to talk to.
       </li>
       <li>
-        An <RouterLink to="/learn/engine"><strong>engine</strong></RouterLink>, which does the work.
-        There are two ways to get one:
+        An <RouterLink to="/learn/engine"><strong>engine</strong></RouterLink
+        >, which does the work. There are two ways to get one:
         <ul>
-          <li><strong>Option A</strong> runs one on your own machine, on your own keys.</li>
+          <li>
+            <strong>Option A</strong> runs one on your own machine, on your own keys. It ships in
+            the same package, so this is a pip extra and one command, not a separate deployment.
+          </li>
           <li><strong>Option B</strong> points at a hosted engine someone else runs.</li>
         </ul>
       </li>
@@ -102,7 +113,19 @@ const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;p
       The <code>[notebook]</code> extra pulls ipywidgets and jupyterlab, which is what makes
       <code>sf.connect()</code> render a live panel instead of static text. Drop it if you are
       writing scripts. Everything else, including
-      <RouterLink to="/learn/url4"><code>url4</code></RouterLink>, resolves automatically.
+      <RouterLink to="/learn/url4"><code>url4</code></RouterLink
+      >, resolves automatically.
+    </p>
+
+    <p>To run the engine yourself as well, add the <code>[runtime]</code> extra:</p>
+
+    <CodeBlock :code="pypiRuntime" language="bash" />
+
+    <p>
+      <code>[runtime]</code> is what turns the client install into a working engine: it brings in
+      the server stack the local runtime needs, and it installs the
+      <code>screamingface</code> command used in Option A. It is a much heavier install than the
+      client alone, so skip it if you are pointing at a hosted engine.
     </p>
 
     <p>A quick check that it worked:</p>
@@ -119,23 +142,26 @@ const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;p
 
     <p>
       The local path runs everything on your machine, on your own keys, with no account and no
-      login. Clone the
-      <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener"
-        >repository</a
-      >, start two small services, and point the client at them.
+      login. With the <code>[runtime]</code> extra installed you need no clone and no compose file:
+      three commands prepare the data, start the stack, and stop it again.
     </p>
 
-    <h4>AI Gateway</h4>
-
-    <p>Holds your provider keys. One command starts it:</p>
-
-    <CodeBlock :code="gateway" language="bash" />
-
-    <h4>Benchmark assets</h4>
+    <h4>Prepare the benchmark data</h4>
 
     <p>
-      The Engine reads datasets from disk rather than downloading them at runtime, so a run cannot
-      silently use a different revision than you expect. Prepare them once:
+      The engine reads benchmark datasets from disk rather than downloading them mid-run, so a run
+      cannot silently use a different revision than you expect. Fetch the one you intend to run,
+      once:
+    </p>
+
+    <CodeBlock :code="prepare" language="bash" />
+
+    <p>
+      The argument is the benchmark family: <code>draco</code>, <code>ifeval</code> or
+      <code>healthbench</code>. Pass <code>--all</code> instead of a name to fetch all three. Assets
+      land under <code>~/.screamingface/benchmark-assets</code>, which you can relocate with
+      <code>--data-dir</code> or <code>SCREAMINGFACE_DATA_DIR</code>. Naming both a benchmark and
+      <code>--all</code> is refused rather than guessed at.
     </p>
 
     <Note>
@@ -143,25 +169,94 @@ const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;p
       the FAQ below.
     </Note>
 
-    <CodeBlock :code="assets" language="bash" />
+    <h4>Start the stack</h4>
 
-    <h4>The Engine</h4>
+    <CodeBlock :code="up" language="bash" />
 
-    <p>Executes runs, serving on <code>127.0.0.1:9108</code>, loopback only.</p>
+    <p>
+      One command, three services: the <strong>engine</strong> executes runs, the
+      <strong>gateway</strong> holds your provider keys and calls the models, and the
+      <strong>scoreboard</strong> serves the local leaderboard. All three bind loopback only, on
+      ports 9105, 9106 and 9108, and <code>up</code> refuses to start if another process already
+      holds one of them rather than half-starting the stack. It runs in the background; add
+      <code>--foreground</code> to keep it attached to your terminal instead.
+    </p>
 
-    <CodeBlock :code="engine" language="bash" />
+    <p>
+      Set <code>AIGW_OPENROUTER_ENABLED=true</code> in that shell first if you plan to use
+      OpenRouter. Provider plugins ship disabled, and the gateway reads the setting at startup, so a
+      key for a disabled provider is refused however good the key is.
+    </p>
+
+    <h4>Check it, read it, stop it</h4>
+
+    <CodeBlock :code="status" language="bash" />
+
+    <p>
+      <code>status</code> reports each service separately, because "the engine is up" and "the
+      gateway is up" are different facts. It exits non-zero when anything is wrong, so it works in a
+      script: <code>running</code> means all three answered, <code>partially healthy</code> means
+      the runtime is alive but a service is not answering yet, <code>stopped</code> means nothing is
+      running, and <code>foreign processes occupy runtime ports</code> means something that is not
+      ScreamingFace holds one of the three ports.
+    </p>
+
+    <p>Everything the stack logs goes to one file, which <code>logs</code> follows:</p>
+
+    <CodeBlock :code="logs" language="bash" />
+
+    <p>And when you are done:</p>
+
+    <CodeBlock :code="down" language="bash" />
+
+    <h4>Give the engine a web-search key</h4>
+
+    <p>
+      Benchmarks like DRACO ask candidates to research an answer, which means the model needs to
+      search the web. There are two ways a route can do that, and the engine decides per route: a
+      provider that offers search natively is asked to use its own, and a route without native
+      search is given a <strong>bounded tool loop the engine runs against Tavily</strong> instead.
+      In the reference configuration a GPT route through OpenRouter searches natively, while the
+      Gemini, Kimi, DeepSeek and Qwen routes go through the Tavily loop.
+    </p>
+
+    <p>
+      This is why your own engine may need a Tavily key while a hosted one never asks you for one:
+      on the hosted path we supply it. Export it in the shell you start the runtime from, before
+      <code>up</code>, because the engine reads it at startup:
+    </p>
+
+    <CodeBlock :code="tavily" language="bash" />
+
+    <p>
+      Without the key, web tools stay off. That is deliberate deny-by-default rather than a degraded
+      mode, and the consequence is worth knowing: a candidate whose route depends on the Tavily loop
+      <strong>fails before its first paid model request</strong>, instead of quietly answering a
+      research question with no research behind it. A key you do not need costs nothing to omit, so
+      it is only required when the providers you are actually running lack search of their own.
+    </p>
+
+    <p>
+      To know which case you are in, ask the engine what a route supports. Anything advertising
+      <code>web_search</code> can search for itself:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="searchCheck" />
+    </div>
+
+    <p>
+      Benchmarks that never search, such as <code>ifeval</code>, need no key at all: their
+      candidates are asked to follow instructions, not to look anything up.
+    </p>
 
     <h4>Point the client at it</h4>
 
     <div class="not-prose">
-      <NbCell :count="1" :code="localPoint" />
+      <NbCell :count="2" :code="localPoint" />
     </div>
 
     <p>No login step: a local engine advertises no Cloudflare Access.</p>
-
-    <h4>Check it works</h4>
-
-    <CodeBlock :code="health" language="bash" />
 
     <h3>Option B: Reach a hosted engine</h3>
 
@@ -199,21 +294,45 @@ const certs = `SSL_CERT_FILE=$(uv run --with certifi python -c "import certifi;p
 
     <h2>Frequently Asked Questions</h2>
 
-    <Collapsible title='AI Gateway crashes with "no such table: secret_master_keys"'>
+    <Collapsible title='"Local runtime dependencies are missing" or command not found'>
       <p>
-        It started before its migrations ran. A fresh install has no schema until you apply them.
-        Stop it, run <code>uv run aigateway migrate</code>, and start it again.
+        The client is installed but the engine is not. The <code>screamingface</code> command and
+        the server stack both come from the <code>[runtime]</code> extra:
+      </p>
+      <CodeBlock :code="pypiRuntime" language="bash" />
+      <p>
+        Reopen your shell afterwards if the command still is not found, so the new entry point is
+        picked up.
+      </p>
+    </Collapsible>
+
+    <Collapsible title="up refuses to start: a port is already in use">
+      <p>
+        The stack needs 9105, 9106 and 9108, and it names the occupied ones rather than starting
+        halfway. Run <code>screamingface status</code>: if it says
+        <code>foreign processes occupy runtime ports</code>, something unrelated holds them and you
+        need to free it. If a previous stack is still up, <code>screamingface down</code> is enough.
       </p>
     </Collapsible>
 
     <Collapsible title="A valid provider key is rejected">
       <p>
-        The OpenRouter plugin ships disabled, so AI Gateway refuses the key regardless of whether it
-        is good. Restart with <code>AIGW_OPENROUTER_ENABLED=true</code>.
+        Provider plugins ship disabled, so the gateway refuses the key regardless of whether it is
+        good. Export <code>AIGW_OPENROUTER_ENABLED=true</code> and restart the stack with
+        <code>screamingface down &amp;&amp; screamingface up</code>.
       </p>
       <p>
         Worth knowing, because the error names the credential rather than the configuration. It is
         easy to spend a while checking a key that was never the problem.
+      </p>
+    </Collapsible>
+
+    <Collapsible title="Do I need a Tavily key?">
+      <p>
+        Only when you run your own engine <em>and</em> the routes you evaluate cannot search the web
+        themselves. A hosted engine supplies its own key, and benchmarks that never search, such as
+        <code>ifeval</code>, do not need one either. See
+        <em>Give the engine a web-search key</em> above.
       </p>
     </Collapsible>
 

--- a/public-docs/src/pages/sf-client/QuickstartPage.vue
+++ b/public-docs/src/pages/sf-client/QuickstartPage.vue
@@ -77,7 +77,7 @@ const connectSteps: { caption: string; providers: Provider[]; forms: Record<stri
     },
   ]
 
-// Ten distinct researched model nodes, nine synthesis reducers, 16 candidate roots.
+// Ten distinct researched model nodes, nine synthesizers, 16 candidate roots.
 const runStats: NbStat[] = [
   { label: 'Models', value: '10/10' },
   { label: 'Synthesis', value: '9/9' },
@@ -91,7 +91,7 @@ const runRecent: NbCheckItem[] = [
   { label: 'Finalized pareto-cross (1/1 cases scored)' },
 ]
 
-// Scores from a real draco-lite@1 run: one case, ten criteria, one judge pass.
+// Scores from a real draco/lite run: one case, ten criteria, one judge pass.
 const studyCandidates = [
   { id: 'claude-fable-5', name: 'claude-fable-5', score: 88.0, casesScored: 1, casesTotal: 1 },
   { id: 'claude-opus-4.8', name: 'claude-opus-4.8', score: 100.0, casesScored: 1, casesTotal: 1 },
@@ -231,10 +231,10 @@ gpt = sf.Model("openrouter/openai/gpt-5.5", prompt=ANSWER)
 gemini = sf.Model("openrouter/google/gemini-3.1-pro-preview", prompt=ANSWER, params={"temperature": 0, "max_tokens": 8192})
 
 frontier_trio = sf.Fusion(
-    "frontier-trio",
-    members=[opus, gpt, gemini],
-    reducer=sf.reducers.Model(
-        model="openrouter/anthropic/claude-opus-4.8",
+    [opus, gpt, gemini],
+    name="frontier-trio",
+    synthesizer=sf.Model(
+        "openrouter/anthropic/claude-opus-4.8",
         prompt=SYNTHESIS,
         params={"temperature": 0, "max_tokens": 8192},
     ),
@@ -243,7 +243,7 @@ frontier_trio = sf.Fusion(
 const lineup = `# Seven solo models answer on their own.
 solos = [opus, gpt, gemini, fable, gemini_flash, kimi, deepseek]
 
-# Nine Fusions combine them through a synthesis reducer. Reusing a Model object
+# Nine Fusions combine them through a synthesizer. Reusing a Model object
 # means that answer is computed once and shared, not requested twice.
 fusions = [
     fable_plus_gpt,      # two frontier models
@@ -259,9 +259,10 @@ fusions = [
 
 candidates = (*solos, *fusions)   # 16 candidate roots, one shared case set`
 
-const load = `draco = sf.benchmarks.load("draco-lite@1")`
+const load = `draco = sf.benchmarks.get("draco/lite")
+draco.title, draco.revision, draco.case_count`
 
-const evaluate = `report = draco.evaluate(candidates)`
+const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 </script>
 
 <template>
@@ -272,24 +273,26 @@ const evaluate = `report = draco.evaluate(candidates)`
     :version="version"
   >
     <p>
-      By the end you will have a scored comparison of <strong>16 candidates</strong>, seven single
-      models and nine fusions built from those same models, on one DRACO case, with ten criteria and
-      one judge pass each. It runs as a single request of roughly 80–85 provider calls.
+      By the end, you'll have a scored comparison of <strong>16 candidates</strong>: seven solo
+      models and nine fusions built from those models, all on one DRACO case with ten criteria and
+      one judge pass each. The whole thing runs as a single request of roughly 80 to 85 provider
+      calls.
     </p>
 
     <blockquote>
-      You need the <RouterLink to="/learn/engine">ScreamingFace Engine</RouterLink> running and an
-      OpenRouter connection first. See
+      You'll need the <RouterLink to="/learn/engine">ScreamingFace Engine</RouterLink> running and
+      an OpenRouter connection first. See
       <RouterLink to="/sf-client/installation">Installation</RouterLink>. Every model below is an
-      OpenRouter route, so one connection covers the whole study.
+      OpenRouter route, so one connection covers everything.
     </blockquote>
 
     <h2>1 · Point at an engine</h2>
 
     <p>
-      The client is a thin wrapper that never calls a model provider itself. All work goes to the
-      <strong>ScreamingFace Engine</strong>, a separate process that owns credentials, datasets, and
-      execution. This first step tells the client where that engine is listening.
+      The client never talks to model providers. That happens on the
+      <strong>ScreamingFace Engine</strong>, a separate process that holds your credentials, the
+      benchmark answer keys, and does the grading. This first step tells the client where to find
+      that engine.
     </p>
 
     <div class="not-prose">
@@ -297,27 +300,25 @@ const evaluate = `report = draco.evaluate(candidates)`
     </div>
 
     <p>
-      That is the whole of setup. <code>sf.configure()</code> validates and stores the URL without a
-      network request, so a wrong address fails later, not here. It defaults to
-      <code>http://127.0.0.1:9108</code> (the local engine), so you can omit the argument while
-      working locally.
+      That's it for setup. <code>sf.configure()</code> validates and stores the URL without making a
+      network request. Omitting it falls back to <code>DEFAULT_ENGINE_URL</code>, which is a hosted
+      engine, so naming the engine you mean is worth doing explicitly.
     </p>
 
     <p>
-      <strong>If the engine is not running</strong>, the first call that needs it raises
-      <code>EngineConnectionError</code>. A health check with
-      <code>curl http://127.0.0.1:9108/healthz</code> can validate it before going further. A remote
-      engine must be served over HTTPS. Provider credentials are refused over plain HTTP outside
-      loopback.
+      <strong>If the engine isn't reachable</strong>, the first call that needs it will raise
+      <code>EngineUnavailableError</code>. You can check a local one beforehand with
+      <code>curl http://127.0.0.1:9108/healthz</code>. Remote engines must use HTTPS, because
+      provider credentials will not travel over plain HTTP outside loopback.
     </p>
 
     <h2>2 · Connect a provider</h2>
 
     <p>
-      The engine holds the credentials, so it needs at least one provider connected before it can
-      call a model. <code>sf.connect()</code> with no arguments renders a panel of every provider
-      this engine advertises. The example below connects <strong>OpenRouter</strong> with an API
-      key, stepping through the six states of the whole auth flow.
+      The engine holds credentials. You need at least one provider connected before you can call a
+      model. <code>sf.connect()</code> with no arguments shows a panel of every provider this engine
+      supports. The example below connects <strong>OpenRouter</strong> with an API key, walking
+      through all six states of the auth flow.
     </p>
 
     <div class="not-prose">
@@ -341,61 +342,64 @@ const evaluate = `report = draco.evaluate(candidates)`
     <h3>Reading the panel</h3>
 
     <p>
-      Each row is one provider: display name, its <strong>live status</strong>, and the available
-      action. The status is read from the engine at render, not remembered, and is one of
+      Each row shows one provider: its display name, <strong>live status</strong>, and what you can
+      do. Status comes fresh from the engine each time (not cached), and will be one of
       <code>NOT CONNECTED</code>, <code>CONNECTING</code>, <code>CONNECTED</code>,
-      <code>NEEDS REAUTH</code>, or <code>ERROR</code>. The header names the engine handling the
-      request, so you cannot connect a key to the wrong one by accident.
+      <code>NEEDS REAUTH</code>, or <code>ERROR</code>. The header shows which engine you're talking
+      to, so you won't accidentally send a key to the wrong one.
     </p>
 
     <blockquote>
-      We chose OpenRouter for simplicity. You can compose fusions with models coming from any of
-      these providers, and we're actively working to expand the local or third-party providers
-      supported.
+      We're using OpenRouter here for simplicity, but you can build fusions with models from any of
+      these providers. We're actively expanding support for local and third-party providers.
     </blockquote>
 
     <h3>Configure OpenRouter via script</h3>
 
     <p>
-      Scripts connect without the panel: name the provider and pass its key directly. Read the key
-      from the environment rather than writing it into source.
+      Scripts skip the panel by naming the provider and passing the key directly. Pull the key from the
+      environment instead of hardcoding it.
     </p>
 
     <CodeBlock :code="connectScript" language="python" />
 
     <p>
-      <code>sf.connect(...)</code> returns a <code>Connection</code> with the validated status, so a
-      bad key fails here, not at evaluation time. <code>sf.connections.list()</code> returns one per
-      provider (the panel's data), and <code>sf.disconnect(...)</code> is safe even if never
-      connected.
+      <code>sf.connect(...)</code> returns a <code>Connection</code> with validated status, so a bad
+      key fails right here, not later during evaluation. <code>sf.connections.list()</code> gives
+      you one per provider (same data the panel shows), and <code>sf.disconnect(...)</code> is safe
+      to call even if you've never connected.
     </p>
 
     <p>
-      Providers that authenticate by OAuth rather than an API key, namely Codex and Anthropic,
-      return an <code>OAuthFlow</code> instead, which you complete in a browser:
+      Providers that use OAuth instead of API keys (Codex and Anthropic) return an
+      <code>OAuthFlow</code>, which you finish in a browser:
     </p>
 
     <CodeBlock :code="connectOauth" language="python" />
 
     <p>
-      The flow expires, so <code>flow.wait()</code> raises rather than blocking forever;
-      <code>flow.expired</code> tells you whether that has happened and
-      <code>flow.cancel()</code> abandons the attempt. Note that connection calls are refused over
-      plain HTTP unless the engine is on loopback. A remote engine must be HTTPS.
+      The flow expires eventually, so <code>flow.wait()</code> will raise an error instead of
+      blocking forever. <code>flow.expired</code> tells you if that's happened, and
+      <code>flow.cancel()</code> abandons the attempt. Connection calls won't work over plain HTTP
+      unless the engine is on loopback, since remote engines must use HTTPS.
     </p>
 
     <h2>3 · Compose the candidates</h2>
 
-    <p>A <strong>candidate</strong> is a model or a fusion submitted for scoring.</p>
+    <p>
+      A <strong>candidate</strong> is anything you are submitting to be scored, whether that is a
+      single model or a fusion.
+    </p>
 
     <ul>
       <li>
-        <code>sf.Model</code>: one configured call: a route, a prompt, and parameters. On its own it
-        is a solo candidate.
+        <code>sf.Model</code>: one configured call (route, prompt, parameters). On its own, it's a
+        solo candidate.
       </li>
       <li>
-        <code>sf.Fusion</code>: several members combined by an explicit <strong>reducer</strong>.
-        Here the reducer is another model that synthesises the members' answers into one.
+        <code>sf.Fusion</code>: several members combined through an explicit
+        <strong>synthesizer</strong>. Here, the synthesizer is another model that combines the
+        members' answers into one.
       </li>
     </ul>
 
@@ -406,46 +410,46 @@ const evaluate = `report = draco.evaluate(candidates)`
     <h3>Caching keeps reruns cheap</h3>
 
     <p>
-      Every model call is cached. When a fusion reuses the same model, its response is served from
-      the cache instead of being paid for again, so a run gets cheaper the more its candidates
-      share. The cache is also shared across the community: if anyone has already run the same model
-      configuration against a benchmark, that call is a cache hit for you as well, at no cost.
+      Every model call gets cached. When a fusion reuses the same model, the response comes from
+      cache instead of being paid for again. Runs get cheaper the more candidates share models. The
+      cache is also shared across the community: if anyone's already run that model config against a
+      benchmark, you get a cache hit at no cost.
     </p>
 
     <p>
-      One detail worth understanding before the next steps:
+      One thing worth understanding now:
       <strong>reusing a Model object means its answer is computed once and shared</strong> across
-      every candidate that contains it. That is what makes 16 candidates affordable and it is why a
-      single failing model can only affect the candidates that depend on it.
+      every candidate using it. That makes 16 candidates affordable. A single failing model only
+      breaks the candidates that depend on it.
     </p>
 
     <Collapsible title="The full 16-candidate lineup">
       <CodeBlock :code="lineup" language="python" />
     </Collapsible>
 
-    <p>The lineup covers three patterns, each answering a different question:</p>
+    <p>The lineup explores three patterns, each testing a different hypothesis:</p>
 
     <ul>
       <li>
-        <strong>Pairs and trios of frontier models</strong>: does adding another strong model help?
+        <strong>Pairs and trios of frontier models</strong>: Does adding another strong model help?
       </li>
       <li>
         <strong><code>opus-self-fusion</code></strong
-        >: one model fused with a second sample of itself at a higher temperature. Does a fusion
-        help without adding a second model?
+        >: One model fused with a second sample of itself at higher temperature. Does fusion help
+        without adding a second model?
       </li>
       <li>
         <strong><code>budget-trio</code></strong
-        >: three cheaper models. Can they reach a frontier model's score at lower cost?
+        >: Three cheaper models. Can they hit a frontier model's score at lower cost?
       </li>
     </ul>
 
-    <h2>4 · Load the benchmark</h2>
+    <h2>4 · Look up the benchmark</h2>
 
     <p>
-      A benchmark lives on the engine, not in the client. Loading it fetches the
-      <strong>manifest</strong>, which describes how the run will be scored: the grader, the judge
-      model, the aggregator, and the tool policy. The client sees these rules before the run starts.
+      Benchmarks live on the engine, not in the client. Fetching one returns its identity and the
+      protocol revision it is pinned to, so you can see what you are about to be graded against
+      before spending anything. This call is free.
     </p>
 
     <div class="not-prose">
@@ -453,45 +457,50 @@ const evaluate = `report = draco.evaluate(candidates)`
     </div>
 
     <p>
-      It does <strong>not</strong> download any questions. Cases are loaded engine-side at evaluation
-      time, so a gated dataset is read with the <code>HF_TOKEN</code> in the
-      <strong>engine's</strong> environment, not the client's. Provide it where the engine runs:
+      It does <strong>not</strong> download the actual questions. Cases are loaded engine-side at
+      eval time. A gated dataset reads the <code>HF_TOKEN</code> from the <strong>engine's</strong>
+      environment, not the client's. Set it where the engine runs:
     </p>
 
     <ul>
       <li>
-        <strong>Your own engine:</strong> put <code>HF_TOKEN=hf_…</code> in the engine's
+        <strong>Your own engine:</strong> Put <code>HF_TOKEN=hf_…</code> in the engine's
         <code>.env</code> file, or <code>export</code> it before starting the engine, then restart.
-        See <RouterLink to="/sf-client/installation">Installation</RouterLink> for the start command.
+        See <RouterLink to="/sf-client/installation">Installation</RouterLink> for the start
+        command.
       </li>
       <li>
-        <strong>A hosted engine:</strong> the operator sets the token, so gated datasets work only if
-        they have configured one. There is nothing to pass from the client.
+        <strong>Hosted engine:</strong> The operator sets the token, so gated datasets only work if
+        they've configured one. You can't pass it from the client.
       </li>
     </ul>
 
     <p>
-      <code>sf.benchmarks.list()</code> shows what this engine advertises.
-      <code>draco-lite@1</code> appears only when its pinned judge model is in the gateway's
-      catalog; if it is missing, check the engine's configuration.
+      <code>sf.benchmarks.list()</code> shows what this engine has. <code>draco/lite</code> only
+      appears if its pinned judge model is in the gateway catalog, so if it is missing, the engine's
+      configuration is the place to look rather than your own code.
     </p>
 
     <p>
-      <code>draco-lite@1</code> is a trimmed-down version of the full benchmark: one pinned case,
-      ten criteria spanning all four rubric sections, and one judge pass per criterion. It runs the
-      same protocol as <code>draco@1</code>, which covers all 100 cases with five judge passes per
-      criterion, so you can rehearse the full run at a fraction of the cost before committing to it.
+      <code>draco/lite</code> is a reduced form of the full benchmark: one pinned case and ten
+      criteria spanning all four rubric sections, with a single judge pass per criterion. It runs the
+      same protocol as <code>draco</code>, which uses all 100 cases and five judge passes per
+      criterion, so you can rehearse the full run at a small fraction of its cost.
     </p>
 
     <h2>5 · Evaluate</h2>
 
-    <p>One call sends all 16 candidates as a <strong>single request</strong>.</p>
+    <p>
+      One call sends all 16 candidates as a <strong>single request</strong>. The benchmark id is
+      passed here rather than to the lookup above, because the lookup was only for reading the
+      protocol.
+    </p>
 
     <div class="not-prose">
       <NbCell :count="5" :code="evaluate">
         <EvaluationReport
           title="16 candidates"
-          benchmark="draco-lite@1"
+          benchmark="draco/lite"
           phase="complete"
           elapsed="4M 51S"
           :done="16"
@@ -505,102 +514,108 @@ const evaluate = `report = draco.evaluate(candidates)`
     </div>
 
     <p>
-      Before the first model call, the client verifies the run: the benchmark manifest still matches
-      the engine (<code>EngineProtocolError</code>), every model route exists
-      (<code>UnknownModelError</code>), members support the benchmark's tools
-      (<code>UnsupportedToolError</code>), reducers are advertised
-      (<code>UnsupportedReducerError</code>), required providers are connected
-      (<code>ConnectionRequiredError</code>), and the compiled request fits the engine's size limit
-      (<code>EngineRequestTooLargeError</code>). It all runs before anything is spent, so a
-      misconfigured run costs nothing.
+      Before the first model call, the client checks the whole plan: that the benchmark agrees with
+      what the engine has, that every model route exists in the catalog, that the parameters you set
+      are ones those models accept, and that each candidate compiles. Anything wrong with the plan
+      raises <code>PlanningError</code>, which names the specific problem in its message; a provider
+      that is not connected raises <code>ProviderConnectionError</code> instead. All of this happens
+      before anything is spent, so a misconfigured run costs nothing.
     </p>
 
     <p>
-      The panel is live while the run proceeds. <code>MODELS</code> counts the distinct answering
-      calls, ten, not sixteen, because shared members are computed once.
-      <code>SYNTHESIS</code> counts the nine reducers, <code>SCORING</code> the graded candidates,
-      and <code>RESULTS</code> the finalised ones. Progress advances on real grader results, never
-      on a timer, so a stalled counter means work genuinely stalled.
+      The panel updates live as the run proceeds. <code>MODELS</code> counts distinct answering
+      calls (ten, not sixteen, because shared members are computed once). <code>SYNTHESIS</code>
+      counts the nine synthesizers, <code>SCORING</code> the graded candidates, and
+      <code>RESULTS</code> the finalized ones. Progress moves on real grader results, never timers,
+      so if a counter stalls, work actually stalled.
     </p>
 
     <blockquote>
       <strong>This step costs money.</strong> Expect roughly 80–85 provider calls: ten answers, nine
-      syntheses, and ten judge passes per graded candidate. It is minutes and cents rather than
-      hours and dollars, but it is not free, and <code>draco@1</code> at 100 cases is a completely
-      different order of spend.
+      syntheses, plus ten judge passes per graded candidate. It's minutes and cents rather than
+      hours and dollars, but it's not free. <code>draco</code> at 100 cases is a completely
+      different scale of spend.
     </blockquote>
 
     <p>
-      If a model fails, only the candidates that depend on it are affected; the rest still score. A
-      failure lowers that candidate's coverage rather than counting as a zero, so a partial result
-      is visibly partial. Because every completed call is cached, re-running after a failure is free
-      for the work that already succeeded: you are charged only for the new, uncached calls.
+      If a model fails, only the candidates using it are affected, and the rest still score. A failure
+      lowers that candidate's coverage instead of counting as zero, so a partial result looks
+      partial. Since every completed call is cached, re-running after a failure is free for work
+      that already succeeded, so you only pay for new, uncached calls.
     </p>
 
     <h2>6 · Read the study</h2>
 
     <p>
-      Displaying the report renders each candidate in the order you declared them, with its score,
-      and marks the highest. Nine are shown here; the remaining seven are summarised as
-      <code>+7 MORE</code>.
+      The report shows each candidate in the order you declared them, with their scores, and marks
+      the best one. Nine are shown here; the rest are summarized as <code>+7 MORE</code>.
     </p>
 
     <div class="not-prose">
       <NbCell :count="6" code="report">
         <CandidateScores
           :candidates="studyCandidates"
-          benchmark="draco-lite@1"
+          benchmark="draco/lite"
           case-label="1 case"
           :limit="9"
         />
       </NbCell>
     </div>
 
-    <h3>What each column means</h3>
+    <h3>What the columns mean</h3>
 
     <ul>
       <li>
-        <strong>Score</strong>: the candidate's normalized rubric score. Ten criteria are judged, so
-        values land on a coarse grid rather than anywhere in 0–100%.
+        <strong>Score</strong>: The candidate's normalized rubric score. Ten criteria get judged, so
+        values land on a coarse grid instead of anywhere in 0–100%.
       </li>
       <li>
-        <strong>Coverage</strong>: how much of the case set produced a grade. Below 100% means
-        something failed, and the score covers only what completed.
+        <strong>Coverage</strong>: How much of the case set produced a grade. Below 100% means
+        something failed, and the score then covers only what completed.
       </li>
       <li>
-        <strong>BEST</strong>: marks the top scorer. Ties resolve to the first in declared order.
+        <strong>BEST</strong>: Marks the top scorer. Ties go to the first in declared order.
       </li>
     </ul>
 
     <h3>Reading it in code</h3>
 
     <ul>
-      <li><code>report.best</code>: the highest-scoring candidate.</li>
       <li><code>report.candidates["frontier-trio"].score</code>: one candidate's score.</li>
       <li>
-        <code>report.candidates["frontier-trio"].coverage</code>: cases that produced a grade.
+        <code>max(report.candidates, key=lambda c: c.score or 0)</code>: the top scorer. There is no
+        <code>best</code> field, because picking a winner is a judgement about your own experiment
+        rather than something the report should decide.
       </li>
-      <li><code>report.url4</code>: the whole run, as one expression.</li>
+      <li>
+        <code>len(report.candidates["frontier-trio"].cases)</code> against
+        <code>report.case_count</code>: how many cases produced a result, next to how many ran.
+      </li>
+      <li>
+        <code>report.candidates["frontier-trio"].url4</code>: that candidate's expression. The url4
+        belongs to a candidate, not to the report, since each one compiled separately.
+      </li>
       <li><code>report.to_dict()</code>: everything above as plain JSON-compatible values.</li>
     </ul>
 
     <blockquote>
-      <strong>Do not over-read a single run.</strong> One case judged once is an integration check,
-      not a measurement: run it twice and the winner can change. Treat it as a shape to explore.
+      <strong>Don't over-read a single run.</strong> One case judged once is an integration check,
+      not a measurement. Run it twice and the winner may change. Treat the result as a shape worth
+      exploring rather than a finding.
     </blockquote>
 
     <h2>What the full benchmark shows</h2>
 
     <p>
-      The claim is demonstrated on all 100 DRACO tasks, not on this one-case sample. These are
-      published figures, not output from the code above. Expect your own numbers to differ.
+      The real claim is demonstrated on all 100 DRACO tasks, not this one-case sample. These are
+      published figures rather than output from the code above, so your own numbers will differ.
     </p>
 
     <div class="not-prose">
       <CandidateScores
         :candidates="publishedDraco"
         title="Published DRACO result"
-        benchmark="draco@1"
+        benchmark="draco"
         case-label="100 tasks"
         section-label="Score by candidate"
         :limit="8"
@@ -608,9 +623,9 @@ const evaluate = `report = draco.evaluate(candidates)`
     </div>
 
     <p>
-      The strongest fusion beat the best single model by <strong>8.4 points</strong>, and five
-      fusions beat every individual model. Three solo models did not complete every task, Gemini 3.1
-      Pro finished only 47 of 100, so their scores are means over completed tasks and are not
+      The best fusion beat the best solo model by <strong>8.4 points</strong>, and five different
+      fusions beat every individual model. Three solo models didn't finish every task (Gemini 3.1
+      Pro only completed 47 of 100), so their scores are averages over completed tasks and aren't
       directly comparable. Full chart and method:
       <a
         href="https://andrewtrask.substack.com/p/6-weeks-ago-frontier-ai-labs-lost"

--- a/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
@@ -13,21 +13,14 @@ import {
 const listRun = `import screamingface as sf
 
 client = sf.Client()
-[(b.id, b.case_count) for b in client.benchmarks.list()]`
-const listRunOut = `[('draco', 100), ('ifeval', 541)]`
-
-const casesSig = `Benchmark.cases(limit: int = 50, offset: int = 0)`
-
-const casesRun = `ifeval = client.benchmarks.get("ifeval")
-ifeval.cases(limit=3)`
-const casesRunOut = `Cases(3 of 541, offset=0)`
-
-const caseRun = `case = ifeval.cases(limit=1)[0]
-case.id, case.input[:60]`
-const caseRunOut = `(1, 'Write a 300+ word summary of the wikipedia page "https://en.')`
+[(b.id, b.variant, b.case_count) for b in client.benchmarks.list()]`
+const listRunOut = `[('draco', 'canonical', 100), ('draco/lite', 'lite', 2), ('ifeval', 'canonical', 541), ('ifeval/self-corrective', 'self-corrective', 541)]`
 
 const modelsRun = `client.models.list()[0]`
-const modelsRunOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthropic')`
+const modelsRunOut = `ModelInfo('anthropic/claude-opus-4-8', provider='anthropic', parameters=9, tools=2)`
+
+const detailsRun = `client.models.get("anthropic/claude-opus-4-8")`
+const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthropic', scope='chat', parameters=9, tools=2, transport=3)`
 </script>
 
 <template>
@@ -39,9 +32,9 @@ const modelsRunOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthro
   >
     <p>
       A benchmark is a fixed set of cases, owned by the Engine and pinned by a revision. This page
-      covers <code>Benchmark</code> itself, alongside <code>CaseInfo</code> for a single case inside
-      it, <code>BenchmarkInfo</code> for the compact identity a report keeps of it, and
-      <code>ModelInfo</code> for the model routes the Engine can run it against. See the
+      covers <code>Benchmark</code> itself, alongside <code>BenchmarkInfo</code> for the compact
+      identity a report keeps of it, and <code>ModelInfo</code> for the model routes the Engine can
+      run it against. See the
       <RouterLink to="/sf-client/guides/benchmarks">Benchmarks guide</RouterLink> for choosing which
       benchmark to run.
     </p>
@@ -57,8 +50,10 @@ const modelsRunOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthro
 
     <p>
       A <code>Benchmark</code> is the Engine's record of one benchmark, carrying its identity, its
-      size, and access to its public cases. <code>client.benchmarks.get(id)</code> returns a single
-      benchmark and <code>client.benchmarks.list()</code> returns every benchmark the Engine offers.
+      size, and what it measures. <code>client.benchmarks.get(id)</code> returns a single benchmark
+      and <code>client.benchmarks.list()</code> returns every benchmark the Engine offers. Protocol
+      variants are separate entries with their own ids, so the list holds <code>ifeval</code> beside
+      <code>ifeval/self-corrective</code>.
     </p>
 
     <div class="not-prose">
@@ -80,8 +75,17 @@ const modelsRunOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthro
           <td><code>id</code></td>
           <td><code>str</code></td>
           <td>
-            Stable identifier, such as <code>ifeval</code>. This is what you pass as
-            <code>benchmark=</code> when evaluating.
+            Stable identifier, such as <code>ifeval</code> or <code>draco/lite</code>. This is what
+            you pass as <code>benchmark=</code> when evaluating.
+          </td>
+        </tr>
+        <tr>
+          <td><code>variant</code></td>
+          <td><code>str</code></td>
+          <td>
+            Which protocol of the underlying benchmark this entry runs, such as
+            <code>canonical</code>, <code>lite</code> or <code>self-corrective</code>. It names the
+            protocol; the <code>id</code> is what selects it.
           </td>
         </tr>
         <tr>
@@ -113,81 +117,12 @@ const modelsRunOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthro
       </tbody>
     </table>
 
-    <h3>cases()</h3>
-
-    <CodeBlock :code="casesSig" language="python" />
-
-    <p>
-      This method fetches one page of the benchmark's public cases from the Engine and returns them
-      as a sequence of <code>CaseInfo</code> values supporting indexing, slicing, iteration and
-      <code>len()</code>. Within a notebook the sequence renders as a table, and as a searchable
-      table where the <code>notebook</code> extra is installed.
-    </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>limit</code></td>
-          <td><code>int</code></td>
-          <td>How many cases to fetch. Defaults to 50.</td>
-        </tr>
-        <tr>
-          <td><code>offset</code></td>
-          <td><code>int</code></td>
-          <td>How many cases to skip first. Defaults to 0.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="2" :code="casesRun"><NbTextOut :text="casesRunOut" /></NbCell>
-    </div>
-
-    <p>
-      This is a live call, so it raises <code>PlanningError</code> when the Engine cannot serve the
-      benchmark's case data.
-    </p>
-
-    <h2>CaseInfo</h2>
-
-    <p>
-      A <code>CaseInfo</code> is one public case from a benchmark, carrying its identifier and the
-      exact text a candidate receives. Nothing further crosses the Engine boundary: grading criteria
-      and rubrics remain on the Engine, so a case's answer key cannot be read through this value.
-    </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>id</code></td>
-          <td><code>int</code></td>
-          <td>Position within the benchmark, counting from 1.</td>
-        </tr>
-        <tr>
-          <td><code>input</code></td>
-          <td><code>str</code></td>
-          <td>The prompt text for this case.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="3" :code="caseRun"><NbTextOut :text="caseRunOut" /></NbCell>
-    </div>
+    <Note>
+      A <code>Benchmark</code> carries no case data. The client cannot page a benchmark's prompts,
+      because the cases and their answer keys stay on the Engine. Case text becomes visible after a
+      run, through the <code>CaseResult</code> values on
+      <RouterLink to="/sf-client/api/reports">CandidateResult.cases</RouterLink>.
+    </Note>
 
     <h2>BenchmarkInfo</h2>
 
@@ -265,26 +200,48 @@ const modelsRunOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthro
           <td><code>str</code></td>
           <td>Which provider serves the route.</td>
         </tr>
+        <tr>
+          <td><code>supported_parameters</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>
+            Which request parameters this route accepts, such as <code>temperature</code>. Passing
+            one it does not accept fails before the run.
+          </td>
+        </tr>
+        <tr>
+          <td><code>supported_tools</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Which tools it can use, such as <code>web_search</code>.</td>
+        </tr>
       </tbody>
     </table>
 
     <div class="not-prose">
-      <NbCell :count="4" :code="modelsRun"><NbTextOut :text="modelsRunOut" /></NbCell>
+      <NbCell :count="2" :code="modelsRun"><NbTextOut :text="modelsRunOut" /></NbCell>
+    </div>
+
+    <p>
+      <code>client.models.get(id)</code> returns the fuller <code>ModelDetails</code> profile for
+      one route: every parameter with its schema and whether the gateway currently projects it, the
+      tool and transport capabilities, and whether the profile is stale or degraded. In a notebook
+      it renders as a card.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="detailsRun"><NbTextOut :text="detailsRunOut" /></NbCell>
     </div>
 
     <h2>Validation</h2>
 
     <p>
-      All four types validate their arguments on construction, so a malformed value cannot exist.
-      Blank strings raise <code>ValueError</code>, non-strings raise <code>TypeError</code>, and the
-      integer fields reject zero and negative values, which is why <code>case_count</code> and a
-      case <code>id</code> are always positive:
+      All three types validate their arguments on construction, so a malformed value cannot exist.
+      Blank strings raise <code>ValueError</code>, non-strings raise <code>TypeError</code>, and
+      <code>case_count</code> rejects zero and negative values:
     </p>
 
     <CodeBlock
-      code="ValueError: Case id must be a positive integer
-ValueError: Case input must be a non-empty string
-ValueError: Benchmark case_count must be a positive integer
+      code="ValueError: Benchmark case_count must be a positive integer
+ValueError: Benchmark variant must be a non-empty string
 ValueError: Model id must be a non-empty string"
       language="text"
     />

--- a/public-docs/src/pages/sf-client/api/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ClientsPage.vue
@@ -5,25 +5,29 @@ import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
+import { SF_ENGINE_URL } from '@/lib/engine'
 import {
   sfClientNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 
-const clientSig = `sf.Client(*, engine_url: str = "http://127.0.0.1:9108")`
+const clientSig = `sf.Client(
+    *,
+    engine_url: str = DEFAULT_ENGINE_URL,
+    scoreboard_url: str = DEFAULT_SCOREBOARD_URL,
+)`
 
 const basic = `import screamingface as sf
 
-client = sf.Client()
+client = sf.Client(engine_url="${SF_ENGINE_URL}")
 client.engine_url, client.closed, client.authenticated`
-const basicOut = `('http://127.0.0.1:9108', False, False)`
+const basicOut = `('${SF_ENGINE_URL}', False, False)`
 
 const evaluateSig = `Client.evaluate(
     candidates: Recipe | Sequence[Recipe],
     *,
     benchmark: str,
     limit: int | None = None,
-    method: str | None = None,
     on_event: Callable[[Event], None] | None = None,
     progress: bool | None = None,
 ) -> Report`
@@ -33,7 +37,6 @@ const withBlock = `with sf.Client() as client:
         sf.Model("openrouter/anthropic/claude-haiku-4.5"),
         benchmark="ifeval",
         limit=1,
-        method="single_pass",
     )`
 
 const closed = `client.close()
@@ -44,18 +47,18 @@ const asyncCode = `import asyncio
 import screamingface as sf
 
 async def main():
-    async with sf.AsyncClient() as client:
+    async with sf.AsyncClient(engine_url="${SF_ENGINE_URL}") as client:
         models = await client.models.list()
         return len(models), client.engine_url
 
 asyncio.run(main())`
-const asyncOut = `(29, 'http://127.0.0.1:9108')`
+const asyncOut = `(29, '${SF_ENGINE_URL}')`
 
 const connection = `client.connections.get("openrouter")`
 const connectionOut = `Connection(provider='openrouter', display_name='OpenRouter', auth_methods=('api_key',), status='connected', auth_method='api_key', account_label=None)`
 
 const panel = `client.connect()`
-const panelOut = `ConnectionPanel(engine='http://127.0.0.1:9108', openrouter=connected)`
+const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connected)`
 </script>
 
 <template>
@@ -88,9 +91,11 @@ const panelOut = `ConnectionPanel(engine='http://127.0.0.1:9108', openrouter=con
     </div>
 
     <Note>
-      The default <code>engine_url</code> points at a local Engine on port 9108. For a hosted
-      Engine, pass its address, or set <code>SCREAMINGFACE_ENGINE_URL</code> and use the
-      module-level functions.
+      <code>DEFAULT_ENGINE_URL</code> is a hosted Engine, so a <code>Client()</code> with no
+      arguments talks to one we operate. To use a local Engine, pass its address explicitly, or set
+      <code>SCREAMINGFACE_ENGINE_URL</code> and use the module-level functions.
+      <code>DEFAULT_SCOREBOARD_URL</code> is the matching hosted leaderboard. Both constants live in
+      <code>screamingface.client</code>.
     </Note>
 
     <h3>Properties</h3>
@@ -125,6 +130,14 @@ const panelOut = `ConnectionPanel(engine='http://127.0.0.1:9108', openrouter=con
           <td>Whether a login is in flight.</td>
         </tr>
         <tr>
+          <td><code>scoreboard_url</code></td>
+          <td><code>str</code></td>
+          <td>
+            Where <RouterLink to="/sf-client/guides/leaderboards">leaderboard</RouterLink>
+            submissions go. Separate from the Engine, and separately configurable.
+          </td>
+        </tr>
+        <tr>
           <td><code>models</code></td>
           <td>catalogue</td>
           <td>
@@ -137,8 +150,8 @@ const panelOut = `ConnectionPanel(engine='http://127.0.0.1:9108', openrouter=con
           <td><code>benchmarks</code></td>
           <td>catalogue</td>
           <td>
-            <code>benchmarks.list()</code>, <code>benchmarks.get(id)</code> and
-            <code>benchmarks.cases(id)</code>.
+            <code>benchmarks.list()</code> and <code>benchmarks.get(id)</code> return
+            <RouterLink to="/sf-client/api/benchmarks">Benchmark</RouterLink> identity cards.
           </td>
         </tr>
         <tr>
@@ -179,7 +192,11 @@ const panelOut = `ConnectionPanel(engine='http://127.0.0.1:9108', openrouter=con
         <tr>
           <td><code>benchmark</code></td>
           <td><code>str</code></td>
-          <td>The benchmark id, such as <code>ifeval</code>. Required keyword argument.</td>
+          <td>
+            The benchmark id, such as <code>ifeval</code>. A protocol variant is its own id, such as
+            <code>ifeval/self-corrective</code>, and it pins a different revision, so it changes
+            what the result is comparable to. Required keyword argument.
+          </td>
         </tr>
         <tr>
           <td><code>limit</code></td>
@@ -187,15 +204,6 @@ const panelOut = `ConnectionPanel(engine='http://127.0.0.1:9108', openrouter=con
           <td>
             Run only this many cases. <code>None</code> runs the whole benchmark. Use a small limit
             while you are still iterating.
-          </td>
-        </tr>
-        <tr>
-          <td><code>method</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>
-            Which protocol variant to run, such as ifeval's <code>single_pass</code>.
-            <code>None</code> runs the benchmark's default. This changes the pinned revision, so it
-            changes what the result is comparable to.
           </td>
         </tr>
         <tr>

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -66,24 +66,24 @@ const equalityOut = `True`
     :version="version"
   >
     <p>
-      A recipe describes how to produce one answer, and is what a benchmark grades. This page covers
-      <code>Model</code> for a single model route, <code>Fusion</code> for several members combined
-      by a synthesizer, <code>Pipeline</code> for members chained in series, and
-      <code>Recipe</code>, the abstract type the other three satisfy.
+      A recipe tells ScreamingFace how to produce one answer. That's what a benchmark grades. This
+      page covers <code>Model</code> (a single model route), <code>Fusion</code> (several members
+      combined by a synthesizer), <code>Pipeline</code> (members chained in series), and
+      <code>Recipe</code> (the abstract type all three inherit from).
     </p>
 
     <p>
-      All three constructible recipes are frozen and hold no client, so building one issues no
-      network request and can be done before connecting to anything. Recipes nest: a
-      <code>Fusion</code> or <code>Pipeline</code> can contain a <code>Model</code>, a
-      <code>Fusion</code> or a <code>Pipeline</code>, in any combination.
+      All three constructible recipes are frozen and hold no client. Building one makes no network
+      requests. You can compose them before connecting to anything. Recipes nest: a
+      <code>Fusion</code> or <code>Pipeline</code> can contain a <code>Model</code>, another
+      <code>Fusion</code>, or another <code>Pipeline</code>, in any combination.
     </p>
 
     <Note>
       Recipes compare by value. Two recipes built with identical arguments are equal, and
       <RouterLink to="/learn/engine">the engine</RouterLink> treats them as one candidate. Give a
-      <code>Model</code> an explicit <code>name</code> when you mean an independent sample — then
-      they differ. Recipes are also unhashable, so they cannot be dictionary keys or set members.
+      <code>Model</code> an explicit <code>name</code> for an independent sample. Recipes are
+      unhashable: you can't use them as dict keys or put them in sets.
     </Note>
 
     <div class="not-prose">
@@ -93,18 +93,18 @@ const equalityOut = `True`
     <h2>Recipe</h2>
 
     <p>
-      <code>Recipe</code> is the abstract base the other three inherit and cannot itself be
-      instantiated. It exists so that a parameter accepting any recipe can be annotated, and so that
-      a <code>Fusion</code> or <code>Pipeline</code> can hold a mixed sequence of members.
+      <code>Recipe</code> is the abstract base the other three inherit from. You can't instantiate
+      it directly. It exists for type annotations and so a <code>Fusion</code> or
+      <code>Pipeline</code> can hold a mixed list of members.
     </p>
 
     <p>
-      Its only public attribute is <code>name</code>, a <code>str</code> every recipe carries. It
-      also provides <code>.then()</code>, the builder that appends a stage and returns a
-      <code>Pipeline</code> (see <a href="#pipeline">Pipeline</a> below).
+      Every recipe has one public attribute: <code>name</code> (a <code>str</code>). It also
+      provides <code>.then()</code>, which appends a stage and returns a <code>Pipeline</code> (see
+      <a href="#pipeline">Pipeline</a> below).
     </p>
 
-    <p>Calling <code>sf.Recipe()</code> raises:</p>
+    <p>Calling <code>sf.Recipe()</code> directly raises:</p>
 
     <CodeBlock
       code="TypeError: Can't instantiate abstract class Recipe without an implementation for abstract method '_recipe_marker'"
@@ -114,9 +114,9 @@ const equalityOut = `True`
     <h2>Model</h2>
 
     <p>
-      A <code>Model</code> is a single model route answering on its own. It is the simplest recipe,
-      and the baseline every other recipe is measured against. See the
-      <RouterLink to="/sf-client/guides/models">Models guide</RouterLink> for choosing a route.
+      A <code>Model</code> is a single model route answering on its own. The simplest recipe, and
+      the baseline for everything else. See the
+      <RouterLink to="/sf-client/guides/models">Models guide</RouterLink> for help picking a route.
     </p>
 
     <CodeBlock :code="modelSig" language="python" />
@@ -136,37 +136,36 @@ const equalityOut = `True`
           <td><code>model</code></td>
           <td><code>str</code></td>
           <td>
-            The provider route, such as <code>openrouter/openai/gpt-5.5</code>. Required and
-            positional.
+            The provider route, like <code>openrouter/openai/gpt-5.5</code>. Required, positional.
           </td>
         </tr>
         <tr>
           <td><code>name</code></td>
           <td><code>str&nbsp;|&nbsp;None</code></td>
           <td>
-            Label used in reports and on the leaderboard. Defaults to the segment of the route after
-            the last <code>/</code>, so <code>openrouter/openai/gpt-5.5</code> becomes
-            <code>gpt-5.5</code>. An explicit name also marks the Model as an independent sample.
+            Label that shows up in reports and on the leaderboard. Defaults to everything after the
+            last <code>/</code> in the route, so <code>openrouter/openai/gpt-5.5</code> becomes
+            <code>gpt-5.5</code>. Setting an explicit name also marks this Model as an independent
+            sample.
           </td>
         </tr>
         <tr>
           <td><code>prompt</code></td>
           <td><code>str&nbsp;|&nbsp;None</code></td>
           <td>
-            The instruction given to the model alongside the case. When omitted the SDK supplies its
-            own default answer prompt, not the benchmark's.
+            The instruction given to the model alongside the case. Leave it out and the SDK uses its
+            own default prompt (not the benchmark's).
           </td>
         </tr>
         <tr>
           <td><code>params</code></td>
           <td><code>Mapping&nbsp;|&nbsp;None</code></td>
           <td>
-            Generation overrides such as <code>temperature</code>. Values must be <code>str</code>,
-            <code>int</code>, <code>float</code> or <code>bool</code>, and floats must be finite.
-            Only the parameters you set are sent — the SDK adds no default generation parameters.
-            Transport, tool and benchmark-protocol names (for example <code>model</code>,
-            <code>messages</code>, <code>tools</code>, <code>web_search</code>) are reserved and
-            rejected.
+            Generation overrides like <code>temperature</code>. Values must be <code>str</code>,
+            <code>int</code>, <code>float</code>, or <code>bool</code> (floats have to be finite).
+            Only the params you set get sent, since the SDK adds no defaults. Transport, tool, and
+            benchmark-protocol names (like <code>model</code>, <code>messages</code>,
+            <code>tools</code>, <code>web_search</code>) are reserved and will be rejected.
           </td>
         </tr>
       </tbody>
@@ -175,8 +174,8 @@ const equalityOut = `True`
     <h3>Attributes</h3>
 
     <p>
-      <code>model</code>, <code>name</code> and <code>prompt</code> read back what you passed.
-      <code>params</code> returns a <code>mappingproxy</code>, so the overrides cannot be mutated
+      <code>model</code>, <code>name</code>, and <code>prompt</code> give you back what you passed
+      in. <code>params</code> returns a <code>mappingproxy</code>, so you can't mutate the overrides
       after construction.
     </p>
 
@@ -221,10 +220,9 @@ const equalityOut = `True`
 
     <p>
       A <code>Fusion</code> combines members: each member answers in parallel, then a
-      <strong>synthesizer</strong> reads their answers and produces the single final one. That final
-      answer is what the benchmark grades. See the
-      <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink> for the reasoning behind
-      the design.
+      <strong>synthesizer</strong> reads those answers and produces one final answer. The benchmark
+      grades that final answer. See the
+      <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink> for the reasoning.
     </p>
 
     <CodeBlock :code="fusionSig" language="python" />
@@ -244,9 +242,8 @@ const equalityOut = `True`
           <td><code>members</code></td>
           <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
           <td>
-            One or more members, in order — a route string, <code>Model</code>,
-            <code>Fusion</code> or <code>Pipeline</code>. Because a member may itself be a
-            <code>Fusion</code> or <code>Pipeline</code>, ensembles nest.
+            One or more members, in order. Each can be a route string, <code>Model</code>,
+            <code>Fusion</code>, or <code>Pipeline</code>. Ensembles nest.
           </td>
         </tr>
         <tr>
@@ -261,9 +258,9 @@ const equalityOut = `True`
           <td><code>synthesizer</code></td>
           <td><code>str&nbsp;|&nbsp;Recipe</code></td>
           <td>
-            <strong>Required, keyword-only.</strong> A route string or any recipe — a
-            <code>Model</code>, <code>Fusion</code> or <code>Pipeline</code> — that reads the
-            members' answers and writes the final one. There is no default.
+            <strong>Required, keyword-only.</strong> A route string or any recipe (a
+            <code>Model</code>, <code>Fusion</code>, or <code>Pipeline</code>) that reads the
+            members' answers and writes the final one. No default.
           </td>
         </tr>
       </tbody>
@@ -272,10 +269,9 @@ const equalityOut = `True`
     <h3>Attributes</h3>
 
     <p>
-      <code>members</code> is a <code>tuple</code> in the order you gave it. <code>name</code> reads
-      back the resolved label, and <code>synthesizer</code> reads back the recipe you passed (a
-      route string is normalized to a <code>Model</code>). There is no <code>reducer</code>
-      attribute.
+      <code>members</code> is a <code>tuple</code> in the order you gave. <code>name</code> is the
+      resolved label. <code>synthesizer</code> is the recipe you passed (route strings normalize to
+      <code>Model</code>). No <code>reducer</code> attribute.
     </p>
 
     <h3>Raises</h3>
@@ -321,11 +317,10 @@ const equalityOut = `True`
     <h2 id="pipeline">Pipeline</h2>
 
     <p>
-      A <code>Pipeline</code> runs its stages in series: the first stage answers the case, and each
-      later stage receives the previous stage's answer as its input. The last stage's answer is what
-      the benchmark grades. See the
-      <RouterLink to="/sf-client/guides/pipelines">Pipelines guide</RouterLink> for serial and
-      recursive composition.
+      A <code>Pipeline</code> runs stages in series: the first stage answers the case, each later
+      stage gets the previous stage's answer as input. The benchmark grades the last stage's answer.
+      See the <RouterLink to="/sf-client/guides/pipelines">Pipelines guide</RouterLink> for serial
+      and recursive composition.
     </p>
 
     <CodeBlock :code="pipelineSig" language="python" />
@@ -345,9 +340,9 @@ const equalityOut = `True`
           <td><code>stages</code></td>
           <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
           <td>
-            One or more stages, in order — a route string or any recipe. An
-            <em>unnamed</em> nested <code>Pipeline</code> is flattened into the surrounding stage
-            sequence; a <em>named</em> one is kept as a single stage.
+            One or more stages, in order. Each can be a route string or any recipe. An
+            <em>unnamed</em> nested <code>Pipeline</code> flattens into the surrounding sequence; a
+            <em>named</em> one stays as a single stage.
           </td>
         </tr>
         <tr>
@@ -364,9 +359,9 @@ const equalityOut = `True`
     <h3>Attributes</h3>
 
     <p>
-      <code>stages</code> is a <code>tuple</code> in canonical order, and <code>name</code> reads
-      back the resolved label. <code>recipe.then(next)</code> — available on every recipe — is the
-      builder equivalent: it appends a stage and returns a new <code>Pipeline</code>.
+      <code>stages</code> is a <code>tuple</code> in canonical order. <code>name</code> is the
+      resolved label. <code>recipe.then(next)</code>, available on every recipe, appends a stage and
+      returns a new <code>Pipeline</code>.
     </p>
 
     <h3>Raises</h3>

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -24,59 +24,70 @@ sf.Model("openrouter/openai/gpt-5.5", name="gpt-hot", params={"temperature": 0.9
 const modelRunOut = `Model('openrouter/openai/gpt-5.5', name='gpt-hot', params={'temperature': 0.9})`
 
 const fusionSig = `sf.Fusion(
-    members: Sequence[Recipe],
+    members: Sequence[str | Recipe],
     *,
     name: str | None = None,
-    reducer: Reducer | None = None,
+    synthesizer: str | Recipe,
 )`
 
 const fusionRun = `opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
 gpt = sf.Model("openrouter/openai/gpt-5.5", name="gpt-hot")
 
-sf.Fusion([opus, gpt], reducer=sf.reducers.Model(model="openrouter/openai/gpt-5.5"))`
-const fusionRunOut = `Fusion(['claude-opus-4.8', 'gpt-hot'], reducer=Model(model='openrouter/openai/gpt-5.5'))`
+sf.Fusion([opus, gpt], synthesizer="openrouter/openai/gpt-5.5")`
+const fusionRunOut = `Fusion(['claude-opus-4.8', 'gpt-hot'], synthesizer=Model('openrouter/openai/gpt-5.5'))`
 
-const correctiveSig = `sf.CorrectiveEnsemble(
-    members: Sequence[Model],
+const pipelineSig = `sf.Pipeline(
+    stages: Sequence[str | Recipe],
     *,
-    judge: Model,
     name: str | None = None,
 )`
 
-const correctiveRun = `sf.CorrectiveEnsemble([opus, gpt], judge=opus)`
-const correctiveRunOut = `CorrectiveEnsemble(['claude-opus-4.8', 'gpt-hot'], judge='claude-opus-4.8')`
+const pipelineRun = `draft = sf.Model("openrouter/openai/gpt-5.5")
+review = sf.Model("openrouter/anthropic/claude-opus-4.8")
 
-const identity = `sf.Model("openrouter/openai/gpt-5.5") == sf.Model("openrouter/openai/gpt-5.5")`
-const identityOut = `False`
+sf.Pipeline([draft, review], name="review-chain")`
+const pipelineRunOut = `Pipeline(['gpt-5.5', 'claude-opus-4.8'], name='review-chain')`
+
+const thenRun = `draft.then(review)`
+const thenRunOut = `Pipeline(['gpt-5.5', 'claude-opus-4.8'])`
+
+const equality = `a = sf.Model("openrouter/openai/gpt-5.5")
+b = sf.Model("openrouter/openai/gpt-5.5")
+
+a == b`
+const equalityOut = `True`
 </script>
 
 <template>
   <DocLayout
     title="Recipes"
-    description="Recipe, Model, Fusion and CorrectiveEnsemble: the things you evaluate."
+    description="Recipe, Model, Fusion and Pipeline: the things you evaluate."
     :navigation="navigation"
     :version="version"
   >
     <p>
       A recipe describes how to produce one answer, and is what a benchmark grades. This page covers
       <code>Model</code> for a single model route, <code>Fusion</code> for several members combined
-      by a reducer, <code>CorrectiveEnsemble</code> for members that check their own drafts
-      against the benchmark's verifier, and <code>Recipe</code>, the abstract type the other three
-      satisfy.
+      by a synthesizer, <code>Pipeline</code> for members chained in series, and
+      <code>Recipe</code>, the abstract type the other three satisfy.
     </p>
 
     <p>
       All three constructible recipes are frozen and hold no client, so building one issues no
-      network request and can be done before connecting to anything.
+      network request and can be done before connecting to anything. Recipes nest: a
+      <code>Fusion</code> or <code>Pipeline</code> can contain a <code>Model</code>, a
+      <code>Fusion</code> or a <code>Pipeline</code>, in any combination.
     </p>
 
     <Note>
-      Recipes compare by identity, not by value. Two separately constructed recipes with identical
-      arguments are not equal, so they cannot be used interchangeably as dictionary keys or in sets.
+      Recipes compare by value. Two recipes built with identical arguments are equal, and
+      <RouterLink to="/learn/engine">the engine</RouterLink> treats them as one candidate. Give a
+      <code>Model</code> an explicit <code>name</code> when you mean an independent sample — then
+      they differ. Recipes are also unhashable, so they cannot be dictionary keys or set members.
     </Note>
 
     <div class="not-prose">
-      <NbCell :count="1" :code="identity"><NbTextOut :text="identityOut" /></NbCell>
+      <NbCell :count="1" :code="equality"><NbTextOut :text="equalityOut" /></NbCell>
     </div>
 
     <h2>Recipe</h2>
@@ -84,10 +95,14 @@ const identityOut = `False`
     <p>
       <code>Recipe</code> is the abstract base the other three inherit and cannot itself be
       instantiated. It exists so that a parameter accepting any recipe can be annotated, and so that
-      a <code>Fusion</code> can hold a mixed sequence of members.
+      a <code>Fusion</code> or <code>Pipeline</code> can hold a mixed sequence of members.
     </p>
 
-    <p>Its only public attribute is <code>name</code>, a <code>str</code> every recipe carries.</p>
+    <p>
+      Its only public attribute is <code>name</code>, a <code>str</code> every recipe carries. It
+      also provides <code>.then()</code>, the builder that appends a stage and returns a
+      <code>Pipeline</code> (see <a href="#pipeline">Pipeline</a> below).
+    </p>
 
     <p>Calling <code>sf.Recipe()</code> raises:</p>
 
@@ -131,7 +146,7 @@ const identityOut = `False`
           <td>
             Label used in reports and on the leaderboard. Defaults to the segment of the route after
             the last <code>/</code>, so <code>openrouter/openai/gpt-5.5</code> becomes
-            <code>gpt-5.5</code>.
+            <code>gpt-5.5</code>. An explicit name also marks the Model as an independent sample.
           </td>
         </tr>
         <tr>
@@ -147,9 +162,11 @@ const identityOut = `False`
           <td><code>Mapping&nbsp;|&nbsp;None</code></td>
           <td>
             Generation overrides such as <code>temperature</code>. Values must be <code>str</code>,
-            <code>int</code>, <code>float</code> or <code>bool</code>, and floats must be finite. At
-            execution time these are merged over the SDK defaults <code>reasoning="low"</code> and
-            <code>max_output_tokens=4096</code>.
+            <code>int</code>, <code>float</code> or <code>bool</code>, and floats must be finite.
+            Only the parameters you set are sent — the SDK adds no default generation parameters.
+            Transport, tool and benchmark-protocol names (for example <code>model</code>,
+            <code>messages</code>, <code>tools</code>, <code>web_search</code>) are reserved and
+            rejected.
           </td>
         </tr>
       </tbody>
@@ -189,6 +206,10 @@ const identityOut = `False`
           <td>A <code>params</code> value is not a scalar, or a float is not finite</td>
           <td><code>TypeError</code> / <code>ValueError</code></td>
         </tr>
+        <tr>
+          <td>A <code>params</code> name is reserved, or a name or value cannot be encoded</td>
+          <td><code>ValueError</code></td>
+        </tr>
       </tbody>
     </table>
 
@@ -199,10 +220,11 @@ const identityOut = `False`
     <h2>Fusion</h2>
 
     <p>
-      A <code>Fusion</code> combines two or more members: each answers, then a reducer combines
-      their answers into the final one. That final answer is what the benchmark grades.
-      See the <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink> for the
-      reasoning behind the design.
+      A <code>Fusion</code> combines members: each member answers in parallel, then a
+      <strong>synthesizer</strong> reads their answers and produces the single final one. That final
+      answer is what the benchmark grades. See the
+      <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink> for the reasoning behind
+      the design.
     </p>
 
     <CodeBlock :code="fusionSig" language="python" />
@@ -220,10 +242,11 @@ const identityOut = `False`
       <tbody>
         <tr>
           <td><code>members</code></td>
-          <td><code>Sequence[Recipe]</code></td>
+          <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
           <td>
-            At least two <code>Model</code> or <code>Fusion</code> values, in order. A
-            <code>Fusion</code> may hold another <code>Fusion</code>, so ensembles nest.
+            One or more members, in order — a route string, <code>Model</code>,
+            <code>Fusion</code> or <code>Pipeline</code>. Because a member may itself be a
+            <code>Fusion</code> or <code>Pipeline</code>, ensembles nest.
           </td>
         </tr>
         <tr>
@@ -235,13 +258,12 @@ const identityOut = `False`
           </td>
         </tr>
         <tr>
-          <td><code>reducer</code></td>
-          <td><code>Reducer&nbsp;|&nbsp;None</code></td>
+          <td><code>synthesizer</code></td>
+          <td><code>str&nbsp;|&nbsp;Recipe</code></td>
           <td>
-            How the members are combined, an <code>sf.reducers</code> value.
-            <code>Model(model,&nbsp;prompt=…,&nbsp;params=…)</code> has a model write the final
-            answer; <code>MajorityVote()</code> picks by agreement, with no extra model call.
-            Defaults to a model reducer.
+            <strong>Required, keyword-only.</strong> A route string or any recipe — a
+            <code>Model</code>, <code>Fusion</code> or <code>Pipeline</code> — that reads the
+            members' answers and writes the final one. There is no default.
           </td>
         </tr>
       </tbody>
@@ -250,8 +272,10 @@ const identityOut = `False`
     <h3>Attributes</h3>
 
     <p>
-      <code>members</code> is a <code>tuple</code> in the order you gave it. <code>name</code> and
-      <code>reducer</code> read back the resolved shape.
+      <code>members</code> is a <code>tuple</code> in the order you gave it. <code>name</code> reads
+      back the resolved label, and <code>synthesizer</code> reads back the recipe you passed (a
+      route string is normalized to a <code>Model</code>). There is no <code>reducer</code>
+      attribute.
     </p>
 
     <h3>Raises</h3>
@@ -265,19 +289,27 @@ const identityOut = `False`
       </thead>
       <tbody>
         <tr>
-          <td>Fewer than two members</td>
-          <td><code>ValueError: a Fusion requires at least two members</code></td>
+          <td>No <code>synthesizer</code> is given</td>
+          <td><code>TypeError: missing a required keyword-only argument: 'synthesizer'</code></td>
         </tr>
         <tr>
-          <td>Two members share a name</td>
-          <td><code>ValueError: duplicate Fusion member name '…'</code></td>
+          <td>The members are empty</td>
+          <td><code>ValueError: a Fusion requires at least one member</code></td>
         </tr>
         <tr>
+          <td><code>members</code> is not an ordered sequence (for example a bare route string)</td>
           <td>
-            A member is not a <code>Model</code> or <code>Fusion</code>, including a
-            <code>CorrectiveEnsemble</code>
+            <code
+              >TypeError: Fusion members must be an ordered sequence of model routes or
+              Recipes</code
+            >
           </td>
-          <td><code>TypeError: Fusion members must be sf.Model or sf.Fusion values</code></td>
+        </tr>
+        <tr>
+          <td>A member or the synthesizer is not a route string or a supported recipe</td>
+          <td>
+            <code>TypeError: … must be a model route or sf.Model, sf.Fusion, or sf.Pipeline</code>
+          </td>
         </tr>
       </tbody>
     </table>
@@ -286,23 +318,17 @@ const identityOut = `False`
       <NbCell :count="3" :code="fusionRun"><NbTextOut :text="fusionRunOut" /></NbCell>
     </div>
 
-    <h2>CorrectiveEnsemble</h2>
+    <h2 id="pipeline">Pipeline</h2>
 
     <p>
-      A <code>CorrectiveEnsemble</code> runs its members in parallel and has the benchmark's own
-      verifier check every draft. Each member then gets a bounded number of retries against the
-      violations it caused, and a judge model picks between the drafts that passed. Nothing is
-      blended: the winning draft is returned verbatim.
+      A <code>Pipeline</code> runs its stages in series: the first stage answers the case, and each
+      later stage receives the previous stage's answer as its input. The last stage's answer is what
+      the benchmark grades. See the
+      <RouterLink to="/sf-client/guides/pipelines">Pipelines guide</RouterLink> for serial and
+      recursive composition.
     </p>
 
-    <Note>
-      This recipe needs a benchmark that advertises <code>check</code>, <code>select</code> and
-      <code>finalize</code> verifier actions, such as <code>ifeval</code>. Evaluating it against any
-      other benchmark raises a <code>PlanningError</code> with code
-      <code>benchmark_without_verifier</code>. The retry cap is three attempts per member.
-    </Note>
-
-    <CodeBlock :code="correctiveSig" language="python" />
+    <CodeBlock :code="pipelineSig" language="python" />
 
     <h3>Parameters</h3>
 
@@ -316,26 +342,20 @@ const identityOut = `False`
       </thead>
       <tbody>
         <tr>
-          <td><code>members</code></td>
-          <td><code>Sequence[Model]</code></td>
+          <td><code>stages</code></td>
+          <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
           <td>
-            Two to four Models. <code>Fusion</code> is rejected, because the verifier grades each
-            member's raw draft and a reducer would hide those drafts.
-          </td>
-        </tr>
-        <tr>
-          <td><code>judge</code></td>
-          <td><code>Model</code></td>
-          <td>
-            Required keyword argument. The model that picks between drafts that passed the verifier.
+            One or more stages, in order — a route string or any recipe. An
+            <em>unnamed</em> nested <code>Pipeline</code> is flattened into the surrounding stage
+            sequence; a <em>named</em> one is kept as a single stage.
           </td>
         </tr>
         <tr>
           <td><code>name</code></td>
           <td><code>str&nbsp;|&nbsp;None</code></td>
           <td>
-            Defaults to the member names joined with <code>+</code> followed by
-            <code>(corrective)</code>.
+            Defaults to the stage names joined with <code>-&gt;</code>, for example
+            <code>gpt-5.5-&gt;claude-opus-4.8</code>.
           </td>
         </tr>
       </tbody>
@@ -344,8 +364,9 @@ const identityOut = `False`
     <h3>Attributes</h3>
 
     <p>
-      <code>members</code> is a <code>tuple[Model, ...]</code>, <code>judge</code> is the Model you
-      passed, and <code>name</code> is the resolved label.
+      <code>stages</code> is a <code>tuple</code> in canonical order, and <code>name</code> reads
+      back the resolved label. <code>recipe.then(next)</code> — available on every recipe — is the
+      builder equivalent: it appends a stage and returns a new <code>Pipeline</code>.
     </p>
 
     <h3>Raises</h3>
@@ -359,22 +380,28 @@ const identityOut = `False`
       </thead>
       <tbody>
         <tr>
-          <td>Fewer than two or more than four members</td>
-          <td><code>ValueError: CorrectiveEnsemble needs 2-4 members, got N</code></td>
+          <td>The stages are empty</td>
+          <td><code>ValueError: a Pipeline requires at least one stage</code></td>
         </tr>
         <tr>
-          <td>A member is not a <code>Model</code></td>
-          <td><code>TypeError: CorrectiveEnsemble members must be sf.Model values</code></td>
+          <td><code>stages</code> is not an ordered sequence (for example a bare route string)</td>
+          <td>
+            <code
+              >TypeError: Pipeline stages must be an ordered sequence of model routes or
+              Recipes</code
+            >
+          </td>
         </tr>
         <tr>
-          <td>The judge is not a <code>Model</code></td>
-          <td><code>TypeError: CorrectiveEnsemble judge must be an sf.Model</code></td>
+          <td><code>.then()</code> is given something other than a route string or recipe</td>
+          <td><code>TypeError: Pipeline stage must be …</code></td>
         </tr>
       </tbody>
     </table>
 
     <div class="not-prose">
-      <NbCell :count="4" :code="correctiveRun"><NbTextOut :text="correctiveRunOut" /></NbCell>
+      <NbCell :count="4" :code="pipelineRun"><NbTextOut :text="pipelineRunOut" /></NbCell>
+      <NbCell :count="5" :code="thenRun"><NbTextOut :text="thenRunOut" /></NbCell>
     </div>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/api/ReportsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ReportsPage.vue
@@ -17,7 +17,6 @@ report = client.evaluate(
     sf.Model("openrouter/anthropic/claude-haiku-4.5"),
     benchmark="ifeval",
     limit=1,
-    method="single_pass",
 )
 report`
 const runItOut = `Report(benchmark='ifeval', candidates=['claude-haiku-4.5'], ok=True)`
@@ -29,14 +28,18 @@ const usage = `report.usage`
 const usageOut = `Usage(input_tokens=103, output_tokens=398, cache_read_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, cost_usd=Decimal('0'))`
 
 const only = `candidate = report.candidates.only
-candidate.name, candidate.kind, candidate.score`
-const onlyOut = `('claude-haiku-4.5', 'model', 1.0)`
+candidate.name, candidate.kind, candidate.score, candidate.coverage`
+const onlyOut = `('claude-haiku-4.5', 'model', 1.0, 1.0)`
 
 const byName = `report.candidates["claude-haiku-4.5"] is candidate`
 const byNameOut = `True`
 
 const metrics = `dict(candidate.metrics)`
-const metricsOut = `{'inst_level_strict_accuracy': 1.0, 'prompt_level_loose_accuracy': 1.0, 'inst_level_loose_accuracy': 1.0, 'cases_checked': 1.0, 'cases_fallback': 0.0}`
+const metricsOut = `{'inst_level_strict_accuracy': 1.0, 'prompt_level_loose_accuracy': 1.0, 'inst_level_loose_accuracy': 1.0, 'pass_rate': 1.0}`
+
+const cases = `case = candidate.cases[0]
+case.status, case.grade.score, case.output[:40]`
+const casesOut = `('scored', 1.0, 'Raymond III, Count of Tripoli (c. 1140 –')`
 
 const ops = `candidate.operations`
 const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haiku-4.5 answer', depends_on=()),)`
@@ -155,9 +158,9 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
     </div>
 
     <p>
-      The revision depends on the method you ran. Evaluating <code>ifeval</code> with
-      <code>method="single_pass"</code> pins a different revision than its default protocol does, so
-      two reports are only comparable when both the id and the revision match.
+      Each protocol variant is a benchmark id of its own, so <code>ifeval</code> and
+      <code>ifeval/self-corrective</code> pin different revisions. Two reports are only comparable
+      when both the id and the revision match.
     </p>
 
     <h3>candidates</h3>
@@ -185,6 +188,8 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
       <code>to_dict()</code> returns a plain JSON-compatible dictionary and
       <code>to_json()</code> returns it as a compact string. Both carry a <code>schema</code> field,
       <code>screamingface.report.v1</code>, so a consumer can tell what it is reading.
+      <code>export(path="report.json")</code> writes that same document to disk, creating parent
+      directories and replacing an existing file, and returns the path it wrote.
     </p>
 
     <div class="not-prose">
@@ -215,7 +220,7 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
         <tr>
           <td><code>kind</code></td>
           <td><code>str</code></td>
-          <td>One of <code>model</code>, <code>fusion</code> or <code>corrective</code>.</td>
+          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
         </tr>
         <tr>
           <td><code>score</code></td>
@@ -225,18 +230,44 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
           </td>
         </tr>
         <tr>
+          <td><code>coverage</code></td>
+          <td><code>float</code></td>
+          <td>
+            How much of the selected case set the score was computed from, between 0 and 1. Below
+            <code>1.0</code> the Engine excluded ungraded cases and the score is a partial result
+            over the rest.
+          </td>
+        </tr>
+        <tr>
           <td><code>metrics</code></td>
           <td><code>Mapping[str, float]</code></td>
           <td>
             The benchmark's individual measures. Empty when <code>score</code> is <code>None</code>:
-            an unscored candidate cannot carry metrics.
+            an unscored candidate cannot carry metrics. Never contains a <code>coverage</code> key,
+            which is the field above instead.
+          </td>
+        </tr>
+        <tr>
+          <td><code>benchmark</code></td>
+          <td><code>BenchmarkInfo</code></td>
+          <td>
+            The benchmark identity this candidate ran against, pinned to its revision. The report
+            carries the same value.
+          </td>
+        </tr>
+        <tr>
+          <td><code>cases</code></td>
+          <td>sequence of <code>CaseResult</code></td>
+          <td>
+            One entry per selected case, carrying its status, the prompt, the answer, and the grade.
           </td>
         </tr>
         <tr>
           <td><code>url4</code></td>
-          <td><code>str</code></td>
+          <td><code>Url4</code></td>
           <td>
-            The complete expression that executed. See the
+            The complete expression that executed, as a <code>str</code> subclass whose
+            <code>to_python()</code> returns editable client code. See the
             <RouterLink to="/sf-client/guides/reproduce-and-share">url4 guide</RouterLink>.
           </td>
         </tr>
@@ -254,14 +285,18 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
           <td><code>members</code></td>
           <td><code>tuple[MemberResult, ...]</code></td>
           <td>
-            Direct members, for a fusion. Always empty for a <code>model</code> candidate, and at
-            least two entries for a fusion.
+            Direct members, for a fusion. Always empty for a <code>model</code> or
+            <code>pipeline</code> candidate, and at least one entry for a fusion.
           </td>
         </tr>
         <tr>
           <td><code>failures</code></td>
           <td><code>tuple[Failure, ...]</code></td>
-          <td>This candidate's own failures. Always empty when it has a score.</td>
+          <td>
+            This candidate's own failures. A scored candidate can carry them: the run finished with
+            warnings worth reading. None of them names a case, since a candidate-level failure is
+            never case-specific.
+          </td>
         </tr>
         <tr>
           <td><code>usage</code></td>
@@ -285,12 +320,39 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
       <NbCell :count="7" :code="metrics"><NbTextOut :text="metricsOut" /></NbCell>
     </div>
 
+    <p>
+      <code>score</code> and <code>coverage</code> together describe four outcomes, and the notebook
+      card labels each one: a score at full coverage and no failures is complete; a score with
+      failures completed with warnings; a score at coverage below <code>1.0</code> is partial; and
+      no score at all means no aggregate was available.
+    </p>
+
+    <h3>cases</h3>
+
+    <p>
+      <code>candidate.cases</code> is a read-only sequence of <code>CaseResult</code> values, one
+      per selected case. Each carries a <code>status</code> of <code>scored</code>,
+      <code>refused</code> or <code>failed</code>, the case <code>input</code>, the candidate's
+      <code>output</code>, and a <code>CaseGrade</code> holding the individual checks behind the
+      score. A refused case is still graded, so a provider refusal is measured rather than dropped.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="8" :code="cases"><NbTextOut :text="casesOut" /></NbCell>
+    </div>
+
     <h2>MemberResult</h2>
 
     <p>
       A <code>MemberResult</code> is one direct member of a fusion, held as a compact view: enough
       to see what the member cost and whether it failed, without repeating the full candidate
       structure. Members carry no score, because only the fusion's final answer is graded.
+    </p>
+
+    <p>
+      Its runtime fields are <code>None</code> until the Engine attributes work to the member's
+      operation id. That is a different statement from an empty value: <code>None</code> means the
+      attribution was unavailable, while an empty tuple means it arrived and reported nothing.
     </p>
 
     <table>
@@ -305,12 +367,16 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
         <tr>
           <td><code>name</code></td>
           <td><code>str</code></td>
-          <td>The member recipe's name, unique among its siblings.</td>
+          <td>
+            The member recipe's display name. Two siblings can share one, for instance the same
+            model reached through two providers, so identity is <code>operation_id</code> rather
+            than this.
+          </td>
         </tr>
         <tr>
           <td><code>kind</code></td>
           <td><code>str</code></td>
-          <td>One of <code>model</code>, <code>fusion</code> or <code>corrective</code>.</td>
+          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
         </tr>
         <tr>
           <td><code>models</code></td>
@@ -324,8 +390,11 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
         </tr>
         <tr>
           <td><code>failures</code></td>
-          <td><code>tuple[Failure, ...]</code></td>
-          <td>This member's failures, which also appear in <code>report.failures</code>.</td>
+          <td><code>tuple[Failure, ...]&nbsp;|&nbsp;None</code></td>
+          <td>
+            This member's failures, which also appear in <code>report.failures</code>.
+            <code>None</code> when the Engine attributed nothing to this member.
+          </td>
         </tr>
         <tr>
           <td><code>duration_ms</code></td>
@@ -334,8 +403,8 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
         </tr>
         <tr>
           <td><code>usage</code></td>
-          <td><code>Usage</code></td>
-          <td>This member's accounting.</td>
+          <td><code>Usage&nbsp;|&nbsp;None</code></td>
+          <td>This member's accounting, or <code>None</code> when it was not attributed.</td>
         </tr>
       </tbody>
     </table>
@@ -383,7 +452,7 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
     </table>
 
     <div class="not-prose">
-      <NbCell :count="8" :code="ops"><NbTextOut :text="opsOut" /></NbCell>
+      <NbCell :count="9" :code="ops"><NbTextOut :text="opsOut" /></NbCell>
     </div>
 
     <p>
@@ -445,7 +514,7 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
     </table>
 
     <div class="not-prose">
-      <NbCell :count="9" :code="usage"><NbTextOut :text="usageOut" /></NbCell>
+      <NbCell :count="10" :code="usage"><NbTextOut :text="usageOut" /></NbCell>
     </div>
 
     <p>
@@ -499,18 +568,31 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
         </tr>
         <tr>
           <td><code>retryable</code></td>
-          <td><code>bool</code></td>
-          <td>Whether running the same thing again could plausibly succeed.</td>
+          <td><code>bool&nbsp;|&nbsp;None</code></td>
+          <td>
+            Whether running the same thing again could plausibly succeed, or <code>None</code> when
+            the Engine did not say.
+          </td>
         </tr>
         <tr>
           <td><code>operation_id</code></td>
-          <td><code>str</code></td>
-          <td>Which step failed, matching an <code>OperationInfo.id</code>.</td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Which step failed, matching an <code>OperationInfo.id</code>. <code>None</code> for a
+            failure no single step owns.
+          </td>
         </tr>
         <tr>
           <td><code>case_id</code></td>
           <td><code>str&nbsp;|&nbsp;None</code></td>
           <td>Which case failed, when the failure was specific to one.</td>
+        </tr>
+        <tr>
+          <td><code>metadata</code></td>
+          <td><code>Mapping[str, object]</code></td>
+          <td>
+            Whatever else the Engine attached to this failure. Empty when it attached nothing.
+          </td>
         </tr>
       </tbody>
     </table>

--- a/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
@@ -11,35 +11,33 @@ import {
 const listing = `import screamingface as sf
 
 for b in sf.benchmarks.list():
-    print(b.id, "|", b.title, "|", b.case_count, "cases |", b.revision)`
-const listingOut = `draco | DRACO | 100 cases | defbb6efdae69211
-ifeval | IFEval | 541 cases | 22ca96fe77b0f7de`
+    print(b.id, "|", b.variant, "|", b.case_count, "cases |", b.revision)`
+const listingOut = `draco | canonical | 100 cases | defbb6efdae69211
+draco/lite | lite | 2 cases | 6a1c04b9c7f21d83
+draco/smoke | smoke | 1 cases | b2f7d5e10a9c4468
+ifeval | canonical | 541 cases | 22ca96fe77b0f7de
+ifeval/self-corrective | self-corrective | 541 cases | 047f1de449639c61
+ifeval/lanl-ensemble | lanl-ensemble | 541 cases | 9c3ba82f5d0e7716
+healthbench/worst30 | worst30 | 30 cases | 41e8c96d2b7a5f30`
 
 const card = `ifeval = sf.benchmarks.get("ifeval")
 ifeval`
-const cardOut = `Benchmark(id='ifeval', title='IFEval', description="The 541-prompt
-instruction-following benchmark (https://arxiv.org/abs/2311.07911) with
-deterministic verification. Default method 'corrective' reproduces the protocol
-of 'Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles'
-(Skurikhin et al., Los Alamos National Laboratory), a bounded 3-attempt retry
-chain fed by the checker's violations (3x candidate calls; scores are NOT
-comparable to published single-pass IFEval numbers). Select method 'single_pass'
-for the paper-comparable protocol.", revision='22ca96fe77b0f7de',
-case_count=541)`
+const cardOut = `Benchmark(id='ifeval', variant='canonical', title='IFEval',
+description='The canonical 541-prompt instruction-following benchmark
+(https://arxiv.org/abs/2311.07911), graded by deterministic strict and loose
+verification. Each Case invokes the Candidate exactly once. Case ids are the
+official IFEval keys; one pinned-dataset row (key 2785) is patched to the
+official harness prompt, whose text matches its graded constraints.',
+revision='22ca96fe77b0f7de', case_count=541)`
 
-const methods = `sf.benchmarks.get("ifeval").revision, sf.benchmarks.get("ifeval", method="single_pass").revision`
-const methodsOut = `('22ca96fe77b0f7de', '047f1de449639c61')`
-
-const cases = `for c in ifeval.cases(limit=2):
-    print(c.id, "|", c.input[:120])`
-const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://en.wikipedia.org/wiki/Raymond_III,_Count_of_Tripoli". Do not us …
-2 | I am planning a trip to Japan, and I would like thee to write an itinerary for my journey in a Shakespearean style. You  …`
+const variants = `sf.benchmarks.get("ifeval").revision, sf.benchmarks.get("ifeval/self-corrective").revision`
+const variantsOut = `('22ca96fe77b0f7de', '047f1de449639c61')`
 </script>
 
 <template>
   <DocLayout
     title="Benchmarks"
-    description="Discover available benchmarks and read their cases before spending."
+    description="Discover the benchmarks an engine publishes and pick the protocol you want to run."
     :navigation="navigation"
     :version="version"
   >
@@ -62,8 +60,8 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
     <ul>
       <li>List the benchmarks this engine publishes.</li>
       <li>Read one's identity card: size, revision, and what it actually measures.</li>
-      <li>Page its real prompts before spending anything.</li>
-      <li>Select a protocol variant with <code>method</code>.</li>
+      <li>Pick a protocol variant, which is a benchmark id of its own.</li>
+      <li>Check that two results are comparable by comparing revisions.</li>
     </ul>
 
     <h2>Main APIs</h2>
@@ -81,27 +79,23 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
           <td>Lists every benchmark this engine publishes, a free discovery request that calls no model.</td>
         </tr>
         <tr>
-          <td><code>sf.benchmarks.get(id, *, method=None)</code></td>
-          <td>Fetches one benchmark's identity card for a chosen protocol variant, where each method is a different pinned protocol with its own revision.</td>
+          <td><code>sf.benchmarks.get(benchmark_id)</code></td>
+          <td>Fetches one benchmark's identity card. A protocol variant has its own id, such as <code>ifeval/self-corrective</code>, and its own revision.</td>
         </tr>
         <tr>
-          <td><code>sf.Benchmark</code> <code>.id</code> <code>.title</code> <code>.description</code> <code>.revision</code> <code>.case_count</code> <code>.cases(limit, offset)</code></td>
-          <td>The identity card itself: its name, what it measures, the opaque revision hash of the pinned protocol, its size, and a paged reader over the real prompts.</td>
+          <td><code>sf.Benchmark</code> <code>.id</code> <code>.variant</code> <code>.title</code> <code>.description</code> <code>.revision</code> <code>.case_count</code></td>
+          <td>The identity card itself: its id, which protocol that id runs, what it measures, the opaque revision hash of the pinned protocol, and its size.</td>
         </tr>
         <tr>
           <td><code>sf.BenchmarkInfo</code></td>
           <td>The pinned subset a report carries, so an old result still names the exact revision it ran against.</td>
         </tr>
-        <tr>
-          <td><code>sf.CaseInfo</code></td>
-          <td>One case as it crosses the boundary to the models, carrying only its <code>id</code> and <code>input</code> and never the grading criteria.</td>
-        </tr>
       </tbody>
     </table>
 
     <p>
-      <strong>All of this is free.</strong> Discovery and case browsing are plain engine requests;
-      no model is called and nothing is charged. Only
+      <strong>Discovery is free.</strong> Listing benchmarks and reading identity cards are plain
+      engine requests; no model is called and nothing is charged. Only
       <RouterLink to="/sf-client/guides/running-an-evaluation">evaluation</RouterLink> spends.
     </p>
 
@@ -114,12 +108,14 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
     </div>
 
     <p>
-      Two benchmarks, and they differ in what grading costs. <strong>DRACO</strong> is 100
-      deep-research tasks graded by a judge model
+      Three benchmarks, listed once per protocol, and they differ in what grading costs.
+      <strong>DRACO</strong> is 100 deep-research tasks graded by a judge model
       (<code>openrouter/google/gemini-3.1-pro-preview</code>) with five independent passes per
-      criterion: the grading itself is the expensive part. <strong>IFEval</strong> is 541
+      criterion: the grading itself is the expensive part, which is why the <code>lite</code> and
+      <code>smoke</code> entries exist for cheap directional runs. <strong>IFEval</strong> is 541
       instruction-following prompts checked by a deterministic verifier, so its grading is
-      <strong>free</strong>: only the answers cost anything.
+      <strong>free</strong> and only the answers cost anything. <strong>HealthBench</strong> exposes
+      the worst-30% subset, rubric-graded by a judge.
     </p>
 
     <h3>2 · Read the identity card</h3>
@@ -134,42 +130,35 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
       name later points at a newer snapshot, your report still names the revision it actually ran.
     </p>
 
-    <h3>3 · Select a method</h3>
+    <h3>3 · Pick a protocol variant</h3>
 
     <p>
-      Some benchmarks publish more than one protocol. IFEval's default is <code>corrective</code>: a
-      bounded three-attempt retry chain fed by the verifier's complaints.
-      <code>single_pass</code> is one answer, one check, and it is the only variant comparable to
-      published IFEval numbers.
+      Some benchmarks publish more than one protocol, and each one is a separate id rather than a
+      flag on a shared exam. <code>ifeval</code> is the canonical protocol: one answer, one
+      deterministic check, and the only IFEval entry comparable to published numbers.
+      <code>ifeval/self-corrective</code> lets the candidate read the verifier's complaints and
+      retry, bounded at three attempts, and <code>ifeval/lanl-ensemble</code> reproduces the
+      Skurikhin et al. early-exit ensemble protocol.
     </p>
 
     <div class="not-prose">
-      <NbCell :count="3" :code="methods"><NbTextOut :text="methodsOut" /></NbCell>
+      <NbCell :count="3" :code="variants"><NbTextOut :text="variantsOut" /></NbCell>
     </div>
 
     <p>
-      Notice the revisions differ. A method is not a flag on one exam. It is a
-      <strong>different pinned protocol</strong>, with a different cost and a score that means
-      something different. Comparing a corrective score against a single-pass one is a mistake the
-      revisions let you catch.
+      Notice the revisions differ. A variant is a <strong>different pinned protocol</strong>, with a
+      different cost and a score that means something different. Comparing a self-corrective score
+      against a canonical one is a mistake the revisions let you catch.
     </p>
 
-    <h3>4 · Read the cases before you spend</h3>
+    <h3>4 · Know what discovery will not tell you</h3>
 
     <p>
-      <code>cases()</code> pages the real prompts, 50 at a time by default. For IFEval this is worth
-      doing: each prompt carries its own constraints in its text, "300+ words", "no commas",
-      "highlight three sections", which is exactly what makes it machine-checkable.
-    </p>
-
-    <div class="not-prose">
-      <NbCell :count="4" :code="cases"><NbTextOut :text="casesOut" /></NbCell>
-    </div>
-
-    <p>
-      A <code>CaseInfo</code> carries only its <code>id</code> and <code>input</code>. Prompts cross
-      the boundary to the models; grading criteria, rubrics and answer keys do not, and that
-      separation is what makes a verified result meaningful rather than self-reported.
+      A <code>Benchmark</code> carries no case data, so the prompts cannot be paged before a run.
+      Cases and their answer keys stay on the engine, and that separation is what makes a verified
+      result meaningful rather than self-reported. The case text a candidate received, its answer,
+      and the grade behind it all arrive with the report afterwards, on
+      <RouterLink to="/sf-client/api/reports">CandidateResult.cases</RouterLink>.
     </p>
 
     <h2>Links</h2>
@@ -177,7 +166,7 @@ const casesOut = `1 | Write a 300+ word summary of the wikipedia page "https://e
     <ul>
       <li>
         <a
-          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/07_ifeval_e2e.ipynb"
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/07_ifeval_e2e.ipynb"
           target="_blank"
           rel="noopener"
           >Companion notebook: <code>07_ifeval_e2e.ipynb</code></a

--- a/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
@@ -275,7 +275,7 @@ const panelProviders: Provider[] = [
     <ul>
       <li>
         <a
-          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/00_quickstart.ipynb"
           target="_blank"
           rel="noopener"
           >Companion notebook: <code>00_quickstart.ipynb</code></a

--- a/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
+++ b/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
@@ -24,25 +24,25 @@ const metrics = `dict(c.metrics)`
 const metricsOut = `{'inst_level_strict_accuracy': 1.0,
  'prompt_level_loose_accuracy': 1.0,
  'inst_level_loose_accuracy': 1.0,
- 'pass_at_1': 1.0,
- 'pass_at_2': 1.0,
- 'pass_at_3': 1.0,
- 'corrected_cases': 0.0,
- 'cases_checked': 3.0,
- 'cases_fallback': 0.0}`
+ 'pass_rate': 1.0}`
 
 const many = `opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
 gpt = sf.Model("openrouter/openai/gpt-5.5")
 
-sf.evaluate([opus, gpt, sf.Fusion([opus, gpt])], benchmark="draco", limit=1)`
+sf.evaluate(
+    [opus, gpt, sf.Fusion([opus, gpt], synthesizer="openrouter/openai/gpt-5.5")],
+    benchmark="draco",
+    limit=1,
+)`
 
-const compare = `corr = sf.evaluate(haiku, benchmark="ifeval", limit=3)
-base = sf.evaluate(haiku, benchmark="ifeval", limit=3, method="single_pass")
+const compare = `base = sf.evaluate(haiku, benchmark="ifeval", limit=3)
+corr = sf.evaluate(haiku, benchmark="ifeval/self-corrective", limit=3)
 
-{"corrective":  {"score": corr.candidates.only.score, "tokens": corr.usage.output_tokens},
- "single_pass": {"score": base.candidates.only.score, "tokens": base.usage.output_tokens}}`
-const compareOut = `{'corrective': {'score': 1.0, 'tokens': 3686},
- 'single_pass': {'score': 1.0, 'tokens': 1167}}`
+{"canonical":       {"score": base.candidates.only.score, "tokens": base.usage.output_tokens},
+ "self-corrective": {"score": corr.candidates.only.score, "tokens": corr.usage.output_tokens,
+                     "corrected": corr.candidates.only.metrics["corrected_cases"]}}`
+const compareOut = `{'canonical': {'score': 1.0, 'tokens': 1167},
+ 'self-corrective': {'score': 1.0, 'tokens': 3686, 'corrected': 0.0}}`
 
 const usage = `report.usage`
 const usageOut = `Usage(input_tokens=3691, output_tokens=3686, cache_read_tokens=0,
@@ -70,15 +70,15 @@ client.close()`
     :version="version"
   >
     <p>
-      <code>sf.evaluate()</code> is the one call that spends money. You hand it candidates and a
-      benchmark id; it compiles each candidate against that benchmark's pinned protocol, runs them
+      <code>sf.evaluate()</code> is the one call that costs money. You give it candidates and a
+      benchmark id. It compiles each candidate against that benchmark's protocol, runs them
       concurrently on <RouterLink to="/learn/engine">the engine</RouterLink>, and returns a single
       <code>Report</code>.
     </p>
 
     <p>
-      Everything expensive is on the far side of this call. Validation happens first and entirely.
-      An unknown benchmark, an unreachable route, a malformed candidate all fail
+      Everything expensive happens inside this call, but validation happens first and in full. An
+      unknown benchmark, an unreachable route, or a malformed candidate all fail
       <strong>before the first paid request</strong>.
     </p>
 
@@ -148,14 +148,14 @@ client.close()`
       </figcaption>
     </figure>
 
-    <h2>What you can do with it</h2>
+    <h2>What you can do</h2>
 
     <ul>
-      <li>Evaluate one candidate, or several in one run.</li>
-      <li>Cap how many cases run with <code>limit</code>.</li>
-      <li>Choose a protocol variant with <code>method</code>.</li>
-      <li>Watch the run as it happens, or silence the progress display.</li>
-      <li>Run against an explicit client, synchronously or with <code>await</code>.</li>
+      <li>Evaluate one candidate, or run several at once.</li>
+      <li>Cap the number of cases with <code>limit</code>.</li>
+      <li>Pick a protocol variant by naming its own benchmark id.</li>
+      <li>Watch the run live, or turn off the progress display.</li>
+      <li>Use an explicit client, sync or with <code>await</code>.</li>
     </ul>
 
     <h2>Main APIs</h2>
@@ -169,16 +169,16 @@ client.close()`
       </thead>
       <tbody>
         <tr>
-          <td><code>sf.evaluate(candidates, *, benchmark, limit=None, method=None, on_event=None, progress=None)</code></td>
-          <td>Runs one or many candidates against a benchmark's pinned protocol concurrently and returns a single <code>sf.Report</code>, validating fully before the first paid request.</td>
+          <td><code>sf.evaluate(candidates, *, benchmark, limit=None, on_event=None, progress=None)</code></td>
+          <td>Runs one or more candidates against a benchmark's protocol concurrently, returning a single <code>sf.Report</code>. Validates everything before the first paid request.</td>
         </tr>
         <tr>
           <td><code>sf.Client.evaluate(...)</code> · <code>await sf.AsyncClient.evaluate(...)</code></td>
-          <td>The same call on an explicit client you hold yourself, synchronously or with <code>await</code>, which is the only way to address two engines from one process.</td>
+          <td>Same call on an explicit client you manage yourself, sync or with <code>await</code>. Only way to talk to two engines from one process.</td>
         </tr>
         <tr>
           <td><code>sf.configure(engine_url=…)</code></td>
-          <td>Repoints the shared client once so every later <code>sf.evaluate()</code> call uses that engine.</td>
+          <td>Repoints the shared client so every later <code>sf.evaluate()</code> call uses that engine.</td>
         </tr>
         <tr>
           <td><code>sf.close()</code></td>
@@ -192,8 +192,8 @@ client.close()`
     <h3>1 · Evaluate one candidate</h3>
 
     <p>
-      The benchmark id is <strong>required</strong>: there is no default and no implicit choice.
-      <code>limit</code> caps the case count, and it is your main cost control.
+      The benchmark id is <strong>required</strong>, with no default and no implicit choice.
+      <code>limit</code> caps the case count and is your main cost control.
     </p>
 
     <div class="not-prose">
@@ -201,15 +201,15 @@ client.close()`
     </div>
 
     <p>
-      The repr is a summary: which benchmark, which candidates, and whether anything failed.
-      <code>ok</code> is <code>True</code> only when no candidate and no member recorded a failure.
+      The repr is a summary: which benchmark, which candidates, whether anything failed.
+      <code>ok</code> is <code>True</code> only when no candidate and no member had a failure.
     </p>
 
     <h3>2 · Read the score</h3>
 
     <p>
-      Scores live on candidates, not on the report: a report may hold several. With one candidate,
-      <code>.only</code> is the direct way to it.
+      Scores live on candidates rather than on the report, since a report can hold several. With one
+      candidate, <code>.only</code> gets you right to it.
     </p>
 
     <div class="not-prose">
@@ -217,13 +217,13 @@ client.close()`
     </div>
 
     <p>
-      Note the two case counts. <code>report.case_count</code> is how many cases <em>ran</em>;
+      Notice the two case counts: <code>report.case_count</code> is how many cases <em>ran</em>;
       <code>report.benchmark.case_count</code> is how many the benchmark has. Running 3 of 541 is a
-      smoke test, and the report says so rather than letting you forget.
+      smoke test, and the report keeps both numbers visible so that stays obvious later.
     </p>
 
     <p>
-      <code>score</code> is always higher-is-better and may be <code>None</code> if a candidate
+      <code>score</code> is always higher-is-better, and can be <code>None</code> if a candidate
       failed. Benchmark-specific diagnostics live under <code>metrics</code>:
     </p>
 
@@ -231,13 +231,20 @@ client.close()`
       <NbCell :count="3" :code="metrics"><NbTextOut :text="metricsOut" /></NbCell>
     </div>
 
+    <p>
+      Read <code>coverage</code> beside the score. It is the fraction of the selected cases the
+      score was computed from, and anything below <code>1.0</code> means the engine graded only part
+      of the run and the score describes that part. A candidate can also finish with both a score
+      and entries in <code>failures</code>, which is a completed run carrying warnings worth
+      reading rather than a broken one.
+    </p>
+
     <h3>3 · Evaluate several at once</h3>
 
     <p>
-      Pass a list. Every candidate runs against the same pinned exam in the same call, which is what
-      makes the comparison fair, and it is the only way to compare, because a report has no
-      "baseline" or "gain" field. You put the solo model and the fusion in one run and read both
-      scores.
+      Pass a list. Every candidate runs against the same pinned exam in the same call. That's what
+      makes the comparison fair. It's the only way to compare, because a report has no "baseline" or
+      "gain" field. You put the solo model and the fusion in one run and read both scores.
     </p>
 
     <div class="not-prose">
@@ -252,8 +259,9 @@ client.close()`
     <h3>4 · Compare two protocols</h3>
 
     <p>
-      Because a <code>method</code> is a different pinned protocol, comparing them is two runs. This
-      is IFEval's retry chain against its single-pass baseline, on the same three cases:
+      Because each protocol variant is a separate benchmark id, comparing them is two runs. This is
+      IFEval's canonical single-pass protocol against its self-corrective retry chain on the same
+      three cases:
     </p>
 
     <div class="not-prose">
@@ -262,9 +270,10 @@ client.close()`
 
     <p>
       An honest result: identical scores, <strong>3.2× the output tokens</strong>. On this slice the
-      retry loop bought nothing: <code>corrected_cases</code> above is <code>0.0</code>, meaning no
-      case failed first and passed later. That is what a three-case sample of a capable model looks
-      like, and it is the reason to run more cases before concluding anything.
+      retry loop bought nothing. <code>corrected_cases</code>, a metric only the corrective variants
+      report, is <code>0.0</code>, meaning no case failed first and passed later. That is what a
+      three-case sample of a capable model looks like, and it is the reason to run more cases before
+      concluding anything.
     </p>
 
     <h3>5 · Read what it cost</h3>
@@ -295,9 +304,10 @@ client.close()`
     <h3>7 · Point at the engine</h3>
 
     <p>
-      <code>sf.evaluate()</code> never asks where the engine is, so it falls back to your own
-      machine: <code>http://127.0.0.1:9108</code>. Against a hosted engine that fails, so name it
-      once with <code>sf.configure()</code> and every later call uses it.
+      <code>sf.evaluate()</code> never asks where the engine is. Left unconfigured it falls back to
+      <code>DEFAULT_ENGINE_URL</code>, a hosted engine, which is not what you want when the engine
+      you mean is your own, so name it once with <code>sf.configure()</code> and every later call
+      uses it.
     </p>
 
     <p>
@@ -324,10 +334,10 @@ client.close()`
     <ul>
       <li>
         <a
-          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/05_draco_e2e.ipynb"
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/05_draco_lite_e2e.ipynb"
           target="_blank"
           rel="noopener"
-          >Companion notebook: <code>05_draco_e2e.ipynb</code></a
+          >Companion notebook: <code>05_draco_lite_e2e.ipynb</code></a
         >
       </li>
     </ul>

--- a/public-docs/src/pages/sf-client/guides/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/FusionsPage.vue
@@ -13,9 +13,9 @@ const basic = `import screamingface as sf
 opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
 gpt = sf.Model("openrouter/openai/gpt-5.5")
 
-pair = sf.Fusion([opus, gpt])
+pair = sf.Fusion([opus, gpt], synthesizer="openrouter/anthropic/claude-opus-4.8")
 pair`
-const basicOut = `Fusion(['claude-opus-4.8', 'gpt-5.5'])`
+const basicOut = `Fusion(['claude-opus-4.8', 'gpt-5.5'], synthesizer=Model('openrouter/anthropic/claude-opus-4.8'))`
 
 const inspect = `pair.name, [m.name for m in pair.members]`
 const inspectOut = `('claude-opus-4.8+gpt-5.5', ['claude-opus-4.8', 'gpt-5.5'])`
@@ -23,41 +23,45 @@ const inspectOut = `('claude-opus-4.8+gpt-5.5', ['claude-opus-4.8', 'gpt-5.5'])`
 const synth = `sf.Fusion(
     [opus, gpt],
     name="pair-gpt-synth",
-    reducer=sf.reducers.Model(model="openrouter/openai/gpt-5.5"),
+    synthesizer=sf.Model(
+        "openrouter/openai/gpt-5.5",
+        prompt="Write the final answer from the drafts.",
+    ),
 )`
-const synthOut = `Fusion(['claude-opus-4.8', 'gpt-5.5'], name='pair-gpt-synth', reducer=Model(model='openrouter/openai/gpt-5.5'))`
+const synthOut = `Fusion(['claude-opus-4.8', 'gpt-5.5'], name='pair-gpt-synth', synthesizer=Model('openrouter/openai/gpt-5.5', prompt='Write the final answer from the drafts.'))`
 
 const nested = `haiku = sf.Model("openrouter/anthropic/claude-haiku-4.5")
 
-sf.Fusion([pair, haiku], name="nested")`
-const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name='nested')`
+sf.Fusion([pair, haiku], name="nested", synthesizer="openrouter/openai/gpt-5.5")`
+const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name='nested', synthesizer=Model('openrouter/openai/gpt-5.5'))`
 </script>
 
 <template>
   <DocLayout
     title="Fusions"
-    description="Combine two or more members into one answer through a reducer."
+    description="Combine members into one answer through a synthesizer."
     :navigation="navigation"
     :version="version"
   >
     <p>
-      A <strong>Fusion</strong> asks several members the same question, then a
-      <strong>reducer</strong> reads their answers and produces the single final one. That final
+      A <strong>Fusion</strong> asks its members the same question, then a
+      <strong>synthesizer</strong> reads their answers and produces the single final one. That final
       answer is what the benchmark grades, so a Fusion competes in exactly the same column as a solo
       <RouterLink to="/sf-client/guides/models">Model</RouterLink>.
     </p>
 
     <p>
-      How the reducer decides is configurable. It can be a model, for example a judge that reads the
-      candidate answers and writes the winner, or your own code that inspects the answers and decides
-      how to pick or combine them.
+      The synthesizer is itself a recipe. It is usually a model that reads the candidate answers and
+      writes the winner, but it can be a
+      <RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink> or even another Fusion — so
+      the way answers are combined is as composable as the members themselves.
     </p>
 
     <figure class="not-prose" style="margin: var(--space-8) 0">
       <svg
         viewBox="0 0 680 236"
         role="img"
-        aria-label="A fusion sends one question to several members; a reducer combines their answers into the single answer the benchmark grades."
+        aria-label="A fusion sends one question to several members; a synthesizer combines their answers into the single answer the benchmark grades."
         style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
       >
         <defs>
@@ -104,11 +108,11 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
           <text x="230" y="48">member 1</text>
           <text x="230" y="122">member 2</text>
           <text x="230" y="196">member 3</text>
-          <text x="445" y="114">reducer</text>
+          <text x="445" y="114">synthesizer</text>
           <text x="620" y="122">answer</text>
         </g>
         <text x="445" y="132" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
-          model · vote · code
+          a model or any recipe
         </text>
       </svg>
       <figcaption
@@ -121,8 +125,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
           margin-top: var(--space-3);
         "
       >
-        Members answer the same question; the reducer combines them into the one answer the benchmark
-        grades.
+        Members answer the same question; the synthesizer combines them into the one answer the
+        benchmark grades.
       </figcaption>
     </figure>
 
@@ -132,8 +136,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
 
     <ul>
       <li>Combine two or more Models into one candidate.</li>
-      <li>Choose the reducer, and how a model reducer is prompted.</li>
-      <li>Nest a Fusion inside another Fusion.</li>
+      <li>Choose the synthesizer, and how a model synthesizer is prompted.</li>
+      <li>Nest a Fusion or a Pipeline inside a Fusion.</li>
       <li>Read back the members and the resolved name.</li>
     </ul>
 
@@ -148,24 +152,22 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
       </thead>
       <tbody>
         <tr>
-          <td><code>sf.Fusion(members, *, name=None, reducer=None)</code></td>
+          <td><code>sf.Fusion(members, *, name=None, synthesizer)</code></td>
           <td>
-            Combines at least two members behind a reducer that reads their answers and produces the
-            single final answer the benchmark grades.
+            Combines members behind a synthesizer that reads their answers and produces the single
+            final answer the benchmark grades. The synthesizer is required.
           </td>
         </tr>
         <tr>
+          <td><code>synthesizer=</code> (route string or recipe)</td>
           <td>
-            <code>sf.reducers.Model(model, *, prompt=None, params=None)</code> ·
-            <code>sf.reducers.MajorityVote()</code>
-          </td>
-          <td>
-            The reducers you pass to <code>reducer=</code>: <code>Model</code> has a model synthesise
-            the answer; <code>MajorityVote</code> picks by agreement, with no extra model call.
+            Any recipe: a route string or <code>sf.Model</code> has a model write the final answer;
+            an <RouterLink to="/sf-client/guides/pipelines"><code>sf.Pipeline</code></RouterLink> or
+            nested <code>sf.Fusion</code> composes a multi-step synthesis.
           </td>
         </tr>
         <tr>
-          <td><code>.name</code> · <code>.members</code> · <code>.reducer</code></td>
+          <td><code>.name</code> · <code>.members</code> · <code>.synthesizer</code></td>
           <td>Read back the resolved shape, including the members and the resolved name.</td>
         </tr>
         <tr>
@@ -179,16 +181,16 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
 
     <h3>1 · Combine two models</h3>
 
-    <p>Members come first and positionally.</p>
+    <p>Members come first and positionally; the synthesizer is a required keyword argument.</p>
 
     <div class="not-prose">
       <NbCell :count="1" :code="basic"><NbTextOut :text="basicOut" /></NbCell>
     </div>
 
     <p>
-      A Fusion needs <strong>at least two</strong> members and their names must be unique: one
-      member is not a fusion, and two identically named ones could not be told apart in a report.
-      Both raise immediately, at construction.
+      A Fusion always needs an explicit <code>synthesizer</code> — there is no default — and at
+      least one member. Omitting the synthesizer, or passing an empty member list, raises
+      immediately at construction.
     </p>
 
     <h3>2 · Read the resolved name</h3>
@@ -202,14 +204,16 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
       <NbCell :count="2" :code="inspect"><NbTextOut :text="inspectOut" /></NbCell>
     </div>
 
-    <h3>3 · Choose the reducer</h3>
+    <h3>3 · Choose the synthesizer</h3>
 
     <p>
-      The <strong>reducer</strong> decides how the members' answers become one. Pass a reducer from
-      <RouterLink to="/learn/engine"><code>sf.reducers</code></RouterLink>: <code>Model</code> has a
-      model read the answers and write the final one, while <code>MajorityVote</code> picks the
-      most-agreed answer with no extra model call. Swapping the reducer is the main lever a Fusion
-      has: the same members with a different reducer is a different candidate, worth measuring as one.
+      The <strong>synthesizer</strong> decides how the members' answers become one, and it is itself
+      a recipe. Pass a route string or an <code>sf.Model</code> to have a model read the drafts and
+      write the final answer, or pass an
+      <RouterLink to="/sf-client/guides/pipelines"><code>sf.Pipeline</code></RouterLink> or nested
+      <code>sf.Fusion</code> for a multi-step synthesis. Swapping the synthesizer is the main lever
+      a Fusion has: the same members with a different synthesizer is a different candidate, worth
+      measuring as one.
     </p>
 
     <div class="not-prose">
@@ -217,17 +221,16 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     </div>
 
     <p>
-      A model reducer carries its own <code>prompt</code> and <code>params</code>
-      (<code>sf.reducers.Model(model, prompt=…, params=…)</code>): they control how the final answer
-      is written, separately from how the members answer. Give a member its own prompt by setting it
-      on that Model.
+      A model synthesizer carries its own <code>prompt</code> and <code>params</code>: they control
+      how the final answer is written, separately from how the members answer. Give a member its own
+      prompt by setting it on that Model.
     </p>
 
     <h3>4 · Nest a fusion</h3>
 
     <p>
-      A member may itself be a Fusion, so a pair can become a member of a larger fusion. The inner
-      Fusion appears under its own resolved name.
+      A member may itself be a Fusion or a Pipeline, so a pair can become a member of a larger
+      fusion. The inner recipe appears under its own resolved name.
     </p>
 
     <div class="not-prose">
@@ -235,8 +238,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     </div>
 
     <p>
-      Members must be Models or Fusions. A corrective ensemble cannot be a member: it grades its own
-      members' raw drafts, which a surrounding reducer would have already replaced.
+      Members must be recipes — a <code>Model</code>, <code>Fusion</code> or <code>Pipeline</code>,
+      or a route string that is normalized to a <code>Model</code>.
     </p>
 
     <h2>Links</h2>
@@ -244,7 +247,7 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     <ul>
       <li>
         <a
-          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/00_quickstart.ipynb"
           target="_blank"
           rel="noopener"
           >Companion notebook: <code>00_quickstart.ipynb</code></a

--- a/public-docs/src/pages/sf-client/guides/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/FusionsPage.vue
@@ -44,17 +44,17 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     :version="version"
   >
     <p>
-      A <strong>Fusion</strong> asks its members the same question, then a
-      <strong>synthesizer</strong> reads their answers and produces the single final one. That final
-      answer is what the benchmark grades, so a Fusion competes in exactly the same column as a solo
+      A <strong>Fusion</strong> sends the same question to all its members, then a
+      <strong>synthesizer</strong> reads their answers and produces one final answer. The benchmark
+      grades that final answer, so a Fusion competes with a solo
       <RouterLink to="/sf-client/guides/models">Model</RouterLink>.
     </p>
 
     <p>
-      The synthesizer is itself a recipe. It is usually a model that reads the candidate answers and
-      writes the winner, but it can be a
-      <RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink> or even another Fusion — so
-      the way answers are combined is as composable as the members themselves.
+      The synthesizer is itself a recipe. Usually a model that reads the candidate answers and picks
+      or writes the winner, but it can be a
+      <RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink> or another Fusion.
+      Synthesis composes the same way members do.
     </p>
 
     <figure class="not-prose" style="margin: var(--space-8) 0">
@@ -130,14 +130,14 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
       </figcaption>
     </figure>
 
-    <p>Like a Model, a Fusion is immutable: building one makes no request.</p>
+    <p>Like a Model, a Fusion is immutable. Building one makes no requests.</p>
 
-    <h2>What you can do with it</h2>
+    <h2>What you can do</h2>
 
     <ul>
       <li>Combine two or more Models into one candidate.</li>
-      <li>Choose the synthesizer, and how a model synthesizer is prompted.</li>
-      <li>Nest a Fusion or a Pipeline inside a Fusion.</li>
+      <li>Pick your synthesizer. Control how a model synthesizer is prompted.</li>
+      <li>Nest a Fusion or Pipeline inside another Fusion.</li>
       <li>Read back the members and the resolved name.</li>
     </ul>
 
@@ -154,21 +154,22 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
         <tr>
           <td><code>sf.Fusion(members, *, name=None, synthesizer)</code></td>
           <td>
-            Combines members behind a synthesizer that reads their answers and produces the single
-            final answer the benchmark grades. The synthesizer is required.
+            Combines members through a synthesizer that reads their answers and produces one final
+            answer for the benchmark to grade. Synthesizer is required.
           </td>
         </tr>
         <tr>
           <td><code>synthesizer=</code> (route string or recipe)</td>
           <td>
-            Any recipe: a route string or <code>sf.Model</code> has a model write the final answer;
-            an <RouterLink to="/sf-client/guides/pipelines"><code>sf.Pipeline</code></RouterLink> or
-            nested <code>sf.Fusion</code> composes a multi-step synthesis.
+            Any recipe works: a route string or <code>sf.Model</code> has a model write the final
+            answer; an
+            <RouterLink to="/sf-client/guides/pipelines"><code>sf.Pipeline</code></RouterLink> or
+            nested <code>sf.Fusion</code> lets you do multi-step synthesis.
           </td>
         </tr>
         <tr>
           <td><code>.name</code> · <code>.members</code> · <code>.synthesizer</code></td>
-          <td>Read back the resolved shape, including the members and the resolved name.</td>
+          <td>Read back the resolved shape: members, synthesizer, and name.</td>
         </tr>
         <tr>
           <td><code>sf.Recipe</code></td>
@@ -181,23 +182,22 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
 
     <h3>1 · Combine two models</h3>
 
-    <p>Members come first and positionally; the synthesizer is a required keyword argument.</p>
+    <p>Members come first (positional). Synthesizer is required (keyword-only).</p>
 
     <div class="not-prose">
       <NbCell :count="1" :code="basic"><NbTextOut :text="basicOut" /></NbCell>
     </div>
 
     <p>
-      A Fusion always needs an explicit <code>synthesizer</code> — there is no default — and at
-      least one member. Omitting the synthesizer, or passing an empty member list, raises
-      immediately at construction.
+      A Fusion always needs an explicit <code>synthesizer</code> (no default) and at least one
+      member. Skip the synthesizer or pass an empty member list and construction fails.
     </p>
 
     <h3>2 · Read the resolved name</h3>
 
     <p>
       Without an explicit <code>name</code>, the Fusion's name is its members' names joined with
-      <code>+</code>. That is the label a report will show.
+      <code>+</code>. Reports show that name.
     </p>
 
     <div class="not-prose">
@@ -207,13 +207,12 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     <h3>3 · Choose the synthesizer</h3>
 
     <p>
-      The <strong>synthesizer</strong> decides how the members' answers become one, and it is itself
-      a recipe. Pass a route string or an <code>sf.Model</code> to have a model read the drafts and
-      write the final answer, or pass an
+      The <strong>synthesizer</strong> decides how the members' answers become one. It's itself a
+      recipe. Pass a route string or <code>sf.Model</code> to have a model read the drafts and write
+      the final answer, or pass an
       <RouterLink to="/sf-client/guides/pipelines"><code>sf.Pipeline</code></RouterLink> or nested
-      <code>sf.Fusion</code> for a multi-step synthesis. Swapping the synthesizer is the main lever
-      a Fusion has: the same members with a different synthesizer is a different candidate, worth
-      measuring as one.
+      <code>sf.Fusion</code> for multi-step synthesis. Swapping synthesizers is the main lever: same
+      members, different synthesizer, different candidate.
     </p>
 
     <div class="not-prose">
@@ -221,16 +220,16 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     </div>
 
     <p>
-      A model synthesizer carries its own <code>prompt</code> and <code>params</code>: they control
-      how the final answer is written, separately from how the members answer. Give a member its own
-      prompt by setting it on that Model.
+      A model synthesizer has its own <code>prompt</code> and <code>params</code>, controlling how
+      it writes the final answer, separate from how members answer. Set a different prompt on a
+      member by setting it on that Model.
     </p>
 
     <h3>4 · Nest a fusion</h3>
 
     <p>
-      A member may itself be a Fusion or a Pipeline, so a pair can become a member of a larger
-      fusion. The inner recipe appears under its own resolved name.
+      A member can be a Fusion or Pipeline, so a pair can become a member in a larger fusion. The
+      inner recipe shows up under its resolved name.
     </p>
 
     <div class="not-prose">
@@ -238,8 +237,8 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
     </div>
 
     <p>
-      Members must be recipes — a <code>Model</code>, <code>Fusion</code> or <code>Pipeline</code>,
-      or a route string that is normalized to a <code>Model</code>.
+      Members must be recipes: a <code>Model</code>, <code>Fusion</code>, or <code>Pipeline</code>
+      (or a route string, which gets normalized to a <code>Model</code>).
     </p>
 
     <h2>Links</h2>

--- a/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
@@ -1,0 +1,298 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const listing = `import screamingface as sf
+
+for board in sf.leaderboards.list():
+    print(board.id, "|", board.display_name)`
+const listingOut = `hle | News Hallucinations
+livetruth | News Livetruth
+livetruth-latest | News Livetruth Latest`
+
+const getOne = `board = sf.leaderboards.get("hle", top=5)
+board`
+const getOneOut = `Leaderboard('hle', entries=2, baselines=0)`
+
+const rows = `for entry in board.entries:
+    print(
+        entry.rank,
+        "|",
+        entry.spec_id,
+        "|",
+        entry.accuracy,
+        "|",
+        "verified" if entry.verified_by_openmined else "unverified",
+        "|",
+        ",".join(entry.ran_with_providers),
+    )`
+const rowsOut = `1 | filip-cf-access-smoke-1 | 0.5 | unverified | smoke
+2 | smoke-test-1 | 0.5 | unverified | smoke`
+
+const configure = `sf.configure(
+    engine_url="http://127.0.0.1:9108",
+    scoreboard_url="http://127.0.0.1:9106",
+)`
+
+const publish = `report = sf.evaluate(candidate, benchmark="ifeval", limit=3)
+
+# opt-in: Run All should never publish by accident
+PUBLISH = False
+submission = sf.leaderboards.submit(report.candidates.only) if PUBLISH else None
+submission`
+
+const fetchScore = `score = sf.leaderboards.get_score("57cc25d7-00bf-44ec-bf9d-55d66cd1e003")
+score.accuracy, score.correct_questions, score.total_questions, score.verified_by_openmined`
+const fetchScoreOut = `(1.0, 1, 1, False)`
+
+const remix = `plan = score.url4.to_python()   # Model / Fusion / Pipeline, free
+sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
+</script>
+
+<template>
+  <DocLayout
+    title="Leaderboards"
+    description="Browse ranked results, publish a CandidateResult, and pull the url4 back out."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A <strong>leaderboard</strong> is one benchmark's public ranking on the Scoreboard. The Client
+      reads and writes it through <code>sf.leaderboards</code>. Discovery and reads are free. They
+      hit the Scoreboard, not a model, and they do not need a provider connection.
+    </p>
+
+    <p>
+      Each ranked row keeps the exact
+      <RouterLink to="/sf-client/guides/reproduce-and-share"><code>url4</code></RouterLink>
+      that produced the score, so anyone can fork or re-run the recipe. The Scoreboard also stores
+      whether OpenMined independently re-ran it (<code>verified_by_openmined</code>). That flag is
+      separate from who submitted the row: a submission starts unverified.
+    </p>
+
+    <p>
+      The public portal is
+      <a href="https://leaderboard.screamingface.ai" target="_blank" rel="noopener"
+        >leaderboard.screamingface.ai</a
+      >. The Client's default Scoreboard origin is
+      <code>https://leaderboard.dev.screamingface.ai</code>. Point <code>scoreboard_url</code> at
+      your own instance when you run the local stack.
+    </p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>List the benchmarks the Scoreboard has registered as leaderboards.</li>
+      <li>Fetch one board's ranked entries and any imported single-model baselines.</li>
+      <li>Publish an evaluated <code>CandidateResult</code> as a new score.</li>
+      <li>Look up one published score by id and reuse its <code>url4</code>.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>API</th>
+          <th>What it does</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>sf.leaderboards.list()</code></td>
+          <td>
+            Lists every benchmark registered with the configured Scoreboard as
+            <code>LeaderboardInfo</code> values.
+          </td>
+        </tr>
+        <tr>
+          <td><code>sf.leaderboards.get(id, *, top=50)</code></td>
+          <td>
+            Fetches one <code>Leaderboard</code>: the board's identity, best-per-spec ranked
+            <code>entries</code>, and imported <code>baselines</code>. <code>top</code> caps how
+            many entries come back (the service clamps above 200).
+          </td>
+        </tr>
+        <tr>
+          <td><code>sf.leaderboards.submit(candidate_result)</code></td>
+          <td>
+            Publishes one evaluated <code>CandidateResult</code>. The Client derives benchmark id,
+            spec id, url4, accuracy counts, providers, and the idempotency key from that result.
+          </td>
+        </tr>
+        <tr>
+          <td><code>sf.leaderboards.get_score(score_id)</code></td>
+          <td>Loads one public <code>LeaderboardScore</code> by UUID (or its string form).</td>
+        </tr>
+        <tr>
+          <td>
+            <code>LeaderboardEntry</code> · <code>LeaderboardScore</code> ·
+            <code>LeaderboardBaseline</code>
+          </td>
+          <td>
+            The public value types: a ranked row, a persisted submission, and an imported
+            single-model line to beat.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      Ranking is best-per-spec: for each <code>spec_id</code> the Scoreboard keeps the highest
+      accuracy, and breaks ties by newest <code>submitted_at</code>. The table is then ordered by
+      accuracy descending. Baselines are imported separately and sit beside community entries; they
+      are not the same as a submitted score.
+    </p>
+
+    <h2>How to</h2>
+
+    <h3>1 · See which boards exist</h3>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="listing"><NbTextOut :text="listingOut" /></NbCell>
+    </div>
+
+    <p>
+      These ids are Scoreboard registrations. They can overlap the engine's
+      <RouterLink to="/sf-client/guides/benchmarks">benchmark</RouterLink> catalog, but they are not
+      the same list. A board has to be registered before you can publish to it.
+    </p>
+
+    <h3>2 · Read one board</h3>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="getOne"><NbTextOut :text="getOneOut" /></NbCell>
+    </div>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="rows"><NbTextOut :text="rowsOut" /></NbCell>
+    </div>
+
+    <p>
+      Each entry carries <code>accuracy</code>, <code>total_questions</code>, the providers used,
+      who submitted it when that is known, the <code>verified_by_openmined</code> flag, and the
+      <code>url4</code> expression. Notebook displays render the board as an interactive widget; the
+      plain loop above is what you get when you print fields yourself.
+    </p>
+
+    <p>
+      On this board both rows are unverified smoke submissions. Treat
+      <code>verified_by_openmined=True</code> as the trust signal, not the mere presence of a row.
+    </p>
+
+    <h3>3 · Point the Client at a Scoreboard</h3>
+
+    <p>
+      Without configuration, leaderboard calls use the default hosted Scoreboard. Local development
+      usually points both the engine and the Scoreboard at the stack
+      <code>just stack-up</code> starts:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="configure" />
+    </div>
+
+    <p>
+      Local writes are typically open. Hosted deployments may require an edge-verified identity
+      before <code>submit</code> succeeds, or they may keep submission closed. Reads stay public
+      either way.
+    </p>
+
+    <h3>4 · Publish a result</h3>
+
+    <p>
+      <code>submit</code> takes the evaluated <code>CandidateResult</code> directly. It does not ask
+      you to re-enter the score. Keep publication behind an explicit flag so a notebook
+      <strong>Run All</strong> cannot change the board by accident.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="5" :code="publish" />
+    </div>
+
+    <p>
+      The Client posts <code>accuracy</code>, <code>correct_questions</code>,
+      <code>total_questions</code>, the compiled <code>url4_expression</code>, provider names, and
+      client metadata. The <code>Idempotency-Key</code> header is the candidate's
+      <code>run_id</code>, so a retry of the same run replays the original score instead of
+      inserting a duplicate.
+    </p>
+
+    <p>
+      The Scoreboard's accuracy contract is strict: every case grade must be binary (<code>0</code>
+      or <code>1</code>), and <code>score</code> must match <code>correct / total</code> within
+      <code>0.01</code>. Rubric-only results that do not reduce to that shape are rejected before
+      they leave the Client. IFEval fits; some judge-scored protocols do not until their grades are
+      represented as binary cases.
+    </p>
+
+    <h3>5 · Fetch a published score</h3>
+
+    <p>
+      Pass the id <code>submit</code> returned (or any public score id). This sample is a real score
+      read back from a local Scoreboard:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="6" :code="fetchScore"><NbTextOut :text="fetchScoreOut" /></NbCell>
+    </div>
+
+    <p>
+      A fresh submission returns with <code>verified_by_openmined=False</code>. Verification is a
+      later, independent mark after OpenMined re-runs the recipe. Read that field before you trust a
+      number you did not produce yourself.
+    </p>
+
+    <h3>6 · Remix or replay from the board</h3>
+
+    <div class="not-prose">
+      <NbCell :count="7" :code="remix" />
+    </div>
+
+    <p>
+      <code>url4.to_python()</code> is local and free. Passing the same <code>url4</code> to
+      <RouterLink to="/sf-client/guides/running-an-evaluation"><code>sf.evaluate</code></RouterLink>
+      is a new paid run. The expression is already linked to its benchmark, so do not pass
+      <code>benchmark=</code> or <code>limit=</code> again. Model output can move; the recipe
+      identity does not.
+    </p>
+
+    <h2>What "verified" means here</h2>
+
+    <p>
+      Anyone with write access can publish a score. The board stores the claim and the recipe.
+      <code>verified_by_openmined</code> means OpenMined re-executed that recipe and accepted the
+      result. Until that flag is true, treat the row as a submission, not a verified ranking.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a href="https://leaderboard.screamingface.ai" target="_blank" rel="noopener"
+          >Public leaderboard portal</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/00_quickstart.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook: <code>00_quickstart.ipynb</code></a
+        >, which walks list → evaluate → optional publish → replay
+      </li>
+      <li>
+        <RouterLink to="/sf-client/guides/reproduce-and-share"
+          >Reproduce &amp; share (url4)</RouterLink
+        >
+        for reading and rebuilding expressions
+      </li>
+    </ul>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/ModelsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ModelsPage.vue
@@ -25,15 +25,19 @@ const policy = `sf.Model(
 const policyOut = `Model('openrouter/openai/gpt-5.5', prompt='Answer concisely.', params={'reasoning': 'high'})`
 
 const listing = `sf.models.list()`
-const listingOut = `ModelInfo(id='anthropic/claude-opus-4-8', provider='anthropic')
-ModelInfo(id='anthropic/claude-haiku-4-5', provider='anthropic')
-ModelInfo(id='codex/gpt-5.5', provider='codex')
-ModelInfo(id='gemini-cli/gemini-2.5-pro', provider='gemini-cli')
-ModelInfo(id='huggingface/deepseek-ai/DeepSeek-R1:novita', provider='huggingface')
-ModelInfo(id='openrouter/anthropic/claude-opus-4.8', provider='openrouter')
-ModelInfo(id='openrouter/openai/gpt-5.5', provider='openrouter')
-ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
+const listingOut = `ModelInfo('anthropic/claude-opus-4-8', provider='anthropic', parameters=9, tools=2)
+ModelInfo('anthropic/claude-haiku-4-5', provider='anthropic', parameters=9, tools=2)
+ModelInfo('codex/gpt-5.5', provider='codex', parameters=4, tools=1)
+ModelInfo('gemini-cli/gemini-2.5-pro', provider='gemini-cli', parameters=4, tools=1)
+ModelInfo('huggingface/deepseek-ai/DeepSeek-R1:novita', provider='huggingface', parameters=7, tools=0)
+ModelInfo('openrouter/anthropic/claude-opus-4.8', provider='openrouter', parameters=12, tools=2)
+ModelInfo('openrouter/openai/gpt-5.5', provider='openrouter', parameters=12, tools=2)
+ModelInfo('openrouter/google/gemini-3.1-pro-preview', provider='openrouter', parameters=12, tools=2)
 …   # 29 entries across 6 providers on this engine`
+
+const details = `gpt = sf.models.get("openrouter/openai/gpt-5.5")
+gpt.parameters["reasoning"].enabled, "web_search" in gpt.tools`
+const detailsOut = `(True, True)`
 </script>
 
 <template>
@@ -62,6 +66,7 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
       <li>Name a Model so two samples of the same route stay distinguishable.</li>
       <li>Override the answer prompt and generation parameters.</li>
       <li>List the routes this engine can actually reach.</li>
+      <li>Read one route's profile to see which parameters and tools it supports.</li>
     </ul>
 
     <h2>Main APIs</h2>
@@ -86,6 +91,13 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
           <td>
             Lists the routes this engine can reach as <code>sf.ModelInfo</code> values, spanning
             every provider the engine knows.
+          </td>
+        </tr>
+        <tr>
+          <td><code>sf.models.get(model_id)</code></td>
+          <td>
+            Returns one route's <code>sf.ModelDetails</code> profile: which parameters and tools it
+            supports, and whether the profile is current.
           </td>
         </tr>
         <tr>
@@ -154,12 +166,25 @@ ModelInfo(id='openrouter/google/gemini-3.1-pro-preview', provider='openrouter')
       retyping it.
     </p>
 
+    <h3>5 · Check that a route accepts your policy</h3>
+
+    <p>
+      <code>sf.models.get(id)</code> returns the fuller <code>sf.ModelDetails</code> profile for one
+      route: each parameter with its schema and whether the gateway currently projects it, the tools
+      and transports it supports, and whether the profile is stale. Consulting it is how you learn
+      that <code>params={"reasoning": "high"}</code> will be honoured before a run spends anything.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="5" :code="details"><NbTextOut :text="detailsOut" /></NbCell>
+    </div>
+
     <h2>Links</h2>
 
     <ul>
       <li>
         <a
-          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/00_quickstart.ipynb"
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/00_quickstart.ipynb"
           target="_blank"
           rel="noopener"
           >Companion notebook: <code>00_quickstart.ipynb</code></a

--- a/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
@@ -50,18 +50,17 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     :version="version"
   >
     <p>
-      A <strong>Pipeline</strong> runs its stages in series. The first stage answers the case, and
-      every later stage receives the <em>previous</em> stage's answer as its input — a draft that
-      gets reviewed, then polished. The last stage's answer is what the benchmark grades, so a
-      Pipeline competes in the same column as a solo
-      <RouterLink to="/sf-client/guides/models">Model</RouterLink> or a
+      A <strong>Pipeline</strong> runs stages one after another. The first stage answers the case,
+      each later stage gets the <em>previous</em> stage's answer as input. A draft gets reviewed,
+      then polished. The benchmark grades the last stage's answer, so a Pipeline competes with a
+      solo <RouterLink to="/sf-client/guides/models">Model</RouterLink> or a
       <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>.
     </p>
 
     <p>
-      A stage is any recipe — a <code>Model</code>, a <code>Fusion</code>, or another
-      <code>Pipeline</code> — so a chain can refine, review, or re-rank as many times as an
-      experiment needs. Like every recipe, a Pipeline is immutable: building one makes no request.
+      A stage can be any recipe: a <code>Model</code>, a <code>Fusion</code>, or another
+      <code>Pipeline</code>. Refine, review, or re-rank as many times as your experiment needs. Like
+      all recipes, a Pipeline is immutable. Building one makes no requests.
     </p>
 
     <figure class="not-prose" style="margin: var(--space-8) 0">
@@ -129,13 +128,13 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
       </figcaption>
     </figure>
 
-    <h2>What you can do with it</h2>
+    <h2>What you can do</h2>
 
     <ul>
-      <li>Chain two or more recipes so each stage refines the last one's answer.</li>
-      <li>Build the same chain fluently with <code>.then()</code>.</li>
-      <li>Nest a Pipeline inside a Fusion, or a Fusion inside a Pipeline.</li>
-      <li>Read back the ordered stages and the resolved name.</li>
+      <li>Chain two or more recipes so each stage refines the previous answer.</li>
+      <li>Build the same chain with <code>.then()</code> for a fluent API.</li>
+      <li>Nest a Pipeline inside a Fusion, or vice versa.</li>
+      <li>Read back the ordered stages and see the resolved name.</li>
     </ul>
 
     <h2>Main APIs</h2>
@@ -151,20 +150,20 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
         <tr>
           <td><code>sf.Pipeline(stages, *, name=None)</code></td>
           <td>
-            Runs the stages in series; each stage receives the previous stage's answer, and the last
+            Runs stages one after another. Each stage gets the previous stage's answer, and the last
             stage's answer is what the benchmark grades.
           </td>
         </tr>
         <tr>
           <td><code>recipe.then(next)</code></td>
           <td>
-            The builder on every recipe: appends a stage and returns a new Pipeline, so
+            Builder method on every recipe: appends a stage and returns a new Pipeline.
             <code>a.then(b).then(c)</code> reads left to right.
           </td>
         </tr>
         <tr>
           <td><code>.name</code> · <code>.stages</code></td>
-          <td>Read back the resolved name and the ordered tuple of stages.</td>
+          <td>Read back the resolved name and the ordered stages (as a tuple).</td>
         </tr>
         <tr>
           <td><code>sf.Recipe</code></td>
@@ -178,9 +177,9 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     <h3>1 · Chain two recipes</h3>
 
     <p>
-      Stages come first and positionally, in the order they run. The Pipeline's name defaults to the
-      stage names joined with <code>-&gt;</code>; give it an explicit <code>name</code> to label the
-      chain in a report.
+      Stages come first (positional), in the order they run. The Pipeline's name defaults to stage
+      names joined with <code>-&gt;</code>. Give it an explicit <code>name</code> for a custom label
+      in reports.
     </p>
 
     <div class="not-prose">
@@ -190,8 +189,8 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     <h3>2 · Build the same chain with <code>.then()</code></h3>
 
     <p>
-      <code>.then()</code> is available on every recipe and appends a stage, so a chain reads left
-      to right. It builds the same canonical Pipeline as passing the stages to the constructor.
+      <code>.then()</code> is on every recipe. It appends a stage so chains read left to right.
+      Builds the same canonical Pipeline as passing stages to the constructor.
     </p>
 
     <div class="not-prose">
@@ -201,8 +200,8 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     <h3>3 · Flatten vs. nest</h3>
 
     <p>
-      An <em>unnamed</em> Pipeline placed inside another Pipeline is flattened into one canonical
-      sequence of stages — nesting for convenience never changes what runs.
+      An <em>unnamed</em> Pipeline inside another Pipeline flattens into one sequence. Nesting for
+      convenience never changes what runs.
     </p>
 
     <div class="not-prose">
@@ -232,8 +231,8 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     </div>
 
     <p>
-      See the <RouterLink to="/sf-client/api/recipes">Recipes reference</RouterLink> for the full
-      <code>Pipeline</code> signature, attributes and errors.
+      Check the <RouterLink to="/sf-client/api/recipes">Recipes reference</RouterLink> for the full
+      <code>Pipeline</code> signature, attributes, and errors.
     </p>
 
     <h2>Links</h2>

--- a/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
@@ -1,0 +1,252 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const basic = `import screamingface as sf
+
+draft = sf.Model("openrouter/openai/gpt-5.5")
+review = sf.Model("openrouter/anthropic/claude-opus-4.8")
+
+chain = sf.Pipeline([draft, review], name="review-chain")
+chain`
+const basicOut = `Pipeline(['gpt-5.5', 'claude-opus-4.8'], name='review-chain')`
+
+const then = `final = sf.Model("openrouter/openai/gpt-5.5", name="polish")
+
+draft.then(review).then(final)`
+const thenOut = `Pipeline(['gpt-5.5', 'claude-opus-4.8', 'polish'])`
+
+const flatten = `constructed = sf.Pipeline([draft, sf.Pipeline([review, final])])
+
+[stage.name for stage in constructed.stages]`
+const flattenOut = `['gpt-5.5', 'claude-opus-4.8', 'polish']`
+
+const nestNamed = `named = sf.Pipeline([review, final], name="polish-pass")
+
+[stage.name for stage in draft.then(named).stages]`
+const nestNamedOut = `['gpt-5.5', 'polish-pass']`
+
+const recursive = `judge = sf.Model("openrouter/anthropic/claude-opus-4.8", name="judge")
+writer = sf.Model("openrouter/openai/gpt-5.5", name="writer")
+
+sf.Fusion(
+    [draft.then(review), sf.Model("openrouter/google/gemini-3.1-pro-preview")],
+    synthesizer=sf.Pipeline([judge, writer]),
+)`
+const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-preview'], synthesizer=Pipeline(['judge', 'writer']))`
+</script>
+
+<template>
+  <DocLayout
+    title="Pipelines"
+    description="Chain recipes in series, so each stage refines the previous stage's answer."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A <strong>Pipeline</strong> runs its stages in series. The first stage answers the case, and
+      every later stage receives the <em>previous</em> stage's answer as its input — a draft that
+      gets reviewed, then polished. The last stage's answer is what the benchmark grades, so a
+      Pipeline competes in the same column as a solo
+      <RouterLink to="/sf-client/guides/models">Model</RouterLink> or a
+      <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>.
+    </p>
+
+    <p>
+      A stage is any recipe — a <code>Model</code>, a <code>Fusion</code>, or another
+      <code>Pipeline</code> — so a chain can refine, review, or re-rank as many times as an
+      experiment needs. Like every recipe, a Pipeline is immutable: building one makes no request.
+    </p>
+
+    <figure class="not-prose" style="margin: var(--space-8) 0">
+      <svg
+        viewBox="0 0 680 120"
+        role="img"
+        aria-label="A pipeline passes the question through ordered stages; each stage receives the previous stage's answer, and the last stage's answer is what the benchmark grades."
+        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+      >
+        <defs>
+          <marker
+            id="pl-arrow"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+        <g
+          style="stroke: var(--text-2); stroke-width: 1.25; fill: none"
+          marker-end="url(#pl-arrow)"
+        >
+          <path d="M104 60 H136" />
+          <path d="M248 60 H280" />
+          <path d="M392 60 H424" />
+          <path d="M536 60 H568" />
+        </g>
+        <g style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1">
+          <rect x="8" y="40" width="96" height="40" />
+          <rect x="136" y="38" width="112" height="44" />
+          <rect x="280" y="38" width="112" height="44" />
+          <rect x="568" y="38" width="96" height="44" />
+        </g>
+        <rect
+          x="424"
+          y="38"
+          width="112"
+          height="44"
+          style="fill: none; stroke: var(--accent); stroke-width: 1.5"
+        />
+        <g text-anchor="middle" style="fill: var(--text)">
+          <text x="56" y="64">question</text>
+          <text x="192" y="64">stage 1</text>
+          <text x="336" y="64">stage 2</text>
+          <text x="480" y="64">final stage</text>
+          <text x="616" y="64">answer</text>
+        </g>
+      </svg>
+      <figcaption
+        style="
+          font-family: var(--f-mono);
+          font-size: var(--text-label);
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: var(--text-2);
+          margin-top: var(--space-3);
+        "
+      >
+        Each stage receives the previous stage's answer; the final stage's answer is what the
+        benchmark grades.
+      </figcaption>
+    </figure>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>Chain two or more recipes so each stage refines the last one's answer.</li>
+      <li>Build the same chain fluently with <code>.then()</code>.</li>
+      <li>Nest a Pipeline inside a Fusion, or a Fusion inside a Pipeline.</li>
+      <li>Read back the ordered stages and the resolved name.</li>
+    </ul>
+
+    <h2>Main APIs</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>API</th>
+          <th>What it does</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>sf.Pipeline(stages, *, name=None)</code></td>
+          <td>
+            Runs the stages in series; each stage receives the previous stage's answer, and the last
+            stage's answer is what the benchmark grades.
+          </td>
+        </tr>
+        <tr>
+          <td><code>recipe.then(next)</code></td>
+          <td>
+            The builder on every recipe: appends a stage and returns a new Pipeline, so
+            <code>a.then(b).then(c)</code> reads left to right.
+          </td>
+        </tr>
+        <tr>
+          <td><code>.name</code> · <code>.stages</code></td>
+          <td>Read back the resolved name and the ordered tuple of stages.</td>
+        </tr>
+        <tr>
+          <td><code>sf.Recipe</code></td>
+          <td>The shared base type of every candidate kind.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>How to</h2>
+
+    <h3>1 · Chain two recipes</h3>
+
+    <p>
+      Stages come first and positionally, in the order they run. The Pipeline's name defaults to the
+      stage names joined with <code>-&gt;</code>; give it an explicit <code>name</code> to label the
+      chain in a report.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="basic"><NbTextOut :text="basicOut" /></NbCell>
+    </div>
+
+    <h3>2 · Build the same chain with <code>.then()</code></h3>
+
+    <p>
+      <code>.then()</code> is available on every recipe and appends a stage, so a chain reads left
+      to right. It builds the same canonical Pipeline as passing the stages to the constructor.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="then"><NbTextOut :text="thenOut" /></NbCell>
+    </div>
+
+    <h3>3 · Flatten vs. nest</h3>
+
+    <p>
+      An <em>unnamed</em> Pipeline placed inside another Pipeline is flattened into one canonical
+      sequence of stages — nesting for convenience never changes what runs.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="flatten"><NbTextOut :text="flattenOut" /></NbCell>
+    </div>
+
+    <p>
+      Give the inner Pipeline a <code>name</code> and it is kept as a single stage instead, so a
+      named chain stays a named, reusable unit.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="nestNamed"><NbTextOut :text="nestNamedOut" /></NbCell>
+    </div>
+
+    <h3>4 · Compose recursively</h3>
+
+    <p>
+      Because a stage is any recipe and a
+      <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>'s members and synthesizer are
+      any recipe, the two compose freely: a Fusion of Pipelines, a Pipeline of Fusions, or a Fusion
+      whose synthesizer is itself a Pipeline.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="5" :code="recursive"><NbTextOut :text="recursiveOut" /></NbCell>
+    </div>
+
+    <p>
+      See the <RouterLink to="/sf-client/api/recipes">Recipes reference</RouterLink> for the full
+      <code>Pipeline</code> signature, attributes and errors.
+    </p>
+
+    <h2>Links</h2>
+
+    <ul>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/README.md"
+          target="_blank"
+          rel="noopener"
+          >Recipe composition in the package README</a
+        >
+      </li>
+    </ul>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/Url4Page.vue
+++ b/public-docs/src/pages/sf-client/guides/Url4Page.vue
@@ -9,15 +9,16 @@ import {
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 
-const read = `opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
-gpt = sf.Model("openrouter/openai/gpt-5.5")
+const read = `c = report.candidates.only
+c.url4          # the exact expression the engine ran
 
-opus.url4                     # a single model's plan
-sf.Fusion([opus, gpt]).url4   # a fusion's plan`
+# Or build one from a string somebody handed you.
+sf.Url4("(candidate='…compiled url4…')!'$model_0'")`
 
 const remix = `plan = report.candidates["frontier-trio"].url4   # or any url4 string you were given
-candidate = sf.from_url4(plan)                    # rebuild it as a runnable candidate
-sf.evaluate([candidate], benchmark="draco-lite@1")`
+
+plan.to_python()    # editable sf.Model / sf.Fusion / sf.Pipeline code, no spend
+sf.evaluate(plan)   # or replay it exactly as it ran, benchmark included`
 
 const ops = `c = report.candidates.only
 len(c.operations), [o.kind for o in c.operations]`
@@ -42,15 +43,15 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
     <p>
       Every candidate result carries a <RouterLink to="/learn/url4"><code>url4</code></RouterLink>
       string: the complete expression <RouterLink to="/learn/engine">the engine</RouterLink>
-      executed. Not a summary of it, not a log of it: the plan itself, the thing that ran. Your
-      candidate, the benchmark's routes, the retry prompts, and the pinned protocol revision, all in
-      one line of text you can read, diff, and send to someone.
+      actually ran. Not a summary, not a log. The plan itself. Your candidate, the benchmark's
+      routes, retry prompts, protocol revision, all in one line of text you can read, diff, and send
+      to others.
     </p>
 
     <p>
-      The shape is always <code>(sources)!intent</code>: the inputs in parentheses, then what to do
-      with them after the <code>!</code>. A source can itself be another url4, so the format is
-      recursive, which makes fusions easy to compose.
+      The shape is always <code>(sources)!intent</code>: inputs in parentheses, then what to do with
+      them after the <code>!</code>. A source can itself be another url4, so the format is
+      recursive, which is how a fusion nests inside a larger expression without special handling.
     </p>
 
     <figure class="not-prose" style="margin: var(--space-8) 0">
@@ -172,29 +173,28 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
     <p>
       A <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink> reads the same way, with more
       members (<code>member_2</code>, <code>member_3</code>, …) and a <code>recipe_answer</code>
-      step, the reducer that reads the members and writes the synthesis, before
-      <code>recipe_result</code>. Nothing is hidden: the routes, parameters, prompts, and the pinned
-      protocol are all in the line. See <RouterLink to="/learn/url4">url4</RouterLink> for the full
-      grammar and protocol.
+      step (the synthesizer that reads members and writes the synthesis) before
+      <code>recipe_result</code>. Nothing is held back from the line: the routes, the parameters,
+      the prompts, and the pinned protocol are all written into it. See
+      <RouterLink to="/learn/url4">url4</RouterLink> for the full grammar and protocol.
     </p>
 
     <p>
-      This is what makes a result auditable. A score on its own is a claim; a score with its url4
-      shows exactly what produced it. And because the expression is also an address the engine
-      resolves, that same string reruns the evaluation, or calls the fusion like a single model, in
-      any workflow you drop it into. See <RouterLink to="/learn/url4">url4</RouterLink> for the
-      protocol itself.
+      This makes results auditable. A score alone is just a claim. A score with its url4 shows
+      exactly what produced it. And since the expression is also an address the engine can resolve,
+      that same string reruns the evaluation or calls the fusion like a single model, in whatever
+      workflow you use. See <RouterLink to="/learn/url4">url4</RouterLink> for the protocol itself.
     </p>
 
-    <h2>What you can do with it</h2>
+    <h2>What you can do</h2>
 
     <ul>
-      <li>Read the <code>url4</code> of any model or fusion, before or after a run.</li>
-      <li>Create a new candidate from a <code>url4</code> string, then run or remix it.</li>
-      <li>Read what actually executed, including defaults you never set.</li>
-      <li>Confirm which benchmark revision the run was pinned to.</li>
+      <li>Read the <code>url4</code> that any candidate in a report actually ran.</li>
+      <li>Turn a <code>url4</code> string back into editable code, then rerun or remix it.</li>
+      <li>See what actually ran, including defaults you never set.</li>
+      <li>Check which benchmark revision the run used.</li>
       <li>Inspect the operation graph a candidate compiled to.</li>
-      <li>Serialise a whole report and hand it over.</li>
+      <li>Serialize a whole report and pass it along.</li>
     </ul>
 
     <h2>Main APIs</h2>
@@ -208,28 +208,32 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
       </thead>
       <tbody>
         <tr>
-          <td><code>Model.url4</code> · <code>Fusion.url4</code></td>
-          <td>The plan a candidate compiles to, available before any run and free to inspect.</td>
+          <td><code>sf.Url4(text)</code></td>
+          <td>
+            Wrap a url4 string you were given, so a copied expression becomes the same first-class
+            value a report hands back.
+          </td>
         </tr>
         <tr>
-          <td><code>sf.from_url4(url4)</code></td>
+          <td><code>Url4.to_python()</code></td>
           <td>
-            Rebuild a runnable candidate from a url4 string, so a shared expression becomes a Model
-            or Fusion you can evaluate or remix.
+            Reconstruct editable <code>sf.Model</code> / <code>sf.Fusion</code> /
+            <code>sf.Pipeline</code> code from an expression, including the
+            <code>sf.evaluate(...)</code> line when the url4 embeds a benchmark. Local and free.
           </td>
         </tr>
         <tr>
           <td><code>CandidateResult.url4</code></td>
           <td>
-            The complete expression the engine executed, a string you can read, diff, and rerun.
+            The complete expression the engine ran, as a string you can read, diff, and rerun.
           </td>
         </tr>
         <tr>
           <td><code>CandidateResult.operations</code></td>
           <td>
-            The same plan as structured data: a DAG of <code>sf.OperationInfo</code> values, each
-            with an <code>id</code>, <code>kind</code>, <code>label</code> and
-            <code>depends_on</code> edges.
+            Same plan as structured data: a DAG of <code>sf.OperationInfo</code> values, each with
+            <code>id</code>, <code>kind</code>, <code>label</code>, and <code>depends_on</code>
+            edges.
           </td>
         </tr>
         <tr>
@@ -255,9 +259,11 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
     <h3>1 · Read a url4</h3>
 
     <p>
-      Every candidate has a <code>url4</code>. A constructed Model or Fusion already carries its
-      plan, before any run and free to inspect, and a completed run carries the exact expression
-      that executed as <code>report.candidates[name].url4</code>.
+      A url4 comes from a completed run. Each candidate in a report carries the expression that
+      actually executed as <code>report.candidates[name].url4</code>. A Recipe on its own does not
+      have one yet, because the benchmark's routes and pinned revision are only linked in at
+      evaluation time. If somebody sends you an expression as plain text, wrap it in
+      <code>sf.Url4()</code> to get the same object back.
     </p>
 
     <div class="not-prose">
@@ -265,19 +271,21 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
     </div>
 
     <p>
-      Each returns the full expression, the shape annotated above: the routes, the parameters, the
-      answer prompt, and, after a run, the pinned benchmark revision. It can run to a few thousand
-      characters even for a small run, because it spells out everything the SDK filled in for you,
-      but all of it is readable.
+      What you get back is the full expression in the shape annotated above: the routes, the
+      parameters, the answer prompt, and the pinned benchmark revision. Even a small run can produce
+      a few thousand characters, because everything the SDK filled in on your behalf is written out
+      explicitly, but all of it is meant to be read.
     </p>
 
-    <h3>2 · Create a candidate from a url4</h3>
+    <h3>2 · Turn a url4 back into code</h3>
 
     <p>
-      Because a <code>url4</code> is a complete plan, you can turn one back into a runnable
-      candidate. <code>sf.from_url4()</code> rebuilds a Model or Fusion from any url4 string, whether
-      you read it off your own run or someone handed it to you, so you can rerun it, or change one
-      thing and remix it into the next attempt.
+      Because a <code>url4</code> is a complete plan, it converts back into the recipe that produced
+      it. <code>to_python()</code> reconstructs the <code>sf.Model</code>, <code>sf.Fusion</code>,
+      and <code>sf.Pipeline</code> calls, nested as they originally were, so you can edit one part
+      and run the result as your own next attempt. It costs nothing, since it is a local
+      transformation rather than a run. Passing the expression to
+      <code>sf.evaluate()</code> instead replays it as it stands, which does spend.
     </p>
 
     <div class="not-prose">
@@ -341,7 +349,7 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
     <ul>
       <li>
         <a
-          href="https://github.com/OpenMined/screamingface/blob/OME-605-screamingface-client-v1/packages/screamingface/examples/07_ifeval_e2e.ipynb"
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/07_ifeval_e2e.ipynb"
           target="_blank"
           rel="noopener"
           >Companion notebook: <code>07_ifeval_e2e.ipynb</code></a

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -54,6 +54,11 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/guides/EvaluationPage.vue'),
     },
     {
+      path: '/sf-client/guides/leaderboards',
+      name: 'sf-client-guides-leaderboards',
+      component: () => import('@/pages/sf-client/guides/LeaderboardsPage.vue'),
+    },
+    {
       path: '/sf-client/guides/reproduce-and-share',
       name: 'sf-client-guides-url4',
       component: () => import('@/pages/sf-client/guides/Url4Page.vue'),
@@ -107,6 +112,11 @@ const router = createRouter({
       path: '/learn/ai-gateway',
       name: 'learn-ai-gateway',
       component: () => import('@/pages/learn/GatewayPage.vue'),
+    },
+    {
+      path: '/learn/leaderboard',
+      name: 'learn-leaderboard',
+      component: () => import('@/pages/learn/LeaderboardPage.vue'),
     },
   ],
   scrollBehavior() {

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -39,6 +39,11 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/guides/FusionsPage.vue'),
     },
     {
+      path: '/sf-client/guides/pipelines',
+      name: 'sf-client-guides-pipelines',
+      component: () => import('@/pages/sf-client/guides/PipelinesPage.vue'),
+    },
+    {
       path: '/sf-client/guides/benchmarks',
       name: 'sf-client-guides-benchmarks',
       component: () => import('@/pages/sf-client/guides/BenchmarksPage.vue'),


### PR DESCRIPTION
## Why

The public docs' recipe pages describe a `screamingface` API that no longer exists, so documented examples raise on copy-paste (`synthesizer` is now required, `sf.Fusion([opus, gpt])` fails). Confirmed against `packages/screamingface/src/screamingface/__init__.py` + the recipe source and tests.

| Docs said (stale) | Source actually exports |
|---|---|
| `Fusion(members, *, reducer=None)` | `Fusion(members, *, synthesizer)` — required |
| `sf.reducers.Model(...)`, `sf.reducers.MajorityVote()` | no `sf.reducers` module |
| `sf.CorrectiveEnsemble(members, *, judge)` | removed |
| *(Pipeline unmentioned)* | `Pipeline(stages)`, `.then()`, recursion |

This is Workstream 1 of the OME-810 epic — the broken core.

## What changed

- **`api/RecipesPage.vue`** — rewritten: `Fusion` `synthesizer` (required); `CorrectiveEnsemble` section removed; new `Pipeline` section. Also corrected three claims that had drifted from source (verified against `model.py`/`fusion.py`/`pipeline.py` + `tests/test_recipes.py`/`test_pipeline_recipes.py`):
  - recipes compare **by value** and are unhashable (was: "compare by identity → `False`");
  - a Fusion needs **≥1** member (was: "≥2") with no construction-time duplicate-name check;
  - a Model applies **no default `params`** (was: `reasoning="low"`/`max_output_tokens=4096`), only a default prompt.
- **`guides/FusionsPage.vue`** — `reducer` → `synthesizer` throughout (diagram, tables, examples); dropped `sf.reducers` / corrective-ensemble references; refreshed the stale companion-notebook link to `main`.
- **NEW `guides/PipelinesPage.vue`** — serial composition, `.then()`, flatten-vs-nest, recursive composition; wired into the sidebar (Compose group) and router.

Every code snippet and `NbTextOut` repr was derived from the current source reprs / tests.

## Test plan

`public-docs/` has no unit suite; CI gates are oxlint + eslint + `npm run build` (type-check + vite). All green locally:

- `npx oxlint .` · `npx eslint .` — PASS
- `npm run type-check` · `npm run build` — PASS (Pipelines/Fusions/Recipes pages all built)
- Scoped stale-term grep over the three recipe pages — clean (one deliberate "there is no `reducer` attribute" note, matching the source test)

## Scope notes

- Remaining stale-term hits on `QuickstartPage.vue` / `Url4Page.vue` are deferred to OME-813 (guides) / OME-814 (cross-cutting sweep).
- `npm run format` surfaced pre-existing prettier drift on 11 unrelated files; reverted (CI doesn't gate prettier) — left for a later pass.

Refs: OME-811