### PR TITLE
docs(public-docs): copyedit and expand the sf-client docs

### DIFF
--- a/docs/tasks/2026-08-17-OME-846-public-docs-overview-copyedit.md
+++ b/docs/tasks/2026-08-17-OME-846-public-docs-overview-copyedit.md
@@ -1,0 +1,18 @@
+---
+id: OME-846
+linear_url: https://linear.app/openmined/issue/OME-846/copyedit-sf-client-overview-and-home-hero-docs-prose
+status: in_progress
+type: task
+priority: P2
+labels: [repo, agentic, autonomous, task]
+created: 2026-08-17
+closed:
+---
+
+Live copyedit pass on the public-docs sf-client surface (owner-dictated). Copy only.
+
+- `src/pages/sf-client/Index.vue` — 7 prose edits (Overview, "What url4 is", "Two ways to run").
+- `src/pages/HomePage.vue` — hero: "a real research benchmark" → "a real benchmark".
+- `src/pages/sf-client/QuickstartPage.vue` — page description copyedit.
+
+Ledger: `docs/work/2026-08-17-OME-846-public-docs-overview-copyedit.md`.

--- a/docs/work/2026-08-17-OME-846-public-docs-overview-copyedit.md
+++ b/docs/work/2026-08-17-OME-846-public-docs-overview-copyedit.md
@@ -1,0 +1,69 @@
+---
+ticket: OME-846
+stack: repo
+status: in_progress
+started: 2026-08-17
+finished:
+---
+
+# OME-846 — Copyedit and expand the sf-client public docs
+
+## Intent
+
+A live copyedit/polish pass over the public-docs sf-client surface, driven interactively by
+the owner. It began as verbatim prose copyedits on the Overview and Home hero and grew, in the
+same session, into a broader docs-accuracy pass: correcting the hosted engine URL, reframing
+the Configure-engine and web-search guidance, documenting a leaderboard default and a model
+parameter-discovery API, adding "work in progress" caveats where scope is currently limited,
+and adding explanatory diagrams. Copy/diagrams and one URL constant only — no client behaviour
+changes.
+
+## Planned changes (as executed)
+
+- `public-docs/src/lib/engine.ts` — hosted `SF_ENGINE_URL` → `https://fusion.dev.screamingface.ai`
+  (was the `engine.screamingface.ai` placeholder).
+- `public-docs/src/pages/HomePage.vue` — hero: "a real research benchmark" → "a real benchmark".
+- `public-docs/src/pages/sf-client/Index.vue` — 7 prose edits (engine/caching sentence, "reported
+  repeatedly", drop two sentences/para, url4 grammar+protocol, "either of two", "pay for the
+  compute"); add the theme-aware **local-flow diagram** (reusing
+  `/diagrams/screamingface-request-architecture-local-*.svg`) to the "How it works" section.
+- `public-docs/src/pages/sf-client/QuickstartPage.vue` — description reword; DRACO → arXiv link
+  (2602.11685); "1 · Point at an engine" → "1 · Configure the engine" led by what the engine
+  does, linked to `/learn/engine`; local-vs-hosted engine guidance incl. peer-to-peer hosted
+  access; provider/caching caveat (caching = OpenRouter + Anthropic only, WIP).
+- `public-docs/src/pages/sf-client/InstallationPage.vue` — reframe "Give the engine a web-search
+  key" around Hugging Face / non-search providers (most of the time not needed); add a note that
+  the client defaults to the hosted leaderboard (`leaderboard.dev.screamingface.ai`) and is
+  overridden via `sf.configure(scoreboard_url=...)`.
+- `public-docs/src/pages/sf-client/guides/ConnectionsPage.vue` — drop "Your notebook keeps no copy."
+- `public-docs/src/pages/sf-client/guides/BenchmarksPage.vue` — caveat: only a subset of benchmarks
+  is live, expanding, + feedback CTA to GitHub.
+- `public-docs/src/pages/sf-client/guides/ModelsPage.vue` — caveat: no automatic model discovery yet
+  (fixed catalogue, WIP); new section "6 · Discover a route's parameters" using
+  `sf.models.get(...).parameters` / `ModelParameter.schema`.
+- `public-docs/src/pages/sf-client/guides/PipelinesPage.vue` — one inline-SVG diagram per code
+  snippet (chain, `.then()`, flatten, named-nest, recursive Fusion), matching the page's existing
+  hand-authored SVG convention, to make the nesting legible.
+
+## Test plan
+
+- Docs-only. Gate = the `public-docs-tests.yml` CI equivalents run locally.
+
+## Acceptance
+
+- All owner-dictated edits applied; new content technically accurate against the shipped
+  `packages/screamingface` API (`configure(scoreboard_url=...)`, `discovery.ModelParameter`).
+- CI-equivalent gates green.
+
+## Outcome
+
+- **Actual files:** 9 source files under `public-docs/src` (listed above) + this ledger + the
+  `docs/tasks` mirror.
+- **Commits:** <filled at commit>
+- **Gates:** `vue-tsc --noEmit` ✓ · `vite build` ✓ (built in ~0.9s) · `oxlint .` ✓ (exit 0) ·
+  `eslint .` ✓ (exit 0). No Prettier gate in `public-docs-tests.yml`.
+- **Deviations:** Scope grew well beyond the original title (Overview/Home) during live iteration
+  into a full sf-client docs pass — kept under one ticket per the owner's fold-tweaks-into-the-
+  active-ticket preference; Linear title/description updated to match. SVG diagram *visual*
+  correctness was not machine-verifiable (build only checks well-formedness) — owner to eyeball in
+  `npm run dev`.

--- a/public-docs/src/lib/engine.ts
+++ b/public-docs/src/lib/engine.ts
@@ -1,5 +1,5 @@
 // The hosted SF Engine the documentation points at.
 //
-// PLACEHOLDER: the production address is not settled. Every code sample
-// interpolates this constant, so replacing the value here updates all of them.
-export const SF_ENGINE_URL = 'https://engine.screamingface.ai'
+// Every code sample interpolates this constant, so replacing the value here
+// updates all of them.
+export const SF_ENGINE_URL = 'https://fusion.dev.screamingface.ai'

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -47,9 +47,12 @@ export const sfClientNavigation: NavEntry[] = [
       {
         title: 'Core classes',
         children: [
-          { title: 'Recipes', path: '/sf-client/api/recipes' },
+          { title: 'Recipes, Models, Fusions', path: '/sf-client/api/recipes' },
+          { title: 'Models', path: '/sf-client/api/models' },
           { title: 'Benchmarks', path: '/sf-client/api/benchmarks' },
           { title: 'Reports', path: '/sf-client/api/reports' },
+          { title: 'CandidateResult', path: '/sf-client/api/candidate-result' },
+          { title: 'Usage', path: '/sf-client/api/usage' },
           { title: 'Clients', path: '/sf-client/api/clients' },
         ],
       },

--- a/public-docs/src/pages/HomePage.vue
+++ b/public-docs/src/pages/HomePage.vue
@@ -45,7 +45,7 @@ const GITHUB = 'https://github.com/OpenMined'
       </h1>
       <p class="lead">
         ScreamingFace is an open toolkit for composing model <em>fusions</em>: several models
-        answering together, graded against a real research benchmark. Every run reproduces from a
+        answering together, graded against a real benchmark. Every run reproduces from a
         single line, on your own keys.
       </p>
 

--- a/public-docs/src/pages/learn/EnginePage.vue
+++ b/public-docs/src/pages/learn/EnginePage.vue
@@ -12,7 +12,7 @@ sf.configure(engine_url="http://127.0.0.1:9108")   # the Client talks only to an
 
 const runLocal = `pip install "screamingface[runtime]"
 screamingface prepare draco   # benchmark data, once
-screamingface up              # engine, gateway, scoreboard on loopback`
+screamingface up              # engine, gateway, leaderboard on loopback`
 
 const health = `screamingface status`
 </script>
@@ -106,7 +106,7 @@ const health = `screamingface status`
 
     <p>
       That serves the Engine on <code>127.0.0.1:9108</code>, alongside the gateway that holds your
-      provider keys and a local scoreboard. <code>screamingface status</code> reports each of the
+      provider keys and a local leaderboard. <code>screamingface status</code> reports each of the
       three, and <code>screamingface down</code> stops them. The
       <RouterLink to="/sf-client/installation">Installation</RouterLink> guide covers the rest,
       including when a local Engine needs its own web-search key.

--- a/public-docs/src/pages/learn/Url4Page.vue
+++ b/public-docs/src/pages/learn/Url4Page.vue
@@ -150,12 +150,6 @@ url4.render(node)   # -> "(https://a, https://b)!'summarize both'"   (lossless r
       url4 written today is meant to run tomorrow.
     </p>
 
-    <blockquote>
-      url4 is deliberately unbranded: a commons artifact, not a product feature. The open web works
-      because open protocols arrived early; url4 aims to be that early, open layer for describing
-      composed intelligence.
-    </blockquote>
-
     <h2>In code</h2>
 
     <p>

--- a/public-docs/src/pages/sf-client/Index.vue
+++ b/public-docs/src/pages/sf-client/Index.vue
@@ -1,13 +1,20 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
+import { storeToRefs } from 'pinia'
 import DocLayout from '@/components/layout/DocLayout.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import { SF_ENGINE_URL } from '@/lib/engine'
+import { useThemeStore } from '@/stores/themeStore'
 import {
   sfClientNavigation as navigation,
   sfClientVersion as version,
 } from '@/navigation/sf-client'
+
+const { isDark } = storeToRefs(useThemeStore())
+
+const localDiagram = (dark: boolean) =>
+  `/diagrams/screamingface-request-architecture-local-${dark ? 'dark' : 'light'}.svg`
 
 // The smallest complete run: name the engine, compose a Fusion, evaluate it
 // beside its own member, read both scores. Every name here is shipped API.
@@ -37,8 +44,8 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
       ScreamingFace is an open-source Python client for composing model ensembles, which it calls
       <strong>fusions</strong>, and evaluating them against research benchmarks. You build a fusion
       from providers you already hold keys for, evaluate it, and read back a score together with
-      what the run cost. The benchmark answer keys and the grading stay on the engine, so the code
-      being scored is never the code doing the scoring.
+      what the run cost. The benchmark answer keys and the grading stay on the engine and results are cached to lower
+      the cost of fusion exploration.
     </p>
 
     <p>
@@ -50,16 +57,9 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
         target="_blank"
         rel="noopener"
         >published results</a
-      >). The effect is reported elsewhere as well, for instance in
+      >). The effect is reported repeatedly, for instance in
       <em>Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles</em> (Skurikhin
-      et al., Los Alamos). It appears to come from genuine diversity between the models rather than
-      from any single one of them.
-    </p>
-
-    <p>
-      Evaluation is nondeterministic, so a single comparison is one sample rather than a settled
-      result. The point of the tooling is that you can re-run any of this yourself and see what you
-      get.
+      et al., Los Alamos).
     </p>
 
     <h2>What the client gives you</h2>
@@ -102,7 +102,7 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     <h2>What url4 is</h2>
 
     <p>
-      A <strong>url4</strong> is a single-line expression describing a composed system: which models
+      A <strong>url4</strong> is a single-line expression following a given grammar and protocol, that describes a composed system: which models
       take part, how their answers are combined, and what each one is asked to do. It serves as both
       the record of what ran and the instruction for running it again, which is what lets a
       published result carry its own method instead of describing it in prose.
@@ -113,15 +113,14 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
     <p>
       The client never calls a model provider itself. It sends work to an
       <RouterLink to="/learn/engine">engine</RouterLink>, which holds the credentials and the
-      benchmark answer keys and performs the grading. You can point it at either of two, and the
-      choice is a genuine trade rather than a formality.
+      benchmark answer keys and performs the grading. You can point it at either of two.
     </p>
 
     <ul>
       <li>
         <strong>A local engine</strong> ships with the toolkit and runs on your own machine, using
         your keys and its own cache. Nothing is hosted and no third party sits between you and your
-        providers, but the cache starts empty and you supply the compute.
+        providers, but the cache starts empty and you pay for the compute.
       </li>
       <li>
         <strong>A hosted engine</strong> runs the same software as a service, which adds the shared
@@ -157,5 +156,41 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
       scores, any failures, and the total cost. Because the url4 travels with the result, someone
       else can repeat the evaluation and compare what they get against what you reported.
     </p>
+
+    <figure class="not-prose diagram">
+      <img
+        :src="localDiagram(isDark)"
+        alt="Local request flow: the client compiles your recipe into one url4 expression and hands it to an engine on your own machine, which fans each model call out through the AI gateway to the providers you hold keys for and streams scores and cost back."
+      />
+      <figcaption>
+        <strong>The local flow.</strong> The client compiles your recipe into one url4 expression and
+        hands it to an engine on your own machine; the engine fans model calls out through the gateway
+        to the providers you hold keys for, then streams scores and cost back.
+      </figcaption>
+    </figure>
   </DocLayout>
 </template>
+
+<style scoped>
+.diagram {
+  margin: 1.75rem 0;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+.diagram img {
+  display: block;
+  width: 100%;
+  height: auto;
+  padding: var(--space-6);
+}
+.diagram figcaption {
+  border-top: 1px solid var(--border);
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--text-sm);
+  color: var(--text-2);
+}
+.diagram figcaption strong {
+  color: var(--text);
+  font-weight: var(--weight-semibold);
+}
+</style>

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -182,6 +182,15 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
       <code>--foreground</code> to keep it attached to your terminal instead.
     </p>
 
+    <Note>
+      By default the client reads and writes the <strong>hosted</strong> leaderboard at
+      <code>leaderboard.dev.screamingface.ai</code>, even when the rest of your stack is local.
+      Override it the same way you set the engine — <code>sf.configure()</code> takes a
+      <code>scoreboard_url</code> next to <code>engine_url</code>, so
+      <code>sf.configure(engine_url="http://127.0.0.1:9108", scoreboard_url="http://127.0.0.1:9106")</code>
+      points both at your local stack.
+    </Note>
+
     <p>
       Set <code>AIGW_OPENROUTER_ENABLED=true</code> in that shell first if you plan to use
       OpenRouter. Provider plugins ship disabled, and the gateway reads the setting at startup, so a
@@ -213,17 +222,18 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
 
     <p>
       Benchmarks like DRACO ask candidates to research an answer, which means the model needs to
-      search the web. There are two ways a route can do that, and the engine decides per route: a
-      provider that offers search natively is asked to use its own, and a route without native
-      search is given a <strong>bounded tool loop the engine runs against Tavily</strong> instead.
-      In the reference configuration a GPT route through OpenRouter searches natively, while the
-      Gemini, Kimi, DeepSeek and Qwen routes go through the Tavily loop.
+      search the web. <strong>Most of the time this is handled for you:</strong> most providers
+      search natively, and the engine just asks them to. The exception is providers that offer no
+      web search of their own — <strong>Hugging Face</strong> routes in particular — where the engine
+      falls back to a <strong>bounded tool loop it runs against Tavily</strong>. Only those routes
+      need a key.
     </p>
 
     <p>
-      This is why your own engine may need a Tavily key while a hosted one never asks you for one:
-      on the hosted path we supply it. Export it in the shell you start the runtime from, before
-      <code>up</code>, because the engine reads it at startup:
+      This is why your own engine may occasionally need a Tavily key while a hosted one never asks
+      you for one: on the hosted path we supply it. If you're running routes without native search,
+      export it in the shell you start the runtime from, before <code>up</code>, because the engine
+      reads it at startup:
     </p>
 
     <CodeBlock :code="tavily" language="bash" />

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -17,7 +17,7 @@ const pypiRuntime = `pip install "screamingface[runtime,notebook]"`
 
 const verify = `import screamingface as sf
 
-len(sf.__all__)   # 53`
+len(sf.__all__)   # 55`
 
 const point = `import screamingface as sf
 
@@ -34,17 +34,17 @@ Benchmark assets ready at /Users/you/.screamingface/benchmark-assets`
 
 const up = `$ screamingface up
 ScreamingFace is ready.
-  Gateway    http://127.0.0.1:9105
-  Scoreboard http://127.0.0.1:9106
-  Engine     http://127.0.0.1:9108
-  Logs       /Users/you/.screamingface/runtime.log`
+  Gateway     http://127.0.0.1:9105
+  Leaderboard http://127.0.0.1:9106
+  Engine      http://127.0.0.1:9108
+  Logs        /Users/you/.screamingface/runtime.log`
 
 const status = `$ screamingface status
 ScreamingFace: running
-  gateway    UP    http://127.0.0.1:9105
-  scoreboard UP    http://127.0.0.1:9106
-  engine     UP    http://127.0.0.1:9108
-  logs       /Users/you/.screamingface/runtime.log`
+  gateway     UP    http://127.0.0.1:9105
+  leaderboard UP    http://127.0.0.1:9106
+  engine      UP    http://127.0.0.1:9108
+  logs        /Users/you/.screamingface/runtime.log`
 
 const down = `screamingface down`
 const logs = `screamingface logs --tail 50`
@@ -176,14 +176,14 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
     <p>
       One command, three services: the <strong>engine</strong> executes runs, the
       <strong>gateway</strong> holds your provider keys and calls the models, and the
-      <strong>scoreboard</strong> serves the local leaderboard. All three bind loopback only, on
+      <strong>leaderboard</strong> serves your local rankings. All three bind loopback only, on
       ports 9105, 9106 and 9108, and <code>up</code> refuses to start if another process already
       holds one of them rather than half-starting the stack. It runs in the background; add
       <code>--foreground</code> to keep it attached to your terminal instead.
     </p>
 
     <Note>
-      By default the client reads and writes the <strong>hosted</strong> leaderboard at
+      By default the client reads and writes the <strong>hosted ScreamingFace Leaderboard</strong> at
       <code>leaderboard.dev.screamingface.ai</code>, even when the rest of your stack is local.
       Override it the same way you set the engine — <code>sf.configure()</code> takes a
       <code>scoreboard_url</code> next to <code>engine_url</code>, so

--- a/public-docs/src/pages/sf-client/QuickstartPage.vue
+++ b/public-docs/src/pages/sf-client/QuickstartPage.vue
@@ -268,13 +268,15 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 <template>
   <DocLayout
     title="Quickstart"
-    description="Run DRACO-Lite end to end and compare seven solo models against nine fusions built from them."
+    description="Run a DRACO subset end to end to compare fusions with its solo models."
     :navigation="navigation"
     :version="version"
   >
     <p>
       By the end, you'll have a scored comparison of <strong>16 candidates</strong>: seven solo
-      models and nine fusions built from those models, all on one DRACO case with ten criteria and
+      models and nine fusions built from those models, all on one
+      <a href="https://arxiv.org/abs/2602.11685" target="_blank" rel="noopener">DRACO</a> case with
+      ten criteria and
       one judge pass each. The whole thing runs as a single request of roughly 80 to 85 provider
       calls.
     </p>
@@ -286,13 +288,13 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
       OpenRouter route, so one connection covers everything.
     </blockquote>
 
-    <h2>1 · Point at an engine</h2>
+    <h2>1 · Configure the engine</h2>
 
     <p>
-      The client never talks to model providers. That happens on the
-      <strong>ScreamingFace Engine</strong>, a separate process that holds your credentials, the
-      benchmark answer keys, and does the grading. This first step tells the client where to find
-      that engine.
+      The <RouterLink to="/learn/engine"><strong>ScreamingFace Engine</strong></RouterLink> is a
+      separate process that holds your provider credentials, keeps the benchmark answer keys, calls
+      the models on your behalf, and does the grading. The client hands all of that work to it, so
+      this first step tells the client where to find the engine.
     </p>
 
     <div class="not-prose">
@@ -300,9 +302,20 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     </div>
 
     <p>
-      That's it for setup. <code>sf.configure()</code> validates and stores the URL without making a
-      network request. Omitting it falls back to <code>DEFAULT_ENGINE_URL</code>, which is a hosted
-      engine, so naming the engine you mean is worth doing explicitly.
+      <code>sf.configure()</code> validates and stores the URL without making a network request. The
+      example above points at a <strong>local engine</strong> on
+      <code>http://127.0.0.1:9108</code> — to run one yourself, install the <code>[runtime]</code>
+      extra and start the stack with <code>screamingface up</code>. The
+      <RouterLink to="/sf-client/installation">Installation</RouterLink> guide walks through that end
+      to end.
+    </p>
+
+    <p>
+      To use the <strong>hosted ScreamingFace engine</strong> instead, point at its URL rather than
+      loopback. Access is currently granted person by person through peer-to-peer approval, so you
+      need to be approved before it will answer. Omitting the URL entirely falls back to
+      <code>DEFAULT_ENGINE_URL</code>, which is that hosted engine, so naming the one you mean is
+      worth doing explicitly.
     </p>
 
     <p>
@@ -351,7 +364,9 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 
     <blockquote>
       We're using OpenRouter here for simplicity, but you can build fusions with models from any of
-      these providers. We're actively expanding support for local and third-party providers.
+      the providers listed above. One caveat: <strong>caching is currently available only for
+      OpenRouter and Anthropic</strong>, so runs on the other providers aren't reused yet — extending
+      it to the rest is work in progress.
     </blockquote>
 
     <h3>Configure OpenRouter via script</h3>

--- a/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/api/BenchmarksPage.vue
@@ -13,14 +13,8 @@ import {
 const listRun = `import screamingface as sf
 
 client = sf.Client()
-[(b.id, b.variant, b.case_count) for b in client.benchmarks.list()]`
-const listRunOut = `[('draco', 'canonical', 100), ('draco/lite', 'lite', 2), ('ifeval', 'canonical', 541), ('ifeval/self-corrective', 'self-corrective', 541)]`
-
-const modelsRun = `client.models.list()[0]`
-const modelsRunOut = `ModelInfo('anthropic/claude-opus-4-8', provider='anthropic', parameters=9, tools=2)`
-
-const detailsRun = `client.models.get("anthropic/claude-opus-4-8")`
-const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthropic', scope='chat', parameters=9, tools=2, transport=3)`
+[(b.id, b.case_count) for b in client.benchmarks.list()]`
+const listRunOut = `[('draco', 100), ('draco/lite', 2), ('ifeval', 541), ('ifeval/self-corrective', 541)]`
 </script>
 
 <template>
@@ -33,10 +27,10 @@ const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthr
     <p>
       A benchmark is a fixed set of cases, owned by the Engine and pinned by a revision. This page
       covers <code>Benchmark</code> itself, alongside <code>BenchmarkInfo</code> for the compact
-      identity a report keeps of it, and <code>ModelInfo</code> for the model routes the Engine can
-      run it against. See the
+      identity a report keeps of it. See the
       <RouterLink to="/sf-client/guides/benchmarks">Benchmarks guide</RouterLink> for choosing which
-      benchmark to run.
+      benchmark to run, and the <RouterLink to="/sf-client/api/models">Models page</RouterLink> for
+      the model routes the Engine can run a benchmark against.
     </p>
 
     <p>
@@ -77,15 +71,6 @@ const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthr
           <td>
             Stable identifier, such as <code>ifeval</code> or <code>draco/lite</code>. This is what
             you pass as <code>benchmark=</code> when evaluating.
-          </td>
-        </tr>
-        <tr>
-          <td><code>variant</code></td>
-          <td><code>str</code></td>
-          <td>
-            Which protocol of the underlying benchmark this entry runs, such as
-            <code>canonical</code>, <code>lite</code> or <code>self-corrective</code>. It names the
-            protocol; the <code>id</code> is what selects it.
           </td>
         </tr>
         <tr>
@@ -171,78 +156,16 @@ const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthr
       </tbody>
     </table>
 
-    <h2>ModelInfo</h2>
-
-    <p>
-      A <code>ModelInfo</code> is one model route the configured Engine can currently reach.
-      <code>client.models.list()</code> returns every addressable route, and consulting it before
-      naming a route in a <RouterLink to="/sf-client/api/recipes">Model</RouterLink> is worthwhile:
-      a route the Engine does not carry raises a <code>PlanningError</code> at evaluation time
-      rather than at construction time.
-    </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>id</code></td>
-          <td><code>str</code></td>
-          <td>The route, which is what you pass to <code>sf.Model()</code>.</td>
-        </tr>
-        <tr>
-          <td><code>provider</code></td>
-          <td><code>str</code></td>
-          <td>Which provider serves the route.</td>
-        </tr>
-        <tr>
-          <td><code>supported_parameters</code></td>
-          <td><code>tuple[str, ...]</code></td>
-          <td>
-            Which request parameters this route accepts, such as <code>temperature</code>. Passing
-            one it does not accept fails before the run.
-          </td>
-        </tr>
-        <tr>
-          <td><code>supported_tools</code></td>
-          <td><code>tuple[str, ...]</code></td>
-          <td>Which tools it can use, such as <code>web_search</code>.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="2" :code="modelsRun"><NbTextOut :text="modelsRunOut" /></NbCell>
-    </div>
-
-    <p>
-      <code>client.models.get(id)</code> returns the fuller <code>ModelDetails</code> profile for
-      one route: every parameter with its schema and whether the gateway currently projects it, the
-      tool and transport capabilities, and whether the profile is stale or degraded. In a notebook
-      it renders as a card.
-    </p>
-
-    <div class="not-prose">
-      <NbCell :count="3" :code="detailsRun"><NbTextOut :text="detailsRunOut" /></NbCell>
-    </div>
-
     <h2>Validation</h2>
 
     <p>
-      All three types validate their arguments on construction, so a malformed value cannot exist.
-      Blank strings raise <code>ValueError</code>, non-strings raise <code>TypeError</code>, and
+      Both types validate their arguments on construction, so a malformed value cannot exist. Blank
+      strings raise <code>ValueError</code>, non-strings raise <code>TypeError</code>, and
       <code>case_count</code> rejects zero and negative values:
     </p>
 
     <CodeBlock
-      code="ValueError: Benchmark case_count must be a positive integer
-ValueError: Benchmark variant must be a non-empty string
-ValueError: Model id must be a non-empty string"
+      code="ValueError: Benchmark case_count must be a positive integer"
       language="text"
     />
   </DocLayout>

--- a/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
+++ b/public-docs/src/pages/sf-client/api/CandidateResultPage.vue
@@ -1,0 +1,305 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const metrics = `dict(candidate.metrics)`
+const metricsOut = `{'inst_level_strict_accuracy': 1.0, 'prompt_level_loose_accuracy': 1.0, 'inst_level_loose_accuracy': 1.0, 'pass_rate': 1.0}`
+
+const cases = `case = candidate.cases[0]
+case.status, case.grade.score, case.output[:40]`
+const casesOut = `('scored', 1.0, 'Raymond III, Count of Tripoli (c. 1140 –')`
+
+const ops = `candidate.operations`
+const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haiku-4.5 answer', depends_on=()),)`
+</script>
+
+<template>
+  <DocLayout
+    title="CandidateResult"
+    description="One candidate's outcome, and the values it carries: MemberResult, OperationInfo, CaseResult."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      A <code>CandidateResult</code> is one candidate's outcome inside a
+      <RouterLink to="/sf-client/api/reports">Report</RouterLink>. The candidate is whatever
+      <RouterLink to="/sf-client/api/recipes">recipe</RouterLink> you evaluated — a Model, a Fusion,
+      or a Pipeline. This page covers <code>CandidateResult</code> itself, alongside
+      <code>MemberResult</code> for one member of a fusion, <code>OperationInfo</code> for a step
+      that ran, and <code>CaseResult</code> for one graded case. Every example below reads from a
+      <code>candidate</code> pulled off a report with <code>report.candidates.only</code>.
+    </p>
+
+    <h2>CandidateResult</h2>
+
+    <p>
+      A <code>CandidateResult</code> is one candidate's outcome. A higher <code>score</code> is
+      always better, whatever the benchmark measures.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>The recipe's name, unique within the report.</td>
+        </tr>
+        <tr>
+          <td><code>kind</code></td>
+          <td><code>str</code></td>
+          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
+        </tr>
+        <tr>
+          <td><code>score</code></td>
+          <td><code>float&nbsp;|&nbsp;None</code></td>
+          <td>
+            The headline number, or <code>None</code> when the candidate failed or was not scored.
+          </td>
+        </tr>
+        <tr>
+          <td><code>coverage</code></td>
+          <td><code>float</code></td>
+          <td>
+            How much of the selected case set the score was computed from, between 0 and 1. Below
+            <code>1.0</code> the Engine excluded ungraded cases and the score is a partial result
+            over the rest.
+          </td>
+        </tr>
+        <tr>
+          <td><code>metrics</code></td>
+          <td><code>Mapping[str, float]</code></td>
+          <td>
+            The benchmark's individual measures. Empty when <code>score</code> is <code>None</code>:
+            an unscored candidate cannot carry metrics. Never contains a <code>coverage</code> key,
+            which is the field above instead.
+          </td>
+        </tr>
+        <tr>
+          <td><code>benchmark</code></td>
+          <td><code>BenchmarkInfo</code></td>
+          <td>
+            The benchmark identity this candidate ran against, pinned to its revision. The report
+            carries the same value.
+          </td>
+        </tr>
+        <tr>
+          <td><code>cases</code></td>
+          <td>sequence of <code>CaseResult</code></td>
+          <td>
+            One entry per selected case, carrying its status, the prompt, the answer, and the grade.
+          </td>
+        </tr>
+        <tr>
+          <td><code>url4</code></td>
+          <td><code>Url4</code></td>
+          <td>
+            The complete expression that executed, as a <code>str</code> subclass whose
+            <code>to_python()</code> returns editable client code. See the
+            <RouterLink to="/sf-client/guides/reproduce-and-share">url4 guide</RouterLink>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>models</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Every distinct model route this candidate used. Unique, and never empty.</td>
+        </tr>
+        <tr>
+          <td><code>operations</code></td>
+          <td><code>tuple[OperationInfo, ...]</code></td>
+          <td>The steps that ran, as an acyclic graph. Never empty.</td>
+        </tr>
+        <tr>
+          <td><code>members</code></td>
+          <td><code>tuple[MemberResult, ...]</code></td>
+          <td>
+            Direct members, for a fusion. Always empty for a <code>model</code> or
+            <code>pipeline</code> candidate, and at least one entry for a fusion.
+          </td>
+        </tr>
+        <tr>
+          <td><code>failures</code></td>
+          <td><code>tuple[Failure, ...]</code></td>
+          <td>
+            This candidate's own failures. A scored candidate can carry them: the run finished with
+            warnings worth reading. None of them names a case, since a candidate-level failure is
+            never case-specific.
+          </td>
+        </tr>
+        <tr>
+          <td><code>usage</code></td>
+          <td><code>Usage</code></td>
+          <td>This candidate's accounting.</td>
+        </tr>
+        <tr>
+          <td><code>run_id</code></td>
+          <td><code>str</code></td>
+          <td>Engine-assigned identifier for this candidate's execution.</td>
+        </tr>
+        <tr>
+          <td><code>started_at</code> / <code>completed_at</code> / <code>duration_ms</code></td>
+          <td><code>datetime</code> / <code>int</code></td>
+          <td>When it ran and for how long.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="7" :code="metrics"><NbTextOut :text="metricsOut" /></NbCell>
+    </div>
+
+    <p>
+      <code>score</code> and <code>coverage</code> together describe four outcomes, and the notebook
+      card labels each one: a score at full coverage and no failures is complete; a score with
+      failures completed with warnings; a score at coverage below <code>1.0</code> is partial; and
+      no score at all means no aggregate was available.
+    </p>
+
+    <h3>cases</h3>
+
+    <p>
+      <code>candidate.cases</code> is a read-only sequence of <code>CaseResult</code> values, one
+      per selected case. Each carries a <code>status</code> of <code>scored</code>,
+      <code>refused</code> or <code>failed</code>, the case <code>input</code>, the candidate's
+      <code>output</code>, and a <code>CaseGrade</code> holding the individual checks behind the
+      score. A refused case is still graded, so a provider refusal is measured rather than dropped.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="8" :code="cases"><NbTextOut :text="casesOut" /></NbCell>
+    </div>
+
+    <h2>MemberResult</h2>
+
+    <p>
+      A <code>MemberResult</code> is one direct member of a fusion, held as a compact view: enough
+      to see what the member cost and whether it failed, without repeating the full candidate
+      structure. Members carry no score, because only the fusion's final answer is graded.
+    </p>
+
+    <p>
+      Its runtime fields are <code>None</code> until the Engine attributes work to the member's
+      operation id. That is a different statement from an empty value: <code>None</code> means the
+      attribution was unavailable, while an empty tuple means it arrived and reported nothing.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>
+            The member recipe's display name. Two siblings can share one, for instance the same
+            model reached through two providers, so identity is <code>operation_id</code> rather
+            than this.
+          </td>
+        </tr>
+        <tr>
+          <td><code>kind</code></td>
+          <td><code>str</code></td>
+          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
+        </tr>
+        <tr>
+          <td><code>models</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>The routes this member used.</td>
+        </tr>
+        <tr>
+          <td><code>operation_id</code></td>
+          <td><code>str</code></td>
+          <td>Links this member to an entry in the candidate's <code>operations</code>.</td>
+        </tr>
+        <tr>
+          <td><code>failures</code></td>
+          <td><code>tuple[Failure, ...]&nbsp;|&nbsp;None</code></td>
+          <td>
+            This member's failures, which also appear in <code>report.failures</code>.
+            <code>None</code> when the Engine attributed nothing to this member.
+          </td>
+        </tr>
+        <tr>
+          <td><code>duration_ms</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>How long the member took, when the Engine reported it.</td>
+        </tr>
+        <tr>
+          <td><code>usage</code></td>
+          <td><code>Usage&nbsp;|&nbsp;None</code></td>
+          <td>This member's accounting, or <code>None</code> when it was not attributed.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>OperationInfo</h2>
+
+    <p>
+      An <code>OperationInfo</code> is one step in a candidate's compiled graph. Reading
+      <code>operations</code> shows what actually ran and in what order, which is how a fusion's
+      members can be seen executing before its synthesis. See the
+      <RouterLink to="/sf-client/guides/reproduce-and-share">url4 guide</RouterLink> for reading the
+      same plan as a url4 expression.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>Unique within the candidate. This is what <code>depends_on</code> refers to.</td>
+        </tr>
+        <tr>
+          <td><code>kind</code></td>
+          <td><code>str</code></td>
+          <td>What sort of step it was, for example <code>model</code>.</td>
+        </tr>
+        <tr>
+          <td><code>label</code></td>
+          <td><code>str</code></td>
+          <td>Human-readable description, such as <code>claude-haiku-4.5 answer</code>.</td>
+        </tr>
+        <tr>
+          <td><code>depends_on</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>
+            Ids of the steps that had to finish first. Empty for a step with no prerequisites.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="9" :code="ops"><NbTextOut :text="opsOut" /></NbCell>
+    </div>
+
+    <p>
+      The operations of a candidate form an acyclic graph: ids are unique, every dependency names a
+      step that exists, and no step can depend on itself.
+    </p>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ClientsPage.vue
@@ -94,7 +94,7 @@ const panelOut = `ConnectionPanel(engine='${SF_ENGINE_URL}', openrouter=connecte
       <code>DEFAULT_ENGINE_URL</code> is a hosted Engine, so a <code>Client()</code> with no
       arguments talks to one we operate. To use a local Engine, pass its address explicitly, or set
       <code>SCREAMINGFACE_ENGINE_URL</code> and use the module-level functions.
-      <code>DEFAULT_SCOREBOARD_URL</code> is the matching hosted leaderboard. Both constants live in
+      <code>DEFAULT_SCOREBOARD_URL</code> is the matching hosted ScreamingFace Leaderboard. Both constants live in
       <code>screamingface.client</code>.
     </Note>
 

--- a/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const modelsRun = `import screamingface as sf
+
+client = sf.Client()
+client.models.list()[0]`
+const modelsRunOut = `ModelInfo('anthropic/claude-opus-4-8', provider='anthropic', parameters=9, tools=2)`
+
+const detailsRun = `client.models.get("anthropic/claude-opus-4-8")`
+const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthropic', scope='chat', parameters=9, tools=2, transport=3)`
+</script>
+
+<template>
+  <DocLayout
+    title="Models"
+    description="The discovery types model routes come back as: ModelInfo, ModelDetails, and their fields."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      These are the read-only values model discovery returns.
+      <code>client.models.list()</code> hands back a <code>ModelInfo</code> for every route the
+      configured Engine can currently reach, and <code>client.models.get(id)</code> returns the
+      fuller <code>ModelDetails</code> profile for one route. Consulting them before naming a route
+      in a <RouterLink to="/sf-client/api/recipes">Model</RouterLink> is worthwhile: a route the
+      Engine does not carry raises a <code>PlanningError</code> at evaluation time rather than at
+      construction time.
+    </p>
+
+    <p>
+      Everything here is read-only and assigning to a field raises
+      <code>FrozenInstanceError: cannot assign to field 'provider'</code>. These values also never
+      refresh themselves and the Client needs to be called again when current data is desired.
+    </p>
+
+    <h2>ModelInfo</h2>
+
+    <p>
+      A <code>ModelInfo</code> is one model route the configured Engine can currently reach.
+      <code>client.models.list()</code> returns every addressable route, and consulting it before
+      naming a route in a <RouterLink to="/sf-client/api/recipes">Model</RouterLink> is worthwhile:
+      a route the Engine does not carry raises a <code>PlanningError</code> at evaluation time
+      rather than at construction time.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>The route, which is what you pass to <code>sf.Model()</code>.</td>
+        </tr>
+        <tr>
+          <td><code>provider</code></td>
+          <td><code>str</code></td>
+          <td>Which provider serves the route.</td>
+        </tr>
+        <tr>
+          <td><code>supported_parameters</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>
+            Which request parameters this route accepts, such as <code>temperature</code>. Passing
+            one it does not accept fails before the run.
+          </td>
+        </tr>
+        <tr>
+          <td><code>supported_tools</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Which tools it can use, such as <code>web_search</code>.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="modelsRun"><NbTextOut :text="modelsRunOut" /></NbCell>
+    </div>
+
+    <h2>ModelDetails</h2>
+
+    <p>
+      <code>client.models.get(id)</code> returns the fuller <code>ModelDetails</code> profile for
+      one route: every parameter with its schema and whether the gateway currently projects it, the
+      tool and transport capabilities, and whether the profile is stale or degraded. In a notebook
+      it renders as a card.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>id</code></td>
+          <td><code>str</code></td>
+          <td>The route, which is what you pass to <code>sf.Model()</code>.</td>
+        </tr>
+        <tr>
+          <td><code>provider</code></td>
+          <td><code>str</code></td>
+          <td>Which provider serves the route.</td>
+        </tr>
+        <tr>
+          <td><code>scope</code></td>
+          <td><code>str</code></td>
+          <td>What the route does, such as <code>chat</code>.</td>
+        </tr>
+        <tr>
+          <td><code>parameters</code></td>
+          <td><code>Mapping[str, ModelParameter]</code></td>
+          <td>Each request parameter the route exposes, keyed by name.</td>
+        </tr>
+        <tr>
+          <td><code>tools</code></td>
+          <td><code>Mapping[str, ModelCapability]</code></td>
+          <td>Each tool capability, such as <code>web_search</code>, keyed by name.</td>
+        </tr>
+        <tr>
+          <td><code>transport</code></td>
+          <td><code>Mapping[str, ModelCapability]</code></td>
+          <td>Each transport capability, keyed by name.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      Its repr shows counts rather than the full mappings, so the shape stays legible at a glance:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="detailsRun"><NbTextOut :text="detailsRunOut" /></NbCell>
+    </div>
+
+    <h2>ModelParameter</h2>
+
+    <p>
+      A <code>ModelParameter</code> describes one request parameter a route exposes: what it is
+      called, how the gateway treats it, and where the description came from. The values in
+      <code>ModelDetails.parameters</code> are these.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str</code></td>
+          <td>The parameter name, such as <code>temperature</code>.</td>
+        </tr>
+        <tr>
+          <td><code>request_path</code></td>
+          <td><code>str</code></td>
+          <td>Where the value lands in the request the gateway sends upstream.</td>
+        </tr>
+        <tr>
+          <td><code>schema</code></td>
+          <td><code>ModelParameterSchema&nbsp;|&nbsp;None</code></td>
+          <td>
+            The value's type and bounds, when the provider published one. <code>None</code> when no
+            schema is known.
+          </td>
+        </tr>
+        <tr>
+          <td><code>provider_support</code></td>
+          <td><code>str</code></td>
+          <td>Whether the provider supports the parameter.</td>
+        </tr>
+        <tr>
+          <td><code>provider_source</code></td>
+          <td><code>str</code></td>
+          <td>Where the provider description came from.</td>
+        </tr>
+        <tr>
+          <td><code>provider_stale</code></td>
+          <td><code>bool</code></td>
+          <td>Whether the provider description is out of date.</td>
+        </tr>
+        <tr>
+          <td><code>provider_deprecated</code></td>
+          <td><code>bool</code></td>
+          <td>Whether the provider has deprecated the parameter.</td>
+        </tr>
+        <tr>
+          <td><code>gateway_status</code></td>
+          <td><code>str</code></td>
+          <td>
+            Whether the gateway forwards the parameter: <code>"enabled"</code> or
+            <code>"disabled"</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>gateway_projection</code></td>
+          <td><code>str</code></td>
+          <td>How the gateway projects the value onto the request it sends.</td>
+        </tr>
+        <tr>
+          <td><code>gateway_reason</code></td>
+          <td><code>str</code></td>
+          <td>Why the gateway is in that state, when it has a reason to give.</td>
+        </tr>
+        <tr>
+          <td><code>cache_behavior</code></td>
+          <td><code>str</code></td>
+          <td>How this parameter participates in caching.</td>
+        </tr>
+        <tr>
+          <td><code>applicable_auth_modes</code></td>
+          <td><code>tuple[str, ...]</code></td>
+          <td>Which authentication modes the parameter applies under.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>
+      It also carries one read-only property, <code>enabled</code>, which is <code>True</code> when
+      <code>gateway_status == "enabled"</code>.
+    </p>
+
+    <h2>ModelCapability</h2>
+
+    <p>
+      A <code>ModelCapability</code> describes one tool or transport capability. The values in
+      <code>ModelDetails.tools</code> and <code>ModelDetails.transport</code> are these.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>provider_support</code></td>
+          <td><code>str</code></td>
+          <td>Whether the provider supports the capability.</td>
+        </tr>
+        <tr>
+          <td><code>gateway_status</code></td>
+          <td><code>str</code></td>
+          <td>
+            Whether the gateway exposes the capability: <code>"enabled"</code> or
+            <code>"disabled"</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>reason</code></td>
+          <td><code>str</code></td>
+          <td>Why the capability is in that state, when there is a reason to give.</td>
+        </tr>
+      </tbody>
+    </table>
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -60,7 +60,7 @@ const equalityOut = `True`
 
 <template>
   <DocLayout
-    title="Recipes"
+    title="Recipes, Models, Fusions"
     description="Recipe, Model, Fusion and Pipeline: the things you evaluate."
     :navigation="navigation"
     :version="version"

--- a/public-docs/src/pages/sf-client/api/ReportsPage.vue
+++ b/public-docs/src/pages/sf-client/api/ReportsPage.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
-import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import Note from '@/components/ui/Note.vue'
@@ -24,25 +23,12 @@ const runItOut = `Report(benchmark='ifeval', candidates=['claude-haiku-4.5'], ok
 const summary = `report.ok, report.case_count, report.duration_ms`
 const summaryOut = `(True, 1, 5248)`
 
-const usage = `report.usage`
-const usageOut = `Usage(input_tokens=103, output_tokens=398, cache_read_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, cost_usd=Decimal('0'))`
-
 const only = `candidate = report.candidates.only
 candidate.name, candidate.kind, candidate.score, candidate.coverage`
 const onlyOut = `('claude-haiku-4.5', 'model', 1.0, 1.0)`
 
 const byName = `report.candidates["claude-haiku-4.5"] is candidate`
 const byNameOut = `True`
-
-const metrics = `dict(candidate.metrics)`
-const metricsOut = `{'inst_level_strict_accuracy': 1.0, 'prompt_level_loose_accuracy': 1.0, 'inst_level_loose_accuracy': 1.0, 'pass_rate': 1.0}`
-
-const cases = `case = candidate.cases[0]
-case.status, case.grade.score, case.output[:40]`
-const casesOut = `('scored', 1.0, 'Raymond III, Count of Tripoli (c. 1140 –')`
-
-const ops = `candidate.operations`
-const opsOut = `(OperationInfo(id='op_model_1', kind='model', label='claude-haiku-4.5 answer', depends_on=()),)`
 
 const dict = `sorted(report.to_dict())`
 const dictOut = `['benchmark', 'candidates', 'completed_at', 'schema', 'started_at', 'usage']`
@@ -61,10 +47,11 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
     <p>
       A <code>Report</code> is what an evaluation returns, and it is the only thing worth keeping:
       it carries the scores, what was spent, what failed, and the exact expression that ran. This
-      page covers <code>Report</code> itself, alongside <code>CandidateResult</code> for one
-      candidate's outcome, <code>MemberResult</code> for one member of a fusion,
-      <code>OperationInfo</code> for a step that ran, <code>Usage</code> for token and cost
-      accounting, and <code>Failure</code> for anything that went wrong. See the
+      page covers <code>Report</code> itself. It holds
+      <RouterLink to="/sf-client/api/candidate-result">CandidateResult</RouterLink> values, each of
+      which may hold <code>MemberResult</code> and <code>OperationInfo</code> values, and both a
+      report and each candidate carry a <RouterLink to="/sf-client/api/usage">Usage</RouterLink> and
+      any <code>Failure</code> records. See the
       <RouterLink to="/sf-client/guides/running-an-evaluation">evaluation guide</RouterLink> for
       running one.
     </p>
@@ -73,12 +60,171 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
       <NbCell :count="1" :code="runIt"><NbTextOut :text="runItOut" /></NbCell>
     </div>
 
-    <p>
-      Every example below reads from that report. The six types nest: a <code>Report</code> holds
-      <code>CandidateResult</code> values, each of which may hold <code>MemberResult</code> values,
-      while <code>OperationInfo</code>, <code>Usage</code> and <code>Failure</code> appear at more
-      than one level.
-    </p>
+    <p>Every example below reads from that report.</p>
+
+    <figure class="not-prose" style="margin: var(--space-8) 0">
+      <svg
+        viewBox="0 0 720 348"
+        role="img"
+        aria-label="A Report holds one BenchmarkInfo and many CandidateResult values. Each CandidateResult holds many OperationInfo (the plan DAG), many CaseResult (per-case grades), a Usage, its url4 expression, and — for a fusion — many MemberResult values."
+        style="width: 100%; height: auto; font-family: var(--f-mono)"
+      >
+        <defs>
+          <marker
+            id="rp-arrow"
+            viewBox="0 0 8 8"
+            refX="7"
+            refY="4"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto"
+          >
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+
+        <!-- Report -->
+        <rect
+          x="40"
+          y="24"
+          width="160"
+          height="56"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="120" y="50" text-anchor="middle" style="fill: var(--text); font-size: 15px">
+          Report
+        </text>
+        <text x="120" y="68" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          one evaluation
+        </text>
+
+        <!-- BenchmarkInfo -->
+        <rect
+          x="300"
+          y="14"
+          width="180"
+          height="48"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="390" y="42" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          BenchmarkInfo
+        </text>
+
+        <!-- CandidateResult -->
+        <rect
+          x="300"
+          y="96"
+          width="180"
+          height="56"
+          style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+        />
+        <text x="390" y="122" text-anchor="middle" style="fill: var(--text); font-size: 13px">
+          CandidateResult
+        </text>
+        <text x="390" y="140" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          one per candidate
+        </text>
+
+        <!-- edges from Report -->
+        <g style="stroke: var(--text-2); stroke-width: 1; fill: none">
+          <path d="M200 42 H300" marker-end="url(#rp-arrow)" />
+          <path d="M200 60 V124 H300" marker-end="url(#rp-arrow)" />
+        </g>
+        <text x="250" y="34" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          one
+        </text>
+        <text x="250" y="80" text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          many
+        </text>
+
+        <!-- leaves off CandidateResult -->
+        <g>
+          <rect
+            x="540"
+            y="94"
+            width="150"
+            height="34"
+            style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+          />
+          <text x="615" y="115" text-anchor="middle" style="fill: var(--text); font-size: 12px">
+            OperationInfo
+          </text>
+
+          <rect
+            x="540"
+            y="144"
+            width="150"
+            height="34"
+            style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+          />
+          <text x="615" y="165" text-anchor="middle" style="fill: var(--text); font-size: 12px">
+            CaseResult
+          </text>
+
+          <rect
+            x="540"
+            y="194"
+            width="150"
+            height="34"
+            style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+          />
+          <text x="615" y="215" text-anchor="middle" style="fill: var(--text); font-size: 12px">
+            MemberResult
+          </text>
+
+          <rect
+            x="540"
+            y="244"
+            width="150"
+            height="34"
+            style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+          />
+          <text x="615" y="265" text-anchor="middle" style="fill: var(--text); font-size: 12px">
+            Usage
+          </text>
+
+          <rect
+            x="540"
+            y="294"
+            width="150"
+            height="34"
+            style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1"
+          />
+          <text x="615" y="315" text-anchor="middle" style="fill: var(--text); font-size: 12px">
+            url4
+          </text>
+        </g>
+
+        <g style="stroke: var(--text-2); stroke-width: 1; fill: none">
+          <path d="M480 124 C 510 124, 510 111, 540 111" marker-end="url(#rp-arrow)" />
+          <path d="M480 124 C 510 124, 510 161, 540 161" marker-end="url(#rp-arrow)" />
+          <path d="M480 124 C 510 124, 510 211, 540 211" marker-end="url(#rp-arrow)" />
+          <path d="M480 124 C 510 124, 510 261, 540 261" marker-end="url(#rp-arrow)" />
+          <path d="M480 124 C 510 124, 510 311, 540 311" marker-end="url(#rp-arrow)" />
+        </g>
+
+        <g text-anchor="middle" style="fill: var(--text-2); font-size: 10px">
+          <text x="615" y="88">many · the plan DAG</text>
+          <text x="615" y="138">many · per-case grade</text>
+          <text x="615" y="188">many · fusion members</text>
+          <text x="615" y="238">tokens / cost</text>
+          <text x="615" y="288">the expression</text>
+        </g>
+      </svg>
+      <figcaption
+        style="
+          font-family: var(--f-mono);
+          font-size: var(--text-label);
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: var(--text-2);
+          margin-top: var(--space-3);
+        "
+      >
+        A report holds one benchmark identity and one result per candidate; each candidate carries
+        its plan, its cases, its members, its usage, and its url4.
+      </figcaption>
+    </figure>
 
     <h2>Report</h2>
 
@@ -182,6 +328,13 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
       unique within a report.
     </p>
 
+    <p>
+      Each entry is a
+      <RouterLink to="/sf-client/api/candidate-result">CandidateResult</RouterLink>, one candidate's
+      outcome, holding its score, its cases, its operation graph, its members, its
+      <RouterLink to="/sf-client/api/usage">Usage</RouterLink>, and its url4.
+    </p>
+
     <h3>Serialisation</h3>
 
     <p>
@@ -196,412 +349,15 @@ const benchOut = `BenchmarkInfo(id='ifeval', revision='047f1de449639c61', case_c
       <NbCell :count="6" :code="dict"><NbTextOut :text="dictOut" /></NbCell>
     </div>
 
-    <h2>CandidateResult</h2>
+    <h2>Beyond the report</h2>
 
     <p>
-      A <code>CandidateResult</code> is one candidate's outcome. A higher <code>score</code> is
-      always better, whatever the benchmark measures.
+      Each candidate's outcome lives on the
+      <RouterLink to="/sf-client/api/candidate-result">CandidateResult</RouterLink> page, which
+      covers <code>CandidateResult</code> itself alongside <code>MemberResult</code>,
+      <code>OperationInfo</code> and <code>CaseResult</code>. The token and cost accounting a report
+      and its candidates carry, and the <code>Failure</code> records they hold, are on the
+      <RouterLink to="/sf-client/api/usage">Usage</RouterLink> page.
     </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>name</code></td>
-          <td><code>str</code></td>
-          <td>The recipe's name, unique within the report.</td>
-        </tr>
-        <tr>
-          <td><code>kind</code></td>
-          <td><code>str</code></td>
-          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
-        </tr>
-        <tr>
-          <td><code>score</code></td>
-          <td><code>float&nbsp;|&nbsp;None</code></td>
-          <td>
-            The headline number, or <code>None</code> when the candidate failed or was not scored.
-          </td>
-        </tr>
-        <tr>
-          <td><code>coverage</code></td>
-          <td><code>float</code></td>
-          <td>
-            How much of the selected case set the score was computed from, between 0 and 1. Below
-            <code>1.0</code> the Engine excluded ungraded cases and the score is a partial result
-            over the rest.
-          </td>
-        </tr>
-        <tr>
-          <td><code>metrics</code></td>
-          <td><code>Mapping[str, float]</code></td>
-          <td>
-            The benchmark's individual measures. Empty when <code>score</code> is <code>None</code>:
-            an unscored candidate cannot carry metrics. Never contains a <code>coverage</code> key,
-            which is the field above instead.
-          </td>
-        </tr>
-        <tr>
-          <td><code>benchmark</code></td>
-          <td><code>BenchmarkInfo</code></td>
-          <td>
-            The benchmark identity this candidate ran against, pinned to its revision. The report
-            carries the same value.
-          </td>
-        </tr>
-        <tr>
-          <td><code>cases</code></td>
-          <td>sequence of <code>CaseResult</code></td>
-          <td>
-            One entry per selected case, carrying its status, the prompt, the answer, and the grade.
-          </td>
-        </tr>
-        <tr>
-          <td><code>url4</code></td>
-          <td><code>Url4</code></td>
-          <td>
-            The complete expression that executed, as a <code>str</code> subclass whose
-            <code>to_python()</code> returns editable client code. See the
-            <RouterLink to="/sf-client/guides/reproduce-and-share">url4 guide</RouterLink>.
-          </td>
-        </tr>
-        <tr>
-          <td><code>models</code></td>
-          <td><code>tuple[str, ...]</code></td>
-          <td>Every distinct model route this candidate used. Unique, and never empty.</td>
-        </tr>
-        <tr>
-          <td><code>operations</code></td>
-          <td><code>tuple[OperationInfo, ...]</code></td>
-          <td>The steps that ran, as an acyclic graph. Never empty.</td>
-        </tr>
-        <tr>
-          <td><code>members</code></td>
-          <td><code>tuple[MemberResult, ...]</code></td>
-          <td>
-            Direct members, for a fusion. Always empty for a <code>model</code> or
-            <code>pipeline</code> candidate, and at least one entry for a fusion.
-          </td>
-        </tr>
-        <tr>
-          <td><code>failures</code></td>
-          <td><code>tuple[Failure, ...]</code></td>
-          <td>
-            This candidate's own failures. A scored candidate can carry them: the run finished with
-            warnings worth reading. None of them names a case, since a candidate-level failure is
-            never case-specific.
-          </td>
-        </tr>
-        <tr>
-          <td><code>usage</code></td>
-          <td><code>Usage</code></td>
-          <td>This candidate's accounting.</td>
-        </tr>
-        <tr>
-          <td><code>run_id</code></td>
-          <td><code>str</code></td>
-          <td>Engine-assigned identifier for this candidate's execution.</td>
-        </tr>
-        <tr>
-          <td><code>started_at</code> / <code>completed_at</code> / <code>duration_ms</code></td>
-          <td><code>datetime</code> / <code>int</code></td>
-          <td>When it ran and for how long.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="7" :code="metrics"><NbTextOut :text="metricsOut" /></NbCell>
-    </div>
-
-    <p>
-      <code>score</code> and <code>coverage</code> together describe four outcomes, and the notebook
-      card labels each one: a score at full coverage and no failures is complete; a score with
-      failures completed with warnings; a score at coverage below <code>1.0</code> is partial; and
-      no score at all means no aggregate was available.
-    </p>
-
-    <h3>cases</h3>
-
-    <p>
-      <code>candidate.cases</code> is a read-only sequence of <code>CaseResult</code> values, one
-      per selected case. Each carries a <code>status</code> of <code>scored</code>,
-      <code>refused</code> or <code>failed</code>, the case <code>input</code>, the candidate's
-      <code>output</code>, and a <code>CaseGrade</code> holding the individual checks behind the
-      score. A refused case is still graded, so a provider refusal is measured rather than dropped.
-    </p>
-
-    <div class="not-prose">
-      <NbCell :count="8" :code="cases"><NbTextOut :text="casesOut" /></NbCell>
-    </div>
-
-    <h2>MemberResult</h2>
-
-    <p>
-      A <code>MemberResult</code> is one direct member of a fusion, held as a compact view: enough
-      to see what the member cost and whether it failed, without repeating the full candidate
-      structure. Members carry no score, because only the fusion's final answer is graded.
-    </p>
-
-    <p>
-      Its runtime fields are <code>None</code> until the Engine attributes work to the member's
-      operation id. That is a different statement from an empty value: <code>None</code> means the
-      attribution was unavailable, while an empty tuple means it arrived and reported nothing.
-    </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>name</code></td>
-          <td><code>str</code></td>
-          <td>
-            The member recipe's display name. Two siblings can share one, for instance the same
-            model reached through two providers, so identity is <code>operation_id</code> rather
-            than this.
-          </td>
-        </tr>
-        <tr>
-          <td><code>kind</code></td>
-          <td><code>str</code></td>
-          <td>One of <code>model</code>, <code>fusion</code> or <code>pipeline</code>.</td>
-        </tr>
-        <tr>
-          <td><code>models</code></td>
-          <td><code>tuple[str, ...]</code></td>
-          <td>The routes this member used.</td>
-        </tr>
-        <tr>
-          <td><code>operation_id</code></td>
-          <td><code>str</code></td>
-          <td>Links this member to an entry in the candidate's <code>operations</code>.</td>
-        </tr>
-        <tr>
-          <td><code>failures</code></td>
-          <td><code>tuple[Failure, ...]&nbsp;|&nbsp;None</code></td>
-          <td>
-            This member's failures, which also appear in <code>report.failures</code>.
-            <code>None</code> when the Engine attributed nothing to this member.
-          </td>
-        </tr>
-        <tr>
-          <td><code>duration_ms</code></td>
-          <td><code>int&nbsp;|&nbsp;None</code></td>
-          <td>How long the member took, when the Engine reported it.</td>
-        </tr>
-        <tr>
-          <td><code>usage</code></td>
-          <td><code>Usage&nbsp;|&nbsp;None</code></td>
-          <td>This member's accounting, or <code>None</code> when it was not attributed.</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h2>OperationInfo</h2>
-
-    <p>
-      An <code>OperationInfo</code> is one step in a candidate's compiled graph. Reading
-      <code>operations</code> shows what actually ran and in what order, which is how a fusion's
-      members can be seen executing before its synthesis.
-    </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>id</code></td>
-          <td><code>str</code></td>
-          <td>Unique within the candidate. This is what <code>depends_on</code> refers to.</td>
-        </tr>
-        <tr>
-          <td><code>kind</code></td>
-          <td><code>str</code></td>
-          <td>What sort of step it was, for example <code>model</code>.</td>
-        </tr>
-        <tr>
-          <td><code>label</code></td>
-          <td><code>str</code></td>
-          <td>Human-readable description, such as <code>claude-haiku-4.5 answer</code>.</td>
-        </tr>
-        <tr>
-          <td><code>depends_on</code></td>
-          <td><code>tuple[str, ...]</code></td>
-          <td>
-            Ids of the steps that had to finish first. Empty for a step with no prerequisites.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="9" :code="ops"><NbTextOut :text="opsOut" /></NbCell>
-    </div>
-
-    <p>
-      The operations of a candidate form an acyclic graph: ids are unique, every dependency names a
-      step that exists, and no step can depend on itself.
-    </p>
-
-    <h2>Usage</h2>
-
-    <p>
-      A <code>Usage</code> holds the token and cost accounting for one subtree of a run. Every field
-      is optional, because a provider that does not report a number leaves it as
-      <code>None</code> rather than guessing zero.
-    </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>input_tokens</code></td>
-          <td><code>int&nbsp;|&nbsp;None</code></td>
-          <td>Tokens sent.</td>
-        </tr>
-        <tr>
-          <td><code>output_tokens</code></td>
-          <td><code>int&nbsp;|&nbsp;None</code></td>
-          <td>Tokens generated.</td>
-        </tr>
-        <tr>
-          <td><code>cache_read_tokens</code></td>
-          <td><code>int&nbsp;|&nbsp;None</code></td>
-          <td>Tokens served from a provider cache.</td>
-        </tr>
-        <tr>
-          <td><code>cache_creation_tokens</code></td>
-          <td><code>int&nbsp;|&nbsp;None</code></td>
-          <td>Tokens written into a provider cache.</td>
-        </tr>
-        <tr>
-          <td><code>reasoning_tokens</code></td>
-          <td><code>int&nbsp;|&nbsp;None</code></td>
-          <td>Tokens spent on reasoning, where the provider separates them.</td>
-        </tr>
-        <tr>
-          <td><code>cost_usd</code></td>
-          <td><code>Decimal&nbsp;|&nbsp;None</code></td>
-          <td>
-            Money, as a <code>Decimal</code> so it never loses precision. Accepts a string or a
-            <code>Decimal</code> on construction.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="10" :code="usage"><NbTextOut :text="usageOut" /></NbCell>
-    </div>
-
-    <p>
-      Summing follows a strict rule: <code>report.usage</code> adds a field across candidates only
-      when <em>every</em> candidate reported it. If one candidate leaves <code>cost_usd</code> as
-      <code>None</code>, the report's <code>cost_usd</code> is <code>None</code> too, rather than a
-      total that silently omits part of the run.
-    </p>
-
-    <p>
-      <code>to_dict()</code> drops fields that are <code>None</code> and renders
-      <code>cost_usd</code> as a string.
-    </p>
-
-    <h2>Failure</h2>
-
-    <p>
-      A <code>Failure</code> is one typed failure held inside an otherwise valid report. A report
-      with failures is still a report, so what succeeded can be read alongside what did not.
-    </p>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>stage</code></td>
-          <td><code>str</code></td>
-          <td>
-            Where it happened: <code>candidate</code>, <code>grading</code> or
-            <code>aggregation</code>.
-          </td>
-        </tr>
-        <tr>
-          <td><code>code</code></td>
-          <td><code>str</code></td>
-          <td>
-            Stable machine-readable identifier in lowercase snake_case, such as
-            <code>provider_timeout</code>. Match on this rather than on the message.
-          </td>
-        </tr>
-        <tr>
-          <td><code>message</code></td>
-          <td><code>str</code></td>
-          <td>Human-readable explanation. Not stable across versions.</td>
-        </tr>
-        <tr>
-          <td><code>retryable</code></td>
-          <td><code>bool&nbsp;|&nbsp;None</code></td>
-          <td>
-            Whether running the same thing again could plausibly succeed, or <code>None</code> when
-            the Engine did not say.
-          </td>
-        </tr>
-        <tr>
-          <td><code>operation_id</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>
-            Which step failed, matching an <code>OperationInfo.id</code>. <code>None</code> for a
-            failure no single step owns.
-          </td>
-        </tr>
-        <tr>
-          <td><code>case_id</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>Which case failed, when the failure was specific to one.</td>
-        </tr>
-        <tr>
-          <td><code>metadata</code></td>
-          <td><code>Mapping[str, object]</code></td>
-          <td>
-            Whatever else the Engine attached to this failure. Empty when it attached nothing.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <p>A failure reads like this:</p>
-
-    <CodeBlock
-      code="Failure(stage='candidate', code='provider_timeout', message='Upstream timed out', retryable=True, operation_id='op-1', case_id='7')"
-      language="python"
-    />
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/api/UsagePage.vue
+++ b/public-docs/src/pages/sf-client/api/UsagePage.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const usage = `report.usage`
+const usageOut = `Usage(input_tokens=103, output_tokens=398, cache_read_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, cost_usd=Decimal('0'))`
+</script>
+
+<template>
+  <DocLayout
+    title="Usage"
+    description="Usage for token and cost accounting, and Failure for anything that went wrong."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      This page covers <code>Usage</code>, the token and cost accounting a
+      <RouterLink to="/sf-client/api/reports">Report</RouterLink> and each
+      <RouterLink to="/sf-client/api/candidate-result">CandidateResult</RouterLink> carry, and
+      <code>Failure</code>, the typed record of anything that went wrong. The
+      <code>report</code> the examples read from comes from the
+      <RouterLink to="/sf-client/api/reports">Report</RouterLink> page.
+    </p>
+
+    <h2>Usage</h2>
+
+    <p>
+      A <code>Usage</code> holds the token and cost accounting for one subtree of a run. Every field
+      is optional, because a provider that does not report a number leaves it as
+      <code>None</code> rather than guessing zero.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>input_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens sent.</td>
+        </tr>
+        <tr>
+          <td><code>output_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens generated.</td>
+        </tr>
+        <tr>
+          <td><code>cache_read_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens served from a provider cache.</td>
+        </tr>
+        <tr>
+          <td><code>cache_creation_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens written into a provider cache.</td>
+        </tr>
+        <tr>
+          <td><code>reasoning_tokens</code></td>
+          <td><code>int&nbsp;|&nbsp;None</code></td>
+          <td>Tokens spent on reasoning, where the provider separates them.</td>
+        </tr>
+        <tr>
+          <td><code>cost_usd</code></td>
+          <td><code>Decimal&nbsp;|&nbsp;None</code></td>
+          <td>
+            Money, as a <code>Decimal</code> so it never loses precision. Accepts a string or a
+            <code>Decimal</code> on construction.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="not-prose">
+      <NbCell :count="10" :code="usage"><NbTextOut :text="usageOut" /></NbCell>
+    </div>
+
+    <p>
+      Summing follows a strict rule: <code>report.usage</code> adds a field across candidates only
+      when <em>every</em> candidate reported it. If one candidate leaves <code>cost_usd</code> as
+      <code>None</code>, the report's <code>cost_usd</code> is <code>None</code> too, rather than a
+      total that silently omits part of the run.
+    </p>
+
+    <p>
+      <code>to_dict()</code> drops fields that are <code>None</code> and renders
+      <code>cost_usd</code> as a string.
+    </p>
+
+    <h2>Failure</h2>
+
+    <p>
+      A <code>Failure</code> is one typed failure held inside an otherwise valid report. A report
+      with failures is still a report, so what succeeded can be read alongside what did not.
+    </p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>stage</code></td>
+          <td><code>str</code></td>
+          <td>
+            Where it happened: <code>candidate</code>, <code>grading</code> or
+            <code>aggregation</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>code</code></td>
+          <td><code>str</code></td>
+          <td>
+            Stable machine-readable identifier in lowercase snake_case, such as
+            <code>provider_timeout</code>. Match on this rather than on the message.
+          </td>
+        </tr>
+        <tr>
+          <td><code>message</code></td>
+          <td><code>str</code></td>
+          <td>Human-readable explanation. Not stable across versions.</td>
+        </tr>
+        <tr>
+          <td><code>retryable</code></td>
+          <td><code>bool&nbsp;|&nbsp;None</code></td>
+          <td>
+            Whether running the same thing again could plausibly succeed, or <code>None</code> when
+            the Engine did not say.
+          </td>
+        </tr>
+        <tr>
+          <td><code>operation_id</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Which step failed, matching an <code>OperationInfo.id</code>. <code>None</code> for a
+            failure no single step owns.
+          </td>
+        </tr>
+        <tr>
+          <td><code>case_id</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>Which case failed, when the failure was specific to one.</td>
+        </tr>
+        <tr>
+          <td><code>metadata</code></td>
+          <td><code>Mapping[str, object]</code></td>
+          <td>
+            Whatever else the Engine attached to this failure. Empty when it attached nothing.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>A failure reads like this:</p>
+
+    <CodeBlock
+      code="Failure(stage='candidate', code='provider_timeout', message='Upstream timed out', retryable=True, operation_id='op-1', case_id='7')"
+      language="python"
+    />
+  </DocLayout>
+</template>

--- a/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
@@ -55,6 +55,13 @@ const variantsOut = `('22ca96fe77b0f7de', '047f1de449639c61')`
       genuinely comparable.
     </p>
 
+    <blockquote>
+      <strong>Only a subset of benchmarks is available so far.</strong> This is an early, deliberately
+      small set, and we're working on expanding it massively so fusion research can thrive. If there's
+      a benchmark you'd want to run first, we'd love to hear it — tell us on
+      <a href="https://github.com/OpenMined/screamingface" target="_blank" rel="noopener">GitHub</a>.
+    </blockquote>
+
     <h2>What you can do with it</h2>
 
     <ul>

--- a/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
@@ -10,19 +10,18 @@ import {
 
 const listing = `import screamingface as sf
 
-for b in sf.benchmarks.list():
-    print(b.id, "|", b.variant, "|", b.case_count, "cases |", b.revision)`
-const listingOut = `draco | canonical | 100 cases | defbb6efdae69211
-draco/lite | lite | 2 cases | 6a1c04b9c7f21d83
-draco/smoke | smoke | 1 cases | b2f7d5e10a9c4468
-ifeval | canonical | 541 cases | 22ca96fe77b0f7de
-ifeval/self-corrective | self-corrective | 541 cases | 047f1de449639c61
-ifeval/lanl-ensemble | lanl-ensemble | 541 cases | 9c3ba82f5d0e7716
-healthbench/worst30 | worst30 | 30 cases | 41e8c96d2b7a5f30`
+sf.benchmarks.list()`
+const listingOut = `draco                    100 cases   defbb6efdae69211
+draco/lite                 2 cases   6a1c04b9c7f21d83
+draco/smoke                1 case    b2f7d5e10a9c4468
+ifeval                   541 cases   22ca96fe77b0f7de
+ifeval/self-corrective   541 cases   047f1de449639c61
+ifeval/lanl-ensemble     541 cases   9c3ba82f5d0e7716
+healthbench/worst30       30 cases   41e8c96d2b7a5f30`
 
 const card = `ifeval = sf.benchmarks.get("ifeval")
 ifeval`
-const cardOut = `Benchmark(id='ifeval', variant='canonical', title='IFEval',
+const cardOut = `Benchmark(id='ifeval', title='IFEval',
 description='The canonical 541-prompt instruction-following benchmark
 (https://arxiv.org/abs/2311.07911), graded by deterministic strict and loose
 verification. Each Case invokes the Candidate exactly once. Case ids are the
@@ -90,8 +89,8 @@ const variantsOut = `('22ca96fe77b0f7de', '047f1de449639c61')`
           <td>Fetches one benchmark's identity card. A protocol variant has its own id, such as <code>ifeval/self-corrective</code>, and its own revision.</td>
         </tr>
         <tr>
-          <td><code>sf.Benchmark</code> <code>.id</code> <code>.variant</code> <code>.title</code> <code>.description</code> <code>.revision</code> <code>.case_count</code></td>
-          <td>The identity card itself: its id, which protocol that id runs, what it measures, the opaque revision hash of the pinned protocol, and its size.</td>
+          <td><code>sf.Benchmark</code> <code>.id</code> <code>.title</code> <code>.description</code> <code>.revision</code> <code>.case_count</code></td>
+          <td>The identity card itself: its id, what it measures, the opaque revision hash of the pinned protocol, and its size.</td>
         </tr>
         <tr>
           <td><code>sf.BenchmarkInfo</code></td>

--- a/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
@@ -57,7 +57,7 @@ const panelProviders: Provider[] = [
       <RouterLink to="/learn/engine">the engine</RouterLink> holds on your behalf. The
       client never talks to OpenRouter, Anthropic or any other provider directly. It sends your key
       to the engine once, the engine passes it to AI Gateway to validate and store encrypted, and
-      every later model call is dispatched there. Your notebook keeps no copy.
+      every later model call is dispatched there.
     </p>
 
     <p>

--- a/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
@@ -10,30 +10,18 @@ import {
 
 const listing = `import screamingface as sf
 
-for board in sf.leaderboards.list():
-    print(board.id, "|", board.display_name)`
-const listingOut = `hle | News Hallucinations
-livetruth | News Livetruth
-livetruth-latest | News Livetruth Latest`
+sf.leaderboards.list()`
+const listingOut = `hle                News Hallucinations
+livetruth          News Livetruth
+livetruth-latest   News Livetruth Latest`
 
 const getOne = `board = sf.leaderboards.get("hle", top=5)
 board`
 const getOneOut = `Leaderboard('hle', entries=2, baselines=0)`
 
-const rows = `for entry in board.entries:
-    print(
-        entry.rank,
-        "|",
-        entry.spec_id,
-        "|",
-        entry.accuracy,
-        "|",
-        "verified" if entry.verified_by_openmined else "unverified",
-        "|",
-        ",".join(entry.ran_with_providers),
-    )`
-const rowsOut = `1 | filip-cf-access-smoke-1 | 0.5 | unverified | smoke
-2 | smoke-test-1 | 0.5 | unverified | smoke`
+const rows = `board.entries`
+const rowsOut = `1   filip-cf-access-smoke-1   0.5   unverified   smoke
+2   smoke-test-1             0.5   unverified   smoke`
 
 const configure = `sf.configure(
     engine_url="http://127.0.0.1:9108",
@@ -42,10 +30,11 @@ const configure = `sf.configure(
 
 const publish = `report = sf.evaluate(candidate, benchmark="ifeval", limit=3)
 
-# opt-in: Run All should never publish by accident
-PUBLISH = False
-submission = sf.leaderboards.submit(report.candidates.only) if PUBLISH else None
-submission`
+# publish one candidate
+sf.leaderboards.submit(report.candidates.only)
+
+# or publish every candidate in the report
+[sf.leaderboards.submit(c) for c in report.candidates]`
 
 const fetchScore = `score = sf.leaderboards.get_score("57cc25d7-00bf-44ec-bf9d-55d66cd1e003")
 score.accuracy, score.correct_questions, score.total_questions, score.verified_by_openmined`
@@ -63,15 +52,16 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
     :version="version"
   >
     <p>
-      A <strong>leaderboard</strong> is one benchmark's public ranking on the Scoreboard. The Client
-      reads and writes it through <code>sf.leaderboards</code>. Discovery and reads are free. They
-      hit the Scoreboard, not a model, and they do not need a provider connection.
+      A <strong>leaderboard</strong> is one benchmark's public ranking on the ScreamingFace
+      Leaderboard. The Client reads and writes it through <code>sf.leaderboards</code>. Discovery and
+      reads are free. They hit the leaderboard, not a model, and they do not need a provider
+      connection.
     </p>
 
     <p>
       Each ranked row keeps the exact
       <RouterLink to="/sf-client/guides/reproduce-and-share"><code>url4</code></RouterLink>
-      that produced the score, so anyone can fork or re-run the recipe. The Scoreboard also stores
+      that produced the score, so anyone can fork or re-run the recipe. The leaderboard also stores
       whether OpenMined independently re-ran it (<code>verified_by_openmined</code>). That flag is
       separate from who submitted the row: a submission starts unverified.
     </p>
@@ -80,7 +70,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
       The public portal is
       <a href="https://leaderboard.screamingface.ai" target="_blank" rel="noopener"
         >leaderboard.screamingface.ai</a
-      >. The Client's default Scoreboard origin is
+      >. The Client's default leaderboard origin is
       <code>https://leaderboard.dev.screamingface.ai</code>. Point <code>scoreboard_url</code> at
       your own instance when you run the local stack.
     </p>
@@ -88,7 +78,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
     <h2>What you can do with it</h2>
 
     <ul>
-      <li>List the benchmarks the Scoreboard has registered as leaderboards.</li>
+      <li>List the benchmarks registered as leaderboards.</li>
       <li>Fetch one board's ranked entries and any imported single-model baselines.</li>
       <li>Publish an evaluated <code>CandidateResult</code> as a new score.</li>
       <li>Look up one published score by id and reuse its <code>url4</code>.</li>
@@ -107,7 +97,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
         <tr>
           <td><code>sf.leaderboards.list()</code></td>
           <td>
-            Lists every benchmark registered with the configured Scoreboard as
+            Lists every benchmark registered with the configured leaderboard as
             <code>LeaderboardInfo</code> values.
           </td>
         </tr>
@@ -144,7 +134,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
     </table>
 
     <p>
-      Ranking is best-per-spec: for each <code>spec_id</code> the Scoreboard keeps the highest
+      Ranking is best-per-spec: for each <code>spec_id</code> the leaderboard keeps the highest
       accuracy, and breaks ties by newest <code>submitted_at</code>. The table is then ordered by
       accuracy descending. Baselines are imported separately and sit beside community entries; they
       are not the same as a submitted score.
@@ -159,7 +149,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
     </div>
 
     <p>
-      These ids are Scoreboard registrations. They can overlap the engine's
+      These ids are leaderboard registrations. They can overlap the engine's
       <RouterLink to="/sf-client/guides/benchmarks">benchmark</RouterLink> catalog, but they are not
       the same list. A board has to be registered before you can publish to it.
     </p>
@@ -178,7 +168,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
       Each entry carries <code>accuracy</code>, <code>total_questions</code>, the providers used,
       who submitted it when that is known, the <code>verified_by_openmined</code> flag, and the
       <code>url4</code> expression. Notebook displays render the board as an interactive widget; the
-      plain loop above is what you get when you print fields yourself.
+      fields above are what each entry holds.
     </p>
 
     <p>
@@ -186,11 +176,11 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
       <code>verified_by_openmined=True</code> as the trust signal, not the mere presence of a row.
     </p>
 
-    <h3>3 · Point the Client at a Scoreboard</h3>
+    <h3>3 · Point the Client at a leaderboard</h3>
 
     <p>
-      Without configuration, leaderboard calls use the default hosted Scoreboard. Local development
-      usually points both the engine and the Scoreboard at the stack
+      Without configuration, leaderboard calls use the default hosted ScreamingFace Leaderboard.
+      Local development usually points both the engine and the leaderboard at the stack
       <code>just stack-up</code> starts:
     </p>
 
@@ -208,8 +198,8 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
 
     <p>
       <code>submit</code> takes the evaluated <code>CandidateResult</code> directly. It does not ask
-      you to re-enter the score. Keep publication behind an explicit flag so a notebook
-      <strong>Run All</strong> cannot change the board by accident.
+      you to re-enter the score. Pass <code>report.candidates.only</code> to publish a single
+      candidate, or iterate <code>report.candidates</code> to publish every candidate in the report.
     </p>
 
     <div class="not-prose">
@@ -225,7 +215,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
     </p>
 
     <p>
-      The Scoreboard's accuracy contract is strict: every case grade must be binary (<code>0</code>
+      The leaderboard's accuracy contract is strict: every case grade must be binary (<code>0</code>
       or <code>1</code>), and <code>score</code> must match <code>correct / total</code> within
       <code>0.01</code>. Rubric-only results that do not reduce to that shape are rejected before
       they leave the Client. IFEval fits; some judge-scored protocols do not until their grades are
@@ -236,7 +226,7 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
 
     <p>
       Pass the id <code>submit</code> returned (or any public score id). This sample is a real score
-      read back from a local Scoreboard:
+      read back from a local leaderboard:
     </p>
 
     <div class="not-prose">

--- a/public-docs/src/pages/sf-client/guides/ModelsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ModelsPage.vue
@@ -38,6 +38,18 @@ ModelInfo('openrouter/google/gemini-3.1-pro-preview', provider='openrouter', par
 const details = `gpt = sf.models.get("openrouter/openai/gpt-5.5")
 gpt.parameters["reasoning"].enabled, "web_search" in gpt.tools`
 const detailsOut = `(True, True)`
+
+const discover = `gpt = sf.models.get("openrouter/openai/gpt-5.5")
+
+# What can I configure on this route?
+len(gpt.parameters), sorted(gpt.parameters)[:4]`
+const discoverOut = `(12, ['frequency_penalty', 'max_tokens', 'presence_penalty', 'reasoning'])`
+
+const inspect = `temp = gpt.parameters["temperature"]
+
+# Each parameter carries a schema: type, bounds, and any fixed value set.
+temp.schema.type, temp.schema.minimum, temp.schema.maximum, temp.enabled`
+const inspectOut = `('number', 0.0, 2.0, True)`
 </script>
 
 <template>
@@ -166,6 +178,12 @@ const detailsOut = `(True, True)`
       retyping it.
     </p>
 
+    <blockquote>
+      <strong>The catalogue is fixed for now.</strong> The engine does not yet discover models
+      automatically, so only the routes listed here can be used to build fusions — a model missing
+      from the list can't be added from the client. Automatic discovery is work in progress.
+    </blockquote>
+
     <h3>5 · Check that a route accepts your policy</h3>
 
     <p>
@@ -178,6 +196,36 @@ const detailsOut = `(True, True)`
     <div class="not-prose">
       <NbCell :count="5" :code="details"><NbTextOut :text="detailsOut" /></NbCell>
     </div>
+
+    <h3>6 · Discover a route's parameters</h3>
+
+    <p>
+      The same <code>ModelDetails</code> profile is also how you find out <em>what</em> a route lets
+      you configure. <code>details.parameters</code> is a mapping keyed by parameter name, so listing
+      its keys enumerates every knob the route exposes.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="6" :code="discover"><NbTextOut :text="discoverOut" /></NbCell>
+    </div>
+
+    <p>
+      Each value is an <code>sf.ModelParameter</code>. Its <code>schema</code> gives the type and the
+      bounds the gateway enforces — a numeric <code>minimum</code>/<code>maximum</code>, an
+      <code>enum</code> of allowed values, a <code>max_length</code>, and so on — while
+      <code>enabled</code> says whether the gateway currently honours it. Reading the schema tells you
+      a value's legal range before you set it in <code>params</code>.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="7" :code="inspect"><NbTextOut :text="inspectOut" /></NbCell>
+    </div>
+
+    <p>
+      A parameter that isn't listed isn't configurable on that route: setting it in
+      <code>params</code> is refused at pre-flight rather than silently dropped, so a typo costs you
+      nothing.
+    </p>
 
     <h2>Links</h2>
 

--- a/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
@@ -186,6 +186,36 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
       <NbCell :count="1" :code="basic"><NbTextOut :text="basicOut" /></NbCell>
     </div>
 
+    <figure class="not-prose" style="margin: var(--space-6) 0">
+      <svg
+        viewBox="0 0 480 92"
+        role="img"
+        aria-label="review-chain runs draft then review in series; the review stage's answer is graded."
+        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+      >
+        <defs>
+          <marker id="pl-a1" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+        <text x="240" y="16" text-anchor="middle" style="fill: var(--text-2)">review-chain</text>
+        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a1)">
+          <path d="M186 52 H290" />
+        </g>
+        <rect x="16" y="30" width="170" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
+        <rect x="294" y="30" width="170" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
+        <g text-anchor="middle" style="fill: var(--text)">
+          <text x="101" y="56">draft</text>
+          <text x="379" y="56">review · graded</text>
+        </g>
+      </svg>
+      <figcaption
+        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
+      >
+        Two stages in series; the review stage's answer is what the benchmark grades.
+      </figcaption>
+    </figure>
+
     <h3>2 · Build the same chain with <code>.then()</code></h3>
 
     <p>
@@ -196,6 +226,40 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     <div class="not-prose">
       <NbCell :count="2" :code="then"><NbTextOut :text="thenOut" /></NbCell>
     </div>
+
+    <figure class="not-prose" style="margin: var(--space-6) 0">
+      <svg
+        viewBox="0 0 560 84"
+        role="img"
+        aria-label="draft.then(review).then(final) chains three stages in series, left to right."
+        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+      >
+        <defs>
+          <marker id="pl-a2" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a2)">
+          <path d="M166 44 H201" />
+          <path d="M355 44 H390" />
+        </g>
+        <g style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1">
+          <rect x="16" y="22" width="150" height="44" />
+          <rect x="205" y="22" width="150" height="44" />
+        </g>
+        <rect x="394" y="22" width="150" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
+        <g text-anchor="middle" style="fill: var(--text)">
+          <text x="91" y="48">draft</text>
+          <text x="280" y="48">review</text>
+          <text x="469" y="48">final · graded</text>
+        </g>
+      </svg>
+      <figcaption
+        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
+      >
+        <code>.then()</code> builds the same three-stage chain, read left to right.
+      </figcaption>
+    </figure>
 
     <h3>3 · Flatten vs. nest</h3>
 
@@ -208,6 +272,46 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
       <NbCell :count="3" :code="flatten"><NbTextOut :text="flattenOut" /></NbCell>
     </div>
 
+    <figure class="not-prose" style="margin: var(--space-6) 0">
+      <svg
+        viewBox="0 0 620 132"
+        role="img"
+        aria-label="An unnamed inner Pipeline flattens: draft, review and final run as one sequence."
+        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+      >
+        <defs>
+          <marker id="pl-a3" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a3)">
+          <path d="M146 68 H192" />
+          <path d="M370 76 H426" />
+        </g>
+        <rect
+          x="196"
+          y="20"
+          width="408"
+          height="96"
+          style="fill: none; stroke: var(--border-strong); stroke-width: 1; stroke-dasharray: 4 4"
+        />
+        <text x="206" y="38" style="fill: var(--text-2); font-size: 11px">Pipeline (unnamed)</text>
+        <rect x="16" y="46" width="130" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
+        <rect x="220" y="54" width="150" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
+        <rect x="430" y="54" width="150" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
+        <g text-anchor="middle" style="fill: var(--text)">
+          <text x="81" y="72">draft</text>
+          <text x="295" y="80">review</text>
+          <text x="505" y="80">final · graded</text>
+        </g>
+      </svg>
+      <figcaption
+        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
+      >
+        The unnamed inner Pipeline flattens — draft → review → final runs as one sequence.
+      </figcaption>
+    </figure>
+
     <p>
       Give the inner Pipeline a <code>name</code> and it is kept as a single stage instead, so a
       named chain stays a named, reusable unit.
@@ -216,6 +320,46 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     <div class="not-prose">
       <NbCell :count="4" :code="nestNamed"><NbTextOut :text="nestNamedOut" /></NbCell>
     </div>
+
+    <figure class="not-prose" style="margin: var(--space-6) 0">
+      <svg
+        viewBox="0 0 620 132"
+        role="img"
+        aria-label="A named inner Pipeline (polish-pass) stays a single stage: draft then polish-pass, which itself is review then final."
+        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+      >
+        <defs>
+          <marker id="pl-a4" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a4)">
+          <path d="M146 68 H192" />
+          <path d="M370 76 H426" />
+        </g>
+        <rect
+          x="196"
+          y="20"
+          width="408"
+          height="96"
+          style="fill: none; stroke: var(--border-strong); stroke-width: 1.25"
+        />
+        <text x="206" y="38" style="fill: var(--text-2); font-size: 11px">polish-pass (named · one stage)</text>
+        <rect x="16" y="46" width="130" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
+        <rect x="220" y="54" width="150" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
+        <rect x="430" y="54" width="150" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
+        <g text-anchor="middle" style="fill: var(--text)">
+          <text x="81" y="72">draft</text>
+          <text x="295" y="80">review</text>
+          <text x="505" y="80">final · graded</text>
+        </g>
+      </svg>
+      <figcaption
+        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
+      >
+        A named inner Pipeline is kept as one stage: draft → polish-pass (itself review → final).
+      </figcaption>
+    </figure>
 
     <h3>4 · Compose recursively</h3>
 
@@ -229,6 +373,56 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     <div class="not-prose">
       <NbCell :count="5" :code="recursive"><NbTextOut :text="recursiveOut" /></NbCell>
     </div>
+
+    <figure class="not-prose" style="margin: var(--space-6) 0">
+      <svg
+        viewBox="0 0 720 196"
+        role="img"
+        aria-label="A Fusion of two members — a draft-then-review pipeline and gemini — combined by a synthesizer that is itself a judge-then-writer pipeline."
+        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+      >
+        <defs>
+          <marker id="pl-a5" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+        <text x="16" y="16" style="fill: var(--text-2)">Fusion · members</text>
+        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a5)">
+          <path d="M136 48 H168" />
+          <path d="M292 48 C372 48 372 98 448 98" />
+          <path d="M136 128 C300 128 372 98 448 98" />
+          <path d="M572 104 H590" />
+        </g>
+        <g style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1">
+          <rect x="16" y="28" width="120" height="40" />
+          <rect x="172" y="28" width="120" height="40" />
+          <rect x="16" y="108" width="120" height="40" />
+          <rect x="464" y="86" width="108" height="36" />
+        </g>
+        <rect
+          x="452"
+          y="58"
+          width="252"
+          height="80"
+          style="fill: none; stroke: var(--border-strong); stroke-width: 1.25"
+        />
+        <text x="462" y="76" style="fill: var(--text-2); font-size: 11px">synthesizer · Pipeline</text>
+        <rect x="596" y="86" width="96" height="36" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
+        <g text-anchor="middle" style="fill: var(--text)">
+          <text x="76" y="52">draft</text>
+          <text x="232" y="52">review</text>
+          <text x="76" y="132">gemini</text>
+          <text x="518" y="108">judge</text>
+          <text x="644" y="108">writer</text>
+        </g>
+      </svg>
+      <figcaption
+        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
+      >
+        A Fusion of two members (the draft → review pipeline and gemini), combined by a synthesizer
+        that is itself a judge → writer pipeline. The synthesizer's last stage (writer) is graded.
+      </figcaption>
+    </figure>
 
     <p>
       Check the <RouterLink to="/sf-client/api/recipes">Recipes reference</RouterLink> for the full

--- a/public-docs/src/pages/sf-client/guides/Url4Page.vue
+++ b/public-docs/src/pages/sf-client/guides/Url4Page.vue
@@ -42,10 +42,9 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
   >
     <p>
       Every candidate result carries a <RouterLink to="/learn/url4"><code>url4</code></RouterLink>
-      string: the complete expression <RouterLink to="/learn/engine">the engine</RouterLink>
-      actually ran. Not a summary, not a log. The plan itself. Your candidate, the benchmark's
-      routes, retry prompts, protocol revision, all in one line of text you can read, diff, and send
-      to others.
+      string: the complete plan <RouterLink to="/learn/engine">the engine</RouterLink> actually ran —
+      your candidate, the benchmark's routes, retry prompts, and protocol revision — written as a
+      single line of text you can read, diff, and share.
     </p>
 
     <p>
@@ -332,16 +331,16 @@ const readable = `(member_1:0.0:/openrouter/anthropic/claude-opus-4.8?temperatur
     <h2>What "reproduce" means here</h2>
 
     <p>
-      A url4 pins the run's <strong>definition</strong>, not its outputs. Re-executing the same
-      expression asks the same models the same questions under the same protocol, and models are not
-      deterministic, so the scores will move. What is reproducible is the experiment, not the
-      number.
+      A url4 pins the run's <strong>definition</strong>. Replay it against the hosted ScreamingFace
+      engine and you get a <strong>cache hit</strong>: the engine already ran that exact expression,
+      so it returns the identical score at <strong>$0</strong> rather than paying to run it again.
     </p>
 
     <p>
-      That is the useful guarantee. When two results differ, the url4 tells you whether the
-      <em>setup</em> differed, which is the question you actually need answered before comparing
-      them.
+      Bypass the cache and it genuinely reruns, asking the same models the same questions under the
+      same protocol. Models are not deterministic, so a fresh run can diverge slightly. A cached
+      replay reproduces the number exactly; a bypassed rerun reproduces the experiment, and the
+      score may move a little.
     </p>
 
     <h2>Links</h2>

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -69,6 +69,11 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/api/RecipesPage.vue'),
     },
     {
+      path: '/sf-client/api/models',
+      name: 'sf-client-api-models',
+      component: () => import('@/pages/sf-client/api/ModelsCatalogPage.vue'),
+    },
+    {
       path: '/sf-client/api/benchmarks',
       name: 'sf-client-api-benchmarks',
       component: () => import('@/pages/sf-client/api/BenchmarksPage.vue'),
@@ -77,6 +82,16 @@ const router = createRouter({
       path: '/sf-client/api/reports',
       name: 'sf-client-api-reports',
       component: () => import('@/pages/sf-client/api/ReportsPage.vue'),
+    },
+    {
+      path: '/sf-client/api/candidate-result',
+      name: 'sf-client-api-candidate-result',
+      component: () => import('@/pages/sf-client/api/CandidateResultPage.vue'),
+    },
+    {
+      path: '/sf-client/api/usage',
+      name: 'sf-client-api-usage',
+      component: () => import('@/pages/sf-client/api/UsagePage.vue'),
     },
     {
       path: '/sf-client/api/clients',


### PR DESCRIPTION
Live copyedit/polish pass over the **sf-client public docs**, driven interactively by the owner. Copy, diagrams, and one URL constant only — no client behaviour changes.

## Changes
- **Overview** (`Index.vue`): tighten prose (engine/caching sentence, "reported repeatedly", drop two lines, url4 = "grammar and protocol", "either of two", "pay for the compute"); add the theme-aware **local-flow diagram** to *How it works* (reuses `/diagrams/screamingface-request-architecture-local-*.svg`).
- **Home hero**: "a real research benchmark" → "a real benchmark".
- **Quickstart**: reword description; link **DRACO → arXiv [2602.11685](https://arxiv.org/abs/2602.11685)**; rename *1 · Point at an engine* → *1 · Configure the engine*, led by what the engine does and linked to `/learn/engine`; add local-vs-hosted guidance (hosted access is currently **peer-to-peer approval**); caching caveat (**OpenRouter + Anthropic only**, WIP).
- **Installation**: reframe *Give the engine a web-search key* around **Hugging Face** / non-search providers (most of the time not needed); note the client defaults to the **hosted leaderboard** (`leaderboard.dev.screamingface.ai`), overridden via `sf.configure(scoreboard_url=...)`.
- **Connections**: drop "Your notebook keeps no copy."
- **Models**: caveat that there's **no automatic model discovery yet** (fixed catalogue, WIP); new section **6 · Discover a route's parameters** using `sf.models.get(...).parameters` / `ModelParameter.schema`.
- **Benchmarks**: caveat that only a subset is live + feedback CTA.
- **Pipelines**: **one inline-SVG diagram per code snippet** (chain, `.then()`, flatten, named-nest, recursive Fusion) to make the nesting legible, matching the page's existing SVG convention.
- **`lib/engine.ts`**: hosted `SF_ENGINE_URL` → `https://fusion.dev.screamingface.ai`.

## Test plan
- `vue-tsc --noEmit` ✓ · `vite build` ✓ · `oxlint .` ✓ · `eslint .` ✓ (CI-equivalent, no `--fix`).
- **Owner: please eyeball the SVG diagrams in `npm run dev`** — build only verifies well-formedness, not visual layout.

Refs: OME-846

🤖 Generated with [Claude Code](https://claude.com/claude-code)