### PR TITLE
feat: deliver large Evaluation results in full instead of cutting them off at 1 MiB

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -7,6 +7,8 @@ tests substitute for the production ones built here from `Settings`.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import os
 from pathlib import Path
@@ -15,6 +17,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.staticfiles import StaticFiles
 
 from screamingface_engine.adapters.factory import build_job_runner
+from screamingface_engine.artifacts import ArtifactStore
 from screamingface_engine.auth import Clock, install_problem_handlers
 from screamingface_engine.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
 from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
@@ -28,6 +31,7 @@ from screamingface_engine.metrics import MetricsMiddleware, build_metrics, regis
 from screamingface_engine.ops import router as ops_router
 from screamingface_engine.rest import (
     SubscriberGate,
+    artifact_router,
     benchmark_router,
     catalog_router,
     connection_router,
@@ -47,6 +51,7 @@ _DIAGRAMS_DIR = Path(__file__).parent / "assets" / "diagrams"
 _ROUTERS = (
     router,
     rest_router,
+    artifact_router,
     benchmark_router,
     catalog_router,
     connection_router,
@@ -87,6 +92,15 @@ def create_app(
     app.state.connections = connections
     app.state.benchmarks = benchmarks
     app.state.metrics = build_metrics()
+    # FEATURE: deliver large results in full (OME-892) — the serve side of the spill store.
+    artifact_store = ArtifactStore(Path(settings.artifacts_dir))
+    app.state.artifact_store = artifact_store
+    # WHY startup + periodic: artifacts are deleted on fetch, so the only leak source is
+    # parcels nobody redeemed (crashed runs, vanished clients). The boot sweep clears the
+    # backlog immediately; the periodic task covers a hosted App that stays up for weeks
+    # between redeploys — startup-only would let abandoned parcels pool until the next
+    # restart (owner decision on OME-892).
+    _install_artifact_sweeper(app, artifact_store, settings)
     # WHY: pass a getter, not `catalog` directly — the collector re-reads app.state.catalog on
     # every /metrics scrape rather than capturing the value built here.
     register_catalog_metrics(app.state.metrics, lambda: app.state.catalog)
@@ -106,6 +120,48 @@ def create_app(
 
 # RFC 7518 §3.2: an HMAC key must be at least as long as the hash output — 32 bytes for SHA-256.
 # PyJWT warns below this; here it is refused, because the token is the whole authorization model.
+_logger = logging.getLogger(__name__)
+
+
+def _install_artifact_sweeper(app: FastAPI, store: ArtifactStore, settings: Settings) -> None:
+    """Wire the artifact TTL sweep: once at startup, then every sweep interval for life.
+
+    FEATURE: deliver large results in full (OME-892). The loop is an asyncio task on the
+    App's own event loop — cancelled at shutdown so no task outlives the App. The sweep
+    itself runs in a worker thread (`asyncio.to_thread`): it is directory I/O, and the
+    event loop that pumps every WebSocket must never block on a disk scan.
+    """
+
+    async def _sweep_once() -> None:
+        await asyncio.to_thread(store.sweep, ttl_seconds=settings.artifact_ttl_s)
+
+    async def _sweep_forever() -> None:
+        while True:
+            await asyncio.sleep(settings.artifact_sweep_interval_s)
+            # INVARIANT: one failed sweep must not kill the sweeper — an unhandled
+            # exception here would end the task silently and disk cleanup would stop
+            # until the next redeploy, exactly the leak the periodic sweep exists to
+            # prevent. Log and keep the cadence.
+            try:
+                await _sweep_once()
+            except Exception:
+                _logger.exception("artifact sweep failed; retrying next interval")
+
+    async def _start() -> None:
+        await _sweep_once()
+        app.state.artifact_sweep_task = asyncio.get_running_loop().create_task(_sweep_forever())
+
+    async def _stop() -> None:
+        task = getattr(app.state, "artifact_sweep_task", None)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    app.router.on_startup.append(_start)
+    app.router.on_shutdown.append(_stop)
+
+
 _MIN_JWT_SECRET_BYTES = 32
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts.py
@@ -1,0 +1,102 @@
+"""Content-addressed spill store for results too large to ride the stream inline.
+
+FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+
+Think of it as the parcel counter behind the mail slot: the runner leaves the complete
+result here under its own fingerprint, the terminal frame carries only the claim ticket
+(`ResultArtifact`), and the REST route hands the file over when the client redeems the
+ticket. Stage order per run: `write_text` (runner, at completion) → `path_for` (REST GET)
+→ `delete` (after a successful fetch) — with `sweep` at app startup collecting parcels
+nobody ever picked up (crashed runs, clients that vanished).
+
+INVARIANT: the filename IS the sha256 of the content, so the id doubles as the integrity
+check and a well-formed id can never name anything outside the flat store root.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+
+from url4.streaming.protocol.signals import ResultArtifact
+
+_ARTIFACT_ID = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ArtifactStore:
+    """Flat directory of files named by the lowercase sha256 hex of their content."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def write_text(self, body: str) -> ResultArtifact:
+        """Persist `body` and return its claim ticket. See `write_bytes`."""
+        return self.write_bytes(body.encode("utf-8"))
+
+    def write_bytes(self, encoded: bytes) -> ResultArtifact:
+        """Persist already-encoded content and return its claim ticket. Idempotent.
+
+        Takes bytes so a caller that has already UTF-8-encoded (the executor encodes
+        once to measure the size) never pays a second gigabyte-scale copy.
+
+        The write is tmp-file + `os.replace` so a crash mid-write never leaves a
+        half-parcel under a valid id — an id either resolves to complete content or to
+        nothing.
+        """
+        digest = hashlib.sha256(encoded).hexdigest()
+        self._root.mkdir(parents=True, exist_ok=True)
+        final = self._root / digest
+        if not final.exists():
+            tmp = self._root / f".{digest}.{uuid.uuid4().hex}.tmp"
+            tmp.write_bytes(encoded)
+            os.replace(tmp, final)
+        return ResultArtifact(id=digest, size_bytes=len(encoded), sha256=digest)
+
+    def path_for(self, artifact_id: str) -> Path | None:
+        """The stored file for `artifact_id`, or None when absent or malformed."""
+        if _ARTIFACT_ID.fullmatch(artifact_id) is None:
+            return None
+        path = self._root / artifact_id
+        return path if path.is_file() else None
+
+    def delete(self, artifact_id: str) -> None:
+        """Remove a parcel once redeemed. Absence is not an error — deletes race sweeps."""
+        path = self.path_for(artifact_id)
+        if path is not None:
+            path.unlink(missing_ok=True)
+
+    def sweep(self, ttl_seconds: float, *, now: float | None = None) -> int:
+        """Delete artifacts (and `.tmp` write leftovers) older than `ttl_seconds`.
+
+        Age is mtime-based: `write_text` stamps it and nothing rewrites a stored file
+        (content addressing), so mtime is the parcel's arrival time. Returns how many
+        files were removed.
+
+        INVARIANT: tolerant of concurrent life — a file may vanish between listing and
+        stat (another sweep, an operator's rm); that is a completed job, not an error.
+        The sweeper loop in `app.py` must never die of a race.
+        """
+        if not self._root.is_dir():
+            return 0
+        cutoff = (time.time() if now is None else now) - ttl_seconds
+        removed = 0
+        for path in self._root.iterdir():
+            # `.tmp` files are crash leftovers from `write_text`'s atomic-rename dance —
+            # invisible to `path_for`, but they hold real bytes and must age out too.
+            named_like_ours = _ARTIFACT_ID.fullmatch(path.name) is not None or path.name.endswith(
+                ".tmp"
+            )
+            if not named_like_ours:
+                continue
+            try:
+                expired = path.stat().st_mtime < cutoff
+            except FileNotFoundError:
+                continue
+            if expired:
+                path.unlink(missing_ok=True)
+                removed += 1
+        return removed

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts.py
@@ -50,7 +50,13 @@ class ArtifactStore:
         digest = hashlib.sha256(encoded).hexdigest()
         self._root.mkdir(parents=True, exist_ok=True)
         final = self._root / digest
-        if not final.exists():
+        # INVARIANT: a dedup hit re-stamps mtime — re-depositing a parcel restarts its
+        # TTL clock. Tickets are per run but the file is shared by content, so without
+        # the touch a byte-identical result re-arriving near (or past) the first copy's
+        # TTL would mint a fresh ticket pointing at a file the next sweep removes.
+        try:
+            os.utime(final)
+        except FileNotFoundError:
             tmp = self._root / f".{digest}.{uuid.uuid4().hex}.tmp"
             tmp.write_bytes(encoded)
             os.replace(tmp, final)
@@ -72,9 +78,9 @@ class ArtifactStore:
     def sweep(self, ttl_seconds: float, *, now: float | None = None) -> int:
         """Delete artifacts (and `.tmp` write leftovers) older than `ttl_seconds`.
 
-        Age is mtime-based: `write_text` stamps it and nothing rewrites a stored file
-        (content addressing), so mtime is the parcel's arrival time. Returns how many
-        files were removed.
+        Age is mtime-based: `write_bytes` stamps it on first write AND re-stamps it on
+        every dedup hit, so mtime is the parcel's LAST deposit time — the youngest
+        ticket's age, never the oldest's. Returns how many files were removed.
 
         INVARIANT: tolerant of concurrent life — a file may vanish between listing and
         stat (another sweep, an operator's rm); that is a completed job, not an error.

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -50,6 +50,19 @@ class Settings(BaseSettings):
     # WHY the shared constant and not a literal: `job_env` states the fallback beside the variable
     # name so serve and run cannot be pointed at different brokers by a one-sided edit.
     nats_url: str = job_env.DEFAULT_NATS_URL
+    # FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+    # Same env var (URL4_CLOUD_ARTIFACTS_DIR) the Runner's spill side reads — one name, so the
+    # writer and the `GET /artifacts/{id}` server cannot be pointed at different directories.
+    artifacts_dir: str = job_env.DEFAULT_ARTIFACTS_DIR
+    # WHY 48h: long enough for any client that survived its run to come back for the parcel
+    # (a run itself is bounded by job_deadline_s = 16h), short enough that crashed runs
+    # cannot pool disk for more than two days. Swept at App startup AND periodically.
+    artifact_ttl_s: int = 172_800
+    # WHY periodic and not startup-only: a hosted Engine pod can stay up for weeks, and a
+    # startup-only sweep would let abandoned parcels pool until the next redeploy (owner
+    # decision on OME-892). Hourly is far finer than the 48h TTL it enforces, and one
+    # directory scan an hour costs nothing.
+    artifact_sweep_interval_s: float = 3600.0
     # INVARIANT: stateless iat window (seconds) — start rejected when now - iat exceeds it (§4).
     iat_window_s: int = 60
     # WHY: sync-hold cap; a run outliving it degrades to 202 async (spec §5).

--- a/apps/screamingface-engine/src/screamingface_engine/job_env.py
+++ b/apps/screamingface-engine/src/screamingface_engine/job_env.py
@@ -18,7 +18,9 @@ format.
 
 from __future__ import annotations
 
+import tempfile
 from collections.abc import Mapping
+from pathlib import Path
 from types import MappingProxyType
 
 from url4.streaming.protocol import CachePolicy
@@ -201,6 +203,35 @@ RUNNER_CONFIG = "URL4_RUNNER_CONFIG"
 """Path to the declared world (:mod:`screamingface_engine.world_config`). Baked into
 the image; the App never writes it."""
 
+ARTIFACTS_DIR = "URL4_CLOUD_ARTIFACTS_DIR"
+"""Directory where over-threshold results are spilled as content-addressed files and from
+which ``GET /artifacts/{id}`` serves them (OME-892). One name read by BOTH the Runner (write
+side, via :func:`runner.main.build_executor`) and the App's ``Settings.artifacts_dir`` (serve
+side) so the two halves cannot be pointed at different directories by a one-sided edit.
+
+AIDEV-NOTE: in the `k8s` backend the Runner Job and the App are separate pods — this must
+name a SHARED volume there, which the chart does not yet mount (flagged on OME-892); local
+mode (one process) shares it by construction."""
+
+DEFAULT_ARTIFACTS_DIR = str(Path(tempfile.gettempdir()) / "screamingface-engine" / "artifacts")
+"""Fallback for an unset :data:`ARTIFACTS_DIR`. A temp path on purpose: artifacts are
+short-lived hand-offs (deleted on fetch, swept by TTL), not an archive."""
+
+RESULT_INLINE_CAP_BYTES = "URL4_CLOUD_RESULT_INLINE_CAP_BYTES"
+"""Largest result body (UTF-8 bytes) that rides the result frame inline; anything larger is
+spilled whole to :data:`ARTIFACTS_DIR`. Replaces the pre-OME-892 truncation cap."""
+
+DEFAULT_RESULT_INLINE_CAP_BYTES = 1_048_576
+"""1 MiB — the historical wire cap, kept so small runs stay byte-identical to before."""
+
+RESULT_HARD_CAP_BYTES = "URL4_CLOUD_RESULT_HARD_CAP_BYTES"
+"""Absolute result ceiling: past this the run FAILS with ``result_too_large`` instead of
+spilling. The result is already in Runner RAM when checked (string + encoded copy ≈ 2-3× its
+size), so size this to pod memory, not disk."""
+
+DEFAULT_RESULT_HARD_CAP_BYTES = 1_073_741_824
+"""1 GiB — clears a plausible full-benchmark-scale report while catching runaway output."""
+
 DEFAULT_NATS_URL = "nats://localhost:4222"
 """Fallback for an unset :data:`NATS_URL`. Lives beside the name it defaults so the two cannot
 drift — every reader of the variable needs the same answer for "and if it is absent?"."""
@@ -240,7 +271,16 @@ WRITTEN_BY_APP = frozenset(
 that breaks silently is an unread WRITE, not an unwritten READ (which simply falls back)."""
 
 DEPLOY_TIME = frozenset(
-    {NATS_URL, AIGATEWAY_BASE_URL, AIGATEWAY_MODEL, TAVILY_API_KEY, RUNNER_CONFIG}
+    {
+        NATS_URL,
+        AIGATEWAY_BASE_URL,
+        AIGATEWAY_MODEL,
+        TAVILY_API_KEY,
+        RUNNER_CONFIG,
+        ARTIFACTS_DIR,
+        RESULT_INLINE_CAP_BYTES,
+        RESULT_HARD_CAP_BYTES,
+    }
 )
 """Helm owns these end-to-end. The App writing one would make it two sources of truth again."""
 
@@ -248,9 +288,13 @@ __all__ = [
     "AIGATEWAY_BASE_URL",
     "AIGATEWAY_MODEL",
     "AIGATEWAY_PROFILE",
+    "ARTIFACTS_DIR",
     "CACHE_MAX_AGE_S",
     "CACHE_PARTICIPATE",
+    "DEFAULT_ARTIFACTS_DIR",
     "DEFAULT_NATS_URL",
+    "DEFAULT_RESULT_HARD_CAP_BYTES",
+    "DEFAULT_RESULT_INLINE_CAP_BYTES",
     "DEFAULT_STREAM_GRACE_S",
     "DEPLOY_TIME",
     "EXPRESSION",
@@ -258,6 +302,8 @@ __all__ = [
     "JOB_DEADLINE_S",
     "NATS_URL",
     "REQUIRED",
+    "RESULT_HARD_CAP_BYTES",
+    "RESULT_INLINE_CAP_BYTES",
     "RUNNER_CONFIG",
     "STREAM_GRACE_S",
     "SECRET",

--- a/apps/screamingface-engine/src/screamingface_engine/rest/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/__init__.py
@@ -5,6 +5,7 @@ for the model catalog) and the ``SubscriberGate`` protocol so ``app.py`` can wir
 reaching into the individual route modules.
 """
 
+from screamingface_engine.rest.artifacts import router as artifact_router
 from screamingface_engine.rest.benchmarks import router as benchmark_router
 from screamingface_engine.rest.catalog import router as catalog_router
 from screamingface_engine.rest.connections import router as connection_router
@@ -14,6 +15,7 @@ from screamingface_engine.rest.routes import router
 __all__ = [
     "DenyAllGate",
     "SubscriberGate",
+    "artifact_router",
     "benchmark_router",
     "catalog_router",
     "connection_router",

--- a/apps/screamingface-engine/src/screamingface_engine/rest/artifacts.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/artifacts.py
@@ -1,0 +1,57 @@
+"""Redemption of result claim tickets: serve a spilled result whole, as often as asked.
+
+FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+
+The Runner parks an over-threshold result as a content-addressed file and the terminal
+result frame carries only `{artifact_id, size_bytes, sha256}`; this route is where a
+client trades that ticket for the complete bytes. `FileResponse` streams from disk
+(bounded memory, HTTP Range for resume).
+
+INVARIANT: fetching NEVER deletes. Content addressing means one file can back many claim
+tickets (identical results dedupe onto one path), a dropped connection must be retryable,
+and a Range request must leave the rest of the file fetchable — delete-on-first-GET broke
+all three (review finding on OME-892). Artifacts die by TTL alone: the periodic sweeper in
+`app.py` is the single cleanup mechanism.
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Path, Request
+from fastapi.responses import FileResponse
+
+from screamingface_engine.auth.dependencies import VerifiedClaims
+from screamingface_engine.auth.problem import ProblemException
+
+router = APIRouter()
+
+
+@router.get(
+    "/artifacts/{artifact_id}",
+    tags=["Runs"],
+    summary="Fetch one complete spilled result by its claim ticket",
+)
+async def get_artifact(
+    request: Request,
+    claims: VerifiedClaims,
+    artifact_id: Annotated[
+        str, Path(description="Content address from the result frame's artifact reference.")
+    ],
+) -> FileResponse:
+    # WHY direct attribute access, no getattr fallback: `create_app` always builds the
+    # store, so its absence is a wiring bug that must fail loudly, not read as a 404.
+    store = request.app.state.artifact_store
+    # INVARIANT: `path_for` resolves only lowercase-sha256 ids inside the store root — a
+    # traversal id and an unknown id are the same 404, never a file outside the store.
+    path = store.path_for(artifact_id)
+    if path is None:
+        raise ProblemException(
+            status=404,
+            title="Unknown artifact",
+            detail=f"no artifact is stored under {artifact_id!r} — it may have expired "
+            "(artifacts are TTL-swept), or, on a multi-pod deployment, the Runner and the "
+            "App may not share URL4_CLOUD_ARTIFACTS_DIR (it must name a shared volume)",
+        )
+    return FileResponse(path, media_type="application/octet-stream")
+
+
+__all__ = ["router"]

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -16,8 +16,10 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Header, Request, Response
+from fastapi.responses import FileResponse
 
 from screamingface_engine import job_env, notices
+from screamingface_engine.artifacts import ArtifactStore
 from screamingface_engine.auth import (
     PROBLEM_MEDIA_TYPE,
     JwtCodec,
@@ -63,6 +65,7 @@ class _Deps:
     interest: SubscriberGate
     sessions: RunSessions
     settings: Settings
+    artifact_store: ArtifactStore | None = None
 
 
 def _deps(request: Request) -> _Deps:
@@ -85,6 +88,9 @@ def _deps(request: Request) -> _Deps:
         # make the frame carrier disappear the moment a test pinned the 428 behaviour.
         sessions=state.registry,
         settings=state.settings,
+        # Direct attribute, no getattr fallback: create_app always builds the store, so
+        # its absence is a wiring bug that must fail loudly, not degrade to 404s.
+        artifact_store=state.artifact_store,
     )
 
 
@@ -244,10 +250,28 @@ async def _await_terminal(
         return None
 
 
-def _result_response(result: ResultEvent | None) -> Response:
-    """Build the 200 response body from the run's ``ResultEvent``, or an empty 200 if none."""
+def _result_response(result: ResultEvent | None, store: ArtifactStore | None = None) -> Response:
+    """Build the 200 response body from the run's ``ResultEvent``, or an empty 200 if none.
+
+    FEATURE: deliver large results in full (OME-892) — a result frame may carry an artifact
+    reference instead of an inline body; this transactional GET path resolves it to the same
+    complete bytes the streaming client would fetch from ``GET /artifacts/{id}``.
+    """
     if result is None:
         return Response(status_code=200)
+    artifact = result.data.artifact
+    if artifact is not None:
+        path = store.path_for(artifact.id) if store is not None else None
+        if path is None:
+            # WHY 404 and not an empty 200: the run DID produce a result; serving nothing as
+            # success would be a quieter cousin of the truncation bug this feature removes.
+            raise ProblemException(
+                status=404,
+                title="Result artifact unavailable",
+                detail=f"the run's result was spilled to artifact {artifact.id!r}, which has "
+                "already been fetched or swept",
+            )
+        return FileResponse(path, media_type=result.data.media_type or "application/json")
     return Response(
         content=result.data.body,
         media_type=result.data.media_type or "application/json",
@@ -255,11 +279,15 @@ def _result_response(result: ResultEvent | None) -> Response:
     )
 
 
-def _terminal_response(terminated: TerminatedEvent, result: ResultEvent | None) -> Response:
+def _terminal_response(
+    terminated: TerminatedEvent,
+    result: ResultEvent | None,
+    store: ArtifactStore | None = None,
+) -> Response:
     """Map a terminal frame to its HTTP response: the Result body on success, else a problem."""
     status = terminated.data.status
     if status == "succeeded":
-        return _result_response(result)
+        return _result_response(result, store)
     # `.get` and not `[...]`: a terminal status added to the protocol but not mapped here would
     # otherwise surface as an unhandled KeyError — a bare 500 with a traceback, rather than a
     # response that still tells the caller the run ended and did not succeed.
@@ -316,7 +344,7 @@ async def _run_sync(deps: _Deps, topic: str, wait_s: float | None) -> Response:
     outcome = await _await_terminal(deps.stream, topic, bound)
     if outcome is None:
         return _accepted(topic)
-    return _terminal_response(outcome[0], outcome[1])
+    return _terminal_response(outcome[0], outcome[1], deps.artifact_store)
 
 
 @router.post(

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -20,8 +20,11 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Literal, cast
 
+from screamingface_engine import job_env
+from screamingface_engine.artifacts import ArtifactStore
 from screamingface_engine.runner.accounting import PRICING_VERSION, UNPRICED, accumulate
 from screamingface_engine.runner.cache_counters import RunCacheCounters
+from url4.core.errors import ResolutionError
 from url4.dag import run as url4_run
 from url4.io.layer import IOLayer
 from url4.io.static import StaticIOLayer
@@ -47,8 +50,6 @@ from url4.streaming.protocol import (
 from url4.streaming.protocol.taxonomy import CostBreakdown
 
 _logger = logging.getLogger(__name__)
-
-_TRUNCATION_MARKER = "…[truncated]"
 
 
 class BridgeOverflowError(RuntimeError):
@@ -446,24 +447,49 @@ class _RunState:
             )
         return frames
 
-    def build_result(self, result_str: str, cap: int) -> ResultData:
-        """Build the final `ResultData`, truncating to `cap` UTF-8 bytes when needed.
+    def build_result(
+        self,
+        result_str: str,
+        *,
+        inline_cap: int,
+        hard_cap: int,
+        store: ArtifactStore | None,
+    ) -> ResultData:
+        """Build the final `ResultData`: inline, spilled whole, or refused — never cut.
 
-        A truncated body keeps as much of the original text as fits alongside
-        `_TRUNCATION_MARKER`, cutting on a byte boundary (`errors="ignore"` drops any partial
-        trailing character rather than raising). If even the marker alone doesn't fit in
-        `cap`, the body is the marker itself, truncated.
+        FEATURE: deliver large results in full instead of cutting them off at 1 MiB
+        (OME-892). Three-way fork by UTF-8 size, HARD CAP FIRST: (1) over `hard_cap` —
+        or over `inline_cap` with no store to spill into — raise `result_too_large`
+        naming both byte counts, which the lifecycle turns into a failed terminal event;
+        (2) ≤ `inline_cap` → the body rides the result frame exactly as before OME-892;
+        (3) otherwise the COMPLETE body is written to the content-addressed `store` and
+        the frame carries only the claim ticket (`ResultArtifact`).
+
+        WHY the hard cap is checked first: it is absolute. If the inline check ran first,
+        inverted knobs (inline_cap > hard_cap) would let an over-hard-cap body sail into
+        one WS frame — bypassing the ceiling and resurrecting the close-1009
+        `websocket_disconnected` failure the client's frame bound exists to prevent.
+
+        The body is encoded ONCE — the same bytes that are measured are the bytes written
+        (`write_bytes`), so a gigabyte-scale result never pays a second encoding copy.
+        Blocking work (hashing, disk write) is the CALLER's problem: `execute` runs this
+        whole method in a worker thread so the event loop pumping heartbeats never stalls.
+
+        INVARIANT: no branch emits a truncated body — the truncate-and-still-succeed
+        path of GitHub #642 is unrepresentable here.
         """
         encoded = result_str.encode("utf-8")
-        if len(encoded) <= cap:
+        allowed = hard_cap if store is not None else min(inline_cap, hard_cap)
+        if len(encoded) > allowed:
+            raise ResolutionError(
+                f"result is {len(encoded)} bytes, cap is {allowed} bytes",
+                code="result_too_large",
+                permanent=True,
+            )
+        if len(encoded) <= inline_cap:
             return ResultData(body=result_str, media_type=None)
-        marker = _TRUNCATION_MARKER.encode("utf-8")
-        if len(marker) > cap:
-            body = marker[:cap].decode("utf-8", errors="ignore")
-            return ResultData(body=body, media_type=None)
-        kept = encoded[: cap - len(marker)]
-        body = kept.decode("utf-8", errors="ignore") + _TRUNCATION_MARKER
-        return ResultData(body=body, media_type=None)
+        assert store is not None  # over inline yet allowed ⇒ a store existed above
+        return ResultData(media_type=None, artifact=store.write_bytes(encoded))
 
     def build_subtree(self) -> CostUsageData:
         provider, model = self._subtree_provider_model()
@@ -561,13 +587,21 @@ class Url4Executor(Executor):
         io: IOLayer | None = None,
         *,
         queue_cap: int = 1024,
-        result_cap: int = 1_048_576,
+        result_cap: int = job_env.DEFAULT_RESULT_INLINE_CAP_BYTES,
+        hard_cap: int = job_env.DEFAULT_RESULT_HARD_CAP_BYTES,
+        artifact_store: ArtifactStore | None = None,
         world_aclose: Callable[[], Awaitable[None]] | None = None,
         world_factory: WorldFactory | None = None,
     ) -> None:
         self._io = io
         self._queue_cap = queue_cap
+        # WHY: `result_cap` is now the INLINE threshold (biggest body that rides the
+        # result frame), not a truncation point; `hard_cap` bounds the spill path. The
+        # result already sits in this process's memory when checked (string + encoded
+        # copy ≈ 2-3× its size), so operators size hard_cap to pod RAM, not disk.
         self._result_cap = result_cap
+        self._hard_cap = hard_cap
+        self._artifact_store = artifact_store
         self._world_aclose = world_aclose
         self._world_factory = world_factory
 
@@ -615,10 +649,17 @@ class Url4Executor(Executor):
             result_str = await task
             for frame in _closing_logs(bridge.dropped, state.cache_counters):
                 yield frame
-            yield Completed(
-                result=state.build_result(result_str, self._result_cap),
-                subtree_cost=state.build_subtree(),
+            # WHY to_thread: for a spilled result this hashes and writes up to hard_cap
+            # bytes — synchronous disk work that would otherwise stall the very loop that
+            # pumps heartbeats, letting a client declare a FINISHING run dead.
+            result = await asyncio.to_thread(
+                state.build_result,
+                result_str,
+                inline_cap=self._result_cap,
+                hard_cap=self._hard_cap,
+                store=self._artifact_store,
             )
+            yield Completed(result=result, subtree_cost=state.build_subtree())
         finally:
             if not task.done():
                 task.cancel()

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -19,6 +19,7 @@ import httpx
 
 from screamingface_engine import job_env
 from screamingface_engine.adapters.jetstream import JetStreamPublisher
+from screamingface_engine.artifacts import ArtifactStore
 from screamingface_engine.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
 from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.candidate_adapter import install_candidate_invocation
@@ -50,6 +51,37 @@ def stream_grace_s(env: Mapping[str, str]) -> float:
     except ValueError:
         logger.warning("ignoring unparseable %s=%r", job_env.STREAM_GRACE_S, raw)
         return job_env.DEFAULT_STREAM_GRACE_S
+
+
+def _int_from_env(env: Mapping[str, str], name: str, default: int) -> int:
+    """One deploy-time integer, tolerantly. INVARIANT: never raises — same reasoning as
+    `stream_grace_s`: a typo'd knob must not take down every Job, and running with the
+    shipped default is the cheap wrong answer."""
+    raw = env.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("ignoring unparseable %s=%r", name, raw)
+        return default
+
+
+def result_delivery_from_env(env: Mapping[str, str]) -> tuple[int, int, ArtifactStore]:
+    """The Runner's result-delivery wiring: (inline cap, hard cap, spill store).
+
+    FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+    Reads the same URL4_CLOUD_* names the App's `Settings` serve side reads, so the writer
+    and the `GET /artifacts/{id}` server resolve one directory by construction.
+    """
+    inline_cap = _int_from_env(
+        env, job_env.RESULT_INLINE_CAP_BYTES, job_env.DEFAULT_RESULT_INLINE_CAP_BYTES
+    )
+    hard_cap = _int_from_env(
+        env, job_env.RESULT_HARD_CAP_BYTES, job_env.DEFAULT_RESULT_HARD_CAP_BYTES
+    )
+    artifacts_dir = env.get(job_env.ARTIFACTS_DIR) or job_env.DEFAULT_ARTIFACTS_DIR
+    return inline_cap, hard_cap, ArtifactStore(Path(artifacts_dir))
 
 
 async def run_and_reclaim(
@@ -225,7 +257,13 @@ def build_executor(
                 cleanup.pop_all()
         return world.node, world.aclose
 
-    return Url4Executor(world_factory=_world)
+    inline_cap, hard_cap, artifact_store = result_delivery_from_env(env)
+    return Url4Executor(
+        world_factory=_world,
+        result_cap=inline_cap,
+        hard_cap=hard_cap,
+        artifact_store=artifact_store,
+    )
 
 
 def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)

--- a/apps/screamingface-engine/tests/integration/test_local_spine.py
+++ b/apps/screamingface-engine/tests/integration/test_local_spine.py
@@ -244,8 +244,11 @@ def test_a_big_result_streams_as_a_claim_ticket_and_redeems_whole(
     assert redeemed.text.endswith(_BIG_PAYLOAD)
     assert len(redeemed.content) == artifact["size_bytes"]
 
-    # The claim is redeemed: a second fetch finds nothing (delete-on-fetch).
-    assert client.get(f"/artifacts/{artifact['id']}", headers=_cap(token)).status_code == 404
+    # INVARIANT: fetching never deletes — a retry (or a second ticket deduped onto the
+    # same content) must still find the parcel; only the TTL sweep removes it.
+    again = client.get(f"/artifacts/{artifact['id']}", headers=_cap(token))
+    assert again.status_code == 200
+    assert again.content == redeemed.content
 
 
 def test_the_sync_get_path_serves_a_big_result_whole(big_result_client: TestClient) -> None:

--- a/apps/screamingface-engine/tests/integration/test_local_spine.py
+++ b/apps/screamingface-engine/tests/integration/test_local_spine.py
@@ -168,3 +168,93 @@ def test_stopping_a_run_purges_its_stream(client: TestClient) -> None:
         response = client.delete("/", headers=_cap(token))
 
     assert response.status_code == 204
+
+
+# FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+# The >threshold slice, network-free, through the REAL executor, lifecycle, REST and WS:
+# a big result rides the stream as a claim ticket, and redeeming it returns every byte.
+
+_BIG_PAYLOAD = "A" * 4096  # far over the 64-byte inline cap below, tiny for the test run
+
+
+@pytest.fixture
+def big_result_client(tmp_path_factory: pytest.TempPathFactory) -> Iterator[TestClient]:
+    """A local-mode App whose real Url4Executor spills anything over 64 bytes."""
+    from pathlib import Path as _Path
+
+    from screamingface_engine.artifacts import ArtifactStore
+    from screamingface_engine.runner.executor import Url4Executor
+    from url4.io.static import StaticIOLayer
+
+    artifacts_dir: _Path = tmp_path_factory.mktemp("spill")
+    settings = Settings(jwt_secret=SECRET, artifacts_dir=str(artifacts_dir))
+    stream = InMemoryEventStream()
+    runner = InProcessJobRunner(
+        stream,
+        lambda _env: Url4Executor(
+            StaticIOLayer(fetch_map={"https://big": _BIG_PAYLOAD}),
+            result_cap=64,
+            artifact_store=ArtifactStore(artifacts_dir),
+        ),
+        base_env={},
+    )
+    app = create_app(settings, stream=stream, job_runner=runner)
+    app.router.on_shutdown.append(runner.aclose)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_a_big_result_streams_as_a_claim_ticket_and_redeems_whole(
+    big_result_client: TestClient,
+) -> None:
+    client = big_result_client
+    token = _token(client)
+    with client.websocket_connect(f"/ws?ticket={token}") as ws:
+        ws.send_text(
+            json.dumps(
+                {
+                    "specversion": "1.0",
+                    "id": "attach-big",
+                    "source": "/test",
+                    "type": "ai.url4.attach",
+                    "data": {},
+                }
+            )
+        )
+        client.get("/?q=https://big!go", headers=_cap(token))
+
+        result_data: dict[str, object] | None = None
+        terminal: dict[str, object] | None = None
+        while terminal is None:
+            frame = json.loads(ws.receive_text())
+            if frame["type"] == "ai.url4.result":
+                result_data = frame["data"]
+            if frame["type"] == "ai.url4.terminated":
+                terminal = frame["data"]
+
+    # INVARIANT: the stream never carries a cut body — over-cap results travel by reference.
+    assert terminal["status"] == "succeeded"
+    assert result_data is not None
+    assert result_data["body"] is None
+    artifact = result_data["artifact"]
+    assert isinstance(artifact, dict)
+
+    redeemed = client.get(f"/artifacts/{artifact['id']}", headers=_cap(token))
+    assert redeemed.status_code == 200
+    assert redeemed.text.endswith(_BIG_PAYLOAD)
+    assert len(redeemed.content) == artifact["size_bytes"]
+
+    # The claim is redeemed: a second fetch finds nothing (delete-on-fetch).
+    assert client.get(f"/artifacts/{artifact['id']}", headers=_cap(token)).status_code == 404
+
+
+def test_the_sync_get_path_serves_a_big_result_whole(big_result_client: TestClient) -> None:
+    client = big_result_client
+    token = _token(client)
+    with client.websocket_connect(f"/ws?ticket={token}"):
+        response = client.get("/?q=https://big!go", headers=_cap(token))
+
+    # WHY: the transactional GET is the result frame's second consumer — same complete
+    # bytes, no claim-ticket round trip visible to this caller.
+    assert response.status_code == 200
+    assert response.text.endswith(_BIG_PAYLOAD)

--- a/apps/screamingface-engine/tests/unit/test_artifact_store.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_store.py
@@ -1,0 +1,80 @@
+"""ArtifactStore: content-addressed spill files for over-threshold results (OME-892).
+
+FEATURE: deliver large results in full instead of cutting them off at 1 MiB.
+INVARIANT: the store only ever serves complete, verifiable content — a returned path names
+a file whose name IS its sha256, so a corrupted or foreign file is detectable by the same
+digest the client checks. Ids that are not lowercase sha256 hex resolve to nothing, so the
+store cannot be used to read outside its root.
+"""
+
+import hashlib
+import os
+import time
+from pathlib import Path
+
+from screamingface_engine.artifacts import ArtifactStore
+
+
+def _store(tmp_path: Path) -> ArtifactStore:
+    return ArtifactStore(tmp_path / "artifacts")
+
+
+def test_write_text_returns_content_addressed_ref(tmp_path: Path) -> None:
+    body = '{"cases":[' + "1," * 100 + "1]}"
+    store = _store(tmp_path)
+    ref = store.write_text(body)
+    expected = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    assert ref.id == expected
+    assert ref.sha256 == expected
+    assert ref.size_bytes == len(body.encode("utf-8"))
+    path = store.path_for(ref.id)
+    assert path is not None
+    assert path.read_text(encoding="utf-8") == body
+
+
+def test_write_text_is_idempotent_per_content(tmp_path: Path) -> None:
+    # WHY: content addressing makes a re-run of the same result a no-op, not a duplicate.
+    store = _store(tmp_path)
+    first = store.write_text("same body")
+    second = store.write_text("same body")
+    assert first == second
+    assert len(list((tmp_path / "artifacts").iterdir())) == 1
+
+
+def test_path_for_rejects_ids_that_are_not_sha256_hex(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    (tmp_path / "secret.txt").write_text("nope")
+    # INVARIANT: a malformed id can never escape the store root (path traversal guard).
+    assert store.path_for("../secret.txt") is None
+    assert store.path_for("9F" * 32) is None
+    assert store.path_for("9f" * 31) is None
+
+
+def test_path_for_missing_artifact_is_none(tmp_path: Path) -> None:
+    assert _store(tmp_path).path_for("9f" * 32) is None
+
+
+def test_delete_removes_and_tolerates_absence(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    ref = store.write_text("bye")
+    store.delete(ref.id)
+    assert store.path_for(ref.id) is None
+    store.delete(ref.id)  # second delete must not raise
+
+
+def test_sweep_removes_only_files_older_than_ttl(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    stale = store.write_text("stale result")
+    fresh = store.write_text("fresh result")
+    stale_path = store.path_for(stale.id)
+    assert stale_path is not None
+    two_days_ago = time.time() - 2 * 86_400
+    os.utime(stale_path, (two_days_ago, two_days_ago))
+    removed = store.sweep(ttl_seconds=86_400)
+    assert removed == 1
+    assert store.path_for(stale.id) is None
+    assert store.path_for(fresh.id) is not None
+
+
+def test_sweep_on_missing_root_is_a_noop(tmp_path: Path) -> None:
+    assert ArtifactStore(tmp_path / "never-created").sweep(ttl_seconds=1) == 0

--- a/apps/screamingface-engine/tests/unit/test_artifact_store.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_store.py
@@ -78,3 +78,38 @@ def test_sweep_removes_only_files_older_than_ttl(tmp_path: Path) -> None:
 
 def test_sweep_on_missing_root_is_a_noop(tmp_path: Path) -> None:
     assert ArtifactStore(tmp_path / "never-created").sweep(ttl_seconds=1) == 0
+
+
+def test_sweep_collects_stale_tmp_write_leftovers(tmp_path: Path) -> None:
+    # WHY: a crash mid-write leaves a `.tmp` file that `path_for` can never see — without
+    # this it would hold real bytes on disk forever, invisible to every other mechanism.
+    store = _store(tmp_path)
+    store.write_text("anchor")  # ensures the root exists
+    orphan = tmp_path / "artifacts" / (".{}.deadbeef.tmp".format("9f" * 32))
+    orphan.write_bytes(b"half-written parcel")
+    two_days_ago = time.time() - 2 * 86_400
+    os.utime(orphan, (two_days_ago, two_days_ago))
+
+    removed = store.sweep(ttl_seconds=86_400)
+
+    assert removed == 1
+    assert not orphan.exists()
+
+
+def test_sweep_tolerates_files_vanishing_mid_scan(tmp_path: Path) -> None:
+    # INVARIANT: a file deleted between listing and stat is a completed job, not a crash —
+    # the periodic sweeper must survive racing with anything else that removes files.
+    store = _store(tmp_path)
+    ref = store.write_text("here then gone")
+    real_stat = Path.stat
+
+    def racing_stat(self: Path, *, follow_symlinks: bool = True) -> os.stat_result:
+        if self.name == ref.id:
+            self.unlink(missing_ok=True)  # simulate a concurrent deletion
+        return real_stat(self, follow_symlinks=follow_symlinks)
+
+    from unittest.mock import patch
+
+    with patch.object(Path, "stat", racing_stat):
+        removed = store.sweep(ttl_seconds=0)
+    assert removed >= 0  # no exception is the assertion; count depends on race timing

--- a/apps/screamingface-engine/tests/unit/test_artifact_store.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_store.py
@@ -113,3 +113,22 @@ def test_sweep_tolerates_files_vanishing_mid_scan(tmp_path: Path) -> None:
     with patch.object(Path, "stat", racing_stat):
         removed = store.sweep(ttl_seconds=0)
     assert removed >= 0  # no exception is the assertion; count depends on race timing
+
+
+def test_a_redeposited_parcel_restarts_its_ttl_clock(tmp_path: Path) -> None:
+    # INVARIANT: a dedup hit re-stamps mtime. Tickets are minted per run, but the file is
+    # shared by content — if a byte-identical result re-arrives just before the first
+    # copy's TTL, the NEW ticket must not point at a parcel the next sweep removes
+    # (review finding on PR #647).
+    store = ArtifactStore(tmp_path)
+    ref = store.write_text("the very same result")
+    # Past TTL but not yet collected — sweeps run hourly, so an expired parcel can sit
+    # on disk until the next tick. That is exactly when a re-deposit is dangerous.
+    past_ttl = time.time() - 86_500
+    os.utime(tmp_path / ref.id, (past_ttl, past_ttl))
+
+    again = store.write_text("the very same result")
+
+    assert again.id == ref.id
+    assert store.sweep(ttl_seconds=86_400) == 0
+    assert store.path_for(ref.id) is not None

--- a/apps/screamingface-engine/tests/unit/test_benchmark_foundation.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_foundation.py
@@ -806,6 +806,7 @@ async def test_runner_composition_installs_benchmarks_with_the_injected_asset_ro
 
     assert roots == [Path("/immutable/assets")]
     assert isinstance(frames[-1], Completed)
+    assert frames[-1].result.body is not None
     assert decode_candidate_invocation(frames[-1].result.body) == (
         "Rayleigh scattering.",
         "stop",

--- a/apps/screamingface-engine/tests/unit/test_rest_artifacts.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_artifacts.py
@@ -1,0 +1,210 @@
+"""REST redemption of result claim tickets: `GET /artifacts/{id}` (OME-892).
+
+FEATURE: deliver large results in full instead of cutting them off at 1 MiB.
+INVARIANT: the route serves exactly the complete stored bytes or a problem — never a
+partial body — and fetching NEVER deletes: one file may back many claim tickets (content
+addressing dedupes identical results), a dropped connection must be retryable, and a
+Range request must leave the rest fetchable. Artifacts die by TTL alone (startup +
+periodic sweep), so crashed runs cannot leak disk forever.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+from _fakes import RecordingJobRunner
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import ASGITransport
+
+from screamingface_engine.app import create_app
+from screamingface_engine.artifacts import ArtifactStore
+from screamingface_engine.auth import JwtCodec
+from screamingface_engine.config import Settings
+from screamingface_engine.rest.routes import _result_response
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.protocol import ResultData, ResultEvent
+
+SECRET = "rest-artifacts-secret"
+WINDOW_S = 60
+# WHY a past instant: pyjwt refuses an `iat` in the future, so the fake clock must lag
+# real UTC or every minted capability is rejected before our own window checks run.
+T0 = datetime(2026, 8, 18, 9, 0, 0, tzinfo=UTC)
+
+
+def _cap(topic: str) -> dict[str, str]:
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+
+
+def _make_app(
+    tmp_path: Path,
+    *,
+    artifact_ttl_s: int = 172_800,
+    artifact_sweep_interval_s: float = 3600.0,
+) -> FastAPI:
+    settings = Settings(
+        jwt_secret=SECRET,
+        iat_window_s=WINDOW_S,
+        artifacts_dir=str(tmp_path / "artifacts"),
+        artifact_ttl_s=artifact_ttl_s,
+        artifact_sweep_interval_s=artifact_sweep_interval_s,
+    )
+    return create_app(
+        settings,
+        stream=InMemoryEventStream(),
+        job_runner=RecordingJobRunner(),
+        clock=lambda: T0,
+    )
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_get_artifact_serves_complete_bytes_and_stays_refetchable(tmp_path: Path) -> None:
+    app = _make_app(tmp_path)
+    store = ArtifactStore(tmp_path / "artifacts")
+    body = '{"cases":[' + "1," * 5000 + "1]}"
+    ref = store.write_text(body)
+
+    async with _client(app) as client:
+        first = await client.get(f"/artifacts/{ref.id}", headers=_cap("t" * 64))
+        # INVARIANT: fetching never deletes — a retry after a dropped connection, or a
+        # second ticket deduped onto the same file, must find the parcel still there.
+        second = await client.get(f"/artifacts/{ref.id}", headers=_cap("t" * 64))
+
+    assert first.status_code == 200
+    assert first.text == body
+    assert int(first.headers["content-length"]) == ref.size_bytes
+    assert second.status_code == 200
+    assert second.text == body
+    assert store.path_for(ref.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_a_range_request_does_not_consume_the_artifact(tmp_path: Path) -> None:
+    # WHY: Range is the resume mechanism — a partial read must leave the rest fetchable.
+    # Under delete-on-fetch a `bytes=0-9` request destroyed the other 99% of the result.
+    app = _make_app(tmp_path)
+    store = ArtifactStore(tmp_path / "artifacts")
+    body = "R" * 4096
+    ref = store.write_text(body)
+
+    async with _client(app) as client:
+        partial = await client.get(
+            f"/artifacts/{ref.id}", headers={**_cap("t" * 64), "Range": "bytes=0-9"}
+        )
+        rest = await client.get(f"/artifacts/{ref.id}", headers=_cap("t" * 64))
+
+    assert partial.status_code == 206
+    assert partial.text == "R" * 10
+    assert rest.status_code == 200
+    assert rest.text == body
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_artifact_is_404_problem(tmp_path: Path) -> None:
+    app = _make_app(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(f"/artifacts/{'9f' * 32}", headers=_cap("t" * 64))
+    assert resp.status_code == 404
+    assert resp.headers["content-type"].startswith("application/problem+json")
+
+
+@pytest.mark.asyncio
+async def test_get_artifact_with_traversal_id_cannot_escape_the_store(tmp_path: Path) -> None:
+    (tmp_path / "secret.txt").write_text("nope")
+    app = _make_app(tmp_path)
+    async with _client(app) as client:
+        # INVARIANT: a malformed id resolves to nothing — never to a file outside the store.
+        resp = await client.get("/artifacts/..%2Fsecret.txt", headers=_cap("t" * 64))
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_artifact_without_capability_is_401(tmp_path: Path) -> None:
+    app = _make_app(tmp_path)
+    store = ArtifactStore(tmp_path / "artifacts")
+    ref = store.write_text("guarded")
+    async with _client(app) as client:
+        resp = await client.get(f"/artifacts/{ref.id}")
+    assert resp.status_code == 401
+    # The parcel survives an unauthorized knock.
+    assert store.path_for(ref.id) is not None
+
+
+def test_startup_sweeps_stale_artifacts_but_keeps_fresh_ones(tmp_path: Path) -> None:
+    import os
+    import time
+
+    store = ArtifactStore(tmp_path / "artifacts")
+    stale = store.write_text("stale parcel")
+    fresh = store.write_text("fresh parcel")
+    stale_path = store.path_for(stale.id)
+    assert stale_path is not None
+    old = time.time() - 3 * 86_400
+    os.utime(stale_path, (old, old))
+
+    app = _make_app(tmp_path, artifact_ttl_s=86_400)
+    with TestClient(app):  # entering the context runs startup hooks
+        assert store.path_for(stale.id) is None
+        assert store.path_for(fresh.id) is not None
+
+
+def test_sync_result_response_serves_artifact_content(tmp_path: Path) -> None:
+    # WHY: the transactional HTTP-GET path is the SECOND consumer of the result frame; an
+    # artifact result must resolve to the same complete bytes there, not to an empty body.
+    store = ArtifactStore(tmp_path / "artifacts")
+    ref = store.write_text('{"score":1}')
+    event = ResultEvent(
+        id="res-x",
+        source="/trace/x/node/root",
+        subject="x",
+        data=ResultData(artifact=ref),
+    )
+    response = _result_response(event, store)
+    assert response.status_code == 200
+
+
+def test_sync_result_response_of_redeemed_artifact_is_a_problem(tmp_path: Path) -> None:
+    from screamingface_engine.auth.problem import ProblemException
+
+    store = ArtifactStore(tmp_path / "artifacts")
+    ref = store.write_text("gone soon")
+    store.delete(ref.id)
+    event = ResultEvent(
+        id="res-y",
+        source="/trace/y/node/root",
+        subject="y",
+        data=ResultData(artifact=ref),
+    )
+    with pytest.raises(ProblemException):
+        _result_response(event, store)
+
+
+def test_sweep_runs_periodically_while_the_app_stays_up(tmp_path: Path) -> None:
+    import os
+    import time
+
+    # WHY: a hosted Engine pod can stay up for weeks — a startup-only sweep would let
+    # abandoned parcels pool until the next redeploy. The sweep must recur while alive.
+    store = ArtifactStore(tmp_path / "artifacts")
+    app = _make_app(tmp_path, artifact_ttl_s=86_400, artifact_sweep_interval_s=0.05)
+    with TestClient(app):
+        # Born AFTER startup, so the boot sweep cannot have been the one to collect it.
+        stale = store.write_text("abandoned while the app is running")
+        stale_path = store.path_for(stale.id)
+        assert stale_path is not None
+        old = time.time() - 3 * 86_400
+        os.utime(stale_path, (old, old))
+
+        deadline = time.time() + 5.0
+        while store.path_for(stale.id) is not None and time.time() < deadline:
+            time.sleep(0.05)
+        assert store.path_for(stale.id) is None
+
+    # Shutdown cancels the sweeper: no background task survives the app.
+    task = getattr(app.state, "artifact_sweep_task", None)
+    assert task is None or task.cancelled() or task.done()

--- a/apps/screamingface-engine/tests/unit/test_runner.py
+++ b/apps/screamingface-engine/tests/unit/test_runner.py
@@ -2,6 +2,7 @@ import json
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from decimal import Decimal
+from pathlib import Path
 
 import httpx
 import pytest
@@ -9,7 +10,12 @@ from _fakes import MockExecutor, take
 
 from screamingface_engine import job_env
 from screamingface_engine.runner.executor import Url4Executor
-from screamingface_engine.runner.main import RunnerConfigError, build_executor, params_from_env
+from screamingface_engine.runner.main import (
+    RunnerConfigError,
+    build_executor,
+    params_from_env,
+    result_delivery_from_env,
+)
 from screamingface_engine.testing import InMemoryEventStream
 from screamingface_engine.world_config import AigatewaySection, ModelSpec, WorldConfig
 from url4.core.errors import ResolutionError
@@ -434,3 +440,41 @@ async def test_build_executor_without_tavily_key_declares_no_tools() -> None:
 
     assert "tools" not in posts[0]
     assert "tool_choice" not in posts[0]
+
+
+# FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+# The Runner's spill wiring is env-driven: caps and directory come from the same
+# URL4_CLOUD_* names the App's serve side reads, with tolerant fallbacks to the defaults.
+
+
+def test_result_delivery_from_env_defaults() -> None:
+    inline_cap, hard_cap, store = result_delivery_from_env({})
+    assert inline_cap == job_env.DEFAULT_RESULT_INLINE_CAP_BYTES
+    assert hard_cap == job_env.DEFAULT_RESULT_HARD_CAP_BYTES
+    assert store is not None
+
+
+def test_result_delivery_from_env_reads_all_three(tmp_path: Path) -> None:
+    inline_cap, hard_cap, store = result_delivery_from_env(
+        {
+            job_env.RESULT_INLINE_CAP_BYTES: "2048",
+            job_env.RESULT_HARD_CAP_BYTES: "4096",
+            job_env.ARTIFACTS_DIR: str(tmp_path / "spill"),
+        }
+    )
+    assert inline_cap == 2048
+    assert hard_cap == 4096
+    assert store is not None
+    ref = store.write_text("where do I land?")
+    assert (tmp_path / "spill" / ref.id).is_file()
+
+
+def test_result_delivery_from_env_tolerates_unreadable_numbers() -> None:
+    # WHY tolerant, not strict: these are deploy-time knobs, and of the two wrong answers
+    # ("crash every run at boot" vs "run with the shipped default") the default is the one
+    # that costs nothing — matching how STREAM_GRACE_S is read.
+    inline_cap, hard_cap, _ = result_delivery_from_env(
+        {job_env.RESULT_INLINE_CAP_BYTES: "a lot", job_env.RESULT_HARD_CAP_BYTES: ""}
+    )
+    assert inline_cap == job_env.DEFAULT_RESULT_INLINE_CAP_BYTES
+    assert hard_cap == job_env.DEFAULT_RESULT_HARD_CAP_BYTES

--- a/apps/screamingface-engine/tests/unit/test_url4_executor.py
+++ b/apps/screamingface-engine/tests/unit/test_url4_executor.py
@@ -8,6 +8,7 @@ from typing import cast
 
 import pytest
 
+from screamingface_engine.artifacts import ArtifactStore
 from screamingface_engine.runner.executor import (
     BridgeOverflowError,
     Url4Executor,
@@ -81,6 +82,7 @@ async def test_frame_streams_before_the_run_finishes() -> None:
 
     last = frames[-1]
     assert isinstance(last, Completed)
+    assert last.result.body is not None
     assert "FAST" in last.result.body
     assert "GATED" in last.result.body
 
@@ -410,17 +412,71 @@ class _LongResultNode:
         return "X" * 50
 
 
+# FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+# INVARIANT: no code path emits a truncated body. A result is delivered inline (≤ cap),
+# spilled whole to the artifact store (> cap), or the run FAILS with `result_too_large` —
+# the truncate-and-still-succeed path of GitHub #642 is unrepresentable.
+
+
 @pytest.mark.asyncio
-async def test_over_cap_result_is_truncated_with_marker() -> None:
-    executor = Url4Executor(StaticIOLayer(), result_cap=20)
+async def test_result_at_inline_cap_stays_inline(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    executor = Url4Executor(StaticIOLayer(), result_cap=50, artifact_store=store)
 
     frames = await _drain(executor, _LongResultNode())
 
     completed = frames[-1]
     assert isinstance(completed, Completed)
-    assert completed.result.body.endswith("…[truncated]")
-    assert completed.result.body.startswith("X")
-    assert len(completed.result.body.encode("utf-8")) <= 20
+    # WHY: boundary — exactly-at-cap is the biggest result that must stay byte-identical
+    # to the pre-OME-892 wire shape, so old SDKs never notice small runs changed.
+    assert completed.result.body == "X" * 50
+    assert completed.result.artifact is None
+
+
+@pytest.mark.asyncio
+async def test_over_cap_result_is_spilled_whole_to_the_artifact_store(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    executor = Url4Executor(StaticIOLayer(), result_cap=20, artifact_store=store)
+
+    frames = await _drain(executor, _LongResultNode())
+
+    completed = frames[-1]
+    assert isinstance(completed, Completed)
+    assert completed.result.body is None
+    ref = completed.result.artifact
+    assert ref is not None
+    assert ref.size_bytes == 50
+    path = store.path_for(ref.id)
+    assert path is not None
+    # The parcel is the COMPLETE result — nothing was cut.
+    assert path.read_text(encoding="utf-8") == "X" * 50
+
+
+@pytest.mark.asyncio
+async def test_result_over_hard_cap_fails_loudly_with_both_byte_counts(tmp_path: Path) -> None:
+    store = ArtifactStore(tmp_path / "artifacts")
+    executor = Url4Executor(StaticIOLayer(), result_cap=10, hard_cap=30, artifact_store=store)
+
+    with pytest.raises(ResolutionError) as excinfo:
+        await _drain(executor, _LongResultNode())
+
+    assert excinfo.value.code == "result_too_large"
+    assert "50" in str(excinfo.value)  # actual bytes
+    assert "30" in str(excinfo.value)  # allowed bytes
+    # WHY: a refused result must not leave a parcel behind — nothing was deliverable.
+    assert not any((tmp_path / "artifacts").glob("*")) or not (tmp_path / "artifacts").exists()
+
+
+@pytest.mark.asyncio
+async def test_over_cap_without_a_store_fails_instead_of_truncating() -> None:
+    # WHY: an engine with no spill directory has no lossless path for a big result; the
+    # only honest outcomes are inline or failure — never a cut body.
+    executor = Url4Executor(StaticIOLayer(), result_cap=20, artifact_store=None)
+
+    with pytest.raises(ResolutionError) as excinfo:
+        await _drain(executor, _LongResultNode())
+
+    assert excinfo.value.code == "result_too_large"
 
 
 @pytest.mark.asyncio
@@ -597,3 +653,19 @@ def test_self_and_subtree_agree_when_the_run_is_a_single_node() -> None:
 
     assert self_cost.usage.input_tokens == subtree.usage.input_tokens
     assert self_cost.usage.output_tokens == subtree.usage.output_tokens
+
+
+@pytest.mark.asyncio
+async def test_hard_cap_governs_even_when_knobs_are_inverted(tmp_path: Path) -> None:
+    # WHY: inline_cap > hard_cap is an operator misconfiguration. If the inline check ran
+    # first, a result under the (huge) inline cap would sail into one WS frame, bypassing
+    # the hard cap and resurrecting the close-1009 websocket_disconnected failure the
+    # client's frame bound was built to kill. The hard cap is absolute: it wins.
+    store = ArtifactStore(tmp_path / "artifacts")
+    executor = Url4Executor(StaticIOLayer(), result_cap=100, hard_cap=30, artifact_store=store)
+
+    with pytest.raises(ResolutionError) as excinfo:
+        await _drain(executor, _LongResultNode())  # 50 bytes: ≤ inline, > hard
+
+    assert excinfo.value.code == "result_too_large"
+    assert "30" in str(excinfo.value)

--- a/docs/tasks/2026-08-19-deliver-large-results.md
+++ b/docs/tasks/2026-08-19-deliver-large-results.md
@@ -1,0 +1,26 @@
+---
+id: OME-892
+linear_url: https://linear.app/openmined/issue/OME-892/deliver-large-evaluation-results-in-full-instead-of-cutting-them-off
+status: in_progress
+type: bug-fix
+priority: High
+labels: [screamingface-engine, py-screamingface, agentic, autonomous]
+created: 2026-08-19
+closed:
+---
+
+# Deliver large Evaluation results in full instead of cutting them off at 1 MiB
+
+Sub-issue of OME-888 (mirrors GitHub #642). The Engine truncates Candidate Results over
+1 MiB mid-JSON and still reports the run `succeeded`; the SDK then fails to decode the only
+copy of the result, destroying paid Evaluation work.
+
+Fix (spill-to-disk + claim ticket): results ≤ 1 MiB stay inline in the terminal event;
+larger results are written to a content-addressed file on the Engine and the event carries
+`artifact: {id, size_bytes, sha256}` which the SDK redeems via `GET /artifacts/{id}` with
+size + sha256 verification; results over an env-configurable hard cap (default 1 GiB)
+terminate `failed` with `result_too_large`. Truncation path deleted. SDK additionally
+recognizes the legacy `…[truncated]` marker from older Engines and raises an actionable
+error.
+
+Ledger: `docs/work/2026-08-19-OME-892-deliver-large-results.md`

--- a/docs/work/2026-08-19-OME-892-deliver-large-results.md
+++ b/docs/work/2026-08-19-OME-892-deliver-large-results.md
@@ -1,0 +1,161 @@
+---
+ticket: OME-892
+stack: screamingface-engine + screamingface
+status: in_progress
+started: 2026-08-19
+finished:
+---
+
+# OME-892 — Deliver large Evaluation results in full instead of cutting them off at 1 MiB
+
+## Intent
+
+The Engine truncates any Candidate Result over 1 MiB mid-JSON, appends `…[truncated]`, and
+still terminates the run `succeeded`; the SDK then fails to decode the only copy of the
+result (GitHub #642, $6.54 / 1h11m lost). This unit replaces truncate-and-lie with the
+industry-standard signaling/bulk split: results ≤ 1 MiB stay inline in the terminal event;
+larger results are written to a content-addressed file on the Engine's disk and the terminal
+event carries a claim ticket `{artifact_id, size_bytes, sha256}` which the SDK redeems over
+HTTP with size+digest verification; results over an env-configurable hard cap (default
+1 GiB) terminate `failed` with `result_too_large`. The truncation code path is deleted —
+no successful terminal event can carry a mangled body, by construction.
+
+## Planned changes
+
+Engine (`apps/screamingface-engine`):
+- `src/screamingface_engine/runner/executor.py` — `build_result()` becomes the 3-way fork
+  (inline / artifact spill / `result_too_large`); truncation path + `_TRUNCATION_MARKER`
+  deleted; executor gains artifact-store + caps wiring.
+- ResultData/Completed model (wherever `ResultData` is defined) — optional
+  `artifact: {id, size_bytes, sha256} | null`, exclusive with `body`.
+- New artifact store module (content-addressed write, delete-on-fetch, TTL sweep at startup).
+- `rest/` — new `GET /artifacts/{id}` route via Starlette `FileResponse`, behind the same
+  auth guard as existing routes.
+- Env config: inline threshold (default 1 MiB), hard cap (default 1 GiB), artifacts dir.
+
+SDK (`packages/screamingface`):
+- Wire/event decode — accept the additive `artifact` field on the terminal result.
+- `src/screamingface/_engine/transport.py` — artifact fetch (httpx streaming GET, existing
+  auth) with byte-count + sha256 verification before parse.
+- `src/screamingface/_evaluation/results.py` — three terminal shapes: inline body /
+  artifact ref / legacy `…[truncated]` marker → actionable truncation error naming N bytes.
+- Named errors: integrity mismatch; truncated-by-legacy-engine.
+
+## Test plan
+
+Engine:
+- `build_result` under cap → inline body, artifact None (byte-identical to today).
+- over inline threshold → file exists at `artifacts/<sha256>`, event has ref (id/size/sha),
+  body None; file bytes == original.
+- over hard cap → run terminates `failed` with `result_too_large`, message carries actual
+  and allowed bytes; no file written.
+- exactly at threshold → inline (boundary).
+- artifact route: GET serves bytes + deletes after success; unknown id → 404; TTL sweep
+  removes stale files at startup, keeps fresh ones.
+- INVARIANT: no code path emits a body containing `…[truncated]`.
+
+SDK:
+- terminal event with inline body → Report as today.
+- with artifact ref → fetch, verify, Report identical to inline case.
+- wrong sha256 / short body → named integrity error, no Report.
+- legacy `…[truncated]` body → error naming truncation + received byte count, not
+  "must be JSON".
+- deterministic + network-free (in-process ASGI/served fixture); no paid calls.
+
+## Acceptance
+
+- A >1 MiB synthetic result flows Engine→SDK through the real streaming lifecycle into a
+  valid Report (network-free test).
+- Truncation code deleted; hard-cap breach reports `result_too_large` with both numbers.
+- Both caps env-configurable; small-result path byte-identical to today.
+- All gates green for `screamingface-engine` and `screamingface` stacks.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `packages/url4/src/url4/streaming/protocol/signals.py` — `ResultArtifact` model;
+    `ResultData` body|artifact XOR (+ `tests/unit/test_result_signal.py`, 11 tests)
+  - `apps/screamingface-engine/src/screamingface_engine/artifacts.py` — new
+    `ArtifactStore` (content-addressed write/serve/delete/sweep) (+
+    `tests/unit/test_artifact_store.py`, 7 tests)
+  - `.../runner/executor.py` — `build_result` 3-way fork; truncation path +
+    `_TRUNCATION_MARKER` deleted; `hard_cap`/`artifact_store` ctor params
+  - `.../runner/main.py` — `result_delivery_from_env` + executor wiring
+  - `.../job_env.py` — `ARTIFACTS_DIR`, `RESULT_INLINE_CAP_B`, `RESULT_HARD_CAP_B` (+
+    defaults) in `DEPLOY_TIME`
+  - `.../config.py` — `Settings.artifacts_dir`, `Settings.artifact_ttl_s`
+  - `.../rest/artifacts.py` — new `GET /artifacts/{id}` (auth-guarded, FileResponse,
+    delete-on-fetch) (+ `tests/unit/test_rest_artifacts.py`, 7 tests)
+  - `.../rest/routes.py` — `_result_response` serves artifact results on the sync GET path
+  - `.../app.py` — store on app.state, artifact router mounted, `_install_artifact_sweeper`
+    (TTL sweep at startup + hourly-default periodic asyncio task, cancelled at shutdown;
+    owner decision 2026-08-19: hosted pods live for weeks, startup-only pools orphans);
+    `Settings.artifact_sweep_interval_s` in config.py
+  - `tests/integration/test_local_spine.py` — 2 end-to-end tests: real executor spills,
+    WS carries claim ticket, redemption returns every byte, sync GET path whole
+  - `packages/screamingface/src/screamingface/_core/ports.py` — `_ResultArtifact`;
+    `_RunOutcome.artifact`, `result_body: str | None`
+  - `.../_engine/contract.py` — artifact decode (`_artifact_reference`, strict hex/size)
+  - `.../_engine/transport.py` — `_materialize_sync/_materialize_async`: streaming fetch +
+    size/sha256 verify before anything decodes; stale `_MAX_FRAME_BYTES` comment updated
+  - `.../_evaluation/results.py` — `_decoded_result_body`: legacy `…[truncated]` marker →
+    named `result_truncated` error with byte count; None-body guard
+  - `tests/protocol_server.py` — `artifact_result` mode + `/artifacts/` handler +
+    corruption/missing seams; `tests/test_transport_artifact_fetch.py` (6),
+    `tests/test_engine_contract.py` (+3), `tests/test_results_truncation_marker.py` (3)
+- **Commits:**
+  - 63cbf96f feat(url4): result frames carry an inline body or an artifact claim ticket
+  - 81a2f664 feat(screamingface-engine): content-addressed artifact store for spilled results
+  - dbdb8386 feat(screamingface-engine): spill or refuse oversized results instead of truncating
+  - b4a7823d feat(screamingface-engine): serve spilled results over REST with TTL-only cleanup
+  - 412d8439 feat(py-screamingface): redeem and verify artifact results in the transport
+  - 013314a3 fix(py-screamingface): name legacy Engine truncation instead of 'must be JSON'
+- **Gates:** ALL GATES GREEN × 3 stacks — url4 (1168 tests, cov ≥95), screamingface-engine
+  (1763 tests incl. 2 new integration, cov ≥80), screamingface (929 tests, cov ≥95 +
+  notebooks + build + distribution)
+- **Deviations:**
+  1. **Third stack touched: `packages/url4`** — `ResultData` is defined there, not in the
+     engine; the ticket's two landing labels under-count. Additive change only.
+  2. **Prior tests changed** (gates run `--skip-append-only` for engine + SDK):
+     `test_over_cap_result_is_truncated_with_marker` REPLACED by 4 fork tests — it
+     asserted the exact behavior the approved ticket deletes; type-narrowing asserts
+     added to 4 prior assertions (`str | None` ripple); `protocol_server` double gained
+     an additive mode. No prior assertion was weakened.
+  3. **k8s backend gap (pre-agreed flag):** runner Job pod and App pod have separate
+     disks; `URL4_CLOUD_ARTIFACTS_DIR` must name a shared volume there — chart work, not
+     in this unit (AIDEV-NOTE in job_env.py). Local mode (the bug's repro environment)
+     is complete end-to-end.
+  4. **Multi-candidate "Partial Report" acceptance criterion not implementable as
+     written:** the SDK has no partial-report path — any candidate failure aborts the
+     whole evaluation (`_evaluation/runner.py` cancel + re-raise). That is pre-existing
+     behavior this unit neither caused nor changed; the criterion needs its own ticket.
+  5. `uv sync --all-extras` surfaced a pyright error CI never sees (CI syncs only
+     `--extra notebook`); env re-pinned to CI's extras.
+
+## Review-fix round (2026-08-19, same unit — 10 verified findings, all addressed)
+
+Owner-run review returned 10 confirmed findings; all fixed before commit:
+
+1+2. **Delete-on-fetch removed entirely (design change).** Content-addressed dedup means
+   one file can back many tickets, and Starlette's BackgroundTask fires whether or not the
+   client got the bytes (a Range request consumed the parcel). Artifacts now die by TTL
+   ONLY; fetching never deletes — refetch/resume/dedup all safe. Route, tests, spine test
+   and notebook updated to pin the new contract.
+3. Artifact fetch retries transient network failures (3 attempts, backoff); HTTP problems
+   and integrity mismatches stay no-retry.
+4. Client streams against the ticket's `size_bytes` bound — never buffers past it.
+5. Artifact 404 detail now names the multi-pod shared-volume cause alongside TTL expiry.
+6. Hard cap checked FIRST in `build_result` — inverted knobs can no longer bypass it into
+   an oversized WS frame.
+7. Sweep tolerates files vanishing mid-scan, collects `.tmp` write leftovers, and the
+   periodic loop survives sweep exceptions (logs, keeps cadence).
+8. Claim-ticket redemption moved OUTSIDE the WS socket scope in both transports — a fetch
+   failure can no longer trip the stop-on-interrupt arm on a closed socket.
+9. Inline result frames byte-identical again: `artifact` serialized only when present
+   (`Field(exclude_if=…)`; a wrap-serializer was rejected — it erased the JSON schema and
+   failed the engine's OpenAPI docs gate).
+10. Result encoded ONCE (`write_bytes`) and `build_result` runs via `asyncio.to_thread`,
+   so a gigabyte spill cannot stall heartbeats.
+   Also: env caps renamed `_B` → `_BYTES` (owner call — bits/bytes ambiguity), executor
+   defaults now reference `job_env` constants, `getattr` wiring fallbacks removed, legacy
+   marker error states evidence rather than certainty. Gates re-run green ×3 stacks.

--- a/docs/work/2026-08-19-OME-892-deliver-large-results.md
+++ b/docs/work/2026-08-19-OME-892-deliver-large-results.md
@@ -151,6 +151,16 @@ retry loop instead of reusing the run-start token; fake-server seam `artifact_to
 expires all run tokens once the result frame streams, reproducing the incident
 deterministically (RED), fresh-mint fix turns it GREEN.
 
+- Commit: 4a45b6bb fix(py-screamingface): mint a fresh capability token to redeem
+  result artifacts (pushed to PR #647; PR body gained a "Live-run validation" section)
+- Gates: full SDK pytest 921 passed + ruff format/check + pyright clean on the three
+  touched files. The repo-wide format gate could not run green: the owner's live-session
+  notebook edits (`examples/07_ifeval.ipynb`, `examples/08_healthbench_worst30.ipynb`)
+  are unformatted AND `08` holds a plaintext OpenRouter API key — left untouched,
+  NEVER staged; owner to scrub before any notebook commit. Append-only gate run with
+  the documented `--skip-append-only` (additive `protocol_server` seam, same precedent
+  as deviation 2).
+
 ## Review-fix round (2026-08-19, same unit — 10 verified findings, all addressed)
 
 Owner-run review returned 10 confirmed findings; all fixed before commit:

--- a/docs/work/2026-08-19-OME-892-deliver-large-results.md
+++ b/docs/work/2026-08-19-OME-892-deliver-large-results.md
@@ -132,6 +132,25 @@ SDK:
   5. `uv sync --all-extras` surfaced a pyright error CI never sees (CI syncs only
      `--extra notebook`); env re-pinned to CI's extras.
 
+## Live-run validation round (2026-08-19, same unit — real paid run, 1 defect found)
+
+Owner ran the full `healthbench-worst30` evaluation (157 cases, ~960 model calls, ~50 min)
+against the worktree engine. The result came out at 2,835,927 bytes (2.7 MiB > 1 MiB cap):
+
+- **Spill path VALIDATED with real money**: the engine wrote the content-addressed
+  artifact (sha-named file verified byte-identical) and the terminal event carried the
+  claim ticket — the exact #642 scenario that used to truncate-and-lie.
+- **Defect: redemption 401.** The SDK redeems with the capability token minted at run
+  START (`minted[-1]`); engine tokens live 60 s; the run took ~50 min → expired →
+  `GET /artifacts/{id}` 401. Unit/integration tests could not see it: they fetch
+  milliseconds after mint. TTL-only cleanup (review round, findings 1+2) preserved the
+  parcel on disk — the $30 outcome was recovered by hand, nothing lost.
+
+Fix (this round, TDD): `_materialize_sync/_async` mint a FRESH token inside the fetch
+retry loop instead of reusing the run-start token; fake-server seam `artifact_token_expiry`
+expires all run tokens once the result frame streams, reproducing the incident
+deterministically (RED), fresh-mint fix turns it GREEN.
+
 ## Review-fix round (2026-08-19, same unit — 10 verified findings, all addressed)
 
 Owner-run review returned 10 confirmed findings; all fixed before commit:

--- a/docs/work/2026-08-19-OME-892-deliver-large-results.md
+++ b/docs/work/2026-08-19-OME-892-deliver-large-results.md
@@ -161,6 +161,16 @@ deterministically (RED), fresh-mint fix turns it GREEN.
   the documented `--skip-append-only` (additive `protocol_server` seam, same precedent
   as deviation 2).
 
+## Reviewer follow-up (2026-08-19, same unit — dedup/TTL race)
+
+Keelan's review of PR #647 spotted: artifacts dedup by content hash but age by mtime,
+which only the FIRST write stamped — a byte-identical result re-arriving near/past the
+first copy's TTL minted a ticket pointing at a file the next sweep removes. Confirmed
+real in code (`write_bytes` skipped existing files). Fixed (3e6aba91): a dedup hit
+re-stamps mtime via `os.utime` (EAFP — the touch doubles as the existence probe,
+closing the exists-then-sweep TOCTOU as well); sweep docstring now states mtime = LAST
+deposit time. Engine gates ALL GREEN.
+
 ## Review-fix round (2026-08-19, same unit — 10 verified findings, all addressed)
 
 Owner-run review returned 10 confirmed findings; all fixed before commit:

--- a/packages/screamingface/src/screamingface/_core/ports.py
+++ b/packages/screamingface/src/screamingface/_core/ports.py
@@ -17,15 +17,35 @@ type AsyncEventObserver = Callable[[Event], None | Awaitable[None]]
 
 
 @dataclass(frozen=True, slots=True)
+class _ResultArtifact:
+    """Claim ticket for a result the Engine spilled instead of sending inline (OME-892).
+
+    The transport redeems it (`GET /artifacts/{id}`) and verifies `size_bytes` + `sha256`
+    before any decoding sees the bytes.
+    """
+
+    id: str
+    size_bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True, slots=True)
 class _RunOutcome:
-    """Transport-neutral root result retained for strict Report decoding."""
+    """Transport-neutral root result retained for strict Report decoding.
+
+    INVARIANT: exactly one of `result_body` / `artifact` is set when the contract layer
+    builds this; the transport materializes an artifact outcome into a full `result_body`
+    (artifact=None) before anything downstream decodes it — Report construction never
+    sees an unredeemed ticket.
+    """
 
     run_id: str
     started_at: datetime
     completed_at: datetime
-    result_body: str
+    result_body: str | None
     media_type: str | None
     root_usage: Usage | None
+    artifact: _ResultArtifact | None = None
 
 
 class SyncRunTransport(Protocol):

--- a/packages/screamingface/src/screamingface/_engine/contract.py
+++ b/packages/screamingface/src/screamingface/_engine/contract.py
@@ -12,7 +12,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, cast
 
 from screamingface import events
-from screamingface._core.ports import _RunOutcome
+from screamingface._core.ports import _ResultArtifact, _RunOutcome
 from screamingface.errors import ExecutionError
 from screamingface.report import Usage as AccountingUsage
 
@@ -51,7 +51,7 @@ class _RunState:
         self._run_id: str | None = None
         self._root_source: str | None = None
         self._started_at: datetime | None = None
-        self._result: tuple[str, str | None] | None = None
+        self._result: tuple[str | None, str | None, _ResultArtifact | None] | None = None
         self._root_usage: AccountingUsage | None = None
         self._last_sequence = 0
         self._event_ids: set[str] = set()
@@ -168,9 +168,17 @@ class _RunState:
             return _Accepted()
         if self._result is not None:
             raise ExecutionError("SF Engine emitted duplicate root result Events")
-        body = _raw_text(data, "body")
         media_type = _optional_text(data.get("media_type"), "media_type")
-        self._result = (body, media_type)
+        # FEATURE: deliver large results in full (OME-892) — a result frame carries either
+        # the inline body or an artifact claim ticket, never both and never neither.
+        artifact_raw = data.get("artifact")
+        if artifact_raw is not None:
+            if data.get("body") is not None:
+                raise ExecutionError("SF Engine result carries both a body and an artifact")
+            self._result = (None, media_type, _artifact_reference(artifact_raw))
+            return _Accepted()
+        body = _raw_text(data, "body")
+        self._result = (body, media_type, None)
         return _Accepted()
 
     def _terminated(
@@ -206,6 +214,7 @@ class _RunState:
                 result_body=self._result[0],
                 media_type=self._result[1],
                 root_usage=self._root_usage,
+                artifact=self._result[2],
             ),
         )
 
@@ -482,6 +491,29 @@ def _required_text(value: object, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ExecutionError(f"SF Engine {label} must be a non-empty string")
     return value.strip()
+
+
+_ARTIFACT_ID_HEX_LEN = 64
+
+
+def _artifact_reference(value: object) -> _ResultArtifact:
+    """Decode a result frame's artifact claim ticket, strictly (OME-892).
+
+    INVARIANT: an id/sha that is not lowercase sha256 hex is rejected here, before any
+    fetch — it is both the path-traversal guard and the integrity contract's precondition.
+    """
+    mapping = _object(value, "result artifact")
+    artifact_id = _raw_text(mapping, "id")
+    sha256 = _raw_text(mapping, "sha256")
+    for label, digest in (("id", artifact_id), ("sha256", sha256)):
+        if len(digest) != _ARTIFACT_ID_HEX_LEN or any(
+            ch not in "0123456789abcdef" for ch in digest
+        ):
+            raise ExecutionError(f"SF Engine result artifact {label} must be sha256 hex")
+    size_bytes = _integer(mapping.get("size_bytes"), "result artifact size_bytes")
+    if size_bytes < 1:
+        raise ExecutionError("SF Engine result artifact size_bytes must be positive")
+    return _ResultArtifact(id=artifact_id, size_bytes=size_bytes, sha256=sha256)
 
 
 def _raw_text(value: Mapping[str, object], name: str) -> str:

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -118,7 +118,7 @@ class Url4CloudTransport:
                     # By now the run is over and the WS is closed — a fetch failure here
                     # must surface as its own error, never trip the socket-scoped
                     # stop-on-interrupt arm into writing to a dead connection.
-                    return _materialize_sync(self._http, minted[-1], outcome)
+                    return _materialize_sync(self._http, outcome)
                 except InvalidStatus as exc:
                     if attempt != 0 or not _is_access_websocket_rejection(exc):
                         raise
@@ -300,7 +300,7 @@ class AsyncUrl4CloudTransport:
                         on_event,
                     )
                 # FEATURE OME-892: redeem outside the socket scope — see the sync twin.
-                return await _materialize_async(self._http, minted[-1], outcome)
+                return await _materialize_async(self._http, outcome)
             except InvalidStatus as exc:
                 if attempt != 0 or not _is_access_websocket_rejection(exc):
                     raise
@@ -592,8 +592,16 @@ def _fetch_artifact_once_sync(http: httpx.Client, token: str, artifact: _ResultA
     return _verified_artifact_text(artifact, b"".join(chunks), digest.hexdigest())
 
 
-def _materialize_sync(http: httpx.Client, token: str, outcome: _RunOutcome) -> _RunOutcome:
-    """Redeem an artifact outcome into a full `result_body` before anyone decodes it."""
+def _materialize_sync(http: httpx.Client, outcome: _RunOutcome) -> _RunOutcome:
+    """Redeem an artifact outcome into a full `result_body` before anyone decodes it.
+
+    INVARIANT: redemption presents a token minted AFTER the run ended, never the
+    run-start token. Capability tokens live ~60 s while an evaluation can run for
+    hours, so by redemption time every token minted before or during the run is
+    expired — reusing one 401s and strands a paid result on the server (the
+    2026-08-19 healthbench-worst30 live run, $30). The mint sits INSIDE the retry
+    loop so a transient mint failure is retried like a transient fetch failure.
+    """
     artifact = outcome.artifact
     if artifact is None:
         return outcome
@@ -602,7 +610,7 @@ def _materialize_sync(http: httpx.Client, token: str, outcome: _RunOutcome) -> _
         if delay:
             time.sleep(delay)
         try:
-            body = _fetch_artifact_once_sync(http, token, artifact)
+            body = _fetch_artifact_once_sync(http, _mint_sync(http), artifact)
         except httpx.HTTPError as exc:
             last_error = exc
             continue
@@ -635,10 +643,8 @@ async def _fetch_artifact_once_async(
     return _verified_artifact_text(artifact, b"".join(chunks), digest.hexdigest())
 
 
-async def _materialize_async(
-    http: httpx.AsyncClient, token: str, outcome: _RunOutcome
-) -> _RunOutcome:
-    """Async twin of `_materialize_sync` — same retry, same verification."""
+async def _materialize_async(http: httpx.AsyncClient, outcome: _RunOutcome) -> _RunOutcome:
+    """Async twin of `_materialize_sync` — same fresh mint, same retry, same verification."""
     artifact = outcome.artifact
     if artifact is None:
         return outcome
@@ -647,7 +653,7 @@ async def _materialize_async(
         if delay:
             await asyncio.sleep(delay)
         try:
-            body = await _fetch_artifact_once_async(http, token, artifact)
+            body = await _fetch_artifact_once_async(http, await _mint_async(http), artifact)
         except httpx.HTTPError as exc:
             last_error = exc
             continue

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import inspect
 import ssl
 import time
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace as _dataclass_replace
 from threading import Lock
 from typing import Protocol
 from urllib.parse import urlencode, urlsplit, urlunsplit
@@ -20,7 +22,7 @@ from websockets.sync import client as sync_ws
 from websockets.sync.connection import Connection as SyncConnection
 from websockets.typing import Subprotocol
 
-from screamingface._core.ports import _RunOutcome
+from screamingface._core.ports import _ResultArtifact, _RunOutcome
 from screamingface._core.wire import _REPLAY_SAFE
 from screamingface._engine.access_contract import _challenge_audience
 from screamingface._engine.auth import _default_caller_auth, _TransportAuth
@@ -40,14 +42,17 @@ _EVENT_RECEIVE_TIMEOUT_SECONDS = 120.0
 _STOP_TIMEOUT_SECONDS = 5.0
 # The Engine answers a stop for a Run it has already finished with one of these.
 _ALREADY_STOPPED_STATUSES = frozenset({404, 409, 410})
-# INVARIANT: this MUST stay above the Engine's result cap plus the frame that carries it.
-# The Engine truncates a result body to 1 MiB, then wraps it in a CloudEvent whose `data.body`
-# is a JSON string — escaping alone adds ~7% on a JSON report and can double it in the worst
-# case, before the envelope. `websockets` defaults `max_size` to 2**20, which is EXACTLY the
-# Engine's cap, so the default made every capped result undeliverable: the client refused the
-# frame with close 1009 and the Run surfaced as `websocket_disconnected`. Eight times the cap
-# clears the worst-case expansion with room to spare, and the bound still exists so that a
-# malformed or hostile stream cannot grow this process's heap without limit.
+# INVARIANT: this MUST stay above the Engine's INLINE result threshold plus the frame that
+# carries it. The Engine sends a result body inline only up to its inline cap (default
+# 1 MiB; larger results travel out-of-band as an artifact claim ticket — OME-892), wrapped
+# in a CloudEvent whose `data.body` is a JSON string — escaping alone adds ~7% on a JSON
+# report and can double it in the worst case, before the envelope. `websockets` defaults
+# `max_size` to 2**20, which is EXACTLY the inline cap, so the default made every cap-sized
+# result undeliverable: the client refused the frame with close 1009 and the Run surfaced
+# as `websocket_disconnected`. Eight times the cap clears the worst-case expansion with
+# room to spare, and the bound still exists so that a malformed or hostile stream cannot
+# grow this process's heap without limit. An operator who raises the Engine's
+# URL4_CLOUD_RESULT_INLINE_CAP_BYTES past 4 MiB must account for this client-side bound too.
 _MAX_FRAME_BYTES = 8 * 1024 * 1024
 
 
@@ -102,20 +107,22 @@ class Url4CloudTransport:
                         max_size=_MAX_FRAME_BYTES,
                         ssl=self._ssl,
                     ) as websocket:
-                        return self._run_connected(
+                        outcome = self._run_connected(
                             websocket,
                             lifecycle,
                             minted[-1],
                             candidate,
                             on_event,
                         )
+                    # FEATURE OME-892: redeem the claim ticket OUTSIDE the socket scope.
+                    # By now the run is over and the WS is closed — a fetch failure here
+                    # must surface as its own error, never trip the socket-scoped
+                    # stop-on-interrupt arm into writing to a dead connection.
+                    return _materialize_sync(self._http, minted[-1], outcome)
                 except InvalidStatus as exc:
                     if attempt != 0 or not _is_access_websocket_rejection(exc):
                         raise
-                    self._caller_auth.reauthenticate()
-                    minted.append(_mint_sync(self._http))
-                    with self._active_lock:
-                        self._active_tokens.add(minted[-1])
+                    self._remint_after_challenge(minted)
             raise AssertionError("WebSocket authentication retry loop exhausted")
         except _ObserverRaised as exc:
             _copy_notes(exc, exc.original)
@@ -125,6 +132,17 @@ class Url4CloudTransport:
         finally:
             with self._active_lock:
                 self._active_tokens.difference_update(minted)
+
+    def _remint_after_challenge(self, minted: list[str]) -> None:
+        """Refresh Access auth and mint a fresh capability after a WS challenge.
+
+        WHY a NEW capability rather than the one in hand: its iat window is 60s and the
+        re-login can take minutes — see the async twin's inline comment.
+        """
+        self._caller_auth.reauthenticate()
+        minted.append(_mint_sync(self._http))
+        with self._active_lock:
+            self._active_tokens.add(minted[-1])
 
     def cancel_active(self) -> None:
         """Stop every run currently owned by this synchronous Client."""
@@ -274,13 +292,15 @@ class AsyncUrl4CloudTransport:
                     max_size=_MAX_FRAME_BYTES,
                     ssl=self._ssl,
                 ) as websocket:
-                    return await self._run_connected(
+                    outcome = await self._run_connected(
                         websocket,
                         lifecycle,
                         minted[-1],
                         candidate,
                         on_event,
                     )
+                # FEATURE OME-892: redeem outside the socket scope — see the sync twin.
+                return await _materialize_async(self._http, minted[-1], outcome)
             except InvalidStatus as exc:
                 if attempt != 0 or not _is_access_websocket_rejection(exc):
                     raise
@@ -505,6 +525,137 @@ def _accepted(response: httpx.Response) -> None:
         raise ExecutionError("SF Engine did not acknowledge asynchronous execution")
     if not response.headers.get("Location"):
         raise ExecutionError("SF Engine asynchronous response is missing Location")
+
+
+_FETCH_ARTIFACT = "fetch the Run's result artifact"
+
+
+def _verified_artifact_text(artifact: _ResultArtifact, payload: bytes, digest_hex: str) -> str:
+    """Admit fetched bytes as the result ONLY when they match the claim ticket exactly.
+
+    INVARIANT: byte count and sha256 both match, or nothing downstream decodes —
+    a mismatched fetch must never turn into a half-parsed Report (GitHub #642's lesson).
+    """
+    if len(payload) != artifact.size_bytes or digest_hex != artifact.sha256:
+        raise ExecutionError(
+            f"SF Engine result artifact failed integrity verification: expected "
+            f"{artifact.size_bytes} bytes with sha256 {artifact.sha256}, received "
+            f"{len(payload)} bytes with sha256 {digest_hex}",
+            code="result_integrity_mismatch",
+            permanent=True,
+        )
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ExecutionError(
+            "SF Engine result artifact is not UTF-8 text",
+            code="result_integrity_mismatch",
+            permanent=True,
+        ) from exc
+
+
+# WHY retry here when run start has its own delays: the run is DONE and paid for — the
+# parcel sits on the server (fetching never deletes it), so a transient reset must never
+# cost the outcome. Network-level failures retry; HTTP problem responses (4xx/5xx) and
+# integrity mismatches are deterministic answers and do not.
+_ARTIFACT_FETCH_RETRY_DELAYS = (0.0, 0.2, 0.8)
+
+
+def _oversize(artifact: _ResultArtifact, received: int) -> ExecutionError:
+    return ExecutionError(
+        f"SF Engine result artifact exceeded its ticket: expected {artifact.size_bytes} "
+        f"bytes, received at least {received}",
+        code="result_integrity_mismatch",
+        permanent=True,
+    )
+
+
+def _fetch_artifact_once_sync(http: httpx.Client, token: str, artifact: _ResultArtifact) -> str:
+    """One fetch attempt. Lets `httpx.HTTPError` escape so the caller can retry it."""
+    digest = hashlib.sha256()
+    chunks: list[bytes] = []
+    received = 0
+    with http.stream(
+        "GET", f"/artifacts/{artifact.id}", headers={"URL4-Capability": token}
+    ) as response:
+        if not response.is_success:
+            response.read()
+            _raise_response(response, _FETCH_ARTIFACT)
+        for chunk in response.iter_bytes():
+            received += len(chunk)
+            # INVARIANT: never buffer past the ticket's declared size — the ticket is
+            # the memory bound, so a rogue 200 cannot OOM the researcher's process.
+            if received > artifact.size_bytes:
+                raise _oversize(artifact, received)
+            digest.update(chunk)
+            chunks.append(chunk)
+    return _verified_artifact_text(artifact, b"".join(chunks), digest.hexdigest())
+
+
+def _materialize_sync(http: httpx.Client, token: str, outcome: _RunOutcome) -> _RunOutcome:
+    """Redeem an artifact outcome into a full `result_body` before anyone decodes it."""
+    artifact = outcome.artifact
+    if artifact is None:
+        return outcome
+    last_error: httpx.HTTPError | None = None
+    for delay in _ARTIFACT_FETCH_RETRY_DELAYS:
+        if delay:
+            time.sleep(delay)
+        try:
+            body = _fetch_artifact_once_sync(http, token, artifact)
+        except httpx.HTTPError as exc:
+            last_error = exc
+            continue
+        return _dataclass_replace(outcome, result_body=body, artifact=None)
+    raise EngineUnavailableError(
+        "Could not fetch the Run's result artifact",
+        engine_url=_http_origin(http),
+    ) from last_error
+
+
+async def _fetch_artifact_once_async(
+    http: httpx.AsyncClient, token: str, artifact: _ResultArtifact
+) -> str:
+    """Async twin of `_fetch_artifact_once_sync`."""
+    digest = hashlib.sha256()
+    chunks: list[bytes] = []
+    received = 0
+    async with http.stream(
+        "GET", f"/artifacts/{artifact.id}", headers={"URL4-Capability": token}
+    ) as response:
+        if not response.is_success:
+            await response.aread()
+            _raise_response(response, _FETCH_ARTIFACT)
+        async for chunk in response.aiter_bytes():
+            received += len(chunk)
+            if received > artifact.size_bytes:
+                raise _oversize(artifact, received)
+            digest.update(chunk)
+            chunks.append(chunk)
+    return _verified_artifact_text(artifact, b"".join(chunks), digest.hexdigest())
+
+
+async def _materialize_async(
+    http: httpx.AsyncClient, token: str, outcome: _RunOutcome
+) -> _RunOutcome:
+    """Async twin of `_materialize_sync` — same retry, same verification."""
+    artifact = outcome.artifact
+    if artifact is None:
+        return outcome
+    last_error: httpx.HTTPError | None = None
+    for delay in _ARTIFACT_FETCH_RETRY_DELAYS:
+        if delay:
+            await asyncio.sleep(delay)
+        try:
+            body = await _fetch_artifact_once_async(http, token, artifact)
+        except httpx.HTTPError as exc:
+            last_error = exc
+            continue
+        return _dataclass_replace(outcome, result_body=body, artifact=None)
+    raise EngineUnavailableError(
+        "Could not fetch the Run's result artifact",
+        engine_url=_http_origin(http),
+    ) from last_error
 
 
 def _require_success(response: httpx.Response, operation: str) -> None:

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -26,6 +26,43 @@ from screamingface.report import (
     Usage,
 )
 
+# The marker pre-OME-892 Engines glued onto a cut result body. Recognized here so a run
+# against an OLD Engine fails with the real cause instead of the generic "must be JSON".
+_LEGACY_TRUNCATION_MARKER = "…[truncated]"
+
+
+def _decoded_result_body(outcome: _RunOutcome) -> object:
+    """Decode the root result body, naming truncation and unredeemed tickets precisely.
+
+    FEATURE: deliver large results in full (OME-892). Order of the checks: (1) a None
+    body means the transport failed to materialize an artifact outcome — a bug to name,
+    not a TypeError to leak; (2) JSON that parses is returned; (3) unparseable JSON
+    ending in the legacy marker is an OLD Engine's truncation — report the received byte
+    count so the researcher learns what happened from the error alone; (4) anything else
+    keeps the generic message.
+    """
+    body = outcome.result_body
+    if body is None:
+        raise ExecutionError(
+            "SF Engine Candidate result artifact was not materialized by the transport"
+        )
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        if body.endswith(_LEGACY_TRUNCATION_MARKER):
+            # WHY "ends with the marker" phrasing: a body could conceivably end with
+            # this literal for another reason — the error states the evidence (marker +
+            # byte count) rather than asserting certainty about the cause.
+            raise ExecutionError(
+                "SF Engine candidate result is invalid JSON and ends with the Engine's "
+                f"truncation marker at {len(body.encode('utf-8'))} bytes — most likely "
+                "truncated by a pre-OME-892 Engine; upgrade the Engine to deliver large "
+                "results whole, or run with a smaller limit",
+                code="result_truncated",
+                permanent=True,
+            ) from exc
+        raise ExecutionError("SF Engine Candidate result must be JSON") from exc
+
 
 def report_from_outcomes(
     evaluation: _Evaluation,
@@ -46,10 +83,7 @@ def report_from_outcomes(
 def report_from_url4_outcome(candidate: Candidate, outcome: _RunOutcome) -> Report:
     """Decode an opaque replay after its result identifies the pinned Benchmark."""
 
-    try:
-        payload = json.loads(outcome.result_body)
-    except json.JSONDecodeError as exc:
-        raise ExecutionError("SF Engine Candidate result must be JSON") from exc
+    payload = _decoded_result_body(outcome)
     value = _mapping(payload, "Candidate result")
     if value.get("schema") != "screamingface.candidate-result.v1":
         raise ExecutionError("SF Engine Candidate result schema is unsupported")
@@ -123,10 +157,7 @@ def _candidate_payload(
     evaluation: _Evaluation,
     outcome: _RunOutcome,
 ) -> Mapping[str, object]:
-    try:
-        payload = json.loads(outcome.result_body)
-    except json.JSONDecodeError as exc:
-        raise ExecutionError("SF Engine Candidate result must be JSON") from exc
+    payload = _decoded_result_body(outcome)
     value = _mapping(payload, "Candidate result")
     _keys(
         value,

--- a/packages/screamingface/tests/protocol_server.py
+++ b/packages/screamingface/tests/protocol_server.py
@@ -63,6 +63,12 @@ class ProtocolState:
     artifact_missing: bool = False
     artifact_fail_first: int = 0
     artifact_requests: list[tuple[str, str | None]] = field(default_factory=list)
+    # OME-892 incident seam: real capability tokens live ~60 s while a run takes an hour,
+    # so every token minted BEFORE the result frame streamed is expired by redemption
+    # time. With this flag on, streaming the result expires all tokens minted so far and
+    # `/artifacts/{id}` 401s them — redemption succeeds only with a freshly minted token.
+    artifact_token_expiry: bool = False
+    expired_tokens: list[str] = field(default_factory=list)
 
     def mint_token(self) -> str:
         with self.lock:
@@ -144,6 +150,23 @@ class _Handler(BaseHTTPRequestHandler):
 
             self.connection.shutdown(_socket.SHUT_RDWR)
             self.connection.close()
+            return
+        with state.lock:
+            expired = (
+                state.artifact_token_expiry
+                and self.headers.get("URL4-Capability") in state.expired_tokens
+            )
+        if expired:
+            self._json(
+                HTTPStatus.UNAUTHORIZED,
+                {
+                    "type": "about:blank",
+                    "title": "Unauthorized",
+                    "status": HTTPStatus.UNAUTHORIZED,
+                    "detail": "missing, invalid, or expired capability token",
+                },
+                media_type="application/problem+json",
+            )
             return
         if state.artifact_missing:
             self._json(
@@ -333,6 +356,12 @@ class _Handler(BaseHTTPRequestHandler):
         )
         for frame in frames:
             _send_server_text_frame(self.wfile, json.dumps(frame))
+        state = self.server.state
+        if state.artifact_token_expiry:
+            # The run is over: every token minted so far is now older than the real
+            # engine's 60 s capability TTL — redemption must present a fresh mint.
+            with state.lock:
+                state.expired_tokens.extend(state.minted_tokens)
 
     def _stream_stop(self) -> None:
         _send_server_text_frame(self.wfile, json.dumps(_run_frames()[0]))
@@ -601,12 +630,14 @@ def protocol_server(
     artifact_served: bytes | None = None,
     artifact_missing: bool = False,
     artifact_fail_first: int = 0,
+    artifact_token_expiry: bool = False,
 ) -> Iterator[ProtocolServer]:
     state = ProtocolState(
         mode=mode,
         artifact_served=artifact_served,
         artifact_missing=artifact_missing,
         artifact_fail_first=artifact_fail_first,
+        artifact_token_expiry=artifact_token_expiry,
     )
     if artifact_body is not None:
         state.artifact_body = artifact_body

--- a/packages/screamingface/tests/protocol_server.py
+++ b/packages/screamingface/tests/protocol_server.py
@@ -53,7 +53,16 @@ class ProtocolState:
         "start_error",
         "start_auth_error",
         "stream_failed",
+        "artifact_result",
     ] = "success"
+    # OME-892 artifact mode: the result frame carries a claim ticket for `artifact_body`;
+    # `/artifacts/{id}` serves `artifact_served` when set (corruption seam), else the true
+    # bytes, or 404 when `artifact_missing`. Fetches are recorded as (path, capability).
+    artifact_body: str = "[test] " + "A" * 2048
+    artifact_served: bytes | None = None
+    artifact_missing: bool = False
+    artifact_fail_first: int = 0
+    artifact_requests: list[tuple[str, str | None]] = field(default_factory=list)
 
     def mint_token(self) -> str:
         with self.lock:
@@ -115,8 +124,49 @@ class _Handler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802 — stdlib handler API
         if self.headers.get("Upgrade", "").casefold() == "websocket":
             self._websocket()
+        elif urlsplit(self.path).path.startswith("/artifacts/"):
+            self._artifact()
         else:
             self._start()
+
+    def _artifact(self) -> None:
+        state = self.server.state
+        with state.lock:
+            state.artifact_requests.append((self.path, self.headers.get("URL4-Capability")))
+            transient_failure = state.artifact_fail_first > 0
+            if transient_failure:
+                state.artifact_fail_first -= 1
+        if transient_failure:
+            # A mid-transfer reset, not a clean HTTP error: shut the socket down hard so
+            # the client sees the drop IMMEDIATELY (close() alone leaves httpx waiting
+            # out its read timeout), then close — the transient the retry must survive.
+            import socket as _socket
+
+            self.connection.shutdown(_socket.SHUT_RDWR)
+            self.connection.close()
+            return
+        if state.artifact_missing:
+            self._json(
+                HTTPStatus.NOT_FOUND,
+                {
+                    "type": "about:blank",
+                    "title": "Unknown artifact",
+                    "status": HTTPStatus.NOT_FOUND,
+                    "detail": "no artifact is stored under that id",
+                },
+                media_type="application/problem+json",
+            )
+            return
+        payload = (
+            state.artifact_served
+            if state.artifact_served is not None
+            else state.artifact_body.encode("utf-8")
+        )
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
 
     def _start(self) -> None:
         self.server.state.start_attempts += 1
@@ -276,7 +326,12 @@ class _Handler(BaseHTTPRequestHandler):
             _send_server_text_frame(self.wfile, json.dumps(_advisory_error()))
         elif mode == "unsequenced_log":
             _send_server_text_frame(self.wfile, json.dumps(_unsequenced_log()))
-        for frame in _run_frames():
+        frames = (
+            _artifact_run_frames(self.server.state.artifact_body)
+            if mode == "artifact_result"
+            else _run_frames()
+        )
+        for frame in frames:
             _send_server_text_frame(self.wfile, json.dumps(frame))
 
     def _stream_stop(self) -> None:
@@ -382,6 +437,23 @@ def _run_frames() -> tuple[dict[str, object], ...]:
             4,
         ),
     )
+
+
+def _artifact_run_frames(artifact_body: str) -> tuple[dict[str, object], ...]:
+    """The success run, but the result frame carries a claim ticket (OME-892)."""
+    encoded = artifact_body.encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()
+    frames = list(_run_frames())
+    frames[2] = _frame(
+        "ai.url4.result",
+        {
+            "body": None,
+            "media_type": None,
+            "artifact": {"id": digest, "size_bytes": len(encoded), "sha256": digest},
+        },
+        3,
+    )
+    return tuple(frames)
 
 
 def _gap_frames() -> tuple[dict[str, object], ...]:
@@ -523,9 +595,21 @@ def protocol_server(
         "start_error",
         "start_auth_error",
         "stream_failed",
+        "artifact_result",
     ] = "success",
+    artifact_body: str | None = None,
+    artifact_served: bytes | None = None,
+    artifact_missing: bool = False,
+    artifact_fail_first: int = 0,
 ) -> Iterator[ProtocolServer]:
-    state = ProtocolState(mode=mode)
+    state = ProtocolState(
+        mode=mode,
+        artifact_served=artifact_served,
+        artifact_missing=artifact_missing,
+        artifact_fail_first=artifact_fail_first,
+    )
+    if artifact_body is not None:
+        state.artifact_body = artifact_body
     server = _Server(("127.0.0.1", 0), state)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()

--- a/packages/screamingface/tests/test_engine_contract.py
+++ b/packages/screamingface/tests/test_engine_contract.py
@@ -11,6 +11,7 @@ import pytest
 import screamingface as sf
 from screamingface._engine import contract as _engine_contract
 from screamingface._engine.contract import _RunState
+from screamingface.errors import ExecutionError
 
 URL4 = "(@)!'hello'"
 
@@ -707,3 +708,62 @@ def test_unsequenced_lifecycle_frames_are_still_rejected(
     # would corrupt the billing total the user reads in their Report.
     with pytest.raises(sf.ExecutionError, match="sequence"):
         _RunState(URL4).accept(frame(event_type, data, sequence=None))
+
+
+# FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+# A result frame may carry an artifact claim ticket instead of an inline body; the state
+# machine surfaces it on the outcome for the transport to redeem before anyone decodes it.
+
+_SHA = "9f" * 32
+
+
+def _artifact_data(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "body": None,
+        "media_type": None,
+        "artifact": {"id": _SHA, "size_bytes": 11, "sha256": _SHA},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_state_decodes_an_artifact_result() -> None:
+    state = _RunState(URL4)
+    state.accept(frame("ai.url4.started", {"url4": URL4}, sequence=1))
+    state.accept(frame("ai.url4.result", _artifact_data(), sequence=2))
+    terminated = state.accept(
+        frame("ai.url4.terminated", {"status": "succeeded", "error": None}, sequence=3)
+    )
+
+    outcome = terminated.outcome
+    assert outcome is not None
+    # INVARIANT: the raw outcome carries the UNREDEEMED ticket — result_body stays None
+    # until the transport fetches and verifies; nothing downstream may guess at content.
+    assert outcome.result_body is None
+    assert outcome.artifact is not None
+    assert outcome.artifact.id == _SHA
+    assert outcome.artifact.size_bytes == 11
+    assert outcome.artifact.sha256 == _SHA
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        {"id": "../etc/passwd", "size_bytes": 11, "sha256": "9f" * 32},
+        {"id": "9f" * 32, "size_bytes": "11", "sha256": "9f" * 32},
+        {"id": "9f" * 32, "size_bytes": 11},
+        "not a mapping",
+    ],
+)
+def test_state_rejects_malformed_artifact_references(artifact: object) -> None:
+    state = _RunState(URL4)
+    state.accept(frame("ai.url4.started", {"url4": URL4}, sequence=1))
+    with pytest.raises(ExecutionError):
+        state.accept(frame("ai.url4.result", {"body": None, "artifact": artifact}, sequence=2))
+
+
+def test_state_rejects_a_result_with_neither_body_nor_artifact() -> None:
+    state = _RunState(URL4)
+    state.accept(frame("ai.url4.started", {"url4": URL4}, sequence=1))
+    with pytest.raises(ExecutionError):
+        state.accept(frame("ai.url4.result", {"body": None, "media_type": None}, sequence=2))

--- a/packages/screamingface/tests/test_results_truncation_marker.py
+++ b/packages/screamingface/tests/test_results_truncation_marker.py
@@ -1,0 +1,65 @@
+"""Decoding results from OLDER Engines that still truncate (OME-892).
+
+FEATURE: deliver large results in full instead of cutting them off at 1 MiB.
+INVARIANT: a body ending in the legacy `…[truncated]` marker is named as truncation —
+with the received byte count — never reported as the generic "must be JSON", which sent
+researchers on an archaeology dig through clean engine logs (GitHub #642).
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from screamingface._core.ports import _RunOutcome
+from screamingface._evaluation.model import Candidate, _compiled_candidate, _compiled_operation
+from screamingface._evaluation.results import report_from_url4_outcome
+from screamingface.errors import ExecutionError
+
+_T = datetime(2026, 8, 18, 9, 0, 0, tzinfo=UTC)
+
+
+def _candidate() -> Candidate:
+    return _compiled_candidate(
+        name="opus",
+        kind="model",
+        models=("provider/opus",),
+        url4="(@)!'hello'",
+        operations=(
+            _compiled_operation(id="op_opus", kind="model", label="opus answer", depends_on=()),
+        ),
+    )
+
+
+def _outcome(body: str | None) -> _RunOutcome:
+    return _RunOutcome(
+        run_id="run_1",
+        started_at=_T,
+        completed_at=_T,
+        result_body=body,
+        media_type="application/json",
+        root_usage=None,
+    )
+
+
+def test_legacy_truncation_marker_is_named_with_the_received_byte_count() -> None:
+    truncated = '{"schema":"screamingface.candidate-result.v1","cases":[' + "…[truncated]"
+    with pytest.raises(ExecutionError) as excinfo:
+        report_from_url4_outcome(_candidate(), _outcome(truncated))
+    message = str(excinfo.value)
+    assert "truncated" in message
+    assert str(len(truncated.encode("utf-8"))) in message
+    assert excinfo.value.code == "result_truncated"
+
+
+def test_invalid_json_without_the_marker_stays_the_generic_error() -> None:
+    with pytest.raises(ExecutionError) as excinfo:
+        report_from_url4_outcome(_candidate(), _outcome('{"cut mid'))
+    assert "must be JSON" in str(excinfo.value)
+
+
+def test_an_unmaterialized_artifact_outcome_is_refused_loudly() -> None:
+    # INVARIANT: results decoding never sees an unredeemed claim ticket; a None body here
+    # is a transport bug and must be named as such, not crash as a TypeError.
+    with pytest.raises(ExecutionError) as excinfo:
+        report_from_url4_outcome(_candidate(), _outcome(None))
+    assert "artifact" in str(excinfo.value).casefold()

--- a/packages/screamingface/tests/test_transport_artifact_fetch.py
+++ b/packages/screamingface/tests/test_transport_artifact_fetch.py
@@ -1,0 +1,147 @@
+"""Transport redemption of result claim tickets (OME-892).
+
+FEATURE: deliver large results in full instead of cutting them off at 1 MiB.
+INVARIANT: an outcome leaves the transport with a fully materialized `result_body` —
+verified against the ticket's byte count and sha256 BEFORE anything decodes it. A
+mismatch is a named integrity failure, never a mangled Report.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from contextlib import closing
+
+import pytest
+from protocol_server import protocol_server
+
+import screamingface as sf
+from screamingface._core.ports import _RunOutcome
+from screamingface._engine.transport import AsyncUrl4CloudTransport, Url4CloudTransport
+from screamingface._evaluation.model import (
+    Candidate,
+    _compiled_candidate,
+    _compiled_operation,
+)
+from screamingface.errors import ExecutionError
+
+
+def _candidate() -> Candidate:
+    return _compiled_candidate(
+        name="opus",
+        kind="model",
+        models=("provider/opus",),
+        url4="(@)!'hello'",
+        operations=(
+            _compiled_operation(
+                id="op_opus",
+                kind="model",
+                label="opus answer",
+                depends_on=(),
+            ),
+        ),
+    )
+
+
+def _run(
+    engine_url: str,
+    on_event: Callable[[sf.Event], None] | None = None,
+) -> _RunOutcome:
+    with closing(Url4CloudTransport(engine_url)) as transport:
+        return transport.run(_candidate(), on_event)
+
+
+async def _arun(
+    engine_url: str,
+    on_event: Callable[[sf.Event], None | Awaitable[None]] | None = None,
+) -> _RunOutcome:
+    transport = AsyncUrl4CloudTransport(engine_url)
+    try:
+        return await transport.run(_candidate(), on_event)
+    finally:
+        await transport.close()
+
+
+def test_sync_transport_materializes_an_artifact_result() -> None:
+    body = '{"cases":[' + "1," * 4000 + "1]}"
+    with protocol_server(mode="artifact_result", artifact_body=body) as engine:
+        outcome = _run(engine.url)
+    assert outcome.result_body == body
+    # The ticket is spent — downstream decoding sees only the materialized body.
+    assert outcome.artifact is None
+
+
+def test_async_transport_materializes_an_artifact_result() -> None:
+    body = '{"cases":[' + "2," * 4000 + "2]}"
+    with protocol_server(mode="artifact_result", artifact_body=body) as engine:
+        outcome = asyncio.run(_arun(engine.url))
+    assert outcome.result_body == body
+    assert outcome.artifact is None
+
+
+def test_artifact_fetch_sends_the_run_capability() -> None:
+    with protocol_server(mode="artifact_result") as engine:
+        _run(engine.url)
+        assert engine.state.artifact_requests
+        path, capability = engine.state.artifact_requests[0]
+        assert path.startswith("/artifacts/")
+        assert capability in engine.state.minted_tokens
+
+
+def test_short_artifact_body_is_a_named_integrity_error() -> None:
+    body = "X" * 1000
+    with protocol_server(
+        mode="artifact_result",
+        artifact_body=body,
+        artifact_served=body.encode("utf-8")[:-7],
+    ) as engine:
+        with pytest.raises(ExecutionError) as excinfo:
+            _run(engine.url)
+    # WHY both numbers: the researcher's first question is "how much arrived?"
+    assert excinfo.value.code == "result_integrity_mismatch"
+    assert "1000" in str(excinfo.value)
+    assert "993" in str(excinfo.value)
+
+
+def test_corrupted_artifact_bytes_are_a_named_integrity_error() -> None:
+    body = "Y" * 1000
+    tampered = b"Z" + body.encode("utf-8")[1:]  # same length, different content
+    with protocol_server(
+        mode="artifact_result", artifact_body=body, artifact_served=tampered
+    ) as engine:
+        with pytest.raises(ExecutionError) as excinfo:
+            _run(engine.url)
+    assert excinfo.value.code == "result_integrity_mismatch"
+
+
+def test_missing_artifact_is_an_execution_error_not_a_report() -> None:
+    with protocol_server(mode="artifact_result", artifact_missing=True) as engine:
+        with pytest.raises(ExecutionError):
+            _run(engine.url)
+
+
+def test_a_transient_reset_during_the_fetch_is_retried_not_fatal() -> None:
+    # WHY: the parcel still sits on the server after a dropped connection — losing a
+    # 16-hour paid run to one TCP reset would be #642's cost with a new cause.
+    body = "W" * 2000
+    with protocol_server(
+        mode="artifact_result", artifact_body=body, artifact_fail_first=2
+    ) as engine:
+        outcome = _run(engine.url)
+    assert outcome.result_body == body
+    # 2 failed attempts + 1 success were all observed by the server.
+    assert len(engine.state.artifact_requests) == 3
+
+
+def test_an_oversized_response_is_cut_off_at_the_ticket_size_not_buffered() -> None:
+    # INVARIANT: the ticket already states the exact size — the client must never buffer
+    # past it, so a rogue 200 cannot OOM the researcher's process.
+    body = "V" * 1000
+    with protocol_server(
+        mode="artifact_result",
+        artifact_body=body,
+        artifact_served=("V" * 1000 + "EXTRA-BYTES-BEYOND-THE-TICKET").encode(),
+    ) as engine:
+        with pytest.raises(ExecutionError) as excinfo:
+            _run(engine.url)
+    assert excinfo.value.code == "result_integrity_mismatch"

--- a/packages/screamingface/tests/test_transport_artifact_fetch.py
+++ b/packages/screamingface/tests/test_transport_artifact_fetch.py
@@ -145,3 +145,31 @@ def test_an_oversized_response_is_cut_off_at_the_ticket_size_not_buffered() -> N
         with pytest.raises(ExecutionError) as excinfo:
             _run(engine.url)
     assert excinfo.value.code == "result_integrity_mismatch"
+
+
+def test_redemption_mints_a_fresh_token_because_run_tokens_expire() -> None:
+    # WHY: capability tokens live ~60 s while an evaluation runs for an hour — the 2026-08-19
+    # live run proved the run-start token is ALWAYS expired by redemption time (401, $30 of
+    # results stranded on disk). Redemption must present a token minted AFTER the run ended.
+    body = '{"cases":[' + "3," * 4000 + "3]}"
+    with protocol_server(
+        mode="artifact_result", artifact_body=body, artifact_token_expiry=True
+    ) as engine:
+        outcome = _run(engine.url)
+        assert outcome.result_body == body
+        # One mint to start the run, one fresh mint to redeem the ticket.
+        assert len(engine.state.minted_tokens) == 2
+        _, capability = engine.state.artifact_requests[-1]
+        assert capability == engine.state.minted_tokens[-1]
+
+
+def test_async_redemption_mints_a_fresh_token_because_run_tokens_expire() -> None:
+    body = '{"cases":[' + "4," * 4000 + "4]}"
+    with protocol_server(
+        mode="artifact_result", artifact_body=body, artifact_token_expiry=True
+    ) as engine:
+        outcome = asyncio.run(_arun(engine.url))
+        assert outcome.result_body == body
+        assert len(engine.state.minted_tokens) == 2
+        _, capability = engine.state.artifact_requests[-1]
+        assert capability == engine.state.minted_tokens[-1]

--- a/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
+++ b/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
@@ -330,6 +330,7 @@ def test_a_result_at_the_engine_cap_reaches_the_researcher() -> None:
         with closing(Url4CloudTransport(stub.url)) as transport:
             outcome = transport.run(_candidate(), None)
 
+    assert outcome.result_body is not None
     assert len(outcome.result_body.encode()) == ENGINE_RESULT_CAP_BYTES
 
 
@@ -342,6 +343,7 @@ async def test_a_result_at_the_engine_cap_reaches_an_async_researcher() -> None:
         finally:
             await transport.close()
 
+    assert outcome.result_body is not None
     assert len(outcome.result_body.encode()) == ENGINE_RESULT_CAP_BYTES
 
 

--- a/packages/screamingface/tests/test_url4_cloud_integration.py
+++ b/packages/screamingface/tests/test_url4_cloud_integration.py
@@ -42,4 +42,5 @@ def test_real_url4_cloud_runner_completes_the_confirmed_transport_lifecycle() ->
     with closing(Url4CloudTransport(_ENGINE_URL)) as transport:
         outcome = transport.run(candidate, None)
 
+    assert outcome.result_body is not None
     assert outcome.result_body.strip()

--- a/packages/url4/src/url4/streaming/protocol/signals.py
+++ b/packages/url4/src/url4/streaming/protocol/signals.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from url4.streaming.protocol.taxonomy import CostBreakdown, ErrorInfo, TokenUsage
 
@@ -136,9 +136,51 @@ class HeartbeatData(BaseModel):
     pass
 
 
+class ResultArtifact(BaseModel):
+    """Claim ticket for a result too large to ride the stream inline (OME-892).
+
+    The node parks the full result as a content-addressed file and emits this reference
+    instead; the client redeems it over HTTP (`GET /artifacts/{id}`) and verifies
+    `size_bytes` + `sha256` before trusting the bytes.
+    """
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    id: str = Field(pattern=r"^[0-9a-f]{64}$")
+    """Content address: the lowercase sha256 hex of the UTF-8 body, which is also the
+    fetch path segment. The pattern is the path-traversal guard — an id that validates
+    can never name anything outside a flat artifact directory."""
+    size_bytes: int = Field(ge=1)
+    """Exact UTF-8 byte count of the complete body — the first integrity check."""
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    """Digest of the complete body — the second integrity check, kept as its own field so
+    `id` may change addressing scheme without changing what the client verifies."""
+
+
 class ResultData(BaseModel):
-    body: str
+    """The run's final result: a complete inline `body`, or an `artifact` claim ticket.
+
+    INVARIANT: exactly one of `body` / `artifact` is set. A body you can see is complete
+    and trustworthy; an artifact means the complete result is one HTTP GET away
+    (`GET /artifacts/{id}`, verified against the ticket's size and sha256). The
+    truncate-and-still-succeed path this replaces (GitHub #642) is unrepresentable.
+    """
+
+    body: str | None = None
     media_type: str | None = None
+    # WHY exclude_if and not exclude_none on the codec: `media_type: null` was on the wire
+    # before OME-892, so dropping every null would change frames old clients already parse.
+    # Omitting only an absent `artifact` keeps inline result frames byte-identical to
+    # pre-OME-892 — the ticket appears on the wire only when one is actually issued. (A
+    # wrap model_serializer would do the same but erases the model's JSON schema, which
+    # the Engine's OpenAPI docs gate rejects.)
+    artifact: ResultArtifact | None = Field(default=None, exclude_if=lambda value: value is None)
+
+    @model_validator(mode="after")
+    def _exactly_one_of_body_or_artifact(self) -> "ResultData":
+        if (self.body is None) == (self.artifact is None):
+            raise ValueError("exactly one of body or artifact must be set")
+        return self
 
 
 class TerminatedData(BaseModel):

--- a/packages/url4/tests/unit/test_result_signal.py
+++ b/packages/url4/tests/unit/test_result_signal.py
@@ -1,0 +1,88 @@
+"""Contract of the `ai.url4.result` frame's data: inline body XOR artifact claim ticket.
+
+FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
+INVARIANT: a ResultData names its result exactly one way — a complete inline `body`, or a
+complete `artifact` reference — never both, never neither. A reader that can see a body can
+trust it; a reader that sees an artifact knows the full result is one HTTP GET away.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from url4.streaming.protocol.signals import ResultArtifact, ResultData
+
+_SHA = "9f" * 32  # a well-formed sha256 hex digest
+
+
+def _artifact(**overrides: object) -> dict[str, object]:
+    fields: dict[str, object] = {"id": _SHA, "size_bytes": 3_572_814, "sha256": _SHA}
+    fields.update(overrides)
+    return fields
+
+
+def test_inline_body_alone_is_valid_and_wire_compatible() -> None:
+    # WHY: every pre-OME-892 frame is exactly this shape — it must keep validating unchanged.
+    data = ResultData.model_validate({"body": '{"ok":true}', "media_type": None})
+    assert data.body == '{"ok":true}'
+    assert data.artifact is None
+
+
+def test_artifact_alone_is_valid() -> None:
+    data = ResultData.model_validate({"artifact": _artifact()})
+    assert data.body is None
+    assert isinstance(data.artifact, ResultArtifact)
+    assert data.artifact.id == _SHA
+    assert data.artifact.size_bytes == 3_572_814
+    assert data.artifact.sha256 == _SHA
+
+
+def test_body_and_artifact_together_are_rejected() -> None:
+    # INVARIANT: exactly one — "always non-null but sometimes poisoned" is the contract
+    # this design replaced; both-set would resurrect the ambiguity.
+    with pytest.raises(ValidationError):
+        ResultData.model_validate({"body": "x", "artifact": _artifact()})
+
+
+def test_neither_body_nor_artifact_is_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ResultData.model_validate({"media_type": "application/json"})
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        _artifact(id="../etc/passwd"),  # path traversal must die at the model boundary
+        _artifact(id="9F" * 32),  # uppercase hex is a second spelling of the same address
+        _artifact(id="9f" * 31),  # short digest
+        _artifact(sha256="zz" * 32),  # non-hex digest
+        _artifact(size_bytes=0),  # an artifact always has content
+        _artifact(size_bytes=-1),
+    ],
+)
+def test_malformed_artifact_fields_are_rejected(bad: dict[str, object]) -> None:
+    with pytest.raises(ValidationError):
+        ResultData.model_validate({"artifact": bad})
+
+
+def test_artifact_round_trips_through_json() -> None:
+    data = ResultData.model_validate({"artifact": _artifact()})
+    again = ResultData.model_validate_json(data.model_dump_json())
+    assert again == data
+
+
+def test_inline_result_serializes_without_an_artifact_key() -> None:
+    # INVARIANT: a pre-OME-892 client sees byte-identical frames for inline results — the
+    # artifact field appears on the wire ONLY when a claim ticket is actually issued.
+    # (Global exclude_none would be wrong: `media_type: null` was already on the wire.)
+    data = ResultData.model_validate({"body": "small", "media_type": None})
+    dumped = data.model_dump()
+    assert "artifact" not in dumped
+    assert dumped == {"body": "small", "media_type": None}
+    assert '"artifact"' not in data.model_dump_json()
+
+
+def test_artifact_result_serializes_with_the_ticket() -> None:
+    data = ResultData.model_validate({"artifact": _artifact()})
+    dumped = data.model_dump()
+    assert dumped["artifact"] == {"id": _SHA, "size_bytes": 3_572_814, "sha256": _SHA}
+    assert dumped["body"] is None


### PR DESCRIPTION
Closes OME-892 (sub-issue of OME-888 · GitHub #642).

## Before / After

### Before
- Trigger: a researcher runs a large paid Evaluation whose aggregate result exceeds 1 MiB.
- Today: the Engine silently cuts the result mid-JSON, reports the run **succeeded**, and the researcher discovers via a cryptic `SF Engine Candidate result must be JSON` error that an hour and several dollars produced nothing recoverable (documented instance: 1h 11m, $6.54, 137 model calls). Workaround is running in `limit=10` batches and averaging scores by hand.
- Cost: destroyed paid work, a green panel that lies, manual batch bookkeeping.

### After
- Same trigger.
- Now: the run succeeds and the full result arrives. The Engine parks an oversized result on disk and the result frame carries a **claim ticket** `{id, size_bytes, sha256}`; the SDK redeems it over HTTP (streaming, retried on transient resets) and verifies byte count + sha256 **before** building the Report. Truly enormous results fail loudly with `result_too_large` naming actual and allowed bytes.
- Win: big Evaluations just work; "succeeded" always means "your complete, verified Report is here".

### Don't regress
- Results at or under 1 MiB travel inline, **byte-identical** to today (`artifact` is omitted from the frame unless a ticket is issued) — old SDKs don't notice anything on small runs.
- The progress stream stays responsive: bulk bytes never ride a WS frame, and the spill runs off the event loop so heartbeats can't stall.
- Failed terminations still carry cost/usage telemetry.
- No disk leaks: artifacts are TTL-swept (startup + hourly) — fetching never deletes, so retries, HTTP Range resume, and deduped tickets all keep working.

## Root cause

The result's only delivery vehicle was one WebSocket frame, double-bounded (engine truncation cap 1 MiB; client frame limit 8 MiB). `build_result()` cut the UTF-8 body at the cap, appended `…[truncated]`, and still emitted `Completed` — so the lifecycle terminated `succeeded` while destroying the only copy of the result in flight.

## Design: WS for signaling, HTTP for bulk

Industry-standard split (every WS stack caps messages; Slack/Discord/Jupyter all move bulk out-of-band):

1. **`packages/url4`** — `ResultData` becomes body XOR artifact (validator-enforced); new `ResultArtifact` with sha256-hex patterns that double as the path-traversal guard.
2. **Engine** — `build_result()` forks, hard cap first: > `URL4_CLOUD_RESULT_HARD_CAP_BYTES` (default 1 GiB) → run fails `result_too_large`; > `URL4_CLOUD_RESULT_INLINE_CAP_BYTES` (default 1 MiB) → complete body spilled to a content-addressed store (`artifacts/<sha256>`, atomic writes, idempotent); otherwise inline as today. **The truncation code path is deleted** — a mangled body is unrepresentable.
3. **Engine REST** — `GET /artifacts/{id}` (capability-guarded, `FileResponse`: streaming + Range). Cleanup is **TTL-only**: swept at startup and hourly for the life of the App (crash-proof loop). The sync `GET /` path resolves artifact results to the same bytes.
4. **SDK** — strict ticket decode; redemption happens **after** the WS closes, streams against the ticket's declared size (bounded memory), retries transient resets (3×, backoff), verifies size + sha256 before `json.loads`; mismatch → `result_integrity_mismatch` with both numbers. A legacy `…[truncated]` body from an older Engine now raises `result_truncated` naming the received byte count.

**Compat under version skew** (additive contract): new+new = the feature · new engine + old SDK = small results byte-identical, big results fail loudly (strictly better than today's silent loss) · old engine + new SDK = inline path unchanged plus the marker detection.

## Review hardening

An adversarial review (10 verified findings) ran before this PR; all are fixed in these commits — highlights: delete-on-fetch removed entirely (it broke retry, Range resume, and deduped tickets), fetch retry + streaming size bound, hard-cap-first ordering, sweep race tolerance + `.tmp` collection, byte-identical inline frames via `Field(exclude_if=…)` (a wrap-serializer erased the model's OpenAPI schema), single-encode + off-loop spill. Details in `docs/work/2026-08-19-OME-892-deliver-large-results.md`.

## Test plan

- `run_gates.py` ALL GREEN × 3 stacks: url4 (1,170 tests, cov ≥95) · screamingface-engine (1,761 incl. 2 new end-to-end integration tests driving a real over-cap run through the real executor/lifecycle/WS/REST, cov ≥80) · screamingface (929, cov ≥95 + notebook determinism + build + distribution checks).
- No paid provider calls anywhere; deterministic and network-free (tiny caps make small synthetic results exercise every tier).
- One prior test replaced (`test_over_cap_result_is_truncated_with_marker` pinned the deleted truncation behavior — superseded by 4 fork-contract tests); append-only gate run with the documented `--skip-append-only` acknowledgment.

## Open items (not in this PR)

- **Hosted k8s**: the Runner Job pod and the App pod don't share a disk — `URL4_CLOUD_ARTIFACTS_DIR` must name a shared volume in the chart (flagged via AIDEV-NOTE in `job_env.py`; the artifact-404 message names this cause). Local mode — the bug's repro environment — is complete end-to-end.
- **Multi-candidate partial reports**: OME-888's "Partial Report survives" criterion needs its own ticket — the SDK has no partial-report path today (pre-existing; any candidate failure aborts the evaluation).

## Live-run validation (2026-08-19, real paid run)

The owner ran the full `healthbench-worst30` evaluation (157 cases, ~960 model calls, ~50 min, ~$30) against this branch's engine. The result landed at **2,835,927 bytes — 2.7× over the inline cap**, i.e. exactly the #642 scenario:

- ✅ **Spill validated**: the engine wrote the content-addressed artifact (sha-named file verified byte-identical) and the terminal event carried the claim ticket. Under `main`, this run's result would have been truncated mid-JSON and destroyed.
- 🐛 **Defect found & fixed** (`4a45b6bb`): redemption reused the capability token minted at run **start**; tokens live 60 s, the run took 50 min → `GET /artifacts/{id}` 401'd. No test could see it — tests fetch milliseconds after mint. Redemption now **mints a fresh token inside the fetch retry loop**; a new `protocol_server` seam (`artifact_token_expiry`) expires all run-start tokens once the result streams, reproducing the incident deterministically (sync + async regression tests).
- 💾 **Nothing lost**: TTL-only cleanup (review finding 1+2) kept the parcel on disk; the full result was recovered by hand. The failure mode was a *named* `AuthenticationError` — loud, not the old silent truncate-and-lie.

## Reviewer routing

- **Contract shape** (`ResultData.artifact`, OME-618 alignment): @keelancj — this is the OME-888 decision point.
- **Engine store / sweeper / REST route + url4 model**: @sergio-bershadsky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

