### PR TITLE
feat(benchmarks): report corrective loop execution

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -19,6 +19,7 @@ from url4_cloud.benchmarks.contract import (
     CaseGrade,
     CaseId,
     CaseResult,
+    CorrectiveExecution,
     Failure,
     candidate_coverage,
     validate_case_id,
@@ -207,10 +208,12 @@ def scored_case_result(
     finish_reason: str | None,
     grade: CaseGrade | Mapping[str, Any],
     metadata: Mapping[str, Any] | None = None,
+    execution: CorrectiveExecution | Mapping[str, Any] | None = None,
 ) -> CaseResult:
     """Construct one scored Case without exposing the wire envelope to adapters."""
 
     typed_grade = grade if isinstance(grade, CaseGrade) else CaseGrade.model_validate(grade)
+    stop_reason, rounds_executed = _execution_fields(execution)
     return CaseResult(
         status="scored",
         case_id=selected_case.case_id,
@@ -218,6 +221,8 @@ def scored_case_result(
         output=output,
         finish_reason=finish_reason,
         refusal=None,
+        stop_reason=stop_reason,
+        rounds_executed=rounds_executed,
         grade=typed_grade,
         failures=[],
         metadata=_case_metadata(selected_case, metadata),
@@ -232,6 +237,7 @@ def failed_case_result(
     finish_reason: str | None = None,
     grade: CaseGrade | Mapping[str, Any] | None = None,
     metadata: Mapping[str, Any] | None = None,
+    execution: CorrectiveExecution | Mapping[str, Any] | None = None,
 ) -> CaseResult:
     """Construct one failed Case while retaining any safe partial grading evidence."""
 
@@ -242,6 +248,7 @@ def failed_case_result(
         failure if isinstance(failure, Failure) else Failure.model_validate(failure)
         for failure in failures
     ]
+    stop_reason, rounds_executed = _execution_fields(execution)
     return CaseResult(
         status="failed",
         case_id=selected_case.case_id,
@@ -249,6 +256,8 @@ def failed_case_result(
         output=output,
         finish_reason=finish_reason,
         refusal=None,
+        stop_reason=stop_reason,
+        rounds_executed=rounds_executed,
         grade=typed_grade,
         failures=typed_failures,
         metadata=_case_metadata(selected_case, metadata),
@@ -263,6 +272,7 @@ def refused_case_result(
     finish_reason: str | None = None,
     failures: Sequence[Failure | Mapping[str, Any]] = (),
     metadata: Mapping[str, Any] | None = None,
+    execution: CorrectiveExecution | Mapping[str, Any] | None = None,
 ) -> CaseResult:
     """Construct a refused Case after normal Benchmark grading."""
 
@@ -271,6 +281,7 @@ def refused_case_result(
         failure if isinstance(failure, Failure) else Failure.model_validate(failure)
         for failure in failures
     ]
+    stop_reason, rounds_executed = _execution_fields(execution)
 
     return CaseResult(
         status="refused",
@@ -279,6 +290,8 @@ def refused_case_result(
         output=None,
         finish_reason=finish_reason,
         refusal=refusal,
+        stop_reason=stop_reason,
+        rounds_executed=rounds_executed,
         grade=typed_grade,
         failures=typed_failures,
         metadata=_case_metadata(selected_case, metadata),
@@ -289,6 +302,19 @@ def _case_metadata(
     selected_case: SelectedCase, metadata: Mapping[str, Any] | None
 ) -> dict[str, Any]:
     return {**selected_case.metadata, **dict(metadata or {})}
+
+
+def _execution_fields(
+    execution: CorrectiveExecution | Mapping[str, Any] | None,
+) -> tuple[Literal["passed", "max_rounds"] | None, int | None]:
+    if execution is None:
+        return None, None
+    typed = (
+        execution
+        if isinstance(execution, CorrectiveExecution)
+        else CorrectiveExecution.model_validate(execution)
+    )
+    return typed.stop_reason, typed.rounds_executed
 
 
 __all__ = [

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/candidate_execution.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/candidate_execution.py
@@ -1,0 +1,60 @@
+"""Task-local execution provenance for one complete Candidate Recipe."""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+
+from url4.core.errors import ResolutionError
+from url4_cloud.benchmarks.contract import CorrectiveExecution
+
+type ExecutionRecorder = list[CorrectiveExecution]
+
+_recorders: contextvars.ContextVar[tuple[ExecutionRecorder, ...]] = contextvars.ContextVar(
+    "url4_cloud_candidate_execution_recorders", default=()
+)
+
+
+@contextmanager
+def capture_candidate_executions(*, isolated: bool = False) -> Iterator[ExecutionRecorder]:
+    """Capture provenance emitted by the Recipe's terminal orchestration boundary."""
+
+    recorder: ExecutionRecorder = []
+    active = () if isolated else _recorders.get()
+    token = _recorders.set((*active, recorder))
+    try:
+        yield recorder
+    finally:
+        _recorders.reset(token)
+
+
+def record_candidate_execution(execution: CorrectiveExecution) -> None:
+    """Publish one already-decided execution outcome to every active scope."""
+
+    for recorder in _recorders.get():
+        recorder.append(execution)
+
+
+def terminal_candidate_execution(
+    executions: Sequence[CorrectiveExecution],
+) -> CorrectiveExecution | None:
+    """Return the one unambiguous execution outcome for the complete Recipe."""
+
+    if not executions:
+        return None
+    first = executions[0]
+    if all(execution == first for execution in executions[1:]):
+        return first
+    raise ResolutionError(
+        "Candidate Recipe emitted ambiguous execution provenance",
+        code="candidate_contract_error",
+        permanent=True,
+    )
+
+
+__all__ = [
+    "capture_candidate_executions",
+    "record_candidate_execution",
+    "terminal_candidate_execution",
+]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -140,6 +140,8 @@ class CaseResult(_StrictWireModel):
     output: str | None
     finish_reason: str | None
     refusal: str | None
+    stop_reason: Literal["passed", "max_rounds"] | None = None
+    rounds_executed: int | None = Field(default=None, ge=1)
     grade: CaseGrade | None
     failures: list[Failure]
     metadata: dict[str, Any]
@@ -165,6 +167,8 @@ class CaseResult(_StrictWireModel):
 
     @model_validator(mode="after")
     def _enforce_status(self) -> CaseResult:
+        if (self.stop_reason is None) != (self.rounds_executed is None):
+            raise ValueError("stop_reason and rounds_executed must be present together")
         if any(failure.case_id != self.case_id for failure in self.failures):
             raise ValueError("every Case Failure must reference its own case_id")
         if self.status == "scored":
@@ -174,6 +178,40 @@ class CaseResult(_StrictWireModel):
         else:
             _require_failed_case(self)
         return self
+
+
+class CorrectiveExecution(_StrictWireModel):
+    """The final, benchmark-neutral execution outcome of one corrective Recipe."""
+
+    schema_version: Literal["screamingface.corrective-execution.v1"] = Field(
+        default="screamingface.corrective-execution.v1", alias="schema"
+    )
+    stop_reason: Literal["passed", "max_rounds"]
+    rounds_executed: int = Field(ge=1)
+
+
+def is_valid_corrective_execution(value: object) -> bool:
+    """Whether a nullable value is one complete corrective execution envelope."""
+
+    if value is None:
+        return True
+    try:
+        validate_corrective_execution(value)
+    except ValueError:
+        return False
+    return True
+
+
+def validate_corrective_execution(value: object) -> CorrectiveExecution:
+    """Decode the exact versioned envelope accepted at Engine wire boundaries."""
+
+    if (
+        not isinstance(value, Mapping)
+        or set(value) != {"schema", "stop_reason", "rounds_executed"}
+        or value.get("schema") != "screamingface.corrective-execution.v1"
+    ):
+        raise ValueError("corrective execution has an invalid shape or schema")
+    return CorrectiveExecution.model_validate(value)
 
 
 def _require_scored_case(case: CaseResult) -> None:
@@ -400,6 +438,7 @@ def encode_candidate_invocation(
     output: str,
     finish_reason: str | None,
     refusal: str | None,
+    execution: CorrectiveExecution | None = None,
 ) -> str:
     """Encode one Candidate answer without discarding its provider-originated outcome."""
 
@@ -410,28 +449,44 @@ def encode_candidate_invocation(
             "output": output,
             "finish_reason": finish_reason,
             "refusal": refusal,
+            "execution": None if execution is None else execution.model_dump(by_alias=True),
         },
         ensure_ascii=False,
         separators=(",", ":"),
     )
 
 
-def decode_candidate_invocation(value: str) -> tuple[str, str | None, str | None]:
-    """Decode and validate the internal value returned by the Candidate adapter."""
-
+def _candidate_invocation_payload(value: str) -> Mapping[str, Any]:
     try:
         decoded = json.loads(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"Candidate Invocation result is not JSON: {exc}") from None
     if not isinstance(decoded, Mapping) or decoded.get("schema") != CANDIDATE_INVOCATION_SCHEMA:
         raise ValueError("Candidate Invocation result has an unsupported schema")
-    if set(decoded) != {"schema", "output", "finish_reason", "refusal"}:
+    if set(decoded) != {"schema", "output", "finish_reason", "refusal", "execution"}:
         raise ValueError("Candidate Invocation result has an invalid shape")
+    execution = decoded["execution"]
+    if execution is not None:
+        validate_corrective_execution(execution)
+    return decoded
+
+
+def decode_candidate_invocation(value: str) -> tuple[str, str | None, str | None]:
+    """Decode and validate the internal value returned by the Candidate adapter."""
+
+    decoded = _candidate_invocation_payload(value)
     output = decoded["output"]
     finish_reason = decoded["finish_reason"]
     refusal = decoded["refusal"]
     _validate_candidate_invocation(output, finish_reason, refusal)
     return output, finish_reason, refusal
+
+
+def decode_candidate_execution(value: str) -> CorrectiveExecution | None:
+    """Decode the optional execution provenance carried by a Candidate Invocation."""
+
+    execution = _candidate_invocation_payload(value)["execution"]
+    return None if execution is None else validate_corrective_execution(execution)
 
 
 def _validate_candidate_invocation(
@@ -459,15 +514,19 @@ __all__ = [
     "CaseGrade",
     "CaseResult",
     "CandidateResult",
+    "CorrectiveExecution",
     "Check",
     "Evidence",
     "EvidenceProducer",
     "Failure",
     "PROVIDER_REFUSAL_PLACEHOLDER",
     "candidate_coverage",
+    "decode_candidate_execution",
     "decode_candidate_invocation",
     "encode_candidate_invocation",
+    "is_valid_corrective_execution",
     "validate_candidate_outcome",
+    "validate_corrective_execution",
     "validate_case_id",
     "validate_finish_reason",
 ]

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_evaluation.py
@@ -10,6 +10,7 @@ import json
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from url4_cloud.benchmarks.contract import is_valid_corrective_execution
 from url4_cloud.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
 from url4_cloud.benchmarks.draco.validation import (
     has_text,
@@ -218,6 +219,8 @@ def _valid_case(value: Mapping[str, Any], case_id: int) -> bool:
         and has_text(value.get("input"))
         and outcome_valid
         and (finish_reason is None or has_text(finish_reason))
+        and "execution" in value
+        and is_valid_corrective_execution(value.get("execution"))
         and isinstance(value.get("metadata"), Mapping)
     )
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -168,12 +168,14 @@ def ungraded_case_result(case_record: Mapping[str, Any], failure: Mapping[str, A
             finish_reason=_finish_reason(case_record.get("finish_reason")),
             grade={"method": "rubric", "score": None, "metrics": {}, "checks": []},
             failures=[failure],
+            execution=case_record.get("execution"),
         )
     return build_failed_case_result(
         selected_case=selected,
         failures=[failure],
         output=str(case_record["output"]),
         finish_reason=_finish_reason(case_record.get("finish_reason")),
+        execution=case_record.get("execution"),
     )
 
 
@@ -217,6 +219,7 @@ def _case_result(
             finish_reason=finish_reason,
             grade=grade,
             failures=failures,
+            execution=case_record.get("execution"),
         )
     if not isinstance(output, str):  # pragma: no cover - sealed by the Case record decoder
         raise AggregateError("a non-refused DRACO Case must carry Candidate output text")
@@ -226,6 +229,7 @@ def _case_result(
             output=output,
             finish_reason=finish_reason,
             grade=grade,
+            execution=case_record.get("execution"),
         )
     return build_failed_case_result(
         selected_case=selected,
@@ -233,6 +237,7 @@ def _case_result(
         output=output,
         finish_reason=finish_reason,
         grade=grade,
+        execution=case_record.get("execution"),
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/records.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 
-from url4_cloud.benchmarks.contract import validate_candidate_outcome
+from url4_cloud.benchmarks.contract import CorrectiveExecution, validate_candidate_outcome
 from url4_cloud.benchmarks.draco.validation import (
     optional_integer,
     require_positive_integer,
@@ -25,6 +25,7 @@ def bind_case(
     output: str | None,
     refusal: str | None,
     finish_reason: str | None,
+    execution: CorrectiveExecution | None,
 ) -> dict[str, object]:
     """Bind evaluator text and exact Candidate outcome to one Engine-owned Case."""
 
@@ -52,6 +53,7 @@ def bind_case(
         "output": output,
         "finish_reason": finish_reason,
         "refusal": refusal,
+        "execution": None if execution is None else execution.model_dump(by_alias=True),
         "metadata": {key: value for key, value in row.items() if key not in {"id", "input"}},
     }
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/runtime.py
@@ -267,6 +267,7 @@ def _task_rows(
                 output=answer.output,
                 refusal=answer.refusal,
                 finish_reason=finish_reason,
+                execution=answer.execution,
             )
             for index, row in enumerate(result):
                 row["case_record"] = (

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ensemble/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ensemble/runtime.py
@@ -38,7 +38,8 @@ from typing import Any
 
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
-from url4_cloud.benchmarks.contract import decode_candidate_invocation
+from url4_cloud.benchmarks.candidate_execution import record_candidate_execution
+from url4_cloud.benchmarks.contract import CorrectiveExecution, decode_candidate_invocation
 from url4_cloud.benchmarks.ensemble.policy import (
     ANSWER_ROUTE,
     CHECK_SURFACE_SCHEMA,
@@ -59,6 +60,7 @@ from url4_cloud.model_outcomes import (
 )
 
 _NESTED_INPUT_BINDING = "_sf_recipe_input"
+_CORRECTIVE_OUTCOME_SCHEMA = "screamingface.corrective-outcome.v1"
 
 
 def install_corrective_runtime(node: Url4Node) -> None:
@@ -184,7 +186,14 @@ def _select(request: Request) -> str:
         chosen = tied[0] if len(tied) == 1 else (_by_label(tied, label) or tied[0])
     invocation = chosen["invocation"]
     assert isinstance(invocation, str)
-    return invocation
+    return compact_json(
+        {
+            "schema": _CORRECTIVE_OUTCOME_SCHEMA,
+            "invocation": invocation,
+            "round": _positive_int(request.intent, "round"),
+            "passed": bool(passers),
+        }
+    )
 
 
 def _answer(request: Request) -> str:
@@ -199,23 +208,15 @@ def _answer(request: Request) -> str:
     payload = json_object(request.context, "corrective answer")
     if set(payload) != {"selected", "next"}:
         raise _unavailable("corrective answer payload must carry exactly selected and next")
-    selected = payload["selected"]
-    if not isinstance(selected, str):
-        raise _unavailable("corrective answer selected must be text")
+    selected = _corrective_outcome(payload["selected"], "corrective answer selected")
     next_value = payload["next"]
     items = json_array(next_value, "corrective continuation") if next_value != "" else []
     if len(items) > 1:
         raise _unavailable("corrective continuation must carry at most one outcome")
     if not items:
-        return selected
-    outcome = items[0]
-    if isinstance(outcome, dict):
-        encoded = compact_json(outcome)
-        _invocation(encoded, "corrective continuation outcome")
-        return encoded
-    if not isinstance(outcome, str):
-        raise _unavailable("corrective continuation outcome must be text")
-    return outcome
+        return compact_json(selected)
+    outcome = _corrective_outcome(items[0], "corrective continuation outcome")
+    return compact_json(outcome)
 
 
 def _result(request: Request) -> str:
@@ -223,12 +224,35 @@ def _result(request: Request) -> str:
 
     if request.params:
         raise _unavailable("corrective result does not accept parameters")
-    output, finish_reason, refusal = _invocation(request.context, "corrective result")
+    outcome = _corrective_outcome(request.context, "corrective result")
+    output, finish_reason, refusal = _invocation(outcome["invocation"], "corrective result")
+    record_candidate_execution(
+        CorrectiveExecution(
+            stop_reason="passed" if outcome["passed"] else "max_rounds",
+            rounds_executed=outcome["round"],
+        )
+    )
     if refusal is not None:
         error = ResolutionError(refusal, code="provider_refusal", permanent=True)
         raise bind_model_outcome(error, ModelOutcome(finish_reason, refusal))
     record_model_outcome(finish_reason, None)
     return output
+
+
+def _corrective_outcome(value: object, label: str) -> dict[str, Any]:
+    outcome = json_object(value, label)
+    expected = {"schema", "invocation", "round", "passed"}
+    if set(outcome) != expected or outcome.get("schema") != _CORRECTIVE_OUTCOME_SCHEMA:
+        raise _unavailable(f"{label} must be a {_CORRECTIVE_OUTCOME_SCHEMA} outcome")
+    invocation = outcome["invocation"]
+    _invocation(invocation, label)
+    round_number = outcome["round"]
+    if isinstance(round_number, bool) or not isinstance(round_number, int) or round_number < 1:
+        raise _unavailable(f"{label} round must be a positive integer")
+    passed = outcome["passed"]
+    if not isinstance(passed, bool):
+        raise _unavailable(f"{label} passed must be a boolean")
+    return dict(outcome)
 
 
 def _gate_intent(intent: str) -> tuple[str, int, int]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/evaluation.py
@@ -9,7 +9,11 @@ from typing import Any
 
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request
-from url4_cloud.benchmarks.contract import decode_candidate_invocation
+from url4_cloud.benchmarks.contract import (
+    CorrectiveExecution,
+    decode_candidate_execution,
+    decode_candidate_invocation,
+)
 
 JsonObject = dict[str, Any]
 CaseEvaluationBinder = Callable[[int, list[JsonObject]], JsonObject]
@@ -24,6 +28,7 @@ class CandidateAnswer:
     output: str | None
     finish_reason: str | None
     refusal: str | None
+    execution: CorrectiveExecution | None
 
 
 def candidate_answer(value: str) -> CandidateAnswer:
@@ -35,6 +40,7 @@ def candidate_answer(value: str) -> CandidateAnswer:
         output=None if refusal is not None else output,
         finish_reason=finish_reason,
         refusal=refusal,
+        execution=decode_candidate_execution(value),
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
@@ -285,6 +285,7 @@ def _scored_outcome(
             finish_reason=fields["finish_reason"],
             grade=grade,
             metadata=fields["metadata"],
+            execution=fields["execution"],
         )
     else:
         scored = scored_case_result(
@@ -293,6 +294,7 @@ def _scored_outcome(
             finish_reason=fields["finish_reason"],
             grade=grade,
             metadata=fields["metadata"],
+            execution=fields["execution"],
         )
     return scored, score, len(verdicts), sum(verdicts.values()), invalid
 
@@ -315,7 +317,13 @@ def _candidate_fields(row: Mapping[str, Any] | None) -> dict[str, Any]:
 
     case = row.get("case") if isinstance(row, Mapping) else None
     if not isinstance(case, Mapping):
-        return {"output": None, "finish_reason": None, "refusal": None, "metadata": {}}
+        return {
+            "output": None,
+            "finish_reason": None,
+            "refusal": None,
+            "execution": None,
+            "metadata": {},
+        }
     metadata = case.get("metadata")
     output = case.get("output")
     finish_reason = case.get("finish_reason")
@@ -324,6 +332,7 @@ def _candidate_fields(row: Mapping[str, Any] | None) -> dict[str, Any]:
         "output": output if isinstance(output, str) else None,
         "finish_reason": finish_reason if isinstance(finish_reason, str) else None,
         "refusal": refusal if isinstance(refusal, str) and refusal.strip() else None,
+        "execution": case.get("execution"),
         "metadata": dict(metadata) if isinstance(metadata, Mapping) else {},
     }
 
@@ -353,6 +362,7 @@ def _failed_result(
             grade=grade,
             failures=[failure],
             metadata=fields["metadata"],
+            execution=fields["execution"],
         )
     return failed_case_result(
         selected_case=selected_case,
@@ -361,6 +371,7 @@ def _failed_result(
         finish_reason=fields["finish_reason"],
         grade=grade,
         metadata=fields["metadata"],
+        execution=fields["execution"],
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/case_evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/case_evaluation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
+from url4_cloud.benchmarks.contract import is_valid_corrective_execution
 from url4_cloud.benchmarks.healthbench.records import CASE_SCHEMA, RUBRIC_SCHEMA
 from url4_cloud.benchmarks.healthbench.verdict import SCHEMA as VERDICT_SCHEMA
 
@@ -20,6 +21,7 @@ _CASE_RECORD_FIELDS = frozenset(
         "output",
         "finish_reason",
         "refusal",
+        "execution",
         "metadata",
     }
 )
@@ -195,6 +197,7 @@ def _valid_case_record(value: Mapping[str, Any], case_id: int) -> bool:
         and (
             finish_reason is None or isinstance(finish_reason, str) and bool(finish_reason.strip())
         )
+        and is_valid_corrective_execution(value.get("execution"))
         and isinstance(value.get("metadata"), Mapping)
     )
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/records.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/records.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 
-from url4_cloud.benchmarks.contract import validate_candidate_outcome
+from url4_cloud.benchmarks.contract import CorrectiveExecution, validate_candidate_outcome
 
 CASE_SCHEMA = "screamingface.healthbench-case-record.v1"
 RUBRIC_SCHEMA = "screamingface.healthbench-rubric-record.v1"
@@ -19,6 +19,7 @@ def bind_case(
     output: str | None,
     refusal: str | None,
     finish_reason: str | None,
+    execution: CorrectiveExecution | None,
 ) -> dict[str, object]:
     """Bind evaluator text and exact Candidate outcome to one Engine-owned Case."""
 
@@ -46,6 +47,7 @@ def bind_case(
         "output": output,
         "finish_reason": finish_reason,
         "refusal": refusal,
+        "execution": None if execution is None else execution.model_dump(by_alias=True),
         "metadata": {key: value for key, value in row.items() if key not in {"id", "input"}},
     }
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/runtime.py
@@ -195,6 +195,7 @@ def _rubric_tasks(root: Path, case_ids: tuple[int, ...]):
                 output=answer.output,
                 refusal=answer.refusal,
                 finish_reason=finish_reason,
+                execution=answer.execution,
             )
             tasks: list[dict[str, str]] = []
             for item in items:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
@@ -27,7 +27,7 @@ from url4_cloud.benchmarks.aggregation import (
     refused_case_result,
     scored_case_result,
 )
-from url4_cloud.benchmarks.contract import CaseResult
+from url4_cloud.benchmarks.contract import CaseResult, is_valid_corrective_execution
 from url4_cloud.benchmarks.ifeval.case_evaluation import (
     CHECK_SCHEMA,
     decode_case_evaluation,
@@ -278,6 +278,8 @@ def _record_content(record: Mapping[str, Any], instruction_count: int) -> bool:
             or isinstance(record["finish_reason"], str)
             and bool(record["finish_reason"].strip())
         )
+        and "execution" in record
+        and is_valid_corrective_execution(record["execution"])
         and isinstance(record.get("descriptions"), list)
         and len(record["descriptions"]) == instruction_count
         and all(isinstance(value, str) and value for value in record["descriptions"])
@@ -326,12 +328,14 @@ def _case_result(selected_case: SelectedCase, record: Mapping[str, Any]) -> Case
             refusal=refusal,
             finish_reason=record["finish_reason"],
             grade=grade,
+            execution=record["execution"],
         )
     return scored_case_result(
         selected_case=selected_case,
         output=str(record["answer"]),
         finish_reason=record["finish_reason"],
         grade=grade,
+        execution=record["execution"],
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
@@ -79,6 +79,11 @@ def _check(root: Path):
             "answer": candidate.text,
             "refusal": candidate.refusal,
             "finish_reason": candidate.finish_reason,
+            "execution": (
+                None
+                if candidate.execution is None
+                else candidate.execution.model_dump(by_alias=True)
+            ),
             "instruction_id_list": spec["instruction_id_list"],
             "descriptions": grading.describe_instructions(
                 instruction_id_list=spec["instruction_id_list"],

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/invocation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/invocation.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 from url4.core.errors import ResolutionError
 from url4.peer.server import Url4Node
+from url4_cloud.benchmarks.candidate_execution import (
+    capture_candidate_executions,
+    terminal_candidate_execution,
+)
 from url4_cloud.benchmarks.contract import (
     PROVIDER_REFUSAL_PLACEHOLDER,
+    CorrectiveExecution,
     encode_candidate_invocation,
 )
 from url4_cloud.model_outcomes import (
@@ -26,35 +31,45 @@ async def evaluate_candidate_recipe(
 ) -> str:
     """Evaluate a Recipe while preserving its exact terminal outcome."""
 
-    with capture_model_outcomes(isolated=isolated) as outcomes:
-        try:
-            result = await node.evaluate(expression, env={input_binding: input_text})
-        except ResolutionError as exc:
-            if exc.code != "provider_refusal":
-                raise
-            outcome = model_outcome_from_error(exc)
-            if outcome is None:
-                raise ResolutionError(
-                    "provider refusal carried no terminal outcome",
-                    code="candidate_contract_error",
-                    permanent=True,
-                ) from exc
-            # A content-filter turn often carries no refusal text. Preserve the
-            # provider-refused path with an explicit gradeable marker rather than
-            # making it indistinguishable from a successful empty answer.
-            if not outcome.refusal:
-                outcome = ModelOutcome(outcome.finish_reason, PROVIDER_REFUSAL_PLACEHOLDER)
-            return _encode("", outcome)
+    with capture_candidate_executions(isolated=isolated) as executions:
+        with capture_model_outcomes(isolated=isolated) as outcomes:
+            try:
+                result = await node.evaluate(expression, env={input_binding: input_text})
+            except ResolutionError as exc:
+                if exc.code != "provider_refusal":
+                    raise
+                outcome = model_outcome_from_error(exc)
+                if outcome is None:
+                    raise ResolutionError(
+                        "provider refusal carried no terminal outcome",
+                        code="candidate_contract_error",
+                        permanent=True,
+                    ) from exc
+                # A content-filter turn often carries no refusal text. Preserve the
+                # provider-refused path with an explicit gradeable marker rather than
+                # making it indistinguishable from a successful empty answer.
+                if not outcome.refusal:
+                    outcome = ModelOutcome(outcome.finish_reason, PROVIDER_REFUSAL_PLACEHOLDER)
+                return _encode("", outcome, terminal_candidate_execution(executions))
 
-    return _encode(result.text, terminal_model_outcome(outcomes))
+    return _encode(
+        result.text,
+        terminal_model_outcome(outcomes),
+        terminal_candidate_execution(executions),
+    )
 
 
-def _encode(output: str, outcome: ModelOutcome) -> str:
+def _encode(
+    output: str,
+    outcome: ModelOutcome,
+    execution: CorrectiveExecution | None,
+) -> str:
     try:
         return encode_candidate_invocation(
             output,
             outcome.finish_reason,
             outcome.refusal,
+            execution,
         )
     except ValueError as exc:
         raise ResolutionError(

--- a/apps/url4-cloud/tests/unit/test_candidate_result_contract.py
+++ b/apps/url4-cloud/tests/unit/test_candidate_result_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -13,9 +14,11 @@ from url4_cloud.benchmarks.contract import (
     CaseGrade,
     CaseResult,
     Check,
+    CorrectiveExecution,
     Evidence,
     EvidenceProducer,
     Failure,
+    decode_candidate_execution,
     decode_candidate_invocation,
     encode_candidate_invocation,
 )
@@ -123,6 +126,8 @@ def test_scored_result_serializes_the_strict_v1_shape() -> None:
                 "output": "{}",
                 "finish_reason": "stop",
                 "refusal": None,
+                "stop_reason": None,
+                "rounds_executed": None,
                 "grade": {
                     "method": "deterministic",
                     "score": 1.0,
@@ -214,6 +219,39 @@ def test_provider_finish_reason_is_preserved_without_a_closed_sdk_vocabulary() -
 def test_candidate_invocation_rejects_an_answer_and_refusal_together() -> None:
     with pytest.raises(ValueError, match="refused Candidate Invocation"):
         encode_candidate_invocation("answer", "content_filter", "exact refusal")
+
+
+def test_candidate_invocation_round_trips_typed_corrective_execution() -> None:
+    execution = CorrectiveExecution(stop_reason="passed", rounds_executed=2)
+
+    encoded = encode_candidate_invocation("answer", "stop", None, execution)
+
+    assert decode_candidate_execution(encoded) == execution
+
+
+def test_candidate_invocation_rejects_unversioned_corrective_execution() -> None:
+    encoded = encode_candidate_invocation(
+        "answer",
+        "stop",
+        None,
+        CorrectiveExecution(stop_reason="passed", rounds_executed=1),
+    )
+    payload = json.loads(encoded)
+    del payload["execution"]["schema"]
+
+    with pytest.raises(ValueError, match="shape or schema"):
+        decode_candidate_execution(json.dumps(payload))
+
+
+def test_case_execution_fields_are_atomic_and_strict() -> None:
+    case = _scored_case(stop_reason="max_rounds", rounds_executed=3)
+    assert case.stop_reason == "max_rounds"
+    assert case.rounds_executed == 3
+
+    with pytest.raises(ValidationError, match="present together"):
+        _scored_case(stop_reason="passed", rounds_executed=None)
+    with pytest.raises(ValidationError, match="stop_reason"):
+        _scored_case(stop_reason="continued", rounds_executed=1)
 
 
 def test_open_wire_fields_accept_only_json_values() -> None:

--- a/apps/url4-cloud/tests/unit/test_corrective_loop_e2e.py
+++ b/apps/url4-cloud/tests/unit/test_corrective_loop_e2e.py
@@ -76,6 +76,7 @@ def _respond(
     member_a_first_round_passes: bool,
     member_b_first_round_passes: bool,
     member_b_refuses: bool,
+    member_b_retry_passes: bool,
 ):
     """Deterministic panel: member-a never passes; member-b improves on coaching."""
 
@@ -84,7 +85,11 @@ def _respond(
         if "telling yourself" in content:
             return "Use lowercase and drop the comma."
         coached = "Judge feedback:" in content or "Feedback:" in content
-        return _PASS_ANSWER if coached or member_b_first_round_passes else _HALF_ANSWER
+        return (
+            _PASS_ANSWER
+            if member_b_first_round_passes or coached and member_b_retry_passes
+            else _HALF_ANSWER
+        )
 
     def respond(request: httpx.Request) -> httpx.Response:
         body = json.loads(request.content)
@@ -119,6 +124,7 @@ async def _run(
     member_a_first_round_passes: bool = False,
     member_b_first_round_passes: bool,
     member_b_refuses: bool = False,
+    member_b_retry_passes: bool = True,
 ) -> tuple[dict[str, object], list[tuple[str, str]]]:
     _assets(tmp_path / "ifeval")
     calls: list[tuple[str, str]] = []
@@ -129,6 +135,7 @@ async def _run(
                 member_a_first_round_passes=member_a_first_round_passes,
                 member_b_first_round_passes=member_b_first_round_passes,
                 member_b_refuses=member_b_refuses,
+                member_b_retry_passes=member_b_retry_passes,
             )
         ),
         base_url="http://aigateway.test",
@@ -183,6 +190,8 @@ async def test_a_round_one_pass_costs_exactly_the_member_calls(tmp_path: Path) -
     assert case["status"] == "scored"
     # INVARIANT: the selected answer is a member answer VERBATIM.
     assert case["output"] == _PASS_ANSWER
+    assert case["stop_reason"] == "passed"
+    assert case["rounds_executed"] == 1
     assert [model for model, _ in calls] == ["prov/member-a", "prov/member-b"]
 
 
@@ -201,6 +210,8 @@ async def test_a_selected_provider_refusal_is_graded_and_published_verbatim(
     assert case["output"] is None
     assert case["refusal"] == _PASS_ANSWER
     assert case["finish_reason"] == "content_filter"
+    assert case["stop_reason"] == "passed"
+    assert case["rounds_executed"] == 1
     grade = case["grade"]
     assert isinstance(grade, dict)
     assert grade["score"] == 1.0
@@ -223,6 +234,8 @@ async def test_a_provider_refusal_does_not_abort_a_passing_sibling(
     assert case["status"] == "scored"
     assert case["output"] == _PASS_ANSWER
     assert case["refusal"] is None
+    assert case["stop_reason"] == "passed"
+    assert case["rounds_executed"] == 1
     assert case["failures"] == []
     # Both texts pass the benchmark checker, so the generic tie-break path runs;
     # the refusal remains a normal checked member rather than aborting the panel.
@@ -237,6 +250,8 @@ async def test_a_no_pass_round_buys_one_coaching_call_and_a_retry(tmp_path: Path
     )
     assert result["score"] == 1.0
     assert _first_case(result)["output"] == _PASS_ANSWER
+    assert _first_case(result)["stop_reason"] == "passed"
+    assert _first_case(result)["rounds_executed"] == 2
     models = [model for model, _ in calls]
     # Round 1 (a+b, no passer) -> judge coaching -> round 2 (a+b, b passes).
     assert sorted(models[:2]) == ["prov/member-a", "prov/member-b"]
@@ -262,3 +277,16 @@ async def test_self_corrective_coaches_itself_between_rounds(tmp_path: Path) -> 
     assert models == ["prov/member-b", "prov/member-b", "prov/member-b"]
     assert "telling yourself" in calls[1][1]
     assert "Feedback:" in calls[2][1]
+
+
+async def test_a_never_passing_loop_reports_its_round_limit(tmp_path: Path) -> None:
+    result, _calls = await _run(
+        tmp_path,
+        "corrective_loop_candidate.url4",
+        member_b_first_round_passes=False,
+        member_b_retry_passes=False,
+    )
+
+    case = _first_case(result)
+    assert case["stop_reason"] == "max_rounds"
+    assert case["rounds_executed"] == 2

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate.py
@@ -106,6 +106,7 @@ def _case_row_from_evidence(
         "output": answer,
         "finish_reason": "stop",
         "refusal": None,
+        "execution": None,
         "metadata": {},
     }
     criteria = []

--- a/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
+++ b/apps/url4-cloud/tests/unit/test_draco_aggregate_case_mapping.py
@@ -71,6 +71,7 @@ def _row(criterion: str, *, case: int | None = None, status: str = "MET") -> obj
             "output": f"Answer {case}",
             "finish_reason": "stop",
             "refusal": None,
+            "execution": None,
             "metadata": {},
         }
         check_record = {

--- a/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
@@ -124,6 +124,8 @@ async def test_draco_smoke_retains_complete_case_evidence(tmp_path: Path) -> Non
             "output": _ANSWER,
             "finish_reason": "stop",
             "refusal": None,
+            "stop_reason": None,
+            "rounds_executed": None,
             "grade": {
                 "method": "rubric",
                 "score": 1.0,

--- a/apps/url4-cloud/tests/unit/test_draco_case_evaluation_route.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_evaluation_route.py
@@ -11,7 +11,10 @@ from url4 import RelExpr, Text, expr, render, src
 from url4.core.errors import ResolutionError
 from url4.peer.server import Url4Node
 from url4_cloud.benchmarks.draco import assets as draco_assets
-from url4_cloud.benchmarks.draco.case_evaluation import CASE_EVALUATION_SCHEMA
+from url4_cloud.benchmarks.draco.case_evaluation import (
+    CASE_EVALUATION_SCHEMA,
+    bind_criterion_evaluation,
+)
 from url4_cloud.benchmarks.draco.definition import (
     CASE_EVALUATION_ROUTE,
     CASES_ROUTE,
@@ -84,6 +87,7 @@ async def test_runtime_packs_one_criterion_then_one_case_evaluation(tmp_path: Pa
         "output": "Answer 1",
         "finish_reason": "stop",
         "refusal": None,
+        "execution": None,
         "metadata": {},
     }
     check = {
@@ -124,6 +128,41 @@ async def test_runtime_packs_one_criterion_then_one_case_evaluation(tmp_path: Pa
         "checks": [check],
         "evidence": [verdict],
     }
+
+
+def test_case_record_requires_explicit_execution_provenance() -> None:
+    case = {
+        "schema": CASE_SCHEMA,
+        "case_id": 1,
+        "input": "Question 1",
+        "answer": "Answer 1",
+        "output": "Answer 1",
+        "finish_reason": "stop",
+        "refusal": None,
+        "metadata": {},
+    }
+    check = {
+        "schema": CHECK_SCHEMA,
+        "case_id": 1,
+        "criterion_id": "c1",
+        "criterion_type": "positive",
+        "requirement": "Be correct",
+    }
+    evidence = {
+        "schema": VERDICT_SCHEMA,
+        "case_id": 1,
+        "criterion_id": "c1",
+        "sequence": 1,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": True,
+        "explanation": "The requirement is met.",
+        "criterion_status": "MET",
+        "raw_output": '{"criterion_status":"MET"}',
+    }
+
+    with pytest.raises(ValueError, match="invalid Case record"):
+        bind_criterion_evaluation(1, case, check, [evidence])
 
 
 def test_install_fails_atomically_when_assets_are_missing(tmp_path: Path) -> None:

--- a/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
+++ b/apps/url4-cloud/tests/unit/test_draco_failure_integrity.py
@@ -31,6 +31,7 @@ def _scored_row(case_id: int) -> dict[str, object]:
             "output": f"Answer {case_id}",
             "finish_reason": "stop",
             "refusal": None,
+            "execution": None,
             "metadata": {},
         },
         {
@@ -107,6 +108,8 @@ def test_partial_result_preserves_the_collected_case_error() -> None:
         "output": None,
         "finish_reason": None,
         "refusal": None,
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": None,
         "failures": expected_failure,
         "metadata": {},
@@ -159,6 +162,31 @@ def test_provider_refusal_is_retained_exactly_and_graded_normally() -> None:
     assert case["failures"] == []
 
 
+def test_corrective_execution_provenance_reaches_the_case_result() -> None:
+    row = _scored_row(1)
+    case_record = row["case"]
+    assert isinstance(case_record, dict)
+    case_record["execution"] = {
+        "schema": "screamingface.corrective-execution.v1",
+        "stop_reason": "max_rounds",
+        "rounds_executed": 3,
+    }
+
+    result = agg.aggregate(
+        json.dumps([row]),
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=_selected(1),
+        judge_passes=1,
+    )
+
+    case = result["cases"][0]
+    assert case["stop_reason"] == "max_rounds"
+    assert case["rounds_executed"] == 3
+    assert case["grade"]["score"] == 1.0
+    assert case["failures"] == []
+
+
 def test_missing_selected_case_rubric_retains_the_case_and_lowers_coverage() -> None:
     result = agg.aggregate(
         json.dumps([_scored_row(1), _scored_row(2)]),
@@ -179,6 +207,8 @@ def test_missing_selected_case_rubric_retains_the_case_and_lowers_coverage() -> 
         "output": "Answer 2",
         "finish_reason": "stop",
         "refusal": None,
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": None,
         "failures": [
             {
@@ -215,6 +245,7 @@ def test_invalid_judge_evidence_is_retained_under_an_unscored_grade() -> None:
         "output": "Answer 1",
         "finish_reason": "stop",
         "refusal": None,
+        "execution": None,
         "metadata": {},
     }
     check = {

--- a/apps/url4-cloud/tests/unit/test_draco_lite_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_draco_lite_protocol.py
@@ -209,6 +209,7 @@ async def test_lite_runtime_reports_its_own_identity_and_one_judge_pass(tmp_path
                 "output": f"Answer {case_id}",
                 "finish_reason": "stop",
                 "refusal": None,
+                "execution": None,
                 "metadata": {"domain": "test"},
             },
         ]

--- a/apps/url4-cloud/tests/unit/test_draco_smoke_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_draco_smoke_protocol.py
@@ -134,6 +134,7 @@ async def test_smoke_runtime_reports_its_own_identity_and_one_judge_pass(tmp_pat
         "output": "Answer",
         "finish_reason": "stop",
         "refusal": None,
+        "execution": None,
         "metadata": {},
     }
     check_record = {

--- a/apps/url4-cloud/tests/unit/test_ensemble_corrective.py
+++ b/apps/url4-cloud/tests/unit/test_ensemble_corrective.py
@@ -62,9 +62,19 @@ def _record(
 
 
 def _answer(invocation: str) -> str:
-    output, _finish_reason, refusal = decode_candidate_invocation(invocation)
+    outcome = json.loads(invocation)
+    output, _finish_reason, refusal = decode_candidate_invocation(outcome["invocation"])
     assert refusal is None
     return output
+
+
+def _outcome(answer: str, *, round: int = 1, passed: bool = True) -> dict[str, object]:
+    return {
+        "schema": "screamingface.corrective-outcome.v1",
+        "invocation": encode_candidate_invocation(answer, "stop", None),
+        "round": round,
+        "passed": passed,
+    }
 
 
 _PASS = _record(passed=True, satisfaction=1.0, answer="passing answer")
@@ -378,15 +388,20 @@ async def test_select_requires_exactly_round_and_tie() -> None:
 @pytest.mark.asyncio
 async def test_answer_returns_the_selection_when_the_continuation_is_empty() -> None:
     node = _node()
-    reply = await _call(node, ANSWER_ROUTE, {"selected": "round one", "next": []}, "1")
-    assert reply == "round one"
+    reply = await _call(node, ANSWER_ROUTE, {"selected": _outcome("round one"), "next": []}, "1")
+    assert _answer(reply) == "round one"
 
 
 @pytest.mark.asyncio
 async def test_answer_prefers_the_continuation_outcome_when_one_exists() -> None:
     node = _node()
-    reply = await _call(node, ANSWER_ROUTE, {"selected": "round one", "next": ["round two"]}, "1")
-    assert reply == "round two"
+    reply = await _call(
+        node,
+        ANSWER_ROUTE,
+        {"selected": _outcome("round one"), "next": [_outcome("round two", round=2)]},
+        "1",
+    )
+    assert _answer(reply) == "round two"
 
 
 @pytest.mark.asyncio
@@ -398,7 +413,7 @@ async def test_answer_treats_blank_continuation_text_as_empty() -> None:
     def collapse(request) -> str:
         return request.context
 
-    payload = json.dumps({"selected": "round one", "next": ""}, separators=(",", ":"))
+    payload = json.dumps({"selected": _outcome("round one"), "next": ""}, separators=(",", ":"))
     result = await node.evaluate(
         render(
             expr(
@@ -408,14 +423,19 @@ async def test_answer_treats_blank_continuation_text_as_empty() -> None:
             )
         )
     )
-    assert result.text == "round one"
+    assert _answer(result.text) == "round one"
 
 
 @pytest.mark.asyncio
 async def test_answer_rejects_a_multi_outcome_continuation() -> None:
     node = _node()
     with pytest.raises(ResolutionError, match="at most one"):
-        await _call(node, ANSWER_ROUTE, {"selected": "one", "next": ["two", "three"]}, "1")
+        await _call(
+            node,
+            ANSWER_ROUTE,
+            {"selected": _outcome("one"), "next": [_outcome("two"), _outcome("three")]},
+            "1",
+        )
 
 
 # --- (3) the port record contract -------------------------------------------------

--- a/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_healthbench_aggregate.py
@@ -66,6 +66,7 @@ def _case_row(
     verdicts: dict[int, bool],
     *,
     refusal: str | None = None,
+    execution: dict[str, object] | None = None,
 ) -> dict[str, object]:
     output = None if refusal is not None else f"output-{case_id}"
     answer = refusal if refusal is not None else output
@@ -80,6 +81,7 @@ def _case_row(
             "output": output,
             "finish_reason": "content_filter" if refusal is not None else "stop",
             "refusal": refusal,
+            "execution": execution,
             "metadata": {},
         },
         "rubric_evaluations": [
@@ -145,6 +147,8 @@ def test_fully_judged_cases_score_and_mean_unclipped(tmp_path: Path) -> None:
         "output",
         "finish_reason",
         "refusal",
+        "stop_reason",
+        "rounds_executed",
         "grade",
         "failures",
         "metadata",
@@ -345,6 +349,27 @@ def test_provider_refusals_are_mapped_by_case_and_preserved_exactly(tmp_path: Pa
     ]
     assert [case["grade"]["score"] for case in result["cases"]] == [1.0, 0.0]
     assert [case["failures"] for case in result["cases"]] == [[], []]
+
+
+def test_corrective_execution_provenance_reaches_the_case_result(tmp_path: Path) -> None:
+    _write_rubric(tmp_path, 1, [7])
+    execution = {
+        "schema": "screamingface.corrective-execution.v1",
+        "stop_reason": "passed",
+        "rounds_executed": 2,
+    }
+
+    result = aggregate(
+        json.dumps([_case_row(1, {1: True}, execution=execution)]),
+        tmp_path,
+        benchmark_id="hb",
+        benchmark_revision="rev",
+        case_ids=(1,),
+    )
+
+    case = result["cases"][0]
+    assert case["stop_reason"] == "passed"
+    assert case["rounds_executed"] == 2
 
 
 def test_a_missing_case_row_is_visible(tmp_path: Path) -> None:

--- a/apps/url4-cloud/tests/unit/test_ifeval_aggregate.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_aggregate.py
@@ -52,6 +52,7 @@ def _record(case_id: int, strict: list[bool], loose: list[bool]) -> dict[str, ob
         "answer": f"Answer {case_id}",
         "refusal": None,
         "finish_reason": "stop",
+        "execution": None,
         "instruction_id_list": spec["instruction_id_list"],
         "descriptions": [
             f"Instruction {index}" for index in range(1, len(spec["instruction_id_list"]) + 1)
@@ -208,6 +209,7 @@ def test_one_flake_at_realistic_size_publishes_partial_score_and_coverage() -> N
             "answer": f"Answer {case_id}",
             "refusal": None,
             "finish_reason": "stop",
+            "execution": None,
             "instruction_id_list": ["punctuation:no_comma"],
             "descriptions": ["Instruction 1"],
             "strict": [passed],

--- a/apps/url4-cloud/tests/unit/test_ifeval_aggregate_case_mapping.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_aggregate_case_mapping.py
@@ -31,6 +31,7 @@ def _record(case_id: int) -> dict[str, object]:
         "answer": f"Answer {case_id}",
         "refusal": None,
         "finish_reason": "stop",
+        "execution": None,
         "instruction_id_list": _SPECS[case_id]["instruction_id_list"],
         "descriptions": ["Fixture instruction"],
         "strict": [True],

--- a/apps/url4-cloud/tests/unit/test_ifeval_official_identity.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_official_identity.py
@@ -158,6 +158,7 @@ def _record(case_id: int) -> dict[str, object]:
         "answer": f"Answer {case_id}",
         "refusal": None,
         "finish_reason": "stop",
+        "execution": None,
         "instruction_id_list": _ORDER_SPECS[case_id]["instruction_id_list"],
         "descriptions": ["Fixture instruction"],
         "strict": [True],

--- a/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
+++ b/apps/url4-cloud/tests/unit/test_ifeval_unscored_results.py
@@ -34,6 +34,7 @@ def _valid_record() -> dict[str, object]:
         "answer": "A compliant answer",
         "refusal": None,
         "finish_reason": "stop",
+        "execution": None,
         "instruction_id_list": ["punctuation:no_comma"],
         "descriptions": ["Do not use commas."],
         "strict": [True],
@@ -70,6 +71,8 @@ def test_collected_candidate_failure_returns_a_complete_unscored_result() -> Non
             "output": None,
             "finish_reason": None,
             "refusal": None,
+            "stop_reason": None,
+            "rounds_executed": None,
             "grade": None,
             "failures": [
                 {

--- a/docs/spec/2026-08-14-OME-796-corrective-loop-generalization.md
+++ b/docs/spec/2026-08-14-OME-796-corrective-loop-generalization.md
@@ -55,7 +55,12 @@ benchmark-independent capability:
   kinds `corrective_loop` / `self_corrective` carrying members, judge, `max_rounds`, and
   the check-surface revision compiled against.
 - **Reporting**: per-case `stop_reason` + `rounds_executed` (generalizing
-  `pass_attempt`/`selected_attempt`).
+  `pass_attempt`/`selected_attempt`). The generic Candidate Invocation envelope carries a
+  nullable typed `execution` value across the `$candidate` boundary; corrective roots publish
+  `screamingface.corrective-execution.v1`, while non-corrective Candidates publish `null`.
+  `CaseResult` flattens that outcome into an atomic pair: both fields are `null`, or
+  `stop_reason` is `passed|max_rounds` and `rounds_executed` is a positive integer. Benchmarks
+  preserve this provenance and never infer loop state themselves.
 - **Failure semantics kept from shipped precedents**: never-passes → last attempt scored;
   tie → judge label pick; tie-of-tie → first member (deterministic — reproducibility);
   judge/member failure → case fallback, coverage-declared.

--- a/docs/tasks/2026-08-14-OME-827-ensemble-module-check-port.md
+++ b/docs/tasks/2026-08-14-OME-827-ensemble-module-check-port.md
@@ -17,6 +17,9 @@ the refusal-safe check-surface port
 `check_surface` in the `screamingface.benchmark.v1` manifest; retire the
 `ifeval/lanl-ensemble` + `ifeval/self-corrective` registry variants; and ship the IFEval
 deterministic adapter. DRACO and HealthBench adapters are owned by OME-829 and OME-830.
+The remaining Engine-side acceptance item is the shared Candidate execution-provenance
+transport that publishes corrective-loop `stop_reason` and `rounds_executed` without
+making any Benchmark adapter understand loop control flow.
 
 Design source: OME-796 issue body ("Design resolution 2026-08-14") + attached diagrams.
 Ledger: `docs/work/2026-08-14-OME-827-ensemble-module-check-port.md`

--- a/docs/tasks/2026-08-14-OME-828-corrective-loop-client-recipes.md
+++ b/docs/tasks/2026-08-14-OME-828-corrective-loop-client-recipes.md
@@ -16,7 +16,9 @@ landed separately in PR #597): `sf.CorrectiveLoop(members, judge=,
 max_rounds=3)` + `sf.SelfCorrective(model, max_rounds=3)` compiling the whole loop into ONE
 `$candidate` against manifest `check_surface` routes; preflight fail-before-spend;
 editable replay and fail-closed topology validation; and the notebook 07 2×2 grid.
-Per-case loop telemetry is an explicit follow-up requiring a shared provenance contract.
+The remaining Client-side acceptance item is strict parsing, immutable values, export,
+and report display for per-case `stop_reason` and `rounds_executed`, carried through the
+shared Candidate execution-provenance contract rather than Recipe-specific result code.
 
 Design source: OME-796 issue body ("Design resolution 2026-08-14") + attached diagrams.
 Ledger: `docs/work/2026-08-14-OME-828-corrective-loop-client-recipes.md`

--- a/docs/work/2026-08-14-OME-796-corrective-loop-generalization.md
+++ b/docs/work/2026-08-14-OME-796-corrective-loop-generalization.md
@@ -126,3 +126,27 @@ OME-801/802/803/804 extraction PRs) — re-verify every touch point before editi
      carry the exact Candidate Invocation that produced their answer/refusal text;
      selection preserves that envelope and the result boundary republishes the
      selected terminal outcome. Judge/coach refusal remains an internal role error.
+
+## 2026-08-14 telemetry continuation
+
+- **Decision:** complete the approved `stop_reason` / `rounds_executed` acceptance item
+  under the still-open OME-827 and OME-828 children; no new issue is required.
+- **Seam:** the generic corrective runtime emits a typed final execution outcome. The
+  Candidate Invocation contract carries it across the existing `$candidate` boundary,
+  and every Benchmark preserves the two generic fields into the shared `CaseResult`.
+  Benchmark adapters do not infer rounds or duplicate corrective-loop policy.
+- **Atomicity:** Engine producer and strict Client consumer ship in one PR so the Client
+  never rejects a newly widened `screamingface.candidate-result.v1` payload.
+- **Compatibility:** pre-release v1 only; no legacy wire shape or fallback parser.
+- **Result:** the corrective runtime now publishes the actual terminal round and reason through
+  the generic Candidate Invocation provenance slot; IFEval, DRACO, and HealthBench preserve it
+  into one strict `CaseResult`, and the Client parses, exports, and displays it.
+- **Verification:** url4-cloud and screamingface full stack gates are green (Ruff, format,
+  Pyright, layering, full tests/coverage, notebooks, build, and distribution checks). The
+  append-only check is deliberately skipped because widening the strict pre-release v1 wire
+  contract requires existing payload fixtures to name both new fields explicitly; no assertion
+  was removed or weakened.
+- **Review closure:** centralized nullable execution validation across all three Benchmarks;
+  DRACO now rejects a missing execution field, the versioned corrective envelope rejects a
+  missing/foreign schema, and non-null provenance propagation is covered explicitly for DRACO
+  and HealthBench as well as the full IFEval corrective-loop path.

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -10,7 +10,7 @@ from screamingface._core.ports import _RunOutcome
 from screamingface._evaluation.model import Candidate, _compiled_evaluation, _Evaluation
 from screamingface._report_primitives import CaseId
 from screamingface._report_primitives import _case_id as _validate_case_id
-from screamingface.case_result import CaseStatus
+from screamingface.case_result import CaseStatus, StopReason
 from screamingface.discovery import BenchmarkInfo
 from screamingface.errors import ExecutionError
 from screamingface.report import (
@@ -204,6 +204,8 @@ def _case_result(value: object) -> CaseResult:
             "output",
             "finish_reason",
             "refusal",
+            "stop_reason",
+            "rounds_executed",
             "grade",
             "failures",
             "metadata",
@@ -227,6 +229,10 @@ def _case_result(value: object) -> CaseResult:
                 else _text(finish_reason_value, "Case Result finish_reason")
             ),
             refusal=_optional_text(raw.get("refusal"), "Case Result refusal"),
+            stop_reason=_stop_reason(raw.get("stop_reason")),
+            rounds_executed=_optional_positive_integer(
+                raw.get("rounds_executed"), "Case Result rounds_executed"
+            ),
             grade=grade,
             failures=failures,
             metadata=_mapping(_required(raw, "metadata", "Case Result"), "Case Result metadata"),
@@ -366,6 +372,10 @@ def _positive_integer(value: object, label: str) -> int:
     return value
 
 
+def _optional_positive_integer(value: object, label: str) -> int | None:
+    return None if value is None else _positive_integer(value, label)
+
+
 def _text(value: object, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ExecutionError(f"{label} must be non-empty text")
@@ -426,6 +436,14 @@ def _case_status(value: object) -> CaseStatus:
     if value == "failed":
         return "failed"
     raise ExecutionError("Case Result status is unsupported")
+
+
+def _stop_reason(value: object) -> StopReason | None:
+    if value is None:
+        return None
+    if value in {"passed", "max_rounds"}:
+        return cast(StopReason, value)
+    raise ExecutionError("Case Result stop_reason must be passed, max_rounds, or null")
 
 
 def _failure_stage(value: object) -> Literal["candidate", "grading", "aggregation"]:

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -669,6 +669,14 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
     # fail criteria for reasons that have nothing to do with the model's knowledge.
     finish = case.finish_reason
     finish_html = _badge(f"finish · {finish}", good=False) if finish and finish != "stop" else ""
+    rounds_html = ""
+    if case.stop_reason is not None and case.rounds_executed is not None:
+        noun = "round" if case.rounds_executed == 1 else "rounds"
+        reason = "passed" if case.stop_reason == "passed" else "round limit"
+        rounds_html = _badge(
+            f"loop · {reason} · {case.rounds_executed} {noun}",
+            good=case.stop_reason == "passed",
+        )
     tags = "".join(
         f"<span class='sf-chip'>{escape(str(key))} · {escape(str(value))}</span>"
         for key, value in (case.metadata or {}).items()
@@ -686,7 +694,7 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
     return (
         "<div class='sf-pane'><div class='sf-pane__h'>"
         f"<span class='sf-report__case-id'>case {escape(str(case.case_id))} · "
-        f"{escape(candidate.name)}</span>{verdict}{finish_html}</div>{tags_html}"
+        f"{escape(candidate.name)}</span>{verdict}{finish_html}{rounds_html}</div>{tags_html}"
         f"{question}{answer_html}{refusal_html}{_case_failures_html(case)}"
         f"{checks_head}{checks}</div>"
     )

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -26,6 +26,7 @@ type CheckOutcome = Literal["MET", "UNMET"]
 # The Engine's explicit per-Case outcome; kept in lock-step with url4-cloud's
 # `benchmarks/contract.py` CaseStatus.
 type CaseStatus = Literal["scored", "refused", "failed"]
+type StopReason = Literal["passed", "max_rounds"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -226,6 +227,8 @@ class CaseResult:
     output: str | None
     finish_reason: str | None
     refusal: str | None
+    stop_reason: StopReason | None
+    rounds_executed: int | None
     grade: CaseGrade | None
     failures: tuple[Failure, ...]
     _metadata: Mapping[str, object] = field(repr=False)
@@ -242,6 +245,8 @@ class CaseResult:
         metadata: Mapping[str, object],
         status: CaseStatus | None = None,
         refusal: str | None = None,
+        stop_reason: StopReason | None = None,
+        rounds_executed: int | None = None,
     ) -> None:
         case_id = _case_id(case_id)
         input = _nonempty_text(input, "Case Result input")
@@ -253,6 +258,7 @@ class CaseResult:
             finish_reason = _nonblank_text(finish_reason, "Case Result finish_reason")
         if refusal is not None:
             refusal = _nonblank_text(refusal, "Case Result refusal")
+        stop_reason, rounds_executed = _validate_execution(stop_reason, rounds_executed)
         selected_failures = tuple(failures)
         if any(not isinstance(item, Failure) for item in selected_failures):
             raise TypeError("Case Result failures must contain sf.Failure values")
@@ -271,6 +277,8 @@ class CaseResult:
             "output": output,
             "finish_reason": finish_reason,
             "refusal": refusal,
+            "stop_reason": stop_reason,
+            "rounds_executed": rounds_executed,
             "grade": grade,
             "failures": selected_failures,
             "_metadata": freeze_mapping(metadata, "Case Result metadata"),
@@ -327,6 +335,8 @@ class CaseResult:
             "output": thaw_json(self.output),
             "finish_reason": self.finish_reason,
             "refusal": self.refusal,
+            "stop_reason": self.stop_reason,
+            "rounds_executed": self.rounds_executed,
             "grade": None if self.grade is None else self.grade.to_dict(),
             "failures": [failure.to_dict() for failure in self.failures],
             "metadata": thaw_mapping(self._metadata),
@@ -363,6 +373,23 @@ def _turn(message: object) -> tuple[str, str] | None:
 
 def _optional_number(value: object, label: str) -> float | None:
     return None if value is None else _required_number(value, label)
+
+
+def _validate_execution(
+    stop_reason: StopReason | None,
+    rounds_executed: int | None,
+) -> tuple[StopReason | None, int | None]:
+    if stop_reason not in {None, "passed", "max_rounds"}:
+        raise ValueError("Case Result stop_reason must be passed, max_rounds, or None")
+    if rounds_executed is not None and (
+        isinstance(rounds_executed, bool)
+        or not isinstance(rounds_executed, int)
+        or rounds_executed < 1
+    ):
+        raise ValueError("Case Result rounds_executed must be a positive integer or None")
+    if (stop_reason is None) != (rounds_executed is None):
+        raise ValueError("Case Result stop_reason and rounds_executed must be present together")
+    return stop_reason, rounds_executed
 
 
 def _optional_check_score(value: object) -> float | None:

--- a/packages/screamingface/tests/test_benchmark_compilation.py
+++ b/packages/screamingface/tests/test_benchmark_compilation.py
@@ -327,6 +327,8 @@ class _Transport:
                             "output": "Answer",
                             "finish_reason": "stop",
                             "refusal": None,
+                            "stop_reason": None,
+                            "rounds_executed": None,
                             "grade": {
                                 "method": "fixture",
                                 "score": 0.8,

--- a/packages/screamingface/tests/test_benchmark_variant_selection.py
+++ b/packages/screamingface/tests/test_benchmark_variant_selection.py
@@ -115,6 +115,8 @@ class _RunTransport:
                             "output": "Answer",
                             "finish_reason": "stop",
                             "refusal": None,
+                            "stop_reason": None,
+                            "rounds_executed": None,
                             "grade": {
                                 "method": "deterministic",
                                 "score": 1.0,

--- a/packages/screamingface/tests/test_candidate_result_coverage.py
+++ b/packages/screamingface/tests/test_candidate_result_coverage.py
@@ -99,6 +99,8 @@ def test_a_refusal_is_normally_graded_without_a_synthetic_failure() -> None:
         "output": None,
         "finish_reason": "content_filter",
         "refusal": "I cannot answer that request.",
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": {
             "method": "deterministic",
             "score": 0.0,
@@ -126,6 +128,8 @@ def test_a_refusal_whose_grading_failed_retains_only_grading_failures() -> None:
         "output": None,
         "finish_reason": "content_filter",
         "refusal": "I cannot answer that request.",
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": {
             "method": "deterministic",
             "score": None,

--- a/packages/screamingface/tests/test_case_outcome_decoding.py
+++ b/packages/screamingface/tests/test_case_outcome_decoding.py
@@ -24,6 +24,8 @@ def _scored_payload() -> dict[str, Any]:
         "output": "Four.",
         "finish_reason": "stop",
         "refusal": None,
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": {"method": "rubric", "score": 1.0, "metrics": {}, "checks": []},
         "failures": [],
         "metadata": {},
@@ -38,6 +40,8 @@ def _refused_payload() -> dict[str, Any]:
         "output": None,
         "finish_reason": "stop",
         "refusal": "I can't help with that request.",
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": {"method": "rubric", "score": 0.0, "metrics": {}, "checks": []},
         "failures": [],
         "metadata": {},
@@ -52,6 +56,8 @@ def _failed_payload() -> dict[str, Any]:
         "output": None,
         "finish_reason": None,
         "refusal": None,
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": None,
         "failures": [
             {
@@ -120,6 +126,31 @@ def test_decoded_outcome_survives_export() -> None:
 
     assert exported["status"] == "refused"
     assert exported["refusal"] == "I can't help with that request."
+
+
+def test_corrective_execution_telemetry_decodes_and_survives_export() -> None:
+    payload = _scored_payload()
+    payload.update(stop_reason="passed", rounds_executed=2)
+
+    case = _case_result(payload)
+
+    assert case.stop_reason == "passed"
+    assert case.rounds_executed == 2
+    assert case.to_dict() == payload
+
+
+@pytest.mark.parametrize(
+    ("stop_reason", "rounds_executed"),
+    [("unknown", 1), ("passed", None), (None, 1), ("max_rounds", 0)],
+)
+def test_malformed_corrective_execution_telemetry_fails_closed(
+    stop_reason: object, rounds_executed: object
+) -> None:
+    payload = _scored_payload()
+    payload.update(stop_reason=stop_reason, rounds_executed=rounds_executed)
+
+    with pytest.raises(sf.ExecutionError, match="stop_reason|rounds_executed"):
+        _case_result(payload)
 
 
 def test_wire_text_and_string_identity_survive_without_normalization() -> None:

--- a/packages/screamingface/tests/test_case_result_contract_boundaries.py
+++ b/packages/screamingface/tests/test_case_result_contract_boundaries.py
@@ -412,6 +412,8 @@ def test_wire_case_result_rejects_a_failure_owned_by_another_case() -> None:
                 "output": None,
                 "finish_reason": None,
                 "refusal": None,
+                "stop_reason": None,
+                "rounds_executed": None,
                 "grade": None,
                 "failures": [
                     {

--- a/packages/screamingface/tests/test_case_results.py
+++ b/packages/screamingface/tests/test_case_results.py
@@ -57,6 +57,8 @@ def test_case_result_serializes_every_observed_fact_losslessly() -> None:
         "output": "Four.",
         "finish_reason": "stop",
         "refusal": None,
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": {
             "method": "rubric",
             "score": 1.0,

--- a/packages/screamingface/tests/test_client_run.py
+++ b/packages/screamingface/tests/test_client_run.py
@@ -208,6 +208,8 @@ class _ReplayTransport:
                             "output": "Fixture answer",
                             "finish_reason": "stop",
                             "refusal": None,
+                            "stop_reason": None,
+                            "rounds_executed": None,
                             "grade": {
                                 "method": "fixture",
                                 "score": 1.0,

--- a/packages/screamingface/tests/test_draco_vertical_slice.py
+++ b/packages/screamingface/tests/test_draco_vertical_slice.py
@@ -120,6 +120,8 @@ def _case_payload(*, score: float = 1.0) -> dict[str, object]:
         "output": "Fixture answer",
         "finish_reason": "stop",
         "refusal": None,
+        "stop_reason": None,
+        "rounds_executed": None,
         "grade": {
             "method": "rubric",
             "score": score,
@@ -819,6 +821,8 @@ def test_candidate_result_decoder_retains_a_normally_graded_refusal() -> None:
                         "output": None,
                         "finish_reason": None,
                         "refusal": "provider refused the request",
+                        "stop_reason": None,
+                        "rounds_executed": None,
                         "grade": {
                             "method": "rubric",
                             "score": 0.0,

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -23,7 +23,14 @@ from screamingface._ui.report_view import (
     _tokens_total,
     report_html,
 )
-from screamingface.case_result import CaseGrade, CaseResult, Check, Evidence, EvidenceProducer
+from screamingface.case_result import (
+    CaseGrade,
+    CaseResult,
+    Check,
+    Evidence,
+    EvidenceProducer,
+    StopReason,
+)
 from screamingface.operation import OperationInfo
 from screamingface.report import BenchmarkInfo, CandidateResult, Report
 
@@ -33,7 +40,13 @@ _METRICS = {"pass_rate": 0.5, "verdicts_expected": 1, "verdicts_accepted": 1}
 _BENCHMARK = BenchmarkInfo("draco/smoke", "74c94830e8de6afd", 1)
 
 
-def case(*, checks: tuple[Check, ...] = (), score: float | None = 0.0) -> CaseResult:
+def case(
+    *,
+    checks: tuple[Check, ...] = (),
+    score: float | None = 0.0,
+    stop_reason: StopReason | None = None,
+    rounds_executed: int | None = None,
+) -> CaseResult:
     return CaseResult(
         case_id=1,
         input="the prompt",
@@ -42,6 +55,8 @@ def case(*, checks: tuple[Check, ...] = (), score: float | None = 0.0) -> CaseRe
         grade=CaseGrade(method="rubric", score=score, metrics={}, checks=list(checks)),
         failures=[],
         metadata={},
+        stop_reason=stop_reason,
+        rounds_executed=rounds_executed,
     )
 
 
@@ -381,6 +396,14 @@ def test_a_refused_case_is_named_and_shows_the_exact_provider_refusal() -> None:
     assert "I cannot provide an answer to that request." in html
     assert "incorrect" not in html
     assert "sf-badge--warn" in html
+
+
+def test_a_corrective_case_names_why_and_when_the_loop_stopped() -> None:
+    corrective = case(stop_reason="passed", rounds_executed=2)
+
+    html = body(report_html(report(candidate("m", 1.0, cases=(corrective,)))))
+
+    assert "loop · passed · 2 rounds" in html
 
 
 def test_partial_grading_evidence_is_presented_as_unscored_not_incorrect() -> None:


### PR DESCRIPTION
Linear: https://linear.app/openmined/issue/OME-827/lift-corrective-loop-substrate-into-generic-ensemble-module-behind-a and https://linear.app/openmined/issue/OME-828/add-correctiveloop-and-selfcorrective-client-recipes-compiling-against

## Summary

- carry one typed corrective execution outcome through the generic Candidate Invocation provenance slot
- preserve stop_reason and rounds_executed through IFEval, DRACO, and HealthBench into the shared CaseResult
- strictly parse, export, and display the fields in the Python client
- report the actual terminal round for early-pass, retry-pass, refusal, and max-round cases
- reject missing DRACO provenance and malformed or unversioned corrective execution envelopes

## Test plan

- url4-cloud full stack gates: Ruff, formatting, Pyright, layering, full tests and coverage
- screamingface full stack gates: Ruff, formatting, Pyright, full tests and coverage, notebooks, build, distribution verification
- focused execution review covers early pass, retry pass, max rounds, selected refusal, ordinary candidates, all three benchmark propagation paths, report/export, and concurrent context isolation

## Confidence-gate note

The append-only test check was deliberately skipped. This strict pre-release v1 wire change requires existing payload fixtures to include explicit null stop_reason and rounds_executed fields. No existing assertion was removed or weakened.