### PR TITLE
feat(aigateway): add direct OpenAI API-key provider

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/openai_provider/__init__.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/__init__.py
@@ -1,0 +1,1 @@
+"""Direct OpenAI Platform provider plugin."""

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/api_key_validation.py
@@ -16,6 +16,9 @@ from aigateway.core.api_key_validation_http import (
 from .settings import OpenAIPluginSettings
 
 _API_BASE = "https://api.openai.com/v1"
+# WHY: OpenAI rejects 1 with HTTP 400 for gpt-5-nano; 16 is the live-verified bounded budget that
+# returns a structurally valid length-limited Chat Completions response.
+_READINESS_MAX_COMPLETION_TOKENS = 16
 
 # Every actionable row needs all three pieces of upstream evidence. The invalid-key row was
 # captured with a synthetic key on 2026-08-17; the billing rows are the exact codes in OpenAI's
@@ -190,7 +193,7 @@ class OpenAIApiKeyValidator:
                     headers=headers,
                     json_body={
                         "model": upstream_model,
-                        "max_completion_tokens": 1,
+                        "max_completion_tokens": _READINESS_MAX_COMPLETION_TOKENS,
                         "stream": False,
                         "messages": [{"role": "user", "content": "ping"}],
                     },

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/api_key_validation.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/api_key_validation.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import httpx
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.api_key_validation_http import (
+    ApiKeyValidationTransportError,
+    BoundedJsonResponse,
+    ValidationHttpSession,
+)
+
+from .settings import OpenAIPluginSettings
+
+_API_BASE = "https://api.openai.com/v1"
+
+# Every actionable row needs all three pieces of upstream evidence. The invalid-key row was
+# captured with a synthetic key on 2026-08-17; the billing rows are the exact codes in OpenAI's
+# current error guide, which also documents `insufficient_quota` as their broader type.
+_ACTIONABLE_ERROR_EVIDENCE: dict[
+    tuple[ApiKeyValidationStage, int, str, str], ApiKeyValidationState
+] = {
+    (
+        ApiKeyValidationStage.AUTHENTICATION,
+        401,
+        "invalid_request_error",
+        "invalid_api_key",
+    ): ApiKeyValidationState.INVALID,
+    (
+        ApiKeyValidationStage.READINESS,
+        401,
+        "invalid_request_error",
+        "invalid_api_key",
+    ): ApiKeyValidationState.INVALID,
+    **{
+        (ApiKeyValidationStage.READINESS, 429, "insufficient_quota", code): (
+            ApiKeyValidationState.NO_QUOTA
+        )
+        for code in (
+            "credit_balance_exhausted",
+            "organization_spend_limit_exceeded",
+            "project_spend_limit_exceeded",
+            "organization_usage_limit_exceeded",
+        )
+    },
+}
+
+# These public states deliberately have no actionable OpenAI tuple yet. Keeping them explicit
+# makes the finite table total without promoting guessed values; unknown tuples stay unavailable.
+_UNPROMOTED_STATES = frozenset(
+    {
+        ApiKeyValidationState.EXPIRED,
+        ApiKeyValidationState.PERMISSION_DENIED,
+        ApiKeyValidationState.RATE_LIMITED,
+    }
+)
+assert set(ApiKeyValidationState) == set(_ACTIONABLE_ERROR_EVIDENCE.values()) | set(
+    _UNPROMOTED_STATES
+) | {
+    ApiKeyValidationState.VALID,
+    ApiKeyValidationState.UNAVAILABLE,
+    ApiKeyValidationState.MISCONFIGURED,
+}
+
+
+def _result(
+    state: ApiKeyValidationState,
+    stage: ApiKeyValidationStage | None,
+    *,
+    response: BoundedJsonResponse | None = None,
+    probe_model: str | None = None,
+) -> ApiKeyValidationResult:
+    retry_after = None
+    if state is ApiKeyValidationState.RATE_LIMITED and response is not None:
+        retry_after = response.retry_after_seconds
+    return ApiKeyValidationResult(
+        state=state,
+        stage=stage,
+        retry_after_seconds=retry_after,
+        probe_model=probe_model,
+    )
+
+
+def _classify(
+    response: BoundedJsonResponse,
+    stage: ApiKeyValidationStage,
+    probe_model: str,
+) -> ApiKeyValidationResult:
+    payload = response.payload
+    if response.status_code == 200:
+        if not isinstance(payload, dict):
+            success = False
+        elif isinstance(payload.get("error"), dict):
+            success = False
+        elif stage is ApiKeyValidationStage.AUTHENTICATION:
+            success = payload.get("object") == "list" and isinstance(payload.get("data"), list)
+        else:
+            choices = payload.get("choices")
+            success = (
+                isinstance(choices, list)
+                and bool(choices)
+                and all(
+                    isinstance(choice, dict)
+                    and "error" not in choice
+                    and isinstance(choice.get("message"), dict)
+                    and choice["message"].get("role") == "assistant"
+                    and isinstance(choice["message"].get("content"), str)
+                    for choice in choices
+                )
+            )
+        return _result(
+            ApiKeyValidationState.VALID if success else ApiKeyValidationState.UNAVAILABLE,
+            stage,
+            probe_model=probe_model,
+        )
+
+    error = payload.get("error") if isinstance(payload, dict) else None
+    raw_type = error.get("type") if isinstance(error, dict) else None
+    raw_code = error.get("code") if isinstance(error, dict) else None
+    error_type = raw_type if isinstance(raw_type, str) else None
+    error_code = raw_code if isinstance(raw_code, str) else None
+    state = None
+    if error_type is not None and error_code is not None:
+        state = _ACTIONABLE_ERROR_EVIDENCE.get(
+            (stage, response.status_code, error_type, error_code)
+        )
+    return _result(
+        state or ApiKeyValidationState.UNAVAILABLE,
+        stage,
+        response=response,
+        probe_model=probe_model,
+    )
+
+
+def _effective_model(settings: OpenAIPluginSettings) -> tuple[str, str] | None:
+    selected = settings.validation_model
+    if selected not in settings.default_models or not selected.startswith("openai/"):
+        return None
+    upstream = selected.removeprefix("openai/")
+    if not upstream or "/" in upstream:
+        return None
+    return selected, upstream
+
+
+class OpenAIApiKeyValidator:
+    def __init__(
+        self,
+        *,
+        settings: OpenAIPluginSettings,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._settings = settings
+        self._transport = transport
+
+    async def validate(self, api_key: str) -> ApiKeyValidationResult:
+        model = _effective_model(self._settings)
+        if model is None:
+            return _result(ApiKeyValidationState.MISCONFIGURED, None)
+        probe_model, upstream_model = model
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        async with ValidationHttpSession(transport=self._transport) as session:
+            try:
+                auth_response = await session.request_json(
+                    "GET",
+                    f"{_API_BASE}/models",
+                    headers=headers,
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.AUTHENTICATION,
+                    probe_model=probe_model,
+                )
+            auth_result = _classify(
+                auth_response,
+                ApiKeyValidationStage.AUTHENTICATION,
+                probe_model,
+            )
+            if auth_result.state is not ApiKeyValidationState.VALID:
+                return auth_result
+
+            try:
+                readiness_response = await session.request_json(
+                    "POST",
+                    f"{_API_BASE}/chat/completions",
+                    headers=headers,
+                    json_body={
+                        "model": upstream_model,
+                        "max_completion_tokens": 1,
+                        "stream": False,
+                        "messages": [{"role": "user", "content": "ping"}],
+                    },
+                )
+            except ApiKeyValidationTransportError:
+                return _result(
+                    ApiKeyValidationState.UNAVAILABLE,
+                    ApiKeyValidationStage.READINESS,
+                    probe_model=probe_model,
+                )
+            return _classify(
+                readiness_response,
+                ApiKeyValidationStage.READINESS,
+                probe_model,
+            )

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/parameters.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/parameters.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from aigateway.core.chat_parameters import ParameterProjectionRule
+from aigateway.core.profile_models import AuthMode
+from aigateway.core.standard_parameters import MAX_TOKENS_SCHEMA, direct_rule
+
+_AUTH: tuple[AuthMode, ...] = ("api_key",)
+_REVISION = "openai-2026-08-p0"
+
+_RULES: tuple[ParameterProjectionRule, ...] = (
+    direct_rule(
+        "max_tokens",
+        auth_modes=_AUTH,
+        schema=MAX_TOKENS_SCHEMA,
+        cache_behavior="bypass",
+        projection_revision=_REVISION,
+    ),
+)
+
+
+def openai_chat_parameter_rules(
+    *, model: str, auth_type: AuthMode | None = None
+) -> tuple[ParameterProjectionRule, ...]:
+    del model, auth_type
+    return _RULES

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, cast
+
+import httpx
+from fastapi import HTTPException
+from openai import AsyncOpenAI, Omit
+
+from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.api_key_validation import ApiKeyValidator
+from aigateway.core.plugin_base import CredentialStrategy, ModelEntry, ProviderPluginBase
+from aigateway.core.request_hardening import strip_dispatch_controls
+from aigateway.core.standard_parameters import direct_parameter_observations
+
+from .api_key_validation import OpenAIApiKeyValidator
+from .parameters import openai_chat_parameter_rules
+from .settings import OpenAIPluginSettings
+
+if TYPE_CHECKING:
+    from aigateway.core.chat_parameters import (
+        ParameterProjectionRule,
+        ProviderParameterObservation,
+    )
+    from aigateway.core.credential_blob.store import CredentialBlobStore
+    from aigateway.core.profile_models import AuthMode
+
+
+_OBSERVATION_SOURCE = "openai:locked-runtime"
+_OFFICIAL_API_BASE = "https://api.openai.com/v1"
+_LITELLM_GLOBAL_CALLBACK_FIELDS = (
+    "callbacks",
+    "input_callback",
+    "success_callback",
+    "failure_callback",
+    "_async_input_callback",
+    "_async_success_callback",
+    "_async_failure_callback",
+)
+_LITELLM_GLOBAL_RULE_FIELDS = (
+    "pre_call_rules",
+    "post_call_rules",
+    "drop_params",
+    "additional_drop_params",
+)
+
+
+def _credential_service_for(profile_name: str) -> str:
+    return f"aigateway:openai:{profile_name}"
+
+
+def _openai_http_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        verify=True,
+        trust_env=False,
+        follow_redirects=False,
+    )
+
+
+def _invalid_model_error() -> HTTPException:
+    return HTTPException(
+        status_code=400,
+        detail={
+            "code": "invalid_model",
+            "provider": "openai",
+            "message": "model is not registered for direct OpenAI dispatch",
+        },
+    )
+
+
+def _unsafe_environment_error() -> HTTPException:
+    error = HTTPException(
+        status_code=503,
+        detail={
+            "code": "unsafe_openai_environment",
+            "provider": "openai",
+            "message": "direct OpenAI dispatch is unavailable",
+        },
+    )
+    cast("Any", error).aigw_non_retryable = True
+    return error
+
+
+def _has_unsafe_litellm_global_state(litellm: Any, model: object) -> bool:
+    aliases = getattr(litellm, "model_alias_map", None)
+    if isinstance(model, str) and isinstance(aliases, Mapping) and model in aliases:
+        return True
+    if getattr(litellm, "model_fallbacks", None):
+        return True
+    if getattr(litellm, "headers", None):
+        return True
+    if getattr(litellm, "proxy_auth", None) is not None:
+        return True
+    if any(bool(getattr(litellm, field, None)) for field in _LITELLM_GLOBAL_RULE_FIELDS):
+        return True
+    return any(
+        callbacks and any(callback != "cache" for callback in callbacks)
+        for callbacks in (
+            getattr(litellm, field, None) for field in _LITELLM_GLOBAL_CALLBACK_FIELDS
+        )
+    )
+
+
+class OpenAIProviderPlugin(ProviderPluginBase[OpenAIPluginSettings]):
+    custom_llm_provider = "openai"
+    provider_display_name = "OpenAI"
+    settings_cls = OpenAIPluginSettings
+
+    def register_models(self) -> list[ModelEntry]:
+        return [
+            ModelEntry(model_name=model, litellm_params={"model": model})
+            for model in self.settings.default_models
+        ]
+
+    def supports_api_key(self) -> bool:
+        return True
+
+    def supports_chat_streaming(self) -> bool:
+        return False
+
+    def api_key_strategy_for(
+        self,
+        profile_name: str,
+        *,
+        credential_store: CredentialBlobStore | None = None,
+    ) -> CredentialStrategy:
+        return ApiKeyStrategy(
+            profile_name,
+            service=_credential_service_for(profile_name),
+            account="default",
+            header_builder=lambda api_key: {"Authorization": f"Bearer {api_key}"},
+            credential_store=credential_store,
+        )
+
+    def should_mark_profile_error_on_dispatch_status(self, status_code: int) -> bool:
+        return status_code == 401
+
+    def api_key_validator(self) -> ApiKeyValidator:
+        return OpenAIApiKeyValidator(settings=self.settings)
+
+    def chat_parameter_rules(
+        self, *, model: str, auth_type: AuthMode | None = None
+    ) -> tuple[ParameterProjectionRule, ...]:
+        return openai_chat_parameter_rules(model=model, auth_type=auth_type)
+
+    def chat_parameter_observations(
+        self, *, model: str, auth_type: AuthMode | None = None
+    ) -> tuple[ProviderParameterObservation, ...]:
+        del model, auth_type
+        return direct_parameter_observations(("max_tokens",), source=_OBSERVATION_SOURCE)
+
+    def prepare_chat_body(self, body: dict[str, Any]) -> dict[str, Any]:
+        out = strip_dispatch_controls(body)
+        model = out.get("model")
+        if model not in self.settings.default_models:
+            raise _invalid_model_error()
+        out["api_base"] = _OFFICIAL_API_BASE
+        return out
+
+    async def chat_completion(self, body: dict[str, Any]) -> Any:
+        import litellm
+
+        if os.environ.get("OPENAI_CUSTOM_HEADERS"):
+            raise _unsafe_environment_error()
+        if _has_unsafe_litellm_global_state(litellm, body.get("model")):
+            raise _unsafe_environment_error()
+
+        dispatch_body = dict(body)
+        api_key = dispatch_body.pop("api_key", None)
+        if not isinstance(api_key, str) or not api_key:
+            raise _unsafe_environment_error()
+        dispatch_body["api_base"] = _OFFICIAL_API_BASE
+        dispatch_body["caching"] = False
+        dispatch_body["cache"] = {"no-cache": True, "no-store": True}
+        dispatch_body["num_retries"] = 0
+        dispatch_body["max_retries"] = 0
+        dispatch_body["ssl_verify"] = True
+        dispatch_body["_skip_responses_api_bridge"] = True
+
+        default_headers: dict[str, Any] = {
+            "OpenAI-Organization": Omit(),
+            "OpenAI-Project": Omit(),
+        }
+        http_client = _openai_http_client()
+        try:
+            client = AsyncOpenAI(
+                api_key=api_key,
+                base_url=_OFFICIAL_API_BASE,
+                max_retries=0,
+                default_headers=default_headers,
+                http_client=http_client,
+            )
+        except Exception:
+            await http_client.aclose()
+            raise
+        dispatch_body["client"] = client
+        try:
+            response = cast("Any", await litellm.acompletion(**dispatch_body))
+        finally:
+            await client.close()
+
+        payload = response.model_dump() if hasattr(response, "model_dump") else response
+        return cast("Any", payload)
+
+
+PLUGIN = OpenAIProviderPlugin()

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py
@@ -175,7 +175,6 @@ class OpenAIProviderPlugin(ProviderPluginBase[OpenAIPluginSettings]):
         dispatch_body["cache"] = {"no-cache": True, "no-store": True}
         dispatch_body["num_retries"] = 0
         dispatch_body["max_retries"] = 0
-        dispatch_body["ssl_verify"] = True
         dispatch_body["_skip_responses_api_bridge"] = True
 
         default_headers: dict[str, Any] = {

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/settings.py
@@ -11,7 +11,9 @@ from aigateway.core.plugin_base import PluginSettings
 
 def _default_models() -> list[str]:
     return [
-        "openai/gpt-5.6",
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-terra",
+        "openai/gpt-5.6-luna",
         "openai/gpt-5.5",
         "openai/gpt-5.1",
         "openai/gpt-5",

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/settings.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import string
+from typing import Self
+
+from pydantic import Field, field_validator, model_validator
+from pydantic_settings import SettingsConfigDict
+
+from aigateway.core.plugin_base import PluginSettings
+
+
+def _default_models() -> list[str]:
+    return [
+        "openai/gpt-5.6",
+        "openai/gpt-5.5",
+        "openai/gpt-5.1",
+        "openai/gpt-5",
+        "openai/gpt-5-mini",
+        "openai/gpt-5-nano",
+        "openai/gpt-4.1",
+        "openai/gpt-4.1-mini",
+        "openai/gpt-4o",
+        "openai/gpt-4o-mini",
+        "openai/o3",
+        "openai/o4-mini",
+    ]
+
+
+def _validate_model_id(model: str) -> str:
+    prefix = "openai/"
+    if not model.startswith(prefix):
+        raise ValueError(f"OpenAI model must start with {prefix!r}: {model!r}")
+    upstream = model[len(prefix) :]
+    allowed = frozenset(string.ascii_letters + string.digits + "._-")
+    if (
+        not 1 <= len(upstream) <= 128
+        or upstream[0] not in string.ascii_letters + string.digits
+        or any(char not in allowed for char in upstream)
+    ):
+        raise ValueError(f"malformed direct OpenAI model: {model!r}")
+    return model
+
+
+class OpenAIPluginSettings(PluginSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="AIGW_OPENAI_",
+        extra="ignore",
+        populate_by_name=True,
+    )
+
+    default_models: list[str] = Field(default_factory=_default_models)
+    validation_model: str = "openai/gpt-5-nano"
+
+    @field_validator("default_models")
+    @classmethod
+    def _validate_models(cls, value: list[str]) -> list[str]:
+        validated = [_validate_model_id(model) for model in value]
+        if not validated:
+            raise ValueError("direct OpenAI requires at least one default model")
+        if len(set(validated)) != len(validated):
+            raise ValueError("direct OpenAI default models must be unique")
+        return validated
+
+    @field_validator("validation_model")
+    @classmethod
+    def _validate_validation_model(cls, value: str) -> str:
+        return _validate_model_id(value)
+
+    @model_validator(mode="after")
+    def _validation_model_must_be_registered(self) -> Self:
+        if self.validation_model not in self.default_models:
+            raise ValueError("direct OpenAI validation model must be registered")
+        return self

--- a/apps/aigateway/tests/live/test_openai_live.py
+++ b/apps/aigateway/tests/live/test_openai_live.py
@@ -1,0 +1,44 @@
+"""Owner-gated direct OpenAI API-key readiness smoke (OME-864).
+
+Skipped unless AIGW_LIVE=1 and OPENAI_API_KEY are both present. The validation
+request can consume quota; the credential is passed only to the production
+validator and is never included in assertions.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from aigateway.core.api_key_validation import ApiKeyValidationStage, ApiKeyValidationState
+from aigateway.plugins.openai_provider.api_key_validation import OpenAIApiKeyValidator
+from aigateway.plugins.openai_provider.settings import OpenAIPluginSettings
+
+pytestmark = pytest.mark.live
+
+
+def _live_enabled() -> bool:
+    return os.environ.get("AIGW_LIVE") == "1"
+
+
+def _live_openai_key() -> str:
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        pytest.skip("Live OpenAI test requires OPENAI_API_KEY")
+    assert key is not None
+    return key
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+@pytest.mark.asyncio
+async def test_openai_api_key_reaches_reasoning_model_readiness() -> None:
+    result = await OpenAIApiKeyValidator(settings=OpenAIPluginSettings()).validate(
+        _live_openai_key()
+    )
+
+    # INVARIANT: a key is persistable only after the configured model produces
+    # a structurally valid Chat Completions response, not after listing models.
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert result.probe_model == "openai/gpt-5-nano"

--- a/apps/aigateway/tests/live/test_openai_live.py
+++ b/apps/aigateway/tests/live/test_openai_live.py
@@ -1,18 +1,21 @@
 """Owner-gated direct OpenAI API-key readiness smoke (OME-864).
 
-Skipped unless AIGW_LIVE=1 and OPENAI_API_KEY are both present. The validation
-request can consume quota; the credential is passed only to the production
-validator and is never included in assertions.
+Skipped unless AIGW_LIVE=1 and OPENAI_API_KEY are both present. Requests can
+consume quota; the credential is passed only to production validation/dispatch
+paths and is never included in assertions.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
 
 import pytest
+from fastapi.testclient import TestClient
 
 from aigateway.core.api_key_validation import ApiKeyValidationStage, ApiKeyValidationState
 from aigateway.plugins.openai_provider.api_key_validation import OpenAIApiKeyValidator
+from aigateway.plugins.openai_provider.plugin import PLUGIN
 from aigateway.plugins.openai_provider.settings import OpenAIPluginSettings
 
 pytestmark = pytest.mark.live
@@ -20,6 +23,10 @@ pytestmark = pytest.mark.live
 
 def _live_enabled() -> bool:
     return os.environ.get("AIGW_LIVE") == "1"
+
+
+def _seed_sweep_enabled() -> bool:
+    return _live_enabled() and os.environ.get("AIGW_LIVE_OPENAI_SEED_SWEEP") == "1"
 
 
 def _live_openai_key() -> str:
@@ -42,3 +49,55 @@ async def test_openai_api_key_reaches_reasoning_model_readiness() -> None:
     assert result.state is ApiKeyValidationState.VALID
     assert result.stage is ApiKeyValidationStage.READINESS
     assert result.probe_model == "openai/gpt-5-nano"
+
+
+@pytest.mark.skipif(
+    not _seed_sweep_enabled(),
+    reason="AIGW_LIVE=1 and AIGW_LIVE_OPENAI_SEED_SWEEP=1 not set",
+)
+@pytest.mark.asyncio
+async def test_every_openai_seed_reaches_chat_completions() -> None:
+    api_key = _live_openai_key()
+
+    for model in OpenAIPluginSettings().default_models:
+        body = PLUGIN.prepare_chat_body(
+            {
+                "model": model,
+                "messages": [{"role": "user", "content": "ping"}],
+                "max_tokens": 16,
+            }
+        )
+        body["api_key"] = api_key
+
+        result = await PLUGIN.chat_completion(body)
+        await asyncio.sleep(0.05)
+
+        assert result["object"] == "chat.completion", model
+        assert isinstance(result.get("choices"), list), model
+
+
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_openai_key_completes_through_gateway_route(authenticated_client: TestClient) -> None:
+    api_key = _live_openai_key()
+    profile_name = "live-openai-smoke"
+    created = authenticated_client.put(
+        f"/v1/auth/openai/profiles/{profile_name}/api-key",
+        json={"api_key": api_key},
+    )
+    assert created.status_code == 200, created.text
+    assert api_key not in created.text
+
+    response = authenticated_client.post(
+        "/v1/chat/completions",
+        headers={"X-Profile": profile_name},
+        json={
+            "model": "openai/gpt-5.6-luna",
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 16,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert api_key not in response.text
+    assert response.json()["object"] == "chat.completion"
+    assert response.headers["X-AIGW-Cache"] == "bypass"

--- a/apps/aigateway/tests/unit/core/test_codex_namespace_guard.py
+++ b/apps/aigateway/tests/unit/core/test_codex_namespace_guard.py
@@ -1,21 +1,19 @@
-"""Phase 10 (OME-479 §Phase 10): the ONE legitimately-named routing regression guard.
+"""Named routing regression guard for the two independent OpenAI-family providers.
 
 FEATURE: provider-namespace routing. Codex serves OpenAI-FAMILY GPT models (``gpt-5.x``)
 over the ChatGPT *subscription* endpoint. They MUST surface under the ``codex`` namespace
-and resolve back to the codex plugin — NEVER under a separate ``openai`` provider that
-would capture the same GPT-family ids and split dispatch across two owners.
+and resolve back to the codex plugin. Direct OpenAI Platform API-key models MUST surface
+under the separate ``openai`` namespace and resolve back to that plugin. The same upstream
+model name can intentionally exist in both namespaces without either owner capturing it.
 
 STORY: as a gateway maintainer, I get a named, greppable alarm if anyone ever introduces an
-``openai`` provider (or renames codex) such that ``codex/gpt-5.x`` ids stop routing to the
-codex plugin — the exact historical sharp edge this contract was built to prevent.
+OpenAI-family model such that its canonical namespace stops resolving to the credential and
+endpoint owner selected by the caller.
 
-INVARIANT: ``registry.get("openai") is None`` (nothing captures the GPT-family ids) AND every
-codex model's canonical id is ``codex/…`` whose first path segment resolves to the codex
-plugin. This is the ONE place a provider name is a domain-correct assertion rather than a
-central inventory — the provider-AGNOSTIC version of this guarantee (proven for EVERY model,
-current and future) lives in ``test_provider_contract_conformance.py``. Keeping the named
-guard in its own codex-dedicated file (never appended to a committed test file) satisfies the
-append-only gate, which admits new test files but flags any edit to an existing one.
+INVARIANT: every model's canonical id starts with its owner's distinct registry key and its
+first path segment resolves to that same plugin, even when the bare upstream names overlap.
+This is the ONE place provider names are domain-correct assertions rather than a central
+inventory; the provider-agnostic form still lives in ``test_provider_contract_conformance.py``.
 """
 
 from __future__ import annotations
@@ -25,18 +23,25 @@ from aigateway.core.model_capabilities import canonical_model_id
 from aigateway.core.registry import ProviderRegistry
 
 
-def test_codex_models_stay_under_codex_namespace_never_openai() -> None:
+def test_codex_and_direct_openai_models_keep_independent_namespaces() -> None:
     registry = ProviderRegistry()
     load_plugins(registry)
 
     codex = registry.get("codex")
+    openai = registry.get("openai")
     assert codex is not None
-    # No `openai` provider may exist to capture the GPT-family ids codex owns.
-    assert registry.get("openai") is None
+    assert openai is not None
+    assert codex is not openai
 
-    for entry in codex.register_models():
-        canonical = canonical_model_id(custom_llm_provider="codex", model_name=entry.model_name)
-        # WHY: the canonical id's first segment IS the owning plugin's registry key, so a
-        # GPT-family id that resolved anywhere but codex would fail here (fail-closed routing).
-        assert canonical.startswith("codex/"), canonical
-        assert registry.get(canonical.split("/", 1)[0]) is codex, canonical
+    for owner in (codex, openai):
+        for entry in owner.register_models():
+            canonical = canonical_model_id(
+                custom_llm_provider=owner.custom_llm_provider,
+                model_name=entry.model_name,
+            )
+            assert canonical.startswith(f"{owner.custom_llm_provider}/"), canonical
+            assert registry.get(canonical.split("/", 1)[0]) is owner, canonical
+
+    codex_upstream = {entry.model_name.split("/", 1)[-1] for entry in codex.register_models()}
+    openai_upstream = {entry.model_name.split("/", 1)[-1] for entry in openai.register_models()}
+    assert codex_upstream & openai_upstream, "the overlap guard must exercise a shared model name"

--- a/apps/aigateway/tests/unit/openai/test_openai_api_key_validation.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_api_key_validation.py
@@ -1,0 +1,229 @@
+"""Two-stage, bounded direct OpenAI API-key validation."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+import httpx
+import pytest
+
+from aigateway.core.api_key_validation import ApiKeyValidationStage, ApiKeyValidationState
+from aigateway.plugins.openai_provider.api_key_validation import OpenAIApiKeyValidator
+from aigateway.plugins.openai_provider.plugin import OpenAIProviderPlugin
+from aigateway.plugins.openai_provider.settings import OpenAIPluginSettings
+
+_KEY = "sk-synthetic-openai-validation-key"
+
+
+def _validator(
+    responses: Iterable[httpx.Response],
+    *,
+    settings: OpenAIPluginSettings | None = None,
+) -> tuple[OpenAIApiKeyValidator, list[httpx.Request]]:
+    queued = list(responses)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return queued.pop(0)
+
+    return (
+        OpenAIApiKeyValidator(
+            settings=settings or OpenAIPluginSettings(),
+            transport=httpx.MockTransport(handler),
+        ),
+        requests,
+    )
+
+
+@pytest.mark.asyncio
+async def test_validation_authenticates_then_proves_chat_readiness() -> None:
+    validator, requests = _validator(
+        [
+            httpx.Response(200, json={"object": "list", "data": []}),
+            httpx.Response(
+                200,
+                json={"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+            ),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert result.probe_model == "openai/gpt-5-nano"
+    assert [str(request.url) for request in requests] == [
+        "https://api.openai.com/v1/models",
+        "https://api.openai.com/v1/chat/completions",
+    ]
+    assert all(request.headers["authorization"] == f"Bearer {_KEY}" for request in requests)
+    assert json.loads(requests[1].content) == {
+        "model": "gpt-5-nano",
+        "max_completion_tokens": 1,
+        "stream": False,
+        "messages": [{"role": "user", "content": "ping"}],
+    }
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.parametrize("stage", list(ApiKeyValidationStage))
+@pytest.mark.asyncio
+async def test_exact_invalid_key_tuple_is_actionable(
+    stage: ApiKeyValidationStage,
+) -> None:
+    responses = []
+    if stage is ApiKeyValidationStage.READINESS:
+        responses.append(httpx.Response(200, json={"object": "list", "data": []}))
+    responses.append(
+        httpx.Response(
+            401,
+            json={
+                "error": {
+                    "message": _KEY,
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key",
+                }
+            },
+        )
+    )
+    validator, requests = _validator(responses)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.INVALID
+    assert result.stage is stage
+    assert len(requests) == (2 if stage is ApiKeyValidationStage.READINESS else 1)
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "credit_balance_exhausted",
+        "organization_spend_limit_exceeded",
+        "project_spend_limit_exceeded",
+        "organization_usage_limit_exceeded",
+    ],
+)
+@pytest.mark.asyncio
+async def test_exact_documented_billing_tuples_are_no_quota_on_readiness(code: str) -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"object": "list", "data": []}),
+            httpx.Response(
+                429,
+                json={
+                    "error": {
+                        "message": _KEY,
+                        "type": "insufficient_quota",
+                        "code": code,
+                    }
+                },
+            ),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.NO_QUOTA
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type", "code"),
+    [
+        (429, "insufficient_quota", "insufficient_quota"),
+        (429, "requests", "rate_limit_exceeded"),
+        (429, None, None),
+        (401, "invalid_request_error", "expired_api_key"),
+        (403, "permission_error", "permission_denied"),
+        (404, "invalid_request_error", "model_not_found"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_unapproved_or_ambiguous_error_tuples_are_unavailable(
+    status: int,
+    error_type: str | None,
+    code: str | None,
+) -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"object": "list", "data": []}),
+            httpx.Response(
+                status,
+                headers={"retry-after": "17"},
+                json={"error": {"message": _KEY, "type": error_type, "code": code}},
+            ),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.READINESS
+    assert result.retry_after_seconds is None
+    assert _KEY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_authentication_failure_stops_before_readiness() -> None:
+    validator, requests = _validator([httpx.Response(200, json={"object": "list", "data": {}})])
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.AUTHENTICATION
+    assert len(requests) == 1
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"choices": []},
+        {"choices": [None]},
+        {"choices": [{"error": {}}]},
+        {"choices": [{"message": "not-an-object"}]},
+        {"choices": [{"message": {}}]},
+        {"choices": [{"message": {"role": "assistant"}}]},
+        {
+            "error": {"type": "invalid_request_error", "code": "invalid_api_key"},
+            "choices": [{"message": {"content": "not-success"}}],
+        },
+    ],
+)
+@pytest.mark.asyncio
+async def test_malformed_http_200_readiness_never_authorizes_persistence(payload: dict) -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"object": "list", "data": []}),
+            httpx.Response(200, json=payload),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.UNAVAILABLE
+    assert result.stage is ApiKeyValidationStage.READINESS
+
+
+@pytest.mark.asyncio
+async def test_unregistered_validation_model_is_misconfigured_without_network() -> None:
+    settings = OpenAIPluginSettings.model_construct(
+        enabled=True,
+        default_models=["openai/gpt-5.6"],
+        validation_model="openai/unregistered",
+    )
+    validator, requests = _validator([], settings=settings)
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.MISCONFIGURED
+    assert result.stage is None
+    assert requests == []
+
+
+def test_plugin_exposes_operational_validator() -> None:
+    assert isinstance(OpenAIProviderPlugin().api_key_validator(), OpenAIApiKeyValidator)

--- a/apps/aigateway/tests/unit/openai/test_openai_api_key_validation.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_api_key_validation.py
@@ -61,11 +61,36 @@ async def test_validation_authenticates_then_proves_chat_readiness() -> None:
     assert all(request.headers["authorization"] == f"Bearer {_KEY}" for request in requests)
     assert json.loads(requests[1].content) == {
         "model": "gpt-5-nano",
-        "max_completion_tokens": 1,
+        "max_completion_tokens": 16,
         "stream": False,
         "messages": [{"role": "user", "content": "ping"}],
     }
     assert _KEY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_length_limited_reasoning_response_with_empty_content_is_ready() -> None:
+    validator, _requests = _validator(
+        [
+            httpx.Response(200, json={"object": "list", "data": []}),
+            httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "finish_reason": "length",
+                            "message": {"role": "assistant", "content": ""},
+                        }
+                    ]
+                },
+            ),
+        ]
+    )
+
+    result = await validator.validate(_KEY)
+
+    assert result.state is ApiKeyValidationState.VALID
+    assert result.stage is ApiKeyValidationStage.READINESS
 
 
 @pytest.mark.parametrize("stage", list(ApiKeyValidationStage))
@@ -213,7 +238,7 @@ async def test_malformed_http_200_readiness_never_authorizes_persistence(payload
 async def test_unregistered_validation_model_is_misconfigured_without_network() -> None:
     settings = OpenAIPluginSettings.model_construct(
         enabled=True,
-        default_models=["openai/gpt-5.6"],
+        default_models=["openai/gpt-5.6-sol"],
         validation_model="openai/unregistered",
     )
     validator, requests = _validator([], settings=settings)

--- a/apps/aigateway/tests/unit/openai/test_openai_dispatch.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_dispatch.py
@@ -1,0 +1,297 @@
+"""No-network characterization of direct OpenAI's final outbound request."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+import litellm
+import pytest
+from fastapi import HTTPException
+from openai import AsyncOpenAI
+
+from aigateway.core.retry import is_retryable_status
+from aigateway.plugins.openai_provider import plugin as plugin_module
+from aigateway.plugins.openai_provider.plugin import PLUGIN
+
+_SELECTED_KEY = "sk-synthetic-selected-account-key"
+
+
+class _FalseyProxyAuth:
+    def __bool__(self) -> bool:
+        return False
+
+
+def _completion_response(model: str) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _capture_client_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[list[AsyncOpenAI], list[dict[str, Any]], httpx.AsyncClient]:
+    clients: list[AsyncOpenAI] = []
+    constructor_kwargs: list[dict[str, Any]] = []
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        trust_env=False,
+        follow_redirects=False,
+    )
+
+    def factory(**kwargs: Any) -> AsyncOpenAI:
+        constructor_kwargs.append(dict(kwargs))
+        client = AsyncOpenAI(**kwargs)
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(plugin_module, "_openai_http_client", lambda: http_client)
+    monkeypatch.setattr(plugin_module, "AsyncOpenAI", factory)
+    return clients, constructor_kwargs, http_client
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_token_field"),
+    [
+        ("openai/gpt-4o", "max_tokens"),
+        ("openai/gpt-5.6", "max_completion_tokens"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_dispatch_pins_chat_completions_and_selected_account_context(
+    monkeypatch: pytest.MonkeyPatch,
+    model: str,
+    expected_token_field: str,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=_completion_response(model.split("/", 1)[1]))
+
+    clients, constructor_kwargs, http_client = _capture_client_factory(monkeypatch, handler)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-ambient-wrong-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://ambient.invalid/v1")
+    monkeypatch.setenv("OPENAI_ORGANIZATION", "org-ambient")
+    monkeypatch.setenv("OPENAI_ORG_ID", "org-ambient-fallback")
+    monkeypatch.setenv("OPENAI_PROJECT_ID", "proj-ambient")
+    monkeypatch.delenv("OPENAI_CUSTOM_HEADERS", raising=False)
+    monkeypatch.setattr(litellm, "api_key", "sk-litellm-wrong-key")
+    monkeypatch.setattr(litellm, "openai_key", "sk-litellm-openai-wrong-key")
+    monkeypatch.setattr(litellm, "api_base", "https://litellm.invalid/v1")
+    monkeypatch.setattr(litellm, "headers", None)
+    monkeypatch.setattr(litellm, "route_all_chat_openai_to_responses", True)
+
+    body = PLUGIN.prepare_chat_body(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 7,
+        }
+    )
+    body["api_key"] = _SELECTED_KEY
+
+    result = await PLUGIN.chat_completion(body)
+    # LiteLLM schedules best-effort success logging; let its queue drain before
+    # pytest closes this parametrized case's event loop.
+    await asyncio.sleep(0.05)
+
+    assert result["choices"][0]["message"]["content"] == "ok"
+    assert len(requests) == 1
+    request = requests[0]
+    assert str(request.url) == "https://api.openai.com/v1/chat/completions"
+    assert request.headers["authorization"] == f"Bearer {_SELECTED_KEY}"
+    assert "openai-organization" not in request.headers
+    assert "openai-project" not in request.headers
+    assert "x-ambient" not in request.headers
+    payload = json.loads(request.content)
+    assert payload["model"] == model.split("/", 1)[1]
+    assert payload[expected_token_field] == 7
+    assert ({"max_tokens", "max_completion_tokens"} - {expected_token_field}).isdisjoint(payload)
+    assert _SELECTED_KEY not in request.content.decode()
+    assert constructor_kwargs[0]["api_key"] == _SELECTED_KEY
+    assert constructor_kwargs[0]["base_url"] == "https://api.openai.com/v1"
+    assert constructor_kwargs[0]["max_retries"] == 0
+    assert constructor_kwargs[0]["http_client"] is http_client
+    assert clients[0].is_closed() is True
+
+
+def test_prepare_chat_body_keeps_only_gateway_owned_origin() -> None:
+    prepared = PLUGIN.prepare_chat_body(
+        {
+            "model": "openai/gpt-5.6",
+            "messages": [{"role": "user", "content": "ping"}],
+            "max_tokens": 7,
+            "api_key": "caller-key",
+            "api_base": "https://caller.invalid/v1",
+            "base_url": "https://caller.invalid/v1",
+            "headers": {"Authorization": "caller"},
+            "extra_headers": {"X-Custom": "caller"},
+            "fallbacks": ["attacker/model"],
+            "model_list": [{"model_name": "attacker/model"}],
+            "callbacks": ["caller"],
+            "success_callback": ["caller"],
+            "failure_callback": ["caller"],
+            "custom_llm_provider": "attacker",
+            "azure": True,
+            "text_completion": True,
+        }
+    )
+
+    assert prepared == {
+        "model": "openai/gpt-5.6",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 7,
+        "api_base": "https://api.openai.com/v1",
+    }
+
+
+def test_prepare_chat_body_rejects_unregistered_model() -> None:
+    with pytest.raises(HTTPException) as raised:
+        PLUGIN.prepare_chat_body({"model": "openai/unregistered", "messages": []})
+
+    assert raised.value.status_code == 400
+    assert raised.value.detail == {
+        "code": "invalid_model",
+        "provider": "openai",
+        "message": "model is not registered for direct OpenAI dispatch",
+    }
+
+
+@pytest.mark.asyncio
+async def test_nonempty_ambient_custom_headers_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_CUSTOM_HEADERS", '{"X-Leak":"ambient"}')
+
+    with pytest.raises(HTTPException) as raised:
+        await PLUGIN.chat_completion(
+            {
+                "model": "openai/gpt-5.6",
+                "messages": [],
+                "api_key": _SELECTED_KEY,
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == {
+        "code": "unsafe_openai_environment",
+        "provider": "openai",
+        "message": "direct OpenAI dispatch is unavailable",
+    }
+    assert "X-Leak" not in repr(raised.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_process_global_litellm_headers_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_CUSTOM_HEADERS", raising=False)
+    monkeypatch.setattr(litellm, "headers", {"X-Leak": "ambient"})
+
+    with pytest.raises(HTTPException) as raised:
+        await PLUGIN.chat_completion(
+            {
+                "model": "openai/gpt-5.6",
+                "messages": [],
+                "api_key": _SELECTED_KEY,
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == {
+        "code": "unsafe_openai_environment",
+        "provider": "openai",
+        "message": "direct OpenAI dispatch is unavailable",
+    }
+    assert "X-Leak" not in repr(raised.value.detail)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("model_fallbacks", ["openai/gpt-4o-mini"]),
+        ("callbacks", [object()]),
+        ("pre_call_rules", [object()]),
+        ("model_alias_map", {"openai/gpt-5.6": "openai/gpt-4o"}),
+        ("proxy_auth", _FalseyProxyAuth()),
+        ("drop_params", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_process_global_routing_or_observation_state_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    value: Any,
+) -> None:
+    monkeypatch.delenv("OPENAI_CUSTOM_HEADERS", raising=False)
+    monkeypatch.setattr(litellm, "headers", None)
+    monkeypatch.setattr(litellm, field, value)
+
+    def forbidden_client(**_kwargs: Any) -> AsyncOpenAI:
+        raise AssertionError("unsafe global state reached client construction")
+
+    monkeypatch.setattr(plugin_module, "AsyncOpenAI", forbidden_client)
+
+    with pytest.raises(HTTPException) as raised:
+        await PLUGIN.chat_completion(
+            {
+                "model": "openai/gpt-5.6",
+                "messages": [],
+                "api_key": _SELECTED_KEY,
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == {
+        "code": "unsafe_openai_environment",
+        "provider": "openai",
+        "message": "direct OpenAI dispatch is unavailable",
+    }
+    assert is_retryable_status(raised.value) is False
+
+
+@pytest.mark.asyncio
+async def test_missing_selected_key_fails_before_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENAI_CUSTOM_HEADERS", raising=False)
+    monkeypatch.setattr(litellm, "headers", None)
+
+    with pytest.raises(HTTPException) as raised:
+        await PLUGIN.chat_completion(
+            {
+                "model": "openai/gpt-5.6",
+                "messages": [],
+                "api_base": "https://api.openai.com/v1",
+            }
+        )
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == {
+        "code": "unsafe_openai_environment",
+        "provider": "openai",
+        "message": "direct OpenAI dispatch is unavailable",
+    }
+
+
+def test_every_seed_is_chat_mode_in_the_locked_runtime() -> None:
+    for entry in PLUGIN.register_models():
+        upstream_model = entry.model_name.split("/", 1)[1]
+        assert litellm.get_model_info(upstream_model)["mode"] == "chat", entry.model_name

--- a/apps/aigateway/tests/unit/openai/test_openai_dispatch.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_dispatch.py
@@ -69,7 +69,9 @@ def _capture_client_factory(
     ("model", "expected_token_field"),
     [
         ("openai/gpt-4o", "max_tokens"),
-        ("openai/gpt-5.6", "max_completion_tokens"),
+        ("openai/gpt-5.6-sol", "max_completion_tokens"),
+        ("openai/gpt-5.6-terra", "max_completion_tokens"),
+        ("openai/gpt-5.6-luna", "max_completion_tokens"),
     ],
 )
 @pytest.mark.asyncio
@@ -123,6 +125,7 @@ async def test_dispatch_pins_chat_completions_and_selected_account_context(
     assert payload["model"] == model.split("/", 1)[1]
     assert payload[expected_token_field] == 7
     assert ({"max_tokens", "max_completion_tokens"} - {expected_token_field}).isdisjoint(payload)
+    assert "ssl_verify" not in payload
     assert _SELECTED_KEY not in request.content.decode()
     assert constructor_kwargs[0]["api_key"] == _SELECTED_KEY
     assert constructor_kwargs[0]["base_url"] == "https://api.openai.com/v1"
@@ -134,7 +137,7 @@ async def test_dispatch_pins_chat_completions_and_selected_account_context(
 def test_prepare_chat_body_keeps_only_gateway_owned_origin() -> None:
     prepared = PLUGIN.prepare_chat_body(
         {
-            "model": "openai/gpt-5.6",
+            "model": "openai/gpt-5.6-sol",
             "messages": [{"role": "user", "content": "ping"}],
             "max_tokens": 7,
             "api_key": "caller-key",
@@ -154,7 +157,7 @@ def test_prepare_chat_body_keeps_only_gateway_owned_origin() -> None:
     )
 
     assert prepared == {
-        "model": "openai/gpt-5.6",
+        "model": "openai/gpt-5.6-sol",
         "messages": [{"role": "user", "content": "ping"}],
         "max_tokens": 7,
         "api_base": "https://api.openai.com/v1",
@@ -182,7 +185,7 @@ async def test_nonempty_ambient_custom_headers_fail_closed(
     with pytest.raises(HTTPException) as raised:
         await PLUGIN.chat_completion(
             {
-                "model": "openai/gpt-5.6",
+                "model": "openai/gpt-5.6-sol",
                 "messages": [],
                 "api_key": _SELECTED_KEY,
                 "api_base": "https://api.openai.com/v1",
@@ -208,7 +211,7 @@ async def test_process_global_litellm_headers_fail_closed(
     with pytest.raises(HTTPException) as raised:
         await PLUGIN.chat_completion(
             {
-                "model": "openai/gpt-5.6",
+                "model": "openai/gpt-5.6-sol",
                 "messages": [],
                 "api_key": _SELECTED_KEY,
                 "api_base": "https://api.openai.com/v1",
@@ -230,7 +233,7 @@ async def test_process_global_litellm_headers_fail_closed(
         ("model_fallbacks", ["openai/gpt-4o-mini"]),
         ("callbacks", [object()]),
         ("pre_call_rules", [object()]),
-        ("model_alias_map", {"openai/gpt-5.6": "openai/gpt-4o"}),
+        ("model_alias_map", {"openai/gpt-5.6-sol": "openai/gpt-4o"}),
         ("proxy_auth", _FalseyProxyAuth()),
         ("drop_params", True),
     ],
@@ -253,7 +256,7 @@ async def test_process_global_routing_or_observation_state_fails_closed(
     with pytest.raises(HTTPException) as raised:
         await PLUGIN.chat_completion(
             {
-                "model": "openai/gpt-5.6",
+                "model": "openai/gpt-5.6-sol",
                 "messages": [],
                 "api_key": _SELECTED_KEY,
                 "api_base": "https://api.openai.com/v1",
@@ -277,7 +280,7 @@ async def test_missing_selected_key_fails_before_dispatch(monkeypatch: pytest.Mo
     with pytest.raises(HTTPException) as raised:
         await PLUGIN.chat_completion(
             {
-                "model": "openai/gpt-5.6",
+                "model": "openai/gpt-5.6-sol",
                 "messages": [],
                 "api_base": "https://api.openai.com/v1",
             }

--- a/apps/aigateway/tests/unit/openai/test_openai_gateway_acceptance.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_gateway_acceptance.py
@@ -1,0 +1,110 @@
+"""Gateway-level direct OpenAI catalog and pre-credential rejection guarantees."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+
+_KEY = "sk-openai-synthetic-gateway-key-1234"
+
+
+@dataclass
+class _ValidValidationService:
+    async def validate(self, _plugin, _provider: str, _api_key: str) -> ApiKeyValidationResult:
+        return ApiKeyValidationResult(
+            ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+            probe_model="openai/gpt-5-nano",
+        )
+
+
+def test_models_and_detail_publish_the_same_minimal_contract(authenticated_client) -> None:
+    listing = authenticated_client.get("/v1/models")
+
+    assert listing.status_code == 200, listing.text
+    openai_models = [row for row in listing.json()["data"] if row["owned_by"] == "openai"]
+    assert len(openai_models) == 12
+    assert {row["id"] for row in openai_models} >= {
+        "openai/gpt-5.6",
+        "openai/gpt-5.5",
+        "openai/gpt-5-nano",
+        "openai/gpt-4o",
+    }
+    assert all(row["supported_parameters"] == ["max_tokens"] for row in openai_models)
+    assert all(row["supported_tools"] == [] for row in openai_models)
+
+    authenticated_client.app.state.api_key_validation_service = _ValidValidationService()
+    created = authenticated_client.put(
+        "/v1/auth/openai/profiles/default/api-key",
+        json={"api_key": _KEY},
+    )
+    assert created.status_code == 200, created.text
+
+    detail = authenticated_client.get(
+        "/v1/model-parameters",
+        params={"model": "openai/gpt-5.6", "auth_type": "api_key"},
+    )
+
+    assert detail.status_code == 200, detail.text
+    parameters = detail.json()["parameters"]
+    assert parameters["max_tokens"]["gateway"]["status"] == "enabled"
+    assert parameters["max_tokens"]["gateway"]["cache_behavior"] == "bypass"
+    assert parameters["max_tokens"]["provider"]["source"] == "openai:locked-runtime"
+    assert all(
+        entry["gateway"]["status"] != "enabled"
+        for path, entry in parameters.items()
+        if path != "max_tokens"
+    )
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_code"),
+    [
+        (
+            {"model": "openai/unregistered", "messages": []},
+            "invalid_model",
+        ),
+        (
+            {"model": "openai/gpt-5.6", "messages": [], "temperature": 0.1},
+            "unsupported_parameters",
+        ),
+        (
+            {"model": "openai/gpt-5.6", "messages": [], "stream": True},
+            "streaming_not_supported",
+        ),
+    ],
+)
+def test_rejected_request_never_reads_openai_credential(
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+    body: dict,
+    expected_code: str,
+) -> None:
+    authenticated_client.app.state.api_key_validation_service = _ValidValidationService()
+    created = authenticated_client.put(
+        "/v1/auth/openai/profiles/default/api-key",
+        json={"api_key": _KEY},
+    )
+    assert created.status_code == 200, created.text
+
+    credential_store = authenticated_client.app.state.credential_store
+    real_read = credential_store.read
+
+    async def guarded_read(service: str, account: str) -> str | None:
+        if service.startswith("aigateway:openai:"):
+            raise AssertionError("rejected request read the OpenAI credential")
+        return await real_read(service, account)
+
+    monkeypatch.setattr(credential_store, "read", guarded_read)
+
+    response = authenticated_client.post("/v1/chat/completions", json=body)
+
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"]["code"] == expected_code

--- a/apps/aigateway/tests/unit/openai/test_openai_gateway_acceptance.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_gateway_acceptance.py
@@ -30,9 +30,11 @@ def test_models_and_detail_publish_the_same_minimal_contract(authenticated_clien
 
     assert listing.status_code == 200, listing.text
     openai_models = [row for row in listing.json()["data"] if row["owned_by"] == "openai"]
-    assert len(openai_models) == 12
+    assert len(openai_models) == 14
     assert {row["id"] for row in openai_models} >= {
-        "openai/gpt-5.6",
+        "openai/gpt-5.6-sol",
+        "openai/gpt-5.6-terra",
+        "openai/gpt-5.6-luna",
         "openai/gpt-5.5",
         "openai/gpt-5-nano",
         "openai/gpt-4o",
@@ -49,7 +51,7 @@ def test_models_and_detail_publish_the_same_minimal_contract(authenticated_clien
 
     detail = authenticated_client.get(
         "/v1/model-parameters",
-        params={"model": "openai/gpt-5.6", "auth_type": "api_key"},
+        params={"model": "openai/gpt-5.6-sol", "auth_type": "api_key"},
     )
 
     assert detail.status_code == 200, detail.text
@@ -72,11 +74,11 @@ def test_models_and_detail_publish_the_same_minimal_contract(authenticated_clien
             "invalid_model",
         ),
         (
-            {"model": "openai/gpt-5.6", "messages": [], "temperature": 0.1},
+            {"model": "openai/gpt-5.6-sol", "messages": [], "temperature": 0.1},
             "unsupported_parameters",
         ),
         (
-            {"model": "openai/gpt-5.6", "messages": [], "stream": True},
+            {"model": "openai/gpt-5.6-sol", "messages": [], "stream": True},
             "streaming_not_supported",
         ),
     ],

--- a/apps/aigateway/tests/unit/openai/test_openai_persistence.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_persistence.py
@@ -1,0 +1,324 @@
+"""Direct OpenAI through both generic encrypted API-key persistence surfaces."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.api_key_validation import (
+    ApiKeyValidationResult,
+    ApiKeyValidationStage,
+    ApiKeyValidationState,
+)
+from aigateway.core.oauth.store import credential_key_for
+from aigateway.core.profile_models import credential_name_for
+from aigateway.plugins.openai_provider.plugin import PLUGIN
+
+_OLD_KEY = "sk-openai-synthetic-old-key-1234"
+_NEW_KEY = "sk-openai-synthetic-new-key-5678"
+_REJECTED_KEY = "sk-openai-synthetic-rejected-key-9012"
+
+
+@dataclass
+class _StubValidationService:
+    result: ApiKeyValidationResult
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    async def validate(self, _plugin, provider: str, api_key: str) -> ApiKeyValidationResult:
+        self.calls.append((provider, api_key))
+        return self.result
+
+
+def _valid_result() -> ApiKeyValidationResult:
+    return ApiKeyValidationResult(
+        ApiKeyValidationState.VALID,
+        stage=ApiKeyValidationStage.READINESS,
+        probe_model="openai/gpt-5-nano",
+    )
+
+
+def _service_for(name: str) -> str:
+    strategy = PLUGIN.api_key_strategy_for(name)
+    assert isinstance(strategy, ApiKeyStrategy)
+    return strategy.credential_service()
+
+
+def test_profile_create_failed_replace_and_delete_preserve_atomic_key_state(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    validation = _StubValidationService(_valid_result())
+    authenticated_client.app.state.api_key_validation_service = validation
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    profile_name = "direct-openai"
+    service = _service_for(credential_name_for(account_id, profile_name))
+
+    created = authenticated_client.put(
+        f"/v1/auth/openai/profiles/{profile_name}/api-key",
+        json={"api_key": _OLD_KEY},
+    )
+
+    assert created.status_code == 200, created.text
+    assert created.json()["auth_type"] == "api_key"
+    assert created.json()["state"] == "authenticated"
+    assert _OLD_KEY not in created.text
+    before = credential_blobs.read(service, "default")
+    assert json.loads(before) == {"auth_type": "api_key", "api_key": _OLD_KEY}
+    assert _OLD_KEY not in (credential_blobs.read_raw(service, "default") or "")
+
+    replaced = authenticated_client.put(
+        f"/v1/auth/openai/profiles/{profile_name}/api-key",
+        json={"api_key": _NEW_KEY},
+    )
+    assert replaced.status_code == 200, replaced.text
+    before = credential_blobs.read(service, "default")
+    assert json.loads(before) == {"auth_type": "api_key", "api_key": _NEW_KEY}
+
+    validation.result = ApiKeyValidationResult(
+        ApiKeyValidationState.INVALID,
+        stage=ApiKeyValidationStage.AUTHENTICATION,
+    )
+    failed = authenticated_client.put(
+        f"/v1/auth/openai/profiles/{profile_name}/api-key",
+        json={"api_key": _REJECTED_KEY},
+    )
+
+    assert failed.status_code == 422
+    assert failed.json()["detail"]["code"] == "api_key_invalid"
+    assert _REJECTED_KEY not in failed.text
+    assert credential_blobs.read(service, "default") == before
+
+    deleted = authenticated_client.delete(f"/v1/auth/openai/profiles/{profile_name}")
+    assert deleted.status_code == 204
+    assert credential_blobs.read(service, "default") is None
+    assert validation.calls == [
+        ("openai", _OLD_KEY),
+        ("openai", _NEW_KEY),
+        ("openai", _REJECTED_KEY),
+    ]
+
+
+def test_connection_create_failed_replace_and_delete_preserve_atomic_key_state(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    validation = _StubValidationService(_valid_result())
+    authenticated_client.app.state.api_key_validation_service = validation
+
+    created_response = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openai", "label": "direct-openai", "api_key": _OLD_KEY},
+    )
+
+    assert created_response.status_code == 201, created_response.text
+    created = created_response.json()
+    assert created["provider"] == "openai"
+    assert created["auth_type"] == "api_key"
+    assert created["status"] == "active"
+    assert _OLD_KEY not in created_response.text
+    credential_name = credential_key_for(created["account_id"], created["id"])
+    service = _service_for(credential_name)
+    before = credential_blobs.read(service, "default")
+    assert json.loads(before) == {"auth_type": "api_key", "api_key": _OLD_KEY}
+    assert _OLD_KEY not in (credential_blobs.read_raw(service, "default") or "")
+
+    replaced = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": _NEW_KEY},
+    )
+    assert replaced.status_code == 200, replaced.text
+    before = credential_blobs.read(service, "default")
+    assert json.loads(before) == {"auth_type": "api_key", "api_key": _NEW_KEY}
+
+    validation.result = ApiKeyValidationResult(
+        ApiKeyValidationState.INVALID,
+        stage=ApiKeyValidationStage.AUTHENTICATION,
+    )
+    failed = authenticated_client.put(
+        f"/v1/oauth/connections/{created['id']}/api-key",
+        json={"api_key": _REJECTED_KEY},
+    )
+
+    assert failed.status_code == 422
+    assert failed.json()["detail"]["code"] == "api_key_invalid"
+    assert _REJECTED_KEY not in failed.text
+    assert credential_blobs.read(service, "default") == before
+
+    deleted = authenticated_client.delete(f"/v1/oauth/connections/{created['id']}")
+    assert deleted.status_code == 204
+    assert credential_blobs.read(service, "default") is None
+    assert validation.calls == [
+        ("openai", _OLD_KEY),
+        ("openai", _NEW_KEY),
+        ("openai", _REJECTED_KEY),
+    ]
+
+
+def test_failed_initial_validation_writes_neither_surface(
+    authenticated_client,
+    monkeypatch,
+) -> None:
+    validation = _StubValidationService(
+        ApiKeyValidationResult(
+            ApiKeyValidationState.INVALID,
+            stage=ApiKeyValidationStage.AUTHENTICATION,
+        )
+    )
+    authenticated_client.app.state.api_key_validation_service = validation
+
+    async def forbidden_write(*_args, **_kwargs) -> None:
+        raise AssertionError("failed validation attempted credential persistence")
+
+    monkeypatch.setattr(authenticated_client.app.state.credential_store, "write", forbidden_write)
+
+    profile = authenticated_client.put(
+        "/v1/auth/openai/profiles/rejected/api-key",
+        json={"api_key": _REJECTED_KEY},
+    )
+    connection = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openai", "label": "rejected", "api_key": _REJECTED_KEY},
+    )
+
+    assert profile.status_code == 422
+    assert connection.status_code == 422
+    assert profile.json()["detail"]["code"] == "api_key_invalid"
+    assert connection.json()["detail"]["code"] == "api_key_invalid"
+    assert authenticated_client.get("/v1/auth/openai/profiles/rejected").status_code == 404
+    assert authenticated_client.get("/v1/oauth/connections").json()["connections"] == []
+
+
+def test_account_scoped_credential_names_do_not_collide() -> None:
+    first = _service_for(credential_name_for("account-a", "default"))
+    second = _service_for(credential_name_for("account-b", "default"))
+
+    assert first != second
+    assert first.startswith("aigateway:openai:")
+    assert second.startswith("aigateway:openai:")
+
+
+def test_chat_selects_openai_api_key_connection_by_label(
+    authenticated_client,
+    monkeypatch,
+) -> None:
+    authenticated_client.app.state.api_key_validation_service = _StubValidationService(
+        _valid_result()
+    )
+    selected = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openai", "label": "selected", "api_key": _OLD_KEY},
+    )
+    other = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openai", "label": "other", "api_key": _NEW_KEY},
+    )
+    assert selected.status_code == 201, selected.text
+    assert other.status_code == 201, other.text
+    plugin = authenticated_client.app.state.providers.get("openai")
+    captured: dict = {}
+
+    async def capture(body: dict):
+        captured.update(body)
+        return {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "gpt-5.6",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(plugin, "chat_completion", capture)
+
+    response = authenticated_client.post(
+        "/v1/chat/completions",
+        headers={"X-Profile": "selected"},
+        json={
+            "model": "openai/gpt-5.6",
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured["api_key"] == _OLD_KEY
+    assert captured["api_base"] == "https://api.openai.com/v1"
+    assert "client" not in captured
+    assert response.headers["X-AIGW-Cache"] == "bypass"
+    metadata = response.json()["_aigw"]
+    assert metadata["usage_accounting"]["capture_status"] == "accounting_not_supported"
+    assert metadata["usage_accounting"]["observed_attempts"] == 0
+    assert metadata["request_economics"]["direct_cost_status"] == "not_applicable"
+
+
+def test_openai_profiles_are_account_isolated(
+    authenticated_client,
+    provisioned_user_factory,
+) -> None:
+    authenticated_client.app.state.api_key_validation_service = _StubValidationService(
+        _valid_result()
+    )
+    created = authenticated_client.put(
+        "/v1/auth/openai/profiles/private/api-key",
+        json={"api_key": _OLD_KEY},
+    )
+    assert created.status_code == 200, created.text
+
+    provisioned_user_factory("openai-other", "other-pass1")
+    login = authenticated_client.post(
+        "/v1/auth/login",
+        json={"username": "openai-other", "password": "other-pass1"},
+    )
+    authenticated_client.headers.update({"Authorization": f"Bearer {login.json()['token']}"})
+
+    assert authenticated_client.get("/v1/auth/openai/profiles").json() == {"profiles": []}
+    assert authenticated_client.get("/v1/auth/openai/profiles/private").status_code == 404
+
+
+def test_chat_selects_named_openai_profile(authenticated_client, monkeypatch) -> None:
+    authenticated_client.app.state.api_key_validation_service = _StubValidationService(
+        _valid_result()
+    )
+    for name, key in (("first", _OLD_KEY), ("second", _NEW_KEY)):
+        created = authenticated_client.put(
+            f"/v1/auth/openai/profiles/{name}/api-key",
+            json={"api_key": key},
+        )
+        assert created.status_code == 200, created.text
+    plugin = authenticated_client.app.state.providers.get("openai")
+    captured: dict = {}
+
+    async def capture(body: dict):
+        captured.update(body)
+        return {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "gpt-5.6",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(plugin, "chat_completion", capture)
+
+    response = authenticated_client.post(
+        "/v1/chat/completions",
+        headers={"X-Profile": "second"},
+        json={
+            "model": "openai/gpt-5.6",
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert captured["api_key"] == _NEW_KEY

--- a/apps/aigateway/tests/unit/openai/test_openai_persistence.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_persistence.py
@@ -224,7 +224,7 @@ def test_chat_selects_openai_api_key_connection_by_label(
             "id": "chatcmpl-test",
             "object": "chat.completion",
             "created": 1,
-            "model": "gpt-5.6",
+            "model": "gpt-5.6-sol",
             "choices": [
                 {
                     "index": 0,
@@ -240,7 +240,7 @@ def test_chat_selects_openai_api_key_connection_by_label(
         "/v1/chat/completions",
         headers={"X-Profile": "selected"},
         json={
-            "model": "openai/gpt-5.6",
+            "model": "openai/gpt-5.6-sol",
             "messages": [{"role": "user", "content": "ping"}],
         },
     )
@@ -299,7 +299,7 @@ def test_chat_selects_named_openai_profile(authenticated_client, monkeypatch) ->
             "id": "chatcmpl-test",
             "object": "chat.completion",
             "created": 1,
-            "model": "gpt-5.6",
+            "model": "gpt-5.6-sol",
             "choices": [
                 {
                     "index": 0,
@@ -315,7 +315,7 @@ def test_chat_selects_named_openai_profile(authenticated_client, monkeypatch) ->
         "/v1/chat/completions",
         headers={"X-Profile": "second"},
         json={
-            "model": "openai/gpt-5.6",
+            "model": "openai/gpt-5.6-sol",
             "messages": [{"role": "user", "content": "ping"}],
         },
     )

--- a/apps/aigateway/tests/unit/openai/test_openai_provider.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_provider.py
@@ -1,0 +1,132 @@
+"""Direct OpenAI provider's seed, capability, and parameter contract."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aigateway.core.cache_ports import CacheBypass
+from aigateway.core.standard_parameters import MAX_TOKENS_SCHEMA
+from aigateway.plugins.openai_provider.plugin import PLUGIN, OpenAIProviderPlugin
+from aigateway.plugins.openai_provider.settings import OpenAIPluginSettings
+
+DEFAULT_MODELS = [
+    "openai/gpt-5.6",
+    "openai/gpt-5.5",
+    "openai/gpt-5.1",
+    "openai/gpt-5",
+    "openai/gpt-5-mini",
+    "openai/gpt-5-nano",
+    "openai/gpt-4.1",
+    "openai/gpt-4.1-mini",
+    "openai/gpt-4o",
+    "openai/gpt-4o-mini",
+    "openai/o3",
+    "openai/o4-mini",
+]
+
+
+def test_plugin_identity_and_api_key_only_transport() -> None:
+    assert isinstance(PLUGIN, OpenAIProviderPlugin)
+    assert PLUGIN.custom_llm_provider == "openai"
+    assert PLUGIN.provider_display_name == "OpenAI"
+    assert PLUGIN.supports_api_key() is True
+    assert PLUGIN.oauth_config() is None
+    assert PLUGIN.oauth_strategy_for("acct:connection") is None
+    assert PLUGIN.available_auth_modes() == ("api_key",)
+    assert PLUGIN.supports_chat_streaming() is False
+
+
+def test_default_seed_and_readiness_model_are_explicit() -> None:
+    assert PLUGIN.settings.default_models == DEFAULT_MODELS
+    assert PLUGIN.settings.validation_model == "openai/gpt-5-nano"
+    assert [entry.model_name for entry in PLUGIN.register_models()] == DEFAULT_MODELS
+    assert [entry.litellm_params for entry in PLUGIN.register_models()] == [
+        {"model": model} for model in DEFAULT_MODELS
+    ]
+
+
+def test_settings_accept_only_direct_openai_model_ids() -> None:
+    with pytest.raises(ValidationError):
+        OpenAIPluginSettings(default_models=["codex/gpt-5"])
+    with pytest.raises(ValidationError):
+        OpenAIPluginSettings(default_models=["openai/"])
+    with pytest.raises(ValidationError):
+        OpenAIPluginSettings(
+            default_models=["openai/gpt-5"], validation_model="openrouter/openai/gpt-5"
+        )
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "openai/gpt/5",
+        "openai/https://example.invalid",
+        "openai/gpt-5?variant=x",
+        "openai/gpt-5#fragment",
+        "openai/gpt%2d5",
+        "openai/gpt\\5",
+        "openai/gpt 5",
+        "openai/gpt\n5",
+        "openai/gpt-五",
+        f"openai/{'x' * 129}",
+    ],
+)
+def test_settings_reject_unsafe_or_unbounded_model_tokens(model: str) -> None:
+    with pytest.raises(ValidationError):
+        OpenAIPluginSettings(default_models=[model], validation_model=model)
+
+
+def test_settings_require_nonempty_unique_seed_and_registered_validation_model() -> None:
+    with pytest.raises(ValidationError):
+        OpenAIPluginSettings(default_models=[])
+    with pytest.raises(ValidationError):
+        OpenAIPluginSettings(
+            default_models=["openai/gpt-5", "openai/gpt-5"],
+            validation_model="openai/gpt-5",
+        )
+    with pytest.raises(ValidationError):
+        OpenAIPluginSettings(
+            default_models=["openai/gpt-5"],
+            validation_model="openai/gpt-5-nano",
+        )
+
+
+def test_max_tokens_is_the_only_enabled_parameter() -> None:
+    rules = PLUGIN.chat_parameter_rules(model="openai/gpt-5.6", auth_type="api_key")
+
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule.request_path == "max_tokens"
+    assert rule.provider_target is None
+    assert rule.parameter_schema == MAX_TOKENS_SCHEMA
+    assert rule.applicable_auth_modes == ("api_key",)
+    assert rule.cache_behavior == "bypass"
+
+
+def test_max_tokens_has_locked_runtime_evidence() -> None:
+    observations = PLUGIN.chat_parameter_observations(model="openai/gpt-5.6", auth_type="api_key")
+
+    assert [(item.request_path, item.support, item.source) for item in observations] == [
+        ("max_tokens", "supported", "openai:locked-runtime")
+    ]
+
+
+def test_provider_bypasses_global_cache_and_contributes_no_accounting_strategy() -> None:
+    assert isinstance(
+        PLUGIN.global_cache_projection(
+            {"model": "openai/gpt-5.6", "messages": [{"role": "user", "content": "hi"}]}
+        ),
+        CacheBypass,
+    )
+    assert not hasattr(PLUGIN, "usage_accounting_strategy")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "marks_error"),
+    [(200, False), (401, True), (403, False), (429, False), (500, False)],
+)
+def test_only_401_marks_the_selected_credential_invalid(
+    status_code: int, marks_error: bool
+) -> None:
+    assert PLUGIN.should_mark_profile_error_on_dispatch_status(status_code) is marks_error

--- a/apps/aigateway/tests/unit/openai/test_openai_provider.py
+++ b/apps/aigateway/tests/unit/openai/test_openai_provider.py
@@ -11,7 +11,9 @@ from aigateway.plugins.openai_provider.plugin import PLUGIN, OpenAIProviderPlugi
 from aigateway.plugins.openai_provider.settings import OpenAIPluginSettings
 
 DEFAULT_MODELS = [
-    "openai/gpt-5.6",
+    "openai/gpt-5.6-sol",
+    "openai/gpt-5.6-terra",
+    "openai/gpt-5.6-luna",
     "openai/gpt-5.5",
     "openai/gpt-5.1",
     "openai/gpt-5",
@@ -93,7 +95,7 @@ def test_settings_require_nonempty_unique_seed_and_registered_validation_model()
 
 
 def test_max_tokens_is_the_only_enabled_parameter() -> None:
-    rules = PLUGIN.chat_parameter_rules(model="openai/gpt-5.6", auth_type="api_key")
+    rules = PLUGIN.chat_parameter_rules(model="openai/gpt-5.6-sol", auth_type="api_key")
 
     assert len(rules) == 1
     rule = rules[0]
@@ -105,7 +107,9 @@ def test_max_tokens_is_the_only_enabled_parameter() -> None:
 
 
 def test_max_tokens_has_locked_runtime_evidence() -> None:
-    observations = PLUGIN.chat_parameter_observations(model="openai/gpt-5.6", auth_type="api_key")
+    observations = PLUGIN.chat_parameter_observations(
+        model="openai/gpt-5.6-sol", auth_type="api_key"
+    )
 
     assert [(item.request_path, item.support, item.source) for item in observations] == [
         ("max_tokens", "supported", "openai:locked-runtime")
@@ -115,7 +119,7 @@ def test_max_tokens_has_locked_runtime_evidence() -> None:
 def test_provider_bypasses_global_cache_and_contributes_no_accounting_strategy() -> None:
     assert isinstance(
         PLUGIN.global_cache_projection(
-            {"model": "openai/gpt-5.6", "messages": [{"role": "user", "content": "hi"}]}
+            {"model": "openai/gpt-5.6-sol", "messages": [{"role": "user", "content": "hi"}]}
         ),
         CacheBypass,
     )

--- a/docs/plan/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/plan/2026-08-17-OME-864-direct-openai-provider.md
@@ -1,0 +1,650 @@
+# Implementation plan: direct OpenAI Platform API-key provider
+
+## 1. Status and authority
+
+This is the implementation plan for P0 issue
+[OME-864](https://linear.app/openmined/issue/OME-864/add-direct-openai-platform-api-key-provider-to-aigateway).
+The issue is `Pick Immediately`; implementation has not started.
+
+Phase 1 may proceed with the owner-approved offline seed and deterministic tests. Release remains
+blocked until the owner supplies an approved OpenAI key mechanism, maximum validation spend, and
+dated direct-OpenAI Chat Completions evidence. Secret material is never recorded in this plan.
+
+`docs/spec/2026-08-17-OME-864-direct-openai-provider.md` owns scope and acceptance when planning
+artifacts differ. Per the owner ruling, Linear OME-864 remains unchanged for now; its broader wording
+does not expand this reviewed implementation increment.
+
+Planning assumptions to confirm before implementation:
+
+1. The P0 increment is API-key-only and uses the existing `/v1/chat/completions` public contract.
+2. The P0 increment is non-streaming.
+3. Every P0 call is proven to remain on OpenAI Chat Completions; Responses API is separate.
+4. Direct model IDs use `openai/<model>` and never replace `codex/<model>`.
+5. The owner-approved offline seed contains twelve locked-runtime chat models; live account evidence
+   is required before release, not before source implementation.
+6. P0 dispatch is restricted to the registered seed so model listing, detailed contracts, and chat
+   enforcement describe the same set. Unlisted models are a follow-up.
+7. OpenAI inherits the standard AIGateway global `CacheBypass`; support caching for OpenAI is a
+   separate, not-yet-filed projection task under OME-787 scope.
+8. No explicit organization/project selector is added in P0.
+9. No Tortoise model, migration, signal, new dependency, hosted credential, or URL4 mirror is added.
+
+## 2. Architecture
+
+### 2.1 Provider flow
+
+```text
+POST /v1/chat/completions model=openai/<model>
+  -> provider-neutral strip_dispatch_controls
+  -> registry.get("openai")
+  -> plugin.strip_provider_dispatch_controls
+  -> global cache plan -> global_cache_projection bypass (no read/write)
+  -> account profile/connection target resolution (may raise; no secret read)
+  -> OpenAI API-key max_tokens rule projection
+  -> OpenAI request preparation
+  -> non-streaming gate
+  -> account-scoped ApiKeyStrategy
+  -> _inject_credentials reads the selected secret
+  -> OpenAIProviderPlugin.chat_completion()
+  -> request-local AsyncOpenAI(key, official base, Omit headers)
+  -> LiteLLM 1.95.0 OpenAI Chat Completions transform
+  -> https://api.openai.com/v1/chat/completions
+```
+
+No central provider switch is introduced. The first model-ID segment remains the only provider
+selector.
+
+### 2.2 Credential flow
+
+```text
+generic API-key route
+  -> OpenAIApiKeyValidator authentication stage
+  -> OpenAIApiKeyValidator readiness stage
+  -> profile path: ProfileIndexStore upsert + ApiKeyStrategy.persist_credentials
+     OR connection path: OAuthConnectionStore create/reactivate + ApiKeyStrategy.persist_credentials
+  -> each path's existing Tortoise transaction and lock ordering
+  -> ORMStore
+  -> SecretStoreMixin encryption
+  -> credential_blobs
+```
+
+Both surfaces store into the account-scoped credential slot selected by the generic route. The
+plugin supplies only its service namespace and Bearer-header builder. Failed validation happens
+before either transaction; failed replacement must preserve the prior key and metadata.
+
+### 2.3 Plugin responsibilities
+
+`OpenAIProviderPlugin` owns:
+
+- settings and model seeds;
+- API-key capability, strategy, and validator;
+- model-ID validation while preserving one `openai/` prefix into LiteLLM;
+- the `max_tokens` rule and observation;
+- fixed-origin and Chat Completions request preparation;
+- the request-local `AsyncOpenAI` client, ambient header suppression, and Responses bridge skip;
+- explicit global-cache bypass inherited from the provider base;
+- safe 401 credential invalidation policy;
+- final LiteLLM dispatch controls.
+
+Core continues to own:
+
+- plugin discovery and registry uniqueness;
+- caller authentication and account selection;
+- profile/connection persistence;
+- provider-neutral control stripping;
+- fail-closed parameter classification;
+- cache orchestration;
+- credential injection ordering;
+- overload/backpressure policy;
+- error rendering and profile-state mutation;
+- accounting session lifecycle, which resolves OpenAI to unsupported in P0.
+
+### 2.4 Tortoise boundary
+
+Tortoise ORM `1.1.7` is already initialized with the existing auth, credential, OAuth, cache, and
+secret model packages. This task changes no model state, so migration autodetection must have no
+operation to generate.
+
+Do not:
+
+- add `openai_provider.models` to `TORTOISE_CONFIG`;
+- create an OpenAI credential table;
+- add fields to `CredentialBlob`, `OAuthConnection`, `Profile`, or `Account`;
+- call `generate_schemas()` in production;
+- introduce Aerich;
+- use Tortoise signals for provider behavior.
+
+The explicit service methods and existing transaction remain the observable write path.
+
+## 3. Intended files
+
+### 3.1 New production files
+
+```text
+apps/aigateway/src/aigateway/plugins/openai_provider/__init__.py
+apps/aigateway/src/aigateway/plugins/openai_provider/settings.py
+apps/aigateway/src/aigateway/plugins/openai_provider/parameters.py
+apps/aigateway/src/aigateway/plugins/openai_provider/api_key_validation.py
+apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py
+```
+
+Keep `plugin.py` as composition, not a policy dump. Do not create `global_cache.py`; OME-864 always
+uses the inherited bypass and the later OpenAI caching task owns projection code.
+
+### 3.2 Existing production files expected to remain unchanged
+
+```text
+apps/aigateway/src/aigateway/core/loader.py
+apps/aigateway/src/aigateway/core/registry.py
+apps/aigateway/src/aigateway/core/api_key_strategy.py
+apps/aigateway/src/aigateway/core/credential_blob/
+apps/aigateway/src/aigateway/core/oauth/models/
+apps/aigateway/src/aigateway/db.py
+apps/aigateway/src/aigateway/routes/auth.py
+apps/aigateway/src/aigateway/routes/oauth_connections.py
+apps/aigateway/src/aigateway/routes/chat.py
+apps/aigateway/src/aigateway/routes/models.py
+apps/aigateway/src/aigateway/routes/providers.py
+apps/aigateway/src/aigateway/migrations/
+apps/aigateway/pyproject.toml
+apps/aigateway/uv.lock
+```
+
+If implementation requires changing one of these, stop and show why the existing generic port is
+insufficient before widening scope.
+
+### 3.3 Tests
+
+Prefer new focused files:
+
+```text
+apps/aigateway/tests/unit/openai/test_settings.py
+apps/aigateway/tests/unit/openai/test_provider.py
+apps/aigateway/tests/unit/openai/test_api_key_validation.py
+apps/aigateway/tests/unit/openai/test_parameters.py
+apps/aigateway/tests/unit/openai/test_dispatch_wire.py
+apps/aigateway/tests/unit/openai/test_security.py
+apps/aigateway/tests/unit/openai/test_cache_bypass.py
+apps/aigateway/tests/live/test_openai_live.py
+```
+
+One existing file necessarily changes:
+
+```text
+apps/aigateway/tests/unit/core/test_codex_namespace_guard.py
+```
+
+Its literal `registry.get("openai") is None` assertion conflicts with the new feature. Retain all
+Codex-prefix and owner-resolution assertions, replace only the obsolete absence claim, and add the
+stronger invariant that overlapping GPT family names remain independently owned by their canonical
+prefixes. Record the required append-only exception in the future work ledger before editing.
+
+Generic conformance files should not need provider-specific edits; their discovery sweep should
+pick up the new plugin automatically.
+
+## 4. Design decisions
+
+### D1. A normal auto-discovered provider
+
+Use `aigateway.plugins.openai_provider` and export `PLUGIN = OpenAIProviderPlugin()`. The package name
+already satisfies the loader's `*_provider` rule. No manifest, entry point, or central inventory is
+added.
+
+### D2. Separate namespaces, even for the same model family
+
+The owning plugin is encoded in the canonical ID:
+
+```text
+codex/gpt-5.x   -> CodexProviderPlugin -> ChatGPT subscription/OAuth endpoint
+openai/gpt-5.x  -> OpenAIProviderPlugin -> OpenAI Platform/API-key endpoint
+```
+
+Do not infer provider ownership from a bare model family name or from LiteLLM metadata. Never rename
+Codex entries into the OpenAI namespace.
+
+### D3. Existing API-key persistence only
+
+Implement:
+
+```python
+supports_api_key() -> True
+api_key_strategy_for(...) -> ApiKeyStrategy(...)
+api_key_validator() -> OpenAIApiKeyValidator(...)
+```
+
+The service locator must include the account-scoped credential name passed by the generic route.
+Use `account="default"` only because account isolation is already embedded in that service string,
+matching the existing provider strategy pattern.
+
+For API-key validation, only an approved authentication evidence tuple containing HTTP 401 plus the
+matching structured OpenAI type/code proves the submitted key invalid. The separate dispatch-error
+hook receives only HTTP status, so it follows the existing provider contract: dispatch 401 may mark
+only the selected stored target errored; permission, quota, rate, timeout, and 5xx do not.
+
+### D4. Curated seed-only dispatch
+
+`OpenAIPluginSettings` uses `AIGW_OPENAI_` and contains:
+
+```text
+default_models: list[str]
+validation_model: str
+```
+
+The approved values are:
+
+```text
+default_models:
+  - openai/gpt-5.6
+  - openai/gpt-5.5
+  - openai/gpt-5.1
+  - openai/gpt-5
+  - openai/gpt-5-mini
+  - openai/gpt-5-nano
+  - openai/gpt-4.1
+  - openai/gpt-4.1-mini
+  - openai/gpt-4o
+  - openai/gpt-4o-mini
+  - openai/o3
+  - openai/o4-mini
+validation_model: openai/gpt-5-nano
+```
+
+Before release:
+
+1. Obtain owner authorization for one bounded Models API query and one minimal readiness completion.
+2. Intersect the requested product lineup with the selected account's `GET /v1/models` result.
+3. Prove each seed against the intended Chat Completions endpoint.
+4. Exclude non-chat, Responses-only, embedding, image, audio, moderation, fine-tuning, and admin IDs.
+5. Record the verification date and account-independent model IDs without storing account data.
+
+Validate configured gateway IDs as one `openai/` prefix followed by a bounded ASCII model token.
+Reject empty IDs, additional path segments, URL schemes, query/fragment syntax, controls,
+whitespace, percent escapes, and backslashes. Reject syntactically valid but unregistered IDs in P0
+so `/v1/models`, `/v1/model-parameters`, conformance, and dispatch expose one coherent model set.
+Implement this as a settings `@field_validator` over `default_models` and `validation_model`; there
+is no plugin-level `validate_model_id` hook.
+
+### D5. Two-stage validation
+
+Implement `OpenAIApiKeyValidator` by adapting the established OpenRouter validator shape with the
+existing `ValidationHttpSession`:
+
+- Authentication: fixed-origin `GET /v1/models`, expecting an OpenAI list object.
+- Readiness: fixed-origin `POST /v1/chat/completions`, non-streaming, minimal input, and the configured
+  validation model.
+
+Use gateway-authored results only. Do not return upstream bodies/messages. Before implementation,
+record a finite classification table whose keys combine HTTP status with the exact structured OpenAI
+`error.type` and `error.code`; admit only tuples proven by official documentation or bounded live
+negative fixtures. A status alone is never actionable. Unlisted tuples, unknown 4xx/5xx, malformed
+payloads, redirects, oversized bodies, compression violations, and transport exceptions remain
+`unavailable`. In particular, an ambiguous `429` is not automatically `rate_limited` or `no_quota`.
+
+Name both core stages, `ApiKeyValidationStage.AUTHENTICATION` and `.READINESS`, and account for all
+eight states: `VALID`, `INVALID`, `EXPIRED`, `NO_QUOTA`, `PERMISSION_DENIED`, `RATE_LIMITED`,
+`UNAVAILABLE`, and `MISCONFIGURED`. `ApiKeyValidationService` downgrades an authentication-only
+`VALID` result to `MISCONFIGURED`, so readiness is a core-enforced persistence invariant.
+
+The readiness request may cost money. The route/API documentation and live-test instructions must
+state that before callers persist a key.
+
+### D6. Chat Completions only
+
+The provider's contract is endpoint-specific, not merely response-shape compatible.
+
+The locked runtime has four bridge triggers. P0 handles them without a combination override:
+
+- set private pinned kwarg `_skip_responses_api_bridge=True` request-locally, defeating the global
+  `route_all_chat_openai_to_responses` flag without mutating it;
+- reject IDs with the extra `responses/` segment in settings validation;
+- assert every approved seed resolves to LiteLLM `mode="chat"`; a Responses-only seed fails closed;
+- enable neither tools nor reasoning controls, making the GPT-5 combination trigger unreachable.
+
+There is no runtime final-URL policy seam after LiteLLM preparation, so do not promise runtime URL
+interception. Treat the full no-network `acompletion()` test as the endpoint contract for locked
+LiteLLM `1.95.0`; dependency upgrades must keep the private skip kwarg and final-wire contract green.
+
+Return `False` from `supports_chat_streaming()`. The route then rejects `stream:true` before
+`_inject_credentials()`.
+
+### D7. Fixed-origin and ambient-context isolation
+
+`prepare_chat_body()` and `chat_completion()` must collectively enforce:
+
+- official `api_base=https://api.openai.com/v1`;
+- selected request-local `api_key` injected only after preparation;
+- verified TLS;
+- a provider-owned HTTP client with `trust_env=False` and redirects disabled;
+- `caching=False` and no-store cache controls;
+- configured `num_retries=0` and `max_retries=0`;
+- request-local `_skip_responses_api_bridge=True`;
+- no caller or global fallbacks, alternate model lists, callbacks, mock response, custom logger, or
+  provider-mode controls;
+- no key in JSON, metadata, logs, callbacks, or exception text.
+
+RED final-wire tests poison at least:
+
+```text
+body.api_key
+body.api_base / body.base_url
+body.headers / body.extra_headers
+body.fallbacks / body.model_list
+body.callbacks / body.success_callback / body.failure_callback
+body.custom_llm_provider / body.azure / body.text_completion
+litellm.api_key / litellm.openai_key / litellm.api_base / litellm.headers
+litellm.proxy_auth / litellm.model_fallbacks / litellm.drop_params
+litellm.additional_drop_params / litellm.callbacks / litellm.pre_call_rules / litellm.post_call_rules
+OPENAI_API_KEY / OPENAI_BASE_URL / OPENAI_API_BASE
+OPENAI_ORGANIZATION / OPENAI_ORG_ID / OPENAI_PROJECT_ID / OPENAI_CUSTOM_HEADERS
+route_all_chat_openai_to_responses
+```
+
+The installed runtime forwards ambient organization and project headers when it owns client
+construction. P0 instead builds a request-local `AsyncOpenAI` inside `chat_completion()` after the
+gateway has injected the selected key. Construct it with the selected key, official base,
+`max_retries=0`, and `default_headers` mapping `OpenAI-Organization` and `OpenAI-Project` to OpenAI
+Python `Omit()` sentinels; pass it through LiteLLM's `client=` seam and close it after the
+non-streaming response. The pinned final-wire contract preserves the selected Bearer key and Chat
+Completions URL while suppressing both headers even when LiteLLM assigns `client.organization`.
+The SDK client owns an explicitly closed HTTP client with verified TLS, `trust_env=False`, and
+redirects disabled. Non-empty LiteLLM proxy auth, global headers, fallbacks, callbacks, rules, or
+drop-parameter state fail closed before SDK client construction.
+
+Do not pass `organization=None` or `project=None` as the fix: `None` means unset and causes OpenAI
+Python to read `OPENAI_ORG_ID` / `OPENAI_PROJECT_ID`. Refuse dispatch when
+`OPENAI_CUSTOM_HEADERS` is non-empty; arbitrary ambient header names are not covered by the two fixed
+sentinels. Declaring accounting unsupported prevents the taxonomy session from replacing this client
+with `AccountingAsyncHTTPHandler`. P0 accepts a fresh, explicitly closed SDK client per dispatch
+rather than adding credential-keyed client pooling or core lifecycle state. Use the OpenAI Python
+runtime already required by locked LiteLLM; do not add a project dependency or replace LiteLLM as
+the dispatch layer.
+
+### D8. Provider-local parameter contract
+
+P0 enables exactly `max_tokens` as the smallest useful universal Chat Completions subset. Reuse
+`MAX_TOKENS_SCHEMA` and construct `direct_rule("max_tokens", auth_modes=("api_key",),
+schema=MAX_TOKENS_SCHEMA, cache_behavior="bypass", ...)`. A keyed rule is forbidden while OpenAI
+inherits `CacheBypass`; OME-787 requires the projection to land before any later promotion to
+`keyed`.
+
+For each rule:
+
+- define a bounded `ParameterSchema`;
+- declare `applicable_auth_modes=("api_key",)`;
+- declare the direct projection through `direct_rule`;
+- declare `cache_behavior="bypass"`;
+- add a labelled installed-transform observation;
+- prove the exact final OpenAI JSON field;
+- prove unsupported families/modes remain disabled;
+- prove both family wire shapes: `max_tokens` for GPT-4.x/4o and `max_completion_tokens` for
+  GPT-5/o-series.
+
+Tools, tool choice, structured output, reasoning controls, and model-family-specific promotions are
+out of scope. Do not override `validate_chat_parameter_combination()` because no enabled P0 pair has
+a cross-field constraint. Stop sequences and broader sampling controls are follow-ups. Dynamic
+Models API evidence never enables a parameter.
+
+### D9. Global-cache bypass
+
+P0 inherits the provider base's standard `CacheBypass`. Every OpenAI request skips AIGateway global
+cache lookup and storage, so a cache hit cannot bypass ambient-context, endpoint-mode, credential,
+or dispatch guards. Do not add an OpenAI projection, adapter revision, or OpenAI cache-key semantics
+in OME-864. A to-be-filed "Support caching for OpenAI" sub-issue under OME-787 defines those after
+endpoint selection and ambient isolation are stable.
+
+### D10. Accounting unsupported in P0
+
+Do not implement `usage_accounting_strategy()` or `usage_accounting.py`. The taxonomy resolves a
+missing duck-typed contribution to exact `UsageAccountingStrategy.unsupported()`, creates no
+collector, and does not inject its shared `AccountingAsyncHTTPHandler` into `body["client"]`.
+
+Native OpenAI dispatch expects an `AsyncOpenAI` SDK client and calls `.chat.completions`; the current
+accounting handler is a LiteLLM `AsyncHTTPHandler` with no `.chat`. The experimental ambient
+`EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER` route is forbidden. Token, attempt, latency, completion
+ID, and direct-cost normalization all move to a separate SDK-client accounting capability task.
+
+### D11. Sanitized errors
+
+Reuse the shared route taxonomy. The plugin adds only provider-specific facts needed to classify
+credential validity and sanitize failures.
+
+- API-key validation requires an approved invalid-key status/type/code tuple. On later chat dispatch,
+  HTTP 401 may mark only the selected OpenAI profile/connection errored because the existing core
+  invalidation hook receives status only.
+- 403, quota, rate limit, timeout, and 5xx do not invalidate the key.
+- Raw OpenAI error bodies and SDK/LiteLLM exception messages never reach client detail or persisted
+  connection errors.
+- Safe status and bounded `Retry-After` may survive through the existing gateway contract.
+- Conversion failures and unknown exceptions become generic provider errors.
+- The request-local OpenAI SDK client and LiteLLM dispatch both receive configured retries of zero.
+
+## 5. TDD implementation sequence
+
+### Phase 0 - Authorize and frame
+
+- Obtain approval for the canonical OME-864 spec and this plan.
+- Do not modify Linear OME-864 during this increment. File the separate OpenAI cache-projection
+  follow-up under OME-787 later; it is not a Phase-1 prerequisite.
+- Record that implementation is offline and live release remains blocked until an approved key,
+  bounded validation spend, and dated Chat Completions evidence are available; never store the key
+  or account-sensitive evidence in planning artifacts.
+- Build the finite validation classification table from exact `status + error.type + error.code`
+  evidence; every unproven tuple maps to `unavailable`.
+- Fix the minimum rule as `max_tokens` using `MAX_TOKENS_SCHEMA`, `direct_rule`, API-key applicability,
+  and `cache_behavior="bypass"`; retain both GPT-4.x/4o and GPT-5/o-series wire assertions.
+- Confirm OME-864 remains assigned to Dmitry and move it to `In Progress` when implementation starts.
+- Create an `OME-864-<description>` branch from fresh `origin/main` in an isolated worktree because the
+  shared checkout is dirty.
+- Load the project-local Python SDLC specialization.
+- Create the required `docs/work/YYYY-MM-DD-OME-864-<description>.md` ledger from the repository
+  template.
+- Confirm `docs/tasks/2026-08-17-OME-864-direct-openai-provider.md` reflects the current Linear
+  status; Linear remains authoritative.
+- Record the Codex-test append-only exception before changing that test. Run the append-only gate
+  normally first and confirm the exact flagged list contains only
+  `tests/unit/core/test_codex_namespace_guard.py`; only then rerun with the run-wide skip and record
+  both outputs in the ledger.
+- Confirm installed dependency versions and run the baseline AIGateway gate.
+- Confirm the approved seed is visible before release.
+
+### Phase 1 - RED: discovery, namespace, and credentials
+
+Add failing tests proving:
+
+- `openai_provider` is discovered through the existing loader;
+- the plugin contributes API-key auth and no OAuth config;
+- approved seeds canonicalize under `openai/`;
+- syntactically valid but unregistered OpenAI models fail before credential access;
+- Codex models remain under and resolve to `codex/`;
+- overlapping bare GPT names are independently owned by their prefixes;
+- generic provider/model routes surface OpenAI without central branches;
+- a duplicate `custom_llm_provider="openai"` registration fails startup;
+- `ApiKeyStrategy` uses the account-scoped OpenAI service locator;
+- every seed lands in the same first green increment as the `max_tokens` API-key rule,
+  `MAX_TOKENS_SCHEMA`, labelled observation, explicit bypass disposition, and focused
+  installed-transform final-wire proof;
+- no model, migration, or dependency change is required.
+
+Implement the minimal settings, plugin, real seed, rule, and observation together. There is no green
+intermediate state with `openai_provider/plugin.py` present and zero conformance models.
+
+### Phase 2 - RED: API-key validation
+
+Add failing deterministic transport tests for:
+
+- fixed-origin Models authentication;
+- fixed-origin minimal Chat Completions readiness;
+- valid only after readiness;
+- all eight validation states and both `ApiKeyValidationStage` values;
+- authentication-only `VALID` is downgraded to `MISCONFIGURED` by the core service;
+- every approved `status + error.type + error.code` tuple and conservative `unavailable` fallback;
+- ambiguous `429`, malformed, oversized, redirect, compressed, timeout, and cancellation behavior;
+- no raw body/key reflection;
+- configurable validation model must exist in the reviewed seed and stay on Chat Completions.
+
+Implement `OpenAIApiKeyValidator` and integrate it through the generic hook.
+
+### Phase 3 - RED: owned SDK client, isolation, and endpoint mode
+
+Add failing real-LiteLLM/no-network wire tests for:
+
+- first, a full no-network `acompletion()` proves the supplied `AsyncOpenAI` survives to the wire;
+- exactly one `openai/` prefix reaches LiteLLM unchanged and LiteLLM emits one bare upstream model;
+- official host and `/v1/chat/completions` path;
+- selected account Bearer key wins every key fallback;
+- key absent from JSON and logs;
+- caller routing/header/callback/retry/cache/mock controls cannot reach the wire;
+- `OPENAI_ORGANIZATION`, `OPENAI_ORG_ID`, and `OPENAI_PROJECT_ID` cannot emit organization/project
+  headers because the client carries `Omit()` sentinels;
+- `organization=None` / `project=None` is covered as an explicit negative test;
+- non-empty `OPENAI_CUSTOM_HEADERS` fails before the selected key is sent;
+- `_skip_responses_api_bridge=True` defeats a true process-global Responses flag;
+- every seed remains LiteLLM `mode="chat"`, and `responses/` IDs are rejected;
+- TLS verification and zero configured LiteLLM/OpenAI SDK retries;
+- the request-local client is closed after dispatch;
+- `stream:true` fails before `_inject_credentials()` reads the credential secret.
+
+Implement the smallest request preparation and dispatch boundary that satisfies these tests. Do not
+add shared client lifecycle state, accounting handler injection, or process-global mutation.
+
+### Phase 4 - RED: minimum parameter-contract hardening
+
+For the one Phase-0-approved minimum rule, complete failing tests in this order:
+
+1. schema admission and rejection;
+2. API-key auth applicability;
+3. observation/evidence composition;
+4. conservative `/v1/models` summary;
+5. detailed contract shape;
+6. exact final-wire JSON;
+7. cache classification;
+8. both family-specific final-wire names for the one caller path.
+
+Do not add another parameter family, generic passthrough, tools, structured output, reasoning, or a
+field enabled only by discovery. Do not override `validate_chat_parameter_combination()`; those are
+sequential follow-up promotions.
+
+### Phase 5 - RED: cache and accounting boundaries
+
+Add failing tests proving:
+
+- every OpenAI request returns the standard provider projection `CacheBypass`;
+- OpenAI requests perform no AIGateway global cache read or write even when cache is enabled;
+- ambient-context and Responses guards cannot be skipped through a pre-existing OpenAI cache row;
+- OpenAI resolves to `UsageAccountingStrategy.unsupported()`;
+- no taxonomy accounting handler overwrites the provider-owned `AsyncOpenAI` client;
+- unsupported accounting emits no fabricated token, attempt, latency, ID, or cost evidence.
+
+Do not add OpenAI cache projection or accounting mapper code.
+
+### Phase 6 - RED: route and lifecycle integration
+
+Add route-level tests covering:
+
+- provider and model listing;
+- profile API-key create, failed-validation no-write, successful replacement, failed replacement
+  preserving the old key, select, account isolation, and delete through `upsert_api_key_profile()`;
+- API-key connection create, failed-validation no-write, successful replacement, failed replacement
+  preserving the old key, select, account isolation, and delete through
+  `create_api_key_connection()` / `set_connection_api_key()`;
+- unknown/unsupported params fail before key read;
+- 401 invalidates only the selected target;
+- non-auth failures preserve the target;
+- safe errors and no raw markers;
+- existing providers remain unchanged.
+
+No Tortoise schema work occurs. Run the existing clean-migration smoke only as a regression check,
+not to generate a migration.
+
+### Phase 7 - Owner-gated live verification
+
+With explicit authorization and a bounded real key:
+
+- call `GET /v1/models` and record only approved model IDs and date;
+- verify the validation model with the minimum readiness request;
+- run one direct non-streaming completion through the AIGateway route;
+- verify the selected model, endpoint family, response shape, and sanitized logs;
+- do not record the API key, prompt, organization/project identity, raw headers, or raw provider
+  error body;
+- leave the live test marked `live` and skipped by default.
+
+If the approved key, budget, seed, or validation model is withdrawn, stop implementation and return
+to owner review; do not substitute guessed defaults.
+
+### Phase 8 - Gates and review
+
+- Run focused OpenAI, Codex namespace, conformance, both credential surfaces, SDK-client isolation,
+  and cache-bypass tests.
+- Run the canonical AIGateway gate from the repository root.
+- Run the no-Enterprise import guard.
+- Review the actual diff for accidental core/provider branches, schema/dependency changes, secret
+  exposure, Responses support, streaming, and URL4 scope.
+- Confirm every new hand-maintained source file follows the SDLC 450-line convention and the
+  automated complexity, statement, branch, and return limits.
+- Confirm the only edited pre-existing test is the documented stronger Codex namespace guard.
+- Update the work ledger with checks actually run and residual release blockers.
+- Do not stage, commit, push, or create a PR without separate authorization.
+
+## 6. Test matrix
+
+| Area | Required proof |
+|---|---|
+| Discovery | Normal `*_provider` loading; no loader/registry branch |
+| Namespace | `openai/*` owns direct API; `codex/*` remains OAuth subscription |
+| Auth | API key only; profile and API-key connection lifecycles both preserve atomic isolation |
+| Tortoise | Existing models/transaction; no model registration or migration change |
+| Validation | Core-enforced authentication + readiness stages; all eight states |
+| Models | Curated live-verified seed only; unregistered IDs rejected before credential access |
+| Endpoint | Pinned official origin; locked LiteLLM final-wire proof for `/v1/chat/completions` |
+| Responses | Request-local private skip defeats global flag; seed modes and IDs exclude other triggers |
+| Streaming | Rejected before `_inject_credentials()` reads the credential secret |
+| Isolation | Owned `AsyncOpenAI` suppresses org/project; ambient custom headers fail closed |
+| Parameters | `max_tokens` + schema + bypass rule + observation land with the real seed |
+| Cache | Standard `CacheBypass` for every OpenAI request; no global read or write |
+| Accounting | Unsupported; no shared handler injection or fabricated evidence |
+| Errors | Validation uses approved tuples; dispatch 401 alone may invalidate only the selected target |
+| Regression | Existing providers and full AIGateway gates remain green |
+| Live | Owner-gated, bounded, skipped by default |
+
+## 7. Stop conditions
+
+Return to owner review instead of broadening scope if any of these occurs:
+
+- live verification requires unbounded spend or storing sensitive account evidence;
+- a seed or required parameter can only use Responses API;
+- the locked LiteLLM version stops honoring `_skip_responses_api_bridge=True` or the supplied
+  `AsyncOpenAI` client;
+- API-key publication requires a new model, field, migration, or credential table;
+- plugin loading requires a central OpenAI branch;
+- implementation requires adding a new package dependency or replacing LiteLLM dispatch; using the
+  already-installed OpenAI SDK required by locked LiteLLM for request-local client construction is
+  expected;
+- streaming becomes necessary for P0 acceptance;
+- URL4 model mirroring or hosted/shared credentials are pulled into the task;
+- a prior test must be deleted or weakened beyond the documented Codex guard repointing.
+
+## 8. Definition of done
+
+- A normally auto-discovered `openai` provider supports direct account-scoped OpenAI Platform API
+  keys under `openai/<model>`.
+- Codex remains OAuth-only and retains exclusive ownership of `codex/<model>`.
+- The generic encrypted API-key lifecycle is reused without schema, migration, signal, route, or
+  dependency changes.
+- Every allowed P0 dispatch is non-streaming and proven to reach only the official Chat Completions
+  endpoint.
+- Caller and ambient OpenAI routing/auth context cannot alter the selected account request.
+- `max_tokens` is the only enabled P0 parameter, uses `MAX_TOKENS_SCHEMA`, is cache-bypassed, and is
+  evidenced and final-wire proven under both family-specific upstream field names.
+- Validation authenticates and proves readiness with documented quota impact.
+- Both generic API-key persistence surfaces prove create, failed-validation no-write, replacement
+  preservation on failure, account isolation, selection, and deletion.
+- Every OpenAI request uses the standard global `CacheBypass`; OpenAI cache projection is absent.
+- OpenAI usage accounting is unsupported in P0; no shared accounting handler replaces the
+  request-local SDK client and no accounting evidence is fabricated.
+- Provider errors and logs expose no key, prompt, raw body, or raw exception text.
+- The approved model seed has dated direct-OpenAI live evidence, or release remains explicitly
+  blocked pending that evidence.
+- Existing provider behavior remains green.
+- The documented Codex test exception strengthens rather than removes namespace ownership coverage.
+- Focused tests and the complete AIGateway gate pass.
+- Work ledger and branch/commit/PR references use `OME-864`.

--- a/docs/plan/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/plan/2026-08-17-OME-864-direct-openai-provider.md
@@ -4,11 +4,11 @@
 
 This is the implementation plan for P0 issue
 [OME-864](https://linear.app/openmined/issue/OME-864/add-direct-openai-platform-api-key-provider-to-aigateway).
-The issue is `Pick Immediately`; implementation has not started.
+Implementation and owner-authorized live verification completed on 2026-08-18. Per owner ruling,
+Linear remained unchanged during this increment.
 
-Phase 1 may proceed with the owner-approved offline seed and deterministic tests. Release remains
-blocked until the owner supplies an approved OpenAI key mechanism, maximum validation spend, and
-dated direct-OpenAI Chat Completions evidence. Secret material is never recorded in this plan.
+The completed bounded live pass covers readiness, all fourteen concrete seeds, and one end-to-end
+AIGateway route request. Secret material and account identity are not recorded in this plan.
 
 `docs/spec/2026-08-17-OME-864-direct-openai-provider.md` owns scope and acceptance when planning
 artifacts differ. Per the owner ruling, Linear OME-864 remains unchanged for now; its broader wording
@@ -20,7 +20,7 @@ Planning assumptions to confirm before implementation:
 2. The P0 increment is non-streaming.
 3. Every P0 call is proven to remain on OpenAI Chat Completions; Responses API is separate.
 4. Direct model IDs use `openai/<model>` and never replace `codex/<model>`.
-5. The owner-approved offline seed contains twelve locked-runtime chat models; live account evidence
+5. The owner-approved seed contains fourteen locked-runtime chat models; live account evidence
    is required before release, not before source implementation.
 6. P0 dispatch is restricted to the registered seed so model listing, detailed contracts, and chat
    enforcement describe the same set. Unlisted models are a follow-up.
@@ -234,7 +234,9 @@ The approved values are:
 
 ```text
 default_models:
-  - openai/gpt-5.6
+  - openai/gpt-5.6-sol
+  - openai/gpt-5.6-terra
+  - openai/gpt-5.6-luna
   - openai/gpt-5.5
   - openai/gpt-5.1
   - openai/gpt-5
@@ -248,6 +250,12 @@ default_models:
   - openai/o4-mini
 validation_model: openai/gpt-5-nano
 ```
+
+The original offline seed used the official `gpt-5.6` family alias. Owner-authorized live evidence
+showed that Chat Completions resolves that alias to `gpt-5.6-sol`, while `/v1/models` publishes the
+three concrete `gpt-5.6-{sol,terra,luna}` IDs and not the alias. The owner therefore replaced the
+alias with all three concrete variants so the gateway catalog exposes the actual capability/cost
+choices without a duplicate default-to-Sol row.
 
 Before release:
 

--- a/docs/spec/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/spec/2026-08-17-OME-864-direct-openai-provider.md
@@ -80,8 +80,8 @@ native `client=` behavior are locked-version contracts enforced by final-wire te
 
 ## Live-release blocker
 
-Source implementation proceeds with deterministic offline coverage. Release remains blocked until
-the owner provides all of the following without recording secret material in this specification:
+Source implementation proceeds with deterministic offline coverage. The owner-authorized live pass
+must provide all of the following without recording secret material in this specification:
 
 - an OpenAI API key available through an approved local live-test mechanism;
 - an explicit maximum spend for the bounded Models/readiness validation requests;
@@ -89,10 +89,16 @@ the owner provides all of the following without recording secret material in thi
 - live account confirmation for the approved low-cost validation model;
 - dated evidence that every selected seed is visible to the account and reaches Chat Completions.
 
-The owner-approved offline seed is:
+Completed 2026-08-18: readiness, all fourteen concrete seeds, and one end-to-end AIGateway route
+smoke passed. The only live-discovered final-wire defect was `ssl_verify` leaking into OpenAI JSON;
+removing that body field preserved TLS verification on the owned HTTP client and made the route pass.
+
+The owner-approved seed, revised from the family alias after live catalog evidence, is:
 
 ```text
-openai/gpt-5.6
+openai/gpt-5.6-sol
+openai/gpt-5.6-terra
+openai/gpt-5.6-luna
 openai/gpt-5.5
 openai/gpt-5.1
 openai/gpt-5
@@ -106,9 +112,9 @@ openai/o3
 openai/o4-mini
 ```
 
-The approved readiness model is `openai/gpt-5-nano`. Locked runtime metadata classifies all twelve
-as direct OpenAI chat models. Live account visibility and real readiness remain release gates, not
-source-implementation prerequisites.
+The approved readiness model is `openai/gpt-5-nano`. Locked runtime metadata classifies all fourteen
+as direct OpenAI chat models. The owner-authorized live catalog lists all fourteen concrete IDs.
+Real Chat Completions evidence for every seed remains a release gate.
 
 Owner ruling: keep Linear OME-864 unchanged for now. This reviewed canonical spec and plan define the
 implementation increment. The separate OpenAI caching issue may be filed later and is not a P0
@@ -213,6 +219,13 @@ validation service and bounded validation transport:
 1. Authenticate with the fixed-origin `GET https://api.openai.com/v1/models` endpoint.
 2. Prove readiness with one minimal non-streaming Chat Completions request against an explicitly
    configured, live-verified low-cost validation model.
+
+The owner-authorized 2026-08-18 live pass established the bounded readiness request for
+`openai/gpt-5-nano`: `max_completion_tokens: 1` is rejected with HTTP 400
+`invalid_request_error`, while `16` returns HTTP 200 `chat.completion` with
+`finish_reason: length`, empty-string assistant content, and exactly 16 reasoning/completion tokens.
+P0 therefore pins 16 as the live-verified upper bound; omitting the parameter would remove the
+deterministic quota and latency ceiling from credential validation.
 
 `ApiKeyValidationStage.AUTHENTICATION` and `.READINESS` are core-enforced: an authentication-only
 `VALID` result is downgraded to `MISCONFIGURED` and cannot authorize persistence. The finite table

--- a/docs/spec/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/spec/2026-08-17-OME-864-direct-openai-provider.md
@@ -1,0 +1,340 @@
+# Add direct OpenAI Platform API-key provider to AIGateway
+
+## Ticket metadata
+
+| Field | Value |
+|---|---|
+| Linear | [OME-864](https://linear.app/openmined/issue/OME-864/add-direct-openai-platform-api-key-provider-to-aigateway) |
+| Status | Pick Immediately |
+| Priority | Urgent (Linear priority 1); P0 implementation scope |
+| Labels | `aigateway`, `agentic`, `autonomous` |
+| Assignee | Dmitry |
+| Project | ScreamingFace V1 |
+
+## Outcome
+
+Add a first-class direct OpenAI Platform provider for users who connect their own OpenAI API key.
+The provider is separate from both existing ways to reach OpenAI-family models:
+
+- `codex/*` remains the OAuth-only ChatGPT subscription provider.
+- `openrouter/openai/*` remains OpenRouter-routed access paid and governed through OpenRouter.
+- `openai/*` becomes direct OpenAI Platform access paid and governed by the selected account's
+  OpenAI API key.
+
+The P0 increment uses the existing AIGateway `/v1/chat/completions` contract. It is deliberately
+non-streaming and supports only models and parameter combinations proven to remain on OpenAI's Chat
+Completions endpoint. It dispatches only the approved registered seed in P0 and explicitly bypasses
+the AIGateway global exact-response cache. Native Responses API support, arbitrary unlisted models,
+and OpenAI global-cache projection are separate follow-ups.
+
+## Verified foundation
+
+- `apps/aigateway` is the smallest relevant project root.
+- Provider discovery loads direct `aigateway.plugins.*_provider` packages whose `plugin.py` exports
+  a module-level `PLUGIN` instance of `ProviderPluginBase`.
+- `custom_llm_provider` is the first segment of every canonical model ID and selects the plugin.
+  Therefore `codex/gpt-*` and `openai/gpt-*` can coexist without a runtime routing collision.
+- The existing generic API-key profile and connection routes call a provider's
+  `api_key_strategy_for()` and `api_key_validator()` hooks. A new provider-specific auth route is
+  unnecessary.
+- `ApiKeyStrategy`, `ProfileIndexStore`, `OAuthConnection`, `ORMStore`, and encrypted
+  `credential_blobs` already provide account-scoped API-key persistence and atomic publication.
+- Locked runtime versions:
+  - Python `3.12.9`
+  - LiteLLM `1.95.0`
+  - OpenAI Python `2.53.0`
+  - Tortoise ORM `1.1.7`
+- Pinned wire behavior transforms `model="openai/gpt-5"`, an explicit request-local key, and the
+  official base into upstream model `gpt-5`, the selected Bearer key, and
+  `https://api.openai.com/v1/chat/completions`, overriding API-key and base fallbacks.
+- Without explicit suppression, ambient
+  `OPENAI_ORGANIZATION` and `OPENAI_PROJECT_ID` are sent as `OpenAI-Organization` and
+  `OpenAI-Project` even when the account-scoped key and official base are explicit.
+- The pinned full-dispatch contract guarantees that a request-local
+  `AsyncOpenAI` with `Omit()` default headers suppresses both organization and project headers,
+  preserves the selected key and official Chat Completions URL, and survives LiteLLM mutating the
+  supplied client's organization field.
+- `_skip_responses_api_bridge=True` keeps both `openai/gpt-4o` and
+  `openai/gpt-5` on `/v1/chat/completions` even when LiteLLM's global Responses flag is true.
+- The existing `litellm_async_http` accounting capability is incompatible with native OpenAI
+  dispatch: it injects an `AsyncHTTPHandler`, while LiteLLM's OpenAI path requires an `AsyncOpenAI`
+  client and calls `.chat.completions`. P0 therefore declares accounting unsupported rather than
+  widening core transport scope.
+- LiteLLM `1.95.0` can implicitly bridge `acompletion()` to the Responses API based on a global
+  flag, model metadata, a `responses/` model name, or selected GPT-5 parameter combinations.
+- OpenAI's Models API reports availability and ownership, not a complete chat-capability schema.
+  Its result cannot be copied wholesale into the AIGateway model seed.
+- The provider-conformance suite auto-discovers every plugin and requires every conformance model
+  to have non-empty, evidenced, auth-scoped parameter rules.
+- OME-305 already owns the global exact-response cache framework. Providers without a proven pure
+  projection safely bypass it; OME-787 is the intended parent for additional provider coverage, but
+  its current table does not include OpenAI and needs a dedicated follow-up sub-issue.
+- `tests/unit/core/test_codex_namespace_guard.py` currently asserts that no `openai` provider
+  exists. The historical intent is to protect Codex ownership, but that literal assertion becomes
+  invalid when this task lands and must be replaced by a stronger two-namespace ownership check.
+
+Public OpenAI Python documentation confirms `AsyncOpenAI` custom HTTP-client construction and the
+`OPENAI_ORG_ID` / `OPENAI_PROJECT_ID` environment contract. The private LiteLLM bridge-skip and
+native `client=` behavior are locked-version contracts enforced by final-wire tests. Tortoise ORM
+`1.1.7` confirms that a behavior-only provider addition using existing models requires no migration.
+
+## Live-release blocker
+
+Source implementation proceeds with deterministic offline coverage. Release remains blocked until
+the owner provides all of the following without recording secret material in this specification:
+
+- an OpenAI API key available through an approved local live-test mechanism;
+- an explicit maximum spend for the bounded Models/readiness validation requests;
+- live account confirmation for the approved production seed;
+- live account confirmation for the approved low-cost validation model;
+- dated evidence that every selected seed is visible to the account and reaches Chat Completions.
+
+The owner-approved offline seed is:
+
+```text
+openai/gpt-5.6
+openai/gpt-5.5
+openai/gpt-5.1
+openai/gpt-5
+openai/gpt-5-mini
+openai/gpt-5-nano
+openai/gpt-4.1
+openai/gpt-4.1-mini
+openai/gpt-4o
+openai/gpt-4o-mini
+openai/o3
+openai/o4-mini
+```
+
+The approved readiness model is `openai/gpt-5-nano`. Locked runtime metadata classifies all twelve
+as direct OpenAI chat models. Live account visibility and real readiness remain release gates, not
+source-implementation prerequisites.
+
+Owner ruling: keep Linear OME-864 unchanged for now. This reviewed canonical spec and plan define the
+implementation increment. The separate OpenAI caching issue may be filed later and is not a P0
+prerequisite.
+
+## Architecture constraints
+
+### Provider package
+
+Add `apps/aigateway/src/aigateway/plugins/openai_provider/` with a module-level `PLUGIN` and:
+
+```text
+custom_llm_provider = "openai"
+provider_display_name = "OpenAI"
+```
+
+The package owns OpenAI settings, model seeds, API-key validation, the `max_tokens` parameter rule
+and observation, request preparation, explicit cache bypass, and dispatch hardening. Do not add an
+OpenAI branch to the loader, registry, chat route, model route, provider route, credential routes, or
+core accounting taxonomy.
+
+### Credential and Tortoise boundary
+
+- Support API-key auth only. `oauth_config()` remains `None`.
+- Reuse `ApiKeyStrategy` with an OpenAI-specific credential service namespace.
+- Reuse the generic encrypted profile/connection lifecycle and its existing transaction ordering.
+- Add no Tortoise model, field, migration, ORMStore change, repository, or signal.
+- Never read or write an OS keychain under `apps/aigateway`.
+- Never write plaintext secrets directly to `credential_blobs`; all writes continue through
+  `ORMStore` and the active `SecretStoreMixin`.
+
+### Model identity
+
+- Public gateway IDs use `openai/<model>`.
+- Validate configured IDs in the settings `@field_validator`; there is no plugin-level
+  `validate_model_id` hook.
+- The plugin validates exactly one `openai/` prefix and passes the prefixed ID unchanged into
+  `litellm.acompletion()`; LiteLLM owns stripping that prefix for the upstream wire model.
+- `/v1/models` contains a curated, live-verified seed of direct OpenAI chat-capable models.
+- P0 dispatch is restricted to those registered seeds so `/v1/models`, `/v1/model-parameters`,
+  parameter enforcement, and chat dispatch describe the same model set.
+- Do not register `responses/<model>` aliases in this P0 task.
+
+### Chat Completions boundary
+
+- All P0 dispatches must reach `https://api.openai.com/v1/chat/completions`.
+- `stream:true` is rejected before `_inject_credentials()` reads the credential secret.
+- No allowed model or parameter combination may trigger LiteLLM's Responses bridge.
+- Pass the pinned private LiteLLM kwarg `_skip_responses_api_bridge=True` request-locally so a
+  process-global `route_all_chat_openai_to_responses` flag cannot redirect this provider.
+- Every approved seed must remain `mode="chat"`; a Responses-only seed fails closed before dispatch.
+- The official Chat Completions path is an executable contract of the locked LiteLLM `1.95.0`
+  runtime, proven by no-network final-wire tests. P0 does not add runtime URL interception.
+- Responses API, streaming, conversation state, and Responses-only tools remain separate work.
+
+### Request and credential isolation
+
+Before the account key is read, retain the existing provider-neutral stripping of caller-supplied
+credentials, bases, headers, fallbacks, callbacks, retries, caches, mocks, and logging controls.
+At the provider boundary:
+
+- Pin `https://api.openai.com/v1` and verified TLS.
+- Inject only the selected account-scoped API key.
+- Set configured LiteLLM retries to zero and disable LiteLLM caching; AIGateway owns those policies.
+- Build a request-local `AsyncOpenAI` after credential injection with the selected key, official
+  base, `max_retries=0`, and `default_headers` containing `Omit()` for
+  `OpenAI-Organization` and `OpenAI-Project`; pass it through LiteLLM's `client=` seam and close it
+  after the non-streaming dispatch.
+- Treat `organization=None` / `project=None` as unsafe: OpenAI Python interprets `None` as unset and
+  reads `OPENAI_ORG_ID` / `OPENAI_PROJECT_ID` from the environment.
+- Refuse dispatch when `OPENAI_CUSTOM_HEADERS` is non-empty; arbitrary ambient header names cannot
+  be exhaustively neutralized by the two fixed `Omit()` entries.
+- Prevent caller and ambient values from selecting the host, credential, organization, project,
+  custom headers, callback destinations, or endpoint mode.
+- Never mutate process environment variables or LiteLLM globals to obtain isolation.
+- Never log or return keys, raw provider bodies, raw exception text, prompts, or complete request
+  headers.
+
+### Parameter contract
+
+- `chat_parameter_rules()` remains the only enabling source.
+- `chat_parameter_observations()` and any later discovery are evidence only and never enable a
+  field.
+- The plugin package, real seed, `max_tokens` rule, schema, observation, and final-wire proof land in
+  one first green increment; a registered provider with zero conformance models is forbidden.
+- P0 enables only `max_tokens` through `direct_rule`, reuses `MAX_TOKENS_SCHEMA`, and declares
+  `cache_behavior="bypass"`. LiteLLM emits `max_tokens` for GPT-4.x/4o and
+  `max_completion_tokens` for GPT-5/o-series; both wire shapes require tests.
+- Do not override `validate_chat_parameter_combination()` in P0: tools and reasoning controls are
+  disabled, so no enabled pair can trigger the Responses bridge.
+- The P0 rule set is otherwise closed. Tools,
+  structured output, reasoning controls, and broader parameter promotions are separate follow-ups.
+- Every enabled field has a schema, projection, cache behavior, labelled evidence, and final-wire
+  test through the installed transform.
+- Unknown, disabled, malformed, or wrong-mode fields fail before credential access.
+
+### API-key validation
+
+Reuse the established OpenRouter two-stage validator shape through the existing provider-neutral
+validation service and bounded validation transport:
+
+1. Authenticate with the fixed-origin `GET https://api.openai.com/v1/models` endpoint.
+2. Prove readiness with one minimal non-streaming Chat Completions request against an explicitly
+   configured, live-verified low-cost validation model.
+
+`ApiKeyValidationStage.AUTHENTICATION` and `.READINESS` are core-enforced: an authentication-only
+`VALID` result is downgraded to `MISCONFIGURED` and cannot authorize persistence. The finite table
+must cover all eight states: `VALID`, `INVALID`, `EXPIRED`, `NO_QUOTA`, `PERMISSION_DENIED`,
+`RATE_LIMITED`, `UNAVAILABLE`, and `MISCONFIGURED`.
+
+The second stage may consume quota and must be documented. Before implementation, define a finite
+classification table keyed by exact HTTP status plus structured OpenAI `error.type` and
+`error.code`, using only official or bounded live evidence. A status alone is not actionable;
+unlisted tuples, ambiguous `429` responses, malformed payloads, and transport failures are
+`unavailable`. Only a readiness-stage `valid` result authorizes persistence.
+
+The implemented P0 evidence table is deliberately conservative:
+
+- `(401, invalid_request_error, invalid_api_key)` is `invalid` at either stage, backed by a bounded
+  synthetic-key fixture captured on 2026-08-17.
+- The readiness-only OpenAI billing codes `credit_balance_exhausted`,
+  `organization_spend_limit_exceeded`, `project_spend_limit_exceeded`, and
+  `organization_usage_limit_exceeded` are `no_quota` only with HTTP 429 and
+  `error.type=insufficient_quota`.
+- `expired`, `permission_denied`, and `rate_limited` remain explicit unpromoted states until an exact
+  tuple has approved evidence. Candidate or status-only responses stay `unavailable`.
+- Local unregistered validation configuration is `misconfigured`; malformed HTTP-200 success
+  payloads are `unavailable`.
+
+### Cache and accounting boundary
+
+- P0 inherits the provider base's global `CacheBypass`; OpenAI requests perform no AIGateway global
+  cache read or write.
+- Support caching for OpenAI is a separate follow-up under the OME-787 projection-coverage scope,
+  after endpoint selection and ambient-context isolation are stable.
+- Keep LiteLLM's own cache disabled independently of the AIGateway global-cache bypass.
+- P0 declares no OpenAI usage-accounting contribution, so the generic taxonomy resolves it to
+  `UsageAccountingStrategy.unsupported()` and does not overwrite the provider-owned `client=`.
+- Token, latency, completion-ID, attempt, and `DirectCost` normalization are deferred to a separate
+  SDK-client accounting capability task. Do not add `usage_accounting.py` in OME-864.
+
+## Scope
+
+- Auto-discovered direct OpenAI provider package.
+- API-key-only auth through existing generic routes and encrypted account-scoped storage.
+- Curated direct OpenAI model seed; P0 dispatch is seed-only.
+- Non-streaming Chat Completions dispatch through installed LiteLLM.
+- Fixed official origin, TLS, credential isolation, ambient-context isolation, and sanitized errors.
+- One provider-local `max_tokens` rule, observation, and final-wire proof.
+- Two-stage API-key validation.
+- Explicit AIGateway global-cache bypass for every OpenAI request.
+- Provider discovery/model/provider route integration through existing generic code.
+- Replacement of the obsolete `registry.get("openai") is None` test assertion with stronger
+  Codex/OpenAI namespace ownership coverage.
+- Deterministic unit, route, conformance, security, cache-bypass, and owner-gated live tests.
+
+## Out of scope
+
+- Codex OAuth changes or routing API keys through Codex.
+- OpenRouter changes or OpenRouter model-seed changes.
+- Hosted/shared OpenAI credentials.
+- OpenAI Responses API and automatic Chat Completions-to-Responses bridging.
+- Streaming/SSE.
+- Arbitrary unlisted OpenAI model dispatch.
+- AIGateway global-cache projection for OpenAI; that belongs to a to-be-filed OME-787 sub-issue.
+- OpenAI usage-accounting instrumentation or a new SDK-client accounting capability.
+- Function tools, structured output, reasoning controls, and parameter promotion beyond the minimal
+  universally proven P0 subset.
+- Realtime, audio, image, embedding, moderation, batch, fine-tuning, assistants, vector-store, and
+  admin endpoints.
+- Explicit client-selectable OpenAI organization/project headers.
+- Runtime registration of the complete account model catalog.
+- A direct OpenAI SDK transport replacing LiteLLM.
+- New dependencies, database state, migrations, signals, billing tables, or pricing calculations.
+- URL4 Cloud `url4.toml` mirroring unless separately requested after the direct seed is approved.
+
+## Acceptance criteria
+
+- `plugins/openai_provider/plugin.py` is discovered without a central loader or registry change.
+- `GET /v1/providers` exposes `openai` with API-key auth after the plugin contributes models.
+- `GET /v1/models` exposes approved `openai/<model>` rows with conservative parameter summaries.
+- Every `openai/<model>` seed resolves to the OpenAI plugin; every `codex/<model>` seed continues to
+  resolve to Codex.
+- The Codex namespace regression keeps its original ownership guarantee while permitting the new
+  direct OpenAI namespace.
+- A valid account-scoped OpenAI key can be created, replaced, selected, and deleted through existing
+  generic routes.
+- Credential publication remains encrypted and transactional with no schema or migration change.
+- Approved status/type/code tuples return the matching sanitized actionable states; every unlisted
+  or ambiguous tuple, including ambiguous `429`, returns `unavailable`.
+- API-key validation reaches readiness and documents that its minimal completion can consume quota.
+- The approved seed and validation model are selected before source implementation; every seed is
+  present in a live account catalog and passes an owner-gated real Chat Completions smoke.
+- Final-wire tests prove the official host, `/v1/chat/completions`, exactly one stripped gateway
+  prefix at the upstream wire while the prefixed ID reaches LiteLLM, the selected Bearer key,
+  verified TLS, and no key in JSON.
+- Poisoned caller controls, LiteLLM globals, OpenAI environment keys/bases, ambient organization and
+  project values, custom headers, callbacks, and Responses bridge flags cannot alter the wire.
+- `stream:true` fails before `_inject_credentials()` reads the credential secret; profile/connection
+  target resolution and request preparation still occur first.
+- The plugin package, production seed, `max_tokens` rule, schema, observation, bypass disposition,
+  and final-wire proof land in one first green increment.
+- Unknown or unsupported fields fail closed before credential access.
+- OpenAI accounting is explicitly unsupported in P0, no shared accounting handler overwrites the
+  provider-owned `AsyncOpenAI` client, and no provider accounting evidence is fabricated.
+- Every OpenAI request reports AIGateway global-cache bypass and performs no global cache read or
+  write.
+- Profile API-key and API-key connection lifecycles both cover create, failed-validation no-write,
+  failed replacement preserving prior state, account isolation, selection, and deletion.
+- Raw provider error bodies, exception messages, prompts, keys, and headers do not reach responses,
+  logs, persisted errors, or cache rows.
+- Existing Anthropic, Antigravity, Codex, Gemini, Hugging Face, Ollama, and OpenRouter behavior
+  remains unchanged.
+- Focused tests and the complete AIGateway quality gate pass.
+- The opt-in live test remains skipped unless explicitly enabled with a real OpenAI key.
+
+## Delivery requirements
+
+- Use `OME-864` for the branch, work ledger, commit body, and PR references.
+- Before source edits, load the project-local Python SDLC specialization and create the required
+  `docs/work/YYYY-MM-DD-OME-864-<description>.md` ledger from the repository template.
+- Use TDD with failing tests first.
+- Preserve prior tests. The one existing Codex namespace test contains a now-impossible literal
+  absence assertion; changing it requires an explicit append-only exception while retaining and
+  strengthening the original Codex ownership behavior.
+- Keep new hand-maintained Python files within the SDLC's 450-line convention and split by cohesive
+  responsibility rather than by line count alone. Automated gates additionally enforce complexity,
+  statement, branch, return, formatting, typing, no-Enterprise, test, and 80% coverage constraints.
+- Do not stage, commit, push, or create a PR without separate authorization.

--- a/docs/tasks/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/tasks/2026-08-17-OME-864-direct-openai-provider.md
@@ -20,6 +20,7 @@ Canonical artifacts:
 - Plan: `docs/plan/2026-08-17-OME-864-direct-openai-provider.md`
 
 Offline source implementation and deterministic verification are complete on the dedicated branch.
-Release remains blocked until the approved twelve-model seed and `openai/gpt-5-nano` readiness probe
-are verified with an owner-supplied local key and bounded spend. Per owner instruction, Linear
+The owner-supplied bounded live pass verified `openai/gpt-5-nano` readiness, all fourteen concrete
+seed IDs in the account catalog and Chat Completions, and one end-to-end AIGateway route request.
+OME-864 has no remaining code or provider-verification blocker. Per owner instruction, Linear
 OME-864 remains unchanged for now; the separate OpenAI caching issue will be filed later.

--- a/docs/tasks/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/tasks/2026-08-17-OME-864-direct-openai-provider.md
@@ -1,0 +1,25 @@
+---
+id: OME-864
+linear_url: https://linear.app/openmined/issue/OME-864/add-direct-openai-platform-api-key-provider-to-aigateway
+status: Pick Immediately
+type: Feature
+priority: Urgent
+labels: [aigateway, agentic, autonomous]
+created: 2026-08-17
+closed:
+---
+
+# Add direct OpenAI Platform API-key provider to AIGateway
+
+Add API-key-only direct OpenAI access under `openai/*` without changing the existing
+`codex/*` OAuth or `openrouter/openai/*` routes.
+
+Canonical artifacts:
+
+- Spec: `docs/spec/2026-08-17-OME-864-direct-openai-provider.md`
+- Plan: `docs/plan/2026-08-17-OME-864-direct-openai-provider.md`
+
+Offline source implementation and deterministic verification are complete on the dedicated branch.
+Release remains blocked until the approved twelve-model seed and `openai/gpt-5-nano` readiness probe
+are verified with an owner-supplied local key and bounded spend. Per owner instruction, Linear
+OME-864 remains unchanged for now; the separate OpenAI caching issue will be filed later.

--- a/docs/work/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/work/2026-08-17-OME-864-direct-openai-provider.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-864
 stack: aigateway
-status: blocked
+status: done
 started: 2026-08-17
-finished:
+finished: 2026-08-18
 ---
 
 # OME-864 - Direct OpenAI Platform API-key provider
@@ -52,9 +52,10 @@ non-streaming, Chat Completions-only, globally cache-bypassed, and usage-account
 - Owner instructed that Linear remain unchanged during this increment, so its status is not moved.
 - `OPENAI_API_KEY` is currently unavailable locally. Live seed/readiness verification remains a
   release blocker unless the owner later supplies a safe local key and spend authorization.
-- Owner selected the twelve-model seed documented in the canonical spec (the reviewed ten plus
-  `openai/gpt-5.5` and `openai/gpt-5.6`), `openai/gpt-5-nano` for readiness, and offline
-  implementation now with live verification deferred.
+- Owner initially selected the twelve-model seed documented in the canonical spec (the reviewed ten
+  plus `openai/gpt-5.5` and the `openai/gpt-5.6` family alias), `openai/gpt-5-nano` for readiness,
+  and offline implementation with live verification deferred. The authorized live pass later
+  superseded the family alias with the three concrete Sol, Terra, and Luna variants.
 
 ## Post-commit review remediation
 
@@ -112,3 +113,63 @@ non-streaming, Chat Completions-only, globally cache-bypassed, and usage-account
   the documented append-only exception.
 - **Status:** the live-test scaffold is complete. Release remains blocked until an owner-authorized
   real-key run executes it; no production readiness behavior was guessed or changed.
+
+## Authorized live verification and readiness remediation
+
+- **Intent:** resolve the readiness false negative from owner-authorized live evidence while keeping
+  validation quota and latency bounded.
+- **Observed evidence:** the first live run timed out during the authentication stage; a direct safe
+  probe then returned `GET /v1/models` HTTP 200 with the expected list shape. The next live run
+  reached readiness and returned `unavailable`. A diagnostic request with
+  `max_completion_tokens: 1` returned HTTP 400 `invalid_request_error` before generation, while the
+  same request with `16` returned HTTP 200 `chat.completion`, `finish_reason: length`, an empty
+  string `content`, and exactly 16 reasoning/completion tokens. No raw provider message, prompt,
+  credential, organization, or project identity was recorded.
+- **Seed evidence:** the original eleven non-alias IDs were visible in `/v1/models`; `gpt-5.6` was
+  absent and its retrieve endpoint returned `404 model_not_found`, but Chat Completions accepted the
+  alias and returned concrete model `gpt-5.6-sol`. The live catalog lists
+  `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, and locked LiteLLM 1.95.0 classifies all three
+  as OpenAI chat models. Owner decision: replace the alias with those three concrete variants,
+  yielding fourteen visible seeds and explicit capability/cost choices.
+- **Final-wire evidence:** the first end-to-end gateway route reached OpenAI but returned sanitized
+  HTTP 400. Direct Luna dispatch passed; production-plugin dispatch failed. Offline capture proved
+  LiteLLM emitted `ssl_verify: true` inside the provider JSON, and a bounded direct request with that
+  field returned HTTP 400 `unknown_parameter` for `ssl_verify`. Removing the body control preserved
+  TLS on the owned `httpx.AsyncClient(verify=True, trust_env=False)` and made the route pass.
+- **Planned changes:** retain the bounded readiness parameter, set its live-verified budget to 16,
+  update the exact wire-contract assertion, and pin the observed empty-string length response as a
+  valid readiness result. Replace the `gpt-5.6` family alias with the three live-listed concrete
+  variants and update catalog/dispatch/persistence contracts. Do not remove the budget or widen any
+  error tuple.
+- **Test plan:** run the focused validator tests, rerun the owner-gated live test, then run the full
+  AIGateway gate with the existing append-only exception.
+- **Acceptance:** the production validator sends `max_completion_tokens: 16`, accepts the observed
+  structurally valid empty-string completion, the live test reaches `VALID` at `READINESS`, no key is
+  exposed, and all non-live gates remain green.
+
+### Authorized live-remediation outcome
+
+- **Actual files:**
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py`
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/api_key_validation.py`
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/settings.py`
+  - `apps/aigateway/tests/live/test_openai_live.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_api_key_validation.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_dispatch.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_gateway_acceptance.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_persistence.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_provider.py`
+  - `docs/plan/2026-08-17-OME-864-direct-openai-provider.md`
+  - `docs/spec/2026-08-17-OME-864-direct-openai-provider.md`
+  - `docs/tasks/2026-08-17-OME-864-direct-openai-provider.md`
+  - `docs/work/2026-08-17-OME-864-direct-openai-provider.md`
+- **Commits:** this live-remediation commit (`fix(aigateway): apply OpenAI live verification
+  fixes`).
+- **Checks:** validator unit suite `24 passed`; owner-gated readiness passed; end-to-end gateway route
+  passed; all fourteen concrete seeds passed the production-plugin sweep; focused OpenAI/Codex
+  regression `74 passed, 3 live deselected`; the pre-existing auth timing test flaked once and passed
+  in isolation; repeated full AIGateway lint, format, Pyright, no-enterprise, and coverage gates
+  green with the documented append-only exception.
+- **Status:** readiness and final-wire behavior are live-confirmed. All OME-864 code and
+  provider-verification gates are complete; no credential, raw provider message, prompt,
+  organization, or project identity was recorded.

--- a/docs/work/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/work/2026-08-17-OME-864-direct-openai-provider.md
@@ -56,6 +56,19 @@ non-streaming, Chat Completions-only, globally cache-bypassed, and usage-account
   `openai/gpt-5.5` and `openai/gpt-5.6`), `openai/gpt-5-nano` for readiness, and offline
   implementation now with live verification deferred.
 
+## Post-commit review remediation
+
+- **Intent:** close the confirmed missing-live-test finding without guessing the unresolved live
+  behavior of the reasoning-model readiness probe.
+- **Planned changes:** add an owner-gated OpenAI live test that exercises the production API-key
+  validator with `openai/gpt-5-nano`; make no production classifier, OpenRouter, core-port, or client
+  lifecycle change without separate evidence and scope.
+- **Test plan:** prove the test artifact is absent, add the live-marked test, verify it skips without
+  explicit authorization/credentials, then run focused OpenAI tests and the full AIGateway gate.
+- **Acceptance:** the test is collected only as `live`, skips unless `AIGW_LIVE=1` and a local
+  `OPENAI_API_KEY` are both present, consumes no quota in normal gates, reports only sanitized
+  validation state, and will fail if the current one-token reasoning probe rejects a valid key.
+
 ## Outcome (fill at the end - required before COMMIT)
 
 - **Actual files:**
@@ -73,8 +86,8 @@ non-streaming, Chat Completions-only, globally cache-bypassed, and usage-account
 - **Commits:** this OME-864 implementation commit (`feat(aigateway): add direct OpenAI API-key
   provider`)
 - **Gates:** baseline full gate green; final focused regression set 90 passed; final full AIGateway
-  lint, format, Pyright, no-enterprise, and coverage test gates green; independent final review found
-  no remaining correctness or security findings
+  lint, format, Pyright, no-enterprise, and coverage test gates green; final source audit found no
+  remaining correctness or security findings
 - **Deviations:**
   - Live seed/readiness verification is deferred by owner choice and remains the release blocker.
   - The append-only check is intentionally skipped for the one existing Codex namespace test whose
@@ -86,3 +99,16 @@ non-streaming, Chat Completions-only, globally cache-bypassed, and usage-account
     conservative classifier.
   - Exact evidence is not available for expired, permission-denied, or rate-limited OpenAI tuples;
     those public states stay explicit but unpromoted, and candidate responses return `unavailable`.
+
+### Post-commit live-test outcome
+
+- **Actual files:**
+  - `apps/aigateway/tests/live/test_openai_live.py`
+  - `docs/work/2026-08-17-OME-864-direct-openai-provider.md`
+- **Commits:** this follow-up commit (`test(aigateway): add OpenAI live readiness smoke`).
+- **Checks:** missing-file RED confirmed; one live test collected; no-authorization and no-key paths
+  each skipped without a network call; focused OpenAI/Codex regression `71 passed, 1 deselected`;
+  isolated pre-existing auth timing failure passed on rerun; repeated full AIGateway gate green with
+  the documented append-only exception.
+- **Status:** the live-test scaffold is complete. Release remains blocked until an owner-authorized
+  real-key run executes it; no production readiness behavior was guessed or changed.

--- a/docs/work/2026-08-17-OME-864-direct-openai-provider.md
+++ b/docs/work/2026-08-17-OME-864-direct-openai-provider.md
@@ -1,0 +1,88 @@
+---
+ticket: OME-864
+stack: aigateway
+status: blocked
+started: 2026-08-17
+finished:
+---
+
+# OME-864 - Direct OpenAI Platform API-key provider
+
+## Intent
+
+Add direct, account-scoped OpenAI Platform API-key dispatch under `openai/*` while preserving the
+existing `codex/*` OAuth and `openrouter/openai/*` routes. The P0 increment is seed-only,
+non-streaming, Chat Completions-only, globally cache-bypassed, and usage-accounting unsupported.
+
+## Planned changes
+
+- Add `apps/aigateway/src/aigateway/plugins/openai_provider/` with settings, parameter contract,
+  two-stage API-key validation, request isolation, and plugin composition.
+- Add focused tests under `apps/aigateway/tests/unit/openai/` and an opt-in live test.
+- Strengthen `apps/aigateway/tests/unit/core/test_codex_namespace_guard.py` to prove independent
+  `codex/*` and `openai/*` ownership.
+- Reuse generic profile/connection persistence without schema, migration, dependency, or core-route
+  changes.
+
+## Test plan
+
+- RED first for plugin discovery, seed registration, API-key-only capability, `max_tokens` rule,
+  bypass disposition, observation evidence, and namespace ownership.
+- RED for bounded authentication/readiness validation and conservative typed-error classification.
+- RED for request-local `AsyncOpenAI`, official endpoint, selected key, ambient-header suppression,
+  Responses-bridge skip, retry/cache controls, client closure, and sanitized failures.
+- RED for global `CacheBypass`, unsupported accounting, and both generic API-key persistence paths.
+- Run focused suites, append-only verification, and the complete AIGateway gate.
+
+## Acceptance
+
+- The auto-discovered `openai` plugin serves only approved seeds and exposes API-key auth.
+- `max_tokens` is the only enabled P0 optional field and is evidenced under both upstream wire names.
+- Every dispatch remains on the official non-streaming Chat Completions endpoint with only the
+  selected account key and no ambient organization/project/custom-header influence.
+- Profile and API-key connection create/replace/select/delete flows preserve encryption,
+  transactions, account isolation, and old state on failed replacement.
+- OpenAI performs no AIGateway global-cache read/write and publishes no fabricated accounting.
+- Existing providers remain green and the complete AIGateway gate passes.
+
+## Process decisions
+
+- Owner authorized implementation in the current checkout on branch
+  `OME-864-direct-openai-provider`; no worktree is used.
+- Owner instructed that Linear remain unchanged during this increment, so its status is not moved.
+- `OPENAI_API_KEY` is currently unavailable locally. Live seed/readiness verification remains a
+  release blocker unless the owner later supplies a safe local key and spend authorization.
+- Owner selected the twelve-model seed documented in the canonical spec (the reviewed ten plus
+  `openai/gpt-5.5` and `openai/gpt-5.6`), `openai/gpt-5-nano` for readiness, and offline
+  implementation now with live verification deferred.
+
+## Outcome (fill at the end - required before COMMIT)
+
+- **Actual files:**
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/__init__.py`
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/api_key_validation.py`
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/parameters.py`
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py`
+  - `apps/aigateway/src/aigateway/plugins/openai_provider/settings.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_api_key_validation.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_dispatch.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_gateway_acceptance.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_persistence.py`
+  - `apps/aigateway/tests/unit/openai/test_openai_provider.py`
+  - `apps/aigateway/tests/unit/core/test_codex_namespace_guard.py`
+- **Commits:** this OME-864 implementation commit (`feat(aigateway): add direct OpenAI API-key
+  provider`)
+- **Gates:** baseline full gate green; final focused regression set 90 passed; final full AIGateway
+  lint, format, Pyright, no-enterprise, and coverage test gates green; independent final review found
+  no remaining correctness or security findings
+- **Deviations:**
+  - Live seed/readiness verification is deferred by owner choice and remains the release blocker.
+  - The append-only check is intentionally skipped for the one existing Codex namespace test whose
+    old assertion prohibited the new provider by definition. The replacement strengthens the guard
+    to prove independent overlapping `codex/*` and `openai/*` ownership. Running the check without
+    that explicit exception fails only on this documented edit.
+  - A pre-guard test accidentally reached OpenAI once with a synthetic invalid key. It consumed no
+    account credential or inference spend and produced the bounded invalid-key tuple used by the
+    conservative classifier.
+  - Exact evidence is not available for expired, permission-denied, or rate-limited OpenAI tuples;
+    those public states stay explicit but unpromoted, and candidate responses return `unavailable`.


### PR DESCRIPTION
## Description

Adds a first-class direct OpenAI Platform provider under `openai/*` for account-scoped API-key access. This remains separate from the existing `codex/*` ChatGPT subscription/OAuth provider and `openrouter/openai/*` OpenRouter routing.

The initial provider is deliberately bounded to non-streaming Chat Completions and fourteen live-verified model IDs. It validates keys through bounded Models and readiness probes, stores credentials through the existing encrypted Tortoise-backed credential store, bypasses the global exact-response cache, disables retries and the Responses API bridge, pins the official OpenAI base URL, and rejects ambient LiteLLM/OpenAI state that could change routing or credential scope.

The existing Codex namespace guard is strengthened to prove that `codex/*` and `openai/*` coexist with independent ownership.

Refs: OME-864

## Affected Dependencies

No new dependencies. The implementation uses the already pinned OpenAI Python `2.53.0`, LiteLLM `1.95.0`, Tortoise ORM `1.1.7`, HTTPX, and existing AIGateway credential/profile infrastructure.

## How has this been tested?

- Full AIGateway lint, formatting, Pyright, no-enterprise, and coverage gates passed with the documented append-only exception for the strengthened Codex namespace test.
- Focused OpenAI/Codex regression suite: `74 passed, 3 live deselected`.
- Tortoise/OpenAI persistence, API-key strategy, profile/connection race, and migration smoke suite: `95 passed, 1 skipped`; the optional PostgreSQL testcontainers smoke was unavailable in the local environment.
- Owner-authorized live validation passed for readiness, all fourteen concrete model IDs, production-plugin Chat Completions dispatch, and an end-to-end AIGateway route.
- The rewritten branch merges cleanly with current `origin/main`, and `git diff --check origin/main...HEAD` passes.

Reproduction commands:

```bash
cd apps/aigateway
uv run python scripts/run_gates.py --skip-append-only
uv run pytest tests/unit/openai tests/unit/test_api_key_strategy.py tests/unit/test_connection_delete_set_race.py tests/unit/test_profile_delete_set_race.py tests/integration/test_tortoise_migration_smoke.py -q
```

Live verification is opt-in and requires an authorized OpenAI API key:

```bash
cd apps/aigateway
AIGW_LIVE=1 uv run pytest tests/live/test_openai_live.py -v -rs
```

## Checklist

- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
