### PR TITLE
feat(screamingface): tolerate and surface per-operation outputs in case results

### DIFF
--- a/docs/work/2026-08-17-OME-843-client-operations-key.md
+++ b/docs/work/2026-08-17-OME-843-client-operations-key.md
@@ -1,0 +1,55 @@
+---
+ticket: OME-843
+stack: screamingface
+status: in_progress
+started: 2026-08-17
+finished:
+---
+
+# OME-843 (client slice) — Tolerate and surface per-operation outputs in the case result contract
+
+## Intent
+
+Lockstep prerequisite for the engine-side member-output capture (OME-843, sub-issue of
+OME-784): the Client's case decoder rejects unknown case-row keys by design, so it must
+learn the optional `operations` key BEFORE any engine emits it. Absent field → behavior
+and exports byte-identical; present → member/synthesis outputs surface on
+`CaseResult.operations` and through `report.json`. A dedicated Linear sub-issue for this
+client slice is pending (Linear MCP token expired mid-session); it will be filed under
+OME-784 and this ledger updated.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/case_result.py` — new `CaseOperation` value
+  (`operation_id`, `output`, `finish_reason`); `CaseResult` gains optional
+  `operations: tuple[CaseOperation, ...] | None`; `to_dict()` emits the key only when
+  present.
+- `packages/screamingface/src/screamingface/_evaluation/results.py` — `_case_result`
+  tolerates optional `operations`; strict per-entry decode (`_case_operation`).
+
+## Test plan
+
+- RED in `tests/test_case_outcome_decoding.py` (append-only): decode + exact round-trip
+  with `operations`; absent key → `operations is None` and no key in export (byte-identical
+  invariant); per-entry strictness (unknown/missing entry keys, blank operation_id reject);
+  other unknown case keys still reject (strictness intact).
+
+## Acceptance
+
+- Old-shape payloads decode and export exactly as today; new payloads round-trip the
+  `operations` key; screamingface stack gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `case_result.py` (CaseOperation + CaseResult.operations +
+  conditional export), `_evaluation/results.py` (optional key + `_case_operations` /
+  `_case_operation` strict decode), `tests/test_case_outcome_decoding.py` (+7 tests,
+  append-only).
+- **Commits:** (filled post-commit)
+- **Gates:** run_gates.py screamingface ALL GREEN — ruff check/format, pyright, pytest
+  859 passed/1 skipped (cov ≥95), notebook check, uv build, distribution check,
+  append-only test check.
+- **Deviations:** dedicated client sub-issue not yet filed (Linear MCP token expired
+  mid-session); unit runs under OME-843 with the client slice named in this ledger.
+  `CaseOperation` deliberately not added to the public `sf.` namespace in this slice —
+  reachable via `CaseResult.operations`; exporting it is a follow-up decision.

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -10,7 +10,7 @@ from screamingface._core.ports import _RunOutcome
 from screamingface._evaluation.model import Candidate, _compiled_evaluation, _Evaluation
 from screamingface._report_primitives import CaseId
 from screamingface._report_primitives import _case_id as _validate_case_id
-from screamingface.case_result import CaseStatus, StopReason
+from screamingface.case_result import CaseOperation, CaseStatus, StopReason
 from screamingface.discovery import BenchmarkInfo
 from screamingface.errors import ExecutionError
 from screamingface.report import (
@@ -210,9 +210,15 @@ def _case_result(value: object) -> CaseResult:
             "failures",
             "metadata",
         },
+        # WHY: `operations` (OME-843 member-output capture) is optional so pre-capture
+        # Engines keep decoding; tolerance is for the key's absence only — present
+        # content still decodes strictly below.
+        optional={"operations"},
         label="Case Result",
     )
     case_id = _case_id(raw.get("case_id"), "Case Result case_id")
+    operations_value = raw.get("operations")
+    operations = None if operations_value is None else _case_operations(operations_value)
     grade_value = _required(raw, "grade", "Case Result")
     grade = None if grade_value is None else _case_grade(grade_value)
     failures = _failures(_required(raw, "failures", "Case Result"), "Case Result failures")
@@ -236,9 +242,32 @@ def _case_result(value: object) -> CaseResult:
             grade=grade,
             failures=failures,
             metadata=_mapping(_required(raw, "metadata", "Case Result"), "Case Result metadata"),
+            operations=operations,
         )
     except (TypeError, ValueError) as exc:
         raise ExecutionError(f"Case Result is invalid: {exc}") from exc
+
+
+def _case_operations(value: object) -> tuple[CaseOperation, ...]:
+    return tuple(_case_operation(item) for item in _sequence(value, "Case Result operations"))
+
+
+def _case_operation(value: object) -> CaseOperation:
+    raw = _mapping(value, "Case Operation")
+    _keys(raw, required={"operation_id", "output", "finish_reason"}, label="Case Operation")
+    finish_reason_value = raw.get("finish_reason")
+    try:
+        return CaseOperation(
+            operation_id=_nonempty_text(raw.get("operation_id"), "Case Operation operation_id"),
+            output=_optional_string(raw.get("output"), "Case Operation output"),
+            finish_reason=(
+                None
+                if finish_reason_value is None
+                else _text(finish_reason_value, "Case Operation finish_reason")
+            ),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"Case Operation is invalid: {exc}") from exc
 
 
 def _case_grade(value: object) -> CaseGrade:

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -217,6 +217,41 @@ class CaseGrade:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class CaseOperation:
+    """One Candidate operation's captured output for a Case.
+
+    FEATURE: OME-843 member-output capture — the Engine attributes each member and
+    synthesis call's terminal output to its stable operation ID so Fusion contribution
+    analysis works from a saved Report. `output`/`finish_reason` stay ``None`` when the
+    Engine could not attribute unambiguously — absence of evidence, never a guess.
+    """
+
+    operation_id: str
+    output: str | None
+    finish_reason: str | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "operation_id", _nonblank_text(self.operation_id, "Case Operation operation_id")
+        )
+        if self.output is not None and not isinstance(self.output, str):
+            raise TypeError("Case Operation output must be text or None")
+        if self.finish_reason is not None:
+            object.__setattr__(
+                self,
+                "finish_reason",
+                _nonblank_text(self.finish_reason, "Case Operation finish_reason"),
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "operation_id": self.operation_id,
+            "output": self.output,
+            "finish_reason": self.finish_reason,
+        }
+
+
 @dataclass(frozen=True, slots=True, init=False)
 class CaseResult:
     """The complete retained result for one selected Benchmark Case."""
@@ -231,6 +266,7 @@ class CaseResult:
     rounds_executed: int | None
     grade: CaseGrade | None
     failures: tuple[Failure, ...]
+    operations: tuple[CaseOperation, ...] | None
     _metadata: Mapping[str, object] = field(repr=False)
 
     def __init__(
@@ -247,6 +283,7 @@ class CaseResult:
         refusal: str | None = None,
         stop_reason: StopReason | None = None,
         rounds_executed: int | None = None,
+        operations: Sequence[CaseOperation] | None = None,
     ) -> None:
         case_id = _case_id(case_id)
         input = _nonempty_text(input, "Case Result input")
@@ -262,6 +299,11 @@ class CaseResult:
         selected_failures = tuple(failures)
         if any(not isinstance(item, Failure) for item in selected_failures):
             raise TypeError("Case Result failures must contain sf.Failure values")
+        selected_operations = None if operations is None else tuple(operations)
+        if selected_operations is not None and any(
+            not isinstance(item, CaseOperation) for item in selected_operations
+        ):
+            raise TypeError("Case Result operations must contain CaseOperation values")
         status = _validate_case_outcome(
             status,
             case_id,
@@ -281,6 +323,7 @@ class CaseResult:
             "rounds_executed": rounds_executed,
             "grade": grade,
             "failures": selected_failures,
+            "operations": selected_operations,
             "_metadata": freeze_mapping(metadata, "Case Result metadata"),
         }
         for name, value in values.items():
@@ -328,7 +371,7 @@ class CaseResult:
         return turns[0][1]
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        selected = {
             "status": self.status,
             "case_id": self.case_id,
             "input": thaw_json(self.input),
@@ -341,6 +384,11 @@ class CaseResult:
             "failures": [failure.to_dict() for failure in self.failures],
             "metadata": thaw_mapping(self._metadata),
         }
+        # INVARIANT: absence stays absence — pre-OME-843 payloads and solo Candidates
+        # export byte-identically, so the key appears only when the Engine attributed.
+        if self.operations is not None:
+            selected["operations"] = [operation.to_dict() for operation in self.operations]
+        return selected
 
 
 def _decode_candidate_envelope(value: object) -> tuple[tuple[str, str], ...] | None:

--- a/packages/screamingface/tests/test_case_outcome_decoding.py
+++ b/packages/screamingface/tests/test_case_outcome_decoding.py
@@ -360,3 +360,76 @@ def test_a_locally_built_case_derives_status_without_weakening_wire_decoding() -
     )
 
     assert refused.status == "refused"
+
+
+# FEATURE: OME-843 member-output capture — the optional `operations` case key carries
+# each member/synthesis operation's output so Fusion contribution analysis works offline.
+def _operations_payload() -> dict[str, Any]:
+    payload = _scored_payload()
+    payload["operations"] = [
+        {"operation_id": "op_model_1", "output": "Member one answer.", "finish_reason": "stop"},
+        {"operation_id": "op_model_2", "output": None, "finish_reason": "length"},
+        {"operation_id": "op_synthesis_1", "output": "Four.", "finish_reason": "stop"},
+    ]
+    return payload
+
+
+def test_operations_decode_in_wire_order_and_survive_export() -> None:
+    # INVARIANT: `operations` is optional, ordered, and round-trips exactly — the client
+    # never reorders, drops, or invents member outputs.
+    payload = _operations_payload()
+
+    case = _case_result(payload)
+
+    assert case.operations is not None
+    assert [item.operation_id for item in case.operations] == [
+        "op_model_1",
+        "op_model_2",
+        "op_synthesis_1",
+    ]
+    assert case.operations[0].output == "Member one answer."
+    assert case.operations[1].output is None
+    assert case.operations[1].finish_reason == "length"
+    assert case.to_dict() == payload
+
+
+def test_a_case_without_operations_exports_byte_identically() -> None:
+    # INVARIANT: absence stays absence — a solo Candidate's artifact gains no member
+    # section, so pre-OME-843 reports and new solo reports stay byte-identical.
+    payload = _scored_payload()
+
+    case = _case_result(payload)
+
+    assert case.operations is None
+    assert "operations" not in case.to_dict()
+
+
+def test_a_null_operations_key_decodes_as_absent() -> None:
+    case = _case_result({**_scored_payload(), "operations": None})
+
+    assert case.operations is None
+    assert "operations" not in case.to_dict()
+
+
+@pytest.mark.parametrize(
+    ("entry", "message"),
+    [
+        ({"output": "x", "finish_reason": None}, "missing 'operation_id'"),
+        (
+            {"operation_id": "op_model_1", "output": "x", "finish_reason": None, "extra": 1},
+            "unsupported field 'extra'",
+        ),
+        ({"operation_id": "  ", "output": "x", "finish_reason": None}, "operation_id"),
+        ({"operation_id": "op_model_1", "output": 7, "finish_reason": None}, "output"),
+    ],
+)
+def test_a_malformed_operation_entry_fails_closed(entry: dict[str, Any], message: str) -> None:
+    # INVARIANT: tolerance is for the key's absence, not for malformed content — a
+    # present `operations` list still decodes strictly, like every other contract field.
+    with pytest.raises(sf.ExecutionError, match=message):
+        _case_result({**_scored_payload(), "operations": [entry]})
+
+
+def test_operations_must_be_a_list_when_present() -> None:
+    with pytest.raises(sf.ExecutionError, match="operations"):
+        _case_result({**_scored_payload(), "operations": {"op_model_1": "answer"}})


### PR DESCRIPTION
First half of OME-843 (member-output capture, sub-issue of OME-784) — the Client-side lockstep prerequisite. **Must merge and release before the engine-side capture PR**: the case decoder rejects unknown keys by design, so an engine emitting `operations` against an older SDK would hard-break every `sf.evaluate()`.

## What changes

The case result contract gains an optional `operations` key — one `{operation_id, output, finish_reason}` entry per member/synthesis operation of a Fusion candidate. The SDK decodes it strictly when present, surfaces it as `CaseResult.operations`, and round-trips it through `report.json`. Absent key → decode and export stay byte-identical to today; every other unknown key still rejects.

## Before / After

### Before
- Trigger: a researcher upgrades to an engine that records member outputs, with today's `screamingface` package installed.
- Today (if the engine shipped first): every evaluation dies with "Case Result contains unsupported field 'operations'".
- Cost: a hard runtime break coupled to someone else's deploy.

### After
- Same trigger, with this merged first.
- Now: old-shape payloads decode exactly as before; new payloads surface each member's answer in `report.cases[].operations`.
- Win: engine capture (OME-843 second PR) can land without coordinating user upgrades; Fusion contribution analysis ("did the solos lack the substance or did the synthesizer drop it?") becomes possible from a saved report.

### Don't regress
- Unknown case keys other than `operations` still hard-reject — contract strictness intact (pinned test untouched).
- Reports without the field export byte-identically (explicit test).
- Malformed `operations` content fails closed: tolerance is for absence, not for garbage.

## Test plan

- +7 append-only tests in `test_case_outcome_decoding.py`: wire-order round-trip, absence byte-identity, null-key tolerance, per-entry strictness (missing/unknown keys, blank operation_id, non-text output), non-list rejection.
- Full gates green: ruff, pyright, pytest 859 passed (cov ≥95%), notebook determinism, build + distribution checks.

Refs: OME-843

🤖 Generated with [Claude Code](https://claude.com/claude-code)