### PR TITLE
fix(url4-cloud): keep provider refusals visible end-to-end (OME-825)

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
@@ -20,6 +20,7 @@ from url4_cloud.benchmarks.contract import (
     CaseId,
     CaseResult,
     Failure,
+    candidate_coverage,
     validate_case_id,
 )
 
@@ -131,7 +132,7 @@ def finalize_candidate_result(
         benchmark_revision=benchmark_revision,
         case_count=len(typed_cases),
         score=scored.score if scored is not None else None,
-        coverage=round(len(gradeable) / len(typed_cases), 4) if typed_cases else 0.0,
+        coverage=candidate_coverage(typed_cases, len(typed_cases)),
         metrics=scored.metrics if scored is not None else {},
         cases=typed_cases,
         failures=typed_failures,

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/candidate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/candidate.py
@@ -8,6 +8,7 @@ from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
 from url4_cloud.benchmarks.contract import (
     CANDIDATE_ROUTE,
+    PROVIDER_REFUSAL_PLACEHOLDER,
     encode_candidate_invocation,
 )
 from url4_cloud.model_outcomes import (
@@ -59,6 +60,14 @@ class _CandidateInvocation:
                             code="candidate_contract_error",
                             permanent=True,
                         ) from exc
+                    # WHY the placeholder: a content-filter turn normally carries NULL
+                    # refusal text (see runner/model_response.py). Encoding it verbatim
+                    # would produce output="" refusal=None — indistinguishable from a
+                    # legitimate empty answer, so the judge would grade it and publish a
+                    # scored plausible-zero. The provider DID signal refusal; only its
+                    # text is missing, so a named marker keeps the refused path intact.
+                    if not outcome.refusal:
+                        outcome = ModelOutcome(outcome.finish_reason, PROVIDER_REFUSAL_PLACEHOLDER)
                     return _encode_candidate_invocation("", outcome)
         except RetrievalPolicyError as exc:
             raise ResolutionError(

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, Literal, cast
 
 from pydantic import (
@@ -25,6 +25,13 @@ CANDIDATE_INPUT_SCHEMA = "screamingface.candidate-input.v1"
 CANDIDATE_INVOCATION_SCHEMA = "screamingface.candidate-invocation.v1"
 CANDIDATE_RESULT_SCHEMA = "screamingface.candidate-result.v1"
 CANDIDATE_MESSAGE_ROLES = frozenset({"system", "developer", "user", "assistant"})
+# The graded marker for a provider refusal that arrived without refusal text (the normal
+# content-filter shape). Precedent: HealthBench's official harness grades the literal
+# marker "No response (bad request)." for provider errors — a named marker string graded
+# as the answer keeps the event visible instead of publishing a plausible-zero empty
+# answer, and keeps the refused path (status, grading, coverage) identical to a refusal
+# that did carry text.
+PROVIDER_REFUSAL_PLACEHOLDER = "No refusal text (provider refused the request)."
 CaseId = StrictInt | StrictStr
 Outcome = Literal["MET", "UNMET", "PASS", "FAIL"]
 FailureStage = Literal["candidate", "grading", "aggregation"]
@@ -196,10 +203,14 @@ def _require_refused_case(case: CaseResult) -> None:
 
 
 def _require_failed_case(case: CaseResult) -> None:
+    # WHY no provider_refusal Failure-code check: no producer can emit one. The Candidate
+    # adapter converts the runner's provider_refusal error into an ordinary refused
+    # invocation before it can become a Failure, and url4's on_error=collect envelope
+    # carries only kind+message — collected error codes always fall back to the
+    # aggregate defaults. Refusals reach this contract only through `case.refusal`.
     if (
         not case.failures
         or case.refusal is not None
-        or any(failure.code == "provider_refusal" for failure in case.failures)
         or case.grade is not None
         and case.grade.score is not None
     ):
@@ -272,13 +283,25 @@ class CandidateResult(_StrictWireModel):
         return self.model_dump(by_alias=True)
 
 
+def candidate_coverage(cases: Sequence[CaseResult], case_count: int) -> float:
+    """The exact fraction of selected Cases carrying a numeric Benchmark grade.
+
+    The ONE copy of the coverage formula: `finalize_candidate_result` produces with it
+    and `_candidate_outcome` validates against it, so producer and validator cannot
+    drift (they used to be two hand-synchronized `round(..., 4)` expressions).
+    """
+
+    gradeable = sum(1 for case in cases if case.grade is not None and case.grade.score is not None)
+    return round(gradeable / case_count, 4) if case_count else 0.0
+
+
 def _candidate_outcome(result: CandidateResult) -> None:
     if "coverage" in result.metrics:
         raise ValueError("metrics.coverage is replaced by top-level coverage")
     gradeable = [
         case for case in result.cases if case.grade is not None and case.grade.score is not None
     ]
-    expected_coverage = round(len(gradeable) / result.case_count, 4) if result.case_count else 0.0
+    expected_coverage = candidate_coverage(result.cases, result.case_count)
     if result.coverage != expected_coverage:
         raise ValueError(
             f"coverage must equal numeric Case grades / selected Cases ({expected_coverage})"
@@ -344,6 +367,33 @@ def _finite_score(value: object) -> object:
     if isinstance(value, int | float) and not math.isfinite(value):
         raise ValueError("score must be a finite number or null")
     return value
+
+
+def validate_candidate_outcome(
+    answer: object,
+    output: object,
+    refusal: object,
+    *,
+    benchmark: str,
+) -> None:
+    """Validate the evaluator-text/output/refusal triple every benchmark record binds.
+
+    The ONE copy of the outcome-triple invariant (it used to live byte-identically in
+    draco and healthbench records, with a drifted third variant in ifeval): the answer
+    is the evaluator text, exactly one of output/refusal is carried, and the answer
+    equals whichever one is present. `benchmark` only labels the error messages.
+    """
+
+    if not isinstance(answer, str):
+        raise ValueError(f"{benchmark} Candidate answer must be text")
+    if (refusal is None) == (output is None):
+        raise ValueError(f"{benchmark} Candidate must carry exactly one of output or refusal")
+    if refusal is not None and (
+        not isinstance(refusal, str) or not refusal.strip() or answer != refusal
+    ):
+        raise ValueError(f"{benchmark} Candidate refusal must be exact non-empty evaluator text")
+    if output is not None and answer != output:
+        raise ValueError(f"{benchmark} Candidate output must equal evaluator text")
 
 
 def encode_candidate_invocation(
@@ -413,8 +463,11 @@ __all__ = [
     "Evidence",
     "EvidenceProducer",
     "Failure",
+    "PROVIDER_REFUSAL_PLACEHOLDER",
+    "candidate_coverage",
     "decode_candidate_invocation",
     "encode_candidate_invocation",
+    "validate_candidate_outcome",
     "validate_case_id",
     "validate_finish_reason",
 ]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 
+from url4_cloud.benchmarks.contract import validate_candidate_outcome
 from url4_cloud.benchmarks.draco.validation import (
     optional_integer,
     require_positive_integer,
@@ -28,7 +29,7 @@ def bind_case(
     """Bind evaluator text and exact Candidate outcome to one Engine-owned Case."""
 
     selected_id = require_positive_integer(case_id, "case_id")
-    _validate_outcome(answer, output, refusal)
+    validate_candidate_outcome(answer, output, refusal, benchmark="DRACO")
     cases = _decode_cases(raw_cases)
     row = next(
         (
@@ -53,19 +54,6 @@ def bind_case(
         "refusal": refusal,
         "metadata": {key: value for key, value in row.items() if key not in {"id", "input"}},
     }
-
-
-def _validate_outcome(answer: object, output: object, refusal: object) -> None:
-    if not isinstance(answer, str):
-        raise ValueError("DRACO Candidate answer must be text")
-    if (refusal is None) == (output is None):
-        raise ValueError("DRACO Candidate must carry exactly one of output or refusal")
-    if refusal is not None and (
-        not isinstance(refusal, str) or not refusal.strip() or answer != refusal
-    ):
-        raise ValueError("DRACO Candidate refusal must be exact non-empty evaluator text")
-    if output is not None and answer != output:
-        raise ValueError("DRACO Candidate output must equal evaluator text")
 
 
 def _decode_cases(raw_cases: str) -> list[object]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/records.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/records.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 
+from url4_cloud.benchmarks.contract import validate_candidate_outcome
+
 CASE_SCHEMA = "screamingface.healthbench-case-record.v1"
 RUBRIC_SCHEMA = "screamingface.healthbench-rubric-record.v1"
 
@@ -21,7 +23,7 @@ def bind_case(
     """Bind evaluator text and exact Candidate outcome to one Engine-owned Case."""
 
     selected_id = _case_id(case_id)
-    _validate_outcome(answer, output, refusal)
+    validate_candidate_outcome(answer, output, refusal, benchmark="HealthBench")
     cases = _decode_cases(raw_cases)
     row = next(
         (
@@ -46,19 +48,6 @@ def bind_case(
         "refusal": refusal,
         "metadata": {key: value for key, value in row.items() if key not in {"id", "input"}},
     }
-
-
-def _validate_outcome(answer: object, output: object, refusal: object) -> None:
-    if not isinstance(answer, str):
-        raise ValueError("HealthBench Candidate answer must be text")
-    if (refusal is None) == (output is None):
-        raise ValueError("HealthBench Candidate must carry exactly one of output or refusal")
-    if refusal is not None and (
-        not isinstance(refusal, str) or not refusal.strip() or answer != refusal
-    ):
-        raise ValueError("HealthBench Candidate refusal must be exact non-empty evaluator text")
-    if output is not None and answer != output:
-        raise ValueError("HealthBench Candidate output must equal evaluator text")
 
 
 def _decode_cases(raw_cases: str) -> list[object]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
@@ -105,7 +105,13 @@ def _failed_case_result(
         selected_case=selected_case,
         failures=[
             {
-                "stage": _failure_stage(diagnostic.code),
+                # WHY the constant stage: a collected url4 error row carries only
+                # kind+message — never a code — so public_error always falls back to
+                # the aggregate defaults and the old provider_/aigateway_ prefix
+                # heuristic could not fire. One IFEval row spans invocation AND
+                # checking, so "grading" (the stage that failed to produce a valid
+                # evaluation record) is the honest constant.
+                "stage": "grading",
                 "code": diagnostic.code,
                 "message": diagnostic.message,
                 "retryable": diagnostic.retryable,
@@ -113,12 +119,6 @@ def _failed_case_result(
                 "metadata": metadata,
             }
         ],
-    )
-
-
-def _failure_stage(code: str) -> str:
-    return (
-        "candidate" if code.startswith("provider_") or code.startswith("aigateway_") else "grading"
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/corrective_policy.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/corrective_policy.py
@@ -70,10 +70,7 @@ SELF_CORRECTIVE_REVISION = hashlib.sha256(
 # The reproduction of Skurikhin et al. §2 (the early-exit ensemble). The paper does
 # not publish its judge prompts, so ours are named revision inputs; the control flow
 # is pinned by LANL_FLOW.
-# v2: member records carry the check record's refusal, and selection re-encodes the
-# chosen member's refusal instead of erasing it — an all-refuse Case publishes as
-# refused, never as a scored output holding refusal prose.
-LANL_PROTOCOL_REVISION = "lanl-early-exit-ensemble-v2"
+LANL_PROTOCOL_REVISION = "lanl-early-exit-ensemble-v1"
 LANL_ENSEMBLE_REVISION = hashlib.sha256(
     "\n".join(
         (

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/corrective_policy.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/corrective_policy.py
@@ -52,7 +52,7 @@ LANL_FLOW = (
     "stopping attempt; judge feedback is authored only for a no-pass attempt; a case "
     "that never passes selects the answer with maximal strict-satisfaction fraction, "
     "judge tie-break on exact ties; the selected answer is always a member answer "
-    "verbatim"
+    "verbatim, carrying the member's refusal marking"
 )
 
 # Every prose constant and shape bound defines score meaning and therefore revision identity.
@@ -70,7 +70,10 @@ SELF_CORRECTIVE_REVISION = hashlib.sha256(
 # The reproduction of Skurikhin et al. §2 (the early-exit ensemble). The paper does
 # not publish its judge prompts, so ours are named revision inputs; the control flow
 # is pinned by LANL_FLOW.
-LANL_PROTOCOL_REVISION = "lanl-early-exit-ensemble-v1"
+# v2: member records carry the check record's refusal, and selection re-encodes the
+# chosen member's refusal instead of erasing it — an all-refuse Case publishes as
+# refused, never as a scored output holding refusal prose.
+LANL_PROTOCOL_REVISION = "lanl-early-exit-ensemble-v2"
 LANL_ENSEMBLE_REVISION = hashlib.sha256(
     "\n".join(
         (

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py
@@ -274,6 +274,7 @@ def _member_round(collection: Node, attempt: int) -> Node:
                             "expression": "$item.expression",
                             "answer": f"${check}.answer",
                             "finish_reason": f"${check}.finish_reason",
+                            "refusal": f"${check}.refusal",
                             "feedback": f"${feedback}",
                         }
                     ),

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
@@ -632,6 +632,9 @@ def _attempt_member(value: object, index: int) -> dict[str, Any]:
     for name in ("answer", "feedback", "finish_reason", "refusal"):
         if name not in member:
             raise _unavailable(f"Candidate member {index + 1} has no {name}")
+    refusal = member["refusal"]
+    if refusal is not None and member["answer"] != refusal:
+        raise _unavailable(f"Candidate member {index + 1} refusal must equal its checked answer")
     return member
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
@@ -338,6 +338,9 @@ def _lanl_select(root: Path):
 
     INVARIANT: the returned text is always a member's exact answer — selection can
     choose but never rewrite, so it cannot break a requirement a member satisfied.
+    The chosen member's refusal marking travels with it: a refused member's answer IS
+    its refusal text, so selection re-encodes it as a refusal, never as an output —
+    otherwise an all-refuse Case would publish refusal prose as a scored answer.
     """
 
     def select(request: Request) -> str:
@@ -360,7 +363,12 @@ def _lanl_select(root: Path):
             best = max(score for _, score in scored)
             tied = [member for member, score in scored if score == best]
             chosen = tied[0] if len(tied) == 1 else (_by_letter(tied, letter) or tied[0])
-        return encode_candidate_invocation(chosen["answer"], chosen["finish_reason"], None)
+        refusal = chosen["refusal"]
+        return encode_candidate_invocation(
+            "" if refusal is not None else chosen["answer"],
+            chosen["finish_reason"],
+            refusal,
+        )
 
     return select
 
@@ -573,6 +581,8 @@ def _member(value: object, index: int) -> dict[str, Any]:
     selected.update(_optional_member_text(value, index))
     if "finish_reason" in value:
         selected["finish_reason"] = _finish_reason(value["finish_reason"], index)
+    if "refusal" in value:
+        selected["refusal"] = _member_refusal(value["refusal"], index)
     return selected
 
 
@@ -607,11 +617,19 @@ def _finish_reason(value: object, index: int) -> str | None:
     return value
 
 
+def _member_refusal(value: object, index: int) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise _unavailable(f"Candidate member {index + 1} refusal must be non-blank text or null")
+    return value
+
+
 def _attempt_member(value: object, index: int) -> dict[str, Any]:
     """Require the complete output contract for one checked member attempt."""
 
     member = _member(value, index)
-    for name in ("answer", "feedback", "finish_reason"):
+    for name in ("answer", "feedback", "finish_reason", "refusal"):
         if name not in member:
             raise _unavailable(f"Candidate member {index + 1} has no {name}")
     return member

--- a/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
+++ b/apps/url4-cloud/tests/unit/test_benchmark_foundation.py
@@ -27,6 +27,7 @@ from url4_cloud.benchmarks.candidate import install_candidate_invocation
 from url4_cloud.benchmarks.contract import (
     CANDIDATE_BINDING,
     CANDIDATE_ROUTE,
+    PROVIDER_REFUSAL_PLACEHOLDER,
     decode_candidate_invocation,
 )
 from url4_cloud.config import Settings
@@ -689,6 +690,42 @@ async def test_provider_refusal_is_a_normal_candidate_envelope() -> None:
         "",
         "content_filter",
         "safety policy",
+    )
+
+
+async def test_a_null_text_refusal_still_publishes_as_a_refusal() -> None:
+    """A content-filter turn normally carries NO refusal text; without the placeholder it
+    would encode as output="" refusal=None — indistinguishable from a legitimate empty
+    answer, so the judge would grade it and publish a scored plausible-zero. A provider
+    refusal must NEVER be publishable as an ordinary scored answer (OME-825)."""
+
+    def refusal(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"content": None, "refusal": None},
+                        "finish_reason": "content_filter",
+                    }
+                ]
+            },
+        )
+
+    benchmark = _benchmark()
+    client, world = await _world(BenchmarkRegistry((benchmark,)), [], response=refusal)
+    model = RelExpr(path="/provider/model", context="$input", intent=text("answer"))
+
+    try:
+        result = await world.node.evaluate(_candidate_call(model, web_search=False))
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    assert decode_candidate_invocation(result.text) == (
+        "",
+        "content_filter",
+        PROVIDER_REFUSAL_PLACEHOLDER,
     )
 
 

--- a/apps/url4-cloud/tests/unit/test_ifeval_lanl_ensemble.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_lanl_ensemble.py
@@ -63,7 +63,9 @@ def _node(tmp_path: Path) -> Url4Node:
     return node
 
 
-def _member(key: str, answer: str, feedback: str) -> dict[str, str]:
+def _member(
+    key: str, answer: str, feedback: str, refusal: str | None = None
+) -> dict[str, str | None]:
     return {
         "key": key.upper(),
         "name": f"member-{key}",
@@ -71,6 +73,7 @@ def _member(key: str, answer: str, feedback: str) -> dict[str, str]:
         "expression": f"/provider/{key}($input)",
         "answer": answer,
         "finish_reason": "stop",
+        "refusal": refusal,
         "feedback": feedback,
     }
 
@@ -101,7 +104,7 @@ async def _call(node: Url4Node, path: str, payload: object, intent: str) -> str:
 # --- (1) the engine semantics the whole design rests on ---------------------------
 
 
-def _probe_expression(members: list[dict[str, str]]) -> str:
+def _probe_expression(members: list[dict[str, str | None]]) -> str:
     """A production-shaped case body: gate + gated iterate as SIBLINGS inside an
     iteration body — the only scope where a collection reference resolves."""
 
@@ -263,7 +266,7 @@ async def test_tie_gate_stays_quiet_on_a_non_final_no_pass_round(tmp_path: Path)
 # --- (2b) selection ----------------------------------------------------------------
 
 
-async def _selected(tmp_path: Path, members: list[dict[str, str]], tie: list[str]) -> str:
+async def _selected(tmp_path: Path, members: list[dict[str, str | None]], tie: list[str]) -> str:
     node = _node(tmp_path)
     reply = await _call(node, LANL_SELECT_ROUTE, {"round": members, "tie": tie}, "1:1")
     output, finish_reason, refusal = decode_candidate_invocation(reply)
@@ -320,6 +323,28 @@ async def test_never_pass_selects_the_maximal_satisfaction_answer(tmp_path: Path
 async def test_a_never_pass_exact_tie_defers_to_the_judge_letter(tmp_path: Path) -> None:
     members = [_member("a", _FAIL, "failed"), _member("b", _FAIL + " twice", "failed")]
     assert await _selected(tmp_path, members, [_judge_envelope("b")]) == _FAIL + " twice"
+
+
+@pytest.mark.asyncio
+async def test_selecting_a_refused_member_carries_its_refusal_marking(tmp_path: Path) -> None:
+    """Selection may choose but must never launder: when every member refused, the
+    chosen member's refusal text must be re-encoded AS a refusal, not as an ordinary
+    output — otherwise an all-refuse Case publishes refusal prose as a scored answer
+    and the refusal disappears from the wire (OME-825)."""
+
+    worse = "I, refuse."  # comma + capitals: satisfies neither check (0.0)
+    better = "i cannot comply"  # no comma + lowercase: trivially satisfies both (1.0)
+    members = [
+        _member("a", worse, "failed", refusal=worse),
+        _member("b", better, "failed", refusal=better),
+    ]
+    node = _node(tmp_path)
+    reply = await _call(node, LANL_SELECT_ROUTE, {"round": members, "tie": []}, "1:1")
+    output, finish_reason, refusal = decode_candidate_invocation(reply)
+    assert output == ""
+    assert finish_reason == "stop"
+    assert refusal == better  # maximal strict satisfaction still picks it...
+    # ...but the refusal marking travels with the selection instead of being erased.
 
 
 # --- (2c) the envelope -------------------------------------------------------------

--- a/apps/url4-cloud/tests/unit/test_ifeval_lanl_ensemble.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_lanl_ensemble.py
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 
 from url4 import RelExpr, Text, build, expr, iterate, ref, render, src, text
+from url4.core.errors import ResolutionError
 from url4.peer.server import Url4Node
 from url4_cloud.benchmarks.contract import decode_candidate_invocation
 from url4_cloud.benchmarks.ifeval.corrective_policy import (
@@ -345,6 +346,19 @@ async def test_selecting_a_refused_member_carries_its_refusal_marking(tmp_path: 
     assert finish_reason == "stop"
     assert refusal == better  # maximal strict satisfaction still picks it...
     # ...but the refusal marking travels with the selection instead of being erased.
+
+
+@pytest.mark.asyncio
+async def test_selection_rejects_a_refusal_that_differs_from_the_checked_answer(
+    tmp_path: Path,
+) -> None:
+    members = [
+        _member("a", "selected answer", "failed", refusal="different refusal"),
+        _member("b", _FAIL, "failed"),
+    ]
+    node = _node(tmp_path)
+    with pytest.raises(ResolutionError, match="refusal must equal its checked answer"):
+        await _call(node, LANL_SELECT_ROUTE, {"round": members, "tie": []}, "1:1")
 
 
 # --- (2c) the envelope -------------------------------------------------------------

--- a/apps/url4-cloud/tests/unit/test_ifeval_member_shape.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_member_shape.py
@@ -43,7 +43,7 @@ def _assets(root: Path) -> None:
     )
 
 
-def _members(*values: tuple[str, str]) -> list[dict[str, str]]:
+def _members(*values: tuple[str, str]) -> list[dict[str, str | None]]:
     return [
         {
             "key": chr(65 + index),
@@ -52,13 +52,14 @@ def _members(*values: tuple[str, str]) -> list[dict[str, str]]:
             "expression": f"/provider/member-{index + 1}",
             "answer": answer,
             "finish_reason": "stop",
+            "refusal": None,
             "feedback": feedback,
         }
         for index, (answer, feedback) in enumerate(values)
     ]
 
 
-async def _select(tmp_path: Path, members: list[dict[str, str]], pick: str) -> str:
+async def _select(tmp_path: Path, members: list[dict[str, str | None]], pick: str) -> str:
     """Call the LANL select with a never-pass round tied on satisfaction, so the
     judge's letter (or its rejection) is the only thing deciding the outcome."""
 

--- a/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
@@ -78,7 +78,12 @@ def test_collected_candidate_failure_returns_a_complete_unscored_result() -> Non
             "grade": None,
             "failures": [
                 {
-                    "stage": "candidate",
+                    # WHY stage "grading": one IFEval row spans invocation AND checking,
+                    # and engine-collected url4 error rows carry no code (kind+message
+                    # only), so a code-prefix stage guess could never fire on real rows —
+                    # the aggregate now reports the one stage it actually knows: the row
+                    # produced no valid evaluation record.
+                    "stage": "grading",
                     "code": "provider_error",
                     "message": "the provider was unavailable",
                     "retryable": False,

--- a/docs/plan/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/plan/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -18,8 +18,9 @@ All changes in `apps/url4-cloud`; one PR; branch `OME-825-benchmark-refusal-inte
    delegation to `validate_candidate_outcome`.
 4. **candidate.py** — in the `provider_refusal` interception, substitute
    `PROVIDER_REFUSAL_PLACEHOLDER` when the outcome carries no refusal text.
-5. **ifeval/corrective_policy.py** — `LANL_PROTOCOL_REVISION = "lanl-early-exit-ensemble-v2"`;
-   LANL_FLOW final clause gains "carrying the member's refusal marking".
+5. **ifeval/corrective_policy.py** — LANL_FLOW final clause gains "carrying the
+   member's refusal marking" (the hash-derived variant revision changes with it;
+   the v1 label stays — the variant is unreleased, nobody to signal).
 6. **ifeval/iterative_correction.py** — member-record payload adds
    `"refusal": f"${check}.refusal"`.
 7. **ifeval/runtime.py** — `_member` parses nullable `refusal` (mirrors `finish_reason`);

--- a/docs/plan/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/plan/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -1,0 +1,44 @@
+# OME-825 — Benchmark refusal integrity (plan)
+
+Spec: `docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md`.
+All changes in `apps/url4-cloud`; one PR; branch `OME-825-benchmark-refusal-integrity`.
+
+## Changes, in dependency order
+
+1. **contract.py**
+   - `PROVIDER_REFUSAL_PLACEHOLDER` constant (the graded marker text).
+   - `validate_candidate_outcome(answer, output, refusal, *, benchmark)` — the shared
+     outcome-triple validator; error messages keep the exact per-benchmark wording.
+   - `candidate_coverage(cases, case_count)` — the single coverage formula;
+     `_candidate_outcome` compares against it.
+   - `_require_failed_case`: drop the dead `provider_refusal` clause.
+2. **aggregation.py** — `finalize_candidate_result` computes `coverage` via
+   `candidate_coverage`.
+3. **draco/records.py, healthbench/records.py** — `_validate_outcome` bodies replaced by
+   delegation to `validate_candidate_outcome`.
+4. **candidate.py** — in the `provider_refusal` interception, substitute
+   `PROVIDER_REFUSAL_PLACEHOLDER` when the outcome carries no refusal text.
+5. **ifeval/corrective_policy.py** — `LANL_PROTOCOL_REVISION = "lanl-early-exit-ensemble-v2"`;
+   LANL_FLOW final clause gains "carrying the member's refusal marking".
+6. **ifeval/iterative_correction.py** — member-record payload adds
+   `"refusal": f"${check}.refusal"`.
+7. **ifeval/runtime.py** — `_member` parses nullable `refusal` (mirrors `finish_reason`);
+   `_attempt_member` requires it; `_lanl_select` encodes
+   `("" if refusal else answer, finish_reason, refusal)`.
+8. **ifeval/aggregate.py** — `_failure_stage` removed; stage is the literal `"grading"`
+   with a WHY comment (collected url4 errors carry no code, so the prefix branch was dead).
+
+## Tests
+
+- `test_benchmark_foundation.py` (or the candidate adapter's home): null-text
+  `provider_refusal` → placeholder refusal, empty output.
+- `test_ifeval_iterative_correction.py`: all-members-refused selection carries refusal;
+  member fixtures gain `refusal`; LANL expression/revision goldens updated.
+- Contract tests: coverage helper; failed-case validator without the dead clause.
+- Full `uv run pytest tests/unit` green.
+
+## Risks
+
+- LANL golden churn is deliberate (revision bump). If url4 `$ref.field` null
+  substitution misbehaves for `refusal`, mirror the existing nullable
+  `finish_reason` handling — same mechanism, already proven.

--- a/docs/plan/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/plan/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -24,7 +24,7 @@ All changes in `apps/url4-cloud`; one PR; branch `OME-825-benchmark-refusal-inte
 6. **ifeval/iterative_correction.py** — member-record payload adds
    `"refusal": f"${check}.refusal"`.
 7. **ifeval/runtime.py** — `_member` parses nullable `refusal` (mirrors `finish_reason`);
-   `_attempt_member` requires it; `_lanl_select` encodes
+   `_attempt_member` requires it and rejects refusal/answer mismatches; `_lanl_select` encodes
    `("" if refusal else answer, finish_reason, refusal)`.
 8. **ifeval/aggregate.py** — `_failure_stage` removed; stage is the literal `"grading"`
    with a WHY comment (collected url4 errors carry no code, so the prefix branch was dead).
@@ -34,7 +34,8 @@ All changes in `apps/url4-cloud`; one PR; branch `OME-825-benchmark-refusal-inte
 - `test_benchmark_foundation.py` (or the candidate adapter's home): null-text
   `provider_refusal` → placeholder refusal, empty output.
 - `test_ifeval_iterative_correction.py`: all-members-refused selection carries refusal;
-  member fixtures gain `refusal`; LANL expression/revision goldens updated.
+  malformed refusal/answer mismatches fail loudly; member fixtures gain `refusal`;
+  LANL expression/revision goldens updated.
 - Contract tests: coverage helper; failed-case validator without the dead clause.
 - Full `uv run pytest tests/unit` green.
 

--- a/docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -1,0 +1,52 @@
+# OME-825 — Benchmark refusal integrity (spec)
+
+Status: approved for implementation (Khoa, 2026-08-14, "fix all these").
+Parent policy: `docs/spec/2026-08-13-OME-807-benchmark-failure-handling.md` — unchanged.
+This spec closes two seams where OME-807's "refusal is data, carried end-to-end"
+doctrine leaks, plus three structural cleanups from the PR #584 review.
+
+## 1. Null-text provider refusal (resolves the open safety-filter question)
+
+A provider content-filter turn normally carries **no refusal text**
+(`runner/model_response.py`'s own invariant comment). Today the Candidate adapter
+encodes that event as `output="" refusal=None` — indistinguishable from a legitimate
+empty answer, so it is judged, scored ~0, and published as `status=scored`: exactly
+the "plausible zero" the OME-807 contract forbids.
+
+Normative rule: **a provider refusal without refusal text is still a refusal.** The
+Candidate adapter substitutes the named placeholder text
+`"No refusal text (provider refused the request)."` as the refusal. Rationale and
+precedent: HealthBench's official harness grades the literal marker
+`"No response (bad request)."` when the provider errors — a synthesized marker string
+graded as the answer is the originals-faithful mechanism. The OME-807 rules then apply
+unchanged: the refusal text flows through the normal checker, the Case publishes
+`status=refused` with its grade, and coverage stays factual. This is not refusal
+inference from answer text (forbidden by OME-807): the provider *signaled* refusal;
+only its text is missing.
+
+## 2. LANL selection carries the refusal marking
+
+LANL member records gain a `refusal` field (from the check record, which already
+carries it), and selection re-encodes the chosen member with **its own refusal**
+instead of hardcoded `None`. A refused member's answer text IS its refusal text, so a
+chosen refused member encodes as `output="", refusal=<text>` — the downstream re-check
+grades the same text, and Aggregation's refused branch fires. LANL_FLOW gains the
+clause "…verbatim, carrying the member's refusal marking"; `LANL_PROTOCOL_REVISION`
+bumps to v2. Only the LANL variant revision changes; canonical IFEval, DRACO, and
+HealthBench protocol expressions stay byte-identical.
+
+## 3. Cleanups (no wire change)
+
+- One shared outcome-triple validator (`contract.validate_candidate_outcome`) replaces
+  the byte-identical copies in `draco/records.py` and `healthbench/records.py`.
+- One shared coverage formula (`contract.candidate_coverage`) used by both the
+  producer (`finalize_candidate_result`) and the contract validator.
+- The dead `provider_refusal` Failure-code clause in `_require_failed_case` and
+  ifeval's dead `provider_`/`aigateway_` stage heuristic are removed: no producer can
+  emit that code (url4 collect strips error codes to kind+message), and the clauses
+  imply a refusal-as-Failure model OME-807 deleted.
+
+## Don't regress
+
+- Refusals are graded through the normal checker (never auto-zeroed) — OME-807 §grading.
+- Duplicate-rubric abort, positional row binding, and coverage semantics unchanged.

--- a/docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -38,6 +38,9 @@ anyone yet, so there is no consumer to signal (decision: Khoa, 2026-08-14). Only
 LANL variant hash changes; canonical IFEval, DRACO, and HealthBench protocol
 expressions stay byte-identical.
 
+Malformed member records where a non-null `refusal` differs from the checked `answer`
+fail loudly before selection. Selection must never score one text and publish another.
+
 ## 3. Cleanups (no wire change)
 
 - One shared outcome-triple validator (`contract.validate_candidate_outcome`) replaces

--- a/docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -31,9 +31,12 @@ carries it), and selection re-encodes the chosen member with **its own refusal**
 instead of hardcoded `None`. A refused member's answer text IS its refusal text, so a
 chosen refused member encodes as `output="", refusal=<text>` — the downstream re-check
 grades the same text, and Aggregation's refused branch fires. LANL_FLOW gains the
-clause "…verbatim, carrying the member's refusal marking"; `LANL_PROTOCOL_REVISION`
-bumps to v2. Only the LANL variant revision changes; canonical IFEval, DRACO, and
-HealthBench protocol expressions stay byte-identical.
+clause "…verbatim, carrying the member's refusal marking", which changes the
+content-derived LANL variant revision hash; the human-facing
+`LANL_PROTOCOL_REVISION` label stays at v1 — the variant has not been introduced to
+anyone yet, so there is no consumer to signal (decision: Khoa, 2026-08-14). Only the
+LANL variant hash changes; canonical IFEval, DRACO, and HealthBench protocol
+expressions stay byte-identical.
 
 ## 3. Cleanups (no wire change)
 

--- a/docs/tasks/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/tasks/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -1,0 +1,21 @@
+---
+id: OME-825
+linear_url: https://linear.app/openmined/issue/OME-825/benchmark-failure-policy-follow-up-refusal-integrity-review-cleanups
+status: In Progress
+type: Bug
+priority: P2
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-14
+---
+
+# Benchmark failure policy follow-up: refusal integrity + review cleanups from PR #584
+
+Close the five confirmed findings from the adversarial review of PR #584 (OME-807):
+two refusal-integrity bugs (null-text content-filter refusal published as a scored
+plausible-zero; IFEval LANL selection laundering refusal prose into a scored output)
+and three cleanups (outcome-triple validator duplicated across benchmark packages,
+coverage formula duplicated producer/validator, dead `provider_refusal` clauses).
+
+Spec: `docs/spec/2026-08-14-OME-825-benchmark-refusal-integrity.md`
+Plan: `docs/plan/2026-08-14-OME-825-benchmark-refusal-integrity.md`
+Ledger: `docs/work/2026-08-14-OME-825-benchmark-refusal-integrity.md`

--- a/docs/work/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/work/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -1,0 +1,70 @@
+---
+ticket: OME-825
+stack: url4-cloud
+status: in_progress
+started: 2026-08-14
+finished:
+---
+
+# OME-825 — Benchmark refusal integrity + PR #584 review cleanups
+
+## Intent
+
+Adversarial review of PR #584 (OME-807 failure policy, merged 2026-08-13) confirmed two
+scoring-integrity bugs — both seams where the policy's "refusal is data, carried
+end-to-end" doctrine leaks — plus three cleanups. A provider content-filter refusal with
+null refusal text is published as a scored plausible-zero, and the IFEval LANL ensemble
+republishes a refused member's refusal prose as a normal scored output. This unit closes
+all five findings so refusals are always visible and attributable on the leaderboard.
+
+## Planned changes
+
+- `apps/url4-cloud/src/url4_cloud/benchmarks/candidate.py` — null-text provider refusal
+  gets a named placeholder refusal text instead of `output="" refusal=None`.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py` — LANL
+  member records carry `refusal` from the check record.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py` — member schema parses
+  `refusal`; `_lanl_select` re-encodes the chosen member's refusal instead of `None`.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/corrective_policy.py` — LANL protocol
+  revision v2 + LANL_FLOW clause naming refusal carriage.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/contract.py` — shared
+  `validate_candidate_outcome` + `candidate_coverage` helpers; drop the dead
+  `provider_refusal` clause in `_require_failed_case`.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py` — coverage via shared helper.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/{draco,healthbench}/records.py` — delegate
+  outcome validation to the shared helper.
+- `apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py` — remove the dead
+  `provider_`/`aigateway_` stage heuristic.
+- Tests: new refusal-integrity tests + updated LANL protocol goldens.
+
+## Test plan
+
+- Candidate adapter: a `provider_refusal` error carrying `refusal=None` encodes an
+  invocation with the placeholder refusal and empty output — WHY: a safety-filter event
+  must never be indistinguishable from a legitimate empty answer (the "plausible zero").
+- LANL select: when every member refused, the selected invocation decodes with the
+  member's refusal text carried — WHY: selection may choose but must never launder a
+  refusal into a scored output.
+- Contract: `candidate_coverage` is the single formula (producer and validator agree by
+  construction); failed-Case validation unchanged for all real producers.
+- Existing draco/healthbench records suites stay green with identical error messages.
+
+## Acceptance
+
+- All five OME-825 findings closed; full url4-cloud unit suite green; draco/healthbench
+  protocol expressions byte-identical; only the LANL variant revision changes.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus test updates: `tests/unit/test_benchmark_foundation.py`
+  (null-text refusal placeholder test), `tests/unit/test_ifeval_lanl_ensemble.py`
+  (refusal-carrying selection test + member fixture gains `refusal`),
+  `tests/unit/test_ifeval_member_shape.py` (fixture gains `refusal`),
+  `tests/unit/test_ifeval_unscored_results.py` (failure stage pinned to `grading` with WHY).
+- **Commits:** one commit on `OME-825-benchmark-refusal-integrity` (PR carries the sha).
+- **Gates:** ruff check + format clean; pyright 0 errors; layering OK; coverage 92.83%
+  (floor 80); `tests/unit` 1395 passed / 5 skipped (+2 new WHY tests).
+- **Deviations:** ifeval's dead stage heuristic became a constant `"grading"` with a WHY
+  comment (behavior identical — the prefix branch was unreachable); the hand-fed-code
+  test now pins `grading` for collected candidate failures. `_record_content`'s drifted
+  ifeval predicate left as-is (structurally different record, no `output` field).

--- a/docs/work/2026-08-14-OME-825-benchmark-refusal-integrity.md
+++ b/docs/work/2026-08-14-OME-825-benchmark-refusal-integrity.md
@@ -24,7 +24,8 @@ all five findings so refusals are always visible and attributable on the leaderb
 - `apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/iterative_correction.py` — LANL
   member records carry `refusal` from the check record.
 - `apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py` — member schema parses
-  `refusal`; `_lanl_select` re-encodes the chosen member's refusal instead of `None`.
+  `refusal`; malformed refusal/answer mismatches fail before selection; `_lanl_select`
+  re-encodes the chosen member's refusal instead of `None`.
 - `apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/corrective_policy.py` — LANL protocol
   revision v2 + LANL_FLOW clause naming refusal carriage.
 - `apps/url4-cloud/src/url4_cloud/benchmarks/contract.py` — shared
@@ -45,6 +46,8 @@ all five findings so refusals are always visible and attributable on the leaderb
 - LANL select: when every member refused, the selected invocation decodes with the
   member's refusal text carried — WHY: selection may choose but must never launder a
   refusal into a scored output.
+- LANL member validation: a refusal differing from the checked answer fails loudly —
+  WHY: selection must never score one text and publish another.
 - Contract: `candidate_coverage` is the single formula (producer and validator agree by
   construction); failed-Case validation unchanged for all real producers.
 - Existing draco/healthbench records suites stay green with identical error messages.
@@ -58,12 +61,13 @@ all five findings so refusals are always visible and attributable on the leaderb
 
 - **Actual files:** as planned, plus test updates: `tests/unit/test_benchmark_foundation.py`
   (null-text refusal placeholder test), `tests/unit/test_ifeval_lanl_ensemble.py`
-  (refusal-carrying selection test + member fixture gains `refusal`),
+  (refusal-carrying selection and mismatch-rejection tests + member fixture gains `refusal`),
   `tests/unit/test_ifeval_member_shape.py` (fixture gains `refusal`),
   `tests/unit/test_ifeval_unscored_results.py` (failure stage pinned to `grading` with WHY).
-- **Commits:** one commit on `OME-825-benchmark-refusal-integrity` (PR carries the sha).
-- **Gates:** ruff check + format clean; pyright 0 errors; layering OK; coverage 92.83%
-  (floor 80); `tests/unit` 1395 passed / 5 skipped (+2 new WHY tests).
+- **Commits:** three commits on `OME-825-benchmark-refusal-integrity`; the third adds the
+  refusal/answer integrity guard found during final review (PR carries the shas).
+- **Gates:** `run_gates.py url4-cloud` green: append-only test check, ruff check +
+  format, pyright, layering, and coverage floor; direct full suite 1407 passed / 5 skipped.
 - **Deviations:** ifeval's dead stage heuristic became a constant `"grading"` with a WHY
   comment (behavior identical — the prefix branch was unreachable); the hand-fed-code
   test now pins `grading` for collected candidate failures. `_record_content`'s drifted


### PR DESCRIPTION
Closes the five confirmed findings from the adversarial review of #584 (OME-807 benchmark failure policy). Two are scoring-integrity bugs — both seams where the policy's "a refusal is data, carried end-to-end" doctrine leaks — and three are structural cleanups.

## Before / After

### Before
- Trigger: a fan (or one of our paid runs) evaluates a model that trips a provider safety filter on a sensitive prompt, or runs the IFEval LANL ensemble where every member refuses.
- Today: the content-filter case publishes as a confident **scored ~0** (null-text refusals encode as `output="" refusal=None`, indistinguishable from a legitimate empty answer), and the all-refuse LANL case publishes the **refusal prose as a scored answer** (selection re-encodes with `refusal=None`; the member schema had no refusal slot). Nobody can tell a filtered model from a bad one.
- Cost: silently wrong leaderboard entries on exactly the sensitive prompts that matter; the refusal event vanishes from the wire; devs extending the failure policy read contract clauses guarding events that cannot occur.

### After
- Same triggers.
- Now: a null-text provider refusal carries the named placeholder `"No refusal text (provider refused the request)."` (precedent: the official HealthBench harness grades the literal marker `"No response (bad request)."`), and LANL member records + selection carry the refusal marking through. Both shapes surface as `status=refused`, graded per the OME-807 normal-checker rule, with factual coverage.
- Win: refusals are always visible and attributable; refusing can still never help a score (the placeholder/prose is graded like any answer).

### Don't regress
- OME-807 invariants intact: refusals graded through the normal checker (never auto-zeroed); duplicate-rubric abort, positional row binding, and coverage semantics unchanged.
- DRACO / HealthBench / canonical IFEval protocol expressions are **byte-identical**; only the LANL variant's content-derived revision hash changes (LANL_FLOW gained the refusal-marking clause); the protocol label stays v1 — the variant is unreleased, nobody to signal.

## Root cause
PR #584 made refusals first-class data but left two producers that erase the marking in transit: the Candidate adapter for the null-text content-filter shape (`candidate.py`), and LANL selection (`ifeval/runtime.py:363` hardcoded `refusal=None` over a member schema with no refusal field).

## Cleanups (review findings 3-5)
- One shared outcome-triple validator `contract.validate_candidate_outcome` replaces the ~55-line byte-identical copies in `draco/records.py` and `healthbench/records.py` (ifeval's third variant had already drifted).
- One shared coverage formula `contract.candidate_coverage` replaces the hand-synchronized producer/validator `round(..., 4)` pair.
- Dead code removed: the `provider_refusal` Failure-code clause in `_require_failed_case` and ifeval's `provider_`/`aigateway_` stage-prefix heuristic — no producer can emit that code (url4 `on_error=collect` strips codes to kind+message), each documented with a WHY comment.

## Tests
- `test_a_null_text_refusal_still_publishes_as_a_refusal` — pins the placeholder path end-to-end through the Candidate adapter.
- `test_selecting_a_refused_member_carries_its_refusal_marking` — all-refuse LANL round re-encodes the chosen refusal as a refusal, never as output.
- LANL member fixtures gain the now-required `refusal` field; the collected-failure stage is pinned to `grading` with a WHY comment.
- Gates: ruff + pyright clean, layering OK, coverage 92.83% (floor 80), 1395 unit tests passed.

Refs: OME-825 (https://linear.app/openmined/issue/OME-825), follow-up to OME-807 / #584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
