### PR TITLE
feat(benchmarks): Benchmark eval quality - working corrective loops, legible failures, truthful report chips

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -165,6 +165,13 @@ def _default_model_slugs() -> list[str]:
         "openrouter/anthropic/claude-opus-4.5",
         "openrouter/anthropic/claude-sonnet-4.6",
         "openrouter/anthropic/claude-sonnet-4.5",
+        # OME-856: open-weight notebook lineup members OME-816 does not cover, present in
+        # the live OpenRouter catalog on 2026-08-17; re-check at release.
+        "openrouter/qwen/qwen3-coder",
+        "openrouter/deepseek/deepseek-v4-flash",
+        # Lightweight open-weight corrective-loop members (IFEval-fallible by design).
+        "openrouter/mistralai/ministral-3b-2512",
+        "openrouter/microsoft/phi-4",
     ]
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
@@ -95,6 +95,11 @@ _SEEDS = [
     "openrouter/anthropic/claude-opus-4.5",
     "openrouter/anthropic/claude-sonnet-4.6",
     "openrouter/anthropic/claude-sonnet-4.5",
+    # OME-856: open-weight notebook lineup members OME-816 does not cover.
+    "openrouter/qwen/qwen3-coder",
+    "openrouter/deepseek/deepseek-v4-flash",
+    "openrouter/mistralai/ministral-3b-2512",
+    "openrouter/microsoft/phi-4",
 ]
 
 

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/case_results.py
@@ -278,30 +278,42 @@ def _checks(
         record = by_id.get(criterion_id)
         if record is None or optional_integer(record.get("case_id")) != case_id:
             raise AggregateError(f"Case {case_id} has no Engine-bound Check {criterion_id!r}")
-        checks.append(
-            {
-                "type": "criterion",
-                "id": criterion_id,
-                "label": record["requirement"],
-                "evidence": [
-                    _evidence(item)
-                    for item in sorted(
-                        (
-                            item
-                            for item in evidence
-                            if str(item.get("criterion_id")) == criterion_id
-                        ),
-                        key=lambda item: int(item["sequence"]),
-                    )
-                ],
-                "metadata": {
-                    "criterion_type": record["criterion_type"],
-                    "weight": criterion["weight"],
-                    "axis": criterion["axis"],
-                },
-            }
-        )
+        selected_evidence = [
+            _evidence(item)
+            for item in sorted(
+                (item for item in evidence if str(item.get("criterion_id")) == criterion_id),
+                key=lambda item: int(item["sequence"]),
+            )
+        ]
+        check: dict[str, Any] = {
+            "type": "criterion",
+            "id": criterion_id,
+            "label": record["requirement"],
+            "evidence": selected_evidence,
+            "metadata": {
+                "criterion_type": record["criterion_type"],
+                "weight": criterion["weight"],
+                "axis": criterion["axis"],
+            },
+        }
+        # Check-level verdict in the report schema's vocabulary — same contract the
+        # healthbench builder documents ("without a top-level outcome the SDK renders
+        # the check as unjudged"). DRACO's 5 seeded passes fold to their MAJORITY over
+        # the VALID passes; no valid pass, or a tie among them (possible only when
+        # invalid passes thin the odd count), leaves the check honestly outcome-less.
+        outcome = _majority_outcome(selected_evidence)
+        if outcome is not None:
+            check["outcome"] = outcome
+        checks.append(check)
     return checks
+
+
+def _majority_outcome(evidence: Sequence[Mapping[str, Any]]) -> str | None:
+    met = sum(1 for item in evidence if item.get("outcome") == "MET")
+    unmet = sum(1 for item in evidence if item.get("outcome") == "UNMET")
+    if met == unmet:
+        return None
+    return "MET" if met > unmet else "UNMET"
 
 
 def _evidence(record: Mapping[str, Any]) -> dict[str, Any]:

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/draco/check_policy.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/draco/check_policy.py
@@ -48,13 +48,22 @@ DRACO_RUBRIC_SHAPE = RubricShape(
 )
 
 
+# The check judge asks for one whole-rubric verdict array in a single call, and the
+# judge is a reasoning model whose thinking tokens count against max_tokens. Canonical
+# grading's 4096 pin (one criterion per call) starves that batched reply — the judge
+# spends the whole budget thinking and the verdict JSON never completes. The check
+# keeps its own budget; JUDGE_PARAMS stays untouched because it feeds REVISION.
+CHECK_JUDGE_PARAMS = tuple(
+    (name, "32768" if name == "max_tokens" else value) for name, value in JUDGE_PARAMS
+)
+
 DRACO_CHECK = RubricCheck(
     label="DRACO",
     criterion=CHECK_CRITERION,
     threshold=CHECK_THRESHOLD,
     shape=DRACO_RUBRIC_SHAPE,
     judge_model=JUDGE_MODEL,
-    judge_params=JUDGE_PARAMS,
+    judge_params=CHECK_JUDGE_PARAMS,
     feedback="areas",
     question="text",
 )

--- a/apps/url4-cloud/src/url4_cloud/benchmarks/rubric_check.py
+++ b/apps/url4-cloud/src/url4_cloud/benchmarks/rubric_check.py
@@ -306,16 +306,40 @@ async def _judged(
     criteria: Sequence[Mapping[str, Any]],
 ) -> dict[str, bool]:
     prompt = build_check_prompt(question, answer, criteria)
+    last_reply = ""
     for attempt in range(1, CHECK_ATTEMPTS + 1):
-        reply = await node.evaluate(
-            _judge_expression(config), env={"prompt": _attempt_prompt(prompt, attempt)}
-        )
+        try:
+            reply = await node.evaluate(
+                _judge_expression(config), env={"prompt": _attempt_prompt(prompt, attempt)}
+            )
+        except ResolutionError as exc:
+            if getattr(exc, "code", None) != "model_token_cap":
+                raise
+            # Re-attribute the runner's token-cap failure to the CHECK JUDGE: without the
+            # role, the report reads as the candidate running dry. Same budget, same
+            # truncation — retrying pays to fail identically, so fail on first strike.
+            raise _unavailable(
+                f"the {config.label} check judge ran out of tokens "
+                f"(judge {_judge_budget(config)}, set in the benchmark's check_policy): {exc}"
+            ) from exc
         verdicts = _verdicts(reply.text, criteria)
         if verdicts is not None:
             return verdicts
+        last_reply = reply.text or ""
+    # Url4Result carries no finish_reason, so the reply's shape is the only signal a
+    # reader gets: a long reply whose tail is mid-JSON means truncation (raise the
+    # judge's token budget); a short prose tail means the judge ignored the format.
     raise _unavailable(
         f"the {config.label} check judge returned no usable verdict in {CHECK_ATTEMPTS} attempts"
+        f" (judge {_judge_budget(config)}, set in the benchmark's check_policy; "
+        f"last reply: {len(last_reply)} chars, tail: {last_reply[-160:]!r})"
     )
+
+
+def _judge_budget(config: RubricCheck) -> str:
+    """The judge's token budget as message text — the knob a failure must name."""
+    cap = dict(config.judge_params).get("max_tokens")
+    return f"max_tokens={cap}" if cap is not None else "max_tokens unset (provider default)"
 
 
 def build_check_prompt(
@@ -405,6 +429,10 @@ def _verdict_row(row: object, count: int) -> tuple[int, bool] | None:
         return None
     ordinal = row.get("id")
     status = row.get("status")
+    # Judges routinely quote the ordinal ('"id": "51"'); a digit string is the same
+    # verdict, so it decodes rather than voiding an otherwise-complete reply.
+    if isinstance(ordinal, str) and ordinal.strip().isdigit():
+        ordinal = int(ordinal.strip())
     numbered = not isinstance(ordinal, bool) and isinstance(ordinal, int) and 1 <= ordinal <= count
     decided = isinstance(status, str) and status.strip().upper() in {"MET", "UNMET"}
     if not (numbered and decided):

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -412,7 +412,7 @@ async def _chat_completion_loop(
         # INVARIANT: report BEFORE classifying. A refused turn is the case a reviewer most needs
         # to audit, and raising first would lose exactly the event OME-679 exists to capture.
         _report_response(choice, outcome)
-        raise_if_unusable(choice)
+        raise_if_unusable(choice, max_tokens=sampling.get("max_tokens"))
         content, tool_calls = choice.content, choice.tool_calls
         if not tool_calls:
             # Recorded HERE, not per round trip: a tool loop is several round trips serving ONE

--- a/apps/url4-cloud/src/url4_cloud/runner/model_response.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/model_response.py
@@ -39,13 +39,36 @@ def parse_choice(data: dict) -> Choice:
     )
 
 
-def raise_if_unusable(choice: Choice) -> None:
-    """Reject a refusal or a choice carrying neither answer nor tool call."""
+def raise_if_unusable(choice: Choice, *, max_tokens: object | None = None) -> None:
+    """Reject a refusal, a token-exhausted empty turn, or a choice carrying neither
+    answer nor tool call.
+
+    `max_tokens` is the budget the REQUEST asked for (when it set one) so the
+    token-cap message can name the exact number to raise instead of a vague hint.
+    """
     # INVARIANT: refusal precedes emptiness because content-filter turns normally carry null text.
     if choice.finish_reason == "content_filter" or choice.refusal is not None:
         raise RunnerRequestError(
             "provider refused the request",
             code="provider_refusal",
+            permanent=True,
+            outcome=ModelOutcome(choice.finish_reason, choice.refusal),
+        )
+    # INVARIANT: token exhaustion precedes the malformed fallback — an all-reasoning
+    # `length` turn carries no text by construction, and labeling it a gateway fault
+    # sends the reader debugging the wrong component. Truncated-but-present text is
+    # NOT rejected here: a partial answer may still be usable downstream.
+    if (
+        choice.finish_reason == "length"
+        and not choice.tool_calls
+        and not (choice.content or "").strip()
+    ):
+        budget = f"max_tokens={max_tokens}" if max_tokens is not None else "its max_tokens budget"
+        raise RunnerRequestError(
+            f"model ran out of tokens before completing an answer (finish_reason=length; "
+            f"{budget} was fully consumed — for reasoning models thinking counts against it). "
+            "Raise max_tokens on this call.",
+            code="model_token_cap",
             permanent=True,
             outcome=ModelOutcome(choice.finish_reason, choice.refusal),
         )

--- a/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
+++ b/apps/url4-cloud/tests/unit/test_draco_case_artifacts.py
@@ -168,6 +168,8 @@ async def test_canonical_draco_retains_complete_case_evidence(tmp_path: Path) ->
                             "weight": 3,
                             "axis": "correctness",
                         },
+                        # OME-848: the 5 passes fold to their majority verdict.
+                        "outcome": "MET",
                     }
                 ],
             },

--- a/apps/url4-cloud/tests/unit/test_draco_check_outcome_aggregation.py
+++ b/apps/url4-cloud/tests/unit/test_draco_check_outcome_aggregation.py
@@ -1,0 +1,132 @@
+"""DRACO's 5-pass verdicts must fold into each check's top-level outcome (OME-848).
+
+FEATURE: DRACO grades every criterion with 5 seeded judge passes. The report schema's
+contract (documented at the healthbench builder: "Without a top-level outcome the SDK
+renders the check as unjudged") expects each check to carry one summary verdict —
+DRACO shipped only the 5 raw evidence entries, so every criterion rendered unjudged
+and the report view colored chips by criterion sign instead of by verdict.
+STORY: as a researcher reading a DRACO case, a criterion my answer met 5/5 shows MET,
+a 3/2 split shows the majority, and only a genuinely undecidable criterion (no valid
+passes, or a tie among the valid ones) stays outcome-less.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from url4_cloud.benchmarks.draco.case_results import _checks
+
+_RUBRIC = {
+    "sections": [
+        {
+            "id": "axis-a",
+            "title": "Axis A",
+            "criteria": [
+                {"id": "c1", "requirement": "says hi", "weight": 5, "axis": "axis-a"},
+                {"id": "c2", "requirement": "avoids jargon", "weight": -2, "axis": "axis-a"},
+            ],
+        }
+    ]
+}
+
+
+def _record(criterion_id: str, criterion_type: str) -> dict[str, Any]:
+    return {
+        "case_id": 1,
+        "criterion_id": criterion_id,
+        "requirement": "says hi" if criterion_id == "c1" else "avoids jargon",
+        "criterion_type": criterion_type,
+    }
+
+
+def _pass(
+    criterion_id: str,
+    sequence: int,
+    status: str | None,
+    *,
+    valid: bool = True,
+) -> dict[str, Any]:
+    value: dict[str, Any] = {
+        "case_id": 1,
+        "criterion_id": criterion_id,
+        "sequence": sequence,
+        "producer_type": "model",
+        "producer_id": "draco/judge",
+        "valid": valid,
+        "raw_output": "raw",
+    }
+    if valid:
+        value["criterion_status"] = status
+        value["explanation"] = "because"
+    else:
+        value["reason"] = "undecodable"
+    return value
+
+
+def _built(evidence: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    records = [_record("c1", "positive"), _record("c2", "negative")]
+    checks = _checks(1, _RUBRIC, records, evidence, 2)
+    return {check["id"]: check for check in checks}
+
+
+def _five(criterion_id: str, statuses: list[str]) -> list[dict[str, Any]]:
+    return [_pass(criterion_id, i + 1, status) for i, status in enumerate(statuses)]
+
+
+def test_unanimous_passes_summarize_to_their_verdict() -> None:
+    checks = _built(
+        _five("c1", ["MET"] * 5) + _five("c2", ["UNMET"] * 5),
+    )
+    assert checks["c1"]["outcome"] == "MET"
+    assert checks["c2"]["outcome"] == "UNMET"
+
+
+def test_a_split_takes_the_majority() -> None:
+    # 3/2 splits are exactly what the 5-pass protocol exists to settle.
+    checks = _built(
+        _five("c1", ["MET", "MET", "UNMET", "MET", "UNMET"])
+        + _five("c2", ["UNMET", "MET", "UNMET", "UNMET", "MET"])
+    )
+    assert checks["c1"]["outcome"] == "MET"
+    assert checks["c2"]["outcome"] == "UNMET"
+
+
+def test_invalid_passes_are_excluded_from_the_majority() -> None:
+    # 2 valid MET vs 1 valid UNMET (2 invalid): majority over VALID passes only.
+    evidence = [
+        _pass("c1", 1, "MET"),
+        _pass("c1", 2, None, valid=False),
+        _pass("c1", 3, "MET"),
+        _pass("c1", 4, None, valid=False),
+        _pass("c1", 5, "UNMET"),
+    ] + _five("c2", ["UNMET"] * 5)
+    checks = _built(evidence)
+    assert checks["c1"]["outcome"] == "MET"
+
+
+def test_a_tie_among_valid_passes_stays_unjudged() -> None:
+    # INVARIANT: absence is honesty — a 2-2 tie (one invalid) has no majority, and
+    # inventing one would be a verdict nobody rendered.
+    evidence = [
+        _pass("c1", 1, "MET"),
+        _pass("c1", 2, "UNMET"),
+        _pass("c1", 3, "MET"),
+        _pass("c1", 4, "UNMET"),
+        _pass("c1", 5, None, valid=False),
+    ] + _five("c2", ["UNMET"] * 5)
+    checks = _built(evidence)
+    assert "outcome" not in checks["c1"]
+
+
+def test_no_valid_passes_stays_unjudged() -> None:
+    evidence = [_pass("c1", i + 1, None, valid=False) for i in range(5)] + _five(
+        "c2", ["UNMET"] * 5
+    )
+    checks = _built(evidence)
+    assert "outcome" not in checks["c1"]
+
+
+def test_evidence_entries_keep_their_per_pass_verdicts() -> None:
+    # The summary is an ADDITION — the 5 raw verdicts stay auditable underneath.
+    checks = _built(_five("c1", ["MET"] * 5) + _five("c2", ["UNMET"] * 5))
+    assert [item["outcome"] for item in checks["c1"]["evidence"]] == ["MET"] * 5

--- a/apps/url4-cloud/tests/unit/test_token_exhaustion_legibility.py
+++ b/apps/url4-cloud/tests/unit/test_token_exhaustion_legibility.py
@@ -1,0 +1,192 @@
+"""Token exhaustion must say "not enough tokens", name the budget, and name the knob.
+
+FEATURE: a reasoning model that spends its whole `max_tokens` budget thinking returns
+`finish_reason="length"` with empty content. Before this feature that surfaced as
+`malformed aigateway response` (wrong component) or as the check judge's generic
+"no usable verdict" (no cause, no knob) — a researcher pays for the run and then
+debugs the gateway instead of raising one parameter.
+STORY: as a researcher whose candidate or check judge runs out of tokens, the failure
+tells me the model hit its token budget, which budget, and where to raise it.
+
+Two seams, mirroring where the signal exists:
+  1. the connector holds `finish_reason` + the request's `max_tokens` — classification
+     happens there (`model_token_cap`), like refusals already do (OME-679);
+  2. `rubric_check._judged` holds the check judge's configured params — its failure
+     message names the judge budget and the check_policy that pins it.
+
+A separate module from `test_finish_reason_capture.py` per that file's own note: the
+append-only gate reads growth of an existing test file as modification.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from url4.core.errors import ResolutionError
+from url4.dag import run as url4_run
+from url4_cloud.benchmarks.rubric_check import (
+    CHECK_ATTEMPTS,
+    RubricCheck,
+    RubricShape,
+    _judged,
+)
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec
+
+_MODEL = "anthropic/claude-haiku-4-5"
+
+
+def _gateway(body: dict) -> httpx.AsyncClient:
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        return httpx.Response(200, json=body)
+
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    )
+
+
+def _body(*, content: str | None, finish_reason: str | None) -> dict:
+    choice = {"message": {"role": "assistant", "content": content}, "finish_reason": finish_reason}
+    return {"choices": [choice], "usage": {"prompt_tokens": 1, "completion_tokens": 1}}
+
+
+async def _run(body: dict, expression: str) -> str:
+    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL),), default_model=_MODEL)
+    async with _gateway(body) as client:
+        world = await build_aigateway_world(cfg, client=client)
+        return await url4_run(expression, io=world.node)
+
+
+# ── seam 1: the connector classifies token exhaustion as its own model outcome ────────────
+
+
+@pytest.mark.asyncio
+async def test_token_exhausted_empty_turn_raises_model_token_cap() -> None:
+    # The conflation this feature removes: an all-reasoning `length` turn used to collapse
+    # into `aigateway_bad_response`, sending the reader off to debug the gateway.
+    with pytest.raises(ResolutionError) as exc_info:
+        await _run(_body(content=None, finish_reason="length"), f"/{_MODEL}(ctx)!go")
+
+    assert exc_info.value.code == "model_token_cap"
+    # WHY permanent: same budget in, same truncation out — a retry pays to fail identically.
+    assert exc_info.value.permanent is True
+    assert "max_tokens" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_token_exhausted_blank_turn_raises_model_token_cap() -> None:
+    # Whitespace content is no answer either; without classification it silently became "".
+    with pytest.raises(ResolutionError) as exc_info:
+        await _run(_body(content=" ", finish_reason="length"), f"/{_MODEL}(ctx)!go")
+
+    assert exc_info.value.code == "model_token_cap"
+
+
+@pytest.mark.asyncio
+async def test_token_cap_message_names_the_requested_budget() -> None:
+    # The knob must be in the message: the request pinned max_tokens=4096, so the failure
+    # names that number — the reader raises it without opening any source file.
+    with pytest.raises(ResolutionError) as exc_info:
+        await _run(
+            _body(content=None, finish_reason="length"),
+            f"(m:0.0:/{_MODEL}?max_tokens=4096&q=(ctx)!'go')!'$m'",
+        )
+
+    assert "max_tokens=4096" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_partially_truncated_answer_still_returns_content() -> None:
+    # A truncated-but-present answer stays usable (grading may still want it); only the
+    # no-answer case is an error. Don't regress this into a hard failure.
+    text = await _run(_body(content="partial answer", finish_reason="length"), f"/{_MODEL}(ctx)!go")
+
+    assert text == "partial answer"
+
+
+@pytest.mark.asyncio
+async def test_content_filter_still_wins_over_length() -> None:
+    # INVARIANT (OME-679): refusal classification precedes emptiness AND token exhaustion —
+    # a filtered turn that also reports `length` is a refusal, not a budget problem.
+    body = {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": None, "refusal": "nope"},
+                "finish_reason": "content_filter",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+    }
+    with pytest.raises(ResolutionError) as exc_info:
+        await _run(body, f"/{_MODEL}(ctx)!go")
+
+    assert exc_info.value.code == "provider_refusal"
+
+
+# ── seam 2: the check judge's failure names its budget and the policy that pins it ────────
+
+
+_CHECK = RubricCheck(
+    label="DRACO",
+    criterion="draco-pass.v1",
+    threshold=0.7,
+    shape=RubricShape(
+        layout="flat",
+        items="items",
+        id_field="id",
+        text_field="text",
+        weight_field="weight",
+    ),
+    judge_model="openrouter/google/gemini-3.1-pro-preview",
+    judge_params=(("temperature", "0.2"), ("max_tokens", "32768")),
+    feedback="severity",
+)
+
+_CRITERIA = ({"id": "c1", "text": "says hi", "weight": 1.0, "area": ""},)
+
+
+class _ProseJudge:
+    """A judge whose replies never decode — the retry-exhaustion path."""
+
+    async def evaluate(self, expression: str, *, env: dict) -> SimpleNamespace:
+        return SimpleNamespace(text="I think the response is fine overall.")
+
+
+class _StarvedJudge:
+    """A judge whose model call itself dies on the token cap — the propagation path."""
+
+    async def evaluate(self, expression: str, *, env: dict) -> SimpleNamespace:
+        raise ResolutionError(
+            "model ran out of tokens before completing an answer",
+            code="model_token_cap",
+            permanent=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_unusable_verdicts_name_the_judge_budget_and_its_home() -> None:
+    with pytest.raises(ResolutionError) as exc_info:
+        await _judged(_ProseJudge(), _CHECK, question="q", answer="a", criteria=_CRITERIA)
+
+    message = str(exc_info.value)
+    assert f"in {CHECK_ATTEMPTS} attempts" in message
+    # The knob and where it lives: the budget value and the policy module that sets it.
+    assert "max_tokens=32768" in message
+    assert "check_policy" in message
+
+
+@pytest.mark.asyncio
+async def test_starved_judge_failure_names_the_check_judge() -> None:
+    # When the judge call itself dies on the cap, the message must still attribute the
+    # failure to the CHECK JUDGE (not the candidate) and keep the token-cap cause.
+    with pytest.raises(ResolutionError) as exc_info:
+        await _judged(_StarvedJudge(), _CHECK, question="q", answer="a", criteria=_CRITERIA)
+
+    message = str(exc_info.value)
+    assert "check judge" in message
+    assert "ran out of tokens" in message
+    assert "max_tokens=32768" in message

--- a/apps/url4-cloud/tests/unit/test_token_exhaustion_legibility.py
+++ b/apps/url4-cloud/tests/unit/test_token_exhaustion_legibility.py
@@ -21,12 +21,14 @@ append-only gate reads growth of an existing test file as modification.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 
 import httpx
 import pytest
 
 from url4.core.errors import ResolutionError
 from url4.dag import run as url4_run
+from url4.peer.server import Url4Node
 from url4_cloud.benchmarks.rubric_check import (
     CHECK_ATTEMPTS,
     RubricCheck,
@@ -170,7 +172,10 @@ class _StarvedJudge:
 @pytest.mark.asyncio
 async def test_unusable_verdicts_name_the_judge_budget_and_its_home() -> None:
     with pytest.raises(ResolutionError) as exc_info:
-        await _judged(_ProseJudge(), _CHECK, question="q", answer="a", criteria=_CRITERIA)
+        # The fakes satisfy the one method _judged calls; cast supplies the port type.
+        await _judged(
+            cast(Url4Node, _ProseJudge()), _CHECK, question="q", answer="a", criteria=_CRITERIA
+        )
 
     message = str(exc_info.value)
     assert f"in {CHECK_ATTEMPTS} attempts" in message
@@ -184,7 +189,9 @@ async def test_starved_judge_failure_names_the_check_judge() -> None:
     # When the judge call itself dies on the cap, the message must still attribute the
     # failure to the CHECK JUDGE (not the candidate) and keep the token-cap cause.
     with pytest.raises(ResolutionError) as exc_info:
-        await _judged(_StarvedJudge(), _CHECK, question="q", answer="a", criteria=_CRITERIA)
+        await _judged(
+            cast(Url4Node, _StarvedJudge()), _CHECK, question="q", answer="a", criteria=_CRITERIA
+        )
 
     message = str(exc_info.value)
     assert "check judge" in message

--- a/apps/url4-cloud/url4.toml
+++ b/apps/url4-cloud/url4.toml
@@ -147,10 +147,31 @@ id = "openrouter/google/gemini-3-flash-preview"
 id = "openrouter/moonshotai/kimi-k2.6"
 
 [[aigateway.models]]
+id = "openrouter/moonshotai/kimi-k3"
+
+[[aigateway.models]]
 id = "openrouter/deepseek/deepseek-v4-pro"
 
 [[aigateway.models]]
+id = "openrouter/deepseek/deepseek-v4-flash"
+
+[[aigateway.models]]
 id = "openrouter/qwen/qwen3.6-plus"
+
+[[aigateway.models]]
+id = "openrouter/qwen/qwen3.8-2.4t-a95b"
+
+[[aigateway.models]]
+id = "openrouter/qwen/qwen3-coder"
+
+[[aigateway.models]]
+id = "openrouter/z-ai/glm-5.2"
+
+[[aigateway.models]]
+id = "openrouter/mistralai/ministral-3b-2512"
+
+[[aigateway.models]]
+id = "openrouter/microsoft/phi-4"
 
 # RESERVED — the format carries these (they are `url4 serve`'s tables) but the Runner does not
 # parse them yet; declaring one is a loud config error, never a silent no-op:

--- a/docs/tasks/2026-08-17-ome-844-benchmark-error-taxonomy.md
+++ b/docs/tasks/2026-08-17-ome-844-benchmark-error-taxonomy.md
@@ -1,0 +1,27 @@
+---
+id: OME-844
+linear_url: https://linear.app/openmined/issue/OME-844/split-benchmark-unavailable-into-a-real-error-taxonomy
+status: Backlog
+type: task
+priority: Medium
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Split benchmark_unavailable into a real error taxonomy
+
+One error code (`benchmark_unavailable`, `benchmarks/evaluation.py`) carries 73 call
+sites spanning four distinct failure classes — genuine asset/infra unavailability,
+protocol/contract violations, check-judge runtime failures, and benchmark-definition
+bugs — all `permanent=True`. The client/report cannot branch on cause and telemetry
+cannot aggregate it.
+
+Fix: keep `benchmark_unavailable` for asset/infra only; add
+`benchmark_contract_violation`, `check_judge_failed`, `benchmark_definition_invalid`;
+reclassify the 73 sites (messages verbatim); set `permanent` per class. Wire-compat
+check first (nothing may pin the old code string).
+
+Out of scope: url4-core `finish_reason` plumbing; gateway `reasoning_effort` support.
+
+Full problem statement, evidence, and Before/After: the Linear issue body.

--- a/docs/tasks/2026-08-17-ome-845-move-check-disclosure-into-panel.md
+++ b/docs/tasks/2026-08-17-ome-845-move-check-disclosure-into-panel.md
@@ -1,0 +1,14 @@
+---
+id: OME-845
+linear_url: https://linear.app/openmined/issue/OME-845/move-the-paid-check-call-disclosure-from-a-stderr-warning-into-the
+status: Backlog
+type: bug
+priority: Medium
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Move the paid-check-call disclosure from a stderr warning into the evaluation panel
+
+Full problem statement, evidence, and Before/After: the Linear issue body.

--- a/docs/tasks/2026-08-17-ome-848-draco-check-outcome-aggregation.md
+++ b/docs/tasks/2026-08-17-ome-848-draco-check-outcome-aggregation.md
@@ -1,0 +1,25 @@
+---
+id: OME-848
+linear_url: https://linear.app/openmined/issue/OME-848/aggregate-dracos-5-pass-verdicts-into-check-outcomes-and-render
+status: Backlog
+type: bug
+priority: Medium
+labels: [url4-cloud, py-screamingface, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Aggregate DRACO's 5-pass verdicts into check outcomes; render missing outcomes as unjudged
+
+DRACO's check builder (`benchmarks/draco/case_results.py`) ships 5 raw evidence
+verdicts per criterion but never fills the top-level `outcome`, and the report view
+paints a missing outcome as "bad" — so every positive criterion renders red and every
+negative green, verdict-blind, and every DRACO case chips INCORRECT. Scores were
+always correct; presentation lied.
+
+Fix: engine sets `outcome` = majority of valid passes (absent on no-valid/tie);
+UI renders outcome-less checks as neutral "unjudged" and excludes them from the case
+verdict. Case-chip binary for rubric benchmarks = open design question in the issue.
+Out of scope: HealthBench points-sign vocabulary mismatch (separate ticket).
+
+Full evidence and Before/After: the Linear issue body.

--- a/docs/tasks/2026-08-17-ome-854-token-exhaustion-legibility.md
+++ b/docs/tasks/2026-08-17-ome-854-token-exhaustion-legibility.md
@@ -1,0 +1,14 @@
+---
+id: OME-854
+linear_url: https://linear.app/openmined/issue/OME-854/name-token-exhaustion-as-a-first-class-model-outcome-with-the-budget
+status: Backlog
+type: bug
+priority: Medium
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Name token exhaustion as a first-class model outcome with the budget and knob in the message
+
+Full problem statement, evidence, and Before/After: the Linear issue body.

--- a/docs/tasks/2026-08-17-ome-855-unstarve-draco-check-judge.md
+++ b/docs/tasks/2026-08-17-ome-855-unstarve-draco-check-judge.md
@@ -1,0 +1,14 @@
+---
+id: OME-855
+linear_url: https://linear.app/openmined/issue/OME-855/unstarve-the-draco-check-judge-and-accept-quoted-verdict
+status: Backlog
+type: bug
+priority: Medium
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Unstarve the DRACO check judge and accept quoted verdict ordinals
+
+Full problem statement, evidence, and Before/After: the Linear issue body.

--- a/docs/tasks/2026-08-17-ome-856-register-open-weight-members.md
+++ b/docs/tasks/2026-08-17-ome-856-register-open-weight-members.md
@@ -1,0 +1,14 @@
+---
+id: OME-856
+linear_url: https://linear.app/openmined/issue/OME-856/register-the-open-weight-fusion-and-corrective-loop-member-models
+status: Backlog
+type: bug
+priority: Medium
+labels: [aigateway, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Register the open-weight fusion and corrective-loop member models
+
+Full problem statement, evidence, and Before/After: the Linear issue body.

--- a/packages/screamingface/src/screamingface/_evaluation/progress.py
+++ b/packages/screamingface/src/screamingface/_evaluation/progress.py
@@ -21,19 +21,32 @@ def _progress_observer(
     benchmark: str | None = None,
     candidate_models: tuple[str, ...] = (),
     candidate_urls: tuple[str, ...] = (),
+    check_disclosure: str | None = None,
 ) -> Callable[[Event], None] | None:
     selected_stream = sys.stderr if stream is None else stream
     in_notebook = _in_notebook()
-    if requested is False:
-        return None
-    if requested is None and not (in_notebook or selected_stream.isatty()):
-        return None
+    enabled = requested is not False and (
+        requested is not None or in_notebook or selected_stream.isatty()
+    )
     # In a notebook the live panel is preferred; text remains the fallback everywhere.
     rich = (
-        _notebook_observer(total_candidates, benchmark, candidate_models, candidate_urls)
-        if in_notebook
+        _notebook_observer(
+            total_candidates, benchmark, candidate_models, candidate_urls, check_disclosure
+        )
+        if enabled and in_notebook
         else None
     )
+    # The paid-check disclosure must never be silent (OME-845): the panel is its calm
+    # carrier, and every path that ends without a panel — progress off, headless, panel
+    # construction failure — falls back to the Python warning the panel replaced.
+    if check_disclosure is not None and rich is None:
+        import warnings
+
+        from screamingface.warnings import EvaluationWarning
+
+        warnings.warn(check_disclosure, EvaluationWarning, stacklevel=5)
+    if not enabled:
+        return None
     return _ProgressObserver(selected_stream) if rich is None else rich
 
 
@@ -42,6 +55,7 @@ def _notebook_observer(
     benchmark: str | None,
     candidate_models: tuple[str, ...],
     candidate_urls: tuple[str, ...],
+    check_disclosure: str | None = None,
 ) -> Callable[[Event], None] | None:
     """The live panel, or None when it cannot be built (text progress then carries it).
 
@@ -58,6 +72,7 @@ def _notebook_observer(
             benchmark,
             candidate_models,
             candidate_urls,
+            check_disclosure=check_disclosure,
         )
     except Exception:
         _logger.debug("Rich notebook progress unavailable; using text progress", exc_info=True)

--- a/packages/screamingface/src/screamingface/_evaluation/runner.py
+++ b/packages/screamingface/src/screamingface/_evaluation/runner.py
@@ -60,7 +60,7 @@ def evaluate_sync(
     _evaluation_options(on_event, progress)
     values = _evaluation_inputs(candidates, benchmark, limit)
     resource = load_benchmark(benchmark, limit)
-    _validate_check_surface(values, benchmark, resource)
+    check_disclosure = _validate_check_surface(values, benchmark, resource)
     evaluation = compile_evaluation(values, resource, limit)
     catalog = load_models()
     _validate_required_models(evaluation, catalog.models)
@@ -72,6 +72,7 @@ def evaluate_sync(
         benchmark,
         candidate_models=_candidate_model_ids(tuple(evaluation.candidates)),
         candidate_urls=tuple(candidate.url4 for candidate in evaluation.candidates),
+        check_disclosure=check_disclosure,
     )
     try:
         outcomes = _run_candidates_sync(transport, tuple(evaluation.candidates), observer)
@@ -100,7 +101,7 @@ async def evaluate_async(
     _evaluation_options(on_event, progress)
     values = _evaluation_inputs(candidates, benchmark, limit)
     resource = await load_benchmark(benchmark, limit)
-    _validate_check_surface(values, benchmark, resource)
+    check_disclosure = _validate_check_surface(values, benchmark, resource)
     evaluation = compile_evaluation(values, resource, limit)
     catalog = await load_models()
     _validate_required_models(evaluation, catalog.models)
@@ -112,6 +113,7 @@ async def evaluate_async(
         benchmark,
         candidate_models=_candidate_model_ids(tuple(evaluation.candidates)),
         candidate_urls=tuple(candidate.url4 for candidate in evaluation.candidates),
+        check_disclosure=check_disclosure,
     )
     try:
         outcomes = await _run_candidates_async(transport, tuple(evaluation.candidates), observer)
@@ -135,6 +137,7 @@ def _sync_event_observer(
     benchmark: str | None = None,
     candidate_models: tuple[str, ...] = (),
     candidate_urls: tuple[str, ...] = (),
+    check_disclosure: str | None = None,
 ) -> Callable[[Event], None] | None:
     from screamingface._evaluation.progress import _progress_observer
 
@@ -144,6 +147,7 @@ def _sync_event_observer(
         benchmark=benchmark,
         candidate_models=candidate_models,
         candidate_urls=candidate_urls,
+        check_disclosure=check_disclosure,
     )
     if builtin is None and callback is None:
         return None
@@ -157,6 +161,7 @@ def _async_event_observer(
     benchmark: str | None = None,
     candidate_models: tuple[str, ...] = (),
     candidate_urls: tuple[str, ...] = (),
+    check_disclosure: str | None = None,
 ) -> Callable[[Event], Awaitable[None]] | None:
     from screamingface._evaluation.progress import _progress_observer
 
@@ -166,6 +171,7 @@ def _async_event_observer(
         benchmark=benchmark,
         candidate_models=candidate_models,
         candidate_urls=candidate_urls,
+        check_disclosure=check_disclosure,
     )
     if builtin is None and callback is None:
         return None
@@ -341,23 +347,22 @@ def _validate_check_surface(
     values: Sequence[Recipe],
     benchmark: str,
     resource: _BenchmarkResource,
-) -> None:
+) -> str | None:
     """Settle loop Recipes against a benchmark's check surface before spend.
 
     A missing surface fails closed. A paid surface declares the maximum number
-    of benchmark-owned check calls so the caller sees the cost multiplier before
-    Candidate compilation or model dispatch.
+    of benchmark-owned check calls; the returned disclosure text carries that
+    cost multiplier to whichever surface shows it — the evaluation panel when
+    one is rendering, a Python warning otherwise (OME-845). Returns None when
+    there is nothing to disclose.
     """
-
-    import warnings
 
     from screamingface.corrective import CorrectiveLoop, SelfCorrective
     from screamingface.errors import PlanningError
-    from screamingface.warnings import EvaluationWarning
 
     loops = tuple(value for value in values if isinstance(value, CorrectiveLoop | SelfCorrective))
     if not loops:
-        return
+        return None
     surface = resource.check_surface
     if surface is None:
         names = ", ".join(repr(value.name) for value in loops)
@@ -369,16 +374,14 @@ def _validate_check_surface(
             details={"benchmark": benchmark, "candidates": [value.name for value in loops]},
         )
     if surface.expected_check_cost != "paid":
-        return
+        return None
     per_case = sum(value.max_rounds * _loop_member_count(value) for value in loops)
     maximum = per_case * resource.case_count
-    warnings.warn(
+    return (
         f"Benchmark {benchmark!r} may make up to {maximum} paid check calls "
         f"({per_case} per case x {resource.case_count} cases), in addition to the "
         "Candidate's own model calls. Passing earlier uses fewer calls; each check "
-        "may retry according to the benchmark's policy.",
-        EvaluationWarning,
-        stacklevel=3,
+        "may retry according to the benchmark's policy."
     )
 
 

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -52,6 +52,10 @@ _STYLE = (
 .sf-eval__act{{margin-top:10px;font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:12px;color:var(--sf-ink-3);white-space:nowrap;overflow:hidden;
   text-overflow:ellipsis}}
+/* pre-flight spend disclosure: calm and present, never a red banner (OME-845) */
+.sf-eval__note{{margin-top:8px;padding:7px 10px;border:1px solid var(--sf-line);
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px;
+  color:var(--sf-ink-2);line-height:1.5}}
 /* the feed: newest first, fixed height — proof of work, not a transcript */
 .sf-eval__feed{{margin-top:12px;border:1px solid var(--sf-line);max-height:132px;
   overflow:auto}}
@@ -78,12 +82,16 @@ def evaluation_panel_html(
     progress: _EvaluationProgress,
     benchmark: str | None = None,
     elapsed: float | None = None,
+    check_disclosure: str | None = None,
 ) -> str:
     """Render the whole panel for the progress fold's current state.
 
     `elapsed` lets a live view pass wall-clock seconds. Without it the panel falls back to
     the span between the first and last Event, which is correct for a finished run but
     freezes between Events while one is still in flight.
+
+    `check_disclosure` is the paid-check-call ceiling text; when the panel renders it,
+    the Python warning it replaces stays suppressed (OME-845).
     """
 
     return (
@@ -93,6 +101,7 @@ def evaluation_panel_html(
         f"{_bar_html(progress)}"
         f"{_meta_html(progress, elapsed)}"
         f"{_activity_html(progress)}"
+        f"{_note_html(check_disclosure)}"
         f"{_stats_html(progress)}"
         f"{_feed_html(progress)}"
         f"{_error_html(progress)}</div>"
@@ -142,6 +151,12 @@ def _candidate_text(progress: _EvaluationProgress) -> str:
 def _activity_html(progress: _EvaluationProgress) -> str:
     activity = progress.activity or "Starting evaluation"
     return f"<div class='sf-eval__act'>phase · {escape(activity)}</div>"
+
+
+def _note_html(check_disclosure: str | None) -> str:
+    if check_disclosure is None:
+        return ""
+    return f"<div class='sf-eval__note'>check surface · {escape(check_disclosure)}</div>"
 
 
 def _stats_html(progress: _EvaluationProgress) -> str:
@@ -240,6 +255,7 @@ class _NotebookEvaluationView:
         candidate_models: tuple[str, ...] = (),
         candidate_urls: tuple[str, ...] = (),
         *,
+        check_disclosure: str | None = None,
         clock: Callable[[], float] | None = None,
         tick: bool = True,
     ) -> None:
@@ -251,6 +267,7 @@ class _NotebookEvaluationView:
             candidate_urls=frozenset(candidate_urls),
         )
         self._benchmark = benchmark
+        self._check_disclosure = check_disclosure
         self._clock = time.monotonic if clock is None else clock
         self._started = self._clock()
         self._lock = threading.Lock()
@@ -283,7 +300,9 @@ class _NotebookEvaluationView:
     def _render(self) -> str:
         # A finished run reports the span it actually took; a live one reports wall clock.
         elapsed = None if self._progress.finished else self._clock() - self._started
-        return evaluation_panel_html(self._progress, self._benchmark, elapsed)
+        return evaluation_panel_html(
+            self._progress, self._benchmark, elapsed, self._check_disclosure
+        )
 
     def _tick_loop(self) -> None:
         deadline = self._started + self._MAX_TICK_SECONDS

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -732,13 +732,20 @@ def _case_failures_html(case: CaseResult) -> str:
 
 
 def _case_passed(case: CaseResult) -> bool:
-    """A case passes only when it was graded and every check landed the desired way."""
+    """A case passes only when it was graded and every JUDGED check landed the desired way.
+
+    WHY judged-only (OME-848): a check without an outcome was never decided — counting
+    it as failed painted every DRACO case INCORRECT while its outcomes went unemitted.
+    Absence must not masquerade as a verdict; with no judged checks at all, the score
+    is the only signal, exactly like the no-checks fallback below.
+    """
 
     grade = case.grade
     if grade is None:
         return False
-    if grade.checks:
-        return all(_check_good(check) for check in grade.checks)
+    judged = [check for check in grade.checks if check.outcome is not None]
+    if judged:
+        return all(_check_good(check) for check in judged)
     return grade.score is not None and grade.score > 0
 
 
@@ -763,8 +770,12 @@ def _check_good(check: Any) -> bool:
 def _check_html(check: Any) -> str:
     """One criterion: its verdict, who judged it, and why — the participant-row analogue."""
 
-    outcome = "" if check.outcome is None else str(check.outcome)
-    badge = _badge(outcome or "—", good=_check_good(check))
+    # An undecided check gets the neutral warn badge (OME-848): red would claim a miss
+    # and green a pass — verdicts nobody rendered.
+    if check.outcome is None:
+        badge = _badge("unjudged", good=False, warn=True)
+    else:
+        badge = _badge(str(check.outcome), good=_check_good(check))
     judge = next(
         (item.producer.id for item in check.evidence if getattr(item, "producer", None)),
         None,

--- a/packages/screamingface/tests/test_check_disclosure_display.py
+++ b/packages/screamingface/tests/test_check_disclosure_display.py
@@ -1,0 +1,97 @@
+"""The paid-check disclosure picks its carrier: panel when rendering, warning otherwise.
+
+FEATURE: OME-845 — the check-call ceiling used to arrive as a Python warning, which
+Jupyter paints as a red stderr banner on every evaluate call. The disclosure is about
+money and must never be silent, but it is information, not an alarm.
+STORY: as a researcher evaluating a corrective loop in a notebook, I read the ceiling
+as a calm pre-flight line inside the evaluation panel; headless callers still get the
+Python warning, so the ceiling never disappears with the panel.
+"""
+
+from __future__ import annotations
+
+import io
+import warnings
+
+import pytest
+
+from screamingface._evaluation import progress as progress_module
+from screamingface._evaluation.progress import _progress_observer
+from screamingface._ui.evaluation_state import _EvaluationProgress
+from screamingface._ui.evaluation_view import evaluation_panel_html
+from screamingface.warnings import EvaluationWarning
+
+_DISCLOSURE = "Benchmark 'draco' may make up to 6 paid check calls (6 per case x 1 cases)"
+
+
+def _headless_stream() -> io.StringIO:
+    # StringIO.isatty() is False — the "no panel, no terminal" environment.
+    return io.StringIO()
+
+
+def test_headless_evaluation_still_warns() -> None:
+    # INVARIANT: the disclosure is never silent — with no panel to carry it, the
+    # Python warning remains the carrier.
+    with pytest.warns(EvaluationWarning, match="6 paid check calls"):
+        observer = _progress_observer(None, stream=_headless_stream(), check_disclosure=_DISCLOSURE)
+    assert observer is None
+
+
+def test_progress_off_still_warns() -> None:
+    # Turning the panel off is a display preference, not consent to hidden spend.
+    with pytest.warns(EvaluationWarning, match="6 paid check calls"):
+        observer = _progress_observer(
+            False, stream=_headless_stream(), check_disclosure=_DISCLOSURE
+        )
+    assert observer is None
+
+
+def test_a_rendering_panel_suppresses_the_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When the notebook panel is built it carries the disclosure itself; warning too
+    # would reintroduce the red banner OME-845 removes.
+    taken: dict[str, str | None] = {}
+
+    def fake_notebook_observer(total, benchmark, models, urls, check_disclosure=None):
+        taken["disclosure"] = check_disclosure
+        return lambda event: None
+
+    monkeypatch.setattr(progress_module, "_in_notebook", lambda: True)
+    monkeypatch.setattr(progress_module, "_notebook_observer", fake_notebook_observer)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        observer = _progress_observer(None, stream=_headless_stream(), check_disclosure=_DISCLOSURE)
+    assert observer is not None
+    assert taken["disclosure"] == _DISCLOSURE
+
+
+def test_panel_construction_failure_falls_back_to_the_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The degrade path (ipywidgets unavailable, comm failure) must not lose the
+    # disclosure along with the panel.
+    monkeypatch.setattr(progress_module, "_in_notebook", lambda: True)
+    monkeypatch.setattr(progress_module, "_notebook_observer", lambda *a, **k: None)
+    with pytest.warns(EvaluationWarning, match="6 paid check calls"):
+        observer = _progress_observer(None, stream=_headless_stream(), check_disclosure=_DISCLOSURE)
+    assert observer is not None  # text progress still runs; only the carrier changed
+
+
+def test_no_disclosure_never_warns() -> None:
+    # Model/Fusion candidates have no check surface — nothing to disclose, no warning.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        observer = _progress_observer(None, stream=_headless_stream(), check_disclosure=None)
+    assert observer is None
+
+
+def test_the_panel_renders_the_disclosure_line() -> None:
+    html = evaluation_panel_html(_EvaluationProgress(), "draco", None, "up to 6 paid check <calls>")
+    assert "sf-eval__note" in html
+    assert "check surface · up to 6 paid check &lt;calls&gt;" in html
+
+
+def test_the_panel_omits_the_line_without_a_disclosure() -> None:
+    html = evaluation_panel_html(_EvaluationProgress(), "draco", None, None)
+    # The class exists in the stylesheet either way; the LINE must not render.
+    assert "check surface ·" not in html
+    assert "<div class='sf-eval__note'>" not in html

--- a/packages/screamingface/tests/test_check_surface_preflight.py
+++ b/packages/screamingface/tests/test_check_surface_preflight.py
@@ -21,7 +21,6 @@ from screamingface._evaluation.benchmark import (
 from screamingface._evaluation.runner import _evaluation_inputs, _validate_check_surface
 from screamingface.discovery import BenchmarkInfo
 from screamingface.errors import PlanningError
-from screamingface.warnings import EvaluationWarning
 
 _CHECK_BLOCK = {
     "check_route": "/benchmarks/ifeval/abc123/check-surface",
@@ -139,8 +138,8 @@ def test_a_paid_surface_warns_with_the_maximum_check_call_count() -> None:
         expected_check_cost="paid",
     )
 
-    with pytest.warns(EvaluationWarning, match="60 paid check calls"):
-        _validate_check_surface((loop,), "quizbench", _bare_resource(surface))
+    message = _validate_check_surface((loop,), "quizbench", _bare_resource(surface))
+    assert message is not None and "60 paid check calls" in message
 
 
 def test_corrective_recipes_are_public_evaluation_inputs() -> None:

--- a/packages/screamingface/tests/test_paid_check_spend.py
+++ b/packages/screamingface/tests/test_paid_check_spend.py
@@ -2,21 +2,19 @@
 
 FEATURE: rubric benchmarks (DRACO, HealthBench) check drafts with a judge call.
 STORY: as a user pointing a three-round panel at DRACO, I learn the check-call
-ceiling from a warning at planning time — not from the invoice afterwards.
+ceiling at planning time — not from the invoice afterwards. Since OME-845 the
+validator RETURNS the disclosure text and the display layer chooses the carrier
+(evaluation panel, or the Python warning when no panel renders).
 """
 
 from __future__ import annotations
 
-import warnings
 from typing import Literal
-
-import pytest
 
 import screamingface as sf
 from screamingface._evaluation.benchmark import _BenchmarkResource, _CheckSurface
 from screamingface._evaluation.runner import _validate_check_surface
 from screamingface.discovery import BenchmarkInfo
-from screamingface.warnings import EvaluationWarning
 
 _URL4 = "(answer:0.0:/candidate?q=(question)!'$candidate')!'$answer'"
 
@@ -34,11 +32,11 @@ def _resource(cost: Literal["free", "paid"], *, case_count: int = 100) -> _Bench
     )
 
 
-def test_a_paid_surface_warns_with_the_check_ceiling() -> None:
+def test_a_paid_surface_discloses_the_check_ceiling() -> None:
     loop = sf.CorrectiveLoop(["prov/a", "prov/b"], judge="prov/j", max_rounds=3)
-    with pytest.warns(EvaluationWarning, match="600 paid check calls") as caught:
-        _validate_check_surface((loop,), "draco", _resource("paid", case_count=100))
-    message = str(caught[0].message)
+    message = _validate_check_surface((loop,), "draco", _resource("paid", case_count=100))
+    assert message is not None
+    assert "600 paid check calls" in message
     # 2 members x 3 rounds = 6 checks per case, x 100 cases.
     assert "6 per case" in message
     assert "may retry according to the benchmark's policy" in message
@@ -46,9 +44,8 @@ def test_a_paid_surface_warns_with_the_check_ceiling() -> None:
 
 def test_the_ceiling_counts_one_member_for_a_solo_loop() -> None:
     solo = sf.SelfCorrective("prov/a", max_rounds=2)
-    with pytest.warns(EvaluationWarning) as caught:
-        _validate_check_surface((solo,), "draco", _resource("paid", case_count=10))
-    assert "20 paid check calls" in str(caught[0].message)
+    message = _validate_check_surface((solo,), "draco", _resource("paid", case_count=10))
+    assert message is not None and "20 paid check calls" in message
 
 
 def test_several_loops_bill_together() -> None:
@@ -56,24 +53,19 @@ def test_several_loops_bill_together() -> None:
         sf.CorrectiveLoop(["prov/a", "prov/b"], judge="prov/j", max_rounds=2),
         sf.SelfCorrective("prov/c", max_rounds=2),
     )
-    with pytest.warns(EvaluationWarning) as caught:
-        _validate_check_surface(loops, "draco", _resource("paid", case_count=5))
+    message = _validate_check_surface(loops, "draco", _resource("paid", case_count=5))
     # (2x2) + (1x2) = 6 checks per case, x 5 cases.
-    assert "30 paid check calls" in str(caught[0].message)
+    assert message is not None and "30 paid check calls" in message
 
 
 def test_a_free_surface_stays_silent() -> None:
-    # INVARIANT: the warning is about MONEY, so a deterministic checker must never
-    # trigger it — a warning that cries wolf on IFEval gets filtered and then the
+    # INVARIANT: the disclosure is about MONEY, so a deterministic checker must never
+    # produce one — a disclosure that cries wolf on IFEval gets ignored and then the
     # DRACO one goes unread too.
     loop = sf.CorrectiveLoop(["prov/a", "prov/b"], judge="prov/j")
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        _validate_check_surface((loop,), "ifeval", _resource("free"))
+    assert _validate_check_surface((loop,), "ifeval", _resource("free")) is None
 
 
 def test_a_non_loop_candidate_is_never_billed_for_checks() -> None:
     fusion = sf.Fusion(["prov/a", "prov/b"], synthesizer="prov/s")
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        _validate_check_surface((fusion,), "draco", _resource("paid"))
+    assert _validate_check_surface((fusion,), "draco", _resource("paid")) is None

--- a/packages/screamingface/tests/test_unjudged_check_display.py
+++ b/packages/screamingface/tests/test_unjudged_check_display.py
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 
 import screamingface as sf
 from screamingface._ui.report_view import report_html
-from screamingface.case_result import CaseGrade, CaseResult, Check
+from screamingface.case_result import CaseGrade, CaseResult, Check, CheckOutcome
 from screamingface.operation import OperationInfo
 from screamingface.report import BenchmarkInfo, CandidateResult, Report
 
@@ -23,7 +23,7 @@ _START = datetime(2026, 8, 17, 10, 0, tzinfo=UTC)
 _END = datetime(2026, 8, 17, 10, 5, tzinfo=UTC)
 
 
-def _check(label: str, outcome: str | None, *, kind: str = "positive") -> Check:
+def _check(label: str, outcome: CheckOutcome | None, *, kind: str = "positive") -> Check:
     return Check(
         type="criterion",
         id=label,

--- a/packages/screamingface/tests/test_unjudged_check_display.py
+++ b/packages/screamingface/tests/test_unjudged_check_display.py
@@ -1,0 +1,108 @@
+"""A check without an outcome renders as unjudged — never as a verdict (OME-848).
+
+FEATURE: DRACO shipped checks with no top-level outcome, and the view's good/bad
+logic collapsed None to "not MET" — every positive criterion painted red and every
+negative green, verdict-blind, and every case chipped INCORRECT.
+STORY: as a researcher reading a case, a criterion the judges never decided shows a
+neutral "unjudged" badge and does not tip the case verdict either way; judged
+criteria alone decide it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import screamingface as sf
+from screamingface._ui.report_view import report_html
+from screamingface.case_result import CaseGrade, CaseResult, Check
+from screamingface.operation import OperationInfo
+from screamingface.report import BenchmarkInfo, CandidateResult, Report
+
+_BENCHMARK = BenchmarkInfo(id="draco", revision="r1", case_count=1)
+_START = datetime(2026, 8, 17, 10, 0, tzinfo=UTC)
+_END = datetime(2026, 8, 17, 10, 5, tzinfo=UTC)
+
+
+def _check(label: str, outcome: str | None, *, kind: str = "positive") -> Check:
+    return Check(
+        type="criterion",
+        id=label,
+        label=label,
+        evidence=[],
+        outcome=outcome,
+        metadata={"criterion_type": kind},
+    )
+
+
+def _case(*checks: Check, score: float | None = 0.8) -> CaseResult:
+    return CaseResult(
+        case_id=1,
+        input="the prompt",
+        output="the answer",
+        finish_reason="stop",
+        grade=CaseGrade(method="rubric", score=score, metrics={}, checks=list(checks)),
+        failures=[],
+        metadata={},
+    )
+
+
+def _report(case: CaseResult) -> Report:
+    candidate = CandidateResult(
+        benchmark=_BENCHMARK,
+        run_id="run-m",
+        started_at=_START,
+        completed_at=_END,
+        name="m",
+        kind="model",
+        url4="(candidate:0.0:'(m:0.0:/openrouter/x)!\\'$m\\'')!''",
+        models=["openrouter/x"],
+        operations=[OperationInfo(id="op", kind="model", label="answer", depends_on=())],
+        score=case.grade.score if case.grade else None,
+        coverage=1.0,
+        metrics={"mean": 0.8} if case.grade and case.grade.score else {},
+        cases=[case],
+        members=[],
+        failures=[],
+        usage=sf.Usage(input_tokens=10, output_tokens=10),
+    )
+    return Report(benchmark=_BENCHMARK, case_count=1, candidates=[candidate])
+
+
+def _body(html: str) -> str:
+    return html[html.index("<div class='sf-ui") :]
+
+
+def test_an_outcomeless_check_renders_unjudged_not_a_verdict() -> None:
+    html = _body(report_html(_report(_case(_check("says hi", None)))))
+
+    assert "unjudged" in html
+    # Neither verdict color may claim the undecided criterion.
+    assert "sf-badge--warn" in html
+
+
+def test_unjudged_checks_do_not_flip_a_good_case_to_incorrect() -> None:
+    # One judged good criterion + one undecided: the case verdict follows the
+    # JUDGED evidence — absence must not masquerade as failure (the pre-fix draco
+    # state painted every such case INCORRECT).
+    html = _body(report_html(_report(_case(_check("says hi", "MET"), _check("undecided", None)))))
+
+    assert "incorrect" not in html
+
+
+def test_a_judged_miss_still_decides_the_case() -> None:
+    # The hardening must not soften real verdicts: one honest UNMET on a positive
+    # criterion keeps the case incorrect even beside unjudged neighbours.
+    graded = _case(
+        _check("says hi", "MET"), _check("cites sources", "UNMET"), _check("undecided", None)
+    )
+    html = _body(report_html(_report(graded)))
+
+    assert "incorrect" in html
+
+
+def test_all_unjudged_falls_back_to_the_score() -> None:
+    # No judged checks at all: the positive score is the only signal — the case
+    # reads as passed, exactly like the pre-existing no-checks fallback.
+    html = _body(report_html(_report(_case(_check("says hi", None), score=0.8))))
+
+    assert "incorrect" not in html


### PR DESCRIPTION
Fixes surfaced by a full day of live benchmark verification (2026-08-17) of Friday's OME-796 corrective-loop stack: before this branch, `sf.CorrectiveLoop` had never completed a case on canonical DRACO, token-starved models were reported as gateway faults, and the report view's per-criterion chips were verdict-blind. Each fix was validated on paid runs the same day.

## Before / After

### Before
- Trigger: a researcher runs a corrective loop or fusion on canonical `draco` and reads the report.
- Today: the check judge fails every case ("no usable verdict", 3 identical paid retries); a reasoning member that burns its budget thinking reads as "malformed aigateway response" at the wrong stage; every positive rubric criterion renders red and every negative green regardless of verdicts, and every case chips INCORRECT; a red warning banner shouts above every corrective evaluate.
- Cost: the flagship protocol doesn't work on the flagship benchmark, and diagnosing any of it costs paid re-runs (four in one real session).

### After
- Same triggers.
- Now: corrective loops complete on draco (validated live — first-ever green run, round-1 pass, 265/265 verdicts accepted); token exhaustion names the cause, the exact budget, and the knob; check chips show real majority MET/UNMET with honest "unjudged" for undecided criteria; the spend ceiling appears as a calm pre-flight line in the evaluation panel (headless callers keep the warning).
- Win: the eval pipeline is trustworthy end-to-end, and its failures teach instead of misdirecting.

### Don't regress
- Canonical DRACO 5-pass `JUDGE_PARAMS` and REVISION hash byte-identical (check judge gets its own params).
- Refusal classification still precedes token exhaustion; partial truncated answers still usable; genuinely malformed payloads keep `aigateway_bad_response`.
- IFEval/HealthBench single-pass outcomes render exactly as before; a real UNMET still fails a case.
- The spend disclosure is never silent: every panel-less path keeps the Python warning.

## Commits (one per unit)
- `feat(aigateway)` OME-856 — register open-weight notebook lineup members (3-registration set, reconciled on top of OME-816).
- `fix(url4-cloud)` OME-854, OME-855 — token exhaustion as a first-class outcome + DRACO check judge unstarved (own 32k budget, quoted-ordinal verdicts, diagnostic failure messages).
- `fix(url4-cloud)` OME-848 — aggregate 5-pass verdicts into check outcomes (majority of valid passes; ties/no-valid stay honestly absent).
- `fix(screamingface)` OME-848 — outcome-less checks render neutral "unjudged" and don't decide the case.
- `feat(screamingface)` OME-845 — paid-check disclosure moves into the evaluation panel.
- `docs(tasks)` OME-844 — mirror for the benchmark error-taxonomy ticket (follow-up work).
- `test(url4-cloud)` — pyright typing for the check-judge test fakes.

## Test plan
- New: `test_token_exhaustion_legibility.py` (7), `test_draco_check_outcome_aggregation.py` (6), `test_unjudged_check_display.py` (4), `test_check_disclosure_display.py` (7) — each named for the invariant it defends.
- Full gates green per stack (`run_gates.py`): aigateway, url4-cloud, screamingface (1494/870/41-suite counts include ruff, pyright, coverage).
- Append-only note: two prior test files changed deliberately — the OpenRouter seed-pin fixture (tracks the seed list by design) and the DRACO case-artifact pin (gains the intentional `outcome` key). Owner-approved push.
- Live validation: first completed corrective-loop draco run (0.6444, `stop_reason: passed`); fusion run with per-criterion outcomes 31 MET / 22 UNMET matching evidence majorities exactly.

## Open questions for review
- Should the check-judge budget change ship as `draco-pass.v2` per the check-policy versioning rule? (Argument against: a starved judge was never a functioning v1.)
- Case-level CORRECT/INCORRECT chip semantics for weighted rubrics — tracked in OME-848.

Refs: OME-844, OME-845, OME-848, OME-854, OME-855, OME-856

🤖 Generated with [Claude Code](https://claude.com/claude-code)
