### PR TITLE
feat(url4-cloud): capture member and synthesis outputs in benchmark case artifacts

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/aggregation.py
@@ -21,6 +21,7 @@ from url4_cloud.benchmarks.contract import (
     CaseResult,
     CorrectiveExecution,
     Failure,
+    OperationOutput,
     candidate_coverage,
     validate_case_id,
 )
@@ -215,6 +216,7 @@ def scored_case_result(
     grade: CaseGrade | Mapping[str, Any],
     metadata: Mapping[str, Any] | None = None,
     execution: CorrectiveExecution | Mapping[str, Any] | None = None,
+    operations: Sequence[OperationOutput | Mapping[str, Any]] | None = None,
 ) -> CaseResult:
     """Construct one scored Case without exposing the wire envelope to adapters."""
 
@@ -232,6 +234,7 @@ def scored_case_result(
         grade=typed_grade,
         failures=[],
         metadata=_case_metadata(selected_case, metadata),
+        operations=_operation_outputs(operations),
     )
 
 
@@ -244,6 +247,7 @@ def failed_case_result(
     grade: CaseGrade | Mapping[str, Any] | None = None,
     metadata: Mapping[str, Any] | None = None,
     execution: CorrectiveExecution | Mapping[str, Any] | None = None,
+    operations: Sequence[OperationOutput | Mapping[str, Any]] | None = None,
 ) -> CaseResult:
     """Construct one failed Case while retaining any safe partial grading evidence."""
 
@@ -267,6 +271,7 @@ def failed_case_result(
         grade=typed_grade,
         failures=typed_failures,
         metadata=_case_metadata(selected_case, metadata),
+        operations=_operation_outputs(operations),
     )
 
 
@@ -279,6 +284,7 @@ def refused_case_result(
     failures: Sequence[Failure | Mapping[str, Any]] = (),
     metadata: Mapping[str, Any] | None = None,
     execution: CorrectiveExecution | Mapping[str, Any] | None = None,
+    operations: Sequence[OperationOutput | Mapping[str, Any]] | None = None,
 ) -> CaseResult:
     """Construct a refused Case after normal Benchmark grading."""
 
@@ -301,6 +307,7 @@ def refused_case_result(
         grade=typed_grade,
         failures=typed_failures,
         metadata=_case_metadata(selected_case, metadata),
+        operations=_operation_outputs(operations),
     )
 
 
@@ -340,6 +347,7 @@ def grading_failure_case_result(
             grade=grade,
             failures=[failure],
             execution=candidate.execution,
+            operations=candidate.operations,
         )
     return failed_case_result(
         selected_case=selected_case,
@@ -348,7 +356,23 @@ def grading_failure_case_result(
         grade=grade,
         failures=[failure],
         execution=candidate.execution,
+        operations=candidate.operations,
     )
+
+
+def _operation_outputs(
+    operations: Sequence[OperationOutput | Mapping[str, Any]] | None,
+) -> list[OperationOutput] | None:
+    """Normalize adapter-supplied operations; absence stays absence (OME-843)."""
+
+    if operations is None:
+        return None
+    return [
+        operation
+        if isinstance(operation, OperationOutput)
+        else OperationOutput.model_validate(operation)
+        for operation in operations
+    ]
 
 
 def _case_metadata(

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/case_records.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/case_records.py
@@ -41,7 +41,7 @@ def bind_case_record(
     input_value = row.get("input")
     if not isinstance(input_value, str) or not input_value.strip():
         raise ValueError(f"{benchmark} Case {selected_id} input must be non-empty text")
-    return {
+    record: dict[str, object] = {
         "schema": schema,
         "case_id": selected_id,
         "input": input_value,
@@ -55,6 +55,13 @@ def bind_case_record(
         ),
         "metadata": {key: value for key, value in row.items() if key not in {"id", "input"}},
     }
+    # INVARIANT: absence stays absence (OME-843) — a solo Candidate's record keeps its
+    # legacy shape; the key exists only when the Engine attributed member outputs.
+    if candidate.operations is not None:
+        record["operations"] = [
+            operation.model_dump(by_alias=True) for operation in candidate.operations
+        ]
+    return record
 
 
 def _decode_cases(raw_cases: str, benchmark: str) -> list[object]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/contract.py
@@ -139,6 +139,11 @@ class CaseResult(_StrictWireModel):
     grade: CaseGrade | None
     failures: list[Failure]
     metadata: dict[str, Any]
+    # WHY: excluded when None so solo-Candidate and pre-OME-843 artifacts stay
+    # byte-identical; consumers see the key only when member outputs were attributed.
+    operations: list[OperationOutput] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
     @field_validator("case_id")
     @classmethod
@@ -174,6 +179,24 @@ class CaseResult(_StrictWireModel):
         return self
 
 
+class OperationOutput(_StrictWireModel):
+    """One Candidate operation's terminal output, keyed by its stable operation id.
+
+    FEATURE: OME-843 member-output capture. ``output``/``finish_reason`` are null
+    when the Engine could not attribute the call unambiguously — absence of
+    evidence, never a positional guess.
+    """
+
+    operation_id: str = Field(min_length=1)
+    output: str | None
+    finish_reason: str | None
+
+    @field_validator("finish_reason")
+    @classmethod
+    def _validate_finish_reason(cls, value: str | None) -> str | None:
+        return validate_finish_reason(value)
+
+
 class CorrectiveExecution(_StrictWireModel):
     """The final, benchmark-neutral execution outcome of one corrective Recipe."""
 
@@ -195,6 +218,11 @@ class CandidateInvocation(_StrictWireModel):
     finish_reason: str | None
     refusal: str | None
     execution: CorrectiveExecution | None
+    # WHY: excluded when None so a solo Candidate's envelope stays byte-identical to
+    # the pre-OME-843 contract — the key exists only when the Engine attributed.
+    operations: list[OperationOutput] | None = Field(
+        default=None, exclude_if=lambda value: value is None
+    )
 
     @field_validator("finish_reason")
     @classmethod
@@ -473,6 +501,7 @@ def encode_candidate_invocation(
     execution: CorrectiveExecution | None = None,
     *,
     status: CandidateInvocationStatus | None = None,
+    operations: Sequence[OperationOutput] | None = None,
 ) -> str:
     """Encode one Candidate answer without discarding its provider-originated outcome."""
 
@@ -482,6 +511,7 @@ def encode_candidate_invocation(
         finish_reason=finish_reason,
         refusal=refusal,
         execution=execution,
+        operations=None if operations is None else list(operations),
     )
     return json.dumps(
         invocation.model_dump(by_alias=True),
@@ -499,7 +529,9 @@ def decode_candidate_invocation_record(value: str) -> CandidateInvocation:
         raise ValueError(f"Candidate Invocation result is not JSON: {exc}") from None
     if not isinstance(decoded, Mapping) or decoded.get("schema") != CANDIDATE_INVOCATION_SCHEMA:
         raise ValueError("Candidate Invocation result has an unsupported schema")
-    if set(decoded) != {
+    # WHY: `operations` (OME-843) is the one optional key — its absence keeps the
+    # legacy shape valid, and no other deviation is tolerated.
+    if set(decoded) - {"operations"} != {
         "schema",
         "status",
         "output",
@@ -543,6 +575,7 @@ __all__ = [
     "CaseResult",
     "CandidateResult",
     "CorrectiveExecution",
+    "OperationOutput",
     "Check",
     "Evidence",
     "EvidenceProducer",

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -167,6 +167,7 @@ def ungraded_case_result(case_record: Mapping[str, Any], failure: Mapping[str, A
             grade={"method": "rubric", "score": None, "metrics": {}, "checks": []},
             failures=[failure],
             execution=case_record.get("execution"),
+            operations=case_record.get("operations"),
         )
     return build_failed_case_result(
         selected_case=selected,
@@ -174,6 +175,7 @@ def ungraded_case_result(case_record: Mapping[str, Any], failure: Mapping[str, A
         output=str(case_record["output"]),
         finish_reason=_finish_reason(case_record.get("finish_reason")),
         execution=case_record.get("execution"),
+        operations=case_record.get("operations"),
     )
 
 
@@ -213,6 +215,7 @@ def _case_result(
             grade=grade,
             failures=failures,
             execution=case_record.get("execution"),
+            operations=case_record.get("operations"),
         )
     if not isinstance(output, str):  # pragma: no cover - sealed by the Case record decoder
         raise AggregateError("a non-refused DRACO Case must carry Candidate output text")
@@ -223,6 +226,7 @@ def _case_result(
             finish_reason=finish_reason,
             grade=grade,
             execution=case_record.get("execution"),
+            operations=case_record.get("operations"),
         )
     return build_failed_case_result(
         selected_case=selected,
@@ -231,6 +235,7 @@ def _case_result(
         finish_reason=finish_reason,
         grade=grade,
         execution=case_record.get("execution"),
+        operations=case_record.get("operations"),
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/evaluation.py
@@ -12,6 +12,7 @@ from url4.peer.server import Request
 from url4_cloud.benchmarks.contract import (
     CandidateInvocationStatus,
     CorrectiveExecution,
+    OperationOutput,
     decode_candidate_invocation_record,
 )
 
@@ -30,6 +31,7 @@ class CandidateAnswer:
     finish_reason: str | None
     refusal: str | None
     execution: CorrectiveExecution | None
+    operations: tuple[OperationOutput, ...] | None = None
 
 
 def candidate_answer(value: str) -> CandidateAnswer:
@@ -43,6 +45,7 @@ def candidate_answer(value: str) -> CandidateAnswer:
         finish_reason=invocation.finish_reason,
         refusal=invocation.refusal,
         execution=invocation.execution,
+        operations=None if invocation.operations is None else tuple(invocation.operations),
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/aggregate.py
@@ -304,6 +304,7 @@ def _scored_outcome(
             grade=grade,
             metadata=fields["metadata"],
             execution=fields["execution"],
+            operations=fields.get("operations"),
         )
     else:
         scored = scored_case_result(
@@ -313,6 +314,7 @@ def _scored_outcome(
             grade=grade,
             metadata=fields["metadata"],
             execution=fields["execution"],
+            operations=fields.get("operations"),
         )
     return scored, score, len(verdicts), sum(verdicts.values()), invalid
 
@@ -341,6 +343,7 @@ def _candidate_fields(row: Mapping[str, Any] | None) -> dict[str, Any]:
             "finish_reason": None,
             "refusal": None,
             "execution": None,
+            "operations": None,
             "metadata": {},
         }
     metadata = case.get("metadata")
@@ -353,6 +356,7 @@ def _candidate_fields(row: Mapping[str, Any] | None) -> dict[str, Any]:
         "finish_reason": finish_reason if isinstance(finish_reason, str) else None,
         "refusal": refusal if isinstance(refusal, str) and refusal.strip() else None,
         "execution": case.get("execution"),
+        "operations": case.get("operations"),
         "metadata": dict(metadata) if isinstance(metadata, Mapping) else {},
     }
 
@@ -383,6 +387,7 @@ def _failed_result(
             failures=[failure],
             metadata=fields["metadata"],
             execution=fields["execution"],
+            operations=fields.get("operations"),
         )
     return failed_case_result(
         selected_case=selected_case,
@@ -392,6 +397,7 @@ def _failed_result(
         grade=grade,
         metadata=fields["metadata"],
         execution=fields["execution"],
+        operations=fields.get("operations"),
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/case_evaluation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/healthbench/case_evaluation.py
@@ -174,7 +174,9 @@ def _decode_rubric_evaluations(values: Sequence[object], case_id: int) -> list[d
 
 
 def _valid_case_record(value: Mapping[str, Any], case_id: int) -> bool:
-    if set(value) != _CASE_RECORD_FIELDS:
+    # WHY: `operations` (OME-843) is the one optional key — present only when the
+    # Engine attributed member outputs; its absence keeps the legacy shape valid.
+    if set(value) - {"operations"} != _CASE_RECORD_FIELDS:
         return False
     answer = value.get("answer")
     status = value.get("status")

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/aggregate.py
@@ -361,6 +361,7 @@ def _case_result(selected_case: SelectedCase, record: Mapping[str, Any]) -> Case
             finish_reason=record["finish_reason"],
             grade=grade,
             execution=record["execution"],
+            operations=record.get("operations"),
         )
     return scored_case_result(
         selected_case=selected_case,
@@ -368,6 +369,7 @@ def _case_result(selected_case: SelectedCase, record: Mapping[str, Any]) -> Case
         finish_reason=record["finish_reason"],
         grade=grade,
         execution=record["execution"],
+        operations=record.get("operations"),
     )
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/ifeval/runtime.py
@@ -85,6 +85,17 @@ def _check(root: Path):
                 if candidate.execution is None
                 else candidate.execution.model_dump(by_alias=True)
             ),
+            # INVARIANT: absence stays absence (OME-843) — the key exists only when
+            # the Engine attributed member outputs.
+            **(
+                {}
+                if candidate.operations is None
+                else {
+                    "operations": [
+                        operation.model_dump(by_alias=True) for operation in candidate.operations
+                    ]
+                }
+            ),
             "instruction_id_list": spec["instruction_id_list"],
             "descriptions": grading.describe_instructions(
                 instruction_id_list=spec["instruction_id_list"],

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/invocation.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/invocation.py
@@ -11,14 +11,17 @@ from url4_cloud.benchmarks.candidate_execution import (
 from url4_cloud.benchmarks.contract import (
     CandidateInvocationStatus,
     CorrectiveExecution,
+    OperationOutput,
     encode_candidate_invocation,
 )
+from url4_cloud.benchmarks.operation_outputs import attribute_operation_outputs
 from url4_cloud.model_outcomes import (
     ModelOutcome,
     capture_model_outcomes,
     model_outcome_from_error,
     terminal_model_outcome,
 )
+from url4_cloud.operation_calls import capture_operation_calls
 
 
 async def evaluate_candidate_recipe(
@@ -33,29 +36,34 @@ async def evaluate_candidate_recipe(
 
     with capture_candidate_executions(isolated=isolated) as executions:
         with capture_model_outcomes(isolated=isolated) as outcomes:
-            try:
-                result = await node.evaluate(expression, env={input_binding: input_text})
-            except ResolutionError as exc:
-                if exc.code != "provider_refusal":
-                    raise
-                outcome = model_outcome_from_error(exc)
-                if outcome is None:
-                    raise ResolutionError(
-                        "provider refusal carried no terminal outcome",
-                        code="candidate_contract_error",
-                        permanent=True,
-                    ) from exc
-                return _encode(
-                    "",
-                    outcome,
-                    terminal_candidate_execution(executions),
-                    status="refused",
-                )
+            with capture_operation_calls(isolated=isolated) as calls:
+                try:
+                    result = await node.evaluate(expression, env={input_binding: input_text})
+                except ResolutionError as exc:
+                    if exc.code != "provider_refusal":
+                        raise
+                    outcome = model_outcome_from_error(exc)
+                    if outcome is None:
+                        raise ResolutionError(
+                            "provider refusal carried no terminal outcome",
+                            code="candidate_contract_error",
+                            permanent=True,
+                        ) from exc
+                    # WHY: members that DID answer before a sibling refused are still
+                    # evidence worth retaining — attribution runs on both exits.
+                    return _encode(
+                        "",
+                        outcome,
+                        terminal_candidate_execution(executions),
+                        status="refused",
+                        operations=attribute_operation_outputs(expression, calls),
+                    )
 
     return _encode(
         result.text,
         terminal_model_outcome(outcomes),
         terminal_candidate_execution(executions),
+        operations=attribute_operation_outputs(expression, calls),
     )
 
 
@@ -65,6 +73,7 @@ def _encode(
     execution: CorrectiveExecution | None,
     *,
     status: CandidateInvocationStatus | None = None,
+    operations: list[OperationOutput] | None = None,
 ) -> str:
     try:
         return encode_candidate_invocation(
@@ -73,6 +82,7 @@ def _encode(
             outcome.refusal,
             execution,
             status=status,
+            operations=operations,
         )
     except ValueError as exc:
         raise ResolutionError(

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/operation_outputs.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/operation_outputs.py
@@ -1,0 +1,128 @@
+"""Attribute captured terminal calls to stable Candidate operation ids (OME-843).
+
+Think of it as matching two ledgers after the fact. During one Candidate
+invocation the connector records every terminal model call with its route
+identity (:mod:`url4_cloud.operation_calls`); this module reads the SAME
+identities out of the candidate expression's named sources and joins the two —
+so a Fusion case artifact can say which member produced which answer.
+
+Stages, in execution order:
+
+1. Parse the candidate expression the adapter already holds and select its
+   named ``model_N`` / ``synthesis_N`` sources — the identical naming rule the
+   Client's operation projection uses (``operation_id = "op_" + binding``), so
+   both sides agree with no protocol change.
+2. Fingerprint each source as (path, sorted params). Two members on the same
+   model route with different params (e.g. temperature) stay distinct.
+3. Join recorded calls to bindings by fingerprint. A fingerprint claimed by ONE
+   binding takes its last (terminal) call. A fingerprint claimed by SEVERAL
+   bindings is genuinely ambiguous: identical recorded outputs attribute to
+   each claimant (no information invented), anything else stays null — never a
+   positional guess.
+
+Worked example — members ``/alpha?temperature=0.0``, ``/beta`` and synthesis
+``/alpha?temperature=0.5`` with calls [(alpha@0.0 → "A"), (beta → "B"),
+(alpha@0.5 → "F")]: three distinct fingerprints, so op_model_1="A",
+op_model_2="B", op_synthesis_1="F". Had both members been ``/alpha?temperature=0.0``
+returning "A1" and "A2", both would be null — the Engine cannot know which was which.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from url4.core.errors import ParseError
+from url4.core.nodes import Expression, RelExpr, Source
+from url4.core.parser import build
+from url4_cloud.benchmarks.contract import OperationOutput
+from url4_cloud.operation_calls import OperationCall
+
+# INVARIANT: kept in lock-step with the Client's operation projection, where
+# `operation_id = "op_" + binding` and bindings are model_N / synthesis_N.
+_BINDING = re.compile(r"^(?:model|synthesis)_\d+$")
+
+type _Fingerprint = tuple[str, tuple[tuple[str, str], ...]]
+
+
+@dataclass(frozen=True, slots=True)
+class _OperationBinding:
+    binding: str
+    fingerprint: _Fingerprint | None
+
+
+def attribute_operation_outputs(
+    expression: str,
+    calls: Sequence[OperationCall],
+) -> list[OperationOutput] | None:
+    """Join recorded calls to the expression's operations; None below two bindings.
+
+    Fewer than two attributable bindings means a solo Candidate (or a shape this
+    slice does not attribute) — no member section is invented for those.
+    """
+
+    bindings = _operation_bindings(expression)
+    if len(bindings) < 2:
+        return None
+    by_fingerprint: dict[_Fingerprint, list[OperationCall]] = {}
+    for call in calls:
+        by_fingerprint.setdefault((call.path, call.params), []).append(call)
+    claims: dict[_Fingerprint, int] = {}
+    for binding in bindings:
+        if binding.fingerprint is not None:
+            claims[binding.fingerprint] = claims.get(binding.fingerprint, 0) + 1
+    return [_attributed(binding, by_fingerprint, claims) for binding in bindings]
+
+
+def _attributed(
+    binding: _OperationBinding,
+    by_fingerprint: dict[_Fingerprint, list[OperationCall]],
+    claims: dict[_Fingerprint, int],
+) -> OperationOutput:
+    output: str | None = None
+    finish_reason: str | None = None
+    matched = [] if binding.fingerprint is None else by_fingerprint.get(binding.fingerprint, [])
+    if matched and claims.get(binding.fingerprint or ("", ()), 0) == 1:
+        # One claimant: every matched call IS this operation; the last one is terminal
+        # (a corrective re-invocation repeats the operation, and only its final answer
+        # is the one the Candidate used).
+        output, finish_reason = matched[-1].output, matched[-1].finish_reason
+    elif matched:
+        distinct = {(call.output, call.finish_reason) for call in matched}
+        if len(distinct) == 1:
+            output, finish_reason = next(iter(distinct))
+    return OperationOutput(
+        operation_id=f"op_{binding.binding}",
+        output=output,
+        finish_reason=finish_reason,
+    )
+
+
+def _operation_bindings(expression: str) -> tuple[_OperationBinding, ...]:
+    try:
+        node = build(expression)
+    except ParseError:
+        return ()
+    if not isinstance(node, Expression):
+        return ()
+    selected: list[_OperationBinding] = []
+    for source in node.sources:
+        if not isinstance(source, Source) or source.name is None:
+            continue
+        if not _BINDING.match(source.name):
+            continue
+        selected.append(_OperationBinding(source.name, _fingerprint(source.value)))
+    return tuple(selected)
+
+
+def _fingerprint(value: object) -> _Fingerprint | None:
+    # A binding whose value is not a direct model call (a nested Recipe, inert text)
+    # has no request identity to match; its entry stays null rather than guessed.
+    if not isinstance(value, RelExpr):
+        return None
+    params = tuple(sorted((name, item) for name, item in value.params if isinstance(item, str)))
+    return (value.path, params)
+
+
+__all__ = ["attribute_operation_outputs"]

--- a/apps/url4-cloud/src/url4_cloud/operation_calls.py
+++ b/apps/url4-cloud/src/url4_cloud/operation_calls.py
@@ -1,0 +1,93 @@
+"""Task-local capture of terminal model calls with their route identity (OME-843).
+
+Sibling of :mod:`url4_cloud.model_outcomes`, and split from it deliberately: an
+outcome is status telemetry every scope wants, while a call's output text is
+payload that only the Candidate invocation boundary may retain — so the two
+recorders stay independently scoped.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class OperationCall:
+    """One terminal provider round trip plus the route identity that requested it.
+
+    ``params`` is the request's parameter set sorted by name — the half of the
+    OME-843 attribution fingerprint that distinguishes two members on the same
+    model route (e.g. different temperatures).
+    """
+
+    path: str
+    params: tuple[tuple[str, str], ...]
+    output: str
+    finish_reason: str | None
+
+
+type OperationCallRecorder = list[OperationCall]
+
+_recorders: contextvars.ContextVar[tuple[OperationCallRecorder, ...]] = contextvars.ContextVar(
+    "url4_cloud_operation_call_recorders", default=()
+)
+_identity: contextvars.ContextVar[tuple[str, tuple[tuple[str, str], ...]] | None] = (
+    contextvars.ContextVar("url4_cloud_operation_call_identity", default=None)
+)
+
+
+@contextmanager
+def capture_operation_calls(*, isolated: bool = False) -> Iterator[OperationCallRecorder]:
+    """Capture terminal calls in this scope; nesting mirrors `capture_model_outcomes`."""
+
+    recorder: OperationCallRecorder = []
+    active = () if isolated else _recorders.get()
+    token = _recorders.set((*active, recorder))
+    try:
+        yield recorder
+    finally:
+        _recorders.reset(token)
+
+
+@contextmanager
+def operation_call_identity(path: str, params: Mapping[str, str]) -> Iterator[None]:
+    """Bind the route identity of the call about to run, for its own task only.
+
+    WHY: the connector's completion loop knows the terminal content and finish
+    reason but not which url4 source asked for them; the endpoint entry knows the
+    request's path and params but not the terminal fields. This contextvar carries
+    the identity across that gap without widening the loop's signature.
+    """
+
+    token = _identity.set((path, tuple(sorted(params.items()))))
+    try:
+        yield
+    finally:
+        _identity.reset(token)
+
+
+def record_operation_call(output: str, finish_reason: str | None) -> None:
+    """Publish one terminal call to every active scope, if an identity is bound."""
+
+    identity = _identity.get()
+    if identity is None:
+        return
+    call = OperationCall(
+        path=identity[0],
+        params=identity[1],
+        output=output,
+        finish_reason=finish_reason,
+    )
+    for recorder in _recorders.get():
+        recorder.append(call)
+
+
+__all__ = [
+    "OperationCall",
+    "capture_operation_calls",
+    "operation_call_identity",
+    "record_operation_call",
+]

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -20,6 +20,7 @@ from url4.peer.server import Request, Url4Node
 from url4.streaming.protocol import CachePolicy
 from url4_cloud.benchmarks.contract import CANDIDATE_INPUT_SCHEMA, CANDIDATE_MESSAGE_ROLES
 from url4_cloud.model_outcomes import bind_model_outcome, record_model_outcome
+from url4_cloud.operation_calls import operation_call_identity, record_operation_call
 from url4_cloud.retrieval_policy import (
     RetrievalPolicy,
     current_retrieval_policy,
@@ -167,19 +168,23 @@ class _ModelEndpoint:
             spec = self._routes[request.path]
             retrieval_policy = current_retrieval_policy()
             params = apply_retrieval_policy(request.params, retrieval_policy)
-            return await _chat_completion_loop(
-                http_client=self._http_client,
-                cfg=self._cfg,
-                profile=self._profile,
-                messages=_messages(request.context, request.intent),
-                params=params,
-                spec=spec,
-                tavily_http=self._tavily_http,
-                tavily_api_key=self._tavily_api_key,
-                retrieval_policy=retrieval_policy,
-                identity_headers=self._identity_headers,
-                cache=self._cache,
-            )
+            # WHY: the identity is the REQUEST's path and params (pre-policy), because
+            # OME-843 attribution matches them against the candidate expression's own
+            # source text — the policy-applied set may differ from what was written.
+            with operation_call_identity(request.path, request.params):
+                return await _chat_completion_loop(
+                    http_client=self._http_client,
+                    cfg=self._cfg,
+                    profile=self._profile,
+                    messages=_messages(request.context, request.intent),
+                    params=params,
+                    spec=spec,
+                    tavily_http=self._tavily_http,
+                    tavily_api_key=self._tavily_api_key,
+                    retrieval_policy=retrieval_policy,
+                    identity_headers=self._identity_headers,
+                    cache=self._cache,
+                )
         except RunnerRequestError as exc:
             error = ResolutionError(str(exc), code=exc.code, permanent=exc.permanent)
             if exc.outcome is not None:
@@ -415,6 +420,7 @@ async def _chat_completion_loop(
             # `tool_calls` rounds too would leave a consumer unable to tell a call that progressed
             # from two calls that disagreed (`_terminal_outcome` in `benchmarks/candidate.py`).
             record_model_outcome(choice.finish_reason, choice.refusal)
+            record_operation_call(content or "", choice.finish_reason)
             return content or ""
         messages.append({"role": "assistant", "content": content, "tool_calls": tool_calls})
         await append_tool_results(messages, tool_calls, tools, cfg)

--- a/apps/url4-cloud/tests/unit/test_operation_output_capture.py
+++ b/apps/url4-cloud/tests/unit/test_operation_output_capture.py
@@ -1,0 +1,341 @@
+"""Per-operation output capture in the Candidate Invocation envelope (OME-843).
+
+INVARIANT defended: a Fusion Case artifact carries each member and synthesis
+operation's terminal output keyed by its stable operation id — attributed by the
+resolved request fingerprint (path + params), never by position — while a solo
+Candidate's envelope stays byte-identical to the pre-capture contract.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from url4 import RelExpr, expr, render, src, text
+from url4_cloud.benchmarks.contract import (
+    OperationOutput,
+    decode_candidate_invocation_record,
+    encode_candidate_invocation,
+)
+from url4_cloud.benchmarks.operation_outputs import attribute_operation_outputs
+from url4_cloud.operation_calls import (
+    OperationCall,
+    capture_operation_calls,
+    operation_call_identity,
+    record_operation_call,
+)
+
+
+def _fusion_expression(*, duplicate_members: bool = False) -> str:
+    """Render the compiled Fusion shape: named member sources plus a synthesis source."""
+
+    member_2_path = "/provider/alpha" if duplicate_members else "/provider/beta"
+    member_2_params: tuple[tuple[str, str], ...] = (
+        (("temperature", "0.0"),) if duplicate_members else ()
+    )
+    return render(
+        expr(
+            src(
+                RelExpr(
+                    path="/provider/alpha",
+                    context="$input",
+                    intent=text("Answer plainly."),
+                    params=(("temperature", "0.0"),),
+                ),
+                name="model_1",
+                weight=0.0,
+            ),
+            src(
+                RelExpr(
+                    path=member_2_path,
+                    context="$input",
+                    intent=text("Answer plainly."),
+                    params=member_2_params,
+                ),
+                name="model_2",
+                weight=0.0,
+            ),
+            src(
+                RelExpr(
+                    path="/provider/alpha",
+                    context="$model_1 / $model_2",
+                    intent=text("Fuse the answers."),
+                    params=(("temperature", "0.5"),),
+                ),
+                name="synthesis_1",
+                weight=0.0,
+            ),
+            intent=text("$synthesis_1"),
+        )
+    )
+
+
+def _call(
+    path: str,
+    params: tuple[tuple[str, str], ...],
+    output: str,
+    finish_reason: str | None = "stop",
+) -> OperationCall:
+    return OperationCall(path=path, params=params, output=output, finish_reason=finish_reason)
+
+
+# --- contract envelope -----------------------------------------------------------------
+
+
+def test_invocation_without_operations_keeps_the_exact_legacy_shape() -> None:
+    encoded = encode_candidate_invocation("answer", "stop", None)
+
+    assert set(json.loads(encoded)) == {
+        "schema",
+        "status",
+        "output",
+        "finish_reason",
+        "refusal",
+        "execution",
+    }
+    assert decode_candidate_invocation_record(encoded).operations is None
+
+
+def test_invocation_operations_round_trip_in_order() -> None:
+    operations = [
+        OperationOutput(operation_id="op_model_1", output="alpha", finish_reason="stop"),
+        OperationOutput(operation_id="op_model_2", output=None, finish_reason=None),
+        OperationOutput(operation_id="op_synthesis_1", output="fused", finish_reason="stop"),
+    ]
+
+    decoded = decode_candidate_invocation_record(
+        encode_candidate_invocation("fused", "stop", None, operations=operations)
+    )
+
+    assert decoded.operations == operations
+
+
+def test_invocation_rejects_a_malformed_operations_entry() -> None:
+    encoded = encode_candidate_invocation("answer", "stop", None)
+    payload = json.loads(encoded)
+    payload["operations"] = [{"operation_id": "", "output": None, "finish_reason": None}]
+
+    with pytest.raises(ValueError, match="operation"):
+        decode_candidate_invocation_record(json.dumps(payload))
+
+
+# --- attribution -----------------------------------------------------------------------
+
+
+def test_each_operation_receives_its_own_fingerprinted_output() -> None:
+    calls = [
+        _call("/provider/alpha", (("temperature", "0.0"),), "alpha answer"),
+        _call("/provider/beta", (), "beta answer"),
+        _call("/provider/alpha", (("temperature", "0.5"),), "fused answer"),
+    ]
+
+    operations = attribute_operation_outputs(_fusion_expression(), calls)
+
+    assert operations is not None
+    assert [(op.operation_id, op.output) for op in operations] == [
+        ("op_model_1", "alpha answer"),
+        ("op_model_2", "beta answer"),
+        ("op_synthesis_1", "fused answer"),
+    ]
+
+
+def test_byte_identical_members_share_only_an_identical_output() -> None:
+    # INVARIANT: two members with the same path AND params are indistinguishable —
+    # identical recorded outputs attribute to both, anything else stays null. Never
+    # a positional guess.
+    identical = [
+        _call("/provider/alpha", (("temperature", "0.0"),), "same answer"),
+        _call("/provider/alpha", (("temperature", "0.0"),), "same answer"),
+        _call("/provider/alpha", (("temperature", "0.5"),), "fused answer"),
+    ]
+    divergent = [
+        _call("/provider/alpha", (("temperature", "0.0"),), "first answer"),
+        _call("/provider/alpha", (("temperature", "0.0"),), "second answer"),
+        _call("/provider/alpha", (("temperature", "0.5"),), "fused answer"),
+    ]
+
+    shared = attribute_operation_outputs(_fusion_expression(duplicate_members=True), identical)
+    nulled = attribute_operation_outputs(_fusion_expression(duplicate_members=True), divergent)
+
+    assert shared is not None and nulled is not None
+    assert [op.output for op in shared] == ["same answer", "same answer", "fused answer"]
+    assert [op.output for op in nulled] == [None, None, "fused answer"]
+
+
+def test_a_member_that_never_called_stays_null() -> None:
+    calls = [
+        _call("/provider/alpha", (("temperature", "0.0"),), "alpha answer"),
+        _call("/provider/alpha", (("temperature", "0.5"),), "fused answer"),
+    ]
+
+    operations = attribute_operation_outputs(_fusion_expression(), calls)
+
+    assert operations is not None
+    assert [(op.operation_id, op.output) for op in operations] == [
+        ("op_model_1", "alpha answer"),
+        ("op_model_2", None),
+        ("op_synthesis_1", "fused answer"),
+    ]
+
+
+def test_a_solo_candidate_records_no_operations() -> None:
+    # INVARIANT: no member section is invented for a solo Candidate — fewer than two
+    # attributable bindings means the envelope stays in its legacy shape.
+    solo = render(RelExpr(path="/provider/alpha", context="$input", intent=text("Answer plainly.")))
+
+    assert attribute_operation_outputs(solo, [_call("/provider/alpha", (), "answer")]) is None
+
+
+def test_an_unparseable_expression_records_no_operations() -> None:
+    assert attribute_operation_outputs("!!not url4", [_call("/p", (), "x")]) is None
+
+
+# --- task-local recorder ---------------------------------------------------------------
+
+
+def test_operation_calls_record_identity_only_inside_a_capture_scope() -> None:
+    with capture_operation_calls() as calls:
+        with operation_call_identity("/provider/alpha", {"temperature": "0.0"}):
+            record_operation_call("captured", "stop")
+        record_operation_call("no identity — dropped", "stop")
+    record_operation_call("no scope — dropped", "stop")
+
+    assert calls == [
+        OperationCall(
+            path="/provider/alpha",
+            params=(("temperature", "0.0"),),
+            output="captured",
+            finish_reason="stop",
+        )
+    ]
+
+
+# --- end to end through the real connector ---------------------------------------------
+
+
+def _per_model_response() -> Callable[[httpx.Request], httpx.Response]:
+    def respond(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if body["model"] == "provider/beta":
+            content = "beta answer"
+        elif body.get("temperature") == 0.5:
+            content = "fused answer"
+        else:
+            content = "alpha answer"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": content}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+            },
+        )
+
+    return respond
+
+
+@pytest.mark.asyncio
+async def test_a_fusion_invocation_carries_every_member_and_synthesis_output() -> None:
+    from url4_cloud.benchmarks.invocation import evaluate_candidate_recipe
+    from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+    from url4_cloud.world_config import ModelSpec
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(_per_model_response()),
+        base_url="http://aigateway.test",
+    )
+    world = await build_aigateway_world(
+        AigatewayConfig(
+            default_model="provider/alpha",
+            models=(ModelSpec(id="provider/alpha"), ModelSpec(id="provider/beta")),
+        ),
+        client=client,
+    )
+    try:
+        encoded = await evaluate_candidate_recipe(
+            world.node, _fusion_expression(), "why is the sky blue?"
+        )
+    finally:
+        await world.aclose()
+        await client.aclose()
+
+    decoded = decode_candidate_invocation_record(encoded)
+
+    assert decoded.output == "fused answer"
+    assert decoded.operations is not None
+    assert [(op.operation_id, op.output, op.finish_reason) for op in decoded.operations] == [
+        ("op_model_1", "alpha answer", "stop"),
+        ("op_model_2", "beta answer", "stop"),
+        ("op_synthesis_1", "fused answer", "stop"),
+    ]
+
+
+# --- case artifact threading -----------------------------------------------------------
+
+
+def test_case_record_carries_operations_only_when_attributed() -> None:
+    from url4_cloud.benchmarks.case_records import bind_case_record
+    from url4_cloud.benchmarks.evaluation import CandidateAnswer
+
+    cases = json.dumps([{"id": 1, "input": "Explain DiD estimators."}])
+    base = {
+        "status": "completed",
+        "text": "fused",
+        "output": "fused",
+        "finish_reason": "stop",
+        "refusal": None,
+        "execution": None,
+    }
+    attributed = bind_case_record(
+        cases,
+        case_id=1,
+        candidate=CandidateAnswer(
+            **base,
+            operations=(
+                OperationOutput(operation_id="op_model_1", output="alpha", finish_reason="stop"),
+            ),
+        ),
+        schema="example.case.v1",
+        benchmark="EXAMPLE",
+    )
+    solo = bind_case_record(
+        cases,
+        case_id=1,
+        candidate=CandidateAnswer(**base, operations=None),
+        schema="example.case.v1",
+        benchmark="EXAMPLE",
+    )
+
+    assert attributed["operations"] == [
+        {"operation_id": "op_model_1", "output": "alpha", "finish_reason": "stop"}
+    ]
+    # INVARIANT: absence stays absence — a solo Candidate's record keeps the legacy shape.
+    assert "operations" not in solo
+
+
+def test_scored_case_result_exports_operations_only_when_present() -> None:
+    from url4_cloud.benchmarks.aggregation import SelectedCase, scored_case_result
+
+    selected = SelectedCase(case_id=1, input="Explain DiD estimators.", metadata={})
+    grade = {"method": "rubric", "score": 1.0, "metrics": {}, "checks": []}
+
+    attributed = scored_case_result(
+        selected_case=selected,
+        output="fused",
+        finish_reason="stop",
+        grade=grade,
+        operations=[{"operation_id": "op_model_1", "output": "alpha", "finish_reason": "stop"}],
+    ).model_dump(by_alias=True)
+    solo = scored_case_result(
+        selected_case=selected,
+        output="fused",
+        finish_reason="stop",
+        grade=grade,
+    ).model_dump(by_alias=True)
+
+    assert attributed["operations"] == [
+        {"operation_id": "op_model_1", "output": "alpha", "finish_reason": "stop"}
+    ]
+    assert "operations" not in solo

--- a/docs/spec/2026-08-17-OME-843-member-output-capture.md
+++ b/docs/spec/2026-08-17-OME-843-member-output-capture.md
@@ -1,0 +1,92 @@
+# OME-843 — Capture member and synthesis output text in benchmark case artifacts
+
+Status: DRAFT — pending owner approval. Sub-issue of OME-784; client fold-in of
+usage/timing stays OME-699; stats export stays OME-842.
+
+## Problem
+
+A Fusion case artifact (`CaseResult`, `apps/url4-cloud/src/url4_cloud/benchmarks/contract.py`)
+keeps only the fused answer. Member answers exist transiently in the engine —
+`_gather()` binds them (`packages/url4/src/url4/dag/nodes.py:588-610`) and
+`ProcessNode.resolve` discards them after substitution (`nodes.py:706-720`); the model
+connector holds each terminal output + finish_reason (`runner/connector.py:409-418`) —
+but nothing persists them. Contribution analysis (draco 2026-08-17: breadth 0.43 vs
+presentation 0.87, cause unknowable) requires paid re-runs.
+
+## Non-solutions (ruled out by recon)
+
+- **`url4.observe` telemetry**: the nested candidate run is unobserved
+  (`packages/url4/src/url4/peer/server.py:374-382` builds an `ExecutionContext` with no
+  observer; `dag/executor.py:177-181` skips sink binding). No per-member spans exist, and
+  `SpanData` carries no output text. Fixing observation is a url4-package unit of its own —
+  out of this slice (rule: url4 core changes get their own ticket).
+- **Manifest/protocol change**: the benchmark protocol expression is contractually frozen
+  (`tests/unit/test_benchmark_protocol.py`); nothing here may alter it.
+
+## Design — widen the CandidateInvocation envelope (the `execution` precedent)
+
+The frozen protocol moves `$candidate_invocation` as opaque text and
+`/benchmarks/case-execution` is a pure re-encoder, so the envelope can grow without any
+protocol change — the exact path OME-796 used for `CorrectiveExecution`
+(`contract.py:177-185` → `case_records.py:53-55` → `draco/case_results.py`).
+
+### Engine (url4-cloud) — the OME-843 unit
+
+1. **Recorder**: a task-local `capture_operation_outputs()` beside
+   `model_outcomes.py`, started in `benchmarks/invocation.py` alongside
+   `capture_model_outcomes`. The connector contributes `(model_route, output_text,
+   finish_reason)` at the same point it reports outcomes today
+   (`runner/connector.py:417`).
+2. **Binding attribution**: the engine derives the operation identity by parsing the
+   candidate expression it already holds (`candidate_adapter.py:30-50`) with
+   `url4.build` — source name `model_N`/`synthesis_N` → `op_<binding>`, the same total
+   function the client uses (`_evaluation/candidate.py:209-211`). Attribution maps the
+   **resolved request fingerprint (model route + params)** → binding, so two members on
+   the same model with different params (e.g. temperature) stay distinct. Residual
+   ambiguity — byte-identical member calls — resolves as: identical recorded outputs →
+   attribute that text to every matching binding (no information invented); differing
+   outputs → `output: null` for the contested bindings (never a positional guess).
+   Solo candidates record nothing (no member section invented). [Owner-decided
+   2026-08-17: fingerprint keying + this ambiguity rule; synthesis output recorded.]
+3. **Envelope**: `CandidateInvocation` gains an optional `operations` list —
+   `{operation_id, output, finish_reason}` per attributed operation — threaded
+   `encode/decode_candidate_invocation` (`contract.py`) → `CandidateAnswer`
+   (`evaluation.py`) → `bind_case_record` (`case_records.py`) → the four
+   `*_case_result` builders (`aggregation.py`) → `CaseResult.operations` (optional,
+   `None` for solos/absent). Deterministic ordering: candidate expression source order.
+4. **Bounds**: values pass the existing `_is_json_value` validation; outputs are
+   ≤ max_tokens-sized by construction. The 1 MiB `result_cap`
+   (`runner/executor.py:327-344`) is acknowledged: N members × full text per case can
+   approach it on large runs — if the cap trips, capture degrades to `null` outputs
+   rather than corrupting the artifact (same "never fabricate, never break the run"
+   stance as the rest of the contract).
+
+### Client (py-screamingface) — lockstep prerequisite, separate sub-issue
+
+`_case_result` hard-rejects unknown case keys (`_evaluation/results.py:355-366`, pinned
+by `test_case_outcome_decoding.py`). Therefore a **client PR ships first**: add
+`operations` to the decoder's `optional={...}` set and surface it on
+`case_result.CaseResult` / `to_dict()`. Until the engine emits it, the field is absent —
+no behavior change. Engine PR follows once the tolerant SDK is merged.
+
+Ship order is a hard constraint: engine-first would make new engines break existing SDKs.
+
+## Acceptance
+
+- Fusion run: each case artifact carries `operations` with the member and synthesis
+  outputs + finish_reasons, keyed by `op_<binding>`, in expression source order.
+- Solo run: artifact byte-identical to today (no `operations` key).
+- Ambiguous route attribution → `output: null` for the contested operations, run
+  unaffected.
+- Old SDK + old engine, new SDK + old engine, new SDK + new engine all green;
+  new engine + old SDK is prevented by ship order.
+- Contract tests extended, protocol-expression test untouched.
+
+## Open questions (owner)
+
+1. RESOLVED 2026-08-17: attribution keys on the resolved request fingerprint
+   (route + params); byte-identical calls attribute only identical outputs, else null.
+2. RESOLVED 2026-08-17: synthesis output is recorded.
+3. Client sub-issue: filed as a second sub-issue of OME-784 (py-screamingface,
+   ships first — SDK must tolerate the optional `operations` key before any engine
+   emits it).

--- a/docs/tasks/2026-08-17-OME-842-report-stats-export.md
+++ b/docs/tasks/2026-08-17-OME-842-report-stats-export.md
@@ -1,0 +1,25 @@
+---
+id: OME-842
+linear_url: https://linear.app/openmined/issue/OME-842/export-per-member-and-per-axis-stats-artifacts-from-a-saved-report
+status: Backlog
+type: Feature
+priority: P3
+labels: [py-screamingface, agentic, deferred]
+created: 2026-08-17
+closed:
+---
+
+# Export per-member and per-axis stats artifacts from a saved Report
+
+The legacy benchmarks pipeline saved per-run stats tables (by model/axis/judge/mode),
+plots, and snapshots. `report.v1` carries none of these derived views. Once `OME-784`
+(per-operation outputs + snapshots) and `OME-699` (member usage/timing attribution) put
+raw per-member data into the report, add a client-side, read-only export that derives the
+legacy-parity artifacts from any saved Report: standard stats tables, plots, and a tabular
+judge-evidence dump.
+
+Blocked-by: `OME-784`, `OME-699` (hence `deferred`). Related: `OME-488`.
+
+Source of truth: legacy `screamingface-benchmarks` saved-outputs layout
+(`draco/<run>/{stats,visual_plots,metrics}`) for artifact shapes; `report.v1`
+(`packages/screamingface/src/screamingface/report.py`) for the input contract.

--- a/docs/tasks/2026-08-17-OME-843-member-output-capture.md
+++ b/docs/tasks/2026-08-17-OME-843-member-output-capture.md
@@ -1,0 +1,19 @@
+---
+id: OME-843
+linear_url: https://linear.app/openmined/issue/OME-843/capture-member-and-synthesis-output-text-in-benchmark-case-artifacts
+status: In Progress
+type: Feature
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Capture member and synthesis output text in benchmark case artifacts
+
+First slice of `OME-784` (parent): persist each member and synthesis operation's raw
+output text + finish_reason into the benchmark case artifact, keyed by the stable
+`operation_id` from the Candidate operation projection. Motivated by the 2026-08-17
+draco fusion run whose weak breadth axis (0.43) is undiagnosable from the fused answer
+alone. Failure evidence / snapshots stay in `OME-784`; usage/timing attribution stays
+in `OME-699`; privacy stance per `OME-316` unchanged.

--- a/docs/work/2026-08-17-OME-843-member-output-capture.md
+++ b/docs/work/2026-08-17-OME-843-member-output-capture.md
@@ -1,0 +1,70 @@
+---
+ticket: OME-843
+stack: url4-cloud
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-843 — Capture member and synthesis output text in benchmark case artifacts
+
+## Intent
+
+First slice of OME-784. A Fusion case artifact keeps only the fused answer; each member
+model's answer (and the synthesis step's, when it differs from the case output) is
+discarded at the engine, so contribution analysis ("did the solos lack the substance or
+did the synthesizer drop it?") requires paid re-runs. Persist per-operation output text +
+finish_reason into the case artifact, keyed by the stable operation_id from the Candidate
+operation projection. Client-side consumption stays in OME-699; the rest of the evidence
+scope stays in OME-784.
+
+## Planned changes
+
+Spec: `docs/spec/2026-08-17-OME-843-member-output-capture.md` (envelope-widening via the
+OME-796 `execution` precedent; telemetry route ruled out — nested candidate run is
+unobserved). Engine side, pending plan approval:
+
+- `apps/url4-cloud/src/url4_cloud/benchmarks/operation_outputs.py` (new recorder)
+- `apps/url4-cloud/src/url4_cloud/benchmarks/invocation.py` (start capture)
+- `apps/url4-cloud/src/url4_cloud/runner/connector.py` (contribute output+finish_reason)
+- `apps/url4-cloud/src/url4_cloud/benchmarks/candidate_adapter.py` (binding derivation)
+- `apps/url4-cloud/src/url4_cloud/benchmarks/contract.py` (`CandidateInvocation.operations`,
+  `CaseResult.operations`)
+- `apps/url4-cloud/src/url4_cloud/benchmarks/{evaluation,case_records,aggregation}.py` (thread)
+
+Client tolerance (`results.py` optional key) is a separate lockstep sub-issue shipping first.
+
+## Test plan
+
+- RED first: contract round-trip for `operations` in `test_candidate_result_contract.py`;
+  fusion-run capture attributing by binding (incl. duplicate-route → null invariant:
+  "never guessed, never fabricated"); solo-run artifact byte-identical (invariant: no
+  member section invented); conformance sweep across draco/ifeval/healthbench aggregates;
+  protocol-expression test stays untouched/green.
+
+## Acceptance
+
+- Given a Fusion run, the case artifact carries each member operation's output text and
+  finish_reason keyed by operation_id; single-model candidates' artifact shape unchanged;
+  unavailable values stay null; report remains JSON-serializable and deterministic.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** new `url4_cloud/operation_calls.py` (task-local recorder + identity
+  contextvar), new `benchmarks/operation_outputs.py` (expression parse + fingerprint
+  attribution); `benchmarks/contract.py` (`OperationOutput`, optional `operations` on
+  `CandidateInvocation` + `CaseResult` via exclude_if, encode/decode); `runner/connector.py`
+  (identity scope + terminal record); `benchmarks/invocation.py` (capture + attach on both
+  exits); `benchmarks/evaluation.py` (`CandidateAnswer.operations`); `benchmarks/
+  case_records.py` (key only when attributed); `benchmarks/aggregation.py` (4 builders +
+  grading_failure + `_operation_outputs`); adapters draco/case_results.py,
+  ifeval/{runtime,aggregate}.py, healthbench/{aggregate,case_evaluation}.py;
+  tests/unit/test_operation_output_capture.py (12 tests incl. connector e2e).
+- **Commits:** (filled post-commit)
+- **Gates:** run_gates.py url4-cloud ALL GREEN — ruff check/format, pyright, layering,
+  pytest 1476 passed/5 skipped (cov ≥80), append-only test check.
+- **Deviations:** healthbench `_valid_case_record` and the invocation decode shape check
+  tolerate the `operations` key as the ONE optional deviation (absence stays absence),
+  so pre-capture records and every existing fixture stay valid. Client tolerance shipped
+  first as PR #613 (separate ledger `2026-08-17-OME-843-client-operations-key.md`).
+  Dedicated client sub-issue still pending Linear re-auth.


### PR DESCRIPTION
Second half of OME-843 (sub-issue of OME-784). **Depends on #613 merging first** — the SDK must tolerate the optional `operations` case key before any engine emits it; this PR is what starts emitting it.

## What changes

A Fusion evaluation's case artifact now carries each member and synthesis operation's terminal output text + finish_reason, keyed by the stable `op_model_N` / `op_synthesis_N` ids the Client's operation projection already defines. Mechanism, in execution order:

1. **Record** — the connector's completion loop records every terminal model call together with its route identity (path + params), via a task-local recorder scoped to the Candidate invocation (`operation_calls.py`, sibling of `model_outcomes.py`).
2. **Attribute** — at the invocation boundary the engine parses the candidate expression it already holds and joins recorded calls to its named `model_N`/`synthesis_N` sources by request fingerprint (`benchmarks/operation_outputs.py`). Same model at different temperatures = distinct fingerprints. Byte-identical member calls are genuinely ambiguous: identical outputs attribute to each claimant, anything else stays null — never a positional guess.
3. **Carry** — the result rides the `CandidateInvocation` envelope exactly like OME-796's `execution` field (opaque text to the frozen benchmark protocol — no manifest change; the protocol-expression pin test is untouched), then threads through case records and the shared case builders into `CaseResult.operations` across draco / ifeval / healthbench.

**Absence stays absence**: the `operations` key exists only when the Engine attributed. Solo-candidate artifacts and every pre-capture record stay byte-identical (`exclude_if` on the wire models; validators tolerate the key as the one optional deviation).

## Before / After

### Before
- Trigger: a dev inspects a finished Fusion evaluation to explain a weak rubric axis (e.g. the 2026-08-17 draco run: breadth 0.43 vs presentation 0.87).
- Today: only the fused answer survives; member answers are discarded at the engine.
- Cost: "did the solos lack the substance or did the synthesizer drop it?" requires re-spending on paid solo runs.

### After
- Same trigger.
- Now: `report.json` cases carry `operations` with each member's and the synthesis step's output and finish reason.
- Win: contribution analysis works offline from one saved report.

### Don't regress
- Solo candidates: artifact byte-identical, no member section invented (explicit tests).
- Frozen benchmark protocol expression untouched (existing pin test green).
- Ambiguous attribution never fabricates: null over guessing (explicit tests for identical vs divergent duplicate members).
- Existing case-record fixtures across all three benchmarks stay valid (`operations` is optional everywhere).

## Test plan

- New `test_operation_output_capture.py` (12 tests): envelope legacy-shape pin, ordered round-trip, malformed-entry rejection, fingerprint attribution (distinct / duplicate-identical / duplicate-divergent / missing-call / solo / unparseable), task-local recorder scoping, **end-to-end through the real connector** with a per-model stubbed gateway, case-record and case-builder threading.
- Full gates green: ruff, pyright, layering check, pytest 1476 passed (cov ≥80%).

Refs: OME-843

🤖 Generated with [Claude Code](https://claude.com/claude-code)