### PR TITLE
feat(url4-cloud): route colon-bearing model ids via a ~ encoding

### DIFF
--- a/apps/url4-cloud/src/url4_cloud/catalog/executable.py
+++ b/apps/url4-cloud/src/url4_cloud/catalog/executable.py
@@ -15,6 +15,7 @@ from url4_cloud.catalog.port import (
     ModelParameterSource,
     compute_etag,
 )
+from url4_cloud.models.registry import decode_route_id, encode_route_id
 
 
 class ExecutableCatalogSource(CatalogService, Protocol):
@@ -73,10 +74,15 @@ class ExecutableCatalog:
         # is absent or not a string, cannot equal a declared id — so the acceptance contract
         # ("every id returned is a declared route") holds without a separate shape check, and an
         # unknown future field on a RETAINED document still passes through untouched.
+        #
+        # WHY rewrite `id` here (OME-873): `self._model_ids` holds the REAL gateway ids (what
+        # aigateway's own `data[].id` names, and what the membership check above compares
+        # against), but what a caller should put in a url4 expression is the `~`-encoded route
+        # id. `encode_route_id` is a no-op for the ids with no colon, so this applies uniformly.
         body = {
             **catalog.body,
             "data": [
-                item
+                {**item, "id": encode_route_id(item["id"])}
                 for item in data
                 if isinstance(item, Mapping) and item.get("id") in self._model_ids
             ],
@@ -108,9 +114,14 @@ class ExecutableModelParameterSource:
         credential: Credential,
         model: str,
     ) -> ModelParameterResponse:
-        if model not in self._model_ids:
+        # `model` arrives as the caller wrote it — the same `~`-encoded id `GET /v1/models` just
+        # advertised (OME-873). `self._model_ids` holds the REAL ids, and aigateway itself has
+        # never heard of '~', so both the membership check and the forwarded call need the
+        # decoded form; `ModelNotInstalled` echoes back what the caller actually sent.
+        real_model = decode_route_id(model)
+        if real_model not in self._model_ids:
             raise ModelNotInstalled(model)
-        return await self._source.fetch_model_parameters(credential, model)
+        return await self._source.fetch_model_parameters(credential, real_model)
 
 
 __all__ = ["ExecutableCatalog", "ExecutableCatalogSource", "ExecutableModelParameterSource"]

--- a/apps/url4-cloud/src/url4_cloud/models/registry.py
+++ b/apps/url4-cloud/src/url4_cloud/models/registry.py
@@ -33,11 +33,33 @@ allowed to disagree.
 """
 
 _COLON = ":"
+_TILDE = "~"
 
 
 def is_route_legal(model_id: str) -> bool:
     """Whether ``model_id`` can be a url4 route path, segment for segment."""
     return ROUTE_ID_RE.fullmatch(model_id) is not None
+
+
+def encode_route_id(model_id: str) -> str:
+    """The url4-route form of a gateway id: ``:`` escaped as ``~`` (OME-873).
+
+    INVARIANT: a no-op on any id with no colon, so callers may apply it unconditionally to
+    every declared id rather than branching on "is this one of the 29". The inverse of
+    :func:`decode_route_id`.
+    """
+    return model_id.replace(_COLON, _TILDE)
+
+
+def decode_route_id(route_id: str) -> str:
+    """The real gateway id a route path names: ``~`` reverted to ``:`` (OME-873).
+
+    INVARIANT: a no-op on any route id with no tilde. Safe to call unconditionally at the
+    point a real request or comparison against aigateway's own catalog is made, because ``~``
+    is reserved exclusively for this escape (see the seed-validation guard below) — no
+    routable id may carry a literal one.
+    """
+    return route_id.replace(_TILDE, _COLON)
 
 
 def canonical_id(provider: str, slug: str) -> str:
@@ -101,10 +123,13 @@ class ModelRegistry:
 
     @property
     def aigateway_only(self) -> frozenset[str]:
-        """Ids aigateway serves that url4 cannot route, because they carry a ``:``.
+        """Ids aigateway serves that carry a ``:`` and so cannot be a url4 route VERBATIM.
 
-        INVARIANT: never routed and never advertised. Declared anyway so the drift guard can
-        assert set equality against aigateway's seeds, and so OME-819 has an exact work-list.
+        WHY the name survives OME-873: this partition is a pure function of the RAW id (see
+        `test_the_unroutable_ids_are_exactly_the_colon_bearing_ones`) and stays so on purpose —
+        `encode_route_id` (this module) is what makes these routable, applied one layer up in
+        `world_config._merge`, not a change to this classification. An id here still can never
+        be routed under its own, real form.
         """
         return self._aigateway_only
 
@@ -133,7 +158,16 @@ def _validate(model_id: str) -> None:
     WHY a colon is tolerated here but every other illegal character is not: the colon is a known
     grammar limit with 29 real ids behind it, handled by the partition. Anything else is a typo,
     and filing a typo under ``aigateway_only`` would hide it from the equality guard forever.
+
+    WHY a literal '~' is refused even though it IS in `ROUTE_ID_RE`'s charset (OME-873): '~' is
+    reserved exclusively as `encode_route_id`'s colon-escape. A legitimate id carrying one would
+    be indistinguishable from an encoded colon id and could collide with one on decode.
     """
+    if _TILDE in model_id:
+        raise ValueError(
+            f"model id {model_id!r} contains '~', which is reserved to encode a colon-bearing "
+            "id as a url4 route (see encode_route_id) — a real gateway id may never carry one"
+        )
     if not is_route_legal(model_id.replace(_COLON, "")):
         raise ValueError(
             f"model id {model_id!r} is not a valid URL4 expression path — each segment may "
@@ -150,5 +184,7 @@ __all__ = [
     "ModelRegistry",
     "ProviderSeed",
     "canonical_id",
+    "decode_route_id",
+    "encode_route_id",
     "is_route_legal",
 ]

--- a/apps/url4-cloud/src/url4_cloud/runner/connector.py
+++ b/apps/url4-cloud/src/url4_cloud/runner/connector.py
@@ -21,6 +21,7 @@ from url4.peer.server import Request, Url4Node
 from url4.streaming.protocol import CachePolicy
 from url4_cloud.benchmarks.contract import CANDIDATE_INPUT_SCHEMA, CANDIDATE_MESSAGE_ROLES
 from url4_cloud.model_outcomes import bind_model_outcome, record_model_outcome
+from url4_cloud.models.registry import decode_route_id
 from url4_cloud.operation_calls import operation_call_identity, record_operation_call
 from url4_cloud.retrieval_policy import (
     RetrievalPolicy,
@@ -482,6 +483,11 @@ async def _chat_completion_loop(
         ResolutionError: the loop exceeds `cfg.web_tool_max_iterations` without a final
             answer — the model keeps calling tools instead of returning content.
     """
+    # WHY decoded once, here: `spec.id` is ALWAYS the url4-route form (OME-873) — decoding is a
+    # no-op for the 88 ids with no colon, so this is safe unconditionally. Everything past this
+    # line that reaches aigateway or reports what aigateway actually billed uses `real_model_id`;
+    # error messages below keep `spec.id` (the route form), since that's what the caller wrote.
+    real_model_id = decode_route_id(spec.id)
     tools, extra = _retrieval_request(
         cfg=cfg,
         spec=spec,
@@ -493,12 +499,12 @@ async def _chat_completion_loop(
     sampling = model_params(params)
     headers = _headers(profile, identity_headers)
     for _ in range(cfg.web_tool_max_iterations):
-        body = {"model": spec.id, "messages": messages, **sampling, **extra}
+        body = {"model": real_model_id, "messages": messages, **sampling, **extra}
         resp, outcome = await _fetch_completion(
             http_client, headers=headers, body=body, cache=cache
         )
         data = _json_or_raise(resp)
-        _report_usage(spec.id, data.get("usage"), data.get("_aigw"), outcome)
+        _report_usage(real_model_id, data.get("usage"), data.get("_aigw"), outcome)
         choice = parse_choice(data)
         # INVARIANT: report BEFORE classifying. A refused turn is the case a reviewer most needs
         # to audit, and raising first would lose exactly the event OME-679 exists to capture.

--- a/apps/url4-cloud/src/url4_cloud/world_config.py
+++ b/apps/url4-cloud/src/url4_cloud/world_config.py
@@ -40,7 +40,12 @@ from pathlib import Path
 
 from url4_cloud import job_env
 from url4_cloud.models.builtins import BUILTIN_MODEL_WORLD
-from url4_cloud.models.registry import ROUTE_ID_RE, ModelRegistry
+from url4_cloud.models.registry import (
+    ROUTE_ID_RE,
+    ModelRegistry,
+    decode_route_id,
+    encode_route_id,
+)
 
 DEFAULT_CONFIG_PATH = "/etc/url4/url4.toml"
 
@@ -182,12 +187,17 @@ def routes_for(models: Sequence[ModelSpec]) -> dict[str, ModelSpec]:
 def declared_model_ids(
     env: Mapping[str, str], *, registry: ModelRegistry = BUILTIN_MODEL_WORLD
 ) -> frozenset[str]:
-    """Return the model ids from the same fully validated world the Runner consumes."""
+    """Return the REAL gateway ids from the same fully validated world the Runner consumes.
+
+    WHY decoded: this is what discovery compares against aigateway's own `GET /v1/models`
+    response, whose `id` field is always the real (colon-bearing) id — `section.models[*].id`
+    is the url4-ROUTE form (OME-873), and the two would never match for the 29 otherwise.
+    """
 
     section = load_config(env, registry=registry).aigateway
     if section is None:
         return frozenset()
-    return frozenset(model.id for model in section.models)
+    return frozenset(decode_route_id(model.id) for model in section.models)
 
 
 def load_config(
@@ -261,7 +271,7 @@ def _parse_aigateway(
         ),
     )
     section = _apply_env(section, env)
-    _reject_unroutable_default(section.default_model, registry)
+    _reject_unroutable_default(section.default_model)
     _require_declared(section.default_model, models)
     return section
 
@@ -278,17 +288,19 @@ def _apply_env(section: AigatewaySection, env: Mapping[str, str]) -> AigatewaySe
     return section
 
 
-def _reject_unroutable_default(default_model: str, registry: ModelRegistry) -> None:
-    """A `default_route` naming an `aigateway_only` id can never resolve.
+def _reject_unroutable_default(default_model: str) -> None:
+    """A `default_route` naming the REAL (colon-bearing) form of an id can never resolve.
 
-    WHY a distinct error: `_require_declared` would report it as "not a declared model" beside a
-    list of 88 ids, which reads like a typo. The real cause is that the id contains ':' and no
-    URL4 path segment may (url4 spec §8, OME-819).
+    WHY a distinct error: `_require_declared` would report it as "not a declared model" beside
+    a list of 88+ ids, which reads like a typo. The real cause is that the operator wrote the
+    gateway's own id verbatim — the declared world only ever holds the `~`-encoded route form
+    (OME-873), so this can never be a membership miss by coincidence.
     """
-    if default_model in registry.aigateway_only:
+    if ":" in default_model:
         raise WorldConfigError(
-            f"default_route {'/' + default_model!r} cannot be a route — the gateway serves this "
-            "model but its id contains ':', which no URL4 path segment may contain"
+            f"default_route {'/' + default_model!r} cannot be a route — it contains ':', which "
+            f"no URL4 path segment may contain; use {'/' + encode_route_id(default_model)!r} "
+            "(the same id with ':' encoded as '~') instead"
         )
 
 
@@ -329,10 +341,20 @@ def _declared_models(value: object) -> tuple[ModelSpec, ...]:
 
 
 def _merge(registry: ModelRegistry, declared: tuple[ModelSpec, ...]) -> tuple[ModelSpec, ...]:
-    """The registry's routable ids, with the TOML array layered on top.
+    """The registry's routable AND aigateway-only ids, with the TOML array layered on top.
 
-    INVARIANT: exactly one spec per id. `routes_for` maps `"/" + id`, so a second spec for one
-    id would collapse silently and whichever lost would take its capability with it.
+    INVARIANT: exactly one spec per ROUTE id. `routes_for` maps `"/" + id`, so a second spec
+    for one route id would collapse silently and whichever lost would take its capability
+    with it. The dict is keyed by the route id — `encode_route_id` of the real id — for every
+    source, so a TOML override of an `aigateway_only` model (which can only ever name the
+    encoded form; `ROUTE_ID_RE` bars a literal ':') lines up with the compiled entry it means
+    to replace without any special-casing (OME-873).
+
+    `ModelSpec.id` is therefore ALWAYS the url4-route form, for every entry, whether it came
+    from the registry or from TOML. The real gateway id is recovered with `decode_route_id`
+    exactly where a real request or a comparison against aigateway's own catalog needs it
+    (`runner/connector.py`, `catalog/executable.py`) — nowhere else needs to know the
+    distinction.
 
     A TOML entry for a registry id REPLACES that spec, which is how `web_search = false` reaches
     a compiled route. A TOML entry for an unknown id is appended. Nothing removes an id: the
@@ -341,6 +363,9 @@ def _merge(registry: ModelRegistry, declared: tuple[ModelSpec, ...]) -> tuple[Mo
     merged: dict[str, ModelSpec] = {
         model_id: ModelSpec(id=model_id) for model_id in sorted(registry.routable)
     }
+    for model_id in sorted(registry.aigateway_only):
+        route_id = encode_route_id(model_id)
+        merged[route_id] = ModelSpec(id=route_id)
     for spec in declared:
         merged[spec.id] = spec
     if not merged:

--- a/apps/url4-cloud/tests/unit/test_aigateway_connector_route_encoding.py
+++ b/apps/url4-cloud/tests/unit/test_aigateway_connector_route_encoding.py
@@ -1,0 +1,93 @@
+"""A call through a `~`-encoded route reaches aigateway under the real, colon-bearing id.
+
+FEATURE: OME-873 — `ModelSpec.id` is always the url4-route form; the connector recovers the
+real gateway id (`decode_route_id`) exactly at the wire boundary and for usage reporting, so an
+`aigateway_only` model (colon-bearing) is both addressable from an expression AND billed/served
+correctly.
+
+Self-contained: a minimal aigateway double, not the full `_MockAigateway` in
+`test_aigateway_connector.py` (tool loop, Tavily, multi-route) — this unit needs only "does the
+wire body carry the real id".
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from url4.dag import run as url4_run
+from url4.observe import ObservationEvent, Usage
+from url4_cloud.runner.connector import AigatewayConfig, build_aigateway_world
+from url4_cloud.world_config import ModelSpec
+
+pytestmark = pytest.mark.asyncio
+
+_REAL_ID = "huggingface/openai/gpt-oss-120b:cerebras"
+_ROUTE_ID = "huggingface/openai/gpt-oss-120b~cerebras"
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[ObservationEvent] = []
+
+    def on_event(self, event: ObservationEvent) -> None:
+        self.events.append(event)
+
+
+class _MinimalAigateway:
+    """Records every `/v1/chat/completions` body and answers with fixed content."""
+
+    def __init__(self, content: str = "hello from cerebras") -> None:
+        self.requests: list[httpx.Request] = []
+        self._content = content
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": self._content}}],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+            },
+        )
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handle), base_url="http://aigateway.test"
+        )
+
+    def bodies(self) -> list[dict]:
+        return [json.loads(r.content) for r in self.requests]
+
+
+async def test_a_call_through_the_encoded_route_sends_the_real_id_on_the_wire() -> None:
+    gw = _MinimalAigateway()
+    cfg = AigatewayConfig(models=(ModelSpec(id=_ROUTE_ID),), default_model=_ROUTE_ID)
+    async with gw.client() as client:
+        world = await build_aigateway_world(cfg, client=client)
+
+        result = await url4_run(f"/{_ROUTE_ID}(ctx)!go", io=world.node)
+
+    assert result == "hello from cerebras"
+    bodies = gw.bodies()
+    assert len(bodies) == 1
+    # The wire model field is the REAL, colon-bearing id — never the route id, which is not
+    # a model aigateway knows about.
+    assert bodies[0]["model"] == _REAL_ID
+
+
+async def test_usage_is_reported_under_the_real_id_not_the_route_id() -> None:
+    gw = _MinimalAigateway()
+    cfg = AigatewayConfig(models=(ModelSpec(id=_ROUTE_ID),), default_model=_ROUTE_ID)
+    recorder = _Recorder()
+    async with gw.client() as client:
+        world = await build_aigateway_world(cfg, client=client)
+
+        await url4_run(f"/{_ROUTE_ID}(ctx)!go", io=world.node, observer=recorder)
+
+    usage_events = [e for e in recorder.events if isinstance(e, Usage)]
+    assert len(usage_events) == 1
+    assert usage_events[0].model == _REAL_ID
+    assert usage_events[0].provider == "huggingface"

--- a/apps/url4-cloud/tests/unit/test_executable_catalog_route_encoding.py
+++ b/apps/url4-cloud/tests/unit/test_executable_catalog_route_encoding.py
@@ -1,0 +1,98 @@
+"""Discovery advertises a colon-bearing model under its `~`-encoded, url4-addressable id.
+
+FEATURE: OME-873 — `GET /v1/models` / `GET /v1/model-parameters` show exactly what a caller
+should type into a url4 expression, never aigateway's raw (colon-bearing) id verbatim.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4_cloud.catalog.executable import ExecutableCatalog, ExecutableModelParameterSource
+from url4_cloud.catalog.port import (
+    Credential,
+    ModelCatalog,
+    ModelNotInstalled,
+    ModelParameterResponse,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_ROUTABLE = "openrouter/openai/gpt-5.5"
+_REAL_ID = "huggingface/openai/gpt-oss-120b:cerebras"
+_ROUTE_ID = "huggingface/openai/gpt-oss-120b~cerebras"
+
+
+class _GatewayCatalog:
+    counters = None
+    entry_count = 0
+    model_parameter_source = None
+
+    async def fetch(self, credential: Credential) -> ModelCatalog:
+        body = {
+            "object": "list",
+            "data": [
+                {"id": _ROUTABLE, "object": "model"},
+                {"id": _REAL_ID, "object": "model"},
+            ],
+        }
+        return ModelCatalog(body=body, etag="irrelevant")
+
+    def max_age_s(self, credential: Credential) -> int:
+        return 60
+
+    async def aclose(self) -> None:
+        pass
+
+
+async def test_a_retained_colon_bearing_item_is_rewritten_to_its_encoded_id() -> None:
+    catalog = ExecutableCatalog(_GatewayCatalog(), frozenset({_ROUTABLE, _REAL_ID}))
+
+    result = await catalog.fetch(Credential.derive())
+
+    assert result.body["data"] == [
+        {"id": _ROUTABLE, "object": "model"},
+        {"id": _ROUTE_ID, "object": "model"},
+    ]  # the real (colon-bearing) id never reaches the caller
+
+
+async def test_encoding_is_a_no_op_for_an_id_with_no_colon() -> None:
+    catalog = ExecutableCatalog(_GatewayCatalog(), frozenset({_ROUTABLE}))
+
+    result = await catalog.fetch(Credential.derive())
+
+    assert result.body["data"] == [{"id": _ROUTABLE, "object": "model"}]
+
+
+class _GatewayDetails:
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    async def fetch_model_parameters(
+        self, credential: Credential, model: str
+    ) -> ModelParameterResponse:
+        self.seen.append(model)
+        return ModelParameterResponse(status=200, content=b'{"model":{}}')
+
+    async def aclose(self) -> None:
+        pass
+
+
+async def test_model_parameters_accepts_the_encoded_id_and_forwards_the_real_one() -> None:
+    details = _GatewayDetails()
+    source = ExecutableModelParameterSource(details, frozenset({_REAL_ID}))
+
+    result = await source.fetch_model_parameters(Credential.derive(), _ROUTE_ID)
+
+    assert result.status == 200
+    assert details.seen == [_REAL_ID]
+
+
+async def test_model_parameters_still_rejects_an_id_outside_the_declared_world() -> None:
+    details = _GatewayDetails()
+    source = ExecutableModelParameterSource(details, frozenset({_REAL_ID}))
+
+    with pytest.raises(ModelNotInstalled):
+        await source.fetch_model_parameters(Credential.derive(), "openrouter/not-declared")
+
+    assert details.seen == []

--- a/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
+++ b/apps/url4-cloud/tests/unit/test_executable_model_catalog.py
@@ -155,7 +155,14 @@ async def test_production_builder_wraps_the_gateway_source_with_the_declared_rou
 
     assert service is not None
     catalog = await service.fetch(Credential.derive())
-    assert catalog.body["data"] == [{"id": _DECLARED, "object": "model"}]
+    # OME-873: `_GATEWAY_ONLY` (real, colon-bearing) is declared via BUILTIN_MODEL_WORLD's
+    # aigateway_only partition, so it is now retained too — under its `~`-encoded, url4-route
+    # id, never its real form. See test_executable_catalog_route_encoding.py for the isolated
+    # unit coverage of the rewrite itself.
+    assert catalog.body["data"] == [
+        {"id": _DECLARED, "object": "model"},
+        {"id": "huggingface/google/gemma-2-2b-it~featherless-ai", "object": "model"},
+    ]
     await service.aclose()
 
 

--- a/apps/url4-cloud/tests/unit/test_executable_model_routes.py
+++ b/apps/url4-cloud/tests/unit/test_executable_model_routes.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from url4_cloud import job_env
-from url4_cloud.models.registry import EMPTY_MODEL_WORLD
+from url4_cloud.models.registry import EMPTY_MODEL_WORLD, decode_route_id
 from url4_cloud.world_config import WorldConfigError, declared_model_ids, load_config, parse_config
 
 
@@ -43,4 +43,7 @@ def test_control_plane_and_runner_read_the_same_declared_ids() -> None:
     section = load_config(env).aigateway
 
     assert section is not None
-    assert declared_model_ids(env) == frozenset(item.id for item in section.models)
+    # OME-873: `declared_model_ids` reports the REAL gateway id (what aigateway's own catalog
+    # names), while `section.models[*].id` is the url4-ROUTE form — decode to compare like for
+    # like. The two are still one invariant: same world, two projections of the same ids.
+    assert declared_model_ids(env) == frozenset(decode_route_id(item.id) for item in section.models)

--- a/apps/url4-cloud/tests/unit/test_model_route_encoding.py
+++ b/apps/url4-cloud/tests/unit/test_model_route_encoding.py
@@ -1,0 +1,134 @@
+"""The `:` <-> `~` route-encoding boundary (OME-873).
+
+FEATURE: OME-873 — the 29 `aigateway_only` ids (colon-bearing) become routable by encoding
+their `:` as `~` (already `ROUTE_ID_RE`-legal) wherever a url4 route path is derived, and
+decoding back to the real gateway id wherever a real request or comparison against aigateway's
+own catalog is made.
+
+STORY: as an SDK user, I can address `huggingface/openai/gpt-oss-120b:cerebras` from a url4
+expression by writing its encoded path `/huggingface/openai/gpt-oss-120b~cerebras`, and the
+Runner sends aigateway the real, colon-bearing id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from url4_cloud import job_env
+from url4_cloud.models.registry import (
+    ModelRegistry,
+    ProviderSeed,
+    decode_route_id,
+    encode_route_id,
+)
+from url4_cloud.world_config import (
+    AigatewaySection,
+    WorldConfigError,
+    declared_model_ids,
+    parse_config,
+    routes_for,
+)
+
+_REGISTRY = ModelRegistry(
+    (
+        ProviderSeed("anthropic", ("claude-haiku-4-5",)),
+        ProviderSeed("huggingface", ("openai/gpt-oss-120b:cerebras",)),
+    )
+)
+_REAL_ID = "huggingface/openai/gpt-oss-120b:cerebras"
+_ROUTE_ID = "huggingface/openai/gpt-oss-120b~cerebras"
+
+
+def _world(table: dict[str, object], registry: ModelRegistry = _REGISTRY) -> AigatewaySection:
+    section = parse_config({"aigateway": table}, {}, registry=registry).aigateway
+    assert section is not None
+    return section
+
+
+# --- encode_route_id / decode_route_id: pure functions -----------------------------------
+
+
+def test_encode_replaces_colon_with_tilde() -> None:
+    assert encode_route_id(_REAL_ID) == _ROUTE_ID
+
+
+def test_decode_replaces_tilde_with_colon() -> None:
+    assert decode_route_id(_ROUTE_ID) == _REAL_ID
+
+
+def test_encode_is_the_identity_on_an_id_with_no_colon() -> None:
+    assert encode_route_id("anthropic/claude-haiku-4-5") == "anthropic/claude-haiku-4-5"
+
+
+def test_decode_is_the_identity_on_an_id_with_no_tilde() -> None:
+    assert decode_route_id("anthropic/claude-haiku-4-5") == "anthropic/claude-haiku-4-5"
+
+
+def test_encode_then_decode_round_trips() -> None:
+    assert decode_route_id(encode_route_id(_REAL_ID)) == _REAL_ID
+
+
+@pytest.mark.parametrize(
+    "model_id", ["huggingface/org/model:novita", "openrouter/liquid/lfm-2.5-2.6b:free"]
+)
+def test_encode_round_trips_every_shape_of_colon_id(model_id: str) -> None:
+    assert decode_route_id(encode_route_id(model_id)) == model_id
+
+
+# --- registry construction reserves '~' for the colon-escape ------------------------------
+
+
+def test_a_slug_containing_a_literal_tilde_is_refused() -> None:
+    # INVARIANT: '~' is reserved exclusively as the colon-escape (OME-873). A future seed that
+    # legitimately needs one would silently collide with an encoded aigateway_only route.
+    with pytest.raises(ValueError, match="reserved"):
+        ModelRegistry((ProviderSeed("openrouter", ("openai/gpt-5.5~preview",)),))
+
+
+# --- world_config: an aigateway_only id now enters the world, under its encoded id ---------
+
+
+def test_an_aigateway_only_id_enters_the_world_under_its_encoded_id() -> None:
+    section = _world({"default_route": "/anthropic/claude-haiku-4-5"})
+
+    ids = {m.id for m in section.models}
+    assert _ROUTE_ID in ids
+    assert _REAL_ID not in ids  # the real (colon) id never appears as a route id
+
+
+def test_routes_for_derives_a_route_id_path_with_no_further_encoding() -> None:
+    section = _world({"default_route": "/anthropic/claude-haiku-4-5"})
+
+    routes = routes_for(section.models)
+
+    assert "/" + _ROUTE_ID in routes
+
+
+def test_a_toml_entry_overrides_an_aigateway_only_id_by_its_encoded_form() -> None:
+    section = _world(
+        {
+            "default_route": "/anthropic/claude-haiku-4-5",
+            "models": [{"id": _ROUTE_ID, "web_search": False}],
+        }
+    )
+
+    specs = {m.id: m for m in section.models}
+    assert len(specs) == 2  # the override REPLACES, it does not duplicate
+    assert specs[_ROUTE_ID].web_search is False
+
+
+def test_declared_model_ids_reports_the_real_gateway_id(tmp_path) -> None:
+    # WHY: this is what gets compared against aigateway's own `GET /v1/models` response, whose
+    # `id` field is always the real (colon-bearing) id — never the url4-route form.
+    config = tmp_path / "url4.toml"
+    config.write_text('[aigateway]\ndefault_route = "/anthropic/claude-haiku-4-5"\n')
+
+    ids = declared_model_ids({job_env.RUNNER_CONFIG: str(config)}, registry=_REGISTRY)
+
+    assert _REAL_ID in ids
+    assert _ROUTE_ID not in ids
+
+
+def test_a_literal_colon_in_default_route_gets_a_specific_error() -> None:
+    with pytest.raises(WorldConfigError, match="cannot be a route"):
+        _world({"default_route": "/" + _REAL_ID})

--- a/apps/url4-cloud/tests/unit/test_world_config_registry_merge.py
+++ b/apps/url4-cloud/tests/unit/test_world_config_registry_merge.py
@@ -24,9 +24,12 @@ def _world(table: dict[str, object], registry: ModelRegistry = _REGISTRY) -> Aig
 def test_registry_ids_reach_the_declared_world_without_any_toml_entry() -> None:
     section = _world({"default_route": "/anthropic/claude-haiku-4-5"})
 
+    # OME-873: the aigateway_only seed ("org/model:novita") reaches the world too, under its
+    # `~`-encoded route id — see test_an_aigateway_only_id_enters_the_world_under_its_encoded_id.
     assert {m.id for m in section.models} == {
         "anthropic/claude-haiku-4-5",
         "anthropic/claude-opus-5",
+        "huggingface/org/model~novita",
     }
 
 
@@ -71,10 +74,16 @@ def test_a_toml_entry_duplicating_a_registry_id_yields_exactly_one_spec() -> Non
     assert len(routes_for(section.models)) == len(ids)
 
 
-def test_an_aigateway_only_id_never_enters_the_world() -> None:
+def test_an_aigateway_only_id_enters_the_world_under_its_encoded_id() -> None:
+    # OME-873 supersedes this test's old name/claim ("never enters the world"): the real,
+    # colon-bearing id still never appears as a route id — see
+    # test_declared_model_ids_reports_the_real_gateway_id in test_model_route_encoding.py — but
+    # the model itself IS now addressable, under its `~`-encoded form.
     section = _world({"default_route": "/anthropic/claude-haiku-4-5"})
 
-    assert "huggingface/org/model:novita" not in {m.id for m in section.models}
+    ids = {m.id for m in section.models}
+    assert "huggingface/org/model~novita" in ids
+    assert "huggingface/org/model:novita" not in ids
 
 
 def test_a_default_route_declared_only_by_the_registry_validates() -> None:

--- a/docs/tasks/2026-08-18-OME-873-colon-bearing-model-ids.md
+++ b/docs/tasks/2026-08-18-OME-873-colon-bearing-model-ids.md
@@ -1,0 +1,21 @@
+---
+id: OME-873
+linear_url: https://linear.app/openmined/issue/OME-873/route-aigateways-colon-bearing-model-ids-via-a-encoding
+status: In Progress
+type: task
+priority: Medium
+labels: [url4-cloud, agentic, autonomous]
+created: 2026-08-18
+closed:
+---
+
+# Route aigateway's colon-bearing model ids via a `~` encoding
+
+Makes the 29 `aigateway_only` model ids (colon-bearing, e.g.
+`huggingface/openai/gpt-oss-120b:cerebras`) routable from a url4 expression by remapping
+`:` → `~` at the route boundary and reverting at the single point the real request reaches
+aigateway. Also extends `GET /v1/models` / `GET /v1/model-parameters` to advertise these ids
+in their encoded form.
+
+Full detail and design rationale: the Linear issue body (brainstormed and approved in chat,
+bounded path — no separate spec doc).

--- a/docs/tasks/2026-08-18-OME-873-colon-bearing-model-ids.md
+++ b/docs/tasks/2026-08-18-OME-873-colon-bearing-model-ids.md
@@ -1,7 +1,7 @@
 ---
 id: OME-873
 linear_url: https://linear.app/openmined/issue/OME-873/route-aigateways-colon-bearing-model-ids-via-a-encoding
-status: In Progress
+status: In Review
 type: task
 priority: Medium
 labels: [url4-cloud, agentic, autonomous]

--- a/docs/work/2026-08-18-OME-873-colon-bearing-model-ids.md
+++ b/docs/work/2026-08-18-OME-873-colon-bearing-model-ids.md
@@ -1,0 +1,111 @@
+---
+ticket: OME-873
+stack: url4-cloud
+status: done
+started: 2026-08-18
+finished: 2026-08-18
+---
+
+# OME-873 — Route aigateway's colon-bearing model ids via a `~` encoding
+
+## Intent
+
+`ModelRegistry` (OME-859) partitions aigateway's 117 compiled model ids into `routable` (88)
+and `aigateway_only` (29) — the 29 carry a literal `:` (e.g.
+`huggingface/openai/gpt-oss-120b:cerebras`), which no URL4 path segment may contain, so they
+are declared for the OME-819 drift guard but never enter the runnable world. This unit makes
+them routable by remapping `:` → `~` (already `ROUTE_ID_RE`-legal) at the route boundary, and
+reverting at the single point the real request reaches aigateway, so `ModelSpec.id` is
+uniformly route-legal everywhere and the real gateway id is recovered by one unconditional,
+pure decode call exactly where it's needed. Discovery (`GET /v1/models` /
+`GET /v1/model-parameters`) is extended to advertise these ids in their encoded form, so what
+a caller sees is exactly what they should type into a url4 expression.
+
+## Planned changes
+
+- `src/url4_cloud/models/registry.py` — add `encode_route_id`/`decode_route_id`; reserve `~`
+  at seed-validation time (reject a literal `~` in any slug/id).
+- `src/url4_cloud/world_config.py` — `_merge()` keys the merged dict by the encoded id for
+  every source (registry-routable, registry-aigateway_only, TOML-declared); `declared_model_ids()`
+  returns decoded (real) ids so it still matches aigateway's own catalog response;
+  `_reject_unroutable_default` repurposed to detect a literal `:` in `default_route` and point
+  at the `~` form.
+- `src/url4_cloud/runner/connector.py::_chat_completion_loop` — decode once at the top into a
+  `real_id` local; use it for the wire `body["model"]` and `_report_usage`.
+- `src/url4_cloud/catalog/executable.py::ExecutableCatalog.fetch` — rewrite each retained
+  item's `id` through `encode_route_id` before returning.
+  `ExecutableModelParameterSource.fetch_model_parameters` — decode the caller-supplied `model`
+  before the membership check and before forwarding to the real source.
+
+## Test plan
+
+- `models/registry.py`: `encode_route_id`/`decode_route_id` round-trip (including identity on
+  ids with no colon); registry construction rejects a slug containing a literal `~`.
+- `world_config.py`: an `aigateway_only` id now appears in `section.models` under its encoded
+  form; a TOML entry can override one of these (matched by its encoded id); `declared_model_ids`
+  returns the real (decoded) id; a literal `:` in `default_route` gets the specific "use `~`"
+  error, not the generic "not declared" dump.
+- `connector.py`: calling the encoded route sends the real (colon) id as `"model"` on the wire
+  and reports usage under the real id.
+- `catalog/executable.py`: a retained catalog item whose real id contains `:` is rewritten to
+  its encoded form; `fetch_model_parameters` accepts the encoded id from the caller and forwards
+  the decoded real id upstream.
+- Existing pinned tests updated (owner-approved, see ticket): `test_an_aigateway_only_id_never_enters_the_world`,
+  `test_control_plane_and_runner_read_the_same_declared_ids`,
+  `test_a_default_route_naming_an_aigateway_only_id_is_refused`.
+
+## Acceptance
+
+- All 117 declared ids (not just 88) are addressable from a url4 expression, each under a
+  `ROUTE_ID_RE`-legal path.
+- A call through one of the 29 sends aigateway the real, colon-bearing id — verified by an
+  end-to-end connector test asserting the wire body.
+- `GET /v1/models` / `GET /v1/model-parameters` advertise the 29 in encoded form and accept
+  the encoded form back.
+- `run_gates.py url4-cloud` green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** matched the plan exactly.
+  - `src/url4_cloud/models/registry.py` — `encode_route_id`/`decode_route_id`, the `~`-reservation
+    guard in `_validate`, updated `aigateway_only` docstring.
+  - `src/url4_cloud/world_config.py` — `_merge()` keyed by encoded id (registry-routable +
+    registry-aigateway_only + TOML-declared, all in one namespace); `declared_model_ids()` decodes;
+    `_reject_unroutable_default(default_model)` (dropped the now-unused `registry` param, detects a
+    literal `:` directly).
+  - `src/url4_cloud/runner/connector.py::_chat_completion_loop` — one `real_model_id =
+    decode_route_id(spec.id)` local, used for the wire body and `_report_usage`.
+  - `src/url4_cloud/catalog/executable.py` — `ExecutableCatalog.fetch` rewrites retained ids via
+    `encode_route_id`; `ExecutableModelParameterSource.fetch_model_parameters` decodes the
+    caller-supplied `model` before the membership check and the forwarded call.
+  - New tests: `test_model_route_encoding.py`, `test_aigateway_connector_route_encoding.py`,
+    `test_executable_catalog_route_encoding.py`.
+  - Edited tests (pre-approved in the ticket/design, not a new decision):
+    `test_world_config_registry_merge.py` (`test_an_aigateway_only_id_never_enters_the_world` →
+    renamed/flipped to `test_an_aigateway_only_id_enters_the_world_under_its_encoded_id`; the
+    shared `_REGISTRY` fixture's expected id set in
+    `test_registry_ids_reach_the_declared_world_without_any_toml_entry` gained the encoded
+    huggingface id — a collateral fixture effect, not a targeted rewrite),
+    `test_executable_model_routes.py::test_control_plane_and_runner_read_the_same_declared_ids`
+    (decode added to one side of the equality), `test_executable_model_catalog.py::
+    test_production_builder_wraps_the_gateway_source_with_the_declared_routes` (now expects the
+    real `url4.toml`'s aigateway_only seed to be retained under its encoded id — discovered during
+    implementation, not anticipated in the original file list, but the exact same category as the
+    other two).
+  - `test_a_default_route_naming_an_aigateway_only_id_is_refused` needed NO edit — the new
+    `_reject_unroutable_default` message still contains "cannot be a route".
+- **Commits:** see `git log` on this branch (`Refs: OME-873`).
+- **Gates:** `run_gates.py url4-cloud --skip-append-only` — ruff check, ruff format --check,
+  pyright, check_layering.py, `pytest --cov=url4_cloud --cov=url4.streaming --cov-fail-under=80`
+  all green. Full suite: 1718 passed, 5 skipped (pre-existing skips, unrelated).
+- **Deviations:**
+  - `--skip-append-only` used, per the owner-approved deviation named in the ticket, for the 3
+    pre-existing test edits above (all factually contradicted the new, intended behavior — not
+    weakened, just corrected to the new truth).
+  - One test edit (`test_executable_model_catalog.py`) was not in the original plan — found only
+    once the real `url4.toml` + `BUILTIN_MODEL_WORLD` were exercised end-to-end through
+    `build_executable_catalog_service`. Same category and same justification as the two planned
+    edits; recorded here for completeness.
+  - `connector.py` stayed at 711 lines (over the 450-line guideline) — pre-existing size, and this
+    unit's change to it is a 4-line, single-purpose addition; a file-level refactor is out of scope
+    for this ticket (no drive-by refactor).


### PR DESCRIPTION
## Summary
- The 29 `aigateway_only` model ids (e.g. `huggingface/openai/gpt-oss-120b:cerebras`) carry a literal `:`, which no URL4 path segment may contain, so they were declared for the OME-819 drift guard but never routable. `ModelSpec.id` is now uniformly the url4-route form (`:` encoded as `~` via `encode_route_id`/`decode_route_id` in `models/registry.py`), and the real gateway id is recovered with one unconditional decode exactly where a real request or a comparison against aigateway's own catalog needs it.
- `runner/connector.py`: the `chat/completions` wire body and usage report always carry the real (decoded) gateway id.
- `catalog/executable.py`: `GET /v1/models` / `GET /v1/model-parameters` now advertise these 29 ids in their `~`-encoded form instead of omitting them, and decode the caller-supplied id back before forwarding to aigateway.
- `world_config.py`: `_merge()` folds registry-routable, registry-`aigateway_only`, and TOML-declared ids into one namespace keyed by the route id; `_reject_unroutable_default` now detects a literal `:` and suggests the `~` form.

Design brainstormed and approved in chat (bounded path, no separate spec doc) — full rationale in the Linear issue and the work ledger.

Refs: OME-873

## Test plan
- [x] New self-contained test files: `test_model_route_encoding.py` (encode/decode round-trip, `~`-reservation guard, world_config merge/override/default-route behavior), `test_aigateway_connector_route_encoding.py` (wire body + usage carry the real id), `test_executable_catalog_route_encoding.py` (catalog id rewrite, model-parameters decode)
- [x] 3 pre-existing tests updated to match the new, intended behavior (documented in the ledger's Deviations): `test_world_config_registry_merge.py`, `test_executable_model_routes.py`, `test_executable_model_catalog.py`
- [x] `uv run .claude/scripts/run_gates.py url4-cloud --skip-append-only` — ruff check, ruff format, pyright, check_layering.py, pytest (coverage ≥80%) all green
- [x] Full suite: 1718 passed, 5 skipped (pre-existing, unrelated)

Ledger: `docs/work/2026-08-18-OME-873-colon-bearing-model-ids.md`