### PR TITLE
feat(scoreboard): rename the verification field to verified_by_screamingface

### DIFF
--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -210,6 +210,28 @@ helm rollback scoreboard <revision> --namespace scoreboard --wait
 
 Helm rollback does not roll back database schema migrations. Keep migrations forward-compatible where possible.
 
+### Breaking migrations and multi-replica rollouts
+
+`values-prod.yaml` sets `replicaCount: 3`, and the migration Job is a `pre-upgrade` hook — it
+finishes **before** the Deployment rolls. So during a production upgrade the old pods keep serving
+against the **new** schema until the rollout completes. A migration that renames or drops a column
+those pods still query makes them fail for that window, and `/healthz` does not touch the database,
+so readiness stays green and Kubernetes keeps them in the Service. Combined with the line above —
+rollback does not revert the schema — a breaking migration is not recoverable by `helm rollback`.
+
+**Before cutting a `scoreboard-v*` tag, check whether any unreleased migration renames or drops a
+column.** If one does, pick one:
+
+- **maintenance window** — scale to 0, migrate, scale back up. Simplest, and fine while the service
+  has no users.
+- **expand/contract** — add the new column, dual-write, backfill, switch reads, drop the old column
+  in a later release. Three deploys, no downtime. Use this once the board has real users.
+
+`0005_auto_20260817_1520` (OME-865, renaming `verified_by_openmined` to
+`verified_by_screamingface`) is the first migration in this category. It is safe on dev, which runs
+a single replica, and was deliberately shipped as a plain rename because production had no users at
+the time. Re-check that assumption before releasing it.
+
 ## Troubleshooting
 
 Inspect resources:

--- a/apps/scoreboard/portal/benchmark.js
+++ b/apps/scoreboard/portal/benchmark.js
@@ -208,7 +208,7 @@
     }
 
     var best = bestAccuracy(entries);
-    // OME-820: the "Verified rows" stat is gone, not relabelled. verified_by_openmined
+    // OME-820: the "Verified rows" stat is gone, not relabelled. verified_by_screamingface
     // now carries no trustworthy verification semantics — nothing re-runs submissions
     // and nothing attests where a run executed — so counting it measures nothing.
     //

--- a/apps/scoreboard/portal/leaderboard-logic.js
+++ b/apps/scoreboard/portal/leaderboard-logic.js
@@ -36,7 +36,7 @@
   // badged an unverified claim would be asserting OpenMined reproduced a run it
   // never did, which is exactly what the page's own disclaimer denies.
   //
-  // AIDEV-NOTE: `verified_by_openmined` is the only reproducibility signal the
+  // AIDEV-NOTE: `verified_by_screamingface` is the only reproducibility signal the
   // Scoreboard API exposes today, and since OME-820 it is a placeholder that
   // asserts NOTHING: the default is true and no service re-runs submissions, so a
   // true value certifies nothing. Rows predating OME-820 keep false (D5 forbids a
@@ -48,7 +48,7 @@
   // this URL4 before" — i.e. a global-cache hit), and OME-821 gives the field a
   // real meaning. When either lands, TWO lines move: the predicate below, and the
   // one-line `entry()` helper at the top of leaderboard-logic.test.js, which names
-  // `verified_by_openmined` when building fixtures. The assertions themselves do
+  // `verified_by_screamingface` when building fixtures. The assertions themselves do
   // not change — they pin the invariant above, not the source of the signal.
   //
   // AIDEV-NOTE: this note used to say "change the predicate and nothing else",
@@ -56,7 +56,7 @@
   // because "nothing else" is exactly the sort of promise a later reader trusts
   // instead of checking.
   function isReproducible(entry) {
-    return entry.verified_by_openmined === true;
+    return entry.verified_by_screamingface === true;
   }
 
   function sotaAccuracy(entries) {

--- a/apps/scoreboard/portal/main.js
+++ b/apps/scoreboard/portal/main.js
@@ -180,10 +180,10 @@ window.ScorePortal = (function () {
 
   /* ---- badges & deep links -------------------------------------------- */
   // Returns a square gain-colored "verified" mark only when
-  // verified_by_openmined === true; otherwise an em dash (no badge —
+  // verified_by_screamingface === true; otherwise an em dash (no badge —
   // absence means unverified).
   //
-  // AIDEV-NOTE: NOTHING CALLS THIS as of OME-820. verified_by_openmined now carries no
+  // AIDEV-NOTE: NOTHING CALLS THIS as of OME-820. verified_by_screamingface now carries no
   // trustworthy verification semantics whatever its value — no service re-runs
   // submissions (OME-414) and nothing attests where a run executed. A badge driven by a
   // signal that means nothing is not a trust signal, so the benchmark board, the spec

--- a/apps/scoreboard/portal/portal.css
+++ b/apps/scoreboard/portal/portal.css
@@ -191,7 +191,7 @@ html { scroll-padding-top: calc(var(--rail-h) + var(--space-4)); }
 /* ---- two-card summary strip (OME-820) ------------------------------ */
 /* style.css sets `.stats { grid-template-columns: repeat(3,1fr) }` and is vendored,
    so it is not edited. The leaderboard summary lost its third metric ("Verified
-   rows") when the verification UI was withdrawn — verified_by_openmined became
+   rows") when the verification UI was withdrawn — verified_by_screamingface became
    meaningless — see benchmark.js — and the metric was dropped. Without a modifier the
    bordered strip
    renders two cards across two thirds of its width, leaving an empty third.

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -45,7 +45,7 @@ class RankedLeaderboardEntry(BaseModel):
     ran_with_providers: list[str]
     submitted_at: datetime
     submitted_by: SubmittedBy
-    verified_by_openmined: bool
+    verified_by_screamingface: bool
     url4_expression: str
 
 
@@ -72,7 +72,7 @@ class HistorySubmission(BaseModel):
     correct_questions: int
     submitted_at: datetime
     submitted_by: SubmittedBy
-    verified_by_openmined: bool
+    verified_by_screamingface: bool
 
 
 class HistoryResponse(BaseModel):
@@ -119,7 +119,7 @@ def _history_submission(score: ScoreSchema) -> HistorySubmission:
         correct_questions=score.correct_questions,
         submitted_at=score.submitted_at,
         submitted_by=score.submitted_by,
-        verified_by_openmined=score.verified_by_openmined,
+        verified_by_screamingface=score.verified_by_screamingface,
     )
 
 

--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -3,7 +3,7 @@
 Reads are always public. Writes trust the client-supplied ``submitted_by`` free text by
 default (``auth_mode=disabled``); setting ``SCOREBOARD_AUTH_MODE=cloudflare_headers``
 requires and trusts the mesh-verified `X-User-Email` identity header instead (OME-404,
-following OME-326). The verified_by_openmined response field is a separate, independent
+following OME-326). The verified_by_screamingface response field is a separate, independent
 trust-tier signal: it is unrelated to how the submitter was identified, and it is never
 settable by a client — it is absent from ScoreSubmission, so sending it is a 422.
 
@@ -193,7 +193,7 @@ async def submit_score(
 async def get_score(score_id: UUID) -> ScoreSchema:
     """Return a public score by id.
 
-    ``verified_by_openmined`` carries no verification claim yet: nothing re-runs
+    ``verified_by_screamingface`` carries no verification claim yet: nothing re-runs
     submissions and nothing attests execution provenance (OME-820, OME-821).
     """
 

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0005_auto_20260817_1520.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0005_auto_20260817_1520.py
@@ -1,0 +1,29 @@
+from tortoise import migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    # WHY two parents: main carried two sibling 0004 migrations, both declaring 0003 —
+    # 0004_auto_20260806_0000 (openness_override, OME-323) and 0004_auto_20260816_0630
+    # (benchmark revision, OME-775) merged independently within minutes of each other.
+    # Depending on both converges that branch so the next migration has one unambiguous
+    # parent instead of an unresolved diamond.
+    dependencies = [
+        ("models", "0004_auto_20260806_0000"),
+        ("models", "0004_auto_20260816_0630"),
+    ]
+
+    initial = False
+
+    operations = [
+        # INVARIANT: this RENAMES the column, it does not drop and recreate it. Existing
+        # rows keep the value they were created with, which OME-820's D5 requires — rows
+        # predating that ticket are genuinely unverified (some are local test
+        # submissions), so losing or defaulting them would publish a claim about runs
+        # nobody checked.
+        ops.RenameField(
+            model_name="Score",
+            old_name="verified_by_openmined",
+            new_name="verified_by_screamingface",
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0005_auto_20260817_1520.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0005_auto_20260817_1520.py
@@ -15,6 +15,17 @@ class Migration(migrations.Migration):
 
     initial = False
 
+    # AIDEV-NOTE: this is a BREAKING migration for a multi-replica rollout. The migration Job is a
+    # pre-upgrade hook, so it completes before the Deployment rolls; production runs replicaCount 3,
+    # and those old pods keep querying verified_by_openmined until the rollout finishes. /healthz
+    # does not touch the database, so they stay in the Service while failing. helm rollback does not
+    # revert schema, so the window is not recoverable that way.
+    #
+    # Shipped as a plain rename deliberately: dev runs a single replica, and production had no users
+    # when this landed (4 demo rows from June, on benchmarks nothing queries). RE-CHECK THAT before
+    # cutting a scoreboard-v* tag — see "Breaking migrations and multi-replica rollouts" in
+    # apps/scoreboard/DEPLOYMENT.md for the two safe options.
+
     operations = [
         # INVARIANT: this RENAMES the column, it does not drop and recreate it. Existing
         # rows keep the value they were created with, which OME-820's D5 requires — rows

--- a/apps/scoreboard/src/scoreboard/scores/models/score.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/score.py
@@ -51,7 +51,7 @@ class BaseScore(BaseScoreboardModel):
     # therefore split rows by whether they predate the default change while presenting
     # itself as a verification filter, which is worse than filtering nothing
     # (review of #588).
-    verified_by_openmined = fields.BooleanField(default=True)
+    verified_by_screamingface = fields.BooleanField(default=True)
     # INVARIANT: the Engine benchmark revision this score was produced against. The
     # leaderboard partitions ranking on (spec_id, benchmark_revision) so results measured
     # against different dataset/protocol revisions never rank against each other (OME-775).

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -250,7 +250,7 @@ class ScoreSchema(BaseModel):
     client_name: str | None
     client_version: str | None
     client_platform: str | None
-    verified_by_openmined: bool
+    verified_by_screamingface: bool
     metadata: dict[str, Any] | None
     # FEATURE: OME-323 — manual open/closed correction; None defers to the
     # classification registry. Operator-only, never set via ScoreSubmission.
@@ -272,7 +272,7 @@ class LeaderboardEntry(BaseModel):
     ran_with_providers: list[str]
     submitted_at: datetime
     submitted_by: SubmittedBy
-    verified_by_openmined: bool
+    verified_by_screamingface: bool
     url4_expression: str
 
 

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -49,7 +49,7 @@ def _score_to_schema(model: Score) -> ScoreSchema:
         client_name=model.client_name,
         client_version=model.client_version,
         client_platform=model.client_platform,
-        verified_by_openmined=model.verified_by_openmined,
+        verified_by_screamingface=model.verified_by_screamingface,
         metadata=model.metadata,
         openness_override=model.openness_override,
     )
@@ -167,7 +167,7 @@ def _build_leaderboard_query(
             scores.ran_with_providers,
             scores.submitted_at,
             scores.submitted_by,
-            scores.verified_by_openmined,
+            scores.verified_by_screamingface,
             scores.url4_expression,
             row_number,
         )
@@ -187,7 +187,7 @@ def _build_leaderboard_query(
             ranked.ran_with_providers,
             ranked.submitted_at,
             ranked.submitted_by,
-            ranked.verified_by_openmined,
+            ranked.verified_by_screamingface,
             ranked.url4_expression,
         )
         .where(ranked.rn == 1)
@@ -375,4 +375,4 @@ class ScoreStore:
         return [_score_to_schema(score) for score in rows]
 
     async def mark_verified(self, score_id: UUID | str) -> None:
-        await Score.filter(id=score_id).update(verified_by_openmined=True)
+        await Score.filter(id=score_id).update(verified_by_screamingface=True)

--- a/apps/scoreboard/tests/portal/leaderboard-logic.test.js
+++ b/apps/scoreboard/tests/portal/leaderboard-logic.test.js
@@ -18,7 +18,7 @@ const L = require("../../portal/leaderboard-logic.js");
 
 // A leaderboard entry, trimmed to the fields these decisions actually read.
 function entry(spec_id, accuracy, verified) {
-  return { spec_id, accuracy, verified_by_openmined: verified };
+  return { spec_id, accuracy, verified_by_screamingface: verified };
 }
 
 test("sotaAccuracy: no entries means no SOTA", () => {

--- a/apps/scoreboard/tests/unit/classification/test_openness.py
+++ b/apps/scoreboard/tests/unit/classification/test_openness.py
@@ -46,7 +46,7 @@ def _score(
         client_name=None,
         client_version=None,
         client_platform=None,
-        verified_by_openmined=False,
+        verified_by_screamingface=False,
         metadata=None,
         openness_override=openness_override,
     )

--- a/apps/scoreboard/tests/unit/scores/test_frontier.py
+++ b/apps/scoreboard/tests/unit/scores/test_frontier.py
@@ -40,7 +40,7 @@ def _score(
         client_name=None,
         client_version=None,
         client_platform=None,
-        verified_by_openmined=False,
+        verified_by_screamingface=False,
         metadata=None,
         openness_override=openness_override,
     )

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -428,7 +428,7 @@ def test_score_schema_publishes_only_the_local_part(stored: str, published: str)
         client_name=None,
         client_version=None,
         client_platform=None,
-        verified_by_openmined=True,
+        verified_by_screamingface=True,
         metadata=None,
     )
 
@@ -463,7 +463,7 @@ def test_a_null_submitter_stays_null() -> None:
         client_name=None,
         client_version=None,
         client_platform=None,
-        verified_by_openmined=True,
+        verified_by_screamingface=True,
         metadata=None,
     )
 
@@ -475,7 +475,7 @@ def test_a_null_submitter_stays_null() -> None:
 
 @pytest.mark.parametrize("claimed", [True, False])
 def test_score_submission_rejects_a_client_supplied_verified_flag(claimed: bool) -> None:
-    """INVARIANT: verified_by_openmined is server-side only.
+    """INVARIANT: verified_by_screamingface is server-side only.
 
     The board's trust signal must never be assertable by the party it exists to
     constrain, and the write path is public (authenticated, but public). This is
@@ -483,7 +483,7 @@ def test_score_submission_rejects_a_client_supplied_verified_flag(claimed: bool)
     pinned here: relaxing that config must break a test, not just widen the DTO.
     """
     payload = _valid_payload()
-    payload["verified_by_openmined"] = claimed
+    payload["verified_by_screamingface"] = claimed
 
     with pytest.raises(ValidationError):
         ScoreSubmission.model_validate(payload)

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -102,7 +102,7 @@ async def test_submit_inserts_and_returns_score(tortoise_db: None) -> None:
     # OME-820: verified defaults to True as a placeholder that asserts NOTHING —
     # nothing re-runs submissions and nothing attests where a run executed. The
     # False case stays covered by the explicit-False row test.
-    assert score.verified_by_openmined is True
+    assert score.verified_by_screamingface is True
     assert await Score.all().count() == 1
 
 
@@ -220,7 +220,7 @@ async def test_mark_verified_flips_score_flag(tortoise_db: None) -> None:
     await store.mark_verified(score.id)
 
     verified = await Score.get(id=score.id)
-    assert verified.verified_by_openmined is True
+    assert verified.verified_by_screamingface is True
 
 
 async def test_submit_identical_recipe_without_header_returns_existing_score(
@@ -776,7 +776,7 @@ async def test_a_new_submission_is_verified_by_default(tortoise_db: None) -> Non
     outcome = await store.submit(_submission(spec_id="fresh"))
 
     assert outcome.created is True
-    assert outcome.score.verified_by_openmined is True
+    assert outcome.score.verified_by_screamingface is True
 
 
 async def test_pre_existing_unverified_rows_are_not_backfilled(tortoise_db: None) -> None:
@@ -798,13 +798,13 @@ async def test_pre_existing_unverified_rows_are_not_backfilled(tortoise_db: None
         total_questions=2,
         correct_questions=1,
         ran_with_providers=["openai"],
-        verified_by_openmined=False,
+        verified_by_screamingface=False,
         content_hash="legacy-hash",
     )
 
     reread = await Score.get(id=legacy.id)
 
-    assert reread.verified_by_openmined is False
+    assert reread.verified_by_screamingface is False
 
 
 async def test_mark_verified_flips_a_false_row_and_is_idempotent(
@@ -825,7 +825,7 @@ async def test_mark_verified_flips_a_false_row_and_is_idempotent(
         total_questions=2,
         correct_questions=1,
         ran_with_providers=["openai"],
-        verified_by_openmined=False,
+        verified_by_screamingface=False,
         content_hash="idem-hash",
     )
     store = ScoreStore()
@@ -835,12 +835,12 @@ async def test_mark_verified_flips_a_false_row_and_is_idempotent(
     await store.mark_verified(score.id)
     after_second = await Score.get(id=score.id)
 
-    assert after_first.verified_by_openmined is True
-    assert after_second.verified_by_openmined is True
+    assert after_first.verified_by_screamingface is True
+    assert after_second.verified_by_screamingface is True
 
 
 def test_no_migration_backfills_the_verified_column() -> None:
-    """INVARIANT (D5): no migration may flip existing rows' verified_by_openmined.
+    """INVARIANT (D5): no migration may flip existing rows' verified_by_screamingface.
 
     This is the real D5 guard. The runtime test above cannot provide it: `tortoise_db`
     builds the schema from the models via `tortoise_test_context`, so migration files
@@ -859,14 +859,18 @@ def test_no_migration_backfills_the_verified_column() -> None:
     sources = sorted(p for p in directory.glob("*.py") if p.name != "__init__.py")
     assert sources, "no migration files found — the guard would pass vacuously"
 
+    # OME-865: check BOTH names. Migrations predating the rename carry the old one and
+    # cannot be edited, while any future backfill would use the new one — so a guard that
+    # knew only one name would go blind on half the history.
+    names = ("verified_by_screamingface", "verified_by_openmined")
     offenders = [
         path.name
         for path in sources
-        if "verified_by_openmined" in (text := path.read_text())
+        if any(name in (text := path.read_text()) for name in names)
         and any(word in text.lower() for word in ("update", "runpython", "runsql"))
     ]
 
     assert offenders == [], (
-        f"migration(s) may backfill verified_by_openmined: {offenders}. "
+        f"migration(s) may backfill verified_by_screamingface: {offenders}. "
         "Existing rows must keep the value they were created with (OME-820 D5)."
     )

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -111,7 +111,7 @@ async def test_get_leaderboard_returns_ranked_best_score_per_spec(
     # OME-820: verified defaults to True as a placeholder that asserts NOTHING —
     # nothing re-runs submissions and nothing attests where a run executed. The
     # False case stays covered by the explicit-False row test.
-    assert body["entries"][0]["verified_by_openmined"] is True
+    assert body["entries"][0]["verified_by_screamingface"] is True
     assert body["entries"][1]["url4_expression"] == "url4://benchmark/hle/spec-a/0.9"
 
 
@@ -201,7 +201,7 @@ async def test_get_spec_history_returns_submissions_newest_first(
         "correct_questions",
         "submitted_at",
         "submitted_by",
-        "verified_by_openmined",
+        "verified_by_screamingface",
     }
 
 
@@ -440,5 +440,5 @@ async def test_a_new_submission_reads_as_verified_on_both_read_paths(
 
     assert board.status_code == 200
     entry = next(e for e in board.json()["entries"] if e["spec_id"] == "verified-default")
-    assert entry["verified_by_openmined"] is True
-    assert history.json()["submissions"][0]["verified_by_openmined"] is True
+    assert entry["verified_by_screamingface"] is True
+    assert history.json()["submissions"][0]["verified_by_screamingface"] is True

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -130,7 +130,7 @@ async def test_post_score_creates_new_row_201(score_client: AsyncClient) -> None
     # OME-820: verified defaults to True as a placeholder that asserts NOTHING —
     # nothing re-runs submissions and nothing attests where a run executed. The
     # False case stays covered by the explicit-False row test.
-    assert body["verified_by_openmined"] is True
+    assert body["verified_by_screamingface"] is True
 
 
 async def test_post_score_without_idempotency_key_dedupes_identical_recipe(

--- a/apps/scoreboard/tests/unit/test_sf_payload.py
+++ b/apps/scoreboard/tests/unit/test_sf_payload.py
@@ -87,7 +87,7 @@ async def test_sf_payload_round_trips_201(sf_client: AsyncClient) -> None:
     # OME-820: verified defaults to True as a placeholder that asserts NOTHING —
     # nothing re-runs submissions and nothing attests where a run executed. The
     # False case stays covered by the explicit-False row test.
-    assert body["verified_by_openmined"] is True
+    assert body["verified_by_screamingface"] is True
     # Nested `client` on the request maps to the flat client_* read fields.
     assert body["client_name"] == "screamingface-desktop"
     assert body["client_version"] == "0.4.2"

--- a/docs/tasks/2026-08-17-OME-865-rename-verified-field.md
+++ b/docs/tasks/2026-08-17-OME-865-rename-verified-field.md
@@ -1,0 +1,33 @@
+---
+id: OME-865
+linear_url: https://linear.app/openmined/issue/OME-865/rename-the-scoreboard-verification-field-to-verified-by-screamingface
+status: In Review
+type: task
+priority: P1
+labels: [scoreboard, agentic, autonomous, task]
+created: 2026-08-17
+closed:
+---
+
+# Rename the Scoreboard verification field to verified_by_screamingface
+
+`OME-858` (#622) renamed this field in the ScreamingFace Client and made its decoder strict.
+Scoreboard still emitted `verified_by_openmined`, so the two contracts disagreed and every
+leaderboard read failed:
+
+```
+sf.leaderboards.get('draco')
+→ LeaderboardError: Leaderboard entry verified_by_screamingface must be a boolean
+```
+
+Reproduced against `origin/main` before starting. This blocked `OME-402` (the leaderboard
+notebook, the path testers submit through) and any Client ↔ Scoreboard end-to-end run.
+
+Renames the field across the model, response schemas, routes, store projections, portal JS and
+tests, and adds migration `0005` using `RenameField` so existing rows keep their values.
+`0001_initial.py` is left untouched — it records applied history.
+
+Semantics are deliberately unchanged: no badge, filter, ranking rule or reproduction claim is
+introduced, and the field stays server-owned. Defining a trustworthy signal remains `OME-821`.
+
+Ledger: `docs/work/2026-08-17-OME-865-rename-verified-field.md`

--- a/docs/work/2026-08-17-OME-865-rename-verified-field.md
+++ b/docs/work/2026-08-17-OME-865-rename-verified-field.md
@@ -1,0 +1,119 @@
+---
+ticket: OME-865
+stack: scoreboard
+status: done
+started: 2026-08-17
+finished: 2026-08-17
+---
+
+# OME-865 — Rename the Scoreboard verification field to verified_by_screamingface
+
+## Intent
+
+`OME-858` (#622, merged 14:42) renamed the field to `verified_by_screamingface` in the Client and
+made its decoder strict. Scoreboard still emits `verified_by_openmined`, so the two no longer
+agree and every read path fails.
+
+**Reproduced against `origin/main` before starting**, not inferred from the ticket:
+
+```
+sf.leaderboards.get('draco')
+→ LeaderboardError: Invalid Scoreboard Leaderboard response:
+  Leaderboard entry verified_by_screamingface must be a boolean
+```
+
+This blocks `OME-402` (the leaderboard notebook, the path testers submit through) and any Client
+↔ Scoreboard end-to-end run. The ticket is scoped by Keelan; this ledger records only what the
+ticket does not already decide.
+
+## Scale
+
+18 files, ~30 occurrences on `origin/main`: model, schemas, routes, store projections, four portal
+JS files, eight test modules, and `0001_initial.py`.
+
+## Decisions
+
+**D1 — data-preserving `RenameField`, not a DB reset.** The ticket allows either. `ops.RenameField`
+exists in this Tortoise version (verified by introspection, signature
+`(model_name, old_name, new_name)`), so the preserving option is available and strictly safer:
+the dev database keeps its rows and nothing has to be reseeded. A reset would be chosen only if
+no preserving path existed.
+
+**D2 — `0001_initial.py` is NOT edited.** It records history and has already been applied
+everywhere. The rename goes on top as a new migration. Editing an applied migration would
+desynchronise every existing database from its recorded history.
+
+**D3 — the new migration is `0005`, depending on BOTH `0004`s.** `main` currently carries two
+sibling `0004` migrations (`_20260806_0000` from `OME-323`, `_20260816_0630` from `OME-775`), each
+declaring `0003` as parent — a branched history with no convergence point. Depending on both
+merges the branch, so a future `0006` has one unambiguous parent. This is a free fix for a latent
+hazard noticed during `OME-775`'s smoke testing.
+
+**D4 — semantics are untouched.** This renames a key. It must not introduce a badge, filter,
+ranking rule or reproduction claim; `OME-820` removed those deliberately and `OME-821` owns
+restoring them once the field means something. The field also stays server-owned and absent from
+`ScoreSubmission`, which a test already pins.
+
+## Planned changes
+
+- `scores/models/score.py`, `scores/schemas.py`, `scores/store.py`, `routes/leaderboard.py`,
+  `routes/scores.py`
+- `portal/{benchmark,leaderboard-logic,main,spec}.js`
+- `scores/migrations/0005_*.py` — new, `RenameField` + convergent dependencies
+- tests: `test_schemas`, `test_store`, `test_frontier`, `test_openness`, `test_leaderboard_routes`,
+  `test_scores_routes`, `test_sf_payload`, `tests/portal/leaderboard-logic.test.js`
+
+## Test plan
+
+The existing suite already pins this field's behaviour throughout, so the rename is verified by
+those tests continuing to pass under the new name rather than by new ones. The contract itself is
+verified end to end: the real Client against a real Scoreboard, which is the check that currently
+fails and must pass.
+
+## Acceptance
+
+- No Scoreboard response emits `verified_by_openmined`.
+- A submission setting the server-owned field is still rejected.
+- `sf.leaderboards.list/get/submit/get_score` all succeed against a local Scoreboard.
+- Existing rows survive the migration with their values intact.
+- Full gates green.
+
+## Outcome
+
+- **Actual files:** as planned — 17 files renamed (45 occurrences), plus the new
+  `0005_auto_20260817_1520.py`. `0001_initial.py` deliberately untouched (D2). One extra file
+  beyond the ticket's list: `portal/portal.css`, which mentioned the field in a comment.
+- **Gates:** ruff check ✓ · ruff format ✓ · pyright ✓ · pytest --cov ✓ **253 passed, 2 skipped**
+  · portal JS 14 passed. `makemigrations` → **"No changes detected"** (no model/migration drift).
+  Ran with `--skip-append-only`: a rename cannot avoid touching prior tests. Owner-approved under
+  rule 5 after I demonstrated the diff is purely the identifier — every changed line is identical
+  once the field name is normalised.
+
+### Verification beyond the unit suite
+
+The two things the suite cannot cover were each proven directly:
+
+1. **Data survives the rename.** Built the schema at `0004` with `0005` held back, inserted two
+   rows through raw SQL (`old-row` false, `new-row` true), then applied `0005`. Both read back
+   with their original values under the new column, and the old column is gone. This is the
+   `OME-820` D5 invariant — a drop-and-recreate would have defaulted `old-row` to true and
+   published a claim about a run nobody checked.
+2. **The contract is repaired.** The real `sf.Client` against a real Scoreboard:
+   `list()` ✓ · `submit()` ✓ · `get()` ✓ · `get_score()` ✓ — all four failed on `origin/main`
+   before this. No response emits the old key on any of the three read endpoints, and a
+   submission claiming the server-owned field is still rejected **422**.
+
+### Deviations
+
+1. **The migration-backfill guard was hardened, not just renamed.**
+   `test_no_migration_backfills_the_verified_column` scans *migration sources* for the field name.
+   A blind rename would have left it checking only the new name, while every pre-rename migration
+   carries the old one — so it would have gone blind on half the history. It now checks both.
+   Found by reading the test rather than trusting the rename; a mechanical sed would have silently
+   degraded it.
+2. **`0005` declares two parents.** `main` carried two sibling `0004` migrations, both claiming
+   `0003`, from `OME-323` and `OME-775` merging minutes apart. Depending on both converges that
+   branch so the next migration has one unambiguous parent. Free fix for a latent hazard noticed
+   during `OME-775`'s smoke testing; not requested by the ticket.
+3. **`portal/portal.css` was in scope after all** — the ticket listed "portal code" and the field
+   appeared in a CSS comment explaining the withdrawn stat.

--- a/docs/work/2026-08-17-OME-865-rename-verified-field.md
+++ b/docs/work/2026-08-17-OME-865-rename-verified-field.md
@@ -117,3 +117,57 @@ The two things the suite cannot cover were each proven directly:
    during `OME-775`'s smoke testing; not requested by the ticket.
 3. **`portal/portal.css` was in scope after all** — the ticket listed "portal code" and the field
    appeared in a CSS comment explaining the withdrawn stat.
+4. **A production-safety note was added** to `DEPLOYMENT.md` and the migration, after review.
+   See below.
+
+## Review finding: the "pre-release" premise was wrong
+
+The ticket's contract decision reads *"this is a clean pre-release rename."* Review flagged that
+this migration is unsafe for a multi-replica rollout, and checking the premise showed the ticket
+was mistaken about the deployment:
+
+| Claim | Verified |
+|---|---|
+| Migration runs as a `pre-upgrade` hook while old pods serve | `charts/scoreboard/templates/job-migrate.yaml:9` |
+| Three replicas | `values-prod.yaml: replicaCount: 3` — **not** pre-release |
+| Rollback leaves the schema renamed | `DEPLOYMENT.md:211` states it |
+| Production is live with data | `scoreboard.screamingface.ai` serves 4 rows created 2026-06-02 |
+
+Worse than the review said: `/healthz` returns a static `{"status": "ok"}` without touching the
+database, so a pod broken by the rename still passes readiness and **stays in the Service**.
+
+### Why it still shipped as a plain rename (owner decision, 2026-08-17)
+
+* **Production has no users** (owner-confirmed). Its 4 rows are June demo data on `hle`/`livetruth`,
+  benchmarks nothing queries, and there has never been a `scoreboard-v*` release tag.
+* **Merging does not touch production.** Prod releases only on that tag; dev auto-builds from
+  `main`. So this reaches dev only, where `replicaCount: 1` makes the window one pod for seconds —
+  and dev is *already* fully broken for the Client, so the rename strictly improves it.
+* **Expand/contract costs three deploys** plus dual-write machinery, to protect four stale demo rows
+  and a rollout window on a service with no users.
+
+### The cheap alternative was tested and rejected
+
+`source_field` (keep the physical column, rename only the Python/API name) would have been one
+deploy with no migration and no rollout risk. **It does not work here:** `_build_leaderboard_query`
+is hand-written pypika, which bypasses the ORM's field-to-column mapping and emits the Python name
+as a literal —
+
+```
+ValidationError: verified_by_screamingface
+  Input should be a valid boolean, input_value='verified_by_screamingface'
+```
+
+Salvageable by hardcoding the physical column in that one query, but it leaves a permanent
+Python/DB name mismatch *and* Tortoise's autodetector keeps proposing a `RenameField` on every
+future `makemigrations`. Recurring friction, rejected.
+
+### What was added instead
+
+The risk is **deferred, not dismissed**, and recorded where a releaser will meet it:
+
+* `DEPLOYMENT.md` — a new "Breaking migrations and multi-replica rollouts" section under *Upgrade
+  And Rollback*, naming the two safe options (maintenance window; expand/contract) and the trigger
+  to re-check.
+* The migration itself — an `AIDEV-NOTE` stating it is breaking for multi-replica, why it shipped
+  anyway, and that the no-users assumption must be re-checked before a `scoreboard-v*` tag.


### PR DESCRIPTION
## The contract is broken on `main` right now

`OME-858` (#622, merged 14:42) renamed this field in the Client and made its decoder strict. Scoreboard still emits `verified_by_openmined`, so the two disagree and every leaderboard read fails. Reproduced against `origin/main` before starting:

```
sf.leaderboards.get('draco')
→ LeaderboardError: Invalid Scoreboard Leaderboard response:
  Leaderboard entry verified_by_screamingface must be a boolean
```

This blocks `OME-402` — the leaderboard notebook, which is the path testers submit through.

## What this does

Renames the field across the model, response schemas, routes, store projections, portal JS and tests (45 occurrences, 17 files), and adds migration `0005` using `RenameField`.

**`0001_initial.py` is deliberately untouched.** It records applied history; editing it would desynchronise every existing database from its recorded state.

Semantics are unchanged — no badge, filter, ranking rule or reproduction claim is introduced, and the field stays server-owned. Defining a trustworthy signal remains `OME-821`.

## Verified beyond the unit suite

Two things the suite structurally cannot cover, each proven directly:

**1 · Existing data survives the rename.** Built the schema at `0004` with `0005` held back, inserted a `false` row and a `true` row through raw SQL, then applied `0005`:

```
new-row|1        old column present: 0
old-row|0
```

Both kept their original values. This is `OME-820`'s D5 invariant — a drop-and-recreate would have defaulted `old-row` to `true` and published a claim about a run nobody checked.

**2 · The contract is repaired.** Real `sf.Client` against a real Scoreboard: `list()` OK, `submit()` OK, `get()` OK, `get_score()` OK — all four fail on `main` today. No response emits the old key on any read endpoint, and a submission claiming the server-owned field is still rejected **422**.

## Two changes beyond a plain rename

**The migration-backfill guard now checks BOTH names.** `test_no_migration_backfills_the_verified_column` scans *migration sources* for the field. Pre-rename migrations keep the old name, so renaming the guard alone would have left it blind to half the history. Found by reading the test — a mechanical sed would have silently degraded it.

**Migration `0005` declares two parents.** `main` carried two sibling `0004` migrations, both claiming `0003`, from `OME-323` and `OME-775` merging minutes apart. Depending on both converges that branch so the next migration has one unambiguous parent. Not requested by the ticket; free fix for a latent hazard.

## Test plan

`run_gates.py scoreboard` — ruff check, ruff format, pyright, pytest --cov all green: **253 passed, 2 skipped**, portal JS 14 passed. `makemigrations` reports **"No changes detected"** (no model/migration drift).

Ran with `--skip-append-only`: a rename cannot avoid touching prior tests. That is a rule-5 decision, approved by the owner after the diff was shown to be purely the identifier — every changed line is identical once the field name is normalised, with the guard hardening the only substantive addition.

Refs: OME-865
