### PR TITLE
fix(url4-cloud): raise the local concurrent run ceiling above the Client fan-out

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/adapters/inprocess.py
+++ b/apps/url4-cloud/src/url4_cloud/adapters/inprocess.py
@@ -37,7 +37,13 @@ Takes the env rather than the run's fields so it is satisfied by `runner.main.bu
 verbatim — the same entry point a real Job's process calls, given the same variables.
 """
 
-DEFAULT_MAX_CONCURRENT_RUNS = 8
+# INVARIANT: strictly above the Client's per-Evaluation fan-out, which is 8 (
+# `_MAX_CANDIDATES_IN_FLIGHT` in `packages/screamingface/src/screamingface/_evaluation/
+# runner.py`). The Client opens one run per Candidate, so an equal value leaves zero headroom
+# and one ordinary Evaluation saturates the runner exactly. Pinned by
+# `tests/unit/test_local_capacity_contract.py`, which also explains why that check is a floor
+# rather than a direct comparison.
+DEFAULT_MAX_CONCURRENT_RUNS = 32
 DEFAULT_MAX_HISTORY = 1000
 
 

--- a/apps/url4-cloud/src/url4_cloud/config.py
+++ b/apps/url4-cloud/src/url4_cloud/config.py
@@ -126,7 +126,16 @@ class Settings(BaseSettings):
     # WHY a concurrency cap at all: k8s spreads Jobs across a cluster and queues the surplus, but
     # every local run shares one event loop and one process, so admitting without bound degrades
     # the runs already in flight instead of delaying new ones.
-    local_max_concurrent_runs: int = 8
+    #
+    # WHY 32 and not a tighter number: the Client opens one run per Candidate and keeps up to 8 in
+    # flight (`_MAX_CANDIDATES_IN_FLIGHT`), so anything at or below 8 leaves no headroom — one
+    # ordinary Evaluation fills the runner exactly and the next schedule 503s. That is worse than
+    # it sounds, because a WebSocket disconnect does not stop a run: an abandoned one holds its
+    # slot until `job_deadline_s` (16h). 32 keeps roughly four Evaluations, or one plus slack for
+    # orphans. INVARIANT (pinned by `tests/unit/test_local_capacity_contract.py`): this stays
+    # strictly above the Client fan-out, and equal to `DEFAULT_MAX_CONCURRENT_RUNS` so capacity
+    # does not depend on which path built the runner.
+    local_max_concurrent_runs: int = 32
     # WHY: the in-memory stream has no retention policy of its own (JetStream does), so a
     # long-lived dev server would accumulate every frame of every run it ever served.
     local_stream_max_frames: int = 10_000

--- a/apps/url4-cloud/tests/unit/test_local_capacity_contract.py
+++ b/apps/url4-cloud/tests/unit/test_local_capacity_contract.py
@@ -1,0 +1,41 @@
+"""The local admission ceiling as a CONTRACT with the Client, not as runner behaviour.
+
+`test_inprocess_runner.py` pins how the adapter refuses once it is full. This module pins the
+separate question of where "full" is set, because that number is only correct in relation to a
+constant living in another distribution.
+"""
+
+from url4_cloud.adapters.inprocess import DEFAULT_MAX_CONCURRENT_RUNS
+from url4_cloud.config import Settings
+
+# INVARIANT: the local admission ceiling stays STRICTLY ABOVE the Client's per-Evaluation
+# fan-out. The Client schedules one run per Candidate and keeps up to `_MAX_CANDIDATES_IN_FLIGHT`
+# of them in flight at once — 8, at `packages/screamingface/src/screamingface/_evaluation/
+# runner.py`. Equal values leave ZERO headroom: one full Evaluation saturates the runner exactly,
+# so a second notebook cell, a second Client, or a single abandoned run turns the next schedule
+# into `503 the runner is at capacity`. Abandoned runs make that sticky rather than momentary — a
+# WebSocket disconnect does NOT stop a run (only a `StopEvent` or `DELETE /?topic=` does), so an
+# orphan holds its slot until `job_deadline_s`, which is 16 hours.
+#
+# WHY a floor rather than a comparison against the real constant: `apps/url4-cloud` does not
+# depend on `packages/screamingface` — the package is absent from this app's `pyproject.toml` and
+# imported nowhere under `src/` or `tests/`. Reading it here would either invert the layering (a
+# server app reaching into the published Client SDK) or force the shared bound up into
+# `packages/url4`, which both sides already depend on. That hoist is the correct end state and is
+# tracked separately; until it lands, this floor is what stops the collision returning silently.
+#
+# AIDEV-NOTE: if the Client's fan-out ever rises above 8, raise this number with it. The two are a
+# contract that no import currently enforces, so nothing else will fail to warn you.
+_CLIENT_CANDIDATE_FAN_OUT = 8
+
+
+def test_the_local_ceiling_leaves_headroom_above_the_client_fan_out() -> None:
+    assert DEFAULT_MAX_CONCURRENT_RUNS > _CLIENT_CANDIDATE_FAN_OUT
+    assert Settings().local_max_concurrent_runs > _CLIENT_CANDIDATE_FAN_OUT
+
+
+def test_the_adapter_default_and_the_setting_agree() -> None:
+    # WHY: `local.py` builds the runner from the setting, while any caller that omits the keyword
+    # gets the adapter default. If the two drift, local capacity depends on which path built the
+    # runner — a split that surfaces only as an unreproducible 503.
+    assert Settings().local_max_concurrent_runs == DEFAULT_MAX_CONCURRENT_RUNS

--- a/docs/plan/2026-08-14-OME-833-local-run-ceiling.md
+++ b/docs/plan/2026-08-14-OME-833-local-run-ceiling.md
@@ -1,0 +1,51 @@
+# OME-833 — Plan
+
+Spec: `docs/spec/2026-08-14-OME-833-local-run-ceiling.md`
+
+## Step 1 — RED
+
+Add a test to `apps/url4-cloud/tests/unit/test_inprocess_runner.py`.
+
+The test asserts that `DEFAULT_MAX_CONCURRENT_RUNS` and `Settings().local_max_concurrent_runs`
+are both larger than 8. The docstring states why: the Client starts up to
+`_MAX_CANDIDATES_IN_FLIGHT = 8` Runs at the same time, from
+`packages/screamingface/src/screamingface/_evaluation/runner.py:40`. It also states that
+url4-cloud cannot import that constant.
+
+The test fails first, because both values are 8.
+
+## Step 2 — GREEN
+
+Change `DEFAULT_MAX_CONCURRENT_RUNS` to 32 in
+`apps/url4-cloud/src/url4_cloud/adapters/inprocess.py:40`.
+
+Change `local_max_concurrent_runs` to 32 in
+`apps/url4-cloud/src/url4_cloud/config.py:129`.
+
+Update the comment above `local_max_concurrent_runs`. Add the reason for the value. Name the
+Client fan-out.
+
+## Step 3 — Gates
+
+Run `uv run .claude/scripts/run_gates.py url4-cloud`.
+
+## Step 4 — Close
+
+Fill the ledger outcome. Open the PR. Add the close comment to OME-833.
+
+## Files
+
+| File | Change |
+|---|---|
+| `apps/url4-cloud/tests/unit/test_inprocess_runner.py` | Add the floor test |
+| `apps/url4-cloud/src/url4_cloud/adapters/inprocess.py` | 8 to 32 |
+| `apps/url4-cloud/src/url4_cloud/config.py` | 8 to 32, and the comment |
+
+## Risks
+
+The change permits more Runs at the same time. Each Run permits up to 32 fetches at the same
+time, from `DEFAULT_RUN_CONCURRENCY` in `packages/url4/src/url4/dag/node.py:174`. Thus the
+theoretical maximum becomes 1024 fetches. Real Evaluations stay far below this maximum. Local
+mode runs on a developer machine, where the provider rate limit binds first.
+
+No change to the Kubernetes path. The setting applies only to local mode.

--- a/docs/spec/2026-08-14-OME-833-local-run-ceiling.md
+++ b/docs/spec/2026-08-14-OME-833-local-run-ceiling.md
@@ -1,0 +1,71 @@
+# OME-833 — Local-mode concurrent run ceiling
+
+## Problem
+
+Local mode refuses a Run too early. The Engine answers `503` with the detail
+`the runner is at capacity — retry shortly`.
+
+`InProcessJobRunner` accepts 8 Runs at the same time. The Client starts one Run for each
+Candidate, and it starts up to 8 Runs at the same time. The two limits are equal. Thus there is
+no spare capacity.
+
+One Evaluation with 8 Candidates fills the runner completely. If one more Run is active, the
+next Run fails. A second notebook cell, a second Client, or an abandoned Run each cause this.
+
+An abandoned Run keeps its slot for a long time. A WebSocket disconnect does not stop the Run.
+Only an explicit stop frame or `DELETE /?topic=` stops it. Thus an abandoned Run keeps its slot
+until it ends, or until the run deadline of 57600 seconds (16 hours).
+
+Only the in-process runner refuses. The Kubernetes runner does not refuse, because the cluster
+scheduler holds the surplus Jobs.
+
+## Sources
+
+| Constant | Location | Value |
+|---|---|---|
+| `local_max_concurrent_runs` | `apps/url4-cloud/src/url4_cloud/config.py:129` | 8 |
+| `DEFAULT_MAX_CONCURRENT_RUNS` | `apps/url4-cloud/src/url4_cloud/adapters/inprocess.py:40` | 8 |
+| `_MAX_CANDIDATES_IN_FLIGHT` | `packages/screamingface/src/screamingface/_evaluation/runner.py:40` | 8 |
+
+## Decision
+
+Increase the local ceiling to 32.
+
+32 is four times the Client fan-out. It permits approximately four Evaluations at the same
+time. It also gives spare capacity for abandoned Runs.
+
+Keep the two url4-cloud constants equal. `local.py` reads the setting. The adapter default
+applies when a caller supplies no setting. If the two values differ, the behaviour changes with
+the call path.
+
+## Constraint to protect
+
+The url4-cloud ceiling must stay larger than the Client fan-out. If the two become equal again,
+the failure returns.
+
+A test cannot read the Client constant. `apps/url4-cloud` does not depend on
+`packages/screamingface`. Its `pyproject.toml` does not list the package, and no module imports
+it. A direct check needs one of these changes:
+
+- The Client depends on the server app. This inverts the layer order. Rejected.
+- A shared constant moves to `packages/url4`, which both sides already use. This is correct,
+  but it changes three units. Out of scope.
+
+Therefore the test asserts a floor. The floor is larger than the known Client fan-out. The test
+rationale names the Client constant and its location.
+
+## Out of scope
+
+- Move the shared concurrency contract to `packages/url4`.
+- Hold surplus Runs in a queue instead of a refusal. The code comments compare local mode with
+  Kubernetes, which holds surplus Jobs. This supports a queue. The `Retry-After: 1` header shows
+  that a delay of one second is sufficient.
+- Make the Client obey `Retry-After`. The Client retries only on `428`.
+- Stop or reap an abandoned Run before the 16-hour deadline.
+- Give `ProblemException` a real `type_`. The Client now shows `Code: about:blank`.
+
+## Acceptance
+
+- Both url4-cloud constants read 32.
+- A test fails if the ceiling becomes 8 or smaller.
+- The url4-cloud gates pass.

--- a/docs/tasks/2026-08-14-OME-833-local-run-ceiling.md
+++ b/docs/tasks/2026-08-14-OME-833-local-run-ceiling.md
@@ -1,0 +1,24 @@
+---
+id: OME-833
+linear_url: https://linear.app/openmined/issue/OME-833/raise-the-local-mode-concurrent-run-ceiling-above-the-client-fan-out
+status: In Progress
+type: task
+priority: Medium
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-14
+closed:
+---
+
+# Raise the local-mode concurrent run ceiling above the Client fan-out
+
+Local mode refuses Runs with `503 the runner is at capacity — retry shortly` because the
+in-process runner ceiling (8) equals the Client's per-Evaluation fan-out (8), leaving no spare
+capacity. Abandoned Runs hold a slot for up to 16 hours, because a WebSocket disconnect does
+not stop a Run.
+
+Raises `local_max_concurrent_runs` and `DEFAULT_MAX_CONCURRENT_RUNS` to 32, and adds a floor
+test that keeps the ceiling above the Client fan-out.
+
+Spec: `docs/spec/2026-08-14-OME-833-local-run-ceiling.md`
+Plan: `docs/plan/2026-08-14-OME-833-local-run-ceiling.md`
+Ledger: `docs/work/2026-08-14-OME-833-local-run-ceiling.md`

--- a/docs/work/2026-08-14-OME-833-local-run-ceiling.md
+++ b/docs/work/2026-08-14-OME-833-local-run-ceiling.md
@@ -1,0 +1,69 @@
+---
+ticket: OME-833
+stack: url4-cloud
+status: done
+started: 2026-08-14
+finished: 2026-08-14
+---
+
+# OME-833 — Raise the local-mode concurrent run ceiling above the Client fan-out
+
+## Intent
+
+Local mode refuses a Run with `503 the runner is at capacity — retry shortly` too early. The
+in-process runner accepts 8 Runs at the same time, and the Client starts up to 8 Runs at the
+same time. The two limits are equal, so there is no spare capacity. Any extra Run fails,
+including an abandoned Run that holds its slot for up to 16 hours. This unit increases the
+local ceiling to 32 and adds a test that keeps the ceiling above the Client fan-out.
+
+## Planned changes
+
+- `apps/url4-cloud/tests/unit/test_inprocess_runner.py` — add the floor test (RED first)
+- `apps/url4-cloud/src/url4_cloud/adapters/inprocess.py` — `DEFAULT_MAX_CONCURRENT_RUNS` 8 to 32
+- `apps/url4-cloud/src/url4_cloud/config.py` — `local_max_concurrent_runs` 8 to 32, and comment
+
+## Test plan
+
+- The floor test asserts that both url4-cloud constants exceed the Client fan-out of 8. It
+  fails first, because both are 8.
+- The existing capacity tests still pass. `test_inprocess_runner.py:248` and `:263` pass an
+  explicit `max_concurrent_runs`, so they do not depend on the default.
+- The existing local app test at `test_local_app.py:84` passes an explicit
+  `local_max_concurrent_runs=3`, so it does not depend on the default.
+
+## Acceptance
+
+- Both url4-cloud constants read 32.
+- The floor test fails if the ceiling drops to 8 or lower.
+- `uv run .claude/scripts/run_gates.py url4-cloud` passes.
+
+## Notes
+
+`apps/url4-cloud` does not depend on `packages/screamingface`, so the test cannot read
+`_MAX_CANDIDATES_IN_FLIGHT` directly. The test asserts a documented floor instead and names the
+Client constant in its rationale. The spec records the two rejected alternatives.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/url4-cloud/tests/unit/test_local_capacity_contract.py` — NEW (planned as an addition to
+    `test_inprocess_runner.py`; see Deviations)
+  - `apps/url4-cloud/src/url4_cloud/adapters/inprocess.py` — `DEFAULT_MAX_CONCURRENT_RUNS` 8 → 32,
+    plus the INVARIANT anchor naming the Client fan-out
+  - `apps/url4-cloud/src/url4_cloud/config.py` — `local_max_concurrent_runs` 8 → 32, plus the
+    WHY-32 rationale
+  - `docs/spec/2026-08-14-OME-833-local-run-ceiling.md`, `docs/plan/…`, `docs/tasks/…` — artifacts
+- **Commits:** `fix(url4-cloud): raise the local concurrent run ceiling above the Client fan-out`
+  (sha recorded in the OME-833 close comment). `fix` rather than `feat`: this resolves spurious
+  503s, so release-please should cut a patch.
+- **Gates:** `run_gates.py url4-cloud` → ALL GATES GREEN — append-only test check, ruff check,
+  ruff format --check, pyright, check_layering.py, pytest with coverage ≥80. Full suite
+  **1415 passed, 5 skipped**.
+- **Deviations:**
+  - The floor test went into a NEW module `tests/unit/test_local_capacity_contract.py` instead of
+    into `test_inprocess_runner.py`. That module carries a module-level `pytestmark =
+    pytest.mark.asyncio`, which makes pytest warn on the two synchronous constant assertions. The
+    separation is also truer to what the tests are: a cross-distribution contract about where the
+    ceiling is set, not runner behaviour when it is reached. `test_inprocess_runner.py` is
+    unmodified.
+  - No other deviation. Both constants read 32; the guard fails at 8 or below.


### PR DESCRIPTION
## Summary

Local mode refused runs with `503 the runner is at capacity — retry shortly` far sooner than it should.

`InProcessJobRunner` admitted **8** runs at once. The Client opens **one run per Candidate** and keeps up to **8** in flight (`_MAX_CANDIDATES_IN_FLIGHT`). The two numbers were equal, so there was **zero headroom** — one ordinary Evaluation saturated the runner exactly, and any other run in flight (a second notebook cell, a second Client, or a single abandoned run) turned the next schedule into a 503.

Abandoned runs made that sticky rather than momentary: a WebSocket disconnect does **not** stop a run — only a `StopEvent` or `DELETE /?topic=` does — so an orphan holds its admission slot until `job_deadline_s`, which is **16 hours**.

This raises both carriers of the ceiling to **32**: roughly four concurrent Evaluations, or one plus slack for orphans.

Only the in-process runner is affected. `K8sJobRunner` never raises `JobRunnerAtCapacity`, because the cluster scheduler queues surplus Jobs.

## Changes

| File | Change |
|---|---|
| `adapters/inprocess.py` | `DEFAULT_MAX_CONCURRENT_RUNS` 8 → 32, with an `INVARIANT:` anchor naming the Client fan-out |
| `config.py` | `local_max_concurrent_runs` 8 → 32, with the `WHY 32` rationale |
| `tests/unit/test_local_capacity_contract.py` | **new** — the regression guard |

## Why the guard is a floor, not a live comparison

`apps/url4-cloud` has **no dependency on `packages/screamingface`** — the package is absent from this app's `pyproject.toml` and imported nowhere under `src/` or `tests/`. Reading `_MAX_CANDIDATES_IN_FLIGHT` here would require either inverting the layering (a server app reaching into the published Client SDK) or hoisting the shared bound into `packages/url4`, which both sides already depend on.

That hoist is the correct end state, but it would make this a three-unit epic, so it is deliberately out of scope and tracked as a follow-up. Until it lands the test asserts a documented floor, and an `AIDEV-NOTE` at the constant says to raise it if the Client fan-out ever rises above 8.

The test went into its own module rather than into `test_inprocess_runner.py`: that file carries a module-level `pytestmark = pytest.mark.asyncio`, which warns on synchronous constant assertions, and the separation is truer to what these tests are — a cross-distribution contract about where the ceiling is set, not runner behaviour when it is reached. `test_inprocess_runner.py` is unmodified.

## Test plan

- **RED first:** the guard failed `assert 8 > 8` before the change.
- **GREEN:** full url4-cloud suite **1415 passed, 5 skipped**. No prior test modified — the append-only gate confirms it.
- **Gates:** `uv run .claude/scripts/run_gates.py url4-cloud` → **ALL GATES GREEN** (append-only check, `ruff check`, `ruff format --check`, `pyright`, `check_layering.py`, `pytest` with coverage ≥80).

## Scope / follow-ups

This fixes the collision, not the underlying design. Deliberately **not** in this PR:

- Hoist the shared concurrency bound into `packages/url4` so both sides read one constant.
- **Queue instead of reject.** The admission rationale in `config.py` and `inprocess.py` argues that k8s "absorbs surplus Jobs by scheduling them later" — which is an argument for a bounded FIFO locally, not a hard 503. The `Retry-After: 1` header concedes a one-second wait is all that is needed.
- **Client ignores `Retry-After`.** Its retry loop re-attempts only on `428`, so a transient 503 raises straight to the user despite being marked retryable.
- **No orphan reaper.** Orphans accumulate monotonically inside a 16-hour window; 32 raises the threshold from 1 orphan to 32, it does not remove it.
- `ProblemException` passes no `type_`, so the SDK surfaces the unhelpful `Code: about:blank`.

Refs: OME-833

🤖 Generated with [Claude Code](https://claude.com/claude-code)
