### PR TITLE
fix(ci): publish to ghcr.io/screamingface after the org transfer

### DIFF
--- a/.github/scripts/verify_chart_wiring.py
+++ b/.github/scripts/verify_chart_wiring.py
@@ -354,7 +354,7 @@ url4_benchmark_tags = {
 }
 check(
     {
-        "ghcr.io/openmined/screamingface-engine-benchmark:"
+        "ghcr.io/screamingface/screamingface-engine-benchmark:"
         "main-${{ needs.image.outputs.short }}",
         "acropenmined.azurecr.io/screamingface-engine-benchmark:"
         "main-${{ needs.image.outputs.short }}",

--- a/.github/workflows/dev-build-aigateway-ui.yml
+++ b/.github/workflows/dev-build-aigateway-ui.yml
@@ -64,7 +64,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/openmined/screamingface-aigateway-ui:main-${{ steps.sha.outputs.short }}
+            ghcr.io/screamingface/screamingface-aigateway-ui:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-aigateway-ui:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-aigateway-ui:main-${{ github.sha }}
           labels: |

--- a/.github/workflows/dev-build-aigateway.yml
+++ b/.github/workflows/dev-build-aigateway.yml
@@ -49,7 +49,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/openmined/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
+            ghcr.io/screamingface/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-aigateway:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-aigateway:main-${{ github.sha }}
           labels: |

--- a/.github/workflows/dev-build-scoreboard.yml
+++ b/.github/workflows/dev-build-scoreboard.yml
@@ -49,7 +49,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/openmined/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
+            ghcr.io/screamingface/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-scoreboard:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-scoreboard:main-${{ github.sha }}
           labels: |

--- a/.github/workflows/dev-build-screamingface-engine.yml
+++ b/.github/workflows/dev-build-screamingface-engine.yml
@@ -52,7 +52,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/openmined/screamingface-engine:main-${{ steps.sha.outputs.short }}
+            ghcr.io/screamingface/screamingface-engine:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-engine:main-${{ steps.sha.outputs.short }}
             acropenmined.azurecr.io/screamingface-engine:main-${{ github.sha }}
           labels: |
@@ -85,9 +85,9 @@ jobs:
           platforms: linux/amd64
           push: true
           build-args: |
-            BASE=ghcr.io/openmined/screamingface-engine:main-${{ needs.image.outputs.short }}
+            BASE=ghcr.io/screamingface/screamingface-engine:main-${{ needs.image.outputs.short }}
           tags: |
-            ghcr.io/openmined/screamingface-engine-benchmark:main-${{ needs.image.outputs.short }}
+            ghcr.io/screamingface/screamingface-engine-benchmark:main-${{ needs.image.outputs.short }}
             acropenmined.azurecr.io/screamingface-engine-benchmark:main-${{ needs.image.outputs.short }}
             acropenmined.azurecr.io/screamingface-engine-benchmark:main-${{ github.sha }}
           cache-from: type=gha,scope=dev-screamingface-engine-benchmark

--- a/.github/workflows/release-aigateway-ui.yml
+++ b/.github/workflows/release-aigateway-ui.yml
@@ -37,7 +37,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE: ghcr.io/openmined/screamingface-aigateway-ui
+  IMAGE: ghcr.io/screamingface/screamingface-aigateway-ui
   CHART: apps/aigateway-ui/charts/aigateway-ui
 
 jobs:
@@ -155,7 +155,7 @@ jobs:
       - name: Push Helm chart
         env:
           VERSION: ${{ needs.verify.outputs.version }}
-        run: helm push "dist/charts/aigateway-ui-$VERSION.tgz" oci://ghcr.io/openmined/screamingface/charts
+        run: helm push "dist/charts/aigateway-ui-$VERSION.tgz" oci://ghcr.io/screamingface/screamingface/charts
 
   release:
     needs: [verify, image, chart]
@@ -183,7 +183,7 @@ jobs:
 
             Helm chart:
             ```
-            helm pull oci://ghcr.io/openmined/screamingface/charts/aigateway-ui --version ${{ needs.verify.outputs.version }}
+            helm pull oci://ghcr.io/screamingface/screamingface/charts/aigateway-ui --version ${{ needs.verify.outputs.version }}
             ```
 
             The chart needs two values it cannot guess — `aigateway.serviceName` (it cannot learn

--- a/.github/workflows/release-aigateway.yml
+++ b/.github/workflows/release-aigateway.yml
@@ -61,8 +61,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/openmined/screamingface-aigateway:${{ needs.verify.outputs.version }}
-            ghcr.io/openmined/screamingface-aigateway:latest
+            ghcr.io/screamingface/screamingface-aigateway:${{ needs.verify.outputs.version }}
+            ghcr.io/screamingface/screamingface-aigateway:latest
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.verify.outputs.version }}
@@ -103,7 +103,7 @@ jobs:
       - name: Push Helm chart
         env:
           VERSION: ${{ needs.verify.outputs.version }}
-        run: helm push "dist/charts/aigateway-$VERSION.tgz" oci://ghcr.io/openmined/screamingface/charts
+        run: helm push "dist/charts/aigateway-$VERSION.tgz" oci://ghcr.io/screamingface/screamingface/charts
 
   release:
     needs: [verify, image, chart]
@@ -119,12 +119,12 @@ jobs:
           body: |
             Container image:
             ```
-            docker pull ghcr.io/openmined/screamingface-aigateway:${{ needs.verify.outputs.version }}
+            docker pull ghcr.io/screamingface/screamingface-aigateway:${{ needs.verify.outputs.version }}
             ```
 
             Helm chart:
             ```
-            helm pull oci://ghcr.io/openmined/screamingface/charts/aigateway --version ${{ needs.verify.outputs.version }}
+            helm pull oci://ghcr.io/screamingface/screamingface/charts/aigateway --version ${{ needs.verify.outputs.version }}
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -136,8 +136,8 @@ jobs:
         run: |
           gh release delete "$TAG" --repo OpenMined/sf-installer --yes 2>/dev/null || true
           NOTES=$(printf 'AI Gateway container image: `%s`\nAI Gateway Helm chart: `%s`\n' \
-            "ghcr.io/openmined/screamingface-aigateway:$VERSION" \
-            "oci://ghcr.io/openmined/screamingface/charts/aigateway --version $VERSION"
+            "ghcr.io/screamingface/screamingface-aigateway:$VERSION" \
+            "oci://ghcr.io/screamingface/screamingface/charts/aigateway --version $VERSION"
           )
           gh release create "$TAG" \
             --repo OpenMined/sf-installer \

--- a/.github/workflows/release-scoreboard.yml
+++ b/.github/workflows/release-scoreboard.yml
@@ -61,8 +61,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/openmined/screamingface-scoreboard:${{ needs.verify.outputs.version }}
-            ghcr.io/openmined/screamingface-scoreboard:latest
+            ghcr.io/screamingface/screamingface-scoreboard:${{ needs.verify.outputs.version }}
+            ghcr.io/screamingface/screamingface-scoreboard:latest
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.verify.outputs.version }}
@@ -103,7 +103,7 @@ jobs:
       - name: Push Helm chart
         env:
           VERSION: ${{ needs.verify.outputs.version }}
-        run: helm push "dist/charts/scoreboard-$VERSION.tgz" oci://ghcr.io/openmined/screamingface/charts
+        run: helm push "dist/charts/scoreboard-$VERSION.tgz" oci://ghcr.io/screamingface/screamingface/charts
 
   release:
     needs: [verify, image, chart]
@@ -119,12 +119,12 @@ jobs:
           body: |
             Container image:
             ```
-            docker pull ghcr.io/openmined/screamingface-scoreboard:${{ needs.verify.outputs.version }}
+            docker pull ghcr.io/screamingface/screamingface-scoreboard:${{ needs.verify.outputs.version }}
             ```
 
             Helm chart:
             ```
-            helm pull oci://ghcr.io/openmined/screamingface/charts/scoreboard --version ${{ needs.verify.outputs.version }}
+            helm pull oci://ghcr.io/screamingface/screamingface/charts/scoreboard --version ${{ needs.verify.outputs.version }}
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-screamingface-engine.yml
+++ b/.github/workflows/release-screamingface-engine.yml
@@ -51,7 +51,7 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     env:
-      REPO: ghcr.io/openmined/screamingface-engine
+      REPO: ghcr.io/screamingface/screamingface-engine
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v4
@@ -83,8 +83,8 @@ jobs:
     needs: [verify, image]
     runs-on: ubuntu-latest
     env:
-      REPO: ghcr.io/openmined/screamingface-engine-benchmark
-      BASE: ghcr.io/openmined/screamingface-engine
+      REPO: ghcr.io/screamingface/screamingface-engine-benchmark
+      BASE: ghcr.io/screamingface/screamingface-engine
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v4
@@ -138,12 +138,12 @@ jobs:
           body: |
             Control-plane image:
             ```
-            docker pull ghcr.io/openmined/screamingface-engine:${{ needs.verify.outputs.version }}
+            docker pull ghcr.io/screamingface/screamingface-engine:${{ needs.verify.outputs.version }}
             ```
 
             DRACO benchmark Runner image:
             ```
-            docker pull ghcr.io/openmined/screamingface-engine-benchmark:${{ needs.verify.outputs.version }}
+            docker pull ghcr.io/screamingface/screamingface-engine-benchmark:${{ needs.verify.outputs.version }}
             ```
 
             Helm chart: OCI publish deferred until the NATS dependency is pinned (see OME-567).

--- a/apps/aigateway-ui/charts/aigateway-ui/values.yaml
+++ b/apps/aigateway-ui/charts/aigateway-ui/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/openmined/screamingface-aigateway-ui
+  repository: ghcr.io/screamingface/screamingface-aigateway-ui
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/apps/aigateway/DEPLOYMENT.md
+++ b/apps/aigateway/DEPLOYMENT.md
@@ -4,8 +4,8 @@ This runbook deploys `apps/aigateway` as a containerized FastAPI service on Kube
 
 ## Artifacts
 
-- Container image: `ghcr.io/openmined/screamingface-aigateway:<version>`.
-- App chart: `oci://ghcr.io/openmined/screamingface/charts/aigateway`.
+- Container image: `ghcr.io/screamingface/screamingface-aigateway:<version>`.
+- App chart: `oci://ghcr.io/screamingface/screamingface/charts/aigateway`.
 - Demo database chart in this repo: `apps/aigateway/charts/db`.
 
 The demo database chart is a single `postgres:16-alpine` Deployment with a PVC. It is useful for k3s smoke tests and demos, but it has no HA, backups, PITR, or managed upgrade policy.
@@ -18,7 +18,7 @@ Build an amd64 image for a single-node Linux k3s server:
 docker buildx build \
   --platform linux/amd64 \
   -f apps/aigateway/Dockerfile \
-  -t ghcr.io/openmined/screamingface-aigateway:sf186-local \
+  -t ghcr.io/screamingface/screamingface-aigateway:sf186-local \
   --load \
   .
 ```
@@ -28,7 +28,7 @@ Import the local image into k3s containerd when you do not want to push a tempor
 ```bash
 export K3S_SSH_TARGET='adminuser@k3s-host.example.com'
 
-docker save ghcr.io/openmined/screamingface-aigateway:sf186-local \
+docker save ghcr.io/screamingface/screamingface-aigateway:sf186-local \
   | ssh "$K3S_SSH_TARGET" \
       "sudo k3s ctr -n k8s.io images import --platform linux/amd64 -"
 ```
@@ -87,7 +87,7 @@ kubectl -n aigw create secret generic aigw-auth \
   --from-literal=jwt-secret="$(openssl rand -base64 48)" \
   --from-literal=admin-password="$(openssl rand -base64 24)"
 
-helm upgrade --install aigw oci://ghcr.io/openmined/screamingface/charts/aigateway \
+helm upgrade --install aigw oci://ghcr.io/screamingface/screamingface/charts/aigateway \
   --version 0.2.0 \
   --namespace aigw \
   --set auth.createSecret=false \

--- a/apps/aigateway/charts/aigateway/README.md
+++ b/apps/aigateway/charts/aigateway/README.md
@@ -107,7 +107,7 @@ Production database infrastructure should be managed separately, for example Clo
 Published releases include the app chart in GHCR:
 
 ```bash
-helm install aigw oci://ghcr.io/openmined/screamingface/charts/aigateway \
+helm install aigw oci://ghcr.io/screamingface/screamingface/charts/aigateway \
   --version 0.2.0 \
   --namespace aigw
 ```

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/openmined/screamingface-aigateway
+  repository: ghcr.io/screamingface/screamingface-aigateway
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -4,8 +4,8 @@ This runbook deploys `apps/scoreboard` as a containerized FastAPI service on Kub
 
 ## Artifacts
 
-- Container image: `ghcr.io/openmined/screamingface-scoreboard:<version>`.
-- App chart: `oci://ghcr.io/openmined/screamingface/charts/scoreboard`.
+- Container image: `ghcr.io/screamingface/screamingface-scoreboard:<version>`.
+- App chart: `oci://ghcr.io/screamingface/screamingface/charts/scoreboard`.
 - Demo database chart in this repo: `apps/scoreboard/charts/db`.
 
 The demo database chart is a single `postgres:16-alpine` Deployment with a PVC. It is useful for k3s smoke tests and demos, but it has no HA, backups, PITR, or managed upgrade policy.
@@ -18,7 +18,7 @@ Build an amd64 image for a single-node Linux k3s server:
 docker buildx build \
   --platform linux/amd64 \
   -f apps/scoreboard/Dockerfile \
-  -t ghcr.io/openmined/screamingface-scoreboard:sf188-local \
+  -t ghcr.io/screamingface/screamingface-scoreboard:sf188-local \
   --load \
   .
 ```
@@ -26,14 +26,14 @@ docker buildx build \
 Check the image size target from the SCORE-007 acceptance criteria:
 
 ```bash
-SIZE_BYTES=$(docker image inspect ghcr.io/openmined/screamingface-scoreboard:sf188-local --format '{{.Size}}')
+SIZE_BYTES=$(docker image inspect ghcr.io/screamingface/screamingface-scoreboard:sf188-local --format '{{.Size}}')
 test "$SIZE_BYTES" -lt 209715200
 ```
 
 Import the local image into k3s containerd when you do not want to push a temporary tag:
 
 ```bash
-docker save ghcr.io/openmined/screamingface-scoreboard:sf188-local \
+docker save ghcr.io/screamingface/screamingface-scoreboard:sf188-local \
   | ssh adminuser@40.76.107.241 \
       "sudo k3s ctr -n k8s.io images import --platform linux/amd64 -"
 ```
@@ -87,7 +87,7 @@ For production, use managed Postgres and a Secret with a `database-url` key:
 kubectl -n scoreboard create secret generic scoreboard-db \
   --from-literal=database-url='postgres://scoreboard:<password>@<host>:5432/scoreboard'
 
-helm upgrade --install scoreboard oci://ghcr.io/openmined/screamingface/charts/scoreboard \
+helm upgrade --install scoreboard oci://ghcr.io/screamingface/screamingface/charts/scoreboard \
   --version 0.1.0 \
   --namespace scoreboard \
   --values apps/scoreboard/charts/scoreboard/values-prod.yaml \
@@ -101,7 +101,7 @@ helm upgrade --install scoreboard oci://ghcr.io/openmined/screamingface/charts/s
 Set `config.authMode: cloudflare_headers` (default: `disabled`) to require the mesh-verified `X-User-Email` identity header on `POST /v1/scores` instead of trusting the client-supplied `submitted_by` free text (OME-404, following OME-326). This is sound ONLY while the service is reachable exclusively through the chain that injects that header — set `config.allowedNetworks` (comma-separated CIDRs) to the peers permitted to present it:
 
 ```bash
-helm upgrade scoreboard oci://ghcr.io/openmined/screamingface/charts/scoreboard \
+helm upgrade scoreboard oci://ghcr.io/screamingface/screamingface/charts/scoreboard \
   --namespace scoreboard \
   --reuse-values \
   --set config.authMode=cloudflare_headers \

--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/openmined/screamingface-scoreboard
+  repository: ghcr.io/screamingface/screamingface-scoreboard
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/apps/screamingface-engine/README.md
+++ b/apps/screamingface-engine/README.md
@@ -14,7 +14,7 @@ REST + WebSocket url4 execution runner (k8s Jobs + NATS). Design: `docs/spec/202
 · epic OME-513.
 
 One app, one image, two modes — `apps/screamingface-engine/`, package `screamingface_engine`, image
-`ghcr.io/openmined/screamingface-engine`. The mode is chosen by **argv**, never sniffed from
+`ghcr.io/screamingface/screamingface-engine`. The mode is chosen by **argv**, never sniffed from
 the environment:
 
 - **`screamingface-engine serve`** — the stateless control-plane App (REST + WebSocket). The **default** when

--- a/apps/screamingface-engine/deploy/helm/README.md
+++ b/apps/screamingface-engine/deploy/helm/README.md
@@ -203,7 +203,7 @@ LABEL org.opencontainers.image.title="screamingface-engine" \
       org.opencontainers.image.vendor="OpenMined"
 ```
 
-`image.repository` defaults to `ghcr.io/openmined/screamingface-engine`; the tag defaults to the
+`image.repository` defaults to `ghcr.io/screamingface/screamingface-engine`; the tag defaults to the
 chart `appVersion`. Both the Deployment and every Runner Job resolve to that one reference.
 
 ## Lint / render

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -24,7 +24,7 @@ replicaCount: 1
 # `runner.image`; private grading assets therefore never reach the client-facing process.
 # Build-time OCI labels are listed in README.md (org.opencontainers.image.*).
 image:
-  repository: ghcr.io/openmined/screamingface-engine
+  repository: ghcr.io/screamingface/screamingface-engine
   tag: ""            # defaults to .Chart.AppVersion
   pullPolicy: IfNotPresent
 

--- a/apps/screamingface-engine/docs/request-workflow.md
+++ b/apps/screamingface-engine/docs/request-workflow.md
@@ -6,7 +6,7 @@ run‑once **Runner Job** Pod, through the **aigateway connector**, and finally 
 **aigateway** service — and back to the client as a CloudEvents stream.
 
 **Both ends of that trip are the same image.** `apps/screamingface-engine` ships one distribution
-(`screamingface_engine`) and one image (`ghcr.io/openmined/screamingface-engine`) with two modes
+(`screamingface_engine`) and one image (`ghcr.io/screamingface/screamingface-engine`) with two modes
 selected by argv: `screamingface-engine serve` is the App, `screamingface-engine run` is the Job. The halves are kept
 apart by an import rule, not by packaging — see `.claude/scripts/check_layering.py`.
 

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -55,7 +55,7 @@ def test_k8s_runner_is_built_from_settings() -> None:
     settings = Settings(
         runner="k8s",
         namespace="url4-prod",
-        runner_image="ghcr.io/openmined/url4-cloud:1.2.3",
+        runner_image="ghcr.io/screamingface/url4-cloud:1.2.3",
         nats_url="nats://nats.url4-prod:4222",
     )
     loaded: list[bool] = []
@@ -68,7 +68,7 @@ def test_k8s_runner_is_built_from_settings() -> None:
     assert isinstance(runner, K8sJobRunner)
     assert loaded == [True]
     assert runner._namespace == "url4-prod"
-    assert runner._image == "ghcr.io/openmined/url4-cloud:1.2.3"
+    assert runner._image == "ghcr.io/screamingface/url4-cloud:1.2.3"
     # The Job runs the App's OWN image in run mode, so the command IS the mode switch.
     assert runner._command == ["url4-cloud", "run"]
 


### PR DESCRIPTION
Fixes the live dev-build break from the org transfer.

## Cause
The workflow `GITHUB_TOKEN` (`packages: write`) can only push to its **own org's** GHCR namespace. Post-transfer the workflows still push to `ghcr.io/openmined/*`, so every dev build fails at the GHCR push (`permission_denied: The requested installation does not exist`). Because the build pushes GHCR **and** ACR in one step, this aborts the whole push — no image reaches ACR and the platform deploy lane is frozen.

## Fix
Mechanical repoint `ghcr.io/openmined` → `ghcr.io/screamingface` (own org; token may write; package auto-creates on first push). **ACR paths unchanged.**

Changed: 8 dev-build/release workflows, 4 chart `values.yaml` defaults, `verify_chart_wiring.py` expected image, one runner test fixture, operational docs. Dated historical notes left as-is. **0 `ghcr.io/openmined` refs remain** in the functional set.

Merging re-triggers the dev builds (workflow files are in their path filters) → push to the new namespace + ACR → promotion unfreezes.