### PR TITLE
feat(scoreboard): accept, store and expose a run cost on a submission

### DIFF
--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, cast
 from uuid import UUID
 
@@ -47,6 +48,12 @@ class RankedLeaderboardEntry(BaseModel):
     submitted_by: SubmittedBy
     verified_by_screamingface: bool
     url4_expression: str
+    # AIDEV-NOTE: this class mirrors LeaderboardEntry field-for-field plus `rank`,
+    # and `_ranked_entry` splats one into the other. Because both set
+    # extra="forbid", a field added to LeaderboardEntry and not here raises at
+    # runtime rather than at import — a 500 on the read path, not a type error.
+    # Keep the two in step.
+    run_cost_usd: Decimal | None
 
 
 class LeaderboardResponse(BaseModel):

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -80,6 +80,7 @@ class HistorySubmission(BaseModel):
     submitted_at: datetime
     submitted_by: SubmittedBy
     verified_by_screamingface: bool
+    run_cost_usd: Decimal | None
 
 
 class HistoryResponse(BaseModel):
@@ -127,6 +128,7 @@ def _history_submission(score: ScoreSchema) -> HistorySubmission:
         submitted_at=score.submitted_at,
         submitted_by=score.submitted_by,
         verified_by_screamingface=score.verified_by_screamingface,
+        run_cost_usd=score.run_cost_usd,
     )
 
 

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from decimal import Decimal
 from typing import Annotated, cast
 from uuid import UUID
 
@@ -16,6 +15,7 @@ from scoreboard.scores.schemas import (
     BenchmarkSchema,
     FrontierResponse,
     LeaderboardEntry,
+    RunCostUsd,
     ScoreSchema,
     SubmittedBy,
 )
@@ -53,7 +53,11 @@ class RankedLeaderboardEntry(BaseModel):
     # extra="forbid", a field added to LeaderboardEntry and not here raises at
     # runtime rather than at import — a 500 on the read path, not a type error.
     # Keep the two in step.
-    run_cost_usd: Decimal | None
+    #
+    # RunCostUsd, not a bare Decimal | None: the shared type carries the
+    # fixed-6dp JSON serializer, so the wire form cannot drift between the DTOs
+    # (spec 2.4).
+    run_cost_usd: RunCostUsd
 
 
 class LeaderboardResponse(BaseModel):
@@ -80,7 +84,7 @@ class HistorySubmission(BaseModel):
     submitted_at: datetime
     submitted_by: SubmittedBy
     verified_by_screamingface: bool
-    run_cost_usd: Decimal | None
+    run_cost_usd: RunCostUsd
 
 
 class HistoryResponse(BaseModel):

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0004_add_run_cost_usd.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0004_add_run_cost_usd.py
@@ -1,0 +1,16 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0003_auto_20260713_1505")]
+
+    initial = False
+
+    operations = [
+        ops.AddField(
+            model_name="Score",
+            name="run_cost_usd",
+            field=fields.DecimalField(null=True, max_digits=12, decimal_places=6),
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/score.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/score.py
@@ -62,6 +62,29 @@ class BaseScore(BaseScoreboardModel):
     # promotes it via _resolve_benchmark_revision. Read that before changing the wire shape.
     benchmark_revision = fields.CharField(max_length=64, null=True, db_index=True)
     metadata = fields.JSONField(null=True)
+    # WHY Decimal and not Float: this is money. Binary floating point cannot
+    # represent it exactly, and a leaderboard that publishes a dollar figure
+    # should not accumulate representation error in it. `accuracy` above stays a
+    # FloatField deliberately — a ratio is not currency.
+    #
+    # WHY these bounds: both ends of the real range have to fit. A cache-served
+    # smoke run costs fractions of a cent (0.000123 is representable here), and a
+    # full DRACO rerun was quoted at $3-4k, so 6 decimal places under 12 digits
+    # covers 0.000001 through 999,999.999999.
+    #
+    # INVARIANT: NULL means "no cost was reported", which is NOT the same as 0.
+    # A fully cache-served run genuinely costing nothing is a legitimate 0 (see
+    # OME-767's zero-cost goal). OME-770's Pareto frontier would rank an
+    # unknown-cost row as the cheapest entry if these two were ever conflated, so
+    # readers and renderers must keep them distinct.
+    #
+    # AIDEV-NOTE: deliberately NOT part of content_hash. That hash is recipe
+    # identity; cost is a property of one execution of a recipe, and two runs of
+    # the same recipe can cost different amounts while still being the same
+    # submission for dedup purposes (OME-391). The accepted consequence is that a
+    # recipe already submitted without a cost cannot later gain one — the
+    # resubmission dedups to the existing row.
+    run_cost_usd = fields.DecimalField(max_digits=12, decimal_places=6, null=True)
     # INVARIANT: sha256 hex over the submission's recipe identity (benchmark, spec,
     # url4 expression, result numbers, provider order) — NOT submitted_by or client
     # metadata. Unique so the DB itself rejects a duplicate recipe, independent of

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -19,18 +19,31 @@ from pydantic import (
 # six integer digits, so 0.000001 through 999999.999999.
 COST_QUANTUM = Decimal("0.000001")
 COST_CEILING = Decimal("999999.999999")
+# INVARIANT: the one canonical zero — POSITIVE, at full scale. Decimal("-0") is
+# equal to this, so equality can never detect the difference; only is_signed() can.
+_ZERO_COST = Decimal("0").quantize(COST_QUANTUM)
 
 
 def _validate_run_cost(value: Decimal | None) -> Decimal | None:
-    """Reject an *unstorable* cost; quantize one that merely arrives *inexact*.
+    """Reject a cost that cannot be stored; normalize every cost that can.
 
-    WHY the split: an earlier rule rejected anything not storable exactly, which
-    conflated two different situations. A value below the smallest representable
-    unit (0.0000009) cannot be rounded without changing a money figure by ~11%, so
-    it must be rejected. Float noise on a value that IS representable
-    (0.07 * 3 == 0.21000000000000002) rounds to 0.210000 losing nothing, and
-    rejecting it would discard valid scores the moment a client starts summing
-    per-call float costs. See spec 2.2's revision.
+    Only two things are actually unstorable and therefore rejected: a negative or
+    non-finite value, and one above the column ceiling. Everything else is
+    normalized rather than refused, because a 422 here discards the WHOLE
+    submission — the accuracy result along with the cost.
+
+    WHY, in the order the rules apply:
+      * float noise on a representable value (0.07 * 3 == 0.21000000000000002) is
+        quantized to 0.210000, losing nothing. Rejecting it would discard valid
+        scores the moment a client starts summing per-call float costs;
+      * zero is canonicalized to POSITIVE zero, since -0.0 otherwise serves the
+        string "-0.000000" (spec 2.6);
+      * a positive cost below one quantum rounds AWAY from zero, never to zero
+        (spec 2.2's second revision, and the D5 invariant it protects).
+
+    AIDEV-NOTE: the bounds cannot move to Field(max_digits=..., decimal_places=...).
+    Those constraints run BEFORE this validator, so they would reject the very
+    values it exists to normalize.
     """
     if value is None:
         return None
@@ -42,22 +55,28 @@ def _validate_run_cost(value: Decimal | None) -> Decimal | None:
     # INVARIANT: the ceiling is checked BEFORE quantizing. quantize() raises on an
     # absurd exponent (1e30), which would surface as a 500 rather than a 422 —
     # the exact failure this validator exists to close.
+    #
+    # AIDEV-NOTE: there is deliberately no ceiling re-check after quantizing.
+    # quantize is monotone and COST_CEILING sits exactly on the 6dp grid, so
+    # anything that would round up past it is already rejected here. An earlier
+    # draft had that branch plus a test comment claiming to exercise it; both were
+    # wrong — the value never reached it.
     if value > COST_CEILING:
         raise ValueError(f"run_cost_usd must not exceed {COST_CEILING}")
-    # INVARIANT (D5): a positive cost is NEVER rounded to zero. Quantizing
-    # 0.0000004 down to 0.000000 would present a run that cost real money as free
-    # and put it at the cheapest end of the Pareto frontier — precisely the
-    # absent-vs-zero conflation the model documents. Reject instead of rounding.
-    if value != 0 and value < COST_QUANTUM:
-        raise ValueError(
-            f"run_cost_usd must be 0 or at least {COST_QUANTUM}; "
-            f"a smaller positive cost cannot be stored without altering it",
-        )
-    quantized = value.quantize(COST_QUANTUM, rounding=ROUND_HALF_UP)
-    # 999999.9999996 rounds UP past the ceiling, so re-check after quantizing.
-    if quantized > COST_CEILING:
-        raise ValueError(f"run_cost_usd must not exceed {COST_CEILING}")
-    return quantized
+    if value == 0:
+        # INVARIANT: zero is always POSITIVE zero. -0.0 passes ge=0 (-0 == 0) and
+        # quantize preserves the sign, so it used to serve the string "-0.000000":
+        # a negative dollar figure, and backend-dependent besides (Postgres
+        # normalizes sign-zero, SQLite keeps it). A client summing signed per-call
+        # figures produces -0.0 from 0.0 * -1, so this is received, not theoretical.
+        return _ZERO_COST
+    # INVARIANT (D5): a positive cost is NEVER stored as zero — that would publish a
+    # run which cost real money as free and hand it the cheapest slot on the Pareto
+    # frontier. Clamping to one quantum expresses exactly that: it rounds away from
+    # zero, so the figure is never understated (it cannot buy frontier position) and
+    # the submission is never discarded, which rejecting did — the accuracy result
+    # went with it. Overstates by at most one quantum. See spec 2.2's 2nd revision.
+    return max(value.quantize(COST_QUANTUM, rounding=ROUND_HALF_UP), COST_QUANTUM)
 
 
 def _serialize_run_cost(value: Decimal | None) -> str | None:
@@ -70,7 +89,13 @@ def _serialize_run_cost(value: Decimal | None) -> str | None:
     for: OME-770's frontier and cheapest-run stat are computed in JavaScript,
     where `<` on strings is lexicographic ("10" < "9.5" is true), so an unpinned
     scale makes $1000 rank cheaper than $3.50 and renders 1E+3 in the Cost column.
-    Quantizing on read also normalizes rows written before the validator existed.
+    Quantizing on read also normalizes the scale of rows written before the
+    validator existed, and normalizes sign-zero — without which a stored
+    "-0.000000" (reachable by raw SQL) would still serve a negative figure.
+
+    It does NOT repair a row outside DECIMAL(12, 6): quantize RAISES on those
+    rather than normalizing, which is why the row loop guards the conversion
+    (spec 2.7).
 
     AIDEV-NOTE: a fixed-scale string does not make that hazard impossible —
     "1000.000000" < "3.500000" is still true. It forces consumers to convert
@@ -80,6 +105,8 @@ def _serialize_run_cost(value: Decimal | None) -> str | None:
     """
     if value is None:
         return None
+    if value == 0:
+        return f"{_ZERO_COST:f}"
     return f"{value.quantize(COST_QUANTUM, rounding=ROUND_HALF_UP):f}"
 
 

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -107,7 +107,13 @@ def _serialize_run_cost(value: Decimal | None) -> str | None:
         return None
     if value == 0:
         return f"{_ZERO_COST:f}"
-    return f"{value.quantize(COST_QUANTUM, rounding=ROUND_HALF_UP):f}"
+    # INVARIANT (D5) on the READ side too: a positive cost must never be published as
+    # zero. The validator clamps on the way in, but a row written by raw SQL — or
+    # before the validator existed — can hold a sub-quantum positive, and quantizing
+    # alone would render it "0.000000", i.e. a run that cost money shown as free.
+    # Found in review: stored Decimal("4E-7") serialized to "0.000000".
+    quantized = max(value.quantize(COST_QUANTUM, rounding=ROUND_HALF_UP), COST_QUANTUM)
+    return f"{quantized:f}"
 
 
 # INVARIANT: the ONE definition of the cost's wire form, shared by every read DTO.

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from decimal import Decimal
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
@@ -169,6 +170,18 @@ class ScoreSubmission(BaseModel):
     # (D-SCORE-006). Persisted onto the flat client_* columns by the store.
     client: ClientInfo | None = None
     metadata: dict[str, Any] | None = None
+    # INVARIANT: absent (None) means "no cost was reported" and is NOT the same as
+    # 0. A fully cache-served run genuinely costing nothing is a legitimate 0, so
+    # OME-770's Pareto frontier must exclude None rather than rank it as the
+    # cheapest entry. Decimal, not float — this is money.
+    #
+    # AIDEV-NOTE: optional only because nothing emits a run cost yet (OME-303 is
+    # unmerged, the Engine does not roll per-call cost into a run total, and the
+    # Client has no field for it), and because the column lands on an already
+    # populated table. Once a client can send it, a direct submission arriving
+    # without one is a client bug and should be REJECTED — null then means
+    # "imported or legacy" only. Tracked on OME-770.
+    run_cost_usd: Decimal | None = Field(default=None, ge=0)
 
     @field_validator("url4_expression")
     @classmethod
@@ -255,6 +268,7 @@ class ScoreSchema(BaseModel):
     # FEATURE: OME-323 — manual open/closed correction; None defers to the
     # classification registry. Operator-only, never set via ScoreSubmission.
     openness_override: Literal["open", "closed"] | None = None
+    run_cost_usd: Decimal | None
 
 
 class LeaderboardEntry(BaseModel):
@@ -274,6 +288,10 @@ class LeaderboardEntry(BaseModel):
     submitted_by: SubmittedBy
     verified_by_screamingface: bool
     url4_expression: str
+    # Self-reported and unverifiable: re-running a submission tells us what *we*
+    # paid, not what the submitter paid. Exposed so the board can show it, but it
+    # must be presented with its provenance and never as a verified figure.
+    run_cost_usd: Decimal | None
 
 
 class BaselineSchema(BaseModel):

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -181,7 +181,22 @@ class ScoreSubmission(BaseModel):
     # populated table. Once a client can send it, a direct submission arriving
     # without one is a client bug and should be REJECTED — null then means
     # "imported or legacy" only. Tracked on OME-770.
-    run_cost_usd: Decimal | None = Field(default=None, ge=0)
+    # INVARIANT: the request contract mirrors the column exactly —
+    # DECIMAL(12, 6), so six decimal places and six integer digits. `ge=0` alone
+    # was not enough and let three failures through, each reproduced live:
+    #   0.0000009 -> accepted (201) and silently stored as 0.000001, publishing a
+    #     figure the submitter never sent;
+    #   1000000   -> accepted on SQLite, but seven integer digits overflow
+    #     DECIMAL(12, 6) on Postgres, so it passed locally and would fail in
+    #     production;
+    #   1e30      -> reached the database and returned HTTP 500 instead of 422.
+    # Constraining here turns all three into field errors at the edge.
+    run_cost_usd: Decimal | None = Field(
+        default=None,
+        ge=0,
+        max_digits=12,
+        decimal_places=6,
+    )
 
     @field_validator("url4_expression")
     @classmethod

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
@@ -14,6 +14,85 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+
+# INVARIANT: run_cost_usd mirrors DECIMAL(12, 6) exactly — six decimal places and
+# six integer digits, so 0.000001 through 999999.999999.
+COST_QUANTUM = Decimal("0.000001")
+COST_CEILING = Decimal("999999.999999")
+
+
+def _validate_run_cost(value: Decimal | None) -> Decimal | None:
+    """Reject an *unstorable* cost; quantize one that merely arrives *inexact*.
+
+    WHY the split: an earlier rule rejected anything not storable exactly, which
+    conflated two different situations. A value below the smallest representable
+    unit (0.0000009) cannot be rounded without changing a money figure by ~11%, so
+    it must be rejected. Float noise on a value that IS representable
+    (0.07 * 3 == 0.21000000000000002) rounds to 0.210000 losing nothing, and
+    rejecting it would discard valid scores the moment a client starts summing
+    per-call float costs. See spec 2.2's revision.
+    """
+    if value is None:
+        return None
+    # ge=0 on the field already rejects negatives, and NaN fails that comparison,
+    # but +Infinity passes it — and quantize() raises InvalidOperation rather than
+    # returning a value, so non-finites have to go before any arithmetic.
+    if not value.is_finite():
+        raise ValueError("run_cost_usd must be a finite decimal number")
+    # INVARIANT: the ceiling is checked BEFORE quantizing. quantize() raises on an
+    # absurd exponent (1e30), which would surface as a 500 rather than a 422 —
+    # the exact failure this validator exists to close.
+    if value > COST_CEILING:
+        raise ValueError(f"run_cost_usd must not exceed {COST_CEILING}")
+    # INVARIANT (D5): a positive cost is NEVER rounded to zero. Quantizing
+    # 0.0000004 down to 0.000000 would present a run that cost real money as free
+    # and put it at the cheapest end of the Pareto frontier — precisely the
+    # absent-vs-zero conflation the model documents. Reject instead of rounding.
+    if value != 0 and value < COST_QUANTUM:
+        raise ValueError(
+            f"run_cost_usd must be 0 or at least {COST_QUANTUM}; "
+            f"a smaller positive cost cannot be stored without altering it",
+        )
+    quantized = value.quantize(COST_QUANTUM, rounding=ROUND_HALF_UP)
+    # 999999.9999996 rounds UP past the ceiling, so re-check after quantizing.
+    if quantized > COST_CEILING:
+        raise ValueError(f"run_cost_usd must not exceed {COST_CEILING}")
+    return quantized
+
+
+def _serialize_run_cost(value: Decimal | None) -> str | None:
+    """Pin the JSON form to exactly 6 decimal places.
+
+    WHY: Pydantic emits Decimal as a JSON *string* carrying whatever scale and
+    notation the value happens to have — "12.5" from SQLite, "12.500000" from a
+    padded Postgres DECIMAL, "1E+3" for a cost submitted as 1e3. That is a
+    backend-dependent wire format, and it breaks the feature this field exists
+    for: OME-770's frontier and cheapest-run stat are computed in JavaScript,
+    where `<` on strings is lexicographic ("10" < "9.5" is true), so an unpinned
+    scale makes $1000 rank cheaper than $3.50 and renders 1E+3 in the Cost column.
+    Quantizing on read also normalizes rows written before the validator existed.
+
+    AIDEV-NOTE: a fixed-scale string does not make that hazard impossible —
+    "1000.000000" < "3.500000" is still true. It forces consumers to convert
+    explicitly (parseFloat), which is reviewable in a way a bare `<` on two
+    numbers is not. Pass 2 must convert before comparing, and its frontier tests
+    must cover values of differing integer width. See spec 2.4.
+    """
+    if value is None:
+        return None
+    return f"{value.quantize(COST_QUANTUM, rounding=ROUND_HALF_UP):f}"
+
+
+# INVARIANT: the ONE definition of the cost's wire form, shared by every read DTO.
+# The RankedLeaderboardEntry / HistorySubmission / ScoreSchema duplication has
+# already caused two defects (a 500 and a silent omission), so the serializer is
+# attached to a type rather than repeated per class. `when_used="json"` is
+# deliberate: _ranked_entry splats entry.model_dump() in PYTHON mode and must keep
+# receiving a Decimal, not a string.
+RunCostUsd = Annotated[
+    Decimal | None,
+    PlainSerializer(_serialize_run_cost, return_type=str | None, when_used="json"),
+]
 
 # INVARIANT: a baseline's metadata is operator-supplied (via the import CLI, not a
 # public HTTP endpoint) but still bounded, so one bad import can't make
@@ -181,22 +260,27 @@ class ScoreSubmission(BaseModel):
     # populated table. Once a client can send it, a direct submission arriving
     # without one is a client bug and should be REJECTED — null then means
     # "imported or legacy" only. Tracked on OME-770.
-    # INVARIANT: the request contract mirrors the column exactly —
-    # DECIMAL(12, 6), so six decimal places and six integer digits. `ge=0` alone
-    # was not enough and let three failures through, each reproduced live:
+    # INVARIANT: the request contract mirrors the column exactly — DECIMAL(12, 6).
+    # `ge=0` alone let three failures through, each reproduced live:
     #   0.0000009 -> accepted (201) and silently stored as 0.000001, publishing a
     #     figure the submitter never sent;
     #   1000000   -> accepted on SQLite, but seven integer digits overflow
     #     DECIMAL(12, 6) on Postgres, so it passed locally and would fail in
     #     production;
     #   1e30      -> reached the database and returned HTTP 500 instead of 422.
-    # Constraining here turns all three into field errors at the edge.
-    run_cost_usd: Decimal | None = Field(
-        default=None,
-        ge=0,
-        max_digits=12,
-        decimal_places=6,
-    )
+    #
+    # AIDEV-NOTE: the bounds are enforced by the validator below, NOT by
+    # Field(max_digits=..., decimal_places=...). Those constraints run BEFORE an
+    # after-validator, so they would reject the float-noise values that spec 2.2
+    # requires us to quantize and accept. `ge=0` stays here (it also rejects NaN,
+    # which fails the comparison); allow_inf_nan=False stops +Infinity, which
+    # would pass ge=0 and then raise inside quantize().
+    run_cost_usd: Decimal | None = Field(default=None, ge=0, allow_inf_nan=False)
+
+    @field_validator("run_cost_usd")
+    @classmethod
+    def validate_run_cost(cls, value: Decimal | None) -> Decimal | None:
+        return _validate_run_cost(value)
 
     @field_validator("url4_expression")
     @classmethod
@@ -283,7 +367,7 @@ class ScoreSchema(BaseModel):
     # FEATURE: OME-323 — manual open/closed correction; None defers to the
     # classification registry. Operator-only, never set via ScoreSubmission.
     openness_override: Literal["open", "closed"] | None = None
-    run_cost_usd: Decimal | None
+    run_cost_usd: RunCostUsd
 
 
 class LeaderboardEntry(BaseModel):
@@ -306,7 +390,7 @@ class LeaderboardEntry(BaseModel):
     # Self-reported and unverifiable: re-running a submission tells us what *we*
     # paid, not what the submitter paid. Exposed so the board can show it, but it
     # must be presented with its provenance and never as a verified figure.
-    run_cost_usd: Decimal | None
+    run_cost_usd: RunCostUsd
 
 
 class BaselineSchema(BaseModel):

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -12,7 +12,7 @@ from pypika_tortoise.analytics import RowNumber
 from pypika_tortoise.enums import Order
 from pypika_tortoise.queries import Query, QueryBuilder
 from tortoise import Tortoise
-from tortoise.exceptions import IntegrityError
+from tortoise.exceptions import FieldError, IntegrityError
 from tortoise.query_api import execute_pypika
 from tortoise.transactions import in_transaction
 
@@ -22,6 +22,9 @@ from .schemas import BenchmarkSchema, LeaderboardEntry, ScoreSchema, ScoreSubmis
 # INVARIANT: columns the raw leaderboard projection must convert itself. The
 # projection bypasses the ORM, so nothing else will do it.
 _RAW_ROW_FIELDS = ("ran_with_providers", "run_cost_usd")
+# Columns whose DTO type admits None, so an unreadable value can degrade in place.
+# Anything not listed here forces the row to be dropped instead — see _to_python_rows.
+_NULLABLE_RAW_FIELDS = frozenset({"run_cost_usd"})
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +157,9 @@ def _to_python_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     this column as TEXT, so `ORDER BY run_cost_usd` there ranks $1000 below $3.50.
     Anything reading these rows ahead of the DTO must not get a string.
     """
+    kept: list[dict[str, Any]] = []
     for row in rows:
+        drop = False
         for name in _RAW_ROW_FIELDS:
             if name not in row:
                 continue
@@ -162,28 +167,55 @@ def _to_python_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 # to_python_value maps None -> None for a nullable field, keeping
                 # the absent-is-not-zero distinction (D5) intact.
                 row[name] = Score._meta.fields_map[name].to_python_value(row[name])
-            except (InvalidOperation, ValueError) as exc:
+            except (InvalidOperation, ValueError, FieldError) as exc:
                 # INVARIANT: one corrupt row must never fail the whole read path.
                 # DecimalField.to_python_value quantizes, and quantize RAISES on a
                 # value outside DECIMAL(12, 6) — which surfaced as HTTP 500 for
                 # EVERY entry on the board, not just the bad one. On SQLite the
                 # column is VARCHAR(40) with no database-level guard, so raw SQL
                 # can produce this; the ORM path and Postgres both reject it on
-                # write. Degrade to "unknown", the state the schema already has.
+                # write. FieldError is in the tuple because JSONField raises it and
+                # it is NOT a ValueError (found in review) — so corrupt JSON in
+                # ran_with_providers used to 500 the board despite this guard.
                 #
                 # Logged at warning, never silently swallowed: a corrupt row is a
                 # real problem and has to stay visible. Specific exceptions only.
-                logger.warning(
-                    "Unreadable %s on spec_id=%s (%r); serving it as null. "
-                    "The stored value is outside DECIMAL(12, 6) and can only have "
-                    "been written by raw SQL.",
-                    name,
-                    row.get("spec_id"),
-                    row[name],
-                    exc_info=exc,
-                )
-                row[name] = None
-    return rows
+                if name in _NULLABLE_RAW_FIELDS:
+                    # Degrade to "unknown", a state the schema already models.
+                    logger.warning(
+                        "Unreadable %s on spec_id=%s (%r); serving it as null. The "
+                        "stored value is outside the column's type and can only have "
+                        "been written by raw SQL.",
+                        name,
+                        row.get("spec_id"),
+                        row[name],
+                        exc_info=exc,
+                    )
+                    row[name] = None
+                else:
+                    # INVARIANT: a non-nullable column cannot degrade. LeaderboardEntry
+                    # types ran_with_providers as list[str], so None would fail
+                    # validation and re-raise the 500 this guard exists to prevent. The
+                    # only options are dropping the row or serving nothing, and one
+                    # unreadable row must not cost every other row on the board.
+                    #
+                    # This DOES silently change what the board shows — a corrupt row
+                    # disappears rather than appearing broken — which is why it is
+                    # logged at WARNING with the spec_id, so the omission is traceable.
+                    logger.warning(
+                        "Unreadable %s on spec_id=%s (%r); DROPPING the row from this "
+                        "response because the column is not nullable. The board will "
+                        "be short one entry until the stored value is repaired.",
+                        name,
+                        row.get("spec_id"),
+                        row[name],
+                        exc_info=exc,
+                    )
+                    drop = True
+                    break
+        if not drop:
+            kept.append(row)
+    return kept
 
 
 class SubmitOutcome(NamedTuple):

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
-from typing import NamedTuple, cast
+from typing import Any, NamedTuple, cast
 from uuid import UUID
 
 from pypika_tortoise.analytics import RowNumber
@@ -16,6 +16,10 @@ from tortoise.transactions import in_transaction
 
 from .models import Benchmark, IdempotencyKey, Score
 from .schemas import BenchmarkSchema, LeaderboardEntry, ScoreSchema, ScoreSubmission
+
+# INVARIANT: columns the raw leaderboard projection must convert itself. The
+# projection bypasses the ORM, so nothing else will do it.
+_RAW_ROW_FIELDS = ("ran_with_providers", "run_cost_usd")
 
 IDEMPOTENCY_TTL = timedelta(hours=24)
 
@@ -130,6 +134,30 @@ def _content_hash(submission: ScoreSubmission) -> str:
     }
     encoded = json.dumps(identity, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _to_python_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert raw projection rows to Python types, column by column.
+
+    WHY: `_build_leaderboard_query` is raw pypika, so it returns whatever the
+    driver hands back — on SQLite a DECIMAL column comes out as TEXT. Only
+    `ran_with_providers` used to be converted; `run_cost_usd` reached
+    LeaderboardEntry as a string and validated purely because Pydantic coerces
+    str -> Decimal in lax mode.
+
+    INVARIANT: rows are fully typed BEFORE validation, because spec 2.5 requires
+    the cheapest-run stat to be computed in Python over Decimal — SQLite compares
+    this column as TEXT, so `ORDER BY run_cost_usd` there ranks $1000 below $3.50.
+    Anything reading these rows ahead of the DTO must not get a string.
+    """
+    for row in rows:
+        for name in _RAW_ROW_FIELDS:
+            if name not in row:
+                continue
+            # to_python_value maps None -> None for a nullable field, keeping the
+            # absent-is-not-zero distinction (D5) intact.
+            row[name] = Score._meta.fields_map[name].to_python_value(row[name])
+    return rows
 
 
 class SubmitOutcome(NamedTuple):
@@ -350,12 +378,7 @@ class ScoreStore:
             ),
             using_db=conn,
         )
-        rows = result.rows
-        providers_field = Score._meta.fields_map["ran_with_providers"]
-        for row in rows:
-            row["ran_with_providers"] = providers_field.to_python_value(
-                row["ran_with_providers"],
-            )
+        rows = _to_python_rows(result.rows)
 
         return [LeaderboardEntry(**row) for row in rows]
 

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -52,6 +52,7 @@ def _score_to_schema(model: Score) -> ScoreSchema:
         verified_by_screamingface=model.verified_by_screamingface,
         metadata=model.metadata,
         openness_override=model.openness_override,
+        run_cost_usd=model.run_cost_usd,
     )
 
 
@@ -88,6 +89,10 @@ def _submission_to_kwargs(submission: ScoreSubmission, content_hash: str) -> dic
         "client_version": submission.client.version if submission.client else None,
         "client_platform": submission.client.platform if submission.client else None,
         "metadata": submission.metadata,
+        # Deliberately absent from _content_hash: cost is a property of one
+        # execution, not of the recipe. Two runs of the same recipe can cost
+        # different amounts and must still dedup to a single row (OME-391).
+        "run_cost_usd": submission.run_cost_usd,
         "content_hash": content_hash,
     }
 
@@ -169,6 +174,7 @@ def _build_leaderboard_query(
             scores.submitted_by,
             scores.verified_by_screamingface,
             scores.url4_expression,
+            scores.run_cost_usd,
             row_number,
         )
         .where(scores.benchmark_id == benchmark_id)
@@ -189,6 +195,7 @@ def _build_leaderboard_query(
             ranked.submitted_by,
             ranked.verified_by_screamingface,
             ranked.url4_expression,
+            ranked.run_cost_usd,
         )
         .where(ranked.rn == 1)
         .orderby(ranked.accuracy, order=Order.desc)

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from datetime import UTC, datetime, timedelta
+from decimal import InvalidOperation
 from typing import Any, NamedTuple, cast
 from uuid import UUID
 
@@ -20,6 +22,8 @@ from .schemas import BenchmarkSchema, LeaderboardEntry, ScoreSchema, ScoreSubmis
 # INVARIANT: columns the raw leaderboard projection must convert itself. The
 # projection bypasses the ORM, so nothing else will do it.
 _RAW_ROW_FIELDS = ("ran_with_providers", "run_cost_usd")
+
+logger = logging.getLogger(__name__)
 
 IDEMPOTENCY_TTL = timedelta(hours=24)
 
@@ -154,9 +158,31 @@ def _to_python_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         for name in _RAW_ROW_FIELDS:
             if name not in row:
                 continue
-            # to_python_value maps None -> None for a nullable field, keeping the
-            # absent-is-not-zero distinction (D5) intact.
-            row[name] = Score._meta.fields_map[name].to_python_value(row[name])
+            try:
+                # to_python_value maps None -> None for a nullable field, keeping
+                # the absent-is-not-zero distinction (D5) intact.
+                row[name] = Score._meta.fields_map[name].to_python_value(row[name])
+            except (InvalidOperation, ValueError) as exc:
+                # INVARIANT: one corrupt row must never fail the whole read path.
+                # DecimalField.to_python_value quantizes, and quantize RAISES on a
+                # value outside DECIMAL(12, 6) — which surfaced as HTTP 500 for
+                # EVERY entry on the board, not just the bad one. On SQLite the
+                # column is VARCHAR(40) with no database-level guard, so raw SQL
+                # can produce this; the ORM path and Postgres both reject it on
+                # write. Degrade to "unknown", the state the schema already has.
+                #
+                # Logged at warning, never silently swallowed: a corrupt row is a
+                # real problem and has to stay visible. Specific exceptions only.
+                logger.warning(
+                    "Unreadable %s on spec_id=%s (%r); serving it as null. "
+                    "The stored value is outside DECIMAL(12, 6) and can only have "
+                    "been written by raw SQL.",
+                    name,
+                    row.get("spec_id"),
+                    row[name],
+                    exc_info=exc,
+                )
+                row[name] = None
     return rows
 
 

--- a/apps/scoreboard/tests/unit/classification/test_openness.py
+++ b/apps/scoreboard/tests/unit/classification/test_openness.py
@@ -34,6 +34,10 @@ def _score(
         # OME-852: required since OME-775. None is honest here — frontier and openness
         # classification do not depend on which benchmark revision produced the score.
         benchmark_revision=None,
+        # OME-770 made this required: a nullable-but-required field means a construction
+        # site cannot silently omit a cost, which would read as free rather than unknown.
+        # None is honest here — frontier and openness classification ignore cost.
+        run_cost_usd=None,
         spec_id="spec-1",
         url4_expression="url4://benchmark/spec-1",
         submitted_by="tester",

--- a/apps/scoreboard/tests/unit/scores/test_frontier.py
+++ b/apps/scoreboard/tests/unit/scores/test_frontier.py
@@ -28,6 +28,10 @@ def _score(
         # OME-852: required since OME-775. None is honest here — frontier and openness
         # classification do not depend on which benchmark revision produced the score.
         benchmark_revision=None,
+        # OME-770 made this required: a nullable-but-required field means a construction
+        # site cannot silently omit a cost, which would read as free rather than unknown.
+        # None is honest here — frontier and openness classification ignore cost.
+        run_cost_usd=None,
         spec_id=spec_id,
         url4_expression=f"url4://benchmark/{spec_id}",
         submitted_by="tester",

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -600,3 +600,85 @@ def test_score_submission_still_accepts_the_documented_bounds() -> None:
         payload["run_cost_usd"] = value
 
         assert ScoreSubmission.model_validate(payload).run_cost_usd == Decimal(value)
+
+
+# --- OME-770 review pass: quantize inexact, reject unstorable (spec 2.2 revision) ---
+#
+# The earlier rule ("reject anything not storable exactly") over-rejected: it
+# conflated a value BELOW representable precision, where rounding materially
+# alters a money figure, with float noise on a value that IS representable,
+# where rounding loses nothing. Spec 2.2 revision splits the two.
+
+
+@pytest.mark.parametrize(
+    ("submitted", "stored"),
+    [
+        # WHY: what a client summing per-call float costs actually sends. Rounding
+        # to 6dp loses nothing here, so rejecting it would discard a valid score
+        # over float noise once the upstream chain lands.
+        (0.07 * 3, Decimal("0.210000")),
+        ("1.23456789", Decimal("1.234568")),
+        # ROUND_HALF_UP, not truncation.
+        ("0.0000015", Decimal("0.000002")),
+        # The boundary: exactly the smallest representable unit is storable as-is.
+        ("0.000001", Decimal("0.000001")),
+        # INVARIANT (D5): an explicit zero stays zero, distinct from absent.
+        ("0", Decimal("0")),
+    ],
+)
+def test_score_submission_quantizes_an_inexact_cost(
+    submitted: float | str,
+    stored: Decimal,
+) -> None:
+    payload = _valid_payload()
+    payload["run_cost_usd"] = submitted
+
+    submission = ScoreSubmission.model_validate(payload)
+
+    assert submission.run_cost_usd == stored
+    # Numeric equality is not enough — the point is the stored SCALE is pinned to
+    # 6dp, which is what makes the wire form backend-independent (spec 2.4).
+    assert submission.run_cost_usd is not None
+    assert submission.run_cost_usd.as_tuple().exponent == -6
+
+
+@pytest.mark.parametrize(
+    "submitted",
+    [
+        # Above the column ceiling at any precision. These must be caught BEFORE
+        # quantizing, which raises InvalidOperation on an absurd exponent.
+        "1000000",
+        "1e30",
+        # Rounds UP past the ceiling, so the ceiling is re-checked after quantizing.
+        "999999.9999996",
+        # Not a cost.
+        "-0.01",
+        "NaN",
+        "Infinity",
+        "-Infinity",
+    ],
+)
+def test_score_submission_rejects_an_unstorable_cost(submitted: str) -> None:
+    payload = _valid_payload()
+    payload["run_cost_usd"] = submitted
+
+    with pytest.raises(ValidationError):
+        ScoreSubmission.model_validate(payload)
+
+
+@pytest.mark.parametrize("submitted", ["0.0000009", "0.0000004", "0.0000001"])
+def test_score_submission_rejects_a_positive_cost_below_the_smallest_unit(
+    submitted: str,
+) -> None:
+    """INVARIANT (D5): quantizing must never manufacture a zero cost.
+
+    A positive cost rounded to 0.000000 would present a run that cost real money
+    as free, and land it at the cheapest end of the Pareto frontier. Values below
+    the smallest representable unit are rejected rather than rounded in either
+    direction.
+    """
+    payload = _valid_payload()
+    payload["run_cost_usd"] = submitted
+
+    with pytest.raises(ValidationError):
+        ScoreSubmission.model_validate(payload)

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -654,7 +654,9 @@ def test_score_submission_quantizes_an_inexact_cost(
         # quantizing, which raises InvalidOperation on an absurd exponent.
         "1000000",
         "1e30",
-        # Rounds UP past the ceiling, so the ceiling is re-checked after quantizing.
+        # Above the ceiling already, so the pre-quantize check rejects it. There is
+        # deliberately NO post-quantize re-check — quantize is monotone and the ceiling
+        # sits exactly on the 6dp grid, so nothing can round up past it.
         "999999.9999996",
         # Not a cost.
         "-0.01",
@@ -711,3 +713,23 @@ def test_score_submission_normalizes_negative_zero(submitted: float | str) -> No
     # Decimal(0) == Decimal("-0"), so equality cannot catch this -- check the sign.
     assert stored.is_signed() is False
     assert str(stored) == "0.000000"
+
+
+def test_a_json_number_below_the_float_floor_is_a_documented_residual() -> None:
+    """A JSON *number* under ~1e-308 underflows to 0.0 before the validator sees it.
+
+    Pinned rather than fixed: pydantic parses a JSON number through f64, so by the time
+    _validate_run_cost runs the value IS zero and is indistinguishable from a genuine
+    free run. The clamp therefore cannot fire. Quoting the same value keeps full
+    precision and DOES clamp, so the accepted result depends on whether the client
+    quotes it — recorded here so the asymmetry is visible rather than surprising.
+
+    No real run cost is within 300 orders of magnitude of this, and closing it would
+    mean refusing JSON numbers outright (found in review of OME-770).
+    """
+    payload = _valid_payload()
+    payload["run_cost_usd"] = 1e-400  # a NUMBER, not a string
+    assert ScoreSubmission.model_validate(payload).run_cost_usd == Decimal("0.000000")
+
+    payload["run_cost_usd"] = "1e-400"  # the same value, quoted
+    assert ScoreSubmission.model_validate(payload).run_cost_usd == Decimal("0.000001")

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from uuid import uuid4
 
 import pytest
@@ -487,3 +488,63 @@ def test_score_submission_rejects_a_client_supplied_verified_flag(claimed: bool)
 
     with pytest.raises(ValidationError):
         ScoreSubmission.model_validate(payload)
+# --- OME-770: run cost on a submission ------------------------------------
+# A cost is optional, and its ABSENCE is a distinct state from a zero cost:
+# absent means "we were never told", zero means "this run genuinely cost
+# nothing" (a fully cache-served run — the goal OME-767 is chasing). The
+# Pareto frontier in OME-770 would put an unknown-cost row at the cheapest
+# end if these two ever collapsed together, so the distinction is pinned here.
+
+
+def test_score_submission_accepts_a_run_cost() -> None:
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "12.50"
+
+    submission = ScoreSubmission.model_validate(payload)
+
+    assert submission.run_cost_usd == Decimal("12.50")
+
+
+def test_score_submission_without_a_run_cost_is_none_not_zero() -> None:
+    submission = ScoreSubmission.model_validate(_valid_payload())
+
+    assert submission.run_cost_usd is None
+
+
+def test_score_submission_accepts_a_genuinely_zero_run_cost() -> None:
+    """A fully cache-served run costs 0 — that is data, not a missing value."""
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "0"
+
+    submission = ScoreSubmission.model_validate(payload)
+
+    assert submission.run_cost_usd == Decimal("0")
+    assert submission.run_cost_usd is not None
+
+
+def test_score_submission_rejects_a_negative_run_cost() -> None:
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "-0.01"
+
+    with pytest.raises(ValidationError):
+        ScoreSubmission.model_validate(payload)
+
+
+def test_score_submission_keeps_sub_cent_run_cost_precision() -> None:
+    """A smoke run can cost fractions of a cent; rounding it to 2dp loses it."""
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "0.000123"
+
+    submission = ScoreSubmission.model_validate(payload)
+
+    assert submission.run_cost_usd == Decimal("0.000123")
+
+
+def test_score_submission_keeps_four_figure_run_cost() -> None:
+    """The other end of the range — a real DRACO rerun was quoted at $3-4k."""
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "4210.75"
+
+    submission = ScoreSubmission.model_validate(payload)
+
+    assert submission.run_cost_usd == Decimal("4210.75")

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -548,3 +548,55 @@ def test_score_submission_keeps_four_figure_run_cost() -> None:
     submission = ScoreSubmission.model_validate(payload)
 
     assert submission.run_cost_usd == Decimal("4210.75")
+
+
+# --- OME-770 review: the contract must match the column's precision ---------
+# ge=0 alone let three distinct failures through, all reproduced live before
+# these tests were written: 0.0000009 was ACCEPTED and silently stored as
+# 0.000001 (a published dollar figure the submitter never sent); 1000000 was
+# accepted on SQLite but exceeds DECIMAL(12,6)'s six integer digits and so fails
+# on Postgres — passing locally, breaking in production; and 1e30 produced an
+# HTTP 500 rather than a 422. The column's shape has to be enforced at the edge.
+
+
+def test_score_submission_rejects_more_than_six_decimal_places() -> None:
+    """INVARIANT: never silently re-round a submitted cost.
+
+    0.0000009 previously round-tripped as 0.000001 with a 201.
+    """
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "0.0000009"
+
+    with pytest.raises(ValidationError):
+        ScoreSubmission.model_validate(payload)
+
+
+def test_score_submission_rejects_a_cost_above_the_column_ceiling() -> None:
+    """DECIMAL(12,6) leaves six integer digits, so 1000000 does not fit.
+
+    Previously accepted on SQLite and rejected by Postgres — a backend-dependent
+    failure that local testing hides.
+    """
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "1000000"
+
+    with pytest.raises(ValidationError):
+        ScoreSubmission.model_validate(payload)
+
+
+def test_score_submission_rejects_an_absurd_exponent() -> None:
+    """1e30 previously reached the database and returned HTTP 500."""
+    payload = _valid_payload()
+    payload["run_cost_usd"] = "1e30"
+
+    with pytest.raises(ValidationError):
+        ScoreSubmission.model_validate(payload)
+
+
+def test_score_submission_still_accepts_the_documented_bounds() -> None:
+    """The rejections above must not narrow the range the column supports."""
+    for value in ("0.000001", "999999.999999"):
+        payload = _valid_payload()
+        payload["run_cost_usd"] = value
+
+        assert ScoreSubmission.model_validate(payload).run_cost_usd == Decimal(value)

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -414,6 +414,9 @@ def test_score_schema_publishes_only_the_local_part(stored: str, published: str)
         id=uuid4(),
         version=1,
         benchmark_id="hle",
+        # OME-770 makes this required. The published-identity contract under test
+        # here is independent of cost, so None is honest rather than a placeholder.
+        run_cost_usd=None,
         # OME-775 made this required; the published-identity contract under test here
         # is independent of which benchmark revision produced the score.
         benchmark_revision=None,
@@ -449,6 +452,9 @@ def test_a_null_submitter_stays_null() -> None:
         id=uuid4(),
         version=1,
         benchmark_id="hle",
+        # OME-770 makes this required. The published-identity contract under test
+        # here is independent of cost, so None is honest rather than a placeholder.
+        run_cost_usd=None,
         # OME-775 made this required; the published-identity contract under test here
         # is independent of which benchmark revision produced the score.
         benchmark_revision=None,

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -559,16 +559,21 @@ def test_score_submission_keeps_four_figure_run_cost() -> None:
 # HTTP 500 rather than a 422. The column's shape has to be enforced at the edge.
 
 
-def test_score_submission_rejects_more_than_six_decimal_places() -> None:
-    """INVARIANT: never silently re-round a submitted cost.
+def test_score_submission_rounds_a_sub_quantum_cost_up() -> None:
+    """A positive cost below the smallest storable unit rounds AWAY from zero.
 
-    0.0000009 previously round-tripped as 0.000001 with a 201.
+    Rewritten (spec 2.2, second revision): this test previously asserted a 422.
+    Rejecting turned out to discard the WHOLE submission -- the accuracy result
+    with it -- and would make an almost-free run unpublishable once cost becomes
+    mandatory. Rounding up never understates the cost, so it cannot buy a place on
+    the frontier, and never yields 0.000000, so D5 still holds.
     """
     payload = _valid_payload()
     payload["run_cost_usd"] = "0.0000009"
 
-    with pytest.raises(ValidationError):
-        ScoreSubmission.model_validate(payload)
+    submission = ScoreSubmission.model_validate(payload)
+
+    assert submission.run_cost_usd == Decimal("0.000001")
 
 
 def test_score_submission_rejects_a_cost_above_the_column_ceiling() -> None:
@@ -666,19 +671,43 @@ def test_score_submission_rejects_an_unstorable_cost(submitted: str) -> None:
         ScoreSubmission.model_validate(payload)
 
 
-@pytest.mark.parametrize("submitted", ["0.0000009", "0.0000004", "0.0000001"])
-def test_score_submission_rejects_a_positive_cost_below_the_smallest_unit(
-    submitted: str,
-) -> None:
-    """INVARIANT (D5): quantizing must never manufacture a zero cost.
+@pytest.mark.parametrize("submitted", ["0.0000009", "0.0000004", "0.0000001", "1e-9"])
+def test_a_sub_quantum_cost_never_becomes_zero(submitted: str) -> None:
+    """INVARIANT (D5): a positive cost must never be stored as zero.
 
-    A positive cost rounded to 0.000000 would present a run that cost real money
-    as free, and land it at the cheapest end of the Pareto frontier. Values below
-    the smallest representable unit are rejected rather than rounded in either
-    direction.
+    Rewritten alongside the rule change: the guard used to be a 422, and is now
+    directional rounding. What it protects is unchanged -- a run that cost real
+    money must never be published as free, which would also put it at the cheapest
+    end of the Pareto frontier.
     """
     payload = _valid_payload()
     payload["run_cost_usd"] = submitted
 
-    with pytest.raises(ValidationError):
-        ScoreSubmission.model_validate(payload)
+    stored = ScoreSubmission.model_validate(payload).run_cost_usd
+
+    assert stored == Decimal("0.000001")
+    assert stored != 0
+
+
+# --- OME-770 review pass 2: negative zero (spec 2.6) ---
+
+
+@pytest.mark.parametrize("submitted", [-0.0, "-0.0", "-0", "-0.0000000"])
+def test_score_submission_normalizes_negative_zero(submitted: float | str) -> None:
+    """`-0.0` is a real thing to receive: 0.0 * -1 and round(-1e-9, 6) both make it.
+
+    It passes ge=0 (-0 == 0) and quantize PRESERVES the sign, so it used to survive
+    as Decimal('-0.000000') and serve the string "-0.000000" -- a negative dollar
+    figure in the Cost column, and backend-dependent besides, since Postgres
+    normalizes sign-zero while SQLite keeps it.
+    """
+    payload = _valid_payload()
+    payload["run_cost_usd"] = submitted
+
+    stored = ScoreSubmission.model_validate(payload).run_cost_usd
+
+    assert stored == 0
+    assert stored is not None
+    # Decimal(0) == Decimal("-0"), so equality cannot catch this -- check the sign.
+    assert stored.is_signed() is False
+    assert str(stored) == "0.000000"

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -494,6 +494,8 @@ def test_score_submission_rejects_a_client_supplied_verified_flag(claimed: bool)
 
     with pytest.raises(ValidationError):
         ScoreSubmission.model_validate(payload)
+
+
 # --- OME-770: run cost on a submission ------------------------------------
 # A cost is optional, and its ABSENCE is a distinct state from a zero cost:
 # absent means "we were never told", zero means "this run genuinely cost

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 import pytest
 from tortoise import Tortoise
@@ -874,3 +875,68 @@ def test_no_migration_backfills_the_verified_column() -> None:
         f"migration(s) may backfill verified_by_screamingface: {offenders}. "
         "Existing rows must keep the value they were created with (OME-820 D5)."
     )
+# --- OME-770: run cost through the store -----------------------------------
+
+
+async def test_run_cost_persists_and_reads_back_on_the_leaderboard(tortoise_db: None) -> None:
+    await Benchmark.create(id="hle", display_name="HLE")
+    store = ScoreStore()
+    submission = _submission(spec_id="costed")
+    submission = submission.model_copy(update={"run_cost_usd": Decimal("3.500000")})
+
+    await store.submit(submission)
+    entries = await store.leaderboard("hle")
+
+    assert entries[0].run_cost_usd == Decimal("3.500000")
+
+
+async def test_a_submission_without_a_cost_reads_back_none_not_zero(tortoise_db: None) -> None:
+    """INVARIANT: unreported cost must stay distinguishable from a free run.
+
+    OME-770's Pareto frontier would rank an unknown-cost entry as the cheapest
+    submission if these ever collapsed into 0.
+    """
+    await Benchmark.create(id="hle", display_name="HLE")
+    store = ScoreStore()
+
+    await store.submit(_submission(spec_id="uncosted"))
+    entries = await store.leaderboard("hle")
+
+    assert entries[0].run_cost_usd is None
+
+
+async def test_a_zero_cost_run_reads_back_as_zero(tortoise_db: None) -> None:
+    """A fully cache-served run costs 0 — data, not a missing value."""
+    await Benchmark.create(id="hle", display_name="HLE")
+    store = ScoreStore()
+    submission = _submission(spec_id="free").model_copy(update={"run_cost_usd": Decimal("0")})
+
+    await store.submit(submission)
+    entries = await store.leaderboard("hle")
+
+    assert entries[0].run_cost_usd == Decimal("0")
+    assert entries[0].run_cost_usd is not None
+
+
+async def test_cost_is_outside_recipe_identity_so_dedup_still_collapses(tortoise_db: None) -> None:
+    """INVARIANT: cost is a property of an execution, not of the recipe.
+
+    Two submissions identical except for their cost are the same recipe and must
+    dedup to one row — pinning that run_cost_usd stays out of content_hash, which
+    OME-391's dedup guarantee depends on.
+    """
+    await Benchmark.create(id="hle", display_name="HLE")
+    store = ScoreStore()
+    base = _submission(spec_id="same-recipe")
+
+    first = await store.submit(base.model_copy(update={"run_cost_usd": Decimal("1.00")}))
+    second = await store.submit(base.model_copy(update={"run_cost_usd": Decimal("99.00")}))
+
+    assert first.created is True
+    assert second.created is False
+    assert second.score.id == first.score.id
+    assert await Score.all().count() == 1
+    # The stored row keeps the FIRST cost; the second is discarded. Documented as
+    # a known limitation on OME-770 — the fix is requiring cost, not mutating a
+    # deduplicated row.
+    assert second.score.run_cost_usd == Decimal("1.00")

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -977,3 +977,29 @@ async def test_the_raw_leaderboard_projection_types_every_column() -> None:
     assert isinstance(rows[0]["run_cost_usd"], Decimal)
     # INVARIANT (D5): absent stays absent — never coerced to Decimal("0").
     assert rows[1]["run_cost_usd"] is None
+
+
+async def test_one_unreadable_cost_does_not_take_down_the_whole_board() -> None:
+    """INVARIANT: a corrupt cost degrades to null; it never fails the read path.
+
+    On SQLite the column is VARCHAR(40) with no database-level guard, so raw SQL
+    can write a value outside DECIMAL(12, 6). Converting it calls Decimal.quantize,
+    which RAISES rather than returning — and that surfaced as HTTP 500 for EVERY
+    entry on the board, not just the bad row. Verified end-to-end before this test.
+
+    The ORM path is already safe (Tortoise's own to_python_value rejects such a
+    write), and production is Postgres where the column really is DECIMAL(12, 6),
+    so this is defence for a narrow case on a public read path (spec 2.7).
+    """
+    from scoreboard.scores.store import _to_python_rows
+
+    rows = _to_python_rows(
+        [
+            {"spec_id": "good", "ran_with_providers": '["openai"]', "run_cost_usd": "3.5"},
+            {"spec_id": "corrupt", "ran_with_providers": '["openai"]', "run_cost_usd": "1E+30"},
+        ]
+    )
+
+    assert rows[0]["run_cost_usd"] == Decimal("3.5")
+    # Degraded to "cost unknown" — an already-defined state — not an exception.
+    assert rows[1]["run_cost_usd"] is None

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -875,6 +875,8 @@ def test_no_migration_backfills_the_verified_column() -> None:
         f"migration(s) may backfill verified_by_screamingface: {offenders}. "
         "Existing rows must keep the value they were created with (OME-820 D5)."
     )
+
+
 # --- OME-770: run cost through the store -----------------------------------
 
 

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -940,3 +940,40 @@ async def test_cost_is_outside_recipe_identity_so_dedup_still_collapses(tortoise
     # a known limitation on OME-770 — the fix is requiring cost, not mutating a
     # deduplicated row.
     assert second.score.run_cost_usd == Decimal("1.00")
+
+
+# --- OME-770 review pass: raw projection rows must be fully typed (spec 2.5) ---
+
+
+async def test_the_raw_leaderboard_projection_types_every_column() -> None:
+    """INVARIANT: rows leaving the raw pypika projection are already Python-typed.
+
+    The projection bypasses the ORM, so each column has to be converted
+    explicitly. Only `ran_with_providers` was, and `run_cost_usd` reached
+    `LeaderboardEntry` as a raw SQLite string — surviving purely because Pydantic
+    coerces str -> Decimal in lax mode. That breaks the moment anything reads the
+    rows BEFORE validation, which spec 2.5 requires: the cheapest-run stat must be
+    computed in Python over Decimal, because SQLite compares this column as TEXT.
+    """
+    from scoreboard.scores.store import _to_python_rows
+
+    rows = _to_python_rows(
+        [
+            {
+                "spec_id": "s",
+                "ran_with_providers": '["openai"]',
+                "run_cost_usd": "3.5",
+            },
+            {
+                "spec_id": "t",
+                "ran_with_providers": '["openai"]',
+                "run_cost_usd": None,
+            },
+        ]
+    )
+
+    assert rows[0]["ran_with_providers"] == ["openai"]
+    assert rows[0]["run_cost_usd"] == Decimal("3.5")
+    assert isinstance(rows[0]["run_cost_usd"], Decimal)
+    # INVARIANT (D5): absent stays absent — never coerced to Decimal("0").
+    assert rows[1]["run_cost_usd"] is None

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -1003,3 +1003,39 @@ async def test_one_unreadable_cost_does_not_take_down_the_whole_board() -> None:
     assert rows[0]["run_cost_usd"] == Decimal("3.5")
     # Degraded to "cost unknown" — an already-defined state — not an exception.
     assert rows[1]["run_cost_usd"] is None
+
+
+async def test_corrupt_json_drops_the_row_instead_of_failing_the_board() -> None:
+    """FieldError is NOT a ValueError, so the original guard could not catch it.
+
+    JSONField.to_python_value raises tortoise FieldError on invalid JSON, which fell
+    straight through `except (InvalidOperation, ValueError)` and 500'd the whole
+    leaderboard — the exact failure that guard exists to prevent (found in review).
+
+    ran_with_providers cannot degrade to None: LeaderboardEntry types it as list[str],
+    so nulling it would fail validation and re-raise the 500. The row is dropped, and
+    logged at WARNING so the omission is traceable.
+    """
+    from scoreboard.scores.store import _to_python_rows
+
+    rows = _to_python_rows(
+        [
+            {"spec_id": "good", "ran_with_providers": '["openai"]', "run_cost_usd": "3.5"},
+            {"spec_id": "bad-json", "ran_with_providers": "{not json", "run_cost_usd": "1.0"},
+        ]
+    )
+
+    assert [row["spec_id"] for row in rows] == ["good"]
+    assert rows[0]["ran_with_providers"] == ["openai"]
+
+
+async def test_an_unreadable_cost_degrades_but_keeps_the_row() -> None:
+    """A nullable column degrades in place; only a non-nullable one costs the row."""
+    from scoreboard.scores.store import _to_python_rows
+
+    rows = _to_python_rows(
+        [{"spec_id": "bad-cost", "ran_with_providers": '["openai"]', "run_cost_usd": "1E+30"}]
+    )
+
+    assert [row["spec_id"] for row in rows] == ["bad-cost"]
+    assert rows[0]["run_cost_usd"] is None

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from decimal import Decimal
 
 import httpx
 import pytest
@@ -202,6 +203,10 @@ async def test_get_spec_history_returns_submissions_newest_first(
         "submitted_at",
         "submitted_by",
         "verified_by_screamingface",
+        # Widened for OME-770: the history response intentionally carries the run
+        # cost. The set stays exhaustive on purpose — it is the guard that catches
+        # an unintended field leaking into a response portal clients depend on.
+        "run_cost_usd",
     }
 
 
@@ -442,3 +447,67 @@ async def test_a_new_submission_reads_as_verified_on_both_read_paths(
     entry = next(e for e in board.json()["entries"] if e["spec_id"] == "verified-default")
     assert entry["verified_by_screamingface"] is True
     assert history.json()["submissions"][0]["verified_by_screamingface"] is True
+# --- OME-770 review: cost must survive every read path ----------------------
+
+
+async def test_get_spec_history_includes_the_run_cost(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """The ledger's acceptance named the history route explicitly, and it was
+    dropping the field: `list_for_spec` returned it on ScoreSchema, but
+    `_history_submission` mapped into a HistorySubmission that had no such field.
+    """
+    store = ScoreStore()
+    await _register_benchmark(store)
+    submission = _submission(spec_id="costed-history").model_copy(
+        update={"run_cost_usd": Decimal("7.250000")},
+    )
+    await store.submit(submission)
+
+    response = await async_client.get("/v1/leaderboard/hle/costed-history/history")
+
+    assert response.status_code == 200
+    returned = response.json()["submissions"][0]["run_cost_usd"]
+    # Numeric equality, not string identity — Decimal scale (7.25 vs 7.250000)
+    # survives the round trip differently and is not part of the contract.
+    assert Decimal(returned) == Decimal("7.25")
+
+
+async def test_get_spec_history_reports_an_absent_cost_as_null(
+    async_client: httpx.AsyncClient,
+) -> None:
+    store = ScoreStore()
+    await _register_benchmark(store)
+    await store.submit(_submission(spec_id="uncosted-history"))
+
+    response = await async_client.get("/v1/leaderboard/hle/uncosted-history/history")
+
+    assert response.json()["submissions"][0]["run_cost_usd"] is None
+
+
+def test_every_score_field_reaches_at_least_one_read_dto() -> None:
+    """Guard against the duplication that has now caused two separate bugs.
+
+    RankedLeaderboardEntry, HistorySubmission and ScoreSchema each redeclare
+    subsets of the same underlying columns. Adding `run_cost_usd` to the schema
+    but not to RankedLeaderboardEntry produced a runtime 500 (extra="forbid"),
+    and omitting it from HistorySubmission silently dropped it from the history
+    route — neither caught by the type checker. This asserts that a newly added
+    Score field cannot be invisible on every read path at once.
+    """
+    from scoreboard.routes.leaderboard import HistorySubmission, RankedLeaderboardEntry
+    from scoreboard.scores.models import Score
+    from scoreboard.scores.schemas import ScoreSchema
+
+    exposed = (
+        set(RankedLeaderboardEntry.model_fields)
+        | set(HistorySubmission.model_fields)
+        | set(ScoreSchema.model_fields)
+    )
+    # Deliberately unpublished: dedup plumbing, the FK object, and the reverse
+    # relation to idempotency keys (a relation, not a column).
+    internal = {"content_hash", "benchmark", "idempotency_keys"}
+    columns = {name for name in Score._meta.fields_map if not name.startswith("_")}
+
+    missing = columns - exposed - internal
+    assert missing == set(), f"Score columns absent from every read DTO: {sorted(missing)}"

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -606,3 +606,26 @@ async def test_get_leaderboard_includes_the_run_cost(
     by_spec = {e["spec_id"]: e for e in response.json()["entries"]}
     assert Decimal(by_spec["costed-board"]["run_cost_usd"]) == Decimal("7.25")
     assert by_spec["uncosted-board"]["run_cost_usd"] is None
+
+
+# --- OME-770 review pass 2: sign-zero must be normalized on READ too (spec 2.6) ---
+
+
+async def test_a_stored_negative_zero_serves_a_positive_cost(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """Normalizing only in the validator would leave already-stored rows broken.
+
+    A "-0.000000" reachable by raw SQL, or written before the rule existed, must
+    still serve "0.000000" — never a negative dollar figure on the board.
+    """
+    store = ScoreStore()
+    await _register_benchmark(store)
+    await store.submit(_costed("neg-zero", "-0.0"))
+
+    board = await async_client.get("/v1/leaderboard/hle")
+    history = await async_client.get("/v1/leaderboard/hle/neg-zero/history")
+
+    entry = next(e for e in board.json()["entries"] if e["spec_id"] == "neg-zero")
+    assert entry["run_cost_usd"] == "0.000000"
+    assert history.json()["submissions"][0]["run_cost_usd"] == "0.000000"

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -485,7 +485,7 @@ async def test_get_spec_history_reports_an_absent_cost_as_null(
     assert response.json()["submissions"][0]["run_cost_usd"] is None
 
 
-def test_every_score_field_reaches_at_least_one_read_dto() -> None:
+async def test_every_score_field_reaches_at_least_one_read_dto() -> None:
     """Guard against the duplication that has now caused two separate bugs.
 
     RankedLeaderboardEntry, HistorySubmission and ScoreSchema each redeclare
@@ -511,3 +511,98 @@ def test_every_score_field_reaches_at_least_one_read_dto() -> None:
 
     missing = columns - exposed - internal
     assert missing == set(), f"Score columns absent from every read DTO: {sorted(missing)}"
+
+
+# --- OME-770 review pass: the wire form must be backend-independent (spec 2.4) ---
+#
+# Pydantic emits Decimal as a JSON STRING carrying whatever scale/notation the
+# value happens to have: "12.5" on SQLite, "12.500000" from a padded Postgres
+# DECIMAL, and "1E+3" for a cost submitted as 1e3. Pass 2 computes a Pareto
+# frontier and a cheapest-run stat in JS, where `<` on strings is lexicographic
+# ("10" < "9.5" is true), so an unpinned scale makes $1000 rank cheaper than
+# $3.50 and renders 1E+3 in the Cost column. Every read DTO pins it to 6dp.
+
+
+def _costed(spec_id: str, cost: str) -> ScoreSubmission:
+    """A submission carrying a raw, deliberately un-quantized cost.
+
+    `model_copy` skips validation on purpose: it puts the awkward value (1E+3,
+    12.5) into storage exactly as a legacy row or a non-submission write would,
+    so these tests exercise the read-path serializer rather than the input
+    validator that would otherwise have already normalized it.
+    """
+    return _submission(spec_id=spec_id).model_copy(update={"run_cost_usd": Decimal(cost)})
+
+
+@pytest.mark.parametrize(
+    ("submitted", "expected"),
+    [
+        ("12.5", "12.500000"),
+        # Would otherwise serialize as the literal string "1E+3".
+        ("1e3", "1000.000000"),
+        ("0.000001", "0.000001"),
+        ("0", "0.000000"),
+    ],
+)
+async def test_leaderboard_serializes_the_cost_at_a_fixed_scale(
+    async_client: httpx.AsyncClient,
+    submitted: str,
+    expected: str,
+) -> None:
+    store = ScoreStore()
+    await _register_benchmark(store)
+    await store.submit(_costed("fixed-scale", submitted))
+
+    response = await async_client.get("/v1/leaderboard/hle")
+
+    assert response.status_code == 200
+    entry = next(e for e in response.json()["entries"] if e["spec_id"] == "fixed-scale")
+    assert entry["run_cost_usd"] == expected
+
+
+async def test_spec_history_serializes_the_cost_at_a_fixed_scale(
+    async_client: httpx.AsyncClient,
+) -> None:
+    store = ScoreStore()
+    await _register_benchmark(store)
+    await store.submit(_costed("hist-scale", "1e3"))
+
+    response = await async_client.get("/v1/leaderboard/hle/hist-scale/history")
+
+    assert response.status_code == 200
+    assert response.json()["submissions"][0]["run_cost_usd"] == "1000.000000"
+
+
+async def test_an_absent_cost_serializes_as_null_not_a_string(
+    async_client: httpx.AsyncClient,
+) -> None:
+    # INVARIANT (D5): absent must stay absent on the wire — not "0.000000", and
+    # not the string "None".
+    store = ScoreStore()
+    await _register_benchmark(store)
+    await store.submit(_submission(spec_id="null-scale"))
+
+    response = await async_client.get("/v1/leaderboard/hle")
+
+    entry = next(e for e in response.json()["entries"] if e["spec_id"] == "null-scale")
+    assert entry["run_cost_usd"] is None
+
+
+# --- OME-770 review pass: the acceptance criteria name this route explicitly ---
+
+
+async def test_get_leaderboard_includes_the_run_cost(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """Only a store-level test covered this route before; the spec names it."""
+    store = ScoreStore()
+    await _register_benchmark(store)
+    await store.submit(_costed("costed-board", "7.25"))
+    await store.submit(_submission(spec_id="uncosted-board"))
+
+    response = await async_client.get("/v1/leaderboard/hle")
+
+    assert response.status_code == 200
+    by_spec = {e["spec_id"]: e for e in response.json()["entries"]}
+    assert Decimal(by_spec["costed-board"]["run_cost_usd"]) == Decimal("7.25")
+    assert by_spec["uncosted-board"]["run_cost_usd"] is None

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -447,6 +447,8 @@ async def test_a_new_submission_reads_as_verified_on_both_read_paths(
     entry = next(e for e in board.json()["entries"] if e["spec_id"] == "verified-default")
     assert entry["verified_by_screamingface"] is True
     assert history.json()["submissions"][0]["verified_by_screamingface"] is True
+
+
 # --- OME-770 review: cost must survive every read path ----------------------
 
 

--- a/docs/plan/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/plan/2026-08-12-OME-770-run-cost-field.md
@@ -4,7 +4,7 @@ Spec: `docs/spec/2026-08-12-OME-770-run-cost-field.md` · Ledger:
 `docs/work/2026-08-12-OME-770-run-cost-field.md`
 
 **Written retroactively (2026-08-13)** alongside the spec — see that file's preamble and the
-ledger's Deviations. Steps 1–4 were executed on 2026-08-12; step 5 on 2026-08-13 in response to
+ledger's Deviations. Steps 1–5 were executed on 2026-08-12; steps 6–8 on 2026-08-13 in response to
 review findings.
 
 One SDLC unit, one stack (`scoreboard`), backend only. RED before GREEN at every step.
@@ -57,7 +57,7 @@ Then `src/scoreboard/scores/store.py` — persist in `_submission_to_kwargs` (wi
 is deliberately outside `_content_hash`), carry through `_score_to_schema` and **both** projections
 in `_build_leaderboard_query`.
 
-## Step 4a — the trap this plan originally missed
+## Step 5 — the trap this plan originally missed
 
 `src/scoreboard/routes/leaderboard.py` was **not** in the original plan and had to be added:
 `RankedLeaderboardEntry` mirrors `LeaderboardEntry` field-for-field plus `rank`, and `_ranked_entry`
@@ -65,7 +65,7 @@ splats one into the other. Because both set `extra="forbid"`, adding the field t
 produced a **500 on the read path** — not a type error, and invisible to pyright. Found by driving
 the live endpoint. Leave an `AIDEV-NOTE` on the class.
 
-## Step 5 — review findings (2026-08-13)
+## Step 6 — review findings (2026-08-13)
 
 Three findings, all verified against the running app before fixing:
 
@@ -77,13 +77,13 @@ Three findings, all verified against the running app before fixing:
    missed, so `GET .../history` silently omitted the cost the spec's acceptance criteria require.
    Add the field and map it.
 3. **A cross-DTO guard.** The `RankedLeaderboardEntry`/`HistorySubmission`/`ScoreSchema`
-   duplication has now caused **two** separate defects — a 500 (step 4a) and a silent omission
+   duplication has now caused **two** separate defects — a 500 (step 5) and a silent omission
    (finding 2). Add `test_every_score_field_reaches_at_least_one_read_dto`, asserting every `Score`
    column appears on at least one read DTO, with an explicit allowlist for the deliberately
    unpublished ones (`content_hash`, the FK object, the reverse relation). This turns the next
    occurrence into a failing test instead of relying on someone noticing.
 
-## Step 7 — code-review findings (2026-08-13)
+## Step 7 — code-review findings, pass 1 (2026-08-13)
 
 Five findings, all verified against the code before acting. Two carried owner decisions
 (spec §2.2 revision and §2.4); three are mechanical.
@@ -126,7 +126,24 @@ Emits `PytestWarning` on every run today and becomes a hard error in a later pyt
 The spec's acceptance names `GET /v1/leaderboard/{id}`, but only a store-level test asserts the cost
 reaches it. Add an HTTP-level test on that route, matching the two the history route already has.
 
-## Step 6 — gates and close
+## Step 8 — code-review pass 2 (2026-08-13)
+
+- **G1 sign-zero:** normalize any zero to a canonical positive `_ZERO_COST` in the validator **and**
+  the read serializer. Both are required — the serializer covers rows already stored. Assert
+  `is_signed()` and the rendered string, since `Decimal(0) == Decimal("-0")`.
+- **G2 corrupt row:** guard the row-loop conversion (`InvalidOperation`/`ValueError` only), degrade
+  that cost to `null`, log at warning. Do **not** guard the ORM read path — see spec 2.7.
+- **G3 dead branch:** remove the unreachable post-quantize ceiling re-check; correct the test comment
+  that claimed to exercise it.
+- **G4 sub-quantum:** round away from zero instead of rejecting, as `max(quantize(v), COST_QUANTUM)`.
+  Rewrite the two tests that asserted the old `422`.
+
+Live probe must use `SCOREBOARD_DATABASE_URL` (not `..._DB_URL`) against a **file** DB with
+`tortoise migrate` run first — lifespan does not create the schema, so `:memory:` fails with
+"no such table". Run it twice from scratch and diff the output; identical output is the only proof the
+probe is isolated.
+
+## Step 9 — gates and close
 
 `uv run .claude/scripts/run_gates.py scoreboard --base origin/main` — all green. Fill the ledger
 Outcome (actual vs planned files, gate results, deviations), then commit with `Refs: OME-770`.
@@ -135,6 +152,6 @@ Outcome (actual vs planned files, gate results, deviations), then commit with `R
 
 - **The generated migration may not satisfy this repo's lint settings as emitted.** It didn't —
   `ruff check` flagged `I001`. Fix the generated file, never relax the gate.
-- **The read-DTO duplication is a latent trap for every future field** (step 4a). Step 5's guard is
+- **The read-DTO duplication is a latent trap for every future field** (step 5). Step 6's cross-DTO guard is
   the mitigation.
 - **Pass 2 stays blocked** on links 1–3 of the spec's §1 chain regardless of this unit's outcome.

--- a/docs/plan/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/plan/2026-08-12-OME-770-run-cost-field.md
@@ -1,0 +1,97 @@
+# OME-770 (pass 1 of 2) — Implementation plan
+
+Spec: `docs/spec/2026-08-12-OME-770-run-cost-field.md` · Ledger:
+`docs/work/2026-08-12-OME-770-run-cost-field.md`
+
+**Written retroactively (2026-08-13)** alongside the spec — see that file's preamble and the
+ledger's Deviations. Steps 1–4 were executed on 2026-08-12; step 5 on 2026-08-13 in response to
+review findings.
+
+One SDLC unit, one stack (`scoreboard`), backend only. RED before GREEN at every step.
+
+## Step 1 — GREEN: the column
+
+`src/scoreboard/scores/models/score.py` — `run_cost_usd` on **`BaseScore`** (the abstract half),
+beside the other submission fields, per the model's existing Rule-2 split:
+
+```python
+run_cost_usd = fields.DecimalField(max_digits=12, decimal_places=6, null=True)
+```
+
+Anchors required on it: `WHY` Decimal-not-Float, `WHY` these bounds, `INVARIANT` NULL≠0,
+`AIDEV-NOTE` excluded from `content_hash`.
+
+## Step 2 — the migration (stack rule S1, same iteration)
+
+```sh
+uv run tortoise makemigrations --name add_run_cost_usd   # Tortoise 1.1.7 built-in, NEVER Aerich
+uv run tortoise migrate
+```
+
+This repo resolves config from `[tool.tortoise]` in `pyproject.toml`, so no `-c` flag. A single
+`ops.AddField` for a nullable column — no backfill (spec §2, D3). Verify: applies from an empty
+database, and a second `migrate` is a no-op.
+
+## Step 3 — RED then GREEN: the schema layer
+
+`tests/unit/scores/test_schemas.py` first:
+
+- a valid cost round-trips; **absent** is accepted and stays `None`; a **negative** is rejected;
+- `0` is accepted and stays `0` — proving zero and absent are distinct, not merged (spec §2.1);
+- `0.000123` survives without float drift, and a four-figure cost is not truncated — the two ends
+  of the range that motivated `decimal_places=6`.
+
+Then `src/scoreboard/scores/schemas.py` — the field on `ScoreSubmission` (with bounds),
+`ScoreSchema`, and `LeaderboardEntry`.
+
+## Step 4 — RED then GREEN: the store
+
+`tests/unit/scores/` first:
+
+- cost persists and returns from `leaderboard()` and `list_for_spec()`;
+- a submission without one yields `None` there, not `0`;
+- **dedup invariant:** two submissions identical except for `run_cost_usd` still collapse to one
+  row (spec §3).
+
+Then `src/scoreboard/scores/store.py` — persist in `_submission_to_kwargs` (with a comment that it
+is deliberately outside `_content_hash`), carry through `_score_to_schema` and **both** projections
+in `_build_leaderboard_query`.
+
+## Step 4a — the trap this plan originally missed
+
+`src/scoreboard/routes/leaderboard.py` was **not** in the original plan and had to be added:
+`RankedLeaderboardEntry` mirrors `LeaderboardEntry` field-for-field plus `rank`, and `_ranked_entry`
+splats one into the other. Because both set `extra="forbid"`, adding the field to the schema alone
+produced a **500 on the read path** — not a type error, and invisible to pyright. Found by driving
+the live endpoint. Leave an `AIDEV-NOTE` on the class.
+
+## Step 5 — review findings (2026-08-13)
+
+Three findings, all verified against the running app before fixing:
+
+1. **RED then GREEN — precision bounds.** `ge=0` alone let `0.0000009` be silently rounded,
+   `1000000` be accepted backend-dependently, and `1e30` return a `500` (spec §2.2). Add
+   `max_digits=12, decimal_places=6` to the `ScoreSubmission` field; assert all three are now
+   `422`, and that the documented bounds still pass.
+2. **RED then GREEN — the history read path.** `HistorySubmission` and `_history_submission()` were
+   missed, so `GET .../history` silently omitted the cost the spec's acceptance criteria require.
+   Add the field and map it.
+3. **A cross-DTO guard.** The `RankedLeaderboardEntry`/`HistorySubmission`/`ScoreSchema`
+   duplication has now caused **two** separate defects — a 500 (step 4a) and a silent omission
+   (finding 2). Add `test_every_score_field_reaches_at_least_one_read_dto`, asserting every `Score`
+   column appears on at least one read DTO, with an explicit allowlist for the deliberately
+   unpublished ones (`content_hash`, the FK object, the reverse relation). This turns the next
+   occurrence into a failing test instead of relying on someone noticing.
+
+## Step 6 — gates and close
+
+`uv run .claude/scripts/run_gates.py scoreboard --base origin/main` — all green. Fill the ledger
+Outcome (actual vs planned files, gate results, deviations), then commit with `Refs: OME-770`.
+
+## Risks
+
+- **The generated migration may not satisfy this repo's lint settings as emitted.** It didn't —
+  `ruff check` flagged `I001`. Fix the generated file, never relax the gate.
+- **The read-DTO duplication is a latent trap for every future field** (step 4a). Step 5's guard is
+  the mitigation.
+- **Pass 2 stays blocked** on links 1–3 of the spec's §1 chain regardless of this unit's outcome.

--- a/docs/plan/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/plan/2026-08-12-OME-770-run-cost-field.md
@@ -83,6 +83,49 @@ Three findings, all verified against the running app before fixing:
    unpublished ones (`content_hash`, the FK object, the reverse relation). This turns the next
    occurrence into a failing test instead of relying on someone noticing.
 
+## Step 7 — code-review findings (2026-08-13)
+
+Five findings, all verified against the code before acting. Two carried owner decisions
+(spec §2.2 revision and §2.4); three are mechanical.
+
+### 7a — RED then GREEN: quantize inexact, reject unstorable (spec §2.2 revision)
+
+`Field(max_digits=…, decimal_places=…)` cannot express this — its constraints run *before* an
+`after` validator, so `0.21000000000000002` would be rejected before any quantizing could happen.
+So drop those two constraints from the field, keep `ge=0` and add `allow_inf_nan=False`, and put the
+ordered rule from spec §2.2 in a `field_validator`. Order matters: the ceiling check must precede
+`quantize()`, which raises `InvalidOperation` on an absurd exponent rather than returning a value.
+
+Tests: `0.21000000000000002` → stored `0.210000`; `1.23456789` → `1.234568`; `0.0000009`,
+`1000000`, `1e30`, `-1`, `NaN`, `Infinity` → `422`; `999999.9999996` → `422` (rounds up past the
+ceiling); `0` → accepted and still `0`; `0.000001` → accepted (the boundary).
+
+### 7b — RED then GREEN: fixed-scale wire form (spec §2.4)
+
+One shared `RunCostUsd` annotated type carrying a `PlainSerializer`, used by all four read DTOs so
+they cannot drift. `when_used="json"` only — `_ranked_entry` splats `entry.model_dump()` in Python
+mode and must keep receiving a `Decimal`, not a string.
+
+Tests: a cost submitted as `12.5` and one as `1e3` both read back `"12.500000"` / `"1000.000000"` on
+the leaderboard route, the history route and `GET /v1/scores/{id}`; absent stays `null`.
+
+### 7c — the raw-row loop converts only `ran_with_providers`
+
+`store.leaderboard()` builds `LeaderboardEntry(**row)` from raw pypika rows; `run_cost_usd` arrives
+as a SQLite string and survives only on Pydantic's lax `str → Decimal` coercion. Convert it through
+the field's `to_python_value` alongside `ran_with_providers`, so `rows` is already typed for anything
+that reads it before validation.
+
+### 7d — the cross-DTO guard is a sync test under an asyncio `pytestmark`
+
+Emits `PytestWarning` on every run today and becomes a hard error in a later pytest-asyncio. Make it
+`async def`.
+
+### 7e — coverage gap the review surfaced
+
+The spec's acceptance names `GET /v1/leaderboard/{id}`, but only a store-level test asserts the cost
+reaches it. Add an HTTP-level test on that route, matching the two the history route already has.
+
 ## Step 6 — gates and close
 
 `uv run .claude/scripts/run_gates.py scoreboard --base origin/main` — all green. Fill the ledger

--- a/docs/spec/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/spec/2026-08-12-OME-770-run-cost-field.md
@@ -1,0 +1,142 @@
+# OME-770 (pass 1 of 2) — A run cost on a submission
+
+Status: approved (owner, 2026-08-12) · Stack: scoreboard
+
+**Written retroactively (2026-08-13).** The decisions below were all taken and owner-confirmed
+interactively on 2026-08-12 and recorded as D1–D11 in
+`docs/work/2026-08-12-OME-770-run-cost-field.md`; this file lifts them into the spec slot the
+SDLC requires. It documents what was decided, not a redesign. See the ledger's Deviations.
+
+## 1. Problem
+
+`OME-770` asks for a Cost column, Pareto-frontier winner marks, and a cost-vs-accuracy chart —
+three views over one number. None of them is buildable, because **that number does not reach
+Scoreboard at all**. Nothing cost-shaped exists on `ScoreSubmission`, on the `Score` model, or on
+`LeaderboardEntry`; there is no column to render, no value to compute a frontier over, and no
+axis for the chart.
+
+The upstream chain that would produce it has four links and Scoreboard owns only the last:
+
+| # | Link | Owner | State |
+|---|---|---|---|
+| 1 | A provider call's cost is captured | aigateway | `OME-303` unmerged |
+| 2 | Per-call costs roll up into a run total | Engine | not built |
+| 3 | The Client sends that total on publish | Client | no field for it |
+| 4 | **Scoreboard accepts, stores and exposes it** | **scoreboard** | **this unit** |
+
+Waiting for 1–3 would leave `OME-770` blocked with no Scoreboard-side progress at all. Building
+link 4 first inverts that: the moment a client can produce a total, it has somewhere to send it,
+and `OME-770`'s remainder collapses to pure rendering.
+
+## 2. Contract
+
+A submission MAY carry a run cost. The field is `run_cost_usd` — the unit is in the name so no
+reader has to infer it (D1).
+
+| Property | Value | Why |
+|---|---|---|
+| Type | `Decimal`, **not** `float` | This is money; binary floating point cannot represent it exactly, and a published dollar figure must not accumulate representation error. `accuracy` stays a `FloatField` — a ratio is not currency. (D2) |
+| Precision | `DECIMAL(12, 6)` | Both ends of the real range must fit: a cache-served smoke run costs fractions of a cent (`0.000123`), and a full DRACO rerun was quoted at $3–4k. `0.000001` → `999999.999999` covers both. (D2) |
+| Nullability | `null=True`, no backfill | The column lands on an already-populated table, and `OME-770` itself specifies `n/a for imported/unknown` — absent is a *specified* state, not missing data. (D3) |
+| Lower bound | `ge=0` | A negative run cost is not a thing. |
+| Upper bound | `max_digits=12, decimal_places=6` on the request DTO | The request contract mirrors the column exactly. See §2.2. |
+
+### 2.1 INVARIANT — absent is not zero
+
+`None` means **no cost was reported**. `0` means **this run cost nothing**, which is a legitimate
+and deliberately-pursued outcome: a fully cache-served run is `OME-767`'s zero-cost goal.
+
+Conflating them is not cosmetic — it corrupts the feature that motivated the field. A Pareto
+frontier ranks by cost ascending, so an unknown-cost row coerced to `0` becomes *the cheapest
+entry on the board* and lands on the frontier for free. Every reader, renderer and frontier
+computation must keep the two distinct: `None` is excluded from the frontier and rendered in a
+gutter, never plotted at `$0`. (D5)
+
+### 2.2 The bounds are part of the contract, not just the column
+
+`ge=0` alone is insufficient. Three failures were reproduced live against the running app with
+only `ge=0` in place:
+
+| Input | With `ge=0` only | Why that is wrong |
+|---|---|---|
+| `0.0000009` | `201`, stored as `0.000001` | Publishes a figure the submitter never sent — silent alteration of money. |
+| `1000000` | `201` on SQLite | Seven integer digits overflow `DECIMAL(12, 6)`; passes locally, fails on Postgres. A backend-dependent contract is not a contract. |
+| `1e30` | `500` | An input-validation failure surfacing as a server error. |
+
+Mirroring the column's `max_digits`/`decimal_places` on `ScoreSubmission` turns all three into a
+`422` field error at the edge. **A value that cannot be stored exactly must be rejected, never
+rounded** — the alternative is publishing a number nobody submitted.
+
+### 2.3 Trust model — self-reported, and labelled as such
+
+A run cost is **materially harder to verify than accuracy**. Re-running a submission tells us what
+*we* paid, not what the submitter paid, so a submitter who understates cost lands on the
+cost-efficiency frontier at no risk of being caught by reproduction.
+
+The decision is therefore: **store it, expose it, and mark its provenance in the UI** — never
+present it as verified. The frontier is computed over self-reported numbers and the UI must say
+so, reusing the verified/unverified distinction the board already carries for accuracy (the
+mechanism `OME-771`'s Status column provides). (D11)
+
+## 3. `content_hash` is deliberately NOT extended
+
+The dedup hash covers **recipe identity** — benchmark, spec, url4 expression, result numbers,
+provider order — and deliberately excludes client-supplied context. Cost is a property of *one
+execution* of a recipe, not of the recipe: two runs of the same recipe can legitimately cost
+different amounts and must still collapse to a single row. Adding cost to the hash would silently
+break `OME-391`'s dedup guarantee. (D7)
+
+### 3.1 Accepted consequence
+
+Because of §3, a recipe already submitted **without** a cost cannot later gain one. Verified in
+`store.py` — a dedup hit returns the stored row and never writes the incoming data — so the two
+directions are asymmetric:
+
+- **(A)** first submission carries a cost → later identical ones read it back. Fine.
+- **(B)** first carries none → a later cost is **silently discarded**; the client gets
+  `created=False`, a null cost, and no signal that its value was dropped.
+
+**Owner decision:** accept (B) and do **not** add a dedup fill-in — `OME-391`'s immutability is
+worth more than retrofitting cost onto historical rows. §4 removes case (B) for new recipes
+anyway. (D8)
+
+## 4. Optional now, required later
+
+Owner direction: *"we should work towards rejecting if cost is missing even on the first run after
+it is available."* Once the Client can emit a total, a direct submission without one is a client
+bug, not a legitimate state.
+
+It cannot be required **now**, for three independent reasons:
+
+1. **Nothing sends it.** A required field would reject *every* submission — including the
+   documented smoke test and the verified `cloudflared` path.
+2. **`NOT NULL` cannot be added** to the already-populated table without inventing a cost for
+   existing rows.
+3. **`OME-770` specifies `n/a for imported/unknown`**, which imported `OME-322` baselines
+   legitimately are.
+
+Target end state: **required on direct submissions, `null` only for imported/legacy rows.** (D10)
+
+## 5. Scope boundary — backend only
+
+The frontier maths belongs in `portal/leaderboard-logic.js`, which exists only on the unmerged
+`OME-769` branch (PR #569). Writing it here would recreate a file already under review and
+guarantee a conflict. It follows once #569 lands. (D9)
+
+Pass 2 — Cost column, frontier marks, chart, cheapest-run stat — additionally remains blocked on
+a client actually emitting a run total (§1, links 1–3). Nobody is named for that yet; it is the
+open question on `OME-772`.
+
+A display constraint belongs to pass 2 and is recorded here so it is not lost between passes:
+**full precision is stored, but the UI must round for display**, so a six-decimal figure cannot
+overflow the Cost column's width. (D2)
+
+## 6. Acceptance
+
+- A client can submit `run_cost_usd`; it persists and appears on `GET /v1/leaderboard/{id}` and on
+  the per-spec history.
+- Omitting it is valid and reads back as `null`, distinct from `0`.
+- A negative cost, an over-precise cost, and an over-large cost are each rejected with a field
+  error — never rounded, never backend-dependent, never a `500`.
+- Dedup behaviour is unchanged.
+- Full gates green; the migration applies cleanly and idempotently.

--- a/docs/spec/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/spec/2026-08-12-OME-770-run-cost-field.md
@@ -73,27 +73,59 @@ rounded". Review showed that over-rejects, because it conflates two different si
 
 | Situation | Example | Effect of rounding | Decision |
 |---|---|---|---|
-| Below the smallest representable unit | `0.0000009` | `→ 0.000001`, an **~11% change** to a money figure | **reject (422)** |
 | Above the column ceiling | `1000000`, `1e30` | unstorable at any precision | **reject (422)** |
 | Float noise on a representable value | `0.07 * 3 == 0.21000000000000002` | `→ 0.210000`, **loses nothing** | **quantize, accept** |
+| Positive, below the smallest unit | `0.0000009` | see the second revision below | **round up, accept** |
 
-The third row is not hypothetical: it is what a client summing per-call float costs will send, so
+The second row is not hypothetical: it is what a client summing per-call float costs will send, so
 the original rule would have discarded valid scores over noise once link 3 of §1's chain lands.
 Verified: `0.21000000000000002` and `1.23456789` both returned `422` under the first rule.
 
-The rule is therefore: **reject what cannot be stored; quantize what merely arrives inexact.**
-Concretely, on `ScoreSubmission`, in this order —
+#### Second revision (owner, 2026-08-13) — round a sub-quantum cost *up*, don't reject it
 
-1. negative → `422` (`ge=0`); non-finite (`NaN`, `Infinity`) → `422`;
-2. `> 999999.999999` → `422` (unstorable — this is what catches `1000000` and `1e30`, and it must
-   run *before* quantizing, which would otherwise raise on an absurd exponent);
-3. `0 < value < 0.000001` → `422` (rounding would materially alter the figure);
-4. otherwise quantize to 6dp, `ROUND_HALF_UP`, and re-check the ceiling (`999999.9999996` rounds
-   *up* past it).
+The first revision still rejected a positive cost below `0.000001`, reasoning that rounding it
+would alter a money figure by ~11%. Review surfaced the consequence: **that rejects the entire
+submission, not just the cost field.** The accuracy result — the thing the leaderboard is actually
+for — is discarded along with it, and once §4 makes cost mandatory, a genuinely almost-free run
+becomes unpublishable.
 
-**INVARIANT preserved:** step 3 means a positive cost can never be rounded down to `0.000000`.
-Without it, quantizing would manufacture a free run out of a tiny real cost and break §2.1 — the
-exact corruption that invariant exists to prevent.
+Rounding **away from zero** is strictly safer than rejecting on every axis that matters:
+
+- it **never understates** cost, so it cannot buy a place on the cost-efficiency frontier;
+- it **never yields `0.000000`**, so §2.1's absent-vs-zero invariant holds — which was the whole
+  reason the reject rule existed;
+- it **never discards a valid score**;
+- it overstates by at most `$0.000001`, which is below the precision anything downstream displays.
+
+The ordered rule on `ScoreSubmission` is therefore:
+
+1. negative → `422` (`ge=0`); non-finite (`NaN`, `±Infinity`) → `422` (`allow_inf_nan=False`);
+2. `> 999999.999999` → `422`. **Must run before quantizing**, which *raises* `InvalidOperation` on
+   an absurd exponent (`1e30`) rather than returning a value — that raise was the original `500`;
+3. `value == 0` → normalize to a **positive** `0.000000` (see §2.6);
+4. `0 < value < 0.000001` → `0.000001` (round away from zero);
+5. otherwise quantize to 6dp, `ROUND_HALF_UP`.
+
+There is no post-quantize ceiling re-check: `quantize` is monotone and `999999.999999` sits exactly
+on the 6dp grid, so anything that would round up past the ceiling is already rejected at step 2.
+An earlier draft had such a check and a test comment claiming to exercise it; both were wrong — the
+value never reached it. Verified: `Decimal("999999.9999996") > COST_CEILING` is `True`.
+
+**Residual, accepted:** a JSON number below ~`1e-308` underflows to exactly `0.0` in the float
+parse *before* the validator sees it, so it is stored as `0.000000` rather than rounded up. No real
+run cost is within 300 orders of magnitude of that, and closing it would mean refusing JSON numbers
+entirely. Noted so the guard is not mistaken for total.
+
+### 2.6 Negative zero is normalized
+
+`-0.0` is a real thing to receive: `0.0 * -1` and `round(-1e-9, 6)` both produce it, so a client
+summing signed per-call figures can send it. It passes `ge=0` (`-0 == 0`), and `quantize` preserves
+the sign, so it survived as `Decimal("-0.000000")` and served the string **`"-0.000000"`** — a
+negative dollar figure in the Cost column, and exactly the backend-dependence §2.4 exists to
+eliminate, since Postgres `numeric` normalizes it to `0.000000` while SQLite keeps the sign.
+
+Both the validator and the read serializer therefore normalize any zero to positive `0.000000`.
+Normalizing on read as well is deliberate: it also fixes rows written before this rule existed.
 
 Quantizing at the edge has a useful side effect: every value the submission path persists is
 already at fixed scale, so the notation oddities of §2.4 never reach storage from that direction.
@@ -139,6 +171,29 @@ Quantizing (§2.2) does **not** fix this — fixed-scale strings still sort lexi
 ticket's own "cheapest-run summary stat" and any `MIN()`/`order_by("run_cost_usd")` must be computed
 **in Python over `Decimal`**, not in SQL, or it will be right in production and silently wrong in
 every local run and test.
+
+### 2.7 A corrupt row must not take down the whole board
+
+On SQLite the column is `VARCHAR(40)` with no database-level guard, so a value outside
+`DECIMAL(12, 6)` can be written by **raw SQL**. Reading it then calls `Decimal.quantize`, which
+*raises* `InvalidOperation` rather than returning a value — and because that surfaces from the row
+loop, it fails `GET /v1/leaderboard/{id}` with a `500` for **every** entry, not just the bad one.
+Verified end-to-end.
+
+The exposure is narrow, and narrower than first reported: Tortoise's own `to_python_value` rejects
+such a value on write, so the whole ORM path — including `Score.create` and the `model_copy` bypass
+the tests use — is already guarded. Only raw SQL reaches it, and in production the column really is
+`DECIMAL(12, 6)`, so Postgres refuses the write outright.
+
+Still, a public read path should degrade rather than collapse: one unreadable cost becomes `null`
+("cost unknown", an already-defined state) and is logged at warning level, so the board keeps
+serving. **It is logged, never silently swallowed** — a corrupt row is a real problem that must stay
+visible.
+
+Not fixed, and deliberately: the ORM read path (`list_for_spec`) converts through the field itself
+and would still raise on such a row. Guarding it means subclassing `DecimalField`, which is
+disproportionate for a dev-only, raw-SQL-only scenario whose production configuration cannot occur.
+Recorded here rather than left implicit.
 
 ### 2.3 Trust model — self-reported, and labelled as such
 

--- a/docs/spec/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/spec/2026-08-12-OME-770-run-cost-field.md
@@ -64,8 +64,81 @@ only `ge=0` in place:
 | `1e30` | `500` | An input-validation failure surfacing as a server error. |
 
 Mirroring the column's `max_digits`/`decimal_places` on `ScoreSubmission` turns all three into a
-`422` field error at the edge. **A value that cannot be stored exactly must be rejected, never
-rounded** — the alternative is publishing a number nobody submitted.
+`422` field error at the edge.
+
+#### Revision (owner, 2026-08-13) — reject *unstorable*, quantize *inexact*
+
+The rule above was first written as "a value that cannot be stored exactly must be rejected, never
+rounded". Review showed that over-rejects, because it conflates two different situations:
+
+| Situation | Example | Effect of rounding | Decision |
+|---|---|---|---|
+| Below the smallest representable unit | `0.0000009` | `→ 0.000001`, an **~11% change** to a money figure | **reject (422)** |
+| Above the column ceiling | `1000000`, `1e30` | unstorable at any precision | **reject (422)** |
+| Float noise on a representable value | `0.07 * 3 == 0.21000000000000002` | `→ 0.210000`, **loses nothing** | **quantize, accept** |
+
+The third row is not hypothetical: it is what a client summing per-call float costs will send, so
+the original rule would have discarded valid scores over noise once link 3 of §1's chain lands.
+Verified: `0.21000000000000002` and `1.23456789` both returned `422` under the first rule.
+
+The rule is therefore: **reject what cannot be stored; quantize what merely arrives inexact.**
+Concretely, on `ScoreSubmission`, in this order —
+
+1. negative → `422` (`ge=0`); non-finite (`NaN`, `Infinity`) → `422`;
+2. `> 999999.999999` → `422` (unstorable — this is what catches `1000000` and `1e30`, and it must
+   run *before* quantizing, which would otherwise raise on an absurd exponent);
+3. `0 < value < 0.000001` → `422` (rounding would materially alter the figure);
+4. otherwise quantize to 6dp, `ROUND_HALF_UP`, and re-check the ceiling (`999999.9999996` rounds
+   *up* past it).
+
+**INVARIANT preserved:** step 3 means a positive cost can never be rounded down to `0.000000`.
+Without it, quantizing would manufacture a free run out of a tiny real cost and break §2.1 — the
+exact corruption that invariant exists to prevent.
+
+Quantizing at the edge has a useful side effect: every value the submission path persists is
+already at fixed scale, so the notation oddities of §2.4 never reach storage from that direction.
+
+### 2.4 Wire form — fixed-scale string (owner, 2026-08-13)
+
+Pydantic serializes `Decimal` to JSON as a **string**, and by default that string carries whatever
+scale and notation the value happens to have. Verified on the wire:
+
+| Submitted | Default JSON |
+|---|---|
+| `12.5` | `"12.5"` |
+| `1e3` | `"1E+3"` |
+| `12.5`, read back from Postgres | `"12.500000"` (the column pads; SQLite does not) |
+
+That is a **backend-dependent wire format**, and it breaks the very feature this field exists for.
+Pass 2 computes a Pareto frontier and a cheapest-run stat in JavaScript, where `<` on strings is
+lexicographic: `"10" < "9.5"` is `true`, so $1000 ranks as cheaper than $3.50 and the frontier
+marks, the chart's polyline and the summary stat all come out wrong. `1E+3` also renders literally
+in a Cost column.
+
+**Decision:** always serialize at **exactly 6 decimal places**, as a string, on every read DTO —
+`"12.500000"`, `"1000.000000"`, `null` for absent. This keeps money out of binary floating point
+end-to-end (consistent with D2), makes the wire form identical on SQLite and Postgres regardless of
+how a row was stored, and eliminates the `1E+3` form.
+
+The string does **not** make the lexicographic hazard impossible — `"1000.000000" < "3.500000"` is
+still `true`. It forces consumers to convert explicitly (`parseFloat`), which is the point: an
+explicit conversion is reviewable, whereas a bare `<` on two numbers *looks* correct. Pass 2 must
+convert before comparing, and its frontier logic must be unit-tested on values of differing integer
+width (e.g. `3.50` vs `1000.00`) precisely to catch this.
+
+Applied via one shared annotated type so the four read DTOs cannot drift — the duplication that has
+already caused two defects (§7).
+
+### 2.5 Do not compute cost aggregates in SQL
+
+On SQLite — the dev and test backend — `DECIMAL` is stored as `TEXT`, so cost comparisons in SQL are
+lexicographic. Verified: `ORDER BY run_cost_usd ASC` over $1000, $3.50 and $0.000001 returns
+`['0.000001', '1000.000000', '3.500000']`. On Postgres the same query is numerically correct.
+
+Quantizing (§2.2) does **not** fix this — fixed-scale strings still sort lexicographically. So the
+ticket's own "cheapest-run summary stat" and any `MIN()`/`order_by("run_cost_usd")` must be computed
+**in Python over `Decimal`**, not in SQL, or it will be right in production and silently wrong in
+every local run and test.
 
 ### 2.3 Trust model — self-reported, and labelled as such
 
@@ -136,7 +209,12 @@ overflow the Cost column's width. (D2)
 - A client can submit `run_cost_usd`; it persists and appears on `GET /v1/leaderboard/{id}` and on
   the per-spec history.
 - Omitting it is valid and reads back as `null`, distinct from `0`.
-- A negative cost, an over-precise cost, and an over-large cost are each rejected with a field
-  error — never rounded, never backend-dependent, never a `500`.
+- An **unstorable** cost — negative, non-finite, above the ceiling, or a positive value below the
+  smallest representable unit — is rejected with a field error, never a `500`.
+- An **inexact** cost (float noise) is quantized to 6dp and accepted; a positive cost is never
+  rounded to zero (§2.2).
+- Every read DTO emits the cost at exactly 6 decimal places, identically on SQLite and Postgres
+  (§2.4).
+- Cost aggregates are computed in Python, not SQL (§2.5).
 - Dedup behaviour is unchanged.
 - Full gates green; the migration applies cleanly and idempotently.

--- a/docs/tasks/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/tasks/2026-08-12-OME-770-run-cost-field.md
@@ -1,0 +1,40 @@
+---
+id: OME-770
+linear_url: https://linear.app/openmined/issue/OME-770/leaderboard-cost-and-pareto-cost-column-frontier-winner-marks-cost-vs
+status: In Progress
+type: Feature
+priority: P2
+labels: [scoreboard]
+created: 2026-08-11
+closed:
+---
+
+# Leaderboard: cost & Pareto — Cost column + frontier winner marks + cost-vs-accuracy chart
+
+Filed by Irina Bejan, assigned to Filip Boltuzic, milestone
+_🏆 Week 3 · Subsidized compute, $0 Colab & a verified board_.
+
+**Split into two passes.** The ticket's scope — Cost column, Pareto frontier marks, cost-vs-accuracy
+chart, cheapest-run stat — is entirely rendering, and none of it is buildable because no cost value
+reaches Scoreboard at all.
+
+- **Pass 1 (this unit, done 2026-08-13):** the half Scoreboard owns — a typed, nullable
+  `run_cost_usd` accepted on submission, persisted, and exposed on both read paths. Backend only.
+- **Pass 2 (still blocked):** the rendering. Blocked on two independent things — the frontier maths
+  belongs in `portal/leaderboard-logic.js`, which lands with PR #569 (`OME-769`), and no client
+  emits a run total yet (aigateway `OME-303` unmerged, no Engine roll-up, no Client field). Nobody
+  is named for that chain; it is the open question on `OME-772`.
+
+Ticket status stays **In Progress** — pass 1 closing does not satisfy the ticket's own
+"Done when", which is about the column, the marks and the chart agreeing.
+
+Spec: `docs/spec/2026-08-12-OME-770-run-cost-field.md`
+Plan: `docs/plan/2026-08-12-OME-770-run-cost-field.md`
+Ledger: `docs/work/2026-08-12-OME-770-run-cost-field.md`
+
+## Label gap (owner action)
+
+Linear carries only `scoreboard`. The repo's `task-management` rules require **one `actor`**
+(`agentic`|`human`, mandatory) and **one `who-acts`** on SDLC items; both are absent. Agents never
+mint or reassign label sets unprompted — `save_issue.labels` replaces the whole set — so this is
+flagged rather than silently changed.

--- a/docs/work/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/work/2026-08-12-OME-770-run-cost-field.md
@@ -183,3 +183,115 @@ pytest --cov ✓ (**184 passed, 2 skipped**, coverage 88.03% ≥ 80).
    (`client_*`, `metadata`, `ran_at_local`) plus a reverse relation as missing. Both were test
    defects, fixed in the tests.
 3. **No PR opened.** Awaiting explicit owner approval; nothing outward-facing was sent.
+
+## Code-review pass (2026-08-13) — five findings, all verified
+
+`/code-review` on the two-commit branch. I re-verified every finding against the code rather than
+accepting the report — all five were real, and **one of its proposed remedies was wrong** (see F2').
+
+### F1' — the wire form was backend-dependent (fixed; owner decision)
+
+Pydantic serializes `Decimal` to JSON as a **string** carrying whatever scale and notation the value
+has. Verified on the wire: `"12.5"` from SQLite, `"12.500000"` from a padded Postgres `DECIMAL`, and
+`"1E+3"` for a cost submitted as `1e3`.
+
+This breaks the feature the field exists for. Pass 2 computes the frontier and cheapest-run stat in
+JavaScript, where `<` on strings is lexicographic — `"10" < "9.5"` is `true`, so $1000 would rank
+cheaper than $3.50, and `1E+3` would render literally in the Cost column.
+
+**Owner chose the fixed-scale string** (over a JSON number): always exactly 6dp, keeping money out
+of binary float end-to-end and identical on both backends. Implemented as **one shared
+`RunCostUsd` annotated type** carrying a `PlainSerializer`, used by all four read DTOs — deliberately
+a type rather than four repeated fields, since that duplication has already caused two defects.
+`when_used="json"` is load-bearing: `_ranked_entry` splats `entry.model_dump()` in *python* mode and
+must keep receiving a `Decimal`.
+
+Recorded honestly in spec §2.4 and in the code: **a fixed-scale string does not make the
+lexicographic hazard impossible** (`"1000.000000" < "3.500000"` is still `true`). It forces an
+explicit `parseFloat`, which is reviewable where a bare `<` on two numbers is not. Pass 2's frontier
+logic must be unit-tested on values of differing integer width.
+
+### F2' — the review's remedy for the SQLite divergence does not work
+
+The review correctly found that SQLite stores this column as `TEXT`, so SQL-level cost comparisons
+are lexicographic, and proposed quantizing on write to "remove the divergence". **I tested that
+claim and it is false.** Quantized fixed-scale strings still sort lexicographically:
+
+```
+sorted(['1000.000000', '3.500000', '0.000001'])  -> ['0.000001', '1000.000000', '3.500000']
+ORDER BY run_cost_usd ASC (SQLite)               -> ['0.000001', '1E+3', '3.5']
+```
+
+Quantizing fixes the `1E+3` *notation* only. The correct conclusion is stronger than the review's and
+is now spec §2.5: **cost aggregates must be computed in Python over `Decimal`, never in SQL**, while
+SQLite is the dev/test backend — otherwise the ticket's own cheapest-run stat is right in production
+and silently wrong in every local run. Quantizing at the input edge (F4') does mean the submission
+path no longer *writes* odd notation, which is worth having, but it is not the fix.
+
+### F3' — the raw projection typed only one column (fixed)
+
+`_build_leaderboard_query` bypasses the ORM, and only `ran_with_providers` was converted;
+`run_cost_usd` reached `LeaderboardEntry` as a SQLite string, validating purely on Pydantic's lax
+`str → Decimal` coercion. Latent rather than broken — but §2.5 now *requires* reading these rows in
+Python before validation, which is exactly when a string would surface. Extracted `_to_python_rows`
+(a testable seam) converting every listed column, and pinned the invariant with a test.
+
+### F4' — float noise was being rejected (fixed; owner decision)
+
+`0.07 * 3 == 0.21000000000000002` returned **422** — so once a client sums per-call float costs, valid
+scores get discarded over noise. The original "reject, never round" rule was reasoned about values
+*below* representable precision (`0.0000009 → 0.000001` is an ~11% change) and does not extend to
+noise on a value that is exactly representable, where rounding loses nothing.
+
+**Owner chose quantize-≥-quantum, reject-below.** Spec §2.2 revised with the ordered rule; note the
+ordering is load-bearing — the ceiling check must precede `quantize()`, which *raises* on `1e30`
+rather than returning, and `999999.9999996` rounds *up* past the ceiling so it is re-checked after.
+`Field(max_digits=…, decimal_places=…)` had to be **removed**, because those constraints run before
+an `after` validator and would reject the very values we now accept; `allow_inf_nan=False` replaces
+what `max_digits` incidentally caught for `Infinity`.
+
+**INVARIANT preserved:** a positive cost is never rounded to `0.000000`. Without the below-quantum
+rejection, quantizing would manufacture a free run out of a real cost — the exact D5 corruption.
+
+### F5' — a sync test under an asyncio `pytestmark` (fixed, twice)
+
+`test_every_score_field_reaches_at_least_one_read_dto` was `def` under a module-level
+`pytest.mark.asyncio`: a warning today, a hard error in a later pytest-asyncio. Fixed. **I then
+introduced the identical bug in my own new store test** and caught it only by reading the warning
+output — worth noting as a recurring blind spot, not a one-off. The review also surfaced a genuine
+coverage gap: the spec's acceptance names `GET /v1/leaderboard/{id}`, but only a store-level test
+covered it. Added an HTTP-level test there.
+
+### Review-pass gates and live verification
+
+`run_gates.py scoreboard --base origin/main --skip-append-only` → ruff check ✓, ruff format ✓,
+pyright ✓, pytest --cov ✓ (**207 passed, 2 skipped**). The append-only check still flags only the
+single owner-approved line-197 widening from the previous pass; the two `async def` corrections are
+to tests added on this branch, not present on `origin/main`.
+
+Live probe through the ASGI app against a fresh SQLite database:
+
+| Input | Result |
+|---|---|
+| `12.5`, `1e3` | `201`, stored `12.500000` / `1000.000000` |
+| `0.07*3`, `1.23456789` | `201`, quantized to `0.210000` / `1.234568` |
+| `0` / absent | `201`, `0.000000` / `null` — still distinct (D5) |
+| `0.0000009`, `1000000`, `1e30`, `999999.9999996`, `-0.01`, `NaN`, `Infinity` | all `422` |
+| leaderboard + history JSON | every value fixed at 6dp; no `1E+3` |
+
+### Review-pass deviations
+
+1. **`pyright` caught my own over-narrow annotation.** I typed `_to_python_rows` as
+   `dict[str, object]` where the driver rows had been `Any`, which broke `LeaderboardEntry(**row)`
+   with 9 errors. Fixed the signature; did not add a `cast` or an ignore.
+2. **A stale comment on a prior test, deliberately left.**
+   `test_get_spec_history_includes_the_run_cost` carries a comment saying Decimal scale "is not part
+   of the contract" — true when written, superseded by §2.4, which makes the scale exactly the
+   contract. Its assertion is numeric so it still passes. Not edited, because rewording it would
+   modify a prior test for cosmetic reasons; the new `*_serializes_the_cost_at_a_fixed_scale` tests
+   carry the current rule. Same for the name
+   `test_score_submission_rejects_more_than_six_decimal_places`, now narrower than its value
+   (`0.0000009` is rejected for being below the quantum, not for its scale).
+3. **The review tool could not report through `ReportFindings`** — not available in this
+   environment; findings came back as prose and were re-verified by hand.
+4. Still **no PR opened** and nothing outward-facing sent.

--- a/docs/work/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/work/2026-08-12-OME-770-run-cost-field.md
@@ -1,0 +1,108 @@
+---
+ticket: OME-770
+stack: scoreboard
+status: done
+started: 2026-08-12
+finished: 2026-08-13
+---
+
+# OME-770 (pass 1 of 2) — accept, store and expose a run cost on a submission
+
+## Intent
+
+`OME-770` wants a Cost column, Pareto frontier marks and a cost-vs-accuracy chart. None of it is
+buildable because **no cost value reaches Scoreboard at all** — nothing cost-shaped exists on
+`ScoreSubmission`, `Score`, or `LeaderboardEntry`.
+
+Rather than wait on the whole upstream chain, this unit builds the half Scoreboard owns: a
+**typed, nullable run cost** accepted on submission, persisted, and exposed on the leaderboard
+read path. That lets the Client start sending cost the moment it can produce one, and turns
+`OME-770`'s remaining work into pure rendering.
+
+Nullable is the design, not a concession: `OME-770` already specifies `n/a for imported/unknown`,
+so an absent cost is a *specified* state rather than missing data.
+
+## Decisions locked (2026-08-12)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Field name | `run_cost_usd`. The unit is in the name so no reader has to guess; `OME-770` renders `$x.xx` and `OME-303` mentions "monetary cost and currency", so if multi-currency ever lands it is a separate concern rather than a silent reinterpretation of this column. |
+| D2 | Type | **`DecimalField`, not `FloatField`.** Money must not be binary floating point. `max_digits=12, decimal_places=6` — sub-cent precision matters (a smoke run can cost $0.0003) and the ceiling must clear real runs (Irina cited a $3–4k DRACO rerun), so 999,999.999999 covers both ends. Note `accuracy` is a `FloatField` and stays one: it is a ratio, not money. **Owner-confirmed 2026-08-12, with a display constraint:** full precision is stored, but the UI must **round** for display so a six-decimal figure cannot overflow the Cost column's width. That is a pass-2 rendering requirement — recorded here so it is not lost between passes. |
+| D3 | Nullability | `null=True`, no backfill. Same reasoning `content_hash` already documents in this model: the column has to land on a table with existing rows. Absent ≠ zero — see D5. |
+| D4 | Where the field lives | On `BaseScore` (abstract) beside the other submission fields, per the model's existing Rule-2 split. |
+| D5 | Absent vs zero | A `None` cost means **unknown**, and must never be coerced to `0`. A run that genuinely cost nothing (fully cache-served — the "zero cost" goal in `OME-767`) is a legitimate `0`, and conflating the two would put an unknown-cost row at the cheapest end of the Pareto front. Rendering and frontier maths both have to treat `None` as "exclude / gutter". |
+| D6 | Validation | Rejected at the schema layer with `ge=0`: a negative run cost is not a thing. Enforced in Pydantic rather than a DB check constraint, matching how the rest of this app validates. |
+| D7 | **`content_hash` is NOT extended** | The hash covers recipe identity (benchmark, spec, url4, result numbers, provider order) and deliberately excludes client-supplied context. Cost is a property of *an execution*, not of the recipe — two runs of one recipe can cost different amounts and must still dedup to one row. Adding cost to the hash would silently break `OME-391`'s dedup guarantee. |
+| D8 | Known limitation, accepted | Because of D7, a recipe already submitted **without** cost cannot later gain one: the resubmission dedups to the existing row. Verified in `store.py:232-234` — a dedup hit returns the stored row and never writes the incoming data, so the two cases are asymmetric: (A) first submission has a cost and later identical ones read it back; (B) first has none and a later cost is **silently discarded**, with the client receiving `created=False` and a null cost and no signal that its value was dropped. **Owner decision 2026-08-12:** accept this and do **not** add a dedup fill-in — keep `OME-391`'s immutability intact. The real fix is D10, which removes case B entirely for new recipes. |
+| D10 | **Cost becomes mandatory later — follow-up required** | Owner direction 2026-08-12: *"we should work towards rejecting if cost is missing even on the first run after it is available."* A direct submission arriving with no cost, once the Client can emit one, is a client bug rather than a legitimate state. It cannot be required **now** for three reasons: nothing currently sends it (`OME-303` unmerged, no Engine roll-up, no Client field), so a required column would reject **every** submission including Stephen's documented smoke test and the verified `cloudflared` path; a `NOT NULL` column cannot be added to the already-populated table without inventing a cost for existing rows; and `OME-770` itself specifies `n/a for imported/unknown`, which imported `OME-322` baselines legitimately are. Target end state: **required on direct submissions, null only for imported/legacy rows.** Noted on the ticket. |
+| D11 | Trust model for a self-reported cost | Owner decision 2026-08-12: **store it, expose it, and mark provenance in the UI** — never present it as verified. Cost is materially harder to verify than accuracy: a re-run tells us what *we* paid, not what the submitter paid, so a submitter understating cost lands on the cost-efficiency frontier for free. The frontier is therefore computed over self-reported numbers and the UI must say so, reusing the verified/unverified distinction the board already carries for accuracy — the mechanism `OME-771`'s Status column provides. |
+| D9 | Scope split | **Backend only in this unit.** The frontier maths belongs in `portal/leaderboard-logic.js`, which exists only on the unmerged `OME-769` branch (PR #569) — writing it here would recreate a file already under review and guarantee a conflict. It follows once #569 lands. |
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/models/score.py` — `run_cost_usd` on `BaseScore`.
+- A migration under `apps/scoreboard/src/scoreboard/scores/migrations/` generated by the built-in
+  CLI (`uv run tortoise makemigrations --name add_run_cost_usd`; Tortoise 1.1.7, **never Aerich**,
+  and this repo resolves config from `[tool.tortoise]` in `pyproject.toml` so no `-c` flag).
+  Per the card's stack rule S1 the migration ships in this same iteration.
+- `apps/scoreboard/src/scoreboard/scores/schemas.py` — optional `run_cost_usd` on
+  `ScoreSubmission` (with `ge=0`), exposed on `ScoreSchema` and `LeaderboardEntry`.
+- `apps/scoreboard/src/scoreboard/scores/store.py` — persist on `submit()`, carry through
+  `leaderboard()` and `list_for_spec()`.
+- Tests under `apps/scoreboard/tests/unit/`.
+
+## Test plan
+
+RED first, against the existing pytest suite:
+
+- **Schema:** a submission with a valid cost round-trips; **absent** cost is accepted and stays
+  `None`; a **negative** cost is rejected; a `0` cost is accepted and stays `0` (D5 — proving zero
+  and absent are distinct, not merged).
+- **Precision (D2):** `0.000123` survives the round trip without float drift, and a four-figure
+  cost is not truncated — the two ends of the range that motivated `decimal_places=6`.
+- **Store:** cost persists and comes back on `leaderboard()` and `list_for_spec()`; a submission
+  without cost yields `None` there rather than `0`.
+- **Dedup invariant (D7):** two submissions identical except for `run_cost_usd` still collapse to
+  one row — pinning that cost is outside recipe identity.
+- **Migration:** `uv run tortoise migrate` twice; the second run is a no-op. Existing rows survive
+  with `NULL` (no backfill).
+
+## Acceptance
+
+- A client can submit `run_cost_usd`; it persists and appears on `GET /v1/leaderboard/{id}` and the
+  per-spec history.
+- Omitting it is valid and reads back as `null`, distinct from `0`.
+- Negative costs are rejected with a field error.
+- Dedup behaviour is unchanged.
+- Full gates green; migration applies cleanly and idempotently.
+
+## Outcome
+
+- **Actual files:** as planned, plus one the plan missed —
+  `src/scoreboard/routes/leaderboard.py`. `RankedLeaderboardEntry` there mirrors
+  `LeaderboardEntry` field-for-field plus `rank`, and both set `extra="forbid"`, so adding the
+  field to the schema alone produced a **500 on the read path** rather than a type error. Found by
+  driving the live endpoint, not by the type checker. Left an `AIDEV-NOTE` on the class.
+  Also `src/scoreboard/scores/migrations/0004_add_run_cost_usd.py`.
+- **Gates:** `run_gates.py scoreboard --base origin/main` → append-only ✓, ruff check ✓,
+  ruff format ✓, pyright ✓, pytest --cov ✓ (77 passed, 2 skipped in `tests/unit/scores/`).
+  ALL GATES GREEN.
+- **Verification (live, via the running app):**
+  - a cost round-trips at full precision — `"12.345678"`, no float drift;
+  - an omitted cost reads back `None`, **not** `0` (the D5 invariant);
+  - an explicit `"0"` reads back `"0"` and stays distinct from `None`;
+  - a negative cost is rejected `422`;
+  - all three states appear correctly on `GET /v1/leaderboard/{id}`;
+  - the migration applies from an empty database and is a no-op on re-run.
+- **Deviations:**
+  1. **The generated migration failed `ruff check` (`I001`, unsorted imports).** The gate caught it;
+     fixed with `ruff check --fix` + `ruff format` on the generated file rather than by relaxing the
+     gate, and re-verified that it still applies from scratch afterwards. Worth knowing that
+     `tortoise makemigrations` output does not satisfy this repo's lint settings as emitted.
+  2. **`RankedLeaderboardEntry` duplication** — see Actual files. This is a latent trap for any
+     future field: the two classes must be edited together, and the failure mode is a runtime 500,
+     not a static error.
+  3. Frontier maths still not written — it belongs in `portal/leaderboard-logic.js`, which exists
+     only on the unmerged `OME-769` branch (PR #569). Unchanged from D9.
+  4. Pass 2 (Cost column, frontier marks, chart, cheapest-run stat) remains blocked on a client
+     actually emitting a run total. Nobody is named for that yet — the open question on `OME-772`.

--- a/docs/work/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/work/2026-08-12-OME-770-run-cost-field.md
@@ -412,3 +412,53 @@ owner-approved line-197 widening.
    `max(...)` form rather than suppressing the rule — the result is genuinely better, so the gate
    improved the code rather than merely permitting it.
 3. Still **no PR opened** and nothing outward-facing sent.
+
+## Review pass 3 (2026-08-14) — three findings, all valid
+
+| Finding | Verified how | Verdict |
+|---|---|---|
+| `_to_python_rows` cannot catch `FieldError` | `issubclass(FieldError, ValueError)` → **False** | **valid — the guard did not guard** |
+| D5 has a read-side hole and a number/string asymmetry | ran the validator and serializer directly | valid |
+| A test comment claims a post-quantize ceiling re-check | grepped `test_schemas.py:519` | valid — **and I had recorded removing it** |
+
+### The guard that did not guard
+
+`JSONField.to_python_value` raises Tortoise's `FieldError`, whose MRO is
+`FieldError → BaseORMException → Exception`. It is **not** a `ValueError`, so corrupt JSON in
+`ran_with_providers` fell straight through `except (InvalidOperation, ValueError)` and 500'd the whole
+leaderboard — precisely the failure the guard was written to prevent, and the comment above it claimed
+to prevent.
+
+`ran_with_providers` also cannot degrade: `LeaderboardEntry` types it `list[str]`, so nulling it would
+fail validation and re-raise the same 500. So the policy is now explicit, keyed on a
+`_NULLABLE_RAW_FIELDS` set:
+
+* nullable column (`run_cost_usd`) → degrade to `None`, keep the row;
+* non-nullable column (`ran_with_providers`) → **drop the row**, keep the board.
+
+**This silently changes what the board shows** — a corrupt row disappears rather than appearing
+broken. That is a real trade-off, taken because one unreadable row must not cost every other row, and
+mitigated by logging at WARNING with the `spec_id` so the omission is traceable. Flagged to the owner
+rather than buried.
+
+### D5's read-side hole
+
+`_serialize_run_cost(Decimal("4E-7"))` returned `"0.000000"` — a stored positive sub-quantum cost
+published as free. The validator clamps on the way in, but a row written by raw SQL, or before the
+validator existed, bypasses it. The serializer now applies the same `max(quantized, COST_QUANTUM)`
+clamp.
+
+The input-side asymmetry is **not fixable and is now pinned by a test**: pydantic parses a JSON
+*number* through f64, so `1e-400` is already `0.0` before the validator runs and is indistinguishable
+from a genuine free run, while `"1e-400"` keeps precision and clamps to `0.000001`. The accepted value
+therefore depends on whether the client quotes it. Recorded so the asymmetry is visible rather than
+surprising; no real cost is within 300 orders of magnitude.
+
+### The comment I said I had removed
+
+`test_schemas.py:519` still read "Rounds UP past the ceiling, so the ceiling is re-checked after
+quantizing." A previous Deviations note in this very ledger claimed that comment had been removed
+alongside the dead branch. **The branch went; the comment stayed.** Corrected, and worth stating
+plainly: a ledger entry asserting a cleanup is not evidence the cleanup happened.
+
+**Gates:** ruff check ✓, ruff format ✓, pyright ✓, pytest --cov ✓ (**216 passed, 2 skipped**).

--- a/docs/work/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/work/2026-08-12-OME-770-run-cost-field.md
@@ -295,3 +295,120 @@ Live probe through the ASGI app against a fresh SQLite database:
 3. **The review tool could not report through `ReportFindings`** — not available in this
    environment; findings came back as prose and were re-verified by hand.
 4. Still **no PR opened** and nothing outward-facing sent.
+
+## Code-review pass 2 (2026-08-13) — four findings, all verified
+
+Second `/code-review` on the three-commit branch. Again each finding was checked against the code
+before acting, and again the report was right about the defects but **wrong in one specific**.
+
+### G1 — `-0.0` served a negative dollar figure (fixed)
+
+`-0.0` passes `ge=0` (`-0 == 0`), and `quantize` **preserves the sign**, so the field became
+`Decimal("-0.000000")` and the routes served the string **`"-0.000000"`**. Two problems at once: a
+negative cost rendered in the Cost column, and backend-dependence of exactly the kind §2.4 exists to
+eliminate, since Postgres `numeric` normalizes sign-zero while SQLite keeps it.
+
+Not theoretical — `0.0 * -1` and `round(-1e-9, 6)` both produce `-0.0`, so a client summing signed
+per-call figures sends it. Normalized to a canonical positive `_ZERO_COST` in **both** the validator
+and the read serializer. Both matter: the owner's own review note pointed at the *serializer* line,
+and fixing only the validator would have left every already-stored row broken. Chose normalizing
+over rejecting, since `-0.0` is a legitimate way to express a genuinely free run.
+
+`Decimal(0) == Decimal("-0")`, so equality cannot detect this — the tests assert `is_signed()` and
+the rendered string.
+
+### G2 — one corrupt row 500'd the entire board (fixed; report narrowed)
+
+`DecimalField.to_python_value` quantizes, and `quantize` **raises** `InvalidOperation` on a value
+outside `DECIMAL(12, 6)` rather than returning one. Verified end-to-end: a single bad row makes
+`GET /v1/leaderboard/{id}` fail with a `500` for **every** entry.
+
+**The report's reachability claim was wrong.** It said the ORM path reaches this, naming "exactly the
+`model_copy(update=...)` bypass the new tests themselves use in `_costed`". It does not: Tortoise's
+own `to_python_value` rejects such a value on `Score.create`, so `model_copy` → `store.submit` is
+already guarded. Verified both directions. Only **raw SQL** reaches it, and only on SQLite, where the
+column is `VARCHAR(40)`; production is Postgres, where the column really is `DECIMAL(12, 6)` and the
+database refuses the write.
+
+Fixed anyway — a public read path should degrade, not collapse. The row loop guards the conversion,
+degrades that one cost to `null` ("unknown", an already-defined state), and **logs at warning with
+specific exception types**; it is not silently swallowed. Recorded in spec §2.7, including what was
+deliberately *not* fixed: the ORM read path (`list_for_spec`) would still raise, and guarding it
+means subclassing `DecimalField` — disproportionate for a dev-only, raw-SQL-only scenario.
+
+The report also correctly caught that `_serialize_run_cost`'s docstring **overclaimed** — quantizing
+on read cannot "normalize rows written before the validator existed" for precisely the `1e30` case,
+because it raises. Docstring corrected.
+
+### G3 — a branch that could not execute, and a test comment that lied about it (fixed)
+
+The post-quantize ceiling re-check was unreachable: `quantize` is monotone and `COST_CEILING` sits
+exactly on the 6dp grid, so anything that would round up past it is already rejected by the
+pre-check. Verified: `Decimal("999999.9999996") > COST_CEILING` is `True`, so it never reaches the
+re-check. My test comment claimed it exercised that branch — it did not. **This is the third case
+this branch of my own commentary asserted behaviour I had not actually traced.** Dead branch removed;
+an `AIDEV-NOTE` now records why there is deliberately no re-check, and the test comment says what
+truly rejects the value.
+
+### G4 — rejecting a sub-quantum cost discarded the whole score (owner decision, changed)
+
+The report surfaced the consequence of the rule I had just written: a positive cost below
+`0.000001` returned `422`, and **a 422 rejects the entire submission** — the accuracy result, the
+thing the leaderboard exists for, along with the cost. Once §4 makes cost mandatory, a genuinely
+almost-free run becomes unpublishable.
+
+**Owner chose round-away-from-zero.** It is strictly safer than rejecting on every axis that matters:
+never understates cost (so it cannot buy frontier position), never yields `0.000000` (so D5 holds —
+which was the whole reason the reject rule existed), never discards a valid score, and overstates by
+at most one quantum. Spec §2.2 carries a second revision.
+
+Implemented as `max(quantize(value), COST_QUANTUM)` — one expression that *is* the invariant, rather
+than a special-case branch. That shape came out of a lint failure (below) and is clearer than what it
+replaced.
+
+**Residual, accepted and documented:** a JSON number below ~`1e-308` underflows to exactly `0.0` in
+the float parse *before* the validator runs, so it stores `0.000000` rather than rounding up. No real
+cost is within 300 orders of magnitude of that, and closing it would mean refusing JSON numbers
+outright. Written into §2.2 so the guard is not mistaken for total.
+
+### Two tests rewritten — the contract changed under them
+
+`test_score_submission_rejects_more_than_six_decimal_places` and
+`test_score_submission_rejects_a_positive_cost_below_the_smallest_unit` both asserted the `422` that
+G4 reversed. They encode an obsolete contract, so both were rewritten to assert the new behaviour
+(and renamed to match what they now check). Neither is on `origin/main` — both were added earlier on
+this branch — so the append-only gate does not flag them, and the change is a **strengthening**: each
+now asserts the stored value, not just that a call raised. Flagged here rather than left to the diff,
+because "a prior test changed" is exactly what that gate exists to make visible.
+
+### Pass-2 gates and live verification
+
+`run_gates.py scoreboard --base origin/main --skip-append-only` → ruff check ✓, ruff format ✓,
+pyright ✓, pytest --cov ✓ (**214 passed, 2 skipped**). Append-only still flags only the one
+owner-approved line-197 widening.
+
+| Input | Result |
+|---|---|
+| `12.5`, `1e3` | `201` → `12.500000`, `1000.000000` |
+| `0.07*3`, `1.23456789` | `201` → `0.210000`, `1.234568` |
+| `0`, `-0.0`, `-0` | `201` → `0.000000`, **unsigned** |
+| `0.0000009`, `1e-9` | `201` → `0.000001` (rounded up, never zero) |
+| absent | `201` → `null` |
+| `1000000`, `1e30`, `999999.9999996`, `-0.01`, `NaN`, `Infinity` | all `422` |
+| board scan | 10 entries, zero negative or mis-scaled values |
+
+### Pass-2 deviations
+
+1. **My live probe was not isolated, and I nearly reported from it.** I used
+   `SCOREBOARD_DB_URL`; the real setting is `SCOREBOARD_DATABASE_URL`, so the override was ignored
+   and both runs shared `apps/scoreboard/scoreboard.sqlite3`. Caught it only because two runs of one
+   script disagreed (`201` then `200` — the second was replaying the first's rows through dedup).
+   Re-verified properly: a file DB under the correct variable, `tortoise migrate` first, run twice
+   from scratch with **byte-identical output**. Two lessons worth keeping: `sqlite://:memory:` cannot
+   be used for an app-level probe because lifespan does not create the schema, and a zsh glob that
+   matches nothing aborts the whole `rm`, which is why the stray file survived my first cleanup. The
+   stray file is gitignored and has been removed.
+2. **`ruff` rejected my first implementation** (`PLR0911`, 4 returns > 3). Restructured into the
+   `max(...)` form rather than suppressing the rule — the result is genuinely better, so the gate
+   improved the code rather than merely permitting it.
+3. Still **no PR opened** and nothing outward-facing sent.

--- a/docs/work/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/work/2026-08-12-OME-770-run-cost-field.md
@@ -106,3 +106,80 @@ RED first, against the existing pytest suite:
      only on the unmerged `OME-769` branch (PR #569). Unchanged from D9.
   4. Pass 2 (Cost column, frontier marks, chart, cheapest-run stat) remains blocked on a client
      actually emitting a run total. Nobody is named for that yet — the open question on `OME-772`.
+
+## Review pass (2026-08-13) — three findings, all valid
+
+Owner-reviewed findings, each reproduced against the running app before being fixed. RED first in
+both code cases.
+
+### F1 — `ge=0` was not a sufficient bound (`schemas.py`)
+
+`ScoreSubmission.run_cost_usd` carried only `ge=0`, so the request contract did **not** mirror the
+`DECIMAL(12, 6)` column. Three distinct failures, all verified live:
+
+| Input | Before | After |
+|---|---|---|
+| `0.0000009` | `201`, silently stored as `0.000001` | `422` |
+| `1000000` | `201` on SQLite; overflows `DECIMAL(12, 6)` on Postgres | `422` |
+| `1e30` | **`500`** | `422` |
+
+The first is the serious one: publishing a money figure the submitter never sent. The second means
+the contract was backend-dependent — it would have passed every local gate and failed in
+production. Fixed by adding `max_digits=12, decimal_places=6`. **A cost that cannot be stored
+exactly is now rejected, never rounded.**
+
+### F2 — the history read path silently omitted the cost
+
+`HistorySubmission` and `_history_submission()` were missed entirely, so
+`GET /v1/leaderboard/{id}/{spec}/history` returned no cost — violating this unit's own acceptance
+criterion ("appears on … the per-spec history"). This is the **second** defect caused by the
+read-DTO duplication recorded in Deviation 2, after the 500 on 2026-08-12. Two occurrences of one
+root cause moved it from "note it" to "test it" — see F3.
+
+### F3 — a cross-DTO guard, so there is no third occurrence
+
+Added `test_every_score_field_reaches_at_least_one_read_dto`: every `Score` column must appear on
+`RankedLeaderboardEntry`, `HistorySubmission` or `ScoreSchema`, with an explicit allowlist for the
+deliberately unpublished ones (`content_hash`, the `benchmark` FK object, the `idempotency_keys`
+reverse relation). The next field added to the model and forgotten on a read path now fails a test
+instead of depending on someone noticing. It failed correctly before F2's fix.
+
+### F4 — the SDLC artifacts were missing (process, not code)
+
+`docs/spec/`, `docs/plan/` and `docs/tasks/` did not exist for `OME-770`; only the ledger did.
+Created retroactively (dated `2026-08-12` to keep the artifact set together), with a preamble in
+each stating plainly that they were written after the fact and lift the already-owner-confirmed
+D1–D11 into their required slots — they document what was decided, not a redesign.
+
+**This was a REPEAT.** The identical omission happened on `OME-769` the previous day and was
+corrected there too. Twice in two consecutive units is a pattern in how I start work, not an
+oversight: the ledger gets created (rule 2 is prominent) while spec-before-plan (rule 3) gets
+skipped when the work feels like a small backend change. The mirror also has no `actor` /
+`who-acts` label on Linear, which the card requires — flagged in the mirror as an owner action
+rather than silently changed, since `save_issue.labels` replaces the whole set.
+
+### Review-pass gates
+
+`run_gates.py scoreboard --base origin/main` → ruff check ✓, ruff format ✓, pyright ✓,
+pytest --cov ✓ (**184 passed, 2 skipped**, coverage 88.03% ≥ 80).
+`routes/leaderboard.py` and `scores/models/score.py` are both at 100%.
+
+### Review-pass deviations
+
+1. **A prior test had to change, and the append-only gate blocked it — correctly.**
+   `test_get_spec_history_returns_submissions_newest_first` asserts the history response's
+   **exact** key set, so F2 broke it. Per sdlc rule 5 this was escalated as a Confidence-Gate
+   decision rather than edited silently; the owner approved widening the set. One line was
+   **added** (`"run_cost_usd"`, with a comment on why the exhaustiveness is deliberate) — nothing
+   removed, weakened or skipped, so the assertion still catches an unintended field leaking into a
+   response portal clients depend on. The final gate run therefore used the runner's documented
+   `--skip-append-only` flag; every other gate ran normally and green. Worth noting the gate did
+   its job precisely: it turned an intentional contract change into an explicit decision.
+2. **Two of my own new tests were wrong and had to be corrected before they were committed** —
+   caught by running them, not by review. (a) One asserted the exact string `"7.250000"`, but
+   Decimal scale does not survive the round trip identically; changed to numeric `Decimal`
+   comparison, since trailing-zero scale is not part of the contract. (b) The F3 guard initially
+   omitted `ScoreSchema` from the set of read DTOs and flagged six already-exposed columns
+   (`client_*`, `metadata`, `ran_at_local`) plus a reverse relation as missing. Both were test
+   defects, fixed in the tests.
+3. **No PR opened.** Awaiting explicit owner approval; nothing outward-facing was sent.

--- a/docs/work/2026-08-12-OME-770-run-cost-field.md
+++ b/docs/work/2026-08-12-OME-770-run-cost-field.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-770
 stack: scoreboard
-status: done
+status: in_review
 started: 2026-08-12
 finished: 2026-08-13
 ---
@@ -294,7 +294,9 @@ Live probe through the ASGI app against a fresh SQLite database:
    (`0.0000009` is rejected for being below the quantum, not for its scale).
 3. **The review tool could not report through `ReportFindings`** — not available in this
    environment; findings came back as prose and were re-verified by hand.
-4. Still **no PR opened** and nothing outward-facing sent.
+4. At the time of writing, no PR was open. Superseded: opened as
+   [#582](https://github.com/OpenMined/screamingface/pull/582) (2026-08-14), CI green,
+   awaiting review. Nothing outward-facing was sent.
 
 ## Code-review pass 2 (2026-08-13) — four findings, all verified
 
@@ -411,7 +413,7 @@ owner-approved line-197 widening.
 2. **`ruff` rejected my first implementation** (`PLR0911`, 4 returns > 3). Restructured into the
    `max(...)` form rather than suppressing the rule — the result is genuinely better, so the gate
    improved the code rather than merely permitting it.
-3. Still **no PR opened** and nothing outward-facing sent.
+3. At the time of writing, no PR was open — see the note above; #582 is now open.
 
 ## Review pass 3 (2026-08-14) — three findings, all valid
 


### PR DESCRIPTION
Linear: [OME-770](https://linear.app/openmined/issue/OME-770/leaderboard-cost-and-pareto-cost-column-frontier-winner-marks-cost-vs)

## Summary

`OME-770` asks for a Cost column, Pareto-frontier marks and a cost-vs-accuracy chart. **None of it
is buildable today, because no cost value reaches Scoreboard at all** — nothing cost-shaped exists
on `ScoreSubmission`, `Score` or `LeaderboardEntry`. The upstream chain has four links and Scoreboard
owns only the last:

| # | Link | Owner | State |
|---|---|---|---|
| 1 | a provider call's cost is captured | aigateway | `OME-303` unmerged |
| 2 | per-call costs roll up into a run total | Engine | not built |
| 3 | the Client sends that total on publish | Client | no field for it |
| 4 | **Scoreboard accepts, stores and exposes it** | **scoreboard** | **this PR** |

So this is **pass 1 of 2** and is **backend only**: a typed, nullable `run_cost_usd` accepted on
submission, persisted, and exposed on both read paths. The moment a client can produce a total it has
somewhere to send it, and the ticket's remainder collapses to pure rendering.

`OME-770` stays **In Progress** — pass 1 does not satisfy the ticket's own "Done when", which is
about the column, the row marks and the chart agreeing.

## What's in it

- `run_cost_usd` on `BaseScore` as `DECIMAL(12, 6)`, nullable, plus migration `0004`. **Decimal, not
  Float** — this is money; `accuracy` stays a `FloatField` because a ratio is not currency. The
  bounds cover both real ends: a cache-served smoke run at `$0.000123` and a full DRACO rerun quoted
  at $3–4k.
- Exposed on `GET /v1/leaderboard/{id}`, the per-spec history, and `GET /v1/scores/{id}`.
- **Deliberately excluded from `content_hash`.** That hash is recipe identity; cost is a property of
  one *execution*, and two runs of one recipe can cost different amounts and must still dedup to a
  single row. Adding it would silently break `OME-391`'s guarantee.

## Decisions worth a reviewer's attention

**`null` is not `0`.** Absent means "no cost was reported"; `0` means "this run cost nothing", which
is a legitimate and deliberately-pursued outcome (`OME-767`'s zero-cost goal). Conflating them
corrupts the feature that motivated the field: a frontier ranks by cost ascending, so an unknown-cost
row coerced to `0` becomes *the cheapest entry on the board*. Several invariants in this diff exist
only to protect that distinction.

**The cost is self-reported and unverifiable.** Re-running a submission tells us what *we* paid, not
what the submitter paid, so understating cost buys frontier position at no risk of being caught by
reproduction. It is stored and exposed, but pass 2 must present it with its provenance and never as a
verified figure — reusing the verified/unverified distinction the board already carries for accuracy.

**Unstorable input is rejected; inexact input is normalized.** These are different, and treating them
alike was wrong in both directions during review:
- `1000000`, `1e30`, negatives, `NaN`/`Infinity` → `422`. (`1e30` previously returned a **500**;
  `1000000` was previously accepted on SQLite and would have failed on Postgres — a
  backend-dependent contract that passes locally and breaks in production.)
- `0.07 * 3 == 0.21000000000000002` → quantized to `0.210000`. This is what a client summing per-call
  float costs sends; rejecting it would discard valid scores over float noise.
- A positive cost below `$0.000001` rounds **away from zero**, never to zero. Rejecting it (an
  earlier iteration) threw away the whole submission — the accuracy result with it.
- `-0.0` is normalized to positive zero. It passes `ge=0` and `quantize` preserves the sign, so it
  previously served the string `"-0.000000"`.

**The wire form is pinned to 6dp.** Pydantic emits `Decimal` as a JSON *string* carrying whatever
scale the value happens to have — `"12.5"` on SQLite, `"12.500000"` from a padded Postgres column,
`"1E+3"` for a cost submitted as `1e3`. That is backend-dependent, and pass 2 computes the frontier in
JavaScript where `<` on strings is lexicographic (`"10" < "9.5"` is `true`), so $1000 would rank
cheaper than $3.50. One shared `RunCostUsd` type carries the serializer so the four read DTOs cannot
drift.

⚠️ **Two constraints this PR imposes on pass 2**, both documented in the spec and in code:
1. **Do not compute cost aggregates in SQL.** On SQLite the column is `TEXT`, so
   `ORDER BY run_cost_usd` is lexicographic — verified returning `$1000` before `$3.50`. Quantizing
   does *not* fix this. The cheapest-run stat must be computed in Python over `Decimal`, or it will be
   right in production and silently wrong in every local run.
2. **A fixed-scale string does not make the JS hazard impossible** — `"1000.000000" < "3.500000"` is
   still `true`. It forces an explicit `parseFloat`, which is reviewable where a bare `<` is not.
   Frontier logic needs tests on values of differing integer width.

## Test plan

- **214 passed, 2 skipped** (Postgres-only tests skipped); `ruff check`, `ruff format`, `pyright` all
  clean; coverage 88% (gate 80%). `routes/leaderboard.py` and `scores/models/score.py` at 100%.
- Migration verified: applies from an empty database, re-run is a no-op, `downgrade` rolls back, and
  `makemigrations` reports **"No changes detected"** — no model/migration drift.
- **Live end-to-end probe** through the app on a freshly migrated database, run twice from scratch
  with byte-identical output:

  | Input | Result |
  |---|---|
  | `12.5`, `1e3` | `201` → `"12.500000"`, `"1000.000000"` |
  | `0.07*3`, `1.23456789` | `201` → `"0.210000"`, `"1.234568"` |
  | `0`, `-0.0`, `-0` | `201` → `"0.000000"`, unsigned |
  | `0.0000009`, `1e-9` | `201` → `"0.000001"` (never zero) |
  | absent | `201` → `null` |
  | `1000000`, `1e30`, `999999.9999996`, `-0.01`, `NaN`, `Infinity` | all `422` |

- A **cross-DTO guard** test asserts every `Score` column reaches at least one read DTO. The
  `RankedLeaderboardEntry`/`HistorySubmission`/`ScoreSchema` duplication caused two separate defects
  during this work (a 500, then a silent omission), so it is now a failing test rather than a comment.

## Notes for the reviewer

- **One prior test was modified**, and the repo's append-only gate correctly blocked it:
  `test_get_spec_history_returns_submissions_newest_first` pins the history response's *exact* key
  set, so adding a field breaks it. Escalated as a Confidence-Gate decision and approved by the
  owner; **one line added, nothing removed or weakened**, so the assertion stays exhaustive and still
  catches an unintended field leak. The final gate run used the runner's documented
  `--skip-append-only`; every other gate ran normally.
- **Pass 2 remains blocked** on links 1–3 above, and nobody is named for that chain yet — the open
  question on `OME-772`. It is additionally sequenced behind #569, since the frontier maths belongs in
  `portal/leaderboard-logic.js`.
- Spec, plan and task mirror were written **retroactively** and say so in their own preambles; the
  decisions in them were owner-confirmed as the work happened, and the full narrative — including
  three review passes and my own errors — is in `docs/work/2026-08-12-OME-770-run-cost-field.md`.
- The Linear issue is missing its `actor` / `who-acts` labels; flagged rather than changed, since
  `save_issue.labels` replaces the whole set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdKCiEFpo188AkWG5kSn1G