### PR TITLE
fix(screamingface): render rubric criterion chips as PASS/FAIL with the judge verdict in the tooltip

### DIFF
--- a/docs/tasks/2026-08-20-passfail-chips.md
+++ b/docs/tasks/2026-08-20-passfail-chips.md
@@ -1,0 +1,25 @@
+---
+id: OME-900
+linear_url: https://linear.app/openmined/issue/OME-900/show-passfail-on-rubric-criterion-chips-so-word-and-color-agree
+status: in_progress
+type: bug
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-20
+closed:
+---
+
+# Show PASS/FAIL on rubric criterion chips so word and color agree
+
+Rubric benchmarks (DRACO, HealthBench) have positive and negative criteria; the judge's
+verdict is polarity-blind (MET = "the response did this thing"). The SDK report panel
+prints that raw word but colors by score consequence — green UNMET / red MET chips on
+negative criteria. Also: `_check_good` misses HealthBench's signed-`points` metadata, so
+HealthBench negative criteria render the wrong color entirely.
+
+Fix (display layer only, `packages/screamingface/.../_ui/report_view.py`): chip text
+becomes derived PASS/FAIL (`PASS = positive∧MET ∨ negative∧UNMET`), color follows text,
+the judge's raw MET/UNMET stays as subtext/tooltip, polarity reads both `criterion_type`
+and `points` sign. Stored/archived verdicts never rewritten.
+
+Ledger: `docs/work/2026-08-20-OME-900-passfail-chips.md`. Full spec in the Linear issue.

--- a/docs/work/2026-08-20-OME-900-passfail-chips.md
+++ b/docs/work/2026-08-20-OME-900-passfail-chips.md
@@ -1,0 +1,61 @@
+---
+ticket: OME-900
+stack: screamingface
+status: done
+started: 2026-08-20
+finished: 2026-08-20
+---
+
+# OME-900 — Show PASS/FAIL on rubric criterion chips so word and color agree
+
+## Intent
+
+The SDK report panel renders each rubric criterion chip with the judge's raw word
+(MET/UNMET) but colors it by score consequence — so a negative criterion shows a green
+"UNMET" or a red "MET", forcing the reader to do polarity math (team Slack thread,
+2026-08-20). Worse, `_check_good` only understands DRACO's `criterion_type` metadata;
+HealthBench checks carry signed `points` instead, so HealthBench negative criteria render
+with the WRONG color today (green MET on a −3 item), and `_case_passed` inherits that.
+This unit derives PASS/FAIL at render time (PASS = positive∧MET ∨ negative∧UNMET), keeps
+the judge's raw verdict as chip subtext/tooltip, and teaches polarity to read both
+metadata vocabularies. Display layer only — stored verdicts are never rewritten.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_ui/report_view.py`
+  - `_check_good`: polarity = `criterion_type == "negative"` OR `metadata.points < 0`
+  - `_check_html`: chip text = derived PASS/FAIL; raw `judge: MET|UNMET` (+ "avoided" /
+    "did the thing to avoid" gloss on negatives) as subtext/tooltip; unjudged unchanged
+- `packages/screamingface/tests/test_report_panel.py` (or sibling): new cases
+
+## Test plan
+
+- Polarity matrix, both vocabularies (DRACO `criterion_type`, HealthBench signed
+  `points`): 4 combinations → chip text PASS/FAIL + ok/bad badge class each
+- HealthBench negative-points regression: MET on `points: -3` renders FAIL/red
+  (invariant: a criterion that subtracted score can never render green)
+- Raw verdict retention: chip still carries the literal judge word (MET/UNMET) in
+  subtext/tooltip (invariant: archived verdict stays visible, only derived text changes)
+- Unjudged check keeps the neutral warn badge (OME-848 invariant)
+- `_case_passed`: HealthBench case with a tripped penalty no longer counts as passed
+
+## Acceptance
+
+- All four chip states render per the OME-900 display table; gates green
+  (`run_gates.py` for the `screamingface` stack, coverage ≥95%)
+- PR open from `OME-900-passfail-chips`; no Engine/schema/stored-data change
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `report_view.py` (`_check_negative` new, `_check_good`,
+  `_check_html`, `_badge` + optional `title`), new `tests/test_criterion_chip_passfail.py`
+  (11 tests), this ledger + `docs/tasks/2026-08-20-passfail-chips.md`
+- **Commits:** single commit on `OME-900-passfail-chips` — `fix(screamingface): render
+  rubric criterion chips as PASS/FAIL with the judge verdict in the tooltip` (sha in the
+  Linear close comment; committed with this ledger, so the sha postdates this file)
+- **Gates:** run_gates.py screamingface ALL GREEN — append-only ✓ ruff ✓ format ✓
+  pyright ✓ pytest 955 passed 1 skipped, cov ≥95% ✓ notebooks ✓ build ✓ distribution ✓
+- **Deviations:** one test sharpened during RED (asserting the badge markup, not the
+  stylesheet, for "incorrect" — the CSS comment made the loose form vacuous); an
+  `--all-extras` sync falsely reddened pyright in `_runtime/server.py` — env reverted to
+  the intended notebook-extra-only install, no code touched there

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -761,12 +761,26 @@ def _case_state(case: CaseResult) -> str:
     return "passed" if _case_passed(case) else "incorrect"
 
 
+def _check_negative(check: Any) -> bool:
+    """A negative criterion, in either Benchmark vocabulary (OME-900).
+
+    DRACO names polarity outright (`criterion_type: negative`); HealthBench carries it
+    as the sign of the rubric item's `points`. One rule reads both so no rubric
+    benchmark's penalties can masquerade as positives.
+    """
+
+    metadata = check.metadata or {}
+    if str(metadata.get("criterion_type", "")).lower() == "negative":
+        return True
+    points = metadata.get("points")
+    return isinstance(points, int | float) and not isinstance(points, bool) and points < 0
+
+
 def _check_good(check: Any) -> bool:
     """MET is only good news on a POSITIVE criterion; a negative criterion inverts it."""
 
     met = ("" if check.outcome is None else str(check.outcome)).upper() == "MET"
-    kind = str((check.metadata or {}).get("criterion_type", "")).lower()
-    return not met if kind == "negative" else met
+    return not met if _check_negative(check) else met
 
 
 def _check_html(check: Any) -> str:
@@ -777,7 +791,19 @@ def _check_html(check: Any) -> str:
     if check.outcome is None:
         badge = _badge("unjudged", good=False, warn=True)
     else:
-        badge = _badge(str(check.outcome), good=_check_good(check))
+        # INVARIANT (OME-900): the chip TEXT is the score consequence (PASS helped,
+        # FAIL hurt) so word and color always agree — the judge's polarity-blind
+        # MET/UNMET stays in the tooltip, because that raw verdict is what archives
+        # store and the paper's vocabulary; it is derived here, never rewritten.
+        good = _check_good(check)
+        gloss = ""
+        if _check_negative(check):
+            gloss = " (avoided)" if good else " (did the thing to avoid)"
+        badge = _badge(
+            "PASS" if good else "FAIL",
+            good=good,
+            title=f"judge: {check.outcome}{gloss}",
+        )
     judge = next(
         (item.producer.id for item in check.evidence if getattr(item, "producer", None)),
         None,
@@ -791,9 +817,10 @@ def _check_html(check: Any) -> str:
     )
 
 
-def _badge(text: str, *, good: bool, warn: bool = False) -> str:
+def _badge(text: str, *, good: bool, warn: bool = False, title: str | None = None) -> str:
     variant = "sf-badge--warn" if warn else ("sf-badge--ok" if good else "sf-badge--bad")
-    return f"<span class='sf-badge {variant}'><i class='sq'></i>{escape(text)}</span>"
+    tooltip = f" title='{escape(title)}'" if title else ""
+    return f"<span class='sf-badge {variant}'{tooltip}><i class='sq'></i>{escape(text)}</span>"
 
 
 def _metric(metrics: Any, name: str) -> float | None:

--- a/packages/screamingface/tests/test_criterion_chip_passfail.py
+++ b/packages/screamingface/tests/test_criterion_chip_passfail.py
@@ -1,0 +1,176 @@
+"""A criterion chip reads PASS/FAIL — the score consequence — never the raw judge word (OME-900).
+
+FEATURE: rubric benchmarks (DRACO, HealthBench) mix positive and negative criteria and
+the judge's MET/UNMET verdict is polarity-blind, so printing it as the chip text made
+green chips read "UNMET" and red chips read "MET" on negative criteria.
+STORY: as a researcher reading a case, every chip says PASS when the criterion helped
+the score and FAIL when it hurt, with the judge's raw verdict kept visible in the chip's
+tooltip so archived verdicts stay auditable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import screamingface as sf
+from screamingface._ui.report_view import report_html
+from screamingface.case_result import CaseGrade, CaseResult, Check, CheckOutcome
+from screamingface.operation import OperationInfo
+from screamingface.report import BenchmarkInfo, CandidateResult, Report
+
+_BENCHMARK = BenchmarkInfo(id="draco", revision="r1", case_count=1)
+_START = datetime(2026, 8, 20, 10, 0, tzinfo=UTC)
+_END = datetime(2026, 8, 20, 10, 5, tzinfo=UTC)
+
+
+def _check(label: str, outcome: CheckOutcome | None, metadata: dict[str, Any]) -> Check:
+    return Check(
+        type="criterion",
+        id=label,
+        label=label,
+        evidence=[],
+        outcome=outcome,
+        metadata=metadata,
+    )
+
+
+def _case(*checks: Check, score: float | None = 0.8) -> CaseResult:
+    return CaseResult(
+        case_id=1,
+        input="the prompt",
+        output="the answer",
+        finish_reason="stop",
+        grade=CaseGrade(method="rubric", score=score, metrics={}, checks=list(checks)),
+        failures=[],
+        metadata={},
+    )
+
+
+def _report(case: CaseResult) -> Report:
+    candidate = CandidateResult(
+        benchmark=_BENCHMARK,
+        run_id="run-m",
+        started_at=_START,
+        completed_at=_END,
+        name="m",
+        kind="model",
+        url4="(candidate:0.0:'(m:0.0:/openrouter/x)!\\'$m\\'')!''",
+        models=["openrouter/x"],
+        operations=[OperationInfo(id="op", kind="model", label="answer", depends_on=())],
+        score=case.grade.score if case.grade else None,
+        coverage=1.0,
+        metrics={"mean": 0.8} if case.grade and case.grade.score else {},
+        cases=[case],
+        members=[],
+        failures=[],
+        usage=sf.Usage(input_tokens=10, output_tokens=10),
+    )
+    return Report(benchmark=_BENCHMARK, case_count=1, candidates=[candidate])
+
+
+def _chip(check: Check) -> str:
+    """The single rendered check row — narrow the haystack to one chip's markup."""
+
+    html = report_html(_report(_case(check)))
+    start = html.index("<div class='sf-check'>")
+    return html[start : html.index("</div>", start)]
+
+
+# ── The four display-table rows, DRACO vocabulary (criterion_type) ──────────────
+
+
+def test_positive_met_reads_pass_in_green() -> None:
+    chip = _chip(_check("cites sources", "MET", {"criterion_type": "positive"}))
+
+    assert ">PASS</span>" in chip.replace("<i class='sq'></i>", ">")
+    assert "sf-badge--ok" in chip
+
+
+def test_positive_unmet_reads_fail_in_red() -> None:
+    chip = _chip(_check("cites sources", "UNMET", {"criterion_type": "positive"}))
+
+    assert "FAIL" in chip
+    assert "sf-badge--bad" in chip
+
+
+def test_negative_unmet_reads_pass_in_green() -> None:
+    # INVARIANT: avoiding the bad thing is good news — the chip must not read like a miss.
+    chip = _chip(_check("invents a dosage", "UNMET", {"criterion_type": "negative"}))
+
+    assert "PASS" in chip
+    assert "sf-badge--ok" in chip
+    assert "UNMET</span>" not in chip  # the raw word never appears as the chip text
+
+
+def test_negative_met_reads_fail_in_red() -> None:
+    chip = _chip(_check("invents a dosage", "MET", {"criterion_type": "negative"}))
+
+    assert "FAIL" in chip
+    assert "sf-badge--bad" in chip
+
+
+# ── HealthBench vocabulary: polarity is the sign of metadata.points ─────────────
+
+
+def test_healthbench_positive_points_met_reads_pass() -> None:
+    chip = _chip(_check("recommends a doctor", "MET", {"points": 5}))
+
+    assert "PASS" in chip
+    assert "sf-badge--ok" in chip
+
+
+def test_healthbench_negative_points_met_reads_fail_in_red() -> None:
+    # INVARIANT (the OME-900 color bug): a criterion that subtracted score can never
+    # render green — before this fix, signed points were ignored and this chip was
+    # a green "MET".
+    chip = _chip(_check("invents a dosage", "MET", {"points": -3}))
+
+    assert "FAIL" in chip
+    assert "sf-badge--bad" in chip
+    assert "sf-badge--ok" not in chip
+
+
+def test_healthbench_negative_points_unmet_reads_pass() -> None:
+    chip = _chip(_check("invents a dosage", "UNMET", {"points": -3}))
+
+    assert "PASS" in chip
+    assert "sf-badge--ok" in chip
+
+
+# ── The raw judge verdict stays auditable on the chip ───────────────────────────
+
+
+def test_tooltip_keeps_the_raw_judge_verdict() -> None:
+    chip = _chip(_check("cites sources", "MET", {"criterion_type": "positive"}))
+
+    assert "judge: MET" in chip
+
+
+def test_negative_tooltip_glosses_the_inversion() -> None:
+    # The one place MET-but-FAIL is explained: the tooltip names what happened.
+    met = _chip(_check("invents a dosage", "MET", {"criterion_type": "negative"}))
+    unmet = _chip(_check("invents a dosage", "UNMET", {"criterion_type": "negative"}))
+
+    assert "judge: MET (did the thing to avoid)" in met
+    assert "judge: UNMET (avoided)" in unmet
+
+
+# ── Ripple: the case verdict rail inherits the points-sign fix ──────────────────
+
+
+def test_a_tripped_healthbench_penalty_marks_the_case_incorrect() -> None:
+    # INVARIANT: _case_passed shares the polarity rule — a case whose only judged
+    # check is a tripped penalty (MET on negative points) cannot read as passed.
+    html = report_html(_report(_case(_check("invents a dosage", "MET", {"points": -3}))))
+
+    # The badge markup, not the stylesheet (a CSS comment also says "incorrect").
+    assert "</i>incorrect</span>" in html
+
+
+def test_unjudged_stays_the_neutral_badge() -> None:
+    # OME-848 invariant restated at the chip level: no verdict word for the undecided.
+    chip = _chip(_check("undecided", None, {"criterion_type": "positive"}))
+
+    assert "unjudged" in chip
+    assert "PASS" not in chip and "FAIL" not in chip


### PR DESCRIPTION
Closes OME-900.

## What changes for the reader

Rubric benchmarks (DRACO, HealthBench) grade an answer against a checklist where items can be **positive** ("+5 recommends seeing a doctor") or **negative** ("−3 invents a dosage"). The AI judge is polarity-blind: it only answers "did the answer do this thing?" — MET or UNMET. So on a negative criterion, MET means *the answer did the bad thing*.

The report panel printed that raw judge word as the chip text while coloring the chip by score consequence. Result: **green chips reading "UNMET"** and **red chips reading "MET"**. Word and color contradicted each other unless the reader knew the criterion's polarity.

Now the chip reads **PASS** (green) when the criterion helped the score and **FAIL** (red) when it hurt, and the judge's raw verdict moves into the chip's tooltip (`judge: MET (did the thing to avoid)`), so archived verdicts stay auditable.

## Root cause — and a second bug found while scoping

`_check_good` decided polarity from `metadata.criterion_type`, which is **DRACO's vocabulary only**. HealthBench checks carry a signed `metadata.points` and no `criterion_type`, so every HealthBench negative criterion was treated as positive: a tripped penalty rendered **green**, and `_case_passed` (same helper) counted such a case as passed. For HealthBench the color itself was wrong, not just the word.

## Implementation

Display layer only, all in `packages/screamingface`:

- new `_check_negative` — polarity from `criterion_type == "negative"` **or** `points < 0`, so one rule reads both benchmark vocabularies
- `_check_html` — chip text is the derived consequence; `PASS = (positive AND MET) OR (negative AND UNMET)`, `FAIL` its complement
- `_badge` — optional `title` for the tooltip carrying the raw verdict

**No Engine, schema, or stored-data change.** Verdicts are derived at render time; MET/UNMET remains the paper's vocabulary and what archives (including backfilled DRACO runs) store.

| Polarity | Judge verdict | Chip text | Color | Tooltip |
|---|---|---|---|---|
| Positive (+pts) | MET | **PASS** | green | judge: MET |
| Positive (+pts) | UNMET | **FAIL** | red | judge: UNMET |
| Negative (−pts) | UNMET | **PASS** | green | judge: UNMET (avoided) |
| Negative (−pts) | MET | **FAIL** | red | judge: MET (did the thing to avoid) |

## Test plan

11 new tests in `packages/screamingface/tests/test_criterion_chip_passfail.py`, written red-first: the four display-table rows in DRACO vocabulary, the same polarity matrix in HealthBench signed-points vocabulary (including the green-penalty regression), tooltip retention of the raw verdict, the case-verdict ripple, and the unjudged badge left untouched.

`run_gates.py screamingface` all green: ruff, format, pyright, pytest (955 passed / 1 skipped, coverage ≥95%), notebooks, build, distribution.

## Before / After

### Before
- Trigger: a dev or reviewer opens a run report and reads a criterion chip on a DRACO or HealthBench case.
- Today: on a negative criterion the chip says UNMET in green or MET in red — word contradicts color unless the reader knows the criterion's polarity. On HealthBench, negative criteria render the wrong color entirely.
- Cost: every reader does polarity math in their head; some walk away with the wrong conclusion about what the model did.

### After
- Same trigger.
- Now: the chip reads PASS (green) or FAIL (red) — one word, one meaning; the tooltip shows the judge's raw MET/UNMET verdict.
- Win: a reader who has never heard of criterion polarity reads every chip correctly on first glance, and an auditor still sees the exact archived verdict.

### Don't regress
- Unjudged checks keep the neutral "unjudged" warn badge — never red or green.
- Stored and archived verdicts are never rewritten; derivation happens only at render time.
- Positive-criterion chips keep their current correct color; only the text vocabulary changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)