### PR TITLE
fix(screamingface): render hosted providers as managed

### DIFF
--- a/docs/plan/2026-08-18-OME-883-hosted-provider-ui.md
+++ b/docs/plan/2026-08-18-OME-883-hosted-provider-ui.md
@@ -1,0 +1,8 @@
+# OME-883 — Implementation plan
+
+1. Append connection-panel tests proving hosted catalogue rows display managed availability with
+   no mutation controls while local loopback rows retain Connect and Disconnect.
+2. Deepen the existing connection-view rendering seam so hosted status language and control
+   suppression are decided in one place and shared by static and interactive views.
+3. Run the focused panel tests, then the full ScreamingFace stack gates.
+4. Record the exact outcome in the work ledger and open a draft PR.

--- a/docs/spec/2026-08-18-OME-883-hosted-provider-ui.md
+++ b/docs/spec/2026-08-18-OME-883-hosted-provider-ui.md
@@ -1,0 +1,26 @@
+# OME-883 — Hosted provider connection-panel behaviour
+
+## Decision
+
+The existing shared Engine-origin classifier is the temporary policy seam. Loopback origins
+(`localhost`, loopback IPs, and unspecified loopback-bound origins) retain BYOK controls. Every
+other origin is hosted and renders provider availability without Connect, Disconnect, API-key,
+OAuth, pending-flow, or cancellation controls.
+
+The Engine's provider catalogue is authoritative for managed availability on hosted origins.
+Every advertised hosted provider is presented as “Connected” and “Available via ScreamingFace”.
+The row's connection status is caller-scoped BYOK state and is deliberately ignored on hosted
+origins because it does not represent the operator-managed credential used for execution.
+
+## Invariants
+
+- Hosted classification is computed once by `_is_hosted_engine` and carried in panel state.
+- Hosted rendering never installs a credential-mutating widget callback.
+- Hosted rendering never exposes caller-scoped account labels or BYOK status.
+- Local rendering and programmatic `Client.connect()` / `disconnect()` remain unchanged.
+- Static HTML and interactive notebook rendering present the same hosted status language.
+
+## Explicit limitation
+
+This is a UI guard for the tester release, not a security boundary. Direct Engine connection
+requests remain possible until an Engine-owned policy is introduced.

--- a/docs/tasks/2026-08-18-OME-883-hosted-provider-ui.md
+++ b/docs/tasks/2026-08-18-OME-883-hosted-provider-ui.md
@@ -1,0 +1,19 @@
+---
+id: OME-883
+linear_url: https://linear.app/openmined/issue/OME-883/render-hosted-engine-provider-access-without-byok-controls-in
+status: In Review
+type: improvement
+priority: high
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-18
+closed:
+---
+
+# Render hosted Engine provider access without BYOK controls in `sf.connect()`
+
+Treat loopback Engine origins as local BYOK environments and other Engine origins as hosted
+environments in the notebook connection panel. Hosted provider rows retain the status reported
+by the Engine only for catalogue membership and expose no credential mutation controls. Every
+advertised hosted provider reads “Connected” and “Available via ScreamingFace”; caller-scoped
+BYOK status is ignored because it does not describe operator-managed credentials. The Engine and
+AI Gateway wire contracts are unchanged.

--- a/docs/work/2026-08-18-OME-883-hosted-provider-ui.md
+++ b/docs/work/2026-08-18-OME-883-hosted-provider-ui.md
@@ -1,0 +1,46 @@
+---
+ticket: OME-883
+stack: screamingface
+status: done
+started: 2026-08-18
+finished: 2026-08-18
+---
+
+# OME-883 — Hosted provider connection-panel behaviour
+
+## Intent
+
+Make `sf.connect()` reflect the tester-release credential policy: local Engines expose BYOK,
+while hosted Engines show every advertised provider as managed by ScreamingFace without
+credential mutation controls.
+
+## Planned changes
+
+- `src/screamingface/_ui/connection_view.py` — hosted status presentation and control suppression.
+- `tests/test_connection_panel.py` — local/hosted static and interactive regression coverage.
+- `docs/{tasks,spec,plan,work}/` — required OME-883 artifacts.
+
+## Test plan
+
+- Hosted provider, regardless of caller-scoped BYOK status: “Connected” and “Available via
+  ScreamingFace”; no provider button.
+- Local loopback provider: existing Connect/Disconnect controls remain.
+- Static HTML uses the same hosted labels.
+
+## Acceptance
+
+- Hosted notebook users cannot initiate or remove BYOK connections from the panel.
+- Local notebook users retain the current connection flow.
+- ScreamingFace gates are green.
+
+## Outcome
+
+- **Actual files:** connection panel state/controller/view, focused panel tests, and the required
+  OME-883 task/spec/plan/work artifacts.
+- **Commits:** this implementation commit — disable hosted provider credential controls.
+- **Gates:** `run_gates.py screamingface --skip-append-only` — all gates green; focused connection
+  panel suite — 22 passed.
+- **Deviations:** the live hosted check showed that connection status is caller-scoped BYOK state,
+  so hosted catalogue rows all render as managed availability instead of exposing that status.
+  The append-only override covers two intentional inherited assertion changes and must be
+  disclosed in the PR description.

--- a/packages/screamingface/src/screamingface/_ui/connection_state.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_state.py
@@ -17,6 +17,7 @@ class _ConnectionPanelState:
 
     hosted: bool
     engine_url: str
+    provider_mutations_enabled: bool
     connections: tuple[Connection, ...] = ()
     notice: str | None = None
     access_pending: bool = False

--- a/packages/screamingface/src/screamingface/_ui/connection_view.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_view.py
@@ -166,7 +166,10 @@ def static_panel_html(
         if state.hosted
         else ""
     )
-    rows = "".join(_static_row(item) for item in state.connections)
+    rows = "".join(
+        _static_row(item, provider_mutations_enabled=state.provider_mutations_enabled)
+        for item in state.connections
+    )
     table = (
         f"<div class='sf-conn-tbl'>{_column_head_html()}{access}{rows}</div>"
         if (access or rows)
@@ -258,7 +261,12 @@ class _NotebookConnectionView:
 
     def _interactive_row(self, connection: Connection):
         widgets = self._widgets
-        meta = widgets.HTML(value=_meta_html(connection))
+        meta = widgets.HTML(
+            value=_meta_html(
+                connection,
+                provider_mutations_enabled=self._state.provider_mutations_enabled,
+            )
+        )
         meta.layout.flex = "1 1 auto"
         meta.layout.min_width = "0"
         return self._row(meta, self._controls_for(connection))
@@ -275,7 +283,9 @@ class _NotebookConnectionView:
         return row
 
     def _controls_for(self, connection: Connection) -> list[Any]:
-        if connection.provider in self._state.flows:
+        if not self._state.provider_mutations_enabled:
+            controls = []
+        elif connection.provider in self._state.flows:
             controls = self._oauth_controls(connection)
         elif connection.status == "pending":
             controls = self._pending_controls(connection)
@@ -397,20 +407,49 @@ def _source_html(text: str | None) -> str:
     return f"<span class='sf-connections__source'>{escape(text) if text else '—'}</span>"
 
 
-def _meta_html(connection: Connection) -> str:
+def _provider_presentation(
+    connection: Connection,
+    *,
+    provider_mutations_enabled: bool,
+) -> tuple[str, str | None]:
+    status = _provider_status(
+        connection,
+        provider_mutations_enabled=provider_mutations_enabled,
+    )
+    if provider_mutations_enabled:
+        return status, connection.account_label
+    # On a hosted Engine the connection rows are caller-scoped BYOK state, not the
+    # operator-managed credentials used for execution. Every provider the hosted Engine
+    # advertises is therefore presented as managed availability; its caller status must not
+    # make a deployment credential look unavailable.
+    return status, "Available via ScreamingFace"
+
+
+def _provider_status(connection: Connection, *, provider_mutations_enabled: bool) -> str:
+    return connection.status if provider_mutations_enabled else "connected"
+
+
+def _meta_html(connection: Connection, *, provider_mutations_enabled: bool) -> str:
+    status, source = _provider_presentation(
+        connection,
+        provider_mutations_enabled=provider_mutations_enabled,
+    )
     return (
         "<div class='sf-connections__meta'>"
         "<span class='sf-conn-prov'>"
         f"{_icon_html(connection.provider, connection.display_name)}"
         f"<span class='sf-connections__provider'>{escape(connection.display_name)}</span>"
         "</span>"
-        f"{_status_html(connection.status)}"
-        f"{_source_html(connection.account_label)}</div>"
+        f"{_status_html(status)}"
+        f"{_source_html(source)}</div>"
     )
 
 
-def _static_row(connection: Connection) -> str:
-    return f"<div class='sf-connections__row'>{_meta_html(connection)}</div>"
+def _static_row(connection: Connection, *, provider_mutations_enabled: bool) -> str:
+    return (
+        "<div class='sf-connections__row'>"
+        f"{_meta_html(connection, provider_mutations_enabled=provider_mutations_enabled)}</div>"
+    )
 
 
 def _screaming_mark_html() -> str:

--- a/packages/screamingface/src/screamingface/_ui/connections.py
+++ b/packages/screamingface/src/screamingface/_ui/connections.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
 from screamingface._ui.connection_state import _ConnectionPanelState, _user_message
 from screamingface._ui.connection_view import (
     _NotebookConnectionView,
+    _provider_status,
     static_panel_html,
 )
 from screamingface._ui.engine_origin import _is_hosted_engine
@@ -82,6 +83,10 @@ class ConnectionPanel:
         self._state = _ConnectionPanelState(
             hosted=hosted,
             engine_url=client.engine_url,
+            # Temporary tester-release policy: only a loopback Engine exposes BYOK controls.
+            # Keep this separate from `hosted`, which may later be cleared when a remote Engine
+            # reports that it does not require Cloudflare Access.
+            provider_mutations_enabled=not hosted,
             access_check_pending=(
                 hosted
                 and not client.authenticated
@@ -152,7 +157,12 @@ class ConnectionPanel:
         display(self.widget())
 
     def __repr__(self) -> str:
-        statuses = ", ".join(f"{item.provider}={item.status}" for item in self._state.connections)
+        provider_mutations_enabled = self._state.provider_mutations_enabled
+        statuses = ", ".join(
+            f"{item.provider}="
+            f"{_provider_status(item, provider_mutations_enabled=provider_mutations_enabled)}"
+            for item in self._state.connections
+        )
         access = (
             f", access={'authenticated' if self._client.authenticated else 'login_required'}"
             if self._state.hosted

--- a/packages/screamingface/tests/test_connection_panel.py
+++ b/packages/screamingface/tests/test_connection_panel.py
@@ -542,7 +542,7 @@ def test_hosted_panel_prompts_for_engine_login_before_loading_providers() -> Non
     assert client.connections.calls == 1
     assert panel.connections == (connection,)
     assert "authenticated" in _text(root)
-    assert [button.description for button in _buttons(root)] == ["Log out", "Connect"]
+    assert [button.description for button in _buttons(root)] == ["Log out"]
 
     _button(root, "Log out").click()
 
@@ -810,7 +810,7 @@ async def test_unprotected_remote_engine_skips_the_access_login_row() -> None:
 
     assert "Hosted Engine" not in _text(root)
     assert "OpenRouter" in _text(root)
-    assert [button.description for button in _buttons(root)] == ["Connect"]
+    assert [button.description for button in _buttons(root)] == []
     root.close()
 
 
@@ -856,4 +856,82 @@ def test_non_screamingface_hosted_engine_shows_a_neutral_label_without_the_mark(
     assert "ScreamingFace Hosted Engine" not in text
     assert "😱" not in text
     assert "login required" in text
+    root.close()
+
+
+def test_authenticated_hosted_provider_rows_show_managed_availability_without_controls() -> None:
+    connected = sf.Connection(
+        provider="openrouter",
+        display_name="OpenRouter",
+        auth_methods=("api_key",),
+        status="connected",
+        auth_method="api_key",
+        account_label="private-account@example.com",
+    )
+    caller_disconnected = sf.Connection(
+        provider="anthropic",
+        display_name="Anthropic",
+        auth_methods=("api_key", "oauth"),
+        status="not_connected",
+        auth_method=None,
+        account_label=None,
+    )
+
+    class Connections:
+        def list(self) -> tuple[sf.Connection, ...]:
+            return (connected, caller_disconnected)
+
+    class HostedClient:
+        engine_url = "https://fusion.dev.screamingface.ai"
+        authenticated = True
+        authenticating = False
+        connections = Connections()
+
+    panel = _panel(HostedClient())
+    root = panel.widget()
+
+    text = _text(root)
+    html = panel._repr_html_()
+    representation = repr(panel)
+    assert [button.description for button in _buttons(root)] == ["Log out"]
+    assert "Available via ScreamingFace" in text
+    assert "Available via ScreamingFace" in html
+    assert text.count("Connected") == 2
+    assert "unavailable" not in text
+    assert "unavailable" not in html
+    assert "private-account@example.com" not in text
+    assert "private-account@example.com" not in html
+    assert "openrouter=connected" in representation
+    assert "anthropic=connected" in representation
+    assert "not_connected" not in representation
+    root.close()
+
+
+@pytest.mark.parametrize("engine_url", ["http://localhost:9108", "http://[::1]:9108"])
+def test_loopback_provider_rows_keep_byok_controls(engine_url: str) -> None:
+    connection = sf.Connection(
+        provider="openrouter",
+        display_name="OpenRouter",
+        auth_methods=("api_key",),
+        status="not_connected",
+        auth_method=None,
+        account_label=None,
+    )
+
+    class Connections:
+        def list(self) -> tuple[sf.Connection, ...]:
+            return (connection,)
+
+    class LocalClient:
+        authenticated = False
+        authenticating = False
+        connections = Connections()
+
+        def __init__(self) -> None:
+            self.engine_url = engine_url
+
+    panel = _panel(LocalClient())
+    root = panel.widget()
+
+    assert [button.description for button in _buttons(root)] == ["Connect"]
     root.close()


### PR DESCRIPTION
## Summary

Render every provider advertised by a remote hosted Engine as managed ScreamingFace availability, while suppressing provider credential mutation controls. Loopback Engines retain the existing BYOK status and Connect/Disconnect flows.

**Linear:** https://linear.app/openmined/issue/OME-883/render-hosted-engine-provider-access-without-byok-controls-in

## Components touched

- packages/screamingface
- docs task/spec/plan/work artifacts for OME-883

## Test plan

- [x] Ran the full ScreamingFace gate: python3 .claude/scripts/run_gates.py screamingface --skip-append-only
- [x] Focused connection-panel suite: 22 passed
- [x] Manual notebook validation against both hosted and local Engines
- [x] Verified hosted providers render Connected / Available via ScreamingFace with no provider controls
- [x] Verified localhost and IPv6 loopback retain BYOK controls

## Append-only disclosure

The append-only check was intentionally skipped and is disclosed here because this policy change updates two inherited assertions: authenticated hosted Engines no longer show a provider Connect button, and unprotected remote Engines no longer re-enable one after the Access row disappears. All new behavior coverage was appended.

## Cross-service notes

Client-only tester-release policy. No Engine, AI Gateway, Scoreboard, or wire-contract changes. The current temporary rule treats loopback as BYOK and every provider advertised by a remote Engine as managed availability.
