### PR TITLE
docs(public-docs): split the Recipes/Models/Fusions API page and clarify Pipelines

### DIFF
--- a/docs/tasks/2026-08-17-OME-853-split-recipes-api-and-pipelines-clarity.md
+++ b/docs/tasks/2026-08-17-OME-853-split-recipes-api-and-pipelines-clarity.md
@@ -1,0 +1,20 @@
+---
+id: OME-853
+linear_url: https://linear.app/openmined/issue/OME-853/split-the-combined-recipesmodelsfusions-api-page-and-clarify-the
+status: in_progress
+type: task
+priority: P2
+labels: [repo, agentic, autonomous, task]
+created: 2026-08-17
+closed:
+---
+
+Follow-up to OME-846 (merged). Split the combined "Recipes, Models, Fusions" API page so each
+recipe type lives in one home, and clarify the Pipelines guide.
+
+- Rename nav + page "Recipes, Models, Fusions" → "Recipes" (keep only the `Recipe` base).
+- Move `Model` → `api/ModelsCatalogPage.vue`; `Fusion` → `guides/FusionsPage.vue`; `Pipeline` →
+  `guides/PipelinesPage.vue`. Update `/api/recipes#…` cross-links.
+- Pipelines guide: clarify Pipeline-vs-evaluation and what a Pipeline is composed of.
+
+Ledger: `docs/work/2026-08-17-OME-853-split-recipes-api-and-pipelines-clarity.md`.

--- a/docs/work/2026-08-17-OME-853-split-recipes-api-and-pipelines-clarity.md
+++ b/docs/work/2026-08-17-OME-853-split-recipes-api-and-pipelines-clarity.md
@@ -48,3 +48,8 @@ one place per type, and clarify the Pipelines guide.
   and gained a "Where each type is documented" pointer list. ModelsCatalogPage's discovery types
   are now grouped under a "Discovery types" heading below the new Model section. Generic "recipe"
   links in CandidateResult/Clients were left pointing at the surviving Recipes overview.
+- **Follow-up (same PR):** overhauled the Pipelines composition diagrams (labelled pipeline frames
+  incl. nested, categorical role colours + legend, always-separate "Graded answer" node, fixed
+  broken `--accent`/`--border-strong` token refs, new "Mix recipe types as stages" example) —
+  visually verified via headless-Chrome screenshots — and rewrote the Clients guide's "two ways to
+  call the SDK" intro into short, plain sentences.

--- a/docs/work/2026-08-17-OME-853-split-recipes-api-and-pipelines-clarity.md
+++ b/docs/work/2026-08-17-OME-853-split-recipes-api-and-pipelines-clarity.md
@@ -1,0 +1,50 @@
+---
+ticket: OME-853
+stack: repo
+status: in_progress
+started: 2026-08-17
+finished:
+---
+
+# OME-853 — Split the Recipes/Models/Fusions API page + clarify the Pipelines guide
+
+## Intent
+
+Follow-up to OME-846 (merged). The combined "Recipes, Models, Fusions" API page documents
+four types at once; move each concrete recipe type to its own home so the reference reads in
+one place per type, and clarify the Pipelines guide.
+
+## Planned changes
+
+- `public-docs/src/navigation/sf-client.ts` — rename "Recipes, Models, Fusions" → "Recipes".
+- `public-docs/src/pages/sf-client/api/RecipesPage.vue` — retitle → "Recipes"; keep only the
+  abstract `Recipe` base + composition overview; drop the Model, Fusion, Pipeline sections and
+  their consts; point to the new homes.
+- `public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue` — add the `Model` recipe class
+  reference (sig/params/attributes/raises) at the top, above the discovery types.
+- `public-docs/src/pages/sf-client/guides/FusionsPage.vue` — add the `Fusion` class reference.
+- `public-docs/src/pages/sf-client/guides/PipelinesPage.vue` — add the `Pipeline` class
+  reference; clarify the Pipeline-vs-evaluation distinction and what a Pipeline is composed of.
+- Cross-links pointing at `/sf-client/api/recipes#…` → new homes (Models page / Fusions guide /
+  Pipelines guide).
+
+## Test plan
+
+- Docs only. Gate = the `public-docs-tests.yml` CI equivalents locally (oxlint, eslint, build).
+
+## Acceptance
+
+- Each recipe type documented once, in its home; nav renamed; no dead `/api/recipes#…` links.
+- CI-equivalent gates green.
+
+## Outcome
+
+- **Actual files:** as planned — `navigation/sf-client.ts`, `api/RecipesPage.vue`,
+  `api/ModelsCatalogPage.vue`, `guides/FusionsPage.vue`, `guides/PipelinesPage.vue` (+ ledger +
+  mirror).
+- **Commits:** <sha — filled at commit>
+- **Gates:** `vue-tsc` + `vite build` ✓ (built in ~0.65s) · `oxlint .` ✓ (0) · `eslint .` ✓ (0).
+- **Deviations:** RecipesPage was rewritten in full (mostly removal) rather than edited in place,
+  and gained a "Where each type is documented" pointer list. ModelsCatalogPage's discovery types
+  are now grouped under a "Discovery types" heading below the new Model section. Generic "recipe"
+  links in CandidateResult/Clients were left pointing at the surviving Recipes overview.

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -48,7 +48,7 @@ export const sfClientNavigation: NavEntry[] = [
       {
         title: 'Core classes',
         children: [
-          { title: 'Recipes, Models, Fusions', path: '/sf-client/api/recipes' },
+          { title: 'Recipes', path: '/sf-client/api/recipes' },
           { title: 'Models', path: '/sf-client/api/models' },
           { title: 'Benchmarks', path: '/sf-client/api/benchmarks' },
           { title: 'Reports', path: '/sf-client/api/reports' },

--- a/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
+++ b/public-docs/src/pages/sf-client/api/ModelsCatalogPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import {
@@ -16,23 +17,139 @@ const modelsRunOut = `ModelInfo('anthropic/claude-opus-4-8', provider='anthropic
 
 const detailsRun = `client.models.get("anthropic/claude-opus-4-8")`
 const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthropic', scope='chat', parameters=9, tools=2, transport=3)`
+
+const modelSig = `sf.Model(
+    model: str,
+    *,
+    name: str | None = None,
+    prompt: str | None = None,
+    params: Mapping[str, str | int | float | bool] | None = None,
+)`
 </script>
 
 <template>
   <DocLayout
     title="Models"
-    description="The discovery types model routes come back as: ModelInfo, ModelDetails, and their fields."
+    description="The Model recipe class you build, and the discovery types routes come back as: ModelInfo, ModelDetails, and their fields."
     :navigation="navigation"
     :version="version"
   >
+    <p>
+      This page documents the <code>Model</code> recipe class you build, and the read-only
+      <strong>discovery types</strong> the Engine returns when you inspect what a route supports.
+    </p>
+
+    <h2 id="model">Model</h2>
+
+    <p>
+      A <code>Model</code> is a single model route answering on its own — the simplest recipe, and
+      the building block every <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink> and
+      <RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink> is made of. See the
+      <RouterLink to="/sf-client/guides/models">Models guide</RouterLink> for help picking a route.
+    </p>
+
+    <CodeBlock :code="modelSig" language="python" />
+
+    <h3>Parameters</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>model</code></td>
+          <td><code>str</code></td>
+          <td>
+            The provider route, like <code>openrouter/openai/gpt-5.5</code>. Required, positional.
+          </td>
+        </tr>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Label that shows up in reports and on the leaderboard. Defaults to everything after the
+            last <code>/</code> in the route, so <code>openrouter/openai/gpt-5.5</code> becomes
+            <code>gpt-5.5</code>. Setting an explicit name also marks this Model as an independent
+            sample.
+          </td>
+        </tr>
+        <tr>
+          <td><code>prompt</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            The instruction given to the model alongside the case. Leave it out and the SDK uses its
+            own default prompt (not the benchmark's).
+          </td>
+        </tr>
+        <tr>
+          <td><code>params</code></td>
+          <td><code>Mapping&nbsp;|&nbsp;None</code></td>
+          <td>
+            Generation overrides like <code>temperature</code>. Values must be <code>str</code>,
+            <code>int</code>, <code>float</code>, or <code>bool</code> (floats have to be finite).
+            Only the params you set get sent, since the SDK adds no defaults. Transport, tool, and
+            benchmark-protocol names (like <code>model</code>, <code>messages</code>,
+            <code>tools</code>, <code>web_search</code>) are reserved and will be rejected.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Attributes</h3>
+
+    <p>
+      <code>model</code>, <code>name</code>, and <code>prompt</code> give you back what you passed
+      in. <code>params</code> returns a <code>mappingproxy</code>, so you can't mutate the overrides
+      after construction.
+    </p>
+
+    <h3>Raises</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>The route or name is not a string</td>
+          <td><code>TypeError</code></td>
+        </tr>
+        <tr>
+          <td>The route or name is empty or only whitespace</td>
+          <td><code>ValueError: model route must not be empty</code></td>
+        </tr>
+        <tr>
+          <td>The route or name contains control characters</td>
+          <td><code>ValueError</code></td>
+        </tr>
+        <tr>
+          <td>A <code>params</code> value is not a scalar, or a float is not finite</td>
+          <td><code>TypeError</code> / <code>ValueError</code></td>
+        </tr>
+        <tr>
+          <td>A <code>params</code> name is reserved, or a name or value cannot be encoded</td>
+          <td><code>ValueError</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Discovery types</h2>
+
     <p>
       These are the read-only values model discovery returns.
       <code>client.models.list()</code> hands back a <code>ModelInfo</code> for every route the
       configured Engine can currently reach, and <code>client.models.get(id)</code> returns the
       fuller <code>ModelDetails</code> profile for one route. Consulting them before naming a route
-      in a <RouterLink to="/sf-client/api/recipes">Model</RouterLink> is worthwhile: a route the
-      Engine does not carry raises a <code>PlanningError</code> at evaluation time rather than at
-      construction time.
+      in a <a href="#model">Model</a> is worthwhile: a route the Engine does not carry raises a
+      <code>PlanningError</code> at evaluation time rather than at construction time.
     </p>
 
     <p>
@@ -46,9 +163,8 @@ const detailsRunOut = `ModelDetails('anthropic/claude-opus-4-8', provider='anthr
     <p>
       A <code>ModelInfo</code> is one model route the configured Engine can currently reach.
       <code>client.models.list()</code> returns every addressable route, and consulting it before
-      naming a route in a <RouterLink to="/sf-client/api/recipes">Model</RouterLink> is worthwhile:
-      a route the Engine does not carry raises a <code>PlanningError</code> at evaluation time
-      rather than at construction time.
+      naming a route in a <a href="#model">Model</a> is worthwhile: a route the Engine does not
+      carry raises a <code>PlanningError</code> at evaluation time rather than at construction time.
     </p>
 
     <table>

--- a/public-docs/src/pages/sf-client/api/RecipesPage.vue
+++ b/public-docs/src/pages/sf-client/api/RecipesPage.vue
@@ -10,47 +10,6 @@ import {
   sfClientVersion as version,
 } from '@/navigation/sf-client'
 
-const modelSig = `sf.Model(
-    model: str,
-    *,
-    name: str | None = None,
-    prompt: str | None = None,
-    params: Mapping[str, str | int | float | bool] | None = None,
-)`
-
-const modelRun = `import screamingface as sf
-
-sf.Model("openrouter/openai/gpt-5.5", name="gpt-hot", params={"temperature": 0.9})`
-const modelRunOut = `Model('openrouter/openai/gpt-5.5', name='gpt-hot', params={'temperature': 0.9})`
-
-const fusionSig = `sf.Fusion(
-    members: Sequence[str | Recipe],
-    *,
-    name: str | None = None,
-    synthesizer: str | Recipe,
-)`
-
-const fusionRun = `opus = sf.Model("openrouter/anthropic/claude-opus-4.8")
-gpt = sf.Model("openrouter/openai/gpt-5.5", name="gpt-hot")
-
-sf.Fusion([opus, gpt], synthesizer="openrouter/openai/gpt-5.5")`
-const fusionRunOut = `Fusion(['claude-opus-4.8', 'gpt-hot'], synthesizer=Model('openrouter/openai/gpt-5.5'))`
-
-const pipelineSig = `sf.Pipeline(
-    stages: Sequence[str | Recipe],
-    *,
-    name: str | None = None,
-)`
-
-const pipelineRun = `draft = sf.Model("openrouter/openai/gpt-5.5")
-review = sf.Model("openrouter/anthropic/claude-opus-4.8")
-
-sf.Pipeline([draft, review], name="review-chain")`
-const pipelineRunOut = `Pipeline(['gpt-5.5', 'claude-opus-4.8'], name='review-chain')`
-
-const thenRun = `draft.then(review)`
-const thenRunOut = `Pipeline(['gpt-5.5', 'claude-opus-4.8'])`
-
 const equality = `a = sf.Model("openrouter/openai/gpt-5.5")
 b = sf.Model("openrouter/openai/gpt-5.5")
 
@@ -60,21 +19,24 @@ const equalityOut = `True`
 
 <template>
   <DocLayout
-    title="Recipes, Models, Fusions"
-    description="Recipe, Model, Fusion and Pipeline: the things you evaluate."
+    title="Recipes"
+    description="The abstract Recipe base every candidate shares, and where each concrete type is documented."
     :navigation="navigation"
     :version="version"
   >
     <p>
-      A recipe tells ScreamingFace how to produce one answer. That's what a benchmark grades. This
-      page covers <code>Model</code> (a single model route), <code>Fusion</code> (several members
-      combined by a synthesizer), <code>Pipeline</code> (members chained in series), and
-      <code>Recipe</code> (the abstract type all three inherit from).
+      A recipe tells ScreamingFace how to produce one answer — that's what a benchmark grades. This
+      page documents <code>Recipe</code>, the abstract base every candidate shares. The three
+      concrete types each have their own home: a single model route in
+      <RouterLink to="/sf-client/api/models">Models</RouterLink>, several members combined by a
+      synthesizer in the <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink>, and
+      stages chained in series in the
+      <RouterLink to="/sf-client/guides/pipelines">Pipelines guide</RouterLink>.
     </p>
 
     <p>
-      All three constructible recipes are frozen and hold no client. Building one makes no network
-      requests. You can compose them before connecting to anything. Recipes nest: a
+      Every constructible recipe is frozen and holds no client. Building one makes no network
+      requests, so you can compose them before connecting to anything. Recipes nest: a
       <code>Fusion</code> or <code>Pipeline</code> can contain a <code>Model</code>, another
       <code>Fusion</code>, or another <code>Pipeline</code>, in any combination.
     </p>
@@ -93,15 +55,15 @@ const equalityOut = `True`
     <h2>Recipe</h2>
 
     <p>
-      <code>Recipe</code> is the abstract base the other three inherit from. You can't instantiate
+      <code>Recipe</code> is the abstract base the concrete types inherit from. You can't instantiate
       it directly. It exists for type annotations and so a <code>Fusion</code> or
       <code>Pipeline</code> can hold a mixed list of members.
     </p>
 
     <p>
       Every recipe has one public attribute: <code>name</code> (a <code>str</code>). It also
-      provides <code>.then()</code>, which appends a stage and returns a <code>Pipeline</code> (see
-      <a href="#pipeline">Pipeline</a> below).
+      provides <code>.then()</code>, which appends a stage and returns a
+      <RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink>.
     </p>
 
     <p>Calling <code>sf.Recipe()</code> directly raises:</p>
@@ -111,292 +73,21 @@ const equalityOut = `True`
       language="text"
     />
 
-    <h2>Model</h2>
+    <h2>Where each type is documented</h2>
 
-    <p>
-      A <code>Model</code> is a single model route answering on its own. The simplest recipe, and
-      the baseline for everything else. See the
-      <RouterLink to="/sf-client/guides/models">Models guide</RouterLink> for help picking a route.
-    </p>
-
-    <CodeBlock :code="modelSig" language="python" />
-
-    <h3>Parameters</h3>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>model</code></td>
-          <td><code>str</code></td>
-          <td>
-            The provider route, like <code>openrouter/openai/gpt-5.5</code>. Required, positional.
-          </td>
-        </tr>
-        <tr>
-          <td><code>name</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>
-            Label that shows up in reports and on the leaderboard. Defaults to everything after the
-            last <code>/</code> in the route, so <code>openrouter/openai/gpt-5.5</code> becomes
-            <code>gpt-5.5</code>. Setting an explicit name also marks this Model as an independent
-            sample.
-          </td>
-        </tr>
-        <tr>
-          <td><code>prompt</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>
-            The instruction given to the model alongside the case. Leave it out and the SDK uses its
-            own default prompt (not the benchmark's).
-          </td>
-        </tr>
-        <tr>
-          <td><code>params</code></td>
-          <td><code>Mapping&nbsp;|&nbsp;None</code></td>
-          <td>
-            Generation overrides like <code>temperature</code>. Values must be <code>str</code>,
-            <code>int</code>, <code>float</code>, or <code>bool</code> (floats have to be finite).
-            Only the params you set get sent, since the SDK adds no defaults. Transport, tool, and
-            benchmark-protocol names (like <code>model</code>, <code>messages</code>,
-            <code>tools</code>, <code>web_search</code>) are reserved and will be rejected.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h3>Attributes</h3>
-
-    <p>
-      <code>model</code>, <code>name</code>, and <code>prompt</code> give you back what you passed
-      in. <code>params</code> returns a <code>mappingproxy</code>, so you can't mutate the overrides
-      after construction.
-    </p>
-
-    <h3>Raises</h3>
-
-    <table>
-      <thead>
-        <tr>
-          <th>When</th>
-          <th>Error</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>The route or name is not a string</td>
-          <td><code>TypeError</code></td>
-        </tr>
-        <tr>
-          <td>The route or name is empty or only whitespace</td>
-          <td><code>ValueError: model route must not be empty</code></td>
-        </tr>
-        <tr>
-          <td>The route or name contains control characters</td>
-          <td><code>ValueError</code></td>
-        </tr>
-        <tr>
-          <td>A <code>params</code> value is not a scalar, or a float is not finite</td>
-          <td><code>TypeError</code> / <code>ValueError</code></td>
-        </tr>
-        <tr>
-          <td>A <code>params</code> name is reserved, or a name or value cannot be encoded</td>
-          <td><code>ValueError</code></td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="2" :code="modelRun"><NbTextOut :text="modelRunOut" /></NbCell>
-    </div>
-
-    <h2>Fusion</h2>
-
-    <p>
-      A <code>Fusion</code> combines members: each member answers in parallel, then a
-      <strong>synthesizer</strong> reads those answers and produces one final answer. The benchmark
-      grades that final answer. See the
-      <RouterLink to="/sf-client/guides/fusions">Fusions guide</RouterLink> for the reasoning.
-    </p>
-
-    <CodeBlock :code="fusionSig" language="python" />
-
-    <h3>Parameters</h3>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>members</code></td>
-          <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
-          <td>
-            One or more members, in order. Each can be a route string, <code>Model</code>,
-            <code>Fusion</code>, or <code>Pipeline</code>. Ensembles nest.
-          </td>
-        </tr>
-        <tr>
-          <td><code>name</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>
-            Defaults to the member names joined with <code>+</code>, for example
-            <code>claude-opus-4.8+gpt-hot</code>.
-          </td>
-        </tr>
-        <tr>
-          <td><code>synthesizer</code></td>
-          <td><code>str&nbsp;|&nbsp;Recipe</code></td>
-          <td>
-            <strong>Required, keyword-only.</strong> A route string or any recipe (a
-            <code>Model</code>, <code>Fusion</code>, or <code>Pipeline</code>) that reads the
-            members' answers and writes the final one. No default.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h3>Attributes</h3>
-
-    <p>
-      <code>members</code> is a <code>tuple</code> in the order you gave. <code>name</code> is the
-      resolved label. <code>synthesizer</code> is the recipe you passed (route strings normalize to
-      <code>Model</code>). No <code>reducer</code> attribute.
-    </p>
-
-    <h3>Raises</h3>
-
-    <table>
-      <thead>
-        <tr>
-          <th>When</th>
-          <th>Error</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>No <code>synthesizer</code> is given</td>
-          <td><code>TypeError: missing a required keyword-only argument: 'synthesizer'</code></td>
-        </tr>
-        <tr>
-          <td>The members are empty</td>
-          <td><code>ValueError: a Fusion requires at least one member</code></td>
-        </tr>
-        <tr>
-          <td><code>members</code> is not an ordered sequence (for example a bare route string)</td>
-          <td>
-            <code
-              >TypeError: Fusion members must be an ordered sequence of model routes or
-              Recipes</code
-            >
-          </td>
-        </tr>
-        <tr>
-          <td>A member or the synthesizer is not a route string or a supported recipe</td>
-          <td>
-            <code>TypeError: … must be a model route or sf.Model, sf.Fusion, or sf.Pipeline</code>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="3" :code="fusionRun"><NbTextOut :text="fusionRunOut" /></NbCell>
-    </div>
-
-    <h2 id="pipeline">Pipeline</h2>
-
-    <p>
-      A <code>Pipeline</code> runs stages in series: the first stage answers the case, each later
-      stage gets the previous stage's answer as input. The benchmark grades the last stage's answer.
-      See the <RouterLink to="/sf-client/guides/pipelines">Pipelines guide</RouterLink> for serial
-      and recursive composition.
-    </p>
-
-    <CodeBlock :code="pipelineSig" language="python" />
-
-    <h3>Parameters</h3>
-
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Meaning</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>stages</code></td>
-          <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
-          <td>
-            One or more stages, in order. Each can be a route string or any recipe. An
-            <em>unnamed</em> nested <code>Pipeline</code> flattens into the surrounding sequence; a
-            <em>named</em> one stays as a single stage.
-          </td>
-        </tr>
-        <tr>
-          <td><code>name</code></td>
-          <td><code>str&nbsp;|&nbsp;None</code></td>
-          <td>
-            Defaults to the stage names joined with <code>-&gt;</code>, for example
-            <code>gpt-5.5-&gt;claude-opus-4.8</code>.
-          </td>
-        </tr>
-      </tbody>
-    </table>
-
-    <h3>Attributes</h3>
-
-    <p>
-      <code>stages</code> is a <code>tuple</code> in canonical order. <code>name</code> is the
-      resolved label. <code>recipe.then(next)</code>, available on every recipe, appends a stage and
-      returns a new <code>Pipeline</code>.
-    </p>
-
-    <h3>Raises</h3>
-
-    <table>
-      <thead>
-        <tr>
-          <th>When</th>
-          <th>Error</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>The stages are empty</td>
-          <td><code>ValueError: a Pipeline requires at least one stage</code></td>
-        </tr>
-        <tr>
-          <td><code>stages</code> is not an ordered sequence (for example a bare route string)</td>
-          <td>
-            <code
-              >TypeError: Pipeline stages must be an ordered sequence of model routes or
-              Recipes</code
-            >
-          </td>
-        </tr>
-        <tr>
-          <td><code>.then()</code> is given something other than a route string or recipe</td>
-          <td><code>TypeError: Pipeline stage must be …</code></td>
-        </tr>
-      </tbody>
-    </table>
-
-    <div class="not-prose">
-      <NbCell :count="4" :code="pipelineRun"><NbTextOut :text="pipelineRunOut" /></NbCell>
-      <NbCell :count="5" :code="thenRun"><NbTextOut :text="thenRunOut" /></NbCell>
-    </div>
+    <ul>
+      <li>
+        <strong><RouterLink to="/sf-client/api/models">Model</RouterLink></strong> — a single model
+        route. Its constructor, parameters, attributes, and errors live on the Models page.
+      </li>
+      <li>
+        <strong><RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink></strong> — members
+        combined by a synthesizer. The Fusions guide carries its full reference.
+      </li>
+      <li>
+        <strong><RouterLink to="/sf-client/guides/pipelines">Pipeline</RouterLink></strong> — stages
+        chained in series. The Pipelines guide carries its full reference.
+      </li>
+    </ul>
   </DocLayout>
 </template>

--- a/public-docs/src/pages/sf-client/guides/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ClientsPage.vue
@@ -86,16 +86,25 @@ client = sf.Client(
     :navigation="navigation"
     :version="version"
   >
+    <p>There are two ways to call the SDK, and both use the same interface.</p>
+
     <p>
-      There are two ways to call this SDK, and they share one interface. The
-      <strong>module-level shortcuts</strong> — <code>sf.evaluate(...)</code>,
-      <code>sf.connect(...)</code>, and the rest — read the shortest, so they open the
-      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> and every notebook.
-      An <strong>explicit <code>Client</code></strong> that you construct and own reads
-      longer but gives you the lifecycle, the second engine, and the event loop when a script
-      grows into something you ship. The shortcuts are not a different SDK: each one runs
-      against a single <code>Client</code> the package holds for you, so everything on this
-      page is really about <em>who owns the Client</em>.
+      Most of the time you'll reach for the <strong>module-level shortcuts</strong> —
+      <code>sf.evaluate(...)</code>, <code>sf.connect(...)</code>, and the rest. They're the shortest
+      to write, which is why the
+      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> and every notebook use them.
+    </p>
+
+    <p>
+      When a script grows into something you ship, construct an explicit
+      <strong><code>Client</code></strong> instead. It takes a little more code, but it hands you the
+      client's lifecycle, lets you point at a second engine, and works with your own event loop.
+    </p>
+
+    <p>
+      These aren't two different SDKs. Every shortcut runs against a single <code>Client</code> the
+      package creates and holds for you — so the only real question this page answers is
+      <em>who owns that Client: you, or the package</em>.
     </p>
 
     <h2>What you can do with it</h2>

--- a/public-docs/src/pages/sf-client/guides/FusionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/FusionsPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import {
@@ -34,6 +35,13 @@ const nested = `haiku = sf.Model("openrouter/anthropic/claude-haiku-4.5")
 
 sf.Fusion([pair, haiku], name="nested", synthesizer="openrouter/openai/gpt-5.5")`
 const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name='nested', synthesizer=Model('openrouter/openai/gpt-5.5'))`
+
+const fusionSig = `sf.Fusion(
+    members: Sequence[str | Recipe],
+    *,
+    name: str | None = None,
+    synthesizer: str | Recipe,
+)`
 </script>
 
 <template>
@@ -240,6 +248,93 @@ const nestedOut = `Fusion(['claude-opus-4.8+gpt-5.5', 'claude-haiku-4.5'], name=
       Members must be recipes: a <code>Model</code>, <code>Fusion</code>, or <code>Pipeline</code>
       (or a route string, which gets normalized to a <code>Model</code>).
     </p>
+
+    <h2>The <code>Fusion</code> class</h2>
+
+    <CodeBlock :code="fusionSig" language="python" />
+
+    <h3>Parameters</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>members</code></td>
+          <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
+          <td>
+            One or more members, in order. Each can be a route string, <code>Model</code>,
+            <code>Fusion</code>, or <code>Pipeline</code>. Ensembles nest.
+          </td>
+        </tr>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Defaults to the member names joined with <code>+</code>, for example
+            <code>claude-opus-4.8+gpt-hot</code>.
+          </td>
+        </tr>
+        <tr>
+          <td><code>synthesizer</code></td>
+          <td><code>str&nbsp;|&nbsp;Recipe</code></td>
+          <td>
+            <strong>Required, keyword-only.</strong> A route string or any recipe (a
+            <code>Model</code>, <code>Fusion</code>, or <code>Pipeline</code>) that reads the
+            members' answers and writes the final one. No default.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Attributes</h3>
+
+    <p>
+      <code>members</code> is a <code>tuple</code> in the order you gave. <code>name</code> is the
+      resolved label. <code>synthesizer</code> is the recipe you passed (route strings normalize to
+      <code>Model</code>). No <code>reducer</code> attribute.
+    </p>
+
+    <h3>Raises</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>No <code>synthesizer</code> is given</td>
+          <td><code>TypeError: missing a required keyword-only argument: 'synthesizer'</code></td>
+        </tr>
+        <tr>
+          <td>The members are empty</td>
+          <td><code>ValueError: a Fusion requires at least one member</code></td>
+        </tr>
+        <tr>
+          <td><code>members</code> is not an ordered sequence (for example a bare route string)</td>
+          <td>
+            <code
+              >TypeError: Fusion members must be an ordered sequence of model routes or
+              Recipes</code
+            >
+          </td>
+        </tr>
+        <tr>
+          <td>A member or the synthesizer is not a route string or a supported recipe</td>
+          <td>
+            <code>TypeError: … must be a model route or sf.Model, sf.Fusion, or sf.Pipeline</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
 
     <h2>Links</h2>
 

--- a/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
@@ -42,6 +42,12 @@ sf.Fusion(
 )`
 const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-preview'], synthesizer=Pipeline(['judge', 'writer']))`
 
+const mixed = `panel = sf.Fusion([draft, review], synthesizer=final)
+refine = sf.Pipeline([review, final], name="refine")
+
+sf.Pipeline([draft, panel, refine], name="mixed")`
+const mixedOut = `Pipeline(['gpt-5.5', 'gpt-5.5+claude-opus-4.8', 'refine'], name='mixed')`
+
 const pipelineSig = `sf.Pipeline(
     stages: Sequence[str | Recipe],
     *,
@@ -76,10 +82,10 @@ const pipelineSig = `sf.Pipeline(
 
     <figure class="not-prose" style="margin: var(--space-8) 0">
       <svg
-        viewBox="0 0 680 120"
+        class="dg"
+        viewBox="0 0 720 104"
         role="img"
-        aria-label="A pipeline passes the question through ordered stages; each stage receives the previous stage's answer, and the last stage's answer is what the benchmark grades."
-        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+        aria-label="The flow of information: member models answer, a synthesizer combines them into one answer, and grading that answer produces the graded answer."
       >
         <defs>
           <marker
@@ -94,50 +100,33 @@ const pipelineSig = `sf.Pipeline(
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <g
-          style="stroke: var(--text-2); stroke-width: 1.25; fill: none"
-          marker-end="url(#pl-arrow)"
-        >
-          <path d="M104 60 H136" />
-          <path d="M248 60 H280" />
-          <path d="M392 60 H424" />
-          <path d="M536 60 H568" />
+        <g class="edge" marker-end="url(#pl-arrow)">
+          <path d="M200 62 H288" />
+          <path d="M450 62 H544" />
         </g>
-        <g style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1">
-          <rect x="8" y="40" width="96" height="40" />
-          <rect x="136" y="38" width="112" height="44" />
-          <rect x="280" y="38" width="112" height="44" />
-          <rect x="568" y="38" width="96" height="44" />
-        </g>
-        <rect
-          x="424"
-          y="38"
-          width="112"
-          height="44"
-          style="fill: none; stroke: var(--accent); stroke-width: 1.5"
-        />
-        <g text-anchor="middle" style="fill: var(--text)">
-          <text x="56" y="64">question</text>
-          <text x="192" y="64">stage 1</text>
-          <text x="336" y="64">stage 2</text>
-          <text x="480" y="64">final stage</text>
-          <text x="616" y="64">answer</text>
+        <text x="250" y="50" text-anchor="middle" class="sub">stage</text>
+        <text x="503" y="50" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="16" y="40" width="184" height="44" />
+        <rect class="box synth" x="300" y="40" width="150" height="44" />
+        <rect class="box graded" x="556" y="40" width="150" height="44" />
+        <g class="lbl" text-anchor="middle">
+          <text x="108" y="66">members / models</text>
+          <text x="375" y="66">synthesizer</text>
+          <text x="631" y="66">Graded answer</text>
         </g>
       </svg>
-      <figcaption
-        style="
-          font-family: var(--f-mono);
-          font-size: var(--text-label);
-          text-transform: uppercase;
-          letter-spacing: 0.08em;
-          color: var(--text-2);
-          margin-top: var(--space-3);
-        "
-      >
-        Each stage receives the previous stage's answer; the final stage's answer is what the
-        benchmark grades.
+      <figcaption class="dgcap">
+        The flow of information: the member models answer, a synthesizer combines them into one
+        answer, and grading that answer produces the graded answer.
       </figcaption>
     </figure>
+
+    <div class="dgkey not-prose">
+      <span><i class="stage"></i>Stage / member</span>
+      <span><i class="synth"></i>Final stage (synthesizer)</span>
+      <span><i class="graded"></i>Graded answer</span>
+      <span><i class="pl"></i>Pipeline (dashed = unnamed, flattens)</span>
+    </div>
 
     <h2>What you can do</h2>
 
@@ -199,31 +188,36 @@ const pipelineSig = `sf.Pipeline(
 
     <figure class="not-prose" style="margin: var(--space-6) 0">
       <svg
-        viewBox="0 0 480 92"
+        class="dg"
+        viewBox="0 0 654 120"
         role="img"
-        aria-label="review-chain runs draft then review in series; the review stage's answer is graded."
-        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+        aria-label="The review-chain Pipeline holds draft then review; grading review's answer produces the graded answer."
       >
         <defs>
           <marker id="pl-a1" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <text x="240" y="16" text-anchor="middle" style="fill: var(--text-2)">review-chain</text>
-        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a1)">
-          <path d="M186 52 H290" />
+        <g class="edge" marker-end="url(#pl-a1)">
+          <path d="M162 80 H240" />
+          <path d="M392 80 H482" />
         </g>
-        <rect x="16" y="30" width="170" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
-        <rect x="294" y="30" width="170" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
-        <g text-anchor="middle" style="fill: var(--text)">
-          <text x="101" y="56">draft</text>
-          <text x="379" y="56">review · graded</text>
+        <rect class="frame" x="16" y="34" width="376" height="80" />
+        <text x="24" y="50" class="sub">review-chain</text>
+        <text x="204" y="66" text-anchor="middle" class="sub">stage</text>
+        <text x="437" y="66" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="32" y="60" width="130" height="40" />
+        <rect class="box synth" x="246" y="60" width="130" height="40" />
+        <rect class="box graded" x="492" y="60" width="150" height="40" />
+        <g class="lbl" text-anchor="middle">
+          <text x="97" y="84">draft</text>
+          <text x="311" y="84">review</text>
+          <text x="567" y="84">Graded answer</text>
         </g>
       </svg>
-      <figcaption
-        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
-      >
-        Two stages in series; the review stage's answer is what the benchmark grades.
+      <figcaption class="dgcap">
+        The review-chain Pipeline holds draft then review; grading review's answer is the graded
+        answer.
       </figcaption>
     </figure>
 
@@ -240,35 +234,40 @@ const pipelineSig = `sf.Pipeline(
 
     <figure class="not-prose" style="margin: var(--space-6) 0">
       <svg
-        viewBox="0 0 560 84"
+        class="dg"
+        viewBox="0 0 868 120"
         role="img"
-        aria-label="draft.then(review).then(final) chains three stages in series, left to right."
-        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+        aria-label="One Pipeline of draft, review and final; grading final's answer produces the graded answer."
       >
         <defs>
           <marker id="pl-a2" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a2)">
-          <path d="M166 44 H201" />
-          <path d="M355 44 H390" />
+        <g class="edge" marker-end="url(#pl-a2)">
+          <path d="M162 80 H240" />
+          <path d="M376 80 H454" />
+          <path d="M606 80 H696" />
         </g>
-        <g style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1">
-          <rect x="16" y="22" width="150" height="44" />
-          <rect x="205" y="22" width="150" height="44" />
-        </g>
-        <rect x="394" y="22" width="150" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
-        <g text-anchor="middle" style="fill: var(--text)">
-          <text x="91" y="48">draft</text>
-          <text x="280" y="48">review</text>
-          <text x="469" y="48">final · graded</text>
+        <rect class="frame" x="16" y="34" width="590" height="80" />
+        <text x="24" y="50" class="sub">Pipeline</text>
+        <text x="204" y="66" text-anchor="middle" class="sub">stage</text>
+        <text x="418" y="66" text-anchor="middle" class="sub">stage</text>
+        <text x="651" y="66" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="32" y="60" width="130" height="40" />
+        <rect class="box stage" x="246" y="60" width="130" height="40" />
+        <rect class="box synth" x="460" y="60" width="130" height="40" />
+        <rect class="box graded" x="706" y="60" width="150" height="40" />
+        <g class="lbl" text-anchor="middle">
+          <text x="97" y="84">draft</text>
+          <text x="311" y="84">review</text>
+          <text x="525" y="84">final</text>
+          <text x="781" y="84">Graded answer</text>
         </g>
       </svg>
-      <figcaption
-        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
-      >
-        <code>.then()</code> builds the same three-stage chain, read left to right.
+      <figcaption class="dgcap">
+        <code>.then()</code> builds one Pipeline of three stages; only the last stage's answer is
+        graded.
       </figcaption>
     </figure>
 
@@ -285,41 +284,41 @@ const pipelineSig = `sf.Pipeline(
 
     <figure class="not-prose" style="margin: var(--space-6) 0">
       <svg
-        viewBox="0 0 620 132"
+        class="dg"
+        viewBox="0 0 938 164"
         role="img"
-        aria-label="An unnamed inner Pipeline flattens: draft, review and final run as one sequence."
-        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+        aria-label="The unnamed inner Pipeline (dashed) flattens into the outer Pipeline; grading the last stage's answer produces the graded answer."
       >
         <defs>
           <marker id="pl-a3" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a3)">
-          <path d="M146 68 H192" />
-          <path d="M370 76 H426" />
+        <g class="edge" marker-end="url(#pl-a3)">
+          <path d="M166 106 H278" />
+          <path d="M430 106 H508" />
+          <path d="M676 106 H766" />
         </g>
-        <rect
-          x="196"
-          y="20"
-          width="408"
-          height="96"
-          style="fill: none; stroke: var(--border-strong); stroke-width: 1; stroke-dasharray: 4 4"
-        />
-        <text x="206" y="38" style="fill: var(--text-2); font-size: 11px">Pipeline (unnamed)</text>
-        <rect x="16" y="46" width="130" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
-        <rect x="220" y="54" width="150" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
-        <rect x="430" y="54" width="150" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
-        <g text-anchor="middle" style="fill: var(--text)">
-          <text x="81" y="72">draft</text>
-          <text x="295" y="80">review</text>
-          <text x="505" y="80">final · graded</text>
+        <rect class="frame" x="16" y="40" width="660" height="108" />
+        <text x="24" y="56" class="sub">Pipeline</text>
+        <rect class="frame" x="284" y="58" width="376" height="80" style="stroke-dasharray: 4 4" />
+        <text x="292" y="74" class="sub">Pipeline (unnamed)</text>
+        <text x="222" y="94" text-anchor="middle" class="sub">stage</text>
+        <text x="721" y="94" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="36" y="86" width="130" height="40" />
+        <rect class="box stage" x="300" y="86" width="130" height="40" />
+        <rect class="box synth" x="514" y="86" width="130" height="40" />
+        <rect class="box graded" x="776" y="86" width="150" height="40" />
+        <g class="lbl" text-anchor="middle">
+          <text x="101" y="110">draft</text>
+          <text x="365" y="110">review</text>
+          <text x="579" y="110">final</text>
+          <text x="851" y="110">Graded answer</text>
         </g>
       </svg>
-      <figcaption
-        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
-      >
-        The unnamed inner Pipeline flattens — draft → review → final runs as one sequence.
+      <figcaption class="dgcap">
+        The unnamed inner Pipeline flattens into the outer one — draft → review → final runs as a
+        single sequence.
       </figcaption>
     </figure>
 
@@ -334,41 +333,41 @@ const pipelineSig = `sf.Pipeline(
 
     <figure class="not-prose" style="margin: var(--space-6) 0">
       <svg
-        viewBox="0 0 620 132"
+        class="dg"
+        viewBox="0 0 938 164"
         role="img"
-        aria-label="A named inner Pipeline (polish-pass) stays a single stage: draft then polish-pass, which itself is review then final."
-        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+        aria-label="The named inner Pipeline polish-pass is kept as one stage inside the outer Pipeline; grading its last stage's answer produces the graded answer."
       >
         <defs>
           <marker id="pl-a4" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a4)">
-          <path d="M146 68 H192" />
-          <path d="M370 76 H426" />
+        <g class="edge" marker-end="url(#pl-a4)">
+          <path d="M166 106 H278" />
+          <path d="M430 106 H508" />
+          <path d="M676 106 H766" />
         </g>
-        <rect
-          x="196"
-          y="20"
-          width="408"
-          height="96"
-          style="fill: none; stroke: var(--border-strong); stroke-width: 1.25"
-        />
-        <text x="206" y="38" style="fill: var(--text-2); font-size: 11px">polish-pass (named · one stage)</text>
-        <rect x="16" y="46" width="130" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
-        <rect x="220" y="54" width="150" height="44" style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1" />
-        <rect x="430" y="54" width="150" height="44" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
-        <g text-anchor="middle" style="fill: var(--text)">
-          <text x="81" y="72">draft</text>
-          <text x="295" y="80">review</text>
-          <text x="505" y="80">final · graded</text>
+        <rect class="frame" x="16" y="40" width="660" height="108" />
+        <text x="24" y="56" class="sub">Pipeline</text>
+        <rect class="frame" x="284" y="58" width="376" height="80" />
+        <text x="292" y="74" class="sub">polish-pass (named · one stage)</text>
+        <text x="222" y="94" text-anchor="middle" class="sub">stage</text>
+        <text x="721" y="94" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="36" y="86" width="130" height="40" />
+        <rect class="box stage" x="300" y="86" width="130" height="40" />
+        <rect class="box synth" x="514" y="86" width="130" height="40" />
+        <rect class="box graded" x="776" y="86" width="150" height="40" />
+        <g class="lbl" text-anchor="middle">
+          <text x="101" y="110">draft</text>
+          <text x="365" y="110">review</text>
+          <text x="579" y="110">final</text>
+          <text x="851" y="110">Graded answer</text>
         </g>
       </svg>
-      <figcaption
-        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
-      >
-        A named inner Pipeline is kept as one stage: draft → polish-pass (itself review → final).
+      <figcaption class="dgcap">
+        A named inner Pipeline (polish-pass) stays one stage of the outer Pipeline: draft →
+        polish-pass, itself review → final.
       </figcaption>
     </figure>
 
@@ -387,51 +386,101 @@ const pipelineSig = `sf.Pipeline(
 
     <figure class="not-prose" style="margin: var(--space-6) 0">
       <svg
-        viewBox="0 0 720 196"
+        class="dg"
+        viewBox="0 0 994 210"
         role="img"
-        aria-label="A Fusion of two members — a draft-then-review pipeline and gemini — combined by a synthesizer that is itself a judge-then-writer pipeline."
-        style="width: 100%; height: auto; font-family: var(--f-mono); font-size: 12px"
+        aria-label="A Fusion whose members are a draft-to-review Pipeline and gemini, combined by a synthesizer that is itself a judge-to-writer Pipeline; grading the writer's answer produces the graded answer."
       >
         <defs>
           <marker id="pl-a5" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
             <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
           </marker>
         </defs>
-        <text x="16" y="16" style="fill: var(--text-2)">Fusion · members</text>
-        <g style="stroke: var(--text-2); stroke-width: 1.25; fill: none" marker-end="url(#pl-a5)">
-          <path d="M136 48 H168" />
-          <path d="M292 48 C372 48 372 98 448 98" />
-          <path d="M136 128 C300 128 372 98 448 98" />
-          <path d="M572 104 H590" />
+        <text x="16" y="18" class="sub">Fusion · members</text>
+        <g class="edge" marker-end="url(#pl-a5)">
+          <path d="M152 70 H230" />
+          <path d="M572 114 H600" />
+          <path d="M372 64 C412 64 412 108 452 108" />
+          <path d="M152 146 C300 146 412 108 452 108" />
+          <path d="M732 108 H822" />
         </g>
-        <g style="fill: var(--surface); stroke: var(--border-strong); stroke-width: 1">
-          <rect x="16" y="28" width="120" height="40" />
-          <rect x="172" y="28" width="120" height="40" />
-          <rect x="16" y="108" width="120" height="40" />
-          <rect x="464" y="86" width="108" height="36" />
-        </g>
-        <rect
-          x="452"
-          y="58"
-          width="252"
-          height="80"
-          style="fill: none; stroke: var(--border-strong); stroke-width: 1.25"
-        />
-        <text x="462" y="76" style="fill: var(--text-2); font-size: 11px">synthesizer · Pipeline</text>
-        <rect x="596" y="86" width="96" height="36" style="fill: none; stroke: var(--accent); stroke-width: 1.5" />
-        <g text-anchor="middle" style="fill: var(--text)">
-          <text x="76" y="52">draft</text>
-          <text x="232" y="52">review</text>
-          <text x="76" y="132">gemini</text>
-          <text x="518" y="108">judge</text>
-          <text x="644" y="108">writer</text>
+        <rect class="frame" x="16" y="28" width="356" height="72" />
+        <text x="24" y="44" class="sub">Pipeline</text>
+        <rect class="frame" x="452" y="72" width="280" height="72" />
+        <text x="460" y="88" class="sub">synthesizer · Pipeline</text>
+        <text x="777" y="94" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="32" y="52" width="120" height="36" />
+        <rect class="box stage" x="236" y="52" width="120" height="36" />
+        <rect class="box stage" x="32" y="128" width="120" height="36" />
+        <rect class="box stage" x="468" y="96" width="104" height="36" />
+        <rect class="box synth" x="604" y="96" width="104" height="36" />
+        <rect class="box graded" x="832" y="90" width="150" height="40" />
+        <g class="lbl" text-anchor="middle">
+          <text x="92" y="74">draft</text>
+          <text x="296" y="74">review</text>
+          <text x="92" y="150">gemini</text>
+          <text x="520" y="118">judge</text>
+          <text x="656" y="118">writer</text>
+          <text x="907" y="114">Graded answer</text>
         </g>
       </svg>
-      <figcaption
-        style="font-family: var(--f-mono); font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-2); margin-top: var(--space-3)"
+      <figcaption class="dgcap">
+        A Fusion of two members — the draft → review Pipeline and gemini — combined by a synthesizer
+        that is itself a judge → writer Pipeline; grading the writer's answer is the graded answer.
+      </figcaption>
+    </figure>
+
+    <h3>5 · Mix recipe types as stages</h3>
+
+    <p>
+      Because a stage is just a recipe, one Pipeline can mix a <code>Model</code>, a
+      <code>Fusion</code>, and a nested <code>Pipeline</code> as its stages. Each one counts as a
+      single stage, and the last stage's answer is still what the benchmark grades.
+    </p>
+
+    <div class="not-prose">
+      <NbCell :count="6" :code="mixed"><NbTextOut :text="mixedOut" /></NbCell>
+    </div>
+
+    <figure class="not-prose" style="margin: var(--space-6) 0">
+      <svg
+        class="dg"
+        viewBox="0 0 860 152"
+        role="img"
+        aria-label="One Pipeline whose stages are a Model, a Fusion and a nested Pipeline; grading the last stage's answer produces the graded answer."
       >
-        A Fusion of two members (the draft → review pipeline and gemini), combined by a synthesizer
-        that is itself a judge → writer pipeline. The synthesizer's last stage (writer) is graded.
+        <defs>
+          <marker id="pl-a6" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <path d="M0 0 L8 4 L0 8 z" style="fill: var(--text-2)" />
+          </marker>
+        </defs>
+        <g class="edge" marker-end="url(#pl-a6)">
+          <path d="M170 82 H240" />
+          <path d="M376 82 H446" />
+          <path d="M598 82 H688" />
+        </g>
+        <rect class="frame" x="16" y="34" width="582" height="104" />
+        <text x="24" y="50" class="sub">Pipeline · mixed</text>
+        <text x="643" y="70" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="40" y="62" width="130" height="40" />
+        <rect class="box stage" x="246" y="62" width="130" height="40" />
+        <rect class="box synth" x="452" y="62" width="130" height="40" />
+        <rect class="box graded" x="698" y="62" width="150" height="40" />
+        <g class="lbl" text-anchor="middle">
+          <text x="105" y="86">draft</text>
+          <text x="311" y="86">panel</text>
+          <text x="517" y="86">refine</text>
+          <text x="773" y="86">Graded answer</text>
+        </g>
+        <g class="sub" text-anchor="middle">
+          <text x="105" y="124">Model</text>
+          <text x="311" y="124">Fusion</text>
+          <text x="517" y="124">Pipeline</text>
+        </g>
+      </svg>
+      <figcaption class="dgcap">
+        A stage is any recipe — here a Model, a Fusion and a nested Pipeline chained in one Pipeline;
+        only the last stage's answer is graded.
       </figcaption>
     </figure>
 
@@ -522,3 +571,88 @@ const pipelineSig = `sf.Pipeline(
     </ul>
   </DocLayout>
 </template>
+
+<style scoped>
+/* Composition diagrams: neutral boxes, role encoded by border colour (categorical
+   --data-* palette per SFDS), never status colours. Pipelines are marked with a
+   labelled frame (dashed = an unnamed pipeline that flattens away). */
+.dg {
+  width: 100%;
+  height: auto;
+  font-family: var(--f-mono);
+  font-size: 13px;
+}
+.dg .box {
+  fill: var(--surface);
+  stroke: var(--border);
+  stroke-width: 1.75;
+}
+.dg .stage {
+  stroke: var(--data-azure-500);
+}
+.dg .synth {
+  stroke: var(--data-orange-500);
+}
+.dg .graded {
+  stroke: var(--data-green-500);
+}
+.dg .lbl {
+  fill: var(--text);
+  font-weight: 500;
+}
+.dg .sub {
+  fill: var(--text-2);
+  font-size: 12px;
+}
+.dg .edge {
+  fill: none;
+  stroke: var(--text-2);
+  stroke-width: 1.25;
+}
+.dg .frame {
+  fill: none;
+  stroke: var(--border-2);
+  stroke-width: 1.25;
+}
+
+.dgcap {
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--text-2);
+  margin-top: var(--space-4);
+  max-width: 62ch;
+}
+
+.dgkey {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-6);
+  margin: var(--space-5) 0 var(--space-8);
+  font-family: var(--f-mono);
+  font-size: var(--text-sm);
+  color: var(--text-2);
+}
+.dgkey span {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.dgkey i {
+  width: 12px;
+  height: 12px;
+  border: 2px solid;
+  flex: none;
+}
+.dgkey .stage {
+  border-color: var(--data-azure-500);
+}
+.dgkey .synth {
+  border-color: var(--data-orange-500);
+}
+.dgkey .graded {
+  border-color: var(--data-green-500);
+}
+.dgkey .pl {
+  border-color: var(--border-2);
+}
+</style>

--- a/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { RouterLink } from 'vue-router'
 import DocLayout from '@/components/layout/DocLayout.vue'
+import CodeBlock from '@/components/ui/CodeBlock.vue'
 import NbCell from '@/components/nb/NbCell.vue'
 import NbTextOut from '@/components/nb/NbTextOut.vue'
 import {
@@ -40,6 +41,12 @@ sf.Fusion(
     synthesizer=sf.Pipeline([judge, writer]),
 )`
 const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-preview'], synthesizer=Pipeline(['judge', 'writer']))`
+
+const pipelineSig = `sf.Pipeline(
+    stages: Sequence[str | Recipe],
+    *,
+    name: str | None = None,
+)`
 </script>
 
 <template>
@@ -50,10 +57,14 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
     :version="version"
   >
     <p>
-      A <strong>Pipeline</strong> runs stages one after another. The first stage answers the case,
-      each later stage gets the <em>previous</em> stage's answer as input. A draft gets reviewed,
-      then polished. The benchmark grades the last stage's answer, so a Pipeline competes with a
-      solo <RouterLink to="/sf-client/guides/models">Model</RouterLink> or a
+      A <strong>Pipeline</strong> is a recipe composed of an ordered list of
+      <strong>stages</strong>. It doesn't run anything by itself — like every recipe, building one
+      makes no requests. The stages run only during an
+      <RouterLink to="/sf-client/guides/running-an-evaluation">evaluation</RouterLink>: the first
+      stage answers the case, and each later stage takes the <em>previous</em> stage's answer as its
+      input (a draft gets reviewed, then polished). The benchmark grades only the last stage's
+      answer, so a Pipeline competes head-to-head with a solo
+      <RouterLink to="/sf-client/guides/models">Model</RouterLink> or a
       <RouterLink to="/sf-client/guides/fusions">Fusion</RouterLink>.
     </p>
 
@@ -424,10 +435,78 @@ const recursiveOut = `Fusion(['gpt-5.5->claude-opus-4.8', 'gemini-3.1-pro-previe
       </figcaption>
     </figure>
 
+    <h2>The <code>Pipeline</code> class</h2>
+
+    <CodeBlock :code="pipelineSig" language="python" />
+
+    <h3>Parameters</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Type</th>
+          <th>Meaning</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>stages</code></td>
+          <td><code>Sequence[str&nbsp;|&nbsp;Recipe]</code></td>
+          <td>
+            One or more stages, in order. Each can be a route string or any recipe. An
+            <em>unnamed</em> nested <code>Pipeline</code> flattens into the surrounding sequence; a
+            <em>named</em> one stays as a single stage.
+          </td>
+        </tr>
+        <tr>
+          <td><code>name</code></td>
+          <td><code>str&nbsp;|&nbsp;None</code></td>
+          <td>
+            Defaults to the stage names joined with <code>-&gt;</code>, for example
+            <code>gpt-5.5-&gt;claude-opus-4.8</code>.
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Attributes</h3>
+
     <p>
-      Check the <RouterLink to="/sf-client/api/recipes">Recipes reference</RouterLink> for the full
-      <code>Pipeline</code> signature, attributes, and errors.
+      <code>stages</code> is a <code>tuple</code> in canonical order. <code>name</code> is the
+      resolved label. <code>recipe.then(next)</code>, available on every recipe, appends a stage and
+      returns a new <code>Pipeline</code>.
     </p>
+
+    <h3>Raises</h3>
+
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Error</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>The stages are empty</td>
+          <td><code>ValueError: a Pipeline requires at least one stage</code></td>
+        </tr>
+        <tr>
+          <td><code>stages</code> is not an ordered sequence (for example a bare route string)</td>
+          <td>
+            <code
+              >TypeError: Pipeline stages must be an ordered sequence of model routes or
+              Recipes</code
+            >
+          </td>
+        </tr>
+        <tr>
+          <td><code>.then()</code> is given something other than a route string or recipe</td>
+          <td><code>TypeError: Pipeline stage must be …</code></td>
+        </tr>
+      </tbody>
+    </table>
 
     <h2>Links</h2>
 


### PR DESCRIPTION
Follow-up to #615 (OME-846, merged). The combined **"Recipes, Models, Fusions"** API page documented four types at once; this moves each concrete recipe type to one home so the reference reads in one place per type, and clarifies the Pipelines guide. Docs only.

## Changes
- **Recipes API page** (`api/RecipesPage.vue`) + nav: retitled **"Recipes, Models, Fusions" → "Recipes"**; keeps only the abstract `Recipe` base, the value-equality note, and a *Where each type is documented* pointer list.
- **Models page** (`api/ModelsCatalogPage.vue`): gains the **`Model` recipe class** reference (constructor/params/attributes/raises) above the discovery types, which are now grouped under a *Discovery types* heading.
- **Fusions guide** (`guides/FusionsPage.vue`): gains **The `Fusion` class** reference section.
- **Pipelines guide** (`guides/PipelinesPage.vue`): gains **The `Pipeline` class** reference; intro rewritten to clarify a Pipeline is a *recipe composed of stages* that run **during an evaluation** (distinct from the Pipeline object itself).
- Cross-links: `ModelsCatalogPage`'s `/api/recipes` "Model" links now point to the on-page `#model` anchor; the moved-out "Recipes reference" pointer on Pipelines is replaced by the reference itself. Generic "recipe" links (CandidateResult/Clients) still point at the Recipes overview.

## Test plan
- `vue-tsc --noEmit` + `vite build` ✓ · `oxlint .` ✓ · `eslint .` ✓ (CI-equivalent, no `--fix`).
- Please eyeball the sidebar + the three moved sections in `npm run dev`.

Refs: OME-853

🤖 Generated with [Claude Code](https://claude.com/claude-code)