### PR TITLE
fix(screamingface): realign release baseline with published PyPI 0.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "apps/aigateway": "0.2.1",
   "packages/url4": "1.4.1",
-  "packages/screamingface": "0.1.0",
+  "packages/screamingface": "0.1.1",
   "apps/url4-cloud": "1.3.0",
   "apps/scoreboard": "0.1.1",
   "apps/aigateway-ui": "0.2.0"

--- a/docs/tasks/2026-08-13-sync-screamingface-pypi-version.md
+++ b/docs/tasks/2026-08-13-sync-screamingface-pypi-version.md
@@ -1,0 +1,23 @@
+---
+id: OME-824
+linear_url: https://linear.app/openmined/issue/OME-824/realign-screamingface-release-baseline-past-manually-published-pypi
+status: in_progress
+type: task
+priority: 2
+labels: [py-screamingface, agentic, autonomous, task]
+created: 2026-08-13
+closed:
+---
+
+# OME-824 — Realign screamingface release baseline past manually-published PyPI 0.1.1
+
+`screamingface` `0.1.0` and `0.1.1` were uploaded to PyPI manually before PR #553 pushed tag
+`screamingface-v0.1.0`. The resulting release run failed `publish-pypi` with PyPI's
+immutability rejection (`400 File already exists`), and would fail identically on the next
+run because `main` records `0.1.0` while PyPI is already at `0.1.1`.
+
+Moves the recorded baseline to `0.1.1` (manifest, `pyproject.toml`, `CHANGELOG.md`) so
+release-please proposes `0.1.2` — the first version published by the Trusted Publishing
+pipeline.
+
+Ledger: `docs/work/2026-08-13-OME-824-sync-screamingface-pypi-version.md`

--- a/docs/work/2026-08-13-OME-824-sync-screamingface-pypi-version.md
+++ b/docs/work/2026-08-13-OME-824-sync-screamingface-pypi-version.md
@@ -1,0 +1,93 @@
+---
+ticket: OME-824
+stack: screamingface
+status: in_progress
+started: 2026-08-13
+finished:
+---
+
+# OME-824 — Realign screamingface release baseline past manually-published PyPI 0.1.1
+
+## Intent
+
+The `packages/screamingface` PyPI release lane is red and cannot self-heal. Both `0.1.0` and
+`0.1.1` were uploaded to PyPI manually (17:37:34Z and 17:48:52Z) before PR #553 merged at
+17:55:23Z and pushed tag `screamingface-v0.1.0`. The resulting
+[run 31728158888](https://github.com/OpenMined/screamingface/actions/runs/31728158888) passed
+`verify` and `build`, then failed `publish-pypi` with PyPI's immutability rejection:
+
+```
+400 File already exists ('screamingface-0.1.0-py3-none-any.whl',
+with blake2_256 hash '5b202898501ee26a912688f353b6a589667a0c386ff3912e0838a37e70e3ea8a').
+```
+
+Trusted Publishing is not at fault — the run obtained an OIDC token and Sigstore signed the
+artifacts (transparency-log entries created) before the upload was refused.
+
+`origin/main` records the component at `0.1.0` while PyPI is one version ahead at `0.1.1`, so
+the next release-please run would propose `0.1.1` and fail identically. Moving the baseline to
+`0.1.1` makes the next automated release `0.1.2` — which will be the first version ever
+published by the Trusted Publishing pipeline.
+
+## Planned changes
+
+- `.release-please-manifest.json` — `packages/screamingface`: `0.1.0` -> `0.1.1`
+- `packages/screamingface/pyproject.toml` — `version`: `0.1.0` -> `0.1.1`
+- `packages/screamingface/CHANGELOG.md` — add a `0.1.1` entry recording that `0.1.0` and
+  `0.1.1` were published outside CI
+- `docs/tasks/2026-08-13-sync-screamingface-pypi-version.md` — issue mirror
+
+Commit type is `fix(screamingface):` so release-please proposes `0.1.2` rather than sitting
+idle on a `chore:`.
+
+## Decisions (owner-approved)
+
+- **No backfill `screamingface-v0.1.1` tag.** `release-screamingface.yml` triggers on
+  `push: tags: ["screamingface-v*"]`; that tag would immediately attempt to publish `0.1.1`
+  and reproduce the same `400`. The manifest — not the tag — determines the next version.
+- **No `skip-existing: true`** on the publish step. A duplicate version stays a loud failure
+  so an out-of-band upload is never silently masked.
+
+## Test plan
+
+No product behaviour changes, so there are no new unit tests. Verification is the release
+machinery itself:
+
+- `uv build` + `scripts/check_distribution.py` + `twine check --strict` still pass (the same
+  gates `screamingface-tests.yml` and the release `build` job run).
+- Built artifact filenames carry `0.1.1`.
+- The tag-vs-manifest guard in `release-screamingface.yml` `verify` would agree: the awk
+  extraction of `version` from `pyproject.toml` returns `0.1.1`.
+- `.release-please-manifest.json` remains valid JSON with every other component untouched.
+
+## Acceptance
+
+- `main` reports `0.1.1` in both `.release-please-manifest.json` and `pyproject.toml`.
+- release-please opens a `screamingface 0.1.2` release PR.
+- Merging that PR drives `release-screamingface.yml` to a green `publish-pypi`.
+
+## Outcome
+
+- **Actual files:** as planned, plus `packages/screamingface/uv.lock` (the lock pins the
+  workspace member's own version, so the bump propagates into it — one line, version only).
+  - `.release-please-manifest.json`
+  - `packages/screamingface/pyproject.toml`
+  - `packages/screamingface/CHANGELOG.md`
+  - `packages/screamingface/uv.lock`
+  - `docs/tasks/2026-08-13-sync-screamingface-pypi-version.md`
+  - `docs/work/2026-08-13-OME-824-sync-screamingface-pypi-version.md`
+- **Commits:** `fix(screamingface): realign release baseline with published PyPI 0.1.1`
+- **Gates:** no unit tests apply (no product behaviour change). Ran the release `build` job's
+  own gates against the bumped tree:
+  - `uv build` -> `screamingface-0.1.1.tar.gz` + `screamingface-0.1.1-py3-none-any.whl`
+  - `scripts/check_distribution.py` -> exit 0
+  - `twine check --strict dist/*` -> PASSED (both artifacts)
+  - `release-screamingface.yml` `verify` awk guard extracts `0.1.1` from `pyproject.toml`
+  - `.release-please-manifest.json` parses; all five other components unchanged
+- **Deviations:**
+  - The backfill `screamingface-v0.1.1` tag named in the originally approved option was
+    **dropped**. `release-screamingface.yml` triggers on `push: tags: ["screamingface-v*"]`,
+    so creating it would have immediately attempted to publish `0.1.1` and reproduced the same
+    `400 File already exists`. The manifest alone determines the next proposed version, so the
+    tag was unnecessary as well as harmful.
+  - `uv.lock` was not in the planned file list (see above).

--- a/packages/screamingface/CHANGELOG.md
+++ b/packages/screamingface/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.1.1 (2026-08-13)
+
+Baseline-only release. `0.1.0` and `0.1.1` were both uploaded to PyPI by hand rather than by
+`release-screamingface.yml`, so this repository never recorded `0.1.1`. This entry realigns the
+recorded version with what PyPI already serves; there is no code change between `0.1.0` and
+`0.1.1` in this repository. The next release cut by release-please (`0.1.2`) is the first
+published through the Trusted Publishing pipeline.
+
 ## 0.1.0 (2026-08-13)
 
 

--- a/packages/screamingface/pyproject.toml
+++ b/packages/screamingface/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "screamingface"
-version = "0.1.0"
+version = "0.1.1"
 description = "Evaluate Models and Fusions on URL4-native research benchmarks"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/screamingface/uv.lock
+++ b/packages/screamingface/uv.lock
@@ -1585,7 +1585,7 @@ wheels = [
 
 [[package]]
 name = "screamingface"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Refs: OME-824 — https://linear.app/openmined/issue/OME-824

Asana: n/a (technical work never goes to Asana).

## Summary

The `packages/screamingface` PyPI release lane is red and cannot self-heal.

`screamingface` `0.1.0` **and** `0.1.1` were uploaded to PyPI by hand *before* the release
tag was ever cut:

| Version | PyPI upload | Source |
| --- | --- | --- |
| `0.1.0` | 2026-08-13 17:37:34Z | manual upload |
| `0.1.1` | 2026-08-13 17:48:52Z | manual upload |

PR #553 merged at 17:55:23Z, pushed `screamingface-v0.1.0`, and
[run 31728158888](https://github.com/OpenMined/screamingface/actions/runs/31728158888) passed
`verify` and `build` then failed `publish-pypi`:

```
400 File already exists ('screamingface-0.1.0-py3-none-any.whl',
with blake2_256 hash '5b202898501ee26a912688f353b6a589667a0c386ff3912e0838a37e70e3ea8a').
```

**Trusted Publishing is working.** The run obtained an OIDC token and Sigstore signed the
artifacts (transparency-log entries created) before PyPI refused the upload. The rejection is
PyPI's immutability rule, not an auth or packaging fault.

`main` recorded `0.1.0` while PyPI already served `0.1.1`, so the next release-please run would
have proposed `0.1.1` and failed with the identical `400`. This PR moves the recorded baseline
to `0.1.1` so the next automated release is **`0.1.2`** — which will be the first version ever
published by the Trusted Publishing pipeline.

## Changes

- `.release-please-manifest.json` — `packages/screamingface`: `0.1.0` -> `0.1.1`
- `packages/screamingface/pyproject.toml` — `version`: `0.1.0` -> `0.1.1`
- `packages/screamingface/uv.lock` — same bump (the lock pins the workspace member's own version)
- `packages/screamingface/CHANGELOG.md` — `0.1.1` entry recording that both prior versions were published outside CI
- `docs/work/` ledger + `docs/tasks/` mirror

Committed as `fix(screamingface):` so release-please proposes `0.1.2` rather than sitting idle
on a `chore:`.

## Deliberately NOT done

- **No backfill `screamingface-v0.1.1` tag.** `release-screamingface.yml` triggers on
  `push: tags: ["screamingface-v*"]`, so such a tag would immediately attempt to publish
  `0.1.1` and reproduce the same `400`. The manifest — not the tag — determines the next
  proposed version.
- **No `skip-existing: true`** on the publish step. Owner decision: a duplicate version should
  stay a loud failure rather than silently pass, so an out-of-band upload is never masked.

## Test plan

No product behaviour changes, so no new unit tests. Verified against the release `build` job's
own gates on the bumped tree:

- `uv build` -> `screamingface-0.1.1.tar.gz` + `screamingface-0.1.1-py3-none-any.whl`
- `uv run python scripts/check_distribution.py` -> exit 0
- `uvx twine check --strict dist/*` -> PASSED (both artifacts)
- `release-screamingface.yml` `verify` awk guard extracts `0.1.1` from `pyproject.toml`
- `.release-please-manifest.json` parses; the five other components are untouched

## After merge

release-please should open a `screamingface 0.1.2` release PR; merging that drives
`release-screamingface.yml` to a green `publish-pypi`.

## Follow-ups (not this PR)

- The `0.1.0`/`0.1.1` artifacts on PyPI carry no Trusted-Publisher provenance and their contents
  were never verified against any commit on `main`.
- `Release Please` [run 31728139093](https://github.com/OpenMined/screamingface/actions/runs/31728139093)
  failed separately and transiently on a GitHub API timeout while paginating commits.
