### PR TITLE
feat(aigateway): expand HuggingFace + Anthropic model seeds with live-verified ids

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/settings.py
@@ -25,13 +25,23 @@ def _default_models() -> list[ModelEntry]:
     aigw-claude-backend plugin derives its suggestions from this list via
     ``GET /v1/models`` (SF-284), so it must NOT be copied SF-side.
 
-    Ordered newest-first within each tier (opus, sonnet, haiku). Older
+    Ordered newest-first within each tier (opus, fable, sonnet, haiku). Older
     snapshots are kept alongside the latest so existing configs pinned to
     them (e.g. the ``claude-sonnet-4-5`` default) keep routing.
+
+    OME-818: the 5.x line (opus-5 / fable-5 / sonnet-5) and the opus 4.5/4.6
+    snapshots were verified live against Anthropic ``GET /v1/models`` on
+    2026-08-13. Ids are the bare aliases (matching the existing 4-5 tier
+    convention); the ``anthropic/`` prefix lives only in ``litellm_params``.
     """
     names = [
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-fable-5",
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-sonnet-4-5",
         "claude-haiku-4-5",

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/thinking.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/thinking.py
@@ -39,10 +39,13 @@ from aigateway.core.model_parameter_contract import upstream_model_id
 from aigateway.core.parameter_projection import IncompatibleParametersError
 from aigateway.core.profile_models import AuthMode
 
-# The two registered models the installed transform still maps to a manual
-# thinking BUDGET. Everything else Anthropic registers is adaptive.
+# The registered models the installed transform still maps to a manual thinking
+# BUDGET. Everything else Anthropic registers is adaptive.
+# OME-818: claude-opus-4-5 joins the 4-5 tier here — litellm's installed transform
+# emits budget_tokens for it (the 5.x line and opus-4-6 are adaptive, so they stay out).
 MANUAL_THINKING_MODELS: frozenset[str] = frozenset(
     {
+        "claude-opus-4-5",
         "claude-sonnet-4-5",
         "claude-haiku-4-5",
     }

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
@@ -37,6 +37,29 @@ def _default_model_slugs() -> list[str]:
         "huggingface/deepseek-ai/DeepSeek-R1:novita",
         "huggingface/google/gemma-2-2b-it:featherless-ai",
         "huggingface/meta-llama/Llama-3.1-8B-Instruct:nscale",
+        # OME-817: text-generation models the unified router serves as chat, each pinned to a
+        # live `:provider` backend. Verified against router.huggingface.co/v1/models on
+        # 2026-08-13 (re-verify at release); embeddings / GGUF quants / self-host-only weights
+        # from the source catalog were dropped because the router does not serve them.
+        "huggingface/moonshotai/Kimi-K3:deepinfra",
+        "huggingface/Qwen/Qwen3.8-2.4T-A95B:together",
+        "huggingface/zai-org/GLM-5.2:deepinfra",
+        "huggingface/deepseek-ai/DeepSeek-V4-Flash-0731:deepinfra",
+        "huggingface/tencent/Hy3:deepinfra",
+        "huggingface/thinkingmachines/Inkling:together",
+        "huggingface/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16:deepinfra",
+        "huggingface/MiniMaxAI/MiniMax-M3:deepinfra",
+        "huggingface/meta-models/Muse-Glimmer-30B:together",
+        "huggingface/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16:fireworks-ai",
+        "huggingface/openai/gpt-oss-20b:deepinfra",
+        "huggingface/meta-llama/Llama-4-Scout-17B-16E-Instruct:nscale",
+        "huggingface/google/gemma-4-31B-it:deepinfra",
+        "huggingface/XiaomiMiMo/MiMo-V2.5:deepinfra",
+        "huggingface/microsoft/phi-4:deepinfra",
+        "huggingface/thinkingmachines/Inkling-Small:together",
+        "huggingface/google/gemma-3-4b-it:deepinfra",
+        "huggingface/CohereLabs/c4ai-command-a-03-2025:cohere",
+        "huggingface/deepseek-ai/DeepSeek-R1-Distill-Llama-8B:nscale",
     ]
 
 

--- a/apps/aigateway/tests/unit/anthropic/test_settings.py
+++ b/apps/aigateway/tests/unit/anthropic/test_settings.py
@@ -37,8 +37,13 @@ def test_anthropic_settings_defaults_preserve_current_values(monkeypatch) -> Non
     assert settings.keychain_account == "default"
     assert settings.bootstrap_user == "alice"
     assert [model.model_name for model in settings.models] == [
+        "claude-opus-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-fable-5",
+        "claude-sonnet-5",
         "claude-sonnet-4-6",
         "claude-sonnet-4-5",
         "claude-haiku-4-5",
@@ -46,6 +51,27 @@ def test_anthropic_settings_defaults_preserve_current_values(monkeypatch) -> Non
     # Every entry's litellm model string must be the "anthropic/"-prefixed alias
     # so the gateway routes it to the Anthropic provider.
     for model in settings.models:
+        assert model.litellm_params == {"model": f"anthropic/{model.model_name}"}
+
+
+def test_ome_818_direct_claude_ids_are_seeded(monkeypatch) -> None:
+    _clear_anthropic_env(monkeypatch)
+    settings = AnthropicPluginSettings()
+    names = [model.model_name for model in settings.models]
+    # OME-818: live-verified direct ids (Anthropic GET /v1/models, 2026-08-13).
+    for new_id in [
+        "claude-opus-5",
+        "claude-fable-5",
+        "claude-sonnet-5",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+    ]:
+        assert new_id in names, f"{new_id} missing from seed"
+    # INVARIANT: a direct id is unprefixed + hyphenated (no dots, no 'anthropic/' on model_name);
+    # the 'anthropic/' prefix lives ONLY in litellm_params so the gateway routes to the provider.
+    for model in settings.models:
+        assert "." not in model.model_name, model.model_name
+        assert not model.model_name.startswith("anthropic/"), model.model_name
         assert model.litellm_params == {"model": f"anthropic/{model.model_name}"}
 
 

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_settings.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_settings.py
@@ -15,7 +15,32 @@ from pydantic import ValidationError
 from aigateway.plugins.huggingface_provider.settings import (
     HuggingFacePluginSettings,
     _validate_model_slug,
+    pinned_router_target,
 )
+
+# OME-817: live-verified router additions (router.huggingface.co/v1/models, 2026-08-13). Each
+# repo is served as chat by the pinned `:provider` backend; re-verify at release.
+_OME_817_ADDED = [
+    "huggingface/moonshotai/Kimi-K3:deepinfra",
+    "huggingface/Qwen/Qwen3.8-2.4T-A95B:together",
+    "huggingface/zai-org/GLM-5.2:deepinfra",
+    "huggingface/deepseek-ai/DeepSeek-V4-Flash-0731:deepinfra",
+    "huggingface/tencent/Hy3:deepinfra",
+    "huggingface/thinkingmachines/Inkling:together",
+    "huggingface/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16:deepinfra",
+    "huggingface/MiniMaxAI/MiniMax-M3:deepinfra",
+    "huggingface/meta-models/Muse-Glimmer-30B:together",
+    "huggingface/nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16:fireworks-ai",
+    "huggingface/openai/gpt-oss-20b:deepinfra",
+    "huggingface/meta-llama/Llama-4-Scout-17B-16E-Instruct:nscale",
+    "huggingface/google/gemma-4-31B-it:deepinfra",
+    "huggingface/XiaomiMiMo/MiMo-V2.5:deepinfra",
+    "huggingface/microsoft/phi-4:deepinfra",
+    "huggingface/thinkingmachines/Inkling-Small:together",
+    "huggingface/google/gemma-3-4b-it:deepinfra",
+    "huggingface/CohereLabs/c4ai-command-a-03-2025:cohere",
+    "huggingface/deepseek-ai/DeepSeek-R1-Distill-Llama-8B:nscale",
+]
 
 
 def test_defaults_use_router_suffix_form() -> None:
@@ -80,3 +105,14 @@ def test_env_override_rejects_unsafe_path_segment_form(
     )
     with pytest.raises(ValidationError):
         HuggingFacePluginSettings()
+
+
+def test_ome_817_additions_are_seeded_with_explicit_backends() -> None:
+    seeds = HuggingFacePluginSettings().default_models
+    for slug in _OME_817_ADDED:
+        assert slug in seeds, f"{slug} missing from seed"
+        assert _validate_model_slug(slug) == slug
+        # INVARIANT: every seeded HF id pins an explicit ':provider' backend, so discovery reports
+        # a real (repo, backend) target instead of guessing the router's per-request choice.
+        target = pinned_router_target(slug)
+        assert target is not None and target[1], f"{slug} has no pinned backend"

--- a/docs/tasks/2026-08-13-OME-817-huggingface-seed.md
+++ b/docs/tasks/2026-08-13-OME-817-huggingface-seed.md
@@ -1,0 +1,17 @@
+---
+id: OME-817
+linear_url: https://linear.app/openmined/issue/OME-817/expand-huggingface-model-seed-with-21-live-verified-router-backends
+status: in_progress
+type: task
+priority: 3
+labels: [aigateway, agentic, autonomous]
+created: 2026-08-13
+closed:
+---
+
+# OME-817 — Expand HuggingFace model seed with live-verified router backends
+
+Sub-issue of epic OME-815. Append 19 live-verified router entries (verified 2026-08-13 vs
+`router.huggingface.co/v1/models`) to `huggingface_provider/settings.py` `_default_model_slugs()`,
+5 → 24. Landed with OME-818 in one aigateway PR. Ledger:
+`docs/work/2026-08-13-OME-817-huggingface-seed.md`.

--- a/docs/tasks/2026-08-13-OME-818-anthropic-seed.md
+++ b/docs/tasks/2026-08-13-OME-818-anthropic-seed.md
@@ -1,0 +1,17 @@
+---
+id: OME-818
+linear_url: https://linear.app/openmined/issue/OME-818/expand-anthropic-direct-model-seed-with-live-verified-claude-ids
+status: in_progress
+type: task
+priority: 3
+labels: [aigateway, agentic, autonomous]
+created: 2026-08-13
+closed:
+---
+
+# OME-818 — Expand Anthropic direct model seed with live-verified Claude ids
+
+Sub-issue of epic OME-815. Add 5 live-verified direct Claude ids (verified 2026-08-13 vs Anthropic
+`/v1/models`): `claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-6`,
+`claude-opus-4-5` → `_default_models()` 5 → 10. Landed with OME-817 in one aigateway PR. Ledger:
+`docs/work/2026-08-13-OME-818-anthropic-seed.md`.

--- a/docs/work/2026-08-13-OME-817-huggingface-seed.md
+++ b/docs/work/2026-08-13-OME-817-huggingface-seed.md
@@ -48,6 +48,6 @@ No schema/model change → no migration (S1 n/a). No Tortoise → tortoise-dev n
 
 - **Actual files:** as planned — `huggingface_provider/settings.py` (+19 seeds, 5→24),
   `test_huggingface_settings.py` (+`_OME_817_ADDED` + backed-additions test), ledger, mirror.
-- **Commits:** <sha> — feat(aigateway): expand HuggingFace model seed with 19 live-verified router backends
+- **Commits:** 5f9a477b — feat(aigateway): expand HuggingFace model seed with 19 live-verified router backends
 - **Gates:** `run_gates.py aigateway` ALL GREEN (shared B+C run). HF+anthropic suites 309 passed.
 - **Deviations:** none for HF (pure addition — no prior test/fixture modified).

--- a/docs/work/2026-08-13-OME-817-huggingface-seed.md
+++ b/docs/work/2026-08-13-OME-817-huggingface-seed.md
@@ -1,0 +1,53 @@
+---
+ticket: OME-817
+stack: aigateway
+status: done
+started: 2026-08-13
+finished: 2026-08-13
+---
+
+# OME-817 — Expand HuggingFace model seed with live-verified router backends
+
+## Intent
+
+Expand the HuggingFace provider seed (`_default_model_slugs()`) with text-generation models the
+HF unified router actually serves, each pinned to a live `:provider` backend, so the SF model
+dropdown (`GET /v1/models`, SF-284) and url4 leaves can address the current open-weight lineup.
+Part of epic OME-815. Landed with OME-818 in one aigateway PR (same worktree).
+
+## Method — verify-then-seed
+
+Candidate repos (HF-50 text tiers) intersected against live `GET https://router.huggingface.co/v1/models`
+(131 models, 2026-08-13). Kept only repos served as chat with a live text-output backend; picked
+the cheapest tool-supporting live provider. 29 doc repos dropped (not on router — embeddings, GGUF
+quants, self-host-only weights). Deduped against the 5 existing seeds by repo path (dropped
+`deepseek-ai/DeepSeek-R1`, `openai/gpt-oss-120b` — already seeded) → **19 new** (24 total).
+
+## Planned changes
+
+- `apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py` — append 19 verified
+  `huggingface/<org>/<model>:<provider>` entries to `_default_model_slugs()`.
+- `apps/aigateway/tests/unit/huggingface/test_huggingface_settings.py` — ADD: every new entry
+  present, passes `_validate_model_slug`, and `pinned_router_target` returns a `(repo, backend)`.
+
+No schema/model change → no migration (S1 n/a). No Tortoise → tortoise-dev n/a.
+
+## Test plan
+
+- RED: new presence/backend test fails against the current 5-seed list.
+- GREEN: after the seed edit, all pass; HF unit suite green.
+- Invariant: 3-segment `<org>/<model>:<provider>` router form (not the forbidden 4-segment
+  path form); every seed carries an explicit backend (`pinned_router_target` non-None).
+
+## Acceptance
+
+- `_default_model_slugs()` returns 24 router-form entries; construction validator accepts all;
+  `run_gates.py aigateway` green. HF ids are aigateway-only (not mirrored to url4.toml — colon).
+
+## Outcome
+
+- **Actual files:** as planned — `huggingface_provider/settings.py` (+19 seeds, 5→24),
+  `test_huggingface_settings.py` (+`_OME_817_ADDED` + backed-additions test), ledger, mirror.
+- **Commits:** <sha> — feat(aigateway): expand HuggingFace model seed with 19 live-verified router backends
+- **Gates:** `run_gates.py aigateway` ALL GREEN (shared B+C run). HF+anthropic suites 309 passed.
+- **Deviations:** none for HF (pure addition — no prior test/fixture modified).

--- a/docs/work/2026-08-13-OME-818-anthropic-seed.md
+++ b/docs/work/2026-08-13-OME-818-anthropic-seed.md
@@ -1,0 +1,60 @@
+---
+ticket: OME-818
+stack: aigateway
+status: done
+started: 2026-08-13
+finished: 2026-08-13
+---
+
+# OME-818 — Expand Anthropic direct model seed with live-verified Claude ids
+
+## Intent
+
+Add the current-generation direct Claude ids to the Anthropic provider seed (`_default_models()`),
+the single source of the SF Settings model dropdown (SF-284), so ensembles can address Opus 5 /
+Fable 5 / Sonnet 5 and the 4.x back-catalog on the direct Anthropic API path (Tavily web-search
+loop). Part of epic OME-815; landed with OME-817 in one aigateway PR.
+
+## Method — verify-then-seed
+
+Verified against the live Anthropic `GET /v1/models` (2026-08-13): returns `claude-opus-5`,
+`claude-sonnet-5`, `claude-fable-5`, `claude-opus-4-8/-4-7/-4-6`, and dated `claude-opus-4-5-*`,
+`claude-haiku-4-5-*`, `claude-sonnet-4-5-*`. New vs the current 5 seeds → 5 additions:
+`claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-5`
+(alias form, matching the existing seed's alias convention for the 4-5 tier).
+
+## Planned changes
+
+- `apps/aigateway/src/aigateway/plugins/anthropic_provider/settings.py` — extend `names` in
+  `_default_models()` to 10, newest-first per tier (opus → fable → sonnet → haiku).
+- `apps/aigateway/tests/unit/anthropic/test_settings.py` — update the inline exact model-name
+  pin (5 → 10) and ADD a focused test: new ids present, unprefixed + hyphenated (no dots),
+  `litellm_params == {"model": f"anthropic/{id}"}`.
+
+No schema/model change → no migration (S1 n/a). No Tortoise → tortoise-dev n/a.
+
+## Test plan
+
+- RED: the inline exact pin fails (5 != 10); new-ids test fails (absent).
+- GREEN: after the seed edit, all pass; anthropic unit suite green.
+- Invariant: every id is unprefixed + hyphenated; litellm model string is `anthropic/<id>`.
+
+## Acceptance
+
+- `_default_models()` returns 10 verified direct ids; `run_gates.py aigateway` green.
+- Mirrorable to url4.toml (no colon) — handled in OME-819.
+
+## Outcome
+
+- **Actual files:** `anthropic_provider/settings.py` (`names` 5→10 + docstring), `test_settings.py`
+  (exact pin 5→10 + new-ids test); **plus** `anthropic_provider/thinking.py` —
+  `MANUAL_THINKING_MODELS` += `claude-opus-4-5` (blast-radius: litellm's installed transform maps
+  opus-4-5 to a manual budget, and `test_the_budget_table_matches_the_installed_transform` requires
+  the set to match). Ledger + mirror.
+- **Commits:** 2cf90ce1 — feat(aigateway): expand Anthropic direct model seed with 5 live-verified Claude ids
+- **Gates:** `run_gates.py aigateway` ALL GREEN (shared B+C run).
+- **Deviations:** (1) updated the inline exact model-name pin (5→10) — owner-approved prior-test
+  change (call-and-return gate 2026-08-13, same pattern as OME-816), applied via
+  `--skip-append-only`. (2) Registered `claude-opus-4-5` in `MANUAL_THINKING_MODELS` (production
+  code, necessary for the new model — not a test change). `INTERLEAVED_BETA_MODELS` deliberately
+  left unchanged (existing fail-closed note excludes Opus 4.5).


### PR DESCRIPTION
Two sub-issues of epic OME-815, both additive `aigateway` provider-seed expansions, landed together per request.

## OME-817 — HuggingFace (+19, 5→24)
Text-generation models the HF unified router serves **as chat**, each pinned to a live `:provider` backend. Verified against `GET https://router.huggingface.co/v1/models` (131 models, 2026-08-13). 29 source-catalog repos dropped — not on the router (embeddings, GGUF quants, self-host-only weights). Deduped vs the 5 existing seeds by repo path. All HF ids are **aigateway-only** (url4.toml can't route a colon).

## OME-818 — Anthropic direct (+5, 5→10)
`claude-opus-5`, `claude-fable-5`, `claude-sonnet-5`, `claude-opus-4-6`, `claude-opus-4-5` — verified against the live Anthropic `GET /v1/models` (2026-08-13), newest-first per opus/fable/sonnet/haiku tier. Bare-alias form matches the existing 4-5-tier convention; the `anthropic/` prefix lives only in `litellm_params`.
- **Blast-radius:** registered `claude-opus-4-5` in `MANUAL_THINKING_MODELS` — litellm's installed transform maps it to a manual `budget_tokens` (the 5.x line and opus-4-6 are adaptive, so they stay out). `test_the_budget_table_matches_the_installed_transform` requires the set to match. `INTERLEAVED_BETA_MODELS` deliberately left unchanged (existing fail-closed note excludes Opus 4.5).

## Tests
- HF: new backed-additions test (present + validator-accepted + explicit pinned backend). Pure addition.
- Anthropic: inline exact model-name pin updated 5→10 + new-ids invariant test (unprefixed, hyphenated, `anthropic/` prefix only in litellm_params).
- `run_gates.py aigateway`: ALL GREEN (ruff, format, pyright, check_no_enterprise, pytest --cov≥80). HF+anthropic suites: 309 passed.
- **Deviation:** `--skip-append-only` used for the Anthropic exact-pin update (owner-approved 2026-08-13, same pattern as OME-816 / PR #581).

Refs: OME-817, OME-818