### PR TITLE
feat: report real run cost from provider-authored OpenRouter evidence

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/runner/accounting.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/accounting.py
@@ -1,0 +1,249 @@
+"""Turns aigateway's `_aigw` usage-accounting block into the cost evidence a run publishes.
+
+FEATURE: per-run cost reporting (`OME-849`). aigateway produces provider-call FACTS and explicitly
+refuses to convert currency, attribute, or roll up — that boundary is stated in
+`apps/aigateway/docs/usage-accounting.md`. This module is the consumer on the other side of it: the
+Executor owns cost, because `url4.streaming` requires the executor to hand it a populated
+`CostUsageData` and performs no arithmetic itself.
+
+STORY: as a researcher reading a run Report, I see what my run cost — and an em dash rather than a
+confident wrong number whenever the gateway could not observe the whole call.
+
+INVARIANT — the rule the whole module exists to enforce: `Decimal("0")` and `None` are DIFFERENT
+answers. Zero means the call was genuinely free (a cache hit); `None` means the evidence cannot
+support a price. Collapsing them reports paid work as free, which is the failure aigateway's own
+review named — treating absence of observation as proof of absence.
+
+Scope today is OpenRouter, whose amounts arrive in `openrouter_credits` and convert to USD 1:1 by
+owner decision. Anthropic authors no cost at all and therefore stays unpriced.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal, localcontext
+from typing import Any
+
+__all__ = [
+    "OPENROUTER_CREDIT_UNIT",
+    "PRICING_VERSION",
+    "UNPRICED",
+    "CallAccounting",
+    "accumulate",
+    "read_aigw",
+    "usd_from_aigw",
+]
+
+# WHY the version names a METHOD rather than a date: a consumer reads it to learn HOW the number was
+# reached, and it is the seam a future rate card arrives through (`ratecard-<date>`) without
+# invalidating runs priced this way.
+PRICING_VERSION = "openrouter-credits-1usd"
+UNPRICED = "unpriced"
+
+OPENROUTER_CREDIT_UNIT = "openrouter_credits"
+# INVARIANT: an owner decision (2026-08-17), not something this code can verify. It lives here as a
+# named constant so the assumption is visible rather than implied by an absent multiplication.
+_CREDIT_TO_USD = Decimal(1)
+# The producer's published amount bound is 18 integer + 33 fractional digits; this leaves headroom
+# so no conversion can round a value that arrived at the bound.
+_AMOUNT_PRECISION = 18 + 33 + 2
+
+# Copied verbatim from the producer's published schema (the `amount` property). Keep it that way:
+# a locally-invented variant would drift from the contract it exists to mirror.
+_CANONICAL_AMOUNT = re.compile(r"^(?:0|[1-9][0-9]{0,17})(?:\.[0-9]{0,32}[1-9])?$")
+
+METADATA_KEY = "_aigw"
+
+
+@dataclass(frozen=True, slots=True)
+class CallAccounting:
+    """One gateway call's accounting, as url4-cloud reports it onto the span that made the call.
+
+    INVARIANT: every field is optional and `None` means "the gateway did not report it" — never
+    zero. A cache hit legitimately has no provider and no tokens while still being priced at zero.
+    """
+
+    provider: str | None
+    response_model: str | None
+    input_tokens: int | None
+    output_tokens: int | None
+    cache_read_tokens: int | None
+    cache_creation_tokens: int | None
+    reasoning_tokens: int | None
+    cost_usd: Decimal | None
+
+
+def accumulate[T: (int, Decimal)](prior: T | None, new: T | None) -> T | None:
+    """Sum two optional quantities, where an unknown part makes the whole unknown.
+
+    INVARIANT: a total that silently omits a part while presenting itself as a total is worse than
+    no total — the caller cannot tell a complete sum from a lossy one. The producing gateway applies
+    the same rule to its own subtotals, where one unreadable amount refuses the whole sum.
+    """
+    if prior is None or new is None:
+        return None
+    return prior + new
+
+
+def _mapping(value: object) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _count(value: object) -> int | None:
+    """A non-negative token count, or `None` for anything that is not one.
+
+    `bool` is refused explicitly: it is an `int` subclass, so a stray `True` would otherwise be
+    counted as one token.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _exact_amount(value: object) -> Decimal | None:
+    """A canonical non-negative amount, or `None`.
+
+    WHY the pattern is copied from the producer rather than re-derived: it IS the published contract
+    (`usage_accounting.schema.json`, the `amount` property), so matching it exactly means this
+    consumer accepts precisely what the producer promises to emit and nothing else. It rules out
+    negatives, exponent spellings, `NaN`/`Infinity`, and trailing-zero spellings of one value — all
+    in one place, with no arithmetic that could round.
+
+    WHY `str` and `int` only: those are the carriers that survived the producer's exact-decimal
+    parsing (its schema types the amount as a string). A `float` has already lost the raw-JSON
+    provenance the producer went to trouble to preserve, so accepting one would launder a number
+    that is no longer exact. `bool` is refused for the same reason as in `_count` — it is an `int`
+    subclass, so `True` would otherwise price as one credit.
+    """
+    text = str(value) if isinstance(value, int) and not isinstance(value, bool) else value
+    if not isinstance(text, str) or _CANONICAL_AMOUNT.fullmatch(text) is None:
+        return None
+    return Decimal(text)
+
+
+def _is_cache_hit(accounting: Mapping[str, Any] | None) -> bool:
+    if accounting is None:
+        return False
+    cache = _mapping(accounting.get("cache"))
+    return cache is not None and cache.get("status") == "hit"
+
+
+def _credits_to_usd(subtotals: object) -> Decimal | None:
+    """USD from exactly one OpenRouter-credit subtotal, else `None`.
+
+    INVARIANT: never add across units. Several subtotals means several currencies, and summing them
+    would invent an exchange rate nobody supplied. An unrecognised unit degrades to unpriced, which
+    is what keeps the 1:1 conversion honest once a second provider appears.
+    """
+    if not isinstance(subtotals, list) or len(subtotals) != 1:
+        return None
+    row = _mapping(subtotals[0])
+    known_unit = row is not None and row.get("unit") == OPENROUTER_CREDIT_UNIT
+    amount = _exact_amount(row.get("amount")) if known_unit and row is not None else None
+    if amount is None:
+        return None
+    # WHY a local context rather than a bare `*`: multiplication rounds to the AMBIENT decimal
+    # context's precision — 28 significant digits by default — which silently truncates an amount at
+    # the producer's 18-integer + 33-fractional bound. With a 1:1 rate the multiply looks like an
+    # identity and is not one. Proven by
+    # `test_an_amount_at_the_contract_precision_bound_survives_exactly`.
+    # INVARIANT: money arithmetic here is independent of whatever decimal context the caller happens
+    # to be running under, exactly as the producing gateway guarantees for its own subtotals.
+    with localcontext() as ctx:
+        ctx.prec = _AMOUNT_PRECISION
+        return amount * _CREDIT_TO_USD
+
+
+def usd_from_aigw(aigw: object) -> Decimal | None:
+    """USD for one gateway call, or `None` when the evidence cannot support a price.
+
+    Implements the normative decision table in
+    `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md` §3.2.
+
+    INVARIANT: total over its input and never raises. The provider call may already be billed by the
+    time this runs, so accounting must never turn a completed response into a run failure — the same
+    rule the producing gateway applies on its own side of the boundary.
+
+    AIDEV-NOTE: `known_direct_cost_subtotals` is populated by the producer ONLY when its capture was
+    complete and nothing was omitted, and it has already summed across retries. Do not re-derive
+    money by walking `attempts[]` — that double-counts, and it discards the producer's own refusal
+    to total unreadable amounts.
+    """
+    envelope = _mapping(aigw)
+    economics = _mapping(envelope.get("request_economics")) if envelope is not None else None
+    if envelope is None or economics is None:
+        return None
+    status = economics.get("direct_cost_status")
+    if status == "complete":
+        return _credits_to_usd(economics.get("known_direct_cost_subtotals"))
+    # INVARIANT: the P0 distinction. `not_applicable` covers BOTH "served from cache, genuinely
+    # free" and "a real billed call through a provider we cannot observe", and both present an
+    # EMPTY subtotal list. Reading the list alone reports paid work as free.
+    free = status == "not_applicable" and _is_cache_hit(_mapping(envelope.get("usage_accounting")))
+    return Decimal(0) if free else None
+
+
+def _attempt_usage(attempt: Mapping[str, Any]) -> tuple[int | None, ...]:
+    """One attempt's five token classes, in `CallAccounting` order."""
+    usage = _mapping(attempt.get("usage")) or {}
+    inputs = _mapping(usage.get("input")) or {}
+    outputs = _mapping(usage.get("output")) or {}
+    return (
+        _count(inputs.get("total")),
+        _count(outputs.get("total")),
+        _count(inputs.get("cache_read")),
+        # WHY the producer's `cache_write` maps to our `cache_creation`: the two names describe the
+        # same quantity — tokens written INTO the prompt cache — in the provider's vocabulary and in
+        # the GenAI semantic conventions respectively.
+        _count(inputs.get("cache_write")),
+        _count(outputs.get("reasoning")),
+    )
+
+
+def read_aigw(aigw: object) -> CallAccounting | None:
+    """Evidence for one gateway call, or `None` when there is no `_aigw` block to read.
+
+    `None` means "no accounting at all" and tells the caller to fall back to the provider's own
+    `usage` object — the pre-`_aigw` behaviour. It is deliberately distinct from evidence whose
+    fields are all `None`, which means the gateway was asked and reported nothing.
+
+    INVARIANT: tokens are summed across EVERY attempt, failures included. A retry genuinely costs
+    twice, and the producer contract states outright that a failed attempt may still carry
+    provider-authored usage, so dropping failures under-reports the run. Identity facts (provider,
+    served model) come from the TERMINAL attempt, which is the one that owns them.
+    """
+    envelope = _mapping(aigw)
+    if envelope is None:
+        return None
+    accounting = _mapping(envelope.get("usage_accounting"))
+    raw_attempts = accounting.get("attempts") if accounting is not None else None
+    attempts = (
+        [m for a in raw_attempts if (m := _mapping(a)) is not None]
+        if (isinstance(raw_attempts, list))
+        else []
+    )
+
+    # Seed from the first attempt, then accumulate: seeding is what lets a genuine `None` in the
+    # first attempt poison the class, rather than being mistaken for "nothing seen yet".
+    totals: tuple[int | None, ...] = (None,) * 5
+    if attempts:
+        totals = _attempt_usage(attempts[0])
+        for attempt in attempts[1:]:
+            observed = _attempt_usage(attempt)
+            totals = tuple(accumulate(totals[i], observed[i]) for i in range(5))
+
+    terminal = attempts[-1] if attempts else None
+    provider = terminal.get("provider") if terminal is not None else None
+    response_model = terminal.get("response_model") if terminal is not None else None
+    return CallAccounting(
+        provider=provider if isinstance(provider, str) and provider else None,
+        response_model=response_model if isinstance(response_model, str) else None,
+        input_tokens=totals[0],
+        output_tokens=totals[1],
+        cache_read_tokens=totals[2],
+        cache_creation_tokens=totals[3],
+        reasoning_tokens=totals[4],
+        cost_usd=usd_from_aigw(envelope),
+    )

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import NoReturn
 
 import httpx
@@ -25,7 +26,7 @@ from url4_cloud.retrieval_policy import (
     RetrievalPolicy,
     current_retrieval_policy,
 )
-from url4_cloud.runner.accounting import read_aigw
+from url4_cloud.runner.accounting import CallAccounting, read_aigw
 from url4_cloud.runner.cache import policy_to_body_field
 from url4_cloud.runner.cache_readback import CacheOutcome, read_cache_outcome, requires_revalidation
 from url4_cloud.runner.errors import RunnerRequestError
@@ -313,7 +314,47 @@ def _token_count(*candidates: object) -> int:
     return 0
 
 
-def _report_usage(model: str, usage: dict | None, aigw: object = None) -> None:
+def _report_served_from_cache(model: str, call: CallAccounting | None) -> None:
+    """Report a cache hit: priced at zero, and zero tokens consumed.
+
+    WHY zero rather than the numbers the response carries: a hit replays a STORED response, whose
+    body still contains the original call's `usage`. aigateway says so explicitly — it labels the
+    cache reference `incurred_in_current_request: false` and publishes no attempts — and
+    `accounting.usd_from_aigw` already honours that boundary by refusing to price the reference.
+    Counting the same reference's tokens as freshly consumed treats one piece of evidence two
+    opposite ways, and inflates every consumption figure a cache-heavy run reports.
+
+    WHY explicit zeros rather than `None`: `None` means "the gateway did not report it". Here the
+    gateway reported something definite — nothing was consumed — and a run total must be able to
+    add that in rather than treat it as a gap.
+
+    INVARIANT: the price stays `Decimal("0")` and never `None`. Zero is a real claim about a real
+    saving; a dash would hide it. `usd_from_aigw` derives it from the SAME hit, so the two agree.
+
+    AIDEV-NOTE: hit-ness is decided by the caller from the published `CacheOutcome` (the response
+    headers), NOT from `_aigw`. That is deliberate — an older gateway emits the header and no
+    accounting block at all, and it keeps these token counts consistent with the `cache_status`
+    published beside them on the same span.
+    """
+    sink = current_usage_sink()
+    if sink is None:
+        return
+    sink(
+        provider=call.provider if call is not None and call.provider else provider_of(model),
+        model=model,
+        input_tokens=0,
+        output_tokens=0,
+        response_model=call.response_model if call is not None else None,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        reasoning_tokens=0,
+        cost_usd=call.cost_usd if call is not None else Decimal(0),
+    )
+
+
+def _report_usage(
+    model: str, usage: dict | None, aigw: object = None, cache: CacheOutcome | None = None
+) -> None:
     """Report one gateway round trip's token and cost evidence onto the calling node's span.
 
     FEATURE: per-run cost reporting (OME-849). Prefers aigateway's `_aigw` accounting, which states
@@ -324,12 +365,20 @@ def _report_usage(model: str, usage: dict | None, aigw: object = None) -> None:
     INVARIANT: reported per ROUND TRIP, not per turn. A tool loop is several gateway calls against
     one span and each carries its own accounting, so the span accumulates them (see
     `executor._RunState._fold_usage`).
+
+    INVARIANT (OME-868): a published `cache_status` of `hit` and a non-zero token count are a
+    CONTRADICTION, and this is the seam that keeps them consistent. A hit is served from the
+    gateway's store, so the provider consumed nothing this request — see
+    `_report_served_from_cache`.
     """
     sink = current_usage_sink()
     if sink is None:
         return
     call = read_aigw(aigw)
     if call is None and usage is None:
+        return
+    if cache is not None and cache.status == "hit":
+        _report_served_from_cache(model, call)
         return
     reported = usage or {}
     sink(
@@ -449,7 +498,7 @@ async def _chat_completion_loop(
             http_client, headers=headers, body=body, cache=cache
         )
         data = _json_or_raise(resp)
-        _report_usage(spec.id, data.get("usage"), data.get("_aigw"))
+        _report_usage(spec.id, data.get("usage"), data.get("_aigw"), outcome)
         choice = parse_choice(data)
         # INVARIANT: report BEFORE classifying. A refused turn is the case a reviewer most needs
         # to audit, and raising first would lose exactly the event OME-679 exists to capture.

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -25,6 +25,7 @@ from url4_cloud.retrieval_policy import (
     RetrievalPolicy,
     current_retrieval_policy,
 )
+from url4_cloud.runner.accounting import read_aigw
 from url4_cloud.runner.cache import policy_to_body_field
 from url4_cloud.runner.cache_readback import CacheOutcome, read_cache_outcome, requires_revalidation
 from url4_cloud.runner.errors import RunnerRequestError
@@ -48,7 +49,7 @@ from url4_cloud.runner.web_tools import (
     build_runtime,
     truncate_tool_result,
 )
-from url4_cloud.world_config import ModelSpec, WorldConfigError, routes_for
+from url4_cloud.world_config import ModelSpec, WorldConfigError, provider_of, routes_for
 
 _COMPLETIONS_PATH = "/v1/chat/completions"
 _truncate_tool_result = truncate_tool_result
@@ -300,14 +301,55 @@ def _report_response(choice: Choice, cache: CacheOutcome) -> None:
     )
 
 
-def _report_usage(model: str, usage: dict | None) -> None:
-    if usage is None or (sink := current_usage_sink()) is None:
+def _token_count(*candidates: object) -> int:
+    """The first candidate that is a real non-negative count, else 0.
+
+    `bool` is refused explicitly: it is an `int` subclass, so a stray `True` would count as one
+    token. Zero is the last resort because the wire's `TokenUsage` has no way to say "unknown".
+    """
+    for candidate in candidates:
+        if not isinstance(candidate, bool) and isinstance(candidate, int) and candidate >= 0:
+            return candidate
+    return 0
+
+
+def _report_usage(model: str, usage: dict | None, aigw: object = None) -> None:
+    """Report one gateway round trip's token and cost evidence onto the calling node's span.
+
+    FEATURE: per-run cost reporting (OME-849). Prefers aigateway's `_aigw` accounting, which states
+    the provider and the served model authoritatively and carries the cache/reasoning token classes
+    plus a provider-authored cost. Falls back to the provider's own `usage` object when no
+    accounting is present — the pre-`_aigw` behaviour, which an older gateway still produces.
+
+    INVARIANT: reported per ROUND TRIP, not per turn. A tool loop is several gateway calls against
+    one span and each carries its own accounting, so the span accumulates them (see
+    `executor._RunState._fold_usage`).
+    """
+    sink = current_usage_sink()
+    if sink is None:
         return
+    call = read_aigw(aigw)
+    if call is None and usage is None:
+        return
+    reported = usage or {}
     sink(
-        provider=model.split("/", 1)[0] if "/" in model else "anthropic",
+        # INVARIANT: `_aigw` is authoritative for the provider. `provider_of` is the shared catalog
+        # rule — an unprefixed id is Anthropic's — and it is the ONLY source when a cache hit means
+        # there are no attempts to read a provider off. Never re-derive that rule locally.
+        provider=call.provider if call is not None and call.provider else provider_of(model),
         model=model,
-        input_tokens=usage.get("prompt_tokens", 0),
-        output_tokens=usage.get("completion_tokens", 0),
+        # A cache hit carries no attempts, so its token counts come from the cached provider body.
+        input_tokens=_token_count(
+            call.input_tokens if call is not None else None, reported.get("prompt_tokens")
+        ),
+        output_tokens=_token_count(
+            call.output_tokens if call is not None else None, reported.get("completion_tokens")
+        ),
+        response_model=call.response_model if call is not None else None,
+        cache_read_tokens=call.cache_read_tokens if call is not None else None,
+        cache_creation_tokens=call.cache_creation_tokens if call is not None else None,
+        reasoning_tokens=call.reasoning_tokens if call is not None else None,
+        cost_usd=call.cost_usd if call is not None else None,
     )
 
 
@@ -407,7 +449,7 @@ async def _chat_completion_loop(
             http_client, headers=headers, body=body, cache=cache
         )
         data = _json_or_raise(resp)
-        _report_usage(spec.id, data.get("usage"))
+        _report_usage(spec.id, data.get("usage"), data.get("_aigw"))
         choice = parse_choice(data)
         # INVARIANT: report BEFORE classifying. A refused turn is the case a reviewer most needs
         # to audit, and raising first would lose exactly the event OME-679 exists to capture.

--- a/apps/url4-cloud/src/url4_cloud/runner/executor.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/executor.py
@@ -43,6 +43,7 @@ from url4.streaming.protocol import (
     TokenUsage,
 )
 from url4.streaming.protocol.taxonomy import CostBreakdown
+from url4_cloud.runner.accounting import PRICING_VERSION, UNPRICED, accumulate
 from url4_cloud.runner.cache_counters import RunCacheCounters
 
 _logger = logging.getLogger(__name__)
@@ -130,6 +131,57 @@ class _Bridge:
             await self._wake.wait()
 
 
+def _pricing_version(total: Decimal | None) -> str:
+    """`PRICING_VERSION` when a total is known, `UNPRICED` otherwise.
+
+    INVARIANT: the ONLY switch a consumer reads to decide dash-versus-figure. Degrade to `UNPRICED`,
+    never to a zero that reads as "this was free".
+    """
+    return UNPRICED if total is None else PRICING_VERSION
+
+
+def _token_usage(usage: _SpanUsage) -> TokenUsage:
+    """The wire token counts for one span.
+
+    AIDEV-NOTE: the wire's `TokenUsage` fields are non-optional ints, so a class the gateway did not
+    report flattens to 0 here — "unknown" and "zero" are indistinguishable ON THE WIRE for tokens.
+    That is tolerable because tokens do NOT enter the price under this pricing method: the amount is
+    provider-authored, so an unknown cache class cannot make the cost wrong. If a rate-card method
+    ever multiplies these counts, that stops being true and the wire type has to gain optionality
+    first.
+    """
+    return TokenUsage(
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        cache_read_tokens=usage.cache_read_tokens or 0,
+        cache_creation_tokens=usage.cache_creation_tokens or 0,
+        reasoning_tokens=usage.reasoning_tokens or 0,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _SpanUsage:
+    """One span's accumulated model accounting, folded from its `Usage` events.
+
+    FEATURE: per-run cost reporting (OME-849). Replaced a positional 4-tuple: nine fields read as
+    `usage[2]` is unreadable, and the tuple could not express "not reported".
+
+    INVARIANT: an optional field is `None` when no call reported it — never zero. `cost_usd` `None`
+    means this span is UNPRICED, which is a different claim from `Decimal("0")` ("the calls were
+    genuinely free", e.g. every one served from cache).
+    """
+
+    provider: str
+    model: str
+    response_model: str | None
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int | None
+    cache_creation_tokens: int | None
+    reasoning_tokens: int | None
+    cost_usd: Decimal | None
+
+
 @dataclass
 class _SpanState:
     """An in-flight span's accumulated fields, held between its `NodeStarted` and matching
@@ -139,7 +191,7 @@ class _SpanState:
     detail: str
     start: datetime
     parent_span_id: str | None
-    usage: tuple[str, str, int, int] | None = field(default=None)
+    usage: _SpanUsage | None = field(default=None)
     # INVARIANT: a LIST, accumulated — one span can make several model calls (the web-tools loop
     # is the normal case), and each round trip's reason is separately auditable.
     #
@@ -175,6 +227,10 @@ class _RunState:
         self._sum_input = 0
         self._sum_output = 0
         self._providers_models: set[tuple[str, str]] = set()
+        # `None` until the first priced call: a run that made no model call at all stays unpriced,
+        # which is the shape it published before cost reporting existed.
+        self._subtree_cost: Decimal | None = None
+        self._subtree_unpriced = False
 
     def map(self, event: ObservationEvent) -> list[Traced]:
         """Fold one observation event into run state, returning the wire frames it produces.
@@ -251,6 +307,17 @@ class _RunState:
         self._sum_input += event.input_tokens
         self._sum_output += event.output_tokens
         self._providers_models.add((event.provider, event.model))
+        # INVARIANT: the run total latches UNPRICED on the first call it cannot price, and never
+        # unlatches. A grand total that silently omits a step while presenting itself as a total is
+        # worse than no total — the consumer cannot tell a complete sum from a lossy one. Counted
+        # here rather than in `_finish` for the same reason the token sums are: a round trip on a
+        # span this run never opened still spent money.
+        if event.cost_usd is None:
+            self._subtree_unpriced = True
+        elif self._subtree_cost is None:
+            self._subtree_cost = event.cost_usd
+        else:
+            self._subtree_cost += event.cost_usd
         span = self.spans.get(event.span_id) if event.span_id is not None else None
         if span is None:
             return
@@ -260,12 +327,36 @@ class _RunState:
         # (as this once did) kept only the final round trip and silently dropped every earlier
         # one from both the span frame and its `scope="self"` cost frame, while `subtree` stayed
         # correct — per-node cost that under-reports against a run total that does not.
-        prior_in, prior_out = (span.usage[2], span.usage[3]) if span.usage else (0, 0)
-        span.usage = (
-            event.provider,
-            event.model,
-            prior_in + event.input_tokens,
-            prior_out + event.output_tokens,
+        prior = span.usage
+        if prior is None:
+            # Seeding rather than accumulating from zero is what lets a genuine `None` in the FIRST
+            # round trip poison the class, instead of being mistaken for "nothing seen yet".
+            span.usage = _SpanUsage(
+                provider=event.provider,
+                model=event.model,
+                response_model=event.response_model,
+                input_tokens=event.input_tokens,
+                output_tokens=event.output_tokens,
+                cache_read_tokens=event.cache_read_tokens,
+                cache_creation_tokens=event.cache_creation_tokens,
+                reasoning_tokens=event.reasoning_tokens,
+                cost_usd=event.cost_usd,
+            )
+            return
+        span.usage = _SpanUsage(
+            provider=event.provider,
+            model=event.model,
+            # Last reported wins, and an unreported one leaves the earlier standing: a later round
+            # trip that named no served model must not blank one an earlier trip did name.
+            response_model=event.response_model or prior.response_model,
+            input_tokens=prior.input_tokens + event.input_tokens,
+            output_tokens=prior.output_tokens + event.output_tokens,
+            cache_read_tokens=accumulate(prior.cache_read_tokens, event.cache_read_tokens),
+            cache_creation_tokens=accumulate(
+                prior.cache_creation_tokens, event.cache_creation_tokens
+            ),
+            reasoning_tokens=accumulate(prior.reasoning_tokens, event.reasoning_tokens),
+            cost_usd=accumulate(prior.cost_usd, event.cost_usd),
         )
 
     def _finish(self, event: NodeFinished) -> list[Traced]:
@@ -282,11 +373,15 @@ class _RunState:
         span_data = SpanData(
             name=detail or kind,
             operation=kind,
-            provider=usage[0] if usage else None,
-            request_model=usage[1] if usage else None,
-            response_model=usage[1] if usage else None,
-            input_tokens=usage[2] if usage else None,
-            output_tokens=usage[3] if usage else None,
+            provider=usage.provider if usage else None,
+            request_model=usage.model if usage else None,
+            # AIDEV-NOTE: this deliberately still ECHOES the requested model when the provider named
+            # no served one, unlike `url4.observe.Usage.response_model`, whose invariant forbids
+            # the echo. Changing `SpanData`'s long-standing behaviour is a wire change for every
+            # existing run and belongs to its own unit of work, not to OME-849.
+            response_model=(usage.response_model or usage.model) if usage else None,
+            input_tokens=usage.input_tokens if usage else None,
+            output_tokens=usage.output_tokens if usage else None,
             # Empty -> None so the attribute is simply ABSENT rather than an empty list, matching
             # how OTel treats `gen_ai.*` attributes. This collapses "no model call" and "a call
             # that reported no reason" into the same wire shape — intended, not an oversight.
@@ -308,11 +403,14 @@ class _RunState:
                 Traced(
                     payload=CostUsageData(
                         scope="self",
-                        provider=usage[0],
-                        model=usage[1],
-                        pricing_version="unpriced",
-                        usage=TokenUsage(input_tokens=usage[2], output_tokens=usage[3]),
-                        cost=CostBreakdown(total_usd=Decimal("0")),
+                        provider=usage.provider,
+                        model=usage.model,
+                        pricing_version=_pricing_version(usage.cost_usd),
+                        usage=_token_usage(usage),
+                        # INVARIANT: an unpriced span publishes total 0 with the `unpriced` version,
+                        # exactly as it did before cost reporting existed — the consumer reads the
+                        # version, not the number, to decide whether to show a figure at all.
+                        cost=CostBreakdown(total_usd=usage.cost_usd or Decimal("0")),
                     ),
                     # INVARIANT: the self-scoped cost carries the SAME span as the span frame it
                     # accompanies. Without it every `scope="self"` frame in a run is published
@@ -345,13 +443,17 @@ class _RunState:
 
     def build_subtree(self) -> CostUsageData:
         provider, model = self._subtree_provider_model()
+        # INVARIANT: priced only when EVERY observed call was priced. `_subtree_unpriced` latches
+        # on the first one that was not; a run with no model call at all has `_subtree_cost is
+        # None` and stays unpriced — the shape it published before cost reporting existed.
+        total = None if self._subtree_unpriced else self._subtree_cost
         return CostUsageData(
             scope="subtree",
             provider=provider,
             model=model,
-            pricing_version="unpriced",
+            pricing_version=_pricing_version(total),
             usage=TokenUsage(input_tokens=self._sum_input, output_tokens=self._sum_output),
-            cost=CostBreakdown(total_usd=Decimal("0")),
+            cost=CostBreakdown(total_usd=total or Decimal("0")),
         )
 
     def _subtree_provider_model(self) -> tuple[str, str]:

--- a/apps/url4-cloud/src/url4_cloud/runner/executor.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/executor.py
@@ -226,6 +226,27 @@ class _RunState:
         self.cache_counters = RunCacheCounters()
         self._sum_input = 0
         self._sum_output = 0
+        # WHY these three are summed as plain ints while the SPAN-level equivalents poison through
+        # `accumulate`: money and tokens have different escape hatches on the wire.
+        #
+        # A run whose price is unknowable says so — `pricing_version: "unpriced"` exists for it —
+        # so poisoning the money total loses nothing. `TokenUsage`'s fields are non-optional ints
+        # with no such spelling, so poisoning a token class cannot publish "unknown"; it publishes
+        # ZERO, which is a false claim rather than an absent one, and it discards the real counts
+        # the reporting calls did supply.
+        #
+        # INVARIANT (OME-869): at RUN level an unreported class contributes nothing and never
+        # erases what its siblings reported. The mixed-provider case is the one that matters — one
+        # model reports cache reads and no reasoning, another the reverse — where poisoning would
+        # zero BOTH real figures to encode an uncertainty the frame cannot carry anyway.
+        #
+        # AIDEV-NOTE: do NOT "make this consistent" with the span-level `accumulate` calls in
+        # `_fold_usage`. The asymmetry is the decision. A span is one model, so mixed reporting is
+        # unlikely there; a run spans many, so it is the normal case. If `TokenUsage` ever gains
+        # optional counts, revisit this — then poisoning could finally say what it means.
+        self._sum_cache_read = 0
+        self._sum_cache_creation = 0
+        self._sum_reasoning = 0
         self._providers_models: set[tuple[str, str]] = set()
         # `None` until the first priced call: a run that made no model call at all stays unpriced,
         # which is the shape it published before cost reporting existed.
@@ -306,6 +327,9 @@ class _RunState:
     def _fold_usage(self, event: Usage) -> None:
         self._sum_input += event.input_tokens
         self._sum_output += event.output_tokens
+        self._sum_cache_read += event.cache_read_tokens or 0
+        self._sum_cache_creation += event.cache_creation_tokens or 0
+        self._sum_reasoning += event.reasoning_tokens or 0
         self._providers_models.add((event.provider, event.model))
         # INVARIANT: the run total latches UNPRICED on the first call it cannot price, and never
         # unlatches. A grand total that silently omits a step while presenting itself as a total is
@@ -452,7 +476,13 @@ class _RunState:
             provider=provider,
             model=model,
             pricing_version=_pricing_version(total),
-            usage=TokenUsage(input_tokens=self._sum_input, output_tokens=self._sum_output),
+            usage=TokenUsage(
+                input_tokens=self._sum_input,
+                output_tokens=self._sum_output,
+                cache_read_tokens=self._sum_cache_read,
+                cache_creation_tokens=self._sum_cache_creation,
+                reasoning_tokens=self._sum_reasoning,
+            ),
             cost=CostBreakdown(total_usd=total or Decimal("0")),
         )
 

--- a/apps/url4-cloud/tests/unit/test_accounting.py
+++ b/apps/url4-cloud/tests/unit/test_accounting.py
@@ -1,0 +1,342 @@
+"""Pricing one gateway call from aigateway's `_aigw` accounting block.
+
+FEATURE: per-run cost reporting (`OME-849`). aigateway publishes provider-authored cost evidence and
+refuses to convert or attribute it; this module is the consumer that turns OpenRouter credits into
+USD at 1:1 and decides when the evidence cannot support a price at all.
+
+STORY: as a researcher reading a run Report, I see what my run cost — and I see an em dash rather
+than a confident wrong number whenever the gateway could not observe the whole call.
+
+Producer contract: `apps/aigateway/docs/usage-accounting.md`.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from url4_cloud.runner.accounting import (
+    OPENROUTER_CREDIT_UNIT,
+    PRICING_VERSION,
+    accumulate,
+    read_aigw,
+    usd_from_aigw,
+)
+
+
+def _aigw(
+    *,
+    direct_cost_status: str = "complete",
+    subtotals: Any = None,
+    cache_status: str = "miss",
+    attempts: Any = None,
+) -> dict[str, Any]:
+    """A minimal, schema-shaped `_aigw` block."""
+    if subtotals is None:
+        subtotals = [
+            {
+                "amount": "0.001",
+                "unit": OPENROUTER_CREDIT_UNIT,
+                "source": "openrouter.usage.cost",
+            }
+        ]
+    return {
+        "usage_accounting": {
+            "schema": "aigw.chat_usage_accounting",
+            "capture_status": "complete",
+            "cache": {"status": cache_status, "reference": None},
+            "observed_attempts": 1,
+            "rendered_attempts": 1,
+            "omitted_attempts": 0,
+            "attempts": [_attempt()] if attempts is None else attempts,
+        },
+        "request_economics": {
+            "schema": "aigw.request_economics",
+            "observed_new_attempts": 1,
+            "direct_cost_status": direct_cost_status,
+            "known_direct_cost_subtotals": subtotals,
+        },
+    }
+
+
+def _attempt(
+    *,
+    provider: str = "openrouter",
+    response_model: str | None = "anthropic/claude-x-20260801",
+    input_total: int | None = 12480,
+    output_total: int | None = 742,
+    cache_read: int | None = 8000,
+    cache_write: int | None = 4000,
+    reasoning: int | None = 610,
+    outcome: str = "succeeded",
+) -> dict[str, Any]:
+    return {
+        "schema": "aigw.provider_attempt",
+        "provider": provider,
+        "requested_model": "openrouter/anthropic/claude-x",
+        "response_model": response_model,
+        "outcome": outcome,
+        "usage": {
+            "status": "complete",
+            "source": "provider_raw_response",
+            "input": {
+                "total": input_total,
+                "uncached": None,
+                "cache_read": cache_read,
+                "cache_write": cache_write,
+                "cache_write_by_ttl": [],
+            },
+            "output": {"total": output_total, "reasoning": reasoning},
+        },
+    }
+
+
+# ── the decision table (spec §3.2) ────────────────────────────────────────────────────────────
+
+
+def test_a_complete_status_prices_the_single_credit_subtotal() -> None:
+    assert usd_from_aigw(_aigw()) == Decimal("0.001")
+
+
+def test_a_cache_hit_is_priced_at_exactly_zero() -> None:
+    """INVARIANT: a cache hit genuinely cost nothing THIS request, so zero is a real claim.
+
+    It must be `Decimal("0")` and not `None` — a dash here would hide a true saving.
+    """
+    priced = usd_from_aigw(
+        _aigw(direct_cost_status="not_applicable", subtotals=[], cache_status="hit", attempts=[])
+    )
+
+    assert priced == Decimal("0")
+
+
+def test_an_unobservable_provider_is_unpriced_not_free() -> None:
+    """INVARIANT: the P0 case. `not_applicable` without a cache hit means a real billed call the
+    gateway could not observe. Both this and the cache hit present an EMPTY subtotal list, so
+    reading the list alone would report a paid call as free."""
+    priced = usd_from_aigw(
+        _aigw(direct_cost_status="not_applicable", subtotals=[], cache_status="miss", attempts=[])
+    )
+
+    assert priced is None
+
+
+@pytest.mark.parametrize("status", ["partial", "unavailable", "unrecognised-future-value"])
+def test_incomplete_or_unknown_statuses_are_unpriced(status: str) -> None:
+    assert usd_from_aigw(_aigw(direct_cost_status=status)) is None
+
+
+def test_a_missing_economics_section_is_unpriced() -> None:
+    assert usd_from_aigw({"usage_accounting": {}}) is None
+
+
+# ── subtotal shape ────────────────────────────────────────────────────────────────────────────
+
+
+def test_an_empty_subtotal_list_under_complete_is_unpriced() -> None:
+    assert usd_from_aigw(_aigw(subtotals=[])) is None
+
+
+def test_several_subtotals_are_unpriced_rather_than_added() -> None:
+    """INVARIANT: never add across units. Two subtotals means two currencies, and summing them
+    would invent an exchange rate nobody supplied."""
+    rows = [
+        {"amount": "0.001", "unit": OPENROUTER_CREDIT_UNIT, "source": "s"},
+        {"amount": "0.002", "unit": "some_other_credits", "source": "s"},
+    ]
+
+    assert usd_from_aigw(_aigw(subtotals=rows)) is None
+
+
+def test_a_non_credits_unit_is_unpriced() -> None:
+    """AIDEV-NOTE: this is what keeps the 1:1 conversion honest when a second provider appears —
+    an unrecognised unit degrades instead of being treated as dollars."""
+    rows = [{"amount": "0.001", "unit": "anthropic_tokens", "source": "s"}]
+
+    assert usd_from_aigw(_aigw(subtotals=rows)) is None
+
+
+# ── hostile input: the function is total and never raises ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, "", 0, [], "not-a-mapping", {"request_economics": "not-a-mapping"}],
+    ids=["none", "empty-str", "int", "list", "str", "wrong-type-section"],
+)
+def test_malformed_accounting_is_unpriced_and_never_raises(payload: object) -> None:
+    """INVARIANT: accounting must never turn a completed provider response into a run failure.
+
+    The provider call may already be billed by the time we parse this.
+    """
+    assert usd_from_aigw(payload) is None
+
+
+@pytest.mark.parametrize(
+    "amount",
+    [None, "", "abc", "-0.001", 0.001, True, "NaN", "Infinity", "1e5"],
+    ids=["none", "empty", "text", "negative", "float", "bool", "nan", "inf", "exponent"],
+)
+def test_a_non_canonical_amount_is_refused(amount: object) -> None:
+    """`float` and `bool` are refused as carriers: a float has already lost the exact JSON
+    provenance, and `bool` is an `int` subclass so `True` would otherwise price as 1 credit."""
+    rows = [{"amount": amount, "unit": OPENROUTER_CREDIT_UNIT, "source": "s"}]
+
+    assert usd_from_aigw(_aigw(subtotals=rows)) is None
+
+
+def test_an_amount_at_the_contract_precision_bound_survives_exactly() -> None:
+    """The producer's bound is 18 integer and 33 fractional digits; nothing may be rounded."""
+    amount = "1" * 18 + "." + "0" * 32 + "1"
+    rows = [{"amount": amount, "unit": OPENROUTER_CREDIT_UNIT, "source": "s"}]
+
+    assert usd_from_aigw(_aigw(subtotals=rows)) == Decimal(amount)
+
+
+def test_an_explicit_zero_amount_is_priced_as_zero() -> None:
+    rows = [{"amount": "0", "unit": OPENROUTER_CREDIT_UNIT, "source": "s"}]
+
+    assert usd_from_aigw(_aigw(subtotals=rows)) == Decimal("0")
+
+
+# ── the cache reference must never be priced ───────────────────────────────────────────────────
+
+
+def test_a_cache_reference_never_contributes_to_the_price() -> None:
+    """INVARIANT: P0. The reference describes the ORIGINAL response and is explicitly labelled
+    `incurred_in_current_request: false`. Pricing it bills the researcher for a free answer."""
+    payload = _aigw(
+        direct_cost_status="not_applicable", subtotals=[], cache_status="hit", attempts=[]
+    )
+    payload["usage_accounting"]["cache"]["reference"] = {
+        "kind": "cached_final_response",
+        "coverage": "final_successful_response_only",
+        "incurred_in_current_request": False,
+        "usage": {"status": "complete", "source": "cached_converted_response"},
+        "direct_cost": {
+            "status": "reported",
+            "amount": "9.99",
+            "unit": OPENROUTER_CREDIT_UNIT,
+            "source": "s",
+        },
+    }
+
+    assert usd_from_aigw(payload) == Decimal("0")
+
+
+# ── token and identity evidence ────────────────────────────────────────────────────────────────
+
+
+def test_evidence_carries_every_token_class_and_the_authoritative_identity() -> None:
+    call = read_aigw(_aigw())
+
+    assert call is not None
+    assert call.provider == "openrouter"
+    assert call.response_model == "anthropic/claude-x-20260801"
+    assert call.input_tokens == 12480
+    assert call.output_tokens == 742
+    assert call.cache_read_tokens == 8000
+    assert call.cache_creation_tokens == 4000
+    assert call.reasoning_tokens == 610
+    assert call.cost_usd == Decimal("0.001")
+
+
+def test_tokens_are_summed_across_attempts_including_failures() -> None:
+    """INVARIANT: a retry genuinely costs twice, and a FAILED attempt may still carry real usage —
+    the producer contract says so outright. Dropping failures under-reports the run."""
+    attempts = [
+        _attempt(input_total=100, output_total=10, outcome="transport_error"),
+        _attempt(input_total=200, output_total=20, outcome="succeeded"),
+    ]
+
+    call = read_aigw(_aigw(attempts=attempts))
+
+    assert call is not None
+    assert call.input_tokens == 300
+    assert call.output_tokens == 30
+
+
+def test_the_cost_is_taken_once_from_economics_not_per_attempt() -> None:
+    """aigateway already summed across attempts. Re-deriving from `attempts[]` double-counts."""
+    attempts = [_attempt(), _attempt()]
+
+    call = read_aigw(_aigw(attempts=attempts))
+
+    assert call is not None
+    assert call.cost_usd == Decimal("0.001")
+
+
+def test_an_unreported_token_class_stays_none() -> None:
+    call = read_aigw(_aigw(attempts=[_attempt(cache_read=None, reasoning=None)]))
+
+    assert call is not None
+    assert call.cache_read_tokens is None
+    assert call.reasoning_tokens is None
+    assert call.cache_creation_tokens == 4000
+
+
+def test_identity_comes_from_the_terminal_attempt() -> None:
+    attempts = [
+        _attempt(provider="openrouter", response_model=None, outcome="transport_error"),
+        _attempt(provider="openrouter", response_model="served/by-this", outcome="succeeded"),
+    ]
+
+    call = read_aigw(_aigw(attempts=attempts))
+
+    assert call is not None
+    assert call.response_model == "served/by-this"
+
+
+def test_absent_accounting_yields_no_evidence_at_all() -> None:
+    """Distinguished from "evidence that says nothing": `None` tells the caller to fall back to the
+    provider's own `usage` object, which is the pre-`_aigw` behaviour."""
+    assert read_aigw(None) is None
+    assert read_aigw("nonsense") is None
+
+
+def test_a_cache_hit_has_no_attempts_yet_is_still_priced() -> None:
+    call = read_aigw(
+        _aigw(direct_cost_status="not_applicable", subtotals=[], cache_status="hit", attempts=[])
+    )
+
+    assert call is not None
+    assert call.cost_usd == Decimal("0")
+    assert call.provider is None
+    assert call.input_tokens is None
+
+
+# ── the poisoning helper ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("prior", "new", "expected"),
+    [
+        (1, 2, 3),
+        (0, 0, 0),
+        (None, 2, None),
+        (1, None, None),
+        (None, None, None),
+    ],
+)
+def test_accumulate_sums_known_counts_and_poisons_on_unknown(
+    prior: int | None, new: int | None, expected: int | None
+) -> None:
+    """INVARIANT: an unknown part makes the whole unknown. A total that silently omits a part while
+    presenting itself as a total is worse than no total — the same rule the producer applies to its
+    own subtotals."""
+    assert accumulate(prior, new) == expected
+
+
+def test_accumulate_keeps_decimal_exactness() -> None:
+    total = accumulate(Decimal("0.1"), Decimal("0.2"))
+
+    assert total == Decimal("0.3")
+    assert isinstance(total, Decimal)
+
+
+def test_the_pricing_version_names_the_method_not_a_date() -> None:
+    """AIDEV-NOTE: the version is how a future rate card coexists with this one. A consumer reads it
+    to know HOW the number was reached, so it must describe the method."""
+    assert PRICING_VERSION == "openrouter-credits-1usd"

--- a/apps/url4-cloud/tests/unit/test_cache_hit_tokens.py
+++ b/apps/url4-cloud/tests/unit/test_cache_hit_tokens.py
@@ -1,0 +1,232 @@
+"""A cache hit consumed nothing, so it reports nothing consumed.
+
+FEATURE: per-run cost reporting (`OME-849`/`OME-868`). `OME-851` reads aigateway's `_aigw` block
+and refuses to price the cache reference, because the producer labels it
+`incurred_in_current_request: false`. The TOKEN counts crossed that same boundary in the opposite
+direction: with no attempts to read, `_report_usage` fell back to the replayed cached body's
+`usage` and published the ORIGINAL call's tokens as freshly consumed.
+
+STORY: as a researcher running a cache-heavy benchmark, the token totals describe what my run
+actually spent. A hit that reports 12,480 input tokens beside `$0` invites exactly the wrong
+conclusion — that the gateway gave away real work — and inflates every consumption figure
+downstream.
+
+INVARIANT under test: a published `cache_status` of `hit` and a non-zero token count are a
+contradiction. `runner/cache_readback` already says so in its own module docstring ("a cache hit
+costs nothing upstream, yet `_report_usage` bills it exactly like a fresh call"); this module
+pins the fix.
+
+A separate module rather than an append to `test_run_cost_capture.py`: the repo's append-only gate
+compares file status, so growing an existing test file reads as a modified prior test even when
+the diff is purely additive.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import httpx
+import pytest
+
+from url4.dag import run as url4_run
+from url4.observe import ObservationEvent, Usage
+from url4_cloud.runner.accounting import OPENROUTER_CREDIT_UNIT, PRICING_VERSION
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec
+
+_MODEL = "openrouter/anthropic/claude-x"
+
+_HIT_HEADERS = {"X-AIGW-Cache": "hit", "X-AIGW-Cache-Reason": "fresh"}
+_MISS_HEADERS = {"X-AIGW-Cache": "miss", "X-AIGW-Cache-Reason": "absent"}
+_BYPASS_HEADERS = {"X-AIGW-Cache": "bypass", "X-AIGW-Cache-Reason": "opted_out"}
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+    @property
+    def usages(self) -> list[Usage]:
+        return [e for e in self.events if isinstance(e, Usage)]
+
+
+def _served_aigw() -> dict[str, Any]:
+    """The `_aigw` shape a HIT produces: no attempts, no subtotals, `not_applicable`."""
+    return {
+        "usage_accounting": {
+            "capture_status": "complete",
+            "cache": {"status": "hit", "reference": None},
+            "attempts": [],
+        },
+        "request_economics": {
+            "direct_cost_status": "not_applicable",
+            "known_direct_cost_subtotals": [],
+        },
+    }
+
+
+def _billed_aigw() -> dict[str, Any]:
+    """The `_aigw` shape a real provider call produces."""
+    return {
+        "usage_accounting": {
+            "capture_status": "complete",
+            "cache": {"status": "miss", "reference": None},
+            "attempts": [
+                {
+                    "provider": "openrouter",
+                    "response_model": "anthropic/claude-x-20260801",
+                    "outcome": "succeeded",
+                    "usage": {
+                        "input": {"total": 12480, "cache_read": 8000, "cache_write": 4000},
+                        "output": {"total": 742, "reasoning": 610},
+                    },
+                }
+            ],
+        },
+        "request_economics": {
+            "direct_cost_status": "complete",
+            "known_direct_cost_subtotals": [
+                {"amount": "0.001", "unit": OPENROUTER_CREDIT_UNIT, "source": "openrouter"}
+            ],
+        },
+    }
+
+
+def _body(aigw: dict[str, Any] | None) -> dict[str, Any]:
+    """A replayed cached response still carries the ORIGINAL call's `usage` — that is the trap."""
+    body: dict[str, Any] = {
+        "choices": [
+            {"message": {"role": "assistant", "content": "an answer"}, "finish_reason": "stop"}
+        ],
+        "usage": {"prompt_tokens": 651, "completion_tokens": 25},
+    }
+    if aigw is not None:
+        body["_aigw"] = aigw
+    return body
+
+
+async def _run(body: dict[str, Any], headers: dict[str, str], rec: _Recorder) -> str:
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        return httpx.Response(200, headers=headers, json=body)
+
+    cfg = AigatewayConfig(models=(ModelSpec(id=_MODEL, web_search=False),), default_model=_MODEL)
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    ) as client:
+        world = await build_aigateway_world(cfg, client=client)
+        return await url4_run(f"/{_MODEL}(ctx)!go", io=world.node, observer=rec)
+
+
+# ── the defect ─────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_reports_no_tokens_consumed() -> None:
+    """INVARIANT: the replayed body's `usage` describes the ORIGINAL call. Publishing it here
+    claims the provider did the work twice."""
+    rec = _Recorder()
+
+    assert await _run(_body(_served_aigw()), _HIT_HEADERS, rec) == "an answer"
+
+    usage = rec.usages[0]
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_zeroes_every_token_class_not_just_the_two() -> None:
+    """Nothing was consumed, so no class may claim otherwise — `None` would read as "unknown"."""
+    rec = _Recorder()
+
+    await _run(_body(_served_aigw()), _HIT_HEADERS, rec)
+
+    usage = rec.usages[0]
+    assert usage.cache_read_tokens == 0
+    assert usage.cache_creation_tokens == 0
+    assert usage.reasoning_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_stays_priced_at_zero_rather_than_unpriced() -> None:
+    """INVARIANT: `OME-851`'s P0, restated so this unit cannot regress it. Zero is a real claim —
+    the call genuinely cost nothing — and a dash here would hide a true saving."""
+    rec = _Recorder()
+
+    await _run(_body(_served_aigw()), _HIT_HEADERS, rec)
+
+    assert rec.usages[0].cost_usd == Decimal("0")
+    assert PRICING_VERSION == "openrouter-credits-1usd"
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_without_any_accounting_block_still_reports_no_tokens() -> None:
+    """INVARIANT: hit-ness is decided from the published cache outcome, not from `_aigw`.
+
+    An older gateway emits the `X-AIGW-Cache` header and no accounting at all. Deriving the hit
+    from `_aigw` alone would leave that gateway reporting phantom consumption forever.
+    """
+    rec = _Recorder()
+
+    await _run(_body(None), _HIT_HEADERS, rec)
+
+    usage = rec.usages[0]
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+
+
+# ── the guard: the zeroing is narrow ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_miss_reports_the_real_token_counts() -> None:
+    """INVARIANT: a miss is a real provider call. The guard must not blanket-zero every response
+    that happens to carry a cache header."""
+    rec = _Recorder()
+
+    await _run(_body(_billed_aigw()), _MISS_HEADERS, rec)
+
+    usage = rec.usages[0]
+    assert usage.input_tokens == 12480
+    assert usage.output_tokens == 742
+    assert usage.cache_read_tokens == 8000
+    assert usage.cost_usd == Decimal("0.001")
+
+
+@pytest.mark.asyncio
+async def test_a_bypass_reports_the_real_token_counts() -> None:
+    """A bypass means the cache refused to serve it, so the provider ran — same as a miss."""
+    rec = _Recorder()
+
+    await _run(_body(_billed_aigw()), _BYPASS_HEADERS, rec)
+
+    assert rec.usages[0].input_tokens == 12480
+    assert rec.usages[0].output_tokens == 742
+
+
+@pytest.mark.asyncio
+async def test_a_response_with_no_cache_header_at_all_is_untouched() -> None:
+    """The overwhelming majority of calls. An absent outcome is not a hit."""
+    rec = _Recorder()
+
+    await _run(_body(_billed_aigw()), {}, rec)
+
+    assert rec.usages[0].input_tokens == 12480
+
+
+@pytest.mark.asyncio
+async def test_the_pre_aigw_fallback_survives_for_a_non_hit() -> None:
+    """INVARIANT: `OME-851` kept an older gateway working by falling back to the provider's own
+    `usage` object. That path must remain for every call that is not a hit."""
+    rec = _Recorder()
+
+    await _run(_body(None), _MISS_HEADERS, rec)
+
+    usage = rec.usages[0]
+    assert usage.input_tokens == 651
+    assert usage.output_tokens == 25
+    assert usage.cost_usd is None

--- a/apps/url4-cloud/tests/unit/test_protocol.py
+++ b/apps/url4-cloud/tests/unit/test_protocol.py
@@ -21,11 +21,27 @@ def _ts() -> datetime:
     return datetime(2026, 7, 21, 9, 0, 0)
 
 
-def test_cost_total_must_equal_sum() -> None:
+def test_a_partial_cost_breakdown_is_accepted() -> None:
+    """OME-849: OpenRouter authors ONE amount with no per-class split, so the components are an
+    optional partial breakdown and `total_usd` is authoritative.
+
+    AIDEV-NOTE: this REPLACED `test_cost_total_must_equal_sum`, which asserted the opposite for
+    the same inputs. Authorised as a Confidence-Gate decision (owner, 2026-08-17) because the
+    contract it pinned is the one OME-849 deliberately changed — see
+    `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md` §2.1.
+    """
+    cb = CostBreakdown(
+        input_usd=Decimal("0.01"), output_usd=Decimal("0.02"), total_usd=Decimal("0.99")
+    )
+
+    assert cb.total_usd == Decimal("0.99")
+
+
+def test_cost_components_may_not_exceed_the_total() -> None:
+    """INVARIANT: the half of the old equality rule that survives. Components may be incomplete,
+    never larger than the whole — that is incoherent whichever number you trust."""
     with pytest.raises(ValidationError):
-        CostBreakdown(
-            input_usd=Decimal("0.01"), output_usd=Decimal("0.02"), total_usd=Decimal("0.99")
-        )
+        CostBreakdown(input_usd=Decimal("0.40"), total_usd=Decimal("0.36"))
 
 
 def test_cost_total_equals_sum_ok() -> None:

--- a/apps/url4-cloud/tests/unit/test_run_cost_capture.py
+++ b/apps/url4-cloud/tests/unit/test_run_cost_capture.py
@@ -1,0 +1,368 @@
+"""Carrying a run's real cost from aigateway's `_aigw` block to the wire cost frame.
+
+FEATURE: per-run cost reporting (`OME-849`). A Report showed an em dash because url4-cloud hardcoded
+`pricing_version="unpriced"` and `total_usd=0`. aigateway now publishes provider-authored cost, so
+the placeholder can go.
+
+STORY: as a researcher reading a run Report, I see what my run cost — and still an em dash, never a
+confident wrong number, whenever the gateway could not observe the whole call.
+
+Three seams, because the signal crosses three:
+  1. the connector reads `_aigw` off the chat-completions payload and reports it (`Usage`);
+  2. `_RunState` folds those events onto the owning span and the run totals;
+  3. `CostUsageData` carries it on the wire, priced or explicitly unpriced.
+
+A separate module rather than an append to `test_aigateway_connector.py`: the repo's append-only
+gate compares file status, so growing an existing test file reads as a modified prior test even
+when the diff is purely additive (same reasoning as `test_finish_reason_capture.py`).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import httpx
+import pytest
+
+from url4.dag import run as url4_run
+from url4.observe import NodeFinished, NodeStarted, ObservationEvent, Usage
+from url4.streaming.interfaces import Traced
+from url4.streaming.protocol import CostUsageData, SpanData
+from url4_cloud.runner.accounting import OPENROUTER_CREDIT_UNIT, PRICING_VERSION, UNPRICED
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.runner.executor import _RunState
+from url4_cloud.world_config import ModelSpec
+
+_MODEL = "openrouter/anthropic/claude-x"
+_BARE_MODEL = "claude-haiku-4-5"
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+    @property
+    def usages(self) -> list[Usage]:
+        return [e for e in self.events if isinstance(e, Usage)]
+
+
+def _aigw(
+    *,
+    direct_cost_status: str = "complete",
+    amount: str | None = "0.001",
+    unit: str = OPENROUTER_CREDIT_UNIT,
+    cache_status: str = "miss",
+    attempts: Any = None,
+) -> dict[str, Any]:
+    subtotals = (
+        []
+        if amount is None
+        else [{"amount": amount, "unit": unit, "source": "openrouter.usage.cost"}]
+    )
+    return {
+        "usage_accounting": {
+            "capture_status": "complete",
+            "cache": {"status": cache_status, "reference": None},
+            "attempts": [_attempt()] if attempts is None else attempts,
+        },
+        "request_economics": {
+            "direct_cost_status": direct_cost_status,
+            "known_direct_cost_subtotals": subtotals,
+        },
+    }
+
+
+def _attempt(
+    *,
+    provider: str = "openrouter",
+    response_model: str | None = "anthropic/claude-x-20260801",
+    input_total: int = 12480,
+    output_total: int = 742,
+    cache_read: int | None = 8000,
+    cache_write: int | None = 4000,
+    reasoning: int | None = 610,
+) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "response_model": response_model,
+        "outcome": "succeeded",
+        "usage": {
+            "input": {"total": input_total, "cache_read": cache_read, "cache_write": cache_write},
+            "output": {"total": output_total, "reasoning": reasoning},
+        },
+    }
+
+
+def _body(*, aigw: dict[str, Any] | None, content: str = "an answer") -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "choices": [
+            {"message": {"role": "assistant", "content": content}, "finish_reason": "stop"}
+        ],
+        "usage": {"prompt_tokens": 11, "completion_tokens": 22},
+    }
+    if aigw is not None:
+        body["_aigw"] = aigw
+    return body
+
+
+def _gateway(bodies: dict | list[dict]) -> httpx.AsyncClient:
+    sequence = bodies if isinstance(bodies, list) else [bodies]
+    index = {"i": 0}
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v1/chat/completions"
+        i = min(index["i"], len(sequence) - 1)
+        index["i"] += 1
+        return httpx.Response(200, json=sequence[i])
+
+    return httpx.AsyncClient(
+        transport=httpx.MockTransport(handle), base_url="http://aigateway.test"
+    )
+
+
+async def _run(
+    bodies: dict | list[dict],
+    recorder: _Recorder | None = None,
+    *,
+    model: str = _MODEL,
+) -> str:
+    cfg = AigatewayConfig(models=(ModelSpec(id=model, web_search=False),), default_model=model)
+    async with _gateway(bodies) as client:
+        world = await build_aigateway_world(cfg, client=client)
+        return await url4_run(f"/{model}(ctx)!go", io=world.node, observer=recorder)
+
+
+def _fold(recorder: _Recorder) -> tuple[list[SpanData], list[CostUsageData], CostUsageData]:
+    """Replay the recorded observation events through `_RunState`, as the runner does."""
+    state = _RunState()
+    frames: list[Traced] = []
+    for event in recorder.events:
+        frames.extend(state.map(event))
+    spans = [f.payload for f in frames if isinstance(f.payload, SpanData)]
+    costs = [f.payload for f in frames if isinstance(f.payload, CostUsageData)]
+    return spans, costs, state.build_subtree()
+
+
+# ── seam 1: the connector reads the accounting ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_priced_cost_reaches_the_usage_event() -> None:
+    rec = _Recorder()
+
+    assert await _run(_body(aigw=_aigw()), rec) == "an answer"
+
+    usage = rec.usages[0]
+    assert usage.cost_usd == Decimal("0.001")
+    assert usage.input_tokens == 12480
+    assert usage.output_tokens == 742
+    assert usage.cache_read_tokens == 8000
+    assert usage.cache_creation_tokens == 4000
+    assert usage.reasoning_tokens == 610
+
+
+@pytest.mark.asyncio
+async def test_the_authoritative_provider_and_served_model_come_from_the_accounting() -> None:
+    """The connector used to derive the provider by splitting the model id and never reported a
+    served model at all, though `Usage.response_model` has existed for it."""
+    rec = _Recorder()
+
+    await _run(_body(aigw=_aigw()), rec)
+
+    usage = rec.usages[0]
+    assert usage.provider == "openrouter"
+    assert usage.model == _MODEL
+    assert usage.response_model == "anthropic/claude-x-20260801"
+
+
+@pytest.mark.asyncio
+async def test_a_response_without_accounting_falls_back_to_the_provider_usage() -> None:
+    """INVARIANT: an older gateway, or any response with no `_aigw`, must keep working exactly as
+    before — tokens from the provider's own object and no price at all."""
+    rec = _Recorder()
+
+    await _run(_body(aigw=None), rec)
+
+    usage = rec.usages[0]
+    assert usage.input_tokens == 11
+    assert usage.output_tokens == 22
+    assert usage.cost_usd is None
+    assert usage.cache_read_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_the_fallback_provider_uses_the_shared_catalog_rule() -> None:
+    """A bare id is Anthropic's — aigateway's catalog leaves exactly that one provider unprefixed.
+    The rule belongs to `world_config.provider_of`, not to a private copy in the connector."""
+    rec = _Recorder()
+
+    await _run(_body(aigw=None), rec, model=_BARE_MODEL)
+
+    assert rec.usages[0].provider == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_several_calls_in_one_turn_each_report_their_own_accounting() -> None:
+    """A tool loop is several gateway calls serving ONE logical model call; each round trip carries
+    its own `_aigw`, so each must be reported rather than only the last."""
+    rec = _Recorder()
+    first = _body(aigw=_aigw(amount="0.001"), content="an answer")
+    second = _body(aigw=_aigw(amount="0.002"), content="an answer")
+
+    await _run([first, second], rec)
+
+    assert [u.cost_usd for u in rec.usages] == [Decimal("0.001")]
+
+
+# ── seam 2 + 3: the span cost frame and the run rollup ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_priced_span_publishes_the_real_total_and_names_the_method() -> None:
+    rec = _Recorder()
+
+    await _run(_body(aigw=_aigw()), rec)
+    _, costs, subtree = _fold(rec)
+
+    self_costs = [c for c in costs if c.scope == "self"]
+    assert len(self_costs) == 1
+    assert self_costs[0].pricing_version == PRICING_VERSION
+    assert self_costs[0].cost.total_usd == Decimal("0.001")
+    assert self_costs[0].usage.cache_read_tokens == 8000
+    assert subtree.pricing_version == PRICING_VERSION
+    assert subtree.cost.total_usd == Decimal("0.001")
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_is_published_as_a_priced_zero() -> None:
+    """INVARIANT: P0. A cache hit genuinely cost nothing this request, so it is priced at zero —
+    a dash here would hide a real saving."""
+    rec = _Recorder()
+    hit = _aigw(direct_cost_status="not_applicable", amount=None, cache_status="hit", attempts=[])
+
+    await _run(_body(aigw=hit), rec)
+    _, costs, subtree = _fold(rec)
+
+    self_costs = [c for c in costs if c.scope == "self"]
+    assert self_costs[0].pricing_version == PRICING_VERSION
+    assert self_costs[0].cost.total_usd == Decimal("0")
+    assert subtree.pricing_version == PRICING_VERSION
+
+
+@pytest.mark.asyncio
+async def test_an_unobservable_call_is_published_unpriced_not_free() -> None:
+    """INVARIANT: P0, and the pair of the test above. Both present an empty subtotal list; this one
+    is a real billed call the gateway could not observe, so it must NOT read as zero."""
+    rec = _Recorder()
+    blind = _aigw(
+        direct_cost_status="not_applicable", amount=None, cache_status="miss", attempts=[]
+    )
+
+    await _run(_body(aigw=blind), rec)
+    _, costs, subtree = _fold(rec)
+
+    self_costs = [c for c in costs if c.scope == "self"]
+    assert self_costs[0].pricing_version == UNPRICED
+    assert subtree.pricing_version == UNPRICED
+
+
+@pytest.mark.asyncio
+async def test_an_anthropic_run_reporting_no_cost_stays_unpriced() -> None:
+    """Regression guard: Anthropic authors no cost field, so its runs keep showing an em dash.
+    Must hold before and after this change."""
+    rec = _Recorder()
+    absent = _aigw(direct_cost_status="unavailable", amount=None)
+
+    await _run(_body(aigw=absent), rec, model=_BARE_MODEL)
+    _, costs, subtree = _fold(rec)
+
+    assert [c.pricing_version for c in costs if c.scope == "self"] == [UNPRICED]
+    assert subtree.pricing_version == UNPRICED
+
+
+def test_one_unpriced_span_makes_the_whole_subtree_unpriced() -> None:
+    """INVARIANT: P0. A run total missing a step while presenting itself as a total is worse than no
+    total. Driven directly through `_RunState` because it needs two spans with different outcomes.
+    """
+    state = _RunState()
+    state.map(_started("span-a"))
+    state.map(_usage("span-a", cost=Decimal("0.001")))
+    state.map(_finished("span-a"))
+    state.map(_started("span-b"))
+    state.map(_usage("span-b", cost=None))
+    state.map(_finished("span-b"))
+
+    subtree = state.build_subtree()
+
+    assert subtree.pricing_version == UNPRICED
+    assert subtree.cost.total_usd == Decimal("0")
+
+
+def test_a_span_sums_the_cost_of_every_call_it_made() -> None:
+    """The web-tools loop: several gateway calls on ONE span. Assigning instead of accumulating
+    would keep only the final round trip — the bug already fixed for token counts."""
+    state = _RunState()
+    state.map(_started("span-a"))
+    state.map(_usage("span-a", cost=Decimal("0.001")))
+    state.map(_usage("span-a", cost=Decimal("0.002")))
+    frames = state.map(_finished("span-a"))
+
+    costs = [f.payload for f in frames if isinstance(f.payload, CostUsageData)]
+    assert costs[0].cost.total_usd == Decimal("0.003")
+    assert state.build_subtree().cost.total_usd == Decimal("0.003")
+
+
+def test_an_unpriced_call_poisons_the_span_that_made_it() -> None:
+    """One unobservable call in a multi-call span makes that span's cost unknown, not partial."""
+    state = _RunState()
+    state.map(_started("span-a"))
+    state.map(_usage("span-a", cost=Decimal("0.001")))
+    state.map(_usage("span-a", cost=None))
+    frames = state.map(_finished("span-a"))
+
+    costs = [f.payload for f in frames if isinstance(f.payload, CostUsageData)]
+    assert costs[0].pricing_version == UNPRICED
+
+
+def test_a_run_with_no_model_call_emits_no_cost_frame() -> None:
+    """Regression guard: a node that called no model must not gain a cost frame."""
+    state = _RunState()
+    state.map(_started("span-a"))
+    frames = state.map(_finished("span-a"))
+
+    assert [f.payload for f in frames if isinstance(f.payload, CostUsageData)] == []
+
+
+def _started(span_id: str) -> NodeStarted:
+    return NodeStarted(span_id=span_id, parent_span_id=None, node_kind="Model", detail="d")
+
+
+def _finished(span_id: str) -> NodeFinished:
+    return NodeFinished(span_id=span_id, status="ok", engine_seq=1)
+
+
+def _usage(span_id: str, *, cost: Decimal | None) -> Usage:
+    return Usage(
+        span_id=span_id,
+        provider="openrouter",
+        model=_MODEL,
+        input_tokens=1,
+        output_tokens=1,
+        response_model=None,
+        cache_read_tokens=None,
+        cache_creation_tokens=None,
+        reasoning_tokens=None,
+        cost_usd=cost,
+    )
+
+
+def test_the_folded_frames_are_timestamped_consistently() -> None:
+    """Sanity: the helpers above build real events, so a drift in the event signatures fails here
+    rather than silently making every cost test vacuous."""
+    assert isinstance(datetime.now(UTC), datetime)
+    assert _usage("s", cost=None).cost_usd is None

--- a/apps/url4-cloud/tests/unit/test_run_total_token_classes.py
+++ b/apps/url4-cloud/tests/unit/test_run_total_token_classes.py
@@ -1,0 +1,174 @@
+"""A run's totals carry every token class its spans do.
+
+FEATURE: per-run cost reporting (`OME-849`/`OME-869`). `OME-851` folded all five token classes onto
+each SPAN but summed only two at run level, so `cache_read_tokens`, `cache_creation_tokens` and
+`reasoning_tokens` reached the wire as `0` on the `scope="subtree"` frame. `packages/screamingface`
+surfaces all three, so a Report showed zeroes for tokens that were really used.
+
+STORY: as a researcher comparing a cached ensemble against an uncached one, the run summary is
+where I look first. A run that reports `cache_read_tokens: 0` while its own spans report 8,000
+tells me caching did nothing, which is the opposite of what happened.
+
+INVARIANT under test: the subtree total equals the sum of the self frames, for EVERY class. A
+partial total is the one shape a reader cannot detect from the frame alone.
+
+A separate module rather than an append to `test_run_cost_capture.py`: the repo's append-only gate
+compares file status, so growing an existing test file reads as a modified prior test even when
+the diff is purely additive.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from url4.observe import NodeFinished, NodeStarted, RunStarted, Usage
+from url4.streaming.interfaces import Traced
+from url4.streaming.protocol import CostUsageData
+from url4_cloud.runner.executor import _RunState
+
+_TRACE = "0" * 32
+_ROOT = "a" * 16
+_CHILD = "b" * 16
+
+
+def _usage(span_id: str, **kwargs: object) -> Usage:
+    """A `Usage` event with the three optional classes defaulting to unreported."""
+    fields: dict[str, object] = {
+        "provider": "openrouter",
+        "model": "openrouter/anthropic/claude-x",
+        "input_tokens": 100,
+        "output_tokens": 10,
+    }
+    fields.update(kwargs)
+    return Usage(span_id=span_id, **fields)  # type: ignore[arg-type]
+
+
+def _drive(*usages: Usage) -> tuple[_RunState, list[CostUsageData]]:
+    """Replay a one-span run carrying `usages`, exactly as the runner folds it."""
+    state = _RunState()
+    frames: list[Traced] = []
+    state.map(RunStarted(trace_id=_TRACE, root_span_id=_ROOT, expression_hash="h"))
+    state.map(NodeStarted(span_id=_ROOT, parent_span_id=None, node_kind="Model", detail="x"))
+    for usage in usages:
+        frames.extend(state.map(usage))
+    frames.extend(state.map(NodeFinished(span_id=_ROOT, status="ok", engine_seq=1)))
+    costs = [f.payload for f in frames if isinstance(f.payload, CostUsageData)]
+    return state, costs
+
+
+# ── the defect ─────────────────────────────────────────────────────────────────────────────────
+
+
+def test_the_run_total_carries_the_cache_and_reasoning_classes() -> None:
+    """INVARIANT: the bug. All three reached the wire as `0` while the span reported them."""
+    state, _ = _drive(
+        _usage(_ROOT, cache_read_tokens=8000, cache_creation_tokens=4000, reasoning_tokens=610)
+    )
+
+    usage = state.build_subtree().usage
+
+    assert usage.cache_read_tokens == 8000
+    assert usage.cache_creation_tokens == 4000
+    assert usage.reasoning_tokens == 610
+
+
+def test_the_run_total_still_carries_input_and_output() -> None:
+    """Regression guard for the two classes that already worked."""
+    state, _ = _drive(_usage(_ROOT, cache_read_tokens=8000))
+
+    usage = state.build_subtree().usage
+
+    assert usage.input_tokens == 100
+    assert usage.output_tokens == 10
+
+
+def test_two_calls_sum_every_class() -> None:
+    state, _ = _drive(
+        _usage(_ROOT, cache_read_tokens=8000, cache_creation_tokens=1, reasoning_tokens=10),
+        _usage(_ROOT, cache_read_tokens=2000, cache_creation_tokens=2, reasoning_tokens=20),
+    )
+
+    usage = state.build_subtree().usage
+
+    assert usage.cache_read_tokens == 10000
+    assert usage.cache_creation_tokens == 3
+    assert usage.reasoning_tokens == 30
+    assert usage.input_tokens == 200
+
+
+def test_the_subtree_total_equals_the_sum_of_the_self_frames() -> None:
+    """INVARIANT: the property the whole unit restores. A per-span number that does not add up to
+    the run number is the shape a reader cannot detect from either frame alone."""
+    state, costs = _drive(
+        _usage(_ROOT, cache_read_tokens=8000, cache_creation_tokens=4000, reasoning_tokens=610),
+        _usage(_ROOT, cache_read_tokens=2000, cache_creation_tokens=1000, reasoning_tokens=90),
+    )
+    selfs = [c for c in costs if c.scope == "self"]
+    subtree = state.build_subtree().usage
+
+    assert len(selfs) == 1
+    assert subtree.cache_read_tokens == selfs[0].usage.cache_read_tokens
+    assert subtree.cache_creation_tokens == selfs[0].usage.cache_creation_tokens
+    assert subtree.reasoning_tokens == selfs[0].usage.reasoning_tokens
+
+
+# ── the design decision: run-level tokens do NOT poison ────────────────────────────────────────
+
+
+def test_a_class_only_some_calls_reported_sums_the_reported_ones() -> None:
+    """INVARIANT (OME-869): run-level tokens deliberately do NOT poison, unlike money.
+
+    Money poisons because the wire CAN say "unknown" — `pricing_version: "unpriced"`. `TokenUsage`
+    has no such escape hatch, so poisoning would publish `0`: a FALSE claim rather than an absent
+    one, and it would destroy the real numbers the reporting calls did supply.
+
+    This is the exact mixed-provider shape: one model reports cache reads and no reasoning, the
+    other reports reasoning and no cache reads. Poisoning would zero BOTH real figures.
+    """
+    state, _ = _drive(
+        _usage(_ROOT, cache_read_tokens=8000, reasoning_tokens=None),
+        _usage(_ROOT, cache_read_tokens=None, reasoning_tokens=610),
+    )
+
+    usage = state.build_subtree().usage
+
+    assert usage.cache_read_tokens == 8000
+    assert usage.reasoning_tokens == 610
+
+
+def test_a_class_no_call_reported_stays_zero() -> None:
+    """An absent class is `0` on the wire because `TokenUsage` cannot spell anything else."""
+    state, _ = _drive(_usage(_ROOT))
+
+    usage = state.build_subtree().usage
+
+    assert usage.cache_read_tokens == 0
+    assert usage.cache_creation_tokens == 0
+    assert usage.reasoning_tokens == 0
+
+
+def test_an_explicit_zero_and_an_unreported_class_agree_at_run_level() -> None:
+    """A cache hit reports explicit zeros (`OME-868`); an older gateway reports nothing. Both mean
+    "add nothing", so a run mixing them must not distinguish them."""
+    state, _ = _drive(
+        _usage(_ROOT, cache_read_tokens=0),
+        _usage(_ROOT, cache_read_tokens=None),
+        _usage(_ROOT, cache_read_tokens=7),
+    )
+
+    assert state.build_subtree().usage.cache_read_tokens == 7
+
+
+def test_money_still_poisons_while_tokens_do_not() -> None:
+    """INVARIANT: the asymmetry stated outright, so neither rule can be "made consistent" with the
+    other by a later reader. Same run, same events: the token class survives, the price does not.
+    """
+    state, _ = _drive(
+        _usage(_ROOT, cache_read_tokens=8000, cost_usd=Decimal("0.001")),
+        _usage(_ROOT, cache_read_tokens=None, cost_usd=None),
+    )
+    subtree = state.build_subtree()
+
+    assert subtree.usage.cache_read_tokens == 8000
+    assert subtree.pricing_version == "unpriced"
+    assert subtree.cost.total_usd == Decimal("0")

--- a/docs/spec/2026-08-17-OME-849-run-cost-openrouter.md
+++ b/docs/spec/2026-08-17-OME-849-run-cost-openrouter.md
@@ -1,0 +1,279 @@
+# OME-849 — Report real run cost from provider-authored OpenRouter evidence (spec)
+
+Status: drafted 2026-08-17, awaiting owner approval to implement.
+Sub-issues: `OME-850` (packages/url4) → `OME-851` (apps/url4-cloud). `OME-850` lands first.
+Producer contract this consumes: `apps/aigateway/docs/usage-accounting.md` (`OME-303`, PR #567).
+
+A run's Report shows `—` where a cost belongs. Everything except one link is already built. This
+spec joins the chain for the OpenRouter case only.
+
+## 0. Locked decisions (owner, 2026-08-17)
+
+- **OpenRouter only.** No rate card in this epic.
+- **1 `openrouter_credits` = 1 USD.**
+- **Anthropic stays unpriced**, and a mixed-provider run reports `unpriced` for the whole run.
+- **Cache status stays reported twice** — response headers *and* `_aigw`. Accepted duplication,
+  explicitly not a defect to chase here.
+- **Degrade to `unpriced`, never to `$0`.**
+
+## 1. Why the chain is cut
+
+`apps/url4-cloud/src/url4_cloud/runner/executor.py:313` and `:352` hardcode
+`pricing_version="unpriced"` with `CostBreakdown(total_usd=Decimal("0"))`, and
+`runner/connector.py:405` passes only the provider's own `usage` object to `_report_usage`,
+discarding `_aigw` entirely.
+
+The placeholder is **honest**: `packages/screamingface/.../_engine/contract.py:357,385` reads
+`pricing_version == "unpriced"` and renders `cost_usd=None`, which `_ui/report_view.py:288` shows as
+`—` titled "cost not reported by this run". Nobody is shown a wrong number today. **The single
+largest risk in this epic is replacing a truthful dash with a confident wrong figure.** Every rule
+below exists to prevent that.
+
+## 2. `packages/url4` — two non-breaking widenings (`OME-850`)
+
+### 2.1 `CostBreakdown` accepts a total without a breakdown
+
+`streaming/protocol/taxonomy.py:47-58` enforces
+`total_usd == Σ(input_usd, output_usd, cache_read_usd, cache_creation_usd, reasoning_usd)`, and every
+component defaults to `Decimal("0")`. OpenRouter authors **one** amount with no per-class split, so
+`CostBreakdown(total_usd=Decimal("0.001"))` raises. Today's `total_usd=Decimal("0")` validates only
+because zero equals zero.
+
+Normative rule: **the per-class components are an optional partial breakdown; `total_usd` is
+authoritative.** The validator changes from equality to `Σ components <= total_usd`. Over-reporting
+stays an error — a breakdown claiming more than the total is still incoherent — while an *incomplete*
+breakdown becomes legal.
+
+Rejected alternative: assigning the whole amount to `input_usd`. It validates and it writes a false
+claim into a structured field that a future breakdown view will believe.
+
+Precedent that this is the right direction: the consumer at the end of the chain was already built
+for it. `_engine/contract.py:350` notices a total that disagrees with its components, logs a warning,
+and uses `total_usd`. The strict validator in the middle is the outlier.
+
+### 2.2 The `Usage` observation event carries the remaining cost facts
+
+`observe.py:66-79` `Usage` carries only `input_tokens` and `output_tokens`. The wire protocol
+(`TokenUsage`, `taxonomy.py:6-33`) already has five classes, so the observation seam is the narrow
+part, and it is the **only** reliable channel: span attribution comes from the sink binding the
+executor installs per node task (`dag/executor.py::_eval`), so a private url4-cloud side channel
+could not attribute cost to the right span.
+
+Add, all optional and defaulted so no existing caller changes:
+
+```python
+cache_read_tokens: int | None = None
+cache_creation_tokens: int | None = None
+reasoning_tokens: int | None = None
+cost_usd: Decimal | None = None   # priced USD for this round trip; None means unpriced
+```
+
+`UsageSink` is already `Callable[..., None]` (`observe.py:150`), so the sink type needs no change, and
+`ResponseSink`'s own comment (`observe.py:178-180`) records the precedent: optional kwargs were added
+to this live seam before, precisely so an adapter that learns nothing can say nothing.
+
+Two invariants on the new fields:
+
+- **`None` means the provider did not say — never `0`.** This mirrors aigateway's own rule and the
+  existing `response_model` invariant at `observe.py:76-78`. The pre-existing `input_tokens` /
+  `output_tokens` stay non-optional `int`; widening them is a breaking change to a live seam and is
+  not required, because incomplete evidence forces `cost_usd=None` anyway.
+- **`cost_usd` is already USD.** Unit conversion happens in the adapter that understands the
+  provider's contract, not here. `packages/url4` performs no arithmetic on it — it stays a carrier
+  (`streaming/lifecycle.py` only copies and re-scopes).
+
+## 3. `apps/url4-cloud` — read the accounting and price it (`OME-851`)
+
+### 3.1 New module: `runner/accounting.py`
+
+One seam, one public function, total over its input:
+
+```python
+PRICING_VERSION = "openrouter-credits-1usd"
+UNPRICED = "unpriced"
+
+def usd_from_aigw(aigw: object) -> Decimal | None:
+    """USD for one gateway call, or None when the evidence cannot support a price."""
+```
+
+`Decimal("0")` and `None` are different answers and the return type keeps them apart:
+`Decimal("0")` is "this call was genuinely free", `None` is "we do not know". Collapsing them is the
+defect this signature exists to prevent.
+
+The function is **total**: a missing, non-dict, or malformed `_aigw` returns `None`. It never raises,
+because a provider call that already succeeded must not be turned into a run failure by accounting —
+the same rule aigateway applies on its side of the boundary.
+
+### 3.2 The normative decision table
+
+Read `_aigw.request_economics`. aigateway populates `known_direct_cost_subtotals` **only** when its
+capture was complete and nothing was omitted; it has already summed across retries and already
+refuses to emit a total if any amount was unreadable. Do not re-walk `attempts[]` to compute money.
+
+| `direct_cost_status` | further condition | result |
+|---|---|---|
+| `complete` | exactly one subtotal, `unit == "openrouter_credits"` | `Decimal(amount)` |
+| `complete` | zero, several, or a non-credits unit | `None` |
+| `not_applicable` | `usage_accounting.cache.status == "hit"` | `Decimal("0")` |
+| `not_applicable` | anything else | `None` |
+| `partial` | — | `None` |
+| `unavailable` | — | `None` |
+| absent / unrecognised | — | `None` |
+
+Rows 3 and 4 are the dangerous pair: **both present an empty subtotal list and mean opposite
+things.** A cache hit genuinely cost nothing this request; `accounting_not_supported` means a real
+billed call the gateway could not observe. This is the same failure aigateway's own review named —
+treating absence of observation as proof of absence.
+
+`amount` is parsed with `Decimal(str(value))`, never `float`. The multi-unit and non-credits rows are
+what keeps this honest when a second provider appears: an unrecognised unit degrades to `unpriced`
+rather than being silently added to a dollar total.
+
+### 3.3 Reporting it — `connector.py`
+
+`_fetch_completion` already returns the response; `_json_or_raise` already parses it. At
+`connector.py:405`, pass the accounting through the existing sink:
+
+```python
+_report_usage(spec.id, data.get("usage"), data.get("_aigw"))
+```
+
+`_report_usage` (`connector.py:298-306`) is rewritten to prefer `_aigw` and to fix three defects that
+are wrong independently of pricing:
+
+- **`provider` is guessed** by splitting the model id, defaulting to `"anthropic"`. Take
+  `_aigw.usage_accounting.attempts[-1].provider`. Pricing keyed on a guessed provider is how a
+  future non-OpenRouter call gets priced as OpenRouter.
+- **`response_model` is never reported.** `observe.py:76-78` states the invariant — `None` means the
+  provider did not say, never a copy of the request — yet `executor.py:286-287` assigns the requested
+  model to *both* request and response model. Report `attempts[-1].response_model`, which for
+  OpenRouter genuinely differs from what was asked for.
+- **`usage.get("prompt_tokens", 0)`** turns a missing count into zero. Read the token classes from
+  `attempts[-1].usage.{input,output}` (`total`, `cache_read`, `cache_write`, `reasoning`), preserving
+  `null` as `None`. Keep the provider `usage` object as the fallback only when `_aigw` is absent, and
+  in that case pass `cost_usd=None`.
+
+Token classes map as: `input.total → input_tokens`, `output.total → output_tokens`,
+`input.cache_read → cache_read_tokens`, `input.cache_write → cache_creation_tokens`,
+`output.reasoning → reasoning_tokens`. **`input.uncached` is deliberately not carried** — it is
+`total` minus the cache classes and the protocol has no slot for it.
+
+Aggregating `attempts[]` for tokens: sum across attempts, and **do not skip failed attempts** — a
+failed attempt may still carry provider-authored usage. `attempts[-1]` is used only for the
+*identity* facts (provider, response model), which the terminal attempt owns.
+
+### 3.4 Accumulating it — `executor.py`
+
+`_SpanState.usage` is a positional `tuple[str, str, int, int]` read as `usage[2]` / `usage[3]`. Nine
+fields make that untenable; replace it with a `@dataclass(frozen=True, slots=True)` value. This is a
+local refactor with no wire effect.
+
+Accumulation follows the rule already established at `executor.py:257-268` — **accumulate, never
+assign**, because one span makes several gateway calls (the web-tools loop is the normal case) and
+assigning once kept only the final round trip. That comment records the bug; the new fields inherit
+the same rule.
+
+Money accumulates with **poisoning**, at both levels:
+
+- a span's cost is `None` if *any* of its calls reported `None`, else the `Decimal` sum;
+- `build_subtree` (`executor.py:346-355`) is `None` if *any* contributing span was `None`.
+
+Nullable token classes accumulate the same way: `None` + anything is `None`. One shared helper does
+both so the rule cannot drift between call sites.
+
+Emission, in `_finish` and `build_subtree`:
+
+- priced → `pricing_version=PRICING_VERSION`, `cost=CostBreakdown(total_usd=<sum>)` with no
+  components set (legal after §2.1);
+- unpriced → `pricing_version=UNPRICED`, `cost=CostBreakdown(total_usd=Decimal("0"))`, exactly as
+  today, because the SDK discards the number when the version says unpriced.
+
+`TokenUsage` on the wire keeps non-optional `int` fields, so an unknown class serializes as `0`.
+That is tolerable **only** because an unknown class forces `unpriced`, which makes the SDK null the
+token fields too (`contract.py:361-380`). Widening the wire `TokenUsage` is out of scope; the
+coupling is recorded here so nobody later prices a run while leaving a class unknown.
+
+## 4. Test plan — risk-ranked, RED first
+
+P0 cases are the two that produce a plausible wrong number rather than a visible failure.
+
+**P0 — money invented from nothing**
+
+1. A cache hit prices to `Decimal("0")` and is marked **priced**; the run reports `$0.00`.
+2. `capture_status: "accounting_not_supported"` with zero attempts prices to `None` and reports
+   `unpriced` — *not* `$0`. Distinguishes rows 3 and 4 of §3.2.
+3. A `cache.reference` (`incurred_in_current_request: false`) never contributes to a price. Its
+   historical usage must not reach `cost_usd`.
+4. One unpriced span makes the whole subtree unpriced, even when every other span priced cleanly.
+
+**P1 — cardinality**
+
+5. Two attempts in one `_aigw`, both `reported` → aigateway's single subtotal is used once, not
+   summed twice from `attempts[]`.
+6. A failed attempt carrying usage contributes its tokens and is not dropped.
+7. Several gateway calls in one span (the web-tools loop) accumulate; the per-span cost equals their
+   sum and reconciles against the subtree total.
+8. `_fetch_completion`'s revalidation double-POST contributes exactly once. This is only correct
+   because the discarded response was a cache hit — pin it, since the function's own comment names
+   double-billing as the error class it exists to prevent.
+
+**P1 — boundaries and hostile input**
+
+9. `direct_cost_status: "partial"` → `unpriced`.
+10. Two subtotals, or one whose `unit` is not `openrouter_credits` → `unpriced`.
+11. `_aigw` absent, `None`, a non-dict, or structurally malformed → `unpriced`, no exception, and the
+    provider response still succeeds.
+12. An amount at the contract's precision bound (18 integer / 33 fractional digits) survives as an
+    exact `Decimal`; a non-canonical or negative amount → `unpriced`.
+13. `usage.status: "partial"` with a `null` token class → `unpriced`, and the class is `None` rather
+    than `0` at the observation seam.
+
+**P1 — the fixed defects**
+
+14. `provider` comes from `_aigw`, not from splitting the model id — a bare model id no longer
+    reports `"anthropic"`.
+15. `response_model` differs from `requested_model` and both reach the span frame.
+
+**P2 — regression guards (must pass before and after)**
+
+16. An Anthropic-only run still reports `unpriced` and the Report still shows `—`.
+17. A run with no model call at all emits no cost frame, exactly as today.
+18. `CostBreakdown` with a full, exactly-matching breakdown still validates; components exceeding
+    the total are still rejected.
+
+**Not covered, deliberately:** live provider calls; streaming (no `_aigw` exists there); any
+Anthropic price; leaderboard submission. Residual risk: the 1 credit = 1 USD constant is an owner
+assertion, not something the code can verify.
+
+## 5. Don't regress
+
+- Accumulate-don't-assign for per-span usage (`executor.py:257-268`) — the bug it fixed made per-node
+  cost under-report while the subtree stayed correct.
+- A span id the run never opened is dropped, never fabricated (`executor.py:208-220`); run-level
+  counters still count before the span guard (`executor.py:229-233`).
+- Accounting never fails a completed provider response.
+- `packages/url4` performs no cost arithmetic — it stays a carrier.
+- The response-cache body is untouched; `_aigw` is read from the returned copy only.
+- `pricing_version` remains the single switch the SDK reads to decide dash-versus-number.
+
+## 6. Leaving room for a rate card
+
+`pricing_version` names the *method*, so a second method is additive rather than a rewrite:
+
+| value | meaning |
+|---|---|
+| `unpriced` | unknown — the SDK shows `—` |
+| `openrouter-credits-1usd` | provider authored the amount; 1 credit = 1 USD |
+| `ratecard-<date>` | tokens × a dated price list (future, not this epic) |
+
+`usd_from_aigw` is the whole seam. A rate card becomes a second branch inside it when Anthropic needs
+pricing. **No plugin, no registry, no port with one implementation, and no cost store** — persistence
+belongs to the SDK and the scoreboard, which is the boundary aigateway drew.
+
+## 7. Open questions
+
+1. **Mixed-provider runs.** §0 locks "whole run unpriced". If mixed OpenRouter + Anthropic ensembles
+   are routine, the alternative is a partial total plus an explicit incompleteness marker — which
+   needs a new wire field and a Report affordance, so it is a separate unit either way.
+2. **When to pin the method for a long run.** Moot while `openrouter-credits-1usd` is a constant;
+   it becomes real with the first dated rate card, and a run can outlive a rate change.

--- a/docs/spec/2026-08-17-OME-849-run-cost-openrouter.md
+++ b/docs/spec/2026-08-17-OME-849-run-cost-openrouter.md
@@ -188,10 +188,16 @@ Emission, in `_finish` and `build_subtree`:
 - unpriced → `pricing_version=UNPRICED`, `cost=CostBreakdown(total_usd=Decimal("0"))`, exactly as
   today, because the SDK discards the number when the version says unpriced.
 
-`TokenUsage` on the wire keeps non-optional `int` fields, so an unknown class serializes as `0`.
-That is tolerable **only** because an unknown class forces `unpriced`, which makes the SDK null the
-token fields too (`contract.py:361-380`). Widening the wire `TokenUsage` is out of scope; the
-coupling is recorded here so nobody later prices a run while leaving a class unknown.
+`TokenUsage` on the wire keeps non-optional `int` fields, so an unknown class serializes as `0` —
+"unknown" and "zero" are indistinguishable on the wire for tokens.
+
+> **CORRECTED after implementation (2026-08-17).** This paragraph originally said an unknown token
+> class must force `unpriced`. That is wrong under this pricing method and was not implemented.
+> Token counts **do not enter the price** here — the amount is provider-authored — so discarding a
+> valid cost because a cache sub-class went unreported would throw away a correct number for no gain.
+> The flattening is tolerable for exactly that reason, and the condition under which it stops being
+> safe is documented at `executor._token_usage`: a rate-card method that multiplies these counts.
+> Widening the wire `TokenUsage` is out of scope and would have to come first.
 
 ## 4. Test plan — risk-ranked, RED first
 
@@ -225,8 +231,8 @@ P0 cases are the two that produce a plausible wrong number rather than a visible
     provider response still succeeds.
 12. An amount at the contract's precision bound (18 integer / 33 fractional digits) survives as an
     exact `Decimal`; a non-canonical or negative amount → `unpriced`.
-13. `usage.status: "partial"` with a `null` token class → `unpriced`, and the class is `None` rather
-    than `0` at the observation seam.
+13. A `null` token class stays `None` at the observation seam rather than becoming `0`, and — per the
+    correction in §3.4 — does **not** by itself make the call unpriced.
 
 **P1 — the fixed defects**
 

--- a/docs/tasks/2026-08-17-OME-849-run-cost-openrouter.md
+++ b/docs/tasks/2026-08-17-OME-849-run-cost-openrouter.md
@@ -1,0 +1,14 @@
+---
+id: OME-849
+linear_url: https://linear.app/openmined/issue/OME-849/report-real-run-cost-from-provider-authored-openrouter-evidence
+status: In Progress
+type: Feature
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Report real run cost from provider-authored OpenRouter evidence
+
+Part of the OME-849 cost epic. Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md`.

--- a/docs/tasks/2026-08-17-OME-850-cost-total-without-breakdown.md
+++ b/docs/tasks/2026-08-17-OME-850-cost-total-without-breakdown.md
@@ -1,0 +1,14 @@
+---
+id: OME-850
+linear_url: https://linear.app/openmined/issue/OME-850/allow-a-cost-total-without-a-per-class-breakdown
+status: In Progress
+type: Feature
+priority: P1
+labels: [url4-python-sdk, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Allow a cost total without a per-class breakdown
+
+Part of the OME-849 cost epic. Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md`.

--- a/docs/tasks/2026-08-17-OME-851-price-runs-from-aigateway.md
+++ b/docs/tasks/2026-08-17-OME-851-price-runs-from-aigateway.md
@@ -1,0 +1,14 @@
+---
+id: OME-851
+linear_url: https://linear.app/openmined/issue/OME-851/price-runs-from-aigateway-provider-authored-cost-evidence
+status: In Progress
+type: Feature
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Price runs from aigateway provider-authored cost evidence
+
+Part of the OME-849 cost epic. Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md`.

--- a/docs/tasks/2026-08-17-OME-861-no-warning-without-breakdown.md
+++ b/docs/tasks/2026-08-17-OME-861-no-warning-without-breakdown.md
@@ -1,0 +1,16 @@
+---
+id: OME-861
+linear_url: https://linear.app/openmined/issue/OME-861/stop-warning-when-the-engine-reports-a-total-with-no-cost-breakdown
+status: In Progress
+type: Feature
+priority: P1
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Stop warning when the Engine reports a total with no cost breakdown
+
+Part of the OME-849 cost epic. A total with no per-class breakdown became legal in OME-850 and is
+what OME-851 publishes, so contract.py's total-vs-parts warning fired on every priced run.
+Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md`.

--- a/docs/tasks/2026-08-17-OME-868-cache-hit-tokens.md
+++ b/docs/tasks/2026-08-17-OME-868-cache-hit-tokens.md
@@ -1,0 +1,16 @@
+---
+id: OME-868
+linear_url: https://linear.app/openmined/issue/OME-868/stop-counting-a-cache-hits-replayed-tokens-as-freshly-consumed
+status: In Progress
+type: Feature
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Stop counting a cache hit's replayed tokens as freshly consumed
+
+Part of the OME-849 cost epic, found in peer review of PR #620. A cache hit falls back to the
+replayed cached body's `usage`, publishing the original call's tokens as consumed while pricing
+the call at zero. Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md`.

--- a/docs/tasks/2026-08-17-OME-869-run-total-token-classes.md
+++ b/docs/tasks/2026-08-17-OME-869-run-total-token-classes.md
@@ -1,0 +1,16 @@
+---
+id: OME-869
+linear_url: https://linear.app/openmined/issue/OME-869/carry-cache-and-reasoning-token-classes-into-the-run-totals
+status: In Progress
+type: Feature
+priority: P1
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Carry cache and reasoning token classes into the run totals
+
+Part of the OME-849 cost epic, found in peer review of PR #620. Spans carry all five token
+classes; the run subtree carries only input and output, so cache-read, cache-creation and
+reasoning reach the wire as zero. Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md`.

--- a/docs/work/2026-08-17-OME-849-run-cost-openrouter.md
+++ b/docs/work/2026-08-17-OME-849-run-cost-openrouter.md
@@ -1,0 +1,48 @@
+---
+ticket: OME-849
+stack: repo
+status: in_progress
+started: 2026-08-17
+finished:
+---
+
+# OME-849 — Report real run cost from provider-authored OpenRouter evidence
+
+## Intent
+
+A run's report shows `—` where a cost belongs, because `apps/url4-cloud` hardcodes
+`pricing_version="unpriced"` and `total_usd=0`. Every other link is built: aigateway now publishes
+per-attempt usage accounting under `_aigw` (`OME-303`), `packages/url4` already carries five token
+classes and five USD components, and the SDK already reads all of it. This epic joins the chain for
+the OpenRouter case, taking the provider-authored amount as the source at 1 credit = 1 USD.
+
+This ledger covers the SPEC unit only. Implementation runs under `OME-850` (packages/url4) and
+`OME-851` (apps/url4-cloud), each with its own ledger.
+
+## Planned changes
+
+- `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md` — the normative spec.
+- `docs/tasks/2026-08-17-OME-849-run-cost-openrouter.md` and the two sub-issue mirrors.
+
+No source change in this unit.
+
+## Test plan
+
+Not applicable — spec unit, no code. The spec itself carries the required test list that
+`OME-850`/`OME-851` must implement RED-first, including the two P0 cases (never price a cache
+reference; never collapse "genuinely free" with "unknown").
+
+## Acceptance
+
+- Spec states the normative pricing rule as a total decision table with no unreachable row.
+- Spec pins the degradation rule (`unpriced`, never `$0`) and the rollup poisoning rule.
+- Spec names every file to change in both components, and the invariants not to regress.
+- Locked decisions from the 2026-08-17 owner session are recorded verbatim.
+- Open questions are listed as open, not silently defaulted.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/docs/work/2026-08-17-OME-849-run-cost-openrouter.md
+++ b/docs/work/2026-08-17-OME-849-run-cost-openrouter.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-849
 stack: repo
-status: in_progress
+status: done
 started: 2026-08-17
-finished:
+finished: 2026-08-17
 ---
 
 # OME-849 — Report real run cost from provider-authored OpenRouter evidence
@@ -40,9 +40,71 @@ reference; never collapse "genuinely free" with "unknown").
 - Locked decisions from the 2026-08-17 owner session are recorded verbatim.
 - Open questions are listed as open, not silently defaulted.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+Status: done (spec unit). Both child units also landed on this branch.
+
+- **Actual files:** as planned — `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md` plus the three
+  `docs/tasks/` mirrors and this ledger.
+
+- **Commits:**
+  - `095f4588` docs(OME-849): spec run cost from provider-authored OpenRouter evidence
+  - `105ef9c1` feat(url4): allow a total-only cost and widen the usage seam (`OME-850`)
+  - `405a6869` feat(url4-cloud): price runs from provider-authored cost evidence (`OME-851`)
+
+- **Gates:** not applicable to this unit (no code). Both child stacks green — see their ledgers.
+
+- **LIVE END-TO-END VERIFICATION (2026-08-17).** Ran a real local stack — aigateway on 9105 with
+  `AIGW_AUTH_MODE=disabled` + `AIGW_OPENROUTER_ENABLED=true`, url4-cloud `serve --local` on 9108, an
+  owner-supplied OpenRouter API key — and compared the published cost against OpenRouter's own
+  billing meter (`GET /api/v1/credits`, `data.total_usage`).
+
+  | run | meter delta (ground truth) | published `subtree.total_usd` | |
+  |---|---|---|---|
+  | direct gateway call | `0.000044` | `0.000044` | exact |
+  | url4 run — "capital of France" | `0.007905000` | `0.007905` | exact |
+  | url4 run — "largest planet" | `0.009372000` | `0.009372` | exact |
+
+  What this proved that no unit test could: the exact-decimal chain survives a real provider —
+  OpenRouter's raw body carries `cost: 4.4e-05` (a float once JSON-parsed) and `"0.000044"` reached
+  the wire unrounded across four processes; the 1 credit = 1 USD assumption holds for this account;
+  and `provider` / `response_model` arrive authoritatively (`openrouter`,
+  `anthropic/claude-haiku-4.5`) rather than derived from the requested id.
+
+  **Method note worth keeping:** OpenRouter's usage endpoint lags roughly 10–40s. A first comparison
+  appeared to be off by `0.000058`, which turned out to be a probe call of my own inside the
+  measurement window — not a defect. Every figure above comes from a settle loop (poll until two
+  consecutive reads agree) around exactly one run.
+
+  **Not exercised live, and stated as such:** every live run was single-call / single-span, so the
+  multi-span rollup and the poisoning rule were NOT proven against a real provider — only by unit
+  tests, each verified to fail with its guard removed. An attempt at a nested two-model expression
+  ran and matched, but the gateway log shows it made one call: the inner expressions resolved as data,
+  not model calls, so the expression form was wrong for a fan-out. Also untested live: the
+  cache-hit-priced-at-zero branch (every run reported `cache: bypass`) and the unpriced branch (no
+  Anthropic credential on the box).
+
+  Secret hygiene: the key lived only in a `600` scratchpad file and process env, was never written to
+  a tracked path (verified by grepping the full key across the repo — no hits), and the key file, env
+  file and the sqlite DB holding the encrypted credential were deleted afterwards. The key was
+  disclosed in a chat transcript and must be rotated regardless.
+
+  **Local bring-up findings (not fixed here):** aigateway has migrations under
+  `src/aigateway/migrations/` but nothing applies them at startup and there is no CLI to do it, so a
+  fresh DB starts with `no such table: credential_blobs`. Tests use `Tortoise.generate_schemas()`; I
+  did the same for a throwaway DB. Separately, a url4 expression with an empty `('')` source produces
+  an empty message that OpenRouter rejects with HTTP 400 surfacing as `bad_request` — the source needs
+  real text.
+
+- **Deviations:**
+  1. §3.4 of the spec was **corrected after implementation**: it required an unknown token class to
+     force `unpriced`, which is wrong under a provider-authored pricing method and was deliberately
+     not implemented. §4 case 13 was corrected to match. Recorded inline in the spec rather than
+     silently, so the spec and the code agree.
+  2. One prior test was changed under owner authorisation — see the `OME-851` ledger for the full
+     Confidence-Gate record.
+
+- **S1 (migrations):** not applicable — no schema change in any unit of this epic.
+
+- **Open at hand-off:** the `packages/screamingface` warning noise (a third sub-issue, not yet filed),
+  and the two questions in spec §7.

--- a/docs/work/2026-08-17-OME-849-run-cost-openrouter.md
+++ b/docs/work/2026-08-17-OME-849-run-cost-openrouter.md
@@ -106,5 +106,6 @@ Status: done (spec unit). Both child units also landed on this branch.
 
 - **S1 (migrations):** not applicable — no schema change in any unit of this epic.
 
-- **Open at hand-off:** the `packages/screamingface` warning noise (a third sub-issue, not yet filed),
-  and the two questions in spec §7.
+- **Open at hand-off:** the two questions in spec §7. The `packages/screamingface` warning noise was
+  filed as `OME-861` and fixed on this branch — see
+  `docs/work/2026-08-17-OME-861-no-warning-without-breakdown.md`.

--- a/docs/work/2026-08-17-OME-850-cost-total-without-breakdown.md
+++ b/docs/work/2026-08-17-OME-850-cost-total-without-breakdown.md
@@ -1,0 +1,111 @@
+---
+ticket: OME-850
+stack: url4
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-850 — Allow a cost total without a per-class breakdown
+
+## Intent
+
+`apps/url4-cloud` must be able to publish the cost OpenRouter authored: one amount, no per-class
+split. Two things in `packages/url4` block that today, and both are widenings that leave every
+existing caller unchanged.
+
+`CostBreakdown` enforces `total_usd == Σ(five components)` with every component defaulting to
+`Decimal("0")`, so a total-only cost raises. And the `Usage` observation event carries only
+`input_tokens` / `output_tokens`, while the wire `TokenUsage` it feeds already has five token
+classes — the observation seam is the narrow part, and it is the only channel that can attribute a
+cost to the right span (the engine binds the sink per node task).
+
+Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md` §2. Parent: `OME-849`.
+Consumer that follows: `OME-851`.
+
+## Planned changes
+
+- `src/url4/streaming/protocol/taxonomy.py` — `CostBreakdown._total_is_sum` becomes
+  `Σ components <= total_usd`; docstrings state that the components are an optional partial
+  breakdown and `total_usd` is authoritative.
+- `src/url4/observe.py` — `Usage` gains `cache_read_tokens`, `cache_creation_tokens`,
+  `reasoning_tokens` (`int | None = None`) and `cost_usd` (`Decimal | None = None`); the
+  `UsageSink` kwargs comment is updated to match.
+- `src/url4/dag/node.py` — `ExecutionContext.report_usage` accepts and forwards the four new
+  keyword arguments.
+- `tests/unit/test_cost_breakdown.py` (new) — the validator contract.
+- `tests/unit/test_usage_sink.py` (append) — the widened sink.
+
+No schema/model change (S1 not applicable — this package has no ORM). No wire-format change: field
+names, aliases and JSON shape are untouched.
+
+## Test plan
+
+RED first, all new files/cases appended — no prior test touched.
+
+`CostBreakdown`:
+1. A total with no components validates (the OpenRouter shape).
+2. Components summing exactly to the total still validate (existing behaviour preserved).
+3. Components summing to LESS than the total validate (partial breakdown).
+4. Components summing to MORE than the total are rejected — over-reporting stays an error.
+5. `total_usd=Decimal("0")` with no components still validates (today's live shape).
+6. A partial breakdown keeps exact `Decimal` precision, no float coercion.
+
+`Usage` / sink:
+7. `Usage` built with no new kwargs is unchanged, and all four new fields default to `None`.
+8. `report_usage` forwards each new kwarg onto the emitted `Usage`.
+9. `None` is preserved as `None` — never coerced to `0` — for every new token class.
+10. `cost_usd` survives as an exact `Decimal`.
+
+## Acceptance
+
+- A `CostBreakdown` carrying only `total_usd` validates; over-reporting components are rejected.
+- Existing exact breakdowns, including `total_usd=0`, keep validating unchanged.
+- `Usage(...)` and `report_usage(...)` calls that pass no new arguments behave exactly as today.
+- New token classes and `cost_usd` distinguish `None` (not reported) from `0`.
+- `uv run .claude/scripts/run_gates.py url4` green (ruff · format · pyright · pytest cov ≥95).
+
+## Outcome
+
+Status: done.
+
+- **Actual files** — as planned, plus one the plan missed:
+  - `src/url4/streaming/protocol/taxonomy.py` — `_total_is_sum` → `_total_covers_components`,
+    equality becomes `components > total_usd` rejection. Private method, single reference, verified
+    by grep before renaming.
+  - `src/url4/observe.py` — the four optional `Usage` fields, `Decimal` import, and the `UsageSink`
+    kwargs comment with its optional-by-invariant note.
+  - `src/url4/dag/node.py` — `ExecutionContext.report_usage` accepts and forwards the four kwargs;
+    `Decimal` import added.
+  - `tests/unit/test_cost_breakdown.py` (new, 6 cases), `tests/unit/test_usage_cost_fields.py`
+    (new, 4 cases).
+  - **Not planned:** `tests/unit/test_usage_sink.py` was NOT appended to. A dedicated new file was
+    used instead, matching the precedent set by `test_usage_response_model.py` — the file created the
+    last time a field was added to `Usage`. Keeps the change append-only by construction.
+
+- **RED evidence:** `7 failed, 3 passed`. The three that passed are the preservation cases (an exact
+  breakdown, `total_usd=0`, and over-reporting rejected) — they must and do pass on both sides of the
+  change, so they are blast-radius guards rather than tautologies. The seven failed for two distinct
+  right reasons: `ValidationError` from the equality rule, and
+  `TypeError: report_usage() got an unexpected keyword argument 'cost_usd'`.
+
+- **Gates:** `uv run .claude/scripts/run_gates.py url4` → **ALL GATES GREEN** (append-only test check
+  vs HEAD · ruff check · ruff format --check · pyright · pytest `--cov=url4 --cov-fail-under=95`).
+  No prior test modified, weakened or deleted — the append-only gate proves it.
+
+- **Blast radius, checked rather than assumed:**
+  - `Usage` is constructed at exactly ONE site (`dag/node.py:384`, verified by grep) and
+    positionally, so appending fields after `response_model` is safe; that site was updated.
+  - Relaxing validation cannot invalidate a previously-valid payload, so no existing producer or
+    consumer breaks. `CostBreakdown` is re-exported from `streaming/protocol/__init__.py`; the wire
+    field names, aliases and JSON shape are untouched.
+  - The three pre-existing `Usage` test files continue to pass unmodified.
+
+- **Deviations:**
+  1. `dag/node.py` is 490 lines, past the card's ≤450 guidance. It was **already 475 before this
+     change** (`git show HEAD:` verified); the 15 lines added are the new kwargs and their docstring.
+     Splitting that module is its own unit of work, not a side effect of this one.
+  2. The validator method was renamed, which the plan did not call out. It is private, had a single
+     reference, and the old name (`_total_is_sum`) would have actively misdescribed the new rule.
+
+- **S1 (migrations):** not applicable — this package has no ORM and no schema.

--- a/docs/work/2026-08-17-OME-851-price-runs-from-aigateway.md
+++ b/docs/work/2026-08-17-OME-851-price-runs-from-aigateway.md
@@ -1,0 +1,161 @@
+---
+ticket: OME-851
+stack: url4-cloud
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-851 — Price runs from aigateway provider-authored cost evidence
+
+## Intent
+
+Publish the cost a run actually incurred instead of the `unpriced` placeholder. `connector.py:405`
+discards aigateway's `_aigw` accounting block, and `executor.py:313`/`:352` hardcode
+`pricing_version="unpriced"` with `total_usd=0`. Read the accounting, convert OpenRouter credits to
+USD 1:1, and degrade to `unpriced` — never to `$0` — whenever the evidence cannot support a price.
+
+Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md` §3. Parent: `OME-849`.
+Depends on `OME-850` (landed: a total-only `CostBreakdown` now validates, and `Usage` carries the
+cache/reasoning classes plus `cost_usd`).
+
+## Planned changes
+
+- `src/url4_cloud/runner/accounting.py` (new) — `CallAccounting` value object, `read_aigw()`,
+  `usd_from_aigw()` implementing the spec §3.2 decision table, and `accumulate()`, the
+  unknown-poisons-the-sum helper shared with the executor.
+- `src/url4_cloud/runner/connector.py` — `_report_usage` prefers `_aigw` and falls back to the
+  provider `usage` object; the call site passes `data.get("_aigw")`; provider derivation uses the
+  existing `world_config.provider_of` instead of a local copy of the same rule.
+- `src/url4_cloud/runner/executor.py` — `_SpanState.usage` becomes a `_SpanUsage` dataclass;
+  `_fold_usage` accumulates the new classes with poisoning; `_finish` and `build_subtree` emit
+  `PRICING_VERSION` + the real total when priced and today's exact shape when not.
+- `tests/unit/test_accounting.py` (new) — the decision table and the poisoning helper.
+- `tests/unit/test_url4_executor_cost.py` (new) — span/subtree emission and rollup poisoning.
+- `tests/unit/test_connector_accounting.py` (new) — evidence extraction and the fallback path.
+
+No schema/model change (S1 not applicable — this app has no ORM). No wire-format change: the
+`ai.url4.cost.usage` field names and JSON shape are untouched.
+
+## Test plan
+
+RED first, in new files only — no prior test touched.
+
+P0 (a wrong number rather than a visible failure):
+1. A cache hit prices to `Decimal("0")` and is marked priced.
+2. `accounting_not_supported` with zero attempts prices to `None`, not `Decimal("0")`.
+3. A `cache.reference` never contributes to a price.
+4. One unpriced span makes the whole subtree unpriced.
+
+P1 (cardinality):
+5. Two attempts in one `_aigw` use aigateway's single subtotal once, not summed twice.
+6. A failed attempt carrying usage still contributes its tokens.
+7. Several gateway calls in one span accumulate; per-span cost equals their sum.
+
+P1 (boundaries / hostile input):
+8. `partial` and `unavailable` both price to `None`.
+9. Two subtotals, or a non-credits unit, price to `None`.
+10. `_aigw` absent / `None` / non-dict / structurally malformed → `None`, no exception.
+11. An amount at the 18/33-digit bound survives exactly; negative, non-canonical, `bool` and
+    `float` carriers are refused.
+12. `accumulate` poisons on either side and sums otherwise.
+
+P1 (the fixed defects):
+13. `provider` comes from `_aigw` when attempts exist.
+14. `response_model` reaches the span and differs from the requested model.
+
+P2 (regression guards, green before and after):
+15. An Anthropic-only run still reports `unpriced`.
+16. A run with no model call emits no cost frame.
+
+## Acceptance
+
+- `pricing_version` is `"openrouter-credits-1usd"` when priced, `"unpriced"` otherwise.
+- `usd_from_aigw` is total over its input and never raises.
+- `Decimal("0")` (genuinely free) and `None` (unknown) are never conflated.
+- `uv run .claude/scripts/run_gates.py url4-cloud` green (ruff · format · pyright · layering ·
+  pytest cov ≥80).
+
+## Outcome
+
+Status: done.
+
+- **Actual files:**
+  - `src/url4_cloud/runner/accounting.py` (new, 249 lines) — `CallAccounting`, `read_aigw`,
+    `usd_from_aigw`, `accumulate`, and the canonical-amount guard.
+  - `src/url4_cloud/runner/connector.py` — `_report_usage` rewritten to prefer `_aigw`; call site
+    passes `data.get("_aigw")`; `_token_count` helper; `provider_of` imported instead of a local copy
+    of the same rule.
+  - `src/url4_cloud/runner/executor.py` — `_SpanUsage` dataclass replaces the positional 4-tuple;
+    `_fold_usage` accumulates the new classes and latches the run-level unpriced flag; `_finish` and
+    `build_subtree` emit through `_pricing_version` / `_token_usage`.
+  - `tests/unit/test_accounting.py` (new, 42 cases), `tests/unit/test_run_cost_capture.py`
+    (new, 14 cases).
+  - **Not planned:** the three planned test files were collapsed into two. `test_run_cost_capture.py`
+    drives the connector, the fold and the wire together, following
+    `test_finish_reason_capture.py`'s precedent of one module per signal across all three seams
+    rather than one per source file.
+
+- **RED evidence:** `test_accounting.py` failed collection with `ModuleNotFoundError`, then
+  `test_run_cost_capture.py` gave `6 failed, 8 passed` — failing on cost never reaching the event or
+  the frame. The 8 that passed are guards (the fallback path, the no-model-call case, and the two
+  poisoning cases, which pass trivially while everything is unpriced).
+
+- **The poisoning guards were proven live, not assumed.** Each was re-run with its specific guard
+  disabled:
+  - `accumulate` changed to skip an unknown instead of poisoning →
+    `test_an_unpriced_call_poisons_the_span_that_made_it` FAILS.
+  - `build_subtree` changed to ignore `_subtree_unpriced` →
+    `test_one_unpriced_span_makes_the_whole_subtree_unpriced` FAILS.
+  Both restored; 56 focused tests green.
+
+- **A real defect the tests caught during GREEN:** `amount * _CREDIT_TO_USD` is **not** the identity
+  even at a 1:1 rate — `Decimal` multiplication rounds to the ambient context's precision (28
+  significant digits by default), which truncated an amount at the producer's 18+33-digit bound.
+  Caught by `test_an_amount_at_the_contract_precision_bound_survives_exactly`. Fixed with an explicit
+  `localcontext()` at precision 53, so the conversion is independent of whatever decimal context the
+  caller runs under.
+
+- **Ruff `PLR0911` (too many returns) was resolved by restructuring, never suppressed.** The fix
+  improved the code: ad-hoc amount validation (an `"e" in value` check plus `is_finite`/`< 0` guards)
+  was replaced by the producer's own published schema regex, so this consumer now accepts exactly
+  what the contract promises and nothing else.
+
+- **Gates:** `uv run .claude/scripts/run_gates.py url4-cloud --skip-append-only` → **ALL GATES GREEN**
+  (ruff · format · pyright · layering · pytest `--cov=url4_cloud --cov=url4.streaming
+  --cov-fail-under=80`, **1542 passed, 5 skipped, coverage 93.09%**). `run_gates.py url4` re-run →
+  **ALL GATES GREEN** including its append-only check.
+
+- **CONFIDENCE-GATE DECISION — one prior test was changed, with owner authorisation
+  (2026-08-17).** `tests/unit/test_protocol.py::test_cost_total_must_equal_sum` asserted that
+  components not equalling the total is a `ValidationError` — exactly the contract `OME-850`
+  deliberately relaxed. Presented to the owner with the alternative (keep equality and instead assert
+  the whole OpenRouter amount as `input_usd`, which writes a false claim into a structured field); the
+  owner chose to replace the test. It became two tests: a partial breakdown is accepted, and
+  components exceeding the total are still rejected. `--skip-append-only` was used for that reason
+  and that reason only; the `url4` stack's append-only check remained green and unskipped.
+  **Process finding worth keeping:** `packages/url4` has no `CostBreakdown` tests of its own —
+  `url4.streaming`'s protocol is tested from `apps/url4-cloud`, whose gate carries
+  `--cov=url4.streaming`. So `OME-850`'s gate went green while a test of the contract it changed sat
+  in another stack. A contract change in `packages/url4` must run the `url4-cloud` gate too.
+
+- **Deviations:**
+  1. `connector.py` (656) and `executor.py` (624) exceed the card's ≤450 guidance. Both were already
+     over before this change (614 and 522, `git show HEAD:` verified). Splitting either is its own
+     unit of work, not a side effect of this one — the same call made for `node.py` in `OME-850`.
+     A partial move was considered and rejected: `accounting.py` deliberately imports nothing from
+     `url4`, and moving `_token_usage` there would couple pure cost policy to the wire types.
+  2. The spec's §3.4 said an unknown token class should force `unpriced`. **Not implemented, and the
+     spec is wrong.** Token counts do not enter the price under this method — the amount is
+     provider-authored — so discarding a valid cost because a cache sub-class was unreported would
+     throw away a correct number for no gain. Unknown classes instead flatten to `0` on the wire
+     (`TokenUsage` has non-optional ints), which is documented at `_token_usage` with the condition
+     under which it stops being safe: a rate-card method that multiplies these counts.
+
+- **S1 (migrations):** not applicable — this app has no ORM and no schema.
+
+- **Discovered, NOT fixed here (needs its own unit):** `packages/screamingface`'s
+  `_engine/contract.py:350` warns whenever `total_usd` disagrees with the sum of its components — so
+  every priced run now logs `SF Engine cost total_usd does not equal its parts`. Harmless (it uses
+  `total_usd` regardless) but user-visible log noise in a notebook. It is a third landing label and
+  therefore a third sub-issue under `OME-849`.

--- a/docs/work/2026-08-17-OME-861-no-warning-without-breakdown.md
+++ b/docs/work/2026-08-17-OME-861-no-warning-without-breakdown.md
@@ -1,0 +1,94 @@
+---
+ticket: OME-861
+stack: screamingface
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-861 — Stop warning when the Engine reports a total with no cost breakdown
+
+## Intent
+
+`_engine/contract.py:350` warns whenever the Engine's `total_usd` disagrees with the sum of its five
+per-class components. `OME-850` made a total with no breakdown legal and `OME-851` publishes exactly
+that (OpenRouter authors one amount, no split), so the condition now fires on **every priced run** —
+confirmed live during the `OME-849` verification: three real runs, three warnings. Harmless, since the
+SDK uses `total_usd` regardless, but it is user-visible log noise on the happy path in a library people
+run in notebooks.
+
+Parent: `OME-849`. Discovered by the live end-to-end test, not by any gate.
+
+## Planned changes
+
+- `src/screamingface/_engine/contract.py` — guard the warning on a breakdown having actually been
+  supplied (`if parts and total != parts`), with a `WHY:`/`INVARIANT:` anchor naming the contract
+  change that made the old condition wrong.
+- `tests/test_engine_cost_breakdown_warning.py` (new) — the total-only case must be silent.
+
+No wire/schema change. No new dependency.
+
+## Test plan
+
+RED first, in a new file — no prior test touched.
+
+1. A cost frame carrying `total_usd` and NO components emits no warning, and `cost_usd` still equals
+   the total. (This is the OME-851 shape; it is the bug.)
+2. A frame whose supplied components disagree with the total still warns and still uses `total_usd`
+   — the behaviour `test_priced_usage_keeps_the_engine_total_when_parts_differ` already pins, asserted
+   again here from the new file's angle so the guard cannot be widened away silently.
+3. An all-zero cost with `total_usd: "0"` is silent (the unpriced shape url4-cloud publishes).
+4. An `unpriced` frame still yields `cost_usd=None` and null cache/reasoning token fields.
+
+## Acceptance
+
+- No warning for a total-only breakdown; warning preserved for a supplied-but-disagreeing one.
+- `test_priced_usage_keeps_the_engine_total_when_parts_differ` passes unchanged.
+- `uv run .claude/scripts/run_gates.py screamingface` green (ruff · format · pyright · pytest
+  cov ≥95 · notebook check · `uv build` · distribution check).
+
+## Outcome
+
+Status: done.
+
+- **Actual files:** as planned —
+  - `src/screamingface/_engine/contract.py` — the warning is guarded on `parts` being non-zero, with
+    `WHY:`/`INVARIANT:`/`AIDEV-NOTE:` anchors naming the contract change that made the old condition
+    wrong and the residual it deliberately keeps.
+  - `tests/test_engine_cost_breakdown_warning.py` (new, 5 cases).
+
+- **RED evidence:** `2 failed, 3 passed`. The two failures were exactly the total-only cases, each
+  reporting the real log line
+  `SF Engine cost total_usd does not equal its parts; using total_usd (total=0.001, parts=0)`. The
+  three that passed are guards — the supplied-but-disagreeing warning, the all-zero unpriced shape,
+  and the unpriced token-nulling — and they hold on both sides of the change.
+
+- **Design choice, and the alternative rejected.** Under the relaxed contract the only *incoherent*
+  case is `parts > total`, so that was the first candidate rule. It was rejected: it would have
+  stopped `test_priced_usage_keeps_the_engine_total_when_parts_differ` (a prior test) from seeing its
+  warning, since there `parts=0.03 < total=0.030001`. Guarding on `if parts and total != parts`
+  fixes the reported problem with **no prior-test change at all**, which is why this stack's
+  append-only gate passes unskipped.
+
+- **Accepted residual:** a producer supplying a genuinely PARTIAL breakdown (some classes known,
+  summing below the total) still warns. No producer sends one — url4-cloud publishes total-only — so
+  handling it now would be speculative. Recorded at the code with the condition to revisit.
+
+- **Gates:** `uv run .claude/scripts/run_gates.py screamingface --base origin/main` →
+  **ALL GATES GREEN**, append-only check included and **unskipped** (ruff · format · pyright · pytest
+  `--cov=screamingface --cov-fail-under=95` · notebook determinism check · `uv build` · distribution
+  check).
+
+- **Rebase during this unit.** The gate first failed its append-only check listing files this unit
+  never touched (a deleted `test_check_disclosure_display.py`, modifications across five others).
+  Cause: `append_only_check` uses a **direct** `git diff <base>`, not a merge-base diff
+  (`run_gates.py:366`), so once `origin/main` moved ahead — ten commits, several in
+  `packages/screamingface` — main's own newer commits read as removals from this branch. Resolved by
+  rebasing onto `origin/main` (`3ef7a70f` → `7c036d90`), which is required by `CLAUDE.md` rule 6
+  regardless. No conflicts. All three stacks re-verified green after the rebase.
+  **AIDEV-NOTE for the next agent:** the append-only gate is only meaningful on a branch current with
+  its base. A stale branch produces a wall of false offenders — rebase before believing it.
+
+- **Deviations:** none.
+
+- **S1 (migrations):** not applicable — no ORM or schema in this package.

--- a/docs/work/2026-08-17-OME-868-cache-hit-tokens.md
+++ b/docs/work/2026-08-17-OME-868-cache-hit-tokens.md
@@ -1,0 +1,110 @@
+---
+ticket: OME-868
+stack: url4-cloud
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-868 — Stop counting a cache hit's replayed tokens as freshly consumed
+
+## Intent
+
+A cache hit publishes the ORIGINAL response's token counts as though the provider had consumed
+them again. `runner/connector.py:342` falls back to the replayed cached body's `usage` whenever
+`_aigw` carries no attempts — which is exactly the cache-hit shape — so a hit publishes
+`input=651, output=25, cost=$0`.
+
+This contradicts the boundary `OME-851` already enforces for money. aigateway labels the cache
+reference `incurred_in_current_request: false`, and
+`test_a_cache_reference_never_contributes_to_the_price` exists so a cached answer is never billed.
+Counting the same reference's tokens as consumed treats one piece of evidence two opposite ways.
+
+`_report_response`'s INVARIANT already concedes that `_report_usage` "bills it as a fresh call"
+and mitigates by publishing `cache_status` beside it — but that mitigation never reaches
+`build_subtree`, which emits bare run totals with no cache status attached. A cache-heavy
+benchmark therefore overstates provider consumption with nothing in the frame to signal it.
+
+Parent: `OME-849`. Found in peer review of PR #620, not by any gate.
+
+## Planned changes
+
+- `src/url4_cloud/runner/connector.py` — `_report_usage` takes the `CacheOutcome` already in hand
+  at the call site (`:449`) and reports zero tokens when `status == "hit"`. Using `CacheOutcome`
+  rather than re-deriving hit-ness from `_aigw` keeps the fix working against an older gateway
+  that emits no accounting block at all. `WHY:`/`INVARIANT:` anchors naming the producer's
+  `incurred_in_current_request: false` contract.
+- `tests/unit/test_cache_hit_tokens.py` (new) — RED first, in its own module so no prior test file
+  is touched.
+
+No wire/schema change. No new dependency.
+
+## Test plan
+
+RED first, in a new file.
+
+1. A cache hit publishes zero tokens for every class, and still prices at `0` with
+   `PRICING_VERSION` — the saving stays visible. (This is the bug.)
+2. The same body served as a MISS publishes the provider's real token counts — the guard is
+   narrow, not a blanket zeroing.
+3. A `bypass` behaves like a miss.
+4. No `_aigw` at all (older gateway) still falls back to the provider's own `usage` for a non-hit
+   call — the pre-`_aigw` behaviour is preserved.
+5. A cache hit still increments `RunCacheCounters`, so "caching saved you this" is not lost.
+
+## Acceptance
+
+- A hit publishes zero tokens and `total_usd == 0`, priced not unpriced.
+- Miss and bypass unchanged; the no-`_aigw` fallback unchanged for non-hit calls.
+- `uv run .claude/scripts/run_gates.py url4-cloud` green (append-only check intact — no prior test
+  is touched).
+
+## Outcome
+
+Status: done.
+
+- **Actual files:** as planned —
+  - `src/url4_cloud/runner/connector.py` — new `_report_served_from_cache`, a `cache: CacheOutcome
+    | None` parameter on `_report_usage`, and the call site passing the `outcome` it already had
+    in hand.
+  - `tests/unit/test_cache_hit_tokens.py` (new, 8 cases).
+
+- **RED evidence:** `3 failed, 5 passed`. Each failure was exactly `assert 651 == 0` — the
+  replayed cached body's token counts arriving as this request's consumption. The five that passed
+  are the guards (miss, bypass, no cache header, the pre-`_aigw` fallback, and the priced-zero
+  invariant), and they hold on both sides of the change, which is what makes the fix narrow rather
+  than a blanket zeroing.
+
+- **Design choice: hit-ness comes from `CacheOutcome`, not from `_aigw`.** Both could answer it —
+  `usd_from_aigw` already reads `usage_accounting.cache.status` to price a hit at zero. The
+  published `CacheOutcome` was chosen for two reasons: it is derived from the response headers, so
+  it still works against an older gateway that emits no accounting block at all (pinned by
+  `test_a_cache_hit_without_any_accounting_block_still_reports_no_tokens`); and it is the SAME
+  value `_report_response` publishes as the span's `cache_status`, so the tokens stay consistent
+  with the cache outcome printed beside them. Consistency with the *published* status is the
+  property that matters — a span reading `cache_status: hit` beside 12,480 consumed tokens is the
+  contradiction this unit removes.
+
+- **Zeros, not `None`.** `None` means "the gateway did not report it". A hit reports something
+  definite — nothing was consumed — and `OME-869`'s run totals must be able to add that in rather
+  than treat it as a gap.
+
+- **Prior art this confirms rather than discovers:** `runner/cache_readback`'s module docstring
+  already stated the defect outright ("A cache hit costs nothing upstream, yet `_report_usage`
+  bills it exactly like a fresh call"). The mitigation chosen then was to publish `cache_status`
+  beside the tokens; that mitigation never reached `build_subtree`, which emits bare run totals
+  with no status attached. This unit fixes the numbers rather than annotating them.
+
+- **Checked, not changed:** the revalidation path (`_fetch_completion`) already refuses to report
+  the discarded response's usage and returns the outcome of the round trip that produced the
+  CONSUMED response, so the outcome passed here is the right one and no double-count is possible.
+
+- **Gates:** `uv run .claude/scripts/run_gates.py url4-cloud --base origin/main` →
+  **ALL GATES GREEN** (ruff · format · pyright · layering · pytest
+  `--cov=url4_cloud --cov=url4.streaming --cov-fail-under=80` → **1697 passed, 5 skipped, 93%**).
+  The append-only check reports only `test_protocol.py`, the owner-authorised `OME-850` exception
+  that predates this unit; this unit touched no prior test.
+
+- **Deviations:** none.
+
+- **S1 (migrations):** not applicable — no ORM or schema in this app.

--- a/docs/work/2026-08-17-OME-869-run-total-token-classes.md
+++ b/docs/work/2026-08-17-OME-869-run-total-token-classes.md
@@ -1,0 +1,117 @@
+---
+ticket: OME-869
+stack: url4-cloud
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-869 — Carry cache and reasoning token classes into the run totals
+
+## Intent
+
+The run-level cost frame reports only two of the five token classes. `_fold_usage`
+(`runner/executor.py:307`) accumulates `input` and `output` only, and `build_subtree` (`:454`)
+emits only those two, so `cache_read_tokens`, `cache_creation_tokens` and `reasoning_tokens` reach
+the wire as `0` — while the per-span path (`_token_usage`, `:153`) carries all five. A span
+reports `cache_read_tokens: 8000` and the run reports `0` for the same call.
+
+User-visible: `packages/screamingface` surfaces all three classes
+(`_engine/contract.py:371-391`), so a Report shows zeroes for tokens that were really used.
+
+A plain omission from `OME-851` with no rationale behind it. Parent: `OME-849`. Found in peer
+review of PR #620.
+
+## Planned changes
+
+- `src/url4_cloud/runner/executor.py` — `_RunState` gains run-level sums for the three missing
+  classes; `_fold_usage` accumulates them; `build_subtree` emits all five.
+- `tests/unit/test_run_total_token_classes.py` (new) — RED first, in its own module.
+
+No wire/schema change. No new dependency.
+
+## Design decision — run-level tokens do NOT poison
+
+Money poisons on purpose: one unpriced call makes the run unpriced. That is correct *because the
+wire can say so* — `pricing_version: "unpriced"` exists to carry it.
+
+Tokens have no such escape hatch. `TokenUsage`'s fields are non-optional ints, so poisoning a
+token class cannot express "unknown" — it publishes **zero**, a false claim rather than an absent
+one. Concretely: an Anthropic call reporting `cache_read=8000, reasoning=None` beside an o1 call
+reporting `cache_read=None, reasoning=610` would poison both to `0`, destroying two real numbers
+to encode an uncertainty the frame cannot carry anyway.
+
+So the poisoning rule stays for money and is deliberately NOT applied to run-level tokens. The
+asymmetry is recorded at the code — it is exactly the kind of inconsistency a later reader would
+otherwise "fix" back.
+
+Per-span poisoning is left alone: a span is one model, so mixed reporting is unlikely there, and
+changing it is out of scope.
+
+## Test plan
+
+RED first, in a new file.
+
+1. A run whose calls report cache-read/cache-creation/reasoning publishes those sums, not zeroes.
+   (This is the bug.)
+2. Two calls each reporting a class sum to their total.
+3. A class SOME calls reported sums the reported ones rather than collapsing to `0` — the
+   no-poisoning decision, asserted directly so it cannot be silently reverted.
+4. A class NO call reported stays `0`.
+5. The run total agrees with the sum of its spans' `scope="self"` frames for every class — the
+   invariant the whole unit restores.
+
+## Acceptance
+
+- All five classes summed across every `Usage` event and published by `build_subtree`.
+- `test_n_usage_reports_sum_into_subtree_cost` passes unchanged — no append-only exception needed.
+- `uv run .claude/scripts/run_gates.py url4-cloud` green with the append-only check intact.
+
+## Outcome
+
+Status: done.
+
+- **Actual files:** as planned —
+  - `src/url4_cloud/runner/executor.py` — three run-level sums on `_RunState`, accumulated in
+    `_fold_usage` and emitted from `build_subtree`, with the money/token asymmetry recorded at the
+    declaration.
+  - `tests/unit/test_run_total_token_classes.py` (new, 8 cases).
+
+- **RED evidence:** `6 failed, 2 passed`, each failure `assert 0 == 8000` — the class reaching the
+  wire as zero while the span reported it. The two that passed are the guards: input/output were
+  already carried, and a class no call reported was already zero.
+
+  A first RED run failed for the WRONG reason — a harness error (`NodeFinished.__init__() got an
+  unexpected keyword argument 'ok'`). Corrected before reading anything into it; a test that fails
+  on its own scaffolding proves nothing about the code.
+
+- **The design decision, and why it is NOT the money rule.** Money poisons: one unpriced call
+  makes the run unpriced. Tokens deliberately do not. The difference is what the wire can spell —
+  `pricing_version: "unpriced"` exists to carry an unknown price, while `TokenUsage`'s fields are
+  non-optional ints. Poisoning a token class therefore cannot publish "unknown"; it publishes
+  **zero**, a FALSE claim rather than an absent one, and it destroys the real counts the reporting
+  calls did supply. The mixed-provider case is the normal one: one model reports cache reads and
+  no reasoning, another the reverse, and poisoning would zero both real figures.
+
+  `test_money_still_poisons_while_tokens_do_not` asserts both halves on the SAME run, so neither
+  rule can later be "made consistent" with the other without a red test.
+
+- **Mutation-checked, not assumed.** Replacing `+= x or 0` with `accumulate(...) or 0` — the exact
+  "consistency" edit a later reader would be tempted to make — turns
+  `test_a_class_only_some_calls_reported_sums_the_reported_ones` and
+  `test_money_still_poisons_while_tokens_do_not` red, and restoring it turns them green. The two
+  tests that pin the decision are load-bearing rather than tautological.
+
+- **Left alone deliberately:** per-span poisoning through `accumulate`. A span is one model, so
+  mixed reporting is unlikely there; a run spans many, which is why the rules differ. Recorded at
+  the code with the condition that would justify revisiting it (optional counts on `TokenUsage`).
+
+- **Gates:** `uv run .claude/scripts/run_gates.py url4-cloud --base origin/main` →
+  **ALL GATES GREEN** (ruff · format · pyright · layering · pytest
+  `--cov=url4_cloud --cov=url4.streaming --cov-fail-under=80` → **1697 passed, 5 skipped, 93%**).
+  `test_n_usage_reports_sum_into_subtree_cost` passes unchanged, as predicted — it reports no such
+  classes, so its zeroes remain correct. No append-only exception needed for this unit.
+
+- **Deviations:** none.
+
+- **S1 (migrations):** not applicable — no ORM or schema in this app.

--- a/packages/screamingface/src/screamingface/_engine/contract.py
+++ b/packages/screamingface/src/screamingface/_engine/contract.py
@@ -347,7 +347,17 @@ def _usage(envelope: dict[str, Any], data: Mapping[str, object]) -> events.Usage
         ),
         Decimal(),
     )
-    if total != parts:
+    # WHY guarded on `parts` (OME-861): a provider may author ONE amount with no per-class split —
+    # OpenRouter reports exactly that — so the Engine legitimately publishes a total with every
+    # component at zero (`url4.streaming`'s CostBreakdown accepts Σ components <= total_usd since
+    # OME-850). A bare `total != parts` therefore fired on EVERY priced run, which is noise a reader
+    # cannot act on, in a library people run in notebooks.
+    # INVARIANT: an ABSENT breakdown is silence, not disagreement. A breakdown that WAS supplied and
+    # still disagrees is incoherent and keeps its warning — the guard narrows the condition, it does
+    # not remove it. Either way `total_usd` wins, because it is the authoritative field.
+    # AIDEV-NOTE: residual — a genuinely PARTIAL breakdown (some classes known, summing below the
+    # total) still warns. No producer sends one today; revisit if that changes.
+    if parts and total != parts:
         _LOG.warning(
             "SF Engine cost total_usd does not equal its parts; using total_usd "
             "(total=%s, parts=%s)",

--- a/packages/screamingface/tests/test_engine_cost_breakdown_warning.py
+++ b/packages/screamingface/tests/test_engine_cost_breakdown_warning.py
@@ -1,0 +1,147 @@
+"""When the Engine reports a cost total with no per-class breakdown, say nothing.
+
+FEATURE: per-run cost reporting (`OME-849`/`OME-861`). A provider may author ONE amount with no
+split — OpenRouter does — so `url4.streaming`'s `CostBreakdown` now accepts
+`Σ components <= total_usd` and the Engine publishes a total with every component at zero. The old
+total-vs-parts warning therefore fired on EVERY priced run.
+
+STORY: as a researcher reading my Report in a notebook, a successful priced run is quiet. A warning
+means something is actually wrong with the numbers, so it has to stay rare enough to be worth
+reading.
+
+A separate module rather than an append to `test_engine_contract.py`: the repo's append-only gate
+compares file status, so growing an existing test file reads as a modified prior test even when the
+diff is purely additive.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+import screamingface as sf
+from screamingface._engine.contract import _RunState
+
+URL4 = "(@)!'hello'"
+_LOGGER = "screamingface._engine.contract"
+
+
+def _cost_frame(cost: dict[str, str], *, pricing_version: str = "openrouter-credits-1usd") -> str:
+    """One `ai.url4.cost.usage` frame carrying `cost` verbatim."""
+    payload: dict[str, Any] = {
+        "specversion": "1.0",
+        "id": "event_1",
+        "source": "/trace/run_1/node/root",
+        "subject": "run_1",
+        "time": "2026-07-25T16:00:00Z",
+        "type": "ai.url4.cost.usage",
+        "datacontenttype": "application/json",
+        "sequence": "1",
+        "sequencetype": "Integer",
+        "data": {
+            "scope": "subtree",
+            "gen_ai.provider.name": "openrouter",
+            "gen_ai.response.model": "openrouter/anthropic/claude-haiku-4.5",
+            "pricing_version": pricing_version,
+            "usage": {
+                "gen_ai.usage.input_tokens": 651,
+                "gen_ai.usage.output_tokens": 25,
+                "gen_ai.usage.cache_read_tokens": 0,
+                "gen_ai.usage.cache_creation_tokens": 0,
+                "gen_ai.usage.reasoning_tokens": 0,
+            },
+            "cost": cost,
+        },
+    }
+    return json.dumps(payload)
+
+
+def _accept(frame: str, caplog: pytest.LogCaptureFixture) -> sf.events.Usage:
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        accepted = _RunState(URL4).accept(frame)
+    event = accepted.event
+    assert isinstance(event, sf.events.Usage)
+    return event
+
+
+def test_a_total_with_no_breakdown_is_not_a_contradiction(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The exact shape url4-cloud publishes for a priced OpenRouter run.
+
+    INVARIANT: an ABSENT breakdown is silence, not disagreement. Warning here fired on every priced
+    run and told the reader nothing they could act on.
+    """
+    event = _accept(
+        _cost_frame(
+            {
+                "input_usd": "0",
+                "output_usd": "0",
+                "cache_read_usd": "0",
+                "cache_creation_usd": "0",
+                "reasoning_usd": "0",
+                "total_usd": "0.007905",
+            }
+        ),
+        caplog,
+    )
+
+    assert event.usage.cost_usd == Decimal("0.007905")
+    assert caplog.text == ""
+
+
+def test_a_bare_total_with_the_components_omitted_is_also_silent(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Components default to zero when absent, so an omitted breakdown must behave as a zero one."""
+    event = _accept(_cost_frame({"total_usd": "0.001"}), caplog)
+
+    assert event.usage.cost_usd == Decimal("0.001")
+    assert caplog.text == ""
+
+
+def test_a_supplied_breakdown_that_disagrees_still_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """INVARIANT: the guard narrows the condition, it does not remove it.
+
+    A producer that DID compute a breakdown and still disagrees with its own total is reporting
+    something incoherent, and that stays worth a line in the log.
+    """
+    event = _accept(
+        _cost_frame({"input_usd": "0.01", "output_usd": "0.02", "total_usd": "0.030001"}),
+        caplog,
+    )
+
+    assert event.usage.cost_usd == Decimal("0.030001")
+    assert "does not equal its parts" in caplog.text
+
+
+def test_an_all_zero_cost_is_silent(caplog: pytest.LogCaptureFixture) -> None:
+    """The shape an unpriced run publishes — total and components all zero."""
+    event = _accept(
+        _cost_frame({"total_usd": "0"}, pricing_version="unpriced"),
+        caplog,
+    )
+
+    assert event.usage.cost_usd is None
+    assert caplog.text == ""
+
+
+def test_an_unpriced_frame_still_nulls_the_derived_token_fields(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Regression guard for the neighbouring behaviour this change must not disturb."""
+    event = _accept(_cost_frame({"total_usd": "0"}, pricing_version="unpriced"), caplog)
+
+    assert event.usage.cost_usd is None
+    assert event.usage.cache_read_tokens is None
+    assert event.usage.cache_creation_tokens is None
+    assert event.usage.reasoning_tokens is None
+    # Input/output counts are NOT nulled by unpriced — they are provider-reported either way.
+    assert event.usage.input_tokens == 651
+    assert event.usage.output_tokens == 25

--- a/packages/url4/src/url4/dag/node.py
+++ b/packages/url4/src/url4/dag/node.py
@@ -35,6 +35,7 @@ import asyncio
 import secrets
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Literal, NoReturn, Protocol, runtime_checkable
 
 from url4.core.context import Context
@@ -361,12 +362,22 @@ class ExecutionContext:
         input_tokens: int,
         output_tokens: int,
         response_model: str | None = None,
+        cache_read_tokens: int | None = None,
+        cache_creation_tokens: int | None = None,
+        reasoning_tokens: int | None = None,
+        cost_usd: Decimal | None = None,
     ) -> None:
         """Report model token usage under this node's current span. A no-op
         when no ``observer`` was passed to :func:`~url4.dag.executor.run`.
 
         ``model`` is the REQUESTED model; pass ``response_model`` when the provider
         reports which model actually served the call (see :class:`~url4.observe.Usage`).
+
+        The cache/reasoning classes and ``cost_usd`` are optional evidence: omit any the
+        provider did not report. INVARIANT: omitting one leaves it ``None``, which means
+        "not reported" and is NOT the same claim as ``0`` — see
+        :class:`~url4.observe.Usage`. ``cost_usd`` is already USD; this layer performs no
+        conversion or arithmetic on it.
         """
         if self._obs is not None:
             self._obs.emit(
@@ -377,6 +388,10 @@ class ExecutionContext:
                     input_tokens,
                     output_tokens,
                     response_model,
+                    cache_read_tokens,
+                    cache_creation_tokens,
+                    reasoning_tokens,
+                    cost_usd,
                 )
             )
 

--- a/packages/url4/src/url4/observe.py
+++ b/packages/url4/src/url4/observe.py
@@ -22,6 +22,7 @@ import contextlib
 import contextvars
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Literal, Protocol, runtime_checkable
 
 
@@ -77,6 +78,25 @@ class Usage:
     # request as the response makes provider-side model drift undetectable, which is exactly
     # what this field exists to expose.
     response_model: str | None = None
+    # FEATURE: per-run cost reporting (OME-849). The wire `TokenUsage` this feeds already carries
+    # five token classes; these three close the gap so cache and reasoning evidence can reach an
+    # embedder at all.
+    # INVARIANT: `None` means the provider did not report the class — NEVER a synonym for 0. An
+    # unknown class priced as zero is money invented from nothing, so the two must stay
+    # distinguishable all the way to the consumer.
+    # AIDEV-NOTE: `input_tokens` / `output_tokens` above stay non-optional `int` deliberately —
+    # widening them breaks a live seam, and a producer with incomplete evidence signals that by
+    # leaving `cost_usd` None rather than by nulling a token count.
+    cache_read_tokens: int | None = None
+    cache_creation_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    # WHY money rides HERE and not on `ModelResponse`: this event IS the cost-accounting seam that
+    # embedders derive cost frames from, so a provider-authored amount belongs on it — unlike a
+    # finish reason, which is why that lives next door.
+    # INVARIANT: already USD. Unit conversion belongs to the adapter that understands the provider's
+    # contract; `url4` performs no arithmetic on this value and never coerces it through float.
+    # `None` means "not priced", which is a different claim from `Decimal("0")` ("was free").
+    cost_usd: Decimal | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,7 +171,12 @@ class NullObserver:
 
 UsageSink = Callable[..., None]  # matches ExecutionContext.report_usage's kwargs:
 # (*, provider: str, model: str, input_tokens: int, output_tokens: int,
-#  response_model: str | None = None) -> None
+#  response_model: str | None = None, cache_read_tokens: int | None = None,
+#  cache_creation_tokens: int | None = None, reasoning_tokens: int | None = None,
+#  cost_usd: Decimal | None = None) -> None
+# INVARIANT: every kwarg after `output_tokens` is OPTIONAL. This is a live seam with callers already
+# written against it, so an adapter that learns nothing about caching or cost must be able to say
+# nothing rather than be forced to invent a zero.
 
 _usage_sink: contextvars.ContextVar[UsageSink | None] = contextvars.ContextVar(
     "url4_usage_sink", default=None

--- a/packages/url4/src/url4/streaming/protocol/taxonomy.py
+++ b/packages/url4/src/url4/streaming/protocol/taxonomy.py
@@ -42,19 +42,33 @@ class CostBreakdown(BaseModel):
     cache_creation_usd: Decimal = Decimal("0")
     reasoning_usd: Decimal = Decimal("0")
     total_usd: Decimal
-    """Sum of the per-type costs — enforced by the validator below."""
+    """The authoritative cost of this scope.
+
+    The per-type fields above are an OPTIONAL partial breakdown: a producer fills in the classes it
+    has evidence for and leaves the rest at zero. Only this field is guaranteed to be populated.
+    """
 
     @model_validator(mode="after")
-    def _total_is_sum(self) -> "CostBreakdown":
-        parts = (
+    def _total_covers_components(self) -> "CostBreakdown":
+        # WHY bounded-by rather than equal-to (OME-849): a provider may author one amount with no
+        # per-class split — OpenRouter reports exactly that — and demanding equality forces the
+        # producer to invent a breakdown it does not have, which is a false claim in a structured
+        # field. So an INCOMPLETE breakdown is legal.
+        # INVARIANT: components may be incomplete, never larger than the whole. A breakdown claiming
+        # more than the total is incoherent whichever number you trust, so that half of the old
+        # equality rule survives.
+        # AIDEV-NOTE: the consumer already behaves this way — screamingface's engine contract warns
+        # on a total that disagrees with its components and then uses total_usd. Do not restore
+        # equality here without changing that consumer too.
+        components = (
             self.input_usd
             + self.output_usd
             + self.cache_read_usd
             + self.cache_creation_usd
             + self.reasoning_usd
         )
-        if self.total_usd != parts:
-            raise ValueError(f"total_usd {self.total_usd} != Σ parts {parts}")
+        if components > self.total_usd:
+            raise ValueError(f"Σ components {components} > total_usd {self.total_usd}")
         return self
 
 

--- a/packages/url4/tests/unit/test_cost_breakdown.py
+++ b/packages/url4/tests/unit/test_cost_breakdown.py
@@ -1,0 +1,81 @@
+"""``CostBreakdown`` — a total with an optional partial per-class breakdown.
+
+FEATURE: per-run cost reporting (`OME-849`). A provider may author the cost of a call as a single
+amount with no per-class split — OpenRouter reports exactly that. The breakdown is therefore
+evidence a producer MAY have, not evidence it must fabricate.
+
+STORY: as a researcher reading a run Report, I see the real cost of my run even when the provider
+told the gateway only a total, and I never see a total that claims less than its own parts.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from url4.streaming.protocol.taxonomy import CostBreakdown
+
+
+def test_a_total_with_no_breakdown_is_accepted() -> None:
+    """The OpenRouter shape: one provider-authored amount, no per-class split.
+
+    INVARIANT: this is the case the feature exists for. Rejecting it would force a producer to
+    invent a split it does not have.
+    """
+    cost = CostBreakdown(total_usd=Decimal("0.001"))
+
+    assert cost.total_usd == Decimal("0.001")
+    assert cost.input_usd == Decimal("0")
+    assert cost.output_usd == Decimal("0")
+
+
+def test_a_complete_breakdown_summing_to_the_total_is_accepted() -> None:
+    """Pre-existing behaviour, preserved: a fully-specified breakdown still validates."""
+    cost = CostBreakdown(
+        input_usd=Decimal("0.10"),
+        output_usd=Decimal("0.20"),
+        cache_read_usd=Decimal("0.01"),
+        cache_creation_usd=Decimal("0.02"),
+        reasoning_usd=Decimal("0.03"),
+        total_usd=Decimal("0.36"),
+    )
+
+    assert cost.total_usd == Decimal("0.36")
+
+
+def test_a_partial_breakdown_below_the_total_is_accepted() -> None:
+    """Some classes known, others not — the total stays authoritative."""
+    cost = CostBreakdown(input_usd=Decimal("0.10"), total_usd=Decimal("0.36"))
+
+    assert cost.input_usd == Decimal("0.10")
+    assert cost.total_usd == Decimal("0.36")
+
+
+def test_a_breakdown_exceeding_the_total_is_rejected() -> None:
+    """INVARIANT: components may be incomplete, never larger than the whole.
+
+    A breakdown claiming more than the total is incoherent whichever number you trust, so it stays
+    an error. This is the half of the old equality rule that must survive.
+    """
+    with pytest.raises(ValidationError):
+        CostBreakdown(input_usd=Decimal("0.40"), total_usd=Decimal("0.36"))
+
+
+def test_zero_with_no_breakdown_is_accepted() -> None:
+    """The shape url4-cloud publishes for an unpriced run today — must not regress."""
+    assert CostBreakdown(total_usd=Decimal("0")).total_usd == Decimal("0")
+
+
+def test_a_partial_breakdown_keeps_exact_decimal_precision() -> None:
+    """INVARIANT: money never round-trips through binary float.
+
+    The relaxed comparison must not coerce either side — a sub-cent total has to survive intact,
+    because these amounts are summed downstream across a whole run.
+    """
+    total = Decimal("0.000000000000000001")
+    cost = CostBreakdown(input_usd=Decimal("0.0000000000000000005"), total_usd=total)
+
+    assert cost.total_usd == total
+    assert str(cost.total_usd) == "1E-18"

--- a/packages/url4/tests/unit/test_usage_cost_fields.py
+++ b/packages/url4/tests/unit/test_usage_cost_fields.py
@@ -1,0 +1,162 @@
+"""``Usage``'s cache/reasoning token classes and its priced ``cost_usd``.
+
+FEATURE: per-run cost reporting (`OME-849`). The wire ``TokenUsage`` already carries five token
+classes, but the observation event that feeds it carried two — so cache and reasoning tokens, and
+the cost a provider authored, had no way to reach an embedder. This widens that seam.
+
+STORY: as a researcher reading a run Report, I see what my prompt caching actually saved and what
+the run cost, attributed to the node that spent it.
+
+WHY the observation seam and not a side channel: span attribution comes from the sink the executor
+binds around each node's ``resolve``, so a channel that bypasses it cannot say WHICH node spent the
+money. See ``url4.dag.executor.Executor._eval``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from url4.dag import run
+from url4.io.static import StaticIOLayer
+from url4.observe import ObservationEvent, Usage, current_usage_sink
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+
+class _FullyAccountedNode:
+    """Reports every class a gateway can observe, plus a priced cost."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        ctx.report_usage(
+            provider="openrouter",
+            model="openrouter/anthropic/claude-x",
+            input_tokens=12480,
+            output_tokens=742,
+            response_model="anthropic/claude-x-20260801",
+            cache_read_tokens=8000,
+            cache_creation_tokens=4000,
+            reasoning_tokens=610,
+            cost_usd=Decimal("0.0413"),
+        )
+        return "ok"
+
+
+class _TokensOnlyNode:
+    """A provider that reports tokens but authors no cost — the Anthropic case."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        ctx.report_usage(
+            provider="anthropic",
+            model="claude-x",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        return "ok"
+
+
+class _SinkReportingNode:
+    """Reports the widened fields through the ctx-less sink a world adapter uses."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs, ctx):
+        sink = current_usage_sink()
+        assert sink is not None
+        sink(
+            provider="openrouter",
+            model="m",
+            input_tokens=1,
+            output_tokens=2,
+            cache_read_tokens=0,
+            cost_usd=Decimal("0"),
+        )
+        return "ok"
+
+
+def _usage(events: list[ObservationEvent]) -> Usage:
+    usages = [e for e in events if isinstance(e, Usage)]
+    assert len(usages) == 1
+    return usages[0]
+
+
+@pytest.mark.asyncio
+async def test_every_token_class_and_the_cost_reach_the_event() -> None:
+    rec = _Recorder()
+
+    await run(_FullyAccountedNode(), StaticIOLayer(), observer=rec)
+
+    usage = _usage(rec.events)
+    assert usage.input_tokens == 12480
+    assert usage.output_tokens == 742
+    assert usage.cache_read_tokens == 8000
+    assert usage.cache_creation_tokens == 4000
+    assert usage.reasoning_tokens == 610
+    assert usage.cost_usd == Decimal("0.0413")
+
+
+@pytest.mark.asyncio
+async def test_unreported_classes_stay_none_rather_than_zero() -> None:
+    """INVARIANT: ``None`` means the provider did not say; ``0`` means it said zero.
+
+    Collapsing the two would let an unknown cache class be priced as free — the exact failure the
+    producing gateway's own contract is written to prevent.
+    """
+    rec = _Recorder()
+
+    await run(_TokensOnlyNode(), StaticIOLayer(), observer=rec)
+
+    usage = _usage(rec.events)
+    assert usage.cache_read_tokens is None
+    assert usage.cache_creation_tokens is None
+    assert usage.reasoning_tokens is None
+    assert usage.cost_usd is None
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_zero_is_distinguishable_from_unreported() -> None:
+    """A cache hit costs zero and reads zero cached tokens — both are real claims, not absences."""
+    rec = _Recorder()
+
+    await run(_SinkReportingNode(), StaticIOLayer(), observer=rec)
+
+    usage = _usage(rec.events)
+    assert usage.cache_read_tokens == 0
+    assert usage.cost_usd == Decimal("0")
+    assert usage.cache_creation_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_the_cost_survives_as_an_exact_decimal() -> None:
+    """INVARIANT: money is never coerced to float anywhere on this seam."""
+    rec = _Recorder()
+
+    class _PreciseNode:
+        deps: dict = {}
+
+        async def resolve(self, inputs, ctx):
+            ctx.report_usage(
+                provider="openrouter",
+                model="m",
+                input_tokens=1,
+                output_tokens=1,
+                cost_usd=Decimal("0.000000000000000001"),
+            )
+            return "ok"
+
+    await run(_PreciseNode(), StaticIOLayer(), observer=rec)
+
+    usage = _usage(rec.events)
+    assert isinstance(usage.cost_usd, Decimal)
+    assert usage.cost_usd == Decimal("0.000000000000000001")


### PR DESCRIPTION
## Summary

A run's Report showed `—` where a cost belonged, because `apps/url4-cloud` hardcoded
`pricing_version="unpriced"` with `total_usd=0` and discarded aigateway's `_aigw` accounting block
entirely. Every other link was already built — aigateway publishes per-attempt usage accounting
(`OME-303`, #567), `packages/url4` already carries five token classes and five USD components, and
the SDK already honours `unpriced` by rendering the dash. This joins the chain for OpenRouter.

Spec: `docs/spec/2026-08-17-OME-849-run-cost-openrouter.md`

## Locked decisions (owner, 2026-08-17)

- OpenRouter only. **No rate card** in this epic.
- 1 `openrouter_credits` = 1 USD.
- Anthropic stays unpriced, and a mixed-provider run reports `unpriced` for the whole run.
- Cache status stays reported twice (response headers *and* `_aigw`) — accepted duplication.
- **Degrade to `unpriced`, never to `$0`.**

## Cross-component contract

Two components, one sub-issue each. `OME-850` must be read first — it is what makes `OME-851`
expressible.

**`packages/url4` (`OME-850`)** — two backward-compatible widenings:

- `CostBreakdown` validation goes from `total == Σ components` to `Σ components <= total`. OpenRouter
  authors **one** amount with no per-class split, so demanding equality forced a producer to invent a
  breakdown it does not have. Over-reporting is still rejected. The consumer already behaved this way:
  `screamingface/_engine/contract.py:350` warns on a mismatch and then uses `total_usd`.
- `Usage` gains `cache_read_tokens`, `cache_creation_tokens`, `reasoning_tokens` and `cost_usd`, all
  optional. The wire `TokenUsage` already had five classes, so the observation event was the narrow
  part — and it is the only channel that can attribute a cost to the span that spent it, because the
  executor binds the sink per node task.

**`apps/url4-cloud` (`OME-851`)** — new `runner/accounting.py` implements the pricing rule as a total
function that never raises, because the provider call may already be billed by the time it runs.

| aigateway reports | published |
|---|---|
| `direct_cost_status: "complete"` | priced, amount from the single credit subtotal |
| `not_applicable` **and** `cache.status: "hit"` | priced, `$0` — genuinely free |
| `not_applicable`, not a cache hit | `unpriced` |
| `partial` / `unavailable` / malformed | `unpriced` |

Rows 2 and 3 both present an **empty** subtotal list and mean opposite things; collapsing them
reports paid work as free. One unpriced call poisons its span, and one unpriced span poisons the run
total — a grand total missing a step while presenting itself as a total is worse than no total.

Cost is read from `request_economics.known_direct_cost_subtotals`, which aigateway populates only
when its capture was complete and nothing was omitted, and which it has already summed across
retries. Money is never re-derived by walking `attempts[]`.

## Two duplications this exposed, also fixed

- The connector derived the provider by splitting the model id instead of calling the existing
  `world_config.provider_of`. (Its `else "anthropic"` was **not** a bug — an unprefixed id genuinely
  is Anthropic's per aigateway's catalog — just a second copy of a documented rule.)
- It never reported `response_model`, though `Usage` has carried that field since it was added, and
  `executor` assigned the *requested* model to both request and response model.

`_SpanState`'s positional 4-tuple became `_SpanUsage`: nine fields read as `usage[2]` is not readable.

## Test plan

- `uv run .claude/scripts/run_gates.py url4` → **ALL GATES GREEN**, append-only check included and
  unskipped.
- `uv run .claude/scripts/run_gates.py url4-cloud --skip-append-only` → **ALL GATES GREEN**
  (ruff · format · pyright · layering · pytest) — **1542 passed, 5 skipped, coverage 93.09%**.
- 56 new focused tests (42 on the decision table, 14 across the three seams).
- **The two poisoning guards were proven live, not assumed.** With `accumulate` changed to skip
  unknowns the span-poisoning test fails; with `build_subtree` ignoring the latch the subtree test
  fails. Neither is a tautology.

### A real defect the tests caught during implementation

`amount * Decimal(1)` is **not** the identity. `Decimal` multiplication rounds to the ambient
context's precision — 28 significant digits by default — which truncated an amount at the producer's
18+33-digit bound. At a 1:1 rate the multiply *looks* like a no-op. Fixed with an explicit
`localcontext()` at precision 53.

Separately, ruff `PLR0911` was resolved by restructuring rather than suppressed, and the restructure
improved the code: ad-hoc amount validation was replaced by the producer's own published schema
regex, so this consumer now accepts exactly what the contract promises.

## Live end-to-end verification

Real local stack — aigateway on 9105 (`AIGW_AUTH_MODE=disabled`, `AIGW_OPENROUTER_ENABLED=true`),
url4-cloud `serve --local` on 9108, a real OpenRouter key — compared against OpenRouter's own billing
meter (`GET /api/v1/credits` → `data.total_usage`).

| run | meter delta (ground truth) | published `subtree.total_usd` | |
|---|---|---|---|
| direct gateway call | `0.000044` | `0.000044` | exact |
| url4 run — "capital of France" | `0.007905000` | `0.007905` | exact |
| url4 run — "largest planet" | `0.009372000` | `0.009372` | exact |

This proved what unit tests cannot: the exact-decimal chain survives a real provider — OpenRouter's
raw body carries `cost: 4.4e-05` (a float once JSON-parsed) and `"0.000044"` reached the wire
unrounded across four processes.

**Not exercised live, stated plainly:** every live run was single-call / single-span, so the
multi-span rollup and the poisoning rule are proven only by unit tests. A nested two-model expression
was attempted; the gateway log shows it made one call, so the expression form was wrong for a fan-out.
Also untested live: the cache-hit-priced-at-zero branch (every run reported `cache: bypass`) and the
unpriced branch (no Anthropic credential available).

## Reviewer attention, please

**One prior test was changed, with owner authorisation.**
`apps/url4-cloud/tests/unit/test_protocol.py::test_cost_total_must_equal_sum` asserted the exact
contract `OME-850` relaxes — same inputs, opposite expectation. The owner was offered the alternative
(keep equality and instead assert the whole OpenRouter amount as `input_usd`, which writes a false
claim into a structured field) and chose to replace the test. It became two: a partial breakdown is
accepted, and components exceeding the total are still rejected.

Because of that, **the push used `--no-verify`** — the pre-push hook runs the append-only check with
no way to encode the owner's approval (no flag, no env var). Both stacks were run green manually
beforehand, and the `url4` stack passes the append-only check unskipped. Same exception, and same
reason, as the `OME-303` delivery.

**Rebased onto `origin/main` (`3ef7a70f` → `7c036d90`)** mid-way, no conflicts, all four stacks
re-verified green afterwards. Worth knowing why: `append_only_check` uses a **direct** `git diff <base>`
rather than a merge-base diff (`run_gates.py:366`), so a branch that has fallen behind reports main's
own newer commits as removals — a wall of false offenders. The gate is only meaningful on a branch
current with its base.

**Process finding worth a follow-up:** `packages/url4` has no `CostBreakdown` tests of its own —
`url4.streaming`'s protocol is tested from `apps/url4-cloud`, whose gate carries
`--cov=url4.streaming`. So `OME-850`'s own gate went green while a test of the very contract it
changed sat in another stack. A contract change in `packages/url4` should run the `url4-cloud` gate
too.

**Spec §3.4 was corrected after implementation.** It required an unknown token class to force
`unpriced`; that is wrong here, because token counts do not enter the price under a provider-authored
method, so discarding a valid cost over an unreported cache sub-class would throw away a correct
number for nothing. The correction is recorded inline in the spec rather than left disagreeing with
the code.

## `packages/screamingface` (`OME-861`) — also in this PR

The live verification surfaced a consequence no gate caught: `_engine/contract.py:350` warns whenever
`total_usd` disagrees with the sum of its components, so a total-only breakdown made it fire on
**every priced run** (three real runs, three warnings). Harmless — the total is used regardless — but
noise a reader cannot act on, in a library people run in notebooks.

An absent breakdown is silence, not disagreement, so the warning is now guarded on a breakdown having
actually been supplied. A supplied-but-disagreeing breakdown keeps its warning: the guard narrows the
condition rather than removing it.

Rejected the stricter `parts > total` rule — arguably the only incoherent case left, but it would have
stopped a prior test from seeing its warning for no gain. Guarding on `parts` needed **no prior-test
change**, so this stack's append-only gate passes unskipped.
`run_gates.py screamingface` → ALL GATES GREEN (incl. notebook determinism, `uv build`, distribution
check).

Accepted residual: a genuinely *partial* breakdown still warns. No producer sends one; recorded at the
code with the condition to revisit.

Still open, in spec §7: whether a mixed-provider run should show a dash or a partial total, and when
to pin the pricing method for a long run (moot while `openrouter-credits-1usd` is a constant).

Refs: OME-849, OME-850, OME-851, OME-861

🤖 Generated with [Claude Code](https://claude.com/claude-code)
