### PR TITLE
fix(screamingface): remove the verified chip and filter from the notebook view

### DIFF
--- a/docs/plan/2026-08-14-OME-832-hide-verified-chip.md
+++ b/docs/plan/2026-08-14-OME-832-hide-verified-chip.md
@@ -1,0 +1,48 @@
+# OME-832 — Implementation plan
+
+Spec: `docs/spec/2026-08-14-OME-832-hide-verified-chip.md` · Ledger:
+`docs/work/2026-08-14-OME-832-hide-verified-chip.md`
+
+One file of production code, one stack (`screamingface`). RED before GREEN.
+
+## Step 1 — RED
+
+Append to `packages/screamingface/tests/test_leaderboards.py`:
+
+1. `"verified only"` absent from the rendered board.
+2. The `verified` chip absent for a candidate with `verified_by_openmined=True` — the strong form
+   the existing `:787` assertion does not cover.
+3. `data-verified` absent.
+4. The `baseline` chip still present for a baseline row.
+5. **The mislabel guard:** a candidate with no forkable url4 is not labelled `baseline`. This is
+   the assertion that catches spec §3's trap, and it should fail *both* before the change (chip
+   says `verified`) and against a naive deletion (chip says `baseline`).
+
+## Step 2 — GREEN
+
+`_ui/leaderboard_view.py`:
+
+- delete `verify_action` and the `sf-lb__checkbox` label markup;
+- delete the `data-verified` attribute from `_board_row`;
+- `_row_chip` becomes a single `kind == "single"` test returning the `baseline` chip.
+
+`_ui/leaderboard_style.py`: note the now-unused `.sf-lb__checkbox*` rules, kept for `OME-821`.
+
+## Step 3 — the prior assertion
+
+`:354` asserts `"verified only" in html` and must invert. **Escalate first** (sdlc rule 5), then
+change one line and note why in place.
+
+## Step 4 — gates
+
+`uv run .claude/scripts/run_gates.py screamingface --base origin/main`. Note this stack's list is
+longer than scoreboard's: ruff, pyright, **pytest with a 95% coverage floor**, the notebook check,
+`uv build`, and the distribution check. Removing code can move coverage in either direction, so
+read the number rather than assuming.
+
+## Risks
+
+- **The mislabel** (spec §3) is the whole risk. A deletion that passes tests is not evidence; the
+  guard in step 1.5 is what makes it evidence.
+- The notebook check and `uv build` gates are slower and unrelated to this change; if one fails it
+  is probably pre-existing, so verify against `origin/main` before treating it as mine.

--- a/docs/spec/2026-08-14-OME-832-hide-verified-chip.md
+++ b/docs/spec/2026-08-14-OME-832-hide-verified-chip.md
@@ -1,0 +1,60 @@
+# OME-832 — the notebook view must not present an inert flag as trust
+
+Status: approved (owner, 2026-08-14) · Stack: screamingface
+
+## 1. Problem
+
+`OME-820` makes `verified_by_openmined` default to `True` for every submission. It asserts
+nothing: nothing re-runs submissions (`OME-414`) and nothing attests where a run executed. The
+scoreboard portal withdrew its verification UI accordingly (#588).
+
+The Python client did not. `_ui/leaderboard_view.py` renders a `verified` chip per row and a
+"verified only" checkbox that hides `[data-verified=false]`. With the flag uniform, the chip
+appears on every row and the checkbox removes nothing.
+
+This is the highest-visibility instance of the problem, because the notebook view is what renders
+in Colab for the tester cohort. A green chip on every row plus a dead filter is a worse first
+impression than no verification UI at all.
+
+## 2. Why relabelling is not an option here
+
+The chip could be reworded. **The filter could not.** Its defect is that every row carries the
+same value, so no wording makes the control do something. Same conclusion as #588: hide.
+
+## 3. The trap in the deletion
+
+`_row_chip` is ordered:
+
+```python
+if value.verified:                 # -> "verified"
+if value.python_source is None:    # -> "baseline"
+return ""
+```
+
+Removing the first branch does **not** simply remove the chip. A candidate with no forkable url4
+falls through to the second branch and is labelled **"baseline"** — presenting a community
+submission as an imported single-model reference. That is a worse error than the one being fixed.
+
+The predicate must key on what actually distinguishes a baseline: `_baseline_row` sets
+`kind="single"`, `_candidate_row` sets `kind="candidate"`.
+
+This also fixes a **pre-existing** case: today an *unverified* candidate with no forkable url4
+already renders the `baseline` chip.
+
+## 4. Contract
+
+- No verification control and no verification chip in the rendered view.
+- `baseline` chips render for baseline rows only, keyed on `kind`.
+- `data-verified` is not emitted; its only consumer was the filter handler.
+- `Leaderboard.verified_by_openmined` stays on the decoded model. The API still returns it; only
+  presentation is withdrawn.
+
+## 5. Reversal
+
+`OME-821` gives the flag a real signal and restores both the chip and the filter. The checkbox CSS
+is therefore kept, unused, rather than deleted and re-added.
+
+## 6. Sequencing
+
+**#588 must not merge before this.** Otherwise the flag goes uniform-true while the notebook still
+badges every row, against a board that has just withdrawn the claim.

--- a/docs/tasks/2026-08-14-OME-832-hide-verified-chip.md
+++ b/docs/tasks/2026-08-14-OME-832-hide-verified-chip.md
@@ -1,0 +1,25 @@
+---
+id: OME-832
+linear_url: https://linear.app/openmined/issue/OME-832/hide-the-verified-chip-and-filter-in-the-python-leaderboard-view
+status: In Progress
+type: Task
+priority: P1
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-14
+closed:
+---
+
+# Hide the verified chip and filter in the Python leaderboard view
+
+Client half of the `OME-820` review fix, raised by `@HupBaHa` on PR #588. The notebook view is what
+Monday's tester cohort sees in Colab, and it rendered a `verified` chip on every row plus a
+"verified only" filter that removed nothing.
+
+The deletion had a trap: `_row_chip` fell through to its `baseline` branch on
+`python_source is None`, so removing the `verified` branch alone would have labelled a candidate
+with an unforkable url4 as **"baseline"**. The predicate now keys on `kind`, which also fixes the
+same mislabel for unverified candidates — a pre-existing bug confirmed by a failing test.
+
+Spec: `docs/spec/2026-08-14-OME-832-hide-verified-chip.md`
+Plan: `docs/plan/2026-08-14-OME-832-hide-verified-chip.md`
+Ledger: `docs/work/2026-08-14-OME-832-hide-verified-chip.md`

--- a/docs/work/2026-08-14-OME-832-hide-verified-chip.md
+++ b/docs/work/2026-08-14-OME-832-hide-verified-chip.md
@@ -112,3 +112,27 @@ would have caught it. D2/D3 hold.
 5. **My `uuid4` import tripped ruff.** I inserted it beside `datetime` while `from uuid import UUID`
    already existed lower down. Merged into one statement by hand rather than running
    `ruff check --fix`, so the result is what I intended rather than what the fixer chose.
+
+## Review pass (2026-08-14) — two findings, no correctness bugs
+
+The review confirmed the central risk was handled correctly (`kind == "single"` is the right
+predicate, HTML stays balanced, the interleaved-comment string concatenation is valid) and found no
+correctness bugs. It also established something useful: **CI never invokes `run_gates.py`**, so the
+append-only check the inverted assertion bypasses is local-only and cannot trip on the PR.
+
+- **`_DisplayRow.verified` is now write-only dead state.** Both its readers went with this change, but
+  `_candidate_row` still populates it and nothing in ruff, pyright or coverage will notice it going
+  stale. Unlike the parallel CSS decision — which carries an in-file note — the field had no marker
+  saying it is parked for `OME-821`. Added one, including an explicit "do not key new presentation on
+  it": a row's value says nothing today, so doing so would reintroduce the inert trust signal this
+  change removed. Kept rather than deleted for the same reason as the CSS.
+- **Residual provenance ambiguity, left as a follow-up.** A candidate with an unforkable url4 renders
+  the same icon, fill and action cell as a baseline, and `leaderboard_style.py:140` hides the `kind`
+  cell below 680px — so in a narrow Colab pane the two are visually indistinguishable. **Pre-existing,
+  and this PR strictly improves it** (that row was previously *labelled* `baseline`), so fixing it
+  here would be scope creep. It belongs with `OME-821`'s presentation work.
+
+Also noted: coverage passes at **95.05%** against a 95% floor — almost no headroom, so the next change
+to this package may need to add tests before it can add code.
+
+**Gates:** all seven green, 783 passed.

--- a/docs/work/2026-08-14-OME-832-hide-verified-chip.md
+++ b/docs/work/2026-08-14-OME-832-hide-verified-chip.md
@@ -1,0 +1,114 @@
+---
+ticket: OME-832
+stack: screamingface
+status: in_progress
+started: 2026-08-14
+finished:
+---
+
+# OME-832 — hide the verified chip and filter in the Python leaderboard view
+
+## Intent
+
+Client half of the `OME-820` review fix, raised by `@HupBaHa` on PR #588.
+
+`OME-820` makes `verified_by_openmined` default to `True` for every submission as a placeholder
+that asserts nothing: no service re-runs submissions (`OME-414`) and nothing attests where a run
+executed. #588 removes the scoreboard portal's Verified column, badge and "Verified rows" stat for
+that reason.
+
+The Python client still presents the flag as a trust signal, and **this is the surface Monday's
+tester cohort sees**, because the notebook view is what renders in Colab:
+
+- `_ui/leaderboard_view.py:117` — a "verified only" checkbox whose handler hides
+  `[data-verified=false]` rows. No such row will exist, so the control does nothing.
+- `_ui/leaderboard_view.py:219` — a `verified` chip, which would appear on every row.
+
+## Decisions locked (2026-08-14)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Hide, not relabel | Same reasoning as #588: the filter is broken because the value is *uniform*, not because the word is wrong. A checkbox that removes nothing is not fixable by renaming it. |
+| D2 | **The baseline chip's predicate must change** | `_row_chip` currently reads `if value.verified: … ; if value.python_source is None: baseline`. Deleting the first branch would make a **verified candidate with no forkable url4** fall through and be labelled **"baseline"** — a mislabel worse than no chip. The predicate becomes `value.kind == "single"`, which is what actually distinguishes a baseline row (`_baseline_row` sets `kind="single"`; `_candidate_row` sets `kind="candidate"`). |
+| D3 | Pre-existing bug fixed as a side effect | Under the old order, an **unverified** candidate with no forkable url4 already fell through to the `baseline` chip. D2 fixes that too. In scope because D2 is required for D1 to be correct. |
+| D4 | `data-verified` removed | Its only consumer was the filter's own handler (`:103`). Grepped: no other reader in the package. |
+| D5 | Checkbox CSS kept | `.sf-lb__checkbox*` in `leaderboard_style.py` becomes unused. Kept with a note, mirroring #588's decision to keep `createVerifiedBadge`: `OME-821` restores the control and would otherwise re-add identical CSS. `.sf-lb__chip` stays in use by the baseline chip. |
+| D6 | The decoded model is untouched | `Leaderboard.verified_by_openmined` stays. The API returns the field; only its *presentation* is withdrawn. |
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_ui/leaderboard_view.py` — drop `verify_action`, the
+  checkbox markup, the `data-verified` attribute, and the `verified` branch of `_row_chip`; change
+  the baseline predicate to `kind == "single"`.
+- `packages/screamingface/src/screamingface/_ui/leaderboard_style.py` — note the now-unused
+  checkbox rules.
+- `packages/screamingface/tests/test_leaderboards.py` — new assertions; one prior assertion inverts
+  (see Test plan).
+
+## Test plan
+
+RED first:
+
+- `"verified only"` is absent from the rendered HTML.
+- The `verified` chip is absent **even for a candidate whose `verified_by_openmined` is true** —
+  the strong form. The existing assertion at `:787` only covers an *unverified* entry.
+- `data-verified` is absent.
+- The `baseline` chip is **still present** for a baseline row.
+- **D2/D3 guard:** a candidate with no forkable url4 is *not* labelled `baseline`, whatever its
+  verified value.
+
+Prior tests affected:
+
+- `:354` asserts `"verified only" in html`. It must invert. That is a Confidence-Gate decision
+  under sdlc rule 5 — escalate, do not edit silently.
+- `:787` asserts the verified chip is absent for an unverified entry. It keeps passing, but becomes
+  **unfalsifiable** once the chip never renders. Left alone; the new strong-form assertion carries
+  the real coverage. Recorded rather than quietly relied upon.
+
+## Acceptance
+
+- No verification control or chip in the rendered notebook view.
+- Baseline rows keep their chip; candidates are never labelled `baseline`.
+- Full `screamingface` gates green, including the 95% coverage floor.
+
+## Outcome
+
+- **Actual files:** as planned — `_ui/leaderboard_view.py`, `_ui/leaderboard_style.py` (comment
+  only), `tests/test_leaderboards.py`, plus the four SDLC artifacts.
+- **Gates:** `run_gates.py screamingface --base origin/main --skip-append-only` → **all seven
+  green**: ruff check, ruff format, pyright, pytest --cov (95% floor), the notebook check,
+  `uv build`, and the distribution check. **783 passed, 1 skipped.**
+
+### The trap was real, and a test proved it
+
+`test_a_candidate_is_never_labelled_baseline[False]` **failed before any production change** —
+confirming from behaviour, not just from reading, that an unverified candidate with an unforkable
+url4 already wore the `baseline` chip. `[True]` passed only because the `verified` branch shadowed
+it. So a naive deletion would have turned the `[True]` case into the same mislabel, and the guard
+would have caught it. D2/D3 hold.
+
+### Deviations
+
+1. **My own test contradicted my own decision, twice, and caught both.** D5 keeps the unused
+   `.sf-lb__checkbox` CSS, but `LEADERBOARD_STYLE` is inlined into the same HTML string, so
+   `assert "sf-lb__checkbox" not in html` failed on dead CSS rather than on a rendered control. The
+   assertion was too broad; narrowed to the markup (`<label class='sf-lb__checkbox'>` and
+   `<input type='checkbox'`). Then the explanatory CSS comment I added contained the literal phrase
+   `"verified only"`, which also ships inline and tripped that assertion too. Reworded, and kept
+   terse on purpose — **a CSS comment in this file is visible to every notebook reader in page
+   source.**
+2. **A prior assertion inverted, owner-approved.** `tests/test_leaderboards.py:356` asserted
+   `"verified only" in html`. Escalated per sdlc rule 5 rather than edited. Inverted to `not in`
+   rather than deleted, so it still catches the control being re-added before `OME-821`; its
+   neighbours already assert absence the same way. Gate run used `--skip-append-only`.
+3. **`tests/test_leaderboards.py:787` is now unfalsifiable and was left alone.** It asserts the
+   verified chip is absent for an *unverified* entry; with the chip gone entirely it passes
+   trivially. The new parametrised test carries the real coverage, including the verified case that
+   assertion never covered. Recorded rather than silently relied on.
+4. **A collection error that was not mine.** The suite first failed with
+   `ModuleNotFoundError: No module named 'ipywidgets'`. Environmental — `uv sync --extra notebook`
+   fixed it. Worth noting because the plan flagged exactly this: verify an unfamiliar gate failure
+   against `origin/main` before treating it as your own.
+5. **My `uuid4` import tripped ruff.** I inserted it beside `datetime` while `from uuid import UUID`
+   already existed lower down. Merged into one statement by hand rather than running
+   `ruff check --fix`, so the result is what I intended rather than what the fixer chose.

--- a/docs/work/2026-08-14-OME-832-hide-verified-chip.md
+++ b/docs/work/2026-08-14-OME-832-hide-verified-chip.md
@@ -136,3 +136,21 @@ Also noted: coverage passes at **95.05%** against a 95% floor — almost no head
 to this package may need to add tests before it can add code.
 
 **Gates:** all seven green, 783 passed.
+
+## Dmitry APPROVED (2026-08-14 14:44Z), with one wording correction
+
+> *"OME-820 does not make the field literally uniform because existing `False` rows are not
+> backfilled. The stronger rationale is that the field temporarily has no trustworthy verification
+> semantics, regardless of its value."*
+
+Correct, and it applied to this PR's test docstring as well as four sites on #588. D5 forbids a
+backfill, so pre-change rows keep `false`: the field is **meaningless, not constant**.
+
+Worth stating why that is the *stronger* rationale rather than a pedantic fix. A uniform value would
+make the pool filter merely useless — it would select everything. A non-uniform but meaningless value
+makes it actively misleading: the filter would split rows by whether they predate the default change
+**while presenting itself as a verification filter**. A control that looks like trust and actually
+sorts by submission date is worse than one that does nothing, so the case for removing the chip and
+the checkbox is stronger than I argued it.
+
+Docstring corrected. No implementation change — he confirmed the implementation and tests as good.

--- a/packages/screamingface/src/screamingface/_ui/leaderboard_style.py
+++ b/packages/screamingface/src/screamingface/_ui/leaderboard_style.py
@@ -50,6 +50,9 @@ LEADERBOARD_STYLE = """<style>
   border-bottom:1px solid var(--sf-lb-line-2);padding:0 4px 8px}
 .sf-lb__field-label{color:var(--sf-lb-ink-2);white-space:nowrap}
 .sf-lb__field-value{font-weight:500;color:var(--sf-lb-ink)}
+/* OME-832: .sf-lb__checkbox is unused. Its control was removed (OME-820) and
+   returns with OME-821, so the rules are kept rather than re-added. This comment
+   ships to the reader in page source, hence the brevity. */
 .sf-lb__checkbox{display:inline-flex;align-items:center;gap:8px;margin-left:auto;
   color:var(--sf-lb-ink-2);cursor:pointer}
 .sf-lb__checkbox input{position:absolute;opacity:0;width:1px;height:1px}

--- a/packages/screamingface/src/screamingface/_ui/leaderboard_view.py
+++ b/packages/screamingface/src/screamingface/_ui/leaderboard_view.py
@@ -99,10 +99,6 @@ def leaderboard_html(board: Leaderboard) -> str:
     rows = _board_rows(values)
     if not rows:
         rows = "<div class='sf-lb__empty'>No scores have been published yet.</div>"
-    verify_action = (
-        "this.closest('.sf-lb').querySelectorAll('[data-verified=false]').forEach((row)=>{"
-        "row.hidden=this.checked})"
-    )
     title = escape(board.benchmark.display_name)
     benchmark_id = escape(board.benchmark.id)
     return (
@@ -112,9 +108,10 @@ def leaderboard_html(board: Leaderboard) -> str:
         "<div class='sf-lb__controls'><span class='sf-lb__field'>"
         "<span class='sf-lb__field-label'>benchmark:</span>"
         f"<span class='sf-lb__field-value'>{title}</span></span>"
-        "<label class='sf-lb__checkbox'><input type='checkbox' "
-        f"onchange=\"{verify_action}\"><span class='sf-lb__checkbox-box'></span>"
-        "<span>verified only</span></label></div></div>"
+        # OME-832: the "verified only" checkbox lived here. Removed, not relabelled —
+        # verified_by_openmined is uniform since OME-820, so no row carries
+        # data-verified=false and the control removed nothing. OME-821 restores it.
+        "</div></div>"
         "<div class='sf-lb__table' role='table'>"
         "<div class='sf-lb__row sf-lb__row--head' role='row'>"
         "<span role='columnheader'>#</span><span role='columnheader'>entry</span>"
@@ -186,7 +183,8 @@ def _board_rows(values: Sequence[_DisplayRow]) -> str:
 def _board_row(value: _DisplayRow, rank: int, maximum: float) -> str:
     winner = rank == 1
     classes = "sf-lb__row" + (" sf-lb__row--winner" if winner else "")
-    verified = "" if value.verified is None else f" data-verified='{str(value.verified).lower()}'"
+    # OME-832: data-verified is no longer emitted. Its only reader was the removed
+    # "verified only" filter handler; nothing else in the package consumes it.
     chip = _row_chip(value)
     fill_class = "sf-lb__score-fill"
     if winner:
@@ -199,7 +197,7 @@ def _board_row(value: _DisplayRow, rank: int, maximum: float) -> str:
     questions = "—" if value.questions is None else str(value.questions)
     icon = "😱" if value.python_source is not None else "●"
     return (
-        f"<div class='{classes}' role='row'{verified}>"
+        f"<div class='{classes}' role='row'>"
         f"<span class='sf-lb__rank' role='cell'>{rank}</span>"
         "<span class='sf-lb__entry' role='cell'>"
         f"<span class='sf-lb__icon' aria-hidden='true'>{icon}</span>"
@@ -215,9 +213,21 @@ def _board_row(value: _DisplayRow, rank: int, maximum: float) -> str:
 
 
 def _row_chip(value: _DisplayRow) -> str:
-    if value.verified:
-        return "<span class='sf-lb__chip'>verified</span>"
-    if value.python_source is None:
+    """The baseline chip, and nothing else.
+
+    INVARIANT: only an imported single-Model row may wear this chip. The predicate is
+    `kind`, NOT `python_source is None` — `_baseline_row` sets kind="single" and
+    `_candidate_row` sets kind="candidate", whereas forkability is a property of the
+    url4 expression and says nothing about where a row came from.
+
+    WHY that matters: this used to read `if value.verified: … ; if value.python_source is
+    None: baseline`. The verified branch was removed in OME-832 because the flag became
+    uniform and asserted nothing (OME-820). Deleting it alone would have let a candidate
+    with an unforkable url4 fall through and be labelled "baseline" — presenting a
+    community submission as an imported reference, a worse error than the one being
+    fixed. It already did that for *unverified* such candidates, which this also fixes.
+    """
+    if value.kind == "single":
         return "<span class='sf-lb__chip'>baseline</span>"
     return ""
 

--- a/packages/screamingface/src/screamingface/_ui/leaderboard_view.py
+++ b/packages/screamingface/src/screamingface/_ui/leaderboard_view.py
@@ -60,6 +60,14 @@ class _DisplayRow:
     kind: str
     accuracy: float
     questions: int | None
+    # AIDEV-NOTE: UNUSED since OME-832. Its readers were the data-verified attribute
+    # and the `verified` chip, both removed because verified_by_openmined became
+    # uniform and asserted nothing (OME-820). `_candidate_row` still populates it, so
+    # nothing in ruff, pyright or coverage will notice it going stale. Parked
+    # deliberately for OME-821, which gives the flag a real signal and restores both
+    # readers. Do NOT key new presentation on it before then — a row's value says
+    # nothing today, and doing so would reintroduce the inert trust signal this
+    # change removed.
     verified: bool | None
     python_source: str | None
     source_url: str | None

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any, cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -352,7 +352,10 @@ def test_leaderboard_rich_display_uses_the_brand_board_with_only_real_fields() -
     assert "single/model" in html
     assert "82.0" in html
     assert "61.0" in html
-    assert "verified only" in html
+    # OME-832: the "verified only" control was removed. verified_by_openmined became
+    # uniform in OME-820, so the checkbox filtered nothing. Inverted rather than
+    # deleted so it still catches the control being re-added before OME-821.
+    assert "verified only" not in html
     assert "data-python=" in html
     assert "candidate = sf.Model(" in html
     assert "&#x27;openrouter/model&#x27;" in html
@@ -786,3 +789,81 @@ def test_empty_and_unforkable_leaderboards_have_complete_widget_states() -> None
 
     assert "<span class='sf-lb__chip'>verified</span>" not in forkable_html
     assert ">fork</button>" in forkable_html
+
+
+# --- OME-832: the notebook view must not present an inert flag as trust ---
+
+
+def _chip_board(*, verified: bool, forkable: bool) -> sf.Leaderboard:
+    """One candidate plus one baseline, so both chip paths are exercised."""
+    entry = sf.LeaderboardEntry(
+        rank=1,
+        spec_id="fusion/alpha",
+        accuracy=0.9,
+        total_questions=10,
+        ran_with_providers=("openrouter",),
+        submitted_at=datetime(2026, 8, 8, 12, tzinfo=UTC),
+        submitted_by="tester@openmined.org",
+        verified_by_openmined=verified,
+        url4=sf.Url4(_linked_url4() if forkable else "(@)!'not a ScreamingFace candidate'"),
+    )
+    baseline = sf.LeaderboardBaseline(
+        id=uuid4(),
+        benchmark_id="draco",
+        model_name="single/model",
+        accuracy=0.6,
+        source="LMArena",
+        source_url="https://example.invalid/board",
+        imported_at=datetime(2026, 8, 1, 10, tzinfo=UTC),
+        metadata=None,
+    )
+    return sf.Leaderboard(
+        benchmark=sf.LeaderboardInfo(
+            id="draco",
+            display_name="DRACO",
+            description=None,
+            dataset_url=None,
+            created_at=datetime(2026, 8, 1, 10, tzinfo=UTC),
+        ),
+        entries=(entry,),
+        baselines=(baseline,),
+    )
+
+
+@pytest.mark.parametrize("verified", [True, False])
+@pytest.mark.parametrize("forkable", [True, False])
+def test_leaderboard_view_shows_no_verification_ui(verified: bool, forkable: bool) -> None:
+    """OME-820 made verified_by_openmined uniform, so it conveys nothing.
+
+    The chip would appear on every row and the "verified only" checkbox would remove
+    nothing, because no row carries data-verified=false any more.
+    """
+    html = cast(Any, _chip_board(verified=verified, forkable=forkable))._repr_html_()
+
+    assert "verified only" not in html
+    # The MARKUP, not the class name: LEADERBOARD_STYLE is inlined into the same string
+    # and still carries the .sf-lb__checkbox rules, kept unused for OME-821 (D5). Dead
+    # CSS renders no control.
+    assert "<label class='sf-lb__checkbox'>" not in html
+    assert "<input type='checkbox'" not in html
+    assert "data-verified" not in html
+    assert "<span class='sf-lb__chip'>verified</span>" not in html
+
+
+@pytest.mark.parametrize("verified", [True, False])
+def test_a_candidate_is_never_labelled_baseline(verified: bool) -> None:
+    """INVARIANT: only an imported single-Model row may wear the baseline chip.
+
+    `_row_chip` used to fall through to the baseline branch on `python_source is None`.
+    Simply deleting the verified branch would therefore label a candidate with no
+    forkable url4 as "baseline" — presenting a community submission as an imported
+    reference, which is a worse error than the one being fixed. The predicate must key
+    on `kind`, not on forkability.
+    """
+    html = cast(Any, _chip_board(verified=verified, forkable=False))._repr_html_()
+
+    # The candidate row carries its spec_id; the baseline row carries the model name.
+    candidate_row = html.split("fusion/alpha")[1].split("</div>")[0]
+
+    assert "baseline" not in candidate_row
+    assert "<span class='sf-lb__chip'>baseline</span>" in html  # the real baseline still has it

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -833,10 +833,14 @@ def _chip_board(*, verified: bool, forkable: bool) -> sf.Leaderboard:
 @pytest.mark.parametrize("verified", [True, False])
 @pytest.mark.parametrize("forkable", [True, False])
 def test_leaderboard_view_shows_no_verification_ui(verified: bool, forkable: bool) -> None:
-    """OME-820 made verified_by_openmined uniform, so it conveys nothing.
+    """OME-820 left verified_by_openmined without trustworthy semantics.
 
-    The chip would appear on every row and the "verified only" checkbox would remove
-    nothing, because no row carries data-verified=false any more.
+    Not uniform — rows predating that change keep false, since D5 forbids a backfill —
+    but meaningless either way, because nothing re-runs submissions and nothing attests
+    where a run executed. So the chip certifies nothing, and the "verified only"
+    checkbox would split rows by whether they predate the default change while
+    presenting itself as a verification filter: worse than filtering nothing.
+    (Dmitry's review note on #601.)
     """
     html = cast(Any, _chip_board(verified=verified, forkable=forkable))._repr_html_()
 


### PR DESCRIPTION
Linear: [OME-832](https://linear.app/openmined/issue/OME-832/hide-the-verified-chip-and-filter-in-the-python-leaderboard-view) · Pairs with **#588** ([OME-820](https://linear.app/openmined/issue/OME-820/default-new-leaderboard-submissions-to-verified-as-a-placeholder))

Client half of the `OME-820` review fix, raised by `@HupBaHa` on #588.

## Why

`OME-820` makes `verified_by_openmined` default to `True` for every submission, as a placeholder that asserts nothing — nothing re-runs submissions (`OME-414`) and nothing attests where a run executed. #588 withdraws the scoreboard portal's verification UI for that reason.

The Python client did not, and **this is the surface that matters most**: the notebook view is what renders in Colab for the tester cohort. It showed a `verified` chip on any row whose flag was truthy — which, after `OME-820`, certifies nothing — plus a "verified only" checkbox whose handler hides `[data-verified=false]`.

Hidden rather than relabelled. The chip could have been reworded; **the filter could not**, because its defect is that the value certifies nothing either way.

`OME-820` does **not** make the field uniform — `D5` forbids backfilling existing `false` rows, so pre-change rows keep it (Dmitry's note on this PR). That makes the filter *worse* than useless rather than merely useless: it would split rows by whether they predate the default change **while presenting itself as a verification filter**. A control that looks like trust and actually sorts by submission date is worse than one that does nothing.

## ⚠️ The deletion had a trap

`_row_chip` was ordered:

```python
if value.verified:                 # -> "verified"
if value.python_source is None:    # -> "baseline"
return ""
```

Removing the first branch does **not** just remove a chip. A candidate with an unforkable url4 falls through to the second branch and is labelled **"baseline"** — presenting a community submission as an imported single-model reference. That is a worse error than the one being fixed.

The predicate now keys on `kind`, which is what actually distinguishes a baseline row (`_baseline_row` sets `kind="single"`, `_candidate_row` sets `kind="candidate"`). Forkability is a property of the url4 expression and says nothing about provenance.

**This was already broken for unverified candidates.** `test_a_candidate_is_never_labelled_baseline[False]` **fails before any production change** — the `verified` branch was merely shadowing it. So the pre-existing mislabel is fixed too, and the guard would have caught the naive deletion turning `[True]` into the same bug.

## What changed

- `_ui/leaderboard_view.py` — dropped `verify_action`, the checkbox markup, the `data-verified` attribute (its only reader was the removed handler), and the `verified` chip branch; baseline predicate now `kind == "single"`.
- `_ui/leaderboard_style.py` — comment only. The `.sf-lb__checkbox` rules are kept unused because `OME-821` restores the control. Deliberately terse: **comments in that file ship to every reader in page source.**
- `Leaderboard.verified_by_openmined` is untouched. The API still returns it; only presentation is withdrawn.

## Test plan

- **All seven `screamingface` gates green**, including the **95% coverage floor**, the notebook check, `uv build` and the distribution check. **783 passed, 1 skipped.**
- New parametrised tests across verified × forkable: no `verified only` control, no checkbox markup, no `data-verified`, no verified chip — **including for a candidate whose `verified_by_openmined` is true**, which the existing assertion at `:787` never covered.
- The mislabel guard above.

## Notes for the reviewer

**One prior assertion inverted, owner-approved.** `tests/test_leaderboards.py:356` asserted `"verified only" in html`. Escalated per sdlc rule 5 rather than edited silently, and **inverted rather than deleted** so it still catches the control being re-added before `OME-821`. Its neighbours already assert absence the same way (`"cost" not in html`, `"mine only" not in html`). The gate run used `--skip-append-only`; everything else ran normally.

**`tests/test_leaderboards.py:787` is now unfalsifiable**, and I left it alone. It asserts the verified chip is absent for an *unverified* entry; with the chip gone entirely it passes trivially. The new tests carry the real coverage. Flagging it rather than quietly relying on it.

**My own tests caught two of my own mistakes**, both worth knowing: `LEADERBOARD_STYLE` is inlined into the same HTML string, so an assertion on the *class name* failed on dead CSS rather than a rendered control (narrowed to the markup); and the explanatory CSS comment I first wrote contained the literal phrase `"verified only"`, which also ships inline and tripped the same assertion.

## Sequencing

**#588 should not merge before this one.** Otherwise new submissions default to a `true` that certifies nothing while the notebook still badges them, against a board that has just withdrawn the claim. Either order works if they land together; this one first is safest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdKCiEFpo188AkWG5kSn1G
