### PR TITLE
fix(scoreboard): trim landing — drop stats strip + Dataset column

### DIFF
--- a/apps/scoreboard/portal/index.html
+++ b/apps/scoreboard/portal/index.html
@@ -55,12 +55,6 @@
 
     <p><a class="btn" href="https://docs.screamingface.ai/" target="_blank" rel="noopener">Get started with ScreamingFace →</a></p>
 
-    <div class="stats" aria-label="Live portal counts">
-      <div class="s"><span class="k">Benchmarks</span><div class="v" id="stat-benchmarks">—</div></div>
-      <div class="s"><span class="k">Datasets published</span><div class="v" id="stat-datasets">—</div></div>
-      <div class="s"><span class="k">Newest benchmark</span><div class="v" id="stat-newest">—</div></div>
-    </div>
-
     <h2 id="benchmarks">Benchmarks</h2>
 
     <p class="faint">Pick a benchmark to open its leaderboard. Inside, you can tab across all benchmarks.</p>
@@ -75,7 +69,6 @@
             <th>Focus</th>
             <th class="num">Fusions</th>
             <th class="num">Best reproducible</th>
-            <th>Dataset</th>
             <th>Open</th>
           </tr>
         </thead>

--- a/apps/scoreboard/portal/main.js
+++ b/apps/scoreboard/portal/main.js
@@ -255,21 +255,6 @@ window.ScorePortal = (function () {
   }
 
   /* ---- index page ------------------------------------------------------ */
-  // Site-root data files (published by the deploy workflow) open in the
-  // in-portal viewer instead of forcing a download — GitHub Pages serves
-  // .jsonl as application/octet-stream with no MIME override available.
-  function publishedDataFileName(href) {
-    try {
-      var u = new URL(href);
-      if (u.hostname !== "scoreboard.screamingface.ai") return null;
-      var m = u.pathname.match(/^\/([A-Za-z0-9][A-Za-z0-9._-]*\.jsonl)$/);
-      if (!m) return null;
-      return ["livetruth-latest.jsonl", "livetruth-masking.dataset.jsonl"].indexOf(m[1]) === -1 ? null : m[1];
-    } catch (e) {
-      return null;
-    }
-  }
-
   // "Subtitle" isn't an explicit field on Benchmark — using `description`
   // provisionally (flagged to Irina on OME-768; easy to swap if she says
   // otherwise, this is the one place it's read).
@@ -298,49 +283,10 @@ window.ScorePortal = (function () {
     var best = board && typeof board.best === "number" ? board.best : null;
     tr.appendChild(el("td", "num mono", best === null ? EM_DASH : formatScore(best)));
 
-    // dataset_url is API-provided/untrusted: only render it when it is a real
-    // http(s) URL, so a javascript:/data: scheme can never reach the href.
-    var datasetTd = el("td");
-    var datasetHref = httpUrlOrNull(b.dataset_url);
-    if (datasetHref) {
-      var viewerName = publishedDataFileName(datasetHref);
-      if (viewerName) {
-        datasetTd.appendChild(link("", "data.html?file=" + encodeURIComponent(viewerName), "Dataset"));
-      } else {
-        var dataset = link("", datasetHref, "Dataset");
-        dataset.setAttribute("rel", "noopener noreferrer nofollow");
-        datasetTd.appendChild(dataset);
-      }
-    } else {
-      datasetTd.textContent = EM_DASH;
-    }
-    tr.appendChild(datasetTd);
-
     var lbTd = el("td", "col-open");
     lbTd.appendChild(link("", "benchmark.html?id=" + encodeURIComponent(b.id), "Open →"));
     tr.appendChild(lbTd);
     return tr;
-  }
-
-  function formatDateOnly(value) {
-    if (!value) return EM_DASH;
-    var d = new Date(value);
-    if (isNaN(d.getTime())) return EM_DASH;
-    return d.toLocaleDateString(PORTAL_LOCALE, { year: "numeric", month: "short", day: "numeric" });
-  }
-
-  function updateIndexStats(benchmarks) {
-    var counts = {
-      "stat-benchmarks": String(benchmarks.length),
-      "stat-datasets": String(benchmarks.filter(function (b) { return httpUrlOrNull(b.dataset_url) !== null; }).length),
-      "stat-newest": formatDateOnly(
-        benchmarks.map(function (b) { return b.created_at; }).filter(Boolean).sort().pop()
-      ),
-    };
-    Object.keys(counts).forEach(function (id) {
-      var node = document.getElementById(id);
-      if (node) node.textContent = counts[id];
-    });
   }
 
   // D11: no aggregate "submission count" endpoint exists yet (OME-772). One
@@ -378,7 +324,6 @@ window.ScorePortal = (function () {
     fetchJson("/v1/benchmarks").then(
       function (data) {
         var benchmarks = (data && data.benchmarks) || [];
-        updateIndexStats(benchmarks);
         if (benchmarks.length === 0) {
           showEmpty(statusNode, "No public benchmarks yet. The API is live; rows will appear here as soon as benchmark specs are registered.");
           return;

--- a/docs/tasks/2026-08-20-OME-902-trim-landing.md
+++ b/docs/tasks/2026-08-20-OME-902-trim-landing.md
@@ -1,0 +1,29 @@
+---
+id: OME-902
+linear_url: https://linear.app/openmined/issue/OME-902/trim-scoreboard-landing-drop-stats-strip-dataset-column-focus-shows
+status: in_progress
+type: task
+priority: medium
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-20
+closed:
+---
+
+# Trim scoreboard landing: drop stats strip + Dataset column
+
+Slim the scoreboard portal landing page (`apps/scoreboard/portal/`) for the leaderboard MVP.
+Frontend-only (static HTML + vanilla JS); no Python/API/model changes.
+
+Changes: (1) remove the three-cell stats strip (Benchmarks / Datasets published / Newest
+benchmark) + the now-dead `updateIndexStats`/`formatDateOnly` in `main.js`; (2) remove the
+Dataset column (`<th>` + the `<td>` block in `benchmarkRow`) + the orphaned
+`publishedDataFileName`.
+
+The Focus column is left unchanged — it still renders the editorial `b.focus` field (a
+mid-PR change to preview `description` there was reverted per owner: the description already
+shows as the name-subtitle, so previewing it in Focus duplicated it).
+
+Owner decisions: Focus keeps editorial copy; name-subtitle stays. Out of scope: backend/
+model/schema, benchmark detail page, CSS, portal test gate / CI wiring.
+
+Ledger: `docs/work/2026-08-20-OME-902-trim-landing-table.md`

--- a/docs/work/2026-08-20-OME-902-trim-landing-table.md
+++ b/docs/work/2026-08-20-OME-902-trim-landing-table.md
@@ -1,0 +1,63 @@
+---
+ticket: OME-902
+stack: scoreboard
+status: in_progress
+started: 2026-08-20
+finished:
+---
+
+# OME-902 — Trim scoreboard landing: drop stats strip + Dataset column
+
+## Intent
+
+Slim the scoreboard portal landing page for the leaderboard MVP: remove the three-cell stats
+strip (Benchmarks / Datasets published / Newest benchmark) and the Dataset column from the
+benchmarks table. Frontend-only change to the static portal — no Python/API/model changes.
+The Focus column is left showing the editorial `b.focus` field (unchanged from `main`).
+
+## Planned changes
+
+- `apps/scoreboard/portal/index.html` — delete the `.stats` strip; delete the Dataset `<th>`.
+- `apps/scoreboard/portal/main.js` — delete the Dataset `<td>` block; delete the now-dead
+  `updateIndexStats` (+ its call in `initIndex`), `formatDateOnly`, and `publishedDataFileName`.
+  Focus cell keeps rendering `b.focus`. Keep `httpUrlOrNull` (exported, used by
+  benchmark.js/spec.js) and `benchmarkSubtitle` (name-subtitle stays per owner).
+
+## Test plan
+
+- No new automated test (owner decision — see Deviations). The Focus truncation is inline
+  display logic in `main.js`, which has no test harness (the portal JS gate runs only the pure
+  ranking logic in `leaderboard-logic.js`).
+- Guard against regression via the existing gates staying green + manual verification:
+  `node --check portal/main.js`; orphan grep for removed helpers/IDs; existing
+  `leaderboard-logic.test.js` still passes; eyeball the served page.
+
+## Acceptance
+
+- Landing page shows no stats strip between the "Get started" button and the Benchmarks heading.
+- Benchmarks table header has 5 columns (Benchmark · Focus · Fusions · Best reproducible ·
+  Open); no Dataset column; every row appends exactly 5 `<td>`s.
+- Focus cell shows the editorial `b.focus` field (unchanged from `main`), em dash when absent.
+- No dangling references to `updateIndexStats` / `formatDateOnly` / `publishedDataFileName` /
+  `stat-benchmarks` / `stat-datasets` / `stat-newest`; `httpUrlOrNull` still present + exported.
+- `run_gates.py scoreboard` green.
+
+## Outcome
+
+- **Status:** done.
+- **Actual files:** `apps/scoreboard/portal/index.html` (stats strip + Dataset `<th>`
+  removed) and `apps/scoreboard/portal/main.js` (Dataset `<td>` block, `updateIndexStats` +
+  call, `formatDateOnly`, and `publishedDataFileName` removed; Focus cell keeps `b.focus`;
+  `httpUrlOrNull` + `benchmarkSubtitle` kept). Plus this ledger and the `docs/tasks/` mirror.
+- **Commits:** `fix(scoreboard): trim landing — drop stats strip + Dataset column`
+  (Refs: OME-902).
+- **Gates:** `run_gates.py scoreboard` — ALL GREEN (append-only check, ruff check, ruff
+  format --check, pyright, pytest --cov=scoreboard --cov-fail-under=80, node --test
+  leaderboard-logic.test.js). Extra verification: `node --check portal/main.js` OK; orphan
+  grep clean (no `updateIndexStats`/`formatDateOnly`/`publishedDataFileName`/`stat-*`);
+  `benchmarkRow` appends exactly 5 `<td>`s matching the 5-column header.
+- **Deviations:** By owner decision, no new automated test — `main.js` is not test-covered by
+  design (the JS gate runs only the ranking logic in `leaderboard-logic.js`); wiring a
+  `main.js` test into the gate/CI is separate work.
+- **Owner-verify:** eyeball the served landing page against a seeded benchmark — confirm no
+  stats strip, no Dataset column, and Focus shows the editorial focus.


### PR DESCRIPTION
## Summary
Slims the scoreboard portal landing page (`apps/scoreboard/portal/`) for the leaderboard MVP. Frontend-only — no Python/API/model changes.

- **Remove the stats strip** (Benchmarks / Datasets published / Newest benchmark), plus the now-dead `updateIndexStats` (+ its call) and `formatDateOnly` in `main.js`.
- **Remove the Dataset column** from the benchmarks table — the `<th>` and the `<td>` block in `benchmarkRow`, plus the orphaned `publishedDataFileName`. `httpUrlOrNull` stays (exported, used by `benchmark.js`/`spec.js`).
- **Focus column is unchanged** — it keeps rendering the editorial `b.focus` field; `benchmarkSubtitle` (the name-subtitle) is unchanged too.

## Test plan
- `run_gates.py scoreboard` — ALL GREEN (append-only check, ruff check, ruff format --check, pyright, pytest --cov=scoreboard --cov-fail-under=80, `node --test tests/portal/leaderboard-logic.test.js`).
- `node --check portal/main.js` OK; orphan grep clean (no `updateIndexStats`/`formatDateOnly`/`publishedDataFileName`/`stat-*`).
- `benchmarkRow` appends exactly 5 `<td>`s matching the 5-column header.

## Owner-verify
Eyeball the served landing page — confirm no stats strip, no Dataset column, and Focus shows the editorial focus.

Refs: OME-902
