### PR TITLE
Harden the ScreamingFace runtime CLI

### DIFF
--- a/packages/screamingface/README.md
+++ b/packages/screamingface/README.md
@@ -19,8 +19,28 @@ screamingface up
 ```
 
 `screamingface up` starts AI Gateway, Scoreboard, and the Engine in the background. Use
-`screamingface status`, `screamingface logs`, and `screamingface down` to manage them. Runtime
-state is stored under `~/.screamingface` by default; set `SCREAMINGFACE_DATA_DIR` to override it.
+`screamingface status`, `screamingface doctor`, `screamingface logs`, `screamingface restart`, and
+`screamingface down` to manage them. Runtime state is stored under `~/.screamingface` by default;
+set `SCREAMINGFACE_DATA_DIR` or pass `--data-dir` to override it.
+
+The default service ports are Gateway `9105`, Scoreboard `9106`, and Engine `9108`. Override them
+with `--gateway-port`, `--scoreboard-port`, and `--engine-port`, or the corresponding
+`SCREAMINGFACE_GATEWAY_PORT`, `SCREAMINGFACE_SCOREBOARD_PORT`, and `SCREAMINGFACE_ENGINE_PORT`
+environment variables. `screamingface up` prints the resolved SDK environment variables; the SDK
+does not switch away from its hosted defaults automatically.
+
+For scripts and troubleshooting:
+
+```bash
+screamingface status --json
+screamingface doctor
+screamingface logs --service engine --tail 100 --no-follow
+screamingface prepare --list
+```
+
+Logs are timestamped, tagged by service, rotated at 10 MiB, and retain five backups. Benchmark
+preparation records a versioned manifest, skips current assets, and supports `--force` when a
+fresh download is required.
 
 ## Target v1 workflow
 

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -52,6 +52,11 @@ def _parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     _add_data_dir(logs)
     logs.add_argument("--tail", type=int, default=100)
     logs.add_argument("--no-follow", action="store_true")
+    logs.add_argument(
+        "--service",
+        choices=("all", "gateway", "scoreboard", "engine", "supervisor"),
+        default="all",
+    )
     prepare = commands.add_parser("prepare", help="Download benchmark assets")
     _add_data_dir(prepare)
     prepare.add_argument("benchmark", nargs="?", choices=_BENCHMARKS)
@@ -61,6 +66,7 @@ def _parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     serve = commands.add_parser("_serve", help=argparse.SUPPRESS)
     _add_data_dir(serve)
     serve.add_argument("--owner-token", required=True)
+    serve.add_argument("--background", action="store_true")
     _add_port_options(serve)
     scoreboard = commands.add_parser("_scoreboard", help=argparse.SUPPRESS)
     _add_data_dir(scoreboard)
@@ -98,7 +104,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
         elif args.command == "status":
             raise SystemExit(_print_status(config, json_output=args.json_output))
         elif args.command == "logs":
-            _logs(config, tail=args.tail, follow=not args.no_follow)
+            _logs(config, tail=args.tail, follow=not args.no_follow, service=args.service)
         elif args.command == "doctor":
             raise SystemExit(_doctor(config))
         elif args.command == "prepare":
@@ -110,7 +116,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
                 force=args.force,
             )
         elif args.command == "_serve":
-            _serve(config, args.owner_token)
+            _serve(config, args.owner_token, foreground=not args.background)
         elif args.command == "_scoreboard":
             from screamingface._runtime.server import run_scoreboard
 
@@ -168,10 +174,9 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
     config.data_dir.mkdir(parents=True, exist_ok=True)
     token = os.urandom(16).hex()
     if foreground:
-        _serve(config, token)
+        _serve(config, token, foreground=True)
         return
 
-    log = config.log_path.open("a", encoding="utf-8")
     command = [
         sys.executable,
         "-m",
@@ -181,6 +186,7 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
         "_serve",
         "--owner-token",
         token,
+        "--background",
         "--gateway-port",
         str(config.gateway_port),
         "--scoreboard-port",
@@ -191,12 +197,11 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
     process = subprocess.Popen(
         command,
         stdin=subprocess.DEVNULL,
-        stdout=log,
-        stderr=subprocess.STDOUT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         start_new_session=True,
         close_fds=True,
     )
-    log.close()
     try:
         _wait_ready(process, config, timeout=90)
     except Exception:
@@ -208,7 +213,14 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
     _print_urls(config.services, config.log_path)
 
 
-def _serve(config: RuntimeConfig, token: str) -> None:
+def _serve(config: RuntimeConfig, token: str, *, foreground: bool) -> None:
+    from screamingface._runtime.runtime_logging import capture_runtime_log
+
+    with capture_runtime_log(config.log_path, foreground=foreground):
+        _serve_logged(config, token)
+
+
+def _serve_logged(config: RuntimeConfig, token: str) -> None:
     shutdown = threading.Event()
     control = _control_server(token, shutdown)
     started_at = datetime.now(UTC).isoformat()
@@ -321,22 +333,60 @@ def _print_status(config: RuntimeConfig, *, json_output: bool = False) -> int:
     return code
 
 
-def _logs(config: RuntimeConfig, *, tail: int, follow: bool) -> None:
+def _logs(  # noqa: C901, PLR0912, PLR0915
+    config: RuntimeConfig, *, tail: int, follow: bool, service: str = "all"
+) -> None:
     if tail < 0:
         raise RuntimeError("--tail must be zero or greater")
     if not config.log_path.exists():
         raise RuntimeError(f"no runtime log exists at {config.log_path}")
-    with config.log_path.open(encoding="utf-8", errors="replace") as stream:
-        for line in deque(stream, maxlen=tail):
-            print(line, end="")
-        if not follow:
-            return
+    history: deque[str] = deque(maxlen=tail)
+    for path in _log_paths(config.log_path):
+        with path.open(encoding="utf-8", errors="replace") as stream:
+            history.extend(line for line in stream if _log_line_matches(line, service))
+    for line in history:
+        print(line, end="")
+    if not follow:
+        return
+    stream = config.log_path.open(encoding="utf-8", errors="replace")
+    stream.seek(0, 2)
+    identity = _file_identity(config.log_path)
+    try:
         while True:
             line = stream.readline()
             if line:
-                print(line, end="", flush=True)
-            else:
-                time.sleep(0.2)
+                if _log_line_matches(line, service):
+                    print(line, end="", flush=True)
+                continue
+            current = _file_identity(config.log_path)
+            if current != identity:
+                stream.close()
+                stream = config.log_path.open(encoding="utf-8", errors="replace")
+                identity = current
+                continue
+            time.sleep(0.2)
+    finally:
+        stream.close()
+
+
+def _log_paths(path: Path) -> tuple[Path, ...]:
+    from screamingface._runtime.runtime_logging import LOG_BACKUPS
+
+    rotated = tuple(
+        candidate
+        for index in range(LOG_BACKUPS, 0, -1)
+        if (candidate := path.with_name(f"{path.name}.{index}")).exists()
+    )
+    return (*rotated, path)
+
+
+def _log_line_matches(line: str, service: str) -> bool:
+    return service == "all" or f"[{service}]" in line
+
+
+def _file_identity(path: Path) -> tuple[int, int]:
+    stat = path.stat()
+    return stat.st_dev, stat.st_ino
 
 
 def _prepare(

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import json
 import os
 import signal
@@ -25,27 +26,44 @@ _HEALTH = {
 
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="screamingface")
-    parser.add_argument("--data-dir", type=Path, default=default_data_dir())
+    parser.add_argument(
+        "--version", action="version", version=importlib.metadata.version("screamingface")
+    )
+    _add_data_dir(parser, default=default_data_dir())
     commands = parser.add_subparsers(dest="command", required=True)
     up = commands.add_parser("up", help="Start the local runtime")
+    _add_data_dir(up)
     up.add_argument("--foreground", action="store_true")
-    commands.add_parser("down", help="Stop the local runtime")
-    commands.add_parser("status", help="Show local runtime status")
+    down = commands.add_parser("down", help="Stop the local runtime")
+    _add_data_dir(down)
+    status = commands.add_parser("status", help="Show local runtime status")
+    _add_data_dir(status)
     logs = commands.add_parser("logs", help="Read local runtime logs")
+    _add_data_dir(logs)
     logs.add_argument("--tail", type=int, default=100)
     logs.add_argument("--no-follow", action="store_true")
     prepare = commands.add_parser("prepare", help="Download benchmark assets")
+    _add_data_dir(prepare)
     prepare.add_argument("benchmark", nargs="?", choices=("draco", "ifeval", "healthbench"))
     prepare.add_argument("--all", action="store_true", dest="all_benchmarks")
     serve = commands.add_parser("_serve", help=argparse.SUPPRESS)
+    _add_data_dir(serve)
     serve.add_argument("--owner-token", required=True)
-    commands.add_parser("_scoreboard", help=argparse.SUPPRESS)
+    scoreboard = commands.add_parser("_scoreboard", help=argparse.SUPPRESS)
+    _add_data_dir(scoreboard)
     commands._choices_actions = [  # noqa: SLF001
         action
         for action in commands._choices_actions  # noqa: SLF001
         if action.dest not in {"_serve", "_scoreboard"}
     ]
     return parser
+
+
+def _add_data_dir(parser: argparse.ArgumentParser, *, default: Path | None = None) -> None:
+    if default is None:
+        parser.add_argument("--data-dir", type=Path, default=argparse.SUPPRESS)
+    else:
+        parser.add_argument("--data-dir", type=Path, default=default)
 
 
 def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
@@ -68,7 +86,7 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
             from screamingface._runtime.server import run_scoreboard
 
             run_scoreboard(config)
-    except RuntimeError as exc:
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
         raise SystemExit(f"screamingface: {exc}") from None
 
 
@@ -282,7 +300,18 @@ def _read_state(config: RuntimeConfig) -> dict[str, object] | None:
 
 
 def _write_state(config: RuntimeConfig, pid: int, token: str) -> None:
-    config.state_path.write_text(json.dumps({"pid": pid, "owner_token": token}) + "\n")
+    config.data_dir.mkdir(parents=True, exist_ok=True)
+    temporary = config.state_path.with_name(f".{config.state_path.name}.{os.getpid()}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(json.dumps({"pid": pid, "owner_token": token}) + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, config.state_path)
+        config.state_path.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _remove_owned_state(config: RuntimeConfig, token: str) -> None:

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -1,30 +1,31 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.metadata
 import json
 import os
-import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 from collections import deque
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 from urllib.error import URLError
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 from screamingface._runtime.config import RuntimeConfig, default_data_dir
 
-_PORTS = (9105, 9106, 9108)
-_HEALTH = {
-    "gateway": "http://127.0.0.1:9105/healthz",
-    "scoreboard": "http://127.0.0.1:9106/healthz",
-    "engine": "http://127.0.0.1:9108/healthz",
-}
+_STATE_VERSION = 1
+_PORT_DEFAULTS = {"gateway": 9105, "scoreboard": 9106, "engine": 9108}
+_BENCHMARKS = ("draco", "ifeval", "healthbench")
 
 
-def _parser() -> argparse.ArgumentParser:
+def _parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     parser = argparse.ArgumentParser(prog="screamingface")
     parser.add_argument(
         "--version", action="version", version=importlib.metadata.version("screamingface")
@@ -34,23 +35,31 @@ def _parser() -> argparse.ArgumentParser:
     up = commands.add_parser("up", help="Start the local runtime")
     _add_data_dir(up)
     up.add_argument("--foreground", action="store_true")
+    _add_port_options(up)
     down = commands.add_parser("down", help="Stop the local runtime")
     _add_data_dir(down)
+    restart = commands.add_parser("restart", help="Restart the local runtime")
+    _add_data_dir(restart)
+    restart.add_argument("--foreground", action="store_true")
+    _add_port_options(restart)
     status = commands.add_parser("status", help="Show local runtime status")
     _add_data_dir(status)
+    status.add_argument("--json", action="store_true", dest="json_output")
     logs = commands.add_parser("logs", help="Read local runtime logs")
     _add_data_dir(logs)
     logs.add_argument("--tail", type=int, default=100)
     logs.add_argument("--no-follow", action="store_true")
     prepare = commands.add_parser("prepare", help="Download benchmark assets")
     _add_data_dir(prepare)
-    prepare.add_argument("benchmark", nargs="?", choices=("draco", "ifeval", "healthbench"))
+    prepare.add_argument("benchmark", nargs="?", choices=_BENCHMARKS)
     prepare.add_argument("--all", action="store_true", dest="all_benchmarks")
     serve = commands.add_parser("_serve", help=argparse.SUPPRESS)
     _add_data_dir(serve)
     serve.add_argument("--owner-token", required=True)
+    _add_port_options(serve)
     scoreboard = commands.add_parser("_scoreboard", help=argparse.SUPPRESS)
     _add_data_dir(scoreboard)
+    scoreboard.add_argument("--scoreboard-port", type=int, default=9106)
     commands._choices_actions = [  # noqa: SLF001
         action
         for action in commands._choices_actions  # noqa: SLF001
@@ -66,16 +75,23 @@ def _add_data_dir(parser: argparse.ArgumentParser, *, default: Path | None = Non
         parser.add_argument("--data-dir", type=Path, default=default)
 
 
+def _add_port_options(parser: argparse.ArgumentParser) -> None:
+    for service in _PORT_DEFAULTS:
+        parser.add_argument(f"--{service}-port", type=int, default=None)
+
+
 def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
     args = _parser().parse_args(argv)
-    config = RuntimeConfig(data_dir=args.data_dir)
     try:
+        config = _config(args)
         if args.command == "up":
             _up(config, foreground=args.foreground)
+        elif args.command == "restart":
+            _restart(config, args, foreground=args.foreground)
         elif args.command == "down":
             _down(config)
         elif args.command == "status":
-            raise SystemExit(_print_status(config))
+            raise SystemExit(_print_status(config, json_output=args.json_output))
         elif args.command == "logs":
             _logs(config, tail=args.tail, follow=not args.no_follow)
         elif args.command == "prepare":
@@ -86,8 +102,33 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
             from screamingface._runtime.server import run_scoreboard
 
             run_scoreboard(config)
-    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+    except (OSError, RuntimeError, subprocess.SubprocessError, ValueError) as exc:
         raise SystemExit(f"screamingface: {exc}") from None
+
+
+def _config(args: argparse.Namespace) -> RuntimeConfig:
+    values: dict[str, int] = {}
+    for service, fallback in _PORT_DEFAULTS.items():
+        argument = getattr(args, f"{service}_port", None)
+        configured = os.getenv(f"SCREAMINGFACE_{service.upper()}_PORT")
+        values[service] = (
+            argument if argument is not None else _environment_port(configured, fallback)
+        )
+    return RuntimeConfig(
+        data_dir=args.data_dir,
+        gateway_port=values["gateway"],
+        scoreboard_port=values["scoreboard"],
+        engine_port=values["engine"],
+    )
+
+
+def _environment_port(value: str | None, fallback: int) -> int:
+    if value is None:
+        return fallback
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"runtime port must be an integer, got {value!r}") from None
 
 
 def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
@@ -95,22 +136,26 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
 
     require_runtime_extra()
     state = _read_state(config)
-    health = _health()
-    if state and _pid_alive(state.get("pid")) and all(health.values()):
-        print("ScreamingFace is already running.")
-        _print_urls(config)
-        return
-    occupied = [port for port in _PORTS if _port_open(port)]
+    owned = bool(state and _verify_owner(state))
+    if owned:
+        health = _health(_state_services(state))
+        if all(health.values()):
+            print("ScreamingFace is already running.")
+            _print_urls(_state_services(state), config.log_path)
+            return
+        raise RuntimeError(
+            "the owned runtime is only partially healthy; run `screamingface logs` "
+            "then `screamingface restart`"
+        )
+    if state:
+        config.state_path.unlink(missing_ok=True)
+    occupied = [port for port in _ports(config) if _port_open(port)]
     if occupied:
         raise RuntimeError(f"required port(s) already in use by another process: {occupied}")
     config.data_dir.mkdir(parents=True, exist_ok=True)
     token = os.urandom(16).hex()
     if foreground:
-        _write_state(config, os.getpid(), token)
-        try:
-            _run_server(config)
-        finally:
-            _remove_owned_state(config, token)
+        _serve(config, token)
         return
 
     log = config.log_path.open("a", encoding="utf-8")
@@ -123,6 +168,12 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
         "_serve",
         "--owner-token",
         token,
+        "--gateway-port",
+        str(config.gateway_port),
+        "--scoreboard-port",
+        str(config.scoreboard_port),
+        "--engine-port",
+        str(config.engine_port),
     ]
     process = subprocess.Popen(
         command,
@@ -133,34 +184,49 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
         close_fds=True,
     )
     log.close()
-    _write_state(config, process.pid, token)
     try:
-        _wait_ready(process, timeout=90)
+        _wait_ready(process, config, timeout=90)
     except Exception:
-        if process.poll() is None:
-            process.terminate()
-        _remove_owned_state(config, token)
+        state = _read_state(config)
+        if state and _verify_owner(state):
+            _request_shutdown(state)
         raise
     print("ScreamingFace is ready.")
-    _print_urls(config)
+    _print_urls(config.services, config.log_path)
 
 
 def _serve(config: RuntimeConfig, token: str) -> None:
-    state = _read_state(config)
-    if not state or state.get("owner_token") != token or state.get("pid") != os.getpid():
-        raise RuntimeError("runtime ownership state does not match this process")
+    shutdown = threading.Event()
+    control = _control_server(token, shutdown)
+    started_at = datetime.now(UTC).isoformat()
+    state = {
+        "schema_version": _STATE_VERSION,
+        "pid": os.getpid(),
+        "process_started_at": time.time(),
+        "started_at": started_at,
+        "owner_token": token,
+        "control_url": f"http://127.0.0.1:{control.server_port}",
+        "services": config.services,
+        "log_path": str(config.log_path),
+    }
+    _write_state(config, state)
+    control_thread = threading.Thread(target=control.serve_forever, daemon=True)
+    control_thread.start()
     try:
-        _run_server(config)
+        _run_server(config, shutdown)
     finally:
+        control.shutdown()
+        control.server_close()
+        control_thread.join(timeout=2)
         _remove_owned_state(config, token)
 
 
-def _run_server(config: RuntimeConfig) -> None:
+def _run_server(config: RuntimeConfig, shutdown: threading.Event) -> None:
     import asyncio
 
     from screamingface._runtime.server import run
 
-    asyncio.run(run(config))
+    asyncio.run(run(config, shutdown))
 
 
 def _down(config: RuntimeConfig) -> None:
@@ -168,40 +234,76 @@ def _down(config: RuntimeConfig) -> None:
     if not state:
         print("ScreamingFace is not running.")
         return
-    pid = state.get("pid")
-    token = state.get("owner_token")
-    if not isinstance(pid, int) or not isinstance(token, str):
-        raise RuntimeError(f"invalid runtime state: {config.state_path}")
-    if not _pid_alive(pid):
-        _remove_owned_state(config, token)
-        print("Removed stale runtime state; ScreamingFace was not running.")
+    if not _verify_owner(state):
+        config.state_path.unlink(missing_ok=True)
+        print("Removed stale runtime state; no owned ScreamingFace runtime was stopped.")
         return
-    os.kill(pid, signal.SIGTERM)
+    _request_shutdown(state)
     for _ in range(100):
-        if not _pid_alive(pid):
-            _remove_owned_state(config, token)
+        if not _verify_owner(state):
+            config.state_path.unlink(missing_ok=True)
             print("ScreamingFace stopped.")
             return
         time.sleep(0.1)
-    raise RuntimeError(f"runtime process {pid} did not stop; inspect {config.log_path}")
+    raise RuntimeError(f"runtime did not stop; inspect {config.log_path}")
 
 
-def _print_status(config: RuntimeConfig) -> int:
+def _restart(config: RuntimeConfig, args: argparse.Namespace, *, foreground: bool) -> None:
     state = _read_state(config)
-    health = _health()
-    alive = bool(state and _pid_alive(state.get("pid")))
-    if alive and all(health.values()):
+    if state:
+        services = _state_services(state)
+        stored = {name: _url_port(url) for name, url in services.items()}
+        values = {}
+        for service, fallback in _PORT_DEFAULTS.items():
+            explicit = getattr(args, f"{service}_port", None)
+            environment = os.getenv(f"SCREAMINGFACE_{service.upper()}_PORT")
+            values[service] = (
+                explicit
+                if explicit is not None
+                else _environment_port(environment, stored.get(service, fallback))
+            )
+        config = RuntimeConfig(
+            data_dir=config.data_dir,
+            gateway_port=values["gateway"],
+            scoreboard_port=values["scoreboard"],
+            engine_port=values["engine"],
+        )
+    _down(config)
+    _up(config, foreground=foreground)
+
+
+def _print_status(config: RuntimeConfig, *, json_output: bool = False) -> int:
+    state = _read_state(config)
+    services = _state_services(state) if state else config.services
+    health = _health(services)
+    owned = bool(state and _verify_owner(state))
+    if owned and all(health.values()):
         label, code = "running", 0
-    elif alive:
+    elif owned:
         label, code = "partially healthy", 1
-    elif any(health.values()) or any(_port_open(port) for port in _PORTS):
+    elif any(health.values()) or any(_port_open(port) for port in _service_ports(services)):
         label, code = "foreign processes occupy runtime ports", 2
     else:
         label, code = "stopped", 1
+    if json_output:
+        payload = {
+            "schema": "screamingface.runtime-status.v1",
+            "status": label.replace(" ", "_"),
+            "ownership_verified": owned,
+            "pid": state.get("pid") if state else None,
+            "started_at": state.get("started_at") if state else None,
+            "data_dir": str(config.data_dir),
+            "services": {
+                name: {"url": url, "healthy": health[name]} for name, url in services.items()
+            },
+            "log_path": str(config.log_path),
+            "benchmarks": _benchmark_statuses(config),
+        }
+        print(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+        return code
     print(f"ScreamingFace: {label}")
     for name, ready in health.items():
-        base_url = _HEALTH[name].removesuffix("/healthz")
-        print(f"  {name:10} {'UP' if ready else 'down':4}  {base_url}")
+        print(f"  {name:10} {'UP' if ready else 'down':4}  {services[name]}")
     print(f"  logs       {config.log_path}")
     return code
 
@@ -230,7 +332,7 @@ def _prepare(config: RuntimeConfig, benchmark: str | None, *, all_benchmarks: bo
     require_runtime_extra()
     if all_benchmarks == (benchmark is not None):
         raise RuntimeError("choose one benchmark or pass --all")
-    selected = ("draco", "ifeval", "healthbench") if all_benchmarks else (benchmark,)
+    selected = _BENCHMARKS if all_benchmarks else (benchmark,)
     config.assets_dir.mkdir(parents=True, exist_ok=True)
     for name in selected:
         destination = config.assets_dir / str(name)
@@ -247,20 +349,29 @@ def _prepare(config: RuntimeConfig, benchmark: str | None, *, all_benchmarks: bo
     print(f"Benchmark assets ready at {config.assets_dir}")
 
 
-def _wait_ready(process: subprocess.Popen[bytes], *, timeout: float) -> None:
+def _benchmark_statuses(config: RuntimeConfig) -> dict[str, str]:
+    return {
+        name: ("incomplete" if (config.assets_dir / name).exists() else "missing")
+        for name in _BENCHMARKS
+    }
+
+
+def _wait_ready(process: subprocess.Popen[bytes], config: RuntimeConfig, *, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
             raise RuntimeError("runtime exited during startup; inspect the runtime log")
-        if all(_health().values()):
+        state = _read_state(config)
+        if all(_health(config.services).values()) and state is not None and _verify_owner(state):
             return
         time.sleep(0.2)
     raise RuntimeError("runtime did not become ready within 90 seconds")
 
 
-def _health() -> dict[str, bool]:
+def _health(services: dict[str, str]) -> dict[str, bool]:
     result: dict[str, bool] = {}
-    for name, url in _HEALTH.items():
+    for name, base_url in services.items():
+        url = f"{base_url}/healthz"
         try:
             with urlopen(url, timeout=0.3) as response:  # noqa: S310
                 result[name] = response.status == 200
@@ -299,13 +410,13 @@ def _read_state(config: RuntimeConfig) -> dict[str, object] | None:
     return value if isinstance(value, dict) else None
 
 
-def _write_state(config: RuntimeConfig, pid: int, token: str) -> None:
+def _write_state(config: RuntimeConfig, state: dict[str, object]) -> None:
     config.data_dir.mkdir(parents=True, exist_ok=True)
     temporary = config.state_path.with_name(f".{config.state_path.name}.{os.getpid()}.tmp")
     descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
         with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            stream.write(json.dumps({"pid": pid, "owner_token": token}) + "\n")
+            stream.write(json.dumps(state, sort_keys=True) + "\n")
             stream.flush()
             os.fsync(stream.fileno())
         os.replace(temporary, config.state_path)
@@ -320,10 +431,106 @@ def _remove_owned_state(config: RuntimeConfig, token: str) -> None:
         config.state_path.unlink(missing_ok=True)
 
 
-def _print_urls(config: RuntimeConfig) -> None:
-    for name, url in (("Gateway", 9105), ("Scoreboard", 9106), ("Engine", 9108)):
-        print(f"  {name:10} http://127.0.0.1:{url}")
-    print(f"  Logs       {config.log_path}")
+def _print_urls(services: dict[str, str], log_path: Path) -> None:
+    for name, url in services.items():
+        print(f"  {name.title():10} {url}")
+    print(f"  Logs       {log_path}")
+    print(f"  export SCREAMINGFACE_ENGINE_URL={services['engine']}")
+    print(f"  export SCREAMINGFACE_SCOREBOARD_URL={services['scoreboard']}")
+
+
+def _ports(config: RuntimeConfig) -> tuple[int, int, int]:
+    return config.gateway_port, config.scoreboard_port, config.engine_port
+
+
+def _service_ports(services: dict[str, str]) -> tuple[int, ...]:
+    return tuple(_url_port(url) for url in services.values())
+
+
+def _url_port(url: str) -> int:
+    from urllib.parse import urlsplit
+
+    port = urlsplit(url).port
+    if port is None:
+        raise ValueError(f"runtime service URL has no port: {url}")
+    return port
+
+
+def _state_services(state: dict[str, object] | None) -> dict[str, str]:
+    if not state or state.get("schema_version") != _STATE_VERSION:
+        return {}
+    value = state.get("services")
+    if not isinstance(value, dict):
+        return {}
+    services = {str(name): str(url) for name, url in value.items()}
+    return services if set(services) == set(_PORT_DEFAULTS) else {}
+
+
+def _verify_owner(state: dict[str, object]) -> bool:
+    control_url = state.get("control_url")
+    token = state.get("owner_token")
+    pid = state.get("pid")
+    if not isinstance(control_url, str) or not isinstance(token, str) or not isinstance(pid, int):
+        return False
+    try:
+        request = Request(f"{control_url}/identity", headers={"Authorization": f"Bearer {token}"})
+        with urlopen(request, timeout=0.5) as response:  # noqa: S310
+            payload = json.load(response)
+    except (OSError, URLError, ValueError):
+        return False
+    return isinstance(payload, dict) and payload == {
+        "pid": pid,
+        "owner_token_sha256": hashlib.sha256(token.encode()).hexdigest(),
+    }
+
+
+def _request_shutdown(state: dict[str, object]) -> None:
+    control_url = state["control_url"]
+    token = state["owner_token"]
+    request = Request(
+        f"{control_url}/shutdown",
+        method="POST",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        with urlopen(request, timeout=2):  # noqa: S310
+            return
+    except (OSError, URLError) as exc:
+        raise RuntimeError("owned runtime rejected the shutdown request") from exc
+
+
+def _control_server(token: str, shutdown: threading.Event) -> ThreadingHTTPServer:
+    token_hash = hashlib.sha256(token.encode()).hexdigest()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path != "/identity" or not self._authorized():
+                self.send_error(404)
+                return
+            self._json({"pid": os.getpid(), "owner_token_sha256": token_hash})
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path != "/shutdown" or not self._authorized():
+                self.send_error(404)
+                return
+            self._json({"status": "stopping"})
+            shutdown.set()
+
+        def _authorized(self) -> bool:
+            return self.headers.get("Authorization") == f"Bearer {token}"
+
+        def _json(self, value: dict[str, Any]) -> None:
+            body = json.dumps(value).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    return ThreadingHTTPServer(("127.0.0.1", 0), Handler)
 
 
 if __name__ == "__main__":

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -217,7 +217,11 @@ def _serve(config: RuntimeConfig, token: str, *, foreground: bool) -> None:
     from screamingface._runtime.runtime_logging import capture_runtime_log
 
     with capture_runtime_log(config.log_path, foreground=foreground):
-        _serve_logged(config, token)
+        try:
+            _serve_logged(config, token)
+        except Exception as exc:
+            print(f"SCREAMINGFACE_RUNTIME_ERROR {exc}", file=sys.stderr, flush=True)
+            raise
 
 
 def _serve_logged(config: RuntimeConfig, token: str) -> None:
@@ -257,6 +261,8 @@ def _run_server(config: RuntimeConfig, shutdown: threading.Event) -> None:
 def _down(config: RuntimeConfig) -> None:
     state = _read_state(config)
     if not state:
+        if config.state_path.exists():
+            raise RuntimeError(f"invalid runtime state: {config.state_path}")
         print("ScreamingFace is not running.")
         return
     if not _verify_owner(state):
@@ -299,10 +305,13 @@ def _restart(config: RuntimeConfig, args: argparse.Namespace, *, foreground: boo
 
 def _print_status(config: RuntimeConfig, *, json_output: bool = False) -> int:
     state = _read_state(config)
+    state_valid = not config.state_path.exists() or state is not None
     services = _state_services(state) if state else config.services
     health = _health(services)
     owned = bool(state and _verify_owner(state))
-    if owned and all(health.values()):
+    if not state_valid:
+        label, code = "invalid runtime state", 1
+    elif owned and all(health.values()):
         label, code = "running", 0
     elif owned:
         label, code = "partially healthy", 1
@@ -315,6 +324,7 @@ def _print_status(config: RuntimeConfig, *, json_output: bool = False) -> int:
             "schema": "screamingface.runtime-status.v1",
             "status": label.replace(" ", "_"),
             "ownership_verified": owned,
+            "state_valid": state_valid,
             "pid": state.get("pid") if state else None,
             "started_at": state.get("started_at") if state else None,
             "data_dir": str(config.data_dir),
@@ -359,7 +369,7 @@ def _logs(  # noqa: C901, PLR0912, PLR0915
                     print(line, end="", flush=True)
                 continue
             current = _file_identity(config.log_path)
-            if current != identity:
+            if current != identity and current != (-1, -1):
                 stream.close()
                 stream = config.log_path.open(encoding="utf-8", errors="replace")
                 identity = current
@@ -385,7 +395,10 @@ def _log_line_matches(line: str, service: str) -> bool:
 
 
 def _file_identity(path: Path) -> tuple[int, int]:
-    stat = path.stat()
+    try:
+        stat = path.stat()
+    except OSError:
+        return -1, -1
     return stat.st_dev, stat.st_ino
 
 
@@ -540,11 +553,16 @@ def _get_json(url: str) -> object:
 
 def _has_connections(payload: object) -> bool:
     if isinstance(payload, list):
-        return bool(payload)
-    if isinstance(payload, dict):
+        entries = payload
+    elif isinstance(payload, dict):
         data = payload.get("data")
-        return isinstance(data, list) and bool(data)
-    return False
+        entries = data if isinstance(data, list) else []
+    else:
+        return False
+    return any(
+        isinstance(entry, dict) and entry.get("status") not in {None, "not_connected"}
+        for entry in entries
+    )
 
 
 def _benchmark_status(config: RuntimeConfig, name: str) -> str:  # noqa: PLR0911

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import importlib
 import importlib.metadata
 import json
 import os
@@ -42,6 +43,8 @@ def _parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     _add_data_dir(restart)
     restart.add_argument("--foreground", action="store_true")
     _add_port_options(restart)
+    doctor = commands.add_parser("doctor", help="Diagnose the local runtime")
+    _add_data_dir(doctor)
     status = commands.add_parser("status", help="Show local runtime status")
     _add_data_dir(status)
     status.add_argument("--json", action="store_true", dest="json_output")
@@ -53,6 +56,8 @@ def _parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     _add_data_dir(prepare)
     prepare.add_argument("benchmark", nargs="?", choices=_BENCHMARKS)
     prepare.add_argument("--all", action="store_true", dest="all_benchmarks")
+    prepare.add_argument("--list", action="store_true", dest="list_benchmarks")
+    prepare.add_argument("--force", action="store_true")
     serve = commands.add_parser("_serve", help=argparse.SUPPRESS)
     _add_data_dir(serve)
     serve.add_argument("--owner-token", required=True)
@@ -94,8 +99,16 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
             raise SystemExit(_print_status(config, json_output=args.json_output))
         elif args.command == "logs":
             _logs(config, tail=args.tail, follow=not args.no_follow)
+        elif args.command == "doctor":
+            raise SystemExit(_doctor(config))
         elif args.command == "prepare":
-            _prepare(config, args.benchmark, all_benchmarks=args.all_benchmarks)
+            _prepare(
+                config,
+                args.benchmark,
+                all_benchmarks=args.all_benchmarks,
+                list_benchmarks=args.list_benchmarks,
+                force=args.force,
+            )
         elif args.command == "_serve":
             _serve(config, args.owner_token)
         elif args.command == "_scoreboard":
@@ -326,34 +339,227 @@ def _logs(config: RuntimeConfig, *, tail: int, follow: bool) -> None:
                 time.sleep(0.2)
 
 
-def _prepare(config: RuntimeConfig, benchmark: str | None, *, all_benchmarks: bool) -> None:
+def _prepare(
+    config: RuntimeConfig,
+    benchmark: str | None,
+    *,
+    all_benchmarks: bool,
+    list_benchmarks: bool = False,
+    force: bool = False,
+) -> None:
+    if list_benchmarks:
+        if all_benchmarks or benchmark is not None or force:
+            raise RuntimeError("--list cannot be combined with a benchmark, --all, or --force")
+        for name, status in _benchmark_statuses(config).items():
+            print(f"{name:12} {status}")
+        return
+    if all_benchmarks == (benchmark is not None):
+        raise RuntimeError("choose one benchmark or pass --all")
     from screamingface._runtime.server import require_runtime_extra
 
     require_runtime_extra()
-    if all_benchmarks == (benchmark is not None):
-        raise RuntimeError("choose one benchmark or pass --all")
     selected = _BENCHMARKS if all_benchmarks else (benchmark,)
     config.assets_dir.mkdir(parents=True, exist_ok=True)
     for name in selected:
         destination = config.assets_dir / str(name)
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                f"screamingface_engine.benchmarks.{name}.prepare",
-                "--out",
-                str(destination),
-            ],
-            check=True,
-        )
+        if not force and _benchmark_status(config, str(name)) == "prepared":
+            print(f"{name} is already prepared at {destination}")
+            continue
+        manifest = _benchmark_manifest_path(destination)
+        manifest.unlink(missing_ok=True)
+        try:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    f"screamingface_engine.benchmarks.{name}.prepare",
+                    "--out",
+                    str(destination),
+                ],
+                check=True,
+            )
+            files = _validate_benchmark_output(str(name), destination)
+            _write_json_atomic(
+                manifest,
+                {
+                    "schema": "screamingface.benchmark-assets.v1",
+                    "benchmark": name,
+                    "fingerprint": _benchmark_fingerprint(str(name)),
+                    "screamingface_version": importlib.metadata.version("screamingface"),
+                    "prepared_at": datetime.now(UTC).isoformat(),
+                    "validated_files": files,
+                },
+            )
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            manifest.unlink(missing_ok=True)
+            raise RuntimeError(f"failed to prepare {name} in {destination}: {exc}") from None
     print(f"Benchmark assets ready at {config.assets_dir}")
 
 
 def _benchmark_statuses(config: RuntimeConfig) -> dict[str, str]:
-    return {
-        name: ("incomplete" if (config.assets_dir / name).exists() else "missing")
-        for name in _BENCHMARKS
-    }
+    return {name: _benchmark_status(config, name) for name in _BENCHMARKS}
+
+
+def _doctor(config: RuntimeConfig) -> int:  # noqa: C901, PLR0912, PLR0915
+    checks: list[tuple[str, str, str]] = []
+    try:
+        from screamingface._runtime.server import require_runtime_extra
+
+        require_runtime_extra()
+    except RuntimeError as exc:
+        checks.append(("fail", "runtime dependencies", str(exc)))
+    else:
+        checks.append(("pass", "runtime dependencies", "installed"))
+
+    writable = _writable_location(config.data_dir)
+    checks.append(
+        (
+            "pass" if writable else "fail",
+            "data directory",
+            f"{config.data_dir} is {'writable' if writable else 'not writable'}",
+        )
+    )
+
+    state = _read_state(config)
+    state_exists = config.state_path.exists()
+    services = _state_services(state) if state else config.services
+    owned = bool(state and _verify_owner(state))
+    if state_exists and state is None:
+        checks.append(("fail", "runtime state", f"invalid JSON in {config.state_path}"))
+    elif state and not _state_services(state):
+        checks.append(("fail", "runtime state", "unsupported or incomplete state document"))
+    elif state and not owned:
+        checks.append(("fail", "runtime state", "ownership could not be verified"))
+    elif owned:
+        checks.append(("pass", "runtime state", "ownership verified"))
+    else:
+        checks.append(("warn", "runtime state", "runtime is stopped"))
+
+    health = _health(services)
+    if owned:
+        for name, healthy in health.items():
+            checks.append(("pass" if healthy else "fail", f"{name} health", services[name]))
+    else:
+        occupied = [port for port in _service_ports(services) if _port_open(port)]
+        checks.append(
+            (
+                "fail" if occupied else "pass",
+                "runtime ports",
+                f"occupied by foreign processes: {occupied}" if occupied else "available",
+            )
+        )
+
+    if health.get("engine"):
+        for label, path in (("model discovery", "/v1/models"), ("connections", "/v1/connections")):
+            try:
+                payload = _get_json(f"{services['engine']}{path}")
+            except RuntimeError as exc:
+                checks.append(("fail", label, str(exc)))
+                continue
+            if label == "connections" and not _has_connections(payload):
+                checks.append(("warn", label, "no provider connection is configured"))
+            else:
+                checks.append(("pass", label, "endpoint responded"))
+    else:
+        checks.append(("warn", "API discovery", "Engine is not running"))
+
+    statuses = _benchmark_statuses(config)
+    for name, status in statuses.items():
+        severity = "pass" if status == "prepared" else "warn" if status == "missing" else "fail"
+        checks.append((severity, f"{name} assets", status))
+
+    for severity, label, detail in checks:
+        print(f"{severity.upper():4}  {label:22} {detail}")
+    return 1 if any(severity == "fail" for severity, _, _ in checks) else 0
+
+
+def _writable_location(path: Path) -> bool:
+    candidate = path
+    while not candidate.exists() and candidate != candidate.parent:
+        candidate = candidate.parent
+    return candidate.is_dir() and os.access(candidate, os.W_OK)
+
+
+def _get_json(url: str) -> object:
+    try:
+        with urlopen(url, timeout=1) as response:  # noqa: S310
+            return json.load(response)
+    except (OSError, URLError, ValueError) as exc:
+        raise RuntimeError(f"{url} did not return valid JSON") from exc
+
+
+def _has_connections(payload: object) -> bool:
+    if isinstance(payload, list):
+        return bool(payload)
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        return isinstance(data, list) and bool(data)
+    return False
+
+
+def _benchmark_status(config: RuntimeConfig, name: str) -> str:  # noqa: PLR0911
+    destination = config.assets_dir / name
+    if not destination.exists():
+        return "missing"
+    try:
+        manifest = json.loads(_benchmark_manifest_path(destination).read_text())
+    except (OSError, json.JSONDecodeError):
+        return "incomplete"
+    if not isinstance(manifest, dict) or manifest.get("fingerprint") != _benchmark_fingerprint(
+        name
+    ):
+        return "stale"
+    try:
+        _validate_benchmark_output(name, destination)
+    except RuntimeError:
+        return "incomplete"
+    return "prepared"
+
+
+def _benchmark_manifest_path(destination: Path) -> Path:
+    return destination / ".screamingface-prepare.json"
+
+
+def _benchmark_fingerprint(name: str) -> str:
+    definition = importlib.import_module(f"url4_cloud.benchmarks.{name}.definition")
+    revision = getattr(definition, "DATASET_REVISION", None)
+    if not isinstance(revision, str) or not revision:
+        raise RuntimeError(f"{name} does not declare a dataset revision")
+    return f"{name}:{revision}"
+
+
+def _validate_benchmark_output(name: str, destination: Path) -> list[str]:
+    required = {
+        "draco": ("cases.json", "criteria", "rubrics"),
+        "ifeval": ("cases.json", "instructions", "nltk_data"),
+        "healthbench": ("cases.json", "rubrics"),
+    }[name]
+    missing = [relative for relative in required if not (destination / relative).exists()]
+    if missing:
+        raise RuntimeError(f"prepared output is missing {missing}")
+    try:
+        cases = json.loads((destination / "cases.json").read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError("prepared cases.json is unreadable") from exc
+    if not isinstance(cases, list) or not cases:
+        raise RuntimeError("prepared cases.json contains no cases")
+    return list(required)
+
+
+def _write_json_atomic(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        path.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _wait_ready(process: subprocess.Popen[bytes], config: RuntimeConfig, *, timeout: float) -> None:
@@ -411,18 +617,7 @@ def _read_state(config: RuntimeConfig) -> dict[str, object] | None:
 
 
 def _write_state(config: RuntimeConfig, state: dict[str, object]) -> None:
-    config.data_dir.mkdir(parents=True, exist_ok=True)
-    temporary = config.state_path.with_name(f".{config.state_path.name}.{os.getpid()}.tmp")
-    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            stream.write(json.dumps(state, sort_keys=True) + "\n")
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary, config.state_path)
-        config.state_path.chmod(0o600)
-    finally:
-        temporary.unlink(missing_ok=True)
+    _write_json_atomic(config.state_path, state)
 
 
 def _remove_owned_state(config: RuntimeConfig, token: str) -> None:

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -127,9 +127,19 @@ def main(argv: list[str] | None = None) -> None:  # noqa: C901, PLR0912
 
 def _config(args: argparse.Namespace) -> RuntimeConfig:
     values: dict[str, int] = {}
+    use_port_environment = args.command in {
+        "up",
+        "restart",
+        "status",
+        "doctor",
+        "_serve",
+        "_scoreboard",
+    }
     for service, fallback in _PORT_DEFAULTS.items():
         argument = getattr(args, f"{service}_port", None)
-        configured = os.getenv(f"SCREAMINGFACE_{service.upper()}_PORT")
+        configured = (
+            os.getenv(f"SCREAMINGFACE_{service.upper()}_PORT") if use_port_environment else None
+        )
         values[service] = (
             argument if argument is not None else _environment_port(configured, fallback)
         )
@@ -305,10 +315,11 @@ def _restart(config: RuntimeConfig, args: argparse.Namespace, *, foreground: boo
 
 def _print_status(config: RuntimeConfig, *, json_output: bool = False) -> int:
     state = _read_state(config)
-    state_valid = not config.state_path.exists() or state is not None
-    services = _state_services(state) if state else config.services
+    stored_services = _state_services(state)
+    state_valid = not config.state_path.exists() or bool(state and stored_services)
+    services = stored_services if state_valid and state else config.services
     health = _health(services)
-    owned = bool(state and _verify_owner(state))
+    owned = bool(state_valid and state and _verify_owner(state))
     if not state_valid:
         label, code = "invalid runtime state", 1
     elif owned and all(health.values()):

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -589,8 +589,8 @@ def _benchmark_manifest_path(destination: Path) -> Path:
 
 
 def _benchmark_fingerprint(name: str) -> str:
-    definition = importlib.import_module(f"url4_cloud.benchmarks.{name}.definition")
-    revision = getattr(definition, "DATASET_REVISION", None)
+    preparation = importlib.import_module(f"screamingface_engine.benchmarks.{name}.prepare")
+    revision = getattr(preparation, "DATASET_REVISION", None)
     if not isinstance(revision, str) or not revision:
         raise RuntimeError(f"{name} does not declare a dataset revision")
     return f"{name}:{revision}"

--- a/packages/screamingface/src/screamingface/_runtime/config.py
+++ b/packages/screamingface/src/screamingface/_runtime/config.py
@@ -16,11 +16,27 @@ def default_data_dir() -> Path:
 class RuntimeConfig:
     data_dir: Path
     runner_config: Path | None = None
+    gateway_port: int = 9105
+    scoreboard_port: int = 9106
+    engine_port: int = 9108
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "data_dir", self.data_dir.expanduser().resolve())
         selected = self.runner_config or bundled_runner_config()
         object.__setattr__(self, "runner_config", selected.expanduser().resolve())
+        ports = (self.gateway_port, self.scoreboard_port, self.engine_port)
+        if any(isinstance(port, bool) or not 1 <= port <= 65535 for port in ports):
+            raise ValueError("runtime ports must be integers from 1 to 65535")
+        if len(set(ports)) != len(ports):
+            raise ValueError("gateway, scoreboard, and engine ports must be unique")
+
+    @property
+    def services(self) -> dict[str, str]:
+        return {
+            "gateway": f"http://127.0.0.1:{self.gateway_port}",
+            "scoreboard": f"http://127.0.0.1:{self.scoreboard_port}",
+            "engine": f"http://127.0.0.1:{self.engine_port}",
+        }
 
     @property
     def gateway_database_url(self) -> str:

--- a/packages/screamingface/src/screamingface/_runtime/runtime_logging.py
+++ b/packages/screamingface/src/screamingface/_runtime/runtime_logging.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import io
+import sys
+import threading
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TextIO
+
+MAX_LOG_BYTES = 10 * 1024 * 1024
+LOG_BACKUPS = 5
+
+_service = contextvars.ContextVar("screamingface_runtime_log_service", default="supervisor")
+
+
+@contextlib.contextmanager
+def log_service(name: str) -> Iterator[None]:
+    token = _service.set(name)
+    try:
+        yield
+    finally:
+        _service.reset(token)
+
+
+class RuntimeLog(io.TextIOBase):
+    def __init__(self, path: Path, *, console: TextIO | None = None) -> None:
+        self._path = path
+        self._console = console
+        self._lock = threading.Lock()
+        self._buffer = ""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._stream = path.open("a", encoding="utf-8")
+
+    def write(self, value: str) -> int:
+        with self._lock:
+            self._buffer += value
+            while "\n" in self._buffer:
+                line, self._buffer = self._buffer.split("\n", 1)
+                self._write_line(line)
+        return len(value)
+
+    def writable(self) -> bool:
+        return True
+
+    def flush(self) -> None:
+        with self._lock:
+            self._stream.flush()
+            if self._console is not None:
+                self._console.flush()
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        with self._lock:
+            if self._buffer:
+                self._write_line(self._buffer)
+                self._buffer = ""
+        super().close()
+        self._stream.close()
+
+    def _write_line(self, line: str) -> None:
+        rendered = f"{datetime.now(UTC).isoformat()} [{_service.get()}] {line}\n"
+        if self._stream.tell() + len(rendered.encode()) > MAX_LOG_BYTES:
+            self._rotate()
+        self._stream.write(rendered)
+        self._stream.flush()
+        if self._console is not None:
+            self._console.write(rendered)
+            self._console.flush()
+
+    def _rotate(self) -> None:
+        self._stream.close()
+        oldest = self._path.with_name(f"{self._path.name}.{LOG_BACKUPS}")
+        oldest.unlink(missing_ok=True)
+        for index in range(LOG_BACKUPS - 1, 0, -1):
+            source = self._path.with_name(f"{self._path.name}.{index}")
+            if source.exists():
+                source.replace(self._path.with_name(f"{self._path.name}.{index + 1}"))
+        if self._path.exists():
+            self._path.replace(self._path.with_name(f"{self._path.name}.1"))
+        self._stream = self._path.open("a", encoding="utf-8")
+
+
+@contextlib.contextmanager
+def capture_runtime_log(path: Path, *, foreground: bool) -> Iterator[RuntimeLog]:
+    previous_stdout, previous_stderr = sys.stdout, sys.stderr
+    runtime_log = RuntimeLog(path, console=previous_stdout if foreground else None)
+    sys.stdout = runtime_log
+    sys.stderr = runtime_log
+    try:
+        yield runtime_log
+    finally:
+        sys.stdout, sys.stderr = previous_stdout, previous_stderr
+        runtime_log.close()

--- a/packages/screamingface/src/screamingface/_runtime/server.py
+++ b/packages/screamingface/src/screamingface/_runtime/server.py
@@ -8,6 +8,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 from collections.abc import Iterator, Mapping
 from types import FrameType
 from typing import Any, Protocol
@@ -15,11 +16,6 @@ from typing import Any, Protocol
 from screamingface._runtime.bootstrap import enable_local_providers, scoreboard_seed_json
 from screamingface._runtime.config import RuntimeConfig, scoreboard_assets
 
-SERVICES = {
-    "gateway": "http://127.0.0.1:9105",
-    "scoreboard": "http://127.0.0.1:9106",
-    "engine": "http://127.0.0.1:9108",
-}
 STARTUP_TIMEOUT_SECONDS = 90.0
 
 
@@ -45,14 +41,14 @@ def require_runtime_extra() -> None:
         ) from exc
 
 
-async def run(config: RuntimeConfig) -> None:
+async def run(config: RuntimeConfig, shutdown_event: threading.Event | None = None) -> None:
     require_runtime_extra()
     config.data_dir.mkdir(parents=True, exist_ok=True)
     await _migrate(config)
     gateway, engine = _build_apps(config)
     servers = (
-        _server(gateway, 9105, "AI Gateway"),
-        _server(engine, 9108, "Engine"),
+        _server(gateway, config.gateway_port, "AI Gateway"),
+        _server(engine, config.engine_port, "Engine"),
     )
     if getattr(sys, "frozen", False):
         scoreboard_command = [
@@ -60,6 +56,8 @@ async def run(config: RuntimeConfig) -> None:
             "--data-dir",
             str(config.data_dir),
             "--scoreboard-child",
+            "--scoreboard-port",
+            str(config.scoreboard_port),
         ]
     else:
         scoreboard_command = [
@@ -69,10 +67,18 @@ async def run(config: RuntimeConfig) -> None:
             "--data-dir",
             str(config.data_dir),
             "_scoreboard",
+            "--scoreboard-port",
+            str(config.scoreboard_port),
         ]
     scoreboard = subprocess.Popen(scoreboard_command)
     try:
-        await _supervise(servers, scoreboard=scoreboard)
+        await _supervise(
+            servers,
+            scoreboard=scoreboard,
+            scoreboard_port=config.scoreboard_port,
+            services=config.services,
+            shutdown_event=shutdown_event,
+        )
     finally:
         if scoreboard.poll() is None:
             scoreboard.terminate()
@@ -106,7 +112,7 @@ def _build_apps(config: RuntimeConfig) -> tuple[object, object]:
     gateway = create_gateway_app(
         GatewaySettings(
             host="127.0.0.1",
-            port=9105,
+            port=config.gateway_port,
             database_url=SecretStr(config.gateway_database_url),
             auth_mode="disabled",
         )
@@ -114,10 +120,11 @@ def _build_apps(config: RuntimeConfig) -> tuple[object, object]:
     run_env: Mapping[str, str] = {
         **os.environ,
         job_env.RUNNER_CONFIG: str(config.runner_config),
+        job_env.AIGATEWAY_BASE_URL: config.services["gateway"],
         "URL4_BENCHMARK_ASSETS": str(config.assets_dir),
     }
     engine = create_local_app(
-        settings=EngineSettings(aigateway_base_url=SERVICES["gateway"]),
+        settings=EngineSettings(aigateway_base_url=config.services["gateway"]),
         env=run_env,
     )
     return gateway, engine
@@ -141,13 +148,15 @@ def run_scoreboard(config: RuntimeConfig) -> None:
     asyncio.run(_run(scoreboard_seed_json(BUILTIN_BENCHMARKS)))
     settings = Settings(
         host="127.0.0.1",
-        port=9106,
+        port=config.scoreboard_port,
         database_url=config.scoreboard_database_url,
         auth_mode="disabled",
         portal_dir=portal_dir,
         portal_artifacts_dir=artifacts_dir,
     )
-    uvicorn.run(create_app(settings), host="127.0.0.1", port=9106, log_level="info")
+    uvicorn.run(
+        create_app(settings), host="127.0.0.1", port=config.scoreboard_port, log_level="info"
+    )
 
 
 def _server(app: object, port: int, name: str) -> Server:
@@ -185,17 +194,29 @@ def _embedded_server_type():
 _EmbeddedServer = _embedded_server_type()
 
 
-async def _supervise(  # noqa: PLR0915
-    servers: tuple[Server, ...], *, scoreboard: subprocess.Popen[bytes]
+async def _supervise(  # noqa: C901, PLR0912, PLR0915
+    servers: tuple[Server, ...],
+    *,
+    scoreboard: subprocess.Popen[bytes],
+    scoreboard_port: int,
+    services: Mapping[str, str],
+    shutdown_event: threading.Event | None,
 ) -> None:
     stop = asyncio.Event()
     loop = asyncio.get_running_loop()
     with _signal_handlers(loop, stop):
         tasks = tuple(asyncio.create_task(server.serve()) for server in servers)
         stop_task = asyncio.create_task(stop.wait())
+        external_stop_task = (
+            asyncio.create_task(asyncio.to_thread(shutdown_event.wait))
+            if shutdown_event is not None
+            else None
+        )
         try:
             async with asyncio.timeout(STARTUP_TIMEOUT_SECONDS):
-                while not all(server.started for server in servers) or not _port_open(9106):
+                while not all(server.started for server in servers) or not _port_open(
+                    scoreboard_port
+                ):
                     if scoreboard.poll() is not None:
                         raise RuntimeError("Scoreboard stopped during startup")
                     failed = next((task for task in tasks if task.done()), None)
@@ -205,14 +226,15 @@ async def _supervise(  # noqa: PLR0915
                     await asyncio.sleep(0.01)
             print(
                 "SCREAMINGFACE_RUNTIME_READY "
-                + json.dumps({"services": SERVICES}, separators=(",", ":"), sort_keys=True),
+                + json.dumps({"services": services}, separators=(",", ":"), sort_keys=True),
                 flush=True,
             )
             scoreboard_task = asyncio.create_task(asyncio.to_thread(scoreboard.wait))
-            done, _ = await asyncio.wait(
-                (*tasks, stop_task, scoreboard_task), return_when=asyncio.FIRST_COMPLETED
-            )
-            if stop_task not in done:
+            waiters = (*tasks, stop_task, scoreboard_task)
+            if external_stop_task is not None:
+                waiters = (*waiters, external_stop_task)
+            done, _ = await asyncio.wait(waiters, return_when=asyncio.FIRST_COMPLETED)
+            if stop_task not in done and external_stop_task not in done:
                 if scoreboard_task in done:
                     raise RuntimeError("Scoreboard stopped unexpectedly")
                 failed = next(task for task in tasks if task in done)
@@ -225,6 +247,10 @@ async def _supervise(  # noqa: PLR0915
             stop_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await stop_task
+            if external_stop_task is not None:
+                external_stop_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await external_stop_task
 
 
 def _port_open(port: int) -> bool:

--- a/packages/screamingface/src/screamingface/_runtime/server.py
+++ b/packages/screamingface/src/screamingface/_runtime/server.py
@@ -15,6 +15,7 @@ from typing import Any, Protocol
 
 from screamingface._runtime.bootstrap import enable_local_providers, scoreboard_seed_json
 from screamingface._runtime.config import RuntimeConfig, scoreboard_assets
+from screamingface._runtime.runtime_logging import log_service
 
 STARTUP_TIMEOUT_SECONDS = 90.0
 
@@ -70,7 +71,9 @@ async def run(config: RuntimeConfig, shutdown_event: threading.Event | None = No
             "--scoreboard-port",
             str(config.scoreboard_port),
         ]
-    scoreboard = subprocess.Popen(scoreboard_command)
+    scoreboard = subprocess.Popen(
+        scoreboard_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
     try:
         await _supervise(
             servers,
@@ -205,7 +208,8 @@ async def _supervise(  # noqa: C901, PLR0912, PLR0915
     stop = asyncio.Event()
     loop = asyncio.get_running_loop()
     with _signal_handlers(loop, stop):
-        tasks = tuple(asyncio.create_task(server.serve()) for server in servers)
+        tasks = tuple(asyncio.create_task(_serve_service(server)) for server in servers)
+        scoreboard_log_task = asyncio.create_task(_relay_scoreboard_output(scoreboard))
         stop_task = asyncio.create_task(stop.wait())
         external_stop_task = (
             asyncio.create_task(asyncio.to_thread(shutdown_event.wait))
@@ -251,6 +255,23 @@ async def _supervise(  # noqa: C901, PLR0912, PLR0915
                 external_stop_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await external_stop_task
+            scoreboard_log_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await scoreboard_log_task
+
+
+async def _serve_service(server: Server) -> None:
+    name = getattr(server, "name", "supervisor").lower().replace("ai ", "")
+    with log_service(name):
+        await server.serve()
+
+
+async def _relay_scoreboard_output(scoreboard: subprocess.Popen[bytes]) -> None:
+    if scoreboard.stdout is None:
+        return
+    with log_service("scoreboard"):
+        while line := await asyncio.to_thread(scoreboard.stdout.readline):
+            print(line.decode(errors="replace").rstrip(), flush=True)
 
 
 def _port_open(port: int) -> bool:

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -62,6 +62,17 @@ def test_port_configuration_prefers_flags_then_environment(
     assert config.scoreboard_port == 9106
 
 
+def test_recovery_commands_ignore_invalid_port_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCREAMINGFACE_GATEWAY_PORT", "invalid")
+    args = cli._parser().parse_args(["--data-dir", str(tmp_path), "down"])
+
+    config = cli._config(args)
+
+    assert config.gateway_port == 9105
+
+
 def test_owned_state_is_removed_but_foreign_state_is_preserved(tmp_path: Path) -> None:
     config = RuntimeConfig(data_dir=tmp_path)
     config.state_path.write_text(json.dumps({"pid": 42, "owner_token": "ours"}))
@@ -128,6 +139,24 @@ def test_json_status_is_stable_and_redacts_the_owner_token(
     output = capsys.readouterr().out
     assert "secret" not in output
     assert json.loads(output)["schema"] == "screamingface.runtime-status.v1"
+
+
+def test_status_rejects_owned_state_without_services(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    cli._write_state(config, {"schema_version": 1, "pid": 42, "owner_token": "secret"})
+    monkeypatch.setattr(cli, "_verify_owner", lambda _state: True)
+    monkeypatch.setattr(cli, "_health", lambda services: dict.fromkeys(services, True))
+
+    assert cli._print_status(config, json_output=True) == 1
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "invalid_runtime_state"
+    assert output["ownership_verified"] is False
+    assert output["state_valid"] is False
 
 
 def test_down_never_signals_an_unverified_pid(

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -16,7 +17,7 @@ from screamingface._runtime.config import RuntimeConfig
 def test_parser_exposes_public_commands() -> None:
     parser = cli._parser()
 
-    for command in ("up", "down", "status", "logs", "prepare"):
+    for command in ("up", "down", "restart", "status", "logs", "prepare"):
         assert parser.parse_args([command]).command == command
 
 
@@ -35,6 +36,32 @@ def test_runtime_data_is_user_scoped(tmp_path: Path) -> None:
     assert config.assets_dir == tmp_path / "benchmark-assets"
 
 
+def test_runtime_ports_are_configurable_and_unique(tmp_path: Path) -> None:
+    config = RuntimeConfig(
+        data_dir=tmp_path, gateway_port=19105, scoreboard_port=19106, engine_port=19108
+    )
+
+    assert config.services == {
+        "gateway": "http://127.0.0.1:19105",
+        "scoreboard": "http://127.0.0.1:19106",
+        "engine": "http://127.0.0.1:19108",
+    }
+    with pytest.raises(ValueError, match="unique"):
+        RuntimeConfig(data_dir=tmp_path, gateway_port=19105, scoreboard_port=19105)
+
+
+def test_port_configuration_prefers_flags_then_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("SCREAMINGFACE_GATEWAY_PORT", "18105")
+    args = cli._parser().parse_args(["--data-dir", str(tmp_path), "up", "--gateway-port", "19105"])
+
+    config = cli._config(args)
+
+    assert config.gateway_port == 19105
+    assert config.scoreboard_port == 9106
+
+
 def test_owned_state_is_removed_but_foreign_state_is_preserved(tmp_path: Path) -> None:
     config = RuntimeConfig(data_dir=tmp_path)
     config.state_path.write_text(json.dumps({"pid": 42, "owner_token": "ours"}))
@@ -48,12 +75,59 @@ def test_owned_state_is_removed_but_foreign_state_is_preserved(tmp_path: Path) -
 def test_state_is_written_atomically_with_private_permissions(tmp_path: Path) -> None:
     config = RuntimeConfig(data_dir=tmp_path)
 
-    cli._write_state(config, 42, "secret")
+    cli._write_state(config, {"pid": 42, "owner_token": "secret"})
 
     assert json.loads(config.state_path.read_text()) == {"pid": 42, "owner_token": "secret"}
     if os.name != "nt":
         assert config.state_path.stat().st_mode & 0o777 == 0o600
     assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_control_endpoint_proves_identity_and_accepts_authenticated_shutdown() -> None:
+    stopped = threading.Event()
+    server = cli._control_server("ours", stopped)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    state: dict[str, object] = {
+        "pid": os.getpid(),
+        "owner_token": "ours",
+        "control_url": f"http://127.0.0.1:{server.server_port}",
+    }
+    try:
+        assert cli._verify_owner(state)
+        foreign = dict(state)
+        foreign["owner_token"] = "theirs"
+        assert not cli._verify_owner(foreign)
+        cli._request_shutdown(state)
+        assert stopped.wait(1)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def test_json_status_is_stable_and_redacts_the_owner_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    state = {
+        "schema_version": 1,
+        "pid": 42,
+        "started_at": "now",
+        "owner_token": "secret",
+        "services": config.services,
+    }
+    cli._write_state(config, state)
+    monkeypatch.setattr(cli, "_verify_owner", lambda _state: True)
+    monkeypatch.setattr(cli, "_health", lambda services: dict.fromkeys(services, True))
+
+    assert cli._print_status(config, json_output=True) == 0
+
+    output = capsys.readouterr().out
+    assert "secret" not in output
+    assert json.loads(output)["schema"] == "screamingface.runtime-status.v1"
 
 
 def test_logs_rejects_negative_tail(tmp_path: Path) -> None:

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -17,7 +17,7 @@ from screamingface._runtime.config import RuntimeConfig
 def test_parser_exposes_public_commands() -> None:
     parser = cli._parser()
 
-    for command in ("up", "down", "restart", "status", "logs", "prepare"):
+    for command in ("up", "down", "restart", "status", "logs", "prepare", "doctor"):
         assert parser.parse_args([command]).command == command
 
 
@@ -135,6 +135,43 @@ def test_logs_rejects_negative_tail(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match="zero or greater"):
         cli._logs(config, tail=-1, follow=False)
+
+
+def test_benchmark_manifest_distinguishes_prepared_stale_and_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    destination = config.assets_dir / "draco"
+    destination.mkdir(parents=True)
+    monkeypatch.setattr(cli, "_benchmark_fingerprint", lambda _name: "draco:revision")
+
+    assert cli._benchmark_status(config, "draco") == "incomplete"
+    for relative in ("criteria", "rubrics"):
+        (destination / relative).mkdir()
+    (destination / "cases.json").write_text('[{"id":1}]')
+    cli._write_json_atomic(
+        cli._benchmark_manifest_path(destination),
+        {"fingerprint": "draco:old"},
+    )
+    assert cli._benchmark_status(config, "draco") == "stale"
+    cli._write_json_atomic(
+        cli._benchmark_manifest_path(destination),
+        {"fingerprint": "draco:revision"},
+    )
+    assert cli._benchmark_status(config, "draco") == "prepared"
+
+
+def test_prepare_list_rejects_mutating_options(tmp_path: Path) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+
+    with pytest.raises(RuntimeError, match="cannot be combined"):
+        cli._prepare(
+            config,
+            "draco",
+            all_benchmarks=False,
+            list_benchmarks=True,
+            force=False,
+        )
 
 
 def test_plain_sdk_import_does_not_load_server_packages() -> None:

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -209,6 +209,22 @@ def test_benchmark_manifest_distinguishes_prepared_stale_and_incomplete(
     assert cli._benchmark_status(config, "draco") == "prepared"
 
 
+@pytest.mark.parametrize("name", ("draco", "ifeval", "healthbench"))
+def test_benchmark_fingerprint_uses_engine_preparation_revision(
+    name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    imported: list[str] = []
+
+    def import_module(module: str) -> object:
+        imported.append(module)
+        return type("Preparation", (), {"DATASET_REVISION": "revision"})
+
+    monkeypatch.setattr(cli.importlib, "import_module", import_module)
+
+    assert cli._benchmark_fingerprint(name) == f"{name}:revision"
+    assert imported == [f"screamingface_engine.benchmarks.{name}.prepare"]
+
+
 def test_prepare_list_rejects_mutating_options(tmp_path: Path) -> None:
     config = RuntimeConfig(data_dir=tmp_path)
 

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -130,6 +130,24 @@ def test_json_status_is_stable_and_redacts_the_owner_token(
     assert json.loads(output)["schema"] == "screamingface.runtime-status.v1"
 
 
+def test_down_never_signals_an_unverified_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    cli._write_state(config, {"pid": os.getpid(), "owner_token": "stale"})
+    monkeypatch.setattr(cli, "_verify_owner", lambda _state: False)
+
+    cli._down(config)
+
+    assert "no owned ScreamingFace runtime was stopped" in capsys.readouterr().out
+    assert not config.state_path.exists()
+
+
+def test_connection_diagnostic_requires_an_active_connection() -> None:
+    assert not cli._has_connections({"data": [{"provider": "codex", "status": "not_connected"}]})
+    assert cli._has_connections({"data": [{"provider": "codex", "status": "connected"}]})
+
+
 def test_logs_rejects_negative_tail(tmp_path: Path) -> None:
     config = RuntimeConfig(data_dir=tmp_path)
 

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +20,13 @@ def test_parser_exposes_public_commands() -> None:
         assert parser.parse_args([command]).command == command
 
 
+def test_data_dir_is_accepted_before_or_after_the_command(tmp_path: Path) -> None:
+    parser = cli._parser()
+
+    assert parser.parse_args(["--data-dir", str(tmp_path), "up"]).data_dir == tmp_path
+    assert parser.parse_args(["up", "--data-dir", str(tmp_path)]).data_dir == tmp_path
+
+
 def test_runtime_data_is_user_scoped(tmp_path: Path) -> None:
     config = RuntimeConfig(data_dir=tmp_path)
 
@@ -35,6 +43,17 @@ def test_owned_state_is_removed_but_foreign_state_is_preserved(tmp_path: Path) -
     assert config.state_path.exists()
     cli._remove_owned_state(config, "ours")
     assert not config.state_path.exists()
+
+
+def test_state_is_written_atomically_with_private_permissions(tmp_path: Path) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+
+    cli._write_state(config, 42, "secret")
+
+    assert json.loads(config.state_path.read_text()) == {"pid": 42, "owner_token": "secret"}
+    if os.name != "nt":
+        assert config.state_path.stat().st_mode & 0o777 == 0o600
+    assert not list(tmp_path.glob("*.tmp"))
 
 
 def test_logs_rejects_negative_tail(tmp_path: Path) -> None:

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from screamingface._runtime import cli
+from screamingface._runtime import cli, runtime_logging
 from screamingface._runtime.bootstrap import enable_local_providers, scoreboard_seed_json
 from screamingface._runtime.config import RuntimeConfig
 
@@ -135,6 +135,36 @@ def test_logs_rejects_negative_tail(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError, match="zero or greater"):
         cli._logs(config, tail=-1, follow=False)
+
+
+def test_runtime_log_prefixes_services_and_rotates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "runtime.log"
+    monkeypatch.setattr(runtime_logging, "MAX_LOG_BYTES", 100)
+    monkeypatch.setattr(runtime_logging, "LOG_BACKUPS", 2)
+    log = runtime_logging.RuntimeLog(path)
+
+    with runtime_logging.log_service("engine"):
+        log.write("first engine line\n")
+        log.write("x" * 100 + "\n")
+    with runtime_logging.log_service("gateway"):
+        log.write("gateway line\n")
+    log.close()
+
+    rendered = "".join(candidate.read_text() for candidate in cli._log_paths(path))
+    assert "[engine] first engine line" in rendered
+    assert "[gateway] gateway line" in rendered
+    assert path.with_name("runtime.log.1").exists()
+
+
+def test_logs_filter_by_service(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    config.log_path.write_text("time [engine] one\ntime [gateway] two\n")
+
+    cli._logs(config, tail=10, follow=False, service="engine")
+
+    assert capsys.readouterr().out == "time [engine] one\n"
 
 
 def test_benchmark_manifest_distinguishes_prepared_stale_and_incomplete(


### PR DESCRIPTION
## What this PR does

#590 added the pip-installable local runtime. This follow-up makes that runtime safe and comfortable to operate as a normal CLI instead of a thin process launcher.

A researcher can manage the complete local stack with:

```bash
screamingface up
screamingface status
screamingface doctor
screamingface logs
screamingface restart
screamingface down
```

`up` starts AI Gateway, Scoreboard, and the ScreamingFace Engine in the background. The SDK continues to default to hosted services; the CLI prints explicit `SCREAMINGFACE_ENGINE_URL` and `SCREAMINGFACE_SCOREBOARD_URL` exports when a notebook should use the local runtime.

## Important behavior

### Safe lifecycle ownership

The runtime no longer assumes that a PID read from disk belongs to ScreamingFace. It creates a private authenticated loopback control endpoint and stores a versioned, user-private state document containing the process identity, control endpoint, resolved service URLs, log path, and start time.

`down` and `restart` authenticate with that endpoint before requesting shutdown. Unreachable or mismatched state is treated as stale without signalling its PID, preventing PID reuse from stopping an unrelated process. Repeated `up` adopts a healthy owned runtime, reports partially healthy runtimes clearly, and refuses foreign port conflicts.

### Configuration and machine-readable status

Ports can be configured independently through flags or matching environment variables:

```bash
screamingface up \
  --gateway-port 19105 \
  --scoreboard-port 19106 \
  --engine-port 19108
```

CLI flags override environment variables, which override the defaults. The resolved Gateway URL is propagated into Engine discovery and execution. `status --json` emits a stable, ownership-token-redacted `screamingface.runtime-status.v1` document. `--data-dir` works before or after a subcommand, and `--version` reports the installed distribution version.

### Diagnostics and benchmark assets

`doctor` performs read-only, no-spend checks for runtime dependencies, writable storage, state ownership, ports, service health, model discovery, provider connections, and benchmark assets. Missing optional setup is a warning; corrupt state or unhealthy owned services is a failure.

Benchmark preparation writes a manifest only after validating its output:

```bash
screamingface prepare --list
screamingface prepare draco
screamingface prepare draco --force
```

Valid current preparation is skipped, partial downloads remain available for retry, and stale assets appear in `prepare --list`, `doctor`, and JSON status. Dataset fingerprints come from the Engine-owned benchmark preparation modules, keeping manifests aligned with the Engine's pinned dataset revisions.

### Service-aware rotating logs

Runtime records are timestamped and tagged as `gateway`, `scoreboard`, `engine`, or `supervisor`. The combined log rotates at 10 MiB and retains five backups. Logs can be followed together or filtered:

```bash
screamingface logs --service engine --tail 100
screamingface logs --service scoreboard --no-follow
```

## Suggested review order

1. `_runtime/config.py`: port validation and resolved service URLs.
2. `_runtime/cli.py`: parser/configuration, lifecycle commands, authenticated ownership, status/doctor, and benchmark preparation.
3. `_runtime/server.py`: configured-port propagation, authenticated shutdown, and Scoreboard output relay.
4. `_runtime/runtime_logging.py`: isolated rotating-log implementation.
5. `tests/test_runtime_cli.py`: behavioral coverage for ownership, precedence, JSON redaction, assets, and logs.

The central safety invariant is: **no command sends a signal to a PID obtained only from disk**. Shutdown goes through the authenticated control endpoint.

## How to verify manually

Build and install the wheel outside the checkout:

```bash
cd packages/screamingface
uv build
python3.12 -m venv /tmp/screamingface-review
/tmp/screamingface-review/bin/pip install "dist/screamingface-0.1.1.post1-py3-none-any.whl[runtime]"
```

Exercise the lifecycle on non-default ports:

```bash
cd /tmp
export SCREAMINGFACE_DATA_DIR=/tmp/screamingface-review-data
/tmp/screamingface-review/bin/screamingface doctor
/tmp/screamingface-review/bin/screamingface up --gateway-port 19105 --scoreboard-port 19106 --engine-port 19108
/tmp/screamingface-review/bin/screamingface status --json
/tmp/screamingface-review/bin/screamingface logs --service engine --tail 20 --no-follow
/tmp/screamingface-review/bin/screamingface restart
/tmp/screamingface-review/bin/screamingface down
```

## Verification

- 969 tests passed, 1 skipped
- 95.14% SDK coverage
- Ruff lint/format and Pyright pass
- Python 3.12 and 3.13 GitHub Actions matrices pass
- CodeQL and all repository checks pass
- sdist, wheel, and distribution-content checks pass
- `screamingface[runtime]` installed from the built `0.1.1.post1` wheel in a clean environment under `/tmp`
- clean install verified for `--version`, `--help`, and stopped `status --json`
- clean runtime install resolved real Engine-owned dataset fingerprints for Draco, IFEval, and HealthBench

## PR stack

- #590 is merged into `main` and provides the underlying `screamingface[runtime]` stack.
- #593 remains stacked on this PR and packages the shared runtime for Studio through PyInstaller and Tauri.
- This PR changes only `packages/screamingface`.
