### PR TITLE
fix(py-screamingface): raise local stack openrouter gateway concurrency to 32

### DIFF
--- a/apps/aigateway/src/aigateway/core/concurrency.py
+++ b/apps/aigateway/src/aigateway/core/concurrency.py
@@ -13,9 +13,12 @@ absorb).
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 def _provider_match_keys(provider: str) -> set[str]:
@@ -71,6 +74,12 @@ def _get_or_create_semaphore(app: Any, provider: str, limit: int) -> asyncio.Sem
         sem = asyncio.Semaphore(limit)
         sem._sf_limit = limit  # type: ignore[attr-defined]
         reg[provider] = sem
+        # WHY: the limit in force is otherwise invisible — a typo'd
+        # AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES silently falls back to the
+        # default and resurfaces as mystery queueing (OME-889). One line per
+        # provider per process (re-logged only on a limit change); structured
+        # admission telemetry is OME-886's territory.
+        logger.info("provider concurrency limit applied provider=%s limit=%d", provider, limit)
     return sem
 
 

--- a/apps/aigateway/src/aigateway/logs.py
+++ b/apps/aigateway/src/aigateway/logs.py
@@ -1,0 +1,59 @@
+"""Log configuration for the aigateway app logger tree.
+
+WHY this module exists: ``uvicorn.run()`` installs handlers for the
+``uvicorn*`` loggers ONLY and leaves the root logger with none. Every
+``aigateway.*`` record therefore fell through to ``logging.lastResort``,
+which emits at WARNING — so the gateway's INFO lines were discarded in every
+deployment that has ever run. Found via OME-889: the per-provider concurrency
+limit line (the operator's only proof of which limit is in force) never
+appeared in the stack log.
+
+Same defect, same cure as the Engine's ``screamingface_engine/logs.py`` —
+mirrored rather than shared because apps must not import each other's
+internals (a 30-line stdlib module does not justify a shared package).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TextIO
+
+APP_LOGGER = "aigateway"
+LEVEL_ENV = "AIGW_LOG_LEVEL"
+DEFAULT_LEVEL = "INFO"
+
+# Matches uvicorn's own column so a deployment's logs read as one stream rather than two.
+_FORMAT = "%(levelname)s:     %(name)s %(message)s"
+
+_INSTALLED = "_aigateway_log_handler"
+"""Marks the handler THIS module installed.
+
+Idempotence has to be about our own handler, not about the logger being empty:
+anything else may have attached one first — a test harness, a sidecar, an
+embedding process — and ``if not logger.handlers`` would then read that as
+"already configured" and install nothing at all. The failure is silent and
+looks exactly like the bug this module exists to fix.
+"""
+
+
+def configure(stream: TextIO | None = None) -> None:
+    """Give the ``aigateway`` logger tree its own handler and level.
+
+    Idempotent: a second call neither stacks handlers nor disturbs anyone
+    else's. ``propagate`` is disabled so that a later root configuration —
+    uvicorn's, a test harness's, a sidecar's — cannot turn every record into
+    two.
+    """
+
+    logger = logging.getLogger(APP_LOGGER)
+    logger.setLevel(os.getenv(LEVEL_ENV, DEFAULT_LEVEL).upper())
+    if not any(getattr(handler, _INSTALLED, False) for handler in logger.handlers):
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logging.Formatter(_FORMAT))
+        setattr(handler, _INSTALLED, True)
+        logger.addHandler(handler)
+    logger.propagate = False
+
+
+__all__ = ["APP_LOGGER", "DEFAULT_LEVEL", "LEVEL_ENV", "configure"]

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -15,6 +15,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from . import logs
 from .config import Settings
 from .core.api_key_validation_service import ApiKeyValidationService
 from .core.auth.bootstrap_admin import ensure_admin_account
@@ -328,6 +329,9 @@ def _describe_admin_security(app: FastAPI) -> None:
 def create_app(settings: Settings | None = None) -> FastAPI:
     if settings is None:
         settings = Settings()
+    # WHY ordered before _attach_log_filter: the redaction filter is added to
+    # the "aigateway" logger's handlers, so our handler must exist first.
+    logs.configure()
     _attach_log_filter()
     app = FastAPI(title="aigateway", version="0.1.0", lifespan=_lifespan)
     app.add_exception_handler(RequestValidationError, _redact_validation_errors)

--- a/apps/aigateway/tests/unit/test_concurrency.py
+++ b/apps/aigateway/tests/unit/test_concurrency.py
@@ -141,6 +141,52 @@ async def test_semaphore_is_keyed_per_provider() -> None:
     await blocker_task
 
 
+# STORY: as an operator raising AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES (OME-889),
+# I need the gateway log itself to prove which limit is in force — a typo'd env
+# var silently falls back to the default and reappears as mystery queueing.
+@pytest.mark.asyncio
+async def test_semaphore_creation_logs_effective_limit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = _app()
+    with caplog.at_level("INFO", logger="aigateway.core.concurrency"):
+        async with provider_slot(app, "openrouter", 32):
+            pass
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("provider=openrouter" in m and "limit=32" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_reacquisition_at_same_limit_does_not_log_again(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """INVARIANT: one line per provider per process — the log marks a limit
+    taking effect, never per-request traffic."""
+    app = _app()
+    async with provider_slot(app, "openrouter", 32):
+        pass
+    with caplog.at_level("INFO", logger="aigateway.core.concurrency"):
+        async with provider_slot(app, "openrouter", 32):
+            pass
+    assert not caplog.records
+
+
+@pytest.mark.asyncio
+async def test_limit_change_logs_new_limit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """INVARIANT: the latest logged limit is the limit in force — a rebuild
+    (config change) must re-announce itself."""
+    app = _app()
+    async with provider_slot(app, "openrouter", 4):
+        pass
+    with caplog.at_level("INFO", logger="aigateway.core.concurrency"):
+        async with provider_slot(app, "openrouter", 32):
+            pass
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("provider=openrouter" in m and "limit=32" in m for m in messages)
+
+
 @pytest.mark.asyncio
 async def test_limit_change_replaces_semaphore() -> None:
     """If the configured limit changes (e.g. settings hot-reload) the next

--- a/apps/aigateway/tests/unit/test_concurrency.py
+++ b/apps/aigateway/tests/unit/test_concurrency.py
@@ -165,10 +165,13 @@ async def test_reacquisition_at_same_limit_does_not_log_again(
     app = _app()
     async with provider_slot(app, "openrouter", 32):
         pass
+    # WHY clear: caplog accumulates from test start, so the first (legitimate)
+    # creation log would trip the assertion once the app logger runs at INFO.
+    caplog.clear()
     with caplog.at_level("INFO", logger="aigateway.core.concurrency"):
         async with provider_slot(app, "openrouter", 32):
             pass
-    assert not caplog.records
+    assert not [r for r in caplog.records if r.name == "aigateway.core.concurrency"]
 
 
 @pytest.mark.asyncio

--- a/apps/aigateway/tests/unit/test_logs.py
+++ b/apps/aigateway/tests/unit/test_logs.py
@@ -1,0 +1,88 @@
+"""Tests for the aigateway app-logger configuration.
+
+WHY this exists: ``uvicorn.run()`` installs handlers for the ``uvicorn*``
+loggers only. Without our own configuration every ``aigateway.*`` record
+falls through to ``logging.lastResort``, which emits at WARNING — so all
+INFO-level operational evidence (e.g. the per-provider concurrency limit,
+OME-889) was silently discarded in every real deployment.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from aigateway import logs
+from aigateway.core.concurrency import provider_slot
+
+
+def _detach_installed_handlers() -> None:
+    logger = logging.getLogger(logs.APP_LOGGER)
+    for handler in list(logger.handlers):
+        if getattr(handler, logs._INSTALLED, False):
+            logger.removeHandler(handler)
+    logger.setLevel(logging.NOTSET)
+    logger.propagate = True
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_logger() -> Iterator[None]:
+    """Detach handlers this module installed — BEFORE each test too: any earlier
+    test that built the app via ``create_app()`` already ran ``configure()``,
+    and the idempotence guard would then (correctly) refuse to install this
+    test's stream handler."""
+    _detach_installed_handlers()
+    yield
+    _detach_installed_handlers()
+
+
+def test_configure_makes_info_records_visible() -> None:
+    """INVARIANT: an INFO record from any aigateway.* module reaches the
+    stream — the exact failure mode being fixed is INFO falling through to
+    lastResort (WARNING+) and vanishing."""
+    stream = io.StringIO()
+    logs.configure(stream)
+    logging.getLogger("aigateway.core.concurrency").info("hello info=1")
+    assert "hello info=1" in stream.getvalue()
+
+
+def test_configure_level_env_is_honored(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(logs.LEVEL_ENV, "WARNING")
+    stream = io.StringIO()
+    logs.configure(stream)
+    logging.getLogger("aigateway.core.concurrency").info("quiet info")
+    assert stream.getvalue() == ""
+
+
+def test_configure_is_idempotent() -> None:
+    """INVARIANT: a second configure (create_app called twice, tests) must not
+    stack handlers and double every log line."""
+    stream = io.StringIO()
+    logs.configure(stream)
+    logs.configure(stream)
+    logging.getLogger(logs.APP_LOGGER).info("once")
+    assert stream.getvalue().count("once") == 1
+
+
+def test_configure_disables_propagation() -> None:
+    """A later root/uvicorn configuration must not duplicate our records."""
+    logs.configure(io.StringIO())
+    assert logging.getLogger(logs.APP_LOGGER).propagate is False
+
+
+# STORY: as an operator tailing aigateway.log after OME-889, the first
+# OpenRouter call must actually print the limit in force — this is the
+# end-to-end proof caplog-based tests could not give.
+@pytest.mark.asyncio
+async def test_concurrency_limit_line_reaches_configured_stream() -> None:
+    from types import SimpleNamespace
+
+    stream = io.StringIO()
+    logs.configure(stream)
+    app = SimpleNamespace(state=SimpleNamespace())
+    async with provider_slot(app, "openrouter", 32):
+        pass
+    assert "provider concurrency limit applied provider=openrouter limit=32" in stream.getvalue()

--- a/docs/tasks/2026-08-19-stack-openrouter-concurrency.md
+++ b/docs/tasks/2026-08-19-stack-openrouter-concurrency.md
@@ -17,7 +17,10 @@ Engine evaluation fans out up to 32; queued calls burn the Engine's 600s per-cal
 inside the gateway's semaphore and die without ever reaching OpenRouter.
 
 Change: one env line in the gateway launch block of `packages/screamingface/justfile` —
-`AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES='{"openrouter": 32}'`.
+`AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES='{"openrouter": 32}'` — plus (owner-directed,
+replacing canceled OME-891) an INFO log in `aigateway/core/concurrency.py` announcing the
+limit each provider's semaphore is created with, so the gateway log proves the limit in
+force.
 
 Out of scope: hosted deployments (operator action via the aigateway chart's `extraEnv`),
 the gateway code default, and the 600s timeout itself. Long-term fix: `OME-886`.

--- a/docs/tasks/2026-08-19-stack-openrouter-concurrency.md
+++ b/docs/tasks/2026-08-19-stack-openrouter-concurrency.md
@@ -1,0 +1,25 @@
+---
+id: OME-889
+linear_url: https://linear.app/openmined/issue/OME-889/raise-the-local-stacks-openrouter-gateway-concurrency-to-match-the
+status: in_progress
+type: task
+priority: high
+labels: [py-screamingface, agentic, autonomous, task]
+created: 2026-08-19
+closed:
+---
+
+# Raise the local stack's OpenRouter gateway concurrency to match the Engine's 32-call fan-out
+
+Short-term unblock for the admission-queue timeouts `OME-886` diagnoses. `just stack-up`
+launches the AI Gateway at its code default of 4 concurrent calls per provider while one
+Engine evaluation fans out up to 32; queued calls burn the Engine's 600s per-call budget
+inside the gateway's semaphore and die without ever reaching OpenRouter.
+
+Change: one env line in the gateway launch block of `packages/screamingface/justfile` —
+`AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES='{"openrouter": 32}'`.
+
+Out of scope: hosted deployments (operator action via the aigateway chart's `extraEnv`),
+the gateway code default, and the 600s timeout itself. Long-term fix: `OME-886`.
+
+Ledger: `docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md`

--- a/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
+++ b/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
@@ -54,7 +54,7 @@ single run's worst-case fan-out removes the queue entirely.
   `docs/tasks/` mirror + (owner-directed addition) `apps/aigateway/src/aigateway/core/
   concurrency.py` and `apps/aigateway/tests/unit/test_concurrency.py`.
 - **Commits:** 0b5d4dc8 — fix(py-screamingface): raise local stack openrouter gateway
-  concurrency to 32; 48779683 — feat(aigateway): log the concurrency limit applied per
+  concurrency to 32; 9689fac4 — feat(aigateway): log the concurrency limit applied per
   provider.
 - **Gates:** justfile env verified through the real settings parser
   (`effective_provider_limit("openrouter") == 32`, others 4). Log line: TDD (3 appended

--- a/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
+++ b/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
@@ -61,7 +61,10 @@ single run's worst-case fan-out removes the queue entirely.
   concurrency.py` and `apps/aigateway/tests/unit/test_concurrency.py`.
 - **Commits:** 0b5d4dc8 — fix(py-screamingface): raise local stack openrouter gateway
   concurrency to 32; 9689fac4 — feat(aigateway): log the concurrency limit applied per
-  provider.
+  provider; e0766e22 — fix(aigateway): configure app logging so INFO records actually
+  emit (live test showed the line missing: uvicorn leaves the root logger handler-less,
+  so all aigateway.* INFO fell through to lastResort at WARNING; mirrored the engine's
+  logs.py).
 - **Gates:** justfile env verified through the real settings parser
   (`effective_provider_limit("openrouter") == 32`, others 4). Log line: TDD (3 appended
   tests, RED first) + `run_gates.py aigateway` ALL GREEN (ruff check/format, pyright,

--- a/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
+++ b/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
@@ -1,0 +1,49 @@
+---
+ticket: OME-889
+stack: repo
+status: done
+started: 2026-08-19
+finished: 2026-08-19
+---
+
+# OME-889 — Raise the local stack's OpenRouter gateway concurrency to match the Engine's 32-call fan-out
+
+## Intent
+
+Short-term unblock for the ~600s eval failures `OME-886` diagnoses: one Engine run fans out
+up to 32 concurrent model calls (`DEFAULT_RUN_CONCURRENCY`, `packages/url4/src/url4/dag/node.py`),
+but the local stack launches the gateway at its code default of 4 concurrent calls per
+provider. Queued calls wait inside the gateway's semaphore with no admission deadline and
+burn the Engine's 600s per-call HTTP budget — full local HealthBench evals die at ~600.1s on
+calls that never reached OpenRouter. Matching the local gateway's OpenRouter admission to a
+single run's worst-case fan-out removes the queue entirely.
+
+## Planned changes
+
+- `packages/screamingface/justfile` — add
+  `AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES='{"openrouter": 32}'` to the gateway launch env
+  in `stack-up`, with a WHY comment. No other files.
+
+## Test plan
+
+- No test harness covers the justfile (shell recipe, env-line only). Verification is
+  behavioral: `just stack-up`, then confirm the gateway process env carries the override
+  (`ps eww <pid>` / log line) — the invariant protected is "local gateway admits ≥ one run's
+  full fan-out for openrouter".
+
+## Acceptance
+
+- `stack-up` launches the gateway with the openrouter override set to 32; other providers
+  keep the default of 4; recipe behavior otherwise unchanged.
+- PR open, CI green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `packages/screamingface/justfile` (as planned) + this ledger + the
+  `docs/tasks/` mirror.
+- **Commits:** 0b5d4dc8 — fix(py-screamingface): raise local stack openrouter gateway
+  concurrency to 32
+- **Gates:** no justfile test harness; verified by parsing the env through the real gateway
+  settings: `Settings()` with the override yields `effective_provider_limit(s, "openrouter")
+  == 32` and `effective_provider_limit(s, "gemini") == 4`. Pre-commit hooks passed.
+- **Deviations:** none.

--- a/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
+++ b/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
@@ -22,7 +22,13 @@ single run's worst-case fan-out removes the queue entirely.
 
 - `packages/screamingface/justfile` — add
   `AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES='{"openrouter": 32}'` to the gateway launch env
-  in `stack-up`, with a WHY comment. No other files.
+  in `stack-up`, with a WHY comment.
+- (owner-directed scope addition, replacing canceled `OME-891`)
+  `apps/aigateway/src/aigateway/core/concurrency.py` — INFO log when a provider's
+  semaphore is created/rebuilt, so the gateway log itself proves which limit is in force:
+  `provider concurrency limit applied provider=openrouter limit=32`. Once per provider per
+  process; re-logged only when the configured limit changes. Structured admission telemetry
+  stays with `OME-886`.
 
 ## Test plan
 
@@ -30,6 +36,11 @@ single run's worst-case fan-out removes the queue entirely.
   behavioral: `just stack-up`, then confirm the gateway process env carries the override
   (`ps eww <pid>` / log line) — the invariant protected is "local gateway admits ≥ one run's
   full fan-out for openrouter".
+- Log line (append-only additions to `apps/aigateway/tests/unit/test_concurrency.py`):
+  (1) first acquisition for a provider logs provider + effective limit at INFO;
+  (2) re-acquisition at the same limit does NOT log again (no per-request noise);
+  (3) a limit change logs the new limit (invariant: the log always reflects the limit in
+  force). Gates: full aigateway stack via `run_gates.py aigateway`.
 
 ## Acceptance
 
@@ -40,10 +51,14 @@ single run's worst-case fan-out removes the queue entirely.
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** `packages/screamingface/justfile` (as planned) + this ledger + the
-  `docs/tasks/` mirror.
+  `docs/tasks/` mirror + (owner-directed addition) `apps/aigateway/src/aigateway/core/
+  concurrency.py` and `apps/aigateway/tests/unit/test_concurrency.py`.
 - **Commits:** 0b5d4dc8 — fix(py-screamingface): raise local stack openrouter gateway
-  concurrency to 32
-- **Gates:** no justfile test harness; verified by parsing the env through the real gateway
-  settings: `Settings()` with the override yields `effective_provider_limit(s, "openrouter")
-  == 32` and `effective_provider_limit(s, "gemini") == 4`. Pre-commit hooks passed.
-- **Deviations:** none.
+  concurrency to 32; 48779683 — feat(aigateway): log the concurrency limit applied per
+  provider.
+- **Gates:** justfile env verified through the real settings parser
+  (`effective_provider_limit("openrouter") == 32`, others 4). Log line: TDD (3 appended
+  tests, RED first) + `run_gates.py aigateway` ALL GREEN (ruff check/format, pyright,
+  no-enterprise check, pytest cov≥80, append-only test check).
+- **Deviations:** scope grew by owner decision — the observability log line originally
+  filed as `OME-891` was folded in here and `OME-891` canceled.

--- a/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
+++ b/docs/work/2026-08-19-OME-889-stack-openrouter-concurrency.md
@@ -29,6 +29,12 @@ single run's worst-case fan-out removes the queue entirely.
   `provider concurrency limit applied provider=openrouter limit=32`. Once per provider per
   process; re-logged only when the configured limit changes. Structured admission telemetry
   stays with `OME-886`.
+- `apps/aigateway/src/aigateway/logs.py` (new) + `create_app()` wiring in `main.py` —
+  found live-testing the log line: aigateway never configures app logging, so every
+  `aigateway.*` INFO record fell through to `logging.lastResort` (WARNING+) and was
+  discarded in every deployment. Same defect the engine fixed in
+  `screamingface_engine/logs.py`; mirrored here (apps must not import each other's
+  internals). `AIGW_LOG_LEVEL` env, default INFO, idempotent handler, propagate off.
 
 ## Test plan
 

--- a/packages/screamingface/justfile
+++ b/packages/screamingface/justfile
@@ -122,10 +122,16 @@ stack-up:
         # OPENROUTER_ENABLED is REQUIRED too: the provider plugin defaults to disabled,
         # Without it the Gateway catalog contains no openrouter/* models. The Engine projects
         # that caller-visible catalog onto its declared routes; it does not fabricate providers.
+        # CONCURRENCY override: one Engine run fans out up to 32 concurrent model calls
+        # (url4 DEFAULT_RUN_CONCURRENCY) but the gateway's per-provider default admits 4;
+        # queued calls wait inside the gateway with no admission deadline and burn the
+        # Engine's 600s per-call budget, so full HealthBench evals die at ~600s on calls
+        # that never reached OpenRouter (OME-889; long-term admission fix: OME-886).
         (
             cd {{repo}}/apps/aigateway
             AIGATEWAY_AUTH_ENABLED=false AIGATEWAY_BOOTSTRAP_FROM_CLAUDE_CODE=1 \
                 AIGW_OPENROUTER_ENABLED=true \
+                AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES='{"openrouter": 32}' \
                 nohup .venv/bin/uvicorn aigateway.main:app --port 9105 \
                 >{{rundir}}/aigateway.log 2>&1 &
             echo $! >{{rundir}}/aigateway.pid


### PR DESCRIPTION
Linear: [OME-889](https://linear.app/openmined/issue/OME-889) · related: OME-886 (long-term admission fix) · supersedes canceled OME-891

## Before / After

### Before
- Trigger: a researcher runs a full HealthBench eval (`limit` ≥ ~10) against the local stack.
- Today: 32 calls queue behind 4 gateway slots; queued calls hit the 600s budget without ever reaching OpenRouter; the eval dies after ~10 minutes with evidence that misleadingly blames provider latency — and the gateway log can't say anything at INFO, so there's nothing to grep.
- Cost: dead evals, wasted paid calls on the few that ran, and debugging time chasing OpenRouter instead of the queue.

### After
- Same trigger.
- Now: the local gateway admits 32 concurrent OpenRouter calls; nothing queues; the first OpenRouter call logs `provider concurrency limit applied provider=openrouter limit=32` — and INFO-level evidence from the gateway is visible at all, for the first time.
- Win: full local HealthBench evals complete, and one grep of `aigateway.log` answers "is the gateway really running at 32?"

### Don't regress
- Non-OpenRouter providers keep the default limit of 4 (override is openrouter-scoped).
- `stack-up` port-claim/adopt behavior unchanged — the env line only affects a freshly launched gateway.
- The limit log fires only when a limit takes effect (create/rebuild), never per request; provider name and integer limit only, no secrets — and the provisioning-token redaction filter attaches to the new handler.
- Operators who want today's quieter output set `AIGW_LOG_LEVEL=WARNING`.


## Summary

The local stack (`just stack-up`) launched the AI Gateway at its per-provider concurrency default of **4**, while one Engine evaluation fans out up to **32** concurrent model calls (url4 `DEFAULT_RUN_CONCURRENCY`). The gateway holds queued calls inside its provider semaphore with no admission deadline, so queue wait burns the Engine's 600s per-call HTTP budget — full local HealthBench evals failed at ~600.1s on calls that never reached OpenRouter.

Three changes:

1. **`stack-up` env**: `AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES='{"openrouter": 32}'` in the gateway launch block — matches local OpenRouter admission to a single run's worst-case fan-out. Other providers keep the default of 4.
2. **Gateway observability (owner-requested)**: one INFO line when a provider's semaphore is created or rebuilt — `provider concurrency limit applied provider=openrouter limit=32` — so the gateway log itself proves which limit is in force. Once per provider per process; no per-request noise. Structured admission telemetry (queue-wait/execution split) stays with OME-886.
3. **Gateway app-logging config (found live-testing #2)**: aigateway never configured logging for its own logger tree, so **every `aigateway.*` INFO record was silently discarded in every deployment that has ever run** — uvicorn installs handlers for its own loggers only, and everything else fell through to `logging.lastResort` (WARNING+). New `aigateway/logs.py` mirrors the engine's identical fix (`screamingface_engine/logs.py`): own handler in uvicorn's format, default INFO, `AIGW_LOG_LEVEL` override, idempotent, propagation off; wired in `create_app()` before the redaction filter so secrets redaction covers the new handler.

Deliberately **not** touched: the gateway code default, chart defaults for hosted deploys (operator action via `extraEnv`; hosted story owned by OME-886), and the 600s timeout itself.

## Test plan

- **Env line**: verified through the real settings parser — `Settings()` with the override yields `effective_provider_limit('openrouter') == 32` and `effective_provider_limit('gemini') == 4`.
- **Limit log**: TDD, three tests appended to `tests/unit/test_concurrency.py` (RED first): first acquisition logs provider+limit at INFO; re-acquisition at the same limit stays silent; a limit change re-announces the new limit.
- **Logging config**: TDD, five tests in new `tests/unit/test_logs.py`, including the end-to-end assertion the caplog tests couldn't make — the concurrency line actually reaches a configured output stream. Level env honored, idempotent (no doubled lines), propagation off.
- **Live**: reproduced the gap on the running stack first (line absent from `aigateway.log` despite 200-OK chat completions), which is what surfaced defect #3.
- **Gates**: `run_gates.py aigateway` ALL GREEN (ruff check/format, pyright, no-enterprise check, pytest with coverage ≥80 — 3530 passed, append-only test check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)