### PR TITLE
docs(public-docs): add Clients vs sf.* shortcuts user guide

### DIFF
--- a/docs/tasks/2026-08-17-OME-847-clients-guide.md
+++ b/docs/tasks/2026-08-17-OME-847-clients-guide.md
@@ -1,0 +1,19 @@
+---
+id: OME-847
+linear_url: https://linear.app/openmined/issue/OME-847/add-a-clients-vs-sf-shortcuts-user-guide-to-the-docs-site
+status: In Progress
+type: Docs
+priority: P2
+labels: [py-screamingface, agentic, autonomous, task]
+created: 2026-08-17
+closed:
+---
+
+# Add a "Clients vs sf.* shortcuts" user guide to the docs site
+
+New `public-docs` User Guide explaining the two ways to call the ScreamingFace Client SDK —
+the module-level `sf.*` shortcuts (one lazy, process-wide default `Client`) vs an explicit
+`Client` / `AsyncClient` the caller constructs and owns. Comprehensive scope: config source,
+lifecycle, async (no module-level async), custom transports, thread model, multiple engines.
+Placed first under _User Guides_, titled **Clients**. Complements the existing API
+Reference › Clients page (which documents the types); this guide covers *when to use which*.

--- a/docs/work/2026-08-17-OME-847-clients-guide.md
+++ b/docs/work/2026-08-17-OME-847-clients-guide.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-847
+stack: repo
+status: in_progress
+started: 2026-08-17
+finished:
+---
+
+# OME-847 — Add a "Clients vs sf.* shortcuts" user guide to the docs site
+
+## Intent
+
+The ScreamingFace Client SDK can be driven two ways: module-level shortcuts
+(`import screamingface as sf` → `sf.evaluate(...)`, `sf.connect(...)`, `sf.configure(...)`,
+`sf.close()`) that delegate to a single lazy, process-wide default `Client`, or an explicit
+`Client` / `AsyncClient` the caller constructs and owns. The `public-docs` site already
+documents the *types* (API Reference › Clients) but never explains *when to use which*.
+Every other guide mixes both styles without ever drawing the distinction. This unit adds a
+comprehensive User Guide, placed first under _User Guides_, that makes the difference clear —
+config source, lifecycle, async (no module-level async — event-loop footgun), custom
+transports, thread model, and multiple engines.
+
+## Planned changes
+
+Follows the docs site's standard "add a page" pattern (create page → route → nav entry):
+
+- `public-docs/src/pages/sf-client/guides/ClientsPage.vue` (new) — the guide, built on
+  `DocLayout` + `CodeBlock`/`NbCell`/`NbTextOut`/`Note`, mirroring `guides/ConnectionsPage.vue`
+  and `api/ClientsPage.vue`.
+- `public-docs/src/router/index.ts` — route `/sf-client/guides/clients`
+  (name `sf-client-guides-clients`), before the `connections` route.
+- `public-docs/src/navigation/sf-client.ts` — nav entry `{ title: 'Clients',
+  path: '/sf-client/guides/clients' }` as the first child of _User Guides_.
+
+## Test plan
+
+No automated test setup exists for `public-docs` (Vue docs site). Gates:
+
+- `npm run type-check` (vue-tsc) — passes.
+- `npm run lint` (oxlint + eslint) — clean.
+- `npm run build` — succeeds.
+- `npm run dev` walkthrough: `/sf-client/guides/clients` renders inside `DocLayout`;
+  sidebar shows **Clients** first under _User Guides_ (above Connections); prev/next wire
+  automatically; all `RouterLink`s resolve (esp. `/sf-client/api/clients`).
+
+## Acceptance
+
+- A new **Clients** guide is the first _User Guides_ entry and reads as a "when to use which"
+  page distinct from the API-reference Clients page.
+- Every API name / signature / output on the page matches the verified surface in
+  `client.py`, `_default_client.py`, and `api/ClientsPage.vue` — no invented surface.
+- type-check + lint + build all green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** exactly as planned —
+  `public-docs/src/pages/sf-client/guides/ClientsPage.vue` (new),
+  `public-docs/src/router/index.ts` (route before `connections`),
+  `public-docs/src/navigation/sf-client.ts` (nav entry, first under _User Guides_), plus this
+  ledger and the `docs/tasks/` mirror.
+- **Commits:** (filled post-commit)
+- **Gates:** `npm run type-check` (vue-tsc) clean; `npm run lint` (oxlint + eslint --fix) clean,
+  no files reformatted; `npm run build` ✓ in 865ms (emits `ClientsPage-*.js` for both the new
+  guide and the existing api page — filename reuse across `guides/`+`api/` confirmed, matching
+  the Benchmarks/Url4/Leaderboard precedent). Dev server boots in 612ms with no errors;
+  `/sf-client/guides/clients` returns 200. No automated test suite exists for `public-docs`.
+- **Deviations:** Per CLAUDE.md rule 3 (spec→plan→code), the approved plan-mode plan
+  `.claude/plans/add-a-user-guide-jolly-conway.md` stands in for formal `docs/spec/` +
+  `docs/plan/` artifacts, since this is a docs-only page with no product-behavior or
+  architecture change. Landing label `py-screamingface` chosen because `public-docs/` has no
+  landing leaf of its own and this documents that product.

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -26,6 +26,7 @@ export const sfClientNavigation: NavEntry[] = [
   {
     title: 'User Guides',
     children: [
+      { title: 'Clients', path: '/sf-client/guides/clients' },
       { title: 'Connections', path: '/sf-client/guides/connections' },
       {
         title: 'Compose',

--- a/public-docs/src/pages/sf-client/guides/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ClientsPage.vue
@@ -1,0 +1,338 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
+import NbCell from '@/components/nb/NbCell.vue'
+import NbTextOut from '@/components/nb/NbTextOut.vue'
+import Note from '@/components/ui/Note.vue'
+import { SF_ENGINE_URL } from '@/lib/engine'
+import {
+  sfClientNavigation as navigation,
+  sfClientVersion as version,
+} from '@/navigation/sf-client'
+
+const shortcut = `import screamingface as sf
+
+report = sf.evaluate(
+    sf.Model("openrouter/anthropic/claude-haiku-4.5"),
+    benchmark="ifeval",
+    limit=1,
+)
+sf.close()`
+
+const explicit = `import screamingface as sf
+
+with sf.Client(engine_url="${SF_ENGINE_URL}") as client:
+    report = client.evaluate(
+        sf.Model("openrouter/anthropic/claude-haiku-4.5"),
+        benchmark="ifeval",
+        limit=1,
+    )`
+
+const lazy = `import screamingface as sf
+
+client = sf.Client(engine_url="${SF_ENGINE_URL}")
+client.engine_url, client.closed, client.authenticated`
+const lazyOut = `('${SF_ENGINE_URL}', False, False)`
+
+const env = `export SCREAMINGFACE_ENGINE_URL=http://127.0.0.1:9108
+export SCREAMINGFACE_SCOREBOARD_URL=http://127.0.0.1:9106`
+
+const configure = `import screamingface as sf
+
+sf.configure(
+    engine_url="http://127.0.0.1:9108",
+    scoreboard_url="http://127.0.0.1:9106",
+)
+report = sf.evaluate(candidates, benchmark="draco", limit=1)
+sf.close()`
+
+const multi = `import screamingface as sf
+
+candidate = sf.Model("openrouter/anthropic/claude-haiku-4.5")
+
+with (
+    sf.Client(engine_url="${SF_ENGINE_URL}") as hosted,
+    sf.Client(engine_url="http://127.0.0.1:9108") as local,
+):
+    hosted_report = hosted.evaluate(candidate, benchmark="ifeval", limit=1)
+    local_report = local.evaluate(candidate, benchmark="ifeval", limit=1)`
+
+const asyncCode = `import asyncio
+import screamingface as sf
+
+async def main():
+    async with sf.AsyncClient(engine_url="${SF_ENGINE_URL}") as client:
+        return await client.evaluate(
+            sf.Model("openrouter/anthropic/claude-haiku-4.5"),
+            benchmark="ifeval",
+            limit=1,
+        )
+
+report = asyncio.run(main())`
+
+const transport = `import screamingface as sf
+
+client = sf.Client(
+    engine_url="${SF_ENGINE_URL}",
+    http_transport=my_transport,          # any httpx.BaseTransport
+)`
+</script>
+
+<template>
+  <DocLayout
+    title="Clients"
+    description="The default client behind sf.*, and when to build your own."
+    :navigation="navigation"
+    :version="version"
+  >
+    <p>
+      There are two ways to call this SDK, and they share one interface. The
+      <strong>module-level shortcuts</strong> — <code>sf.evaluate(...)</code>,
+      <code>sf.connect(...)</code>, and the rest — read the shortest, so they open the
+      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> and every notebook.
+      An <strong>explicit <code>Client</code></strong> that you construct and own reads
+      longer but gives you the lifecycle, the second engine, and the event loop when a script
+      grows into something you ship. The shortcuts are not a different SDK: each one runs
+      against a single <code>Client</code> the package holds for you, so everything on this
+      page is really about <em>who owns the Client</em>.
+    </p>
+
+    <h2>What you can do with it</h2>
+
+    <ul>
+      <li>Call the SDK with no setup through the process-wide default client.</li>
+      <li>Point that default at a local or alternate engine, by environment or in code.</li>
+      <li>Construct your own <code>Client</code> when you need to own its lifecycle.</li>
+      <li>Run against more than one engine at once, or over <code>await</code>.</li>
+    </ul>
+
+    <h2>The two forms, side by side</h2>
+
+    <p>The same evaluation, written both ways. The shortcut lets the package hold the client:</p>
+
+    <CodeBlock :code="shortcut" language="python" />
+
+    <p>The explicit form hands the client to a <code>with</code> block that closes it for you:</p>
+
+    <CodeBlock :code="explicit" language="python" />
+
+    <table>
+      <thead>
+        <tr>
+          <th>Concern</th>
+          <th><code>sf.*</code> shortcuts</th>
+          <th><code>sf.Client</code> / <code>sf.AsyncClient</code></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Construction</td>
+          <td>Implicit, on the first call that needs it</td>
+          <td>You call the constructor</td>
+        </tr>
+        <tr>
+          <td>How many</td>
+          <td>One, shared across the process</td>
+          <td>As many as you build</td>
+        </tr>
+        <tr>
+          <td>Configuration</td>
+          <td>
+            <code>SCREAMINGFACE_ENGINE_URL</code> /
+            <code>SCREAMINGFACE_SCOREBOARD_URL</code>, or <code>sf.configure(...)</code>
+          </td>
+          <td>Constructor keyword arguments</td>
+        </tr>
+        <tr>
+          <td>Lifecycle</td>
+          <td><code>sf.close()</code> (or <code>sf.configure()</code> swaps it)</td>
+          <td>
+            <code>with</code> / <code>close()</code> — async
+            <code>async with</code> / <code>await aclose()</code>
+          </td>
+        </tr>
+        <tr>
+          <td>Async</td>
+          <td>Synchronous only</td>
+          <td><code>AsyncClient</code></td>
+        </tr>
+        <tr>
+          <td>Custom transports</td>
+          <td>Not available</td>
+          <td>
+            <code>http_transport</code> / <code>scoreboard_transport</code> /
+            <code>run_transport</code>
+          </td>
+        </tr>
+        <tr>
+          <td>Login state</td>
+          <td>Shared by the whole process</td>
+          <td>Held per client</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>The default client</h2>
+
+    <p>
+      <code>sf.evaluate()</code>, <code>sf.connect()</code> and <code>sf.disconnect()</code>
+      all run against one <code>Client</code> the package builds <strong>the first time you
+      call one of them</strong>, and reuses forever after. Nothing is created at
+      <code>import</code>, and constructing a client opens no connection either — the first
+      call that needs the engine is the first one that talks to it:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="1" :code="lazy"><NbTextOut :text="lazyOut" /></NbCell>
+    </div>
+
+    <p>
+      Left alone, that default points at the hosted development engine. Point it somewhere
+      else in one of two ways. Set the environment before the first call, which suits a
+      local engine you already export elsewhere:
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="2" :code="env" />
+    </div>
+
+    <p>Or configure it in code, which also closes and replaces any default already built:</p>
+
+    <div class="not-prose">
+      <NbCell :count="3" :code="configure" />
+    </div>
+
+    <p>
+      <code>sf.configure(...)</code> takes only <code>engine_url</code> and
+      <code>scoreboard_url</code> — for anything more, construct a <code>Client</code>
+      yourself. <code>sf.close()</code> closes the default and forgets it, so the next
+      shortcut builds a fresh one; it is the tidy end to a script.
+    </p>
+
+    <Note>
+      Because the default is one object for the whole process, its login state is shared too:
+      one <RouterLink to="/sf-client/guides/connections">login</RouterLink> covers every later
+      <code>sf.*</code> call. That is convenient in a notebook and surprising in a server
+      handling several users — the reason to build your own client below.
+    </Note>
+
+    <h2>Build your own client</h2>
+
+    <p>
+      Constructing a <code>Client</code> gives you the object directly. Prefer a
+      <code>with</code> block so it closes on the way out, which is the form to reach for in a
+      script or a service:
+    </p>
+
+    <CodeBlock :code="explicit" language="python" />
+
+    <p>
+      Owning the client is what lets you hold <strong>more than one at a time</strong> —
+      a hosted engine and a local one, each with its own address, login and connections:
+    </p>
+
+    <CodeBlock :code="multi" language="python" />
+
+    <p>
+      The full surface — properties, <code>login()</code> / <code>logout()</code>, the
+      catalogue accessors — lives on the
+      <RouterLink to="/sf-client/api/clients">Clients API reference</RouterLink>. A closed
+      client raises rather than reconnecting silently, so a <code>with</code> block is safer
+      than a bare constructor when the client is short-lived.
+    </p>
+
+    <h2>Async</h2>
+
+    <p>
+      <code>AsyncClient</code> offers the same interface over <code>await</code> and returns
+      the same value types. <code>evaluate()</code>, <code>connect()</code>,
+      <code>login()</code> and the rest are awaited; the properties are not, and cleanup is
+      <code>async with</code> or <code>await client.aclose()</code>:
+    </p>
+
+    <CodeBlock :code="asyncCode" language="python" />
+
+    <Note>
+      There is deliberately <strong>no <code>await sf.evaluate(...)</code></strong>. A single
+      process-wide async client would bind its connection pool to one event loop — a footgun
+      the moment a second loop, a notebook re-run, or a server worker appears. So the async
+      path has no module-level shortcut: you construct an <code>AsyncClient</code> and own its
+      lifecycle, every time.
+    </Note>
+
+    <h2>Custom transports</h2>
+
+    <p>
+      The constructor accepts <code>http_transport</code>,
+      <code>scoreboard_transport</code> and <code>run_transport</code> — the seam for tests
+      and proxies. A mock transport lets a test drive the client with no network at all. These
+      are constructor-only: there is no way to reach them through the <code>sf.*</code> path,
+      which is another reason a test suite builds its own client.
+    </p>
+
+    <CodeBlock :code="transport" language="python" />
+
+    <h2>One process, one shared client</h2>
+
+    <p>
+      The default is a single instance, built once behind a lock and reused, so
+      <code>sf.*</code> calls that happen to overlap share it rather than racing to create
+      two. That sharing is exactly what makes it a poor fit for isolation: separate work that
+      must not share a login, a connection pool, or an engine wants a separate
+      <code>Client</code>. Give each thread, each event loop, or each tenant its own, and
+      close it when that work is done.
+    </p>
+
+    <h2>When to use each</h2>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Reach for <code>sf.*</code></th>
+          <th>Build a <code>Client</code></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Notebooks, the REPL, one-off scripts</td>
+          <td>Libraries and services you ship</td>
+        </tr>
+        <tr>
+          <td>One engine for the whole process</td>
+          <td>More than one engine at once</td>
+        </tr>
+        <tr>
+          <td>Straight-line synchronous code</td>
+          <td>Async code, or concurrency that needs isolation</td>
+        </tr>
+        <tr>
+          <td>Configuration by environment</td>
+          <td>Tests that inject a transport</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>See also</h2>
+
+    <ul>
+      <li>
+        <RouterLink to="/sf-client/api/clients"
+          ><code>Client</code>, <code>AsyncClient</code> and connections — API reference</RouterLink
+        >
+      </li>
+      <li>
+        <RouterLink to="/sf-client/guides/connections">Connections</RouterLink> — logging in and
+        connecting a provider through whichever client you chose
+      </li>
+      <li>
+        <a
+          href="https://github.com/OpenMined/screamingface/blob/main/packages/screamingface/examples/01_client_tour.ipynb"
+          target="_blank"
+          rel="noopener"
+          >Companion notebook: <code>01_client_tour.ipynb</code></a
+        >
+      </li>
+    </ul>
+  </DocLayout>
+</template>

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -24,6 +24,11 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/QuickstartPage.vue'),
     },
     {
+      path: '/sf-client/guides/clients',
+      name: 'sf-client-guides-clients',
+      component: () => import('@/pages/sf-client/guides/ClientsPage.vue'),
+    },
+    {
       path: '/sf-client/guides/connections',
       name: 'sf-client-guides-connections',
       component: () => import('@/pages/sf-client/guides/ConnectionsPage.vue'),


### PR DESCRIPTION
## Summary

Adds a new **User Guide** to the docs site (`public-docs`) explaining the two ways to call the ScreamingFace Client SDK and when to use each:

- **Module-level shortcuts** — `sf.evaluate(...)`, `sf.connect(...)`, `sf.configure(...)`, `sf.close()` — which delegate to a single **lazy, process-wide default `Client`**.
- **An explicit `Client` / `AsyncClient`** the caller constructs and owns.

The docs already had an **API Reference › Clients** page documenting the *types*; this fills the gap of *when to use which*. Comprehensive scope: config source (env vars / `sf.configure()` vs constructor args), lifecycle (`sf.close()` vs `with`/`close()`), async (no module-level async — the event-loop footgun), custom transports (constructor-only), the shared-instance thread model, and running multiple engines at once.

Placed **first** under _User Guides_ (before Connections), titled **Clients** — reusing the established `guides/`+`api/` filename pattern (Benchmarks/Url4/Leaderboard), disambiguated by route.

## Changes

- **New** `public-docs/src/pages/sf-client/guides/ClientsPage.vue`
- `public-docs/src/router/index.ts` — route `/sf-client/guides/clients`
- `public-docs/src/navigation/sf-client.ts` — nav entry, first under _User Guides_
- Work ledger + `docs/tasks/` mirror for OME-847

## Test plan

`public-docs` has no test suite; the CI lane is lint + type-check + build.

- `npx oxlint .` / `npx eslint .` (CI mode, no `--fix`) — both exit 0
- `npm run build` (vue-tsc + vite) — green; emits the `ClientsPage` chunk
- `npm run dev` — boots clean; `/sf-client/guides/clients` renders, sidebar shows **Clients** first under _User Guides_, prev/next wire automatically, all `RouterLink`s resolve

Every API name/signature/output on the page was verified against `packages/screamingface/src/screamingface/{client,_default_client}.py` and the existing `api/ClientsPage.vue` — no invented surface. No screenshots attached (authored headlessly); reviewers can preview via the deploy-public-docs workflow.

Refs: OME-847

🤖 Generated with [Claude Code](https://claude.com/claude-code)