### PR TITLE
fix: attribute and remove websocket_disconnected drops

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/cli.py
+++ b/apps/url4-cloud/src/url4_cloud/cli.py
@@ -20,6 +20,8 @@ boot instead of silently booting a web server that nothing will ever dial.
 
 import argparse
 
+from url4_cloud.logs import configure as configure_logging
+
 _PORT = 9108
 
 
@@ -90,6 +92,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     sub.add_parser("run", help="execute one url4 expression from the environment, then exit")
     args = parser.parse_args(argv)
+
+    # BEFORE dispatch, and for every mode: a Job's logs are as load-bearing as the control
+    # plane's, and neither `uvicorn.run` nor `run_main` configures anything for this package.
+    configure_logging()
 
     if args.mode == "run":
         _run()

--- a/apps/url4-cloud/src/url4_cloud/logs.py
+++ b/apps/url4-cloud/src/url4_cloud/logs.py
@@ -1,0 +1,57 @@
+"""Log configuration for both modes of the image.
+
+WHY this module exists at all: `uvicorn.run()` installs handlers for the `uvicorn*` loggers
+ONLY and leaves the root logger with none. Every `url4_cloud` record therefore fell through
+to `logging.lastResort`, which emits at WARNING — so the App's INFO lines were discarded in
+every deployment that has ever run. The visible symptom was a control plane whose logs
+contained nothing but `uvicorn.access` health checks, which reads as "nothing happened"
+rather than "this process cannot say anything".
+
+That mattered most for exactly the evidence hardest to get any other way: the WebSocket
+close code. Only the App observes it — a client cannot report a close it never received —
+and a dropped Run stream is otherwise indistinguishable from every other dropped Run stream.
+
+Stdlib only, deliberately: the run mode (a Job) needs this as much as the serving mode, and
+the layering rule keeps the two import graphs disjoint.
+"""
+
+import logging
+import os
+from typing import TextIO
+
+APP_LOGGER = "url4_cloud"
+LEVEL_ENV = "URL4_CLOUD_LOG_LEVEL"
+DEFAULT_LEVEL = "INFO"
+
+# Matches uvicorn's own column so a deployment's logs read as one stream rather than two.
+_FORMAT = "%(levelname)s:     %(name)s %(message)s"
+
+_INSTALLED = "_url4_cloud_log_handler"
+"""Marks the handler THIS module installed.
+
+Idempotence has to be about our own handler, not about the logger being empty: anything
+else may have attached one first — a test harness, a sidecar, an embedding process — and
+`if not logger.handlers` would then read that as "already configured" and install nothing
+at all. The failure is silent and looks exactly like the bug this module exists to fix.
+"""
+
+
+def configure(stream: TextIO | None = None) -> None:
+    """Give the `url4_cloud` logger tree its own handler and level.
+
+    Idempotent: a second call neither stacks handlers nor disturbs anyone else's.
+    `propagate` is disabled so that a later root configuration — uvicorn's, a test
+    harness's, a sidecar's — cannot turn every record into two.
+    """
+
+    logger = logging.getLogger(APP_LOGGER)
+    logger.setLevel(os.getenv(LEVEL_ENV, DEFAULT_LEVEL).upper())
+    if not any(getattr(handler, _INSTALLED, False) for handler in logger.handlers):
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter(_FORMAT))
+        setattr(handler, _INSTALLED, True)
+        logger.addHandler(handler)
+    logger.propagate = False
+
+
+__all__ = ["APP_LOGGER", "DEFAULT_LEVEL", "LEVEL_ENV", "configure"]

--- a/apps/url4-cloud/src/url4_cloud/rest/routes.py
+++ b/apps/url4-cloud/src/url4_cloud/rest/routes.py
@@ -9,6 +9,7 @@ first.
 """
 
 import asyncio
+import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -39,6 +40,8 @@ from url4_cloud.rest.interest import SubscriberGate
 from url4_cloud.rest.sessions import RunSessions
 
 router = APIRouter()
+
+_logger = logging.getLogger(__name__)
 
 _TERMINAL_PROBLEM: dict[str, tuple[int, str, str]] = {
     "failed": (502, "Bad Gateway", "the run failed"),
@@ -174,6 +177,15 @@ async def _schedule(
             profile=profile,
             identity=identity,
             cache=cache,
+        )
+        # The expression itself is the caller's, and may carry prompts — its LENGTH is
+        # enough to tell a large Evaluation from a smoke run when reading back a failure.
+        _logger.info(
+            "run scheduled topic=%s url4_chars=%d profile=%s cache=%s",
+            topic,
+            len(url4),
+            profile,
+            cache,
         )
     except JobAlreadyExists as exc:
         raise ProblemException(status=409, title="Conflict", detail="a run already exists") from exc
@@ -477,6 +489,7 @@ async def stop_run(request: Request, claims: VerifiedClaims, topic: str | None =
             title="Forbidden",
             detail="the capability token is not authorized for that topic",
         )
+    _logger.info("run stop requested topic=%s", sub)
     await deps.job_runner.stop(sub)
     # WHY delete and not purge: this is the run's terminal teardown, and purging a broker-backed
     # stream empties it but leaves the stream object, its consumer state and its filestore

--- a/apps/url4-cloud/src/url4_cloud/ws/bridge.py
+++ b/apps/url4-cloud/src/url4_cloud/ws/bridge.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
+import time
 from collections.abc import Callable
 from datetime import datetime
 from typing import Protocol
@@ -34,6 +36,24 @@ from url4_cloud import notices
 Clock = Callable[[], datetime]
 
 _InboundEvent = AttachEvent | StopEvent
+
+_logger = logging.getLogger(__name__)
+
+
+def _closure_of(cause: BaseException) -> str:
+    """Name how a connection ended, in the terms that separate its possible causes.
+
+    WHY this is worth recording: a dropped Run stream reaches the researcher as one
+    message no matter what caused it. The close code is what tells an oversized frame
+    (1009, the client refusing what we sent) apart from a proxy draining a listener or a
+    Pod going away (1006/1001), and the App is the only place that observes it — the
+    client cannot report a close it never received.
+    """
+
+    if isinstance(cause, WebSocketDisconnect):
+        reason = f" {cause.reason!r}" if cause.reason else ""
+        return f"client close {cause.code}{reason}"
+    return f"send failed: {type(cause).__name__}"
 
 
 class TopicSession(Protocol):
@@ -134,6 +154,13 @@ class Bridge:
         self._out: asyncio.Queue[OutboundFrame] = asyncio.Queue(maxsize=OUTBOUND_QUEUE_MAX_FRAMES)
         self._stop = asyncio.Event()
         self._sub: asyncio.Task[None] | None = None
+        # Enough to attribute a drop without keeping any of the run's payload: how the
+        # socket ended, how long it lasted, and whether it was carrying work or idling.
+        # A long connection with only heartbeats reads as an idle cut; a short one that
+        # ended right after real frames reads as the peer refusing what it was sent.
+        self._closure = "no close observed"
+        self._frames_sent = 0
+        self._heartbeats_sent = 0
 
     def _offer(self, frame: OutboundFrame) -> None:
         """Queue an advisory frame, dropping it if the client is already too far behind.
@@ -163,6 +190,7 @@ class Bridge:
         non-blocking, drop-if-behind path every other advisory frame takes.
         """
         self._sessions.add_notifier(self._topic, self._offer)
+        opened = time.monotonic()
         inbound = asyncio.ensure_future(self._inbound())
         writer = asyncio.ensure_future(self._writer())
         try:
@@ -170,6 +198,14 @@ class Bridge:
         finally:
             self._sessions.remove_notifier(self._topic, self._offer)
             await self._teardown(inbound, writer)
+            _logger.info(
+                "ws stream ended topic=%s duration_s=%.1f frames=%d heartbeats=%d outcome=%s",
+                self._topic,
+                time.monotonic() - opened,
+                self._frames_sent,
+                self._heartbeats_sent,
+                self._closure,
+            )
 
     async def _inbound(self) -> None:
         # INVARIANT: `_stop` is set in `finally` regardless of how this loop exits, so
@@ -189,8 +225,8 @@ class Bridge:
                     )
                     continue
                 await self._handle(event)
-        except WebSocketDisconnect:
-            pass
+        except WebSocketDisconnect as exc:
+            self._closure = _closure_of(exc)
         finally:
             self._stop.set()
 
@@ -200,6 +236,11 @@ class Bridge:
         else queues an `unsupported` error frame.
         """
         if isinstance(event, AttachEvent):
+            _logger.info(
+                "ws attach topic=%s from_sequence=%s",
+                self._topic,
+                event.data.from_sequence,
+            )
             # ORDER MATTERS, and only in this direction: the declaration is recorded before the
             # subscription is (re)started, so a run cannot be scheduled — nor a replayed frame
             # delivered — under a policy the session state has not seen yet.
@@ -305,8 +346,15 @@ class Bridge:
         """
         try:
             await _send(self._ws, event)
-        except (WebSocketDisconnect, RuntimeError):
+        except (WebSocketDisconnect, RuntimeError) as exc:
+            self._closure = _closure_of(exc)
             return False
+        # Counted on the way OUT, not on creation: only a frame that actually left the
+        # socket says anything about what the peer received before it went away.
+        if isinstance(event, HeartbeatEvent):
+            self._heartbeats_sent += 1
+        else:
+            self._frames_sent += 1
         return True
 
     async def _teardown(self, *tasks: asyncio.Task[None]) -> None:

--- a/apps/url4-cloud/src/url4_cloud/ws/endpoint.py
+++ b/apps/url4-cloud/src/url4_cloud/ws/endpoint.py
@@ -3,6 +3,7 @@ the caller's topic, then hands the accepted socket off to `Bridge` for the
 duration of the connection.
 """
 
+import logging
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, WebSocket
@@ -18,6 +19,8 @@ router = APIRouter()
 _SUBPROTOCOL = "cloudevents.json"
 _POLICY_VIOLATION = 1008
 _INTERNAL_ERROR = 1011
+
+_logger = logging.getLogger(__name__)
 
 
 def _default_clock() -> datetime:
@@ -63,6 +66,14 @@ async def ws_endpoint(websocket: WebSocket, ticket: str | None = None) -> None:
     """
     topic = _ticket_topic(websocket, ticket)
     if topic is None:
+        # WHY worth a log line: this is invisible from the client, which sees only a
+        # refused handshake. A burst of these says capabilities are arriving stale —
+        # the ticket's `iat_window_s` is short enough that anything delaying the
+        # connect (a Cloudflare Access login, a suspended host) outlives it.
+        _logger.info(
+            "ws rejected reason=%s",
+            "missing ticket" if ticket is None else "unverifiable ticket",
+        )
         await websocket.close(code=_POLICY_VIOLATION)
         return
     stream: EventConsumer | None = websocket.app.state.stream

--- a/apps/url4-cloud/tests/unit/test_logs_configuration.py
+++ b/apps/url4-cloud/tests/unit/test_logs_configuration.py
@@ -1,0 +1,92 @@
+"""The App's own log records have to survive the process that hosts them.
+
+`uvicorn.run()` configures the `uvicorn*` loggers and nothing else, so before this the
+App's INFO records reached `logging.lastResort` — a WARNING-level fallback — and were
+discarded. Every deployment logged health checks and nothing else, which reads as an idle
+service rather than a muted one.
+
+Self-contained by design (sdlc rule 5), including restoring the global logger it touches.
+"""
+
+import io
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from url4_cloud.logs import APP_LOGGER, LEVEL_ENV, configure
+
+
+@pytest.fixture(autouse=True)
+def _restore_app_logger() -> Iterator[None]:
+    """Logging is process-global; leave it exactly as found."""
+    logger = logging.getLogger(APP_LOGGER)
+    handlers = list(logger.handlers)
+    level, propagate = logger.level, logger.propagate
+    logger.handlers.clear()
+    try:
+        yield
+    finally:
+        logger.handlers.clear()
+        logger.handlers.extend(handlers)
+        logger.setLevel(level)
+        logger.propagate = propagate
+
+
+def test_an_info_record_from_the_app_reaches_a_handler() -> None:
+    # STORY: as the engineer reading back a drop, the line the App wrote is actually there.
+    # Before this, `_logger.info(...)` anywhere in `url4_cloud` produced no output at all in
+    # a deployed process — the evidence existed in the code and nowhere else.
+    stream = io.StringIO()
+    configure(stream)
+
+    logging.getLogger("url4_cloud.ws.bridge").info("ws stream ended outcome=client close 1006")
+
+    assert "ws stream ended outcome=client close 1006" in stream.getvalue()
+
+
+def test_configuration_is_idempotent_so_records_are_not_doubled() -> None:
+    # A second call must not stack a second handler: duplicated lines would make the frame
+    # and heartbeat counts read as twice what they were.
+    stream = io.StringIO()
+    configure(stream)
+    configure(stream)
+
+    logging.getLogger("url4_cloud.ws.bridge").info("once")
+
+    assert stream.getvalue().count("once") == 1
+
+
+def test_the_app_logger_does_not_propagate_into_a_root_configuration() -> None:
+    # uvicorn, a test harness, or a sidecar may configure the root logger later. Propagating
+    # would then emit every record twice through two different formatters.
+    configure(io.StringIO())
+
+    assert logging.getLogger(APP_LOGGER).propagate is False
+
+
+def test_an_operator_can_lower_the_level_without_a_code_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Debugging a live drop should not require a new image.
+    monkeypatch.setenv(LEVEL_ENV, "debug")
+    stream = io.StringIO()
+    configure(stream)
+
+    logging.getLogger("url4_cloud.ws.bridge").debug("cursor detail")
+
+    assert "cursor detail" in stream.getvalue()
+
+
+def test_a_foreign_handler_does_not_suppress_our_own() -> None:
+    # REGRESSION: idempotence used to be "the logger has no handlers", so anything that
+    # attached one first — a harness, a sidecar, an embedding process — made `configure`
+    # install nothing. The App then logged into that foreign handler's level and format, or
+    # nowhere at all, which is indistinguishable from the muting this module exists to fix.
+    logging.getLogger(APP_LOGGER).addHandler(logging.NullHandler())
+    stream = io.StringIO()
+
+    configure(stream)
+    logging.getLogger("url4_cloud.ws.bridge").info("still recorded")
+
+    assert "still recorded" in stream.getvalue()

--- a/apps/url4-cloud/tests/unit/test_ws_stream_diagnostics.py
+++ b/apps/url4-cloud/tests/unit/test_ws_stream_diagnostics.py
@@ -1,0 +1,136 @@
+"""What the App records about a WebSocket that ended, and why it records it.
+
+A dropped Run stream reaches the researcher as one undifferentiated message. The close
+code is what separates the causes, and only the App observes it — a client cannot report
+a close it never received. These pin the record that makes a drop attributable.
+
+Self-contained by design (sdlc rule 5): builds its own app rather than reaching into the
+shared WS test module.
+"""
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, WebSocketDisconnect
+from fastapi.testclient import TestClient
+
+from url4.streaming.protocol import (
+    AttachData,
+    AttachEvent,
+    StartedData,
+    StartedEvent,
+    TerminatedData,
+    TerminatedEvent,
+)
+from url4_cloud.app import create_app
+from url4_cloud.auth import JwtCodec
+from url4_cloud.config import Settings
+from url4_cloud.testing import InMemoryEventStream
+
+SECRET = "ws-diagnostics-secret"
+WINDOW_S = 60
+SUBPROTOCOL = "cloudevents.json"
+TOPIC = "topic-diag"
+T0 = datetime(2026, 8, 13, 9, 0, 0, tzinfo=UTC)
+
+
+def _token(topic: str) -> str:
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+
+
+def _app(stream: InMemoryEventStream | None, *, heartbeat_s: float = 30.0) -> FastAPI:
+    settings = Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S, ws_heartbeat_s=heartbeat_s)
+    return create_app(settings, stream=stream, job_runner=None, clock=lambda: T0)
+
+
+def _attach() -> dict[str, Any]:
+    return AttachEvent(
+        id="att", source="/client", subject=TOPIC, data=AttachData(from_sequence=None)
+    ).model_dump(mode="json", by_alias=True)
+
+
+def _seed(client: TestClient, stream: InMemoryEventStream) -> None:
+    portal = client.portal
+    assert portal is not None
+    for event in (
+        StartedEvent(
+            id="s1",
+            source=f"/trace/{TOPIC}/node/root",
+            subject=TOPIC,
+            data=StartedData(url4="gpt()"),
+        ),
+        TerminatedEvent(
+            id="t1",
+            source=f"/trace/{TOPIC}/node/root",
+            subject=TOPIC,
+            data=TerminatedData(status="succeeded"),
+        ),
+    ):
+        portal.call(stream.publish, TOPIC, event)
+
+
+def test_a_finished_stream_records_how_it_ended_and_what_it_carried(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # STORY: as the engineer reading back a failure, the App tells me the shape of the
+    # connection — how long it lived, whether it was carrying work or idling, and the
+    # close code. Without those, every cause of a drop is the same log line: none.
+    stream = InMemoryEventStream()
+    with caplog.at_level(logging.INFO, logger="url4_cloud.ws.bridge"):
+        with TestClient(_app(stream)) as client:
+            with client.websocket_connect(
+                f"/ws?ticket={_token(TOPIC)}", subprotocols=[SUBPROTOCOL]
+            ) as websocket:
+                websocket.send_json(_attach())
+                _seed(client, stream)
+                websocket.receive_json()
+                websocket.receive_json()
+
+    ended = [record for record in caplog.records if "ws stream ended" in record.getMessage()]
+    assert len(ended) == 1
+    message = ended[0].getMessage()
+    assert f"topic={TOPIC}" in message
+    assert "frames=2" in message
+    assert "heartbeats=0" in message
+    assert "duration_s=" in message
+
+
+def test_an_attach_records_the_cursor_it_resumed_from(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # A re-attach is the client telling us it lost frames. Recording the cursor is what
+    # distinguishes a clean first attach from a stream that is being repaired.
+    stream = InMemoryEventStream()
+    with caplog.at_level(logging.INFO, logger="url4_cloud.ws.bridge"):
+        with TestClient(_app(stream)) as client:
+            with client.websocket_connect(
+                f"/ws?ticket={_token(TOPIC)}", subprotocols=[SUBPROTOCOL]
+            ) as websocket:
+                websocket.send_json(_attach())
+                _seed(client, stream)
+                websocket.receive_json()
+
+    attaches = [record for record in caplog.records if "ws attach" in record.getMessage()]
+    assert [record.getMessage() for record in attaches] == [
+        f"ws attach topic={TOPIC} from_sequence=None"
+    ]
+
+
+def test_a_refused_handshake_is_recorded_rather_than_silently_closed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # STORY: as the engineer on call, a burst of refusals is visible. A capability whose
+    # window elapsed before the client could connect is otherwise invisible here — the
+    # client only ever sees a refused handshake with no reason attached.
+    with caplog.at_level(logging.INFO, logger="url4_cloud.ws.endpoint"):
+        with TestClient(_app(InMemoryEventStream())) as client:
+            with pytest.raises(WebSocketDisconnect):
+                with client.websocket_connect(
+                    "/ws?ticket=not-a-real-capability", subprotocols=[SUBPROTOCOL]
+                ) as websocket:
+                    websocket.receive_json()
+
+    refused = [record for record in caplog.records if "ws rejected" in record.getMessage()]
+    assert [record.getMessage() for record in refused] == ["ws rejected reason=unverifiable ticket"]

--- a/docs/spec/2026-08-13-websocket-disconnected-drops.md
+++ b/docs/spec/2026-08-13-websocket-disconnected-drops.md
@@ -1,0 +1,115 @@
+---
+title: Attribute and remove websocket_disconnected drops
+ticket: none filed — investigation of OME-806
+status: approved
+date: 2026-08-13
+---
+
+# Attribute and remove `websocket_disconnected` drops
+
+## Problem
+
+`ExecutionError: SF Engine WebSocket disconnected before the Run completed` (code
+`websocket_disconnected`) is raised from exactly one place, and every way a Run stream can be
+lost arrives there as the same sentence. An oversized result frame, a proxy draining a
+listener, a rolled Pod and a refused capability are indistinguishable to the researcher who
+hits one and to the engineer who reads the report afterwards.
+
+Two of those causes turned out to be defects the Client creates itself. Both were reproduced
+before anything was changed.
+
+### A — a capped Report can never be delivered
+
+`Url4Executor.result_cap` is `1_048_576`. The `websockets` client's `max_size` default is
+`2**20` — the same number — and the Client never overrode it. The Engine truncates a body to
+the cap and then wraps it in a CloudEvent whose `data.body` is a JSON string, so the frame
+always exceeds the body it carries. Measured against a real socket: a body at the cap
+produces a **1,048,884 byte frame**, 308 bytes over the limit before a single character of
+JSON escaping (escaping adds ~7% on a real Report, and can double it in the worst case).
+
+The truncation guard therefore never produced a deliverable frame. Any Evaluation whose
+Report approached 1 MiB — roughly 125 Cases on a rubric-heavy Benchmark — failed, every time,
+with close 1009.
+
+### E — the Access retry outlives the capability it retries with
+
+On a Cloudflare Access challenge, `run()` calls `reauthenticate()` — an interactive browser
+login with a **300 second** timeout — and then retries the handshake with the capability it
+already held. That capability's `iat_window_s` is **60 seconds**, in the default and in the
+shipped chart values. Any login slower than a minute presents an expired ticket, the Engine
+refuses the handshake with 1008, and the Run dies. Because `_MAX_CANDIDATES_IN_FLIGHT`
+capabilities are minted together, one slow login fails the whole Evaluation.
+
+### The reason neither was visible
+
+The Client discards the WebSocket close code into a generic message, and the App cannot log
+below WARNING at all: `cli.py` calls `uvicorn.run()` with no `log_config`, uvicorn configures
+only the `uvicorn*` loggers, and the root logger is left without a handler — so every
+`url4_cloud` record falls through to `logging.lastResort`. Production log exports show
+`uvicorn.access` health checks and nothing else, which reads as an idle service rather than a
+muted one. This has been true of every deployment.
+
+## Outcome
+
+A dropped Run stream names its own cause, from either end, and the two causes above stop
+happening.
+
+- The Client's frame limit is above the Engine's result cap plus envelope and escaping, so a
+  capped Report is delivered rather than refused.
+- An Access challenge is retried with a capability minted after the login, not before it.
+- The Client's error carries the close code and the elapsed Run time.
+- The App records the close code, duration, and whether the connection was carrying work or
+  idling — and its records actually reach a handler.
+
+## Interfaces and seams
+
+**Client (`packages/screamingface`).** `Url4CloudTransport` and its asynchronous twin gain an
+explicit `max_size`, track the capabilities they mint as a list rather than one value, and
+report the close code. No public API changes; `_RunOutcome`, the event stream and the Report
+are untouched.
+
+**Engine (`apps/url4-cloud`).** A new `url4_cloud.logs` module owns log configuration for both
+modes of the image, wired from `cli.main` before dispatch. The WS bridge records the shape of
+each connection. Stdlib only, so the layering rule keeps the run mode's import graph disjoint
+from the serving mode's.
+
+## Behavioral invariants
+
+- A result body at exactly `result_cap` reaches the researcher.
+- The retry after an Access challenge presents a capability that did not exist when the
+  challenge was issued.
+- Every cause of a lost stream is distinguishable from the Client's error text alone.
+- The App's INFO records survive the process that hosts them, and configuring twice neither
+  stacks handlers nor suppresses one another component already installed.
+- Counters describe frames that actually left the socket, so `frames` and `heartbeats` are
+  disjoint and neither counts a frame that was queued but never sent.
+- No payload is logged. The url4 expression is recorded by length only — it carries prompts.
+
+## Explicitly out of scope
+
+The observability lands so these can be settled with evidence rather than argument:
+
+- **Envoy Gateway listener drain.** The dev cluster's control plane pushes new xDS roughly
+  once a minute while idle; whether that drains in-flight WebSockets is unverified.
+- **Cloudflare edge idle or duration cuts.** Not reproducible without the real edge.
+- **Pod rollout.** `replicaCount` must stay 1 while the 428 subscriber gate is in-process, so
+  every rollout drops in-flight Runs by construction.
+
+Also deliberately left alone, each its own unit:
+
+- **Reconnect after a drop.** Still impossible: a 60 second capability cannot outlive the Run
+  it authorizes, so resuming from `from_sequence` needs a token-lifetime decision first.
+- **The stop fallback on long Runs.** `cancel_active()` presents the original capability, which
+  a Run older than 60 seconds has already outlived; 401 is not treated as already-stopped, and
+  the synchronous fan-out cannot cancel running threads, so interrupting a long Evaluation
+  still leaves paid work running.
+- **Advisory frames dropped under backpressure.** `Bridge._offer` discards on a full queue,
+  including the `stream_failed` nack that drives recovery — the control signal shares the
+  bounded queue it exists to repair.
+
+## Compatibility
+
+Both changes are behaviour-preserving for every Run that already succeeded. The Client's frame
+limit only admits frames it previously refused; the capability re-mint only occurs on a path
+that previously failed. No wire contract, schema or public signature changes, so no Benchmark
+revision moves.

--- a/docs/work/2026-08-13-websocket-disconnected-drops.md
+++ b/docs/work/2026-08-13-websocket-disconnected-drops.md
@@ -1,0 +1,91 @@
+---
+ticket: none filed — investigation of OME-806
+stack: screamingface, url4-cloud
+status: done
+started: 2026-08-13
+finished: 2026-08-13
+---
+
+# Attribute and remove `websocket_disconnected` drops
+
+## Intent
+
+A user reported frequent `ExecutionError: SF Engine WebSocket disconnected before the Run
+completed` when running a pipeline. OME-806 tracks the symptom and proposes three candidate
+causes, none of which turned out to be the two that are demonstrable in the code. This unit
+removes those two and makes every remaining candidate self-identifying, so the rest can be
+settled with evidence instead of argument.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_engine/transport.py` — explicit `max_size`;
+  re-mint the capability after `reauthenticate()`; close code + elapsed time in the error.
+- `packages/screamingface/tests/test_transport_disconnect_diagnosis.py` — new, self-contained.
+- `apps/url4-cloud/src/url4_cloud/logs.py` — new; log configuration for both modes.
+- `apps/url4-cloud/src/url4_cloud/cli.py` — configure logging before dispatch.
+- `apps/url4-cloud/src/url4_cloud/ws/bridge.py` — record how each connection ended.
+- `apps/url4-cloud/src/url4_cloud/ws/endpoint.py` — record refused handshakes.
+- `apps/url4-cloud/src/url4_cloud/rest/routes.py` — record run scheduled / stop requested.
+- `apps/url4-cloud/tests/unit/test_ws_stream_diagnostics.py` — new, self-contained.
+- `apps/url4-cloud/tests/unit/test_logs_configuration.py` — new, self-contained.
+
+## Test plan
+
+Failing first, in this order:
+
+- A result body at exactly `result_cap` is delivered (sync and async).
+- An Access challenge is retried with a freshly minted capability (sync and async).
+- A dropped stream reports its close code and elapsed time.
+- A finished stream is recorded with duration, frame count and heartbeat count.
+- An attach is recorded with the cursor it resumed from.
+- A refused handshake is recorded rather than silently closed.
+- An INFO record from the App reaches a handler; configuring twice does not double it; a
+  foreign handler does not suppress ours; the level is settable from the environment.
+
+## Acceptance
+
+- All of the above fail against `origin/main` and pass after the change.
+- `run_gates.py screamingface` and `run_gates.py url4-cloud` both green.
+- The four causes produce four distinguishable error texts.
+
+## Outcome
+
+- **Actual files:** as planned, plus `docs/spec/2026-08-13-websocket-disconnected-drops.md`
+  and this ledger.
+- **Gates:** `screamingface` — ALL GATES GREEN (8 gates, 756 tests, 95% coverage floor).
+  `url4-cloud` — ALL GATES GREEN (6 gates, 1390 tests, 80% floor, layering check).
+- **Verification beyond the suites:**
+  - Each new test was confirmed to fail with the fix stashed and pass with it restored.
+  - L1 end-to-end against real uvicorn, the real app and a real `websockets` client: a
+    pre-fix client (`max_size=2**20`) refuses the capped result and the App logs
+    `outcome=client close 1009 'frame exceeds limit of 1048576 bytes'`; a post-fix client
+    receives the full 1,048,884 byte frame and closes 1000. Confirms both that the fix works
+    through real framing and that mechanism A is attributable from the Engine alone, with no
+    SDK update deployed.
+
+## Deviations
+
+- **No Linear issue and no `docs/tasks/` mirror.** The owner directed an exploratory pass and
+  explicitly deferred filing. OME-806 already tracks the symptom; this branch references it
+  without claiming to close it, since two of its candidate causes remain unresolved.
+- **The append-only gate fired once, and was obeyed rather than skipped.** The first attempt
+  extended the shared `packages/screamingface/tests/protocol_server.py` with two new modes.
+  That edits a prior fixture, which rule 5 forbids. The work was reverted and rewritten as one
+  self-contained test file with its own Engine stub — the house pattern. `--skip-append-only`
+  was NOT used. The restructure also proved better: the scenarios are investigation-specific
+  and do not belong in the shared fixture.
+- **A defect was found while testing the fix, not before.** `logs.configure` first guarded
+  idempotence with `if not logger.handlers`, which silently installs nothing whenever any other
+  component attached a handler first — the exact failure it exists to prevent. Caught because
+  the new tests passed alone and failed in the full suite, where `test_cli` had already
+  configured the logger. Now keyed to a marker on our own handler, with a regression test.
+- **The engine logging was nearly shipped inert.** Verified before recommending a deploy that
+  `uvicorn.run()` leaves root without a handler and `url4_cloud` records never reach one, so
+  every INFO line added here would have been discarded in production. `logs.py` was added in
+  response; without it the observability half of this unit would have been a no-op.
+- **Scope held.** Three adjacent defects were found and deliberately left out, each recorded
+  in the spec's out-of-scope section: reconnect-after-drop, the stop fallback that cannot
+  authenticate past 60 seconds, and advisory frames dropped under backpressure.
+- **Two stacks in one branch.** Rule 8 would normally split a cross-cutting change into an
+  epic with one sub-issue per app. Kept together here because the observability and the fixes
+  were verified as one system; splitting into two PRs remains available and was recommended.

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -14,7 +14,7 @@ from urllib.parse import urlencode, urlsplit, urlunsplit
 import httpx
 from websockets.asyncio import client as async_ws
 from websockets.asyncio.client import ClientConnection as AsyncClientConnection
-from websockets.exceptions import InvalidStatus, WebSocketException
+from websockets.exceptions import ConnectionClosed, InvalidStatus, WebSocketException
 from websockets.sync import client as sync_ws
 from websockets.sync.connection import Connection as SyncConnection
 from websockets.typing import Subprotocol
@@ -39,6 +39,15 @@ _EVENT_RECEIVE_TIMEOUT_SECONDS = 120.0
 _STOP_TIMEOUT_SECONDS = 5.0
 # The Engine answers a stop for a Run it has already finished with one of these.
 _ALREADY_STOPPED_STATUSES = frozenset({404, 409, 410})
+# INVARIANT: this MUST stay above the Engine's result cap plus the frame that carries it.
+# The Engine truncates a result body to 1 MiB, then wraps it in a CloudEvent whose `data.body`
+# is a JSON string — escaping alone adds ~7% on a JSON report and can double it in the worst
+# case, before the envelope. `websockets` defaults `max_size` to 2**20, which is EXACTLY the
+# Engine's cap, so the default made every capped result undeliverable: the client refused the
+# frame with close 1009 and the Run surfaced as `websocket_disconnected`. Eight times the cap
+# clears the worst-case expansion with room to spare, and the bound still exists so that a
+# malformed or hostile stream cannot grow this process's heap without limit.
+_MAX_FRAME_BYTES = 8 * 1024 * 1024
 
 
 class _SyncSender(Protocol):
@@ -72,24 +81,26 @@ class Url4CloudTransport:
         candidate: Candidate,
         on_event: SyncEventCallback | None,
     ) -> _RunOutcome:
-        token = _mint_sync(self._http)
+        minted = [_mint_sync(self._http)]
         with self._active_lock:
-            self._active_tokens.add(token)
+            self._active_tokens.add(minted[0])
         lifecycle = _Lifecycle(candidate)
+        started = time.monotonic()
         try:
             for attempt in range(2):
                 try:
                     with sync_ws.connect(
-                        _websocket_url(self._engine_url, token),
+                        _websocket_url(self._engine_url, minted[-1]),
                         subprotocols=[_SUBPROTOCOL],
                         additional_headers=self._caller_auth.websocket_headers(),
                         open_timeout=30,
                         close_timeout=10,
+                        max_size=_MAX_FRAME_BYTES,
                     ) as websocket:
                         return self._run_connected(
                             websocket,
                             lifecycle,
-                            token,
+                            minted[-1],
                             candidate,
                             on_event,
                         )
@@ -97,15 +108,18 @@ class Url4CloudTransport:
                     if attempt != 0 or not _is_access_websocket_rejection(exc):
                         raise
                     self._caller_auth.reauthenticate()
+                    minted.append(_mint_sync(self._http))
+                    with self._active_lock:
+                        self._active_tokens.add(minted[-1])
             raise AssertionError("WebSocket authentication retry loop exhausted")
         except _ObserverRaised as exc:
             _copy_notes(exc, exc.original)
             raise exc.original
         except (WebSocketException, OSError, TimeoutError) as exc:
-            raise _disconnected() from exc
+            raise _disconnected(exc, time.monotonic() - started) from exc
         finally:
             with self._active_lock:
-                self._active_tokens.discard(token)
+                self._active_tokens.difference_update(minted)
 
     def cancel_active(self) -> None:
         """Stop every run currently owned by this synchronous Client."""
@@ -210,11 +224,12 @@ class AsyncUrl4CloudTransport:
         candidate: Candidate,
         on_event: AsyncEventCallback | None,
     ) -> _RunOutcome:
-        token = await _mint_async(self._http)
-        self._active_tokens.add(token)
+        minted = [await _mint_async(self._http)]
+        self._active_tokens.add(minted[0])
         cancelled = False
+        started = time.monotonic()
         try:
-            return await self._connected_run(token, candidate, on_event)
+            return await self._connected_run(minted, candidate, on_event)
         # WHY: a cancelled Run keeps its capability registered so the Evaluation's sweep can
         # still stop it. asyncio.gather cancels its children and only re-raises once they have
         # all unwound, so by the time the sweep runs every Run here has already finished its
@@ -229,14 +244,14 @@ class AsyncUrl4CloudTransport:
             _copy_notes(exc, exc.original)
             raise exc.original
         except (WebSocketException, OSError, TimeoutError) as exc:
-            raise _disconnected() from exc
+            raise _disconnected(exc, time.monotonic() - started) from exc
         finally:
             if not cancelled:
-                self._active_tokens.discard(token)
+                self._active_tokens.difference_update(minted)
 
     async def _connected_run(
         self,
-        token: str,
+        minted: list[str],
         candidate: Candidate,
         on_event: AsyncEventCallback | None,
     ) -> _RunOutcome:
@@ -244,16 +259,17 @@ class AsyncUrl4CloudTransport:
         for attempt in range(2):
             try:
                 async with async_ws.connect(
-                    _websocket_url(self._engine_url, token),
+                    _websocket_url(self._engine_url, minted[-1]),
                     subprotocols=[_SUBPROTOCOL],
                     additional_headers=await self._caller_auth.websocket_headers_async(),
                     open_timeout=30,
                     close_timeout=10,
+                    max_size=_MAX_FRAME_BYTES,
                 ) as websocket:
                     return await self._run_connected(
                         websocket,
                         lifecycle,
-                        token,
+                        minted[-1],
                         candidate,
                         on_event,
                     )
@@ -261,6 +277,14 @@ class AsyncUrl4CloudTransport:
                 if attempt != 0 or not _is_access_websocket_rejection(exc):
                     raise
                 await self._caller_auth.reauthenticate_async()
+                # WHY a NEW capability rather than the one already in hand: its iat window is
+                # 60s, and `reauthenticate` runs a Cloudflare Access browser login worth up to
+                # 300s. Retrying with the pre-challenge token therefore presents an expired
+                # capability, the Engine refuses the handshake with 1008, and the Run dies as
+                # `websocket_disconnected`. Minting is unauthenticated and per-Run, so
+                # replacing the token is cheaper than widening the window that protects it.
+                minted.append(await _mint_async(self._http))
+                self._active_tokens.add(minted[-1])
         raise AssertionError("WebSocket authentication retry loop exhausted")
 
     async def _run_connected(
@@ -562,12 +586,39 @@ def _copy_notes(source: BaseException, target: BaseException) -> None:
         target.add_note(note)
 
 
-def _disconnected() -> ExecutionError:
+def _disconnected(cause: BaseException, elapsed_s: float) -> ExecutionError:
+    """Report the disconnection with the two facts that identify which one it was.
+
+    WHY: every cause of a dropped Run stream arrives here as the same message — an
+    oversized frame, a proxy draining a listener, a rolled Pod, a refused capability. The
+    close code separates them and the elapsed time separates a size-driven failure (varies
+    with the Report) from a duration-driven one (lands on the same second every time).
+    Without both, the error is a symptom report that no one can act on.
+    """
+
     return ExecutionError(
-        "SF Engine WebSocket disconnected before the Run completed",
+        "SF Engine WebSocket disconnected before the Run completed "
+        f"after {elapsed_s:.1f}s ({_close_detail(cause)})",
         code="websocket_disconnected",
         permanent=False,
     )
+
+
+def _close_detail(cause: BaseException) -> str:
+    if not isinstance(cause, ConnectionClosed):
+        return type(cause).__name__
+    # `rcvd` is the peer's close frame and `sent` is ours; whichever is present names the
+    # side that decided. The client sends 1009 itself when a frame exceeds `max_size`, so
+    # preferring `rcvd` alone would hide exactly that case behind "no close frame".
+    close = cause.rcvd or cause.sent
+    if close is None:
+        # RFC 6455 §7.1.5: the connection vanished without a close handshake. Nothing on the
+        # wire says 1006 — it is the code reserved for precisely this, and naming it is what
+        # tells an operator to look at proxies and Pod lifetimes rather than at the Run.
+        return "close 1006 abnormal closure, no close frame"
+    origin = "engine sent" if cause.rcvd is not None else "client sent"
+    reason = f" — {close.reason}" if close.reason else ""
+    return f"{origin} close {close.code}{reason}"
 
 
 __all__: list[str] = []

--- a/packages/screamingface/tests/test_transport_close_reporting.py
+++ b/packages/screamingface/tests/test_transport_close_reporting.py
@@ -1,0 +1,70 @@
+"""The text a dropped Run stream reports, cause by cause.
+
+`websocket_disconnected` is raised from one place, so an oversized frame, a drained proxy,
+a rolled Pod and a socket that never connected all arrive at the researcher as the same
+sentence unless the close code is carried through. These pin that each reads differently.
+
+Self-contained by design (sdlc rule 5), and deliberately free of any server: what is under
+test is the message, not the transport that produces the exception.
+"""
+
+from __future__ import annotations
+
+import pytest
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
+
+from screamingface._engine.transport import _disconnected
+
+
+@pytest.mark.parametrize(
+    ("cause", "expected"),
+    [
+        pytest.param(
+            ConnectionClosedError(None, Close(1009, "frame exceeds limit of 1048576 bytes"), None),
+            "client sent close 1009 — frame exceeds limit of 1048576 bytes",
+            id="oversize-result-refused-by-this-client",
+        ),
+        pytest.param(
+            ConnectionClosedError(Close(1001, "going away"), None, None),
+            "engine sent close 1001 — going away",
+            id="engine-going-away",
+        ),
+        pytest.param(
+            ConnectionClosedError(None, None, None),
+            "close 1006 abnormal closure, no close frame",
+            id="dropped-with-no-close-handshake",
+        ),
+        pytest.param(
+            OSError("connection refused"),
+            "OSError",
+            id="never-reached-the-engine",
+        ),
+    ],
+)
+def test_each_cause_of_a_drop_reads_differently(cause: BaseException, expected: str) -> None:
+    # STORY: as the engineer triaging a report, the message alone tells me which failure this
+    # was, and the four candidates stop being one undifferentiated bucket.
+    #
+    # `sent` is read as well as `rcvd` on purpose: THIS client is what sends 1009 when a frame
+    # exceeds its limit, so reading only the peer's frame would hide the one cause we know we
+    # cause ourselves behind a generic "no close frame".
+    assert expected in str(_disconnected(cause, 41.2))
+
+
+def test_the_report_carries_how_long_the_run_had_been_going() -> None:
+    # The second discriminator, and the one the close code cannot supply: a size-driven
+    # failure moves with the Report, while an idle cut or a drained listener lands on the
+    # same second every time.
+    message = str(_disconnected(ConnectionClosedError(None, None, None), 300.0))
+
+    assert "after 300.0s" in message
+
+
+def test_the_diagnostic_does_not_change_the_error_contract() -> None:
+    # The text grew; the code and its retryability are what callers branch on, and a caller
+    # keying on `permanent` to decide whether to retry must not be affected by any of this.
+    error = _disconnected(ConnectionClosedError(None, Close(1009, "too big"), None), 1.0)
+
+    assert error.code == "websocket_disconnected"
+    assert error.permanent is False

--- a/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
+++ b/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
@@ -1,0 +1,390 @@
+"""Why a Run stream drops, and the two drops the Client used to cause itself.
+
+Every cause of a lost Run stream reaches the researcher as one message — an oversized
+result frame, a proxy draining a listener, a rolled Pod, a refused capability. These pin
+the two the Client is responsible for, plus the diagnostic that tells the other two apart.
+
+Self-contained by design (sdlc rule 5): the Engine stub here serves only these three
+scenarios rather than extending the shared protocol server.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import struct
+import threading
+from collections.abc import Iterator
+from contextlib import closing, contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Literal
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+import screamingface as sf
+from screamingface._engine.auth_base import _TransportAuth
+from screamingface._engine.transport import AsyncUrl4CloudTransport, Url4CloudTransport
+from screamingface._evaluation.model import (
+    Candidate,
+    _compiled_candidate,
+    _compiled_operation,
+)
+
+_WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+_CANDIDATE_URL4 = "(@)!'hello'"
+
+ENGINE_RESULT_CAP_BYTES = 1_048_576
+"""`url4_cloud.runner.executor.Url4Executor.result_cap` — the largest body the Engine emits.
+
+The Engine truncates a result body to exactly this, then wraps it in a CloudEvent envelope,
+so the frame on the wire is ALWAYS larger than the cap. A Client whose frame limit equals
+the cap can therefore never receive a capped result.
+"""
+
+Mode = Literal["oversize_result", "access_challenge", "abrupt_disconnect"]
+
+
+@dataclass
+class EngineState:
+    mode: Mode
+    attached: threading.Event = field(default_factory=threading.Event)
+    started: threading.Event = field(default_factory=threading.Event)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    minted_tokens: list[str] = field(default_factory=list)
+    handshakes: int = 0
+    challenged_tokens: list[str] = field(default_factory=list)
+    """Capabilities that already existed when Access challenged.
+
+    url4-cloud refuses these on the retry: `iat_window_s` is 60s while `reauthenticate()`
+    runs a browser login worth up to 300s, so a capability minted before the challenge is
+    always expired by the time the retry presents it. Modelled by identity rather than a
+    clock — the retry must present a capability that did not exist at challenge time.
+    """
+
+    def mint(self) -> str:
+        with self.lock:
+            token = f"diag-capability-{len(self.minted_tokens) + 1}"
+            self.minted_tokens.append(token)
+            return token
+
+
+@dataclass(frozen=True)
+class Engine:
+    url: str
+    state: EngineState
+
+
+class _Server(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], state: EngineState) -> None:
+        self.state = state
+        super().__init__(address, _Handler)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server: _Server
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+    def do_POST(self) -> None:  # noqa: N802 — stdlib handler API
+        if urlsplit(self.path).path != "/token":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        self._json(HTTPStatus.OK, {"token": self.server.state.mint()})
+
+    def do_DELETE(self) -> None:  # noqa: N802 — stdlib handler API
+        self._no_content(HTTPStatus.NO_CONTENT)
+
+    def do_GET(self) -> None:  # noqa: N802 — stdlib handler API
+        if self.headers.get("Upgrade", "").casefold() == "websocket":
+            self._websocket()
+        else:
+            self._start()
+
+    def _start(self) -> None:
+        state = self.server.state
+        if not state.attached.is_set():
+            self._json(
+                HTTPStatus.PRECONDITION_REQUIRED,
+                {
+                    "type": "about:blank",
+                    "title": "Precondition Required",
+                    "status": HTTPStatus.PRECONDITION_REQUIRED,
+                    "detail": "Attach a WebSocket to the topic before starting the run.",
+                },
+                media_type="application/problem+json",
+            )
+            return
+        self.send_response(HTTPStatus.ACCEPTED)
+        self.send_header("Preference-Applied", "respond-async")
+        self.send_header("Location", "/?topic=run_diag")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+        state.started.set()
+
+    def _websocket(self) -> None:
+        if self.server.state.mode == "access_challenge" and self._refuse_handshake():
+            return
+        if not self._accept_websocket():
+            return
+        if not self._read_attach():
+            return
+        self.server.state.attached.set()
+        if self.server.state.started.wait(timeout=5):
+            self._stream()
+
+    def _refuse_handshake(self) -> bool:
+        """The two ways url4-cloud refuses a WebSocket before ever accepting it."""
+        state = self.server.state
+        state.handshakes += 1
+        if state.handshakes == 1:
+            # Cloudflare Access challenges an unauthenticated handshake.
+            with state.lock:
+                state.challenged_tokens = list(state.minted_tokens)
+            self._no_content(HTTPStatus.FORBIDDEN, {"cf-access-aud": "a" * 32})
+            return True
+        ticket = parse_qs(urlsplit(self.path).query).get("ticket", [""])[0]
+        if ticket in state.challenged_tokens:
+            # ws/endpoint.py: an unverifiable ticket is close(1008) before accept, which
+            # reaches the Client as a plain handshake refusal.
+            self._no_content(HTTPStatus.FORBIDDEN)
+            return True
+        return False
+
+    def _accept_websocket(self) -> bool:
+        key = self.headers.get("Sec-WebSocket-Key")
+        if key is None:
+            self.send_error(HTTPStatus.BAD_REQUEST)
+            return False
+        accept = base64.b64encode(
+            hashlib.sha1(f"{key}{_WEBSOCKET_GUID}".encode()).digest()
+        ).decode()
+        self.send_response(HTTPStatus.SWITCHING_PROTOCOLS)
+        self.send_header("Upgrade", "websocket")
+        self.send_header("Connection", "Upgrade")
+        self.send_header("Sec-WebSocket-Accept", accept)
+        self.send_header("Sec-WebSocket-Protocol", "cloudevents.json")
+        self.end_headers()
+        self.close_connection = True
+        return True
+
+    def _read_attach(self) -> bool:
+        try:
+            event = json.loads(_read_client_text_frame(self.rfile))
+        except (AssertionError, IndexError, json.JSONDecodeError):
+            return False
+        return isinstance(event, dict) and event.get("type") == "ai.url4.attach"
+
+    def _stream(self) -> None:
+        if self.server.state.mode == "abrupt_disconnect":
+            # The socket vanishes mid-Run with no close handshake, exactly as a drained
+            # proxy listener or an evicted Pod leaves it.
+            _send_server_text_frame(self.wfile, json.dumps(_run_frames("unused")[0]))
+            return
+        body = (
+            "x" * ENGINE_RESULT_CAP_BYTES
+            if self.server.state.mode == "oversize_result"
+            else "[diag] done"
+        )
+        for frame in _run_frames(body):
+            _send_server_text_frame(self.wfile, json.dumps(frame))
+
+    def _json(self, status: HTTPStatus, value: object, *, media_type: str = "application/json"):
+        body = json.dumps(value).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", media_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _no_content(self, status: HTTPStatus, headers: dict[str, str] | None = None) -> None:
+        self.send_response(status)
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def _frame(kind: str, data: dict[str, object], sequence: int) -> dict[str, object]:
+    return {
+        "specversion": "1.0",
+        "id": f"event_{sequence}",
+        "source": "/trace/run_diag/node/root",
+        "subject": "run_diag",
+        "time": datetime.now(UTC).isoformat(),
+        "type": kind,
+        "datacontenttype": "application/json",
+        "sequence": str(sequence),
+        "sequencetype": "Integer",
+        "data": data,
+    }
+
+
+def _run_frames(body: str) -> tuple[dict[str, object], ...]:
+    return (
+        _frame("ai.url4.started", {"url4": _CANDIDATE_URL4}, 1),
+        _frame("ai.url4.result", {"body": body, "media_type": "application/json"}, 2),
+        _frame("ai.url4.terminated", {"status": "succeeded", "error": None}, 3),
+    )
+
+
+def _read_client_text_frame(stream: Any) -> str:
+    header = stream.read(2)
+    length = header[1] & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", stream.read(2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", stream.read(8))[0]
+    mask = stream.read(4) if header[1] & 0x80 else b""
+    payload = stream.read(length)
+    if mask:
+        payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return payload.decode()
+
+
+def _send_server_text_frame(stream: Any, value: str) -> None:
+    payload = value.encode()
+    if len(payload) < 126:
+        header = bytes((0x81, len(payload)))
+    elif len(payload) < 65536:
+        header = bytes((0x81, 126)) + struct.pack("!H", len(payload))
+    else:
+        header = bytes((0x81, 127)) + struct.pack("!Q", len(payload))
+    stream.write(header + payload)
+    stream.flush()
+
+
+@contextmanager
+def engine(*, mode: Mode) -> Iterator[Engine]:
+    state = EngineState(mode=mode)
+    server = _Server(("127.0.0.1", 0), state)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        yield Engine(url=f"http://{host}:{port}", state=state)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _candidate() -> Candidate:
+    return _compiled_candidate(
+        name="opus",
+        kind="model",
+        models=("provider/opus",),
+        url4=_CANDIDATE_URL4,
+        operations=(
+            _compiled_operation(id="op_opus", kind="model", label="opus answer", depends_on=()),
+        ),
+    )
+
+
+class _StubAccessAuth(_TransportAuth):
+    """Caller auth whose reauthentication always succeeds, counting its invocations.
+
+    Stands in for the Cloudflare Access browser flow. What decides the contract below is
+    not how long that flow takes but which capability the Client presents afterwards.
+    """
+
+    def __init__(self) -> None:
+        self.reauthentications = 0
+
+    def auth_flow(self, request: httpx.Request):  # type: ignore[override]
+        yield request
+
+    def reauthenticate(self, *, timeout: float = 300.0) -> None:
+        self.reauthentications += 1
+
+    async def reauthenticate_async(self, *, timeout: float = 300.0) -> None:
+        self.reauthentications += 1
+
+    def websocket_headers(self) -> dict[str, str]:
+        return {}
+
+    async def websocket_headers_async(self) -> dict[str, str]:
+        return {}
+
+    def close(self) -> None:
+        return None
+
+
+def test_a_result_at_the_engine_cap_reaches_the_researcher() -> None:
+    # STORY: as a researcher evaluating a few hundred Cases, my Report is large and it
+    # arrives. Before this the Client's frame limit was EXACTLY the Engine's body cap, so
+    # the envelope around a capped body always overflowed it: the Client refused the frame
+    # with close 1009 and every large Evaluation died as `websocket_disconnected`.
+    with engine(mode="oversize_result") as stub:
+        with closing(Url4CloudTransport(stub.url)) as transport:
+            outcome = transport.run(_candidate(), None)
+
+    assert len(outcome.result_body.encode()) == ENGINE_RESULT_CAP_BYTES
+
+
+@pytest.mark.asyncio
+async def test_a_result_at_the_engine_cap_reaches_an_async_researcher() -> None:
+    with engine(mode="oversize_result") as stub:
+        transport = AsyncUrl4CloudTransport(stub.url)
+        try:
+            outcome = await transport.run(_candidate(), None)
+        finally:
+            await transport.close()
+
+    assert len(outcome.result_body.encode()) == ENGINE_RESULT_CAP_BYTES
+
+
+def test_an_access_challenge_retries_with_a_freshly_minted_capability() -> None:
+    # STORY: as a researcher on a hosted Engine, my Run survives being asked to log in
+    # again. Before this the retry re-presented the capability minted BEFORE the challenge;
+    # a 60s capability cannot outlive a 300s browser login, so the Engine refused the
+    # handshake and the whole Evaluation failed on a successful login.
+    auth = _StubAccessAuth()
+    with engine(mode="access_challenge") as stub:
+        with closing(Url4CloudTransport(stub.url, auth)) as transport:
+            outcome = transport.run(_candidate(), None)
+
+    assert auth.reauthentications == 1
+    assert len(stub.state.minted_tokens) == 2
+    assert outcome.result_body == "[diag] done"
+
+
+@pytest.mark.asyncio
+async def test_an_access_challenge_retries_with_a_fresh_capability_when_async() -> None:
+    auth = _StubAccessAuth()
+    with engine(mode="access_challenge") as stub:
+        transport = AsyncUrl4CloudTransport(stub.url, auth)
+        try:
+            outcome = await transport.run(_candidate(), None)
+        finally:
+            await transport.close()
+
+    assert auth.reauthentications == 1
+    assert len(stub.state.minted_tokens) == 2
+    assert outcome.result_body == "[diag] done"
+
+
+def test_a_dropped_stream_reports_its_close_code_and_elapsed_time() -> None:
+    # STORY: as the engineer on call, the error tells me WHICH drop this was. An oversized
+    # frame (1009), a drained proxy (1006), a rolled Pod (1001) and a refused capability
+    # all read identically otherwise, which is what made these causes indistinguishable in
+    # production for weeks.
+    with engine(mode="abrupt_disconnect") as stub:
+        with closing(Url4CloudTransport(stub.url)) as transport:
+            with pytest.raises(sf.ExecutionError) as caught:
+                transport.run(_candidate(), None)
+
+    assert caught.value.code == "websocket_disconnected"
+    assert caught.value.permanent is False
+    assert "1006" in str(caught.value)
+    assert "after" in str(caught.value)


### PR DESCRIPTION
Investigation of the `websocket_disconnected` reports tracked by OME-806. Two of the causes turned out to be defects we create ourselves; both are fixed here. The rest are made self-identifying so they can be settled with evidence rather than argument.

**This does not close OME-806** — three of its candidate causes remain open (see Scope below).

## The two fixes

**A capped Report could never be delivered.** `Url4Executor.result_cap` is `1_048_576`, and the `websockets` client's `max_size` default is `2**20` — the same number, never overridden. The Engine truncates a body to the cap and then wraps it in a CloudEvent whose `data.body` is a JSON string, so the frame always exceeds the body it carries. Measured against a real socket: a body at the cap yields a **1,048,884 byte frame**, over the limit before a single character of JSON escaping. The truncation guard never produced a deliverable frame. Any Evaluation approaching 1 MiB — roughly 125 Cases on a rubric-heavy Benchmark — failed every time with close 1009.

**The Access retry outlived its own capability.** On a Cloudflare Access challenge, `run()` calls `reauthenticate()` (an interactive browser login, 300s timeout) and then retried the handshake with the capability it already held — whose `iat_window_s` is 60s, in the default and in the shipped chart values. Any login slower than a minute presented an expired ticket. Because the in-flight capabilities are minted together, one slow login failed the whole Evaluation. The retry now mints a fresh capability rather than widening the window that protects it.

## Why neither was visible

The Client discarded the WebSocket close code into a generic message, and **the App cannot log below WARNING at all**: `uvicorn.run()` is called with no `log_config`, uvicorn configures only its own loggers, and root is left without a handler — so every `url4_cloud` record fell through to `logging.lastResort`. Production log exports show health checks and nothing else, which reads as an idle service rather than a muted one. That has been true of every deployment.

Both ends now report the close code. The four candidate causes finally read differently:

```
oversize result   ... after 41.2s (client sent close 1009 — frame exceeds limit of 1048576 bytes)
proxy drain       ... after 300.0s (close 1006 abnormal closure, no close frame)
pod rollout       ... after 128.7s (engine sent close 1001 — going away)
stale ticket      ... after 0.4s (OSError)
```

Engine side records the shape of each connection — `duration_s`, `frames` vs `heartbeats`, and the close code. A long connection carrying only heartbeats reads as an idle cut; a short one that died right after real frames reads as the peer refusing what it was sent.

## Verification

- Each new test confirmed to fail against `main` and pass with the change.
- `run_gates.py screamingface` and `run_gates.py url4-cloud` both **ALL GATES GREEN**.
- **L1 end-to-end** — real uvicorn, real app, real `websockets` client: a pre-fix client (`max_size=2**20`) refuses the capped result and the App logs `outcome=client close 1009 'frame exceeds limit of 1048576 bytes'`; a post-fix client receives the full 1,048,884 byte frame and closes 1000. Confirms the fix works through real framing, and that the oversize cause is attributable **from the Engine alone** with no SDK update deployed.

## Scope — deliberately not fixed

Left open, each recorded in the spec:

- **Envoy listener drain / Cloudflare edge cut / pod rollout** — the three remaining candidates. This PR makes them identifiable, not impossible.
- **Reconnect after a drop** — still impossible; a 60s capability cannot outlive the Run it authorizes, so resuming from `from_sequence` needs a token-lifetime decision first.
- **The stop fallback on long Runs** — `cancel_active()` presents the original capability, which a Run older than 60s has outlived; 401 is not treated as already-stopped, so interrupting a long synchronous Evaluation still leaves paid work running.
- **Advisory frames dropped under backpressure** — `Bridge._offer` discards on a full queue, including the `stream_failed` nack that drives recovery; the control signal shares the bounded queue it exists to repair.

## Notes for review

- **No Linear issue, by direction** — exploratory pass; OME-806 already tracks the symptom. Spec and ledger are in `docs/`.
- **The append-only gate fired once and was obeyed, not skipped.** The first attempt extended the shared `protocol_server.py`; that edits a prior fixture, so it was reverted and rewritten as a self-contained test file. `--skip-append-only` was not used.
- **Two stacks, so two CODEOWNERS** — `packages/screamingface` (@IonesioJunior @keelancj) and `apps/url4-cloud` (@sergio-bershadsky). Happy to split into two PRs; see below.
- ⚠️ **Squash-merge caveat:** this carries both a `fix(screamingface)` and a `feat(url4-cloud)` commit. A single squash commit can only declare one, so release-please will attribute the release to one component and miss the other. Splitting into two PRs avoids that.
- Separately noticed: `.githooks/pre-push` has no `run_stack packages/screamingface screamingface` line, so that stack is never gated on push. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
