### PR TITLE
feat(scoreboard): register DRACO, IFEval and HealthBench with revision identity

### DIFF
--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -101,7 +101,40 @@ seedBenchmarks:
   backoffLimit: 3
   ttlSecondsAfterFinished: 600
   annotations: {}
+  # The `revision` of each entry MUST match the Engine benchmark's computed REVISION exactly
+  # (apps/url4-cloud/src/url4_cloud/benchmarks/<name>/definition.py). A submission carries the
+  # Engine's value, and the board ranks per revision — a mismatch makes every real submission
+  # look incomparable to the registered board. Re-copy these whenever a benchmark's dataset or
+  # protocol revision changes; seeding is idempotent, so redeploying just moves the value.
   benchmarks:
+    # --- Engine benchmarks (OME-775) --------------------------------------------------
+    - id: draco
+      display_name: DRACO
+      description: >-
+        A 100-task DRACO reproduction with official score arithmetic. It uses the successor
+        Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a
+        host-only approximation of the reference blocklist, so its scores are not
+        paper-identical.
+      dataset_url: https://huggingface.co/datasets/perplexity-ai/draco
+      revision: 1c58b3085912e304
+    - id: ifeval
+      display_name: IFEval
+      description: >-
+        The canonical 541-prompt instruction-following benchmark, graded by deterministic
+        strict and loose verification. Each Case invokes the Candidate exactly once.
+      # WHY no dataset_url: the IFEval dataset is vendored inside the Engine
+      # (url4_cloud.benchmarks.ifeval.vendor), so no single public URL is authoritative.
+      revision: 0b88a52b5f10a6d9
+    - id: healthbench-worst30
+      display_name: HealthBench Worst-30% Challenge
+      description: >-
+        The 157 hardest conversations from HealthBench Professional — the 30% that top
+        models score worst on. An AI judge grades each answer against a physician-written
+        rubric; safety mistakes subtract points, so per-case scores can be negative.
+      dataset_url: https://huggingface.co/datasets/openai/healthbench
+      revision: 6cd57aee171fbdc4
+    # --- Legacy demo entries, deliberately retained (OME-775 D2) -----------------------
+    # No Engine revision exists for these; they predate the Engine benchmark catalogue.
     - id: livetruth-latest
       display_name: News Livetruth Latest
       description: OpenMined Livetruth latest demo dataset

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -34,6 +34,9 @@ class RankedLeaderboardEntry(BaseModel):
 
     rank: int
     spec_id: str
+    # WHY: the board ranks best-per-spec PER REVISION (OME-775), so one spec can legitimately
+    # appear twice. Without this field a client cannot tell why the two are not competing.
+    benchmark_revision: str | None
     accuracy: float
     total_questions: int
     ran_with_providers: list[str]

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -98,6 +98,7 @@ async def _get_benchmark_or_404(benchmark_id: str) -> BenchmarkSchema:
         display_name=benchmark.display_name,
         description=benchmark.description,
         dataset_url=benchmark.dataset_url,
+        revision=benchmark.revision,
         created_at=benchmark.created_at,
     )
 

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -61,6 +61,9 @@ class HistorySubmission(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: UUID
+    # WHY: a spec's history can span benchmark revisions, and two entries measured against
+    # different revisions are not comparable to each other (OME-775).
+    benchmark_revision: str | None
     accuracy: float
     total_questions: int
     correct_questions: int
@@ -106,6 +109,7 @@ def _ranked_entry(rank: int, entry: LeaderboardEntry) -> RankedLeaderboardEntry:
 def _history_submission(score: ScoreSchema) -> HistorySubmission:
     return HistorySubmission(
         id=score.id,
+        benchmark_revision=score.benchmark_revision,
         accuracy=score.accuracy,
         total_questions=score.total_questions,
         correct_questions=score.correct_questions,

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0004_auto_20260816_0630.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0004_auto_20260816_0630.py
@@ -1,0 +1,25 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [("models", "0003_auto_20260713_1505")]
+
+    initial = False
+
+    operations = [
+        # WHY both are nullable with no backfill: the retained legacy demo benchmarks have no
+        # Engine revision, and every pre-existing score genuinely ran before revisions were
+        # recorded — inventing a value would assert something false about what was measured
+        # (OME-775 D4).
+        ops.AddField(
+            model_name="Benchmark",
+            name="revision",
+            field=fields.CharField(null=True, max_length=64),
+        ),
+        ops.AddField(
+            model_name="Score",
+            name="benchmark_revision",
+            field=fields.CharField(null=True, db_index=True, max_length=64),
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/benchmark.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/benchmark.py
@@ -13,6 +13,12 @@ class BaseBenchmark(BaseScoreboardModel):
     display_name = fields.CharField(max_length=255)
     description = fields.TextField(null=True)
     dataset_url = fields.CharField(max_length=2048, null=True)
+    # INVARIANT: mirrors the Engine benchmark's immutable REVISION — a sha256 over its
+    # dataset + protocol (+ verifier) revisions. It identifies *what was measured*, so two
+    # revisions of one benchmark are not comparable results (OME-775).
+    # WHY nullable: the retained legacy demo entries (hle/livetruth/livetruth-latest) have no
+    # Engine revision, so this column is added without a backfill.
+    revision = fields.CharField(max_length=64, null=True)
     created_at = fields.DatetimeField(auto_now_add=True)
 
 

--- a/apps/scoreboard/src/scoreboard/scores/models/score.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/score.py
@@ -26,6 +26,15 @@ class BaseScore(BaseScoreboardModel):
     client_version = fields.CharField(max_length=64, null=True)
     client_platform = fields.CharField(max_length=32, null=True)
     verified_by_openmined = fields.BooleanField(default=False)
+    # INVARIANT: the Engine benchmark revision this score was produced against. The
+    # leaderboard partitions ranking on (spec_id, benchmark_revision) so results measured
+    # against different dataset/protocol revisions never rank against each other (OME-775).
+    # WHY nullable + indexed: OME-322's imported LMArena baselines never ran at any revision
+    # and every row predating this change has none, so no backfill is possible; indexed
+    # because it is a ranking partition key.
+    # AIDEV-NOTE: the Client sends this inside the free-form `metadata` dict today; the store
+    # promotes it via _resolve_benchmark_revision. Read that before changing the wire shape.
+    benchmark_revision = fields.CharField(max_length=64, null=True, db_index=True)
     metadata = fields.JSONField(null=True)
     # INVARIANT: sha256 hex over the submission's recipe identity (benchmark, spec,
     # url4 expression, result numbers, provider order) — NOT submitted_by or client

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -179,6 +179,10 @@ class LeaderboardEntry(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     spec_id: str
+    # WHY exposed: the board partitions ranking on this, so a client seeing two rows for one
+    # spec needs the revision to know why they are not competing (OME-775). Null for rows that
+    # predate the column and for imported baselines.
+    benchmark_revision: str | None
     accuracy: float
     total_questions: int
     ran_with_providers: list[str]

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -78,6 +78,10 @@ class ScoreSubmission(BaseModel):
 
     version: Literal[1] = 1
     benchmark_id: str
+    # WHY optional: the deployed Client sends this nested in `metadata` rather than as a typed
+    # field, so the store resolves either shape (_resolve_benchmark_revision). Requiring it
+    # here would 422 every submission in the field; see OME-775 D5.
+    benchmark_revision: str | None = None
     spec_id: str
     url4_expression: Annotated[str, Field(max_length=32_000)]
     submitted_by: str | None = None

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -157,6 +157,9 @@ class ScoreSchema(BaseModel):
     id: UUID
     version: int
     benchmark_id: str
+    # WHY: the Engine benchmark revision this score was measured against, resolved from either
+    # wire shape by the store. Null for imported baselines and rows predating OME-775.
+    benchmark_revision: str | None
     spec_id: str
     url4_expression: str
     submitted_by: str | None

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -146,6 +146,9 @@ class BenchmarkSchema(BaseModel):
     display_name: str
     description: str | None
     dataset_url: str | None
+    # WHY exposed: a client comparing its run against the board needs to know which revision
+    # the board is registered at, so it can tell a real score gap from an incomparable one.
+    revision: str | None
     created_at: datetime
 
 

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -26,6 +26,7 @@ def _benchmark_to_schema(model: Benchmark) -> BenchmarkSchema:
         display_name=model.display_name,
         description=model.description,
         dataset_url=model.dataset_url,
+        revision=model.revision,
         created_at=model.created_at,
     )
 
@@ -186,12 +187,14 @@ class ScoreStore:
         display_name: str,
         description: str | None = None,
         dataset_url: str | None = None,
+        revision: str | None = None,
     ) -> BenchmarkSchema:
         benchmark, _ = await Benchmark.update_or_create(
             defaults={
                 "display_name": display_name,
                 "description": description,
                 "dataset_url": dataset_url,
+                "revision": revision,
             },
             id=benchmark_id,
         )

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -35,6 +35,7 @@ def _score_to_schema(model: Score) -> ScoreSchema:
         id=model.id,
         version=model.version,
         benchmark_id=cast(str, getattr(model, "benchmark_id")),
+        benchmark_revision=model.benchmark_revision,
         spec_id=model.spec_id,
         url4_expression=model.url4_expression,
         submitted_by=model.submitted_by,

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -131,12 +131,24 @@ class SubmitOutcome(NamedTuple):
     created: bool
 
 
-def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
+def _build_leaderboard_query(
+    benchmark_id: str, top_n: int, registered_revision: str | None
+) -> QueryBuilder:
     scores = Score.get_table()
-    # INVARIANT: best-per-spec is computed PER REVISION. Results measured against different
-    # benchmark revisions are not comparable, so one must never displace the other from the
-    # board (OME-775). Rows predating the revision column share a NULL partition value and so
-    # keep collapsing to best-per-spec exactly as before.
+    # INVARIANT: every entry the board ranks was measured against the revision the benchmark is
+    # REGISTERED at. The board presents a single ordered ranking, so admitting a second revision
+    # would assert that two incomparable numbers can be compared — a stale-revision score could
+    # hold rank 1 on a board registered elsewhere (OME-775).
+    #
+    # WHY partitioning alone was not enough: the window below stops one revision displacing
+    # another in the best-per-spec collapse, but the outer query still orders every surviving
+    # row into ONE accuracy ranking. Both are needed — the partition keeps each revision's best
+    # intact, the filter decides which revision the board is actually about.
+    #
+    # AIDEV-NOTE: a benchmark with NO registered revision filters nothing — the retained legacy
+    # demo entries (hle/livetruth) have no Engine revision, and filtering would empty their
+    # boards. Once a benchmark DOES declare one, a row that cannot be asserted comparable to it
+    # (including a NULL row predating this column) does not rank.
     row_number = (
         RowNumber()
         .over(scores.spec_id, scores.benchmark_revision)
@@ -159,7 +171,10 @@ def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
             row_number,
         )
         .where(scores.benchmark_id == benchmark_id)
-    ).as_("ranked")
+    )
+    if registered_revision is not None:
+        ranked = ranked.where(scores.benchmark_revision == registered_revision)
+    ranked = ranked.as_("ranked")
 
     return (
         Query.from_(ranked)
@@ -318,8 +333,13 @@ class ScoreStore:
 
     async def leaderboard(self, benchmark_id: str, top_n: int = 50) -> list[LeaderboardEntry]:
         conn = Tortoise.get_connection("default")
+        # The board is defined by the revision its benchmark is registered at; entries measured
+        # against anything else are not comparable to it and do not rank (OME-775).
+        benchmark = await Benchmark.get_or_none(id=benchmark_id)
         result = await execute_pypika(
-            _build_leaderboard_query(benchmark_id, top_n),
+            _build_leaderboard_query(
+                benchmark_id, top_n, benchmark.revision if benchmark else None
+            ),
             using_db=conn,
         )
         rows = result.rows

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -52,9 +52,26 @@ def _score_to_schema(model: Score) -> ScoreSchema:
     )
 
 
+def _resolve_benchmark_revision(submission: ScoreSubmission) -> str | None:
+    # WHY: the deployed Client sends the Engine benchmark revision nested in the free-form
+    # `metadata` dict, not as a typed field (packages/screamingface/.../leaderboards.py).
+    # Reading only the typed field would silently drop it for every client in the field;
+    # rejecting the metadata copy would 422 every live submission. So the typed field wins
+    # when usable and metadata is the fallback (OME-775 D5).
+    # INVARIANT: this reads metadata, it never mutates or strips it — the payload is stored
+    # exactly as sent.
+    if submission.benchmark_revision:
+        return submission.benchmark_revision
+    candidate = (submission.metadata or {}).get("benchmark_revision")
+    # INVARIANT: metadata is client-supplied and unvalidated, so a non-string or empty value
+    # is absent input, never an error.
+    return candidate if isinstance(candidate, str) and candidate else None
+
+
 def _submission_to_kwargs(submission: ScoreSubmission, content_hash: str) -> dict[str, object]:
     return {
         "benchmark_id": submission.benchmark_id,
+        "benchmark_revision": _resolve_benchmark_revision(submission),
         "version": submission.version,
         "spec_id": submission.spec_id,
         "url4_expression": submission.url4_expression,

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -131,9 +131,13 @@ class SubmitOutcome(NamedTuple):
 
 def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
     scores = Score.get_table()
+    # INVARIANT: best-per-spec is computed PER REVISION. Results measured against different
+    # benchmark revisions are not comparable, so one must never displace the other from the
+    # board (OME-775). Rows predating the revision column share a NULL partition value and so
+    # keep collapsing to best-per-spec exactly as before.
     row_number = (
         RowNumber()
-        .over(scores.spec_id)
+        .over(scores.spec_id, scores.benchmark_revision)
         .orderby(scores.accuracy, order=Order.desc)
         .orderby(scores.submitted_at, order=Order.desc)
         .as_("rn")
@@ -142,6 +146,7 @@ def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
         Query.from_(scores)
         .select(
             scores.spec_id,
+            scores.benchmark_revision,
             scores.accuracy,
             scores.total_questions,
             scores.ran_with_providers,
@@ -158,6 +163,7 @@ def _build_leaderboard_query(benchmark_id: str, top_n: int) -> QueryBuilder:
         Query.from_(ranked)
         .select(
             ranked.spec_id,
+            ranked.benchmark_revision,
             ranked.accuracy,
             ranked.total_questions,
             ranked.ran_with_providers,

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -102,8 +102,17 @@ def _content_hash(submission: ScoreSubmission) -> str:
     # 0.01 of that ratio, so the same result (e.g. 2/3 correct) could otherwise be
     # reported as 0.67 or 0.6666666667 and hash differently, defeating dedup for the
     # exact near-duplicate case this hash exists to catch (found in PR review).
+    # OME-775: the benchmark revision IS identity, unlike the rest of `metadata` it may arrive
+    # in — a different dataset/protocol revision is a different thing measured, not incidental
+    # provenance. It reads the RESOLVED value, not the wire position, so a client migrating
+    # from the metadata form to the typed form does not duplicate its whole history.
+    # AIDEV-NOTE: stored content_hash values predating this were computed WITHOUT the revision
+    # and were deliberately not backfilled (D3). The bounded consequence: resubmitting a recipe
+    # that predates this change creates a second row instead of deduping. Accepted over the
+    # alternative, which silently discarded a second revision's result entirely.
     identity = {
         "benchmark_id": submission.benchmark_id,
+        "benchmark_revision": _resolve_benchmark_revision(submission),
         "spec_id": submission.spec_id,
         "url4_expression": submission.url4_expression,
         "accuracy": submission.correct_questions / submission.total_questions,

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -23,6 +23,10 @@ class SeedBenchmark(BaseModel):
     display_name: str = Field(min_length=1, max_length=255)
     description: str | None = None
     dataset_url: str | None = None
+    # INVARIANT: must match the Engine benchmark's computed REVISION exactly — a submission
+    # carries the Engine's value, and the two are compared for comparability (OME-775).
+    # Optional because the retained legacy demo entries have no Engine revision.
+    revision: str | None = Field(default=None, max_length=64)
 
 
 _BENCHMARKS_ADAPTER = TypeAdapter(list[SeedBenchmark])
@@ -50,6 +54,7 @@ async def seed_benchmarks(benchmarks: Sequence[SeedBenchmark]) -> list[Benchmark
                 display_name=benchmark.display_name,
                 description=benchmark.description,
                 dataset_url=benchmark.dataset_url,
+                revision=benchmark.revision,
             )
         )
     return seeded

--- a/apps/scoreboard/tests/unit/scores/test_models.py
+++ b/apps/scoreboard/tests/unit/scores/test_models.py
@@ -113,3 +113,24 @@ def test_baseline_model_package_exports_and_abstract_base() -> None:
 
 def test_baseline_model_lives_in_its_own_file() -> None:
     assert Baseline.__module__ == "scoreboard.scores.models.baseline"
+
+
+def test_benchmark_model_carries_a_nullable_revision() -> None:
+    # WHY: OME-775 registers the Engine's canonical benchmarks, whose identity includes an
+    # immutable revision hash over dataset + protocol. Nullable because the retained legacy
+    # demo entries (hle/livetruth) have no Engine revision at all — no backfill (D4).
+    revision_field = cast(Any, Benchmark._meta.fields_map["revision"])
+
+    assert revision_field.null is True
+    assert revision_field.max_length == 64
+
+
+def test_score_model_carries_a_nullable_indexed_benchmark_revision() -> None:
+    # WHY: the leaderboard partitions ranking on this column (OME-775), so it is indexed.
+    # Nullable because OME-322's imported LMArena baselines genuinely never ran at any
+    # revision, and every row predating this change has none.
+    revision_field = cast(Any, Score._meta.fields_map["benchmark_revision"])
+
+    assert revision_field.null is True
+    assert revision_field.max_length == 64
+    assert revision_field.index is True

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -671,3 +671,62 @@ async def test_score_read_schema_serialises_an_absent_revision_as_null(
 
     assert "benchmark_revision" in score.model_dump()
     assert score.benchmark_revision is None
+
+
+# --- OME-775 follow-up: the board shows only the registered revision ------------------------
+# The partition alone was not enough. It stopped one revision displacing another in the
+# best-per-spec collapse, but the outer query still ordered every surviving row into ONE
+# accuracy ranking — so a stale-revision score could hold rank 1 on a board registered at a
+# different revision, presenting two incomparable numbers as a ranking. Verified against a
+# running server before this was written.
+
+
+async def _benchmark_at(revision: str | None) -> ScoreStore:
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="Fixture", revision=revision)
+    return store
+
+
+async def test_leaderboard_excludes_scores_from_a_non_registered_revision(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: every entry the board ranks was measured against the revision the board is
+    # registered at. A higher score from an obsolete revision must not outrank a current one.
+    store = await _benchmark_at("REV-CURRENT")
+    await store.submit(
+        _revision_submission(spec_id="old-winner", benchmark_revision="REV-OBSOLETE")
+    )
+    await store.submit(_revision_submission(spec_id="new-entry", benchmark_revision="REV-CURRENT"))
+
+    rows = await store.leaderboard("hle")
+
+    assert [row.spec_id for row in rows] == ["new-entry"]
+    assert all(row.benchmark_revision == "REV-CURRENT" for row in rows)
+
+
+async def test_leaderboard_without_a_registered_revision_filters_nothing(
+    tortoise_db: None,
+) -> None:
+    # WHY: the retained legacy demo benchmarks have no Engine revision (D2). Filtering on a
+    # null registered revision would empty their boards entirely.
+    store = await _benchmark_at(None)
+    await store.submit(_revision_submission(spec_id="legacy-a", benchmark_revision=None))
+    await store.submit(_revision_submission(spec_id="legacy-b", benchmark_revision="whatever"))
+
+    rows = await store.leaderboard("hle")
+
+    assert {row.spec_id for row in rows} == {"legacy-a", "legacy-b"}
+
+
+async def test_leaderboard_at_a_registered_revision_excludes_pre_revision_rows(
+    tortoise_db: None,
+) -> None:
+    # Rows predating OME-775 carry a NULL revision. Once a benchmark declares a revision, such
+    # a row cannot be asserted comparable to it, so it does not rank.
+    store = await _benchmark_at("REV-CURRENT")
+    await store.submit(_revision_submission(spec_id="pre-revision", benchmark_revision=None))
+    await store.submit(_revision_submission(spec_id="current", benchmark_revision="REV-CURRENT"))
+
+    rows = await store.leaderboard("hle")
+
+    assert [row.spec_id for row in rows] == ["current"]

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -574,3 +574,76 @@ async def test_identity_follows_the_resolved_revision_not_its_wire_position(
     assert first_created is True
     assert second_created is False
     assert first.id == second.id
+
+
+# --- OME-775: ranking partitions on (spec_id, benchmark_revision) ---------------------------
+
+
+async def test_leaderboard_ranks_each_revision_of_a_spec_separately(tortoise_db: None) -> None:
+    # INVARIANT: results measured against different benchmark revisions are not comparable, so
+    # the board must not let one beat the other. Before OME-775 this returned a single row —
+    # the higher accuracy winning across an incomparable boundary.
+    store = await _store_with_benchmark()
+    await store.submit(
+        _revision_submission(spec_id="spec-x", benchmark_revision="rev-old"),
+    )
+    await store.submit(
+        _revision_submission(spec_id="spec-x", benchmark_revision="rev-new"),
+    )
+
+    rows = await store.leaderboard("hle")
+
+    assert len(rows) == 2
+    assert {row.benchmark_revision for row in rows} == {"rev-old", "rev-new"}
+    assert {row.spec_id for row in rows} == {"spec-x"}
+
+
+async def test_leaderboard_still_collapses_within_one_revision(tortoise_db: None) -> None:
+    # Best-per-spec is preserved inside a revision — the partition adds a dimension, it does
+    # not stop collapsing.
+    store = await _store_with_benchmark()
+    await store.submit(
+        ScoreSubmission(
+            benchmark_id="hle",
+            spec_id="spec-y",
+            url4_expression="url4://benchmark/spec-y/low",
+            accuracy=0.60,
+            total_questions=100,
+            correct_questions=60,
+            ran_with_providers=["openai"],
+            benchmark_revision="rev-same",
+        )
+    )
+    await store.submit(
+        ScoreSubmission(
+            benchmark_id="hle",
+            spec_id="spec-y",
+            url4_expression="url4://benchmark/spec-y/high",
+            accuracy=0.90,
+            total_questions=100,
+            correct_questions=90,
+            ran_with_providers=["openai"],
+            benchmark_revision="rev-same",
+        )
+    )
+
+    rows = await store.leaderboard("hle")
+
+    assert len(rows) == 1
+    assert rows[0].accuracy == 0.90
+
+
+async def test_leaderboard_groups_null_revision_rows_exactly_as_before(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: backward compatibility. Every row predating OME-775 has a NULL revision, so
+    # they must keep collapsing to best-per-spec rather than splintering into one row each.
+    store = await _store_with_benchmark()
+    await store.submit(_submission(spec_id="spec-legacy", accuracy=0.60))
+    await store.submit(_submission(spec_id="spec-legacy", accuracy=0.85))
+
+    rows = await store.leaderboard("hle")
+
+    assert len(rows) == 1
+    assert rows[0].accuracy == 0.85
+    assert rows[0].benchmark_revision is None

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -647,3 +647,27 @@ async def test_leaderboard_groups_null_revision_rows_exactly_as_before(
     assert len(rows) == 1
     assert rows[0].accuracy == 0.85
     assert rows[0].benchmark_revision is None
+
+
+# --- OME-775: the revision reaches the score read DTO ---------------------------------------
+
+
+async def test_score_read_schema_carries_the_resolved_revision(tortoise_db: None) -> None:
+    store = await _store_with_benchmark()
+
+    score, _ = await store.submit(_revision_submission(metadata={"benchmark_revision": "rev-read"}))
+
+    assert score.benchmark_revision == "rev-read"
+
+
+async def test_score_read_schema_serialises_an_absent_revision_as_null(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: absent means null, never omitted — a client must be able to distinguish
+    # "no revision recorded" from "field missing from this deployment".
+    store = await _store_with_benchmark()
+
+    score, _ = await store.submit(_revision_submission(metadata={"source": "unit"}))
+
+    assert "benchmark_revision" in score.model_dump()
+    assert score.benchmark_revision is None

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -524,3 +524,53 @@ async def test_submit_treats_an_unusable_metadata_revision_as_absent(
 
     assert created is True
     assert await _stored_revision(score.id) is None
+
+
+# --- OME-775: revision participates in dedup identity (D3) ----------------------------------
+
+
+async def test_same_recipe_at_two_revisions_does_not_dedup(tortoise_db: None) -> None:
+    # INVARIANT: a different benchmark revision is a different thing measured, so it is part
+    # of the recipe's identity. Before OME-775 these two collided and the second was silently
+    # discarded — which would have made the ranking partition unreachable, since the second
+    # revision's row never existed.
+    store = await _store_with_benchmark()
+
+    first, first_created = await store.submit(_revision_submission(benchmark_revision="rev-a"))
+    second, second_created = await store.submit(_revision_submission(benchmark_revision="rev-b"))
+
+    assert first_created is True
+    assert second_created is True
+    assert first.id != second.id
+    assert await Score.all().count() == 2
+
+
+async def test_identical_submissions_still_dedup_with_a_revision(tortoise_db: None) -> None:
+    # The OME-391 guarantee must survive the identity change.
+    store = await _store_with_benchmark()
+
+    first, first_created = await store.submit(_revision_submission(benchmark_revision="rev-a"))
+    second, second_created = await store.submit(_revision_submission(benchmark_revision="rev-a"))
+
+    assert first_created is True
+    assert second_created is False
+    assert first.id == second.id
+    assert await Score.all().count() == 1
+
+
+async def test_identity_follows_the_resolved_revision_not_its_wire_position(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: a revision sent typed and the same revision sent in metadata are the same
+    # submission. If identity read the wire shape instead of the resolved value, a client
+    # upgrading from the metadata form to the typed form would duplicate its whole history.
+    store = await _store_with_benchmark()
+
+    first, first_created = await store.submit(
+        _revision_submission(metadata={"benchmark_revision": "rev-a"})
+    )
+    second, second_created = await store.submit(_revision_submission(benchmark_revision="rev-a"))
+
+    assert first_created is True
+    assert second_created is False
+    assert first.id == second.id

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -412,3 +412,115 @@ async def test_postgres_concurrent_identical_recipe_submissions_share_winner(
 
     assert len({outcome.score.id for outcome in results}) == 1
     assert await Score.all().count() == 1
+
+
+# --- OME-775: benchmark revision resolution ------------------------------------------------
+# INVARIANT: the resolved revision is the same value whether the Client sent it as a typed
+# top-level field or nested in the free-form metadata dict. Wire position must not change
+# identity — the store has one resolution rule and everything downstream reads its output.
+
+
+def _revision_submission(
+    *,
+    spec_id: str = "spec-rev",
+    benchmark_revision: str | None = None,
+    metadata: dict[str, object] | None = None,
+) -> ScoreSubmission:
+    return ScoreSubmission(
+        benchmark_id="hle",
+        spec_id=spec_id,
+        url4_expression=f"url4://benchmark/{spec_id}",
+        submitted_by="tester",
+        accuracy=0.75,
+        total_questions=100,
+        correct_questions=75,
+        ran_with_providers=["openai"],
+        benchmark_revision=benchmark_revision,
+        metadata=metadata,
+    )
+
+
+async def _stored_revision(score_id: object) -> str | None:
+    # WHY assert on the persisted row rather than the returned schema: this step's contract is
+    # resolution + storage. Exposure on the read schemas is a separate contract with its own
+    # tests, so the two can fail independently.
+    row = await Score.get(id=score_id)
+    return row.benchmark_revision
+
+
+async def test_submit_stores_a_typed_top_level_benchmark_revision(tortoise_db: None) -> None:
+    store = await _store_with_benchmark()
+
+    score, _ = await store.submit(_revision_submission(benchmark_revision="rev-typed"))
+
+    assert await _stored_revision(score.id) == "rev-typed"
+
+
+async def test_submit_promotes_the_revision_from_metadata(tortoise_db: None) -> None:
+    # WHY: this is the shape every deployed Client sends today
+    # (packages/screamingface/.../leaderboards.py) — it must keep working.
+    store = await _store_with_benchmark()
+
+    score, _ = await store.submit(
+        _revision_submission(metadata={"benchmark_revision": "rev-meta", "run_id": "r1"})
+    )
+
+    assert await _stored_revision(score.id) == "rev-meta"
+
+
+async def test_submit_prefers_the_typed_revision_over_the_metadata_copy(
+    tortoise_db: None,
+) -> None:
+    store = await _store_with_benchmark()
+
+    score, _ = await store.submit(
+        _revision_submission(
+            benchmark_revision="rev-typed",
+            metadata={"benchmark_revision": "rev-meta"},
+        )
+    )
+
+    assert await _stored_revision(score.id) == "rev-typed"
+
+
+async def test_submit_leaves_the_metadata_copy_intact(tortoise_db: None) -> None:
+    # INVARIANT: promotion reads metadata, it never mutates or strips it. The client's
+    # payload is stored as sent.
+    store = await _store_with_benchmark()
+
+    score, _ = await store.submit(
+        _revision_submission(metadata={"benchmark_revision": "rev-meta", "run_id": "r1"})
+    )
+
+    assert score.metadata == {"benchmark_revision": "rev-meta", "run_id": "r1"}
+
+
+async def test_submit_accepts_a_submission_with_no_revision_anywhere(tortoise_db: None) -> None:
+    store = await _store_with_benchmark()
+
+    score, created = await store.submit(_revision_submission(metadata={"source": "unit"}))
+
+    assert created is True
+    assert await _stored_revision(score.id) is None
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"benchmark_revision": ""},
+        {"benchmark_revision": 42},
+        {"benchmark_revision": None},
+        {"benchmark_revision": ["rev"]},
+    ],
+)
+async def test_submit_treats_an_unusable_metadata_revision_as_absent(
+    tortoise_db: None, metadata: dict[str, object]
+) -> None:
+    # WHY: metadata is free-form and client-supplied, so a non-string or empty value is
+    # untrustworthy input, not a crash — it resolves to None rather than raising.
+    store = await _store_with_benchmark()
+
+    score, created = await store.submit(_revision_submission(metadata=metadata))
+
+    assert created is True
+    assert await _stored_revision(score.id) is None

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -189,6 +189,10 @@ async def test_get_spec_history_returns_submissions_newest_first(
     assert [submission["accuracy"] for submission in body["submissions"]] == [0.8, 0.5]
     assert set(body["submissions"][0]) == {
         "id",
+        # OME-775: a spec's history can span benchmark revisions, and entries measured against
+        # different revisions are not comparable. Owner-approved contract change; the
+        # assertion stays exact rather than being loosened to a subset check.
+        "benchmark_revision",
         "accuracy",
         "total_questions",
         "correct_questions",

--- a/apps/scoreboard/tests/unit/test_seed.py
+++ b/apps/scoreboard/tests/unit/test_seed.py
@@ -30,3 +30,50 @@ async def test_seed_benchmarks_inserts_and_updates(tortoise_db: None) -> None:
 async def test_load_benchmarks_json_rejects_invalid_payload() -> None:
     with pytest.raises(ValueError, match="invalid benchmark seed payload"):
         load_benchmarks_json('{"id":"hle"}')
+
+
+# --- OME-775: benchmarks carry the Engine revision through seeding --------------------------
+
+
+async def test_seed_benchmarks_persists_the_revision(tortoise_db: None) -> None:
+    # INVARIANT: the registered revision must match the Engine's computed REVISION exactly, or
+    # a submission's revision will never match the board's and every result looks incomparable.
+    benchmarks = load_benchmarks_json(
+        '[{"id":"draco","display_name":"DRACO","revision":"1c58b3085912e304"}]'
+    )
+
+    seeded = await seed_benchmarks(benchmarks)
+
+    assert seeded[0].revision == "1c58b3085912e304"
+    assert (await Benchmark.get(id="draco")).revision == "1c58b3085912e304"
+
+
+async def test_seed_benchmarks_allows_an_absent_revision(tortoise_db: None) -> None:
+    # WHY: the retained legacy demo entries (hle/livetruth) have no Engine revision at all.
+    benchmarks = load_benchmarks_json('[{"id":"hle","display_name":"News Hallucinations"}]')
+
+    seeded = await seed_benchmarks(benchmarks)
+
+    assert seeded[0].revision is None
+
+
+async def test_reseeding_updates_the_revision_without_duplicating(tortoise_db: None) -> None:
+    # WHY: an Engine benchmark's revision changes whenever its dataset or protocol does, and
+    # redeploying must move the registered value rather than create a second row.
+    await seed_benchmarks(
+        load_benchmarks_json('[{"id":"draco","display_name":"DRACO","revision":"rev-old"}]')
+    )
+
+    reseeded = await seed_benchmarks(
+        load_benchmarks_json('[{"id":"draco","display_name":"DRACO","revision":"rev-new"}]')
+    )
+
+    assert await Benchmark.all().count() == 1
+    assert reseeded[0].revision == "rev-new"
+
+
+async def test_load_benchmarks_json_still_rejects_an_unknown_key() -> None:
+    # INVARIANT: the seed payload is extra="forbid", so a typo'd key fails the deploy loudly
+    # rather than silently registering a benchmark without its revision.
+    with pytest.raises(ValueError, match="invalid benchmark seed payload"):
+        load_benchmarks_json('[{"id":"draco","display_name":"DRACO","revsion":"typo"}]')

--- a/docs/plan/2026-08-16-OME-775-flat-benchmark-registration.md
+++ b/docs/plan/2026-08-16-OME-775-flat-benchmark-registration.md
@@ -1,0 +1,132 @@
+# OME-775 — Implementation plan
+
+**Spec:** `docs/spec/2026-08-16-OME-775-flat-benchmark-registration.md`
+· **Ledger:** `docs/work/2026-08-16-OME-775-register-flat-benchmarks.md`
+· **Branch:** `OME-775-register-flat-benchmarks` · **Stack:** scoreboard
+
+Gates (from `.claude/sdlc.local.md`), run after every step:
+`python3 .claude/scripts/run_gates.py scoreboard --base origin/main`
+→ append-only · ruff check · ruff format --check · pyright · pytest --cov=scoreboard --cov-fail-under=80
+
+Companion skill `tortoise-dev` is **mandatory** for this unit (models + migration).
+
+## Ordering principle
+
+Schema first, then the resolution rule, then identity, then ranking, then config. Each step is
+RED-first and leaves the suite green before the next begins. Steps 2–5 each change one observable
+behaviour, so a regression bisects to one step.
+
+---
+
+### Step 1 — schema: two nullable columns + migration
+
+**RED:** a test asserting `Benchmark.revision` and `Score.benchmark_revision` exist, default to
+`None`, and that a `Score` row can be created without either.
+
+**GREEN:**
+- `scores/models/benchmark.py` — `revision = fields.CharField(max_length=64, null=True)`
+- `scores/models/score.py` — `benchmark_revision = fields.CharField(max_length=64, null=True, db_index=True)`
+  with a WHY comment covering D4 (nullable because legacy demo entries and `OME-322` imports
+  genuinely have no revision).
+- `scores/migrations/0004_*.py` — two `ops.AddField`, `dependencies = [("models", "0003_auto_20260713_1505")]`,
+  `initial = False`. Built-in Tortoise migrations, never Aerich.
+
+**Guard:** confirm `makemigrations` reports no *further* drift after the hand-written migration.
+
+---
+
+### Step 2 — the resolution rule (typed field + metadata fallback)
+
+**RED:**
+- a submission with the typed top-level `benchmark_revision` stores it;
+- a submission carrying it **only** in `metadata` (today's Client shape, F5) stores it too;
+- top-level wins when both are present and disagree;
+- a non-string or empty `metadata.benchmark_revision` resolves to `None` rather than raising;
+- a submission with neither is accepted and stores `None`;
+- the `metadata` dict is **not** mutated or stripped — the copy stays.
+
+**GREEN:**
+- `scores/schemas.py` — `ScoreSubmission.benchmark_revision: str | None = None`.
+- `scores/store.py` — one `_resolve_benchmark_revision(submission)` helper implementing the
+  three-step order from spec §4.3; `_submission_to_kwargs` persists it.
+
+**Why a named helper:** §4.4 needs the same resolved value, and the rule must not be written twice.
+
+---
+
+### Step 3 — identity: revision joins `_content_hash` (D3)
+
+**RED:**
+- two submissions identical but for `benchmark_revision` produce **different** hashes and both
+  persist (today they collide and the second is discarded);
+- two identical submissions still dedup;
+- a submission carrying the revision in metadata hashes the same as the equivalent typed one —
+  i.e. identity follows the resolved value, not its wire position.
+
+**GREEN:** add `"benchmark_revision": _resolve_benchmark_revision(submission)` to the `identity`
+dict; extend the existing WHY comment to say why revision is identity while the rest of `metadata`
+is not, and to record the no-backfill consequence (D3) in place.
+
+**Explicitly not done:** no backfill of stored `content_hash` values.
+
+---
+
+### Step 4 — ranking partitions by `(spec_id, benchmark_revision)`
+
+**RED:**
+- one spec with two revisions returns **two** ranked entries, each best-within-its-revision (today:
+  one entry, the higher accuracy winning across an incomparable boundary);
+- rows with `NULL` revision group together exactly as before — the backward-compatibility guard;
+- existing single-revision ordering and `MAX_LEADERBOARD_TOP` behaviour unchanged;
+- the per-spec history route still resolves.
+
+**GREEN:** `_build_leaderboard_query` — `RowNumber().over(scores.spec_id, scores.benchmark_revision)`.
+
+---
+
+### Step 5 — expose on read paths
+
+**RED:** `benchmark_revision` appears on the leaderboard entry, per-spec history and score read
+schemas; absent revision serialises as `null`, not omitted.
+
+**GREEN:** additive fields on the read schemas, following `OME-770`'s pattern. Portal untouched.
+
+---
+
+### Step 6 — seed config
+
+**RED:** `SeedBenchmark` accepts an optional `revision`; `load_benchmarks_json` rejects an unknown
+key (`extra="forbid"` already) and accepts the three real entries; re-running the seed is idempotent
+and does not duplicate.
+
+**GREEN:**
+- `seed.py` — `revision: str | None = None` on `SeedBenchmark`, threaded into
+  `store.register_benchmark(...)`;
+- `store.register_benchmark(..., revision: str | None = None)` into the `update_or_create` defaults;
+- `charts/scoreboard/values.yaml` — append the three entries from spec §4.8, **keeping** the three
+  legacy demo entries (D2). Revisions copied verbatim from the Engine definitions.
+
+**Revision values** are read from `apps/url4-cloud/.../{draco,ifeval,healthbench}/definition.py` at
+implementation time rather than transcribed here, so the plan cannot drift from the source.
+
+---
+
+### Step 7 — close-out
+
+- Fill the ledger Outcome (files, commits, gates, deviations).
+- Conventional commits, body `Refs: OME-775`, no `Co-Authored-By`.
+- Open the PR; squash-merge on green CI + approval; never `--admin`.
+- Close-comment on OME-775 per the card's `close_template`; close the `docs/tasks/` mirror.
+
+## Risks
+
+| Risk | Handling |
+|---|---|
+| Dedup identity changes the night before launch (D3) | Steps 3 and 4 are separate commits with independent tests, so either can be reverted alone without unpicking the schema. |
+| The chart's seed list is the only thing that unblocks Monday | Step 6 is last but is also the smallest and least coupled — if time runs out, it can land as its own PR ahead of the rest. |
+| Hand-written migration drifts from the models | Step 1's guard runs `makemigrations` and asserts no further drift. |
+
+## Out of scope
+
+Retiring legacy demo benchmarks · backfilling hashes or revisions · portal rendering · any Client
+change (it already sends the revision).

--- a/docs/spec/2026-08-16-OME-775-flat-benchmark-registration.md
+++ b/docs/spec/2026-08-16-OME-775-flat-benchmark-registration.md
@@ -43,7 +43,7 @@ design:
 | D3 | `benchmark_revision` **joins** the dedup identity hash; **no backfill** | Owner call, taken with the trade-off stated: forward-correct identity, at the cost that a resubmitted pre-existing recipe creates a second row rather than deduping. The alternative silently discards a second-revision result, which defeats the partitioning this unit adds. |
 | D4 | Every new column is **nullable**; no backfill migration | Legacy demo entries (D2) have no Engine revision, and `OME-322`'s imported LMArena baselines genuinely never ran at any revision. Same reasoning `OME-770` applied to cost and `OME-391` to `content_hash`. |
 | D5 | The typed field is **additive**, and `metadata.benchmark_revision` remains accepted | Making the typed field authoritative-and-exclusive would break every currently-deployed Client, which sends it only in metadata. Forbidding the metadata copy would `422` live submissions — the failure mode `OME-820` was reviewed for. |
-| D6 | Ranking **partitions** by revision rather than filtering to the registered revision | See §5. |
+| D6 | Ranking partitions by revision **and** filters to the benchmark's registered revision | Revised 2026-08-16 — partitioning alone was proven insufficient against a running server. See §4.5. |
 
 ## 4. Design
 
@@ -85,18 +85,31 @@ a different benchmark revision is *a different thing measured*, not incidental p
 No backfill. Stored hashes stay as computed. The bounded consequence is documented in the code
 comment and the ledger, not left for a reader to rediscover.
 
-### 4.5 Ranking partitions by `(spec_id, benchmark_revision)`
+### 4.5 The board ranks one revision — the one its benchmark is registered at
 
-`RowNumber().over(scores.spec_id)` becomes `.over(scores.spec_id, scores.benchmark_revision)`.
+**Two mechanisms, both required:**
 
-Best-per-spec becomes best-per-spec-per-revision, so two revisions of one spec surface as separate
-ranked entries instead of one silently beating the other across an incomparable boundary.
+1. `RowNumber().over(scores.spec_id)` becomes `.over(scores.spec_id, scores.benchmark_revision)`,
+   so best-per-spec is computed per revision and one revision's result cannot displace another's.
+2. The query **filters to the benchmark's registered revision**. When the benchmark has no
+   registered revision, nothing is filtered.
 
-**Rejected alternative — filter to the benchmark's currently-registered revision.** Stricter, and it
-reads more literally as "not ranked together", but it *hides* submitted scores rather than
-separating them, and under D2 the retained legacy entries have a null registered revision, so the
-rule would empty their boards. Partitioning is also backward-safe: every existing row has a null
-revision, so they group exactly as they do today.
+**Revised 2026-08-16 — mechanism 2 was added after mechanism 1 alone was proven insufficient.**
+The original design partitioned only, on the reasoning that separating rows satisfied "not ranked
+together". It does not. The outer query still orders every surviving row into **one** accuracy
+ranking, so a stale-revision score can hold rank 1 on a board registered elsewhere. Demonstrated
+against a running server: with draco registered at `REV-CURRENT`, a `REV-OBSOLETE` score of 0.90
+ranked **#1**, above a `REV-CURRENT` score of 0.80 — two incomparable numbers presented as a
+ranking. The partition keeps each revision's best intact; the filter decides which revision the
+board is about.
+
+The earlier objection to filtering — that it would empty the legacy demo boards (D2), whose
+entries have no registered revision — is handled by making the filter conditional on the benchmark
+declaring a revision at all.
+
+Consequence, accepted: once a benchmark declares a revision, rows that cannot be asserted
+comparable to it — including `NULL` rows predating this column — no longer rank. They remain
+stored and remain visible in per-spec history.
 
 ### 4.6 Read paths expose it
 

--- a/docs/spec/2026-08-16-OME-775-flat-benchmark-registration.md
+++ b/docs/spec/2026-08-16-OME-775-flat-benchmark-registration.md
@@ -1,0 +1,138 @@
+# OME-775 — Flat benchmark registration + revision identity
+
+**Ticket:** [OME-775](https://linear.app/openmined/issue/OME-775/register-draco-ifeval-and-healthbench-in-the-scoreboard-benchmark)
+· **Ledger:** `docs/work/2026-08-16-OME-775-register-flat-benchmarks.md`
+· **Stack:** scoreboard · **Date:** 2026-08-16
+
+## 1. Problem
+
+Scoreboard's benchmark registry seeds only `hle` / `livetruth` / `livetruth-latest` — legacy demo
+entries. The Engine advertises `draco`, `ifeval`, `healthbench-worst30`. Consequences today, on the
+live dev board:
+
+- The Leaderboard v1 catalogue renders three demo boards and none of the real ones.
+- A Client submission for a real benchmark fails with `unknown_leaderboard` **after** a successful
+  Engine evaluation — the failure lands at the end of the user's run, not the start.
+
+The public launch is 2026-08-17.
+
+Separately, the board has no notion of *which revision of a benchmark* a score was produced
+against, so results from incompatible dataset/protocol revisions would rank against each other as
+if comparable.
+
+## 2. Established facts
+
+Verified against `origin/main`; none assumed. Full table in the ledger. The three that drive the
+design:
+
+- **F5 — the revision already arrives.** The Client sends `benchmark_revision` on every submission,
+  nested in the free-form `metadata` dict (`packages/screamingface/.../leaderboards.py:333`).
+  Unlike `OME-770`'s cost field, there is no upstream dependency to wait on. This work *promotes an
+  existing untyped wire value*, it does not invent one.
+- **F7 — dedup deliberately ignores `metadata`.** `_content_hash` (`scores/store.py:75-96`) hashes
+  benchmark_id, spec_id, url4_expression, the result numbers and provider order, with an explicit
+  WHY comment excluding metadata. So the revision currently has no effect on identity.
+- **F8 — ranking is revision-blind.** `RowNumber().over(scores.spec_id)` (`store.py:106-114`).
+
+## 3. Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | Build the full ticket, including revision partitioning — not seeding alone | Owner call, 2026-08-16, taken with F4/F5 known. |
+| D2 | Keep `hle` / `livetruth` / `livetruth-latest` registered alongside the three real benchmarks | Owner call. Retiring them is not this unit's business and would need a copy decision. |
+| D3 | `benchmark_revision` **joins** the dedup identity hash; **no backfill** | Owner call, taken with the trade-off stated: forward-correct identity, at the cost that a resubmitted pre-existing recipe creates a second row rather than deduping. The alternative silently discards a second-revision result, which defeats the partitioning this unit adds. |
+| D4 | Every new column is **nullable**; no backfill migration | Legacy demo entries (D2) have no Engine revision, and `OME-322`'s imported LMArena baselines genuinely never ran at any revision. Same reasoning `OME-770` applied to cost and `OME-391` to `content_hash`. |
+| D5 | The typed field is **additive**, and `metadata.benchmark_revision` remains accepted | Making the typed field authoritative-and-exclusive would break every currently-deployed Client, which sends it only in metadata. Forbidding the metadata copy would `422` live submissions — the failure mode `OME-820` was reviewed for. |
+| D6 | Ranking **partitions** by revision rather than filtering to the registered revision | See §5. |
+
+## 4. Design
+
+### 4.1 `Benchmark.revision`
+
+```python
+revision = fields.CharField(max_length=64, null=True)
+```
+
+`register_benchmark()` and `SeedBenchmark` gain an optional `revision`. The chart's seed list
+carries the Engine's computed `REVISION` for the three real benchmarks; the retained legacy three
+carry none (D2 + D4).
+
+### 4.2 `Score.benchmark_revision`
+
+```python
+benchmark_revision = fields.CharField(max_length=64, null=True, db_index=True)
+```
+
+Indexed because §4.5 partitions on it.
+
+### 4.3 `ScoreSubmission.benchmark_revision` — typed, optional
+
+Added as `str | None = None`. Resolution order on submit:
+
+1. the typed top-level field, when present;
+2. otherwise `metadata["benchmark_revision"]` when it is a non-empty string;
+3. otherwise `None`.
+
+Step 2 is what keeps today's Client working (F5, D5). Step 3 is the legitimate legacy/import case
+(D4). The metadata copy is **not** stripped or rejected — it stays where it is.
+
+### 4.4 `_content_hash` gains the resolved revision (D3)
+
+The `identity` dict gains `"benchmark_revision": <resolved value from §4.3>`. The existing WHY
+comment is extended to say why revision belongs to identity while the rest of `metadata` does not:
+a different benchmark revision is *a different thing measured*, not incidental provenance.
+
+No backfill. Stored hashes stay as computed. The bounded consequence is documented in the code
+comment and the ledger, not left for a reader to rediscover.
+
+### 4.5 Ranking partitions by `(spec_id, benchmark_revision)`
+
+`RowNumber().over(scores.spec_id)` becomes `.over(scores.spec_id, scores.benchmark_revision)`.
+
+Best-per-spec becomes best-per-spec-per-revision, so two revisions of one spec surface as separate
+ranked entries instead of one silently beating the other across an incomparable boundary.
+
+**Rejected alternative — filter to the benchmark's currently-registered revision.** Stricter, and it
+reads more literally as "not ranked together", but it *hides* submitted scores rather than
+separating them, and under D2 the retained legacy entries have a null registered revision, so the
+rule would empty their boards. Partitioning is also backward-safe: every existing row has a null
+revision, so they group exactly as they do today.
+
+### 4.6 Read paths expose it
+
+`benchmark_revision` is added to the leaderboard entry, per-spec history and score read schemas,
+following the additive pattern `OME-770` used for cost. The portal is **not** changed in this unit.
+
+### 4.7 Migration
+
+One Tortoise migration `0004_*` (built-in migrations, never Aerich), adding two nullable columns and
+the index. Idempotent seeding is unchanged — `register_benchmark` already uses `update_or_create`.
+
+### 4.8 Seed values
+
+| id | display_name | dataset_url |
+|---|---|---|
+| `draco` | DRACO | `https://huggingface.co/datasets/perplexity-ai/draco` |
+| `ifeval` | IFEval | none — the dataset is vendored in the Engine, no single public URL is asserted |
+| `healthbench-worst30` | HealthBench Worst-30% Challenge | `https://huggingface.co/datasets/openai/healthbench` |
+
+Display names and revisions are taken verbatim from the Engine definitions (F1–F3) so the registered
+identity matches the Engine's exactly, as the ticket's acceptance requires.
+
+## 5. Out of scope
+
+- Retiring the legacy demo benchmarks (D2).
+- Backfilling `content_hash` or revision on existing rows (D3, D4).
+- Portal rendering of the revision (§4.6).
+- Any change to the Client — it already sends what is needed (F5).
+
+## 6. Acceptance
+
+- `GET /v1/benchmarks` advertises `draco`, `ifeval`, `healthbench-worst30` plus the retained legacy
+  entries.
+- A real Client `CandidateResult` for each family submits without `unknown_leaderboard`.
+- Registered IDs and revisions match the Engine definitions exactly.
+- Two scores for one spec at different revisions do not rank against each other.
+- A submission carrying the revision only in `metadata` is still accepted and still gets it promoted.
+- Re-running the seed job neither duplicates nor corrupts benchmark records.
+- Full gates green.

--- a/docs/tasks/2026-08-12-OME-769-submissions-board.md
+++ b/docs/tasks/2026-08-12-OME-769-submissions-board.md
@@ -1,12 +1,12 @@
 ---
 id: OME-769
 linear_url: https://linear.app/openmined/issue/OME-769/leaderboard-fill-submissions-board-ranked-rows-core-columns-sota-medal
-status: in_review
+status: done
 type: task
 priority: P1
 labels: [scoreboard]
 created: 2026-08-12
-closed:
+closed: 2026-08-13
 ---
 
 Fill the per-benchmark board that `OME-768` shelled out: rows ranked by accuracy, an Author

--- a/docs/tasks/2026-08-16-OME-775-register-flat-benchmarks.md
+++ b/docs/tasks/2026-08-16-OME-775-register-flat-benchmarks.md
@@ -1,0 +1,33 @@
+---
+id: OME-775
+linear_url: https://linear.app/openmined/issue/OME-775/register-draco-ifeval-and-healthbench-in-the-scoreboard-benchmark
+status: In Review
+priority: P1
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-11
+closed:
+---
+
+# Register DRACO, IFEval and HealthBench in the Scoreboard benchmark catalogue
+
+Scoreboard's deployed registry seeded only the legacy `hle` / `livetruth` / `livetruth-latest`
+demo entries, so the Leaderboard v1 catalogue rendered no real board and a Client submission for
+a real benchmark failed with `unknown_leaderboard` **after** a successful Engine evaluation — the
+failure landing at the end of the user's run rather than the start. Launch-critical: verified
+against the live dev board on 2026-08-16, which advertised no real benchmark.
+
+Registers the three canonical flat identities the Engine now advertises after OME-836/837/838 —
+`draco`, `ifeval`, `healthbench-worst30` — each carrying the Engine's computed `REVISION`, and
+gives the board the revision identity needed so scores measured against incompatible
+dataset/protocol revisions are not ranked against each other.
+
+The revision was already arriving on every submission, untyped, inside the free-form `metadata`
+dict, so this promotes an existing wire value rather than waiting on any upstream producer.
+
+Owner decisions: build the full ticket including revision partitioning (not seeding alone); keep
+the legacy demo entries registered alongside; the revision joins the dedup identity hash with no
+backfill.
+
+Spec: `docs/spec/2026-08-16-OME-775-flat-benchmark-registration.md`
+Plan: `docs/plan/2026-08-16-OME-775-flat-benchmark-registration.md`
+Ledger: `docs/work/2026-08-16-OME-775-register-flat-benchmarks.md`

--- a/docs/work/2026-08-12-OME-769-submissions-board.md
+++ b/docs/work/2026-08-12-OME-769-submissions-board.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-769
 stack: scoreboard
-status: in_progress
+status: done
 started: 2026-08-12
-finished:
+finished: 2026-08-13
 ---
 
 # OME-769 — Leaderboard: fill the submissions board (ranked rows, core columns, SOTA medal)

--- a/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
+++ b/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
@@ -1,0 +1,92 @@
+---
+ticket: OME-775
+stack: scoreboard
+status: in_progress
+started: 2026-08-16
+finished:
+---
+
+# OME-775 — Register DRACO, IFEval and HealthBench in the Scoreboard catalogue
+
+## Intent
+
+Scoreboard's benchmark registry seeds only the legacy `hle` / `livetruth` / `livetruth-latest`
+demo entries, so the Leaderboard v1 catalogue renders three demo boards instead of the real ones
+and a Client submission for a real benchmark fails with `unknown_leaderboard` after a successful
+Engine evaluation. Register the three canonical flat benchmarks the Engine now advertises, and
+give the board the revision identity it needs so scores from incompatible benchmark revisions are
+not ranked against each other.
+
+Launch-critical: the public launch is 2026-08-17 and the live board today advertises no real
+benchmark.
+
+## Facts established before design (all verified against `origin/main`, not assumed)
+
+| # | Finding | Evidence |
+|---|---|---|
+| F1 | The Engine's canonical IDs are now flat: `draco`, `ifeval`, `healthbench-worst30` | `apps/url4-cloud/.../{draco,ifeval,healthbench}/definition.py` — `BENCHMARK_ID`. Flattened by OME-836/837/838, all merged 2026-08-14. |
+| F2 | Titles are `DRACO`, `IFEval`, `HealthBench Worst-30% Challenge` | same files, `title=` |
+| F3 | Each Engine benchmark computes an immutable `REVISION` sha256 over its dataset + protocol (+ verifier for IFEval) revisions | `definition.py` — `REVISION = hashlib.sha256(...)` |
+| F4 | Scoreboard's `Benchmark` model has **no** revision field | `scores/models/benchmark.py` — id, display_name, description, dataset_url, created_at only |
+| F5 | The Client **already sends** `benchmark_revision` on every submission — nested inside the free-form `metadata` dict | `packages/screamingface/.../leaderboards.py:333` — `"metadata": {"benchmark_revision": candidate_result.benchmark.revision, ...}` |
+| F6 | `ScoreSubmission` is `extra="forbid"` with no typed revision field, so F5 arrives untyped and unvalidated | `scores/schemas.py:74-92` |
+| F7 | **`_content_hash` deliberately excludes `metadata`** — so the revision does not participate in dedup identity | `scores/store.py:75-96`, and the explicit WHY comment at :76-78 |
+| F8 | The leaderboard query partitions by `spec_id` alone, ordered by accuracy — no revision awareness | `scores/store.py:106-114`, `RowNumber().over(scores.spec_id)` |
+| F9 | Seeding is chart-driven config, applied by a Job from `SCOREBOARD_SEED_BENCHMARKS_JSON` | `charts/scoreboard/values.yaml:98-116`, `templates/job-seed-benchmarks.yaml`, `src/scoreboard/seed.py` |
+
+F5 is the load-bearing good news: unlike `OME-770`'s cost field, the data already flows. This is a
+promotion of an existing untyped wire value to a typed one, not a new upstream dependency.
+
+F7 is the load-bearing risk — see the open decision below.
+
+## Owner decisions taken (2026-08-16)
+
+- **D1 — build the whole ticket as written**, including revision partitioning, not just the seed
+  config. (Owner's call, taken with F4/F5 known.)
+- **D2 — keep the legacy `hle` / `livetruth` / `livetruth-latest` entries registered** alongside
+  the three real benchmarks rather than retiring them for launch.
+
+## Open decision — blocks the spec
+
+**Does `benchmark_revision` join the dedup identity hash (`_content_hash`)?**
+
+Discovered after D1 was taken, and it materially changes the unit's blast radius, so it is not
+assumed either way.
+
+- **If it does not join:** two runs of the same recipe at two different benchmark revisions hash
+  identically, so the second dedups into the first and its result is silently discarded — the
+  partitioning this ticket adds would then never see the second revision at all. This is the same
+  shape as the `OME-770` "case B" hole recorded on that ticket.
+- **If it does join:** identity is forward-correct, but every `content_hash` already stored was
+  computed without the revision, so stored hashes no longer match what the current code would
+  compute for the same payload. Consequence is bounded (a resubmitted pre-existing recipe creates
+  a second row instead of deduping) but it is a silent semantic change to a value `OME-391`
+  established as the board's immutability backstop.
+
+Recorded here rather than decided unilaterally, per the 95% confidence gate.
+
+## Planned changes
+
+_Pending the open decision above and the spec. Not started._
+
+## Test plan
+
+_Pending spec._
+
+## Acceptance
+
+- `GET /v1/benchmarks` advertises `draco`, `ifeval`, `healthbench-worst30` (plus the retained
+  legacy demo entries, per D2).
+- A real Client `CandidateResult` for each family submits without `unknown_leaderboard`.
+- Registered IDs match the Engine result identity exactly (F1).
+- Scores from incompatible benchmark revisions are not ranked together.
+- Re-running the seed job does not duplicate or corrupt benchmark records.
+- `OME-768` renders the three board shells from the live API.
+- Full gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
+++ b/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
@@ -159,11 +159,50 @@ the NULL-revision backward-compatibility guard.
    (`url4_cloud.benchmarks.ifeval.vendor`), so no single public URL is authoritative. Left null
    rather than inventing one; flagged to the owner at spec time.
 
+5. **The ranking design was wrong on the first pass, and local end-to-end testing caught it.**
+   Partitioning alone was shipped and believed sufficient. It is not: the outer query still orders
+   every surviving row into one accuracy ranking, so a stale-revision score can hold rank 1 on a
+   board registered elsewhere. Found by running the real Client against a real server rather than
+   by review — the unit tests passed throughout, because each asserted its own mechanism rather
+   than the end-to-end guarantee. Fixed by adding a filter to the benchmark's registered revision
+   (spec §4.5, revised). **Lesson worth keeping: "rows are separated" is not "results are not
+   ranked together" — an acceptance criterion phrased about presentation needs a test that reads
+   the presented output.**
+
+## Local end-to-end verification (2026-08-16)
+
+Run after the unit work, because the seed config and the ranking guarantee are both invisible to
+the unit suite. Real `sf.Client` → real scoreboard on the branch → chart-rendered seed payload.
+
+| Check | Result |
+|---|---|
+| `GET /v1/benchmarks` after seeding from rendered chart values | `draco`, `ifeval`, `healthbench-worst30` with correct revisions ✓ |
+| `sf.leaderboards.submit(...)` for a real `CandidateResult` | **201, not `unknown_leaderboard`** ✓ |
+| Revision promoted from `metadata` to the typed column | `1c58b3085912e304` stored ✓ |
+| Submission appears on `GET /v1/leaderboard/draco` | ✓ |
+| `OME-391` dedup still holds on an identical resubmission | ✓ |
+| Second revision creates a distinct row | ✓ |
+| All three families accept submissions | ✓ |
+| Migration `0004` applies to a fresh DB | ✓ |
+| **Board excludes stale-revision entries** | ✗ **FAILED, then fixed** — see deviation 5 |
+| Legacy board with no registered revision filters nothing | ✓ |
+
+Two false alarms worth recording so they are not re-investigated:
+
+- A first run showed the second revision deduping into the first. **The test was wrong, not the
+  code:** the Client sends `Idempotency-Key: candidate_result.run_id`, which short-circuits ahead
+  of `content_hash`, and both submissions shared a `run_id`. Correct behaviour — one run is one
+  execution against one benchmark revision. Real runs always carry distinct run ids.
+- The Client reports `benchmark_revision` as absent. **Server-side is correct** — the raw JSON
+  carries it on both the leaderboard entry and the score. The Client's read models simply do not
+  parse the field yet; see the follow-ups.
+
 ### Follow-ups (not filed — owner decision)
 
-- **The portal does not render the revision.** Out of scope per §5, but the board can now show
-  one spec twice with no visible explanation. Worth a ticket before the revision actually
-  differs in production.
+- **Revision surfacing in the UI belongs to `OME-771`** (owner decision, 2026-08-16): correctness
+  landed here, presentation goes there. Two surfaces need it — the portal does not render the
+  revision, and the **Python Client's read models do not parse `benchmark_revision`** even though
+  the server returns it, so a Client user cannot see which revision a board is showing.
 - **Legacy demo benchmarks remain registered** (D2). A launch-copy decision, not a technical one.
 - **No backfill of `content_hash`** (D3): resubmitting a recipe that predates this change creates
   a second row instead of deduping. Bounded and documented in code; file if it ever bites.

--- a/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
+++ b/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-775
 stack: scoreboard
-status: in_progress
+status: done
 started: 2026-08-16
-finished:
+finished: 2026-08-16
 ---
 
 # OME-775 — Register DRACO, IFEval and HealthBench in the Scoreboard catalogue
@@ -46,12 +46,10 @@ F7 is the load-bearing risk — see the open decision below.
 - **D2 — keep the legacy `hle` / `livetruth` / `livetruth-latest` entries registered** alongside
   the three real benchmarks rather than retiring them for launch.
 
-## Open decision — blocks the spec
+## D3 — does `benchmark_revision` join the dedup identity hash (`_content_hash`)?
 
-**Does `benchmark_revision` join the dedup identity hash (`_content_hash`)?**
-
-Discovered after D1 was taken, and it materially changes the unit's blast radius, so it is not
-assumed either way.
+Discovered after D1 was taken, and it materially changed the unit's blast radius, so it was
+escalated rather than assumed either way. **Resolved below.** The two options as they stood:
 
 - **If it does not join:** two runs of the same recipe at two different benchmark revisions hash
   identically, so the second dedups into the first and its result is silently discarded — the
@@ -63,11 +61,9 @@ assumed either way.
   a second row instead of deduping) but it is a silent semantic change to a value `OME-391`
   established as the board's immutability backstop.
 
-Recorded here rather than decided unilaterally, per the 95% confidence gate.
+Recorded rather than decided unilaterally, per the 95% confidence gate.
 
-## Open decision — RESOLVED 2026-08-16
-
-**D3 — the revision joins `_content_hash`, with no backfill.** Owner's call, taking the
+**RESOLVED 2026-08-16 — the revision joins `_content_hash`, with no backfill.** Owner's call, taking the
 forward-correct identity over the alternative that silently discards a second revision's result.
 The bounded consequence (a resubmitted pre-existing recipe creates a second row rather than
 deduping) is recorded in a code comment beside the hash, not left to be rediscovered.
@@ -106,9 +102,68 @@ the NULL-revision backward-compatibility guard.
 - `OME-768` renders the three board shells from the live API.
 - Full gates green.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files:** as planned, 15 files / +852 −1. Production: `scores/models/{benchmark,score}.py`,
+  `scores/migrations/0004_auto_20260816_0630.py`, `scores/schemas.py`, `scores/store.py`,
+  `seed.py`, `routes/leaderboard.py`, `charts/scoreboard/values.yaml`. Tests:
+  `tests/unit/scores/{test_models,test_store}.py`, `tests/unit/{test_seed,test_leaderboard_routes}.py`.
+  Plus the spec, plan and this ledger. No unplanned production file was touched.
+
+- **Commits** (7, in order):
+
+  | sha | message |
+  |---|---|
+  | `2a205e65` | docs(scoreboard): spec and plan the flat benchmark registration |
+  | `d0f14e05` | feat(scoreboard): carry the Engine benchmark revision on benchmarks and scores |
+  | `e9d4d073` | feat(scoreboard): resolve the benchmark revision from either wire shape |
+  | `aa18554b` | feat(scoreboard): make the benchmark revision part of dedup identity |
+  | `edd2586b` | feat(scoreboard): rank each benchmark revision separately |
+  | `df2e4e57` | feat(scoreboard): expose the benchmark revision on the remaining read paths |
+  | `39765054` | feat(scoreboard): register DRACO, IFEval and HealthBench with their revisions |
+
+- **Gates:** `run_gates.py scoreboard --base origin/main` run after every step — append-only ✓,
+  ruff check ✓, ruff format ✓, pyright ✓, pytest --cov=scoreboard --cov-fail-under=80 ✓.
+  Final suite **190 passed, 2 skipped**. Two commits (`df2e4e57`, `39765054`) ran with
+  `--skip-append-only`; see deviation 3.
+
+- **Verification beyond the unit tests.** The seed config is deploy-time YAML that no unit test
+  executes, so it was proven end to end instead of assumed:
+  1. `helm template` renders all six benchmarks into `SCOREBOARD_SEED_BENCHMARKS_JSON`.
+  2. That **rendered** payload — not a hand-written fixture — was fed through the real
+     `load_benchmarks_json` + `seed_benchmarks`, producing 6 rows with the right revisions, and
+     **6 rows again after seeding twice** (idempotency).
+  3. The three revisions were diffed **programmatically** against the Engine definitions
+     (`ALL MATCH`) to rule out transcription drift, rather than eyeballed.
+  4. `tortoise makemigrations` reported **"No changes detected"** against the hand-written
+     migration, proving `0004` matches the models exactly.
+
+### Deviations
+
+1. **Step 5's leaderboard-entry exposure moved into Step 4.** The ranking partition is not
+   observable without the field on the entry — a test could only assert "two rows instead of
+   one", never *which* revisions — so the assertion would have been weaker than the invariant
+   deserves. Step 5 kept the remaining read paths.
+2. **Four read-DTO construction sites needed the field, not the two the plan implied.**
+   `ScoreSchema`, `LeaderboardEntry`, `RankedLeaderboardEntry`, `BenchmarkSchema` and both
+   `_*_to_schema` helpers build by explicit mapping under `extra="forbid"`, so each surfaced as
+   a failing test rather than silently defaulting. Caught by the suite, not by review.
+3. **The append-only gate was skipped on two commits, with owner approval, for one edit.**
+   `test_get_spec_history_returns_submissions_newest_first` pins the exact key set of the
+   history payload, which §4.6 legitimately extends. Escalated per sdlc rule 5 rather than
+   quietly edited. The assertion **remains exact** — it gained one member and was deliberately
+   NOT loosened to a subset check, which would have traded a real guarantee for convenience.
+   The gate has no per-change acknowledgement mechanism, only a whole-check skip; the skip is
+   recorded in both commit messages. Step 6's own test diff was **47 insertions, 0 deletions**.
+4. **`ifeval` is registered with no `dataset_url`.** Its dataset is vendored inside the Engine
+   (`url4_cloud.benchmarks.ifeval.vendor`), so no single public URL is authoritative. Left null
+   rather than inventing one; flagged to the owner at spec time.
+
+### Follow-ups (not filed — owner decision)
+
+- **The portal does not render the revision.** Out of scope per §5, but the board can now show
+  one spec twice with no visible explanation. Worth a ticket before the revision actually
+  differs in production.
+- **Legacy demo benchmarks remain registered** (D2). A launch-copy decision, not a technical one.
+- **No backfill of `content_hash`** (D3): resubmitting a recipe that predates this change creates
+  a second row instead of deduping. Bounded and documented in code; file if it ever bites.

--- a/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
+++ b/docs/work/2026-08-16-OME-775-register-flat-benchmarks.md
@@ -65,13 +65,35 @@ assumed either way.
 
 Recorded here rather than decided unilaterally, per the 95% confidence gate.
 
+## Open decision — RESOLVED 2026-08-16
+
+**D3 — the revision joins `_content_hash`, with no backfill.** Owner's call, taking the
+forward-correct identity over the alternative that silently discards a second revision's result.
+The bounded consequence (a resubmitted pre-existing recipe creates a second row rather than
+deduping) is recorded in a code comment beside the hash, not left to be rediscovered.
+
 ## Planned changes
 
-_Pending the open decision above and the spec. Not started._
+Per `docs/plan/2026-08-16-OME-775-flat-benchmark-registration.md`, seven steps: schema+migration →
+resolution rule → identity → ranking partition → read paths → seed config → close-out.
 
 ## Test plan
 
-_Pending spec._
+Per the plan — RED-first at every step. Contracts pinned: revision resolution from either wire
+shape, identity separating revisions while preserving `OME-391` dedup, the ranking partition, and
+the NULL-revision backward-compatibility guard.
+
+## Running deviations
+
+1. **Step 5's leaderboard-entry exposure was pulled forward into Step 4.** The plan separated the
+   ranking partition from exposing the field on read schemas, but the partition is not observable
+   without it — a test can only see "two rows instead of one", not *which* revisions, so the
+   assertion would have been far weaker than the invariant deserves. `LeaderboardEntry` and
+   `RankedLeaderboardEntry` therefore gained the field in Step 4. Step 5 keeps the remaining read
+   paths (per-spec history, score read schema).
+2. **Three pre-existing route tests failed during Step 4** because `_ranked_entry` splats
+   `entry.model_dump()` into `RankedLeaderboardEntry`, which is `extra="forbid"`. Fixed by adding
+   the field to the route model — the prior tests were not modified, and they pass unchanged.
 
 ## Acceptance
 


### PR DESCRIPTION
## Why

Scoreboard's deployed registry seeds only the legacy `hle` / `livetruth` / `livetruth-latest` demo entries. Verified against the live dev board today:

```
$ curl leaderboard.dev.screamingface.ai/v1/benchmarks
→ hle, livetruth, livetruth-latest        # no real benchmark
```

So the Leaderboard v1 catalogue renders no real board, and a Client submission for a real benchmark fails with `unknown_leaderboard` **after** a successful Engine evaluation — the failure lands at the end of a user's run, not the start. `OME-836/837/838` (merged 2026-08-14) flattened the Engine's identities to `draco`, `ifeval`, `healthbench-worst30`; Scoreboard has never heard of any of them.

Launch-blocking for 2026-08-17.

## What

Registers the three canonical benchmarks with their Engine `REVISION`, and gives the board the revision identity that makes those registrations meaningful.

**The revision was already arriving on every submission** — untyped, inside the free-form `metadata` dict (`packages/screamingface/.../leaderboards.py:333`). Unlike `OME-770`'s cost field there is no upstream producer to wait on; this promotes an existing wire value.

Six focused commits:

| | |
|---|---|
| `d0f14e05` | `Benchmark.revision` + `Score.benchmark_revision`, both nullable, migration `0004` |
| `e9d4d073` | resolve the revision typed-field-first, metadata as fallback |
| `aa18554b` | the revision joins the dedup identity hash |
| `edd2586b` | rank per `(spec_id, benchmark_revision)` |
| `df2e4e57` | expose it on the remaining read paths |
| `39765054` | seed the three benchmarks in the chart |

## Decisions worth reviewing

- **The metadata fallback is not a convenience.** Reading only the typed field would silently drop the revision for every deployed Client; rejecting the metadata copy would `422` every live submission. The copy is read, never mutated or stripped.
- **The revision joins `_content_hash` (owner call).** Without it, the same recipe at a second revision deduped into the first and the second result was discarded — which would have made the new partition unreachable, since that row never existed. **No backfill:** a resubmitted pre-existing recipe now creates a second row instead of deduping. Bounded, and documented beside the hash.
- **Ranking partitions rather than filters.** Filtering to the registered revision reads more literally as "not ranked together", but it *hides* scores instead of separating them, and would empty the retained legacy boards (which have no revision). Partitioning is also backward-safe — every existing row shares a `NULL` partition and groups exactly as before.
- **Legacy demo entries retained** (owner call), so this adds three boards rather than replacing three.
- **`ifeval` has no `dataset_url`** — its dataset is vendored in the Engine, so no public URL is authoritative. Left null rather than invented.

## Test plan

`run_gates.py scoreboard --base origin/main` after every step — ruff, ruff format, pyright, pytest --cov ≥80. Final suite **190 passed, 2 skipped**. RED-first throughout.

The seed config is deploy-time YAML that **no unit test executes**, so it was verified end to end instead of assumed:

1. `helm template` renders all six benchmarks into `SCOREBOARD_SEED_BENCHMARKS_JSON`.
2. That **rendered** payload — not a fixture — was fed through the real `load_benchmarks_json` + `seed_benchmarks`: 6 rows with correct revisions, and **6 rows again after seeding twice** (idempotency).
3. The three revisions were diffed **programmatically** against the Engine definitions (`ALL MATCH`), ruling out transcription drift.
4. `tortoise makemigrations` reports **"No changes detected"**, proving `0004` matches the models.

## Reviewer notes

- **One prior test changed, with owner approval:** `test_get_spec_history_returns_submissions_newest_first` pins the exact key set of the history payload, which this legitimately extends. It stays exact — it gained one member and was deliberately **not** loosened to a subset check. Two commits therefore ran `--skip-append-only`; the gate has no per-change acknowledgement, only a whole-check skip. Every other gate green, and `39765054`'s own test diff is 47 insertions / 0 deletions.
- **Not included:** portal rendering of the revision. The board can now legitimately show one spec twice with no visible explanation — worth a follow-up before revisions actually diverge in production.
- The last commit closes `OME-769`'s stale mirror and ledger (merged 2026-08-13, still reading in-progress in the repo), carried in separately per the precedent `OME-769` itself set.

Refs: OME-775
