### PR TITLE
fix(screamingface): resolve PR #571 post-merge review findings

### DIFF
--- a/docs/tasks/2026-08-11-ome-786-pipeline-composition.md
+++ b/docs/tasks/2026-08-11-ome-786-pipeline-composition.md
@@ -1,12 +1,12 @@
 ---
 id: OME-786
 linear_url: https://linear.app/openmined/issue/OME-786/support-serial-pipelines-and-recursively-composed-candidates-in-the
-status: In Progress
+status: Done
 type: Feature
 priority: P1
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-08-11
-closed:
+closed: 2026-08-12
 ---
 
 # Support serial Pipelines and recursively composed Candidates in the Python Client

--- a/docs/tasks/2026-08-14-ome-826-pr571-review-fixes.md
+++ b/docs/tasks/2026-08-14-ome-826-pr571-review-fixes.md
@@ -1,0 +1,21 @@
+---
+id: OME-826
+linear_url: https://linear.app/openmined/issue/OME-826/fix-pr-571-post-merge-review-findings-money-bug-equality-walker
+status: In Progress
+type: task
+priority: High
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-14
+closed:
+---
+
+# Fix PR #571 post-merge review findings
+
+Implements all 8 fixes from the adversarially-verified /code-review of PR #571
+(OME-786 pipeline composition): the post-paid-run duplicate-display-name money bug,
+the `_is_named` structural-equality break, the removed rendered-surface linker guard,
+the 3-way duplicate topology walkers, dead `_recipe_kind`/`synthesis_root` machinery,
+`then()` re-implementing Pipeline flattening, the per-candidate benchmark re-parse,
+and the unclosed OME-786 ledger/mirror.
+
+Ledger: `docs/work/2026-08-14-OME-826-pr571-review-fixes.md`

--- a/docs/work/2026-08-12-OME-786-pipeline-composition.md
+++ b/docs/work/2026-08-12-OME-786-pipeline-composition.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-786
 stack: screamingface
-status: in_progress
+status: done
 started: 2026-08-12
-finished:
+finished: 2026-08-12
 ---
 
 # OME-786 — serial Pipeline and recursive Candidate composition

--- a/docs/work/2026-08-14-OME-826-pr571-review-fixes.md
+++ b/docs/work/2026-08-14-OME-826-pr571-review-fixes.md
@@ -1,0 +1,67 @@
+---
+ticket: OME-826
+stack: screamingface
+status: done
+started: 2026-08-14
+finished: 2026-08-14
+---
+
+# OME-826 — Fix PR #571 post-merge review findings
+
+## Intent
+
+PR #571 (OME-786 pipeline composition) merged with 8 review findings surviving adversarial
+verification (plan: `.dk/plans/2026-08-14-pr571-review-findings.md`, local). The worst is a
+money bug: duplicate member display names pass construction, compile, and preflight, then
+`report.py::_members` raises **after the paid evaluation** — the researcher pays and loses
+the run, violating the fail-before-spend doctrine. The rest: a structural-equality lie
+(hidden `_is_named`), a deleted rendered-surface guard, 3 duplicate topology walkers,
+dead kind machinery, `then()` re-implementing Pipeline flattening, a per-candidate re-parse
+of the invariant benchmark url4, and the unclosed OME-786 ledger/mirror.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/report.py` — drop `_members` uniqueness raise; disambiguate duplicate display names at render
+- `packages/screamingface/src/screamingface/pipeline.py` — `_is_named` excluded from equality (`field(compare=False)`) or repr un-suppressed; document topology effect
+- `packages/screamingface/src/screamingface/_evaluation/linking.py` — re-add `_require_every_reference_bound`; hoist benchmark parse out of per-candidate loop
+- `packages/screamingface/src/screamingface/_evaluation/topology.py` — one shared dependency walker
+- `packages/screamingface/src/screamingface/_evaluation/url4.py` — use shared walker
+- `packages/screamingface/src/screamingface/_evaluation/candidate.py` — delete `_recipe_kind`, dead `synthesis_root` param; one typed kind-function
+- `packages/screamingface/src/screamingface/_ui/cards.py` — import the kind-function
+- `packages/screamingface/src/screamingface/recipe.py` — `then()` → `Pipeline((self, next_recipe))`
+- `docs/work/2026-08-12-OME-786-*.md` + `docs/tasks/2026-08-11-ome-786-*.md` — close (bookkeeping)
+- Tests per finding in `packages/screamingface/tests/`
+
+## Test plan
+
+- RED: duplicate-display-name Fusion run reaches Report without ValueError; report renders disambiguated names (protects fail-before-spend: no post-spend raise)
+- RED: `Pipeline(["p/a","p/b"], name="a->b") == Pipeline(["p/a","p/b"])` iff spec's structural equality (protects spec promise)
+- RED: unresolved `$candidate*` in rendered surface fails at plan time (protects walker-blindness insurance)
+- Walker unification, `then()` one-liner, hoist: behavior-identical — existing suite is the net; add dependency-tuple equivalence test for the shared walker
+- Kind-function: subclass rename doesn't break cards (protects against `type(...).__name__` fork)
+
+## Acceptance
+
+- All 7 code findings fixed, #8 ledger/mirror closed, gates green (`ruff`, `pyright`, pytest cov≥95, notebooks, build, distribution)
+- Draft PR open on `OME-826-pr571-review-fixes`
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus `_evaluation/compilation.py` (uses the hoisted
+  `_prepare_benchmark`) and `_ui/report_view.py` `MemberResult` type import; the shared
+  walker landed as `_topology_bindings` in `topology.py` (the plan's named
+  `url4.py::_validate_topology_node` did not exist — the three real walkers were
+  `_topology_model_nodes`, `_validate_topology_dependencies`,
+  `_topology_operation_dependencies`, all unified).
+- **Commits:** b20630a6 — fix(screamingface): resolve PR #571 post-merge review findings;
+  (docs close commit follows)
+- **Gates:** ALL GATES GREEN — append-only test check, ruff check, ruff format, pyright,
+  pytest 794 passed / 1 skipped with cov ≥95, notebooks, uv build, distribution check.
+- **Deviations:** (1) equality fix #2 chose repr-visibility (keep `_is_named` in `__eq__`,
+  always show `name=` when explicitly named) over `field(compare=False)` — the spec makes
+  namedness behavioral (named nested Pipelines keep their grouping), so hiding it from
+  equality would create the opposite lie. (2) Adversarial topology metadata carrying the
+  same binding twice with equal nodes but different dependencies now raises "conflicting
+  Recipe topology metadata" instead of "does not match its model calls" — same ValueError
+  type, unreachable from compiler output. (3) Render disambiguation suffixes the provider
+  (first route segment) only for colliding names.

--- a/packages/screamingface/src/screamingface/_evaluation/candidate.py
+++ b/packages/screamingface/src/screamingface/_evaluation/candidate.py
@@ -79,8 +79,8 @@ class _CandidateCompiler:
         self._model_count = 0
         self._synthesis_count = 0
 
-    def compile(self, recipe: Recipe, *, synthesis_root: bool = False) -> _CompiledCandidate:
-        root = self._recipe(recipe, synthesis=synthesis_root)
+    def compile(self, recipe: Recipe) -> _CompiledCandidate:
+        root = self._recipe(recipe)
         members = (
             tuple(
                 _member_projection(
@@ -355,16 +355,6 @@ def _fusion_context(input_context: str, members: tuple[_ResolvedRecipe, ...]) ->
             }
         )
     )
-
-
-def _recipe_kind(recipe: Recipe) -> Literal["model", "fusion", "pipeline"]:
-    if isinstance(recipe, Model):
-        return "model"
-    if isinstance(recipe, Fusion):
-        return "fusion"
-    if isinstance(recipe, Pipeline):
-        return "pipeline"
-    raise TypeError("candidate must be an sf.Model, sf.Fusion, or sf.Pipeline")
 
 
 def _required_topology(value: _ResolvedRecipe) -> _RecipeTopology:

--- a/packages/screamingface/src/screamingface/_evaluation/compilation.py
+++ b/packages/screamingface/src/screamingface/_evaluation/compilation.py
@@ -9,7 +9,7 @@ from screamingface._evaluation.candidate import (
     _CompiledCandidate,
     compile_candidate,
 )
-from screamingface._evaluation.linking import link_candidate
+from screamingface._evaluation.linking import _prepare_benchmark
 from screamingface._evaluation.model import (
     _compiled_candidate,
     _compiled_evaluation,
@@ -26,10 +26,10 @@ def compile_evaluation(
     """Compile all Candidates locally against one selected Benchmark."""
 
     compiled = tuple(compile_candidate(recipe) for recipe in recipes)
-    linked = tuple(
-        link_candidate(value.url4, resource.url4)
-        for recipe, value in zip(recipes, compiled, strict=True)
-    )
+    # WHY: the Benchmark is identical for every Candidate — parse it once and bind
+    # each compiler-produced (already canonical) Candidate expression into it.
+    prepared = _prepare_benchmark(resource.url4)
+    linked = tuple(prepared.bind(value.url4) for value in compiled)
     candidates = []
     for recipe, value, result in zip(recipes, compiled, linked, strict=True):
         candidates.append(

--- a/packages/screamingface/src/screamingface/_evaluation/linking.py
+++ b/packages/screamingface/src/screamingface/_evaluation/linking.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, fields, is_dataclass
 
-from url4 import Iteration, Text, VarRef, build, expr, render, src, text
+from url4 import Iteration, Node, Text, VarRef, build, expr, render, src, text
 
 from screamingface.errors import PlanningError
 
@@ -21,9 +21,37 @@ class _LinkedCandidate:
     url4: str
 
 
-def link_candidate(candidate_url4: str, benchmark_url4: str) -> _LinkedCandidate:
-    """Bind the sole public Candidate seam without interpreting Benchmark behavior."""
+@dataclass(frozen=True, slots=True)
+class _PreparedBenchmark:
+    """One parsed-and-validated Benchmark expression, reusable across Candidates.
 
+    WHY: the Benchmark is loop-invariant across an Evaluation's Candidates — parse
+    and reference-scan it once, then bind each compiled Candidate's canonical text.
+    """
+
+    node: Node
+
+    def bind(self, candidate_url4: str) -> _LinkedCandidate:
+        """Bind one canonical Candidate expression text into this Benchmark."""
+
+        binding = src(text(candidate_url4), name="candidate", weight=0.0)
+        rendered = render(expr(binding, self.node, intent=text("")))
+        _require_candidate_references_bound(rendered)
+        return _LinkedCandidate(url4=rendered)
+
+
+def link_candidate(candidate_url4: str, benchmark_url4: str) -> _LinkedCandidate:
+    """Bind the sole public Candidate seam without interpreting Benchmark behavior.
+
+    Canonicalizes arbitrary caller Candidate text through build+render; the internal
+    Evaluation path calls ``_prepare_benchmark(...).bind(...)`` directly because the
+    compiler's output is already canonical.
+    """
+
+    return _prepare_benchmark(benchmark_url4).bind(render(build(candidate_url4)))
+
+
+def _prepare_benchmark(benchmark_url4: str) -> _PreparedBenchmark:
     benchmark = build(benchmark_url4)
     references = _text_references(benchmark)
     if _WHOLE_CANDIDATE not in references:
@@ -50,15 +78,35 @@ def link_candidate(candidate_url4: str, benchmark_url4: str) -> _LinkedCandidate
             code="candidate_shape_mismatch",
             permanent=True,
         )
-
-    candidate = build(candidate_url4)
-    binding = src(text(render(candidate)), name="candidate", weight=0.0)
     if isinstance(benchmark, Iteration):
         benchmark = expr(
             src(benchmark, name="benchmark_result", weight=0.0),
             intent=text("$benchmark_result"),
         )
-    return _LinkedCandidate(url4=render(expr(binding, benchmark, intent=text(""))))
+    return _PreparedBenchmark(node=benchmark)
+
+
+def _require_candidate_references_bound(rendered: str) -> None:
+    """Refuse to ship a linked artifact that still names something nothing binds.
+
+    INVARIANT: every ``$candidate*`` reference in the shipped artifact resolves to the
+    one ``candidate`` binding emitted above. This is checked on the RENDERED surface
+    rather than the parsed tree on purpose: ``_text_references`` reasons over an AST
+    where a reference has several shapes and the node set can grow upstream, while
+    ``render`` collapses them all into one form. The check is therefore
+    representation-independent — it closes the whole class of walker-blindness bugs
+    rather than the one shape that motivated it, and it turns a mid-Run failure into
+    a plan-time one, before the Candidate has been paid for.
+    """
+
+    unresolved = _references(rendered) - {_WHOLE_CANDIDATE}
+    if unresolved:
+        names = ", ".join(sorted(unresolved))
+        raise PlanningError(
+            f"Benchmark URL4 references {names}, which this Candidate does not bind",
+            code="candidate_shape_mismatch",
+            permanent=True,
+        )
 
 
 def _text_references(value: object) -> set[str]:

--- a/packages/screamingface/src/screamingface/_evaluation/topology.py
+++ b/packages/screamingface/src/screamingface/_evaluation/topology.py
@@ -30,6 +30,74 @@ class _RecipeTopology:
     stages: tuple[_RecipeTopology, ...] = ()
 
 
+@dataclass(frozen=True, slots=True)
+class _TopologyBinding:
+    """One executable model call: its leaf node plus both dependency notions."""
+
+    node: _RecipeTopology
+    context_dependencies: tuple[str, ...]
+    operation_dependencies: tuple[str, ...]
+
+
+def _topology_bindings(value: _RecipeTopology) -> dict[str, _TopologyBinding]:
+    """One walk of a Recipe topology, shared by every consumer.
+
+    Think of it as the topology's dependency rulebook evaluated once: each model
+    leaf gets its binding plus TWO dependency tuples, because the same tree carries
+    two distinct notions —
+
+    - ``context_dependencies``: which earlier bindings this call's rendered context
+      references (a Fusion synthesizer reads the upstream input AND every member's
+      answer, deduplicated in that order). Replay validation compares these against
+      the ``$``-references parsed out of the executable calls.
+    - ``operation_dependencies``: the operation DAG's edges as the compiler records
+      them (a Fusion synthesizer depends only on its members — the upstream edge is
+      already carried by each member).
+
+    Worked example — ``pipeline(model_1, fusion(members=[model_2], synth))`` where
+    the synthesizer executes as ``synthesis_1``: ``model_2`` has context AND
+    operation deps ``("model_1",)`` (fusion members inherit the pipeline stage
+    input), while ``synthesis_1`` has context deps ``("model_1", "model_2")`` but
+    operation deps ``("model_2",)`` only.
+
+    INVARIANT: a new Recipe kind extends THIS walker (one branch), never a fork —
+    replay decoding and validation must agree by construction.
+    """
+
+    selected: dict[str, _TopologyBinding] = {}
+
+    def visit(
+        node: _RecipeTopology,
+        context: tuple[str, ...],
+        operations: tuple[str, ...],
+    ) -> None:
+        if node.kind == "model":
+            entry = _TopologyBinding(node, context, operations)
+            previous = selected.setdefault(node.binding, entry)
+            if previous != entry:
+                raise ValueError("Evaluation URL4 has conflicting Recipe topology metadata")
+            return
+        if node.kind == "pipeline":
+            stage_context, stage_operations = context, operations
+            for stage in node.stages:
+                visit(stage, stage_context, stage_operations)
+                stage_context = (stage.binding,)
+                stage_operations = (stage.binding,)
+            return
+        for member in node.members:
+            visit(member, context, operations)
+        assert node.synthesizer is not None
+        member_bindings = tuple(member.binding for member in node.members)
+        visit(
+            node.synthesizer,
+            tuple(dict.fromkeys((*context, *member_bindings))),
+            member_bindings,
+        )
+
+    visit(value, (), ())
+    return selected
+
+
 def _topology_source(value: _RecipeTopology) -> Node:
     return src(Text(_encode_topology(value)), name=_SOURCE_NAME, weight=0.0)
 

--- a/packages/screamingface/src/screamingface/_evaluation/url4.py
+++ b/packages/screamingface/src/screamingface/_evaluation/url4.py
@@ -16,7 +16,11 @@ from screamingface._evaluation.model import (
     _member_projection,
 )
 from screamingface._evaluation.results import report_from_url4_outcome
-from screamingface._evaluation.topology import _RecipeTopology, _topology_from_expression
+from screamingface._evaluation.topology import (
+    _RecipeTopology,
+    _topology_bindings,
+    _topology_from_expression,
+)
 from screamingface.events import Event
 from screamingface.report import Report
 
@@ -116,21 +120,26 @@ def _candidate_from_topology(
     final: str,
     selected: set[str],
 ) -> Candidate:
-    nodes = _topology_model_nodes(topology)
-    if topology.binding != final or set(nodes) != set(calls):
+    bindings = _topology_bindings(topology)
+    if topology.binding != final or set(bindings) != set(calls):
         raise ValueError("Evaluation URL4 Recipe topology does not match its model calls")
-    _validate_topology_dependencies(topology, calls, input_dependencies=())
+    # INVARIANT: the inert topology metadata must agree with the executable calls —
+    # each call's parsed `$`-references equal the walker's context dependencies.
+    for name, (_, context_dependencies) in calls.items():
+        if bindings[name].context_dependencies != context_dependencies:
+            raise ValueError("Evaluation URL4 Recipe topology does not match its model calls")
     fusion_names = _direct_fusion_output_names(topology)
-    dependencies = _topology_operation_dependencies(topology)
     operations = tuple(
         _compiled_operation(
             id=f"op_{name}",
-            kind=nodes[name].role or "model",
+            kind=bindings[name].node.role or "model",
             label=(
-                f"{fusion_names.get(name, nodes[name].name)} "
-                f"{'synthesis' if nodes[name].role == 'synthesis' else 'answer'}"
+                f"{fusion_names.get(name, bindings[name].node.name)} "
+                f"{'synthesis' if bindings[name].node.role == 'synthesis' else 'answer'}"
             ),
-            depends_on=tuple(f"op_{dependency}" for dependency in dependencies[name]),
+            depends_on=tuple(
+                f"op_{dependency}" for dependency in bindings[name].operation_dependencies
+            ),
         )
         for name in calls
         if name in selected
@@ -158,62 +167,6 @@ def _candidate_from_topology(
     )
 
 
-def _topology_model_nodes(value: _RecipeTopology) -> dict[str, _RecipeTopology]:
-    selected: dict[str, _RecipeTopology] = {}
-
-    def visit(node: _RecipeTopology) -> None:
-        if node.kind == "model":
-            previous = selected.setdefault(node.binding, node)
-            if previous != node:
-                raise ValueError("Evaluation URL4 has conflicting Recipe topology metadata")
-            return
-        children = node.stages if node.kind == "pipeline" else node.members
-        for child in children:
-            visit(child)
-        if node.synthesizer is not None:
-            visit(node.synthesizer)
-
-    visit(value)
-    return selected
-
-
-def _validate_topology_dependencies(
-    value: _RecipeTopology,
-    calls: dict[str, tuple[str, tuple[str, ...]]],
-    *,
-    input_dependencies: tuple[str, ...],
-) -> None:
-    if value.kind == "model":
-        if calls[value.binding][1] != input_dependencies:
-            raise ValueError("Evaluation URL4 Recipe topology does not match its model calls")
-        return
-    if value.kind == "pipeline":
-        dependencies = input_dependencies
-        for stage in value.stages:
-            _validate_topology_dependencies(
-                stage,
-                calls,
-                input_dependencies=dependencies,
-            )
-            dependencies = (stage.binding,)
-        return
-    for member in value.members:
-        _validate_topology_dependencies(
-            member,
-            calls,
-            input_dependencies=input_dependencies,
-        )
-    assert value.synthesizer is not None
-    synthesis_dependencies = tuple(
-        dict.fromkeys((*input_dependencies, *(member.binding for member in value.members)))
-    )
-    _validate_topology_dependencies(
-        value.synthesizer,
-        calls,
-        input_dependencies=synthesis_dependencies,
-    )
-
-
 def _direct_fusion_output_names(value: _RecipeTopology) -> dict[str, str]:
     selected: dict[str, str] = {}
 
@@ -229,30 +182,6 @@ def _direct_fusion_output_names(value: _RecipeTopology) -> dict[str, str]:
                 selected[node.binding] = node.name
 
     visit(value)
-    return selected
-
-
-def _topology_operation_dependencies(
-    value: _RecipeTopology,
-) -> dict[str, tuple[str, ...]]:
-    selected: dict[str, tuple[str, ...]] = {}
-
-    def visit(node: _RecipeTopology, upstream: tuple[str, ...]) -> None:
-        if node.kind == "model":
-            selected[node.binding] = upstream
-            return
-        if node.kind == "pipeline":
-            dependencies = upstream
-            for stage in node.stages:
-                visit(stage, dependencies)
-                dependencies = (stage.binding,)
-            return
-        for member in node.members:
-            visit(member, upstream)
-        assert node.synthesizer is not None
-        visit(node.synthesizer, tuple(member.binding for member in node.members))
-
-    visit(value, ())
     return selected
 
 

--- a/packages/screamingface/src/screamingface/_ui/cards.py
+++ b/packages/screamingface/src/screamingface/_ui/cards.py
@@ -7,6 +7,7 @@ from html import escape
 from typing import TYPE_CHECKING
 
 from screamingface._ui.card_style import CARD_STYLE
+from screamingface.recipe import _recipe_kind
 
 if TYPE_CHECKING:
     from screamingface.discovery import Benchmark, ModelDetails, ModelInfo
@@ -192,10 +193,6 @@ def _synthesizer_fields(recipe: Recipe) -> str:
     if params:
         fields += _field("params", _params(params), wide=True)
     return fields
-
-
-def _recipe_kind(recipe: Recipe) -> str:
-    return type(recipe).__name__.lower()
 
 
 def _provider_of(route: str) -> str:

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -14,7 +14,7 @@ from screamingface._ui.style import FUSION_GRADIENT_Y, STYLE
 
 if TYPE_CHECKING:
     from screamingface.case_result import CaseResult
-    from screamingface.report import CandidateResult, Report
+    from screamingface.report import CandidateResult, MemberResult, Report
 
 # Long free text (a case prompt, a model answer, a judge's reasoning) is shown behind a
 # disclosure and clipped: a Report can carry many thousands of words per case, and the
@@ -418,9 +418,14 @@ def _members_html(candidate: CandidateResult) -> str:
 
     if not candidate.members:
         return ""
+    # WHY: display names are cosmetic and may collide (the same model reached via two
+    # providers); identity is the operation_id, so a collision disambiguates here at
+    # render — with the provider — instead of failing a run that was already paid for.
+    names = [member.name for member in candidate.members]
+    duplicated = {name for name in names if names.count(name) > 1}
     rows = "".join(
         "<div class='sf-member'>"
-        f"<span class='sf-member__n'>{escape(member.name)}</span>"
+        f"<span class='sf-member__n'>{escape(_member_display_name(member, duplicated))}</span>"
         f"<span class='sf-member__k'>{escape(member.kind)}</span>"
         f"<span class='sf-member__m'>{escape(', '.join(member.models))}</span>"
         f"<span class='sf-member__d'>"
@@ -430,6 +435,13 @@ def _members_html(candidate: CandidateResult) -> str:
         for member in candidate.members
     )
     return f"<div class='sf-detail__k'>members</div><div class='sf-members'>{rows}</div>"
+
+
+def _member_display_name(member: MemberResult, duplicated: set[str]) -> str:
+    if member.name not in duplicated or not member.models:
+        return member.name
+    provider = member.models[0].split("/", 1)[0]
+    return f"{member.name} ({provider})" if provider else member.name
 
 
 def _recipe_html(candidate: CandidateResult) -> str:

--- a/packages/screamingface/src/screamingface/pipeline.py
+++ b/packages/screamingface/src/screamingface/pipeline.py
@@ -39,9 +39,13 @@ class Pipeline(Recipe):
 
     def __repr__(self) -> str:
         stages = ", ".join(repr(stage.name) for stage in self.stages)
-        inferred_name = "->".join(stage.name for stage in self.stages)
         arguments = [f"[{stages}]"]
-        if self.name != inferred_name:
+        # WHY: explicit naming is behavioral, not cosmetic — a named Pipeline keeps its
+        # grouping when nested instead of flattening, and `_is_named` participates in
+        # equality. The repr therefore shows `name=` whenever the value was explicitly
+        # named, even when it equals the inferred name, so equal-looking reprs never
+        # hide unequal values.
+        if self._is_named:
             arguments.append(f"name={self.name!r}")
         return f"Pipeline({', '.join(arguments)})"
 

--- a/packages/screamingface/src/screamingface/recipe.py
+++ b/packages/screamingface/src/screamingface/recipe.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unicodedata
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from screamingface.pipeline import Pipeline
@@ -16,18 +16,15 @@ class Recipe(ABC):
     name: str
 
     def then(self, next_recipe: str | Recipe) -> Pipeline:
-        """Return an immutable serial Pipeline ending in ``next_recipe``."""
+        """Return an immutable serial Pipeline ending in ``next_recipe``.
+
+        WHY: unnamed-Pipeline flattening lives once, in the Pipeline constructor —
+        this method only expresses "these two, in order".
+        """
 
         from screamingface.pipeline import Pipeline
 
-        selected = _recipe(next_recipe, "Pipeline stage")
-        before = self.stages if isinstance(self, Pipeline) and not self._is_named else (self,)
-        after = (
-            selected.stages
-            if isinstance(selected, Pipeline) and not selected._is_named
-            else (selected,)
-        )
-        return Pipeline((*before, *after))
+        return Pipeline((self, next_recipe))
 
     @property
     @abstractmethod
@@ -57,6 +54,27 @@ def _recipe(value: object, label: str) -> Recipe:
         raise TypeError(f"{label} must be a model route or sf.Model, sf.Fusion, or sf.Pipeline")
     assert isinstance(value, Recipe)
     return value
+
+
+def _recipe_kind(value: Recipe) -> Literal["model", "fusion", "pipeline"]:
+    """The single authority mapping a Recipe value to its kind.
+
+    WHY: kinds are the Recipe's type, never its Python class name — a renamed
+    subclass is still its base kind, and every consumer (compiler, cards, future
+    Recipe kinds) reads this one function instead of forking its own mapping.
+    """
+
+    from screamingface.fusion import Fusion
+    from screamingface.model import Model
+    from screamingface.pipeline import Pipeline
+
+    if isinstance(value, Model):
+        return "model"
+    if isinstance(value, Fusion):
+        return "fusion"
+    if isinstance(value, Pipeline):
+        return "pipeline"
+    raise TypeError("candidate must be an sf.Model, sf.Fusion, or sf.Pipeline")
 
 
 def _is_supported_recipe(value: object) -> bool:

--- a/packages/screamingface/src/screamingface/report.py
+++ b/packages/screamingface/src/screamingface/report.py
@@ -420,9 +420,10 @@ def _members(values: Sequence[MemberResult]) -> tuple[MemberResult, ...]:
     selected = tuple(values)
     if any(not isinstance(value, MemberResult) for value in selected):
         raise TypeError("Candidate members must be sf.MemberResult values")
-    names = [value.name for value in selected]
-    if len(names) != len(set(names)):
-        raise ValueError("Candidate member names must be unique")
+    # WHY: display names are cosmetic and may collide (the same model reached via two
+    # providers); identity is the operation_id. INVARIANT: fail-before-spend — this
+    # constructor runs after the paid evaluation, so it must never reject a shape the
+    # authoring constructors accepted. Collisions are disambiguated at render instead.
     operation_ids = [value.operation_id for value in selected]
     if len(operation_ids) != len(set(operation_ids)):
         raise ValueError("Candidate member operation IDs must be unique")

--- a/packages/screamingface/tests/test_pipeline_recipes.py
+++ b/packages/screamingface/tests/test_pipeline_recipes.py
@@ -155,3 +155,20 @@ def test_recipe_values_have_structural_equality_and_are_unhashable() -> None:
     assert left == right
     with pytest.raises(TypeError, match="unhashable"):
         hash(left)
+
+
+def test_explicit_naming_is_visible_even_when_it_matches_the_inferred_name() -> None:
+    unnamed = sf.Pipeline(["provider/a", "provider/b"])
+    named = sf.Pipeline(["provider/a", "provider/b"], name="a->b")
+
+    # WHY: the spec keeps an explicitly named nested Pipeline grouped instead of
+    # flattening it, so namedness is behavioral — equality AND repr must show it.
+    assert named != unnamed
+    assert repr(unnamed) == "Pipeline(['a', 'b'])"
+    assert repr(named) == "Pipeline(['a', 'b'], name='a->b')"
+    assert sf.Pipeline([named, "provider/c"]).stages == (named, sf.Model("provider/c"))
+    assert sf.Pipeline([unnamed, "provider/c"]).stages == (
+        sf.Model("provider/a"),
+        sf.Model("provider/b"),
+        sf.Model("provider/c"),
+    )

--- a/packages/screamingface/tests/test_report.py
+++ b/packages/screamingface/tests/test_report.py
@@ -503,3 +503,105 @@ def test_report_representation_is_a_compact_run_summary() -> None:
     value = report(candidate("opus"), candidate("gpt"))
 
     assert repr(value) == ("Report(benchmark='draco@1', candidates=['opus', 'gpt'], ok=True)")
+
+
+def test_duplicate_member_display_names_do_not_fail_a_finished_run() -> None:
+    # INVARIANT: fail-before-spend — Report construction happens AFTER the paid
+    # evaluation, so a cosmetic display-name collision (same model via two
+    # providers) must never raise here; members stay keyed by operation_id.
+    value = sf.CandidateResult(
+        benchmark=benchmark(),
+        run_id="run_same_model_twice",
+        started_at=datetime(2026, 7, 25, 16, 0, tzinfo=UTC),
+        completed_at=datetime(2026, 7, 25, 16, 0, 2, tzinfo=UTC),
+        name="gpt-5.5+gpt-5.5",
+        kind="fusion",
+        url4="(@)!'same model, two providers'",
+        models=("openrouter/openai/gpt-5.5", "azure/openai/gpt-5.5", "provider/synth"),
+        operations=(
+            _compiled_operation(
+                id="op_model_1", kind="model", label="gpt-5.5 answer", depends_on=()
+            ),
+            _compiled_operation(
+                id="op_model_2", kind="model", label="gpt-5.5 answer", depends_on=()
+            ),
+            _compiled_operation(
+                id="op_synthesis_1",
+                kind="synthesis",
+                label="gpt-5.5+gpt-5.5 synthesis",
+                depends_on=("op_model_1", "op_model_2"),
+            ),
+        ),
+        score=0.5,
+        coverage=1.0,
+        metrics={},
+        cases=case_results(),
+        members=(
+            sf.MemberResult(
+                operation_id="op_model_1",
+                name="gpt-5.5",
+                kind="model",
+                models=("openrouter/openai/gpt-5.5",),
+                failures=None,
+                duration_ms=None,
+                usage=None,
+            ),
+            sf.MemberResult(
+                operation_id="op_model_2",
+                name="gpt-5.5",
+                kind="model",
+                models=("azure/openai/gpt-5.5",),
+                failures=None,
+                duration_ms=None,
+                usage=None,
+            ),
+        ),
+        failures=(),
+        usage=sf.Usage(input_tokens=200, output_tokens=20),
+    )
+
+    result = report(value)
+
+    assert tuple(member.name for member in result.candidates.only.members) == (
+        "gpt-5.5",
+        "gpt-5.5",
+    )
+
+    with pytest.raises(ValueError, match="operation IDs must be unique"):
+        sf.CandidateResult(
+            **{
+                **{
+                    "benchmark": benchmark(),
+                    "run_id": "run_same_model_twice",
+                    "started_at": datetime(2026, 7, 25, 16, 0, tzinfo=UTC),
+                    "completed_at": datetime(2026, 7, 25, 16, 0, 2, tzinfo=UTC),
+                    "name": "gpt-5.5+gpt-5.5",
+                    "kind": "fusion",
+                    "url4": "(@)!'same model, two providers'",
+                    "models": ("openrouter/openai/gpt-5.5", "provider/synth"),
+                    "operations": (
+                        _compiled_operation(
+                            id="op_model_1", kind="model", label="a", depends_on=()
+                        ),
+                    ),
+                    "score": 0.5,
+                    "coverage": 1.0,
+                    "metrics": {},
+                    "cases": case_results(),
+                    "members": tuple(
+                        sf.MemberResult(
+                            operation_id="op_model_1",
+                            name="gpt-5.5",
+                            kind="model",
+                            models=("openrouter/openai/gpt-5.5",),
+                            failures=None,
+                            duration_ms=None,
+                            usage=None,
+                        )
+                        for _ in range(2)
+                    ),
+                    "failures": (),
+                    "usage": sf.Usage(),
+                }
+            }
+        )

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -528,3 +528,108 @@ def test_an_envelope_input_renders_as_a_transcript_not_wire_json() -> None:
     assert "assistant: Do not treat it at home." in html
     assert "candidate-input.v1" not in html
     assert "&quot;schema&quot;" not in html
+
+
+def test_duplicate_member_names_render_disambiguated_by_provider() -> None:
+    def member(operation_id: str, route: str) -> sf.MemberResult:
+        return sf.MemberResult(
+            operation_id=operation_id,
+            name="gpt-5.5",
+            kind="model",
+            models=(route,),
+            failures=None,
+            duration_ms=None,
+            usage=None,
+        )
+
+    value = CandidateResult(
+        benchmark=_BENCHMARK,
+        run_id="run-same-model-twice",
+        started_at=_START,
+        completed_at=_END,
+        name="gpt-5.5+gpt-5.5",
+        kind="fusion",
+        url4="(candidate:0.0:'(m:0.0:/openrouter/x)!\\'$m\\'')!''",
+        models=["openrouter/openai/gpt-5.5", "azure/openai/gpt-5.5", "p/synth"],
+        operations=[
+            OperationInfo(id="op_model_1", kind="model", label="answer", depends_on=()),
+            OperationInfo(id="op_model_2", kind="model", label="answer", depends_on=()),
+            OperationInfo(
+                id="op_synthesis_1",
+                kind="synthesis",
+                label="synthesis",
+                depends_on=("op_model_1", "op_model_2"),
+            ),
+        ],
+        score=0.5,
+        coverage=1.0,
+        metrics=_METRICS,
+        cases=[case()],
+        members=[
+            member("op_model_1", "openrouter/openai/gpt-5.5"),
+            member("op_model_2", "azure/openai/gpt-5.5"),
+        ],
+        failures=(),
+        usage=sf.Usage(input_tokens=10, output_tokens=5),
+    )
+
+    html = body(report_html(report(value)))
+
+    # WHY: display names are cosmetic and may collide (same model via two
+    # providers) — the panel disambiguates at render instead of failing the run.
+    assert "gpt-5.5 (openrouter)" in html
+    assert "gpt-5.5 (azure)" in html
+
+
+def test_unique_member_names_render_without_provider_suffix() -> None:
+    value = CandidateResult(
+        benchmark=_BENCHMARK,
+        run_id="run-two-models",
+        started_at=_START,
+        completed_at=_END,
+        name="opus+gpt",
+        kind="fusion",
+        url4="(candidate:0.0:'(m:0.0:/openrouter/x)!\\'$m\\'')!''",
+        models=["provider/opus", "provider/gpt", "p/synth"],
+        operations=[
+            OperationInfo(id="op_model_1", kind="model", label="answer", depends_on=()),
+            OperationInfo(id="op_model_2", kind="model", label="answer", depends_on=()),
+            OperationInfo(
+                id="op_synthesis_1",
+                kind="synthesis",
+                label="synthesis",
+                depends_on=("op_model_1", "op_model_2"),
+            ),
+        ],
+        score=0.5,
+        coverage=1.0,
+        metrics=_METRICS,
+        cases=[case()],
+        members=[
+            sf.MemberResult(
+                operation_id="op_model_1",
+                name="opus",
+                kind="model",
+                models=("provider/opus",),
+                failures=None,
+                duration_ms=None,
+                usage=None,
+            ),
+            sf.MemberResult(
+                operation_id="op_model_2",
+                name="gpt",
+                kind="model",
+                models=("provider/gpt",),
+                failures=None,
+                duration_ms=None,
+                usage=None,
+            ),
+        ],
+        failures=(),
+        usage=sf.Usage(input_tokens=10, output_tokens=5),
+    )
+
+    html = body(report_html(report(value)))
+
+    assert ">opus</span>" in html
+    assert "opus (" not in html

--- a/packages/screamingface/tests/test_rich_display.py
+++ b/packages/screamingface/tests/test_rich_display.py
@@ -345,3 +345,21 @@ def test_cards_cover_provider_fallback_and_nested_fusions() -> None:
     )
     fusion_html = cast(Any, outer)._repr_html_()
     assert "nested fusion" in fusion_html
+
+
+def test_nested_recipe_kind_reflects_the_recipe_type_not_the_class_name() -> None:
+    class RenamedFusion(sf.Fusion):
+        pass
+
+    nested = RenamedFusion(["provider/a"], synthesizer="provider/inner-synth")
+    outer = sf.Fusion(
+        [nested, sf.Model("provider/c")],
+        synthesizer="provider/outer-synth",
+    )
+
+    html = cast(Any, outer)._repr_html_()
+
+    # WHY: the nested kind is the Recipe's type, never its Python class name —
+    # a renamed subclass must still read as a fusion.
+    assert "nested fusion" in html
+    assert "renamedfusion" not in html

--- a/packages/screamingface/tests/test_shape_adaptive_linking.py
+++ b/packages/screamingface/tests/test_shape_adaptive_linking.py
@@ -86,3 +86,48 @@ def test_similarly_named_plumbing_is_not_a_candidate_binding() -> None:
         link_candidate(_candidate_url4(), benchmark)
 
     assert caught.value.code == "invalid_benchmark_resource"
+
+
+def test_rendered_surface_guard_refuses_unbound_candidate_references() -> None:
+    from screamingface._evaluation.linking import _require_candidate_references_bound
+
+    # INVARIANT: every $candidate* reference in the SHIPPED artifact resolves to a
+    # binding — checked on the rendered surface so it stays representation-independent
+    # insurance against walker blindness, failing at plan time instead of after spend.
+    _require_candidate_references_bound("(answer:0.0:/x(q)!'$candidate')!'$answer'")
+    _require_candidate_references_bound("literal '$$candidate_member_1' stays escaped")
+
+    with pytest.raises(sf.PlanningError, match="does not bind") as caught:
+        _require_candidate_references_bound("(answer:0.0:/x(q)!'$candidate_member_1')!''")
+
+    assert caught.value.code == "candidate_shape_mismatch"
+
+
+def test_the_benchmark_expression_is_parsed_once_for_a_whole_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from screamingface._evaluation import linking
+
+    benchmark = "(answer:0.0:/candidate(question)!'$candidate')!'$answer'"
+    candidate = _candidate_url4()
+    expected = link_candidate(candidate, benchmark).url4
+
+    calls = 0
+    real = linking.build
+
+    def counting(value: str) -> object:
+        nonlocal calls
+        calls += 1
+        return real(value)
+
+    monkeypatch.setattr(linking, "build", counting)
+
+    # WHY: the benchmark is loop-invariant across an Evaluation's candidates, and
+    # compiler-produced candidate text is already canonical — one parse total.
+    prepared = linking._prepare_benchmark(benchmark)
+    first = prepared.bind(candidate)
+    second = prepared.bind(candidate)
+
+    assert calls == 1
+    assert first.url4 == expected
+    assert second.url4 == expected

--- a/packages/screamingface/tests/test_url4.py
+++ b/packages/screamingface/tests/test_url4.py
@@ -353,3 +353,57 @@ def test_url4_conversion_requires_the_canonical_recipe_descriptor() -> None:
 
     with pytest.raises(ValueError, match="missing required Recipe metadata"):
         value.to_python()
+
+
+def test_topology_bindings_separate_context_references_from_operation_edges() -> None:
+    from screamingface._evaluation.topology import (
+        _RecipeTopology,
+        _topology_bindings,
+    )
+
+    topology = _RecipeTopology(
+        kind="pipeline",
+        name="draft->panel",
+        binding="synthesis_1",
+        stages=(
+            _RecipeTopology(kind="model", name="draft", binding="model_1", role="model"),
+            _RecipeTopology(
+                kind="fusion",
+                name="panel",
+                binding="synthesis_1",
+                members=(_RecipeTopology(kind="model", name="a", binding="model_2", role="model"),),
+                synthesizer=_RecipeTopology(
+                    kind="model",
+                    name="synth",
+                    binding="synthesis_1",
+                    role="synthesis",
+                ),
+            ),
+        ),
+    )
+
+    bindings = _topology_bindings(topology)
+
+    # WHY: one walker, two dependency notions — context references mirror the
+    # rendered call's `$` references (a fusion synthesizer sees upstream input AND
+    # members), while operation edges mirror the compiler's DAG (members only).
+    assert set(bindings) == {"model_1", "model_2", "synthesis_1"}
+    assert bindings["model_1"].context_dependencies == ()
+    assert bindings["model_1"].operation_dependencies == ()
+    assert bindings["model_2"].context_dependencies == ("model_1",)
+    assert bindings["model_2"].operation_dependencies == ("model_1",)
+    assert bindings["synthesis_1"].context_dependencies == ("model_1", "model_2")
+    assert bindings["synthesis_1"].operation_dependencies == ("model_2",)
+    assert bindings["synthesis_1"].node.role == "synthesis"
+
+    conflicting = _RecipeTopology(
+        kind="pipeline",
+        name="twice",
+        binding="model_1",
+        stages=(
+            _RecipeTopology(kind="model", name="one", binding="model_1", role="model"),
+            _RecipeTopology(kind="model", name="two", binding="model_1", role="model"),
+        ),
+    )
+    with pytest.raises(ValueError, match="conflicting Recipe topology"):
+        _topology_bindings(conflicting)


### PR DESCRIPTION
Implements all 8 adversarially-verified findings from the post-merge /code-review of #571 (OME-786 pipeline composition). Linear: [OME-826](https://linear.app/openmined/issue/OME-826/fix-pr-571-post-merge-review-findings-money-bug-equality-walker).

## Before / After

### Before
- Trigger: a researcher runs `sf.Fusion` with the same model via two providers — both members infer the display name `gpt-5.5`.
- Today: construction, compile, preflight and the **paid evaluation** all succeed, then the Report constructor raises `Candidate member names must be unique`. The money is spent, the report is lost.
- Cost: burned paid tokens with zero output; violates the platform's fail-before-spend doctrine. Separately, `Pipeline(["p/a","p/b"], name="a->b")` and `Pipeline(["p/a","p/b"])` print identical reprs but compare unequal and compile to different url4 — a debugging trap.

### After
- Same triggers.
- Now: duplicate display names are structurally harmless (identity is the `operation_id`) and the report panel disambiguates them at render — `gpt-5.5 (openrouter)` / `gpt-5.5 (azure)`. Explicitly named Pipelines always show `name=` in repr, so equal-looking reprs never hide unequal values (per the spec, naming is behavioral: a named nested Pipeline keeps its grouping).
- Win: no lost paid runs; the next dev reading a repr sees exactly why two recipes differ.

### Don't regress
- Same-model-two-providers comparison (deliberately enabled by #571) stays legal end-to-end.
- Named vs unnamed Pipelines still compile to their respective topologies; all 785 pre-existing tests unchanged and green (append-only gate).
- `then()` flattening, replay decoding, and linking output are byte-identical.

## Findings fixed

1. **Money bug** — report-side member-name uniqueness check dropped (post-spend raise); render-time provider disambiguation added.
2. **Equality lie** — `_is_named` stays in `__eq__` (it is behavioral); repr now always shows `name=` for explicitly named Pipelines.
3. **Rendered-surface guard restored** — `_require_candidate_references_bound` scans the shipped artifact for unbound `$candidate*` refs: representation-independent, plan-time, pre-spend.
4. **Topology walkers unified** — `_topology_model_nodes` + `_validate_topology_dependencies` + `_topology_operation_dependencies` collapsed into one shared `_topology_bindings` walker in `topology.py` returning both dependency notions (context refs vs DAG edges) per binding. The next Recipe kind (OME-796 `corrective_loop`) extends one place.
5. **Dead kind machinery deleted** — unused `_recipe_kind` + ignored `synthesis_root` param removed; one typed `_recipe_kind` in `recipe.py`, imported by cards (a renamed subclass still reads as its base kind).
6. **`Recipe.then()`** reduced to `Pipeline((self, next_recipe))` — flattening lives once, in the constructor.
7. **Benchmark parsed once per Evaluation** — `_prepare_benchmark(...).bind(...)`; compiler output (already canonical) passes through without a build+render round-trip.
8. **Bookkeeping** — merged OME-786 ledger + task mirror closed.

Refuted-by-review candidates deliberately untouched: `max_tokens` default removal, synthesizer `web_search` inheritance, unhashable Recipes, the constructor-side name relaxation itself.

## Test plan

- 9 new tests (RED-first): duplicate-name Report construction + render disambiguation ± suffix, named-Pipeline repr/equality/grouping, rendered-surface guard (incl. `$$` escape), single-parse hoist (build call-count), shared-walker dependency notions + conflict raise, subclass kind rendering.
- Gates: append-only test check, ruff, ruff format, pyright, pytest 794 passed / 1 skipped (cov ≥ 95%), notebook determinism, `uv build`, distribution check — all green.

Refs: OME-826

🤖 Generated with [Claude Code](https://claude.com/claude-code)