### PR TITLE
feat(screamingface-engine): stop runs whose client died (OME-890)

### DIFF
--- a/.claude/scripts/check_layering.py
+++ b/.claude/scripts/check_layering.py
@@ -9,8 +9,8 @@ One image ships two modes, and the whole point of that shape is a rule about wha
     control plane   run mode                    Every concrete implementation, in the half that
     (serve)         (run)                       runs it — and the two halves stay disjoint.
 
-  Control plane: app · rest · ws · auth · catalog · connections · config · metrics · ops · schemas
-                 adapters.k8s · adapters.factory    (FastAPI, uvicorn, the kubernetes client)
+  Control plane: app · rest · ws · auth · catalog · connections · config · metrics · ops · reaper
+                 schemas · adapters.k8s · adapters.factory  (FastAPI, uvicorn, the k8s client)
   Run mode:      runner.executor (the url4 engine) · runner.connector · runner.main
 
   Shared leaves, importable by BOTH: job_env · subjects · adapters.jetstream · world_config
@@ -55,6 +55,11 @@ CONTROL_PLANE = {
     "local",
     "metrics",
     "ops",
+    # WHY named here rather than left unlisted (OME-890): an unlisted top-level module is a
+    # SHARED LEAF by this gate's own definition, importable by both halves — which would let a
+    # Runner Job import the control plane's orphan reaper. It watches WS subscriber counts and
+    # calls the job runner from the serving process; it belongs to the control plane.
+    "reaper",
     "rest",
     "schemas",
     "ws",

--- a/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
@@ -11,6 +11,12 @@ data:
   URL4_CLOUD_SYNC_MAX_WAIT_S: {{ .Values.config.syncMaxWaitS | quote }}
   URL4_CLOUD_WS_HEARTBEAT_S: {{ .Values.config.wsHeartbeatS | quote }}
   URL4_CLOUD_JOB_DEADLINE_S: {{ .Values.config.jobDeadlineS | quote }}
+  # How long a run may keep going with no WebSocket subscriber before the App stops it (OME-890).
+  # INVARIANT: the reaper's audience count is IN-PROCESS, so this chart's `replicaCount: 1` is
+  # load-bearing for it — a second replica would answer "nobody is listening" for runs the other
+  # replica is streaming and stop healthy runs. Multi-replica needs a shared subscriber gate
+  # (NATS consumer interest) before this can be scaled out. 0 disables the reaper.
+  URL4_CLOUD_ORPHAN_GRACE_S: {{ .Values.config.orphanGraceS | quote }}
   # The run substrate the App schedules on (spec §9). `k8s` is what makes this chart functional —
   # without it the App bridges NATS but answers every `GET /?q=` with 503.
   URL4_CLOUD_RUNNER: {{ .Values.runner.backend | quote }}

--- a/apps/screamingface-engine/deploy/helm/values.schema.json
+++ b/apps/screamingface-engine/deploy/helm/values.schema.json
@@ -57,6 +57,11 @@
           "maximum": 57600,
           "description": "Job activeDeadlineSeconds. INVARIANT: the 16h ceiling is spec \u00a73."
         },
+        "orphanGraceS": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Seconds a run may keep going with no WebSocket subscriber before the App stops it (OME-890); 0 disables the reaper. INVARIANT: the audience count is in-process, so replicaCount must stay 1 while this is non-zero \u2014 a second replica would answer \"nobody is listening\" for runs another replica is streaming. Keep it above uvicorn's WS ping window (~40s), which is what closes a partitioned client's socket in the first place."
+        },
         "aigatewayBaseUrl": {
           "type": "string"
         },

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -93,6 +93,12 @@ config:
   wsHeartbeatS: 15
   # k8s Job activeDeadlineSeconds ceiling = 16h (spec §3); the Runner Job's hard timeout.
   jobDeadlineS: 57600
+  # Seconds a run may keep going with NO WebSocket subscriber before the App stops it (OME-890).
+  # 0 disables the reaper. Keep this comfortably above uvicorn's WS ping window (~40s), which is
+  # what closes a partitioned client's socket in the first place — below it, the reaper races the
+  # detection it depends on. This bounds SPEND on runs whose client died; `jobDeadlineS` above
+  # remains the backstop.
+  orphanGraceS: 120
   # Overrides the default model route declared in the Runner image's url4.toml. Empty => the
   # image's own default. Must be one of the models that url4.toml declares.
   aigatewayModel: ""

--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -27,8 +27,14 @@ from screamingface_engine.catalog.port import ModelParameterSource
 from screamingface_engine.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from screamingface_engine.connections import build_connections
 from screamingface_engine.connections.port import Connections
-from screamingface_engine.metrics import MetricsMiddleware, build_metrics, register_catalog_metrics
+from screamingface_engine.metrics import (
+    MetricsMiddleware,
+    build_metrics,
+    register_catalog_metrics,
+    register_reaper_metrics,
+)
 from screamingface_engine.ops import router as ops_router
+from screamingface_engine.reaper import RunReaper
 from screamingface_engine.rest import (
     SubscriberGate,
     artifact_router,
@@ -108,6 +114,8 @@ def create_app(
     registry = ConnectionRegistry()
     app.state.registry = registry
     app.state.interest = interest if interest is not None else registry
+    # FEATURE: tie a run's lifetime to its audience (OME-890).
+    _install_orphan_reaper(app, registry, job_runner, settings)
     if clock is not None:
         app.state.clock = clock
     install_problem_handlers(app)
@@ -153,6 +161,76 @@ def _install_artifact_sweeper(app: FastAPI, store: ArtifactStore, settings: Sett
 
     async def _stop() -> None:
         task = getattr(app.state, "artifact_sweep_task", None)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    app.router.on_startup.append(_start)
+    app.router.on_shutdown.append(_stop)
+
+
+def _install_orphan_reaper(
+    app: FastAPI,
+    registry: ConnectionRegistry,
+    job_runner: JobRunner | None,
+    settings: Settings,
+) -> None:
+    """Wire the orphan-run reaper: arm on audience-empty, sweep on a cadence, stop on expiry.
+
+    FEATURE: tie a run's lifetime to its audience (OME-890). Modelled on
+    `_install_artifact_sweeper` above — the policy object owns no task, the loop is an asyncio
+    task on the App's own event loop, and shutdown cancels it so nothing outlives the App. No
+    sweep at startup, unlike that one: nothing can be armed before a WebSocket has attached and
+    then left, so a boot sweep would have nothing to look at.
+
+    INVARIANT: the reaper is handed `registry` — the REAL one — and never `app.state.interest`.
+    The gate seam answers "no subscriber" for every topic under `DenyAllGate`, which as a reap
+    input would stop every run in this process one grace window after boot. Same call as
+    `rest/routes.py::_deps` taking `registry` over `interest` for session state.
+    """
+    app.state.reaper = None
+    app.state.reaper_task = None
+    # WHY registered unconditionally, and via a getter: the collector reads whatever
+    # `app.state.reaper` holds at scrape time, so a stream-only App exposes no reaper series
+    # rather than a stale zero, and `/metrics` never depends on wiring order.
+    register_reaper_metrics(app.state.metrics, lambda: app.state.reaper)
+    if job_runner is None or settings.orphan_grace_s <= 0:
+        # WHY the early return: a stream-only App has nothing to stop, and an operator may turn
+        # the reaper off with `URL4_CLOUD_ORPHAN_GRACE_S=0`. Either way, no task is created — the
+        # many tests that inject no runner must not grow a background task.
+        return
+    reaper = RunReaper(job_runner, registry, grace_s=settings.orphan_grace_s)
+    app.state.reaper = reaper
+    registry.listen(reaper)
+
+    async def _sweep_forever() -> None:
+        while True:
+            await asyncio.sleep(reaper.tick_s)
+            # INVARIANT: one failed sweep must not kill the reaper. An unhandled exception here
+            # would end the task silently and every later orphan would run to the 16h ceiling
+            # with no signal at all — worse than the bug this fixes, because it would LOOK fixed.
+            # Log and keep the cadence. `CancelledError` is a BaseException and still propagates,
+            # so shutdown is unaffected.
+            try:
+                await reaper.sweep()
+            except Exception:
+                _logger.exception("orphan sweep failed; retrying next interval")
+
+    async def _start() -> None:
+        app.state.reaper_task = asyncio.get_running_loop().create_task(_sweep_forever())
+        # AIDEV-NOTE: the single-replica assumption is LOGGED, not merely noted in the chart. The
+        # audience count lives in this process's memory, so a second replica would answer "nobody
+        # is listening" for runs another replica is streaming and stop healthy runs. Multi-replica
+        # needs a shared SubscriberGate (NATS consumer interest) first.
+        _logger.info(
+            "orphan reaper armed grace_s=%.0f tick_s=%.0f (assumes a single replica)",
+            settings.orphan_grace_s,
+            reaper.tick_s,
+        )
+
+    async def _stop() -> None:
+        task = app.state.reaper_task
         if task is not None:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/apps/screamingface-engine/src/screamingface_engine/cli.py
+++ b/apps/screamingface-engine/src/screamingface_engine/cli.py
@@ -41,6 +41,12 @@ def _serve() -> None:
     # so a chart value for it could only ever point the probes and the Service's `targetPort` at a
     # port nothing listens on — which is exactly what `config.port` did before it was removed.
     # Changing this means changing the containerPort in the same commit.
+    # INVARIANT (OME-890): uvicorn's WS ping defaults are LOAD-BEARING and deliberately not
+    # overridden. `ws_ping_interval=20` / `ws_ping_timeout=20` are what close a partitioned or
+    # sleeping peer's socket within ~40s, which is what fires `ConnectionRegistry.remove` and so
+    # arms the orphan reaper. Disable or lengthen them and a dead client's run is detected only by
+    # TCP retransmission timeout (~15-30 min), which silently reopens most of the spend the
+    # reaper closed. Measured on uvicorn 0.52.1; re-check on a major bump.
     uvicorn.run(
         "screamingface_engine.app:create_app_from_env", factory=True, host="0.0.0.0", port=_PORT
     )
@@ -60,6 +66,7 @@ def _serve_local() -> None:
     # JWT secret, so the bind address is the only thing keeping it unreachable.
     from screamingface_engine.local import LOCAL_HOST
 
+    # INVARIANT: the WS ping defaults matter here too — see the note in `_serve` (OME-890).
     uvicorn.run(
         "screamingface_engine.local:create_local_app", factory=True, host=LOCAL_HOST, port=_PORT
     )

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -3,7 +3,7 @@ environment variables."""
 
 from typing import Literal, Self
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from screamingface_engine import job_env
@@ -63,6 +63,16 @@ class Settings(BaseSettings):
     # decision on OME-892). Hourly is far finer than the 48h TTL it enforces, and one
     # directory scan an hour costs nothing.
     artifact_sweep_interval_s: float = 3600.0
+    # FEATURE: tie a run's lifetime to its audience (OME-890).
+    #
+    # WHY 120s: a run whose last WebSocket subscriber disconnects gets this long to get one back
+    # before the App stops it. Uvicorn needs up to ws_ping_interval + ws_ping_timeout (~40s on
+    # its defaults) to notice a partitioned peer, so anything much below a minute reaps mostly on
+    # clean closes while starting to risk live runs on slow reconnects. 0 disables the reaper.
+    #
+    # INVARIANT: this bounds SPEND, not correctness — job_deadline_s (16h) remains the backstop.
+    # Raising it costs money per orphaned run; lowering it risks stopping a live one.
+    orphan_grace_s: float = Field(default=120.0, ge=0.0)
     # INVARIANT: stateless iat window (seconds) — start rejected when now - iat exceeds it (§4).
     iat_window_s: int = 60
     # WHY: sync-hold cap; a run outliving it degrades to 202 async (spec §5).

--- a/apps/screamingface-engine/src/screamingface_engine/metrics.py
+++ b/apps/screamingface-engine/src/screamingface_engine/metrics.py
@@ -164,3 +164,34 @@ class _CatalogCollector:
 def register_catalog_metrics(metrics: Metrics, get_service: Callable[[], Any]) -> None:
     """Register a `_CatalogCollector` for `get_service` on `metrics.registry`."""
     metrics.registry.register(_CatalogCollector(get_service))
+
+
+class _ReaperCollector:
+    """A `prometheus_client` custom collector for the orphan reaper's counters (OME-890)."""
+
+    def __init__(self, get_reaper: Callable[[], Any]) -> None:
+        self._get_reaper = get_reaper
+
+    def collect(self) -> Iterable[Any]:
+        """Called by `prometheus_client` once per `/metrics` scrape."""
+        reaper = self._get_reaper()
+        if reaper is None:
+            return
+        yield CounterMetricFamily(
+            "screamingface_engine_orphan_runs_reaped",
+            "Runs stopped for having no WebSocket subscriber.",
+            value=reaper.reaped_total,
+        )
+        # WHY a gauge beside the counter: a value that never returns to zero is the only signal
+        # that distinguishes "the sweep task died" from "no orphans happened" — the counter reads
+        # identically in both cases.
+        yield GaugeMetricFamily(
+            "screamingface_engine_orphan_runs_armed",
+            "Runs currently inside their no-subscriber grace window.",
+            value=float(reaper.armed_count),
+        )
+
+
+def register_reaper_metrics(metrics: Metrics, get_reaper: Callable[[], Any]) -> None:
+    """Register a `_ReaperCollector` for `get_reaper` on `metrics.registry`."""
+    metrics.registry.register(_ReaperCollector(get_reaper))

--- a/apps/screamingface-engine/src/screamingface_engine/reaper.py
+++ b/apps/screamingface-engine/src/screamingface_engine/reaper.py
@@ -1,0 +1,160 @@
+"""Stops runs whose audience has gone and not come back.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+
+STORY: as a researcher whose notebook kernel died mid-evaluation, I do not keep paying for a run
+nobody can receive, and the next evaluation gets its concurrency slot back.
+
+WHY this module exists: the 428 gate (`rest/routes.py::_require_subscriber`) proves an audience
+exists when a run starts, and then nothing ever asks again. A client that dies before it can send
+`ai.url4.stop` — `kill -9`, a Jupyter kernel restart, laptop sleep, a network partition — leaves
+the run issuing paid model calls until `job_deadline_s` (16h), holding one of
+`local_max_concurrent_runs` slots and the gateway's per-provider slots the whole time. This
+closes the loop: the audience leaving arms a grace window, the audience returning disarms it, and
+expiry stops the run through the same idempotent `JobRunner.stop` the explicit paths use.
+
+AIDEV-NOTE: POLICY ONLY — no FastAPI, no task ownership, and deliberately no import from `ws`.
+The sweep loop lives in `app.py::_install_orphan_reaper`, beside the artifact sweeper it is
+modelled on. The registry's `AudienceListener` is satisfied structurally, which is what keeps
+these two modules decoupled.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Protocol
+
+from url4.streaming.interfaces import JobRunner
+
+_logger = logging.getLogger(__name__)
+
+_MIN_TICK_S = 1.0
+_TICKS_PER_GRACE = 8
+"""How many sweeps fit inside one grace window. WHY derived rather than a second setting: reap
+latency is `grace` to `grace + grace/8`, so an operator tunes ONE knob and gets a bounded
+overshoot, instead of two knobs that can be set into disagreement."""
+
+
+class Audience(Protocol):
+    """The subscriber question, as `ConnectionRegistry` answers it."""
+
+    async def has_subscriber(self, topic: str) -> bool: ...
+
+
+class RunReaper:
+    """Arms a grace window when a topic's audience empties; stops the run if it stays empty.
+
+    INVARIANT: `audience` is the REAL `ConnectionRegistry` — never the `SubscriberGate` DI seam.
+    `DenyAllGate` and the tests' `FixedGate(False)` answer "nobody is listening" for EVERY topic.
+    That is harmless as an admission gate, where the result is a visible refused start, and
+    catastrophic here, where it means "stop every run in this process". Same call as
+    `rest/routes.py::_deps` taking `registry` over `interest` for session state.
+
+    INVARIANT: deadlines are monotonic. A wall clock would let an NTP step or a suspend jump
+    expire a window that has not elapsed, and reap a live run.
+    """
+
+    def __init__(
+        self,
+        job_runner: JobRunner,
+        audience: Audience,
+        *,
+        grace_s: float,
+        clock: Callable[[], float] = time.monotonic,
+        tick_s: float | None = None,
+    ) -> None:
+        self._job_runner = job_runner
+        self._audience = audience
+        self._grace_s = grace_s
+        self._clock = clock
+        self._tick_s = (
+            tick_s if tick_s is not None else max(_MIN_TICK_S, grace_s / _TICKS_PER_GRACE)
+        )
+        self._deadlines: dict[str, float] = {}
+        self._reaped_total = 0
+
+    @property
+    def tick_s(self) -> float:
+        """Seconds between sweeps. The loop in `app.py` reads its cadence from here."""
+        return self._tick_s
+
+    @property
+    def armed_count(self) -> int:
+        """Topics currently inside a grace window.
+
+        WHY exposed: it is the `/metrics` gauge, and a value that never returns to zero is how an
+        operator sees that sweeps have stopped running — a silently dead reaper otherwise looks
+        exactly like "no orphans happened".
+        """
+        return len(self._deadlines)
+
+    @property
+    def reaped_total(self) -> int:
+        """Runs stopped for having no audience, since boot."""
+        return self._reaped_total
+
+    def is_armed(self, topic: str) -> bool:
+        """Whether ``topic`` is inside a grace window."""
+        return topic in self._deadlines
+
+    # --- AudienceListener (satisfied structurally; see ws.registry.AudienceListener) ---
+
+    def audience_left(self, topic: str) -> None:
+        """Arm: ``topic`` has until now + grace to get its audience back."""
+        self._deadlines[topic] = self._clock() + self._grace_s
+
+    def audience_arrived(self, topic: str) -> None:
+        """Disarm: somebody is listening again."""
+        self._deadlines.pop(topic, None)
+
+    async def sweep(self) -> tuple[str, ...]:
+        """Stop every armed run whose grace window has closed; return the topics stopped.
+
+        Split from the loop that calls it so tests drive the policy against an injected clock
+        with no sleeps at all.
+        """
+        now = self._clock()
+        due = [topic for topic, deadline in self._deadlines.items() if now >= deadline]
+        reaped: list[str] = []
+        for topic in due:
+            if await self._reap(topic, now):
+                reaped.append(topic)
+        return tuple(reaped)
+
+    async def _reap(self, topic: str, now: float) -> bool:
+        """Stop one expired topic's run; ``True`` when it was actually stopped.
+
+        AIDEV-NOTE: this stays within ruff's `max-returns = 3`. The two guards share one `or`
+        deliberately — do not split them into separate `return False` branches.
+        """
+        # INVARIANT: the topic is CLAIMED — popped — before the first `await`. On a
+        # single-threaded loop that makes "this window closed and it is mine to decide" one
+        # atomic step, so a reconnect cannot land between the check and the claim. One arriving
+        # afterwards simply finds nothing armed, which is the same end state as a disarm.
+        self._deadlines.pop(topic, None)
+        # First guard: the audience came back and the disarm was missed or raced.
+        # Second guard: the run is already terminal. `stop` is idempotent, but on the k8s runner
+        # it DELETEs the Job, which would drop a finished Job before the TTL that is its
+        # single-use replay guard. The order matters: an in-process dict lookup short-circuits
+        # ahead of a possible Kubernetes API call.
+        if await self._audience.has_subscriber(topic) or not await self._job_runner.exists(topic):
+            return False
+        try:
+            await self._job_runner.stop(topic)
+        except Exception:
+            # INVARIANT: a failed stop RE-ARMS rather than gives up, without bound. Abandoning
+            # the topic would hand the run back to the 16h ceiling, which is the exact spend this
+            # module exists to prevent; the per-tick warning is the operator's signal that the
+            # runner itself needs attention.
+            self._deadlines[topic] = now + self._tick_s
+            _logger.warning("orphan stop failed topic=%s; will retry", topic, exc_info=True)
+            return False
+        self._reaped_total += 1
+        _logger.info(
+            "orphan run reaped topic=%s reason=no_subscriber grace_s=%.0f",
+            topic,
+            self._grace_s,
+        )
+        return True

--- a/apps/screamingface-engine/src/screamingface_engine/reaper.py
+++ b/apps/screamingface-engine/src/screamingface_engine/reaper.py
@@ -26,8 +26,6 @@ import time
 from collections.abc import Callable
 from typing import Protocol
 
-from url4.streaming.interfaces import JobRunner
-
 _logger = logging.getLogger(__name__)
 
 _MIN_TICK_S = 1.0
@@ -41,6 +39,20 @@ class Audience(Protocol):
     """The subscriber question, as `ConnectionRegistry` answers it."""
 
     async def has_subscriber(self, topic: str) -> bool: ...
+
+
+class RunControl(Protocol):
+    """The two things the reaper needs from a job runner, and deliberately nothing else.
+
+    WHY a narrow Protocol instead of the `JobRunner` ABC: reaping reads liveness and cancels. It
+    has no business scheduling a run or closing the runner, and declaring the whole ABC would say
+    it might. `IdentityAwareJobRunner` satisfies this structurally, so the composition root passes
+    the real runner unchanged.
+    """
+
+    async def exists(self, topic: str) -> bool: ...
+
+    async def stop(self, topic: str) -> None: ...
 
 
 class RunReaper:
@@ -58,7 +70,7 @@ class RunReaper:
 
     def __init__(
         self,
-        job_runner: JobRunner,
+        job_runner: RunControl,
         audience: Audience,
         *,
         grace_s: float,

--- a/apps/screamingface-engine/src/screamingface_engine/ws/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/ws/__init__.py
@@ -3,6 +3,6 @@ in-process registry that tracks active per-topic subscribers.
 """
 
 from screamingface_engine.ws.endpoint import router
-from screamingface_engine.ws.registry import ConnectionRegistry
+from screamingface_engine.ws.registry import AudienceListener, ConnectionRegistry
 
-__all__ = ["ConnectionRegistry", "router"]
+__all__ = ["AudienceListener", "ConnectionRegistry", "router"]

--- a/apps/screamingface-engine/src/screamingface_engine/ws/registry.py
+++ b/apps/screamingface-engine/src/screamingface_engine/ws/registry.py
@@ -17,6 +17,7 @@ connection is the only path that does not change that posture.
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import Protocol
 
 from url4.streaming.protocol import CachePolicy, OutboundFrame
 
@@ -24,6 +25,25 @@ Notify = Callable[[OutboundFrame], None]
 """How one live connection accepts an out-of-band frame. Synchronous and non-blocking by
 contract: it is called from a request handler, so it hands the frame to that connection's own
 outbound queue and returns — it must never await the socket."""
+
+
+class AudienceListener(Protocol):
+    """Where the registry announces a topic's audience arriving and leaving.
+
+    FEATURE: tie a run's lifetime to its audience (OME-890). The 428 gate proves an audience
+    exists when a run is scheduled and then nothing asks again, so these two edges are what let
+    anything downstream react to "my last subscriber vanished".
+
+    INVARIANT: both methods are synchronous and must not raise. They run inside `add`/`remove`,
+    and `remove` runs in the WS endpoint's `finally` — a path that also executes under
+    cancellation, where an exception would mask the very disconnect it is reporting.
+    """
+
+    def audience_arrived(self, topic: str) -> None:
+        """``topic`` went from no subscribers to one."""
+
+    def audience_left(self, topic: str) -> None:
+        """``topic``'s last subscriber disconnected."""
 
 
 @dataclass
@@ -50,9 +70,23 @@ class ConnectionRegistry:
 
     def __init__(self) -> None:
         self._sessions: dict[str, _Session] = {}
+        self._audience: AudienceListener | None = None
+
+    def listen(self, audience: AudienceListener) -> None:
+        """Register the one listener for audience transitions — COMPOSITION ROOT ONLY.
+
+        A setter rather than a constructor argument because the registry is built before the
+        reaper that watches it, and the reaper needs the registry (`app.py::create_app`).
+        """
+        self._audience = audience
 
     def add(self, topic: str) -> None:
-        self._sessions.setdefault(topic, _Session()).subscribers += 1
+        session = self._sessions.setdefault(topic, _Session())
+        session.subscribers += 1
+        # INVARIANT: 0->1 ONLY. `add_notifier` can create a session at zero subscribers, and the
+        # second of two watchers attaching must not read as "the audience arrived".
+        if session.subscribers == 1 and self._audience is not None:
+            self._audience.audience_arrived(topic)
 
     def remove(self, topic: str) -> None:
         session = self._sessions.get(topic)
@@ -61,6 +95,10 @@ class ConnectionRegistry:
         session.subscribers -= 1
         if session.subscribers <= 0:
             del self._sessions[topic]
+            # INVARIANT: 1->0 ONLY, and announced AFTER the session is discarded, so a listener
+            # that asks `has_subscriber` from inside the callback gets the post-transition answer.
+            if self._audience is not None:
+                self._audience.audience_left(topic)
 
     async def has_subscriber(self, topic: str) -> bool:
         session = self._sessions.get(topic)

--- a/apps/screamingface-engine/tests/integration/test_orphan_reaper_spine.py
+++ b/apps/screamingface-engine/tests/integration/test_orphan_reaper_spine.py
@@ -1,0 +1,289 @@
+"""End to end: a dead client's run is stopped, a reconnecting client's run is not.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+
+STORY: as a researcher whose notebook kernel died mid-evaluation, I stop paying for a run nobody
+can receive, and the next evaluation gets its concurrency slot back.
+
+WHY this file exists beside the unit tests: `test_reaper.py` proves the policy against fakes and
+`test_reaper_wiring.py` proves the composition. Neither proves the SPINE — that a REAL WebSocket
+disconnect reaches the reaper through the real registry, and that the reaper's `stop` reaches a
+real in-process run and ends it as `Terminated(stopped)`. That is what these cover, on the same
+local-mode App `test_local_spine.py` uses.
+
+AIDEV-NOTE: these tests wait on CONDITIONS with a deadline, never on a fixed sleep. The reaper's
+sweep runs on the App's own event loop inside `TestClient`'s portal, so the test thread cannot
+await it directly; the observable it polls instead is `/metrics`, which is the surface an operator
+uses for exactly this question. `orphan_grace_s` is set small so a sweep tick actually lands
+during the test — `_TICKS_PER_GRACE` floors the tick at 1s, so budget just over a second per reap.
+"""
+
+import json
+import time
+from collections.abc import AsyncIterator, Callable, Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from screamingface_engine.adapters.inprocess import InProcessJobRunner
+from screamingface_engine.adapters.memory import InMemoryEventStream
+from screamingface_engine.app import create_app
+from screamingface_engine.config import Settings
+from url4.streaming.interfaces import ExecStep, Executor, TraceContext
+from url4.streaming.protocol import LogData
+
+SECRET = "s" * 32
+
+# Small enough that a 1s sweep tick closes the window during the test, large enough that it is not
+# already closed the instant the socket drops.
+SHORT_GRACE_S = 0.25
+# Long enough that no sweep can close the window while the test reconnects, so a run that survives
+# proves the DISARM and not merely that the clock had not run out.
+LONG_GRACE_S = 300.0
+
+_WAIT_TIMEOUT_S = 10.0
+_POLL_S = 0.02
+
+
+class _SpendingExecutor(Executor):
+    """Never finishes on its own, and counts what it "spent" — the shape of an abandoned run.
+
+    Each loop stands for one paid model call. A real orphan keeps issuing these for up to
+    `job_deadline_s`; the counter is how a test proves the spending actually stopped rather than
+    merely that a frame said so.
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def execute(
+        self, url4: str, *, trace: TraceContext | None = None
+    ) -> AsyncIterator[ExecStep]:
+        import asyncio
+
+        while True:
+            self.calls += 1
+            yield LogData.at("INFO", f"model call {self.calls}")
+            await asyncio.sleep(0.01)
+
+
+def _spine(
+    *, grace_s: float, max_concurrent_runs: int = 32
+) -> Iterator[tuple[TestClient, _SpendingExecutor]]:
+    """A local-mode App whose run never ends by itself, assembled as `create_local_app` does."""
+    executor = _SpendingExecutor()
+    settings = Settings(
+        jwt_secret=SECRET,
+        orphan_grace_s=grace_s,
+        # WHY: the run never completes, so a sync hold would block for the full default 30s.
+        # Every test here starts its run with `Prefer: respond-async`; this is the safety net.
+        sync_max_wait_s=0.2,
+    )
+    stream = InMemoryEventStream()
+    runner = InProcessJobRunner(
+        stream,
+        lambda _env: executor,
+        base_env={},
+        max_concurrent_runs=max_concurrent_runs,
+    )
+    app = create_app(settings, stream=stream, job_runner=runner)
+    app.router.on_shutdown.append(runner.aclose)
+    with TestClient(app) as client:
+        yield client, executor
+
+
+@pytest.fixture
+def abandoned() -> Iterator[tuple[TestClient, _SpendingExecutor]]:
+    yield from _spine(grace_s=SHORT_GRACE_S)
+
+
+@pytest.fixture
+def patient() -> Iterator[tuple[TestClient, _SpendingExecutor]]:
+    yield from _spine(grace_s=LONG_GRACE_S)
+
+
+@pytest.fixture
+def single_slot() -> Iterator[tuple[TestClient, _SpendingExecutor]]:
+    yield from _spine(grace_s=SHORT_GRACE_S, max_concurrent_runs=1)
+
+
+def _cap(token: str) -> dict[str, str]:
+    return {"URL4-Capability": token}
+
+
+def _async_start(token: str) -> dict[str, str]:
+    """Start headers: the capability plus RFC 7240 `respond-async`, because the run never ends."""
+    return {"URL4-Capability": token, "Prefer": "respond-async"}
+
+
+def _token(client: TestClient) -> str:
+    response = client.post("/token")
+    assert response.status_code == 200
+    return str(response.json()["token"])
+
+
+def _attach(ws: object, ident: str, from_sequence: int | None = None) -> None:
+    data: dict[str, object] = {} if from_sequence is None else {"from_sequence": from_sequence}
+    ws.send_text(  # type: ignore[attr-defined]
+        json.dumps(
+            {
+                "specversion": "1.0",
+                "id": ident,
+                "source": "/test",
+                "type": "ai.url4.attach",
+                "data": data,
+            }
+        )
+    )
+
+
+def _metric(client: TestClient, name: str) -> float:
+    """One metric's current value, read from the real `/metrics` surface."""
+    for line in client.get("/metrics").text.splitlines():
+        if line.startswith(f"{name} "):
+            return float(line.rsplit(" ", 1)[1])
+    return 0.0
+
+
+def _reaped(client: TestClient) -> float:
+    return _metric(client, "screamingface_engine_orphan_runs_reaped_total")
+
+
+def _armed(client: TestClient) -> float:
+    return _metric(client, "screamingface_engine_orphan_runs_armed")
+
+
+def _wait_until(predicate: Callable[[], bool], what: str) -> None:
+    """Poll ``predicate`` until true or the deadline passes.
+
+    AIDEV-NOTE: a deadline-bounded condition wait, never a bare sleep — the reap lands one sweep
+    tick after the window closes, and pinning that to a fixed sleep is how a suite becomes flaky.
+    """
+    deadline = time.monotonic() + _WAIT_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(_POLL_S)
+    raise AssertionError(f"timed out after {_WAIT_TIMEOUT_S}s waiting for {what}")
+
+
+def _terminal_of(client: TestClient, token: str) -> dict[str, object]:
+    """Replay the topic from the start and return its terminal frame's data."""
+    with client.websocket_connect(f"/ws?ticket={token}") as ws:
+        _attach(ws, "replay", from_sequence=1)
+        while True:
+            frame = json.loads(ws.receive_text())
+            if frame["type"] == "ai.url4.terminated":
+                return dict(frame["data"])
+
+
+def test_an_abandoned_run_is_stopped_and_stops_spending(
+    abandoned: tuple[TestClient, _SpendingExecutor],
+) -> None:
+    client, executor = abandoned
+    token = _token(client)
+
+    with client.websocket_connect(f"/ws?ticket={token}") as ws:
+        _attach(ws, "attach-1")
+        response = client.get("/?q=hello", headers=_async_start(token))
+        assert response.status_code == 202
+        # The run must actually be spending before it is abandoned, or this proves nothing.
+        _wait_until(lambda: executor.calls > 0, "the run to issue its first model call")
+
+    # The socket is closed: the audience is empty and the grace window is open.
+    _wait_until(lambda: _armed(client) == 1.0, "the topic to be armed")
+    _wait_until(lambda: _reaped(client) >= 1.0, "the abandoned run to be reaped")
+
+    # INVARIANT: no further paid work after the stop. The executor bills once per 10ms, so a
+    # window this wide would add dozens of calls if the run were still going.
+    settled = executor.calls
+    time.sleep(0.3)
+
+    assert executor.calls == settled
+    assert _armed(client) == 0.0
+    assert _terminal_of(client, token)["status"] == "stopped"
+
+
+def test_a_client_that_reconnects_inside_the_window_keeps_its_run(
+    patient: tuple[TestClient, _SpendingExecutor],
+) -> None:
+    # STORY: as a researcher whose wifi blipped, my reconnected notebook keeps its evaluation.
+    client, executor = patient
+    token = _token(client)
+
+    with client.websocket_connect(f"/ws?ticket={token}") as ws:
+        _attach(ws, "attach-1")
+        assert client.get("/?q=hello", headers=_async_start(token)).status_code == 202
+        _wait_until(lambda: executor.calls > 0, "the run to issue its first model call")
+
+    assert _armed(client) == 1.0  # armed by the disconnect
+
+    with client.websocket_connect(f"/ws?ticket={token}") as ws:
+        _attach(ws, "attach-2", from_sequence=1)
+        # INVARIANT: the reconnect DISARMS. Asserted against a 300s window so a surviving run
+        # cannot be explained by the clock simply not having run out yet.
+        assert _armed(client) == 0.0
+
+        replayed = json.loads(ws.receive_text())
+        while replayed["type"] == "ai.url4.heartbeat":
+            replayed = json.loads(ws.receive_text())
+        assert replayed["type"] == "ai.url4.started"
+
+        # The run is still spending, which is the point: it was never stopped.
+        spending = executor.calls
+        _wait_until(lambda: executor.calls > spending, "the resumed run to keep working")
+
+    assert _reaped(client) == 0.0
+
+
+def test_an_explicit_delete_is_unchanged_and_is_not_reaped_afterwards(
+    abandoned: tuple[TestClient, _SpendingExecutor],
+) -> None:
+    client, executor = abandoned
+    token = _token(client)
+
+    with client.websocket_connect(f"/ws?ticket={token}") as ws:
+        _attach(ws, "attach-1")
+        assert client.get("/?q=hello", headers=_async_start(token)).status_code == 202
+        _wait_until(lambda: executor.calls > 0, "the run to issue its first model call")
+        # Unchanged behaviour: still 204, still idempotent.
+        assert client.delete("/", headers=_cap(token)).status_code == 204
+        assert client.delete("/", headers=_cap(token)).status_code == 204
+
+    # INVARIANT: the reaper does not double-stop an already-stopped run. The topic is armed by
+    # the disconnect, the window closes, and the `exists()` guard declines to act — so nothing is
+    # counted as reaped and no second terminal frame is produced.
+    _wait_until(lambda: _armed(client) == 1.0, "the topic to be armed")
+    _wait_until(lambda: _armed(client) == 0.0, "the window to close")
+
+    assert _reaped(client) == 0.0
+
+
+def test_reaping_releases_the_concurrency_slot(
+    single_slot: tuple[TestClient, _SpendingExecutor],
+) -> None:
+    # WHY this test: the capacity symptom is what actually got noticed in the field — orphaned
+    # Evaluations filled every local slot and the next eval looked frozen until the whole stack
+    # was restarted. Freeing the slot is half of what OME-890 buys.
+    client, executor = single_slot
+    first = _token(client)
+
+    with client.websocket_connect(f"/ws?ticket={first}") as ws:
+        _attach(ws, "attach-1")
+        assert client.get("/?q=hello", headers=_async_start(first)).status_code == 202
+        _wait_until(lambda: executor.calls > 0, "the run to issue its first model call")
+
+        second = _token(client)
+        with client.websocket_connect(f"/ws?ticket={second}") as ws2:
+            _attach(ws2, "attach-2")
+            # The single slot is taken by a run nobody is watching any more.
+            assert client.get("/?q=hello", headers=_async_start(second)).status_code == 503
+
+    _wait_until(lambda: _reaped(client) >= 1.0, "the abandoned run to be reaped")
+
+    third = _token(client)
+    with client.websocket_connect(f"/ws?ticket={third}") as ws3:
+        _attach(ws3, "attach-3")
+        recovered = client.get("/?q=hello", headers=_async_start(third))
+
+    assert recovered.status_code == 202

--- a/apps/screamingface-engine/tests/unit/test_reaper.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper.py
@@ -1,0 +1,279 @@
+"""The orphan-run reaper's policy: arm on audience-empty, disarm on return, stop on expiry.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+
+Every test drives an injected clock and calls `sweep()` directly. Nothing here sleeps: a reaper
+verified against real time would be both slow and flaky, and the grace window it enforces is
+measured in minutes.
+"""
+
+import pytest
+
+from screamingface_engine.reaper import RunReaper
+
+GRACE = 120.0
+
+
+class _FakeClock:
+    """A monotonic clock the test advances by hand."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeAudience:
+    """Which topics have a subscriber, as the real ConnectionRegistry would answer."""
+
+    def __init__(self, present: set[str] | None = None) -> None:
+        self.present = present if present is not None else set()
+
+    async def has_subscriber(self, topic: str) -> bool:
+        return topic in self.present
+
+
+class _FakeRunner:
+    """Records stop calls; `live` is the set of topics `exists` answers True for."""
+
+    def __init__(self, live: set[str] | None = None, fail_on: set[str] | None = None) -> None:
+        self.live = live if live is not None else set()
+        self.fail_on = fail_on if fail_on is not None else set()
+        self.stopped: list[str] = []
+
+    async def exists(self, topic: str) -> bool:
+        return topic in self.live
+
+    async def stop(self, topic: str) -> None:
+        if topic in self.fail_on:
+            raise RuntimeError("runner unavailable")
+        self.stopped.append(topic)
+        self.live.discard(topic)
+
+
+def _reaper(
+    clock: _FakeClock,
+    audience: _FakeAudience,
+    runner: _FakeRunner,
+    grace_s: float = GRACE,
+) -> RunReaper:
+    return RunReaper(runner, audience, grace_s=grace_s, clock=clock, tick_s=10.0)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_an_armed_run_is_stopped_once_the_window_closes() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ("t",)
+    assert runner.stopped == ["t"]
+    assert reaper.armed_count == 0
+    assert reaper.reaped_total == 1
+
+
+@pytest.mark.asyncio
+async def test_nothing_happens_before_the_window_closes() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE - 0.01)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+    assert reaper.armed_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_subscriber_returning_inside_the_window_saves_the_run() -> None:
+    # STORY: as a researcher whose wifi blipped, my reconnected notebook keeps its evaluation.
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE / 2)
+    reaper.audience_arrived("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+    assert reaper.armed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_subscriber_present_at_expiry_is_re_checked_and_the_run_survives() -> None:
+    # INVARIANT: claim-then-verify. Even with a STALE arm — a disarm that never arrived — the
+    # sweep asks the registry again before stopping anything, because reaping a watched run is
+    # far worse than reaping late.
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    audience.present.add("t")  # the arm is stale; the registry disagrees
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+    assert reaper.armed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_finished_run_is_not_stopped() -> None:
+    # INVARIANT: no second terminal frame. `exists` is False once the run is terminal, and on
+    # the k8s runner a stop would DELETE the finished Job before the TTL that is its
+    # single-use replay guard.
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live=set())
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+
+
+@pytest.mark.asyncio
+async def test_a_topic_that_never_started_a_run_is_dropped_quietly() -> None:
+    # WHY this case exists: a client may attach and disconnect without ever issuing `GET /?q=`.
+    # The arm is unconditional, so it must expire harmlessly rather than raise.
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live=set())
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("attached-then-left-without-starting")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert reaper.armed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_flapping_leaves_exactly_one_arm_and_the_last_one_wins() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    for _ in range(5):
+        reaper.audience_left("t")
+        clock.advance(1.0)
+        reaper.audience_arrived("t")
+    reaper.audience_left("t")
+
+    assert reaper.armed_count == 1
+
+    clock.advance(GRACE - 0.01)
+    assert await reaper.sweep() == ()  # measured from the LAST leave, not the first
+
+    clock.advance(0.01)
+    assert await reaper.sweep() == ("t",)
+
+
+@pytest.mark.asyncio
+async def test_a_second_sweep_does_not_stop_the_run_again() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+    await reaper.sweep()
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == ["t"]
+    assert reaper.reaped_total == 1
+
+
+@pytest.mark.asyncio
+async def test_a_failed_stop_is_retried_rather_than_abandoned() -> None:
+    # INVARIANT: giving up would hand the run back to the 16h ceiling — the exact spend this
+    # module exists to stop. A transient runner error must re-arm.
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _FakeRunner(live={"t"}, fail_on={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert reaper.armed_count == 1  # re-armed, not dropped
+    assert reaper.reaped_total == 0
+
+    runner.fail_on.clear()
+    clock.advance(reaper.tick_s)
+
+    assert await reaper.sweep() == ("t",)
+    assert runner.stopped == ["t"]
+
+
+@pytest.mark.asyncio
+async def test_only_the_due_topics_are_swept() -> None:
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _FakeRunner(live={"early", "late"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("early")
+    clock.advance(GRACE / 2)
+    reaper.audience_left("late")
+    clock.advance(GRACE / 2)
+
+    assert await reaper.sweep() == ("early",)
+    assert reaper.armed_count == 1
+    assert reaper.is_armed("late") is True
+
+
+def test_the_tick_is_derived_from_the_grace_window_with_a_floor() -> None:
+    # WHY one knob: reap latency is `grace` to `grace + grace/8`, so the operator tunes the
+    # window and gets a bounded overshoot instead of a second setting to keep consistent.
+    runner, audience = _FakeRunner(), _FakeAudience()
+
+    assert RunReaper(runner, audience, grace_s=120.0).tick_s == pytest.approx(15.0)  # type: ignore[arg-type]
+    assert RunReaper(runner, audience, grace_s=0.5).tick_s == pytest.approx(1.0)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_armed_implies_no_subscriber_across_a_scripted_sequence() -> None:
+    # INVARIANT (the whole safety property, stated once): a topic is armed only while its
+    # audience is empty, and the deadline map never outgrows the live topic set. Scripted
+    # rather than property-based because `hypothesis` is not a dependency of this stack.
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _FakeRunner(live={"a", "b", "c"})
+    reaper = _reaper(clock, audience, runner)
+    topics = ("a", "b", "c")
+
+    script: list[tuple[str, str | float]] = [
+        ("arrive", "a"),
+        ("arrive", "b"),
+        ("leave", "a"),
+        ("tick", 30.0),
+        ("arrive", "a"),
+        ("leave", "b"),
+        ("leave", "c"),
+        ("tick", 200.0),
+        ("arrive", "c"),
+        ("leave", "a"),
+        ("tick", 5.0),
+        ("leave", "c"),
+        ("tick", 500.0),
+        ("arrive", "b"),
+    ]
+    for action, value in script:
+        if action == "arrive":
+            audience.present.add(str(value))
+            reaper.audience_arrived(str(value))
+        elif action == "leave":
+            audience.present.discard(str(value))
+            reaper.audience_left(str(value))
+        else:
+            clock.advance(float(value))
+            await reaper.sweep()
+        assert reaper.armed_count <= len(topics)
+        for topic in topics:
+            if reaper.is_armed(topic):
+                assert not await audience.has_subscriber(topic), (
+                    f"{topic} is armed while its audience is present"
+                )

--- a/apps/screamingface-engine/tests/unit/test_reaper.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper.py
@@ -61,7 +61,7 @@ def _reaper(
     runner: _FakeRunner,
     grace_s: float = GRACE,
 ) -> RunReaper:
-    return RunReaper(runner, audience, grace_s=grace_s, clock=clock, tick_s=10.0)  # type: ignore[arg-type]
+    return RunReaper(runner, audience, grace_s=grace_s, clock=clock, tick_s=10.0)
 
 
 @pytest.mark.asyncio
@@ -231,8 +231,8 @@ def test_the_tick_is_derived_from_the_grace_window_with_a_floor() -> None:
     # window and gets a bounded overshoot instead of a second setting to keep consistent.
     runner, audience = _FakeRunner(), _FakeAudience()
 
-    assert RunReaper(runner, audience, grace_s=120.0).tick_s == pytest.approx(15.0)  # type: ignore[arg-type]
-    assert RunReaper(runner, audience, grace_s=0.5).tick_s == pytest.approx(1.0)  # type: ignore[arg-type]
+    assert RunReaper(runner, audience, grace_s=120.0).tick_s == pytest.approx(15.0)
+    assert RunReaper(runner, audience, grace_s=0.5).tick_s == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio

--- a/apps/screamingface-engine/tests/unit/test_reaper_wiring.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper_wiring.py
@@ -7,11 +7,13 @@ import asyncio
 
 import pytest
 from _fakes import FixedGate, RecordingJobRunner
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from screamingface_engine.app import create_app
 from screamingface_engine.config import Settings
 from screamingface_engine.reaper import RunReaper
+from screamingface_engine.rest import SubscriberGate
 from screamingface_engine.testing import InMemoryEventStream
 
 SECRET = "reaper-wiring-secret"
@@ -21,14 +23,14 @@ def _app(
     *,
     grace_s: float = 120.0,
     job_runner: RecordingJobRunner | None = None,
-    interest: object | None = None,
-):
+    interest: SubscriberGate | None = None,
+) -> FastAPI:
     settings = Settings(jwt_secret=SECRET, orphan_grace_s=grace_s)
     return create_app(
         settings,
         stream=InMemoryEventStream(),
         job_runner=job_runner,
-        interest=interest,  # type: ignore[arg-type]
+        interest=interest,
     )
 
 

--- a/apps/screamingface-engine/tests/unit/test_reaper_wiring.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper_wiring.py
@@ -1,0 +1,138 @@
+"""How the orphan reaper is wired into the App: what it asks, when it exists, how it shuts down.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+"""
+
+import asyncio
+
+import pytest
+from _fakes import FixedGate, RecordingJobRunner
+from fastapi.testclient import TestClient
+
+from screamingface_engine.app import create_app
+from screamingface_engine.config import Settings
+from screamingface_engine.reaper import RunReaper
+from screamingface_engine.testing import InMemoryEventStream
+
+SECRET = "reaper-wiring-secret"
+
+
+def _app(
+    *,
+    grace_s: float = 120.0,
+    job_runner: RecordingJobRunner | None = None,
+    interest: object | None = None,
+):
+    settings = Settings(jwt_secret=SECRET, orphan_grace_s=grace_s)
+    return create_app(
+        settings,
+        stream=InMemoryEventStream(),
+        job_runner=job_runner,
+        interest=interest,  # type: ignore[arg-type]
+    )
+
+
+def test_the_reaper_asks_the_real_registry_and_never_the_subscriber_gate() -> None:
+    # INVARIANT — THE TRAP THIS TEST EXISTS FOR: `DenyAllGate`, and every test that injects
+    # `FixedGate(False)`, answers "no subscriber" for EVERY topic. Wiring the reaper to that seam
+    # instead of the real registry would stop every run in the process one grace window after
+    # boot. A refused start is visible and annoying; a silently killed four-hour evaluation is
+    # not recoverable. Same call as `rest/routes.py::_deps` taking `registry` over `interest`.
+    # If this test ever fails, do NOT relax it.
+    app = _app(job_runner=RecordingJobRunner(exists=True), interest=FixedGate(False))
+    reaper = app.state.reaper
+    assert isinstance(reaper, RunReaper)
+
+    app.state.registry.add("watched")
+
+    assert reaper.is_armed("watched") is False
+
+
+def test_a_disconnect_arms_the_reaper_through_the_registry() -> None:
+    app = _app(job_runner=RecordingJobRunner(exists=True))
+    reaper = app.state.reaper
+
+    app.state.registry.add("t")
+    assert reaper.is_armed("t") is False
+
+    app.state.registry.remove("t")
+
+    assert reaper.is_armed("t") is True
+
+
+def test_a_reconnect_disarms_the_reaper_through_the_registry() -> None:
+    app = _app(job_runner=RecordingJobRunner(exists=True))
+    reaper = app.state.reaper
+
+    app.state.registry.add("t")
+    app.state.registry.remove("t")
+    app.state.registry.add("t")
+
+    assert reaper.is_armed("t") is False
+
+
+def test_no_reaper_is_built_without_a_job_runner() -> None:
+    # WHY: a stream-only App (`URL4_CLOUD_RUNNER=none`) has nothing to stop, and the many unit
+    # tests that inject no runner must not grow a background task.
+    app = _app(job_runner=None)
+
+    assert app.state.reaper is None
+
+
+def test_a_zero_grace_disables_the_reaper() -> None:
+    app = _app(grace_s=0.0, job_runner=RecordingJobRunner(exists=True))
+
+    assert app.state.reaper is None
+
+
+def test_a_negative_grace_is_refused_at_startup() -> None:
+    with pytest.raises(ValueError):
+        Settings(jwt_secret=SECRET, orphan_grace_s=-1.0)
+
+
+def test_the_default_grace_leaves_room_above_the_ws_ping_window() -> None:
+    # INVARIANT: uvicorn needs up to ws_ping_interval + ws_ping_timeout (~40s on its defaults)
+    # to notice a partitioned peer, so the default window must sit comfortably above that or the
+    # reaper would race the very detection it depends on.
+    assert Settings(jwt_secret=SECRET).orphan_grace_s == 120.0
+
+
+def test_the_sweep_task_starts_with_the_app_and_is_cancelled_with_it() -> None:
+    app = _app(job_runner=RecordingJobRunner(exists=True))
+
+    with TestClient(app):
+        task = app.state.reaper_task
+        assert isinstance(task, asyncio.Task)
+        assert not task.done()
+
+    assert app.state.reaper_task.done()
+
+
+def test_a_stream_only_app_starts_no_sweep_task() -> None:
+    app = _app(job_runner=None)
+
+    with TestClient(app):
+        assert app.state.reaper_task is None
+
+
+def test_the_reaper_metrics_are_registered_and_scrapeable() -> None:
+    app = _app(job_runner=RecordingJobRunner(exists=True))
+
+    with TestClient(app) as client:
+        body = client.get("/metrics").text
+
+    assert "screamingface_engine_orphan_runs_reaped" in body
+    assert "screamingface_engine_orphan_runs_armed" in body
+
+
+def test_the_armed_gauge_follows_the_registry() -> None:
+    # WHY this is worth asserting: the gauge is the only signal that distinguishes "no orphans
+    # happened" from "the sweep task died", so it has to track real state, not a constant.
+    app = _app(job_runner=RecordingJobRunner(exists=True))
+    app.state.registry.add("t")
+    app.state.registry.remove("t")
+
+    with TestClient(app) as client:
+        body = client.get("/metrics").text
+
+    assert "screamingface_engine_orphan_runs_armed 1.0" in body

--- a/apps/screamingface-engine/tests/unit/test_ws_registry_audience.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_registry_audience.py
@@ -1,0 +1,120 @@
+"""The registry's audience-transition edges — the arm/disarm signal the reaper listens to.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+"""
+
+from screamingface_engine.ws.registry import ConnectionRegistry
+
+
+class _Recorder:
+    """Records transitions in order, as ("arrived"|"left", topic) pairs."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def audience_arrived(self, topic: str) -> None:
+        self.events.append(("arrived", topic))
+
+    def audience_left(self, topic: str) -> None:
+        self.events.append(("left", topic))
+
+
+def test_first_subscriber_arrives_and_last_one_leaves() -> None:
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("t")
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t"), ("left", "t")]
+
+
+def test_second_watcher_is_not_an_arrival_and_first_leaver_is_not_a_departure() -> None:
+    # INVARIANT: two sockets may legitimately observe one run. The reaper must arm only when
+    # the LAST of them goes, never when one of two goes.
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("t")
+    registry.add("t")
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t")]
+
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t"), ("left", "t")]
+
+
+def test_notifier_created_session_still_reads_the_first_add_as_an_arrival() -> None:
+    # WHY: `add_notifier` creates a session at ZERO subscribers, so a naive "session already
+    # existed" check would swallow the arrival and leave the reaper armed on a watched run.
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add_notifier("t", lambda _frame: None)
+    registry.add("t")
+
+    assert recorder.events == [("arrived", "t")]
+
+
+def test_remove_without_add_fires_nothing() -> None:
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.remove("never-attached")
+
+    assert recorder.events == []
+
+
+def test_repeated_remove_does_not_fire_left_twice() -> None:
+    # INVARIANT: `audience_left` is edge-triggered. A double fire would re-arm a topic whose
+    # window the reaper may have already closed.
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("t")
+    registry.remove("t")
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t"), ("left", "t")]
+
+
+def test_transitions_are_per_topic() -> None:
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("a")
+    registry.add("b")
+    registry.remove("a")
+
+    assert recorder.events == [("arrived", "a"), ("arrived", "b"), ("left", "a")]
+
+
+def test_re_attaching_after_the_last_leave_arrives_again() -> None:
+    # WHY this matters to the reaper: `remove` discards the whole session at zero, so the
+    # re-attach starts from a fresh one. The arrival edge must still fire, or the topic would
+    # stay armed while somebody is watching it.
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("t")
+    registry.remove("t")
+    registry.add("t")
+
+    assert recorder.events == [("arrived", "t"), ("left", "t"), ("arrived", "t")]
+
+
+def test_registry_without_a_listener_behaves_exactly_as_before() -> None:
+    # INVARIANT: the listener is optional. Every existing test builds a bare registry.
+    registry = ConnectionRegistry()
+
+    registry.add("t")
+    registry.remove("t")  # must not raise

--- a/docs/plan/2026-08-19-OME-890-orphan-run-reaper.md
+++ b/docs/plan/2026-08-19-OME-890-orphan-run-reaper.md
@@ -1,0 +1,1278 @@
+# Orphan Run Reaper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop an Engine run when its last WebSocket subscriber disconnects and does not come back inside a configurable grace window.
+
+**Architecture:** The `ConnectionRegistry` already knows exactly when a topic's audience empties, so it becomes the arm/disarm signal: it calls an `AudienceListener` on the 0→1 and 1→0 transitions. A `RunReaper` policy object holds one `dict[topic, monotonic_deadline]`, and a single background sweep task in `app.py` calls `reaper.sweep()` on a cadence. `sweep()` claims an expired topic by popping it before any `await`, re-verifies that the audience is still gone and the job still exists, then calls the existing idempotent `JobRunner.stop`. The run terminates as a clean `Terminated(stopped)` — no protocol change, no SDK change, no port change.
+
+**Tech Stack:** Python 3.12+, asyncio, FastAPI, pydantic-settings v2, pytest + pytest-asyncio (`asyncio_mode = "strict"`), ruff, pyright, Helm.
+
+**Spec:** `docs/spec/2026-08-19-OME-890-orphan-run-reaper.md`
+
+## Global Constraints
+
+- Stack: `screamingface-engine`, root `apps/screamingface-engine`. All commands run from that directory unless stated.
+- Gates (must all be green before every commit): `uv run .claude/scripts/run_gates.py screamingface-engine` from the repo root.
+- ruff: `line-length = 100`, `target-version = "py312"`. Lint selects `E, F, I, UP, C901, PLR0911, PLR0912, PLR0915, PLR1702`.
+- ruff pylint limits are tight and enforced: **`max-returns = 3`**, `max-branches = 7`, `max-statements = 26`, `max-complexity = 8`. The `_reap` helper in Task 2 is shaped specifically to stay inside `max-returns = 3` — do not refactor it into four `return` statements.
+- pytest: `asyncio_mode = "strict"` — every async test needs an explicit `@pytest.mark.asyncio`.
+- Coverage gate: `--cov=screamingface_engine --cov=url4.streaming --cov-fail-under=80`.
+- **No new dependencies.** `hypothesis` is not in the dev group; the invariant test in Task 2 is a scripted deterministic sequence, not a property-based test.
+- Semantic comment anchors are mandatory and the vocabulary is closed: `WHY:`, `INVARIANT:`, `AIDEV-NOTE:`, `FEATURE:`, `STORY:`. Python syntax is `#`. Never add a comment that restates the code.
+- Commit messages: conventional, body carries `Refs: OME-890`, **never** a `Co-Authored-By` trailer.
+- Tests are append-only. Do not modify or weaken any existing test to make new code pass.
+- Files stay under 450 lines.
+- `time.monotonic` for all deadlines. Never a wall clock.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/screamingface_engine/ws/registry.py` (modify) | Gains the `AudienceListener` protocol, a `listen()` composition-root seam, and the two transition calls. Still owns per-topic session state. |
+| `src/screamingface_engine/reaper.py` (create) | **Policy only.** Arm/disarm, the deadline map, `sweep()`, and the counters the metrics collector reads. No FastAPI, no task ownership, no imports from `ws`. |
+| `src/screamingface_engine/app.py` (modify) | Owns the background sweep task, mirroring the existing `_install_artifact_sweeper`. Wires the reaper to the **real registry**. |
+| `src/screamingface_engine/config.py` (modify) | `orphan_grace_s` setting. |
+| `src/screamingface_engine/metrics.py` (modify) | `_ReaperCollector` + `register_reaper_metrics`, mirroring `_CatalogCollector`. |
+| `src/screamingface_engine/cli.py` (modify) | One comment recording that uvicorn's WS ping defaults are load-bearing. |
+| `.claude/scripts/check_layering.py` (modify) | Adds `reaper` to `CONTROL_PLANE`. |
+| `deploy/helm/values.yaml`, `deploy/helm/templates/configmap.yaml` (modify) | Expose `config.orphanGraceS`. |
+
+Four test files, one per task: `tests/unit/test_ws_registry_audience.py`, `tests/unit/test_reaper.py`, `tests/unit/test_reaper_wiring.py`, `tests/integration/test_orphan_reaper_spine.py`.
+
+---
+
+## Task 1: Registry audience transitions
+
+The arm/disarm signal. Nothing consumes it yet, which is deliberate — this task is independently reviewable and cannot change any runtime behaviour, because no listener is registered.
+
+**Files:**
+- Modify: `apps/screamingface-engine/src/screamingface_engine/ws/registry.py` (add protocol after line 26; modify `__init__` line 51-52, `add` line 54-55, `remove` line 57-63)
+- Modify: `apps/screamingface-engine/src/screamingface_engine/ws/__init__.py` (export `AudienceListener`)
+- Test: `apps/screamingface-engine/tests/unit/test_ws_registry_audience.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `AudienceListener` protocol with `audience_arrived(topic: str) -> None` and `audience_left(topic: str) -> None`, both sync, both returning `None`. `ConnectionRegistry.listen(audience: AudienceListener) -> None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/screamingface-engine/tests/unit/test_ws_registry_audience.py`:
+
+```python
+"""The registry's audience-transition edges — the arm/disarm signal the reaper listens to.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+"""
+
+from screamingface_engine.ws.registry import ConnectionRegistry
+
+
+class _Recorder:
+    """Records transitions in order, as ("arrived"|"left", topic) pairs."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str]] = []
+
+    def audience_arrived(self, topic: str) -> None:
+        self.events.append(("arrived", topic))
+
+    def audience_left(self, topic: str) -> None:
+        self.events.append(("left", topic))
+
+
+def test_first_subscriber_arrives_and_last_one_leaves() -> None:
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("t")
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t"), ("left", "t")]
+
+
+def test_second_watcher_is_not_an_arrival_and_first_leaver_is_not_a_departure() -> None:
+    # INVARIANT: two sockets may legitimately observe one run. The reaper must arm only when
+    # the LAST of them goes, never when one of two goes.
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("t")
+    registry.add("t")
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t")]
+
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t"), ("left", "t")]
+
+
+def test_notifier_created_session_still_reads_the_first_add_as_an_arrival() -> None:
+    # WHY: `add_notifier` creates a session at ZERO subscribers, so a naive "session already
+    # existed" check would swallow the arrival and leave the reaper armed on a watched run.
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add_notifier("t", lambda frame: None)
+    registry.add("t")
+
+    assert recorder.events == [("arrived", "t")]
+
+
+def test_remove_without_add_fires_nothing() -> None:
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.remove("never-attached")
+
+    assert recorder.events == []
+
+
+def test_repeated_remove_does_not_fire_left_twice() -> None:
+    # INVARIANT: `audience_left` is edge-triggered. A double fire would re-arm a topic whose
+    # window the reaper may have already closed.
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("t")
+    registry.remove("t")
+    registry.remove("t")
+
+    assert recorder.events == [("arrived", "t"), ("left", "t")]
+
+
+def test_transitions_are_per_topic() -> None:
+    registry = ConnectionRegistry()
+    recorder = _Recorder()
+    registry.listen(recorder)
+
+    registry.add("a")
+    registry.add("b")
+    registry.remove("a")
+
+    assert recorder.events == [("arrived", "a"), ("arrived", "b"), ("left", "a")]
+
+
+def test_registry_without_a_listener_behaves_exactly_as_before() -> None:
+    # INVARIANT: the listener is optional. Every existing test builds a bare registry.
+    registry = ConnectionRegistry()
+
+    registry.add("t")
+    registry.remove("t")  # must not raise
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/screamingface-engine && uv run pytest tests/unit/test_ws_registry_audience.py -v`
+
+Expected: FAIL — `AttributeError: 'ConnectionRegistry' object has no attribute 'listen'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `src/screamingface_engine/ws/registry.py`, add `Protocol` to the `typing` imports (the file currently imports `Callable` from `collections.abc` and `dataclass, field` from `dataclasses`; add `from typing import Protocol`), then insert this after the `Notify` type alias (after line 26) and before `class _Session`:
+
+```python
+class AudienceListener(Protocol):
+    """Where the registry announces a topic's audience arriving and leaving.
+
+    FEATURE: tie a run's lifetime to its audience (OME-890).
+
+    INVARIANT: both methods are synchronous and must not raise. They run inside `add`/`remove`,
+    and `remove` runs in the WS endpoint's `finally` — a path that also executes under
+    cancellation, where an exception would mask the very disconnect it is reporting.
+    """
+
+    def audience_arrived(self, topic: str) -> None:
+        """``topic`` went from no subscribers to one."""
+
+    def audience_left(self, topic: str) -> None:
+        """``topic``'s last subscriber disconnected."""
+```
+
+Replace `ConnectionRegistry.__init__`, `add`, and `remove` (lines 51-63) with:
+
+```python
+    def __init__(self) -> None:
+        self._sessions: dict[str, _Session] = {}
+        self._audience: AudienceListener | None = None
+
+    def listen(self, audience: AudienceListener) -> None:
+        """Register the one listener for audience transitions — COMPOSITION ROOT ONLY.
+
+        A setter rather than a constructor argument because the registry is built before the
+        reaper that watches it, and the reaper needs the registry (`app.py::create_app`).
+        """
+        self._audience = audience
+
+    def add(self, topic: str) -> None:
+        session = self._sessions.setdefault(topic, _Session())
+        session.subscribers += 1
+        # INVARIANT: 0->1 ONLY. `add_notifier` can create a session at zero subscribers, and the
+        # second of two watchers attaching must not read as "the audience arrived".
+        if session.subscribers == 1 and self._audience is not None:
+            self._audience.audience_arrived(topic)
+
+    def remove(self, topic: str) -> None:
+        session = self._sessions.get(topic)
+        if session is None:
+            return
+        session.subscribers -= 1
+        if session.subscribers <= 0:
+            del self._sessions[topic]
+            # INVARIANT: 1->0 ONLY, and announced AFTER the session is discarded, so a listener
+            # that asks `has_subscriber` from inside the callback gets the post-transition answer.
+            if self._audience is not None:
+                self._audience.audience_left(topic)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/screamingface-engine && uv run pytest tests/unit/test_ws_registry_audience.py -v`
+Expected: PASS (7 tests)
+
+Then run the whole suite — no existing test may break:
+Run: `cd apps/screamingface-engine && uv run pytest -q`
+Expected: PASS, same count as before plus 7.
+
+- [ ] **Step 5: Export the protocol**
+
+In `src/screamingface_engine/ws/__init__.py`, add `AudienceListener` to the imports from `.registry` and to `__all__`, keeping the existing alphabetical order of `__all__`.
+
+- [ ] **Step 6: Run the gates**
+
+Run: `cd /home/junior/workspace/screamingface && uv run .claude/scripts/run_gates.py screamingface-engine`
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/screamingface-engine/src/screamingface_engine/ws/registry.py \
+        apps/screamingface-engine/src/screamingface_engine/ws/__init__.py \
+        apps/screamingface-engine/tests/unit/test_ws_registry_audience.py
+git commit -m "$(cat <<'EOF'
+feat(screamingface-engine): announce WS audience arrive/leave transitions
+
+The registry knew when a topic's last subscriber left and told nobody. It now
+calls an optional AudienceListener on the 0->1 and 1->0 edges, which is the
+signal the orphan-run reaper arms and disarms on. No listener is registered
+yet, so runtime behaviour is unchanged.
+
+Refs: OME-890
+EOF
+)"
+```
+
+---
+
+## Task 2: The RunReaper policy object
+
+**Files:**
+- Create: `apps/screamingface-engine/src/screamingface_engine/reaper.py`
+- Test: `apps/screamingface-engine/tests/unit/test_reaper.py`
+
+**Interfaces:**
+- Consumes: `AudienceListener` shape from Task 1 (structurally — `reaper.py` does **not** import from `ws`, so the two stay decoupled and the layering gate stays quiet).
+- Produces: `RunReaper(job_runner: JobRunner, audience: Audience, *, grace_s: float, clock: Callable[[], float] = time.monotonic, tick_s: float | None = None)`. Properties `tick_s: float`, `armed_count: int`, `reaped_total: int`. Methods `audience_left(topic: str) -> None`, `audience_arrived(topic: str) -> None`, `async sweep() -> tuple[str, ...]`. Also the `Audience` protocol with `async has_subscriber(topic: str) -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/screamingface-engine/tests/unit/test_reaper.py`:
+
+```python
+"""The orphan-run reaper's policy: arm on audience-empty, disarm on return, stop on expiry.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+
+Every test drives an injected clock and calls `sweep()` directly. No test sleeps: a reaper
+verified by real time would be both slow and flaky.
+"""
+
+import pytest
+
+from screamingface_engine.reaper import RunReaper
+
+GRACE = 120.0
+
+
+class _FakeClock:
+    """A monotonic clock the test advances by hand."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _FakeAudience:
+    """Subscriber counts per topic, as the real ConnectionRegistry would answer them."""
+
+    def __init__(self, present: set[str] | None = None) -> None:
+        self.present = present or set()
+
+    async def has_subscriber(self, topic: str) -> bool:
+        return topic in self.present
+
+
+class _FakeRunner:
+    """Records stop calls; `live` is the set of topics `exists` answers True for."""
+
+    def __init__(self, live: set[str] | None = None, fail_on: set[str] | None = None) -> None:
+        self.live = live if live is not None else set()
+        self.fail_on = fail_on or set()
+        self.stopped: list[str] = []
+
+    async def exists(self, topic: str) -> bool:
+        return topic in self.live
+
+    async def stop(self, topic: str) -> None:
+        if topic in self.fail_on:
+            raise RuntimeError("runner unavailable")
+        self.stopped.append(topic)
+        self.live.discard(topic)
+
+
+def _reaper(
+    clock: _FakeClock,
+    audience: _FakeAudience,
+    runner: _FakeRunner,
+    grace_s: float = GRACE,
+) -> RunReaper:
+    return RunReaper(runner, audience, grace_s=grace_s, clock=clock, tick_s=10.0)
+
+
+@pytest.mark.asyncio
+async def test_an_armed_run_is_stopped_once_the_window_closes() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ("t",)
+    assert runner.stopped == ["t"]
+    assert reaper.armed_count == 0
+    assert reaper.reaped_total == 1
+
+
+@pytest.mark.asyncio
+async def test_nothing_happens_before_the_window_closes() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE - 0.01)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+    assert reaper.armed_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_subscriber_returning_inside_the_window_saves_the_run() -> None:
+    # STORY: as a researcher whose wifi blipped, my reconnected notebook keeps its evaluation.
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE / 2)
+    reaper.audience_arrived("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+    assert reaper.armed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_subscriber_present_at_expiry_is_re_checked_and_the_run_survives() -> None:
+    # INVARIANT: claim-then-verify. Even with a stale arm — a disarm that never arrived — the
+    # sweep asks the registry again before stopping anything, because reaping a watched run is
+    # far worse than reaping late.
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    audience.present.add("t")  # the arm is stale; the registry disagrees
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+    assert reaper.armed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_a_finished_run_is_not_stopped() -> None:
+    # INVARIANT: no second terminal frame. `exists` is False once the run is terminal, and on
+    # the k8s runner a stop would DELETE the finished Job before its replay-guard TTL.
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live=set())
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == []
+
+
+@pytest.mark.asyncio
+async def test_a_topic_that_never_started_a_run_is_dropped_quietly() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live=set())
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("attached-then-left-without-starting")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert reaper.armed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_flapping_leaves_exactly_one_arm_and_the_last_one_wins() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    for _ in range(5):
+        reaper.audience_left("t")
+        clock.advance(1.0)
+        reaper.audience_arrived("t")
+    reaper.audience_left("t")
+
+    assert reaper.armed_count == 1
+
+    clock.advance(GRACE - 0.01)
+    assert await reaper.sweep() == ()  # measured from the LAST leave, not the first
+
+    clock.advance(0.01)
+    assert await reaper.sweep() == ("t",)
+
+
+@pytest.mark.asyncio
+async def test_a_second_sweep_does_not_stop_the_run_again() -> None:
+    clock, audience, runner = _FakeClock(), _FakeAudience(), _FakeRunner(live={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+    await reaper.sweep()
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert runner.stopped == ["t"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_stop_is_retried_rather_than_abandoned() -> None:
+    # INVARIANT: giving up would hand the run back to the 16h ceiling — the exact spend this
+    # module exists to stop. A transient runner error must re-arm.
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _FakeRunner(live={"t"}, fail_on={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert reaper.armed_count == 1  # re-armed, not dropped
+
+    runner.fail_on.clear()
+    clock.advance(reaper.tick_s)
+
+    assert await reaper.sweep() == ("t",)
+    assert runner.stopped == ["t"]
+
+
+@pytest.mark.asyncio
+async def test_only_the_due_topics_are_swept() -> None:
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _FakeRunner(live={"early", "late"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("early")
+    clock.advance(GRACE / 2)
+    reaper.audience_left("late")
+    clock.advance(GRACE / 2)
+
+    assert await reaper.sweep() == ("early",)
+    assert reaper.armed_count == 1
+
+
+@pytest.mark.asyncio
+async def test_armed_implies_no_subscriber_across_a_scripted_sequence() -> None:
+    # INVARIANT (the whole safety property, stated once): a topic is armed only while its
+    # audience is empty, and the deadline map never grows without bound. Scripted rather than
+    # property-based because `hypothesis` is not a dependency of this stack.
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _FakeRunner(live={"a", "b", "c"})
+    reaper = _reaper(clock, audience, runner)
+    topics = ("a", "b", "c")
+
+    script = [
+        ("arrive", "a"), ("arrive", "b"), ("leave", "a"), ("tick", 30.0),
+        ("arrive", "a"), ("leave", "b"), ("leave", "c"), ("tick", 200.0),
+        ("arrive", "c"), ("leave", "a"), ("tick", 5.0), ("leave", "c"),
+        ("tick", 500.0), ("arrive", "b"),
+    ]
+    for action, value in script:
+        if action == "arrive":
+            audience.present.add(str(value))
+            reaper.audience_arrived(str(value))
+        elif action == "leave":
+            audience.present.discard(str(value))
+            reaper.audience_left(str(value))
+        else:
+            clock.advance(float(value))
+            await reaper.sweep()
+        assert reaper.armed_count <= len(topics)
+        for topic in topics:
+            if reaper.is_armed(topic):
+                assert not await audience.has_subscriber(topic), (
+                    f"{topic} is armed while its audience is present"
+                )
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/screamingface-engine && uv run pytest tests/unit/test_reaper.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'screamingface_engine.reaper'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `apps/screamingface-engine/src/screamingface_engine/reaper.py`:
+
+```python
+"""Stops runs whose audience has gone and not come back.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+
+STORY: as a researcher whose notebook kernel died mid-evaluation, I do not keep paying for a
+run nobody can receive, and the next evaluation gets its concurrency slot back.
+
+WHY this module exists: the 428 gate (`rest/routes.py::_require_subscriber`) proves an audience
+exists when a run starts, and then nothing ever asks again. A client that dies before it can
+send `ai.url4.stop` — `kill -9`, a Jupyter kernel restart, laptop sleep, a network partition —
+leaves the run issuing paid model calls until `job_deadline_s` (16h), holding one of
+`local_max_concurrent_runs` slots and the gateway's per-provider slots the whole time. This
+closes the loop: the audience leaving arms a grace window, the audience returning disarms it,
+and expiry stops the run through the same idempotent `JobRunner.stop` the explicit paths use.
+
+AIDEV-NOTE: POLICY ONLY — no FastAPI, no task ownership, and deliberately no import from `ws`.
+The sweep loop lives in `app.py::_install_orphan_reaper`, beside the artifact sweeper it is
+modelled on. The registry's `AudienceListener` is satisfied structurally, which is what keeps
+these two modules decoupled.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Protocol
+
+from url4.streaming.interfaces import JobRunner
+
+_logger = logging.getLogger(__name__)
+
+_MIN_TICK_S = 1.0
+_TICKS_PER_GRACE = 8
+"""How many sweeps fit inside one grace window. WHY derived rather than a second setting: reap
+latency is `grace` to `grace + grace/8`, so an operator tunes ONE knob and gets a bounded
+overshoot, instead of two knobs that can be set into disagreement."""
+
+
+class Audience(Protocol):
+    """The subscriber question, as `ConnectionRegistry` answers it."""
+
+    async def has_subscriber(self, topic: str) -> bool: ...
+
+
+class RunReaper:
+    """Arms a grace window when a topic's audience empties; stops the run if it stays empty.
+
+    INVARIANT: `audience` is the REAL `ConnectionRegistry` — never the `SubscriberGate` DI seam.
+    `DenyAllGate` and the tests' `FixedGate(False)` answer "nobody is listening" for EVERY
+    topic. That is harmless as an admission gate, where the result is a visible refused start,
+    and catastrophic here, where it means "stop every run in this process". Same call as
+    `rest/routes.py::_deps` taking `registry` over `interest` for session state.
+
+    INVARIANT: deadlines are monotonic. A wall clock would let an NTP step or a suspend jump
+    expire a window that has not elapsed, and reap a live run.
+    """
+
+    def __init__(
+        self,
+        job_runner: JobRunner,
+        audience: Audience,
+        *,
+        grace_s: float,
+        clock: Callable[[], float] = time.monotonic,
+        tick_s: float | None = None,
+    ) -> None:
+        self._job_runner = job_runner
+        self._audience = audience
+        self._grace_s = grace_s
+        self._clock = clock
+        self._tick_s = (
+            tick_s if tick_s is not None else max(_MIN_TICK_S, grace_s / _TICKS_PER_GRACE)
+        )
+        self._deadlines: dict[str, float] = {}
+        self._reaped_total = 0
+
+    @property
+    def tick_s(self) -> float:
+        """Seconds between sweeps. The loop in `app.py` reads its cadence from here."""
+        return self._tick_s
+
+    @property
+    def armed_count(self) -> int:
+        """Topics currently inside a grace window.
+
+        WHY exposed: it is the /metrics gauge, and a value that never returns to zero is how an
+        operator sees that sweeps have stopped running.
+        """
+        return len(self._deadlines)
+
+    @property
+    def reaped_total(self) -> int:
+        """Runs stopped for having no audience, since boot."""
+        return self._reaped_total
+
+    def is_armed(self, topic: str) -> bool:
+        """Whether ``topic`` is inside a grace window."""
+        return topic in self._deadlines
+
+    # --- AudienceListener (satisfied structurally; see ws.registry.AudienceListener) ---
+
+    def audience_left(self, topic: str) -> None:
+        """Arm: ``topic`` has until now + grace to get its audience back."""
+        self._deadlines[topic] = self._clock() + self._grace_s
+
+    def audience_arrived(self, topic: str) -> None:
+        """Disarm: somebody is listening again."""
+        self._deadlines.pop(topic, None)
+
+    async def sweep(self) -> tuple[str, ...]:
+        """Stop every armed run whose grace window has closed; return the topics stopped.
+
+        Split from the loop that calls it so tests drive the policy against an injected clock
+        with no sleeps at all.
+        """
+        now = self._clock()
+        due = [topic for topic, deadline in self._deadlines.items() if now >= deadline]
+        reaped: list[str] = []
+        for topic in due:
+            if await self._reap(topic, now):
+                reaped.append(topic)
+        return tuple(reaped)
+
+    async def _reap(self, topic: str, now: float) -> bool:
+        """Stop one expired topic's run; ``True`` when it was actually stopped.
+
+        AIDEV-NOTE: this stays within ruff's `max-returns = 3`. The two guards share one
+        `or` deliberately — do not split them into separate `return False` branches.
+        """
+        # INVARIANT: the topic is CLAIMED — popped — before the first `await`. On a
+        # single-threaded loop that makes "this window closed and it is mine to decide" one
+        # atomic step, so a reconnect cannot land between the check and the claim. One arriving
+        # afterwards simply finds nothing armed, which is the same end state as a disarm.
+        self._deadlines.pop(topic, None)
+        # First guard: the audience came back and the disarm was missed or raced.
+        # Second guard: the run is already terminal. `stop` is idempotent, but on the k8s runner
+        # it DELETEs the Job, which would drop a finished Job before the TTL that is its
+        # single-use replay guard. Short-circuit order matters: an in-process dict lookup before
+        # a possible Kubernetes API call.
+        if await self._audience.has_subscriber(topic) or not await self._job_runner.exists(topic):
+            return False
+        try:
+            await self._job_runner.stop(topic)
+        except Exception:
+            # INVARIANT: a failed stop RE-ARMS rather than gives up, without bound. Abandoning
+            # the topic would hand the run back to the 16h ceiling, which is the exact spend
+            # this module exists to prevent; the per-tick warning is the operator's signal that
+            # the runner itself needs attention.
+            self._deadlines[topic] = now + self._tick_s
+            _logger.warning("orphan stop failed topic=%s; will retry", topic, exc_info=True)
+            return False
+        self._reaped_total += 1
+        _logger.info(
+            "orphan run reaped topic=%s reason=no_subscriber grace_s=%.0f",
+            topic,
+            self._grace_s,
+        )
+        return True
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/screamingface-engine && uv run pytest tests/unit/test_reaper.py -v`
+Expected: PASS (11 tests)
+
+Run: `cd apps/screamingface-engine && uv run pytest -q`
+Expected: PASS, nothing regressed.
+
+- [ ] **Step 5: Add `reaper` to the layering gate's control plane**
+
+In `.claude/scripts/check_layering.py`, add `"reaper",` to the `CONTROL_PLANE` set, in alphabetical position between `"ops"` and `"rest"`.
+
+**Why this is required, not cosmetic:** the gate treats any module in neither half as a *shared leaf* that both halves may import. A new top-level `reaper.py` would silently become one, and `runner/*` would then be allowed to import the control plane's reaper. Naming it here makes that import a gate failure.
+
+Also update the docstring's control-plane list (line ~14) to include `reaper`, and the comment above `CONTROL_PLANE` if it enumerates members.
+
+- [ ] **Step 6: Run the gates**
+
+Run: `cd /home/junior/workspace/screamingface && uv run .claude/scripts/run_gates.py screamingface-engine`
+Expected: all green, including `LAYERING OK`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/screamingface-engine/src/screamingface_engine/reaper.py \
+        apps/screamingface-engine/tests/unit/test_reaper.py \
+        .claude/scripts/check_layering.py
+git commit -m "$(cat <<'EOF'
+feat(screamingface-engine): add the orphan-run reaper policy
+
+RunReaper arms a monotonic grace window when a topic's audience empties and
+stops the run through the existing idempotent JobRunner.stop if the window
+closes with nobody listening. Claim-then-verify means a reconnect at the
+boundary keeps its run, and a finished run is never stopped twice.
+
+Policy only: no task ownership, no FastAPI, and no import from ws. Nothing
+constructs it yet. `reaper` joins CONTROL_PLANE in the layering gate so it
+cannot be mistaken for a shared leaf the run mode may import.
+
+Refs: OME-890
+EOF
+)"
+```
+
+---
+
+## Task 3: Configuration, wiring, and the metrics surface
+
+This is the task that makes the feature live. It also carries the single most important test in the plan (Step 1's trap test).
+
+**Files:**
+- Modify: `apps/screamingface-engine/src/screamingface_engine/config.py` (add the setting beside `artifact_sweep_interval_s`)
+- Modify: `apps/screamingface-engine/src/screamingface_engine/app.py` (import `RunReaper`; call `_install_orphan_reaper` inside `create_app` after line 110; add the installer beside `_install_artifact_sweeper`)
+- Modify: `apps/screamingface-engine/src/screamingface_engine/metrics.py` (add `_ReaperCollector` + `register_reaper_metrics`)
+- Modify: `apps/screamingface-engine/src/screamingface_engine/cli.py` (one comment at the `uvicorn.run` calls)
+- Modify: `apps/screamingface-engine/deploy/helm/values.yaml`, `apps/screamingface-engine/deploy/helm/templates/configmap.yaml`
+- Test: `apps/screamingface-engine/tests/unit/test_reaper_wiring.py`
+
+**Interfaces:**
+- Consumes: `RunReaper` from Task 2; `ConnectionRegistry.listen` from Task 1.
+- Produces: `Settings.orphan_grace_s: float`; `app.state.reaper: RunReaper | None`; `app.state.reaper_task: asyncio.Task | None`; `register_reaper_metrics(metrics: Metrics, get_reaper: Callable[[], Any]) -> None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/screamingface-engine/tests/unit/test_reaper_wiring.py`:
+
+```python
+"""How the reaper is wired into the App: what it asks, when it exists, and how it shuts down.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+"""
+
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+from screamingface_engine.app import create_app
+from screamingface_engine.config import Settings
+from screamingface_engine.reaper import RunReaper
+
+from ._fakes import FixedGate, RecordingJobRunner
+
+
+def _settings(**overrides: object) -> Settings:
+    base: dict[str, object] = {"jwt_secret": "x" * 32, "orphan_grace_s": 120.0}
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def test_the_reaper_asks_the_real_registry_and_never_the_subscriber_gate() -> None:
+    # INVARIANT — THE TRAP THIS TEST EXISTS FOR: `DenyAllGate`, and every test that injects
+    # `FixedGate(False)`, answers "no subscriber" for EVERY topic. Wiring the reaper to that
+    # seam instead of the real registry would stop every run in the process one grace window
+    # after boot. A refused start is visible and annoying; a silently killed 4-hour evaluation
+    # is not recoverable. Same call as `rest/routes.py::_deps` taking `registry` over
+    # `interest`. If this test ever fails, do NOT relax it.
+    app = create_app(_settings(), job_runner=RecordingJobRunner(), interest=FixedGate(False))
+
+    reaper = app.state.reaper
+
+    assert isinstance(reaper, RunReaper)
+    app.state.registry.add("watched")
+    assert reaper.is_armed("watched") is False
+
+
+@pytest.mark.asyncio
+async def test_a_disconnect_arms_the_reaper_through_the_registry() -> None:
+    app = create_app(_settings(), job_runner=RecordingJobRunner())
+    reaper = app.state.reaper
+
+    app.state.registry.add("t")
+    assert reaper.is_armed("t") is False
+
+    app.state.registry.remove("t")
+    assert reaper.is_armed("t") is True
+
+
+def test_no_reaper_is_built_without_a_job_runner() -> None:
+    # WHY: a stream-only App (`URL4_CLOUD_RUNNER=none`) has nothing to stop, and every unit
+    # test that injects no runner must not grow a background task.
+    app = create_app(_settings(), job_runner=None)
+
+    assert app.state.reaper is None
+
+
+def test_a_zero_grace_disables_the_reaper() -> None:
+    app = create_app(_settings(orphan_grace_s=0.0), job_runner=RecordingJobRunner())
+
+    assert app.state.reaper is None
+
+
+def test_a_negative_grace_is_refused_at_startup() -> None:
+    with pytest.raises(ValueError):
+        _settings(orphan_grace_s=-1.0)
+
+
+def test_the_default_grace_is_two_minutes() -> None:
+    # INVARIANT: uvicorn needs up to ws_ping_interval + ws_ping_timeout (~40s) to notice a
+    # partitioned peer, so the default must leave room above that.
+    assert Settings(jwt_secret="x" * 32).orphan_grace_s == 120.0
+
+
+def test_the_sweep_task_starts_and_is_cancelled_with_the_app() -> None:
+    app = create_app(_settings(), job_runner=RecordingJobRunner())
+
+    with TestClient(app):
+        task = app.state.reaper_task
+        assert isinstance(task, asyncio.Task)
+        assert not task.done()
+
+    assert app.state.reaper_task.done()
+
+
+def test_a_stream_only_app_starts_no_sweep_task() -> None:
+    app = create_app(_settings(), job_runner=None)
+
+    with TestClient(app):
+        assert getattr(app.state, "reaper_task", None) is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd apps/screamingface-engine && uv run pytest tests/unit/test_reaper_wiring.py -v`
+Expected: FAIL — `Settings` has no field `orphan_grace_s` (pydantic raises on the unexpected kwarg), and `app.state.reaper` does not exist.
+
+If `RecordingJobRunner` is not exported from `tests/unit/_fakes.py`, read that file and use whatever job-runner fake it provides (the module is known to contain `FixedGate` and `RecordingJobRunner`); the fake must supply `async exists(topic) -> bool` and `async stop(topic) -> None`. If its `exists` always returns False, construct it so `exists` can report True, or add a small local fake in this test file rather than modifying the shared one.
+
+- [ ] **Step 3a: Add the setting**
+
+In `src/screamingface_engine/config.py`, add `Field` to the pydantic import (`from pydantic import Field, model_validator`), then add this field immediately after `artifact_sweep_interval_s`:
+
+```python
+    # FEATURE: tie a run's lifetime to its audience (OME-890).
+    #
+    # WHY 120s: a run whose last WebSocket subscriber disconnects gets this long to get one
+    # back before the Engine stops it. Uvicorn needs up to ws_ping_interval + ws_ping_timeout
+    # (~40s on its defaults) to notice a partitioned peer, so anything much below a minute
+    # reaps mostly on clean closes while starting to risk live runs on slow reconnects.
+    # 0 disables the reaper entirely.
+    #
+    # INVARIANT: this bounds SPEND, not correctness — the backstop is still job_deadline_s
+    # (16h). Raising it costs money per orphan; lowering it risks a live run.
+    orphan_grace_s: float = Field(default=120.0, ge=0.0)
+```
+
+- [ ] **Step 3b: Wire the reaper**
+
+In `src/screamingface_engine/app.py`, add the import `from screamingface_engine.reaper import RunReaper` (isort places it after `screamingface_engine.ops`), and add `register_reaper_metrics` to the existing `screamingface_engine.metrics` import.
+
+Replace lines 108-110 with:
+
+```python
+    registry = ConnectionRegistry()
+    app.state.registry = registry
+    app.state.interest = interest if interest is not None else registry
+    # FEATURE: tie a run's lifetime to its audience (OME-890).
+    _install_orphan_reaper(app, registry, job_runner, settings)
+```
+
+Add `register_reaper_metrics(app.state.metrics, lambda: app.state.reaper)` immediately after the existing `register_catalog_metrics(...)` call — note this must come *after* `_install_orphan_reaper` sets `app.state.reaper`, or move it below that call.
+
+Add this function immediately after `_install_artifact_sweeper` (after line 162):
+
+```python
+def _install_orphan_reaper(
+    app: FastAPI,
+    registry: ConnectionRegistry,
+    job_runner: JobRunner | None,
+    settings: Settings,
+) -> None:
+    """Wire the orphan-run reaper: arm on audience-empty, sweep on a cadence, stop on expiry.
+
+    FEATURE: tie a run's lifetime to its audience (OME-890). Modelled on
+    `_install_artifact_sweeper` above: the policy object owns no task, the loop is an asyncio
+    task on the App's own event loop, and shutdown cancels it so nothing outlives the App.
+
+    INVARIANT: the reaper is handed `registry` — the REAL one — and never `app.state.interest`.
+    The gate seam answers "no subscriber" for every topic under `DenyAllGate`, which as a reap
+    input would stop every run in this process one grace window after boot.
+    """
+    app.state.reaper = None
+    app.state.reaper_task = None
+    if job_runner is None or settings.orphan_grace_s <= 0:
+        # WHY the early return: a stream-only App has nothing to stop, and an operator may turn
+        # the reaper off. Either way no background task is created.
+        return
+    reaper = RunReaper(job_runner, registry, grace_s=settings.orphan_grace_s)
+    app.state.reaper = reaper
+    registry.listen(reaper)
+
+    async def _sweep_forever() -> None:
+        while True:
+            await asyncio.sleep(reaper.tick_s)
+            # INVARIANT: one failed sweep must not kill the reaper. An unhandled exception here
+            # would end the task silently, and every later orphan would run to the 16h ceiling
+            # with no signal at all — worse than the bug this feature fixes, because it would
+            # look fixed. Log and keep the cadence.
+            try:
+                await reaper.sweep()
+            except Exception:
+                _logger.exception("orphan sweep failed; retrying next interval")
+
+    async def _start() -> None:
+        # WHY no sweep at startup, unlike the artifact sweeper: nothing can be armed before a
+        # WebSocket has attached and then left, so a boot sweep would have nothing to look at.
+        app.state.reaper_task = asyncio.get_running_loop().create_task(_sweep_forever())
+        # AIDEV-NOTE: the single-replica assumption is logged, not merely documented in the
+        # chart. The audience count is in-process, so a second replica would answer "nobody is
+        # listening" for runs another replica is streaming and stop healthy runs. Multi-replica
+        # needs a shared SubscriberGate (NATS consumer interest) first.
+        _logger.info(
+            "orphan reaper armed grace_s=%.0f tick_s=%.0f (assumes a single replica)",
+            settings.orphan_grace_s,
+            reaper.tick_s,
+        )
+
+    async def _stop() -> None:
+        task = app.state.reaper_task
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    app.router.on_startup.append(_start)
+    app.router.on_shutdown.append(_stop)
+```
+
+- [ ] **Step 3c: Add the metrics collector**
+
+In `src/screamingface_engine/metrics.py`, add after `_CatalogCollector` and before `register_catalog_metrics`:
+
+```python
+class _ReaperCollector:
+    """A `prometheus_client` custom collector for the orphan reaper's counters."""
+
+    def __init__(self, get_reaper: Callable[[], Any]) -> None:
+        self._get_reaper = get_reaper
+
+    def collect(self) -> Iterable[Any]:
+        """Called by `prometheus_client` once per `/metrics` scrape."""
+        reaper = self._get_reaper()
+        if reaper is None:
+            return
+        yield CounterMetricFamily(
+            "screamingface_engine_orphan_runs_reaped",
+            "Runs stopped for having no WebSocket subscriber.",
+            value=reaper.reaped_total,
+        )
+        # WHY a gauge and not just the counter: a value that never returns to zero is how an
+        # operator sees that sweeps have stopped running — a silently dead reaper otherwise
+        # looks identical to "no orphans happened".
+        yield GaugeMetricFamily(
+            "screamingface_engine_orphan_runs_armed",
+            "Runs currently inside their no-subscriber grace window.",
+            value=float(reaper.armed_count),
+        )
+
+
+def register_reaper_metrics(metrics: Metrics, get_reaper: Callable[[], Any]) -> None:
+    """Register a `_ReaperCollector` for `get_reaper` on `metrics.registry`."""
+    metrics.registry.register(_ReaperCollector(get_reaper))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd apps/screamingface-engine && uv run pytest tests/unit/test_reaper_wiring.py -v`
+Expected: PASS (8 tests)
+
+Run: `cd apps/screamingface-engine && uv run pytest -q`
+Expected: PASS. Watch specifically for tests that assert on `/metrics` output or on `create_app` state — if any break, that is a real finding to report, not a test to edit.
+
+- [ ] **Step 5: Record the load-bearing uvicorn assumption**
+
+In `src/screamingface_engine/cli.py`, add this comment immediately above the `uvicorn.run(` call in `_serve` (and a one-line pointer above the one in `_serve_local`):
+
+```python
+    # INVARIANT (OME-890): uvicorn's WS ping defaults are LOAD-BEARING and deliberately not
+    # overridden here. `ws_ping_interval=20` / `ws_ping_timeout=20` are what close a
+    # partitioned or sleeping peer's socket within ~40s, which is what fires
+    # `ConnectionRegistry.remove` and arms the orphan reaper. Disabling or lengthening them
+    # would leave a dead client's run detected only by TCP retransmission timeout (~15-30
+    # min) and silently reopen most of the spend OME-890 closed.
+```
+
+- [ ] **Step 6: Expose the setting in the chart**
+
+In `deploy/helm/values.yaml`, add to the `config:` block, beside `jobDeadlineS`:
+
+```yaml
+  # Seconds a run may keep running with no WebSocket subscriber attached before the App stops
+  # it (OME-890). 0 disables the reaper. Keep this comfortably above uvicorn's WS ping window
+  # (~40s) so a partitioned client is detected before the window closes.
+  orphanGraceS: 120
+```
+
+In `deploy/helm/templates/configmap.yaml`, add after the `URL4_CLOUD_JOB_DEADLINE_S` line:
+
+```yaml
+  # INVARIANT: this bounds SPEND on runs whose client died, not correctness — job_deadline_s
+  # remains the backstop. The reaper's audience count is IN-PROCESS, so this chart's
+  # `replicaCount: 1` is load-bearing for it: a second replica would answer "nobody is
+  # listening" for runs the other replica is streaming.
+  URL4_CLOUD_ORPHAN_GRACE_S: {{ .Values.config.orphanGraceS | quote }}
+```
+
+- [ ] **Step 7: Run the gates**
+
+Run: `cd /home/junior/workspace/screamingface && uv run .claude/scripts/run_gates.py screamingface-engine`
+Expected: all green.
+
+Also render the chart to prove the template is valid:
+Run: `cd apps/screamingface-engine && helm template t deploy/helm --set config.natsUrl=nats://n:4222 | grep ORPHAN`
+Expected: one line showing `URL4_CLOUD_ORPHAN_GRACE_S: "120"`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/screamingface-engine/src/screamingface_engine/config.py \
+        apps/screamingface-engine/src/screamingface_engine/app.py \
+        apps/screamingface-engine/src/screamingface_engine/metrics.py \
+        apps/screamingface-engine/src/screamingface_engine/cli.py \
+        apps/screamingface-engine/deploy/helm/values.yaml \
+        apps/screamingface-engine/deploy/helm/templates/configmap.yaml \
+        apps/screamingface-engine/tests/unit/test_reaper_wiring.py
+git commit -m "$(cat <<'EOF'
+feat(screamingface-engine): stop runs whose audience never comes back
+
+Wires the orphan reaper into create_app: the real ConnectionRegistry arms it,
+a background sweep task modelled on the artifact sweeper drives it, and
+URL4_CLOUD_ORPHAN_GRACE_S (default 120s, 0 disables) tunes it. A run whose
+last WebSocket subscriber disconnects is now stopped within the grace window
+instead of spending for up to job_deadline_s (16h).
+
+The reaper reads the registry and never app.state.interest: DenyAllGate
+answers "no subscriber" for every topic, which as a reap input would stop
+every run in the process. A test pins that.
+
+Refs: OME-890
+EOF
+)"
+```
+
+---
+
+## Task 4: End-to-end proof on the local spine
+
+**Files:**
+- Create: `apps/screamingface-engine/tests/integration/test_orphan_reaper_spine.py`
+- Read first (exemplar, do not modify): `apps/screamingface-engine/tests/integration/test_local_spine.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–3.
+- Produces: no source changes. If a test here fails, the defect is in Tasks 1–3.
+
+- [ ] **Step 1: Read the exemplar**
+
+Read `tests/integration/test_local_spine.py` in full. It already builds the whole spine: `POST /token`, a `TestClient` WebSocket at `/ws?ticket=...`, an `AttachEvent`, `GET /?q=...` with the `URL4-Capability` header, and frame assertions with a stub executor (`_EchoExecutor`). Reuse its fixtures and helpers rather than rebuilding them — copy its setup shape, and note how it constructs the local app and injects the executor.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `apps/screamingface-engine/tests/integration/test_orphan_reaper_spine.py`. Mirror the exemplar's app construction, and pass a small `orphan_grace_s` plus an injected clock or a direct `sweep()` call so no test sleeps. The four scenarios, each asserting behaviour and not just "it ran":
+
+```python
+"""End-to-end: a dead client's run is stopped, a reconnecting client's run is not.
+
+FEATURE: tie a run's lifetime to its audience (OME-890).
+
+AIDEV-NOTE: these drive `app.state.reaper.sweep()` directly after moving an injected clock,
+rather than waiting on the background task. The task's own cadence is covered in
+tests/unit/test_reaper_wiring.py; what these prove is the SPINE — that a real WS disconnect
+reaches the reaper and that a real run reaches Terminated(stopped).
+"""
+```
+
+Test 1 — `test_an_abandoned_run_is_stopped_and_stops_spending`:
+1. Mint a token, attach a WebSocket, send the attach frame.
+2. `GET /?q=...` with `Prefer: respond-async`; assert 202.
+3. Assert the executor has begun (at least one call recorded).
+4. Close the WebSocket abruptly (exit the `websocket_connect` context).
+5. Advance the injected clock past `orphan_grace_s`; `await app.state.reaper.sweep()`.
+6. Assert the returned tuple contains the topic, that the run's terminal frame is
+   `TerminatedEvent` with `status == "stopped"`, and — the money assertion — that the
+   executor's recorded call count did not increase after the stop.
+
+Test 2 — `test_a_reconnecting_client_keeps_its_run`:
+1. Same setup through the 202.
+2. Close the WebSocket.
+3. Advance the clock to half the grace window and sweep; assert nothing was reaped.
+4. Reattach with `AttachEvent(from_sequence=1)`; assert the replayed frames arrive.
+5. Advance the clock well past the original deadline and sweep; assert nothing was reaped and
+   `app.state.job_runner.exists(topic)` is still True.
+
+Test 3 — `test_an_explicit_stop_is_unchanged_and_is_not_stopped_twice`:
+1. Same setup. Send an in-band `ai.url4.stop` frame (and, in a second case, `DELETE /`).
+2. Assert the terminal frame and status match today's behaviour exactly.
+3. Close the WebSocket, advance the clock past the grace window, sweep.
+4. Assert the sweep reaped nothing (the `exists()` guard held) and no second terminal frame
+   was published.
+
+Test 4 — `test_reaping_releases_the_concurrency_slot`:
+1. Build the local app with `local_max_concurrent_runs=1`.
+2. Start one run, then abandon its WebSocket.
+3. Assert a second `GET /?q=` returns 503 (`the runner is at capacity`).
+4. Advance the clock past the grace window and sweep.
+5. Assert the second `GET /?q=` now succeeds — this is the capacity symptom from the issue.
+
+- [ ] **Step 3: Run to verify they fail for the right reason**
+
+Run: `cd apps/screamingface-engine && uv run pytest tests/integration/test_orphan_reaper_spine.py -v`
+
+Expected before Tasks 1–3 are complete: failures. Expected *after* them: these should pass. If a test fails here after Tasks 1–3, treat it as a real defect and fix the source — do not weaken the test.
+
+- [ ] **Step 4: Run the full suite and the gates**
+
+Run: `cd apps/screamingface-engine && uv run pytest -q`
+Run: `cd /home/junior/workspace/screamingface && uv run .claude/scripts/run_gates.py screamingface-engine`
+Expected: all green, coverage at or above 80.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/screamingface-engine/tests/integration/test_orphan_reaper_spine.py
+git commit -m "$(cat <<'EOF'
+test(screamingface-engine): prove the orphan reaper end-to-end
+
+Covers the four acceptance criteria on the local spine: an abandoned run is
+stopped and issues no further model calls, a client reconnecting inside the
+window keeps its run, the explicit stop paths are byte-identical to before,
+and reaping releases the concurrency slot a wedged eval was waiting on.
+
+Refs: OME-890
+EOF
+)"
+```
+
+---
+
+## Task 5: Close out
+
+- [ ] **Step 1: Fill in the ledger Outcome**
+
+Edit `docs/work/2026-08-19-OME-890-orphan-run-reaper.md`: set `status: done`, fill `finished: 2026-08-19`, and complete the Outcome section with actual files, the commit SHAs and messages, the gate result line, and any deviations from this plan.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+git push -u origin OME-890-orphan-run-reaper
+gh pr create --title "feat(screamingface-engine): stop runs whose client died (OME-890)" --body "$(cat <<'EOF'
+## Summary
+
+An Engine run's lifetime was tied to nothing. The 428 gate proved an audience existed at
+schedule time and nothing asked again, so a client that died before it could send
+`ai.url4.stop` left the run spending for up to `job_deadline_s` (16h) and holding a
+concurrency slot.
+
+The registry now announces audience arrive/leave transitions. A `RunReaper` arms a monotonic
+grace window when a topic's audience empties and stops the run through the existing idempotent
+`JobRunner.stop` if the window closes with nobody listening. Total exposure drops from 57600s
+to about 160s (uvicorn's ~40s WS ping detection plus the 120s default grace).
+
+## Test plan
+
+- `tests/unit/test_ws_registry_audience.py` — the 0->1 / 1->0 edges, including two watchers.
+- `tests/unit/test_reaper.py` — arm, disarm, claim-then-verify, finished runs, flapping,
+  failed-stop retry, and the armed-implies-no-subscriber invariant.
+- `tests/unit/test_reaper_wiring.py` — including the trap test that pins the reaper to the
+  real registry rather than the `SubscriberGate` seam.
+- `tests/integration/test_orphan_reaper_spine.py` — the four acceptance criteria end-to-end.
+- Gates: `uv run .claude/scripts/run_gates.py screamingface-engine` green.
+
+## Cross-service contract
+
+None changed. No protocol change, no SDK change, no `JobRunner` port change — the reap
+reuses `Terminated(stopped)`.
+
+## Notes for the reviewer
+
+- `reaper` is added to `CONTROL_PLANE` in `check_layering.py` on purpose: without it a new
+  top-level module is treated as a shared leaf the run mode may import.
+- Uvicorn's WS ping defaults are load-bearing and now commented as such in `cli.py`.
+- Single-replica is assumed and logged at startup. Multi-replica needs a shared
+  `SubscriberGate` first — see the spec's residual-risk section.
+
+Spec: `docs/spec/2026-08-19-OME-890-orphan-run-reaper.md`
+Plan: `docs/plan/2026-08-19-OME-890-orphan-run-reaper.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Close the ticket**
+
+After CI is green and the PR is squash-merged, move OME-890 to Done and add a comment naming the commits, the gate result, and the ledger path. Then remove the worktree: `git worktree remove .claude/worktrees/OME-890-orphan-run-reaper`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| §2 uvicorn ping is load-bearing | Task 3 Step 5 (comment), ledger Acceptance |
+| §3.1 the R1 trap | Task 3 Step 1 trap test; `RunReaper` docstring invariant |
+| §4.1 edge-armed / tick-verified shape | Tasks 1, 2, 3 |
+| §4.2 D1 no port change | Verified: only `exists`/`stop` are used |
+| §4.2 D2 one loop | Task 3 `_sweep_forever` |
+| §4.2 D3 arm unconditionally | Task 2 `audience_left`; Task 2 test `test_a_topic_that_never_started_a_run_is_dropped_quietly` |
+| §4.2 D4 claim before verify | Task 2 `_reap`; test `test_a_subscriber_present_at_expiry_...` |
+| §4.2 D5 monotonic | Task 2 default `clock=time.monotonic` |
+| §4.2 D6 stop only, no purge | Task 2 `_reap` calls only `stop` |
+| §4.2 D7 reuse `Terminated(stopped)` | Task 4 Test 1 asserts the status |
+| §4.2 D8 unbounded retry | Task 2 test `test_a_failed_stop_is_retried_rather_than_abandoned` |
+| §4.2 D9 layering | Task 2 Step 5 |
+| §4.3 race table | Task 2 tests (rows 1, 3, 4, 5, 6) + Task 3 (shutdown row) |
+| §5 config + observability | Task 3 Steps 3a, 3c, 6 |
+| §6.1 single-replica assumption logged | Task 3 `_start` log line |
+
+Gap found and closed: §6.1 originally said only "documented"; Task 3 now emits a startup log line so the assumption is discoverable at runtime.
+
+**Placeholder scan:** no TBD/TODO. Every code step carries real code. Task 4's tests are specified as numbered scenarios with exact assertions rather than full source, because they must be shaped around `test_local_spine.py`'s existing fixtures, which Step 1 requires reading first — the assertions themselves are fully specified.
+
+**Type consistency:** `audience_arrived` / `audience_left` are spelled identically in Task 1 (protocol), Task 2 (`RunReaper` methods), and Task 3 (wiring). `is_armed`, `armed_count`, `reaped_total`, and `tick_s` are defined in Task 2 and used in Tasks 2, 3, and 4. `orphan_grace_s` is spelled consistently across config, app, tests, and the chart's `orphanGraceS`. `app.state.reaper` and `app.state.reaper_task` are both initialised to `None` in every path.

--- a/docs/spec/2026-08-19-OME-890-orphan-run-reaper.md
+++ b/docs/spec/2026-08-19-OME-890-orphan-run-reaper.md
@@ -1,0 +1,228 @@
+# OME-890 — Tie a run's lifetime to its audience
+
+Status: approved (owner, 2026-08-19) · Stack: screamingface-engine
+
+## 1. Problem
+
+A run's lifetime is tied to nothing. The Engine asks "is anyone listening?" exactly once,
+at the door:
+
+| Fact | File | Consequence |
+|---|---|---|
+| The 428 gate is the only reader of `has_subscriber` | `rest/routes.py:138-145` | Audience is proved at schedule time, then never again |
+| `registry.remove` is bare arithmetic — no callback, no event | `ws/registry.py:57-63` | Nothing reacts to "my last subscriber vanished" |
+| The bridge's `_teardown` cancels the pump, reader, and writer — never the job | `ws/bridge.py:360-368` | A dead client's run keeps running |
+| The only remaining clock is `job_deadline_s` | `config.py` (57600 s = 16 h) | An orphan spends for up to 16 h |
+
+Cancellation today needs the client to still be alive to ask for it. The SDK sends an
+in-band `ai.url4.stop` on interrupt, and the multi-candidate path adds a `DELETE /` sweep.
+Neither runs when the process dies: `kill -9`, a Jupyter kernel restart, laptop sleep, a
+network partition, or a single-candidate run whose stop frame never leaves.
+
+Cost when this happens:
+
+- **Money.** A HealthBench Fusion run spends at roughly $6.5/hour scale. Sixteen hours is
+  about $104 with nobody receiving the result.
+- **Capacity.** The orphan holds one of `local_max_concurrent_runs` slots and keeps
+  saturating the gateway's per-provider slots. Four orphaned Evaluations at the client's
+  `_MAX_CANDIDATES_IN_FLIGHT = 8` fill all 32 local slots, which is what wedged a stuck
+  `limit=1` eval until `just stack-down && just stack-up`.
+
+## 2. The signal already exists, and it is prompt
+
+`registry.remove` runs in a `finally` and is documented as firing on every disconnect
+flavour (`ws/endpoint.py:103-107`). The open question was whether it fires *promptly*. The
+WS heartbeat cannot help: it is outbound-only (`ws/bridge.py:334-341`), and the inbound
+read has no timeout.
+
+Uvicorn's own RFC 6455 ping answers it. Verified on uvicorn 0.52.1:
+
+```
+ws = auto    ws_ping_interval = 20.0    ws_ping_timeout = 20.0
+```
+
+`cli.py:44` passes no `ws_*` override, so both serve modes take these defaults. A
+partitioned or sleeping peer is pinged, fails to pong, and uvicorn closes the socket within
+about 40 s. That closes `registry.remove`.
+
+**This is a load-bearing assumption.** Without WS ping, a dead peer would be detected only
+by TCP retransmission timeout (roughly 15–30 minutes with default Linux settings), and the
+reaper would barely help the ticket's headline cases. With it, total exposure is
+`≤40 s + grace`.
+
+At a 120 s grace that is about 160 s against 57600 s today — a **~360× reduction**, or
+about $0.29 per orphan instead of about $104.
+
+## 3. Risk model
+
+This drives every decision below.
+
+| # | Risk | Severity | Source |
+|---|---|---|---|
+| **R1** | **A healthy, actively-watched run is killed** | Critical | Wrong audience source; lost disarm; multi-replica |
+| R2 | The reaper never fires — the issue is unfixed | High | Loop task dies; arm lost; `exists()` wrong |
+| R3 | A second terminal frame corrupts the stream contract | High | Stop on an already-finished run |
+| R4 | The reaper dies silently — an invisible regression to 16 h | Medium | Unhandled exception in the loop |
+| R5 | Reconnect/resume regresses | Medium | Disarm not wired to `add` |
+| R6 | Task leak or a hung shutdown | Medium | Fire-and-forget task |
+
+R1 is not symmetric with the others. Failing to reap costs money. Wrongly reaping destroys
+a researcher's multi-hour evaluation. **The design is biased toward not reaping.**
+
+### 3.1 The R1 trap, and the precedent that settles it
+
+`DenyAllGate.has_subscriber` returns `False` for every topic (`rest/interest.py:17-25`), and
+the unit tests inject `FixedGate(False)` (`tests/unit/_fakes.py:164-169`). A reaper that
+asked `app.state.interest` would read "nobody is listening" for every topic and **reap the
+whole fleet** one grace window after boot.
+
+The codebase already ruled on this exact distinction, at `rest/routes.py:82-83`:
+
+> `registry` and not `interest`: the subscriber gate is a DI seam tests replace with a fixed
+> answer, while the session state is the real registry the WS transport writes […]
+
+**Decision.** The reaper asks the real `ConnectionRegistry`. It never reads the
+`SubscriberGate` seam. The same answer that is harmless as an admission gate — a refused
+start is visible and annoying — is destructive as a reap input.
+
+## 4. Design
+
+### 4.1 Shape: edge-armed, tick-verified
+
+```
+                 registry.add 0→1                    registry.remove 1→0
+                 (endpoint.py:87)                    (endpoint.py:107)
+                        │                                    │
+                        ▼                                    ▼
+   ┌──────────────┐  disarm   ┌──────────────┐   arm    ┌──────────────┐
+   │   WATCHED    │◄──────────│  (no entry)  │─────────►│    ARMED     │
+   │ audience > 0 │           │              │          │ deadline =   │
+   └──────────────┘           └──────────────┘          │ mono + grace │
+                                     ▲                  └──────┬───────┘
+                                     │                         │ sweep(): mono ≥ deadline
+                       drop (nothing to do)                    ▼
+                                     │            ┌────────────────────────┐
+                                     └────────────│ claim → re-verify:     │
+                                                  │  audience back? → drop │
+                                                  │  job gone?      → drop │
+                                                  │  else → stop(topic)    │
+                                                  └────────────────────────┘
+```
+
+The audience transition arms and disarms. One background loop verifies and stops.
+
+### 4.2 Decisions, with the alternative each one rejected
+
+**D1 — Edge-arm from the registry, not a periodic sweep over all live jobs.**
+A level-triggered sweeper must enumerate live runs. The `JobRunner` port cannot: it exposes
+`schedule` / `stop` / `exists` / `status` / `aclose`. Edge-arming needs **no port change**
+and **no `routes.py` change**, because the registry already knows exactly when the audience
+empties. What pure-level would buy is surviving a control-plane restart; see §6.2.
+
+**D2 — One sweep loop with a deadline map, not a per-topic `sleep(grace)` timer task.**
+Per-topic timers need cancel-and-replace on every reconnect (a race per flap), N tasks per
+orphan burst, and they force real sleeps into tests. One loop makes a flap a plain dict
+assignment, keeps a single owned task, and lets `sweep()` run directly against an injected
+clock. Cost: reap latency is `grace` to `grace + tick` rather than exactly `grace`. For a
+cost-control mechanism that is free.
+
+**D3 — Arm unconditionally; check `exists()` only at expiry.**
+A client can die *during* `_schedule`'s awaits, before the job is registered. Arming only
+when a job already exists would drop that edge and leak the orphan forever. Arming
+unconditionally is safe because the job appears within milliseconds and the deadline is
+120 s out.
+
+**D4 — Claim before verifying.**
+`sweep()` pops the topic from the deadline map *before* any `await`. On a single-threaded
+loop that makes "this topic is mine to decide" one atomic step. A reconnect that lands later
+finds nothing armed, which is the correct end state either way.
+
+**D5 — Monotonic clock.**
+Deadlines use `time.monotonic`. Wall-clock would let an NTP step or a suspend jump reap a
+live run. This matches `ws/bridge.py:193`, which already uses `time.monotonic()` for
+duration and keeps `app.state.clock` for wire timestamps.
+
+**D6 — Stop only. Do not purge the stream.**
+`DELETE /` stops and purges. The reaper only stops. Existing stream reclamation already
+covers the rest (`runner`'s `run_and_reclaim`, plus the JetStream sweep at
+`adapters/jetstream.py:172-207`). Smallest in-contract change.
+
+**D7 — Reuse `Terminated(stopped)`; no protocol change.**
+The reap is indistinguishable on the wire from a client-requested stop. This keeps the
+protocol, the AsyncAPI document, and the SDK untouched. The *reason* lives in the log line
+and the metric. If a reconnecting client ever needs to tell them apart, that is a protocol
+change and a separate issue.
+
+**D8 — Retry `stop()` without bound.**
+A transient k8s error must not hand the run back to the 16 h ceiling. On failure the topic
+is re-armed one tick out. The per-tick warning log is the operator signal. Giving up would
+cost real money.
+
+**D9 — `reaper` joins `CONTROL_PLANE` in the layering gate.**
+`check_layering.py` treats any module in neither half as a *shared leaf* that both halves
+may import. A new top-level `reaper.py` would silently become one, which would let
+`runner/*` import the control plane's reaper. Naming it in `CONTROL_PLANE` makes that
+import a gate failure, which is correct.
+
+### 4.3 Race analysis
+
+Model: a single-threaded asyncio loop. No data races are possible. Logical races across
+`await` points are the whole risk surface. `registry.add` / `remove` and the two transition
+calls contain no awaits, so each is atomic by construction.
+
+| Race | Outcome | Why it is safe |
+|---|---|---|
+| A reconnect lands during the sweep that expires the topic | No reap | Claim-then-verify (D4) re-checks `has_subscriber` |
+| A reconnect lands after `stop()` is dispatched | Run stops; client sees `Terminated(stopped)` | Accepted. The window is sub-millisecond after a 120 s wait; committing beats an unbounded abort protocol |
+| The run finishes normally, then the client disconnects | No reap | `exists()` is False at expiry, **and** `stop()` on a done task is a documented no-op — R3 is closed twice |
+| Explicit `ai.url4.stop` or `DELETE /`, then a disconnect | Unchanged | Same `exists()` guard; the reaper adds nothing |
+| Flap: leave / arrive / leave / arrive × N | One entry, last arm wins | Dict assignment; no tasks to cancel, so no cancel-replace race |
+| The client dies mid-`_schedule`, before the job is registered | Reaped correctly | D3 |
+| Two watchers, one leaves | No arm | `remove` signals only at `<= 0` |
+| A sync-hold run whose WS dies | Reaped | The same dead client holds both, and `sync_max_wait_s`=30 < grace=120, so the hold converts to 202 first |
+| App shutdown mid-sweep | Clean | `cancel()` + `suppress(CancelledError)` + `await`, matching `ws/bridge.py::_teardown` |
+
+Patterns applied: **confinement** (all reaper state is owned by one object on one loop, so
+no lock is needed and none is added), **structured ownership** (the task is held and awaited
+by the app, never fire-and-forget), **claim-before-act** to collapse a check-then-act TOCTOU
+into one step, and **idempotency** at the `stop()` boundary so retries are free.
+
+## 5. Configuration
+
+```
+orphan_grace_s: float = 120.0     # URL4_CLOUD_ORPHAN_GRACE_S; ge=0; 0 disables
+```
+
+Helm: `config.orphanGraceS` → ConfigMap. Tick is derived as
+`max(1.0, grace_s / 8)`, overridable for tests, so operators get one knob.
+
+Values below about 60 s are not recommended. Uvicorn needs up to
+`ws_ping_interval + ws_ping_timeout` (about 40 s) to notice a partitioned peer, so a shorter
+window reaps mostly on clean closes and starts risking live runs on slow reconnects.
+
+Observability: a reaped-runs counter and an armed-topics gauge on the existing
+`app.state.metrics`. A gauge that stays non-zero is the "reaper is stuck" alarm.
+
+## 6. Residual risk — what this does not close
+
+1. **Multi-replica becomes dangerous, not merely annoying.** Today a second replica causes
+   spurious 428s, which are visible. With the reaper it would kill live runs, silently. The
+   chart already pins `replicaCount: 1`, and the fix when that changes is the shared
+   `SubscriberGate` over NATS consumer interest that the issue's own comment describes. A
+   startup log line states the single-replica assumption so it is discoverable at runtime,
+   not only in a chart comment.
+2. **A control-plane restart in k8s mode.** Jobs survive; the registry does not. Those
+   orphans cannot be reaped and fall back to `job_deadline_s`. Fixing this needs job
+   enumeration, which is a port addition — the same follow-up bucket as item 1.
+3. **In-flight gateway calls still bill.** `stop()` ends the run, but calls already
+   dispatched complete. That is OME-886's scope, as the issue states.
+4. **The reap is indistinguishable on the wire** from a client-requested stop (D7).
+5. **Uvicorn WS ping must stay enabled** (§2). A comment at `cli.py:44` records this so
+   nobody "cleans up" the defaults and reopens the partition path.
+
+## 7. Out of scope
+
+- Gateway client-disconnect awareness — belongs with OME-886's admission/execution bounding.
+- The SDK's single-candidate `DELETE /` fallback — the reaper closes every orphan path
+  including that one, so the fallback is optional cleanup, not part of this fix.
+- Multi-replica shared interest (item 1 above).

--- a/docs/tasks/2026-08-19-OME-890-orphan-run-reaper.md
+++ b/docs/tasks/2026-08-19-OME-890-orphan-run-reaper.md
@@ -1,0 +1,37 @@
+---
+id: OME-890
+linear_url: https://linear.app/openmined/issue/OME-890/stop-engine-runs-that-keep-spending-after-their-client-dies
+status: In Progress
+type: Feature
+priority: High
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-19
+closed:
+---
+
+# Stop Engine runs that keep spending after their client dies
+
+Tie a run's lifetime to its audience. When a topic's last WebSocket subscriber disconnects,
+a grace window opens. If no subscriber returns before it closes, the Engine stops the run
+through the existing idempotent `JobRunner.stop`, and the run terminates as a clean
+`Terminated(stopped)`.
+
+Before this, the 428 gate proved an audience existed when the run started and nothing asked
+again. A client that died before it could send `ai.url4.stop` — `kill -9`, a Jupyter kernel
+restart, laptop sleep, a network partition — left the run issuing paid model calls until
+`job_deadline_s` (16 h), holding one of `local_max_concurrent_runs` slots and the gateway's
+per-provider slots throughout.
+
+Canonical artifacts:
+
+- Spec: `docs/spec/2026-08-19-OME-890-orphan-run-reaper.md`
+- Plan: `docs/plan/2026-08-19-OME-890-orphan-run-reaper.md`
+- Ledger: `docs/work/2026-08-19-OME-890-orphan-run-reaper.md`
+
+Reassigned from @khoa to @ionesio on 2026-08-19 by agreement between them.
+
+Scope notes carried from the issue: gateway client-disconnect awareness stays with OME-886.
+The SDK's missing single-candidate `DELETE /` fallback is not needed — the reaper closes every
+orphan path including that one. Multi-replica liveness (a shared `SubscriberGate` backed by
+NATS consumer interest) is a separate follow-up; the reaper targets today's single-replica
+deployment and logs that assumption at startup.

--- a/docs/work/2026-08-19-OME-890-orphan-run-reaper.md
+++ b/docs/work/2026-08-19-OME-890-orphan-run-reaper.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-890
 stack: screamingface-engine
-status: in_progress   # planned | in_progress | done | blocked
+status: done   # planned | in_progress | done | blocked
 started: 2026-08-19
-finished:
+finished: 2026-08-19
 ---
 
 # OME-890 — Stop Engine runs that keep spending after their client dies
@@ -105,9 +105,60 @@ Batch 4 — integration, on the local spine:
   socket and therefore what make subscriber-zero a prompt signal. Disabling them would
   silently regress the partition path.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files:** as planned, plus two the plan did not foresee:
+  - `deploy/helm/values.schema.json` — the chart validates `config` with
+    `additionalProperties: false`, so `helm template` refused `orphanGraceS` until the
+    schema declared it. Caught by rendering the chart, not by any Python gate.
+  - `src/screamingface_engine/reaper.py` grew a second protocol, `RunControl` (see
+    Deviations).
+  - Not needed after all: no change to `metrics.py`'s existing collectors, and no new
+    dependency (the invariant test is a scripted sequence, not `hypothesis`).
+
+  Full set (19 files, +2849/-7): `ws/registry.py`, `ws/__init__.py`, `reaper.py` (new),
+  `app.py`, `config.py`, `metrics.py`, `cli.py`, `.claude/scripts/check_layering.py`,
+  `deploy/helm/{values.yaml,values.schema.json,templates/configmap.yaml}`, four new test
+  files, four `docs/` artifacts.
+
+- **Commits:**
+  - `4c8274ef` — docs(work): add OME-890 spec, plan, ledger and task mirror
+  - `96585d83` — feat(screamingface-engine): announce WS audience arrive/leave transitions
+  - `db18912d` — feat(screamingface-engine): add the orphan-run reaper policy
+  - `b622f868` — feat(screamingface-engine): stop runs whose audience never comes back
+  - `6ebeaffa` — test(screamingface-engine): prove the orphan reaper end to end
+  - `c6bc2ad4` — refactor(screamingface-engine): narrow the reaper's runner dependency
+
+- **Gates:** `ALL GATES GREEN` on the final clean run (append-only check active) —
+  ruff check · ruff format · pyright · check_layering · pytest.
+  **1796 passed, 5 skipped**; coverage **93%** against the 80% floor.
+  `reaper.py` and `ws/registry.py` are both at 100%. 40 tests added across four files.
+
+- **Deviations:**
+  1. **`create_app` hit ruff's `max-statements = 26`** (27 > 26) when the wiring call and the
+     metrics registration were both added. Fixed the code rather than the gate: the
+     metrics registration moved inside `_install_orphan_reaper`, which is where it belongs
+     anyway — one function now owns everything about the reaper's presence in the App.
+     Note for the next change: `create_app` now sits exactly at the 26-statement ceiling.
+  2. **`RunControl` protocol added** during the wisdom review. `RunReaper` had declared the
+     whole `JobRunner` ABC while calling two of its five methods, which also forced four
+     `# type: ignore[arg-type]` escapes onto the tests' fakes — a Python-stack red flag.
+     Narrowing to a two-method protocol removed all four.
+  3. **Prior tests were edited** (comment/annotation only) to remove those escapes, which
+     tripped the append-only gate. Raised as a Confidence-Gate decision and **approved by
+     the owner**; that one gate run used `--skip-append-only`, and the final run passes the
+     check naturally. No assertion, test name, or coverage was changed.
+  4. **The uvicorn WS-ping assumption was verified, not assumed.** `ws_ping_interval=20` /
+     `ws_ping_timeout=20` on uvicorn 0.52.1, with no override in `cli.py`. This is what
+     makes subscriber-zero prompt (~40 s) for the sleep/partition cases rather than
+     dependent on TCP retransmission (~15–30 min). Recorded as an `INVARIANT:` comment at
+     both `uvicorn.run` call sites.
+  5. **Non-vacuity of the headline test was proved directly.** Running the same spine with
+     the reaper disabled shows the abandoned run *keeps* spending; with it enabled the run
+     is reaped and the executor's call count stops moving. So the committed test fails
+     without the feature.
+
+- **Residual risk carried forward** (documented in the spec, not fixed here): multi-replica
+  liveness needs a shared `SubscriberGate` before `replicaCount` can exceed 1 — the reaper
+  logs that assumption at startup; a control-plane restart in k8s mode leaves an unreapable
+  orphan bounded by `job_deadline_s`; and in-flight gateway calls still bill (OME-886).

--- a/docs/work/2026-08-19-OME-890-orphan-run-reaper.md
+++ b/docs/work/2026-08-19-OME-890-orphan-run-reaper.md
@@ -1,0 +1,113 @@
+---
+ticket: OME-890
+stack: screamingface-engine
+status: planned   # planned | in_progress | done | blocked
+started: 2026-08-19
+finished:
+---
+
+# OME-890 — Stop Engine runs that keep spending after their client dies
+
+## Intent
+
+An Engine run's lifetime is tied to nothing. The 428 gate
+(`rest/routes.py::_require_subscriber`) proves an audience exists when the run starts, and
+then the Engine never asks again. A client that dies before it can send `ai.url4.stop` —
+`kill -9`, a Jupyter kernel restart, laptop sleep, a network partition, or a
+single-candidate run with no `DELETE /` fallback — leaves the run alive. The run keeps
+issuing paid model calls until `job_deadline_s` (57600 s = 16 h). It also holds one of
+`local_max_concurrent_runs` slots and keeps saturating the gateway's per-provider slots.
+
+This unit ties a run's lifetime to its audience. When a topic's last WebSocket subscriber
+disconnects, a grace window opens. If no subscriber returns before the window closes, the
+Engine stops the run through the same idempotent `JobRunner.stop` the explicit paths use.
+The run terminates as a clean `Terminated(stopped)`.
+
+## Planned changes
+
+Source:
+
+- `src/screamingface_engine/ws/registry.py` — add the `AudienceListener` protocol, a
+  `listen()` composition-root seam, and the 0→1 / 1→0 transition calls in `add`/`remove`.
+- `src/screamingface_engine/reaper.py` — NEW. `RunReaper`: arm/disarm, `sweep()`, and the
+  owned background loop (`start` / `aclose`).
+- `src/screamingface_engine/app.py` — build and wire the reaper in `create_app`; register
+  `on_startup` / `on_shutdown`.
+- `src/screamingface_engine/config.py` — add `orphan_grace_s: float = 120.0` (`ge=0`;
+  0 disables).
+- `src/screamingface_engine/metrics.py` — reaped-runs counter and armed-topics gauge.
+- `.claude/scripts/check_layering.py` — add `reaper` to `CONTROL_PLANE`.
+- `deploy/helm/values.yaml` + `templates/configmap.yaml` — expose `config.orphanGraceS`.
+- `cli.py` — comment that uvicorn's WS ping defaults are load-bearing (see Acceptance).
+
+Tests:
+
+- `tests/unit/test_ws_registry_audience.py` — NEW (batch 1).
+- `tests/unit/test_reaper.py` — NEW (batch 2).
+- `tests/unit/test_reaper_wiring.py` — NEW (batch 3).
+- `tests/integration/test_orphan_reaper_spine.py` — NEW (batch 4).
+
+## Test plan
+
+Written RED first, in four batches. No test uses a sleep: the clock is injected and
+`sweep()` is called directly.
+
+Batch 1 — registry transitions (the arm/disarm signal):
+
+- `audience_arrived` fires only on 0→1; `audience_left` only on 1→0.
+- Two subscribers, one leaves → no `audience_left` (audience is not empty).
+- `add_notifier` creates a session at 0 subscribers → the next `add` still reads as 0→1.
+- `remove` on an absent session is a no-op and fires nothing (no double-fire).
+
+Batch 2 — reaper policy:
+
+- Arm, advance the clock past the window, sweep → `stop` called exactly once.
+- Audience returns before expiry → no stop, nothing armed.
+- At expiry the registry reports a subscriber → no stop (claim-then-verify).
+- `exists()` is False → no stop (already terminal, or never started).
+- Flap (leave/arrive × N) → exactly one armed entry, last arm wins.
+- Sweep before expiry → nothing happens.
+- `stop()` raises → the topic is re-armed and the next sweep retries.
+- Second sweep after a reap → no second stop (idempotent).
+- A topic that never started a run → no stop, no error, entry dropped.
+- INVARIANT, over a scripted sequence of add/remove/sweep/clock steps: an armed topic
+  never has a subscriber, and the deadline map never grows without bound.
+
+Batch 3 — lifecycle and wiring:
+
+- THE TRAP: `create_app(interest=FixedGate(False))` plus a real subscriber in the
+  registry → zero stops. Pins the mistake that would reap the whole fleet.
+- `orphan_grace_s=0` → no reaper is built. `runner="none"` → no reaper is built.
+- `aclose()` cancels and awaits the loop; no "task was destroyed" warning.
+- `start()` twice → one task.
+- The loop survives a sweep that raises and keeps ticking.
+
+Batch 4 — integration, on the local spine:
+
+- Abrupt WS close (1006), no reconnect → the run terminates `stopped`, and the executor
+  issues no further calls after the stop.
+- Close, then reattach with `from_sequence` inside the window → the run stays alive and
+  frames resume.
+- In-band `ai.url4.stop` and `DELETE /` behave exactly as today; no double stop.
+- Capacity: saturated slots are released after a reap, so a schedule that returned 503
+  now succeeds.
+
+## Acceptance
+
+- A run whose WS subscriber disappears abnormally and never returns is stopped within the
+  grace window. No further gateway calls are issued after the stop.
+- A subscriber that reconnects inside the window resumes untouched.
+- Clean in-band stop and `DELETE /` behaviour are unchanged.
+- The grace period is operator-configurable. Reap events are logged with topic + reason.
+- All card gates green: `uv run .claude/scripts/run_gates.py screamingface-engine`.
+- Load-bearing assumption recorded: uvicorn's `ws_ping_interval`/`ws_ping_timeout`
+  defaults (20 s / 20 s, verified on uvicorn 0.52.1) are what close a partitioned peer's
+  socket and therefore what make subscriber-zero a prompt signal. Disabling them would
+  silently regress the partition path.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/docs/work/2026-08-19-OME-890-orphan-run-reaper.md
+++ b/docs/work/2026-08-19-OME-890-orphan-run-reaper.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-890
 stack: screamingface-engine
-status: planned   # planned | in_progress | done | blocked
+status: in_progress   # planned | in_progress | done | blocked
 started: 2026-08-19
 finished:
 ---


### PR DESCRIPTION
## Summary

An Engine run's lifetime was tied to nothing. The 428 gate proved an audience existed at schedule time and then nothing asked again, so a client that died before it could send `ai.url4.stop` — `kill -9`, a Jupyter kernel restart, laptop sleep, a network partition — left the run issuing paid model calls until `job_deadline_s` (16 h), holding one of `local_max_concurrent_runs` slots and the gateway's per-provider slots the whole time.

The registry now announces audience arrive/leave transitions. A `RunReaper` arms a monotonic grace window when a topic's audience empties and stops the run through the existing idempotent `JobRunner.stop` if the window closes with nobody listening. The run ends as a clean `Terminated(stopped)`.

Total exposure drops from 57600 s to about 160 s — roughly $104 to $0.29 per orphan at the issue's $6.5/hour figure.

**No protocol change, no SDK change, no `JobRunner` port change.**

## Two findings that shaped the design

**Uvicorn's WS ping is load-bearing.** The issue noted the WS heartbeat cannot serve as liveness (it is outbound-only). Uvicorn's own RFC 6455 ping can: `ws_ping_interval=20` / `ws_ping_timeout=20` are the defaults on 0.52.1 and `cli.py` overrides neither, so a partitioned or sleeping peer's socket closes within ~40 s and fires `ConnectionRegistry.remove`. Without it, a dead peer would be detected only by TCP retransmission timeout (~15–30 min) and this feature would barely help its headline cases. Now recorded as an `INVARIANT:` at both `uvicorn.run` sites.

**Wiring the reaper to the `SubscriberGate` seam would have been catastrophic.** `DenyAllGate` — and every test injecting `FixedGate(False)` — answers "no subscriber" for *every* topic. Harmless for the 428 admission gate, where the result is a visible refused start; as a reap input it means "stop every run in this process". The reaper therefore reads the real `ConnectionRegistry`, the same call `rest/routes.py:82-83` already documents for session state. A test pins it and says why.

## Design

Edge-armed, tick-verified. The registry's 0→1 / 1→0 edges arm and disarm; one background sweep task (modelled on the existing `_install_artifact_sweeper` in the same file) verifies and stops.

- **Claim-then-verify** — `sweep()` pops the topic before its first `await`, which on a single-threaded loop makes "this window closed and it is mine to decide" one atomic step. A reconnect at the boundary either disarms first or finds nothing armed.
- **`exists()` guard** — a finished run is never stopped, so no second terminal frame reaches the stream and no finished k8s Job is deleted before the TTL that is its replay guard.
- **Monotonic deadlines** — a wall clock would let an NTP step or suspend jump expire a window that has not elapsed.
- **Unbounded stop retries** — giving up would hand the run back to the 16 h ceiling; the per-tick warning is the operator signal instead.
- **`reaper` joins `CONTROL_PLANE`** in `check_layering.py`. An unlisted top-level module is a *shared leaf* by that gate's definition, which would have let a Runner Job import the serving half's reaper.

## Test plan

40 tests added; `reaper.py` and `ws/registry.py` at 100% line coverage.

- `tests/unit/test_ws_registry_audience.py` — the 0→1 / 1→0 edges, two watchers, the `add_notifier`-at-zero case, no double-fire.
- `tests/unit/test_reaper.py` — arm, disarm, claim-then-verify against a stale arm, finished runs, flapping, failed-stop retry, and the armed-implies-no-subscriber invariant over a scripted sequence. Injected clock, no sleeps.
- `tests/unit/test_reaper_wiring.py` — including the trap test above, the disabled paths (`grace=0`, `runner=none`), and task start/cancel.
- `tests/integration/test_orphan_reaper_spine.py` — the four acceptance criteria on the same local-mode spine `test_local_spine.py` uses. The executor counts what it "spends", so the central assertion is the money one: the call count stops moving after the stop.

**Verified non-vacuous:** running that same spine with the reaper disabled shows the abandoned run keeps spending indefinitely; enabled, it is reaped and spending stops.

Gates: `ALL GATES GREEN` — 1796 passed, 5 skipped, coverage 93% against the 80% floor.

## Reviewer notes

- `create_app` now sits exactly at ruff's `max-statements = 26` ceiling. Adding a statement there will trip the gate; the metrics registration was moved into `_install_orphan_reaper` for this reason.
- `deploy/helm/values.schema.json` had to be updated — the chart's `config` block is `additionalProperties: false`, so `helm template` rejected the new value until it was declared. No Python gate would have caught that.
- **Single-replica is assumed and now logged at startup.** Multi-replica liveness needs a shared `SubscriberGate` (NATS consumer interest) first; the port already exists, so it is an adapter plus one wiring line. Until then `replicaCount: 1` is load-bearing for correctness, not just for the 428 gate.
- Prior-test edits in the last commit (removing `# type: ignore` escapes) were owner-approved under the append-only rule; no assertion or coverage changed.

## Not in scope

Gateway client-disconnect awareness stays with OME-886 — `stop()` ends the run, but calls already dispatched to the gateway complete and bill. The SDK's missing single-candidate `DELETE /` fallback is no longer needed: the reaper closes every orphan path including that one.

Spec: `docs/spec/2026-08-19-OME-890-orphan-run-reaper.md`
Plan: `docs/plan/2026-08-19-OME-890-orphan-run-reaper.md`
Ledger: `docs/work/2026-08-19-OME-890-orphan-run-reaper.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
