### PR TITLE
chore(screamingface): remove the live openrouter_credits() cell from example notebooks

### DIFF
--- a/docs/work/2026-08-19-OME-857-remove-notebook-credits-cell.md
+++ b/docs/work/2026-08-19-OME-857-remove-notebook-credits-cell.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-857
+stack: screamingface
+status: done   # planned | in_progress | done | blocked
+started: 2026-08-19
+finished: 2026-08-19
+---
+
+# OME-857 — Remove the `openrouter_credits()` cell from the example notebooks
+
+## Intent
+
+The example notebooks each opened with an ad-hoc cell:
+
+```python
+from helpers import openrouter_credits
+
+openrouter_credits()
+```
+
+`helpers.openrouter_credits()` makes a **live OpenRouter API call** (`GET
+https://openrouter.ai/api/v1/credits`) and raises `RuntimeError` when `OPENROUTER_KEY`
+is unset — a poor, network-dependent, non-deterministic lead-in for a public example
+notebook that must run cleanly under **Run All** without a provider key (00_quickstart
+already ships a committed traceback from this cell). Surfacing available provider
+credit/balance is a real product feature, tracked properly under `OME-893` (Surface
+available provider credit/balance for BYOK and hosted). This unit removes the ad-hoc
+notebook cell; the product surface is built under `OME-893`.
+
+Folded into `OME-857` (Refresh the example notebooks: credits helper, …) per owner
+decision — that ticket owns the credits-helper notebook cells.
+
+## Planned changes
+
+- `packages/screamingface/scripts/build_notebooks.py` — remove the three
+  `new_code_cell("from helpers import openrouter_credits\n\nopenrouter_credits()")`
+  blocks (00_quickstart, 01_client_tour, 08_healthbench_worst30).
+- `packages/screamingface/examples/00_quickstart.ipynb` — drop the matching cell.
+- `packages/screamingface/examples/01_client_tour.ipynb` — drop the matching cell.
+- `packages/screamingface/examples/08_healthbench_worst30.ipynb` — drop the matching cell.
+- `helpers.openrouter_credits` (in `examples/helpers.py`) is intentionally LEFT in place —
+  it is the prototype the `OME-893` product surface will evolve from; keeping scope to the
+  notebook cell removal the owner asked for.
+
+## Test plan
+
+- Executable contract = the existing deterministic-notebook gate
+  `scripts/check_notebooks.py` (append-only; not modified). RED first: edit the generator
+  only → gate reports "generated notebooks are stale". GREEN: drop the matching `.ipynb`
+  cell → gate passes and the public-surface story markers still hold. No new unit test is
+  warranted — this is generator/content removal, no `src/screamingface` logic changes.
+
+## Acceptance
+
+- `grep -r openrouter_credits packages/screamingface/examples/*.ipynb` returns nothing.
+- `check_notebooks.py` green; full `run_gates.py screamingface` green.
+- `OME-893` linked as `related` and referenced from the PR as the feature ticket.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** exactly as planned — `scripts/build_notebooks.py` (3 generator blocks
+  removed) and the 3 notebooks (`00_quickstart`, `01_client_tour`,
+  `08_healthbench_worst30`), one cell each. 48 pure deletions, 0 insertions, no reformatting
+  (surgical `nbformat` read→filter→write kept outputs/ids/formatting intact).
+- **Commits:** `chore(screamingface): remove the live openrouter_credits() cell from example
+  notebooks` — sha in the PR / Linear close-comment.
+- **Gates:** `run_gates.py screamingface` → ALL GATES GREEN (append-only ✓, ruff ✓,
+  ruff format ✓, pyright ✓, pytest --cov≥95 ✓, check_notebooks ✓, uv build ✓,
+  check_distribution ✓).
+- **Deviations:** none. `helpers.openrouter_credits` intentionally retained as the prototype
+  for the `OME-893` product surface (out of scope for this cell removal).

--- a/docs/work/2026-08-19-OME-857-remove-notebook-credits-cell.md
+++ b/docs/work/2026-08-19-OME-857-remove-notebook-credits-cell.md
@@ -18,14 +18,22 @@ from helpers import openrouter_credits
 openrouter_credits()
 ```
 
-`helpers.openrouter_credits()` makes a **live OpenRouter API call** (`GET
-https://openrouter.ai/api/v1/credits`) and raises `RuntimeError` when `OPENROUTER_KEY`
-is unset — a poor, network-dependent, non-deterministic lead-in for a public example
-notebook that must run cleanly under **Run All** without a provider key (00_quickstart
-already ships a committed traceback from this cell). Surfacing available provider
-credit/balance is a real product feature, tracked properly under `OME-893` (Surface
-available provider credit/balance for BYOK and hosted). This unit removes the ad-hoc
-notebook cell; the product surface is built under `OME-893`.
+`helpers.openrouter_credits()` reads a standalone `OPENROUTER_KEY` env var and prints that
+key's OpenRouter balance — but that figure is **disconnected from the account actually
+paying for the run in both provider modes**, so it misleads:
+
+- **BYOK** — the connected key is stored encrypted + write-only in the AI Gateway
+  credential store; the notebook cannot read it back, so the helper falls back to a
+  *separate* `OPENROUTER_KEY` env var that generally is **not** the key the user configured
+  their provider with.
+- **Hosted / subsidized engine** — runs are powered by OpenMined's shared credentials; the
+  user never sees or holds that key, so there is nothing meaningful to put in
+  `OPENROUTER_KEY`.
+
+Either way the printed credit belongs to the wrong (or no) account. Surfacing *real*
+per-mode credit/balance is a product feature, tracked under `OME-893` (Surface available
+provider credit/balance for BYOK and hosted). This unit removes the ad-hoc notebook cell;
+the product surface is built under `OME-893`.
 
 Folded into `OME-857` (Refresh the example notebooks: credits helper, …) per owner
 decision — that ticket owns the credits-helper notebook cells.

--- a/packages/screamingface/examples/00_quickstart.ipynb
+++ b/packages/screamingface/examples/00_quickstart.ipynb
@@ -49,18 +49,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-04",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from helpers import openrouter_credits\n",
-    "\n",
-    "openrouter_credits()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-05",
    "metadata": {},

--- a/packages/screamingface/examples/01_client_tour.ipynb
+++ b/packages/screamingface/examples/01_client_tour.ipynb
@@ -45,18 +45,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-04",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from helpers import openrouter_credits\n",
-    "\n",
-    "openrouter_credits()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-05",
    "metadata": {},

--- a/packages/screamingface/examples/08_healthbench_worst30.ipynb
+++ b/packages/screamingface/examples/08_healthbench_worst30.ipynb
@@ -53,18 +53,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cell-05",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from helpers import openrouter_credits\n",
-    "\n",
-    "openrouter_credits()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "cell-06",
    "metadata": {},

--- a/packages/screamingface/scripts/build_notebooks.py
+++ b/packages/screamingface/scripts/build_notebooks.py
@@ -114,10 +114,6 @@ sf.configure(
 )
 
 BENCHMARK_ID = "draco\""""),
-        nbformat.v4.new_code_cell("""\
-from helpers import openrouter_credits
-
-openrouter_credits()"""),
         nbformat.v4.new_markdown_cell("""\
 ## 1 · Leaderboards
 
@@ -239,10 +235,6 @@ Use `screamingface logs` to inspect startup failures and `screamingface down` wh
 management stays outside the notebook so **Run All** never starts or stops local services."""),
         nbformat.v4.new_code_cell("""\
 import screamingface as sf"""),
-        nbformat.v4.new_code_cell("""\
-from helpers import openrouter_credits
-
-openrouter_credits()"""),
         nbformat.v4.new_markdown_cell("""\
 ## 1. Choose a Client lifecycle
 
@@ -910,10 +902,6 @@ management stays outside the notebook so **Run All** never starts or stops local
 import screamingface as sf
 
 sf.connect()"""),
-        nbformat.v4.new_code_cell("""\
-from helpers import openrouter_credits
-
-openrouter_credits()"""),
         nbformat.v4.new_markdown_cell("""\
 ## 1. Run the benchmark with 1 model"""),
         nbformat.v4.new_code_cell("""\


### PR DESCRIPTION
## Summary

Removes the cell that opened three example notebooks:

```python
from helpers import openrouter_credits

openrouter_credits()
```

`helpers.openrouter_credits()` reads a standalone `OPENROUTER_KEY` from the environment and prints *that* key's OpenRouter balance. The problem: **that number is disconnected from the account actually paying for the run in both provider modes**, so it misleads more than it informs.

- **BYOK** — the key you connect is stored **encrypted and write-only** in the AI Gateway credential store; the notebook cannot read it back out. So the helper falls back to a separate `OPENROUTER_KEY` env var, which is **not** the key you configured your provider with. The balance shown is for some other key, not the one powering your runs.
- **Hosted / subsidized engine** — runs are powered by **OpenMined's shared credentials**. You never see or hold that key, so there is nothing meaningful to put in `OPENROUTER_KEY`; anything printed is either an unrelated personal key's balance or a `RuntimeError`.

Either way the cell reports a credit figure that isn't the headroom of the account paying for the run. Removing it from the three notebooks (`00_quickstart`, `01_client_tour`, `08_healthbench_worst30`) and from the deterministic generator `scripts/build_notebooks.py`.

Surfacing *real* available credit/balance per mode — reconciling BYOK vs hosted so the researcher always knows their headroom — is a product feature, tracked as the design ticket `OME-893` (linked as related on `OME-857`). The `examples/helpers.py` prototype is intentionally **retained** as the starting point for that work.

- Tracking ticket (folded here): `OME-857` — Refresh the example notebooks
- Feature ticket for the real credit-surfacing work: `OME-893`

## Test plan

- `scripts/check_notebooks.py` (deterministic-notebook gate) green — generator and notebooks agree; public-surface story markers still present.
- Full stack gate suite green: `run_gates.py screamingface` → ruff · ruff format · pyright · pytest `--cov≥95` · check_notebooks · uv build · check_distribution.
- `grep -r openrouter_credits examples/*.ipynb` → no matches.

Diff is 48 pure deletions across 4 files, no reformatting (surgical `nbformat` read→filter→write preserved outputs/ids).

Refs: OME-857
