### PR TITLE
test(aigateway): cover malformed admin JSON

### DIFF
--- a/apps/aigateway/tests/unit/test_admin_malformed_json.py
+++ b/apps/aigateway/tests/unit/test_admin_malformed_json.py
@@ -1,0 +1,27 @@
+"""OME-387 regression coverage for malformed JSON on the admin surface."""
+
+from __future__ import annotations
+
+from ipaddress import ip_network
+
+from fastapi.testclient import TestClient
+
+ADMIN = "admin@openmined.org"
+
+
+def test_admin_malformed_json_returns_sanitized_422(client) -> None:
+    client.app.state.settings.auth_mode = "cloudflare_headers"
+    client.app.state.settings.allowed_networks = (ip_network("10.0.0.0/8"),)
+    client.app.state.settings.admin_emails = frozenset({ADMIN})
+    admin_client = TestClient(client.app, client=("10.1.2.3", 50000))
+    marker = "raw-api-secret-marker"
+
+    response = admin_client.post(
+        "/v1/admin/accounts",
+        content=f'{{"email":"{marker}"',
+        headers={"Content-Type": "application/json", "X-User-Email": ADMIN},
+    )
+
+    assert response.status_code == 422
+    # INVARIANT: malformed request bytes can contain credentials and never echo to the caller.
+    assert marker not in response.text


### PR DESCRIPTION
## Description
Adds focused regression coverage for malformed JSON on the AIGateway admin surface.

The admin routes already use Pydantic request models, while chat has separate malformed-body coverage. This test completes the remaining representative admin-route coverage by verifying that `/v1/admin/accounts` returns a sanitized `422` and does not echo a marker from the malformed request body.

Refs: OME-387

## Affected Dependencies
None.

## How has this been tested?
- `uv run pytest tests/unit/test_admin_malformed_json.py -q` (`1 passed`)
- `uv run .claude/scripts/run_gates.py aigateway` (`ALL GATES GREEN`)
- Test configuration: Python 3.13.11 with the existing isolated SQLite application fixture.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests