### PR TITLE
fix(scoreboard): repair main after the benchmark_revision requirement landed

### DIFF
--- a/apps/scoreboard/tests/unit/classification/test_openness.py
+++ b/apps/scoreboard/tests/unit/classification/test_openness.py
@@ -31,6 +31,9 @@ def _score(
         id=uuid4(),
         version=1,
         benchmark_id="hle",
+        # OME-852: required since OME-775. None is honest here — frontier and openness
+        # classification do not depend on which benchmark revision produced the score.
+        benchmark_revision=None,
         spec_id="spec-1",
         url4_expression="url4://benchmark/spec-1",
         submitted_by="tester",

--- a/apps/scoreboard/tests/unit/scores/test_frontier.py
+++ b/apps/scoreboard/tests/unit/scores/test_frontier.py
@@ -25,6 +25,9 @@ def _score(
         id=uuid4(),
         version=1,
         benchmark_id="hle",
+        # OME-852: required since OME-775. None is honest here — frontier and openness
+        # classification do not depend on which benchmark revision produced the score.
+        benchmark_revision=None,
         spec_id=spec_id,
         url4_expression=f"url4://benchmark/{spec_id}",
         submitted_by="tester",

--- a/docs/work/2026-08-17-OME-852-repair-main-benchmark-revision.md
+++ b/docs/work/2026-08-17-OME-852-repair-main-benchmark-revision.md
@@ -1,0 +1,79 @@
+---
+ticket: OME-852
+stack: scoreboard
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-852 — Repair main: test helpers omit the required benchmark_revision
+
+## Intent
+
+`origin/main` is red — 9 failing tests and 2 pyright errors in `apps/scoreboard`. Restore it
+without weakening the guarantee that caused the break.
+
+## Cause
+
+A semantic conflict git cannot detect. Two PRs merged three minutes apart, each green alone:
+
+| commit | time | change |
+|---|---|---|
+| `62a0735d` | 14:22 | `OME-323` / #519 — frontier + openness tests building `ScoreSchema` |
+| `e431b715` | 14:25 | `OME-775` / #611 — made `benchmark_revision` **required** on `ScoreSchema` |
+
+Neither branch contained the other, so neither CI run saw the combination. No textual conflict
+existed for git to report. Both PRs were legitimately green at merge time.
+
+## Blast radius — test-only
+
+Production is unaffected. The one production construction site, `store.py:353`
+(`LeaderboardEntry(**row)`), takes the column straight from the query and is correct.
+
+All 9 failures trace to **two shared test helpers**, not 9 independent call sites:
+
+- `tests/unit/scores/test_frontier.py` `_score()` — 6 failures
+- `tests/unit/classification/test_openness.py` `_score()` — 3 failures
+
+## Decision (owner, 2026-08-17)
+
+Pass `benchmark_revision=None` explicitly in both helpers. **The field stays required.**
+
+**Rejected: defaulting the field to `None`.** One line, no test edits, fastest to green — but a
+site that forgets the revision would then silently receive `None`, which since `OME-775` means
+*"excluded from every registered board"* rather than a loud type error. That silent-exclusion
+failure mode is exactly what `OME-775` was fixed to prevent, so the loudness is load-bearing.
+
+`None` is honest in these two helpers: frontier and openness classification genuinely do not
+depend on benchmark revision.
+
+**Rule 5:** this edits prior tests. Owner approved 2026-08-17.
+
+## Planned changes
+
+- `apps/scoreboard/tests/unit/scores/test_frontier.py` — `benchmark_revision=None` in `_score()`
+- `apps/scoreboard/tests/unit/classification/test_openness.py` — same in `_score()`
+
+## Test plan
+
+No new tests. This restores 9 existing ones. The guard is that the field stays required, which
+`test_schemas.py` already pins and which pyright enforces at every construction site.
+
+## Acceptance
+
+- `pytest` green (was 9 failed, 214 passed).
+- `pyright` clean (was 2 errors).
+- `benchmark_revision` still required on `ScoreSchema`.
+- Full gates green.
+
+## Outcome
+
+- **Actual files:** exactly as planned — the two `_score()` helpers. The `BaselineSchema`
+  helpers in the same files were checked and correctly left alone; baselines carry no
+  benchmark revision.
+- **Gates:** ruff check ✓ · ruff format ✓ · pyright ✓ (was 2 errors) · pytest --cov ✓
+  **223 passed, 2 skipped** (was 9 failed, 214 passed) · portal JS 14 passed.
+  Ran with `--skip-append-only`: the whole point of this unit is editing two prior test
+  helpers, owner-approved under rule 5 and recorded in the ticket.
+- **Deviations:** none. Two helpers rather than the 9 call sites first estimated — the
+  failures were all downstream of two shared constructions.


### PR DESCRIPTION
## main is red — this restores it

`origin/main` currently fails with **9 tests and 2 pyright errors** in `apps/scoreboard`.

## Cause: a semantic conflict git could not detect

Two PRs merged three minutes apart, each green on its own:

| commit | time | change |
|---|---|---|
| `62a0735d` | 14:22 | OME-323 / #519 added frontier + openness tests building `ScoreSchema` |
| `e431b715` | 14:25 | OME-775 / #611 made `benchmark_revision` **required** on `ScoreSchema` |

Neither branch contained the other, so **neither CI run ever saw the combination**, and there was no textual conflict for git to report. Both were legitimately green at merge time. Worth noting as a process signal: nothing in the current setup catches this class, and today's burst of seven merges made it likely.

## Blast radius: test-only

Production is unaffected. The single production construction site, `store.py:353` `LeaderboardEntry(**row)`, takes the column straight from the query.

All 9 failures come from **two shared test helpers**, not 9 independent sites:

- `tests/unit/scores/test_frontier.py` `_score()` — 6 failures
- `tests/unit/classification/test_openness.py` `_score()` — 3 failures

The `BaselineSchema` helpers in the same two files were checked and deliberately left alone: baselines carry no benchmark revision.

## The fix, and what was rejected

Both helpers now pass `benchmark_revision=None` explicitly. **The field stays required.**

Rejected: giving it a default. One line, no test edits, fastest to green — but a site that forgets the revision would then silently receive `None`, which since OME-775 means *excluded from every registered board* rather than a loud type error. That silent exclusion is the exact failure mode OME-775 was fixed to prevent, so the loudness is load-bearing.

`None` is honest in these two helpers: frontier and openness classification do not depend on which revision produced a score.

## Test plan

No new tests; this restores 9 existing ones.

- `pytest` → **223 passed, 2 skipped** (was 9 failed, 214 passed)
- `pyright` → clean (was 2 errors)
- ruff check ✓ · ruff format ✓ · portal JS 14 passed

Ran with `--skip-append-only`: editing two prior test helpers *is* this unit's purpose. That is a rule-5 confidence-gate decision, approved by the owner and recorded on OME-852.

Refs: OME-852
