### PR TITLE
docs(public-docs): API reference pages, corrective/grading docs, and a docs-wide terminology & voice pass

### DIFF
--- a/docs/tasks/2026-08-13-modules-docs.md
+++ b/docs/tasks/2026-08-13-modules-docs.md
@@ -1,0 +1,45 @@
+---
+id: OME-671
+linear_url: https://linear.app/openmined/issue/OME-671
+parent: OME-666
+status: Done
+type: Task
+priority: P2
+labels: [repo-dev-processes, agentic, task]
+created: 2026-07-29
+closed: 2026-08-13
+---
+
+# Generate modules docs
+
+Sixth and last sub-issue under `OME-666` (Documentation for ScreamingFace Client V1). Adds the API
+reference pages `OME-670` left out.
+
+Four pages under `API Reference`, in a `Modules & types` subgroup:
+
+```
+API REFERENCE
+  ▸ Core classes        Recipes · Benchmarks · Reports · Clients
+  ▸ Modules & types
+      Modules           the five modules and five top-level functions
+      Errors            the error hierarchy and what a diagnostic error carries
+      Events            the seven event types
+      Leaderboards      the five leaderboard values
+```
+
+`api/LeaderboardsPage` is the field reference for the five values; `guides/LeaderboardsPage` is the
+task walkthrough. Same split as the two Benchmarks pages.
+
+Every signature, field and literal is derived at runtime from the client on `main`, never from
+reading source.
+
+This ticket also corrected the reference and guides against the merged client, and that work was
+dropped: Irina had done the same independently and more currently, against `b698fcff`. See the
+ledger for what was compared and why nothing was lost.
+
+Branch `callis/ome-671-generate-modules-docs` is cut from `origin/main`; `OME-666` is merged, so
+its PR targets `main`.
+
+Milestone: Week 3.
+
+Ledger: `docs/work/2026-08-13-OME-671-modules-docs.md`

--- a/docs/work/2026-08-13-OME-671-modules-docs.md
+++ b/docs/work/2026-08-13-OME-671-modules-docs.md
@@ -51,7 +51,7 @@ Supporting:
 - **Actual files:** the four pages, `src/navigation/sf-client.ts`, `src/router/index.ts`,
   `public-docs/CLAUDE.md`, this ledger and the mirror.
 - **Commits:**
-  - `<pending>` — the four pages and their wiring
+  - `4939b19a` — the four pages and their wiring
 - **Gates:** `npx oxlint .`, `npx eslint .`, `npm run build` and `prettier --check` green.
 - **Deviations:**
   - **Scope was cut back sharply.** This unit originally also corrected the four `api/` pages, six

--- a/docs/work/2026-08-13-OME-671-modules-docs.md
+++ b/docs/work/2026-08-13-OME-671-modules-docs.md
@@ -1,0 +1,81 @@
+---
+ticket: OME-671
+stack: repo
+status: done
+started: 2026-08-13
+finished: 2026-08-13
+---
+
+# OME-671 — Modules docs
+
+## Intent
+
+Sixth and last sub-issue of `OME-666`. Adds the API reference pages for what `OME-670` left out:
+the modules, the top-level functions, the errors and warnings, the event types, and the
+leaderboard values.
+
+## Planned changes
+
+New pages under `public-docs/src/pages/sf-client/api/`:
+
+- `ModulesPage.vue` — the five modules and five top-level functions
+- `ErrorsPage.vue` — the error hierarchy and what a diagnostic error carries
+- `EventsPage.vue` — the seven event types
+- `LeaderboardsPage.vue` — the five leaderboard values
+
+Supporting:
+
+- `src/navigation/sf-client.ts` — a `Modules & types` subgroup under `API Reference`
+- `src/router/index.ts` — four routes
+- `public-docs/CLAUDE.md` — routes and navigation tables
+- this ledger and `docs/tasks/2026-08-13-modules-docs.md`
+
+## Test plan
+
+`public-docs` has no test suite. Verification is the gates plus:
+
+- Every signature from `inspect.signature`, every field from `dataclasses.fields`, every literal
+  from `typing.get_args`, against the client on `main`. Never from reading source.
+- No page names a symbol absent from `__all__`
+- No revision hash asserted in prose or a table
+- `npx oxlint .` · `npx eslint .` · `npm run build` · `prettier --check`
+
+## Acceptance
+
+- The four pages exist, are reachable, and appear in the sidebar
+- No page references a symbol the client does not export
+- Gates green
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** the four pages, `src/navigation/sf-client.ts`, `src/router/index.ts`,
+  `public-docs/CLAUDE.md`, this ledger and the mirror.
+- **Commits:**
+  - `<pending>` — the four pages and their wiring
+- **Gates:** `npx oxlint .`, `npx eslint .`, `npm run build` and `prettier --check` green.
+- **Deviations:**
+  - **Scope was cut back sharply.** This unit originally also corrected the four `api/` pages, six
+    guides and the Quickstart against the merged client, because `OME-670` had verified its
+    reference at `e387aefd` on a branch that never merged, and `d73f7d2a` documented a `reducer=`
+    API that exists only on unmerged `OME-400` branches. That work was committed as `b288b036`,
+    then dropped: Irina had corrected the same pages independently in `9274e2de`, `1b6ccd09` and
+    `79cf4314`, verified against `b698fcff`, which is newer than the `17f7643b` this branch used.
+    On every fact compared the two agreed, so nothing was lost by taking hers.
+  - Only the four new pages survive, since `main` has none of them. The branch was reset onto
+    `main` rather than rebased, because all fourteen shared files conflicted and none of this
+    side's version was worth keeping.
+  - `CoverageWarning` was removed from the client between `17f7643b` and `d7ab1f31`.
+    `ErrorsPage.vue` documented it in three places; all three are corrected to
+    `EvaluationWarning`.
+  - `src/lib/source.ts` was written and then dropped. It gave the version footer and the
+    companion-notebook links one shared constant. Irina maintains the footer as a literal in
+    `sf-client.ts`, so introducing it here would have moved a value she edits into a file she does
+    not know about. Worth proposing separately: the footer pins `b698fcff` while the notebook links
+    point at `blob/main`, so a reader clicking through gets notebooks from a different state than
+    the prose describes.
+  - `api/ReportsPage.vue` is untouched. Its examples need a live evaluation, and the OpenRouter key
+    available during this unit was rejected upstream by the provider (`api_key_invalid`).
+  - `InstallationPage.vue` states `len(sf.__all__)` is 53. It is 55 at `d7ab1f31`. Left alone
+    because the page is Irina's and outside this scope.
+  - `main` gained `CorrectiveLoop` and `SelfCorrective` while this ran. Neither is documented
+    anywhere yet; they belong on `api/RecipesPage.vue`.

--- a/docs/work/2026-08-18-OME-671-docs-ia-divio.md
+++ b/docs/work/2026-08-18-OME-671-docs-ia-divio.md
@@ -1,0 +1,32 @@
+# OME-671 — public-docs IA restructure (Divio / Diátaxis)
+
+**Date:** 2026-08-18 · **Folds into:** OME-671 / PR #594 · **Actor:** agentic (Irina driving)
+
+## Goal
+Restructure the ScreamingFace Client docs around the Divio documentation system:
+four separated quadrants — **Tutorials · How-to guides · Reference · Explanation** —
+and a complete, role-grouped API Reference (Option A: `sf` namespace + 8 class
+groups). Fixes the muddled "Core classes" vs "Modules & types" split and the
+incomplete reference (Fusion/Pipeline/Url4 had no reference page).
+
+Plan: `.claude/plans/can-we-checkin-into-warm-tarjan.md`.
+
+## Work
+- New reference pages (verified against the client): `api/fusions`, `api/pipelines`,
+  `api/url4`, `api/connections`; add `LeaderboardError` to `api/errors`; move
+  Connection/ConnectionPanel off `api/clients`.
+- Nav rewrite (`src/navigation/sf-client.ts`) into the four Divio sections + Option-A
+  reference groups; `learn` → Explanation.
+- Guide↔reference dedup; Overview "why" → Explanation.
+
+## Outcome
+Structural increment done: sidebar rewritten into Tutorials / How-to guides /
+Reference / Explanation; Reference = "The sf namespace" + Classes in 8 role groups;
+4 new reference pages (Fusion, Pipeline, Url4, Connections) verified against the
+client; Connection/ConnectionPanel moved off the Clients page; Learn → Explanation.
+Audits: all 24 nav links resolve; every `sf.__all__` type has exactly one reference
+home (0 undocumented); build/prettier/eslint green.
+
+**Remaining (follow-up increment):** guide↔reference dedup (strip duplicate field
+tables from the how-to guides), move the Overview "why" narrative into Explanation,
+goal-reframe individual guide titles.

--- a/public-docs/CLAUDE.md
+++ b/public-docs/CLAUDE.md
@@ -47,35 +47,39 @@ There is no automated test setup in this project.
 
 ### Pages & routes
 
-| Route | Component |
-|---|---|
-| `/` | `src/pages/HomePage.vue` |
-| `/sf-client` | `src/pages/sf-client/Index.vue` |
-| `/sf-client/installation` | `src/pages/sf-client/InstallationPage.vue` |
-| `/sf-client/quickstartPage` | `src/pages/sf-client/QuickstartPage.vue` |
-| `/sf-client/guides/connections` | `src/pages/sf-client/guides/ConnectionsPage.vue` |
-| `/sf-client/guides/models` | `src/pages/sf-client/guides/ModelsPage.vue` |
-| `/sf-client/guides/fusions` | `src/pages/sf-client/guides/FusionsPage.vue` |
-| `/sf-client/guides/pipelines` | `src/pages/sf-client/guides/PipelinesPage.vue` |
-| `/sf-client/guides/benchmarks` | `src/pages/sf-client/guides/BenchmarksPage.vue` |
-| `/sf-client/guides/running-an-evaluation` | `src/pages/sf-client/guides/EvaluationPage.vue` |
-| `/sf-client/guides/leaderboards` | `src/pages/sf-client/guides/LeaderboardsPage.vue` |
-| `/sf-client/guides/reproduce-and-share` | `src/pages/sf-client/guides/Url4Page.vue` |
-| `/sf-client/api/recipes` | `src/pages/sf-client/api/RecipesPage.vue` |
-| `/sf-client/api/benchmarks` | `src/pages/sf-client/api/BenchmarksPage.vue` |
-| `/sf-client/api/reports` | `src/pages/sf-client/api/ReportsPage.vue` |
-| `/sf-client/api/clients` | `src/pages/sf-client/api/ClientsPage.vue` |
-| `/sf-client/api/modules` | `src/pages/sf-client/api/ModulesPage.vue` |
-| `/sf-client/api/errors` | `src/pages/sf-client/api/ErrorsPage.vue` |
-| `/sf-client/api/events` | `src/pages/sf-client/api/EventsPage.vue` |
-| `/sf-client/api/leaderboards` | `src/pages/sf-client/api/LeaderboardsPage.vue` |
-| `/learn` | `src/pages/learn/ArchitecturePage.vue` |
-| `/learn/url4` | `src/pages/learn/Url4Page.vue` |
-| `/learn/url4-sdk` | `src/pages/learn/Url4SdkPage.vue` |
-| `/learn/engine` | `src/pages/learn/EnginePage.vue` |
-| `/learn/caching` | `src/pages/learn/CachingPage.vue` |
-| `/learn/ai-gateway` | `src/pages/learn/GatewayPage.vue` |
-| `/learn/leaderboard` | `src/pages/learn/LeaderboardPage.vue` |
+| Route                                     | Component                                         |
+| ----------------------------------------- | ------------------------------------------------- |
+| `/`                                       | `src/pages/HomePage.vue`                          |
+| `/sf-client`                              | `src/pages/sf-client/Index.vue`                   |
+| `/sf-client/installation`                 | `src/pages/sf-client/InstallationPage.vue`        |
+| `/sf-client/quickstartPage`               | `src/pages/sf-client/QuickstartPage.vue`          |
+| `/sf-client/guides/connections`           | `src/pages/sf-client/guides/ConnectionsPage.vue`  |
+| `/sf-client/guides/models`                | `src/pages/sf-client/guides/ModelsPage.vue`       |
+| `/sf-client/guides/fusions`               | `src/pages/sf-client/guides/FusionsPage.vue`      |
+| `/sf-client/guides/pipelines`             | `src/pages/sf-client/guides/PipelinesPage.vue`    |
+| `/sf-client/guides/benchmarks`            | `src/pages/sf-client/guides/BenchmarksPage.vue`   |
+| `/sf-client/guides/running-an-evaluation` | `src/pages/sf-client/guides/EvaluationPage.vue`   |
+| `/sf-client/guides/leaderboards`          | `src/pages/sf-client/guides/LeaderboardsPage.vue` |
+| `/sf-client/guides/reproduce-and-share`   | `src/pages/sf-client/guides/Url4Page.vue`         |
+| `/sf-client/api/recipes`                  | `src/pages/sf-client/api/RecipesPage.vue`         |
+| `/sf-client/api/benchmarks`               | `src/pages/sf-client/api/BenchmarksPage.vue`      |
+| `/sf-client/api/reports`                  | `src/pages/sf-client/api/ReportsPage.vue`         |
+| `/sf-client/api/clients`                  | `src/pages/sf-client/api/ClientsPage.vue`         |
+| `/sf-client/api/fusions`                  | `src/pages/sf-client/api/FusionsPage.vue`         |
+| `/sf-client/api/pipelines`                | `src/pages/sf-client/api/PipelinesPage.vue`       |
+| `/sf-client/api/url4`                     | `src/pages/sf-client/api/Url4Page.vue`            |
+| `/sf-client/api/connections`              | `src/pages/sf-client/api/ConnectionsPage.vue`     |
+| `/sf-client/api/modules`                  | `src/pages/sf-client/api/ModulesPage.vue`         |
+| `/sf-client/api/errors`                   | `src/pages/sf-client/api/ErrorsPage.vue`          |
+| `/sf-client/api/events`                   | `src/pages/sf-client/api/EventsPage.vue`          |
+| `/sf-client/api/leaderboards`             | `src/pages/sf-client/api/LeaderboardsPage.vue`    |
+| `/learn`                                  | `src/pages/learn/ArchitecturePage.vue`            |
+| `/learn/url4`                             | `src/pages/learn/Url4Page.vue`                    |
+| `/learn/url4-sdk`                         | `src/pages/learn/Url4SdkPage.vue`                 |
+| `/learn/engine`                           | `src/pages/learn/EnginePage.vue`                  |
+| `/learn/caching`                          | `src/pages/learn/CachingPage.vue`                 |
+| `/learn/ai-gateway`                       | `src/pages/learn/GatewayPage.vue`                 |
+| `/learn/leaderboard`                      | `src/pages/learn/LeaderboardPage.vue`             |
 
 Note that `BenchmarksPage.vue` exists twice — under `guides/` (how to choose a
 benchmark) and under `api/` (the `Benchmark` type). The route names
@@ -121,10 +125,10 @@ export const sfClientNavigation: NavEntry[] = [
 ]
 ```
 
-| File | Export | Used by | Entries |
-|---|---|---|---|
+| File                          | Export                                  | Used by                  | Entries                                                                                                                                                               |
+| ----------------------------- | --------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `src/navigation/sf-client.ts` | `sfClientNavigation`, `sfClientVersion` | All `/sf-client/*` pages | Overview, then **Get Started**, **User Guides** (with a nested **Compose** group) and **API Reference** (with nested **Core classes** and **Modules & types** groups) |
-| `src/navigation/sdk.ts` | `sdkNavigation` | All `/sdk/*` pages | **Getting Started**: Overview |
+| `src/navigation/sdk.ts`       | `sdkNavigation`                         | All `/sdk/*` pages       | **Getting Started**: Overview                                                                                                                                         |
 
 **Versioning.** `sf-client.ts` also exports `sfClientVersion`
 (`{ prefix, label, url }`), rendered once in the sidebar footer rather than on

--- a/public-docs/CLAUDE.md
+++ b/public-docs/CLAUDE.md
@@ -65,6 +65,10 @@ There is no automated test setup in this project.
 | `/sf-client/api/benchmarks` | `src/pages/sf-client/api/BenchmarksPage.vue` |
 | `/sf-client/api/reports` | `src/pages/sf-client/api/ReportsPage.vue` |
 | `/sf-client/api/clients` | `src/pages/sf-client/api/ClientsPage.vue` |
+| `/sf-client/api/modules` | `src/pages/sf-client/api/ModulesPage.vue` |
+| `/sf-client/api/errors` | `src/pages/sf-client/api/ErrorsPage.vue` |
+| `/sf-client/api/events` | `src/pages/sf-client/api/EventsPage.vue` |
+| `/sf-client/api/leaderboards` | `src/pages/sf-client/api/LeaderboardsPage.vue` |
 | `/learn` | `src/pages/learn/ArchitecturePage.vue` |
 | `/learn/url4` | `src/pages/learn/Url4Page.vue` |
 | `/learn/url4-sdk` | `src/pages/learn/Url4SdkPage.vue` |
@@ -119,7 +123,7 @@ export const sfClientNavigation: NavEntry[] = [
 
 | File | Export | Used by | Entries |
 |---|---|---|---|
-| `src/navigation/sf-client.ts` | `sfClientNavigation`, `sfClientVersion` | All `/sf-client/*` pages | Overview, then **Get Started**, **User Guides** (with a nested **Compose** group) and **API Reference** (with a nested **Core classes** group) |
+| `src/navigation/sf-client.ts` | `sfClientNavigation`, `sfClientVersion` | All `/sf-client/*` pages | Overview, then **Get Started**, **User Guides** (with a nested **Compose** group) and **API Reference** (with nested **Core classes** and **Modules & types** groups) |
 | `src/navigation/sdk.ts` | `sdkNavigation` | All `/sdk/*` pages | **Getting Started**: Overview |
 
 **Versioning.** `sf-client.ts` also exports `sfClientVersion`

--- a/public-docs/CLAUDE.md
+++ b/public-docs/CLAUDE.md
@@ -52,6 +52,7 @@ There is no automated test setup in this project.
 | `/`                                       | `src/pages/HomePage.vue`                          |
 | `/sf-client`                              | `src/pages/sf-client/Index.vue`                   |
 | `/sf-client/installation`                 | `src/pages/sf-client/InstallationPage.vue`        |
+| `/sf-client/first-fusion`                 | `src/pages/sf-client/FirstFusionPage.vue`         |
 | `/sf-client/quickstartPage`               | `src/pages/sf-client/QuickstartPage.vue`          |
 | `/sf-client/guides/connections`           | `src/pages/sf-client/guides/ConnectionsPage.vue`  |
 | `/sf-client/guides/models`                | `src/pages/sf-client/guides/ModelsPage.vue`       |

--- a/public-docs/src/components/layout/DocLayout.vue
+++ b/public-docs/src/components/layout/DocLayout.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RouterLink, useRoute } from 'vue-router'
-import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { Menu, X } from 'lucide-vue-next'
 import { useCodeLangStore } from '@/stores/codelangStore'
 import { useDocNavigation, type NavEntry } from '@/composables/useDocNavigation'
@@ -36,8 +36,28 @@ watch(
 const onKeydown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') navOpen.value = false
 }
-onMounted(() => document.addEventListener('keydown', onKeydown))
-onBeforeUnmount(() => document.removeEventListener('keydown', onKeydown))
+
+// Keep the sidebar scroll position across navigations. Each page renders its own
+// DocLayout, so the scroll container remounts on every route change and would
+// otherwise jump back to the top. Persist it per section (keyed by the first nav
+// entry's title, which is distinct per tab) so the get-started, reference and
+// Learn sidebars keep independent positions.
+const sidebarScroll = ref<HTMLElement | null>(null)
+const scrollKey = `docSidebarScroll:${props.navigation[0]?.title ?? 'root'}`
+const saveSidebarScroll = () => {
+  if (sidebarScroll.value) sessionStorage.setItem(scrollKey, String(sidebarScroll.value.scrollTop))
+}
+
+onMounted(async () => {
+  document.addEventListener('keydown', onKeydown)
+  await nextTick()
+  const saved = sessionStorage.getItem(scrollKey)
+  if (saved !== null && sidebarScroll.value) sidebarScroll.value.scrollTop = Number(saved)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown)
+  saveSidebarScroll()
+})
 
 // Active state and the sidebar tree belong to NavTree; this layout only needs
 // the prev/next pair.
@@ -72,7 +92,7 @@ const { prevPage, nextPage } = useDocNavigation(() => props.navigation)
         <X class="w-5 h-5" />
       </button>
 
-      <div class="flex-1 overflow-y-auto py-6 px-4">
+      <div ref="sidebarScroll" class="flex-1 overflow-y-auto py-6 px-4" @scroll="saveSidebarScroll">
         <nav>
           <NavTree :entries="navigation" />
         </nav>

--- a/public-docs/src/components/layout/TheNavbar.vue
+++ b/public-docs/src/components/layout/TheNavbar.vue
@@ -14,19 +14,26 @@ const { toggleTheme } = themeStore
 // section you introduce (see src/navigation/ for the matching sidebar data).
 const products = [
   { name: 'Home', path: '/' },
-  { name: 'ScreamingFace Client', path: '/sf-client' },
+  { name: 'Get started with SF Client', path: '/sf-client' },
+  { name: 'API reference', path: '/sf-client/api/modules' },
   { name: 'Learn more', path: '/learn' },
 ]
 
 const currentProduct = computed(() => {
   const path = route.path
-  if (path.startsWith('/sf-client')) return 'ScreamingFace Client'
+  if (path.startsWith('/sf-client/api')) return 'API reference'
+  if (path.startsWith('/sf-client')) return 'Get started with SF Client'
   if (path.startsWith('/learn')) return 'Learn more'
   return 'Home'
 })
 
 const isActive = (productPath: string) => {
   if (productPath === '/') return route.path === '/'
+  // Both tabs live under /sf-client/*, so the reference tab owns /sf-client/api/*
+  // and the get-started tab owns everything else under /sf-client.
+  if (productPath.startsWith('/sf-client/api')) return route.path.startsWith('/sf-client/api')
+  if (productPath === '/sf-client')
+    return route.path.startsWith('/sf-client') && !route.path.startsWith('/sf-client/api')
   return route.path.startsWith(productPath)
 }
 

--- a/public-docs/src/navigation/learn.ts
+++ b/public-docs/src/navigation/learn.ts
@@ -1,12 +1,13 @@
 import type { NavEntry } from '@/composables/useDocNavigation'
 
-// "Learn" section sidebar. Uses the shared NavEntry model: a group labels its
-// children and is never clickable; a link points at a page. Architecture is a
-// plain top-level link, so it sits above the labelled Concepts group.
+// "Learn" section sidebar — the Divio "Explanation" quadrant (the "why" and the
+// background, read away from the code). Uses the shared NavEntry model: a group
+// labels its children and is never clickable; a link points at a page.
+// Architecture is a plain top-level link, so it sits above the labelled group.
 export const learnNavigation: NavEntry[] = [
   { title: 'Architecture', path: '/learn' },
   {
-    title: 'Concepts',
+    title: 'Explanation',
     children: [
       { title: 'url4', path: '/learn/url4' },
       { title: 'url4 SDK', path: '/learn/url4-sdk' },

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -65,7 +65,7 @@ export const sfClientReferenceNavigation: NavEntry[] = [
           { title: 'Url4', path: '/sf-client/api/url4' },
         ],
       },
-      { title: 'Catalog', path: '/sf-client/api/benchmarks' },
+      { title: 'Benchmark', path: '/sf-client/api/benchmarks' },
       { title: 'Connections', path: '/sf-client/api/connections' },
       {
         title: 'Results & grading',

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -10,60 +10,72 @@ export const sfClientVersion = {
   url: 'https://github.com/OpenMined/screamingface/commit/b698fcffd20d3dbe19c17a7b6654e302adeaf6ee',
 }
 
-// ScreamingFace Client sidebar (OME-666). A group labels its children and is
-// never clickable; a link points at a page. Overview is a plain top-level link,
-// so it sits above the labelled groups without needing a group of its own.
-// API Reference is added by the tickets that own those pages.
+// ScreamingFace Client sidebar. Organised on the Divio documentation system
+// (https://docs.divio.com/documentation-system/): four separated modes —
+// Tutorials (learn by doing) · How-to guides (solve one goal) · Reference
+// (austere, complete) · Explanation (the "why", in the Learn section). A group
+// labels its children and is never clickable; a link points at a page. The
+// Reference groups mirror `sf`: the namespace (functions + submodules), then
+// classes by role, so every public symbol has exactly one home.
 export const sfClientNavigation: NavEntry[] = [
   { title: 'Overview', path: '/sf-client' },
   {
-    title: 'Get Started',
+    title: 'Tutorials',
     children: [
-      { title: 'Quickstart', path: '/sf-client/quickstartPage' },
       { title: 'Installation', path: '/sf-client/installation' },
+      { title: 'Quickstart', path: '/sf-client/quickstartPage' },
     ],
   },
   {
-    title: 'User Guides',
+    title: 'How-to guides',
     children: [
-      { title: 'Clients', path: '/sf-client/guides/clients' },
-      { title: 'Connections', path: '/sf-client/guides/connections' },
+      { title: 'Connect a provider', path: '/sf-client/guides/connections' },
       {
-        title: 'Compose',
+        title: 'Compose a candidate',
         children: [
           { title: 'Models', path: '/sf-client/guides/models' },
           { title: 'Fusions', path: '/sf-client/guides/fusions' },
           { title: 'Pipelines', path: '/sf-client/guides/pipelines' },
         ],
       },
-      { title: 'Benchmarks', path: '/sf-client/guides/benchmarks' },
-      { title: 'Running an evaluation', path: '/sf-client/guides/running-an-evaluation' },
-      { title: 'Leaderboards', path: '/sf-client/guides/leaderboards' },
-      { title: 'Reproduce & share (URL4)', path: '/sf-client/guides/reproduce-and-share' },
+      { title: 'Choose a benchmark', path: '/sf-client/guides/benchmarks' },
+      { title: 'Run an evaluation', path: '/sf-client/guides/running-an-evaluation' },
+      { title: 'Publish to the leaderboard', path: '/sf-client/guides/leaderboards' },
+      { title: 'Reproduce & share', path: '/sf-client/guides/reproduce-and-share' },
+      { title: 'Manage the Client', path: '/sf-client/guides/clients' },
     ],
   },
   {
-    title: 'API Reference',
+    title: 'Reference',
     children: [
+      { title: 'The sf namespace', path: '/sf-client/api/modules' },
       {
-        title: 'Core classes',
+        title: 'Classes',
         children: [
-          { title: 'Recipes', path: '/sf-client/api/recipes' },
-          { title: 'Models', path: '/sf-client/api/models' },
-          { title: 'Benchmarks', path: '/sf-client/api/benchmarks' },
-          { title: 'Reports', path: '/sf-client/api/reports' },
-          { title: 'CandidateResult', path: '/sf-client/api/candidate-result' },
-          { title: 'Usage', path: '/sf-client/api/usage' },
-          { title: 'Clients', path: '/sf-client/api/clients' },
-        ],
-      },
-      {
-        title: 'Modules & types',
-        children: [
-          { title: 'Modules', path: '/sf-client/api/modules' },
-          { title: 'Errors', path: '/sf-client/api/errors' },
-          { title: 'Events', path: '/sf-client/api/events' },
-          { title: 'Leaderboards', path: '/sf-client/api/leaderboards' },
+          { title: 'Client & session', path: '/sf-client/api/clients' },
+          {
+            title: 'Candidates',
+            children: [
+              { title: 'Recipe', path: '/sf-client/api/recipes' },
+              { title: 'Model', path: '/sf-client/api/models' },
+              { title: 'Fusion', path: '/sf-client/api/fusions' },
+              { title: 'Pipeline', path: '/sf-client/api/pipelines' },
+              { title: 'Url4', path: '/sf-client/api/url4' },
+            ],
+          },
+          { title: 'Catalog', path: '/sf-client/api/benchmarks' },
+          { title: 'Connections', path: '/sf-client/api/connections' },
+          {
+            title: 'Results & grading',
+            children: [
+              { title: 'Report', path: '/sf-client/api/reports' },
+              { title: 'CandidateResult', path: '/sf-client/api/candidate-result' },
+              { title: 'Usage', path: '/sf-client/api/usage' },
+            ],
+          },
+          { title: 'Leaderboard', path: '/sf-client/api/leaderboards' },
+          { title: 'Run events', path: '/sf-client/api/events' },
+          { title: 'Errors & warnings', path: '/sf-client/api/errors' },
         ],
       },
     ],

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -6,8 +6,8 @@ import type { NavEntry } from '@/composables/useDocNavigation'
 // nothing else changes.
 export const sfClientVersion = {
   prefix: 'Based on state at commit',
-  label: 'b698fcff',
-  url: 'https://github.com/OpenMined/screamingface/commit/b698fcffd20d3dbe19c17a7b6654e302adeaf6ee',
+  label: '90a104e3',
+  url: 'https://github.com/OpenMined/screamingface/commit/90a104e39186801553103b9342b60dcd64677562',
 }
 
 // The "Get started with SF Client" navbar tab: everything but the reference —

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -10,20 +10,19 @@ export const sfClientVersion = {
   url: 'https://github.com/OpenMined/screamingface/commit/b698fcffd20d3dbe19c17a7b6654e302adeaf6ee',
 }
 
-// ScreamingFace Client sidebar. Organised on the Divio documentation system
-// (https://docs.divio.com/documentation-system/): four separated modes —
-// Tutorials (learn by doing) · How-to guides (solve one goal) · Reference
-// (austere, complete) · Explanation (the "why", in the Learn section). A group
-// labels its children and is never clickable; a link points at a page. The
-// Reference groups mirror `sf`: the namespace (functions + submodules), then
-// classes by role, so every public symbol has exactly one home.
+// The "Get started with SF Client" navbar tab: everything but the reference —
+// Overview, Tutorials (learn by doing) and How-to guides (solve one goal),
+// following the Divio documentation system. The pure API reference is its own
+// navbar tab; see `sfClientReferenceNavigation` below. A group labels its
+// children and is never clickable; a link points at a page.
 export const sfClientNavigation: NavEntry[] = [
   { title: 'Overview', path: '/sf-client' },
   {
     title: 'Tutorials',
     children: [
       { title: 'Installation', path: '/sf-client/installation' },
-      { title: 'Quickstart', path: '/sf-client/quickstartPage' },
+      { title: 'Your first fusion', path: '/sf-client/first-fusion' },
+      { title: 'Reproduce DRACO state-of-art', path: '/sf-client/quickstartPage' },
     ],
   },
   {
@@ -45,39 +44,40 @@ export const sfClientNavigation: NavEntry[] = [
       { title: 'Manage the Client', path: '/sf-client/guides/clients' },
     ],
   },
+]
+
+// The "API reference" navbar tab — the pure Divio Reference mode. The `sf`
+// namespace (functions + submodules), then classes by role, so every public
+// symbol has exactly one home. Pages under /sf-client/api/* consume this tree.
+export const sfClientReferenceNavigation: NavEntry[] = [
+  { title: 'The sf namespace', path: '/sf-client/api/modules' },
   {
-    title: 'Reference',
+    title: 'Classes',
     children: [
-      { title: 'The sf namespace', path: '/sf-client/api/modules' },
+      { title: 'Client & session', path: '/sf-client/api/clients' },
       {
-        title: 'Classes',
+        title: 'Candidates',
         children: [
-          { title: 'Client & session', path: '/sf-client/api/clients' },
-          {
-            title: 'Candidates',
-            children: [
-              { title: 'Recipe', path: '/sf-client/api/recipes' },
-              { title: 'Model', path: '/sf-client/api/models' },
-              { title: 'Fusion', path: '/sf-client/api/fusions' },
-              { title: 'Pipeline', path: '/sf-client/api/pipelines' },
-              { title: 'Url4', path: '/sf-client/api/url4' },
-            ],
-          },
-          { title: 'Catalog', path: '/sf-client/api/benchmarks' },
-          { title: 'Connections', path: '/sf-client/api/connections' },
-          {
-            title: 'Results & grading',
-            children: [
-              { title: 'Report', path: '/sf-client/api/reports' },
-              { title: 'CandidateResult', path: '/sf-client/api/candidate-result' },
-              { title: 'Usage', path: '/sf-client/api/usage' },
-            ],
-          },
-          { title: 'Leaderboard', path: '/sf-client/api/leaderboards' },
-          { title: 'Run events', path: '/sf-client/api/events' },
-          { title: 'Errors & warnings', path: '/sf-client/api/errors' },
+          { title: 'Recipe', path: '/sf-client/api/recipes' },
+          { title: 'Model', path: '/sf-client/api/models' },
+          { title: 'Fusion', path: '/sf-client/api/fusions' },
+          { title: 'Pipeline', path: '/sf-client/api/pipelines' },
+          { title: 'Url4', path: '/sf-client/api/url4' },
         ],
       },
+      { title: 'Catalog', path: '/sf-client/api/benchmarks' },
+      { title: 'Connections', path: '/sf-client/api/connections' },
+      {
+        title: 'Results & grading',
+        children: [
+          { title: 'Report', path: '/sf-client/api/reports' },
+          { title: 'CandidateResult', path: '/sf-client/api/candidate-result' },
+          { title: 'Usage', path: '/sf-client/api/usage' },
+        ],
+      },
+      { title: 'Leaderboard', path: '/sf-client/api/leaderboards' },
+      { title: 'Run events', path: '/sf-client/api/events' },
+      { title: 'Errors & warnings', path: '/sf-client/api/errors' },
     ],
   },
 ]

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -57,6 +57,15 @@ export const sfClientNavigation: NavEntry[] = [
           { title: 'Clients', path: '/sf-client/api/clients' },
         ],
       },
+      {
+        title: 'Modules & types',
+        children: [
+          { title: 'Modules', path: '/sf-client/api/modules' },
+          { title: 'Errors', path: '/sf-client/api/errors' },
+          { title: 'Events', path: '/sf-client/api/events' },
+          { title: 'Leaderboards', path: '/sf-client/api/leaderboards' },
+        ],
+      },
     ],
   },
 ]

--- a/public-docs/src/pages/HomePage.vue
+++ b/public-docs/src/pages/HomePage.vue
@@ -8,7 +8,7 @@ const docs = [
     title: 'Overview',
     to: '/sf-client',
     kicker: 'start here',
-    desc: 'What ScreamingFace is, the smallest end-to-end example, and how the client, engine, and url4 fit together.',
+    desc: 'What ScreamingFace is, the smallest end-to-end example, and how the Client, engine, and url4 fit together.',
   },
   {
     title: 'Quickstart',
@@ -20,7 +20,7 @@ const docs = [
     title: 'Installation',
     to: '/sf-client/installation',
     kicker: 'setup',
-    desc: 'Install the screamingface client and point it at an engine.',
+    desc: 'Install the ScreamingFace Client and point it at an engine.',
     draft: true,
   },
   {
@@ -45,8 +45,8 @@ const GITHUB = 'https://github.com/OpenMined'
       </h1>
       <p class="lead">
         ScreamingFace is an open toolkit for composing model <em>fusions</em>: several models
-        answering together, graded against a real benchmark. Every run reproduces from a
-        single line, on your own keys.
+        answering together, graded against a real benchmark. Every run reproduces from a single
+        line, on your own keys.
       </p>
 
       <div class="actions">
@@ -56,7 +56,7 @@ const GITHUB = 'https://github.com/OpenMined'
         <a class="btn btn--sec" :href="GITHUB" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
 
-      <div class="term" role="img" aria-label="Install the client with pip install screamingface">
+      <div class="term" role="img" aria-label="Install the Client with pip install screamingface">
         <div class="term__bar">
           <span class="term__dot"></span><span class="term__dot"></span
           ><span class="term__dot"></span>
@@ -93,7 +93,9 @@ const GITHUB = 'https://github.com/OpenMined'
           </dd>
         </div>
         <div class="def">
-          <dt><RouterLink to="/learn/url4"><code>url4</code></RouterLink></dt>
+          <dt>
+            <RouterLink to="/learn/url4"><code>url4</code></RouterLink>
+          </dt>
           <dd>
             A grammar and protocol: one line that describes a fusion and its benchmark run, and
             reproduces it. It is also an address the engine resolves, so anyone holding the
@@ -101,9 +103,11 @@ const GITHUB = 'https://github.com/OpenMined'
           </dd>
         </div>
         <div class="def">
-          <dt><RouterLink to="/learn/engine"><code>engine</code></RouterLink></dt>
+          <dt>
+            <RouterLink to="/learn/engine"><code>engine</code></RouterLink>
+          </dt>
           <dd>
-            The runtime that executes a fusion. You point the client at one you run locally, or a
+            The runtime that executes a fusion. You point the Client at one you run locally, or a
             hosted one.
           </dd>
         </div>

--- a/public-docs/src/pages/learn/ArchitecturePage.vue
+++ b/public-docs/src/pages/learn/ArchitecturePage.vue
@@ -16,8 +16,8 @@ const cloudDiagram = (dark: boolean) =>
 
 const components = [
   { name: 'url4: the protocol', path: 'packages/url4' },
-  { name: 'Engine: the cloud service', path: 'apps/url4-cloud' },
-  { name: 'Engine: the DAG executor', path: 'packages/url4/src/url4/dag' },
+  { name: 'engine: the cloud service', path: 'apps/url4-cloud' },
+  { name: 'engine: the DAG executor', path: 'packages/url4/src/url4/dag' },
   { name: 'AI gateway', path: 'apps/aigateway' },
   { name: 'Client: the Python library', path: 'packages/screamingface' },
   // Studio hidden for now: { name: 'Studio: the desktop app', path: 'apps/screamingface-studio' },
@@ -28,7 +28,7 @@ const components = [
 <template>
   <DocLayout
     title="Architecture"
-    description="How the pieces fit (url4 the protocol, the Engine that runs it, and the surfaces you compose from) and where each one lives in the codebase."
+    description="How the pieces fit (url4 the protocol, the engine that runs it, and the surfaces you compose from) and where each one lives in the codebase."
     :navigation="navigation"
   >
     <p>
@@ -51,20 +51,20 @@ const components = [
       </li>
       <li>
         <RouterLink to="/learn/engine"
-          ><strong>The Engine: runtime and trust boundary.</strong></RouterLink
+          ><strong>The engine: runtime and trust boundary.</strong></RouterLink
         >
         Runs a url4 expression: it schedules the graph, sends each model call out to a provider, and
-        streams back tokens, cost, and the result. It holds the provider credentials, so the client
+        streams back tokens, cost, and the result. It holds the provider credentials, so the Client
         never sees them.
       </li>
       <li>
         <RouterLink to="/learn/ai-gateway"><strong>The AI gateway.</strong></RouterLink> A
-        LiteLLM-based gateway the Engine calls to reach every provider through one OpenAI-shaped
+        LiteLLM-based gateway the engine calls to reach every provider through one OpenAI-shaped
         endpoint. It stores provider credentials encrypted at rest.
       </li>
       <li>
         <RouterLink to="/sf-client"><strong>The Client.</strong></RouterLink> The Python library
-        researchers use. It composes fusions and benchmarks and talks only to an Engine, never to a
+        researchers use. It composes fusions and benchmarks and talks only to an engine, never to a
         provider directly.
       </li>
       <!-- Studio is hidden for now.
@@ -88,14 +88,14 @@ const components = [
 
     <p>
       A run always follows the same path. The Client compiles what you built into a url4 expression
-      and sends it to an Engine. The Engine runs the expression as a graph, with independent nodes
+      and sends it to an engine. The engine runs the expression as a graph, with independent nodes
       running in parallel, and sends each model call out through the AI gateway to the provider.
       Usage and results stream back as the graph runs. Replay the same expression and the whole
       system runs again.
     </p>
 
     <p>
-      There are two ways to run, and only the engine URL changes. A <strong>local</strong> Engine
+      There are two ways to run, and only the engine URL changes. A <strong>local</strong> engine
       runs on your own machine, on your own keys, with its own cache, and nothing on the local path
       takes a cut.
     </p>
@@ -103,16 +103,16 @@ const components = [
     <figure class="not-prose diagram">
       <img
         :src="localDiagram(isDark)"
-        alt="Local request flow: the client drives an Engine on your own machine, which fans model calls out through the AI gateway to the providers you hold keys for."
+        alt="Local request flow: the Client drives an engine on your own machine, which fans model calls out through the AI gateway to the providers you hold keys for."
       />
       <figcaption>
-        <strong>Local.</strong> The Client drives an Engine on your own machine; model calls fan out
+        <strong>Local.</strong> The Client drives an engine on your own machine; model calls fan out
         through the gateway to the providers you hold keys for.
       </figcaption>
     </figure>
 
     <p>
-      A <strong>hosted</strong> Engine, one we operate, runs the identical protocol but adds the
+      A <strong>hosted</strong> engine, one we operate, runs the identical protocol but adds the
       <RouterLink to="/learn/caching">shared community cache</RouterLink> and subsidized compute for
       chosen cohorts, so reproducing or building on a published run is usually a cache hit rather
       than a fresh spend.
@@ -121,10 +121,10 @@ const components = [
     <figure class="not-prose diagram">
       <img
         :src="cloudDiagram(isDark)"
-        alt="Cloud request flow: a hosted Engine runs the same protocol; a control plane schedules the run and streams execution events back to the client."
+        alt="Cloud request flow: a hosted engine runs the same protocol; a control plane schedules the run and streams execution events back to the Client."
       />
       <figcaption>
-        <strong>Cloud.</strong> A hosted Engine runs the same protocol; a control plane schedules
+        <strong>Cloud.</strong> A hosted engine runs the same protocol; a control plane schedules
         the run and streams execution events back.
       </figcaption>
     </figure>
@@ -132,9 +132,9 @@ const components = [
     <h2>The trust boundary</h2>
 
     <p>
-      Provider credentials live behind the Engine and gateway, never in the client. A key is handed
-      to the Engine once, stored encrypted (AES-256-GCM), and used to reach providers on your
-      behalf. The client keeps none. In an evaluation, the benchmark prompts go out to the models,
+      Provider credentials live behind the engine and gateway, never in the Client. A key is handed
+      to the engine once, stored encrypted (AES-256-GCM), and used to reach providers on your
+      behalf. The Client keeps none. In an evaluation, the benchmark prompts go out to the models,
       but the answer keys and grading stay engine-side. That is what makes a verified result mean
       something. The credential store is the
       <a :href="`${GH}/apps/aigateway`" target="_blank" rel="noopener">AI gateway</a>'s encrypted

--- a/public-docs/src/pages/learn/CachingPage.vue
+++ b/public-docs/src/pages/learn/CachingPage.vue
@@ -12,16 +12,17 @@ import { learnNavigation as navigation } from '@/navigation/learn'
   >
     <p>
       Evaluating a fusion means many model calls, and calls cost money and time. ScreamingFace keeps
-      that cost low in two ways: it caches every call, and it gives you a choice of where the
-      compute comes from.
+      that cost low in two ways: it caches calls to the providers that support it, and it gives you
+      a choice of where the compute comes from.
     </p>
 
-    <h2>Every call is cached</h2>
+    <h2>How caching works</h2>
 
     <p>
-      When the <RouterLink to="/learn/engine">engine</RouterLink> calls a model, it stores the
-      response keyed by the exact request. Reuse the same model in another candidate, or run the
-      same evaluation again, and the stored response is served instead of paying for it twice.
+      When the <RouterLink to="/learn/engine">engine</RouterLink> calls a model on a provider that
+      supports caching, it stores the response keyed by the exact request. Reuse the same model in
+      another candidate, or run the same evaluation again, and the stored response is served instead
+      of paying for it twice. Only some providers support it; the Providers table below shows which.
     </p>
 
     <ul>
@@ -165,10 +166,10 @@ import { learnNavigation as navigation } from '@/navigation/learn'
     <h2>Providers</h2>
 
     <p>
-      Whichever engine you run, these are the providers it can reach. Caching is provider-agnostic:
-      every call is keyed by its exact request, so a hit is a hit no matter who would have served
-      it. How you connect each one varies (a pasted key, a local runtime, or a login through a CLI
-      tool); the
+      Whichever engine you run, these are the providers it can reach. Caching is opt-in per
+      provider, and only <code>anthropic</code> and <code>openrouter</code> are served from the
+      cache today; the rest bypass it and dispatch every time. How you connect each one varies (a
+      pasted key or a login through a CLI tool); the
       <RouterLink to="/sf-client/guides/connections">Connect a provider</RouterLink> guide has the
       specifics.
     </p>
@@ -178,6 +179,7 @@ import { learnNavigation as navigation } from '@/navigation/learn'
         <tr>
           <th>Provider</th>
           <th>Reached via</th>
+          <th>Cached?</th>
           <th>What it is</th>
         </tr>
       </thead>
@@ -185,6 +187,7 @@ import { learnNavigation as navigation } from '@/navigation/learn'
         <tr>
           <td><code>openrouter</code></td>
           <td>API key</td>
+          <td>Yes</td>
           <td>
             A router over many hosted models (OpenAI, Anthropic, Google, DeepSeek, Qwen and more)
             behind one key.
@@ -193,31 +196,31 @@ import { learnNavigation as navigation } from '@/navigation/learn'
         <tr>
           <td><code>anthropic</code></td>
           <td>API key</td>
+          <td>Yes</td>
           <td>Claude models, direct.</td>
         </tr>
         <tr>
           <td><code>huggingface</code></td>
           <td>API key</td>
+          <td>No</td>
           <td>Hugging Face inference endpoints.</td>
-        </tr>
-        <tr>
-          <td><code>ollama</code></td>
-          <td>Local</td>
-          <td>Open-weight models on your own machine. No key and no per-call bill.</td>
         </tr>
         <tr>
           <td><code>gemini-cli</code></td>
           <td>CLI plugin</td>
+          <td>No</td>
           <td>Google Gemini through the gemini CLI.</td>
         </tr>
         <tr>
           <td><code>codex</code></td>
           <td>CLI plugin</td>
+          <td>No</td>
           <td>OpenAI models through the Codex CLI.</td>
         </tr>
         <tr>
           <td><code>antigravity</code></td>
           <td>CLI plugin</td>
+          <td>No</td>
           <td>Gemini through the Antigravity CLI.</td>
         </tr>
       </tbody>

--- a/public-docs/src/pages/learn/CachingPage.vue
+++ b/public-docs/src/pages/learn/CachingPage.vue
@@ -60,7 +60,10 @@ import { learnNavigation as navigation } from '@/navigation/learn'
 
     <h2>Where the compute comes from</h2>
 
-    <p>There are two ways to run. They differ in who supplies the compute and which cache you draw from.</p>
+    <p>
+      There are two ways to run. They differ in who supplies the compute and which cache you draw
+      from.
+    </p>
 
     <ul>
       <li>
@@ -93,7 +96,10 @@ import { learnNavigation as navigation } from '@/navigation/learn'
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#cc-arrow)">
+        <g
+          style="stroke: var(--text-2); stroke-width: 1.25; fill: none"
+          marker-end="url(#cc-arrow)"
+        >
           <path d="M326 54 C 220 68, 152 86, 141 104" />
           <path d="M354 54 C 460 68, 528 86, 539 104" />
           <path d="M140 162 V190" />
@@ -155,5 +161,66 @@ import { learnNavigation as navigation } from '@/navigation/learn'
       The client code is identical either way; only the engine URL changes. The
       <RouterLink to="/sf-client/installation">Installation</RouterLink> guide walks through both.
     </p>
+
+    <h2>Providers</h2>
+
+    <p>
+      Whichever engine you run, these are the providers it can reach. Caching is provider-agnostic:
+      every call is keyed by its exact request, so a hit is a hit no matter who would have served
+      it. How you connect each one varies (a pasted key, a local runtime, or a login through a CLI
+      tool); the
+      <RouterLink to="/sf-client/guides/connections">Connect a provider</RouterLink> guide has the
+      specifics.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Provider</th>
+          <th>Reached via</th>
+          <th>What it is</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>openrouter</code></td>
+          <td>API key</td>
+          <td>
+            A router over many hosted models (OpenAI, Anthropic, Google, DeepSeek, Qwen and more)
+            behind one key.
+          </td>
+        </tr>
+        <tr>
+          <td><code>anthropic</code></td>
+          <td>API key</td>
+          <td>Claude models, direct.</td>
+        </tr>
+        <tr>
+          <td><code>huggingface</code></td>
+          <td>API key</td>
+          <td>Hugging Face inference endpoints.</td>
+        </tr>
+        <tr>
+          <td><code>ollama</code></td>
+          <td>Local</td>
+          <td>Open-weight models on your own machine. No key and no per-call bill.</td>
+        </tr>
+        <tr>
+          <td><code>gemini-cli</code></td>
+          <td>CLI plugin</td>
+          <td>Google Gemini through the gemini CLI.</td>
+        </tr>
+        <tr>
+          <td><code>codex</code></td>
+          <td>CLI plugin</td>
+          <td>OpenAI models through the Codex CLI.</td>
+        </tr>
+        <tr>
+          <td><code>antigravity</code></td>
+          <td>CLI plugin</td>
+          <td>Gemini through the Antigravity CLI.</td>
+        </tr>
+      </tbody>
+    </table>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/learn/EnginePage.vue
+++ b/public-docs/src/pages/learn/EnginePage.vue
@@ -24,10 +24,10 @@ const health = `screamingface status`
     :navigation="navigation"
   >
     <p>
-      The Engine is the runtime that runs
+      The engine is the runtime that runs
       <RouterLink to="/learn/url4">url4</RouterLink> expressions. The
       <RouterLink to="/sf-client">Client</RouterLink> never calls a model provider itself. It hands
-      a url4 expression to an Engine. The Engine does the work: schedules the graph, reaches the
+      a url4 expression to an engine. The engine does the work: schedules the graph, reaches the
       providers, and streams back usage and the result. Because it sits between you and the
       providers, it is also the system's <strong>trust boundary</strong>, the one place that holds
       both your credentials and the benchmark answer keys.
@@ -36,7 +36,7 @@ const health = `screamingface status`
     <p>
       You mostly will not touch it directly. The
       <RouterLink to="/sf-client">Client</RouterLink> talks to it for you, and the only decision
-      that usually matters is which Engine to point at.
+      that usually matters is which engine to point at.
     </p>
 
     <h2>How it executes</h2>
@@ -64,9 +64,9 @@ const health = `screamingface status`
     <h2>The trust boundary</h2>
 
     <p>
-      The Engine holds what must not leak. Provider credentials are handed to it once and stored
+      The engine holds what must not leak. Provider credentials are handed to it once and stored
       encrypted at rest (AES-256-GCM) by the AI gateway's credential store, and are never returned
-      to the client. Benchmark answer keys, rubrics, and grading stay engine-side. That separation
+      to the Client. Benchmark answer keys, rubrics, and grading stay engine-side. That separation
       is what makes a score mean something: the code being graded cannot read the answers it is
       being graded against, and neither can the person who wrote it.
     </p>
@@ -85,7 +85,7 @@ const health = `screamingface status`
         master key <code>AIGATEWAY_SECRET_KEY</code> is never stored with the data or logged.
       </li>
       <li>
-        <strong>One endpoint, every provider</strong>: the Engine fans out to open and closed
+        <strong>One endpoint, every provider</strong>: the engine fans out to open and closed
         providers alike through the LiteLLM-based gateway, so a fusion can mix models from different
         vendors behind a single connection.
       </li>
@@ -98,31 +98,31 @@ const health = `screamingface status`
     <h2>Running one</h2>
 
     <p>
-      Your own Engine ships in the client package, behind the <code>runtime</code> extra. Three
+      Your own engine ships in the client package, behind the <code>runtime</code> extra. Three
       commands install it, fetch the benchmark data it reads from disk, and start it:
     </p>
 
     <CodeBlock :code="runLocal" language="bash" />
 
     <p>
-      That serves the Engine on <code>127.0.0.1:9108</code>, alongside the gateway that holds your
+      That serves the engine on <code>127.0.0.1:9108</code>, alongside the gateway that holds your
       provider keys and a local leaderboard. <code>screamingface status</code> reports each of the
       three, and <code>screamingface down</code> stops them. The
       <RouterLink to="/sf-client/installation">Installation</RouterLink> guide covers the rest,
-      including when a local Engine needs its own web-search key.
+      including when a local engine needs its own web-search key.
     </p>
 
     <CodeBlock :code="health" language="bash" />
 
     <p>
-      Point the Client at an Engine with one call. Its default is a hosted Engine, so a local one is
+      Point the Client at an engine with one call. Its default is a hosted engine, so a local one is
       always named explicitly:
     </p>
 
     <CodeBlock :code="point" language="python" />
 
     <p>
-      The same Engine runs three ways: <strong>bundled</strong> invisibly inside the Client and
+      The same engine runs three ways: <strong>bundled</strong> invisibly inside the Client and
       <RouterLink to="/learn/url4-sdk">SDK</RouterLink>, <strong>self-hosted</strong> for a team
       that wants the whole system inside its own walls, or <strong>hosted</strong> for shared,
       subsidized capacity that we run. The cloud deployment (Kubernetes Jobs, a streaming event bus,
@@ -133,7 +133,7 @@ const health = `screamingface status`
     </p>
 
     <blockquote>
-      The Engine is not a router. A router picks one model per call. The Engine composes many into a
+      The engine is not a router. A router picks one model per call. The engine composes many into a
       graph. It is not open compute either: hosted capacity is subsidized for chosen cohorts, and
       self-hosting is on your own hardware.
     </blockquote>
@@ -144,7 +144,7 @@ const health = `screamingface status`
       <li>
         <a :href="`${GH_TREE}/apps/url4-cloud`" target="_blank" rel="noopener"
           ><code>apps/url4-cloud</code></a
-        >: the Engine service (backend, runner, shared wire protocol).
+        >: the engine service (backend, runner, shared wire protocol).
       </li>
       <li>
         <a :href="`${GH_TREE}/packages/url4/src/url4/dag`" target="_blank" rel="noopener"

--- a/public-docs/src/pages/learn/GatewayPage.vue
+++ b/public-docs/src/pages/learn/GatewayPage.vue
@@ -7,13 +7,13 @@ import { learnNavigation as navigation } from '@/navigation/learn'
 <template>
   <DocLayout
     title="AI gateway"
-    description="Where your provider keys live, encrypted, and the one endpoint the Engine calls to reach every model provider."
+    description="Where your provider keys live, encrypted, and the one endpoint the engine calls to reach every model provider."
     :navigation="navigation"
   >
     <p>
-      The <strong>AI gateway</strong> is the component that actually reaches model providers, and the
-      place your provider credentials are stored. The
-      <RouterLink to="/learn/engine">Engine</RouterLink> never calls a provider directly and never
+      The <strong>AI gateway</strong> is the component that actually reaches model providers, and
+      the place your provider credentials are stored. The
+      <RouterLink to="/learn/engine">engine</RouterLink> never calls a provider directly and never
       holds a raw key: it calls the gateway, and the gateway reaches OpenRouter, Anthropic, and the
       rest.
     </p>
@@ -21,9 +21,9 @@ import { learnNavigation as navigation } from '@/navigation/learn'
     <h2>One endpoint, every provider</h2>
 
     <p>
-      It is a LiteLLM-based gateway that exposes a single, OpenAI-shaped endpoint. The Engine sends
+      It is a LiteLLM-based gateway that exposes a single, OpenAI-shaped endpoint. The engine sends
       one request shape and the gateway routes it to the right provider, so adding a provider does
-      not change how the Engine calls out.
+      not change how the engine calls out.
     </p>
 
     <h2>Where your keys live</h2>
@@ -31,7 +31,7 @@ import { learnNavigation as navigation } from '@/navigation/learn'
     <p>
       A key you connect is handed to the gateway once, validated, and stored
       <strong>encrypted at rest</strong> (AES-256-GCM) as credential blobs. It is never returned to
-      the Engine or the client, and never written into your notebook. The master key that unlocks
+      the engine or the Client, and never written into your notebook. The master key that unlocks
       them, <code>AIGATEWAY_SECRET_KEY</code>, is never stored alongside the data and never logged,
       and no OS keychain is involved.
     </p>
@@ -48,11 +48,11 @@ import { learnNavigation as navigation } from '@/navigation/learn'
       Every provider the gateway can reach is a <strong>plugin</strong>. Each one adapts a provider,
       OpenRouter, Anthropic, the Codex and Gemini CLIs, Hugging Face, and so on, to the gateway's
       single OpenAI-shaped interface, so supporting a new provider means adding a plugin, not
-      changing the Engine or the client.
+      changing the engine or the Client.
     </p>
 
     <p>
-      Plugins are enabled per deployment, and the set that is turned on is exactly what the Engine
+      Plugins are enabled per deployment, and the set that is turned on is exactly what the engine
       advertises: it is the list you see when you call <code>sf.connect()</code> or
       <RouterLink to="/sf-client/guides/connections">read your connections</RouterLink>. A route
       whose plugin is off never appears, so a missing provider is usually a disabled plugin rather
@@ -61,15 +61,15 @@ import { learnNavigation as navigation } from '@/navigation/learn'
 
     <p>
       A plugin may also ship <strong>disabled</strong>. The OpenRouter plugin, for example, refuses
-      a valid key until you turn it on with <code>AIGW_OPENROUTER_ENABLED=true</code>. Worth knowing,
-      because the error names the credential rather than the configuration, and it is easy to spend a
-      while checking a key that was never the problem.
+      a valid key until you turn it on with <code>AIGW_OPENROUTER_ENABLED=true</code>. Worth
+      knowing, because the error names the credential rather than the configuration, and it is easy
+      to spend a while checking a key that was never the problem.
     </p>
 
     <h2>Running it</h2>
 
     <p>
-      On a hosted Engine the gateway runs for you. If you run the Engine yourself, you run the
+      On a hosted engine the gateway runs for you. If you run the engine yourself, you run the
       gateway too, and it needs its database schema migrated before the first start. The
       <RouterLink to="/sf-client/installation">Installation</RouterLink> guide has the commands.
     </p>

--- a/public-docs/src/pages/learn/LeaderboardPage.vue
+++ b/public-docs/src/pages/learn/LeaderboardPage.vue
@@ -101,7 +101,7 @@ sf.evaluate(entry.url4)  # or replay it verbatim, benchmark included`
       usually far cheaper than the original run was.
     </p>
 
-    <h2>From the client</h2>
+    <h2>From the Client</h2>
 
     <p>
       The <RouterLink to="/sf-client">Client</RouterLink> reads and writes the board directly. To
@@ -133,7 +133,7 @@ sf.evaluate(entry.url4)  # or replay it verbatim, benchmark included`
 
     <blockquote>
       The board is not a vote and not a vendor chart. Rankings come from graded benchmark runs
-      behind the <RouterLink to="/learn/engine">Engine</RouterLink>'s trust boundary, where the
+      behind the <RouterLink to="/learn/engine">engine</RouterLink>'s trust boundary, where the
       answer keys stay, and no rank can be bought or self-reported.
     </blockquote>
 

--- a/public-docs/src/pages/learn/LeaderboardPage.vue
+++ b/public-docs/src/pages/learn/LeaderboardPage.vue
@@ -12,7 +12,7 @@ sf.leaderboards.list()                      # benchmarks with a public board
 
 board = sf.leaderboards.get("draco", top=10)
 for entry in board.entries:
-    print(entry.rank, entry.accuracy, entry.verified_by_openmined)
+    print(entry.rank, entry.accuracy, entry.verified_by_screamingface)
 
 board.baselines                             # single-model numbers, for comparison`
 
@@ -66,9 +66,9 @@ sf.evaluate(entry.url4)  # or replay it verbatim, benchmark included`
         idempotency window replays the original instead of creating a duplicate.
       </li>
       <li>
-        <strong>Independent re-run.</strong> OpenMined re-runs the submission. Entries that survive
-        carry <code>verified_by_openmined</code>, which is the flag worth reading before you trust a
-        row.
+        <strong>Independent re-run.</strong> ScreamingFace re-runs the submission. Entries that
+        survive carry <code>verified_by_screamingface</code>, which is the flag worth reading before
+        you trust a row.
       </li>
       <li>
         <strong>Ranking.</strong> The board keeps the best result per spec, ties broken by recency,

--- a/public-docs/src/pages/learn/Url4Page.vue
+++ b/public-docs/src/pages/learn/Url4Page.vue
@@ -36,7 +36,7 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
       these, whether it is a single model, a
       <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>, or a whole benchmark run. The
       line is also an <strong>address</strong>: hand it to the
-      <RouterLink to="/learn/engine">Engine</RouterLink> and it resolves, the way a URL resolves.
+      <RouterLink to="/learn/engine">engine</RouterLink> and it resolves, the way a URL resolves.
     </p>
 
     <p>
@@ -52,7 +52,7 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
     <p>
       A url4 string has two layers. The <strong>grammar</strong>, <code>(data)!intent</code>, is
       what you write and what a node parses: sources in parentheses, an intent after the
-      <code>!</code>. The <strong>protocol</strong> is how any conforming node, such as the Engine,
+      <code>!</code>. The <strong>protocol</strong> is how any conforming node, such as the engine,
       resolves each source, runs the intent, and returns a result. You write the grammar; the
       protocol is what makes the same string runnable anywhere.
     </p>
@@ -82,7 +82,7 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
 
     <p>
       <strong>Model mode</strong> (the spec's <em>LLM mode</em>). Sources are context and the intent
-      is a natural-language prompt. The Engine feeds the resolved sources to a model, or to a
+      is a natural-language prompt. The engine feeds the resolved sources to a model, or to a
       <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink> of models, and synthesizes one
       answer. This is the mode the Client uses: a Fusion is a url4 expression in model mode.
     </p>
@@ -90,7 +90,7 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
     <p>
       <strong>Compute mode</strong> (the spec's <em>remote data science</em>, or <em>RDS</em>,
       mode). Sources are structured inputs and the intent points at code, a script or a notebook.
-      The Engine binds the inputs to the code's contract and runs it, so computation can run next to
+      The engine binds the inputs to the code's contract and runs it, so computation can run next to
       data that never has to move. A single expression can chain the two: a compute step that
       prepares data, feeding a model step that summarizes it. The whole chain stays one addressable
       url4.
@@ -117,10 +117,10 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
     <h2>An address, not just a string</h2>
 
     <p>
-      Because the whole request lives in one URI, the Engine treats a url4 expression the way
+      Because the whole request lives in one URI, the engine treats a url4 expression the way
       <code>http</code> treats a URL: as an address it resolves. The same expression always
       describes the same work, which makes the call cacheable and safe to repeat. Save a Fusion's
-      url4, hand it to an <RouterLink to="/learn/engine">Engine</RouterLink>, and it runs like any
+      url4, hand it to an <RouterLink to="/learn/engine">engine</RouterLink>, and it runs like any
       other model call. A source inside one expression can be the result of another expression on
       another node, so fusions nest into larger systems without anyone having to unpack them.
     </p>
@@ -131,7 +131,7 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
       without understanding the grammar, and attribution metadata travels <em>with</em> the request
       instead of beside it. To serve and call a url4 node yourself, see the
       <RouterLink to="/learn/url4-sdk">url4 SDK</RouterLink>, which exposes the same shape the
-      Engine does.
+      engine does.
     </p>
 
     <h2>Why it exists</h2>

--- a/public-docs/src/pages/learn/Url4SdkPage.vue
+++ b/public-docs/src/pages/learn/Url4SdkPage.vue
@@ -99,7 +99,7 @@ url4 serve`
 
     <p>
       A url4 node can also be served over HTTP, so other expressions can call it as a source. This
-      is the same shape the <RouterLink to="/learn/engine">Engine</RouterLink> exposes. Serving
+      is the same shape the <RouterLink to="/learn/engine">engine</RouterLink> exposes. Serving
       needs uvicorn, which comes with the <code>url4[server]</code> extra rather than the base
       install:
     </p>
@@ -121,7 +121,7 @@ url4 serve`
       <strong>url4 SDK vs the ScreamingFace Client.</strong> This library is the low-level protocol:
       parse, build, and run url4. The
       <RouterLink to="/sf-client">ScreamingFace Client</RouterLink> (<code>screamingface</code>) is
-      the research-facing layer on top: it composes fusions and benchmarks, drives an Engine, and
+      the research-facing layer on top: it composes fusions and benchmarks, drives an engine, and
       reads back scored reports. Reach for the SDK when you are working with url4 itself; reach for
       the Client when you are running evaluations.
     </blockquote>

--- a/public-docs/src/pages/sf-client/FirstFusionPage.vue
+++ b/public-docs/src/pages/sf-client/FirstFusionPage.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const importCell = `import screamingface as sf`
+
+const build = `fusion = sf.Fusion(
+    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
+    synthesizer="anthropic/claude-opus-4-8",
+)`
+
+const run = `report = sf.evaluate(fusion, benchmark="ifeval", limit=3)`
+
+const read = `candidate = report.candidates.only
+candidate.score`
+</script>
+
+<template>
+  <DocLayout
+    title="Your first fusion"
+    description="Combine two models into one, run it on a benchmark, and read the score."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A fusion is a few models answering together, combined into one answer. In this tutorial you
+      build one, run it on a handful of benchmark cases, and read its score. It takes a few lines
+      and a couple of minutes.
+    </p>
+
+    <Note>
+      You need the Client installed and one provider connected first — see
+      <RouterLink to="/sf-client/installation">Installation</RouterLink> and
+      <RouterLink to="/sf-client/guides/connections">Connect a provider</RouterLink>. This tutorial
+      talks to the hosted engine, so once a provider is connected you are ready to go.
+    </Note>
+
+    <h2>1 · Import the library</h2>
+
+    <p>Everything you need hangs off the top-level <code>sf</code> module.</p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="importCell" />
+    </div>
+
+    <h2>2 · Build the fusion</h2>
+
+    <p>
+      Give <code>sf.Fusion</code> two model routes and a synthesizer. The two members answer the
+      same question in parallel; the synthesizer reads both drafts and writes the single answer that
+      gets graded. Here the second model plays both roles — a member and the synthesizer — which is
+      a fine way to start.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="build" />
+    </div>
+
+    <h2>3 · Run it</h2>
+
+    <p>
+      <code>sf.evaluate</code> runs your fusion against a benchmark and grades the answers.
+      <code>ifeval</code> checks whether a model follows instructions; <code>limit=3</code> runs
+      just three cases, so this stays quick and cheap while you are finding your feet.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="run" />
+    </div>
+
+    <h2>4 · Read the score</h2>
+
+    <p>
+      The run comes back as a <RouterLink to="/sf-client/api/reports">Report</RouterLink>. You gave
+      it one candidate, so <code>report.candidates.only</code> is your fusion, and its
+      <code>score</code> is the fraction of cases it got right — higher is better.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="read" />
+    </div>
+
+    <p>
+      That is a whole evaluation: compose, run, read. Nothing here was mocked — the same three steps
+      scale from three cases to a full benchmark.
+    </p>
+
+    <h2>Where to go next</h2>
+
+    <ul>
+      <li>
+        <strong><RouterLink to="/sf-client/guides/fusions">Compose a candidate</RouterLink></strong>
+        — weights, judges, and nesting fusions inside fusions.
+      </li>
+      <li>
+        <strong
+          ><RouterLink to="/sf-client/quickstartPage"
+            >Reproduce DRACO state-of-art</RouterLink
+          ></strong
+        >
+        — put a fusion up against its solo models on a real board.
+      </li>
+      <li>
+        <strong><RouterLink to="/sf-client/api/fusions">Fusion reference</RouterLink></strong> —
+        every field and argument, in full.
+      </li>
+    </ul>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/FirstFusionPage.vue
+++ b/public-docs/src/pages/sf-client/FirstFusionPage.vue
@@ -90,6 +90,14 @@ candidate.score`
       just three cases, so this stays quick and cheap while you are finding your feet.
     </p>
 
+    <Note>
+      <code>ifeval</code> is one of several benchmarks the engine publishes. Others include
+      <code>draco</code> (deep research) and <code>healthbench-worst30</code> (hard medical
+      conversations); list everything available with <code>sf.benchmarks.list()</code>, and see
+      <RouterLink to="/sf-client/guides/benchmarks">Choose a benchmark</RouterLink> for how to pick
+      one.
+    </Note>
+
     <div class="not-prose">
       <NbCell :count="4" :code="run" />
     </div>
@@ -109,6 +117,23 @@ candidate.score`
     <p>
       That is a whole evaluation: compose, run, read. Nothing here was mocked — the same three steps
       scale from three cases to a full benchmark.
+    </p>
+
+    <h2>How far this goes</h2>
+
+    <p>
+      What you built is a <strong>parallel fan-out</strong>: the members answer at once and a
+      synthesizer folds their drafts into one. That is one of two ways recipes compose. The other is
+      a <RouterLink to="/sf-client/api/pipelines">Pipeline</RouterLink>, the serial counterpart,
+      where each stage refines the previous stage's answer instead of running alongside it.
+    </p>
+
+    <p>
+      Recipes nest, so the reach is larger than it looks. A member, a synthesizer, or a pipeline
+      stage can itself be a <RouterLink to="/sf-client/api/fusions">Fusion</RouterLink> or a
+      Pipeline: a fusion of pipelines, a pipeline whose last stage is a fusion, a fusion whose
+      synthesizer is itself a fusion. Every one is built from those same two moves, parallel and
+      serial. Start flat, like here, and add depth when a task needs it.
     </p>
 
     <h2>Where to go next</h2>

--- a/public-docs/src/pages/sf-client/FirstFusionPage.vue
+++ b/public-docs/src/pages/sf-client/FirstFusionPage.vue
@@ -16,7 +16,7 @@ sf.connect("openrouter", api_key=os.environ["OPENROUTER_API_KEY"])
 sf.connect("anthropic", api_key=os.environ["ANTHROPIC_API_KEY"])`
 
 const build = `fusion = sf.Fusion(
-    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
+    ["openrouter/deepseek/deepseek-v4-pro", "anthropic/claude-opus-4-8"],
     synthesizer="anthropic/claude-opus-4-8",
 )`
 

--- a/public-docs/src/pages/sf-client/FirstFusionPage.vue
+++ b/public-docs/src/pages/sf-client/FirstFusionPage.vue
@@ -10,6 +10,11 @@ import {
 
 const importCell = `import screamingface as sf`
 
+const connect = `import os
+
+sf.connect("openrouter", api_key=os.environ["OPENROUTER_API_KEY"])
+sf.connect("anthropic", api_key=os.environ["ANTHROPIC_API_KEY"])`
+
 const build = `fusion = sf.Fusion(
     ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
     synthesizer="anthropic/claude-opus-4-8",
@@ -35,10 +40,12 @@ candidate.score`
     </p>
 
     <Note>
-      You need the Client installed and one provider connected first — see
-      <RouterLink to="/sf-client/installation">Installation</RouterLink> and
-      <RouterLink to="/sf-client/guides/connections">Connect a provider</RouterLink>. This tutorial
-      talks to the hosted engine, so once a provider is connected you are ready to go.
+      You need the Client installed (see
+      <RouterLink to="/sf-client/installation">Installation</RouterLink>) and API keys for
+      OpenRouter and Anthropic. This tutorial talks to the hosted engine and connects both providers
+      explicitly below; the
+      <RouterLink to="/sf-client/guides/connections">Connect a provider</RouterLink> guide covers
+      OAuth and the interactive panel.
     </Note>
 
     <h2>1 · Import the library</h2>
@@ -49,7 +56,20 @@ candidate.score`
       <NbCell :count="1" :code="importCell" />
     </div>
 
-    <h2>2 · Build the fusion</h2>
+    <h2>2 · Connect your providers</h2>
+
+    <p>
+      The fusion below uses one model from OpenRouter and one from Anthropic, so connect both. Each
+      call hands a key to the engine, which stores it encrypted and uses it to reach that provider;
+      the key never lands in your recipe or your report. Read keys from the environment rather than
+      pasting them into a cell.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="connect" />
+    </div>
+
+    <h2>3 · Build the fusion</h2>
 
     <p>
       Give <code>sf.Fusion</code> two model routes and a synthesizer. The two members answer the
@@ -59,10 +79,10 @@ candidate.score`
     </p>
 
     <div class="not-prose">
-      <NbCell :count="2" :code="build" />
+      <NbCell :count="3" :code="build" />
     </div>
 
-    <h2>3 · Run it</h2>
+    <h2>4 · Run it</h2>
 
     <p>
       <code>sf.evaluate</code> runs your fusion against a benchmark and grades the answers.
@@ -71,10 +91,10 @@ candidate.score`
     </p>
 
     <div class="not-prose">
-      <NbCell :count="3" :code="run" />
+      <NbCell :count="4" :code="run" />
     </div>
 
-    <h2>4 · Read the score</h2>
+    <h2>5 · Read the score</h2>
 
     <p>
       The run comes back as a <RouterLink to="/sf-client/api/reports">Report</RouterLink>. You gave
@@ -83,7 +103,7 @@ candidate.score`
     </p>
 
     <div class="not-prose">
-      <NbCell :count="4" :code="read" />
+      <NbCell :count="5" :code="read" />
     </div>
 
     <p>

--- a/public-docs/src/pages/sf-client/Index.vue
+++ b/public-docs/src/pages/sf-client/Index.vue
@@ -41,11 +41,11 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     :version="version"
   >
     <p>
-      ScreamingFace is an open-source Python client for composing model ensembles, which it calls
+      ScreamingFace is an open-source Python Client for composing model ensembles, which it calls
       <strong>fusions</strong>, and evaluating them against research benchmarks. You build a fusion
       from providers you already hold keys for, evaluate it, and read back a score together with
-      what the run cost. The benchmark answer keys and the grading stay on the engine and results are cached to lower
-      the cost of fusion exploration.
+      what the run cost. The benchmark answer keys and the grading stay on the engine and results
+      are cached to lower the cost of fusion exploration.
     </p>
 
     <p>
@@ -62,12 +62,12 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
       et al., Los Alamos).
     </p>
 
-    <h2>What the client gives you</h2>
+    <h2>What the Client gives you</h2>
 
     <ul>
       <li>
         <strong>Grading you did not perform yourself.</strong> Benchmark answer keys, rubrics, and
-        judges live on the engine and are never returned to the client, so a score does not rest on
+        judges live on the engine and are never returned to the Client, so a score does not rest on
         trusting whoever produced it.
       </li>
       <li>
@@ -102,16 +102,17 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     <h2>What url4 is</h2>
 
     <p>
-      A <strong>url4</strong> is a single-line expression following a given grammar and protocol, that describes a composed system: which models
-      take part, how their answers are combined, and what each one is asked to do. It serves as both
-      the record of what ran and the instruction for running it again, which is what lets a
-      published result carry its own method instead of describing it in prose.
+      A <strong>url4</strong> is a single-line expression following a given grammar and protocol,
+      that describes a composed system: which models take part, how their answers are combined, and
+      what each one is asked to do. It serves as both the record of what ran and the instruction for
+      running it again, which is what lets a published result carry its own method instead of
+      describing it in prose.
     </p>
 
     <h2>Two ways to run</h2>
 
     <p>
-      The client never calls a model provider itself. It sends work to an
+      The Client never calls a model provider itself. It sends work to an
       <RouterLink to="/learn/engine">engine</RouterLink>, which holds the credentials and the
       benchmark answer keys and performs the grading. You can point it at either of two.
     </p>
@@ -130,7 +131,7 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     </ul>
 
     <p>
-      Client code is identical either way and only the engine URL differs, so the decision is
+      The code you write is identical either way and only the engine URL differs, so the decision is
       reversible. The <RouterLink to="/sf-client/installation">Installation</RouterLink> guide
       covers both.
     </p>
@@ -150,7 +151,7 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     <h2>How it works</h2>
 
     <p>
-      The client compiles your recipe into one <strong>url4</strong> expression and hands it to the
+      The Client compiles your recipe into one <strong>url4</strong> expression and hands it to the
       <strong>engine</strong>. The engine resolves that expression, calls each model, applies the
       benchmark's grader, and streams usage back while the run proceeds. What returns is the set of
       scores, any failures, and the total cost. Because the url4 travels with the result, someone
@@ -160,12 +161,12 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     <figure class="not-prose diagram">
       <img
         :src="localDiagram(isDark)"
-        alt="Local request flow: the client compiles your recipe into one url4 expression and hands it to an engine on your own machine, which fans each model call out through the AI gateway to the providers you hold keys for and streams scores and cost back."
+        alt="Local request flow: the Client compiles your recipe into one url4 expression and hands it to an engine on your own machine, which fans each model call out through the AI gateway to the providers you hold keys for and streams scores and cost back."
       />
       <figcaption>
-        <strong>The local flow.</strong> The client compiles your recipe into one url4 expression and
-        hands it to an engine on your own machine; the engine fans model calls out through the gateway
-        to the providers you hold keys for, then streams scores and cost back.
+        <strong>The local flow.</strong> The Client compiles your recipe into one url4 expression
+        and hands it to an engine on your own machine; the engine fans model calls out through the
+        gateway to the providers you hold keys for, then streams scores and cost back.
       </figcaption>
     </figure>
   </DocLayout>

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -64,7 +64,7 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
 <template>
   <DocLayout
     title="Installation"
-    description="Install the client, and point it at an engine you run yourself, or a hosted one."
+    description="Install the Client, and point it at an engine you run yourself, or a hosted one."
     :navigation="navigation"
     :version="version"
   >
@@ -72,7 +72,7 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
 
     <ul>
       <li>
-        The <strong>client</strong>, a Python library. It never calls a model provider itself, so it
+        The <strong>Client</strong>, a Python library. It never calls a model provider itself, so it
         always needs an engine to talk to.
       </li>
       <li>
@@ -88,9 +88,9 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
       </li>
     </ul>
 
-    <p>The client code is the same either way, so pick whichever you prefer.</p>
+    <p>The code you write is the same either way, so pick whichever you prefer.</p>
 
-    <h2>1 · Install the client</h2>
+    <h2>1 · Install the Client</h2>
 
     <p>Python <strong>3.12 or newer</strong>. In a notebook, one cell:</p>
 
@@ -122,10 +122,10 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
     <CodeBlock :code="pypiRuntime" language="bash" />
 
     <p>
-      <code>[runtime]</code> is what turns the client install into a working engine: it brings in
+      <code>[runtime]</code> is what turns the Client install into a working engine: it brings in
       the server stack the local runtime needs, and it installs the
       <code>screamingface</code> command used in Option A. It is a much heavier install than the
-      client alone, so skip it if you are pointing at a hosted engine.
+      Client alone, so skip it if you are pointing at a hosted engine.
     </p>
 
     <p>A quick check that it worked:</p>
@@ -183,11 +183,15 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
     </p>
 
     <Note>
-      By default the client reads and writes the <strong>hosted ScreamingFace Leaderboard</strong> at
+      By default the Client reads and writes the
+      <strong>hosted ScreamingFace Leaderboard</strong> at
       <code>leaderboard.dev.screamingface.ai</code>, even when the rest of your stack is local.
       Override it the same way you set the engine — <code>sf.configure()</code> takes a
       <code>scoreboard_url</code> next to <code>engine_url</code>, so
-      <code>sf.configure(engine_url="http://127.0.0.1:9108", scoreboard_url="http://127.0.0.1:9106")</code>
+      <code
+        >sf.configure(engine_url="http://127.0.0.1:9108",
+        scoreboard_url="http://127.0.0.1:9106")</code
+      >
       points both at your local stack.
     </Note>
 
@@ -224,7 +228,7 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
       Benchmarks like DRACO ask candidates to research an answer, which means the model needs to
       search the web. <strong>Most of the time this is handled for you:</strong> most providers
       search natively, and the engine just asks them to. The exception is providers that offer no
-      web search of their own — <strong>Hugging Face</strong> routes in particular — where the engine
+      web search of their own, <strong>Hugging Face</strong> routes in particular, where the engine
       falls back to a <strong>bounded tool loop it runs against Tavily</strong>. Only those routes
       need a key.
     </p>
@@ -260,7 +264,7 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
       candidates are asked to follow instructions, not to look anything up.
     </p>
 
-    <h4>Point the client at it</h4>
+    <h4>Point the Client at it</h4>
 
     <div class="not-prose">
       <NbCell :count="2" :code="localPoint" />
@@ -271,7 +275,7 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
     <h3>Option B: Reach a hosted engine</h3>
 
     <p>
-      Prefer not to run anything yourself? Point the client at a hosted engine instead. Name it once
+      Prefer not to run anything yourself? Point the Client at a hosted engine instead. Name it once
       and every later call uses it.
     </p>
 
@@ -306,7 +310,7 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
 
     <Collapsible title='"Local runtime dependencies are missing" or command not found'>
       <p>
-        The client is installed but the engine is not. The <code>screamingface</code> command and
+        The Client is installed but the engine is not. The <code>screamingface</code> command and
         the server stack both come from the <code>[runtime]</code> extra:
       </p>
       <CodeBlock :code="pypiRuntime" language="bash" />

--- a/public-docs/src/pages/sf-client/QuickstartPage.vue
+++ b/public-docs/src/pages/sf-client/QuickstartPage.vue
@@ -276,9 +276,8 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
       By the end, you'll have a scored comparison of <strong>16 candidates</strong>: seven solo
       models and nine fusions built from those models, all on one
       <a href="https://arxiv.org/abs/2602.11685" target="_blank" rel="noopener">DRACO</a> case with
-      ten criteria and
-      one judge pass each. The whole thing runs as a single request of roughly 80 to 85 provider
-      calls.
+      ten criteria and one judge pass each. The whole thing runs as a single request of roughly 80
+      to 85 provider calls.
     </p>
 
     <blockquote>
@@ -293,8 +292,8 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     <p>
       The <RouterLink to="/learn/engine"><strong>ScreamingFace Engine</strong></RouterLink> is a
       separate process that holds your provider credentials, keeps the benchmark answer keys, calls
-      the models on your behalf, and does the grading. The client hands all of that work to it, so
-      this first step tells the client where to find the engine.
+      the models on your behalf, and does the grading. The Client hands all of that work to it, so
+      this first step tells the Client where to find the engine.
     </p>
 
     <div class="not-prose">
@@ -304,10 +303,10 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     <p>
       <code>sf.configure()</code> validates and stores the URL without making a network request. The
       example above points at a <strong>local engine</strong> on
-      <code>http://127.0.0.1:9108</code> — to run one yourself, install the <code>[runtime]</code>
-      extra and start the stack with <code>screamingface up</code>. The
-      <RouterLink to="/sf-client/installation">Installation</RouterLink> guide walks through that end
-      to end.
+      <code>http://127.0.0.1:9108</code> — to run one yourself, install the
+      <code>[runtime]</code> extra and start the stack with <code>screamingface up</code>. The
+      <RouterLink to="/sf-client/installation">Installation</RouterLink> guide walks through that
+      end to end.
     </p>
 
     <p>
@@ -364,16 +363,16 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 
     <blockquote>
       We're using OpenRouter here for simplicity, but you can build fusions with models from any of
-      the providers listed above. One caveat: <strong>caching is currently available only for
-      OpenRouter and Anthropic</strong>, so runs on the other providers aren't reused yet — extending
-      it to the rest is work in progress.
+      the providers listed above. One caveat:
+      <strong>caching is currently available only for OpenRouter and Anthropic</strong>, so runs on
+      the other providers aren't reused yet — extending it to the rest is work in progress.
     </blockquote>
 
     <h3>Configure OpenRouter via script</h3>
 
     <p>
-      Scripts skip the panel by naming the provider and passing the key directly. Pull the key from the
-      environment instead of hardcoding it.
+      Scripts skip the panel by naming the provider and passing the key directly. Pull the key from
+      the environment instead of hardcoding it.
     </p>
 
     <CodeBlock :code="connectScript" language="python" />
@@ -462,7 +461,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     <h2>4 · Look up the benchmark</h2>
 
     <p>
-      Benchmarks live on the engine, not in the client. Fetching one returns its identity and the
+      Benchmarks live on the engine, not in the Client. Fetching one returns its identity and the
       protocol revision it is pinned to, so you can see what you are about to be graded against
       before spending anything. This call is free.
     </p>
@@ -474,7 +473,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     <p>
       It does <strong>not</strong> download the actual questions. Cases are loaded engine-side at
       eval time. A gated dataset reads the <code>HF_TOKEN</code> from the <strong>engine's</strong>
-      environment, not the client's. Set it where the engine runs:
+      environment, not the Client's. Set it where the engine runs:
     </p>
 
     <ul>
@@ -486,7 +485,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
       </li>
       <li>
         <strong>Hosted engine:</strong> The operator sets the token, so gated datasets only work if
-        they've configured one. You can't pass it from the client.
+        they've configured one. You can't pass it from the Client.
       </li>
     </ul>
 
@@ -498,8 +497,8 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 
     <p>
       <code>draco/lite</code> is a reduced form of the full benchmark: one pinned case and ten
-      criteria spanning all four rubric sections, with a single judge pass per criterion. It runs the
-      same protocol as <code>draco</code>, which uses all 100 cases and five judge passes per
+      criteria spanning all four rubric sections, with a single judge pass per criterion. It runs
+      the same protocol as <code>draco</code>, which uses all 100 cases and five judge passes per
       criterion, so you can rehearse the full run at a small fraction of its cost.
     </p>
 
@@ -529,7 +528,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     </div>
 
     <p>
-      Before the first model call, the client checks the whole plan: that the benchmark agrees with
+      Before the first model call, the Client checks the whole plan: that the benchmark agrees with
       what the engine has, that every model route exists in the catalog, that the parameters you set
       are ones those models accept, and that each candidate compiles. Anything wrong with the plan
       raises <code>PlanningError</code>, which names the specific problem in its message; a provider
@@ -539,10 +538,10 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 
     <p>
       The panel updates live as the run proceeds. <code>MODELS</code> counts distinct answering
-      calls (ten, not sixteen, because shared members are computed once). <code>SYNTHESIS</code>
-      counts the nine synthesizers, <code>SCORING</code> the graded candidates, and
-      <code>RESULTS</code> the finalized ones. Progress moves on real grader results, never timers,
-      so if a counter stalls, work actually stalled.
+      calls (ten, not sixteen, because shared members are computed once).
+      <code>SYNTHESIS</code> counts the nine synthesizers, <code>SCORING</code> the graded
+      candidates, and <code>RESULTS</code> the finalized ones. Progress moves on real grader
+      results, never timers, so if a counter stalls, work actually stalled.
     </p>
 
     <blockquote>
@@ -553,10 +552,10 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     </blockquote>
 
     <p>
-      If a model fails, only the candidates using it are affected, and the rest still score. A failure
-      lowers that candidate's coverage instead of counting as zero, so a partial result looks
-      partial. Since every completed call is cached, re-running after a failure is free for work
-      that already succeeded, so you only pay for new, uncached calls.
+      If a model fails, only the candidates using it are affected, and the rest still score. A
+      failure lowers that candidate's coverage instead of counting as zero, so a partial result
+      looks partial. Since every completed call is cached, re-running after a failure is free for
+      work that already succeeded, so you only pay for new, uncached calls.
     </p>
 
     <h2>6 · Read the study</h2>
@@ -588,9 +587,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
         <strong>Coverage</strong>: How much of the case set produced a grade. Below 100% means
         something failed, and the score then covers only what completed.
       </li>
-      <li>
-        <strong>BEST</strong>: Marks the top scorer. Ties go to the first in declared order.
-      </li>
+      <li><strong>BEST</strong>: Marks the top scorer. Ties go to the first in declared order.</li>
     </ul>
 
     <h3>Reading it in code</h3>

--- a/public-docs/src/pages/sf-client/QuickstartPage.vue
+++ b/public-docs/src/pages/sf-client/QuickstartPage.vue
@@ -267,7 +267,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 
 <template>
   <DocLayout
-    title="Quickstart"
+    title="Reproduce DRACO state-of-art"
     description="Run a DRACO subset end to end to compare fusions with its solo models."
     :navigation="navigation"
     :version="version"

--- a/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
@@ -6,7 +6,7 @@ import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
@@ -25,27 +25,27 @@ const listRunOut = `[('draco', 100), ('draco/lite', 2), ('ifeval', 541), ('ifeva
     :version="version"
   >
     <p>
-      A benchmark is a fixed set of cases, owned by the Engine and pinned by a revision. This page
+      A benchmark is a fixed set of cases, owned by the engine and pinned by a revision. This page
       covers <code>Benchmark</code> itself, alongside <code>BenchmarkInfo</code> for the compact
       identity a report keeps of it. See the
       <RouterLink to="/sf-client/guides/benchmarks">Benchmarks guide</RouterLink> for choosing which
       benchmark to run, and the <RouterLink to="/sf-client/api/models">Models page</RouterLink> for
-      the model routes the Engine can run a benchmark against.
+      the model routes the engine can run a benchmark against.
     </p>
 
     <p>
-      A <RouterLink to="/sf-client/api/clients">Client</RouterLink> returns these values which are
-      all read-only and assigning to a field raises
+      A <RouterLink to="/sf-client/api/clients">Client</RouterLink> returns these values, which are
+      all read-only, and assigning to a field raises
       <code>FrozenInstanceError: cannot assign to field 'provider'</code>. They also never refresh
-      themselves and the Client needs to be called again when current data is desired.
+      themselves, so the Client needs to be called again when current data is desired.
     </p>
 
     <h2>Benchmark</h2>
 
     <p>
-      A <code>Benchmark</code> is the Engine's record of one benchmark, carrying its identity, its
+      A <code>Benchmark</code> is the engine's record of one benchmark, carrying its identity, its
       size, and what it measures. <code>client.benchmarks.get(id)</code> returns a single benchmark
-      and <code>client.benchmarks.list()</code> returns every benchmark the Engine offers. Protocol
+      and <code>client.benchmarks.list()</code> returns every benchmark the engine offers. Protocol
       variants are separate entries with their own ids, so the list holds <code>ifeval</code> beside
       <code>ifeval/self-corrective</code>.
     </p>
@@ -103,8 +103,8 @@ const listRunOut = `[('draco', 100), ('draco/lite', 2), ('ifeval', 541), ('ifeva
     </table>
 
     <Note>
-      A <code>Benchmark</code> carries no case data. The client cannot page a benchmark's prompts,
-      because the cases and their answer keys stay on the Engine. Case text becomes visible after a
+      A <code>Benchmark</code> carries no case data. The Client cannot page a benchmark's prompts,
+      because the cases and their answer keys stay on the engine. Case text becomes visible after a
       run, through the <code>CaseResult</code> values on
       <RouterLink to="/sf-client/api/reports">CandidateResult.cases</RouterLink>.
     </Note>
@@ -164,9 +164,6 @@ const listRunOut = `[('draco', 100), ('draco/lite', 2), ('ifeval', 541), ('ifeva
       <code>case_count</code> rejects zero and negative values:
     </p>
 
-    <CodeBlock
-      code="ValueError: Benchmark case_count must be a positive integer"
-      language="text"
-    />
+    <CodeBlock code="ValueError: Benchmark case_count must be a positive integer" language="text" />
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
+++ b/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
@@ -4,7 +4,7 @@ import DocLayout from '@/components/layout/DocLayout.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
+++ b/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
@@ -22,7 +22,7 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
 <template>
   <DocLayout
     title="CandidateResult"
-    description="One candidate's outcome, and the values it carries: MemberResult, OperationInfo, CaseResult."
+    description="One candidate's outcome and the values it carries — MemberResult, OperationInfo, CaseResult — and the CaseGrade tree behind each case score."
     :navigation="navigation"
     :version="version"
   >
@@ -180,6 +180,284 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
     <div class="not-prose">
       <NbCell :count="8" :code="cases"><NbTextOut :text="casesOut" /></NbCell>
     </div>
+
+    <h2>How a case is graded</h2>
+
+    <p>
+      A <code>CaseResult</code>'s <code>grade</code> is a <code>CaseGrade</code>, and it is the top
+      of a small tree. A grade holds ordered <code>Check</code>s; each check holds the
+      <code>Evidence</code> gathered for it; each piece of evidence names the
+      <code>EvidenceProducer</code> that observed it. Reading down takes you from one case score to
+      the exact observation a benchmark accepted or rejected.
+    </p>
+
+    <figure class="not-prose" style="margin: var(--space-8) 0">
+      <svg
+        viewBox="0 0 740 130"
+        role="img"
+        aria-label="A CaseGrade holds many ordered Checks; each Check holds the Evidence gathered for it; each Evidence names the one EvidenceProducer that observed it."
+        style="width: 100%; height: auto; font-family: var(--f-mono)"
+      >
+        <defs>
+          <marker
+            id="cg-arrow"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+
+        <rect
+          x="8"
+          y="40"
+          width="150"
+          height="54"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="83" y="64" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          CaseGrade
+        </text>
+        <text x="83" y="82" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          the case score
+        </text>
+
+        <rect
+          x="204"
+          y="40"
+          width="150"
+          height="54"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="279" y="64" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          Check
+        </text>
+        <text x="279" y="82" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          one rule
+        </text>
+
+        <rect
+          x="400"
+          y="40"
+          width="150"
+          height="54"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="475" y="64" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          Evidence
+        </text>
+        <text x="475" y="82" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          one observation
+        </text>
+
+        <rect
+          x="580"
+          y="40"
+          width="152"
+          height="54"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="656" y="64" text-anchor="middle" style="fill: var(--text); font-size: 11px">
+          EvidenceProducer
+        </text>
+        <text x="656" y="82" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          the observer
+        </text>
+
+        <g style="stroke: var(--text-2); stroke-width: 1; fill: none">
+          <path d="M158 67 H204" marker-end="url(#cg-arrow)" />
+          <path d="M354 67 H400" marker-end="url(#cg-arrow)" />
+          <path d="M550 67 H580" marker-end="url(#cg-arrow)" />
+        </g>
+        <text x="181" y="59" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          many
+        </text>
+        <text x="377" y="59" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          many
+        </text>
+        <text x="565" y="59" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          one
+        </text>
+      </svg>
+    </figure>
+
+    <h2>CaseGrade</h2>
+
+    <p>
+      The aggregate for one case: a <code>score</code>, the <code>method</code> that produced it,
+      and the ordered <code>Check</code>s it was built from.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>method</code></td>
+          <td><code>str</code></td>
+          <td>How the score was produced.</td>
+        </tr>
+        <tr>
+          <td><code>score</code></td>
+          <td><code>float&nbsp;|&nbsp;None</code></td>
+          <td>The case's score, or <code>None</code> when no aggregate was available.</td>
+        </tr>
+        <tr>
+          <td><code>checks</code></td>
+          <td><code>tuple[Check, ...]</code></td>
+          <td>The ordered checks behind the score.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Check</h2>
+
+    <p>
+      One ordered grading check and all the <code>Evidence</code> gathered for it. The benchmark
+      owns the check; the client only reports what it returned, so match on <code>id</code> rather
+      than on <code>label</code>.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>type</code></td>
+          <td><code>str</code></td>
+          <td>The check's kind.</td>
+        </tr>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>Identifies the check within the case. The stable value to match on.</td>
+        </tr>
+        <tr>
+          <td><code>label</code></td>
+          <td><code>str</code></td>
+          <td>A human-readable description of what it checks.</td>
+        </tr>
+        <tr>
+          <td><code>evidence</code></td>
+          <td><code>tuple[Evidence, ...]</code></td>
+          <td>The observations gathered for it, in sequence order.</td>
+        </tr>
+        <tr>
+          <td><code>outcome</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            <code>MET</code> or <code>UNMET</code>, or <code>None</code> when it produced no
+            verdict.
+          </td>
+        </tr>
+        <tr>
+          <td><code>score</code></td>
+          <td><code>float&nbsp;|&nbsp;None</code></td>
+          <td>The check's own score, where it has one.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Evidence</h2>
+
+    <p>
+      One exact observation a check accepted or rejected. When <code>valid</code> is
+      <code>False</code> the observation could not be read, so it carries no
+      <code>outcome</code> and no <code>explanation</code> — that state records a gap rather than a
+      verdict.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>sequence</code></td>
+          <td><code>int</code></td>
+          <td>Position within the check, unique and 1-based. This is the true order.</td>
+        </tr>
+        <tr>
+          <td><code>producer</code></td>
+          <td><code>EvidenceProducer</code></td>
+          <td>What observed it.</td>
+        </tr>
+        <tr>
+          <td><code>valid</code></td>
+          <td><code>bool</code></td>
+          <td>Whether the observation could be read at all.</td>
+        </tr>
+        <tr>
+          <td><code>outcome</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            <code>MET</code>, <code>UNMET</code>, <code>PASS</code> or <code>FAIL</code>. Unset on
+            invalid evidence.
+          </td>
+        </tr>
+        <tr>
+          <td><code>explanation</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Why, when the producer gave a reason. Unset on invalid evidence.</td>
+        </tr>
+        <tr>
+          <td><code>raw_output</code></td>
+          <td><code>object</code></td>
+          <td>The producer's raw output, as it was returned.</td>
+        </tr>
+        <tr>
+          <td><code>metadata</code></td>
+          <td><code>Mapping</code></td>
+          <td>Anything else recorded with the observation.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>EvidenceProducer</h2>
+
+    <p>
+      The producer the Engine credits with one observation — what looked at the output and reported.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>type</code></td>
+          <td><code>str</code></td>
+          <td>The kind of producer, such as the grader that ran.</td>
+        </tr>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>Identifies the producer.</td>
+        </tr>
+      </tbody>
+    </table>
 
     <h2>MemberResult</h2>
 

--- a/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
+++ b/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
@@ -60,7 +60,10 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
         <tr>
           <td><code>kind</code></td>
           <td><code>str</code></td>
-          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
+          <td>
+            One of <code>model</code>, <code>fusion</code>, <code>pipeline</code>,
+            <code>corrective_loop</code> or <code>self_corrective</code>.
+          </td>
         </tr>
         <tr>
           <td><code>score</code></td>
@@ -125,8 +128,9 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
           <td><code>members</code></td>
           <td><code>tuple[MemberResult, ...]</code></td>
           <td>
-            Direct members, for a fusion. Always empty for a <code>model</code> or
-            <code>pipeline</code> candidate, and at least one entry for a fusion.
+            The candidate's direct members. Always empty for a <code>model</code>,
+            <code>pipeline</code> or <code>self_corrective</code> candidate; at least one entry for
+            a <code>fusion</code>; at least two for a <code>corrective_loop</code>.
           </td>
         </tr>
         <tr>
@@ -180,6 +184,137 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
     <div class="not-prose">
       <NbCell :count="8" :code="cases"><NbTextOut :text="casesOut" /></NbCell>
     </div>
+
+    <h2>CaseResult</h2>
+
+    <p>
+      A <code>CaseResult</code> is the complete retained result for one selected case. Its
+      <code>status</code> records the closed outcome, and the remaining fields carry the prompt, the
+      answer, the grade, and anything that went wrong. A scored case carries an
+      <code>output</code> and a numeric <code>grade</code> and no failures; a refused case carries a
+      <code>refusal</code> and no output; a failed case carries <code>failures</code> and no numeric
+      grade.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>status</code></td>
+          <td><code>str</code></td>
+          <td>
+            The closed outcome: <code>scored</code>, <code>refused</code> or <code>failed</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>case_id</code></td>
+          <td><code>int&nbsp;|&nbsp;str</code></td>
+          <td>The benchmark's identifier for this case.</td>
+        </tr>
+        <tr>
+          <td><code>input</code></td>
+          <td><code>str</code></td>
+          <td>The case prompt as it was sent, structured multi-turn cases included.</td>
+        </tr>
+        <tr>
+          <td><code>output</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>The candidate's answer, or <code>None</code> when it refused or failed.</td>
+        </tr>
+        <tr>
+          <td><code>finish_reason</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Why generation stopped, when the engine reported it.</td>
+        </tr>
+        <tr>
+          <td><code>refusal</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>The provider's refusal message, set only on a refused case.</td>
+        </tr>
+        <tr>
+          <td><code>stop_reason</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            For a multi-round case, why the loop stopped: <code>passed</code> or
+            <code>max_rounds</code>. <code>None</code> for a single-round case.
+          </td>
+        </tr>
+        <tr>
+          <td><code>rounds_executed</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>
+            How many rounds ran, present together with <code>stop_reason</code> and
+            <code>None</code> otherwise.
+          </td>
+        </tr>
+        <tr>
+          <td><code>grade</code></td>
+          <td><code>CaseGrade&nbsp;|&nbsp;None</code></td>
+          <td>The grade behind the case score. <code>None</code> when the case was not graded.</td>
+        </tr>
+        <tr>
+          <td><code>failures</code></td>
+          <td><code>tuple[Failure, ...]</code></td>
+          <td>This case's own failures, each naming this case. Empty when nothing went wrong.</td>
+        </tr>
+        <tr>
+          <td><code>operations</code></td>
+          <td><code>tuple[CaseOperation, ...]&nbsp;|&nbsp;None</code></td>
+          <td>
+            The per-operation outputs captured during the run, or <code>None</code> when the engine
+            attributed none. See <a href="#case-operation">CaseOperation</a> below.
+          </td>
+        </tr>
+        <tr>
+          <td><code>metadata</code></td>
+          <td><code>Mapping[str, object]</code></td>
+          <td>Anything else the engine recorded with the case. Empty when it recorded nothing.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 id="case-operation">CaseOperation</h2>
+
+    <p>
+      A <code>CaseOperation</code> carries one operation's captured terminal output for a case: the
+      member or synthesis text the engine attributed to that step's stable operation id, so a
+      fusion's contribution can be read back from a saved report. Its <code>output</code> and
+      <code>finish_reason</code> stay <code>None</code> when the engine could not attribute the
+      output unambiguously. Reach these through <code>CaseResult.operations</code>.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>operation_id</code></td>
+          <td><code>str</code></td>
+          <td>The step this output belongs to, matching an <code>OperationInfo.id</code>.</td>
+        </tr>
+        <tr>
+          <td><code>output</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>The step's terminal output, or <code>None</code> when it was not attributed.</td>
+        </tr>
+        <tr>
+          <td><code>finish_reason</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Why that step stopped, or <code>None</code> when it was not attributed.</td>
+        </tr>
+      </tbody>
+    </table>
 
     <h2>How a case is graded</h2>
 
@@ -494,7 +629,10 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
         <tr>
           <td><code>kind</code></td>
           <td><code>str</code></td>
-          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
+          <td>
+            One of <code>model</code>, <code>fusion</code>, <code>pipeline</code>,
+            <code>corrective_loop</code> or <code>self_corrective</code>.
+          </td>
         </tr>
         <tr>
           <td><code>models</code></td>

--- a/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
+++ b/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
@@ -22,7 +22,7 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
 <template>
   <DocLayout
     title="CandidateResult"
-    description="One candidate's outcome and the values it carries — MemberResult, OperationInfo, CaseResult — and the CaseGrade tree behind each case score."
+    description="One candidate's outcome and the values it carries (MemberResult, OperationInfo, CaseResult), and the CaseGrade tree behind each case score."
     :navigation="navigation"
     :version="version"
   >
@@ -74,7 +74,7 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
           <td><code>float</code></td>
           <td>
             How much of the selected case set the score was computed from, between 0 and 1. Below
-            <code>1.0</code> the Engine excluded ungraded cases and the score is a partial result
+            <code>1.0</code> the engine excluded ungraded cases and the score is a partial result
             over the rest.
           </td>
         </tr>
@@ -323,7 +323,7 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
 
     <p>
       One ordered grading check and all the <code>Evidence</code> gathered for it. The benchmark
-      owns the check; the client only reports what it returned, so match on <code>id</code> rather
+      owns the check; the Client only reports what it returned, so match on <code>id</code> rather
       than on <code>label</code>.
     </p>
 
@@ -434,7 +434,7 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
     <h2>EvidenceProducer</h2>
 
     <p>
-      The producer the Engine credits with one observation — what looked at the output and reported.
+      The producer the engine credits with one observation: what looked at the output and reported.
     </p>
 
     <table>
@@ -468,7 +468,7 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
     </p>
 
     <p>
-      Its runtime fields are <code>None</code> until the Engine attributes work to the member's
+      Its runtime fields are <code>None</code> until the engine attributes work to the member's
       operation id. That is a different statement from an empty value: <code>None</code> means the
       attribution was unavailable, while an empty tuple means it arrived and reported nothing.
     </p>
@@ -511,13 +511,13 @@ const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haik
           <td><code>tuple[Failure, ...]&nbsp;|&nbsp;None</code></td>
           <td>
             This member's failures, which also appear in <code>report.failures</code>.
-            <code>None</code> when the Engine attributed nothing to this member.
+            <code>None</code> when the engine attributed nothing to this member.
           </td>
         </tr>
         <tr>
           <td><code>duration_ms</code></td>
           <td><code>int&nbsp;|&nbsp;None</code></td>
-          <td>How long the member took, when the Engine reported it.</td>
+          <td>How long the member took, when the engine reported it.</td>
         </tr>
         <tr>
           <td><code>usage</code></td>

--- a/public-docs/src/pages/sf-client/api/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ClientsPage.vue
@@ -7,7 +7,7 @@ import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
 import { SF_ENGINE_URL } from '@/lib/engine'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ClientsPage.vue
@@ -69,11 +69,11 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
     :version="version"
   >
     <p>
-      A <code>Client</code> is the connection to one Engine, and the object that every other page in
+      A <code>Client</code> is the connection to one engine, and the object that every other page in
       this reference depends on: recipes are passed to it, and benchmarks and reports come back from
       it. This page covers <code>Client</code> itself, alongside <code>AsyncClient</code> for the
       same interface over <code>await</code>, <code>Connection</code> for a provider's state on the
-      Engine, and <code>ConnectionPanel</code> for the interactive view that
+      engine, and <code>ConnectionPanel</code> for the interactive view that
       <code>connect()</code> returns.
     </p>
 
@@ -83,7 +83,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
 
     <p>
       Creating a <code>Client</code> opens no connection and makes no request. The first call that
-      needs the Engine is the first one that talks to it.
+      needs the engine is the first one that talks to it.
     </p>
 
     <div class="not-prose">
@@ -91,11 +91,11 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
     </div>
 
     <Note>
-      <code>DEFAULT_ENGINE_URL</code> is a hosted Engine, so a <code>Client()</code> with no
-      arguments talks to one we operate. To use a local Engine, pass its address explicitly, or set
+      <code>DEFAULT_ENGINE_URL</code> is a hosted engine, so a <code>Client()</code> with no
+      arguments talks to one we operate. To use a local engine, pass its address explicitly, or set
       <code>SCREAMINGFACE_ENGINE_URL</code> and use the module-level functions.
-      <code>DEFAULT_SCOREBOARD_URL</code> is the matching hosted ScreamingFace Leaderboard. Both constants live in
-      <code>screamingface.client</code>.
+      <code>DEFAULT_SCOREBOARD_URL</code> is the matching hosted ScreamingFace Leaderboard. Both
+      constants live in <code>screamingface.client</code>.
     </Note>
 
     <h3>Properties</h3>
@@ -112,7 +112,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
         <tr>
           <td><code>engine_url</code></td>
           <td><code>str</code></td>
-          <td>The Engine origin this Client was built for. Fixed for the Client's life.</td>
+          <td>The engine origin this Client was built for. Fixed for the Client's life.</td>
         </tr>
         <tr>
           <td><code>closed</code></td>
@@ -134,7 +134,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
           <td><code>str</code></td>
           <td>
             Where <RouterLink to="/sf-client/guides/leaderboards">leaderboard</RouterLink>
-            submissions go. Separate from the Engine, and separately configurable.
+            submissions go. Separate from the engine, and separately configurable.
           </td>
         </tr>
         <tr>
@@ -142,7 +142,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
           <td>catalogue</td>
           <td>
             <code>models.list()</code> returns the
-            <RouterLink to="/sf-client/api/benchmarks">ModelInfo</RouterLink> routes this Engine can
+            <RouterLink to="/sf-client/api/benchmarks">ModelInfo</RouterLink> routes this engine can
             reach.
           </td>
         </tr>
@@ -222,14 +222,14 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
     <h3>connect() and disconnect()</h3>
 
     <p>
-      <code>connect(provider, api_key=...)</code> stores a provider credential on the Engine and
+      <code>connect(provider, api_key=...)</code> stores a provider credential on the engine and
       returns the resulting <code>Connection</code>. <code>connect()</code> with no arguments
       returns a <code>ConnectionPanel</code> instead. <code>disconnect(provider)</code> removes the
       credential and is safe to call repeatedly.
     </p>
 
     <p>
-      Passing a key requires a secure origin: an <code>https</code> Engine, or a local one over
+      Passing a key requires a secure origin: an <code>https</code> engine, or a local one over
       <code>http</code>. Supplying <code>api_key</code> without a provider raises
       <code>TypeError</code>; a provider without <code>api_key</code> raises
       <code>ValueError</code>.
@@ -253,8 +253,8 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
     <CodeBlock :code="withBlock" language="python" />
 
     <p>
-      <code>login(timeout=300.0)</code> and <code>logout()</code> apply to hosted Engines that sit
-      behind browser-based access. A local Engine needs neither.
+      <code>login(timeout=300.0)</code> and <code>logout()</code> apply to hosted engines that sit
+      behind browser-based access. A local engine needs neither.
     </p>
 
     <h2>AsyncClient</h2>
@@ -302,7 +302,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
     <h2>Connection</h2>
 
     <p>
-      A <code>Connection</code> is sanitized provider state as the Engine reports it. It never
+      A <code>Connection</code> is sanitized provider state as the engine reports it. It never
       carries the credential itself, so an API key cannot be read back out of one.
     </p>
 
@@ -365,7 +365,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
 
     <p>
       A <code>ConnectionPanel</code> is what <code>client.connect()</code> returns when called with
-      no arguments: a live view of every provider the Engine knows about. Within a notebook it
+      no arguments: a live view of every provider the engine knows about. Within a notebook it
       renders as an interactive widget, allowing a key to be pasted without placing it in a cell.
       Outside a notebook it remains readable as a value.
     </p>
@@ -384,7 +384,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
       <tbody>
         <tr>
           <td><code>engine</code></td>
-          <td>The Engine origin this panel is bound to.</td>
+          <td>The engine origin this panel is bound to.</td>
         </tr>
         <tr>
           <td><code>connections</code></td>
@@ -396,7 +396,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
         </tr>
         <tr>
           <td><code>refresh()</code></td>
-          <td>Re-read connections from the Engine and return them.</td>
+          <td>Re-read connections from the engine and return them.</td>
         </tr>
         <tr>
           <td><code>widget()</code></td>

--- a/public-docs/src/pages/sf-client/api/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ClientsPage.vue
@@ -53,28 +53,22 @@ async def main():
 
 asyncio.run(main())`
 const asyncOut = `(29, '${SF_ENGINE_URL}')`
-
-const connection = `client.connections.get("openrouter")`
-const connectionOut = `Connection(provider='openrouter', display_name='OpenRouter', auth_methods=('api_key',), status='connected', auth_method='api_key', account_label=None)`
-
-const panel = `client.connect()`
-const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connected)`
 </script>
 
 <template>
   <DocLayout
     title="Clients"
-    description="Client, AsyncClient, and provider connections."
+    description="Client and AsyncClient — how you reach an engine."
     :navigation="navigation"
     :version="version"
   >
     <p>
       A <code>Client</code> is the connection to one engine, and the object that every other page in
       this reference depends on: recipes are passed to it, and benchmarks and reports come back from
-      it. This page covers <code>Client</code> itself, alongside <code>AsyncClient</code> for the
-      same interface over <code>await</code>, <code>Connection</code> for a provider's state on the
-      engine, and <code>ConnectionPanel</code> for the interactive view that
-      <code>connect()</code> returns.
+      it. This page covers <code>Client</code> itself and <code>AsyncClient</code> for the same
+      interface over <code>await</code>. The connection values it returns — <code>Connection</code>,
+      the OAuth flows, and <code>ConnectionPanel</code> — are documented under
+      <RouterLink to="/sf-client/api/connections">Connections</RouterLink>.
     </p>
 
     <h2>Client</h2>
@@ -297,121 +291,6 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
       <code>evaluate()</code>, <code>connect()</code>, <code>disconnect()</code>,
       <code>login()</code> and <code>logout()</code> are all awaited. The properties
       (<code>engine_url</code>, <code>closed</code>, <code>authenticated</code>) are not.
-    </p>
-
-    <h2>Connection</h2>
-
-    <p>
-      A <code>Connection</code> is sanitized provider state as the engine reports it. It never
-      carries the credential itself, so an API key cannot be read back out of one.
-    </p>
-
-    <div class="not-prose">
-      <NbCell :count="4" :code="connection"><NbTextOut :text="connectionOut" /></NbCell>
-    </div>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>provider</code></td>
-          <td><code>str</code></td>
-          <td>Identifier, such as <code>openrouter</code>.</td>
-        </tr>
-        <tr>
-          <td><code>display_name</code></td>
-          <td><code>str</code></td>
-          <td>Human-readable name, such as <code>OpenRouter</code>.</td>
-        </tr>
-        <tr>
-          <td><code>auth_methods</code></td>
-          <td><code>tuple[str, ...]</code></td>
-          <td>
-            What this provider supports: <code>api_key</code>, <code>oauth</code>, or both. Never
-            empty.
-          </td>
-        </tr>
-        <tr>
-          <td><code>status</code></td>
-          <td><code>str</code></td>
-          <td>
-            One of <code>disconnected</code>, <code>pending</code>, <code>connected</code>,
-            <code>needs_reauth</code> or <code>error</code>.
-          </td>
-        </tr>
-        <tr>
-          <td><code>auth_method</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>
-            Which method is in use, or <code>None</code> when not connected. Always one of
-            <code>auth_methods</code>.
-          </td>
-        </tr>
-        <tr>
-          <td><code>account_label</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>Which account, where the provider identifies one.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h2>ConnectionPanel</h2>
-
-    <p>
-      A <code>ConnectionPanel</code> is what <code>client.connect()</code> returns when called with
-      no arguments: a live view of every provider the engine knows about. Within a notebook it
-      renders as an interactive widget, allowing a key to be pasted without placing it in a cell.
-      Outside a notebook it remains readable as a value.
-    </p>
-
-    <div class="not-prose">
-      <NbCell :count="5" :code="panel"><NbTextOut :text="panelOut" /></NbCell>
-    </div>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Member</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>engine</code></td>
-          <td>The engine origin this panel is bound to.</td>
-        </tr>
-        <tr>
-          <td><code>connections</code></td>
-          <td>The <code>Connection</code> values as of the last refresh.</td>
-        </tr>
-        <tr>
-          <td><code>authenticated</code> / <code>authenticating</code></td>
-          <td>Mirror the Client's login state.</td>
-        </tr>
-        <tr>
-          <td><code>refresh()</code></td>
-          <td>Re-read connections from the engine and return them.</td>
-        </tr>
-        <tr>
-          <td><code>widget()</code></td>
-          <td>The notebook widget, when you want to place it yourself.</td>
-        </tr>
-        <tr>
-          <td><code>close()</code></td>
-          <td>Release the panel's background work. It does not close the Client.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <p>
-      See the <RouterLink to="/sf-client/guides/connections">Connections guide</RouterLink> for
-      choosing between the panel and a direct <code>connect()</code> call.
     </p>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/api/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ConnectionsPage.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const panel = `panel = sf.connect()
+panel.connections`
+</script>
+
+<template>
+  <DocLayout
+    title="Connections"
+    description="The provider-connection values: Connection, the OAuth flows, and the interactive panel."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      The values the connections API hands back — from <code>sf.connections</code> /
+      <code>client.connections</code> and
+      <RouterLink to="/sf-client/api/modules">sf.connect() / sf.disconnect()</RouterLink>. For the
+      walkthrough, see the
+      <RouterLink to="/sf-client/guides/connections">Connections guide</RouterLink>.
+    </p>
+
+    <h2>Connection</h2>
+
+    <p>Sanitized provider state as the engine reports it.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>provider</code></td>
+          <td><code>str</code></td>
+          <td>The provider id.</td>
+        </tr>
+        <tr>
+          <td><code>display_name</code></td>
+          <td><code>str</code></td>
+          <td>Its human-readable name.</td>
+        </tr>
+        <tr>
+          <td><code>auth_methods</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>The methods it offers: <code>api_key</code>, <code>oauth</code>, or both.</td>
+        </tr>
+        <tr>
+          <td><code>status</code></td>
+          <td><code>str</code></td>
+          <td>
+            One of <code>not_connected</code>, <code>pending</code>, <code>connected</code>,
+            <code>needs_reauth</code>, <code>error</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>auth_method</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>The method currently in use, when connected.</td>
+        </tr>
+        <tr>
+          <td><code>account_label</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>The connected account, where the provider reports one.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>OAuthFlow</h2>
+
+    <p>
+      The pending browser authorization returned by
+      <code>connect(provider, method="oauth")</code>.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>provider</code></td>
+          <td><code>str</code></td>
+          <td>Which provider is being authorized.</td>
+        </tr>
+        <tr>
+          <td><code>authorize_url</code></td>
+          <td><code>str</code></td>
+          <td>Open this to authorize.</td>
+        </tr>
+        <tr>
+          <td><code>expires_in</code></td>
+          <td><code>int</code></td>
+          <td>Seconds the flow stays valid.</td>
+        </tr>
+        <tr>
+          <td><code>status</code></td>
+          <td><code>str</code></td>
+          <td><code>pending</code> until it resolves.</td>
+        </tr>
+        <tr>
+          <td><code>wait(*, poll_interval=0.5, timeout=None)</code></td>
+          <td><code>Connection</code></td>
+          <td>Block until the browser flow completes, then return the <code>Connection</code>.</td>
+        </tr>
+        <tr>
+          <td><code>cancel()</code></td>
+          <td><code>Connection</code></td>
+          <td>Abandon the flow.</td>
+        </tr>
+        <tr>
+          <td><code>expired</code></td>
+          <td><code>bool</code></td>
+          <td>Whether the authorization window has passed.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>AsyncOAuthFlow</h2>
+
+    <p>
+      The async form of <code>OAuthFlow</code>: <code>await flow.wait(...)</code> and
+      <code>await flow.cancel(...)</code>; the same fields and the same <code>expired</code> check.
+    </p>
+
+    <h2>ConnectionPanel</h2>
+
+    <p>
+      An engine-scoped connection view with optional notebook controls, returned by
+      <code>connect()</code> with no arguments.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>engine</code></td>
+          <td><code>str</code></td>
+          <td>The engine origin the panel is bound to.</td>
+        </tr>
+        <tr>
+          <td><code>connections</code></td>
+          <td><code>tuple[Connection, ...]</code></td>
+          <td>Every provider the engine advertises, connected or not.</td>
+        </tr>
+        <tr>
+          <td><code>authenticated</code></td>
+          <td><code>bool</code></td>
+          <td>Whether a hosted-engine login is in effect.</td>
+        </tr>
+        <tr>
+          <td><code>authenticating</code></td>
+          <td><code>bool</code></td>
+          <td>Whether a login is in progress.</td>
+        </tr>
+        <tr>
+          <td><code>refresh()</code></td>
+          <td><code>tuple[Connection, ...]</code></td>
+          <td>Re-read connections from the engine and return them.</td>
+        </tr>
+        <tr>
+          <td><code>widget()</code></td>
+          <td></td>
+          <td>The notebook widget for interactive connect/disconnect.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="panel" />
+    </div>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ConnectionsPage.vue
@@ -3,7 +3,7 @@ import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/ErrorsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ErrorsPage.vue
@@ -34,12 +34,12 @@ with warnings.catch_warnings():
 <template>
   <DocLayout
     title="Errors"
-    description="What the client raises, and the warnings it emits when a run completes with a caveat."
+    description="What the Client raises, and the warnings it emits when a run completes with a caveat."
     :navigation="navigation"
     :version="version"
   >
     <p>
-      Everything the client raises on purpose inherits from <code>ScreamingFaceError</code>, so one
+      Everything the Client raises on purpose inherits from <code>ScreamingFaceError</code>, so one
       <code>except</code> catches the lot. Six subclasses say where the failure happened, and each
       carries a machine-readable code alongside its message.
     </p>
@@ -87,21 +87,21 @@ Warning
           <td><code>PlanningError</code></td>
           <td>
             An evaluation could not be resolved or validated safely, so nothing ran and nothing was
-            charged. A route the Engine does not carry, or a benchmark id that does not exist.
+            charged. A route the engine does not carry, or a benchmark id that does not exist.
           </td>
         </tr>
         <tr>
           <td><code>ExecutionError</code></td>
-          <td>A run reached the Engine and ended without a valid report.</td>
+          <td>A run reached the engine and ended without a valid report.</td>
         </tr>
         <tr>
           <td><code>EngineUnavailableError</code></td>
-          <td>The configured Engine could not be reached at all.</td>
+          <td>The configured engine could not be reached at all.</td>
         </tr>
         <tr>
           <td><code>AuthenticationError</code></td>
           <td>
-            The Engine rejected caller authentication. On a hosted Engine this usually means
+            The engine rejected caller authentication. On a hosted engine this usually means
             <code>login()</code> is needed.
           </td>
         </tr>
@@ -199,7 +199,7 @@ Warning
 
     <p>
       A warning means the run <em>completed</em>. It produced a report you can read, but something
-      about its quality needs attention. <code>EvaluationWarning</code> is the one the client emits,
+      about its quality needs attention. <code>EvaluationWarning</code> is the one the Client emits,
       and it subclasses <code>UserWarning</code>, so it appears in normal warning output and
       <code>warnings.simplefilter</code> controls it.
     </p>

--- a/public-docs/src/pages/sf-client/api/ErrorsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ErrorsPage.vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const catchAll = `import screamingface as sf
+
+try:
+    report = sf.evaluate(recipe, benchmark="ifeval", limit=1)
+except sf.ScreamingFaceError as exc:
+    print(exc.code, exc.retryable, exc.hint)`
+
+const attrs = `e = sf.PlanningError("boom", code="model_unavailable", permanent=True)
+e.code, e.retryable, e.permanent, e.hint`
+const attrsOut = `('model_unavailable', False, True, None)`
+
+const real = `client.models.get("antigravity/gemini-3-flash")`
+const realOut = `ProviderConnectionError: Antigravity profile 'default' is not connected`
+
+const warn = `import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("error", sf.EvaluationWarning)
+    report = sf.evaluate(recipe, benchmark="draco", limit=1)`
+</script>
+
+<template>
+  <DocLayout
+    title="Errors"
+    description="What the client raises, and the warnings it emits when a run completes with a caveat."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      Everything the client raises on purpose inherits from <code>ScreamingFaceError</code>, so one
+      <code>except</code> catches the lot. Six subclasses say where the failure happened, and each
+      carries a machine-readable code alongside its message.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="catchAll" />
+    </div>
+
+    <h2>The hierarchy</h2>
+
+    <CodeBlock
+      code="Exception
+└── ScreamingFaceError
+    ├── AuthenticationError
+    ├── EngineUnavailableError
+    ├── ExecutionError
+    ├── LeaderboardError
+    ├── PlanningError
+    └── ProviderConnectionError
+
+Warning
+└── UserWarning
+    └── EvaluationWarning"
+      language="text"
+    />
+
+    <h2>Errors</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Class</th>
+          <th>Raised when</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>ScreamingFaceError</code></td>
+          <td>
+            Never directly. It is the base for expected failures at the public interface, and the
+            one to catch when you do not care which.
+          </td>
+        </tr>
+        <tr>
+          <td><code>PlanningError</code></td>
+          <td>
+            An evaluation could not be resolved or validated safely, so nothing ran and nothing was
+            charged. A route the Engine does not carry, or a benchmark id that does not exist.
+          </td>
+        </tr>
+        <tr>
+          <td><code>ExecutionError</code></td>
+          <td>A run reached the Engine and ended without a valid report.</td>
+        </tr>
+        <tr>
+          <td><code>EngineUnavailableError</code></td>
+          <td>The configured Engine could not be reached at all.</td>
+        </tr>
+        <tr>
+          <td><code>AuthenticationError</code></td>
+          <td>
+            The Engine rejected caller authentication. On a hosted Engine this usually means
+            <code>login()</code> is needed.
+          </td>
+        </tr>
+        <tr>
+          <td><code>ProviderConnectionError</code></td>
+          <td>
+            A provider connection could not be read or updated safely, including a key the provider
+            refuses.
+          </td>
+        </tr>
+        <tr>
+          <td><code>LeaderboardError</code></td>
+          <td>
+            A <RouterLink to="/sf-client/api/leaderboards">scoreboard</RouterLink> operation could
+            not be completed safely.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      <code>PlanningError</code> is the one worth distinguishing: it means the run never started, so
+      the fix is to change the candidate, benchmark or configuration and try again at no cost.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="real"><NbTextOut :text="realOut" /></NbCell>
+    </div>
+
+    <h2>What an error carries</h2>
+
+    <p>
+      The six subclasses share a diagnostic shape, so you can branch on a stable value rather than
+      on message text.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Attribute</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>code</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Stable identifier such as <code>model_unavailable</code>. Match on this, never on
+            <code>message</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>message</code> · <code>user_message</code></td>
+          <td><code>str</code></td>
+          <td>What went wrong, and the form intended for display.</td>
+        </tr>
+        <tr>
+          <td><code>retryable</code></td>
+          <td><code>bool</code></td>
+          <td>
+            Whether the same call could plausibly succeed again. The inverse of
+            <code>permanent</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>permanent</code></td>
+          <td><code>bool&nbsp;|&nbsp;None</code></td>
+          <td>Whether retrying is pointless.</td>
+        </tr>
+        <tr>
+          <td><code>hint</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>A suggested next step, where one applies.</td>
+        </tr>
+        <tr>
+          <td><code>status</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>The HTTP status behind the failure, when there was one.</td>
+        </tr>
+        <tr>
+          <td><code>details</code></td>
+          <td><code>object</code></td>
+          <td>Structured context, such as which model routes were missing.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="attrs"><NbTextOut :text="attrsOut" /></NbCell>
+    </div>
+
+    <h2>Warnings</h2>
+
+    <p>
+      A warning means the run <em>completed</em>. It produced a report you can read, but something
+      about its quality needs attention. <code>EvaluationWarning</code> is the one the client emits,
+      and it subclasses <code>UserWarning</code>, so it appears in normal warning output and
+      <code>warnings.simplefilter</code> controls it.
+    </p>
+
+    <Note>
+      A warning does not invalidate a report. It means the score is less well supported than the
+      same benchmark would normally give. Promote it to an error if that matters to you.
+    </Note>
+
+    <div class="not-prose">
+      <NbCell :count="4" :code="warn" />
+    </div>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/ErrorsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ErrorsPage.vue
@@ -115,7 +115,7 @@ Warning
         <tr>
           <td><code>LeaderboardError</code></td>
           <td>
-            A <RouterLink to="/sf-client/api/leaderboards">scoreboard</RouterLink> operation could
+            A <RouterLink to="/sf-client/api/leaderboards">leaderboard</RouterLink> operation could
             not be completed safely.
           </td>
         </tr>

--- a/public-docs/src/pages/sf-client/api/ErrorsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ErrorsPage.vue
@@ -6,7 +6,7 @@ import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/EventsPage.vue
+++ b/public-docs/src/pages/sf-client/api/EventsPage.vue
@@ -107,7 +107,7 @@ const filter = `def observe(event: sf.Event) -> None:
 
     <h2>Started</h2>
 
-    <p>A URL4 operation began executing. It adds one field:</p>
+    <p>A url4 operation began executing. It adds one field:</p>
 
     <table>
       <thead>
@@ -222,8 +222,8 @@ const filter = `def observe(event: sf.Event) -> None:
 
     <Note>
       Two distinct types are called Usage. This one is the event.
-      <RouterLink to="/sf-client/api/reports">sf.Usage</RouterLink> is the accounting value, and it
-      is what this event's own <code>usage</code> field holds.
+      <RouterLink to="/sf-client/api/usage">sf.Usage</RouterLink> is the accounting value, and it is
+      what this event's own <code>usage</code> field holds.
     </Note>
 
     <p>Cost and token accounting, reported as the run spends rather than at the end.</p>
@@ -242,7 +242,7 @@ const filter = `def observe(event: sf.Event) -> None:
           <td><code>Usage</code></td>
           <td>
             The accounting value itself, with the same fields as
-            <RouterLink to="/sf-client/api/reports">report.usage</RouterLink>.
+            <RouterLink to="/sf-client/api/usage">report.usage</RouterLink>.
           </td>
         </tr>
         <tr>

--- a/public-docs/src/pages/sf-client/api/EventsPage.vue
+++ b/public-docs/src/pages/sf-client/api/EventsPage.vue
@@ -4,7 +4,7 @@ import DocLayout from '@/components/layout/DocLayout.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/EventsPage.vue
+++ b/public-docs/src/pages/sf-client/api/EventsPage.vue
@@ -1,0 +1,336 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const watch = `import screamingface as sf
+
+def observe(event: sf.Event) -> None:
+    print(event.kind, event.sequence, event.source)
+
+sf.evaluate(recipe, benchmark="ifeval", limit=1, on_event=observe, progress=False)`
+
+const filter = `def observe(event: sf.Event) -> None:
+    if isinstance(event, sf.events.Usage):
+        print(event.model, event.usage.output_tokens, event.usage.cost_usd)`
+</script>
+
+<template>
+  <DocLayout
+    title="Events"
+    description="What a run reports through on_event while it is still running."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      Passing <code>on_event</code> to
+      <RouterLink to="/sf-client/api/clients">evaluate()</RouterLink> gives you a callback that
+      fires as the run proceeds, rather than waiting for the
+      <RouterLink to="/sf-client/api/reports">Report</RouterLink> at the end. It is how a progress
+      display, a log, or a running cost total is built.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="watch" />
+    </div>
+
+    <p>
+      Four event types arrive: <code>Started</code>, <code>Span</code>, <code>Log</code> and
+      <code>Usage</code>, with <code>Terminated</code> last. <code>Event</code> is their shared base
+      and <code>TerminationError</code> is a value one of them carries.
+    </p>
+
+    <h2>Event</h2>
+
+    <p>
+      The base every event inherits. These fields are present on all of them, so a callback can sort
+      and correlate without knowing which kind it received.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>kind</code></td>
+          <td><code>str</code></td>
+          <td>
+            Which type this is: <code>started</code>, <code>span</code>, <code>log</code>,
+            <code>usage</code> or <code>terminated</code>. A class attribute, not a field.
+          </td>
+        </tr>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>Identifies this event.</td>
+        </tr>
+        <tr>
+          <td><code>run_id</code></td>
+          <td><code>str</code></td>
+          <td>
+            Which run emitted it. Several candidates run concurrently, so this is what separates
+            them.
+          </td>
+        </tr>
+        <tr>
+          <td><code>sequence</code></td>
+          <td><code>int</code></td>
+          <td>Order within the run. Events can arrive out of order; this is the true order.</td>
+        </tr>
+        <tr>
+          <td><code>timestamp</code></td>
+          <td><code>datetime</code></td>
+          <td>When it happened.</td>
+        </tr>
+        <tr>
+          <td><code>source</code></td>
+          <td><code>str</code></td>
+          <td>Which part of the system emitted it.</td>
+        </tr>
+        <tr>
+          <td><code>traceparent</code> · <code>tracestate</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>W3C trace context, for stitching these into your own tracing.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Started</h2>
+
+    <p>A URL4 operation began executing. It adds one field:</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>url4</code></td>
+          <td><code>str</code></td>
+          <td>The expression that is about to run.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Span</h2>
+
+    <p>
+      One OpenTelemetry span with portable GenAI attributes. This is the event that says what a
+      model call cost in time and tokens.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code> · <code>operation</code></td>
+          <td><code>str</code></td>
+          <td>What the span covers, and which operation it belongs to.</td>
+        </tr>
+        <tr>
+          <td><code>start</code> · <code>end</code></td>
+          <td><code>datetime&nbsp;|&nbsp;None</code></td>
+          <td>When it opened and closed. Both unset while it is still open.</td>
+        </tr>
+        <tr>
+          <td><code>status</code> · <code>span_kind</code></td>
+          <td><code>str</code></td>
+          <td>How it finished, and what sort of span it is.</td>
+        </tr>
+        <tr>
+          <td><code>provider</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Which provider served the call.</td>
+        </tr>
+        <tr>
+          <td><code>request_model</code> · <code>response_model</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            What was asked for and what answered. They differ when a provider silently substitutes.
+          </td>
+        </tr>
+        <tr>
+          <td><code>input_tokens</code> · <code>output_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Token counts for this call alone.</td>
+        </tr>
+        <tr>
+          <td><code>finish_reasons</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Why generation stopped.</td>
+        </tr>
+        <tr>
+          <td><code>refusal</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Set when the model declined to answer.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Log</h2>
+
+    <p>One log record from the run.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>body</code></td>
+          <td><code>str</code></td>
+          <td>The message.</td>
+        </tr>
+        <tr>
+          <td><code>severity_text</code></td>
+          <td><code>str</code></td>
+          <td>The level as a name.</td>
+        </tr>
+        <tr>
+          <td><code>severity_number</code></td>
+          <td><code>int</code></td>
+          <td>The same level as a number, which is what you compare against.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Usage</h2>
+
+    <Note>
+      Two distinct types are called Usage. This one is the event.
+      <RouterLink to="/sf-client/api/reports">sf.Usage</RouterLink> is the accounting value, and it
+      is what this event's own <code>usage</code> field holds.
+    </Note>
+
+    <p>Cost and token accounting, reported as the run spends rather than at the end.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>usage</code></td>
+          <td><code>Usage</code></td>
+          <td>
+            The accounting value itself, with the same fields as
+            <RouterLink to="/sf-client/api/reports">report.usage</RouterLink>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>scope</code></td>
+          <td><code>str</code></td>
+          <td>
+            <code>self</code> for this operation alone, or <code>subtree</code> for it and
+            everything beneath it. Summing both double-counts.
+          </td>
+        </tr>
+        <tr>
+          <td><code>provider</code> · <code>model</code></td>
+          <td><code>str</code></td>
+          <td>Who was billed and for which model.</td>
+        </tr>
+        <tr>
+          <td><code>pricing_version</code></td>
+          <td><code>str</code></td>
+          <td>Which price list produced the cost.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="filter" />
+    </div>
+
+    <h2>Terminated</h2>
+
+    <p>The run reached its terminal state. This is the last event.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>status</code></td>
+          <td><code>str</code></td>
+          <td>
+            One of <code>succeeded</code>, <code>failed</code>, <code>stopped</code> or
+            <code>timed_out</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>error</code></td>
+          <td><code>TerminationError&nbsp;|&nbsp;None</code></td>
+          <td>Why it failed, when it did.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>TerminationError</h2>
+
+    <p>
+      The structured failure a <code>Terminated</code> event carries. It is a plain value, not an
+      exception, and not something you raise or catch.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>code</code></td>
+          <td><code>str</code></td>
+          <td>Stable identifier to match on.</td>
+        </tr>
+        <tr>
+          <td><code>message</code></td>
+          <td><code>str</code></td>
+          <td>What went wrong.</td>
+        </tr>
+        <tr>
+          <td><code>permanent</code></td>
+          <td><code>bool</code></td>
+          <td>Whether retrying is pointless.</td>
+        </tr>
+      </tbody>
+    </table>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/api/FusionsPage.vue
@@ -17,8 +17,8 @@ const fusionSig = `sf.Fusion(
 )`
 
 const fusionExample = `fusion = sf.Fusion(
-    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
-    synthesizer="anthropic/claude-opus-4-8",
+    ["openrouter/deepseek/deepseek-v4-pro", "openrouter/z-ai/glm-5.2"],
+    synthesizer="openrouter/moonshotai/kimi-k3",
 )
 report = sf.evaluate(fusion, benchmark="ifeval", limit=1)`
 </script>

--- a/public-docs/src/pages/sf-client/api/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/api/FusionsPage.vue
@@ -5,7 +5,7 @@ import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/api/FusionsPage.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const fusionSig = `sf.Fusion(
+    members: Sequence[str | Recipe],
+    *,
+    name: str | None = None,
+    synthesizer: str | Recipe,
+)`
+
+const fusionExample = `fusion = sf.Fusion(
+    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
+    synthesizer="anthropic/claude-opus-4-8",
+)
+report = sf.evaluate(fusion, benchmark="ifeval", limit=1)`
+</script>
+
+<template>
+  <DocLayout
+    title="Fusion"
+    description="Combine parallel members into one answer through a synthesizer."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A Fusion is a <RouterLink to="/sf-client/api/recipes">Recipe</RouterLink> that runs several
+      members in parallel and combines their answers with an explicit synthesizer. Like every recipe
+      it is frozen and holds no Client, so you can build it before connecting. The
+      <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink> walks through building
+      one.
+    </p>
+
+    <CodeBlock :code="fusionSig" language="python" />
+
+    <table>
+      <thead>
+        <tr>
+          <th>Attribute</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>
+            The fusion's name. Inferred by joining member names with <code>+</code> unless you pass
+            one.
+          </td>
+        </tr>
+        <tr>
+          <td><code>members</code></td>
+          <td><code>tuple[Recipe, ...]</code></td>
+          <td>The members that run in parallel. At least one.</td>
+        </tr>
+        <tr>
+          <td><code>synthesizer</code></td>
+          <td><code>Recipe</code></td>
+          <td>The recipe that combines the members' answers into the single graded answer.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Note>
+      Members and the synthesizer are themselves recipes, so any of them can be a
+      <code>Model</code>, another <code>Fusion</code>, or a
+      <RouterLink to="/sf-client/api/pipelines">Pipeline</RouterLink>, nested in any combination.
+      Only the synthesizer's final answer is graded.
+    </Note>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="fusionExample" />
+    </div>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
@@ -175,9 +175,9 @@ client.leaderboards.submit(report.candidates.only)`
           <td>When it was published, and by whom where that is recorded.</td>
         </tr>
         <tr>
-          <td><code>verified_by_openmined</code></td>
+          <td><code>verified_by_screamingface</code></td>
           <td><code>bool</code></td>
-          <td>Whether OpenMined re-ran the entry and confirmed the score.</td>
+          <td>Whether ScreamingFace re-ran the entry and confirmed the score.</td>
         </tr>
       </tbody>
     </table>
@@ -295,9 +295,9 @@ client.leaderboards.submit(report.candidates.only)`
           <td>When it was published, and by whom.</td>
         </tr>
         <tr>
-          <td><code>verified_by_openmined</code></td>
+          <td><code>verified_by_screamingface</code></td>
           <td><code>bool</code></td>
-          <td>Whether OpenMined re-ran it and confirmed the score.</td>
+          <td>Whether ScreamingFace re-ran it and confirmed the score.</td>
         </tr>
         <tr>
           <td><code>metadata</code></td>

--- a/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
@@ -35,7 +35,7 @@ client.leaderboards.submit(report.candidates.only)`
     </p>
 
     <Note>
-      These are the only values that do not come from the Engine. They come from the leaderboard, a
+      These are the only values that do not come from the engine. They come from the leaderboard, a
       separate service set by <code>scoreboard_url</code> on a
       <RouterLink to="/sf-client/api/clients">Client</RouterLink>.
     </Note>
@@ -74,7 +74,7 @@ client.leaderboards.submit(report.candidates.only)`
         <tr>
           <td><code>baselines</code></td>
           <td><code>tuple[LeaderboardBaseline, ...]</code></td>
-          <td>Published results imported for comparison, not submitted through the client.</td>
+          <td>Published results imported for comparison, not submitted through the Client.</td>
         </tr>
       </tbody>
     </table>
@@ -186,7 +186,7 @@ client.leaderboards.submit(report.candidates.only)`
 
     <p>
       A published result imported for comparison. Baselines are not submissions and carry no url4,
-      because nobody ran them through this client.
+      because nobody ran them through this Client.
     </p>
 
     <table>

--- a/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
@@ -5,7 +5,7 @@ import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
@@ -35,7 +35,7 @@ client.leaderboards.submit(report.candidates.only)`
     </p>
 
     <Note>
-      These are the only values that do not come from the Engine. They come from the scoreboard, a
+      These are the only values that do not come from the Engine. They come from the leaderboard, a
       separate service set by <code>scoreboard_url</code> on a
       <RouterLink to="/sf-client/api/clients">Client</RouterLink>.
     </Note>
@@ -308,7 +308,7 @@ client.leaderboards.submit(report.candidates.only)`
     </table>
 
     <p>
-      A scoreboard call that cannot be completed safely raises
+      A leaderboard call that cannot be completed safely raises
       <RouterLink to="/sf-client/api/errors">LeaderboardError</RouterLink>.
     </p>
   </DocLayout>

--- a/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
@@ -123,7 +123,7 @@ client.leaderboards.submit(report.candidates.only)`
     <h2>LeaderboardEntry</h2>
 
     <p>
-      One ranked row. Every entry carries the URL4 that produced it, so any position on the board
+      One ranked row. Every entry carries the url4 that produced it, so any position on the board
       can be re-executed rather than taken on trust.
     </p>
 
@@ -185,7 +185,7 @@ client.leaderboards.submit(report.candidates.only)`
     <h2>LeaderboardBaseline</h2>
 
     <p>
-      A published result imported for comparison. Baselines are not submissions and carry no URL4,
+      A published result imported for comparison. Baselines are not submissions and carry no url4,
       because nobody ran them through this client.
     </p>
 

--- a/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
@@ -1,0 +1,315 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const listRun = `import screamingface as sf
+
+client = sf.Client()
+[(b.id, b.display_name) for b in client.leaderboards.list()]`
+const listRunOut = `[('draco/smoke', 'DRACO Smoke')]`
+
+const submit = `report = client.evaluate(recipe, benchmark="ifeval", limit=1)
+client.leaderboards.submit(report.candidates.only)`
+</script>
+
+<template>
+  <DocLayout
+    title="Leaderboards"
+    description="The public board: what it holds, and what a submission records."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A leaderboard is the public ranking for one benchmark. This page covers
+      <code>Leaderboard</code> itself, alongside <code>LeaderboardInfo</code> for a board's
+      identity, <code>LeaderboardEntry</code> for a ranked row, <code>LeaderboardBaseline</code> for
+      a published number to measure against, and <code>LeaderboardScore</code> for the full record a
+      submission creates.
+    </p>
+
+    <Note>
+      These are the only values that do not come from the Engine. They come from the scoreboard, a
+      separate service set by <code>scoreboard_url</code> on a
+      <RouterLink to="/sf-client/api/clients">Client</RouterLink>.
+    </Note>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="listRun"><NbTextOut :text="listRunOut" /></NbCell>
+    </div>
+
+    <h2>Leaderboard</h2>
+
+    <p>
+      One board, returned by <code>client.leaderboards.get(benchmark_id, top=50)</code>. It holds
+      the ranking and the published numbers side by side, so a submitted result can be read against
+      what the literature reports.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>benchmark</code></td>
+          <td><code>LeaderboardInfo</code></td>
+          <td>Which board this is.</td>
+        </tr>
+        <tr>
+          <td><code>entries</code></td>
+          <td><code>tuple[LeaderboardEntry, ...]</code></td>
+          <td>The ranking, capped by the <code>top</code> argument.</td>
+        </tr>
+        <tr>
+          <td><code>baselines</code></td>
+          <td><code>tuple[LeaderboardBaseline, ...]</code></td>
+          <td>Published results imported for comparison, not submitted through the client.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>LeaderboardInfo</h2>
+
+    <p>A board's identity, and what <code>list()</code> returns.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>The benchmark id this board ranks, including its variant.</td>
+        </tr>
+        <tr>
+          <td><code>display_name</code></td>
+          <td><code>str</code></td>
+          <td>The board's name.</td>
+        </tr>
+        <tr>
+          <td><code>description</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>What it measures.</td>
+        </tr>
+        <tr>
+          <td><code>dataset_url</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Where the underlying dataset lives.</td>
+        </tr>
+        <tr>
+          <td><code>created_at</code></td>
+          <td><code>datetime</code></td>
+          <td>When the board was created.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>LeaderboardEntry</h2>
+
+    <p>
+      One ranked row. Every entry carries the URL4 that produced it, so any position on the board
+      can be re-executed rather than taken on trust.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>rank</code></td>
+          <td><code>int</code></td>
+          <td>Position on the board.</td>
+        </tr>
+        <tr>
+          <td><code>spec_id</code></td>
+          <td><code>str</code></td>
+          <td>Identifies the candidate that produced the result.</td>
+        </tr>
+        <tr>
+          <td><code>accuracy</code></td>
+          <td><code>float</code></td>
+          <td>The score it is ranked by.</td>
+        </tr>
+        <tr>
+          <td><code>total_questions</code></td>
+          <td><code>int</code></td>
+          <td>How many cases the result covered.</td>
+        </tr>
+        <tr>
+          <td><code>ran_with_providers</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Which providers served the run.</td>
+        </tr>
+        <tr>
+          <td><code>url4</code></td>
+          <td><code>Url4</code></td>
+          <td>
+            The expression that produced it. Pass it to
+            <RouterLink to="/sf-client/api/clients">evaluate()</RouterLink> to reproduce the entry.
+          </td>
+        </tr>
+        <tr>
+          <td><code>submitted_at</code> · <code>submitted_by</code></td>
+          <td><code>datetime</code> / <code>str&nbsp;|&nbsp;None</code></td>
+          <td>When it was published, and by whom where that is recorded.</td>
+        </tr>
+        <tr>
+          <td><code>verified_by_openmined</code></td>
+          <td><code>bool</code></td>
+          <td>Whether OpenMined re-ran the entry and confirmed the score.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>LeaderboardBaseline</h2>
+
+    <p>
+      A published result imported for comparison. Baselines are not submissions and carry no URL4,
+      because nobody ran them through this client.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>model_name</code></td>
+          <td><code>str</code></td>
+          <td>What the published number is for.</td>
+        </tr>
+        <tr>
+          <td><code>accuracy</code></td>
+          <td><code>float</code></td>
+          <td>The reported score.</td>
+        </tr>
+        <tr>
+          <td><code>source</code> · <code>source_url</code></td>
+          <td><code>str</code> / <code>str&nbsp;|&nbsp;None</code></td>
+          <td>Where the number was published.</td>
+        </tr>
+        <tr>
+          <td><code>benchmark_id</code></td>
+          <td><code>str</code></td>
+          <td>Which board it belongs to.</td>
+        </tr>
+        <tr>
+          <td><code>id</code> · <code>imported_at</code> · <code>metadata</code></td>
+          <td><code>UUID</code> / <code>datetime</code> / <code>Mapping&nbsp;|&nbsp;None</code></td>
+          <td>Identity, when it was imported, and anything else recorded with it.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>LeaderboardScore</h2>
+
+    <p>
+      The stored record a submission creates, returned by both <code>submit()</code> and
+      <code>get_score(score_id)</code>. It keeps more than the board shows: where an entry has a
+      rank and a score, a score has the full provenance of the run behind it.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="submit" />
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code> · <code>version</code></td>
+          <td><code>UUID</code> / <code>int</code></td>
+          <td>Identifies the stored score, and which revision of it this is.</td>
+        </tr>
+        <tr>
+          <td><code>benchmark_id</code> · <code>spec_id</code></td>
+          <td><code>str</code></td>
+          <td>What was evaluated, and against which board.</td>
+        </tr>
+        <tr>
+          <td><code>accuracy</code></td>
+          <td><code>float</code></td>
+          <td>The score.</td>
+        </tr>
+        <tr>
+          <td><code>total_questions</code> · <code>correct_questions</code></td>
+          <td><code>int</code></td>
+          <td>How many cases ran, and how many were correct.</td>
+        </tr>
+        <tr>
+          <td><code>url4</code></td>
+          <td><code>Url4</code></td>
+          <td>The expression that produced the score.</td>
+        </tr>
+        <tr>
+          <td><code>ran_with_providers</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Which providers served the run.</td>
+        </tr>
+        <tr>
+          <td><code>ran_at_local</code></td>
+          <td><code>datetime&nbsp;|&nbsp;None</code></td>
+          <td>When it ran on the submitter's machine.</td>
+        </tr>
+        <tr>
+          <td>
+            <code>client_name</code> · <code>client_version</code> · <code>client_platform</code>
+          </td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>What submitted it, which matters when results disagree.</td>
+        </tr>
+        <tr>
+          <td><code>submitted_at</code> · <code>submitted_by</code></td>
+          <td><code>datetime</code> / <code>str&nbsp;|&nbsp;None</code></td>
+          <td>When it was published, and by whom.</td>
+        </tr>
+        <tr>
+          <td><code>verified_by_openmined</code></td>
+          <td><code>bool</code></td>
+          <td>Whether OpenMined re-ran it and confirmed the score.</td>
+        </tr>
+        <tr>
+          <td><code>metadata</code></td>
+          <td><code>Mapping&nbsp;|&nbsp;None</code></td>
+          <td>Anything else recorded with the submission.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      A scoreboard call that cannot be completed safely raises
+      <RouterLink to="/sf-client/api/errors">LeaderboardError</RouterLink>.
+    </p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
@@ -36,7 +36,7 @@ const modelSig = `sf.Model(
   >
     <p>
       This page documents the <code>Model</code> recipe class you build, and the read-only
-      <strong>discovery types</strong> the Engine returns when you inspect what a route supports.
+      <strong>discovery types</strong> the engine returns when you inspect what a route supports.
     </p>
 
     <h2 id="model">Model</h2>
@@ -146,9 +146,9 @@ const modelSig = `sf.Model(
     <p>
       These are the read-only values model discovery returns.
       <code>client.models.list()</code> hands back a <code>ModelInfo</code> for every route the
-      configured Engine can currently reach, and <code>client.models.get(id)</code> returns the
+      configured engine can currently reach, and <code>client.models.get(id)</code> returns the
       fuller <code>ModelDetails</code> profile for one route. Consulting them before naming a route
-      in a <a href="#model">Model</a> is worthwhile: a route the Engine does not carry raises a
+      in a <a href="#model">Model</a> is worthwhile: a route the engine does not carry raises a
       <code>PlanningError</code> at evaluation time rather than at construction time.
     </p>
 
@@ -161,9 +161,9 @@ const modelSig = `sf.Model(
     <h2>ModelInfo</h2>
 
     <p>
-      A <code>ModelInfo</code> is one model route the configured Engine can currently reach.
+      A <code>ModelInfo</code> is one model route the configured engine can currently reach.
       <code>client.models.list()</code> returns every addressable route, and consulting it before
-      naming a route in a <a href="#model">Model</a> is worthwhile: a route the Engine does not
+      naming a route in a <a href="#model">Model</a> is worthwhile: a route the engine does not
       carry raises a <code>PlanningError</code> at evaluation time rather than at construction time.
     </p>
 

--- a/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
@@ -5,7 +5,7 @@ import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
@@ -235,9 +235,37 @@ const modelSig = `sf.Model(
           <td>Which provider serves the route.</td>
         </tr>
         <tr>
+          <td><code>upstream_id</code></td>
+          <td><code>str</code></td>
+          <td>The provider's own id for the route, before canonicalization.</td>
+        </tr>
+        <tr>
+          <td><code>contract_id</code></td>
+          <td><code>str</code></td>
+          <td>Identifies the capability contract this profile was built from.</td>
+        </tr>
+        <tr>
           <td><code>scope</code></td>
           <td><code>str</code></td>
           <td>What the route does, such as <code>chat</code>.</td>
+        </tr>
+        <tr>
+          <td><code>auth_mode</code></td>
+          <td><code>str</code></td>
+          <td>
+            The authentication mode this profile applies under: <code>api_key</code>,
+            <code>oauth</code> or <code>none</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>context_revision</code></td>
+          <td><code>str</code></td>
+          <td>The revision of the discovery context this profile was resolved against.</td>
+        </tr>
+        <tr>
+          <td><code>source_revision</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>The revision of the provider source it came from, when known.</td>
         </tr>
         <tr>
           <td><code>parameters</code></td>
@@ -253,6 +281,35 @@ const modelSig = `sf.Model(
           <td><code>transport</code></td>
           <td><code>Mapping[str, ModelCapability]</code></td>
           <td>Each transport capability, keyed by name.</td>
+        </tr>
+        <tr>
+          <td><code>observed_at</code></td>
+          <td><code>datetime&nbsp;|&nbsp;None</code></td>
+          <td>
+            When the profile was observed, as a timezone-aware value. <code>None</code> on a
+            degraded profile.
+          </td>
+        </tr>
+        <tr>
+          <td><code>expires_at</code></td>
+          <td><code>datetime&nbsp;|&nbsp;None</code></td>
+          <td>
+            When the observation window ends. Present together with <code>observed_at</code> and
+            <code>None</code> otherwise.
+          </td>
+        </tr>
+        <tr>
+          <td><code>stale</code></td>
+          <td><code>bool</code></td>
+          <td>Whether the profile is past its observation window and should be refetched.</td>
+        </tr>
+        <tr>
+          <td><code>degraded</code></td>
+          <td><code>bool</code></td>
+          <td>
+            Whether the profile was served without a fresh observation. Mutually exclusive with
+            <code>stale</code>.
+          </td>
         </tr>
       </tbody>
     </table>
@@ -317,7 +374,7 @@ const modelSig = `sf.Model(
         </tr>
         <tr>
           <td><code>provider_deprecated</code></td>
-          <td><code>bool</code></td>
+          <td><code>bool&nbsp;|&nbsp;None</code></td>
           <td>Whether the provider has deprecated the parameter.</td>
         </tr>
         <tr>
@@ -330,12 +387,12 @@ const modelSig = `sf.Model(
         </tr>
         <tr>
           <td><code>gateway_projection</code></td>
-          <td><code>str</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
           <td>How the gateway projects the value onto the request it sends.</td>
         </tr>
         <tr>
           <td><code>gateway_reason</code></td>
-          <td><code>str</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
           <td>Why the gateway is in that state, when it has a reason to give.</td>
         </tr>
         <tr>
@@ -354,6 +411,70 @@ const modelSig = `sf.Model(
     <p>
       It also carries one read-only property, <code>enabled</code>, which is <code>True</code> when
       <code>gateway_status == "enabled"</code>.
+    </p>
+
+    <h2>ModelParameterSchema</h2>
+
+    <p>
+      A <code>ModelParameterSchema</code> is the bounded value schema the gateway applies to one
+      request parameter: its type and whatever constraints the provider published. It is the type of
+      <code>ModelParameter.schema</code>. Only the fields that constrain the declared
+      <code>type</code> are set; the rest stay <code>None</code>.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>type</code></td>
+          <td><code>str&nbsp;|&nbsp;tuple[str, ...]</code></td>
+          <td>
+            The allowed value type, such as <code>number</code> or <code>string</code>, or a tuple
+            when more than one is accepted.
+          </td>
+        </tr>
+        <tr>
+          <td><code>minimum</code></td>
+          <td><code>float&nbsp;|&nbsp;None</code></td>
+          <td>The lowest allowed value, for a numeric type.</td>
+        </tr>
+        <tr>
+          <td><code>maximum</code></td>
+          <td><code>float&nbsp;|&nbsp;None</code></td>
+          <td>The highest allowed value, for a numeric type.</td>
+        </tr>
+        <tr>
+          <td><code>enum</code></td>
+          <td><code>tuple[str, ...]&nbsp;|&nbsp;None</code></td>
+          <td>The closed set of allowed values, when the parameter is restricted to one.</td>
+        </tr>
+        <tr>
+          <td><code>items</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>The element type each array entry must be, for an array type.</td>
+        </tr>
+        <tr>
+          <td><code>pattern</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>An anchored regular expression a string value must match.</td>
+        </tr>
+        <tr>
+          <td><code>max_length</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>The longest allowed string length.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      It also carries a <code>validate(value)</code> method that raises <code>ValueError</code> when
+      a value violates the published schema, and returns <code>None</code> otherwise.
     </p>
 
     <h2>ModelCapability</h2>

--- a/public-docs/src/pages/sf-client/api/ModulesPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModulesPage.vue
@@ -67,7 +67,7 @@ const evaluateSig = `sf.evaluate(
         <tr>
           <td><code>list()</code></td>
           <td>
-            Every <RouterLink to="/sf-client/api/benchmarks">Benchmark</RouterLink> the Engine
+            Every <RouterLink to="/sf-client/api/benchmarks">Benchmark</RouterLink> the engine
             offers, one entry per protocol variant.
           </td>
         </tr>
@@ -91,7 +91,7 @@ const evaluateSig = `sf.evaluate(
         <tr>
           <td><code>list()</code></td>
           <td>
-            Every <RouterLink to="/sf-client/api/models">ModelInfo</RouterLink> route the Engine can
+            Every <RouterLink to="/sf-client/api/models">ModelInfo</RouterLink> route the engine can
             reach.
           </td>
         </tr>
@@ -124,7 +124,7 @@ const evaluateSig = `sf.evaluate(
           <td><code>list()</code></td>
           <td>
             A <RouterLink to="/sf-client/api/clients">Connection</RouterLink> for every provider the
-            Engine advertises, connected or not.
+            engine advertises, connected or not.
           </td>
         </tr>
         <tr>
@@ -137,7 +137,7 @@ const evaluateSig = `sf.evaluate(
     <h2>sf.leaderboards</h2>
 
     <p>
-      Alone among the four, this module talks to the leaderboard rather than the Engine. See
+      Alone among the four, this module talks to the leaderboard rather than the engine. See
       <RouterLink to="/sf-client/api/leaderboards">Leaderboards</RouterLink> for the values it
       returns.
     </p>
@@ -204,7 +204,7 @@ const evaluateSig = `sf.evaluate(
 
     <p>
       Replaces the shared Client and returns the new one. Call it once, before anything else, to
-      point the module-level functions at a different Engine. Setting
+      point the module-level functions at a different engine. Setting
       <code>SCREAMINGFACE_ENGINE_URL</code> in the environment does the same thing without a call.
     </p>
 

--- a/public-docs/src/pages/sf-client/api/ModulesPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModulesPage.vue
@@ -137,7 +137,7 @@ const evaluateSig = `sf.evaluate(
     <h2>sf.leaderboards</h2>
 
     <p>
-      Alone among the four, this module talks to the scoreboard rather than the Engine. See
+      Alone among the four, this module talks to the leaderboard rather than the Engine. See
       <RouterLink to="/sf-client/api/leaderboards">Leaderboards</RouterLink> for the values it
       returns.
     </p>

--- a/public-docs/src/pages/sf-client/api/ModulesPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModulesPage.vue
@@ -40,9 +40,12 @@ const evaluateSig = `sf.evaluate(
     :version="version"
   >
     <p>
-      A <RouterLink to="/sf-client/api/clients">Client</RouterLink> exposes these as attributes. The
-      same names sit on <code>sf</code> itself, acting on a Client the library builds for you, which
-      is what a notebook wants.
+      Every name on this page works two ways. On a
+      <RouterLink to="/sf-client/api/clients">Client</RouterLink> you build yourself, they are its
+      attributes and methods: <code>client.benchmarks</code>, <code>client.evaluate(...)</code>. On
+      the <code>sf</code> module, the same names act on a default Client the library creates and
+      manages for you, so a script or notebook can call <code>sf.evaluate(...)</code> without
+      constructing one.
     </p>
 
     <div class="not-prose">

--- a/public-docs/src/pages/sf-client/api/ModulesPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModulesPage.vue
@@ -1,0 +1,247 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const shared = `import screamingface as sf
+
+sf.configure(engine_url="http://127.0.0.1:9108")
+[(b.id, b.variant) for b in sf.benchmarks.list()][:3]`
+const sharedOut = `[('draco', 'canonical'), ('draco/lite', 'lite'), ('draco/smoke', 'smoke')]`
+
+const configureSig = `sf.configure(
+    *,
+    engine_url: str = "https://fusion.dev.screamingface.ai",
+    scoreboard_url: str = "https://leaderboard.dev.screamingface.ai",
+) -> Client`
+
+const evaluateSig = `sf.evaluate(
+    candidates: Recipe | Sequence[Recipe] | str,
+    *,
+    benchmark: str | None = None,
+    limit: int | None = None,
+    on_event: Callable[[Event], None] | None = None,
+    progress: bool | None = None,
+) -> Report`
+</script>
+
+<template>
+  <DocLayout
+    title="Modules"
+    description="The five modules and five functions you can call on sf directly."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A <RouterLink to="/sf-client/api/clients">Client</RouterLink> exposes these as attributes. The
+      same names sit on <code>sf</code> itself, acting on a Client the library builds for you, which
+      is what a notebook wants.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="shared"><NbTextOut :text="sharedOut" /></NbCell>
+    </div>
+
+    <Note>
+      Both forms return the same values. Mixing them is fine, but a Client you construct yourself is
+      separate from the shared one, so <code>sf.configure()</code> does not affect it.
+    </Note>
+
+    <h2>sf.benchmarks</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Function</th>
+          <th>Returns</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>list()</code></td>
+          <td>
+            Every <RouterLink to="/sf-client/api/benchmarks">Benchmark</RouterLink> the Engine
+            offers, one entry per protocol variant.
+          </td>
+        </tr>
+        <tr>
+          <td><code>get(benchmark_id)</code></td>
+          <td>One <code>Benchmark</code>. The id carries the variant.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>sf.models</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Function</th>
+          <th>Returns</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>list()</code></td>
+          <td>
+            Every <RouterLink to="/sf-client/api/benchmarks">ModelInfo</RouterLink> route the Engine
+            can reach.
+          </td>
+        </tr>
+        <tr>
+          <td><code>get(model_id)</code></td>
+          <td>
+            The full <code>ModelDetails</code> profile for one route. Needs that provider connected.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>sf.connections</h2>
+
+    <p>
+      This module also re-exports the connection types themselves:
+      <code>Connection</code>, <code>ConnectionStatus</code>, <code>OAuthFlow</code> and
+      <code>AsyncOAuthFlow</code>.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Function</th>
+          <th>Returns</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>list()</code></td>
+          <td>
+            A <RouterLink to="/sf-client/api/clients">Connection</RouterLink> for every provider the
+            Engine advertises, connected or not.
+          </td>
+        </tr>
+        <tr>
+          <td><code>get(provider)</code></td>
+          <td>One provider's current state.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>sf.leaderboards</h2>
+
+    <p>
+      Alone among the four, this module talks to the scoreboard rather than the Engine. See
+      <RouterLink to="/sf-client/api/leaderboards">Leaderboards</RouterLink> for the values it
+      returns.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Function</th>
+          <th>Returns</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>list()</code></td>
+          <td>A <code>LeaderboardInfo</code> for every board.</td>
+        </tr>
+        <tr>
+          <td><code>get(benchmark_id, *, top=50)</code></td>
+          <td>One <code>Leaderboard</code>, its entries capped by <code>top</code>.</td>
+        </tr>
+        <tr>
+          <td><code>get_score(score_id)</code></td>
+          <td>One <code>LeaderboardScore</code> by its identifier.</td>
+        </tr>
+        <tr>
+          <td><code>submit(candidate_result)</code></td>
+          <td>
+            Publishes one
+            <RouterLink to="/sf-client/api/reports">CandidateResult</RouterLink> to the public board
+            and returns the stored <code>LeaderboardScore</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>sf.events</h2>
+
+    <p>
+      Unlike the four above, <code>sf.events</code> exposes no functions. It holds the event types a
+      run reports through <code>on_event</code>, covered in
+      <RouterLink to="/sf-client/api/events">Events</RouterLink>.
+    </p>
+
+    <h2>Top-level functions</h2>
+
+    <p>
+      These five act on the shared Client. They exist so a script or notebook never has to build one
+      explicitly.
+    </p>
+
+    <h3>evaluate()</h3>
+
+    <CodeBlock :code="evaluateSig" language="python" />
+
+    <p>
+      The one call that spends money. Identical to
+      <code>Client.evaluate()</code>, including replaying a URL4 string. Its parameters are
+      documented on the <RouterLink to="/sf-client/api/clients">Clients</RouterLink> page.
+    </p>
+
+    <h3>configure()</h3>
+
+    <CodeBlock :code="configureSig" language="python" />
+
+    <p>
+      Replaces the shared Client and returns the new one. Call it once, before anything else, to
+      point the module-level functions at a different Engine. Setting
+      <code>SCREAMINGFACE_ENGINE_URL</code> in the environment does the same thing without a call.
+    </p>
+
+    <h3>connect() and disconnect()</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Call</th>
+          <th>Returns</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>connect()</code></td>
+          <td>A <code>ConnectionPanel</code> listing every provider.</td>
+        </tr>
+        <tr>
+          <td><code>connect(provider, api_key=...)</code></td>
+          <td>The resulting <code>Connection</code>.</td>
+        </tr>
+        <tr>
+          <td><code>connect(provider, method="oauth")</code></td>
+          <td>An <code>OAuthFlow</code> carrying a URL to open.</td>
+        </tr>
+        <tr>
+          <td><code>disconnect(provider)</code></td>
+          <td>The provider's <code>Connection</code>, now disconnected.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>close()</h3>
+
+    <p>
+      Releases the shared Client. A later module-level call simply builds a new one, so this is
+      about releasing resources rather than shutting anything down permanently.
+    </p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/ModulesPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModulesPage.vue
@@ -91,8 +91,8 @@ const evaluateSig = `sf.evaluate(
         <tr>
           <td><code>list()</code></td>
           <td>
-            Every <RouterLink to="/sf-client/api/benchmarks">ModelInfo</RouterLink> route the Engine
-            can reach.
+            Every <RouterLink to="/sf-client/api/models">ModelInfo</RouterLink> route the Engine can
+            reach.
           </td>
         </tr>
         <tr>
@@ -166,8 +166,8 @@ const evaluateSig = `sf.evaluate(
           <td><code>submit(candidate_result)</code></td>
           <td>
             Publishes one
-            <RouterLink to="/sf-client/api/reports">CandidateResult</RouterLink> to the public board
-            and returns the stored <code>LeaderboardScore</code>.
+            <RouterLink to="/sf-client/api/candidate-result">CandidateResult</RouterLink> to the
+            public board and returns the stored <code>LeaderboardScore</code>.
           </td>
         </tr>
       </tbody>
@@ -194,7 +194,7 @@ const evaluateSig = `sf.evaluate(
 
     <p>
       The one call that spends money. Identical to
-      <code>Client.evaluate()</code>, including replaying a URL4 string. Its parameters are
+      <code>Client.evaluate()</code>, including replaying a url4 string. Its parameters are
       documented on the <RouterLink to="/sf-client/api/clients">Clients</RouterLink> page.
     </p>
 

--- a/public-docs/src/pages/sf-client/api/ModulesPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModulesPage.vue
@@ -6,7 +6,7 @@ import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/api/PipelinesPage.vue
@@ -5,7 +5,7 @@ import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/api/PipelinesPage.vue
@@ -16,7 +16,7 @@ const pipelineSig = `sf.Pipeline(
 )`
 
 const pipelineExample = `pipeline = sf.Pipeline(
-    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
+    ["openrouter/deepseek/deepseek-v4-pro", "openrouter/z-ai/glm-5.2"],
 )
 report = sf.evaluate(pipeline, benchmark="ifeval", limit=1)`
 </script>

--- a/public-docs/src/pages/sf-client/api/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/api/PipelinesPage.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const pipelineSig = `sf.Pipeline(
+    stages: Sequence[str | Recipe],
+    *,
+    name: str | None = None,
+)`
+
+const pipelineExample = `pipeline = sf.Pipeline(
+    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
+)
+report = sf.evaluate(pipeline, benchmark="ifeval", limit=1)`
+</script>
+
+<template>
+  <DocLayout
+    title="Pipeline"
+    description="Chain recipes in series, each stage refining the last."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A Pipeline is a <RouterLink to="/sf-client/api/recipes">Recipe</RouterLink> that passes one
+      input through an ordered sequence of stages; each stage refines the previous stage's answer,
+      and the last stage's answer is graded. Like every recipe it is frozen and holds no Client. The
+      <RouterLink to="/sf-client/guides/pipelines">Pipelines guide</RouterLink> walks through
+      building one.
+    </p>
+
+    <CodeBlock :code="pipelineSig" language="python" />
+
+    <table>
+      <thead>
+        <tr>
+          <th>Attribute</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>
+            The pipeline's name. Inferred by joining stage names with <code>-&gt;</code> unless you
+            pass one.
+          </td>
+        </tr>
+        <tr>
+          <td><code>stages</code></td>
+          <td><code>tuple[Recipe, ...]</code></td>
+          <td>The ordered stages, each refining the previous answer. At least one.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Note>
+      An unnamed Pipeline nested inside another flattens into the outer pipeline's stages; a
+      Pipeline you give an explicit <code>name</code> stays grouped as one stage. Naming is
+      behavioral, not cosmetic: it participates in equality, so two pipelines with the same stages
+      but different naming are not equal.
+    </Note>
+
+    <p>
+      Any recipe also has <code>.then(stage)</code>, which appends a stage and returns a Pipeline —
+      see <RouterLink to="/sf-client/api/recipes">Recipe</RouterLink>.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="pipelineExample" />
+    </div>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -15,12 +15,34 @@ b = sf.Model("openrouter/openai/gpt-5.5")
 
 a == b`
 const equalityOut = `True`
+
+const correctiveSig = `sf.CorrectiveLoop(
+    members: Sequence[str | Recipe],
+    *,
+    judge: str | Recipe,
+    max_rounds: int = 3,
+    name: str | None = None,
+)`
+
+const selfCorrectiveSig = `sf.SelfCorrective(
+    model: str | Recipe,
+    *,
+    max_rounds: int = 3,
+    name: str | None = None,
+)`
+
+const correctiveExample = `loop = sf.CorrectiveLoop(
+    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
+    judge="anthropic/claude-opus-4-8",
+    max_rounds=2,
+)
+report = sf.evaluate(loop, benchmark="ifeval", limit=1)`
 </script>
 
 <template>
   <DocLayout
     title="Recipes"
-    description="The abstract Recipe base every candidate shares, and where each concrete type is documented."
+    description="The abstract Recipe base every candidate shares, where each concrete type is documented, and the corrective loops that draft under a benchmark's check."
     :navigation="navigation"
     :version="version"
   >
@@ -55,8 +77,8 @@ const equalityOut = `True`
     <h2>Recipe</h2>
 
     <p>
-      <code>Recipe</code> is the abstract base the concrete types inherit from. You can't instantiate
-      it directly. It exists for type annotations and so a <code>Fusion</code> or
+      <code>Recipe</code> is the abstract base the concrete types inherit from. You can't
+      instantiate it directly. It exists for type annotations and so a <code>Fusion</code> or
       <code>Pipeline</code> can hold a mixed list of members.
     </p>
 
@@ -89,5 +111,188 @@ const equalityOut = `True`
         chained in series. The Pipelines guide carries its full reference.
       </li>
     </ul>
+
+    <h2>Corrective loops</h2>
+
+    <p>
+      Two further recipes, documented here, draft under the benchmark's own check and retry until a
+      draft passes. Members draft in parallel; the benchmark marks each draft; the first passing
+      draft is submitted word for word. A round where nothing passes buys one judge coaching call
+      and a retry, up to <code>max_rounds</code> — a cost cap, not a target. The whole loop compiles
+      into one candidate expression on the client, so it runs on any benchmark that advertises a
+      check.
+    </p>
+
+    <figure class="not-prose" style="margin: var(--space-8) 0">
+      <svg
+        viewBox="0 0 720 170"
+        role="img"
+        aria-label="Members draft in parallel; the benchmark check marks each draft; the first passing draft is submitted verbatim. A round where nothing passes returns to the members through a judge coaching call, retried up to max_rounds."
+        style="width: 100%; height: auto; font-family: var(--f-mono)"
+      >
+        <defs>
+          <marker
+            id="cl-arrow"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+
+        <rect
+          x="24"
+          y="34"
+          width="150"
+          height="54"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="99" y="58" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          members
+        </text>
+        <text x="99" y="76" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          draft in parallel
+        </text>
+
+        <rect
+          x="270"
+          y="34"
+          width="170"
+          height="54"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="355" y="58" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          benchmark check
+        </text>
+        <text x="355" y="76" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          marks each draft
+        </text>
+
+        <rect
+          x="548"
+          y="34"
+          width="150"
+          height="54"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="623" y="58" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          passing draft
+        </text>
+        <text x="623" y="76" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          submitted verbatim
+        </text>
+
+        <g style="stroke: var(--text-2); stroke-width: 1; fill: none">
+          <path d="M174 61 H270" marker-end="url(#cl-arrow)" />
+          <path d="M440 61 H548" marker-end="url(#cl-arrow)" />
+          <path d="M355 88 V132 H99 V88" marker-end="url(#cl-arrow)" />
+        </g>
+        <text x="222" y="53" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          drafts
+        </text>
+        <text x="494" y="53" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          first pass
+        </text>
+        <text x="227" y="150" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          no pass — judge coaches, retry ≤ max_rounds
+        </text>
+      </svg>
+    </figure>
+
+    <h3>CorrectiveLoop</h3>
+
+    <p>
+      A panel of members drafting under the check. The single <code>judge</code> plays two roles the
+      loop keeps apart: it selects among passing drafts, and it coaches after a no-pass round. It
+      never writes the answer itself. A panel needs at least two members.
+    </p>
+
+    <CodeBlock :code="correctiveSig" language="python" />
+
+    <table>
+      <thead>
+        <tr>
+          <th>Attribute</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>
+            The loop's name. Inferred by joining member names with <code>+</code> unless you pass
+            one.
+          </td>
+        </tr>
+        <tr>
+          <td><code>members</code></td>
+          <td><code>tuple[Recipe, ...]</code></td>
+          <td>The panel that drafts. At least two.</td>
+        </tr>
+        <tr>
+          <td><code>judge</code></td>
+          <td><code>Recipe</code></td>
+          <td>
+            Selects among passing drafts and coaches after a no-pass round. Never writes the answer.
+          </td>
+        </tr>
+        <tr>
+          <td><code>max_rounds</code></td>
+          <td><code>int</code></td>
+          <td>
+            The most rounds the loop will run. A cost cap, not a target; defaults to <code>3</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="correctiveExample" />
+    </div>
+
+    <h3>SelfCorrective</h3>
+
+    <p>
+      The solo shape: one model drafts under the same check and writes its own retry feedback from
+      the check's sanitized violations — the coaching role the panel gives to a separate judge,
+      played by the only model present.
+    </p>
+
+    <CodeBlock :code="selfCorrectiveSig" language="python" />
+
+    <table>
+      <thead>
+        <tr>
+          <th>Attribute</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>The recipe's name. Taken from the member unless you pass one.</td>
+        </tr>
+        <tr>
+          <td><code>member</code></td>
+          <td><code>Recipe</code></td>
+          <td>The single model that drafts and coaches itself between rounds.</td>
+        </tr>
+        <tr>
+          <td><code>max_rounds</code></td>
+          <td><code>int</code></td>
+          <td>
+            The most rounds it will run. A cost cap, not a target; defaults to <code>3</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -99,16 +99,17 @@ report = sf.evaluate(loop, benchmark="ifeval", limit=1)`
 
     <ul>
       <li>
-        <strong><RouterLink to="/sf-client/api/models">Model</RouterLink></strong> — a single model
-        route. Its constructor, parameters, attributes, and errors live on the Models page.
+        <strong><RouterLink to="/sf-client/api/models">Model</RouterLink></strong
+        >: a single model route. Its constructor, parameters, attributes, and errors live on the
+        Models page.
       </li>
       <li>
-        <strong><RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink></strong> — members
-        combined by a synthesizer. The Fusions guide carries its full reference.
+        <strong><RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink></strong
+        >: members combined by a synthesizer. The Fusions guide carries its full reference.
       </li>
       <li>
-        <strong><RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink></strong> — stages
-        chained in series. The Pipelines guide carries its full reference.
+        <strong><RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink></strong
+        >: stages chained in series. The Pipelines guide carries its full reference.
       </li>
     </ul>
 
@@ -260,7 +261,7 @@ report = sf.evaluate(loop, benchmark="ifeval", limit=1)`
 
     <p>
       The solo shape: one model drafts under the same check and writes its own retry feedback from
-      the check's sanitized violations — the coaching role the panel gives to a separate judge,
+      the check's sanitized violations: the coaching role the panel gives to a separate judge,
       played by the only model present.
     </p>
 

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -10,8 +10,8 @@ import {
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 
-const equality = `a = sf.Model("openrouter/openai/gpt-5.5")
-b = sf.Model("openrouter/openai/gpt-5.5")
+const equality = `a = sf.Model("openrouter/deepseek/deepseek-v4-pro")
+b = sf.Model("openrouter/deepseek/deepseek-v4-pro")
 
 a == b`
 const equalityOut = `True`
@@ -32,9 +32,9 @@ const selfCorrectiveSig = `sf.SelfCorrective(
 )`
 
 const correctiveExample = `loop = sf.CorrectiveLoop(
-    ["openrouter/openai/gpt-5.5", "anthropic/claude-opus-4-8"],
-    judge="anthropic/claude-opus-4-8",
-    max_rounds=2,
+    ["openrouter/deepseek/deepseek-v4-pro", "openrouter/qwen/qwen3.8-2.4t-a95b", "openrouter/z-ai/glm-5.2"],
+    judge="openrouter/moonshotai/kimi-k3",
+    max_rounds=3,
 )
 report = sf.evaluate(loop, benchmark="ifeval", limit=1)`
 </script>
@@ -123,6 +123,41 @@ report = sf.evaluate(loop, benchmark="ifeval", limit=1)`
       into one candidate expression on the client, so it runs on any benchmark that advertises a
       check.
     </p>
+
+    <p>
+      The two corrective recipes are the bottom row of a small grid: the same models, run with or
+      without a correction loop.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>Solo</th>
+          <th>Panel</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>No loop</strong></td>
+          <td><code>Model</code></td>
+          <td><code>Fusion</code></td>
+        </tr>
+        <tr>
+          <td><strong>Corrective</strong></td>
+          <td><code>SelfCorrective</code></td>
+          <td><code>CorrectiveLoop</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <Note>
+      What a correction round costs depends on the benchmark's check surface. A deterministic
+      verifier such as <code>ifeval</code> checks every draft for free, so only the correction
+      rounds add model spend. A rubric-graded benchmark such as <code>healthbench-worst30</code> or
+      <code>draco</code> spends a judge call per draft on every round, first-round pass included,
+      and <code>max_rounds</code> caps that.
+    </Note>
 
     <figure class="not-prose" style="margin: var(--space-8) 0">
       <svg

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -6,7 +6,7 @@ import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/ReportsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ReportsPage.vue
@@ -5,7 +5,7 @@ import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/Url4Page.vue
+++ b/public-docs/src/pages/sf-client/api/Url4Page.vue
@@ -5,7 +5,7 @@ import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import Note from '@/components/ui/Note.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/Url4Page.vue
+++ b/public-docs/src/pages/sf-client/api/Url4Page.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import Note from '@/components/ui/Note.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const signature = `class Url4(str):
+    def to_python(self) -> str: ...`
+
+const example = `line = report.candidates.only.url4
+print(line.to_python())`
+</script>
+
+<template>
+  <DocLayout
+    title="Url4"
+    description="The string value a run carries, and the editable Python it forks to."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A <code>Url4</code> is the complete expression a candidate executed — you get it as
+      <code>candidate.url4</code> and on every
+      <RouterLink to="/sf-client/api/leaderboards">leaderboard entry</RouterLink>. It subclasses
+      <code>str</code>, so every string operation works and it compares and serializes as its own
+      text. Pass one back to <RouterLink to="/sf-client/api/clients">evaluate()</RouterLink> to
+      reproduce the run.
+    </p>
+
+    <Note>
+      Two things share the name. The lowercase <code>url4</code> is the protocol — a text grammar
+      covered on the <RouterLink to="/learn/url4">url4 concept page</RouterLink>. <code>Url4</code>
+      here is the Python value the Client hands back. The
+      <RouterLink to="/sf-client/guides/reproduce-and-share"
+        >Reproduce &amp; share guide</RouterLink
+      >
+      is the how-to.
+    </Note>
+
+    <CodeBlock :code="signature" language="python" />
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Returns</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>to_python()</code></td>
+          <td><code>str</code></td>
+          <td>
+            Editable ScreamingFace Python for the compiled candidate or evaluation: a fork you can
+            modify and re-run.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      You rarely build one by hand; when you do, <code>sf.Url4(value: str)</code> wraps a string.
+      Because it is a <code>str</code>, it prints, slices, and stores like any string —
+      <code>to_python()</code> is the one extra affordance.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="example" />
+    </div>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/UsagePage.vue
+++ b/public-docs/src/pages/sf-client/api/UsagePage.vue
@@ -140,7 +140,7 @@ const usageOut = `Usage(input_tokens=103, output_tokens=398, cache_read_tokens=0
           <td><code>bool&nbsp;|&nbsp;None</code></td>
           <td>
             Whether running the same thing again could plausibly succeed, or <code>None</code> when
-            the Engine did not say.
+            the engine did not say.
           </td>
         </tr>
         <tr>
@@ -160,7 +160,7 @@ const usageOut = `Usage(input_tokens=103, output_tokens=398, cache_read_tokens=0
           <td><code>metadata</code></td>
           <td><code>Mapping[str, object]</code></td>
           <td>
-            Whatever else the Engine attached to this failure. Empty when it attached nothing.
+            Whatever else the engine attached to this failure. Empty when it attached nothing.
           </td>
         </tr>
       </tbody>

--- a/public-docs/src/pages/sf-client/api/UsagePage.vue
+++ b/public-docs/src/pages/sf-client/api/UsagePage.vue
@@ -5,7 +5,7 @@ import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import {
-  sfClientNavigation as navigation,
+  sfClientReferenceNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 

--- a/public-docs/src/pages/sf-client/api/UsagePage.vue
+++ b/public-docs/src/pages/sf-client/api/UsagePage.vue
@@ -153,7 +153,7 @@ const usageOut = `Usage(input_tokens=103, output_tokens=398, cache_read_tokens=0
         </tr>
         <tr>
           <td><code>case_id</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td><code>int&nbsp;|&nbsp;str&nbsp;|&nbsp;None</code></td>
           <td>Which case failed, when the failure was specific to one.</td>
         </tr>
         <tr>

--- a/public-docs/src/pages/sf-client/guides/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ClientsPage.vue
@@ -82,35 +82,36 @@ client = sf.Client(
 <template>
   <DocLayout
     title="Clients"
-    description="The default client behind sf.*, and when to build your own."
+    description="The default Client behind sf.*, and when to build your own."
     :navigation="navigation"
     :version="version"
   >
     <p>There are two ways to call the SDK, and both use the same interface.</p>
 
     <p>
-      Most of the time you'll reach for the <strong>module-level shortcuts</strong> —
-      <code>sf.evaluate(...)</code>, <code>sf.connect(...)</code>, and the rest. They're the shortest
-      to write, which is why the
-      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> and every notebook use them.
+      Most of the time you'll reach for the <strong>module-level shortcuts</strong>:
+      <code>sf.evaluate(...)</code>, <code>sf.connect(...)</code>, and the rest. They're the
+      shortest to write, which is why the
+      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> and every notebook use
+      them.
     </p>
 
     <p>
       When a script grows into something you ship, construct an explicit
-      <strong><code>Client</code></strong> instead. It takes a little more code, but it hands you the
-      client's lifecycle, lets you point at a second engine, and works with your own event loop.
+      <strong><code>Client</code></strong> instead. It takes a little more code, but it hands you
+      the Client's lifecycle, lets you point at a second engine, and works with your own event loop.
     </p>
 
     <p>
       These aren't two different SDKs. Every shortcut runs against a single <code>Client</code> the
-      package creates and holds for you — so the only real question this page answers is
+      package creates and holds for you. The only real question this page answers is
       <em>who owns that Client: you, or the package</em>.
     </p>
 
     <h2>What you can do with it</h2>
 
     <ul>
-      <li>Call the SDK with no setup through the process-wide default client.</li>
+      <li>Call the SDK with no setup through the process-wide default Client.</li>
       <li>Point that default at a local or alternate engine, by environment or in code.</li>
       <li>Construct your own <code>Client</code> when you need to own its lifecycle.</li>
       <li>Run against more than one engine at once, or over <code>await</code>.</li>
@@ -118,11 +119,11 @@ client = sf.Client(
 
     <h2>The two forms, side by side</h2>
 
-    <p>The same evaluation, written both ways. The shortcut lets the package hold the client:</p>
+    <p>The same evaluation, written both ways. The shortcut lets the package hold the Client:</p>
 
     <CodeBlock :code="shortcut" language="python" />
 
-    <p>The explicit form hands the client to a <code>with</code> block that closes it for you:</p>
+    <p>The explicit form hands the Client to a <code>with</code> block that closes it for you:</p>
 
     <CodeBlock :code="explicit" language="python" />
 
@@ -148,8 +149,8 @@ client = sf.Client(
         <tr>
           <td>Configuration</td>
           <td>
-            <code>SCREAMINGFACE_ENGINE_URL</code> /
-            <code>SCREAMINGFACE_SCOREBOARD_URL</code>, or <code>sf.configure(...)</code>
+            <code>SCREAMINGFACE_ENGINE_URL</code> / <code>SCREAMINGFACE_SCOREBOARD_URL</code>, or
+            <code>sf.configure(...)</code>
           </td>
           <td>Constructor keyword arguments</td>
         </tr>
@@ -157,8 +158,8 @@ client = sf.Client(
           <td>Lifecycle</td>
           <td><code>sf.close()</code> (or <code>sf.configure()</code> swaps it)</td>
           <td>
-            <code>with</code> / <code>close()</code> — async
-            <code>async with</code> / <code>await aclose()</code>
+            <code>with</code> / <code>close()</code>; async <code>async with</code> /
+            <code>await aclose()</code>
           </td>
         </tr>
         <tr>
@@ -177,19 +178,19 @@ client = sf.Client(
         <tr>
           <td>Login state</td>
           <td>Shared by the whole process</td>
-          <td>Held per client</td>
+          <td>Held per Client</td>
         </tr>
       </tbody>
     </table>
 
-    <h2>The default client</h2>
+    <h2>The default Client</h2>
 
     <p>
-      <code>sf.evaluate()</code>, <code>sf.connect()</code> and <code>sf.disconnect()</code>
-      all run against one <code>Client</code> the package builds <strong>the first time you
-      call one of them</strong>, and reuses forever after. Nothing is created at
-      <code>import</code>, and constructing a client opens no connection either — the first
-      call that needs the engine is the first one that talks to it:
+      <code>sf.evaluate()</code>, <code>sf.connect()</code> and <code>sf.disconnect()</code> all run
+      against one <code>Client</code> the package builds
+      <strong>the first time you call one of them</strong>, and reuses forever after. Nothing is
+      created at <code>import</code>, and constructing a Client opens no connection either. The
+      first call that needs the engine is the first one that talks to it:
     </p>
 
     <div class="not-prose">
@@ -197,9 +198,9 @@ client = sf.Client(
     </div>
 
     <p>
-      Left alone, that default points at the hosted development engine. Point it somewhere
-      else in one of two ways. Set the environment before the first call, which suits a
-      local engine you already export elsewhere:
+      Left alone, that default points at the hosted development engine. Point it somewhere else in
+      one of two ways. Set the environment before the first call, which suits a local engine you
+      already export elsewhere:
     </p>
 
     <div class="not-prose">
@@ -214,19 +215,19 @@ client = sf.Client(
 
     <p>
       <code>sf.configure(...)</code> takes only <code>engine_url</code> and
-      <code>scoreboard_url</code> — for anything more, construct a <code>Client</code>
-      yourself. <code>sf.close()</code> closes the default and forgets it, so the next
-      shortcut builds a fresh one; it is the tidy end to a script.
+      <code>scoreboard_url</code>. For anything more, construct a <code>Client</code> yourself.
+      <code>sf.close()</code> closes the default and forgets it, so the next shortcut builds a fresh
+      one; it is the tidy end to a script.
     </p>
 
     <Note>
-      Because the default is one object for the whole process, its login state is shared too:
-      one <RouterLink to="/sf-client/guides/connections">login</RouterLink> covers every later
-      <code>sf.*</code> call. That is convenient in a notebook and surprising in a server
-      handling several users — the reason to build your own client below.
+      Because the default is one object for the whole process, its login state is shared too: one
+      <RouterLink to="/sf-client/guides/connections">login</RouterLink> covers every later
+      <code>sf.*</code> call. That is convenient in a notebook and surprising in a server handling
+      several users, which is the reason to build your own Client below.
     </Note>
 
-    <h2>Build your own client</h2>
+    <h2>Build your own Client</h2>
 
     <p>
       Constructing a <code>Client</code> gives you the object directly. Prefer a
@@ -237,60 +238,59 @@ client = sf.Client(
     <CodeBlock :code="explicit" language="python" />
 
     <p>
-      Owning the client is what lets you hold <strong>more than one at a time</strong> —
-      a hosted engine and a local one, each with its own address, login and connections:
+      Owning the Client is what lets you hold <strong>more than one at a time</strong>: a hosted
+      engine and a local one, each with its own address, login and connections:
     </p>
 
     <CodeBlock :code="multi" language="python" />
 
     <p>
-      The full surface — properties, <code>login()</code> / <code>logout()</code>, the
-      catalogue accessors — lives on the
-      <RouterLink to="/sf-client/api/clients">Clients API reference</RouterLink>. A closed
-      client raises rather than reconnecting silently, so a <code>with</code> block is safer
-      than a bare constructor when the client is short-lived.
+      The full surface (properties, <code>login()</code> / <code>logout()</code>, the catalogue
+      accessors) lives on the
+      <RouterLink to="/sf-client/api/clients">Clients API reference</RouterLink>. A closed Client
+      raises rather than reconnecting silently, so a <code>with</code> block is safer than a bare
+      constructor when the Client is short-lived.
     </p>
 
     <h2>Async</h2>
 
     <p>
-      <code>AsyncClient</code> offers the same interface over <code>await</code> and returns
-      the same value types. <code>evaluate()</code>, <code>connect()</code>,
-      <code>login()</code> and the rest are awaited; the properties are not, and cleanup is
-      <code>async with</code> or <code>await client.aclose()</code>:
+      <code>AsyncClient</code> offers the same interface over <code>await</code> and returns the
+      same value types. <code>evaluate()</code>, <code>connect()</code>, <code>login()</code> and
+      the rest are awaited; the properties are not, and cleanup is <code>async with</code> or
+      <code>await client.aclose()</code>:
     </p>
 
     <CodeBlock :code="asyncCode" language="python" />
 
     <Note>
-      There is deliberately <strong>no <code>await sf.evaluate(...)</code></strong>. A single
-      process-wide async client would bind its connection pool to one event loop — a footgun
-      the moment a second loop, a notebook re-run, or a server worker appears. So the async
-      path has no module-level shortcut: you construct an <code>AsyncClient</code> and own its
+      There is deliberately <strong>no <code>await sf.evaluate(...)</code></strong
+      >. A single process-wide async Client would bind its connection pool to one event loop. That
+      is a footgun the moment a second loop, a notebook re-run, or a server worker appears. So the
+      async path has no module-level shortcut: you construct an <code>AsyncClient</code> and own its
       lifecycle, every time.
     </Note>
 
     <h2>Custom transports</h2>
 
     <p>
-      The constructor accepts <code>http_transport</code>,
-      <code>scoreboard_transport</code> and <code>run_transport</code> — the seam for tests
-      and proxies. A mock transport lets a test drive the client with no network at all. These
-      are constructor-only: there is no way to reach them through the <code>sf.*</code> path,
-      which is another reason a test suite builds its own client.
+      The constructor accepts <code>http_transport</code>, <code>scoreboard_transport</code> and
+      <code>run_transport</code>: the seam for tests and proxies. A mock transport lets a test drive
+      the Client with no network at all. These are constructor-only: there is no way to reach them
+      through the <code>sf.*</code> path, which is another reason a test suite builds its own
+      Client.
     </p>
 
     <CodeBlock :code="transport" language="python" />
 
-    <h2>One process, one shared client</h2>
+    <h2>One process, one shared Client</h2>
 
     <p>
       The default is a single instance, built once behind a lock and reused, so
-      <code>sf.*</code> calls that happen to overlap share it rather than racing to create
-      two. That sharing is exactly what makes it a poor fit for isolation: separate work that
-      must not share a login, a connection pool, or an engine wants a separate
-      <code>Client</code>. Give each thread, each event loop, or each tenant its own, and
-      close it when that work is done.
+      <code>sf.*</code> calls that happen to overlap share it rather than racing to create two. That
+      sharing is exactly what makes it a poor fit for isolation: separate work that must not share a
+      login, a connection pool, or an engine wants a separate <code>Client</code>. Give each thread,
+      each event loop, or each tenant its own, and close it when that work is done.
     </p>
 
     <h2>When to use each</h2>
@@ -327,12 +327,12 @@ client = sf.Client(
     <ul>
       <li>
         <RouterLink to="/sf-client/api/clients"
-          ><code>Client</code>, <code>AsyncClient</code> and connections — API reference</RouterLink
+          ><code>Client</code>, <code>AsyncClient</code> and connections: API reference</RouterLink
         >
       </li>
       <li>
         <RouterLink to="/sf-client/guides/connections">Connections</RouterLink> — logging in and
-        connecting a provider through whichever client you chose
+        connecting a provider through whichever Client you chose
       </li>
       <li>
         <a

--- a/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
@@ -54,10 +54,10 @@ const panelProviders: Provider[] = [
   >
     <p>
       A <strong>connection</strong> is a provider credential
-      <RouterLink to="/learn/engine">the engine</RouterLink> holds on your behalf. The
-      client never talks to OpenRouter, Anthropic or any other provider directly. It sends your key
-      to the engine once, the engine passes it to AI Gateway to validate and store encrypted, and
-      every later model call is dispatched there.
+      <RouterLink to="/learn/engine">the engine</RouterLink> holds on your behalf. The Client never
+      talks to OpenRouter, Anthropic or any other provider directly. It sends your key to the engine
+      once, the engine passes it to AI Gateway to validate and store encrypted, and every later
+      model call is dispatched there.
     </p>
 
     <p>
@@ -69,7 +69,7 @@ const panelProviders: Provider[] = [
     <h2>What you can do with it</h2>
 
     <ul>
-      <li>Login to the engine, or point the client at your own engine instead.</li>
+      <li>Login to the engine, or point the Client at your own engine instead.</li>
       <li>
         Connect a provider interactively from a notebook, or with an explicit key from a script.
       </li>
@@ -110,7 +110,10 @@ const panelProviders: Provider[] = [
         </tr>
         <tr>
           <td><code>sf.connections.get(provider)</code></td>
-          <td>Fetches a single provider by name, returning its current state as a <code>Connection</code>.</td>
+          <td>
+            Fetches a single provider by name, returning its current state as a
+            <code>Connection</code>.
+          </td>
         </tr>
         <tr>
           <td><code>sf.disconnect(provider)</code></td>
@@ -128,7 +131,9 @@ const panelProviders: Provider[] = [
         </tr>
         <tr>
           <td><code>sf.ConnectionPanel</code></td>
-          <td>The live widget that <code>sf.connect()</code> returns when called with no arguments.</td>
+          <td>
+            The live widget that <code>sf.connect()</code> returns when called with no arguments.
+          </td>
         </tr>
         <tr>
           <td><code>sf.Client.login()</code> · <code>sf.Client.logout()</code></td>
@@ -144,7 +149,7 @@ const panelProviders: Provider[] = [
 
     <h3>1 · Configure engine</h3>
 
-    <p>Point the client at an engine. There are two ways, depending on where it runs.</p>
+    <p>Point the Client at an engine. There are two ways, depending on where it runs.</p>
 
     <h4>Hosted engine</h4>
 
@@ -167,7 +172,7 @@ const panelProviders: Provider[] = [
     <h4>Local engine</h4>
 
     <p>
-      If you run the engine yourself, point the client at it and skip the login step entirely: a
+      If you run the engine yourself, point the Client at it and skip the login step entirely: a
       local engine advertises no Cloudflare Access, so the panel shows provider rows immediately.
     </p>
 

--- a/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
+++ b/public-docs/src/pages/sf-client/guides/EvaluationPage.vue
@@ -102,7 +102,10 @@ client.close()`
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#ev-arrow)">
+        <g
+          style="stroke: var(--text-2); stroke-width: 1.25; fill: none"
+          marker-end="url(#ev-arrow)"
+        >
           <path d="M164 66 C 206 66, 206 100, 246 100" />
           <path d="M164 140 C 206 140, 206 100, 246 100" />
           <path d="M450 100 H534" />
@@ -155,7 +158,7 @@ client.close()`
       <li>Cap the number of cases with <code>limit</code>.</li>
       <li>Pick a protocol variant by naming its own benchmark id.</li>
       <li>Watch the run live, or turn off the progress display.</li>
-      <li>Use an explicit client, sync or with <code>await</code>.</li>
+      <li>Use an explicit Client, sync or with <code>await</code>.</li>
     </ul>
 
     <h2>Main APIs</h2>
@@ -169,20 +172,35 @@ client.close()`
       </thead>
       <tbody>
         <tr>
-          <td><code>sf.evaluate(candidates, *, benchmark, limit=None, on_event=None, progress=None)</code></td>
-          <td>Runs one or more candidates against a benchmark's protocol concurrently, returning a single <code>sf.Report</code>. Validates everything before the first paid request.</td>
+          <td>
+            <code
+              >sf.evaluate(candidates, *, benchmark, limit=None, on_event=None, progress=None)</code
+            >
+          </td>
+          <td>
+            Runs one or more candidates against a benchmark's protocol concurrently, returning a
+            single <code>sf.Report</code>. Validates everything before the first paid request.
+          </td>
         </tr>
         <tr>
-          <td><code>sf.Client.evaluate(...)</code> · <code>await sf.AsyncClient.evaluate(...)</code></td>
-          <td>Same call on an explicit client you manage yourself, sync or with <code>await</code>. Only way to talk to two engines from one process.</td>
+          <td>
+            <code>sf.Client.evaluate(...)</code> · <code>await sf.AsyncClient.evaluate(...)</code>
+          </td>
+          <td>
+            Same call on an explicit Client you manage yourself, sync or with <code>await</code>.
+            Only way to talk to two engines from one process.
+          </td>
         </tr>
         <tr>
           <td><code>sf.configure(engine_url=…)</code></td>
-          <td>Repoints the shared client so every later <code>sf.evaluate()</code> call uses that engine.</td>
+          <td>
+            Repoints the shared Client so every later <code>sf.evaluate()</code> call uses that
+            engine.
+          </td>
         </tr>
         <tr>
           <td><code>sf.close()</code></td>
-          <td>Releases the shared client.</td>
+          <td>Releases the shared Client.</td>
         </tr>
       </tbody>
     </table>
@@ -235,8 +253,8 @@ client.close()`
       Read <code>coverage</code> beside the score. It is the fraction of the selected cases the
       score was computed from, and anything below <code>1.0</code> means the engine graded only part
       of the run and the score describes that part. A candidate can also finish with both a score
-      and entries in <code>failures</code>, which is a completed run carrying warnings worth
-      reading rather than a broken one.
+      and entries in <code>failures</code>, which is a completed run carrying warnings worth reading
+      rather than a broken one.
     </p>
 
     <h3>3 · Evaluate several at once</h3>
@@ -293,7 +311,7 @@ client.close()`
 
     <p>
       <code>on_event</code> receives typed events in sequence as the run executes, and
-      <code>progress=False</code> silences the default display. If your callback raises, the client
+      <code>progress=False</code> silences the default display. If your callback raises, the Client
       cancels every active run and re-raises your exception.
     </p>
 

--- a/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
@@ -37,7 +37,7 @@ sf.leaderboards.submit(report.candidates.only)
 [sf.leaderboards.submit(c) for c in report.candidates]`
 
 const fetchScore = `score = sf.leaderboards.get_score("57cc25d7-00bf-44ec-bf9d-55d66cd1e003")
-score.accuracy, score.correct_questions, score.total_questions, score.verified_by_openmined`
+score.accuracy, score.correct_questions, score.total_questions, score.verified_by_screamingface`
 const fetchScoreOut = `(1.0, 1, 1, False)`
 
 const remix = `plan = score.url4.to_python()   # Model / Fusion / Pipeline, free
@@ -53,8 +53,8 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
   >
     <p>
       A <strong>leaderboard</strong> is one benchmark's public ranking on the ScreamingFace
-      Leaderboard. The Client reads and writes it through <code>sf.leaderboards</code>. Discovery and
-      reads are free. They hit the leaderboard, not a model, and they do not need a provider
+      Leaderboard. The Client reads and writes it through <code>sf.leaderboards</code>. Discovery
+      and reads are free. They hit the leaderboard, not a model, and they do not need a provider
       connection.
     </p>
 
@@ -62,8 +62,8 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
       Each ranked row keeps the exact
       <RouterLink to="/sf-client/guides/reproduce-and-share"><code>url4</code></RouterLink>
       that produced the score, so anyone can fork or re-run the recipe. The leaderboard also stores
-      whether OpenMined independently re-ran it (<code>verified_by_openmined</code>). That flag is
-      separate from who submitted the row: a submission starts unverified.
+      whether ScreamingFace independently re-ran it (<code>verified_by_screamingface</code>). That
+      flag is separate from who submitted the row: a submission starts unverified.
     </p>
 
     <p>
@@ -166,14 +166,15 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
 
     <p>
       Each entry carries <code>accuracy</code>, <code>total_questions</code>, the providers used,
-      who submitted it when that is known, the <code>verified_by_openmined</code> flag, and the
+      who submitted it when that is known, the <code>verified_by_screamingface</code> flag, and the
       <code>url4</code> expression. Notebook displays render the board as an interactive widget; the
       fields above are what each entry holds.
     </p>
 
     <p>
       On this board both rows are unverified smoke submissions. Treat
-      <code>verified_by_openmined=True</code> as the trust signal, not the mere presence of a row.
+      <code>verified_by_screamingface=True</code> as the trust signal, not the mere presence of a
+      row.
     </p>
 
     <h3>3 · Point the Client at a leaderboard</h3>
@@ -234,9 +235,9 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
     </div>
 
     <p>
-      A fresh submission returns with <code>verified_by_openmined=False</code>. Verification is a
-      later, independent mark after OpenMined re-runs the recipe. Read that field before you trust a
-      number you did not produce yourself.
+      A fresh submission returns with <code>verified_by_screamingface=False</code>. Verification is
+      a later, independent mark after ScreamingFace re-runs the recipe. Read that field before you
+      trust a number you did not produce yourself.
     </p>
 
     <h3>6 · Remix or replay from the board</h3>
@@ -257,8 +258,9 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
 
     <p>
       Anyone with write access can publish a score. The board stores the claim and the recipe.
-      <code>verified_by_openmined</code> means OpenMined re-executed that recipe and accepted the
-      result. Until that flag is true, treat the row as a submission, not a verified ranking.
+      <code>verified_by_screamingface</code> means ScreamingFace re-executed that recipe and
+      accepted the result. Until that flag is true, treat the row as a submission, not a verified
+      ranking.
     </p>
 
     <h2>Links</h2>

--- a/public-docs/src/pages/sf-client/guides/ModelsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ModelsPage.vue
@@ -113,7 +113,9 @@ const inspectOut = `('number', 0.0, 2.0, True)`
           </td>
         </tr>
         <tr>
-          <td><code>.name</code> · <code>.model</code> · <code>.prompt</code> · <code>.params</code></td>
+          <td>
+            <code>.name</code> · <code>.model</code> · <code>.prompt</code> · <code>.params</code>
+          </td>
           <td>Read back what a Model resolved to, including its inferred or explicit name.</td>
         </tr>
       </tbody>
@@ -137,8 +139,8 @@ const inspectOut = `('number', 0.0, 2.0, True)`
     <p>
       Two Models on the same route with the same policy are the <em>same</em> candidate:
       <RouterLink to="/learn/engine">the engine</RouterLink> deduplicates them by content inside one
-      compiled graph. An explicit <code>name</code> is how
-      you say you meant two independent samples, and it is the name the report uses.
+      compiled graph. An explicit <code>name</code> is how you say you meant two independent
+      samples, and it is the name the report uses.
     </p>
 
     <div class="not-prose">
@@ -180,8 +182,8 @@ const inspectOut = `('number', 0.0, 2.0, True)`
 
     <blockquote>
       <strong>The catalogue is fixed for now.</strong> The engine does not yet discover models
-      automatically, so only the routes listed here can be used to build fusions — a model missing
-      from the list can't be added from the client. Automatic discovery is work in progress.
+      automatically, so only the routes listed here can be used to build fusions. A model missing
+      from the list can't be added from the Client. Automatic discovery is work in progress.
     </blockquote>
 
     <h3>5 · Check that a route accepts your policy</h3>
@@ -201,8 +203,8 @@ const inspectOut = `('number', 0.0, 2.0, True)`
 
     <p>
       The same <code>ModelDetails</code> profile is also how you find out <em>what</em> a route lets
-      you configure. <code>details.parameters</code> is a mapping keyed by parameter name, so listing
-      its keys enumerates every knob the route exposes.
+      you configure. <code>details.parameters</code> is a mapping keyed by parameter name, so
+      listing its keys enumerates every knob the route exposes.
     </p>
 
     <div class="not-prose">
@@ -210,11 +212,11 @@ const inspectOut = `('number', 0.0, 2.0, True)`
     </div>
 
     <p>
-      Each value is an <code>sf.ModelParameter</code>. Its <code>schema</code> gives the type and the
-      bounds the gateway enforces — a numeric <code>minimum</code>/<code>maximum</code>, an
+      Each value is an <code>sf.ModelParameter</code>. Its <code>schema</code> gives the type and
+      the bounds the gateway enforces — a numeric <code>minimum</code>/<code>maximum</code>, an
       <code>enum</code> of allowed values, a <code>max_length</code>, and so on — while
-      <code>enabled</code> says whether the gateway currently honours it. Reading the schema tells you
-      a value's legal range before you set it in <code>params</code>.
+      <code>enabled</code> says whether the gateway currently honours it. Reading the schema tells
+      you a value's legal range before you set it in <code>params</code>.
     </p>
 
     <div class="not-prose">

--- a/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
@@ -64,7 +64,7 @@ const pipelineSig = `sf.Pipeline(
   >
     <p>
       A <strong>Pipeline</strong> is a recipe composed of an ordered list of
-      <strong>stages</strong>. It doesn't run anything by itself — like every recipe, building one
+      <strong>stages</strong>. It doesn't run anything by itself; like every recipe, building one
       makes no requests. The stages run only during an
       <RouterLink to="/sf-client/guides/running-an-evaluation">evaluation</RouterLink>: the first
       stage answers the case, and each later stage takes the <em>previous</em> stage's answer as its
@@ -194,7 +194,15 @@ const pipelineSig = `sf.Pipeline(
         aria-label="The review-chain Pipeline holds draft then review; grading review's answer produces the graded answer."
       >
         <defs>
-          <marker id="pl-a1" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+          <marker
+            id="pl-a1"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
@@ -240,7 +248,15 @@ const pipelineSig = `sf.Pipeline(
         aria-label="One Pipeline of draft, review and final; grading final's answer produces the graded answer."
       >
         <defs>
-          <marker id="pl-a2" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+          <marker
+            id="pl-a2"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
@@ -290,7 +306,15 @@ const pipelineSig = `sf.Pipeline(
         aria-label="The unnamed inner Pipeline (dashed) flattens into the outer Pipeline; grading the last stage's answer produces the graded answer."
       >
         <defs>
-          <marker id="pl-a3" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+          <marker
+            id="pl-a3"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
@@ -339,7 +363,15 @@ const pipelineSig = `sf.Pipeline(
         aria-label="The named inner Pipeline polish-pass is kept as one stage inside the outer Pipeline; grading its last stage's answer produces the graded answer."
       >
         <defs>
-          <marker id="pl-a4" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+          <marker
+            id="pl-a4"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
@@ -392,7 +424,15 @@ const pipelineSig = `sf.Pipeline(
         aria-label="A Fusion whose members are a draft-to-review Pipeline and gemini, combined by a synthesizer that is itself a judge-to-writer Pipeline; grading the writer's answer produces the graded answer."
       >
         <defs>
-          <marker id="pl-a5" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+          <marker
+            id="pl-a5"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
@@ -425,7 +465,7 @@ const pipelineSig = `sf.Pipeline(
         </g>
       </svg>
       <figcaption class="dgcap">
-        A Fusion of two members — the draft → review Pipeline and gemini — combined by a synthesizer
+        A Fusion of two members, the draft → review Pipeline and gemini, combined by a synthesizer
         that is itself a judge → writer Pipeline; grading the writer's answer is the graded answer.
       </figcaption>
     </figure>
@@ -450,7 +490,15 @@ const pipelineSig = `sf.Pipeline(
         aria-label="One Pipeline whose stages are a Model, a Fusion and a nested Pipeline; grading the last stage's answer produces the graded answer."
       >
         <defs>
-          <marker id="pl-a6" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+          <marker
+            id="pl-a6"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
@@ -479,7 +527,7 @@ const pipelineSig = `sf.Pipeline(
         </g>
       </svg>
       <figcaption class="dgcap">
-        A stage is any recipe — here a Model, a Fusion and a nested Pipeline chained in one Pipeline;
+        A stage is any recipe: here a Model, a Fusion and a nested Pipeline chained in one Pipeline;
         only the last stage's answer is graded.
       </figcaption>
     </figure>

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -19,6 +19,11 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/InstallationPage.vue'),
     },
     {
+      path: '/sf-client/first-fusion',
+      name: 'sf-client-first-fusion',
+      component: () => import('@/pages/sf-client/FirstFusionPage.vue'),
+    },
+    {
       path: '/sf-client/quickstartPage',
       name: 'sf-client-quickstart',
       component: () => import('@/pages/sf-client/QuickstartPage.vue'),

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -104,6 +104,26 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/api/ClientsPage.vue'),
     },
     {
+      path: '/sf-client/api/fusions',
+      name: 'sf-client-api-fusions',
+      component: () => import('@/pages/sf-client/api/FusionsPage.vue'),
+    },
+    {
+      path: '/sf-client/api/pipelines',
+      name: 'sf-client-api-pipelines',
+      component: () => import('@/pages/sf-client/api/PipelinesPage.vue'),
+    },
+    {
+      path: '/sf-client/api/url4',
+      name: 'sf-client-api-url4',
+      component: () => import('@/pages/sf-client/api/Url4Page.vue'),
+    },
+    {
+      path: '/sf-client/api/connections',
+      name: 'sf-client-api-connections',
+      component: () => import('@/pages/sf-client/api/ConnectionsPage.vue'),
+    },
+    {
       path: '/sf-client/api/modules',
       name: 'sf-client-api-modules',
       component: () => import('@/pages/sf-client/api/ModulesPage.vue'),

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -104,6 +104,26 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/api/ClientsPage.vue'),
     },
     {
+      path: '/sf-client/api/modules',
+      name: 'sf-client-api-modules',
+      component: () => import('@/pages/sf-client/api/ModulesPage.vue'),
+    },
+    {
+      path: '/sf-client/api/errors',
+      name: 'sf-client-api-errors',
+      component: () => import('@/pages/sf-client/api/ErrorsPage.vue'),
+    },
+    {
+      path: '/sf-client/api/events',
+      name: 'sf-client-api-events',
+      component: () => import('@/pages/sf-client/api/EventsPage.vue'),
+    },
+    {
+      path: '/sf-client/api/leaderboards',
+      name: 'sf-client-api-leaderboards',
+      component: () => import('@/pages/sf-client/api/LeaderboardsPage.vue'),
+    },
+    {
       path: '/learn',
       name: 'learn',
       component: () => import('@/pages/learn/ArchitecturePage.vue'),


### PR DESCRIPTION
## Summary

Adds the four API reference pages `OME-670` left out, under a new `Modules & types` group.

| Page | Covers |
|---|---|
| **Modules** | `sf.benchmarks`, `sf.models`, `sf.connections`, `sf.leaderboards`, `sf.events`, and the five top-level functions |
| **Errors** | the `ScreamingFaceError` hierarchy, the seven diagnostic attributes, and `EvaluationWarning` |
| **Events** | `Event`, `Started`, `Span`, `Log`, `Usage`, `Terminated`, `TerminationError` |
| **Leaderboards** | `Leaderboard`, `LeaderboardInfo`, `LeaderboardEntry`, `LeaderboardBaseline`, `LeaderboardScore` |

`api/LeaderboardsPage` is the field reference for the five values; `guides/LeaderboardsPage` is the task walkthrough. Same split as the two Benchmarks pages.

**Asana:** n/a (technical work, tracked as OME-671)

## Components touched

`public-docs` only. Purely additive: four new pages, four routes, one nav group, four rows in `CLAUDE.md`.

## Test plan

- [x] Every signature from `inspect.signature`, every field from `dataclasses.fields`, every literal from `typing.get_args`, against the client on `main`
- [x] No page names a symbol absent from `__all__`, checked programmatically
- [x] `npx oxlint .`, `npx eslint .`, `npm run build`, `prettier --check` green
- [x] No revision hash asserted in prose or a table
- [ ] Screenshots attached

## Note on scope

This branch previously also corrected the four `api/` pages, six guides and the Quickstart against the merged client, because `OME-670` had verified its reference at `e387aefd` on a branch that never merged.

That work has been **dropped**. @IrinaBejan had corrected the same pages independently in `9274e2de`, `1b6ccd09` and `79cf4314`, verified against `b698fcff`, which is newer than the commit this branch had used. On every fact compared the two agreed, so nothing was lost by taking hers. The branch was reset onto current `main` and now conflicts with nothing.

## Three things noticed, not fixed here

- `InstallationPage.vue` states `len(sf.__all__)` is 53. It is 55 on `main`.
- `CorrectiveLoop` and `SelfCorrective` landed recently and are documented nowhere. They belong on `api/RecipesPage.vue`.
- The sidebar footer pins commit `b698fcff` while the companion-notebook links point at `blob/main`, so a reader clicking through gets notebooks from a different state than the prose describes. One shared constant would keep them in step.

`api/ReportsPage.vue` is also still uncorrected; its examples need a live evaluation and a working provider key.

---

## Follow-up revision (on top of Callis' four pages)

Branch is already rebased on current `main` (fast-forward — no history rewrite). Added on top:

**Terminology & cross-links**
- `url4` lowercased in prose throughout (canon: always lowercase, like `http`).
- Re-pointed cross-links to pages `main` added since this branch was written: `ModelInfo → api/models`, `CandidateResult → api/candidate-result`, `sf.Usage`/`report.usage → api/usage`.
- Board is called the **leaderboard** in prose (the `scoreboard_url` field and `apps/scoreboard` service keep their names).

**Newly documented types** — five `sf.__all__` symbols that were undocumented everywhere, verified against the client:
- `api/RecipesPage`: `CorrectiveLoop`, `SelfCorrective`, with a flow diagram of the corrective loop.
- `api/CandidateResultPage`: the `CaseGrade → Check → Evidence → EvidenceProducer` grading tree, with a hierarchy diagram.
- This closes the "documented nowhere" item above; `len(sf.__all__)` already reads **55** on `main`, so the "53" note is stale.

**Docs-wide terminology & voice pass** (all pages)
- `Client` uppercase in prose (the product/library/class); `engine` lowercase (the runtime); em-dash overload cut to ≤2/page (`guides/ClientsPage` 13→1); AI-slop / negative-parallelism scrub.

Code blocks, verified example outputs, `<code>` symbols, routes and diagrams untouched. `prettier --check`, `eslint`, and `npm run build` green.

_Refs: OME-671_
