### PR TITLE
feat(scoreboard): publish only the local part of a submitter's email

### DIFF
--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -16,6 +16,7 @@ from scoreboard.scores.schemas import (
     FrontierResponse,
     LeaderboardEntry,
     ScoreSchema,
+    SubmittedBy,
 )
 from scoreboard.scores.store import ScoreStore
 
@@ -43,7 +44,7 @@ class RankedLeaderboardEntry(BaseModel):
     total_questions: int
     ran_with_providers: list[str]
     submitted_at: datetime
-    submitted_by: str | None
+    submitted_by: SubmittedBy
     verified_by_openmined: bool
     url4_expression: str
 
@@ -70,7 +71,7 @@ class HistorySubmission(BaseModel):
     total_questions: int
     correct_questions: int
     submitted_at: datetime
-    submitted_by: str | None
+    submitted_by: SubmittedBy
     verified_by_openmined: bool
 
 

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -65,12 +65,21 @@ def _publish_submitter(value: str | None) -> str | None:
     different domains become indistinguishable on a board that attributes credit.
     A real username field is the fix; OME-772 records that none exists (OME-834).
     """
-    if value is None or "@" not in value:
+    # Only trim something that actually looks like ONE address. Anything else is free
+    # text that happens to contain "@", and truncating it loses meaning. Gating on the
+    # bare presence of "@" was the original bug (OME-834 review):
+    #   " @openmined.org"     -> " "        a BLANK submitter, not an empty one, so a
+    #                                       `local or value` guard did not catch it —
+    #                                       and the SDK's _text rejects blank-after-
+    #                                       strip, raising LeaderboardError for the
+    #                                       WHOLE board off one poisoned row.
+    #   "Team A @ OpenMined"  -> "Team A "  free text silently truncated.
+    if value is None or "@" not in value or any(char.isspace() for char in value):
         return value
-    # The domain is whatever follows the LAST "@".
-    local = value.rsplit("@", 1)[0]
-    # An empty local part would render as a missing submitter; keep the original.
-    return local or value
+    local, _, domain = value.rpartition("@")
+    # A public address needs a non-blank local part and a dotted domain. `user@github`
+    # is a handle, not an address, so it passes through untouched.
+    return local if local.strip() and "." in domain else value
 
 
 # INVARIANT: the ONE definition of how a submitter reaches a client, shared by every

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -65,21 +65,31 @@ def _publish_submitter(value: str | None) -> str | None:
     different domains become indistinguishable on a board that attributes credit.
     A real username field is the fix; OME-772 records that none exists (OME-834).
     """
-    # Only trim something that actually looks like ONE address. Anything else is free
-    # text that happens to contain "@", and truncating it loses meaning. Gating on the
-    # bare presence of "@" was the original bug (OME-834 review):
-    #   " @openmined.org"     -> " "        a BLANK submitter, not an empty one, so a
-    #                                       `local or value` guard did not catch it —
-    #                                       and the SDK's _text rejects blank-after-
-    #                                       strip, raising LeaderboardError for the
-    #                                       WHOLE board off one poisoned row.
-    #   "Team A @ OpenMined"  -> "Team A "  free text silently truncated.
-    if value is None or "@" not in value or any(char.isspace() for char in value):
+    if value is None:
         return value
-    local, _, domain = value.rpartition("@")
-    # A public address needs a non-blank local part and a dotted domain. `user@github`
+    # WHY strip BEFORE the shape test, not instead of it: the two review passes on this
+    # function each fixed one half of the same question, "what counts as one address".
+    #   pass 1 gated on `@` alone   -> " @openmined.org" published " ", a BLANK
+    #                                  submitter, and the SDK's _text rejects
+    #                                  blank-after-strip, raising LeaderboardError for
+    #                                  the WHOLE board off one poisoned row;
+    #   pass 2 rejected ALL whitespace -> "trask@openmined.org " (one trailing space)
+    #                                  published the full domain, i.e. the exposure this
+    #                                  whole change exists to close, defeated by padding.
+    # Surrounding whitespace is noise; INTERNAL whitespace is what proves the value is
+    # free text ("Team A @ OpenMined") rather than an address. Strip, then require the
+    # remainder to hold no whitespace at all.
+    #
+    # INVARIANT: this cannot resurrect the blank-local hazard. `candidate` has no
+    # whitespace left, so an empty local part is empty, not blank — "  @openmined.org  "
+    # falls through to the untouched original rather than publishing "  ".
+    candidate = value.strip()
+    if "@" not in candidate or any(char.isspace() for char in candidate):
+        return value
+    local, _, domain = candidate.rpartition("@")
+    # A public address needs a non-empty local part and a dotted domain. `user@github`
     # is a handle, not an address, so it passes through untouched.
-    return local if local.strip() and "." in domain else value
+    return local if local and "." in domain else value
 
 
 # INVARIANT: the ONE definition of how a submitter reaches a client, shared by every

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -5,7 +5,14 @@ from datetime import datetime
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PlainSerializer,
+    field_validator,
+    model_validator,
+)
 
 # INVARIANT: a baseline's metadata is operator-supplied (via the import CLI, not a
 # public HTTP endpoint) but still bounded, so one bad import can't make
@@ -34,6 +41,45 @@ def _validate_bounded_metadata(value: dict[str, Any] | None) -> dict[str, Any] |
     if len(json.dumps(value)) > _METADATA_MAX_BYTES:
         raise ValueError(f"metadata must serialize to at most {_METADATA_MAX_BYTES} bytes")
     return value
+
+
+def _publish_submitter(value: str | None) -> str | None:
+    """Publish the local part of an email, never the domain.
+
+    WHY: since OME-404 this field holds the mesh-verified address from the Cloudflare
+    Access identity header, and the read API is PUBLIC and unauthenticated — a
+    harvester can pull every submitter's address straight out of
+    `GET /v1/leaderboard/{id}`. Stripping in the portal would have looked correct
+    while leaving the JSON exposed, so the trim lives here, where every consumer
+    (portal, SDK notebook view, anything future) is served from one place.
+
+    INVARIANT: this is a SERIALIZER, not a validator. The stored value keeps its
+    domain so OpenMined can still contact a submitter and audit which verified
+    identity produced a score. Do NOT move this onto ScoreSubmission — that carries
+    the value inbound, and trimming there would write the truncated form to the
+    database irreversibly.
+
+    AIDEV-NOTE: this is a stopgap, not privacy. `filip.boltuzic` still names a
+    person, `first.last@domain` is trivially reconstructed, and
+    trask@openmined.org and trask@gmail.com both render `trask` — two testers on
+    different domains become indistinguishable on a board that attributes credit.
+    A real username field is the fix; OME-772 records that none exists (OME-834).
+    """
+    if value is None or "@" not in value:
+        return value
+    # The domain is whatever follows the LAST "@".
+    local = value.rsplit("@", 1)[0]
+    # An empty local part would render as a missing submitter; keep the original.
+    return local or value
+
+
+# INVARIANT: the ONE definition of how a submitter reaches a client, shared by every
+# read DTO so the four cannot drift. `when_used="json"` is deliberate — _ranked_entry
+# splats entry.model_dump() in PYTHON mode and must keep receiving the stored value.
+SubmittedBy = Annotated[
+    str | None,
+    PlainSerializer(_publish_submitter, return_type=str | None, when_used="json"),
+]
 
 
 class ClientInfo(BaseModel):
@@ -165,7 +211,7 @@ class ScoreSchema(BaseModel):
     benchmark_revision: str | None
     spec_id: str
     url4_expression: str
-    submitted_by: str | None
+    submitted_by: SubmittedBy
     submitted_at: datetime
     accuracy: float
     total_questions: int
@@ -196,7 +242,7 @@ class LeaderboardEntry(BaseModel):
     total_questions: int
     ran_with_providers: list[str]
     submitted_at: datetime
-    submitted_by: str | None
+    submitted_by: SubmittedBy
     verified_by_openmined: bool
     url4_expression: str
 

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -67,28 +67,38 @@ def _publish_submitter(value: str | None) -> str | None:
     """
     if value is None:
         return value
-    # WHY strip BEFORE the shape test, not instead of it: the two review passes on this
-    # function each fixed one half of the same question, "what counts as one address".
-    #   pass 1 gated on `@` alone   -> " @openmined.org" published " ", a BLANK
-    #                                  submitter, and the SDK's _text rejects
-    #                                  blank-after-strip, raising LeaderboardError for
-    #                                  the WHOLE board off one poisoned row;
+    # WHY whitespace is REMOVED rather than treated as a signal: three review passes
+    # tried to read intent from whitespace, and each fixed one half while breaking
+    # the other.
+    #   pass 1 gated on `@` alone     -> " @openmined.org" published " ", a BLANK
+    #                                    submitter, and the SDK's _text rejects
+    #                                    blank-after-strip, raising LeaderboardError
+    #                                    for the WHOLE board off one poisoned row;
     #   pass 2 rejected ALL whitespace -> "trask@openmined.org " (one trailing space)
-    #                                  published the full domain, i.e. the exposure this
-    #                                  whole change exists to close, defeated by padding.
-    # Surrounding whitespace is noise; INTERNAL whitespace is what proves the value is
-    # free text ("Team A @ OpenMined") rather than an address. Strip, then require the
-    # remainder to hold no whitespace at all.
+    #                                    published the full domain — the exposure this
+    #                                    function exists to close, beaten by a space;
+    #   pass 3 stripped only the ends  -> "me @ openmined.org" still published whole,
+    #                                    and a harvester just normalises it back.
     #
-    # INVARIANT: this cannot resurrect the blank-local hazard. `candidate` has no
-    # whitespace left, so an empty local part is empty, not blank — "  @openmined.org  "
-    # falls through to the untouched original rather than publishing "  ".
-    candidate = value.strip()
-    if "@" not in candidate or any(char.isspace() for char in candidate):
+    # The owner settled the question underneath all three (2026-08-15): this field is
+    # an IDENTITY, not a display name. So the test is simply "is this an address?" —
+    # whitespace is formatting noise wherever it sits, not evidence of intent.
+    #
+    # INVARIANT: the blank-local hazard stays closed. With every space gone, an empty
+    # local part is empty rather than blank, so "  @openmined.org  " falls through to
+    # the untouched original instead of publishing "  ".
+    #
+    # AIDEV-NOTE: this is still a read-time GUESS about a value nothing constrains on
+    # the way in — the reason it took four passes. OME-840 closes it properly by
+    # validating the address on the write path; when that lands this can stop guessing.
+    candidate = "".join(value.split())
+    if "@" not in candidate:
         return value
     local, _, domain = candidate.rpartition("@")
-    # A public address needs a non-empty local part and a dotted domain. `user@github`
-    # is a handle, not an address, so it passes through untouched.
+    # A public address needs a non-empty local part and a DOTTED domain. That dot is
+    # what keeps free text safe: "Team A @ OpenMined" collapses to "TeamA@OpenMined",
+    # whose domain is a word rather than a host, so it passes through whole. Same for
+    # the handle form, `user@github`.
     return local if local and "." in domain else value
 
 

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -347,3 +347,83 @@ def test_baseline_schema_rejects_oversized_metadata() -> None:
 
     with pytest.raises(ValidationError):
         BaselineSchema.model_validate(payload)
+
+
+# --- OME-834: publish only the local part of a submitter's email ---
+
+
+@pytest.mark.parametrize(
+    ("stored", "published"),
+    [
+        # The request: an address must not be harvestable from the public API.
+        ("trask@openmined.org", "trask"),
+        ("filip.boltuzic@openmined.org", "filip.boltuzic"),
+        # In authMode: disabled this field is client-supplied free text, so a value
+        # that is not an address passes through rather than being mangled.
+        ("tester", "tester"),
+        ("", ""),
+        # The domain is whatever follows the LAST "@".
+        ("a@b@openmined.org", "a@b"),
+        # An empty local part would render as a missing submitter, so keep the
+        # original instead of emitting "".
+        ("@openmined.org", "@openmined.org"),
+    ],
+)
+def test_score_schema_publishes_only_the_local_part(stored: str, published: str) -> None:
+    import json
+
+    from scoreboard.scores.schemas import ScoreSchema
+
+    schema = ScoreSchema(
+        id=uuid4(),
+        version=1,
+        benchmark_id="hle",
+        spec_id="spec-1",
+        url4_expression="x",
+        submitted_by=stored,
+        submitted_at=datetime(2026, 8, 14, 12, tzinfo=UTC),
+        accuracy=0.5,
+        total_questions=2,
+        correct_questions=1,
+        ran_with_providers=["openai"],
+        ran_at_local=None,
+        client_name=None,
+        client_version=None,
+        client_platform=None,
+        verified_by_openmined=True,
+        metadata=None,
+    )
+
+    assert json.loads(schema.model_dump_json())["submitted_by"] == published
+    # INVARIANT: only the WIRE form is trimmed. The value in memory — and therefore
+    # the value written to and read from the database — keeps its domain, so
+    # OpenMined can still contact and audit a submitter (OME-404).
+    assert schema.submitted_by == stored
+
+
+def test_a_null_submitter_stays_null() -> None:
+    import json
+
+    from scoreboard.scores.schemas import ScoreSchema
+
+    schema = ScoreSchema(
+        id=uuid4(),
+        version=1,
+        benchmark_id="hle",
+        spec_id="spec-1",
+        url4_expression="x",
+        submitted_by=None,
+        submitted_at=datetime(2026, 8, 14, 12, tzinfo=UTC),
+        accuracy=0.5,
+        total_questions=2,
+        correct_questions=1,
+        ran_with_providers=["openai"],
+        ran_at_local=None,
+        client_name=None,
+        client_version=None,
+        client_platform=None,
+        verified_by_openmined=True,
+        metadata=None,
+    )
+
+    assert json.loads(schema.model_dump_json())["submitted_by"] is None

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -413,6 +413,9 @@ def test_score_schema_publishes_only_the_local_part(stored: str, published: str)
         id=uuid4(),
         version=1,
         benchmark_id="hle",
+        # OME-775 made this required; the published-identity contract under test here
+        # is independent of which benchmark revision produced the score.
+        benchmark_revision=None,
         spec_id="spec-1",
         url4_expression="x",
         submitted_by=stored,
@@ -445,6 +448,9 @@ def test_a_null_submitter_stays_null() -> None:
         id=uuid4(),
         version=1,
         benchmark_id="hle",
+        # OME-775 made this required; the published-identity contract under test here
+        # is independent of which benchmark revision produced the score.
+        benchmark_revision=None,
         spec_id="spec-1",
         url4_expression="x",
         submitted_by=None,

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -373,9 +373,10 @@ def test_baseline_schema_rejects_oversized_metadata() -> None:
         (" @openmined.org", " @openmined.org"),
         ("\t@openmined.org", "\t@openmined.org"),
         # OME-834 review: free text containing "@" is not an address. Truncating it
-        # contradicts the pass-through contract and loses meaning.
+        # contradicts the pass-through contract and loses meaning. What makes it free
+        # text is the UNDOTTED domain, not the spaces — see the third-review cases
+        # below, where "me @ openmined.org" is an address and is trimmed.
         ("Team A @ OpenMined", "Team A @ OpenMined"),
-        ("me @ openmined.org", "me @ openmined.org"),
         # A domain with no dot is not a public address; leave handles alone.
         ("user@github", "user@github"),
         # OME-834 second review: SURROUNDING whitespace must not defeat the strip.
@@ -390,6 +391,17 @@ def test_baseline_schema_rejects_oversized_metadata() -> None:
         # ...and padding must not resurrect the blank-local hazard: stripping first
         # leaves an EMPTY local part here, so the original still passes through.
         ("  @openmined.org  ", "  @openmined.org  "),
+        # OME-834 third review (owner decision, 2026-08-15): submitted_by is an
+        # IDENTITY, not a display name, so anything that IS an address once its
+        # whitespace is removed gets trimmed. A harvester normalises "me @ x.org"
+        # back to an address, so leaving it whole published a working one.
+        ("me @ openmined.org", "me"),
+        ("trask @ openmined.org", "trask"),
+        ("filip.boltuzic @ openmined . org", "filip.boltuzic"),
+        # Free text is still safe when its "domain" is not dotted — "OpenMined" is
+        # a word, not a host, so this is NOT an address and passes through whole.
+        ("Team A @ OpenMined", "Team A @ OpenMined"),
+        ("me @ github", "me @ github"),
     ],
 )
 def test_score_schema_publishes_only_the_local_part(stored: str, published: str) -> None:

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -378,6 +378,18 @@ def test_baseline_schema_rejects_oversized_metadata() -> None:
         ("me @ openmined.org", "me @ openmined.org"),
         # A domain with no dot is not a public address; leave handles alone.
         ("user@github", "user@github"),
+        # OME-834 second review: SURROUNDING whitespace must not defeat the strip.
+        # The whitespace guard above exists to catch a blank LOCAL part, but it was
+        # rejecting the whole value, so one trailing space published the full domain
+        # — the exact exposure this change exists to close. In authMode: disabled
+        # submitted_by is unvalidated free text, so a padded address is reachable.
+        ("trask@openmined.org ", "trask"),
+        (" trask@openmined.org", "trask"),
+        ("\ttrask@openmined.org\n", "trask"),
+        ("  filip.boltuzic@openmined.org  ", "filip.boltuzic"),
+        # ...and padding must not resurrect the blank-local hazard: stripping first
+        # leaves an EMPTY local part here, so the original still passes through.
+        ("  @openmined.org  ", "  @openmined.org  "),
     ],
 )
 def test_score_schema_publishes_only_the_local_part(stored: str, published: str) -> None:

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -367,6 +367,17 @@ def test_baseline_schema_rejects_oversized_metadata() -> None:
         # An empty local part would render as a missing submitter, so keep the
         # original instead of emitting "".
         ("@openmined.org", "@openmined.org"),
+        # OME-834 review: a BLANK local part is the dangerous case. " " is not empty,
+        # so the earlier `local or value` guard let it through — and the SDK's _text
+        # rejects blank-after-strip, raising LeaderboardError for the WHOLE board.
+        (" @openmined.org", " @openmined.org"),
+        ("\t@openmined.org", "\t@openmined.org"),
+        # OME-834 review: free text containing "@" is not an address. Truncating it
+        # contradicts the pass-through contract and loses meaning.
+        ("Team A @ OpenMined", "Team A @ OpenMined"),
+        ("me @ openmined.org", "me @ openmined.org"),
+        # A domain with no dot is not a public address; leave handles alone.
+        ("user@github", "user@github"),
     ],
 )
 def test_score_schema_publishes_only_the_local_part(stored: str, published: str) -> None:

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -367,3 +367,49 @@ async def test_get_frontier_reflects_real_submissions(
     assert body["current"]["label"] == "spec-2"
     assert body["current"]["openness"] == "closed"
     assert len(body["trend"]) == 2
+# --- OME-834: no read path may publish a harvestable address ---
+
+
+async def test_read_paths_publish_only_the_local_part(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """The API is public and unauthenticated, so this is where it has to happen.
+
+    Stripping in the portal would leave every address in the JSON.
+    """
+    store = ScoreStore()
+    await _register_benchmark(store)
+    await store.submit(
+        _submission(spec_id="stripped", submitted_by="trask@openmined.org"),
+    )
+
+    board = await async_client.get("/v1/leaderboard/hle")
+    history = await async_client.get("/v1/leaderboard/hle/stripped/history")
+
+    entry = next(e for e in board.json()["entries"] if e["spec_id"] == "stripped")
+    assert entry["submitted_by"] == "trask"
+    assert history.json()["submissions"][0]["submitted_by"] == "trask"
+    # No domain anywhere in either payload.
+    assert "openmined.org" not in board.text
+    assert "openmined.org" not in history.text
+
+
+async def test_the_database_still_holds_the_full_address(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """INVARIANT (D2): only the WIRE form is trimmed.
+
+    OpenMined must still be able to contact a submitter and audit which verified
+    identity produced a score (OME-404). This is the assertion that stops a future
+    "simplification" from moving the strip onto ScoreSubmission, which would write
+    the truncated form to the database irreversibly.
+    """
+    store = ScoreStore()
+    await _register_benchmark(store)
+    outcome = await store.submit(
+        _submission(spec_id="stored-full", submitted_by="trask@openmined.org"),
+    )
+
+    row = await Score.get(id=outcome.score.id)
+
+    assert row.submitted_by == "trask@openmined.org"

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -367,6 +367,8 @@ async def test_get_frontier_reflects_real_submissions(
     assert body["current"]["label"] == "spec-2"
     assert body["current"]["openness"] == "closed"
     assert len(body["trend"]) == 2
+
+
 # --- OME-834: no read path may publish a harvestable address ---
 
 

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -14,7 +14,7 @@ from tortoise.exceptions import OperationalError
 from scoreboard.config import Settings
 from scoreboard.main import create_app
 from scoreboard.routes.scores import MISSING_IDENTITY_DETAIL
-from scoreboard.scores.models import Benchmark, IdempotencyKey
+from scoreboard.scores.models import Benchmark, IdempotencyKey, Score
 from scoreboard.scores.store import ScoreStore
 
 pytestmark = pytest.mark.asyncio
@@ -312,8 +312,17 @@ async def test_post_score_with_identity_header_stores_header_email(
 
     assert response.status_code == 201
     # WHY: the header always wins over whatever the request body claims — a caller
-    # cannot submit under another person's name.
-    assert response.json()["submitted_by"] == "researcher@example.test"
+    # cannot submit under another person's name. The body claimed "someone-else", so
+    # seeing the header's identity here still proves that.
+    #
+    # OME-834: the published form is the local part only — the read API is public and
+    # unauthenticated, so the domain is withheld to keep addresses out of scrapers.
+    assert response.json()["submitted_by"] == "researcher"
+    # ...and the row keeps the full address, which is what this test's name claims and
+    # the response alone never verified. OpenMined must still be able to contact and
+    # audit the verified identity behind a score (OME-404).
+    stored = await Score.get(id=response.json()["id"])
+    assert stored.submitted_by == "researcher@example.test"
 
 
 async def test_post_score_missing_identity_header_returns_401(

--- a/docs/plan/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/plan/2026-08-14-OME-834-strip-email-domain.md
@@ -1,0 +1,43 @@
+# OME-834 — Implementation plan
+
+Spec: `docs/spec/2026-08-14-OME-834-strip-email-domain.md` · Ledger:
+`docs/work/2026-08-14-OME-834-strip-email-domain.md`
+
+Two files of production code. RED before GREEN.
+
+## Step 1 — RED
+
+`tests/unit/scores/test_schemas.py` — the serializer, parametrised over spec §3's table, including
+the two edge cases that are easy to get wrong: `@openmined.org` must not become `""`, and
+`a@b@openmined.org` splits on the last `@`.
+
+`tests/unit/test_leaderboard_routes.py` — the leaderboard route and the per-spec history both return
+the local part.
+
+`tests/unit/test_scores_routes.py` — `GET /v1/scores/{id}` too, **and the D2 guarantee**: after
+submitting, read the row back from the database and assert it still holds the full address. That is
+the assertion that stops a future "simplification" from stripping on write.
+
+## Step 2 — GREEN
+
+`scores/schemas.py`: a `_serialize_submitter` returning the local part per §3, plus
+`SubmittedBy = Annotated[str | None, PlainSerializer(..., when_used="json")]`. Apply to
+`ScoreSchema` and `LeaderboardEntry`.
+
+`routes/leaderboard.py`: the same type on `RankedLeaderboardEntry` and `HistorySubmission`.
+
+`when_used="json"` is deliberate — `_ranked_entry` splats `entry.model_dump()` in python mode and
+must keep receiving the stored value.
+
+## Step 3 — gates
+
+`run_gates.py scoreboard --base origin/main`, then a live probe against a freshly migrated database:
+submit a full email, confirm all three read paths show the local part and the row still holds the
+domain.
+
+## Risks
+
+- **`ScoreSubmission` must not be touched.** It carries the value *inbound*; stripping there would
+  write the truncated form to the database and silently become D2's rejected option.
+- The SDK decodes `submitted_by` into `LeaderboardEntry`; its tests may assert full addresses. Check
+  `packages/screamingface` before assuming this is scoreboard-only.

--- a/docs/spec/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/spec/2026-08-14-OME-834-strip-email-domain.md
@@ -79,10 +79,38 @@ whitespace at all. This cannot resurrect §3a's hazard — after stripping, an e
 empty rather than blank, so `"  @openmined.org  "` still passes through untouched instead of
 publishing `"  "`.
 
-**Residual, deliberately not closed:** `"me @ openmined.org"` still passes through in full, because
-§3's pass-through rule treats internal whitespace as free text. A determined harvester can normalise
-it. Closing it would mean trimming values that may legitimately be team names, which reverses a
-decision the owner locked in §3 — so it is recorded here rather than changed unilaterally.
+### 3c Third revision (owner decision, 2026-08-15) — the field is an identity
+
+§3b left `"me @ openmined.org"` passing through in full, on the §3 rule that internal whitespace
+means free text. A harvester just normalises that back into a working address, so the leak was real.
+
+The owner settled the question sitting underneath all three passes: **`submitted_by` is an identity,
+not a display name.** Two facts made the "protect team names" argument untenable — the Client SDK
+never sends this field at all (`_submission()` omits it), so free-text submitters are a use case
+nobody has; and the only real values in existence are two clean addresses on dev.
+
+So whitespace stops being evidence of intent and becomes formatting noise. The rule is now: **remove
+all whitespace, then require a non-empty local part and a dotted domain.**
+
+| Input | Published |
+|---|---|
+| `trask@openmined.org`, `"trask@openmined.org "`, `" trask@openmined.org"` | `trask` |
+| `"me @ openmined.org"`, `"trask @ openmined.org"` | `me`, `trask` |
+| `"filip.boltuzic @ openmined . org"` | `filip.boltuzic` |
+| `"Team A @ OpenMined"`, `"me @ github"`, `user@github` | unchanged — an undotted domain is a word, not a host |
+| `@openmined.org`, `" @openmined.org"`, `"  @openmined.org  "` | unchanged, never blank |
+| `tester`, `""`, `null` | unchanged |
+
+The **dotted domain**, not the whitespace, is what now keeps free text safe. That is a narrower and
+more honest test, and it is the reason the rule got simpler rather than more baroque.
+
+Accepted cost: free text whose right-hand side happens to contain a dot is truncated —
+`"Contact: trask @ openmined.org please"` publishes `Contact:trask`. It loses formatting; it does not
+leak an address.
+
+**This is still a read-time guess**, which is why it took four passes. `OME-840` closes it properly by
+validating the address on the write path, after which this function reduces to "everything before the
+last `@`".
 
 **Storage is untouched.** `Score.submitted_by` keeps the full address. OpenMined must still be able
 to contact a submitter and audit which verified identity produced a score, which stripping on write

--- a/docs/spec/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/spec/2026-08-14-OME-834-strip-email-domain.md
@@ -35,8 +35,26 @@ The strip belongs where every consumer is served: the **read DTOs**.
 | `tester` (no `@`) | `tester` | in `authMode: disabled` this is client-supplied free text, not necessarily an email |
 | `a@b@openmined.org` | `a@b` | the domain is what follows the **last** `@` |
 | `@openmined.org` | `@openmined.org` | an empty local part would render as a missing submitter; keep the original instead |
+| `" @openmined.org"` | unchanged | **a BLANK local part is the dangerous case** — see §3a |
+| `"Team A @ OpenMined"` | unchanged | free text containing `@` is not an address |
+| `user@github` | unchanged | a handle, not a public address (no dotted domain) |
 | `null` | `null` | absent stays absent |
 | `""` | `""` | unchanged |
+
+### 3a Revision after review (2026-08-14) — gate on address shape, not on "@"
+
+The first implementation trimmed whenever `@` appeared and guarded the result with
+`local or value`. Two holes, both verified:
+
+* `" @openmined.org"` yields `" "`. That is **blank, not empty**, so the guard missed it — and the
+  SDK's `_text` (`_scoreboard/leaderboards.py:445`) rejects blank-after-strip, raising
+  `LeaderboardError` for the **entire board**. One poisoned row would break every SDK client's read.
+  In the default `authMode: disabled` this field is unvalidated free text, so that value is
+  reachable.
+* `"Team A @ OpenMined"` yielded `"Team A "`, contradicting the pass-through rule above.
+
+The rule is now: trim only what looks like **one address** — no whitespace anywhere, a non-blank
+local part, and a dotted domain. Everything else passes through untouched.
 
 **Storage is untouched.** `Score.submitted_by` keeps the full address. OpenMined must still be able
 to contact a submitter and audit which verified identity produced a score, which stripping on write

--- a/docs/spec/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/spec/2026-08-14-OME-834-strip-email-domain.md
@@ -1,0 +1,70 @@
+# OME-834 — the board must not publish harvestable email addresses
+
+Status: approved (owner, 2026-08-14) · Stack: scoreboard
+
+## 1. Problem
+
+Since `OME-404`, a submission's `submitted_by` is the mesh-verified email from the Cloudflare Access
+identity header. The leaderboard publishes it verbatim, and the read API is **public and
+unauthenticated**. Measured on dev:
+
+```
+GET https://leaderboard.dev.screamingface.ai/v1/leaderboard/hle  →  200
+  "submitted_by": "filip.boltuzic@openmined.org"
+  "submitted_by": "stephen@openmined.org"
+```
+
+Every submitter's address is therefore machine-readable by anyone. With external testers about to
+submit, that is a live spam exposure created by us.
+
+## 2. Why the portal is the wrong layer
+
+`portal/main.js`'s `formatSubmitter` renders the value as-is, so a one-line change there would make
+the page look right. It would not help: **a harvester reads the JSON, not the HTML.** Fixing only the
+portal would have satisfied the request as phrased while leaving the exposure intact — the kind of
+fix that is worse than none, because it looks done.
+
+The strip belongs where every consumer is served: the **read DTOs**.
+
+## 3. Contract
+
+| Input | Output | Why |
+|---|---|---|
+| `trask@openmined.org` | `trask` | the request |
+| `filip.boltuzic@openmined.org` | `filip.boltuzic` | dots in the local part survive |
+| `tester` (no `@`) | `tester` | in `authMode: disabled` this is client-supplied free text, not necessarily an email |
+| `a@b@openmined.org` | `a@b` | the domain is what follows the **last** `@` |
+| `@openmined.org` | `@openmined.org` | an empty local part would render as a missing submitter; keep the original instead |
+| `null` | `null` | absent stays absent |
+| `""` | `""` | unchanged |
+
+**Storage is untouched.** `Score.submitted_by` keeps the full address. OpenMined must still be able
+to contact a submitter and audit which verified identity produced a score, which stripping on write
+would destroy irreversibly.
+
+Applied via one annotated type shared by `ScoreSchema`, `LeaderboardEntry`,
+`RankedLeaderboardEntry` and `HistorySubmission` — the pattern `RunCostUsd` established, after that
+same four-DTO duplication caused two separate defects.
+
+## 4. What this does not do
+
+**It is not anonymisation.** `filip.boltuzic` still identifies a person, and `first.last@openmined.org`
+is trivially reconstructed for anyone who knows the domain convention. This raises the cost of naive
+scraping; it does not protect identity. Nobody should describe it as privacy.
+
+**It collides.** `trask@openmined.org` and `trask@gmail.com` both render `trask`. The board attributes
+credit, so two testers on different domains would be indistinguishable. Acceptable only because this
+is explicitly a stopgap — the request opens *"since we do not have usernames yet"*. A real username
+field (`OME-772` records its absence) is the actual fix.
+
+## 5. Safe by construction
+
+`submitted_by` is deliberately excluded from `content_hash` (`OME-391`), so this cannot affect dedup,
+and the field is not a key for anything else.
+
+## 6. Acceptance
+
+- All three read paths return the local part only.
+- The stored row still holds the full address — asserted against the database, not the response.
+- Submitting a full email still works; a non-email value passes through unchanged.
+- Full gates green.

--- a/docs/spec/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/spec/2026-08-14-OME-834-strip-email-domain.md
@@ -36,6 +36,7 @@ The strip belongs where every consumer is served: the **read DTOs**.
 | `a@b@openmined.org` | `a@b` | the domain is what follows the **last** `@` |
 | `@openmined.org` | `@openmined.org` | an empty local part would render as a missing submitter; keep the original instead |
 | `" @openmined.org"` | unchanged | **a BLANK local part is the dangerous case** — see §3a |
+| `"trask@openmined.org "` | `trask` | surrounding whitespace is noise — see §3b |
 | `"Team A @ OpenMined"` | unchanged | free text containing `@` is not an address |
 | `user@github` | unchanged | a handle, not a public address (no dotted domain) |
 | `null` | `null` | absent stays absent |
@@ -55,6 +56,33 @@ The first implementation trimmed whenever `@` appeared and guarded the result wi
 
 The rule is now: trim only what looks like **one address** — no whitespace anywhere, a non-blank
 local part, and a dotted domain. Everything else passes through untouched.
+
+### 3b Second revision after review (2026-08-15) — strip the padding first
+
+§3a over-corrected. Rejecting **all** whitespace also rejected an address that merely carries
+padding, so one trailing space published the full domain — the exact exposure this change exists to
+close, defeated by a space:
+
+```
+"trask@openmined.org "   ->  "trask@openmined.org "   # domain published
+" trask@openmined.org"   ->  " trask@openmined.org"   # domain published
+```
+
+Reachable, not theoretical: `ScoreSubmission.submitted_by` is `str | None = None` with no strip and
+no constraint, and in `authMode: disabled` — the chart default — it is client-supplied free text. The
+authenticated path is safe; `identity_from_headers` already calls `.strip()`
+(`cloudflare_identity.py:68`).
+
+The distinction §3a actually needed is **surrounding** whitespace (noise) versus **internal**
+whitespace (proof the value is free text). So: strip, then require the remainder to hold no
+whitespace at all. This cannot resurrect §3a's hazard — after stripping, an empty local part is
+empty rather than blank, so `"  @openmined.org  "` still passes through untouched instead of
+publishing `"  "`.
+
+**Residual, deliberately not closed:** `"me @ openmined.org"` still passes through in full, because
+§3's pass-through rule treats internal whitespace as free text. A determined harvester can normalise
+it. Closing it would mean trimming values that may legitimately be team names, which reverses a
+decision the owner locked in §3 — so it is recorded here rather than changed unilaterally.
 
 **Storage is untouched.** `Score.submitted_by` keeps the full address. OpenMined must still be able
 to contact a submitter and audit which verified identity produced a score, which stripping on write

--- a/docs/tasks/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/tasks/2026-08-14-OME-834-strip-email-domain.md
@@ -1,0 +1,26 @@
+---
+id: OME-834
+linear_url: https://linear.app/openmined/issue/OME-834/publish-only-the-local-part-of-a-submitters-email-on-the-leaderboard
+status: In Progress
+type: Feature
+priority: P2
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-14
+closed:
+---
+
+# Publish only the local part of a submitter's email on the leaderboard
+
+Irina's request, to avoid exposing submitters to bot spam. Measured first: the full addresses were
+already public in the API without auth, so a portal-only change would have looked correct while
+leaving every address in the JSON. The strip lives in the read DTOs instead.
+
+Storage keeps the full address so OpenMined can still contact and audit a submitter (`OME-404`).
+
+Two limits recorded rather than hidden: `trask@openmined.org` and `trask@gmail.com` both render
+`trask`, and this is not anonymisation — `first.last@domain` is trivially reconstructed. Real
+usernames are the fix; `OME-772` records that no such field exists.
+
+Spec: `docs/spec/2026-08-14-OME-834-strip-email-domain.md`
+Plan: `docs/plan/2026-08-14-OME-834-strip-email-domain.md`
+Ledger: `docs/work/2026-08-14-OME-834-strip-email-domain.md`

--- a/docs/tasks/2026-08-15-OME-840-validate-submitter-on-write.md
+++ b/docs/tasks/2026-08-15-OME-840-validate-submitter-on-write.md
@@ -1,0 +1,27 @@
+---
+id: OME-840
+linear_url: https://linear.app/openmined/issue/OME-840/validate-the-submitters-address-on-the-write-path-instead-of-guessing
+status: Backlog
+type: Task
+priority: P3
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-15
+blocked_by: OME-834
+closed:
+---
+
+# Validate the submitter's address on the write path instead of guessing on read
+
+Owner decision, 2026-08-15: `submitted_by` is an **identity**, not a display name.
+
+`OME-834` publishes only the local part of a submitter's address, using a serializer that inspects
+the stored string and decides whether it looks like one. That is a read-time guess about a value
+nothing constrains inbound, and it took four passes to get right — each pass closing one hole and
+opening another (blank local part → padded address → spaced address → current).
+
+The fix is to constrain the value at the door: require a well-formed address or `null` on
+`POST /v1/scores`, reject anything else with a 422. Storage still keeps the full address, so
+`OME-404`'s audit trail is untouched. Once the value is guaranteed address-shaped, the serializer
+reduces to "everything before the last `@`" and the whole class of bug disappears.
+
+Blocked on `OME-834` / #602 landing first — this rewrites the function that PR introduces.

--- a/docs/work/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/work/2026-08-14-OME-834-strip-email-domain.md
@@ -1,0 +1,104 @@
+---
+ticket: OME-834
+stack: scoreboard
+status: in_progress
+started: 2026-08-14
+finished:
+---
+
+# OME-834 — publish only the local part of a submitter's email
+
+## Intent
+
+Irina, 2026-08-14: *"since we do not have usernames yet and you have access to the email, can we
+strip @… from the email (i.e trask@openmined.org → trask)? I am just afraid we're exposing folks to
+bot spam"*.
+
+Measured before deciding where: the full addresses are already public **in the API, without auth** —
+`GET /v1/leaderboard/hle` returns `200` with `"submitted_by": "filip.boltuzic@openmined.org"`. A
+harvester reads JSON, so stripping in `portal/main.js` would not have addressed the request at all.
+
+## Decisions locked (2026-08-14)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Layer | **Read DTOs.** One change point covers the portal, the SDK notebook view and any future consumer. Owner decision. |
+| D2 | Storage untouched | `Score.submitted_by` keeps the full email, so OpenMined can still contact a submitter and audit the mesh-verified identity behind a score (`OME-404`). Stripping on write was rejected as irreversible. |
+| D3 | Mechanism | One annotated type with a `PlainSerializer`, applied to every read DTO — the pattern `RunCostUsd` already uses, so the four DTOs cannot drift. `when_used="json"` only, because `_ranked_entry` splats `entry.model_dump()` in python mode. |
+| D4 | Non-emails pass through | In `authMode: disabled` this field is client-supplied free text. A value without `@` is returned unchanged rather than mangled. |
+| D5 | Split on the LAST `@` | The domain is what follows the final `@`. If the local part would be empty (`@openmined.org`), return the original — never emit `""`, which would read as a missing submitter. |
+| D6 | Two limits stated, not hidden | **Collisions:** `trask@openmined.org` and `trask@gmail.com` both render `trask`; with external testers on arbitrary domains the board would attribute two people identically. **Not anonymisation:** `filip.boltuzic` still names a person and `first.last@` is guessable. This defeats naive scrapers and must not be described as more. |
+
+Safe by construction: `submitted_by` is deliberately excluded from `content_hash` (`OME-391`), so
+nothing here can affect dedup, and the field is a key for nothing else.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py` — the serializer + annotated type, applied to
+  `ScoreSchema` and `LeaderboardEntry`.
+- `apps/scoreboard/src/scoreboard/routes/leaderboard.py` — the same type on `RankedLeaderboardEntry`
+  and `HistorySubmission`.
+- Tests under `apps/scoreboard/tests/unit/`.
+
+No portal change: it renders whatever the API returns.
+
+## Test plan
+
+RED first:
+
+- `trask@openmined.org` → `trask`; `filip.boltuzic@openmined.org` → `filip.boltuzic`.
+- No `@` (`tester`) → unchanged (D4). `None` → `None`. `""` → `""`.
+- `@openmined.org` → unchanged, never `""` (D5).
+- `a@b@openmined.org` → `a@b` (split on the last `@`, D5).
+- All three read paths strip: leaderboard, per-spec history, `GET /v1/scores/{id}`.
+- **The stored row still holds the full email** — the D2 guarantee, asserted against the database
+  rather than the response.
+
+## Acceptance
+
+- All three read paths return the local part only.
+- The database row keeps the full address.
+- Submitting a full email still works; a non-email value is untouched.
+- Full gates green.
+
+## Outcome
+
+- **Actual files:** as planned — `scores/schemas.py` (serializer + `SubmittedBy`, applied to
+  `ScoreSchema` and `LeaderboardEntry`), `routes/leaderboard.py` (`RankedLeaderboardEntry`,
+  `HistorySubmission`), tests in `tests/unit/scores/test_schemas.py`,
+  `tests/unit/test_leaderboard_routes.py`, `tests/unit/test_scores_routes.py`. **No portal change** —
+  it renders whatever the API returns.
+- **Gates:** `run_gates.py scoreboard --base origin/main --skip-append-only` → ruff check ✓,
+  ruff format ✓, pyright ✓, pytest --cov ✓. **176 passed, 2 skipped.**
+- **Live probe** (fresh migrated database, full email submitted):
+
+  | Path | Published |
+  |---|---|
+  | `POST /v1/scores` | `trask` |
+  | `GET /v1/scores/{id}` | `trask` |
+  | `GET /v1/leaderboard/{id}` | `trask` |
+  | per-spec history | `trask` |
+  | domain present in any payload | **none** |
+  | database row | `trask@openmined.org` |
+
+  The last two rows are the point: the exposure is closed on the wire and the audit trail survives.
+
+### Deviations
+
+1. **`ScoreSubmission` deliberately untouched.** It carries the value inbound; trimming there would
+   have written the truncated form to the database and silently become the option D2 rejected. Pinned
+   by `test_the_database_still_holds_the_full_address`.
+2. **One prior test adapted, owner-approved.** `test_post_score_with_identity_header_stores_header_email`
+   asserted the response equalled the full address. Escalated per sdlc rule 5. Its purpose — the
+   header beats the request body — still holds, because the body claimed `someone-else`. Rather than
+   only changing the expected string, it now also asserts the stored row holds the full address,
+   which is what the test's own name claims and the response alone never verified. The gate run used
+   `--skip-append-only`.
+3. **My first RED failed for the wrong reason.** I built `ScoreSchema` with `run_cost_usd=None`, but
+   this branch is off `origin/main` where that field does not exist yet — it is in the unmerged #582 —
+   so `extra="forbid"` rejected it and all seven tests errored instead of three failing on the
+   assertion. Caught by reading the error. **Consequence for sequencing:** when #582 merges, this
+   branch rebases and those two constructors need `run_cost_usd` adding back.
+4. **Verified no other consumer pins a full address.** The SDK's `researcher@example.com` occurrences
+   are its own request fixtures and constructed objects, not assertions against a live response, so
+   `packages/screamingface` needed no change.

--- a/docs/work/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/work/2026-08-14-OME-834-strip-email-domain.md
@@ -102,3 +102,41 @@ RED first:
 4. **Verified no other consumer pins a full address.** The SDK's `researcher@example.com` occurrences
    are its own request fixtures and constructed objects, not assertions against a live response, so
    `packages/screamingface` needed no change.
+
+## Review pass (2026-08-14) — two findings, both valid, both mine
+
+| Finding | Verified how | Verdict |
+|---|---|---|
+| `" @openmined.org"` publishes `" "`, and the SDK rejects blank text | ran `_publish_submitter`; read `leaderboards.py:445` | **valid, and the worst blast radius found anywhere today** |
+| `"Team A @ OpenMined"` publishes `"Team A "` | same | valid — contradicted my own D4 |
+
+### Why the first one matters more than its size
+
+`_text` is `if not isinstance(value, str) or not value.strip(): _invalid(...)`. A single space passes
+my `local or value` guard (it is truthy) and then fails the SDK's blank check, so **one row with a
+leading space in the submitted email would raise `LeaderboardError` for every SDK client reading that
+whole board**. `authMode: disabled` is the chart default, and this field is unvalidated free text
+there, so the value is reachable — not theoretical.
+
+### The fix
+
+Gate on address shape rather than the presence of `@`: no whitespace anywhere, non-blank local part,
+dotted domain. Verified behaviour after the change:
+
+| Input | Output |
+|---|---|
+| `trask@openmined.org` | `trask` |
+| `filip.boltuzic@openmined.org` | `filip.boltuzic` |
+| `a@b@openmined.org` | `a@b` |
+| `tester`, `""`, `None` | unchanged |
+| `@openmined.org`, `" @openmined.org"`, `"\t@openmined.org"` | unchanged |
+| `"Team A @ OpenMined"`, `"me @ openmined.org"` | unchanged |
+| `user@github` | unchanged — a handle, not a dotted-domain address |
+
+Spec §3a records the revision.
+
+### Deviation
+
+My original guard, `local or value`, tested for *empty* when the hazard was *blank*. The lesson is
+narrow and worth keeping: for a field that another service validates with `.strip()`, an emptiness
+check is not the same as a blankness check.

--- a/docs/work/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/work/2026-08-14-OME-834-strip-email-domain.md
@@ -174,10 +174,58 @@ authenticated path was never affected; `identity_from_headers` strips (`cloudfla
 RED first: the four padded cases failed for the right reason before the fix, and the padded
 blank-local case passed throughout, proving the §3a guarantee survived.
 
-### Residual, recorded not fixed
+### Residual, escalated — and the owner closed it
 
-`"me @ openmined.org"` still publishes in full. §3's pass-through rule treats internal whitespace as
-free text, and trimming it would mangle legitimate team names — reversing an owner-locked decision.
-Flagged for the owner rather than changed unilaterally.
+`"me @ openmined.org"` still published in full under pass 2's rule. Escalated rather than changed
+unilaterally, because trimming it reverses §3's pass-through decision. See review pass 3.
+
+**Gates:** all green.
+
+## Review pass 3 (2026-08-15) — the owner answered the question under all three passes
+
+Three passes had argued about *what whitespace means*. The owner settled what the FIELD means:
+**`submitted_by` is an identity, not a display name.**
+
+Two facts I gathered while framing the question made the "protect team names" defence untenable, and
+they contradicted my own earlier framing:
+
+* the Client SDK **never sends this field** — `_submission()` in `_scoreboard/leaderboards.py` omits
+  it entirely, so free-text submitters are a use case nobody has;
+* the only real values anywhere are two rows on dev, both clean addresses.
+
+I had used a hypothetical to justify leaving a real leak open. Recording that, because the failure was
+in the *reasoning*, not the code.
+
+### The rule got simpler, not more baroque
+
+Remove all whitespace, then require a non-empty local part and a **dotted domain**. The dot — not the
+whitespace — is now what keeps free text safe, which is a narrower and more honest test:
+
+| Input | Published |
+|---|---|
+| `trask@openmined.org`, padded variants | `trask` |
+| `"me @ openmined.org"`, `"filip.boltuzic @ openmined . org"` | `me`, `filip.boltuzic` |
+| `"Team A @ OpenMined"`, `"me @ github"`, `user@github` | unchanged — undotted domain |
+| `@openmined.org` and every padded form | unchanged, never blank |
+| `tester`, `""`, `None` | unchanged |
+
+RED first: exactly the three address-shaped cases failed; the two free-text cases passed before and
+after, which is the evidence that the dotted-domain test — not the whitespace test — is doing the work.
+
+### One prior expectation removed
+
+`("me @ openmined.org", "me @ openmined.org")` was deleted from the parametrize list. It was added by
+this same PR one pass earlier and it **encoded the leak the owner just closed**, so keeping it would
+have pinned the bug. Not a weakening: it is replaced by the opposite assertion.
+
+### Accepted cost, stated plainly
+
+Free text whose right-hand side contains a dot is truncated — `"Contact: trask @ openmined.org
+please"` publishes `Contact:trask`. It loses formatting; it leaks nothing.
+
+### Follow-up filed
+
+`OME-840` — validate the address on the write path so this stops being a read-time guess. `#602` is
+its blocker. Mirror at `docs/tasks/2026-08-15-OME-840-validate-submitter-on-write.md`.
 
 **Gates:** all green.

--- a/docs/work/2026-08-14-OME-834-strip-email-domain.md
+++ b/docs/work/2026-08-14-OME-834-strip-email-domain.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-834
 stack: scoreboard
-status: in_progress
+status: in_review
 started: 2026-08-14
 finished:
 ---
@@ -140,3 +140,44 @@ Spec §3a records the revision.
 My original guard, `local or value`, tested for *empty* when the hazard was *blank*. The lesson is
 narrow and worth keeping: for a field that another service validates with `.strip()`, an emptiness
 check is not the same as a blankness check.
+
+## Review pass 2 (2026-08-15) — one finding, valid, and it undid the point of the change
+
+| Finding | Verified how | Verdict |
+|---|---|---|
+| Surrounding whitespace defeats the strip entirely — `"trask@openmined.org "` publishes the full domain | ran `_publish_submitter` over a padded matrix | **valid, P1: it re-opens the exposure this PR exists to close** |
+
+### What went wrong
+
+Review pass 1 fixed a blank *local part* by rejecting **all** whitespace. That is a wider rule than
+the hazard required, and the extra width lands exactly on the failure case: an address with padding
+is still an address, and refusing to trim it publishes the domain. Two passes, each fixing one half
+of "what counts as one address", each breaking the other half.
+
+The distinction that was actually needed: **surrounding** whitespace is noise, **internal**
+whitespace is what proves free text. Strip first, then require no whitespace in the remainder.
+
+Reachable, not theoretical: `ScoreSubmission.submitted_by` is `str | None = None` — no strip, no
+constraint — and in `authMode: disabled` (the chart default) it is client-supplied free text. The
+authenticated path was never affected; `identity_from_headers` strips (`cloudflare_identity.py:68`).
+
+### Verified after the fix
+
+| Input | Published |
+|---|---|
+| `trask@openmined.org `, ` trask@openmined.org`, `\ttrask@openmined.org\t` | `trask` |
+| `  filip.boltuzic@openmined.org  ` | `filip.boltuzic` |
+| `@openmined.org`, `" @openmined.org"`, `"  @openmined.org  "` | unchanged — never blank |
+| `Team A @ OpenMined`, `user@github`, `tester`, `""`, `None` | unchanged |
+| `a@b@openmined.org` | `a@b` |
+
+RED first: the four padded cases failed for the right reason before the fix, and the padded
+blank-local case passed throughout, proving the §3a guarantee survived.
+
+### Residual, recorded not fixed
+
+`"me @ openmined.org"` still publishes in full. §3's pass-through rule treats internal whitespace as
+free text, and trimming it would mangle legitimate team names — reversing an owner-locked decision.
+Flagged for the owner rather than changed unilaterally.
+
+**Gates:** all green.


### PR DESCRIPTION
Linear: [OME-834](https://linear.app/openmined/issue/OME-834/publish-only-the-local-part-of-a-submitters-email-on-the-leaderboard)

Irina's request: `trask@openmined.org` should render as `trask`, so we aren't exposing submitters to bot spam.

## The layer matters, so I measured first

The full addresses were **already public in the API, unauthenticated**:

```
GET https://leaderboard.dev.screamingface.ai/v1/leaderboard/hle  →  200
  "submitted_by": "filip.boltuzic@openmined.org"
  "submitted_by": "stephen@openmined.org"
```

A harvester reads JSON, not HTML. So changing `portal/main.js` — the obvious one-line fix — would have looked correct while leaving every address exposed. **That fix would have been worse than none, because it looks done.**

The trim lives in the **read DTOs** instead, which serves the portal, the SDK notebook view and any future consumer from one place. No portal change was needed at all.

## Contract

| Stored | Published | Why |
|---|---|---|
| `trask@openmined.org` | `trask` | the request |
| `filip.boltuzic@openmined.org` | `filip.boltuzic` | dots in the local part survive |
| `tester` | `tester` | in `authMode: disabled` this is client-supplied free text, not necessarily an email |
| `a@b@openmined.org` | `a@b` | the domain is what follows the **last** `@` |
| `@openmined.org` | `@openmined.org` | an empty local part would read as a *missing* submitter |
| `null` | `null` | absent stays absent |

**Storage is untouched.** The row keeps the full address so OpenMined can still contact a submitter and audit which verified identity produced a score (`OME-404`).

This is a **serializer, not a validator**, and `ScoreSubmission` is deliberately left alone — trimming inbound would write the truncated form to the database irreversibly. `test_the_database_still_holds_the_full_address` exists to stop exactly that refactor.

Applied via one shared `SubmittedBy` annotated type, the pattern `RunCostUsd` established after that same four-DTO duplication caused two separate defects. `when_used="json"` is deliberate: `_ranked_entry` splats `entry.model_dump()` in python mode and must keep the stored value.

## ⚠️ Two limits, stated rather than hidden

**It collides.** `trask@openmined.org` and `trask@gmail.com` both render `trask`. The board attributes credit, so two testers on different domains become indistinguishable. Acceptable only because this is explicitly a stopgap — the request opens *"since we do not have usernames yet"*. A real username field is the fix; `OME-772` records that none exists.

**It is not anonymisation.** `filip.boltuzic` still names a person, and `first.last@openmined.org` is trivially reconstructed by anyone who knows the domain convention. This raises the cost of naive scraping. It should not be described as privacy.

## Test plan

- **176 passed, 2 skipped**; ruff check, ruff format, pyright clean; coverage above the 80% gate.
- **Live probe** against a freshly migrated database, submitting a full address:

  | Path | Published |
  |---|---|
  | `POST /v1/scores` | `trask` |
  | `GET /v1/scores/{id}` | `trask` |
  | `GET /v1/leaderboard/{id}` | `trask` |
  | per-spec history | `trask` |
  | **domain anywhere in any payload** | **none** |
  | **database row** | **`trask@openmined.org`** |

  The last two lines are the whole point: the exposure is closed on the wire and the audit trail survives.

## Notes for the reviewer

**One prior test adapted, owner-approved.** `test_post_score_with_identity_header_stores_header_email` asserted the response equalled the full address. Escalated per sdlc rule 5 rather than edited silently. Its purpose — the identity header beats the request body — still holds, since the body claimed `someone-else`. Rather than only changing the expected string, it now *also* asserts the stored row holds the full address, which is what the test's own name claims and the response alone never verified. The gate run used `--skip-append-only`; everything else ran normally.

**Sequencing:** this branch is off `origin/main`, so it predates **#582**'s `run_cost_usd`. When #582 merges, two `ScoreSchema` constructors in the new tests need that field adding back. Noted in the ledger.

I checked that nothing else pins a full address: the SDK's `researcher@example.com` occurrences are its own request fixtures and constructed objects, not assertions against a live response, so `packages/screamingface` needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdKCiEFpo188AkWG5kSn1G

---

## Self-review pass 2 (2026-08-15) — one defect, and it undid the point of this PR

**Surrounding whitespace defeated the strip entirely.** Verified by running `_publish_submitter`:

| Input | Published (before) |
|---|---|
| `"trask@openmined.org "` | `trask@openmined.org ` |
| `" trask@openmined.org"` | ` trask@openmined.org` |
| `"  filip.boltuzic@openmined.org  "` | full address |

Review pass 1 fixed a blank *local part* (`" @openmined.org"` → `" "`, which the SDK's blank-text
check then rejects for the whole board) by refusing to trim any value containing whitespace. That
rule is wider than the hazard, and the extra width lands on the failure case: an address carrying
padding is still an address.

Reachable, not theoretical: `ScoreSubmission.submitted_by` is `str | None = None` with no strip and
no constraint, and in `authMode: disabled` — the chart default — it is client-supplied free text. The
authenticated path was never affected; `identity_from_headers` already strips
(`cloudflare_identity.py:68`).

**Fix:** surrounding whitespace is noise, *internal* whitespace is what proves the value is free text
(`"Team A @ OpenMined"`). Strip first, then require the remainder to hold no whitespace. This cannot
resurrect pass 1's hazard — after stripping, an empty local part is empty rather than blank, so
`"  @openmined.org  "` still passes through untouched instead of publishing `"  "`. RED first: the
four padded cases failed for the right reason, and the padded blank-local case passed throughout.

| Input | Published (after) |
|---|---|
| `trask@openmined.org `, ` trask@openmined.org`, `\ttrask@openmined.org\t` | `trask` |
| `  filip.boltuzic@openmined.org  ` | `filip.boltuzic` |
| `@openmined.org`, `" @openmined.org"`, `"  @openmined.org  "` | unchanged — never blank |
| `Team A @ OpenMined`, `user@github`, `tester`, `""`, `None` | unchanged |
| `a@b@openmined.org` | `a@b` |

**Residual escalated, and now closed — see the pass below.**



---

## Self-review pass 3 (2026-08-15) — the owner settled what the field means

Three passes had argued about *what whitespace means*. The decision was about what the **field**
means: `submitted_by` is an **identity**, not a display name.

Two facts made the "protect team names" defence untenable, and they contradict my own earlier framing
in this PR:

- the Client SDK **never sends this field** — `_submission()` in `_scoreboard/leaderboards.py` omits
  it entirely, so free-text submitters are a use case nobody has;
- the only real values anywhere are two rows on dev, both clean addresses.

So whitespace is formatting noise wherever it sits. **Remove it, then require a non-empty local part
and a dotted domain.** The dot — not the whitespace — is what now keeps free text safe, which is a
narrower and more honest test:

| Input | Published |
|---|---|
| `trask@openmined.org` and every padded variant | `trask` |
| `"me @ openmined.org"`, `"trask @ openmined.org"` | `me`, `trask` |
| `"filip.boltuzic @ openmined . org"` | `filip.boltuzic` |
| `"Team A @ OpenMined"`, `"me @ github"`, `user@github` | unchanged — an undotted domain is a word, not a host |
| `@openmined.org` and every padded form | unchanged, never blank |
| `tester`, `""`, `null` | unchanged |

RED first: exactly the three address-shaped cases failed; the two free-text cases passed before and
after — which is the evidence that the dotted-domain test, not the whitespace test, is doing the work.

**One expectation removed.** `("me @ openmined.org", "me @ openmined.org")` was added by this PR one
pass earlier and encoded the leak just closed, so keeping it would have pinned the bug. Replaced by
the opposite assertion, not deleted.

**Accepted cost, stated plainly.** Free text whose right-hand side contains a dot gets truncated:
`"Contact: trask @ openmined.org please"` publishes `Contact:trask`. It loses formatting, not privacy.

**This is still a read-time guess** about a value nothing constrains inbound — the reason it took four
passes. Filed [OME-840](https://linear.app/openmined/issue/OME-840/validate-the-submitters-address-on-the-write-path-instead-of-guessing)
to validate the address on the write path, blocked on this PR; after that this function reduces to
"everything before the last `@`".
