### PR TITLE
feat(scoreboard): adopt the leaderboard-mvp masthead nav and landing copy

### DIFF
--- a/apps/scoreboard/portal/benchmark.html
+++ b/apps/scoreboard/portal/benchmark.html
@@ -23,7 +23,13 @@
   <div class="rail">
     <span class="brand"><span class="m">😱</span> screamingface</span><span class="sep">/</span>
     <nav class="crumbs"><a href="index.html">portal</a><a href="#" class="here">leaderboard</a></nav>
-    <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
+    <span class="spacer"></span>
+    <nav class="rail-nav" aria-label="Site">
+      <a class="rail-link" href="index.html#benchmarks">benchmarks</a>
+      <a class="rail-link" href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener">github</a>
+      <a class="rail-link" href="https://docs.screamingface.ai" target="_blank" rel="noopener">docs</a>
+    </nav>
+    <button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
   </div>
 
   <div class="wrap wide">
@@ -66,6 +72,7 @@
     </div>
 
     <div class="foot">
+      <span>😱 screamingface</span>
       <span><a href="https://github.com/OpenMined/screamingface" rel="noopener noreferrer nofollow">GitHub</a></span>
     </div>
   </div>

--- a/apps/scoreboard/portal/data.html
+++ b/apps/scoreboard/portal/data.html
@@ -23,7 +23,13 @@
   <div class="rail">
     <span class="brand"><span class="m">😱</span> screamingface</span><span class="sep">/</span>
     <nav class="crumbs"><a href="index.html">portal</a><a href="#" class="here">data</a></nav>
-    <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
+    <span class="spacer"></span>
+    <nav class="rail-nav" aria-label="Site">
+      <a class="rail-link" href="index.html#benchmarks">benchmarks</a>
+      <a class="rail-link" href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener">github</a>
+      <a class="rail-link" href="https://docs.screamingface.ai" target="_blank" rel="noopener">docs</a>
+    </nav>
+    <button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
   </div>
 
   <div class="wrap wide">
@@ -49,6 +55,7 @@
     </div>
 
     <div class="foot">
+      <span>😱 screamingface</span>
       <span><a href="https://github.com/OpenMined/screamingface" rel="noopener noreferrer nofollow">GitHub</a></span>
     </div>
   </div>

--- a/apps/scoreboard/portal/index.html
+++ b/apps/scoreboard/portal/index.html
@@ -23,7 +23,13 @@
   <div class="rail">
     <span class="brand"><span class="m">😱</span> screamingface</span><span class="sep">/</span>
     <nav class="crumbs"><a href="index.html" class="here">portal</a></nav>
-    <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
+    <span class="spacer"></span>
+    <nav class="rail-nav" aria-label="Site">
+      <a class="rail-link" href="index.html#benchmarks">benchmarks</a>
+      <a class="rail-link" href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener">github</a>
+      <a class="rail-link" href="https://docs.screamingface.ai" target="_blank" rel="noopener">docs</a>
+    </nav>
+    <button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
   </div>
 
   <div class="wrap wide">
@@ -32,7 +38,7 @@
       <h1>Results you can rerun, not just read.</h1>
     </header>
 
-    <p class="lead">Public benchmark results for specs you can inspect and rerun locally. Accuracy, providers, verification status, and the exact run link stay attached to every row.</p>
+    <p class="lead">A <em>fusion</em> is one or more models scored on a public benchmark.</p>
 
     <p><a href="https://screamingface.ai/">Install screamingface — one command</a></p>
 
@@ -49,7 +55,9 @@
       <div class="s"><span class="k">Newest benchmark</span><div class="v" id="stat-newest">—</div></div>
     </div>
 
-    <h2>Benchmarks</h2>
+    <h2 id="benchmarks">Benchmarks</h2>
+
+    <p class="faint">Pick a benchmark to open its leaderboard. Inside, you can tab across all benchmarks.</p>
 
     <div id="benchmark-status" class="state" role="status" aria-live="polite">Loading…</div>
 
@@ -68,6 +76,7 @@
     </div>
 
     <div class="foot">
+      <span>😱 screamingface</span>
       <span><a href="https://github.com/OpenMined/screamingface" rel="noopener noreferrer nofollow">GitHub</a></span>
     </div>
   </div>

--- a/apps/scoreboard/portal/portal.css
+++ b/apps/scoreboard/portal/portal.css
@@ -158,3 +158,23 @@ table .btn { white-space: nowrap; }
   -webkit-mask: none;
   mask: none;
 }
+
+/* ---- masthead nav links (OME-839) ---------------------------------- */
+/* Adopted from the leaderboard-mvp design, which defines these in its own board.css —
+   they are NOT in the vendored style.css, so they belong here.
+   WHY the group is a container and not three bare anchors: the theme toggle is
+   `position: fixed; right: var(--space-5)` (style.css:58 — it pins itself because the
+   rail's sticky is defeated by the page's overflow-x clipping), so it takes NO flex space
+   and the rail will happily lay links out underneath it. Measured in Chrome, "◐ light"
+   is 55px wide, and the collisions were real in both directions:
+     1200px — the mockup's 32px end margin left `docs` overlapping the toggle by 23px;
+      375px — the rail wraps (style.css:667) and `github` landed under the toggle.
+   A container fixes both: --space-11 reserves the toggle's footprint on desktop, and
+   `flex: 0 0 100%` moves the whole group onto its own wrapped line on mobile, where the
+   toggle only ever shares row one. */
+.rail .rail-nav { display: flex; gap: var(--space-4); margin-right: var(--space-11); }
+.rail .rail-link { color: var(--ink-2); text-decoration: none; }
+.rail .rail-link:hover { color: var(--ink); }
+@media (max-width: 620px) {
+  .rail .rail-nav { flex: 0 0 100%; margin-right: 0; gap: var(--space-3); }
+}

--- a/apps/scoreboard/portal/portal.css
+++ b/apps/scoreboard/portal/portal.css
@@ -159,6 +159,16 @@ table .btn { white-space: nowrap; }
   mask: none;
 }
 
+/* ---- fragment targets clear the rail (OME-839) --------------------- */
+/* WHY: the rail is sticky at top:0 and its JS re-pins it as `fixed` once scrolled
+   past (style.css:44), so a bare fragment jump parks the target under it. Measured
+   in Chrome on `index.html#benchmarks`: the heading landed at y=7 with the rail's
+   bottom at y=44 — 37px of a 57px heading hidden. Nothing in the vendored CSS sets
+   scroll-padding, so this is additive, and it fixes every future in-page anchor
+   rather than the one this ticket adds. --rail-h is the same token the rail's own
+   height uses, so the two cannot drift. */
+html { scroll-padding-top: calc(var(--rail-h) + var(--space-4)); }
+
 /* ---- masthead nav links (OME-839) ---------------------------------- */
 /* Adopted from the leaderboard-mvp design, which defines these in its own board.css —
    they are NOT in the vendored style.css, so they belong here.

--- a/apps/scoreboard/portal/spec.html
+++ b/apps/scoreboard/portal/spec.html
@@ -23,7 +23,13 @@
   <div class="rail">
     <span class="brand"><span class="m">😱</span> screamingface</span><span class="sep">/</span>
     <nav class="crumbs"><a href="index.html">portal</a><a id="back-link" href="index.html">leaderboard</a><a href="#" class="here">spec</a></nav>
-    <span class="spacer"></span><button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
+    <span class="spacer"></span>
+    <nav class="rail-nav" aria-label="Site">
+      <a class="rail-link" href="index.html#benchmarks">benchmarks</a>
+      <a class="rail-link" href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener">github</a>
+      <a class="rail-link" href="https://docs.screamingface.ai" target="_blank" rel="noopener">docs</a>
+    </nav>
+    <button class="toggle" id="theme-toggle" aria-label="Toggle light/dark theme">◐</button>
   </div>
 
   <div class="wrap">
@@ -70,6 +76,7 @@
     </div>
 
     <div class="foot">
+      <span>😱 screamingface</span>
       <span><a href="https://github.com/OpenMined/screamingface" rel="noopener noreferrer nofollow">GitHub</a></span>
     </div>
   </div>

--- a/docs/plan/2026-08-14-OME-839-mvp-copy-and-nav.md
+++ b/docs/plan/2026-08-14-OME-839-mvp-copy-and-nav.md
@@ -11,7 +11,7 @@ Match the mockup's own rules (`board.css:27-30`, plus its `620px` margin rule), 
 only per `portal.css`'s header rule. `.rail-link--end` carries the right margin so nothing sits
 under the toggle glyph.
 
-## Step 2 — the three links, on all three pages
+## Step 2 — the three links, on all FOUR pages
 
 Insert before the toggle in each `.rail`. `github` and `docs` are external:
 `target="_blank" rel="noopener"`. `benchmarks` → `index.html#benchmarks` (spec §3).

--- a/docs/plan/2026-08-14-OME-839-mvp-copy-and-nav.md
+++ b/docs/plan/2026-08-14-OME-839-mvp-copy-and-nav.md
@@ -1,0 +1,44 @@
+# OME-839 — Implementation plan
+
+Spec: `docs/spec/2026-08-14-OME-839-mvp-copy-and-nav.md` · Ledger:
+`docs/work/2026-08-14-OME-839-mvp-copy-and-nav.md`
+
+Copy and three anchors. No logic, so verification is by rendering.
+
+## Step 1 — `portal.css`: `.rail-link`
+
+Match the mockup's own rules (`board.css:27-30`, plus its `620px` margin rule), using token vars
+only per `portal.css`'s header rule. `.rail-link--end` carries the right margin so nothing sits
+under the toggle glyph.
+
+## Step 2 — the three links, on all three pages
+
+Insert before the toggle in each `.rail`. `github` and `docs` are external:
+`target="_blank" rel="noopener"`. `benchmarks` → `index.html#benchmarks` (spec §3).
+
+## Step 3 — `index.html` copy
+
+- lead → the fusion definition;
+- `id="benchmarks"` on the Benchmarks heading so the nav link lands;
+- the picker sentence beneath it;
+- footer wordmark.
+
+## Step 4 — verify by rendering, not reading
+
+Serve the portal locally and check in Chrome at ~1200px and ~420px:
+
+- the three links present and resolving on all three pages;
+- the rail does not wrap or overlap the toggle at mobile width;
+- **grep the rendered HTML** for `verif`, `reproduc`, `cost`, `SOTA` — the `OME-820` invariant. Three
+  previous passes missed a stale claim by reading the diff instead.
+
+## Step 5 — gates, ledger, commit, PR
+
+`run_gates.py scoreboard --base origin/main`.
+
+## Risks
+
+- **`#588` touches the same three files** and is unmerged; the overlap on `index.html`'s lead is real.
+  It should land first. Adopting the mockup's lead preserves `#588`'s honesty fix, since the mockup's
+  lead makes no verification claim — so the rebase is a text conflict, not a semantic one.
+- `.rail-link` is new CSS in an extension file that forbids raw values. Use token vars.

--- a/docs/spec/2026-08-14-OME-839-mvp-copy-and-nav.md
+++ b/docs/spec/2026-08-14-OME-839-mvp-copy-and-nav.md
@@ -1,0 +1,66 @@
+# OME-839 — adopt what the mockup says that we can stand behind
+
+Status: approved (owner, 2026-08-14) · Stack: scoreboard
+
+## 1. Problem
+
+The live portal and `brand.screamingface.ai/leaderboard-mvp` share the same design system, so they
+already look like one product. What differs is **content**: the mockup names the product's core term,
+offers three navigation links, and explains how to move around the board. The live portal does none
+of that — it has only a theme toggle in the rail and never defines "fusion".
+
+Irina asked for the mockup's copy "more faithfully", and specifically for the three links, expecting
+them to matter for the tester cohort.
+
+## 2. Why "faithfully" cannot mean "verbatim"
+
+Roughly half the mockup's landing copy describes capabilities that do not exist:
+
+| Mockup copy | Reality |
+|---|---|
+| `REPRODUCIBLE` — *"Ran on shared compute… Anyone can re-run it and get the same score."* | nothing re-runs submissions; `OME-414` unstarted, unstaffed |
+| *"the top **reproducible** result is the current SOTA (the one place gold appears)"* | medal descoped to `OME-771` |
+| *"The chart shows what accuracy each dollar of run-cost buys."* | no chart, no cost data; `OME-770` pass 2 blocked |
+| `FUSIONS` / `REPRODUCIBLE` / `BEST REPRODUCIBLE` columns | no verification signal exists |
+| footer *"leaderboard.screamingface.ai · MVP preview · mock data"* | that host has **no DNS record**; the data is not mock |
+
+`OME-820` spent two review rounds removing precisely these claims from this portal, at the reviewer's
+request, after they were found to contradict the rendered UI. Re-adding them as "copy fidelity" would
+undo that.
+
+So the rule is: **adopt the copy that is true now; the rest lands with the ticket that makes it true.**
+
+## 3. Contract
+
+Adopted:
+
+- Masthead: `benchmarks` · `github` · `docs`, right-aligned before the theme toggle, on every page.
+- Lead: *"A fusion is one or more models scored on a public benchmark."*
+- Benchmarks section: *"Pick a benchmark to open its leaderboard. Inside, you can tab across all
+  benchmarks."*
+- Footer: the wordmark cell.
+
+Two adaptations, both because the mockup is backed by mock data and we are not:
+
+- **`benchmarks` targets `index.html#benchmarks`.** The mockup links bare `benchmark.html`; on live,
+  `benchmark.js` requires an `id` query parameter and renders an error state without one. The landing
+  page is the catalogue, so it is the correct target.
+- **The footer's second cell is dropped**, not reworded — its three claims are a nonexistent
+  hostname, a preview label, and "mock data".
+
+Not adopted: the headline. *"Fusions, ranked and reproducible."* asserts reproduction; the live
+*"Results you can rerun, not just read."* claims only what the board delivers. Left for Irina to
+decide, since brand voice is hers.
+
+## 4. The invariant this must not break
+
+**No portal copy may claim reproduction, verification status, or cost** until the owning ticket lands.
+`OME-820` established this and it has already been broken twice by edits that looked unrelated.
+Verification is a grep of the rendered output, not a reading of the diff.
+
+## 5. Acceptance
+
+- Three links on all three pages, each resolving.
+- Adopted copy verbatim.
+- No verification or cost claim in any portal HTML.
+- Rail does not wrap or collide with the toggle at mobile widths.

--- a/docs/spec/2026-08-14-OME-839-mvp-copy-and-nav.md
+++ b/docs/spec/2026-08-14-OME-839-mvp-copy-and-nav.md
@@ -34,7 +34,11 @@ So the rule is: **adopt the copy that is true now; the rest lands with the ticke
 
 Adopted:
 
-- Masthead: `benchmarks` · `github` · `docs`, right-aligned before the theme toggle, on every page.
+- Masthead: `benchmarks` · `github` · `docs`, right-aligned before the theme toggle, on every page
+  — all four of them: `index`, `benchmark`, `spec` and `data` (the last renders a published JSONL
+  file and is easy to miss, since the mockup has no equivalent).
+- A fragment target must clear the rail. The rail pins itself as `fixed` when scrolled, so an
+  unadjusted `#benchmarks` jump hides the heading behind it.
 - Lead: *"A fusion is one or more models scored on a public benchmark."*
 - Benchmarks section: *"Pick a benchmark to open its leaderboard. Inside, you can tab across all
   benchmarks."*

--- a/docs/tasks/2026-08-14-OME-839-mvp-copy-and-nav.md
+++ b/docs/tasks/2026-08-14-OME-839-mvp-copy-and-nav.md
@@ -1,0 +1,30 @@
+---
+id: OME-839
+linear_url: https://linear.app/openmined/issue/OME-839/adopt-the-leaderboard-mvp-masthead-nav-and-landing-copy
+status: In Progress
+priority: P2
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-14
+milestone: "🏆 Week 3 · Subsidized compute, $0 Colab & a verified board"
+---
+
+# Adopt the leaderboard-mvp masthead nav and landing copy
+
+Irina's request (2026-08-14 DM): implement the `brand.screamingface.ai/leaderboard-mvp` copy more
+faithfully, and add the top-right `benchmarks` / `github` / `docs` links.
+
+Adopted: the three nav links, the fusion definition as the lead, the benchmark-picker sentence, and
+the footer wordmark.
+
+Deferred to `OME-770` / `OME-771`: roughly half the mockup's landing copy asserts capabilities that
+do not exist (a reproducible/unverified legend, a reproducible-SOTA medal, a cost-vs-accuracy chart).
+Adopting it would republish the exact claims `OME-820` withdrew two review rounds ago. The mockup's
+footer line naming `leaderboard.screamingface.ai` is not adopted either — that host has no DNS
+record and the data is not mock.
+
+Sequencing: touches the same three HTML files as `#588`, which is unmerged; `#588` lands first and
+this rebases.
+
+Ledger: `docs/work/2026-08-14-OME-839-mvp-copy-and-nav.md` ·
+Spec: `docs/spec/2026-08-14-OME-839-mvp-copy-and-nav.md` ·
+Plan: `docs/plan/2026-08-14-OME-839-mvp-copy-and-nav.md`

--- a/docs/work/2026-08-14-OME-839-mvp-copy-and-nav.md
+++ b/docs/work/2026-08-14-OME-839-mvp-copy-and-nav.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-839
 stack: scoreboard
-status: in_progress
+status: in_review
 started: 2026-08-14
-finished:
+finished: 2026-08-15
 ---
 
 # OME-839 — adopt the leaderboard-mvp masthead nav and landing copy
@@ -33,7 +33,8 @@ anchors, not a redesign.
   token vars only).
 - `apps/scoreboard/portal/index.html` — the three nav links; lead → the fusion definition; an
   anchorable `id` on the Benchmarks heading plus the picker sentence; footer wordmark.
-- `apps/scoreboard/portal/benchmark.html`, `spec.html` — the same three nav links and footer.
+- `apps/scoreboard/portal/benchmark.html`, `spec.html`, `data.html` — the same three nav
+  links and footer.
 
 ## Test plan
 
@@ -105,3 +106,36 @@ pages at 1200px and 375px, light and dark, plus `.rail-link` color = `--ink-2` i
 (`portal / leaderboard / spec`) reaches x=326 while the fixed toggle starts at x=300. Confirmed
 **pre-existing**: hiding `.rail-nav` and re-measuring reproduces it, so this change neither causes
 nor worsens it. Both sides are vendored CSS. Not touched here; it wants its own ticket.
+
+## Review pass (2026-08-15) — two findings, both valid, both mine
+
+| Finding | Verified how | Verdict |
+|---|---|---|
+| The `benchmarks` link parks its target under the rail | measured after `scrollIntoView()` in Chrome | **valid — the link this ticket adds does not work properly** |
+| `data.html` is a fourth portal page and has no nav | `curl` on dev returned 200; reached from `main.js:280` | **valid — the ticket and PR both claimed "every portal page"** |
+
+### The anchor lands under the masthead
+
+I verified the `#benchmarks` target *existed* and never verified where it *lands*. The rail is sticky
+at `top: 0` and its JS re-pins it as `fixed` once scrolled past (`style.css:44`), so a bare fragment
+jump parks the heading beneath it. Measured: heading top at **y=7**, rail bottom at **y=44** — 37px
+of a 57px heading hidden, with `scroll-margin-top: 0px` and no `scroll-padding` anywhere in the
+vendored CSS.
+
+Fixed with one additive rule, `html { scroll-padding-top: calc(var(--rail-h) + var(--space-4)) }`,
+which covers every future in-page anchor rather than only this one, and reuses the same token the
+rail's height uses so the two cannot drift. After: heading top **y=63**, rail bottom y=44 — **19px
+clearance, 0px obscured**.
+
+### The fourth page
+
+`data.html` renders a published JSONL file. It is reached from the index's "Dataset" links
+(`main.js:280`), it is live (`leaderboard.dev.screamingface.ai/data.html` → 200), and I never looked
+past the three pages the mockup has. Both the ticket and the PR body claimed the nav appears on every
+portal page; that was false until now. Nav and footer wordmark added; verified at 1200px (25px gap to
+the toggle, no overlap) and 375px (nav on its own wrapped row, no overflow).
+
+Worth keeping: "I changed the three files the design mocks up" is not the same as "I changed every
+page that ships". The check is `ls *.html`, not the mockup's sitemap.
+
+**Gates:** all green.

--- a/docs/work/2026-08-14-OME-839-mvp-copy-and-nav.md
+++ b/docs/work/2026-08-14-OME-839-mvp-copy-and-nav.md
@@ -1,0 +1,107 @@
+---
+ticket: OME-839
+stack: scoreboard
+status: in_progress
+started: 2026-08-14
+finished:
+---
+
+# OME-839 — adopt the leaderboard-mvp masthead nav and landing copy
+
+## Intent
+
+Irina, 2026-08-14 DM: implement the copy from `brand.screamingface.ai/leaderboard-mvp` more
+faithfully, and add the top-right `benchmarks` / `github` / `docs` links — *"quick changes, but I
+suspect it would make a difference for testers"*.
+
+The two surfaces already share `fonts.css`, `tokens.css` and `style.css`, so this is copy and three
+anchors, not a redesign.
+
+## Decisions locked (2026-08-14)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Adopt only the copy that is **true today** | Owner decision. About half the mockup's landing copy asserts capabilities that do not exist, and adopting it would republish the exact claims `OME-820` withdrew at `@HupBaHa`'s request over two review rounds. Deferred to `OME-770` / `OME-771`, which is when each becomes true. |
+| D2 | `benchmarks` points at `index.html#benchmarks`, **not** `benchmark.html` | The mockup links bare `benchmark.html`, which works there because its board is hardcoded mock data. On live, `benchmark.js:283` calls `P.requireParam("id")`, so a bare link renders an error state. `index.html` *is* the benchmark catalogue, so it is the honest target. Verified rather than copied. |
+| D3 | `.rail-link` goes in `portal.css` | It is **not** in the vendored `style.css` (grepped) — it lives in the mockup's own `board.css`. `portal.css` is the extension file, and its header rule is token-vars only, no raw values. |
+| D4 | Footer: wordmark only | The mockup's right-hand cell reads *"leaderboard.screamingface.ai · MVP preview · mock data"*. That host has **no DNS record** (verified: `dig` empty, `curl` exit 6), and this data is not mock. Adopting the wordmark and dropping that line. |
+| D5 | Headline left alone | The mockup's *"Fusions, ranked and reproducible."* claims reproduction the board cannot back. The live *"Results you can rerun, not just read."* is honest about what is actually on offer — a re-runnable recipe. Flagged for Irina rather than changed unilaterally, since brand voice is hers. |
+
+## Planned changes
+
+- `apps/scoreboard/portal/portal.css` — `.rail-link` (extension; matches the mockup's rules,
+  token vars only).
+- `apps/scoreboard/portal/index.html` — the three nav links; lead → the fusion definition; an
+  anchorable `id` on the Benchmarks heading plus the picker sentence; footer wordmark.
+- `apps/scoreboard/portal/benchmark.html`, `spec.html` — the same three nav links and footer.
+
+## Test plan
+
+No logic changes, so this is verified by rendering, not by assertions:
+
+- Every portal page shows the three links, and each resolves (`index.html#benchmarks`, the GitHub
+  repo, `docs.screamingface.ai`).
+- Adopted copy matches the mockup verbatim.
+- **No copy this change introduces claims reproduction, verification status, or cost** — the
+  `OME-820` invariant. Note the scope: `index.html`'s `.note` block still carries the
+  *"Verified means OpenMined independently reproduced the run"* text. That block is `#588`'s to
+  remove and is untouched here; duplicating it would collide with two rounds of review.
+- Rendered at desktop and mobile widths, measured in Chrome (getBoundingClientRect, not eyeballed):
+  the rail must not overflow and no rail item may overlap the fixed theme toggle.
+
+## Acceptance
+
+- The three links appear on all three pages and resolve.
+- The adopted copy is verbatim.
+- Nothing this change adds claims verification, reproduction or cost.
+- Full gates green.
+
+## Outcome
+
+Status: **DONE** (2026-08-14)
+
+- **Actual files** (4, all as planned):
+  - `apps/scoreboard/portal/portal.css` — `.rail-nav` / `.rail-link`
+  - `apps/scoreboard/portal/index.html` — nav · lead · `id="benchmarks"` + picker sentence · footer
+  - `apps/scoreboard/portal/benchmark.html`, `spec.html` — nav · footer
+- **Gates:** `run_gates.py scoreboard --base origin/main` — ALL GREEN (append-only, ruff check,
+  ruff format, pyright, pytest ≥80% cov). No Python touched; no test added — this is copy and CSS,
+  and the portal has no DOM-rendering harness (its JS tests cover pure logic only).
+
+### What the rendering check caught that the diff did not
+
+Adopting the mockup's CSS verbatim was wrong, in both directions, because the two rails differ in
+one detail the markup does not show: **here the theme toggle is `position: fixed`**
+(`style.css:58` — it pins itself because the rail's sticky is defeated by the page's overflow-x
+clipping), so it consumes no flex space. Measured, "◐ light" is 55px wide:
+
+| Width | Symptom with the mockup's CSS | After |
+|---|---|---|
+| 1200px | the mockup's 32px end margin left `docs` **overlapping the toggle by 23px** | 25px gap |
+| 375px | the rail wraps (`style.css:667`) and **`github` landed under the toggle** | links on their own row, no overlap |
+
+Fix: group the anchors in a `.rail-nav` container — `--space-11` reserves the toggle's footprint on
+desktop, `flex: 0 0 100%` moves the group to its own wrapped row on mobile. Verified on all three
+pages at 1200px and 375px, light and dark, plus `.rail-link` color = `--ink-2` in both themes
+(identical to the crumbs).
+
+### Deviations from the plan
+
+1. **`.rail-nav` container added**, not the three bare anchors the plan described — forced by the
+   collision above. `.rail-link--end` and the mockup's `620px` per-link margin were both dropped;
+   neither is needed once the group owns its own row.
+2. **`.rail-link.here` not adopted.** Nothing sets it — the crumbs already carry the active state.
+   Dead CSS.
+3. **Both external links checked live**, which the plan only implied: `docs.screamingface.ai` 200
+   (Cloudflare, `172.67.172.6`), the GitHub repo 200. Worth doing — the footer line this change
+   *declined* to adopt names `leaderboard.screamingface.ai`, which still has no DNS record at all.
+4. **"Inside, you can tab across all benchmarks" was verified before adoption**, not assumed:
+   `benchmark.html:34` has `#benchmark-tabs` and `benchmark.js:258` renders the strip across every
+   benchmark. True on live, not just in the mockup.
+
+### Found, not fixed — out of scope
+
+**`spec.html`'s crumbs collide with the theme toggle below ~400px.** At 375px the three-level trail
+(`portal / leaderboard / spec`) reaches x=326 while the fixed toggle starts at x=300. Confirmed
+**pre-existing**: hiding `.rail-nav` and re-measuring reproduces it, so this change neither causes
+nor worsens it. Both sides are vendored CSS. Not touched here; it wants its own ticket.


### PR DESCRIPTION
Linear: [OME-839](https://linear.app/openmined/issue/OME-839/adopt-the-leaderboard-mvp-masthead-nav-and-landing-copy)

Irina asked (2026-08-14 DM) for the `brand.screamingface.ai/leaderboard-mvp` copy "more
faithfully", and specifically for the top-right `benchmarks` / `github` / `docs` links —
*"quick changes, but I suspect it would make a difference for testers"*.

## What's adopted

| | |
|---|---|
| Masthead nav | `benchmarks` · `github` · `docs`, on all four portal pages |
| Lead | *"A **fusion** is one or more models scored on a public benchmark."* |
| Benchmarks section | *"Pick a benchmark to open its leaderboard. Inside, you can tab across all benchmarks."* |
| Footer | the 😱 wordmark cell |

Two adaptations, both because the mockup is backed by mock data and we are not:

- **`benchmarks` → `index.html#benchmarks`**, not the mockup's bare `benchmark.html`. That page
  calls `P.requireParam("id")` (`benchmark.js:283`), so a bare link renders an error state on live.
  The landing page *is* the catalogue, so an `id` was added to its heading.
- **The footer's second cell is dropped**, not reworded. It reads
  *"leaderboard.screamingface.ai · MVP preview · mock data"* — that host has no DNS record
  (`dig` empty, `curl` exit 6) and this data is not mock.

## What's deliberately not adopted

Roughly half the mockup's landing copy asserts capabilities that do not exist. Adopting it would
republish the exact claims **OME-820 / #588** withdrew at review request:

| Mockup copy | Reality |
|---|---|
| `REPRODUCIBLE` legend — *"Anyone can re-run it and get the same score"* | nothing re-runs submissions; OME-414 unstarted |
| *"the top **reproducible** result is the current SOTA (the one place gold appears)"* | medal descoped to OME-771 |
| *"The chart shows what accuracy each dollar of run-cost buys."* | no chart, no cost data; OME-770 pass 2 blocked |
| `FUSIONS` / `REPRODUCIBLE` / `BEST REPRODUCIBLE` columns | no verification signal exists |

Also not adopted: the mockup's headline *"Fusions, ranked and reproducible."* The live
*"Results you can rerun, not just read."* claims only what the board delivers — a re-runnable
recipe, not a reproduced result. Left for Irina, since brand voice is hers.

## The mockup's CSS could not be taken verbatim

The two rails look identical in markup but differ in one detail: **here the theme toggle is
`position: fixed`** (`style.css:58` — it pins itself because the rail's sticky is defeated by the
page's overflow-x clipping), so it consumes no flex space and the rail lays links out underneath it.
Measured in Chrome (`getBoundingClientRect`, "◐ light" is 55px wide):

| Width | With the mockup's CSS | After |
|---|---|---|
| 1200px | its 32px end margin left `docs` **overlapping the toggle by 23px** | 25px gap |
| 375px | the rail wraps (`style.css:667`) and **`github` landed under the toggle** | links on their own row, no overlap |

Fix: group the anchors in a `.rail-nav`. `--space-11` reserves the toggle's footprint on desktop;
`flex: 0 0 100%` gives the group its own wrapped row on mobile, where the toggle only ever shares
row one. `.rail-link` is new CSS in `portal.css` (the extension file, token vars only) because it is
not in the vendored `style.css` — the mockup defines it in its own `board.css`.

## Test plan

No logic changed, so this is verified by rendering, not assertions.

- `run_gates.py scoreboard --base origin/main` — **ALL GREEN** (append-only, ruff check, ruff format,
  pyright, pytest ≥80% cov).
- All four pages at **1200px and 375px**, light and dark: no rail item overlaps the fixed toggle,
  no horizontal overflow, `.rail-link` color = `--ink-2` (identical to the crumbs) in both themes.
- The `#benchmarks` jump clears the rail: measured 19px clearance, 0px obscured.
- Both external links resolve: `docs.screamingface.ai` → 200, the GitHub repo → 200.
- *"you can tab across all benchmarks"* verified before adoption, not assumed —
  `benchmark.html:34` has `#benchmark-tabs`, `benchmark.js:258` renders it across every benchmark.

## Reviewer notes

- **Sequencing:** touches the same three HTML files as **#588** (unmerged), with real overlap on
  `index.html`'s lead. #588 is further along, so it should land first and this rebases. The rebase is
  a text conflict, not a semantic one — the mockup's lead makes no verification claim either.
- **Still present, and #588's to rewrite:** `index.html`'s `.note` block still says *"Verified means
  OpenMined independently reproduced the run."* #588 replaces that text (it does not delete the
  block). Untouched here on purpose — duplicating it would collide with two rounds of review.
- **Found, not fixed:** `spec.html`'s three-level crumb trail collides with the fixed toggle below
  ~400px (crumbs reach x=326, toggle starts at x=300). Confirmed **pre-existing** by hiding
  `.rail-nav` and re-measuring; both sides are vendored CSS. Wants its own ticket.


---

## Self-review pass (2026-08-15) — two defects found and fixed

Both were mine, both in the nav this PR adds.

**The `benchmarks` link parked its target under the masthead.** I verified the anchor *existed* and
never verified where it *lands*. The rail is sticky at `top: 0` and its JS re-pins it as `fixed` once
scrolled past (`style.css:44`). Measured after `scrollIntoView()`: heading top **y=7**, rail bottom
**y=44** — 37px of a 57px heading hidden, with `scroll-margin-top: 0px` and no `scroll-padding`
anywhere in the vendored CSS. Fixed with one additive rule,
`html { scroll-padding-top: calc(var(--rail-h) + var(--space-4)) }`, which covers every future in-page
anchor and reuses the rail's own height token. After: **19px clearance, 0px obscured**.

**`data.html` is a fourth portal page and had no nav.** It renders a published JSONL file, is reached
from the index's "Dataset" links (`main.js:280`), and is live
(`leaderboard.dev.screamingface.ai/data.html` → 200). I only changed the three pages the mockup has,
while both this PR and OME-839 claimed "every portal page". Nav and footer wordmark added; verified at
1200px (25px gap to the toggle) and 375px (own wrapped row, no overflow).
