### PR TITLE
docs(screamingface): correct why the verified filter was removed

### DIFF
--- a/docs/plan/2026-08-15-OME-841-notebook-verified-comment.md
+++ b/docs/plan/2026-08-15-OME-841-notebook-verified-comment.md
@@ -1,0 +1,44 @@
+# OME-841 — Implementation plan
+
+Spec: `docs/spec/2026-08-15-OME-841-notebook-verified-comment.md` · Ledger:
+`docs/work/2026-08-15-OME-841-notebook-verified-comment.md`
+
+Two comments in one file.
+
+## Step 1 — `_ui/leaderboard_view.py:119-121`
+
+The load-bearing one. Replace the uniformity claim with the certifies-nothing reason, keeping the
+"removed, not relabelled" framing and the `OME-821` pointer.
+
+## Step 2 — `_ui/leaderboard_view.py:63-64`
+
+Same word, smaller stakes: "became uniform and asserted nothing". Keep "asserted nothing", drop
+"uniform".
+
+## Step 2b — the third occurrence, in the `_row_chip` docstring
+
+Found by Step 3, not by reading. Same correction.
+
+## Step 3 — prove the diff is inert
+
+Not by reading it. Tokenize both revisions, drop COMMENT and NL tokens, compare the rest. A
+"comment-only" change that quietly moved a line of code is exactly the failure this catches — and it
+is why the check must use the tokenizer rather than a regex, since this file is full of HTML string
+literals containing `#`.
+
+It also distinguishes a comment from a docstring, which a `grep '^#'` cannot: docstrings survive
+tokenization as STRING tokens, so a docstring edit shows up here as a real difference and has to be
+justified rather than assumed harmless.
+
+## Step 4 — gates, ledger, commit, PR
+
+`run_gates.py screamingface --base origin/main`. Note the suite is heavier than scoreboard's: it
+includes the notebook determinism check, `uv build`, and a distribution check.
+
+## Risks
+
+- **Low blast radius, wrong reviewers.** `.github/CODEOWNERS` assigns `/packages/screamingface/` to
+  `@IonesioJunior @keelancj`, not the scoreboard owner. The PR body has to carry enough context that a
+  reader who was not in the `#588` review can judge it without reading `#588`.
+- **Wording drift.** Three places now describe this flag. The replacement text should echo `OME-820`'s
+  phrasing rather than invent a fourth variant.

--- a/docs/spec/2026-08-15-OME-841-notebook-verified-comment.md
+++ b/docs/spec/2026-08-15-OME-841-notebook-verified-comment.md
@@ -1,0 +1,69 @@
+# OME-841 — a removal's recorded reason must survive being checked
+
+Status: approved (owner, 2026-08-15) · Stack: screamingface
+
+## 1. Problem
+
+`#601` removed the notebook view's `verified` chip and "verified only" filter. Beside the deletion it
+records why:
+
+> `verified_by_openmined` is **uniform** since `OME-820`, so **no row carries `data-verified=false`**
+> and the control removed nothing.
+
+That is a factual claim about the data, and it is false. `OME-820` explicitly forbids a backfill, so
+every row created before it still holds `false`.
+
+This matters more than a typo because of *where* the claim sits. It is the justification for deleting
+a user-facing control. The next person to touch this area will read it, check it, find it untrue, and
+reasonably conclude the deletion was unjustified — and restore the filter.
+
+## 2. The real reason is stronger, not weaker
+
+Established during the `#588` review and already recorded in `OME-820`, `OME-821` and
+`apps/scoreboard/portal`:
+
+`verified_by_openmined` **certifies nothing, whatever value it holds.** Nothing re-runs submissions
+(`OME-414` unstarted) and nothing attests where a run executed.
+
+So a "verified only" filter would not be harmlessly inert. It would partition rows by **whether they
+predate the default change**, while presenting itself as a verification filter — measuring submission
+date and looking like it measured trust. That is worse than filtering nothing, and it is why the
+control was removed rather than relabelled.
+
+Note the asymmetry the wrong wording introduced: "uniform" implies the control is *harmless* and could
+come back any time. "Certifies nothing" implies it is *actively misleading* and must not come back
+until `OME-821` gives the flag a meaning. The wrong word argued for the opposite conclusion to the one
+the code took.
+
+## 3. Contract
+
+- **All three** occurrences stop claiming uniformity: `:63-64`, `:119-121`, and the `_row_chip`
+  docstring. The third was found by the mechanical check below, not by reading — see §3a.
+- Both state the real reason, in wording consistent with `OME-820` and the scoreboard portal, so the
+  three copies cannot drift apart again.
+- **Not** a mere deletion of the word: a removal with no recorded justification is how the control
+  gets re-added.
+- No executable line changes. The removal `#601` made was correct and is not revisited here.
+
+### 3a Correction (2026-08-15) — three occurrences, and one is not a comment
+
+Drafted as "two comments". Checking mechanically rather than by eye found a **third** in the
+`_row_chip` docstring, which is a **string literal, not a comment** — so the acceptance criterion
+"the diff touches comment lines only" was itself wrong.
+
+Restated: the diff must touch **no executable statement**. Comment and docstring text may change.
+Verified that the docstring is inert here — nothing in `src/`, `tests/` or `scripts/` reads
+`__doc__`, there are no doctests, and `_row_chip` is private.
+
+## 4. Out of scope
+
+Restoring the chip or the filter, giving the flag a real signal, and re-emitting `data-verified` — all
+`OME-821`. This ticket only makes the record true.
+
+## 5. Acceptance
+
+- No comment in the file claims the field is uniform.
+- The recorded reason matches `OME-820` / `OME-821` / the scoreboard portal.
+- The diff touches no executable statement, verified by comparing tokenized source rather than by
+  reading the diff.
+- Full gates green.

--- a/docs/tasks/2026-08-15-OME-841-notebook-verified-comment.md
+++ b/docs/tasks/2026-08-15-OME-841-notebook-verified-comment.md
@@ -1,0 +1,26 @@
+---
+id: OME-841
+linear_url: https://linear.app/openmined/issue/OME-841/correct-the-notebook-views-justification-for-removing-the-verified
+status: In Progress
+type: Task
+priority: P4
+labels: [py-screamingface, agentic, autonomous, task]
+created: 2026-08-15
+closed:
+---
+
+# Correct the notebook view's justification for removing the verified filter
+
+`OME-832` (merged as #601) removed the `verified` chip and the "verified only" filter from the
+notebook leaderboard view. The removal was right; the reason recorded beside it is false and
+undercuts it — it says `verified_by_openmined` is "uniform", when `OME-820` forbids a backfill so
+rows predating it keep `false`.
+
+The real reason is stronger: the field certifies nothing whatever it holds, so a filter would split
+rows by whether they predate the default change while presenting itself as a verification filter.
+
+Comments and one docstring only. No behaviour change.
+
+Ledger: `docs/work/2026-08-15-OME-841-notebook-verified-comment.md` ·
+Spec: `docs/spec/2026-08-15-OME-841-notebook-verified-comment.md` ·
+Plan: `docs/plan/2026-08-15-OME-841-notebook-verified-comment.md`

--- a/docs/work/2026-08-15-OME-841-notebook-verified-comment.md
+++ b/docs/work/2026-08-15-OME-841-notebook-verified-comment.md
@@ -1,0 +1,120 @@
+---
+ticket: OME-841
+stack: screamingface
+status: in_review
+started: 2026-08-15
+finished: 2026-08-15
+---
+
+# OME-841 — correct the notebook view's justification for removing the verified filter
+
+## Intent
+
+`OME-832` (merged as `#601`) removed the `verified` chip and the "verified only" filter from the
+client's notebook leaderboard view. **The removal was right and stays exactly as merged.** The reason
+recorded beside it is wrong, and wrong in a way that undercuts the removal.
+
+`_ui/leaderboard_view.py:119-121` on `main`:
+
+> `OME-832`: the "verified only" checkbox lived here. Removed, not relabelled —
+> `verified_by_openmined` is **uniform** since `OME-820`, so **no row carries `data-verified=false`**
+> and the control removed nothing. `OME-821` restores it.
+
+Two things are wrong with that:
+
+1. **It is false.** `OME-820` forbids a backfill, so rows created before that change keep `false`.
+   The field is not uniform and rows *do* carry `data-verified=false`.
+2. **It is load-bearing.** It is the stated justification for deleting a user-facing control. A
+   reader who checks it finds it untrue and may conclude the deletion was unjustified.
+
+The real reason is stronger, and was established during the `#588` review: the field **certifies
+nothing whatever it holds**. A filter on it would split rows by whether they predate the default
+change while presenting itself as a verification filter — measuring submission date and looking like
+it measured trust. That is worse than filtering nothing.
+
+Found while verifying `#588`'s review asks. The corrected reasoning already lives in `OME-820`,
+`OME-821` and `apps/scoreboard`; only this merged copy still carries the old claim.
+
+## Decisions locked (2026-08-15)
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | Comments only | The removal was correct. Nothing about behaviour, API or tests changes. |
+| D2 | A dedicated PR, not folded into `OME-821` | Owner decision. `OME-821` rewrites this area and would carry the fix for free, but it is Backlog and blocked on `OME-820`/`#588`, which is itself waiting on a re-review — so folding in leaves a false claim on `main` indefinitely and drags a doc fix into a ticket with open product questions. |
+| D3 | Fix both occurrences | `:63-64` also says "became uniform and asserted nothing". The second half is right; only the word is wrong. Leaving one occurrence would just relocate the error. |
+| D4 | State the real reason, do not merely delete the word | Deleting "uniform" would leave a removal with no recorded justification, which is how the next person re-adds the control. |
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_ui/leaderboard_view.py` — three corrections (two
+  comments and one docstring; the third was found by the mechanical check, not by reading).
+
+Nothing else. No test changes: there is no assertion that could express "this comment is true", and
+inventing one would be worse than the defect.
+
+## Test plan
+
+There is no behaviour to test — this is a comment fix, so a RED test is not available and pretending
+otherwise would be dishonest. Verification is:
+
+- the full `screamingface` gate suite stays green (it must be unaffected — that is the claim);
+- `git diff` shows **comment lines only**, checked mechanically rather than by eye;
+- the word `uniform` survives only where it is explicitly **denied**, and the replacement reasoning
+  matches what `OME-820` and `apps/scoreboard` already say, so the copies cannot drift again.
+
+## Acceptance
+
+- No comment or docstring claims the field is uniform.
+- Both state the real reason: the value certifies nothing, so a filter would split by submission date.
+- The diff changes no executable statement, proven by token comparison.
+- Full gates green.
+
+## Outcome
+
+Status: **DONE** (2026-08-15)
+
+- **Actual files:** one — `packages/screamingface/src/screamingface/_ui/leaderboard_view.py`
+  (+19/−9, all of it prose).
+- **Gates:** `run_gates.py screamingface --base origin/main` — **ALL 8 GREEN**: append-only, ruff
+  check, ruff format, pyright, pytest ≥95% cov, notebook determinism, `uv build`, distribution check.
+
+### What the mechanical check caught that reading would not have
+
+The plan's Step 3 compared **tokenized** source rather than the diff text. It paid for itself twice:
+
+1. **Three occurrences, not two.** I had found `:63-64` and `:119-121` by reading. The third lived in
+   the `_row_chip` docstring, where `grep`-by-eye over a diff would not have put it.
+2. **One of them is not a comment.** A docstring is a STRING token, so the acceptance criterion this
+   ledger originally carried — *"the diff touches comment lines only"* — was itself false. Restated as
+   "no executable statement changes", which is the property that actually matters.
+
+An earlier run of that check also produced a **false pass**: the shell invocation used an unexpanded
+`$F`, so `git diff` matched no path, the grep found nothing, and the "comment lines only" branch
+fired on an empty diff. Caught by adding a `git diff --stat` sanity line first. Worth keeping: a
+verification step that cannot fail is not a verification step.
+
+### Docstring change justified rather than assumed harmless
+
+Docstrings are runtime objects, so changing one is not automatically inert. Checked: nothing in
+`src/`, `tests/` or `scripts/` reads `__doc__`, there are no doctests, and `_row_chip` is private
+(its only other mention is inside a test's own comment).
+
+### Deviations
+
+1. **Three corrections, not the two planned** — see above.
+2. **`uniform` still appears twice in the file, and that is deliberate.** Both remaining uses
+   explicitly *deny* it (`"the value is NOT uniform"`, and a note that the old wording was wrong).
+   Deleting the word entirely would lose the correction's own record.
+
+### Found, not fixed — out of scope
+
+**The `screamingface` gate card omits a prerequisite.** `run_gates.py screamingface` runs
+`uv run pyright` on a plain checkout and produces **9 errors** for unresolved `ipywidgets` /
+`IPython.display` imports across `connection_view.py`, `connections.py`, `evaluation_view.py` and
+`test_connection_panel.py` — none of them related to the change under test. CI avoids this by running
+`uv sync --extra notebook` first (`screamingface-tests.yml:48`); the card in `.claude/sdlc.local.md`
+does not say so, so a local run and CI disagree about whether the stack is green.
+
+Same class of gap as the Node prerequisite `OME-798` documented. Not fixed here: it is a
+`.claude/sdlc.local.md` edit, which would pull a second set of reviewers onto a PR whose entire
+argument is "prose only, zero risk".

--- a/packages/screamingface/src/screamingface/_ui/leaderboard_view.py
+++ b/packages/screamingface/src/screamingface/_ui/leaderboard_view.py
@@ -61,13 +61,12 @@ class _DisplayRow:
     accuracy: float
     questions: int | None
     # AIDEV-NOTE: UNUSED since OME-832. Its readers were the data-verified attribute
-    # and the `verified` chip, both removed because verified_by_openmined became
-    # uniform and asserted nothing (OME-820). `_candidate_row` still populates it, so
-    # nothing in ruff, pyright or coverage will notice it going stale. Parked
-    # deliberately for OME-821, which gives the flag a real signal and restores both
-    # readers. Do NOT key new presentation on it before then — a row's value says
-    # nothing today, and doing so would reintroduce the inert trust signal this
-    # change removed.
+    # and the `verified` chip, both removed because verified_by_openmined asserts
+    # nothing (OME-820). `_candidate_row` still populates it, so nothing in ruff,
+    # pyright or coverage will notice it going stale. Parked deliberately for OME-821,
+    # which gives the flag a real signal and restores both readers. Do NOT key new
+    # presentation on it before then — a row's value says nothing today, and doing so
+    # would reintroduce the inert trust signal this change removed.
     verified: bool | None
     python_source: str | None
     source_url: str | None
@@ -117,8 +116,19 @@ def leaderboard_html(board: Leaderboard) -> str:
         "<span class='sf-lb__field-label'>benchmark:</span>"
         f"<span class='sf-lb__field-value'>{title}</span></span>"
         # OME-832: the "verified only" checkbox lived here. Removed, not relabelled —
-        # verified_by_openmined is uniform since OME-820, so no row carries
-        # data-verified=false and the control removed nothing. OME-821 restores it.
+        # verified_by_openmined CERTIFIES NOTHING whatever it holds: nothing re-runs
+        # submissions (OME-414) and nothing attests where a run executed.
+        #
+        # WHY that is a reason to delete the control rather than leave it: the value is
+        # NOT uniform. OME-820 forbids a backfill, so rows predating it keep false while
+        # newer rows are true. A filter would therefore partition rows by whether they
+        # predate the default change, while presenting itself as a verification filter —
+        # measuring submission date and reading as though it measured trust. That is
+        # worse than filtering nothing, which is why relabelling could not have fixed it.
+        #
+        # OME-821 restores the control once the flag means something (OME-841 corrected
+        # this note, which previously said the field was "uniform" — it is not, and that
+        # wording argued for the opposite conclusion to the one this code took).
         "</div></div>"
         "<div class='sf-lb__table' role='table'>"
         "<div class='sf-lb__row sf-lb__row--head' role='row'>"
@@ -229,11 +239,11 @@ def _row_chip(value: _DisplayRow) -> str:
     url4 expression and says nothing about where a row came from.
 
     WHY that matters: this used to read `if value.verified: … ; if value.python_source is
-    None: baseline`. The verified branch was removed in OME-832 because the flag became
-    uniform and asserted nothing (OME-820). Deleting it alone would have let a candidate
-    with an unforkable url4 fall through and be labelled "baseline" — presenting a
-    community submission as an imported reference, a worse error than the one being
-    fixed. It already did that for *unverified* such candidates, which this also fixes.
+    None: baseline`. The verified branch was removed in OME-832 because the flag asserts
+    nothing (OME-820). Deleting it alone would have let a candidate with an unforkable
+    url4 fall through and be labelled "baseline" — presenting a community submission as
+    an imported reference, a worse error than the one being fixed. It already did that
+    for *unverified* such candidates, which this also fixes.
     """
     if value.kind == "single":
         return "<span class='sf-lb__chip'>baseline</span>"


### PR DESCRIPTION
Linear: [OME-841](https://linear.app/openmined/issue/OME-841/correct-the-notebook-views-justification-for-removing-the-verified)

**Prose only. No executable statement changes.** Follow-up to #601, which I merged yesterday — the
change it made was right, the reason it recorded for it is false.

## Context, for a reader who was not in #588

`verified_by_openmined` is a leaderboard flag that was *meant* to mean "OpenMined verified this run".
Nothing actually verifies runs — the re-run service (OME-414) is unstarted — so OME-820 turned the
field into a placeholder that **asserts nothing**, and OME-832 (#601) removed this package's
`verified` chip and "verified only" filter accordingly.

## What's wrong

`_ui/leaderboard_view.py:119-121` records why the filter went:

> `verified_by_openmined` is **uniform** since OME-820, so **no row carries `data-verified=false`**
> and the control removed nothing.

That is a factual claim about the data, and it is false. OME-820 explicitly forbids a backfill, so
every row created before it still holds `false`.

It matters because of *where* it sits: it is the justification for deleting a user-facing control.
The next person to touch this reads it, checks it, finds it untrue, and may reasonably restore the
filter.

## The real reason is stronger, not weaker

The field **certifies nothing, whatever value it holds.** So a "verified only" filter would not be
harmlessly inert — it would partition rows by **whether they predate the default change**, while
presenting itself as a verification filter. It would look like it measured trust and actually measure
submission date. That is worse than filtering nothing, which is why the control was removed rather
than relabelled.

Note the asymmetry the wrong word introduced: *"uniform"* implies the control is harmless and could
come back any time. *"Certifies nothing"* implies it is actively misleading and must not, until
OME-821 gives the flag a meaning. **The wrong word argued for the opposite conclusion to the one this
code took.**

## What changed

Three occurrences, not the two I found by reading:

| Location | Was | Now |
|---|---|---|
| `_DisplayRow.verified` note | "became uniform and asserted nothing" | "asserts nothing" |
| the removed-checkbox note | the false claim above | the certifies-nothing reason, plus why that means it must not return |
| `_row_chip` docstring | "the flag became uniform and asserted nothing" | "the flag asserts nothing" |

The wording matches what OME-820, OME-821 and `apps/scoreboard/portal` already say, so the copies
cannot drift apart again.

`uniform` still appears twice, both times explicitly **denied** — deleting the word entirely would
lose the correction's own record.

## How I verified it is inert

Not by reading the diff. The check compares **tokenized source** between `origin/main` and the branch,
dropping COMMENT and NL tokens — a regex would not do, because this file is full of HTML string
literals containing `#`.

It paid for itself twice:

1. **It found the third occurrence**, in the docstring, which I had missed by reading.
2. **It showed my own acceptance criterion was wrong.** A docstring is a STRING token, not a comment,
   so "the diff touches comment lines only" was false. Restated as "no executable statement changes",
   which is the property that actually matters. Then justified the docstring edit rather than
   assuming it harmless: nothing in `src/`, `tests/` or `scripts/` reads `__doc__`, there are no
   doctests, and `_row_chip` is private.

An earlier run of that check also produced a **false pass** — an unexpanded shell variable meant
`git diff` matched no path, so the "comment lines only" branch fired on an empty diff. Caught by
adding a `--stat` sanity line first.

## Test plan

- `run_gates.py screamingface --base origin/main` — **all 8 green**: append-only, ruff check, ruff
  format, pyright, pytest ≥95% cov, notebook determinism, `uv build`, distribution check.
- No test added. There is no assertion that can express "this comment is true", and inventing one
  would be worse than the defect.

## Reviewer note

CODEOWNERS puts `/packages/screamingface/` with @IonesioJunior and @keelancj, so this needs your
sign-off rather than the scoreboard owner's, despite originating from scoreboard work. Sorry for the
tiny PR — the alternative was folding it into OME-821, which is blocked behind an open review and
would have left the false claim on `main` indefinitely.

**Found, not fixed:** `run_gates.py screamingface` on a plain checkout produces 9 pyright errors for
unresolved `ipywidgets` / `IPython.display` imports, because the gate card never says to run
`uv sync --extra notebook` first — CI does it at `screamingface-tests.yml:48`. Nothing to do with this
change; happy to file it separately.