### PR TITLE
fix(screamingface): verify the WebSocket against the same roots as HTTP

### DIFF
--- a/docs/spec/2026-08-13-websocket-disconnected-drops.md
+++ b/docs/spec/2026-08-13-websocket-disconnected-drops.md
@@ -40,6 +40,26 @@ shipped chart values. Any login slower than a minute presents an expired ticket,
 refuses the handshake with 1008, and the Run dies. Because `_MAX_CANDIDATES_IN_FLIGHT`
 capabilities are minted together, one slow login fails the whole Evaluation.
 
+### T — the two halves of the transport trust different roots
+
+Found by deploying the observability below and asking the reporting user to try again. The
+Client reaches one Engine two ways, and they disagreed about certificate authorities.
+`httpx` resolves `SSL_CERT_FILE`, then `SSL_CERT_DIR`, and otherwise falls back to the
+`certifi` bundle shipped with this package. `websockets`, given no context, trusts OpenSSL's
+own CA paths. They agree while those variables are set and **diverge in the default case**,
+which is the common one — a python.org macOS build whose `Install Certificates.command` was
+never run has nothing in OpenSSL's paths at all.
+
+The Client therefore minted its capability over HTTPS successfully and then failed to open a
+WebSocket to the same host, 0.0 seconds in, with `SSLCertVerificationError`. The engine-side
+log confirms the asymmetry exactly: `POST /token 200 OK`, the catalog and benchmark reads all
+`200`, and no `ws attach` or `ws rejected` line at all — the socket never arrived.
+
+This is also the real explanation for the "local runs are unaffected" observation that framed
+OME-806 from the start. A local Engine is reached over plain `ws://`, which never negotiates
+TLS, so the split could only ever appear against a hosted Engine — and read as a property of
+being remote rather than a property of the trust store.
+
 ### The reason neither was visible
 
 The Client discards the WebSocket close code into a generic message, and the App cannot log
@@ -57,6 +77,8 @@ happening.
 - The Client's frame limit is above the Engine's result cap plus envelope and escaping, so a
   capped Report is delivered rather than refused.
 - An Access challenge is retried with a capability minted after the login, not before it.
+- The WebSocket verifies against exactly what the HTTP half verifies against, so a host the
+  Client just reached over HTTPS cannot be unreachable over WSS.
 - The Client's error carries the close code and the elapsed Run time.
 - The App records the close code, duration, and whether the connection was carrying work or
   idling — and its records actually reach a handler.

--- a/docs/work/2026-08-13-websocket-tls-trust.md
+++ b/docs/work/2026-08-13-websocket-tls-trust.md
@@ -1,0 +1,87 @@
+---
+ticket: none filed — investigation of OME-806
+stack: screamingface
+status: done
+started: 2026-08-13
+finished: 2026-08-13
+---
+
+# Verify the WebSocket against the same roots as HTTP
+
+## Intent
+
+Follow-up to `2026-08-13-websocket-disconnected-drops`, and the unit that unit's
+observability was built to make possible. The diagnostic half was deployed to `fusion.dev`
+and the reporting user retried; the error named a cause nobody had hypothesised:
+
+```
+websocket_disconnected after 0.0s (SSLCertVerificationError)
+```
+
+`httpx` and `websockets` resolve certificate authorities differently, so the Client could
+mint its capability over HTTPS and then fail to open a WebSocket to the same host.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_engine/transport.py` — `_websocket_ssl_context`,
+  built once per transport beside the `httpx` client it must agree with, passed to both
+  `connect()` calls.
+- `packages/screamingface/tests/test_transport_tls_trust.py` — new, self-contained.
+- `docs/spec/2026-08-13-websocket-disconnected-drops.md` — record mechanism T in the catalog
+  the spec already keeps.
+
+## Test plan
+
+Failing first:
+
+- The WebSocket's trust store equals the HTTP half's, certificate for certificate.
+- That store is non-empty — the failure guarded against is "trusts nothing", not "trusts the
+  wrong roots".
+- A plain-HTTP Engine is given no context at all, because `websockets` refuses one on a
+  `ws://` URI.
+
+## Acceptance
+
+- The three above fail against `main` and pass after the change.
+- `run_gates.py screamingface` green.
+- Local development over `http://127.0.0.1` is byte-identical to before.
+
+## Outcome
+
+- **Actual files:** as planned.
+- **Gates:** `screamingface` — ALL GATES GREEN.
+- **Evidence for the diagnosis:**
+  - Client: `websocket_disconnected after 0.0s (SSLCertVerificationError)` — 0.0s places the
+    failure in the TLS handshake, before any WebSocket protocol ran.
+  - Engine: `POST /token 200 OK`, `/v1/models 200`, `/v1/benchmarks/draco/lite 200`,
+    `/v1/connections 200`, and **no** `ws attach` or `ws rejected` line. HTTPS reached the
+    host; the socket never did.
+  - Source: `httpx._config.create_ssl_context` resolves `SSL_CERT_FILE` → `SSL_CERT_DIR` →
+    `certifi`; `websockets` calls `ssl.create_default_context()`, which trusts OpenSSL's own
+    paths. They agree while those variables are set and diverge in the default case.
+- **Regression safety:** the HTTP capability mint runs BEFORE the WebSocket and now uses the
+  same context, so any trust configuration that reaches the WebSocket has already satisfied
+  it. There is no working configuration this changes. Verified that `http://` yields `None`,
+  which is the library's own default for `ssl`, so the local path is unchanged; 45 tests
+  driving the real transport against a local `http://` Engine pass.
+
+## Deviations
+
+- **No Linear issue and no `docs/tasks/` mirror**, by direction — exploratory pass. OME-806
+  tracks the symptom; this does not close it (Envoy drain, edge idle cuts and Pod rollout
+  remain open).
+- **Branched from `main` after the parent PR merged**, rather than stacking on it, at the
+  owner's request. The parent's ledger was left exactly as merged; this is its own unit.
+- **`httpx.create_ssl_context()` rather than `certifi.where()`**, deliberately. Naming
+  `certifi` would make the WebSocket ignore `SSL_CERT_FILE` that the HTTP half honours,
+  recreating this same class of bug pointing the other way and breaking private-CA and
+  TLS-inspecting-proxy setups. The invariant worth holding is that the two halves agree.
+- **Two measurement errors made and corrected while investigating.** `get_ca_certs()`
+  returning `[]` was first read as "the store is empty"; it does not enumerate
+  capath-loaded certificates, and this machine's store verifies fine. A first attempt to
+  simulate the user's environment set `SSL_CERT_FILE`, which `httpx` also honours, so it
+  broke both halves rather than one. The mechanism was then established from both
+  libraries' source instead.
+- **Not reproduced on the reporting user's machine.** The mechanism is confirmed from
+  source and the symptom matches exactly, but the environment was not available. A
+  one-line check they can run is recorded in the PR.

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import ssl
 import time
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -73,6 +74,9 @@ class Url4CloudTransport:
         self._owns_auth = caller_auth is None
         self._caller_auth = caller_auth or _default_caller_auth(engine_url)
         self._http = httpx.Client(base_url=engine_url, timeout=30.0, auth=self._caller_auth)
+        # INVARIANT: built from the same source as the client above, so the two halves of
+        # this transport can never verify against different roots.
+        self._ssl = _websocket_ssl_context(engine_url)
         self._active_lock = Lock()
         self._active_tokens: set[str] = set()
 
@@ -96,6 +100,7 @@ class Url4CloudTransport:
                         open_timeout=30,
                         close_timeout=10,
                         max_size=_MAX_FRAME_BYTES,
+                        ssl=self._ssl,
                     ) as websocket:
                         return self._run_connected(
                             websocket,
@@ -195,6 +200,8 @@ class AsyncUrl4CloudTransport:
         self._owns_auth = caller_auth is None
         self._caller_auth = caller_auth or _default_caller_auth(engine_url)
         self._http = httpx.AsyncClient(base_url=engine_url, timeout=30.0, auth=self._caller_auth)
+        # INVARIANT: see the synchronous twin — one trust store for HTTP and WebSocket.
+        self._ssl = _websocket_ssl_context(engine_url)
         self._active_tokens: set[str] = set()
 
     async def cancel_active(self) -> None:
@@ -265,6 +272,7 @@ class AsyncUrl4CloudTransport:
                     open_timeout=30,
                     close_timeout=10,
                     max_size=_MAX_FRAME_BYTES,
+                    ssl=self._ssl,
                 ) as websocket:
                     return await self._run_connected(
                         websocket,
@@ -535,6 +543,36 @@ def _raise_response(response: httpx.Response, operation: str) -> None:
         permanent=response.status_code < 500,
         details=problem if media_type == "application/problem+json" else None,
     )
+
+
+def _websocket_ssl_context(engine_url: str) -> ssl.SSLContext | None:
+    """The trust store the WebSocket must use: the one the HTTP half already uses.
+
+    WHY this cannot be left to `websockets`: given no context it builds one with
+    `ssl.create_default_context()`, which trusts OpenSSL's own CA paths. `httpx` resolves
+    `SSL_CERT_FILE`, then `SSL_CERT_DIR`, and otherwise falls back to the `certifi` bundle
+    installed with this package. The two therefore agree only while those environment
+    variables are set — and diverge in the DEFAULT case, where `httpx` trusts `certifi` and
+    `websockets` trusts whatever OpenSSL was compiled to look at. A python.org macOS build
+    whose ``Install Certificates.command`` was never run has nothing there at all.
+
+    The split is invisible until it isn't: the Client mints its capability over HTTPS, which
+    succeeds against `certifi`, and then fails to open a WebSocket to the SAME host with
+    `SSLCertVerificationError`. A local Engine is reached over plain `ws://`, which never
+    negotiates TLS, so this only ever appeared against a hosted Engine — and read as a
+    property of being remote rather than a property of the trust store.
+
+    Deferring to `httpx` rather than naming `certifi` here is deliberate: the invariant worth
+    holding is that the two halves agree, including about the environment, not that either
+    one trusts a particular bundle.
+
+    Returns ``None`` for a plain-HTTP Engine, because `websockets` refuses a context on a
+    ``ws://`` URI.
+    """
+
+    if urlsplit(engine_url).scheme != "https":
+        return None
+    return httpx.create_ssl_context()
 
 
 def _websocket_url(engine_url: str, token: str) -> str:

--- a/packages/screamingface/tests/test_transport_tls_trust.py
+++ b/packages/screamingface/tests/test_transport_tls_trust.py
@@ -1,0 +1,46 @@
+"""Both halves of the transport verify against the same roots.
+
+The Client reaches one Engine two ways — HTTPS for the capability and the catalog, a
+WebSocket for the Run stream — and they used to disagree about which certificate
+authorities to trust. `httpx` resolves `SSL_CERT_FILE`, then `SSL_CERT_DIR`, and otherwise
+falls back to the `certifi` bundle installed with this package; `websockets`, given no
+context, trusts OpenSSL's own CA paths. They agree while those environment variables are
+set and diverge in the default case, which is the common one.
+
+Where they disagree the Run mints its capability over HTTPS and then fails to open a
+WebSocket to the SAME host with `SSLCertVerificationError`. A python.org macOS build whose
+`Install Certificates.command` was never run has nothing in OpenSSL's paths at all — and
+because a local Engine is `ws://`, the split never appeared except against a hosted one.
+
+Self-contained by design (sdlc rule 5).
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from screamingface._engine.transport import _websocket_ssl_context
+
+
+def test_the_websocket_trusts_exactly_what_the_http_half_trusts() -> None:
+    # STORY: as a researcher on a hosted Engine, my Run does not die at the handshake for a
+    # certificate the very same process just accepted moments earlier over HTTPS.
+    context = _websocket_ssl_context("https://fusion.example.ai")
+
+    assert context is not None
+    assert context.get_ca_certs() == httpx.create_ssl_context().get_ca_certs()
+
+
+def test_the_websocket_trust_store_is_not_empty() -> None:
+    # The failure this guards is not "the wrong roots" but "no roots at all": an unconfigured
+    # OpenSSL store verifies nothing and rejects every certificate presented to it.
+    context = _websocket_ssl_context("https://fusion.example.ai")
+
+    assert context is not None
+    assert context.get_ca_certs(), "the WebSocket would trust nothing and refuse every Engine"
+
+
+def test_a_local_engine_over_plain_http_is_given_no_context() -> None:
+    # `websockets` refuses an SSL context on a `ws://` URI, so local mode must get None —
+    # and this is why the trust split never showed up against a local Engine.
+    assert _websocket_ssl_context("http://127.0.0.1:9108") is None


### PR DESCRIPTION
Follow-up to #585, and the bug that PR's observability was built to find. The diagnostic half was deployed to `fusion.dev`, the reporting user retried, and the new error named a cause nobody had hypothesised:

```
ExecutionError: SF Engine WebSocket disconnected before the Run completed after 0.0s (SSLCertVerificationError)
```

## What was wrong

The Client reaches one Engine two ways — HTTPS for the capability and catalog via `httpx`, a WebSocket for the Run stream via `websockets` — and the two libraries resolve certificate authorities differently:

| Library | Resolution order |
|---|---|
| `httpx` | `SSL_CERT_FILE` → `SSL_CERT_DIR` → **`certifi`** |
| `websockets` | `ssl.create_default_context()` → **OpenSSL's own paths** |

They agree while those environment variables are set, and **diverge in the default case**, which is the common one. A python.org macOS build whose `Install Certificates.command` was never run has nothing in OpenSSL's paths at all.

So the Client minted its capability over HTTPS successfully and then could not open a WebSocket to the same host.

## Evidence

- **Client:** failure at `0.0s` places it in the TLS handshake, before any WebSocket protocol ran.
- **Engine:** `POST /token 200 OK`, `/v1/models 200`, `/v1/benchmarks/draco/lite 200`, `/v1/connections 200` — and **no** `ws attach` or `ws rejected` line at all. HTTPS reached the host; the socket never did.
- **Source:** `httpx._config.create_ssl_context` versus `websockets`' default context, read directly.

## This also explains OME-806's framing

OME-806 was reported as *"remote-authed runs fail, local runs are unaffected"*, which pointed everyone at Cloudflare and Access. But a local Engine is reached over `ws://`, which never negotiates TLS — so this bug is **invisible locally by construction**. "Remote-only" was a property of the trust store showing up as a property of the deployment.

## The fix

```python
def _websocket_ssl_context(engine_url: str) -> ssl.SSLContext | None:
    if urlsplit(engine_url).scheme != "https":
        return None                      # websockets refuses a context on a ws:// URI
    return httpx.create_ssl_context()
```

Built once per transport beside the `httpx` client it must agree with, and passed to both `connect()` calls.

**Why delegate to `httpx` rather than name `certifi`:** hardcoding `certifi.where()` would make the WebSocket ignore `SSL_CERT_FILE` that the HTTP half honours, recreating this same class of bug pointing the other way and breaking private-CA and TLS-inspecting-proxy setups. The invariant worth holding is that the two halves agree — including about the environment.

## Regression safety

The HTTP capability mint runs **before** the WebSocket and now uses the same context, so any trust configuration that reaches the WebSocket has already satisfied it. There is no working configuration this changes.

Local development is unaffected and provably so: `http://` yields `None`, which is `websockets`' own default for `ssl`, so that path is byte-identical. `_websocket_ssl_context` uses the same `scheme == "https"` predicate that `_websocket_url` already uses to choose `ws://` vs `wss://`, so the two can never disagree. 45 tests driving the real transport against a local `http://` Engine pass.

It also makes private-CA setups *easier*: previously such a user needed the CA in two places (the system store for `websockets`, `SSL_CERT_FILE` for `httpx`); now `SSL_CERT_FILE` alone serves both.

## Verification

- New tests fail against `main` (the function does not exist) and pass with the change.
- `run_gates.py screamingface` — **ALL GATES GREEN**.
- Tests assert the *property* — that the WebSocket's trust store equals the HTTP half's, that it is non-empty, and that `ws://` gets no context — rather than any particular bundle.

## Notes

- **Not reproduced on the reporting user's machine.** The mechanism is confirmed from source and the symptom matches exactly, but their environment was unavailable. A check they can run to confirm on their box:
  ```
  python -c "import ssl,socket; c=ssl.create_default_context(); s=socket.create_connection(('fusion.dev.screamingface.ai',443)); c.wrap_socket(s,server_hostname='fusion.dev.screamingface.ai')"
  ```
  If that raises `SSLCertVerificationError` while their `sf` HTTPS calls work, the diagnosis is proven.
- **Does not close OME-806** — Envoy listener drain, Cloudflare edge cuts and Pod rollout remain open.
- No Linear issue, by direction. Spec (mechanism T) and a ledger for this unit are in `docs/`.
- Separately: `.githooks/pre-push` still has no `run_stack packages/screamingface screamingface` line, so this stack is never gated on push. Gates were run manually. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
