### PR TITLE
feat(scoreboard): seed benchmark text from the Engine catalogue

### DIFF
--- a/apps/scoreboard/charts/scoreboard/README.md
+++ b/apps/scoreboard/charts/scoreboard/README.md
@@ -20,7 +20,11 @@ The app chart is database-agnostic. It consumes `SCOREBOARD_DATABASE_URL` from `
 
 ## Benchmarks
 
-The post-install/post-upgrade seed Job runs `python -m scoreboard.seed` and passes `.Values.seedBenchmarks.benchmarks` as JSON. Re-running the Job is safe because benchmark registration is idempotent.
+The post-install/post-upgrade seed Job runs `python -m scoreboard.seed`. Re-running the Job is safe because benchmark registration is idempotent.
+
+Each benchmark's text — display name, description, focus line, dataset link — is read at deploy from the Engine named by `.Values.seedBenchmarks.engineUrl`, over its public `GET /v1/benchmarks` catalog. That Engine definition is the only place the text is written, so `revision` cannot drift from the Engine's computed value and a values override cannot blank the prose (OME-904). Set `engineUrl` per deployment; leaving it empty seeds only the configured entries.
+
+`.Values.seedBenchmarks.benchmarks` is passed as JSON alongside it and carries only the retained legacy demo entries, which have no Engine definition. An entry whose id the Engine also publishes is ignored, and the Job names it in its output.
 
 Disable seeding with:
 

--- a/apps/scoreboard/charts/scoreboard/templates/job-seed-benchmarks.yaml
+++ b/apps/scoreboard/charts/scoreboard/templates/job-seed-benchmarks.yaml
@@ -43,6 +43,13 @@ spec:
                   key: {{ .Values.database.existingSecretKey }}
             - name: SCOREBOARD_SEED_BENCHMARKS_JSON
               value: {{ .Values.seedBenchmarks.benchmarks | toJson | quote }}
+            {{- with .Values.seedBenchmarks.engineUrl }}
+            # The Engine whose benchmark catalog supplies every published benchmark's text
+            # (OME-904). One string, so an override can change WHICH Engine is read but cannot
+            # carry or omit the text itself.
+            - name: SCOREBOARD_SEED_ENGINE_URL
+              value: {{ . | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 {{- end }}

--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -114,8 +114,16 @@ seedBenchmarks:
   # copy that used to live here was silently lost. An entry whose id the Engine publishes is
   # ignored by the seed job and named in its output.
   #
-  # Deployment-owned: set this to the Engine this board ranks submissions against. Left empty,
-  # the job seeds only the entries listed below.
+  # Deployment-owned: the Engine this board ranks submissions against.
+  #
+  # AIDEV-NOTE: this MUST be the Engine's in-cluster address (its Service DNS name), never the
+  # public hostname. The public host sits behind Cloudflare Access, which answers 200 with an
+  # HTML sign-in page rather than a 401 — verified 2026-08-20. The seed job then fails to parse
+  # it, falls back, refuses the stale configured entries, and exits zero, so the deploy looks
+  # clean while benchmark text silently stops being refreshed. The job logs a WARNING naming
+  # the content type when this happens.
+  #
+  # Left empty, the job seeds only the entries listed below.
   engineUrl: ""
   # Retained legacy demo entries (OME-775 D2). They predate the Engine benchmark catalogue and
   # have no Engine definition, so their text has nowhere else to live.

--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -101,43 +101,25 @@ seedBenchmarks:
   backoffLimit: 3
   ttlSecondsAfterFinished: 600
   annotations: {}
-  # The `revision` of each entry MUST match the Engine benchmark's computed REVISION exactly
-  # (apps/screamingface-engine/src/screamingface_engine/benchmarks/<name>/definition.py). A submission carries the
-  # Engine's value, and the board ranks per revision — a mismatch makes every real submission
-  # look incomparable to the registered board. Re-copy these whenever a benchmark's dataset or
-  # protocol revision changes; seeding is idempotent, so redeploying just moves the value.
+  # FEATURE: benchmark descriptions on the leaderboard (OME-904).
+  #
+  # A benchmark's text — display name, description, focus line, dataset link — is written ONCE,
+  # in the Engine benchmark definition it describes
+  # (apps/screamingface-engine/src/screamingface_engine/benchmarks/<name>/definition.py). The
+  # seed job reads it from that Engine's public catalog at deploy, so `revision` cannot drift
+  # from the Engine's computed value and no deploy-time override can blank the prose.
+  #
+  # AIDEV-NOTE: do NOT reintroduce descriptions for an Engine-published benchmark below. Helm
+  # replaces lists wholesale rather than merging them, which is exactly how the hand-copied
+  # copy that used to live here was silently lost. An entry whose id the Engine publishes is
+  # ignored by the seed job and named in its output.
+  #
+  # Deployment-owned: set this to the Engine this board ranks submissions against. Left empty,
+  # the job seeds only the entries listed below.
+  engineUrl: ""
+  # Retained legacy demo entries (OME-775 D2). They predate the Engine benchmark catalogue and
+  # have no Engine definition, so their text has nowhere else to live.
   benchmarks:
-    # --- Engine benchmarks (OME-775) --------------------------------------------------
-    - id: draco
-      display_name: DRACO
-      description: >-
-        A 100-task DRACO reproduction with official score arithmetic. It uses the successor
-        Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a
-        host-only approximation of the reference blocklist, so its scores are not
-        paper-identical.
-      dataset_url: https://huggingface.co/datasets/perplexity-ai/draco
-      revision: 1c58b3085912e304
-      focus: Research reports with citations
-    - id: ifeval
-      display_name: IFEval
-      description: >-
-        The canonical 541-prompt instruction-following benchmark, graded by deterministic
-        strict and loose verification. Each Case invokes the Candidate exactly once.
-      # WHY no dataset_url: the IFEval dataset is vendored inside the Engine
-      # (screamingface_engine.benchmarks.ifeval.vendor), so no single public URL is authoritative.
-      revision: 0b88a52b5f10a6d9
-      focus: Instruction following
-    - id: healthbench-worst30
-      display_name: HealthBench Worst-30% Challenge
-      description: >-
-        The 157 hardest conversations from HealthBench Professional — the 30% that top
-        models score worst on. An AI judge grades each answer against a physician-written
-        rubric; safety mistakes subtract points, so per-case scores can be negative.
-      dataset_url: https://huggingface.co/datasets/openai/healthbench
-      revision: 6cd57aee171fbdc4
-      focus: Clinical safety, hardest cases
-    # --- Legacy demo entries, deliberately retained (OME-775 D2) -----------------------
-    # No Engine revision exists for these; they predate the Engine benchmark catalogue.
     - id: livetruth-latest
       display_name: News Livetruth Latest
       description: OpenMined Livetruth latest demo dataset

--- a/apps/scoreboard/pyproject.toml
+++ b/apps/scoreboard/pyproject.toml
@@ -5,6 +5,9 @@ description = "ScreamingFace benchmark scoreboard service"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.141.1",
+    # WHY a runtime dependency, not a dev one: the seed job reads the Engine benchmark catalogue
+    # over HTTP inside the production image, which is built with `uv sync --frozen --no-dev`.
+    "httpx>=0.28.1",
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.2",
     "tortoise-orm[asyncpg]==1.1.8",
@@ -58,7 +61,6 @@ filterwarnings = [
 
 [dependency-groups]
 dev = [
-    "httpx>=0.28.1",
     "pyright>=1.1.411",
     "pytest>=9.1.1",
     "pytest-asyncio>=1.4.0,<2",

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -323,6 +323,16 @@ class ScoreStore:
         )
         return benchmark_to_schema(benchmark)
 
+    async def has_registered_revision(self) -> bool:
+        """Has any benchmark row ever been registered with an Engine revision?
+
+        INVARIANT: only a benchmark the Engine publishes carries a revision — the retained
+        legacy demo entries have none — so a False answer means no successful Engine seed has
+        ever run against this database (OME-904).
+        """
+
+        return await Benchmark.filter(revision__isnull=False).exists()
+
     async def list_benchmarks(self) -> list[BenchmarkSchema]:
         rows = await Benchmark.all().order_by("id")
         return [benchmark_to_schema(benchmark) for benchmark in rows]

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -5,7 +5,9 @@ import asyncio
 import json
 import os
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 
+import httpx
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
 
 from .config import Settings
@@ -14,6 +16,23 @@ from .scores.schemas import BenchmarkSchema
 from .scores.store import ScoreStore
 
 SEED_BENCHMARKS_ENV = "SCOREBOARD_SEED_BENCHMARKS_JSON"
+# FEATURE: benchmark descriptions on the leaderboard (OME-904). The Engine's benchmark
+# definitions are the ONLY place a benchmark's prose is written; this deployment names which
+# Engine to ask, and nothing else. A values override can therefore change the Engine consulted
+# but can no longer carry, alter, or omit the text itself.
+ENGINE_URL_ENV = "SCOREBOARD_SEED_ENGINE_URL"
+_CATALOG_PATH = "/v1/benchmarks"
+# The catalogue is a small static document behind an ETag; a deploy hook should not hang on it.
+_FETCH_TIMEOUT_SECONDS = 15.0
+
+
+class EngineCatalogUnavailable(RuntimeError):
+    """The Engine benchmark catalogue could not be read.
+
+    INVARIANT: every transport, status, and payload failure surfaces as this one type. No
+    `httpx` or `json` exception escapes this module, so a deploy log names the thing that
+    failed rather than leaking a library's internals.
+    """
 
 
 class SeedBenchmark(BaseModel):
@@ -30,6 +49,167 @@ class SeedBenchmark(BaseModel):
     # Short editorial line for the portal catalogue's "Focus" column (OME-874). Optional: it is
     # copy someone writes, not a value the Engine derives.
     focus: str | None = Field(default=None, max_length=120)
+
+
+class _CatalogEntry(BaseModel):
+    """One benchmark as the Engine publishes it at ``GET /v1/benchmarks``.
+
+    AIDEV-NOTE: ``extra="ignore"`` deliberately, opposite to :class:`SeedBenchmark`'s
+    ``extra="forbid"``. A configured entry is written by hand here, so a typo must fail the
+    deploy; the catalogue is written by another service that will keep growing fields
+    (``case_count``, ``href``, ``check_surface``, whatever comes next), and a board that
+    refuses to seed because the Engine added a field is a board that breaks on someone else's
+    release. Read the fields the board displays; ignore the rest.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1, max_length=64)
+    title: str = Field(min_length=1, max_length=255)
+    description: str = Field(min_length=1)
+    revision: str = Field(min_length=1, max_length=64)
+    focus: str | None = Field(default=None, max_length=120)
+    dataset_url: str | None = None
+
+    def as_seed(self) -> SeedBenchmark:
+        # The Engine calls it `title`; this board's column is `display_name`. One mapping site.
+        return SeedBenchmark(
+            id=self.id,
+            display_name=self.title,
+            description=self.description,
+            dataset_url=self.dataset_url,
+            revision=self.revision,
+            focus=self.focus,
+        )
+
+
+class _Catalog(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    data: list[_CatalogEntry]
+
+
+@dataclass(slots=True)
+class SeedReport:
+    """What one seeding pass did, in the terms the deploy log and its exit code need."""
+
+    seeded: list[BenchmarkSchema] = field(default_factory=list)
+    """Rows written this pass, Engine-published first."""
+
+    shadowed: list[str] = field(default_factory=list)
+    """Configured ids the Engine also publishes; the configured copy was ignored."""
+
+    engine_error: str | None = None
+    """Why the catalogue could not be read, when it could not."""
+
+    bootstrap_failed: bool = False
+    """The catalogue was unreadable AND this board has never been seeded from one."""
+
+
+def fetch_engine_benchmarks(
+    engine_url: str,
+    *,
+    client: httpx.Client | None = None,
+) -> list[SeedBenchmark]:
+    """Read the Engine's benchmark catalogue and return it as rows this board can register.
+
+    Think of it as copying a menu from the kitchen that cooks the food, rather than retyping
+    it at the front desk: the Engine defines each benchmark and writes the words describing
+    it, and this function carries those words across unchanged.
+
+    Stage 1 — address the catalogue: ``{engine_url}/v1/benchmarks``. Public and read-only, so
+    the seed job holds no Engine credential.
+    Stage 2 — fetch it, converting every transport failure, error status, and non-JSON body
+    into :class:`EngineCatalogUnavailable`.
+    Stage 3 — validate the payload, ignoring fields this board does not display.
+    Stage 4 — map each entry onto a seed row, renaming ``title`` to ``display_name``.
+
+    Args:
+        engine_url: origin of the Engine to ask, with or without a trailing slash.
+        client: an HTTP client to use instead of opening one — the injection seam the tests
+            drive; production passes nothing and gets a timeout-bounded client.
+
+    Returns:
+        One row per published benchmark, in the Engine's own order.
+
+    Raises:
+        EngineCatalogUnavailable: the catalogue could not be read or could not be understood.
+    """
+
+    url = engine_url.rstrip("/") + _CATALOG_PATH
+    http = client if client is not None else httpx.Client(timeout=_FETCH_TIMEOUT_SECONDS)
+    try:
+        response = http.get(url)
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPStatusError as exc:
+        raise EngineCatalogUnavailable(f"{url} answered HTTP {exc.response.status_code}") from exc
+    except httpx.HTTPError as exc:
+        raise EngineCatalogUnavailable(f"{url} could not be reached: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise EngineCatalogUnavailable(f"{url} did not answer JSON: {exc.msg}") from exc
+    finally:
+        if client is None:
+            http.close()
+
+    try:
+        catalog = _Catalog.model_validate(payload)
+    except ValidationError as exc:
+        raise EngineCatalogUnavailable(f"{url} answered an unreadable catalog: {exc}") from exc
+    return [entry.as_seed() for entry in catalog.data]
+
+
+async def seed_from_sources(
+    *,
+    engine_url: str | None,
+    configured: Sequence[SeedBenchmark],
+    client: httpx.Client | None = None,
+) -> SeedReport:
+    """Register every benchmark this board should show, with the Engine as the only copy.
+
+    Think of it as a merge with a fixed winner: whatever the Engine publishes is the truth,
+    and configuration may only fill gaps the Engine leaves.
+
+    Stage 1 — read the Engine catalogue when one is configured. A failure here is recorded,
+    not raised: re-seeding refreshes a populated board, so failing a Scoreboard deploy on an
+    unrelated service's health would cost availability and buy nothing.
+    Stage 2 — Engine rows win over any configured entry sharing their id, and the shadowed ids
+    are reported. This precedence is what makes the Engine the ONLY copy rather than merely
+    the preferred one — prose reintroduced by a deploy is ignored rather than applied.
+    Stage 3 — write every row through the same idempotent registration as before.
+    Stage 4 — decide whether an unreadable catalogue was survivable. It was, unless no row in
+    the database carries a revision at all: only Engine-published benchmarks carry one, so
+    that case means no successful seed has ever run, and exiting zero would publish a board
+    holding nothing but legacy demo entries and call it a success.
+
+    Args:
+        engine_url: the Engine to read, or None for a deployment that runs without one.
+        configured: entries from deployment configuration — the retained legacy demos, plus
+            anything the Engine does not publish.
+        client: an HTTP client to use instead of opening one (see
+            :func:`fetch_engine_benchmarks`).
+
+    Returns:
+        A :class:`SeedReport`; ``bootstrap_failed`` is the caller's non-zero exit signal.
+    """
+
+    report = SeedReport()
+    engine_rows: list[SeedBenchmark] = []
+    if engine_url:
+        try:
+            engine_rows = fetch_engine_benchmarks(engine_url, client=client)
+        except EngineCatalogUnavailable as exc:
+            report.engine_error = str(exc)
+
+    published = {row.id for row in engine_rows}
+    report.shadowed = sorted(row.id for row in configured if row.id in published)
+    merged = [*engine_rows, *(row for row in configured if row.id not in published)]
+
+    report.seeded = await seed_benchmarks(merged)
+    report.bootstrap_failed = (
+        report.engine_error is not None and not await ScoreStore().has_registered_revision()
+    )
+    return report
 
 
 _BENCHMARKS_ADAPTER = TypeAdapter(list[SeedBenchmark])
@@ -71,33 +251,54 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=f"JSON benchmark list. Defaults to ${SEED_BENCHMARKS_ENV}; empty list if unset.",
     )
+    parser.add_argument(
+        "--engine-url",
+        default=None,
+        help=(
+            "Engine origin whose benchmark catalog supplies every published benchmark's text. "
+            f"Defaults to ${ENGINE_URL_ENV}; omitted means seed configured entries only."
+        ),
+    )
     return parser
 
 
-async def _run(raw_json: str) -> None:
-    benchmarks = load_benchmarks_json(raw_json)
-    if not benchmarks:
+async def _run(raw_json: str, engine_url: str | None) -> int:
+    configured = load_benchmarks_json(raw_json)
+    if not configured and not engine_url:
         print("no benchmarks configured")
-        return
+        return 0
 
     settings = Settings()
     await init_db(settings.database_url)
     try:
-        seeded = await seed_benchmarks(benchmarks)
-        for benchmark in seeded:
+        report = await seed_from_sources(engine_url=engine_url, configured=configured)
+        for benchmark in report.seeded:
             print(f"seeded benchmark {benchmark.id}")
+        for benchmark_id in report.shadowed:
+            # Named rather than silent: an operator who added prose to the deploy values needs
+            # to know it was ignored, and where the text they see actually comes from.
+            print(f"ignored configured entry {benchmark_id}: the Engine publishes it")
+        if report.engine_error is not None:
+            print(f"engine catalog unavailable: {report.engine_error}")
+        if report.bootstrap_failed:
+            print("no benchmark carries an Engine revision: this board has never been seeded")
+            return 1
     finally:
         await close_db()
+    return 0
 
 
 def main(argv: Sequence[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
     raw_json = args.benchmarks_json or os.getenv(SEED_BENCHMARKS_ENV, "[]")
+    engine_url = args.engine_url or os.getenv(ENGINE_URL_ENV) or None
     try:
-        asyncio.run(_run(raw_json))
+        exit_code = asyncio.run(_run(raw_json, engine_url))
     except ValueError as exc:
         parser.error(str(exc))
+    if exit_code:
+        raise SystemExit(exit_code)
 
 
 if __name__ == "__main__":

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, ValidationError, field_validator
 
 from .config import Settings
 from .db import close_db, init_db
@@ -62,6 +62,13 @@ class SeedBenchmark(BaseModel):
 class _CatalogEntry(BaseModel):
     """One benchmark as the Engine publishes it at ``GET /v1/benchmarks``.
 
+    AIDEV-NOTE: this is one half of a cross-app contract that no single test can run, because
+    the two apps have separate virtualenvs and neither may import the other. The producer half
+    is pinned by ``test_the_catalog_keeps_the_field_names_the_leaderboard_seeds_from`` in
+    apps/screamingface-engine — rename a field here or there and BOTH must change together, in
+    one pull request. ``tests/fixtures/engine_catalog.json`` is a recorded real response that
+    keeps this side honest between such changes.
+
     AIDEV-NOTE: ``extra="ignore"`` deliberately, opposite to :class:`SeedBenchmark`'s
     ``extra="forbid"``. A configured entry is written by hand here, so a typo must fail the
     deploy; the catalogue is written by another service that will keep growing fields
@@ -74,15 +81,28 @@ class _CatalogEntry(BaseModel):
 
     id: str = Field(min_length=1, max_length=64)
     title: str = Field(min_length=1, max_length=255)
-    # INVARIANT: an empty description fails the whole entry, so the benchmark is not registered
-    # at all — no row, no board, and a submission against it is refused rather than merely
-    # looking plain. That is deliberate (an undescribed benchmark is not ready to publish) but
-    # the consequence is much larger than "missing text", so it is stated here. Existing rows
-    # survive it, because seeding upserts and never deletes; only a NEW benchmark is affected.
-    description: str = Field(min_length=1)
+    # WHY optional here while the Engine requires it: rejecting an entry costs the benchmark
+    # its whole ROW — no board entry, and a submission against it refused — which is a far
+    # bigger failure than a row that reads plain (owner decision, 2026-08-20). The Engine
+    # already refuses to define a benchmark without a description, so requiring it again here
+    # buys nothing and can only turn missing text into a missing benchmark. Require it where
+    # it is written; tolerate it where it is read.
+    #
+    # INVARIANT: blank normalizes to None, never to a placeholder sentence. The reader-facing
+    # wording lives in the client that renders it (`leaderboard_view.py` prints "No description
+    # published." for an absent one) — prose written into this database could never be told
+    # apart from prose an author actually wrote.
+    description: str | None = None
     revision: str = Field(min_length=1, max_length=64)
     focus: str | None = Field(default=None, max_length=120)
     dataset_url: str | None = None
+
+    @field_validator("description", "focus", mode="after")
+    @classmethod
+    def _blank_is_absent(cls, value: str | None) -> str | None:
+        """Treat whitespace-only display text as absent, so the client's fallback renders."""
+
+        return value if value is not None and value.strip() else None
 
     def as_seed(self) -> SeedBenchmark:
         # The Engine calls it `title`; this board's column is `display_name`. One mapping site.

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import json
 import os
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 
@@ -24,6 +25,13 @@ ENGINE_URL_ENV = "SCOREBOARD_SEED_ENGINE_URL"
 _CATALOG_PATH = "/v1/benchmarks"
 # The catalogue is a small static document behind an ETag; a deploy hook should not hang on it.
 _FETCH_TIMEOUT_SECONDS = 15.0
+# WHY retry at all: an unreachable Engine is survivable and exits zero, which means Kubernetes
+# never retries this Job — `backoffLimit` only fires on a non-zero exit. A Helm upgrade that
+# rolls Scoreboard and Engine together can land this single GET inside the Engine's restart
+# window, and without an in-process retry that release's benchmark changes silently miss the
+# board until somebody deploys again.
+_FETCH_ATTEMPTS = 3
+_RETRY_DELAY_SECONDS = 2.0
 
 
 class EngineCatalogUnavailable(RuntimeError):
@@ -86,7 +94,18 @@ class _CatalogEntry(BaseModel):
 class _Catalog(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
-    data: list[_CatalogEntry]
+    data: list[object]
+
+
+@dataclass(slots=True)
+class CatalogRead:
+    """One catalogue response, split into what this board can use and what it cannot."""
+
+    rows: list[SeedBenchmark] = field(default_factory=list)
+    """Entries this board can register, in the Engine's own order."""
+
+    rejected: list[str] = field(default_factory=list)
+    """Entries the board could not read — reported rather than silently dropped."""
 
 
 @dataclass(slots=True)
@@ -99,6 +118,12 @@ class SeedReport:
     shadowed: list[str] = field(default_factory=list)
     """Configured ids the Engine also publishes; the configured copy was ignored."""
 
+    refused: list[str] = field(default_factory=list)
+    """Configured ids not written at all, because writing them could undo an Engine seed."""
+
+    rejected: list[str] = field(default_factory=list)
+    """Catalogue entries the board could not read."""
+
     engine_error: str | None = None
     """Why the catalogue could not be read, when it could not."""
 
@@ -110,53 +135,114 @@ def fetch_engine_benchmarks(
     engine_url: str,
     *,
     client: httpx.Client | None = None,
-) -> list[SeedBenchmark]:
+    attempts: int = _FETCH_ATTEMPTS,
+    retry_delay: float = _RETRY_DELAY_SECONDS,
+) -> CatalogRead:
     """Read the Engine's benchmark catalogue and return it as rows this board can register.
 
-    Think of it as copying a menu from the kitchen that cooks the food, rather than retyping
-    it at the front desk: the Engine defines each benchmark and writes the words describing
-    it, and this function carries those words across unchanged.
+    Think of it as copying a menu from the kitchen that cooks the food, rather than retyping it
+    at the front desk: the Engine defines each benchmark and writes the words describing it,
+    and this function carries those words across unchanged.
 
     Stage 1 — address the catalogue: ``{engine_url}/v1/benchmarks``. Public and read-only, so
     the seed job holds no Engine credential.
-    Stage 2 — fetch it, converting every transport failure, error status, and non-JSON body
-    into :class:`EngineCatalogUnavailable`.
-    Stage 3 — validate the payload, ignoring fields this board does not display.
-    Stage 4 — map each entry onto a seed row, renaming ``title`` to ``display_name``.
+    Stage 2 — fetch it, following redirects, retrying only what a retry can fix: a transport
+    failure or a 5xx. A 4xx will not become a 200 by asking again, and neither will a mangled
+    body, so both fail immediately.
+    Stage 3 — read the envelope, then each entry INDEPENDENTLY. One unusable entry is reported
+    and skipped; it does not reject its siblings. Refusing the batch would mean every untouched
+    benchmark silently keeps its old text because one of them outgrew a column.
+    Stage 4 — map each usable entry onto a seed row, renaming ``title`` to ``display_name``.
+
+    Worked example: a catalogue of two entries where DRACO carries a 200-character focus line
+    (the board stores 120) returns ``rows=[ifeval]`` and ``rejected=["draco"]`` — IFEval's text
+    still refreshes, and DRACO's problem is named in the deploy log rather than swallowed.
 
     Args:
         engine_url: origin of the Engine to ask, with or without a trailing slash.
         client: an HTTP client to use instead of opening one — the injection seam the tests
             drive; production passes nothing and gets a timeout-bounded client.
+        attempts: how many times to ask before calling the Engine unreachable.
+        retry_delay: seconds to wait between attempts.
 
     Returns:
-        One row per published benchmark, in the Engine's own order.
+        A :class:`CatalogRead` holding the usable rows and the ids of any unusable entries.
 
     Raises:
-        EngineCatalogUnavailable: the catalogue could not be read or could not be understood.
+        EngineCatalogUnavailable: the catalogue could not be reached, answered an error status,
+            or was not a readable catalogue document at all.
     """
 
     url = engine_url.rstrip("/") + _CATALOG_PATH
     http = client if client is not None else httpx.Client(timeout=_FETCH_TIMEOUT_SECONDS)
     try:
-        response = http.get(url)
-        response.raise_for_status()
-        payload = response.json()
-    except httpx.HTTPStatusError as exc:
-        raise EngineCatalogUnavailable(f"{url} answered HTTP {exc.response.status_code}") from exc
-    except httpx.HTTPError as exc:
-        raise EngineCatalogUnavailable(f"{url} could not be reached: {exc}") from exc
-    except json.JSONDecodeError as exc:
-        raise EngineCatalogUnavailable(f"{url} did not answer JSON: {exc.msg}") from exc
+        payload = _read_catalog(http, url, attempts=attempts, retry_delay=retry_delay)
     finally:
         if client is None:
             http.close()
 
     try:
-        catalog = _Catalog.model_validate(payload)
+        entries = _Catalog.model_validate(payload).data
     except ValidationError as exc:
         raise EngineCatalogUnavailable(f"{url} answered an unreadable catalog: {exc}") from exc
-    return [entry.as_seed() for entry in catalog.data]
+
+    read = CatalogRead()
+    for position, entry in enumerate(entries):
+        try:
+            read.rows.append(_CatalogEntry.model_validate(entry).as_seed())
+        except ValidationError:
+            read.rejected.append(_entry_label(entry, position))
+    return read
+
+
+def _entry_label(entry: object, position: int) -> str:
+    """Name an unusable entry the way a human reading the deploy log would look for it."""
+
+    if isinstance(entry, dict):
+        identifier = entry.get("id")
+        if isinstance(identifier, str) and identifier:
+            return identifier
+    return f"entry #{position}"
+
+
+def _read_catalog(
+    http: httpx.Client,
+    url: str,
+    *,
+    attempts: int,
+    retry_delay: float,
+) -> object:
+    """Fetch and decode the catalogue document, retrying only what a retry can fix."""
+
+    unreachable: EngineCatalogUnavailable | None = None
+    for attempt in range(1, max(attempts, 1) + 1):
+        try:
+            # WHY follow_redirects: httpx defaults to False, so an ordinary http->https or
+            # trailing-slash redirect at the ingress would be reported as a permanent outage and
+            # the board would never update again.
+            response = http.get(url, follow_redirects=True)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            unreachable = EngineCatalogUnavailable(f"{url} answered HTTP {status}")
+            if status < 500:
+                raise unreachable from exc
+        except httpx.HTTPError as exc:
+            unreachable = EngineCatalogUnavailable(f"{url} could not be reached: {exc}")
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            # INVARIANT: BOTH belong here. `.json()` raises UnicodeDecodeError on a body that is
+            # not valid UTF-8, and both types are ValueErrors — an uncaught one used to surface
+            # from the CLI as a command-line usage error, blaming the operator's arguments for a
+            # mangled Engine response.
+            raise EngineCatalogUnavailable(f"{url} did not answer readable JSON: {exc}") from exc
+        if attempt < attempts:
+            time.sleep(retry_delay)
+    raise (
+        unreachable
+        if unreachable is not None
+        else EngineCatalogUnavailable(f"{url} was never asked")
+    )
 
 
 async def seed_from_sources(
@@ -164,23 +250,35 @@ async def seed_from_sources(
     engine_url: str | None,
     configured: Sequence[SeedBenchmark],
     client: httpx.Client | None = None,
+    retry_delay: float = _RETRY_DELAY_SECONDS,
 ) -> SeedReport:
     """Register every benchmark this board should show, with the Engine as the only copy.
 
-    Think of it as a merge with a fixed winner: whatever the Engine publishes is the truth,
-    and configuration may only fill gaps the Engine leaves.
+    Think of it as a merge with a fixed winner: whatever the Engine publishes is the truth, and
+    configuration may only fill gaps the Engine leaves. The subtle part is what happens when
+    the Engine says nothing — because "the Engine wins" is vacuous when there is nothing to
+    win with, and that is exactly when stale configuration would walk back in.
 
-    Stage 1 — read the Engine catalogue when one is configured. A failure here is recorded,
-    not raised: re-seeding refreshes a populated board, so failing a Scoreboard deploy on an
+    Stage 1 — ask whether this board has ever been seeded from a catalogue, BEFORE writing
+    anything. Reading this afterwards would let the pass count its own writes and call an empty
+    board healthy.
+    Stage 2 — read the Engine catalogue when one is configured. A failure here is recorded, not
+    raised: re-seeding refreshes a populated board, so failing a Scoreboard deploy on an
     unrelated service's health would cost availability and buy nothing.
-    Stage 2 — Engine rows win over any configured entry sharing their id, and the shadowed ids
-    are reported. This precedence is what makes the Engine the ONLY copy rather than merely
-    the preferred one — prose reintroduced by a deploy is ignored rather than applied.
-    Stage 3 — write every row through the same idempotent registration as before.
-    Stage 4 — decide whether an unreadable catalogue was survivable. It was, unless no row in
-    the database carries a revision at all: only Engine-published benchmarks carry one, so
-    that case means no successful seed has ever run, and exiting zero would publish a board
-    holding nothing but legacy demo entries and call it a success.
+    Stage 3 — decide what configuration is allowed to write. Two entries are refused outright:
+    one asserting a ``revision`` the Engine did not publish in this same pass (a revision is
+    the Engine's claim about its own benchmark, and configuration restating it is the second
+    copy this ticket deletes), and one whose id names an existing Engine-owned row (any row
+    carrying a revision). Without this, one transient Engine blip would let the deploy's own
+    stale entries overwrite good rows with null descriptions — OME-904 reproduced by its fix.
+    Stage 4 — Engine rows win over any surviving configured entry sharing their id.
+    Stage 5 — write every row through the same idempotent registration as before.
+    Stage 6 — an unreadable catalogue was survivable unless Stage 1 found no seeded row at all.
+
+    Worked example: the Engine is down, and configuration still lists draco (revision
+    ``1c58b30…``, no description) plus hle (no revision). draco is refused twice over — it
+    asserts a revision, and it names an Engine-owned row — so the good draco row keeps its
+    text; hle is written; the pass exits zero because Stage 1 saw a seeded row.
 
     Args:
         engine_url: the Engine to read, or None for a deployment that runs without one.
@@ -188,27 +286,44 @@ async def seed_from_sources(
             anything the Engine does not publish.
         client: an HTTP client to use instead of opening one (see
             :func:`fetch_engine_benchmarks`).
+        retry_delay: seconds between catalogue attempts (see
+            :func:`fetch_engine_benchmarks`).
 
     Returns:
-        A :class:`SeedReport`; ``bootstrap_failed`` is the caller's non-zero exit signal.
+        A :class:`SeedReport`; ``bootstrap_failed`` is the caller's non-zero exit signal, and
+        ``refused``/``rejected`` are what the deploy log must show a human.
     """
+
+    store = ScoreStore()
+    # Stage 1 — read the prior state before this pass can contribute to it.
+    seeded_before = await store.has_registered_revision()
+    engine_owned = {row.id for row in await store.list_benchmarks() if row.revision is not None}
 
     report = SeedReport()
     engine_rows: list[SeedBenchmark] = []
     if engine_url:
         try:
-            engine_rows = fetch_engine_benchmarks(engine_url, client=client)
+            read = fetch_engine_benchmarks(engine_url, client=client, retry_delay=retry_delay)
         except EngineCatalogUnavailable as exc:
             report.engine_error = str(exc)
+        else:
+            engine_rows = read.rows
+            report.rejected = read.rejected
 
     published = {row.id for row in engine_rows}
-    report.shadowed = sorted(row.id for row in configured if row.id in published)
-    merged = [*engine_rows, *(row for row in configured if row.id not in published)]
+    allowed: list[SeedBenchmark] = []
+    for row in configured:
+        if row.id in published:
+            report.shadowed.append(row.id)
+        elif row.revision is not None or row.id in engine_owned:
+            report.refused.append(row.id)
+        else:
+            allowed.append(row)
+    report.shadowed.sort()
+    report.refused.sort()
 
-    report.seeded = await seed_benchmarks(merged)
-    report.bootstrap_failed = (
-        report.engine_error is not None and not await ScoreStore().has_registered_revision()
-    )
+    report.seeded = await seed_benchmarks([*engine_rows, *allowed])
+    report.bootstrap_failed = report.engine_error is not None and not seeded_before
     return report
 
 
@@ -262,8 +377,28 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-async def _run(raw_json: str, engine_url: str | None) -> int:
-    configured = load_benchmarks_json(raw_json)
+def _print_report(report: SeedReport) -> None:
+    """Say what happened, in the terms an operator reading the deploy log needs."""
+
+    for benchmark in report.seeded:
+        print(f"seeded benchmark {benchmark.id}")
+    for benchmark_id in report.shadowed:
+        # Named rather than silent: an operator who added prose to the deploy values needs to
+        # know it was ignored, and where the text they see actually comes from.
+        print(f"ignored configured entry {benchmark_id}: the Engine publishes it")
+    for benchmark_id in report.refused:
+        print(
+            f"REFUSED configured entry {benchmark_id}: it claims an Engine benchmark this run "
+            "did not read from the Engine. Set seedBenchmarks.engineUrl, and keep revisions "
+            "and descriptions out of deployment configuration."
+        )
+    for benchmark_id in report.rejected:
+        print(f"REJECTED catalog entry {benchmark_id}: the board could not read it")
+    if report.engine_error is not None:
+        print(f"engine catalog unavailable: {report.engine_error}")
+
+
+async def _run(configured: Sequence[SeedBenchmark], engine_url: str | None) -> int:
     if not configured and not engine_url:
         print("no benchmarks configured")
         return 0
@@ -272,14 +407,7 @@ async def _run(raw_json: str, engine_url: str | None) -> int:
     await init_db(settings.database_url)
     try:
         report = await seed_from_sources(engine_url=engine_url, configured=configured)
-        for benchmark in report.seeded:
-            print(f"seeded benchmark {benchmark.id}")
-        for benchmark_id in report.shadowed:
-            # Named rather than silent: an operator who added prose to the deploy values needs
-            # to know it was ignored, and where the text they see actually comes from.
-            print(f"ignored configured entry {benchmark_id}: the Engine publishes it")
-        if report.engine_error is not None:
-            print(f"engine catalog unavailable: {report.engine_error}")
+        _print_report(report)
         if report.bootstrap_failed:
             print("no benchmark carries an Engine revision: this board has never been seeded")
             return 1
@@ -293,10 +421,14 @@ def main(argv: Sequence[str] | None = None) -> None:
     args = parser.parse_args(argv)
     raw_json = args.benchmarks_json or os.getenv(SEED_BENCHMARKS_ENV, "[]")
     engine_url = args.engine_url or os.getenv(ENGINE_URL_ENV) or None
+    # WHY parse here rather than inside the run: `parser.error` must only ever describe a bad
+    # argument. Wrapping the whole run in `except ValueError` swallowed unrelated ValueErrors
+    # from deep inside it — a mangled Engine response surfaced as a command-line usage error.
     try:
-        exit_code = asyncio.run(_run(raw_json, engine_url))
+        configured = load_benchmarks_json(raw_json)
     except ValueError as exc:
         parser.error(str(exc))
+    exit_code = asyncio.run(_run(configured, engine_url))
     if exit_code:
         raise SystemExit(exit_code)
 

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -74,6 +74,11 @@ class _CatalogEntry(BaseModel):
 
     id: str = Field(min_length=1, max_length=64)
     title: str = Field(min_length=1, max_length=255)
+    # INVARIANT: an empty description fails the whole entry, so the benchmark is not registered
+    # at all — no row, no board, and a submission against it is refused rather than merely
+    # looking plain. That is deliberate (an undescribed benchmark is not ready to publish) but
+    # the consequence is much larger than "missing text", so it is stated here. Existing rows
+    # survive it, because seeding upserts and never deletes; only a NEW benchmark is affected.
     description: str = Field(min_length=1)
     revision: str = Field(min_length=1, max_length=64)
     focus: str | None = Field(default=None, max_length=120)
@@ -171,6 +176,12 @@ def fetch_engine_benchmarks(
     Raises:
         EngineCatalogUnavailable: the catalogue could not be reached, answered an error status,
             or was not a readable catalogue document at all.
+
+    AIDEV-NOTE: this is SYNCHRONOUS on purpose and blocks its caller — `httpx.Client` plus
+    `time.sleep`, up to roughly 49s worst case (3 attempts x 15s timeout + 2 x 2s backoff).
+    That is harmless in the one-shot seed Job it was written for, where nothing else shares the
+    event loop, but `seed_from_sources` is `async` and could tempt a caller into running this
+    from a live server. Do not: convert to `httpx.AsyncClient` first.
     """
 
     url = engine_url.rstrip("/") + _CATALOG_PATH
@@ -193,6 +204,26 @@ def fetch_engine_benchmarks(
         except ValidationError:
             read.rejected.append(_entry_label(entry, position))
     return read
+
+
+def _unreadable_body(url: str, response: httpx.Response, exc: Exception) -> str:
+    """Explain a 200 that is not JSON, naming the cause an operator is most likely hitting.
+
+    WHY this is worth a function: the obvious address to put in ``engineUrl`` is the Engine's
+    PUBLIC hostname, and that host sits behind Cloudflare Access, which answers **200 with an
+    HTML sign-in page**. Every layer below then behaves correctly — the status check passes,
+    the parse fails, the failure is survivable, the job exits zero — and the feature is
+    silently off. This message is the only thing between an operator and a long afternoon.
+    """
+
+    content_type = response.headers.get("content-type", "unknown")
+    detail = f"{url} answered content-type {content_type} instead of JSON ({exc})"
+    if "html" in content_type.lower():
+        return (
+            f"{detail}. A public hostname behind an authentication proxy answers 200 with a "
+            "sign-in page: engineUrl must name the in-cluster Engine address, not the public one."
+        )
+    return detail
 
 
 def _entry_label(entry: object, position: int) -> str:
@@ -235,7 +266,7 @@ def _read_catalog(
             # not valid UTF-8, and both types are ValueErrors — an uncaught one used to surface
             # from the CLI as a command-line usage error, blaming the operator's arguments for a
             # mangled Engine response.
-            raise EngineCatalogUnavailable(f"{url} did not answer readable JSON: {exc}") from exc
+            raise EngineCatalogUnavailable(_unreadable_body(url, response, exc)) from exc
         if attempt < attempts:
             time.sleep(retry_delay)
     raise (
@@ -403,7 +434,14 @@ def _print_report(report: SeedReport) -> None:
     for benchmark_id in report.rejected:
         print(f"REJECTED catalog entry {benchmark_id}: the board could not read it")
     if report.engine_error is not None:
-        print(f"engine catalog unavailable: {report.engine_error}")
+        # WHY loud: this is the path where the feature is OFF. The deploy still succeeds and
+        # the board still serves whatever it held, so nothing else here would tell anyone that
+        # benchmark text just stopped being refreshed.
+        print(f"WARNING engine catalog unavailable: {report.engine_error}")
+        print(
+            "WARNING benchmark text was NOT refreshed this deploy; the board is serving "
+            "whatever the last successful seed wrote"
+        )
 
 
 async def _run(

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -249,6 +249,7 @@ async def seed_from_sources(
     *,
     engine_url: str | None,
     configured: Sequence[SeedBenchmark],
+    engine_rows: Sequence[SeedBenchmark] | None = None,
     client: httpx.Client | None = None,
     retry_delay: float = _RETRY_DELAY_SECONDS,
 ) -> SeedReport:
@@ -262,9 +263,12 @@ async def seed_from_sources(
     Stage 1 — ask whether this board has ever been seeded from a catalogue, BEFORE writing
     anything. Reading this afterwards would let the pass count its own writes and call an empty
     board healthy.
-    Stage 2 — read the Engine catalogue when one is configured. A failure here is recorded, not
-    raised: re-seeding refreshes a populated board, so failing a Scoreboard deploy on an
-    unrelated service's health would cost availability and buy nothing.
+    Stage 2 — obtain the Engine's catalogue. There are two adapters for the same thing: a
+    deployment fetches it over HTTP, and a local stack — where the board and the Engine share
+    one virtualenv — hands its imported registry straight in as ``engine_rows``. Either way
+    those rows are Engine-owned. A fetch failure is recorded, not raised: re-seeding refreshes
+    a populated board, so failing a Scoreboard deploy on an unrelated service's health would
+    cost availability and buy nothing.
     Stage 3 — decide what configuration is allowed to write. Two entries are refused outright:
     one asserting a ``revision`` the Engine did not publish in this same pass (a revision is
     the Engine's claim about its own benchmark, and configuration restating it is the second
@@ -284,6 +288,10 @@ async def seed_from_sources(
         engine_url: the Engine to read, or None for a deployment that runs without one.
         configured: entries from deployment configuration — the retained legacy demos, plus
             anything the Engine does not publish.
+        engine_rows: the Engine's benchmarks supplied directly, for a caller that already has
+            the registry in process. Given these, nothing is fetched and ``engine_url`` is
+            unused. Passing registry rows as ``configured`` instead would be a bug: they carry
+            revisions, so the Stage 3 refusal would reject every one of them.
         client: an HTTP client to use instead of opening one (see
             :func:`fetch_engine_benchmarks`).
         retry_delay: seconds between catalogue attempts (see
@@ -300,17 +308,17 @@ async def seed_from_sources(
     engine_owned = {row.id for row in await store.list_benchmarks() if row.revision is not None}
 
     report = SeedReport()
-    engine_rows: list[SeedBenchmark] = []
-    if engine_url:
+    published_rows: list[SeedBenchmark] = list(engine_rows) if engine_rows is not None else []
+    if engine_rows is None and engine_url:
         try:
             read = fetch_engine_benchmarks(engine_url, client=client, retry_delay=retry_delay)
         except EngineCatalogUnavailable as exc:
             report.engine_error = str(exc)
         else:
-            engine_rows = read.rows
+            published_rows = read.rows
             report.rejected = read.rejected
 
-    published = {row.id for row in engine_rows}
+    published = {row.id for row in published_rows}
     allowed: list[SeedBenchmark] = []
     for row in configured:
         if row.id in published:
@@ -322,7 +330,7 @@ async def seed_from_sources(
     report.shadowed.sort()
     report.refused.sort()
 
-    report.seeded = await seed_benchmarks([*engine_rows, *allowed])
+    report.seeded = await seed_benchmarks([*published_rows, *allowed])
     report.bootstrap_failed = report.engine_error is not None and not seeded_before
     return report
 
@@ -398,15 +406,21 @@ def _print_report(report: SeedReport) -> None:
         print(f"engine catalog unavailable: {report.engine_error}")
 
 
-async def _run(configured: Sequence[SeedBenchmark], engine_url: str | None) -> int:
-    if not configured and not engine_url:
+async def _run(
+    configured: Sequence[SeedBenchmark],
+    engine_url: str | None,
+    engine_rows: Sequence[SeedBenchmark] | None = None,
+) -> int:
+    if not configured and not engine_url and not engine_rows:
         print("no benchmarks configured")
         return 0
 
     settings = Settings()
     await init_db(settings.database_url)
     try:
-        report = await seed_from_sources(engine_url=engine_url, configured=configured)
+        report = await seed_from_sources(
+            engine_url=engine_url, configured=configured, engine_rows=engine_rows
+        )
         _print_report(report)
         if report.bootstrap_failed:
             print("no benchmark carries an Engine revision: this board has never been seeded")

--- a/apps/scoreboard/tests/fixtures/engine_catalog.json
+++ b/apps/scoreboard/tests/fixtures/engine_catalog.json
@@ -5,7 +5,7 @@
       "object": "benchmark",
       "id": "draco",
       "title": "DRACO",
-      "description": "A 100-task DRACO reproduction with official score arithmetic. It uses the successor Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a host-only approximation of the reference blocklist, so its scores are not paper-identical.",
+      "description": "A 100-task DRACO reproduction with official score arithmetic. It uses the successor Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a host-only approximation of the reference blocklist, so its scores are not paper-identical. Every answer is judged five times — the paper's stability protocol.",
       "revision": "66a463248586b277",
       "case_count": 100,
       "focus": "Research reports with citations",
@@ -16,6 +16,22 @@
         "expected_check_cost": "paid"
       },
       "href": "/v1/benchmarks/draco"
+    },
+    {
+      "object": "benchmark",
+      "id": "draco-3pass",
+      "title": "DRACO 3-Pass",
+      "description": "The DRACO 100-case reproduction judged three times per answer instead of five. Identical dataset, criteria, Judge, and retrieval policy to the canonical board — only the judge-pass count differs. The draco-cache-seed archive covers exactly these three passes, so re-running its candidates is served fully from the shared response cache; scores carry their own benchmark revision and are not compared against five-pass results.",
+      "revision": "b8c8afd8f9dddca0",
+      "case_count": 100,
+      "focus": "Research reports, three judge passes",
+      "dataset_url": "https://huggingface.co/datasets/perplexity-ai/draco",
+      "check_surface": {
+        "check_route": "/benchmarks/draco-3pass/b8c8afd8f9dddca0/check-surface/draco-pass.v1",
+        "feedback_intent": "feedback",
+        "expected_check_cost": "paid"
+      },
+      "href": "/v1/benchmarks/draco-3pass"
     },
     {
       "object": "benchmark",

--- a/apps/scoreboard/tests/fixtures/engine_catalog.json
+++ b/apps/scoreboard/tests/fixtures/engine_catalog.json
@@ -1,0 +1,68 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "benchmark",
+      "id": "draco",
+      "title": "DRACO",
+      "description": "A 100-task DRACO reproduction with official score arithmetic. It uses the successor Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a host-only approximation of the reference blocklist, so its scores are not paper-identical.",
+      "revision": "66a463248586b277",
+      "case_count": 100,
+      "focus": "Research reports with citations",
+      "dataset_url": "https://huggingface.co/datasets/perplexity-ai/draco",
+      "check_surface": {
+        "check_route": "/benchmarks/draco/66a463248586b277/check-surface/draco-pass.v1",
+        "feedback_intent": "feedback",
+        "expected_check_cost": "paid"
+      },
+      "href": "/v1/benchmarks/draco"
+    },
+    {
+      "object": "benchmark",
+      "id": "healthbench-professional",
+      "title": "HealthBench Professional",
+      "description": "The complete 525-conversation HealthBench Professional exam. An AI judge grades each answer against a physician-written rubric; safety mistakes subtract points, so an individual case can score below zero. Benchmark score = the official HealthBench metric — the average of the 525 case scores, floored at 0 — so it lines up with published HealthBench numbers.",
+      "revision": "d8fb037307f35415",
+      "case_count": 525,
+      "focus": "Clinical safety, full official exam",
+      "dataset_url": "https://huggingface.co/datasets/openai/healthbench",
+      "check_surface": {
+        "check_route": "/benchmarks/healthbench-professional/d8fb037307f35415/check-surface/healthbench-pass.v1",
+        "feedback_intent": "feedback",
+        "expected_check_cost": "paid"
+      },
+      "href": "/v1/benchmarks/healthbench-professional"
+    },
+    {
+      "object": "benchmark",
+      "id": "healthbench-worst30",
+      "title": "HealthBench Worst-30% Challenge",
+      "description": "The 157 hardest conversations from HealthBench Professional — the 30% that top models score worst on. An AI judge grades each answer against a physician-written rubric; safety mistakes subtract points, so per-case scores can be negative. Challenge score = plain average of the 157 case scores, negatives kept (the official HealthBench score floors negative averages at 0, which would flatten this hard subset to all-zeros).",
+      "revision": "39cfd96b068f7230",
+      "case_count": 157,
+      "focus": "Clinical safety, hardest cases",
+      "dataset_url": "https://huggingface.co/datasets/openai/healthbench",
+      "check_surface": {
+        "check_route": "/benchmarks/healthbench-worst30/39cfd96b068f7230/check-surface/healthbench-pass.v1",
+        "feedback_intent": "feedback",
+        "expected_check_cost": "paid"
+      },
+      "href": "/v1/benchmarks/healthbench-worst30"
+    },
+    {
+      "object": "benchmark",
+      "id": "ifeval",
+      "title": "IFEval",
+      "description": "The canonical 541-prompt instruction-following benchmark (https://arxiv.org/abs/2311.07911), graded by deterministic strict and loose verification. Each Case invokes the Candidate exactly once. Case ids are the official IFEval keys; one pinned-dataset row (key 2785) is patched to the official harness prompt, whose text matches its graded constraints.",
+      "revision": "1cba769ece27f7ef",
+      "case_count": 541,
+      "focus": "Instruction following",
+      "check_surface": {
+        "check_route": "/benchmarks/ifeval/1cba769ece27f7ef/check-surface",
+        "feedback_intent": "feedback",
+        "expected_check_cost": "free"
+      },
+      "href": "/v1/benchmarks/ifeval"
+    }
+  ]
+}

--- a/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
+++ b/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
@@ -6,6 +6,7 @@ STORY: as a leaderboard reader, I see what a benchmark tests without leaving the
 
 from __future__ import annotations
 
+import json
 import tomllib
 from collections.abc import Callable
 from pathlib import Path
@@ -506,3 +507,56 @@ async def test_supplied_registry_rows_are_used_instead_of_fetching(tortoise_db: 
         )
 
     assert [row.id for row in report.seeded] == ["draco"]
+
+
+# --- review findings: the catalogue this parser will actually meet ---------------------------
+
+
+async def test_the_real_engine_response_parses_into_every_board_row() -> None:
+    # WHY a recorded fixture: every other test here feeds this parser a payload written in this
+    # repo, so they prove the parser agrees with ITSELF. The bug this ticket fixes lived in a
+    # deploy-time path no test executed. `engine_catalog.json` is the actual body
+    # `rest/benchmarks.py` assembles from the real registry — regenerate it with the header in
+    # that file when the Engine's catalogue shape changes.
+    payload = json.loads(
+        (Path(__file__).resolve().parents[1] / "fixtures" / "engine_catalog.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    with _serving(payload) as client:
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert read.rejected == []
+    assert [row.id for row in read.rows] == [
+        "draco",
+        "healthbench-professional",
+        "healthbench-worst30",
+        "ifeval",
+    ]
+    draco = read.rows[0]
+    assert draco.display_name == "DRACO"
+    assert draco.description is not None
+    assert draco.description.startswith("A 100-task DRACO reproduction")
+    assert draco.revision
+    assert draco.focus == "Research reports with citations"
+    # INVARIANT: the Engine publishes keys this board does not store (case_count, href,
+    # check_surface). Meeting one must never cost a benchmark its row.
+    assert {"case_count", "href", "check_surface"} <= set(payload["data"][0])
+
+
+async def test_an_auth_proxy_sign_in_page_is_diagnosed_rather_than_just_rejected() -> None:
+    # WHY: the obvious hostname to paste into engineUrl is the PUBLIC one, and that host sits
+    # behind Cloudflare Access — verified 2026-08-20, it answers 200 with an HTML sign-in page.
+    # Every layer then behaves correctly and the feature is silently off, so the error message
+    # is the only thing standing between an operator and a long afternoon.
+    page = "<!DOCTYPE html><html><head><title>Sign in ・ Cloudflare Access</title></head></html>"
+    with _client(
+        lambda request: httpx.Response(
+            200, text=page, headers={"content-type": "text/html; charset=utf-8"}
+        )
+    ) as client:
+        with pytest.raises(EngineCatalogUnavailable, match="text/html") as raised:
+            fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert "in-cluster" in str(raised.value)

--- a/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
+++ b/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
@@ -527,14 +527,13 @@ async def test_the_real_engine_response_parses_into_every_board_row() -> None:
     with _serving(payload) as client:
         read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
+    # WHY not a hardcoded id list: benchmarks get added, and a test that names them turns every
+    # new board into a failure here. The invariant is that EVERY published benchmark survives
+    # the trip — that is what breaks when the Engine renames or outgrows a field.
     assert read.rejected == []
-    assert [row.id for row in read.rows] == [
-        "draco",
-        "healthbench-professional",
-        "healthbench-worst30",
-        "ifeval",
-    ]
-    draco = read.rows[0]
+    assert len(read.rows) == len(payload["data"])
+    assert {row.id for row in read.rows} == {entry["id"] for entry in payload["data"]}
+    draco = next(row for row in read.rows if row.id == "draco")
     assert draco.display_name == "DRACO"
     assert draco.description is not None
     assert draco.description.startswith("A 100-task DRACO reproduction")

--- a/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
+++ b/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
@@ -6,7 +6,9 @@ STORY: as a leaderboard reader, I see what a benchmark tests without leaving the
 
 from __future__ import annotations
 
+import tomllib
 from collections.abc import Callable
+from pathlib import Path
 
 import httpx
 import pytest
@@ -71,9 +73,9 @@ def _refusing(exc: Exception) -> httpx.Client:
 
 async def test_a_catalog_entry_becomes_a_seed_row() -> None:
     with _serving(_CATALOG) as client:
-        rows = fetch_engine_benchmarks(ENGINE_URL, client=client)
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
-    draco = rows[0]
+    draco = read.rows[0]
     assert draco.id == "draco"
     # The Engine calls it `title`; the board's column is `display_name`. One mapping, one place.
     assert draco.display_name == "DRACO"
@@ -87,7 +89,7 @@ async def test_an_entry_without_display_extras_seeds_them_as_absent() -> None:
     # WHY: the Engine omits the key rather than sending null, and the portal already renders an
     # em dash for a benchmark with no focus line.
     with _serving(_CATALOG) as client:
-        ifeval = fetch_engine_benchmarks(ENGINE_URL, client=client)[1]
+        ifeval = fetch_engine_benchmarks(ENGINE_URL, client=client).rows[1]
 
     assert ifeval.focus is None
     assert ifeval.dataset_url is None
@@ -113,9 +115,9 @@ async def test_catalog_fields_the_board_does_not_display_are_ignored() -> None:
         ],
     }
     with _serving(payload) as client:
-        rows = fetch_engine_benchmarks(ENGINE_URL, client=client)
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
-    assert [row.id for row in rows] == ["draco"]
+    assert [row.id for row in read.rows] == ["draco"]
 
 
 async def test_the_catalog_path_is_appended_to_the_configured_engine_url() -> None:
@@ -139,26 +141,44 @@ async def test_a_transport_failure_is_reported_as_a_seed_error() -> None:
     # thing that failed, not leak a library's internals.
     with _refusing(httpx.ConnectError("no route to host")) as client:
         with pytest.raises(EngineCatalogUnavailable, match="engine.test"):
-            fetch_engine_benchmarks(ENGINE_URL, client=client)
+            fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
 
 async def test_an_error_status_is_reported_as_a_seed_error() -> None:
     with _serving({"detail": "down"}, status=503) as client:
         with pytest.raises(EngineCatalogUnavailable, match="503"):
-            fetch_engine_benchmarks(ENGINE_URL, client=client)
+            fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
 
 async def test_a_body_that_is_not_json_is_reported_as_a_seed_error() -> None:
     with _client(lambda request: httpx.Response(200, text="<html>proxy error</html>")) as client:
         with pytest.raises(EngineCatalogUnavailable):
-            fetch_engine_benchmarks(ENGINE_URL, client=client)
+            fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
 
-async def test_a_catalog_entry_missing_a_displayed_field_is_reported_as_a_seed_error() -> None:
-    payload = {"object": "list", "data": [{"id": "draco", "revision": "rev"}]}
+async def test_a_catalog_entry_missing_a_displayed_field_is_reported_and_skipped() -> None:
+    # WHY reported rather than fatal: one unreadable entry must not cost every other benchmark
+    # its refresh. The board keeps that one benchmark's old text and names it in the deploy log.
+    payload = {
+        "object": "list",
+        "data": [
+            {"id": "draco", "revision": "rev"},
+            {"id": "ifeval", "title": "IFEval", "description": "Text.", "revision": "rev-ifeval"},
+        ],
+    }
     with _serving(payload) as client:
-        with pytest.raises(EngineCatalogUnavailable):
-            fetch_engine_benchmarks(ENGINE_URL, client=client)
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert [row.id for row in read.rows] == ["ifeval"]
+    assert read.rejected == ["draco"]
+
+
+async def test_a_document_that_is_not_a_catalog_at_all_is_a_seed_error() -> None:
+    # INVARIANT: a missing envelope is not a partial read — there is nothing to skip past, so
+    # it fails rather than seeding an empty board.
+    with _serving({"totally": "unrelated"}) as client:
+        with pytest.raises(EngineCatalogUnavailable, match="unreadable catalog"):
+            fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
 
 # --- the Engine is the only copy, not merely the preferred one -------------------------------
@@ -174,7 +194,7 @@ async def test_an_engine_row_wins_over_a_configured_row_with_the_same_id(
     )
     with _serving(_CATALOG) as client:
         report = await seed_from_sources(
-            engine_url=ENGINE_URL, configured=configured, client=client
+            engine_url=ENGINE_URL, configured=configured, client=client, retry_delay=0
         )
 
     draco = await Benchmark.get(id="draco")
@@ -222,7 +242,7 @@ async def test_an_unreachable_engine_leaves_an_already_seeded_board_untouched(
 
     with _refusing(httpx.ConnectError("down")) as client:
         report = await seed_from_sources(
-            engine_url=ENGINE_URL, configured=configured, client=client
+            engine_url=ENGINE_URL, configured=configured, client=client, retry_delay=0
         )
 
     assert (await Benchmark.get(id="draco")).description == "Kept"
@@ -241,7 +261,7 @@ async def test_an_unreachable_engine_fails_when_no_row_carries_a_revision(
 
     with _refusing(httpx.ConnectError("down")) as client:
         report = await seed_from_sources(
-            engine_url=ENGINE_URL, configured=configured, client=client
+            engine_url=ENGINE_URL, configured=configured, client=client, retry_delay=0
         )
 
     assert report.bootstrap_failed is True
@@ -256,3 +276,183 @@ async def test_no_configured_engine_url_seeds_only_the_configured_rows(tortoise_
     assert [row.id for row in await Benchmark.all()] == ["hle"]
     assert report.engine_error is None
     assert report.bootstrap_failed is False
+
+
+# --- review findings: the promise must hold when things go wrong too ------------------------
+
+
+async def test_httpx_is_a_runtime_dependency_not_a_dev_one() -> None:
+    # INVARIANT: the seed job runs inside the production image, which is built with
+    # `uv sync --frozen --no-dev`. A dev-group-only dependency imported by scoreboard.seed is a
+    # ModuleNotFoundError at deploy that no test suite can see, because tests install the dev
+    # group. Every import in the shipped package must be declared under [project.dependencies].
+    manifest = tomllib.loads(
+        (Path(__file__).resolve().parents[2] / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    runtime = {
+        requirement.split(">")[0].split("=")[0].split("[")[0].strip()
+        for requirement in manifest["project"]["dependencies"]
+    }
+
+    assert "httpx" in runtime
+
+
+async def test_an_unreachable_engine_cannot_let_configuration_overwrite_an_engine_row(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: this is OME-904 reproduced by its own fix. The shadowing rule needs the
+    # catalogue to know what to shadow WITH; when the fetch fails it shadows nothing, and the
+    # deploy's own stale draco entry would overwrite the good row with a null description.
+    # A row carrying a revision is Engine-owned, and configuration may not overwrite one the
+    # Engine did not publish in this same pass.
+    await seed_benchmarks(
+        load_benchmarks_json(
+            '[{"id":"draco","display_name":"DRACO","description":"Good text",'
+            '"revision":"rev-draco"}]'
+        )
+    )
+    configured = load_benchmarks_json('[{"id":"draco","display_name":"Stale DRACO"}]')
+
+    with _refusing(httpx.ConnectError("down")) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=configured, client=client, retry_delay=0
+        )
+
+    draco = await Benchmark.get(id="draco")
+    assert draco.description == "Good text"
+    assert draco.display_name == "DRACO"
+    assert report.refused == ["draco"]
+
+
+async def test_configuration_may_never_assert_a_revision_the_engine_did_not_publish(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: a revision is the Engine's claim about its own benchmark. Configuration
+    # asserting one is the hand-copied second copy this ticket deletes, so it is refused and
+    # named rather than written.
+    configured = load_benchmarks_json(
+        '[{"id":"draco","display_name":"Stale DRACO","revision":"stale-rev"}]'
+    )
+
+    with _refusing(httpx.ConnectError("down")) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=configured, client=client, retry_delay=0
+        )
+
+    assert await Benchmark.filter(id="draco").exists() is False
+    assert report.refused == ["draco"]
+
+
+async def test_the_bootstrap_guard_cannot_be_satisfied_by_this_passs_own_writes(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: the guard asks "has a successful Engine seed ever run against this database",
+    # so it must read the database BEFORE this pass writes to it. Reading afterwards lets the
+    # pass count its own rows and call an empty board healthy.
+    configured = load_benchmarks_json(
+        '[{"id":"draco","display_name":"DRACO","revision":"stale-rev"},'
+        '{"id":"hle","display_name":"News Hallucinations"}]'
+    )
+
+    with _refusing(httpx.ConnectError("down")) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=configured, client=client, retry_delay=0
+        )
+
+    assert report.bootstrap_failed is True
+
+
+async def test_an_unconfigured_engine_url_names_every_entry_claiming_to_be_an_engine_benchmark(
+    tortoise_db: None,
+) -> None:
+    # WHY: the likeliest misconfiguration is a deploy repo that upgrades the chart without
+    # adding engineUrl. Nothing is fetched, so nothing errors, and the board would quietly seed
+    # the old list and exit 0 — the original bug with no log line to find it by.
+    configured = load_benchmarks_json(
+        '[{"id":"draco","display_name":"DRACO","revision":"stale-rev"}]'
+    )
+
+    report = await seed_from_sources(engine_url=None, configured=configured)
+
+    assert report.refused == ["draco"]
+    assert await Benchmark.filter(id="draco").exists() is False
+
+
+async def test_one_unusable_entry_does_not_reject_the_whole_catalog() -> None:
+    # WHY: rejecting the batch means every untouched benchmark silently keeps its old text
+    # because one of them grew a focus line past the board's column width.
+    payload = {
+        "object": "list",
+        "data": [
+            {
+                "id": "draco",
+                "title": "DRACO",
+                "description": "Text.",
+                "revision": "rev-draco",
+                "focus": "x" * 200,
+            },
+            {"id": "ifeval", "title": "IFEval", "description": "Text.", "revision": "rev-ifeval"},
+        ],
+    }
+    with _serving(payload) as client:
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert [row.id for row in read.rows] == ["ifeval"]
+    assert read.rejected == ["draco"]
+
+
+async def test_a_redirect_is_followed_rather_than_reported_as_a_failure() -> None:
+    # WHY: an http->https or trailing-slash redirect at the ingress is ordinary. Treating one
+    # as an outage means the board never updates again and never says why.
+    def _redirect(request: httpx.Request) -> httpx.Response:
+        if request.url.scheme == "http":
+            return httpx.Response(301, headers={"location": "https://engine.test/v1/benchmarks"})
+        return httpx.Response(200, json=_CATALOG)
+
+    with _client(_redirect) as client:
+        read = fetch_engine_benchmarks("http://engine.test", client=client)
+
+    assert [row.id for row in read.rows] == ["draco", "ifeval"]
+
+
+async def test_a_body_that_is_not_valid_utf8_is_reported_as_a_seed_error() -> None:
+    # INVARIANT: `.json()` raises UnicodeDecodeError here, not JSONDecodeError. Both are
+    # ValueErrors, so an uncaught one used to surface as a command-line usage error — the deploy
+    # log blamed the operator's arguments for a mangled Engine response.
+    with _client(lambda request: httpx.Response(200, content=b'{"a": "\xff\xfe"}')) as client:
+        with pytest.raises(EngineCatalogUnavailable):
+            fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+
+async def test_a_transient_failure_is_retried_before_the_engine_is_called_unreachable() -> None:
+    # WHY: a Helm upgrade that rolls Scoreboard and Engine together can land this single GET in
+    # the Engine's restart window. Exiting 0 is right for a populated board, but it also means
+    # Kubernetes never retries the Job, so one unlucky second costs a whole release.
+    attempts: list[int] = []
+
+    def _flaky(request: httpx.Request) -> httpx.Response:
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise httpx.ConnectError("still starting")
+        return httpx.Response(200, json=_CATALOG)
+
+    with _client(_flaky) as client:
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert len(attempts) == 3
+    assert [row.id for row in read.rows] == ["draco", "ifeval"]
+
+
+async def test_a_client_error_is_not_retried() -> None:
+    # WHY: a 404 does not become a 200 by asking again; retrying only delays the deploy.
+    attempts: list[int] = []
+
+    def _missing(request: httpx.Request) -> httpx.Response:
+        attempts.append(1)
+        return httpx.Response(404)
+
+    with _client(_missing) as client:
+        with pytest.raises(EngineCatalogUnavailable, match="404"):
+            fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert len(attempts) == 1

--- a/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
+++ b/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
@@ -1,0 +1,258 @@
+"""Benchmark prose is seeded from the Engine catalogue, never from chart values (OME-904).
+
+FEATURE: benchmark descriptions on the leaderboard, with one authoring site.
+STORY: as a leaderboard reader, I see what a benchmark tests without leaving the board.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from scoreboard.scores.models import Benchmark
+from scoreboard.seed import (
+    EngineCatalogUnavailable,
+    fetch_engine_benchmarks,
+    load_benchmarks_json,
+    seed_benchmarks,
+    seed_from_sources,
+)
+
+pytestmark = pytest.mark.asyncio
+
+ENGINE_URL = "https://engine.test"
+
+_CATALOG = {
+    "object": "list",
+    "data": [
+        {
+            "object": "benchmark",
+            "id": "draco",
+            "title": "DRACO",
+            "description": "A 100-task DRACO reproduction with official score arithmetic.",
+            "revision": "rev-draco",
+            "case_count": 100,
+            "focus": "Research reports with citations",
+            "dataset_url": "https://huggingface.co/datasets/perplexity-ai/draco",
+            "href": "/v1/benchmarks/draco",
+        },
+        {
+            "object": "benchmark",
+            "id": "ifeval",
+            "title": "IFEval",
+            "description": "The canonical 541-prompt instruction-following benchmark.",
+            "revision": "rev-ifeval",
+            "case_count": 541,
+            "href": "/v1/benchmarks/ifeval",
+        },
+    ],
+}
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _serving(payload: object, *, status: int = 200) -> httpx.Client:
+    return _client(lambda request: httpx.Response(status, json=payload))
+
+
+def _refusing(exc: Exception) -> httpx.Client:
+    def _raise(request: httpx.Request) -> httpx.Response:
+        raise exc
+
+    return _client(_raise)
+
+
+# --- reading the catalogue ------------------------------------------------------------------
+
+
+async def test_a_catalog_entry_becomes_a_seed_row() -> None:
+    with _serving(_CATALOG) as client:
+        rows = fetch_engine_benchmarks(ENGINE_URL, client=client)
+
+    draco = rows[0]
+    assert draco.id == "draco"
+    # The Engine calls it `title`; the board's column is `display_name`. One mapping, one place.
+    assert draco.display_name == "DRACO"
+    assert draco.description == "A 100-task DRACO reproduction with official score arithmetic."
+    assert draco.revision == "rev-draco"
+    assert draco.focus == "Research reports with citations"
+    assert draco.dataset_url == "https://huggingface.co/datasets/perplexity-ai/draco"
+
+
+async def test_an_entry_without_display_extras_seeds_them_as_absent() -> None:
+    # WHY: the Engine omits the key rather than sending null, and the portal already renders an
+    # em dash for a benchmark with no focus line.
+    with _serving(_CATALOG) as client:
+        ifeval = fetch_engine_benchmarks(ENGINE_URL, client=client)[1]
+
+    assert ifeval.focus is None
+    assert ifeval.dataset_url is None
+    assert ifeval.revision == "rev-ifeval"
+
+
+async def test_catalog_fields_the_board_does_not_display_are_ignored() -> None:
+    # INVARIANT: the Engine may grow its catalogue (case_count, href, check_surface, whatever
+    # comes next) without breaking a deploy. The board reads the fields it displays and no more.
+    payload = {
+        "object": "list",
+        "data": [
+            {
+                "id": "draco",
+                "title": "DRACO",
+                "description": "Text.",
+                "revision": "rev",
+                "case_count": 100,
+                "href": "/v1/benchmarks/draco",
+                "check_surface": {"check_route": "/x", "feedback_intent": "f"},
+                "a_field_invented_next_quarter": True,
+            }
+        ],
+    }
+    with _serving(payload) as client:
+        rows = fetch_engine_benchmarks(ENGINE_URL, client=client)
+
+    assert [row.id for row in rows] == ["draco"]
+
+
+async def test_the_catalog_path_is_appended_to_the_configured_engine_url() -> None:
+    seen: list[str] = []
+
+    def _record(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, json={"object": "list", "data": []})
+
+    with _client(_record) as client:
+        fetch_engine_benchmarks("https://engine.test/", client=client)
+
+    assert seen == ["https://engine.test/v1/benchmarks"]
+
+
+# --- refusing to guess when the catalogue cannot be read -------------------------------------
+
+
+async def test_a_transport_failure_is_reported_as_a_seed_error() -> None:
+    # INVARIANT: an httpx exception never escapes the seed module. The deploy log must name the
+    # thing that failed, not leak a library's internals.
+    with _refusing(httpx.ConnectError("no route to host")) as client:
+        with pytest.raises(EngineCatalogUnavailable, match="engine.test"):
+            fetch_engine_benchmarks(ENGINE_URL, client=client)
+
+
+async def test_an_error_status_is_reported_as_a_seed_error() -> None:
+    with _serving({"detail": "down"}, status=503) as client:
+        with pytest.raises(EngineCatalogUnavailable, match="503"):
+            fetch_engine_benchmarks(ENGINE_URL, client=client)
+
+
+async def test_a_body_that_is_not_json_is_reported_as_a_seed_error() -> None:
+    with _client(lambda request: httpx.Response(200, text="<html>proxy error</html>")) as client:
+        with pytest.raises(EngineCatalogUnavailable):
+            fetch_engine_benchmarks(ENGINE_URL, client=client)
+
+
+async def test_a_catalog_entry_missing_a_displayed_field_is_reported_as_a_seed_error() -> None:
+    payload = {"object": "list", "data": [{"id": "draco", "revision": "rev"}]}
+    with _serving(payload) as client:
+        with pytest.raises(EngineCatalogUnavailable):
+            fetch_engine_benchmarks(ENGINE_URL, client=client)
+
+
+# --- the Engine is the only copy, not merely the preferred one -------------------------------
+
+
+async def test_an_engine_row_wins_over_a_configured_row_with_the_same_id(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: this is what makes the Engine the ONLY copy. A deploy that reintroduces prose
+    # under a published id is ignored, so the text cannot drift back into configuration.
+    configured = load_benchmarks_json(
+        '[{"id":"draco","display_name":"Stale DRACO","description":"Hand-typed copy"}]'
+    )
+    with _serving(_CATALOG) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=configured, client=client
+        )
+
+    draco = await Benchmark.get(id="draco")
+    assert draco.display_name == "DRACO"
+    assert draco.description == "A 100-task DRACO reproduction with official score arithmetic."
+    assert report.shadowed == ["draco"]
+
+
+async def test_a_configured_row_the_engine_does_not_publish_is_kept(tortoise_db: None) -> None:
+    # WHY: the legacy demo entries predate the Engine catalogue and have no Engine counterpart.
+    configured = load_benchmarks_json(
+        '[{"id":"hle","display_name":"News Hallucinations","description":"OpenMined HLE"}]'
+    )
+    with _serving(_CATALOG) as client:
+        await seed_from_sources(engine_url=ENGINE_URL, configured=configured, client=client)
+
+    assert sorted(row.id for row in await Benchmark.all()) == ["draco", "hle", "ifeval"]
+
+
+async def test_the_seeded_revision_is_the_catalog_revision(tortoise_db: None) -> None:
+    # INVARIANT: a submission carries the Engine's revision and the board ranks per revision.
+    # Both values now come from one response, so they cannot drift apart the way a hand-copied
+    # chart value did.
+    configured = load_benchmarks_json('[{"id":"draco","display_name":"X","revision":"stale"}]')
+    with _serving(_CATALOG) as client:
+        await seed_from_sources(engine_url=ENGINE_URL, configured=configured, client=client)
+
+    assert (await Benchmark.get(id="draco")).revision == "rev-draco"
+
+
+# --- what happens when the Engine is unreachable at deploy -----------------------------------
+
+
+async def test_an_unreachable_engine_leaves_an_already_seeded_board_untouched(
+    tortoise_db: None,
+) -> None:
+    # WHY not fail the deploy: re-seeding refreshes a populated board, so blocking a Scoreboard
+    # release on an unrelated service's health would cost availability and buy nothing.
+    await seed_benchmarks(
+        load_benchmarks_json(
+            '[{"id":"draco","display_name":"DRACO","description":"Kept","revision":"rev-draco"}]'
+        )
+    )
+    configured = load_benchmarks_json('[{"id":"hle","display_name":"News Hallucinations"}]')
+
+    with _refusing(httpx.ConnectError("down")) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=configured, client=client
+        )
+
+    assert (await Benchmark.get(id="draco")).description == "Kept"
+    assert await Benchmark.filter(id="hle").exists()
+    assert report.engine_error is not None
+    assert report.bootstrap_failed is False
+
+
+async def test_an_unreachable_engine_fails_when_no_row_carries_a_revision(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: only a benchmark the Engine published carries a revision, so "no row has one"
+    # means no successful seed has ever run. Exiting zero there would publish a board holding
+    # nothing but legacy demo entries and call it a success.
+    configured = load_benchmarks_json('[{"id":"hle","display_name":"News Hallucinations"}]')
+
+    with _refusing(httpx.ConnectError("down")) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=configured, client=client
+        )
+
+    assert report.bootstrap_failed is True
+
+
+async def test_no_configured_engine_url_seeds_only_the_configured_rows(tortoise_db: None) -> None:
+    # WHY: a local or test deployment may run the board without an Engine at all.
+    configured = load_benchmarks_json('[{"id":"hle","display_name":"News Hallucinations"}]')
+
+    report = await seed_from_sources(engine_url=None, configured=configured)
+
+    assert [row.id for row in await Benchmark.all()] == ["hle"]
+    assert report.engine_error is None
+    assert report.bootstrap_failed is False

--- a/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
+++ b/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
@@ -456,3 +456,53 @@ async def test_a_client_error_is_not_retried() -> None:
             fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
     assert len(attempts) == 1
+
+
+# --- the in-process adapter: a local stack imports the registry instead of fetching it -------
+
+
+async def test_registry_rows_are_engine_rows_not_configuration(tortoise_db: None) -> None:
+    # INVARIANT: a local stack (the pip-installable runtime) runs Engine and board in one venv,
+    # so it reads the registry by import rather than over HTTP. Those rows are just as
+    # Engine-owned as fetched ones — passing them as `configured` would trip the refusal rule
+    # (they carry revisions) and seed an empty local leaderboard.
+    engine_rows = load_benchmarks_json(
+        '[{"id":"draco","display_name":"DRACO","description":"From the registry",'
+        '"revision":"rev-draco","focus":"Research reports with citations"}]'
+    )
+
+    report = await seed_from_sources(engine_url=None, engine_rows=engine_rows, configured=[])
+
+    draco = await Benchmark.get(id="draco")
+    assert draco.description == "From the registry"
+    assert draco.revision == "rev-draco"
+    assert draco.focus == "Research reports with citations"
+    assert report.refused == []
+    assert report.engine_error is None
+
+
+async def test_supplied_registry_rows_still_win_over_configuration(tortoise_db: None) -> None:
+    engine_rows = load_benchmarks_json('[{"id":"draco","display_name":"DRACO"}]')
+    configured = load_benchmarks_json('[{"id":"draco","display_name":"Stale"}]')
+
+    report = await seed_from_sources(
+        engine_url=None, engine_rows=engine_rows, configured=configured
+    )
+
+    assert (await Benchmark.get(id="draco")).display_name == "DRACO"
+    assert report.shadowed == ["draco"]
+
+
+async def test_supplied_registry_rows_are_used_instead_of_fetching(tortoise_db: None) -> None:
+    # WHY: the local stack has no Engine URL at all, and must never reach the network to seed.
+    def _explode(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("the in-process adapter must not make an HTTP request")
+
+    engine_rows = load_benchmarks_json('[{"id":"draco","display_name":"DRACO"}]')
+
+    with _client(_explode) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, engine_rows=engine_rows, configured=[], client=client
+        )
+
+    assert [row.id for row in report.seeded] == ["draco"]

--- a/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
+++ b/apps/scoreboard/tests/unit/test_seed_engine_catalog.py
@@ -560,3 +560,51 @@ async def test_an_auth_proxy_sign_in_page_is_diagnosed_rather_than_just_rejected
             fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
 
     assert "in-cluster" in str(raised.value)
+
+
+# --- owner decision: a missing description costs text, never the whole benchmark -------------
+
+
+@pytest.mark.parametrize("prose", ["", "   "])
+async def test_a_benchmark_without_prose_still_registers(prose: str) -> None:
+    # WHY not reject it: the consequence of rejecting is a benchmark MISSING from the board —
+    # no row, and a submission against it refused — which is far worse than a row that reads
+    # plain. The Engine already refuses to define a benchmark without a description, so this
+    # side is deliberately the lenient one: require it where it is written, tolerate it where
+    # it is read.
+    payload = {
+        "object": "list",
+        "data": [{"id": "draco", "title": "DRACO", "description": prose, "revision": "rev"}],
+    }
+    with _serving(payload) as client:
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert read.rejected == []
+    assert [row.id for row in read.rows] == ["draco"]
+    # INVARIANT: stored as absent, NOT as a placeholder sentence. The reader-facing wording
+    # ("No description published.") belongs to the client that renders it, in one place — a
+    # placeholder written into the database could never be told apart from real text later.
+    assert read.rows[0].description is None
+
+
+async def test_a_benchmark_with_no_description_field_at_all_still_registers() -> None:
+    payload = {
+        "object": "list",
+        "data": [{"id": "draco", "title": "DRACO", "revision": "rev"}],
+    }
+    with _serving(payload) as client:
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert read.rejected == []
+    assert read.rows[0].description is None
+
+
+async def test_an_entry_missing_its_identity_is_still_rejected() -> None:
+    # INVARIANT: leniency stops at the fields that make a row addressable. Without an id, a
+    # title or a revision there is nothing to register or rank; those still fail the entry.
+    payload = {"object": "list", "data": [{"title": "DRACO", "description": "Text."}]}
+    with _serving(payload) as client:
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert read.rows == []
+    assert read.rejected == ["entry #0"]

--- a/apps/scoreboard/uv.lock
+++ b/apps/scoreboard/uv.lock
@@ -603,6 +603,7 @@ version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "tortoise-orm", extra = ["asyncpg"] },
@@ -611,7 +612,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -622,6 +622,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.141.1" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "tortoise-orm", extras = ["asyncpg"], specifier = "==1.1.8" },
@@ -630,7 +631,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.28.1" },
     { name = "pyright", specifier = ">=1.1.411" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0,<2" },

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/definition.py
@@ -23,6 +23,12 @@ _BENCHMARK_ID = re.compile(r"[a-z0-9][a-z0-9._-]*")
 # scheme a browser will not follow (or a bare host that resolves relative to the board) is a
 # broken link published under the Engine's name.
 _WEB_URL = re.compile(r"https?://\S+")
+# WHY the Engine enforces the leaderboard's column widths: this definition is the ONE place a
+# benchmark's text is written (OME-904), which means an author here never runs the board's
+# validation. Without a cap, over-long text passes every Engine test and is only discovered at
+# the next deploy, where the board can do no better than skip that benchmark and keep its old
+# text. Fail where the text is written instead.
+_DISPLAY_LIMITS = {"title": 255, "revision": 64, "focus": 120}
 
 
 def _no_routes(_node: Url4Node, _assets_root: Path) -> None:
@@ -93,10 +99,7 @@ class Benchmark:
             value = getattr(self, name)
             if not isinstance(value, str) or not value.strip():
                 raise ValueError(f"Benchmark {name} must be non-empty text")
-        if self.focus is not None and (not isinstance(self.focus, str) or not self.focus.strip()):
-            raise ValueError("Benchmark focus must be non-empty text when declared")
-        if self.dataset_url is not None and not _WEB_URL.fullmatch(self.dataset_url):
-            raise ValueError("Benchmark dataset_url must be an absolute http(s) URL when declared")
+        self._validate_display_metadata()
         if not isinstance(self.id, str) or _BENCHMARK_ID.fullmatch(self.id) is None:
             raise ValueError("Benchmark id must be one lowercase identifier")
         if (
@@ -105,6 +108,21 @@ class Benchmark:
             or self.case_count < 1
         ):
             raise ValueError("Benchmark case_count must be a positive integer")
+
+    def _validate_display_metadata(self) -> None:
+        """Refuse text the leaderboard could not show (OME-904)."""
+
+        if self.focus is not None and (not isinstance(self.focus, str) or not self.focus.strip()):
+            raise ValueError("Benchmark focus must be non-empty text when declared")
+        if self.dataset_url is not None and not _WEB_URL.fullmatch(self.dataset_url):
+            raise ValueError("Benchmark dataset_url must be an absolute http(s) URL when declared")
+        for name, limit in _DISPLAY_LIMITS.items():
+            value = getattr(self, name)
+            if isinstance(value, str) and len(value) > limit:
+                raise ValueError(
+                    f"Benchmark {name} must be at most {limit} characters "
+                    "so the leaderboard can store it"
+                )
 
     def catalog_entry(self) -> dict[str, object]:
         """Return metadata sufficient for one-request Benchmark discovery."""

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/definition.py
@@ -19,6 +19,10 @@ type BenchmarkInstaller = Callable[[Url4Node, Path], None]
 type CheckCost = Literal["free", "paid"]
 
 _BENCHMARK_ID = re.compile(r"[a-z0-9][a-z0-9._-]*")
+# WHY only http(s): the dataset link is rendered as a clickable target on a public web page, so a
+# scheme a browser will not follow (or a bare host that resolves relative to the board) is a
+# broken link published under the Engine's name.
+_WEB_URL = re.compile(r"https?://\S+")
 
 
 def _no_routes(_node: Url4Node, _assets_root: Path) -> None:
@@ -74,12 +78,25 @@ class Benchmark:
     build: Callable[[int], Node]
     install: BenchmarkInstaller = _no_routes
     check_surface: CheckSurface | None = None
+    # FEATURE: benchmark descriptions on the leaderboard (OME-904). `title`, `description`,
+    # `focus` and `dataset_url` are the four fields the public board displays, and this
+    # definition is their ONLY authoring site — the board seeds them from the catalogue rather
+    # than from hand-copied deployment configuration.
+    # INVARIANT: neither field enters `revision`, which is computed from dataset and protocol
+    # constants alone. Editing editorial text must never make a recorded submission look
+    # incomparable.
+    focus: str | None = None
+    dataset_url: str | None = None
 
     def __post_init__(self) -> None:
         for name in ("title", "description", "revision"):
             value = getattr(self, name)
             if not isinstance(value, str) or not value.strip():
                 raise ValueError(f"Benchmark {name} must be non-empty text")
+        if self.focus is not None and (not isinstance(self.focus, str) or not self.focus.strip()):
+            raise ValueError("Benchmark focus must be non-empty text when declared")
+        if self.dataset_url is not None and not _WEB_URL.fullmatch(self.dataset_url):
+            raise ValueError("Benchmark dataset_url must be an absolute http(s) URL when declared")
         if not isinstance(self.id, str) or _BENCHMARK_ID.fullmatch(self.id) is None:
             raise ValueError("Benchmark id must be one lowercase identifier")
         if (
@@ -106,6 +123,10 @@ class Benchmark:
             "revision": self.revision,
             "case_count": self.case_count,
         }
+        if self.focus is not None:
+            metadata["focus"] = self.focus
+        if self.dataset_url is not None:
+            metadata["dataset_url"] = self.dataset_url
         if self.check_surface is not None:
             metadata["check_surface"] = self.check_surface.as_block()
         return metadata

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/definition.py
@@ -44,6 +44,10 @@ from screamingface_engine.benchmarks.draco.exam import (
     draco_benchmark,
 )
 
+# Both boards replay the same 100 DRACO tasks over the same public dataset; they differ only in
+# how many times each answer is judged.
+DRACO_DATASET_URL = "https://huggingface.co/datasets/perplexity-ai/draco"
+
 # ── Board 1 — the canonical five-pass reproduction ──────────────────────────────────
 CANONICAL_EXAM, DRACO = draco_benchmark(
     id="draco",
@@ -56,6 +60,8 @@ CANONICAL_EXAM, DRACO = draco_benchmark(
     ),
     judge_passes=5,
     protocol_revision="five-pass-reproduction-v1",
+    focus="Research reports with citations",
+    dataset_url=DRACO_DATASET_URL,
 )
 
 # ── Board 2 — the three-pass cache-seeded replay ────────────────────────────────────
@@ -71,6 +77,10 @@ THREE_PASS_EXAM, DRACO_3PASS = draco_benchmark(
         "against five-pass results."
     ),
     judge_passes=3,
+    # The dataset and the subject are identical to the canonical board; the pass count is the
+    # only thing a reader needs to tell them apart, so that is what the Focus column says.
+    focus="Research reports, three judge passes",
+    dataset_url=DRACO_DATASET_URL,
     protocol_revision="three-pass-reproduction-v1",
 )
 

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py
@@ -273,6 +273,8 @@ def draco_benchmark(
     description: str,
     judge_passes: int,
     protocol_revision: str,
+    focus: str | None = None,
+    dataset_url: str | None = None,
 ) -> tuple[DracoExam, Benchmark]:
     """Wire one DRACO board: identity → addresses → expression → private routes.
 
@@ -284,6 +286,9 @@ def draco_benchmark(
         judge_passes: how many times the Judge grades each answer (the pass seeds
             derive from it).
         protocol_revision: this board's own protocol version string (hashed).
+        focus: the short editorial line the leaderboard shows in its "Focus" column. It has
+            to separate this board from its siblings at a glance, since they share a dataset.
+        dataset_url: where a reader can go and look at the source data.
 
     Returns:
         ``(exam, benchmark)`` — the ``DracoExam`` for the runtime's private routes, and
@@ -322,6 +327,10 @@ def draco_benchmark(
         case_count=CASE_COUNT,
         build=build,
         install=install,
+        # FEATURE: benchmark descriptions on the leaderboard (OME-904). This definition is the
+        # only place the board's text is written; it is seeded from the catalogue at deploy.
+        focus=focus,
+        dataset_url=dataset_url,
         # The mid-run check is a real Judge call over the case rubric, so a corrective
         # loop's check budget is paid (same surface as canonical).
         check_surface=CheckSurface(

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/definition.py
@@ -34,6 +34,10 @@ from screamingface_engine.benchmarks.healthbench.exam import case_ids_sha, healt
 from screamingface_engine.benchmarks.healthbench.scoring import clipped_mean, unclipped_mean
 from screamingface_engine.benchmarks.healthbench.subset import WORST30_CASE_IDS, subset_sha
 
+# Both boards grade the same physician-written rubrics over the same public dataset; they
+# differ in which conversations they serve and how they average the per-case scores.
+HEALTHBENCH_DATASET_URL = "https://huggingface.co/datasets/openai/healthbench"
+
 # ── Board 1 — the worst-30% challenge ────────────────────────────────────────────────
 WORST30_EXAM, HEALTHBENCH_WORST30 = healthbench_benchmark(
     id="healthbench-worst30",
@@ -54,6 +58,8 @@ WORST30_EXAM, HEALTHBENCH_WORST30 = healthbench_benchmark(
     # worst-30% selection out of the dataset, so its fingerprint is taken over the
     # dataset's own stable row ids (subset.py).
     selection_sha=subset_sha(),
+    focus="Clinical safety, hardest cases",
+    dataset_url=HEALTHBENCH_DATASET_URL,
 )
 
 # ── Board 2 — the full professional exam ─────────────────────────────────────────────
@@ -82,6 +88,8 @@ PROFESSIONAL_EXAM, HEALTHBENCH_PROFESSIONAL = healthbench_benchmark(
     # WHY the Case ids, not dataset row ids: this board's selection IS "every position in
     # the baked file", so the id list is the honest fingerprint of what it serves.
     selection_sha=case_ids_sha(PROFESSIONAL_CASE_IDS),
+    focus="Clinical safety, full official exam",
+    dataset_url=HEALTHBENCH_DATASET_URL,
 )
 
 # AIDEV-NOTE: a board exposes exactly two names — the `Exam` (what the runtime installs:

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/exam.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/exam.py
@@ -261,6 +261,8 @@ def healthbench_benchmark(
     scoring: str,
     mean: ExamMean,
     selection_sha: str,
+    focus: str | None = None,
+    dataset_url: str | None = None,
 ) -> tuple[Exam, Benchmark]:
     """Wire one HealthBench board: identity → addresses → expression → private routes.
 
@@ -274,6 +276,9 @@ def healthbench_benchmark(
         scoring: this board's scoring-rule name (hashed) — the metric's identity.
         mean: the exam-level reduction over per-Case scores.
         selection_sha: the fingerprint of the case selection (hashed).
+        focus: the short editorial line the leaderboard shows in its "Focus" column. It has
+            to separate this board from its siblings at a glance, since they share a dataset.
+        dataset_url: where a reader can go and look at the source data.
 
     Returns:
         ``(exam, benchmark)`` — the ``Exam`` for the runtime's private routes, and the
@@ -314,6 +319,10 @@ def healthbench_benchmark(
         case_count=len(case_ids),
         build=build,
         install=install,
+        # FEATURE: benchmark descriptions on the leaderboard (OME-904). This definition is the
+        # only place the board's text is written; it is seeded from the catalogue at deploy.
+        focus=focus,
+        dataset_url=dataset_url,
         # Every check is a Judge call over the case rubric, so the loop's cost is real.
         check_surface=CheckSurface(
             check_route=exam.routes.check_surface,

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/definition.py
@@ -114,6 +114,9 @@ IFEVAL = Benchmark(
         "official IFEval keys; one pinned-dataset row (key 2785) is patched to the "
         "official harness prompt, whose text matches its graded constraints."
     ),
+    focus="Instruction following",
+    # WHY no dataset_url: the IFEval dataset is vendored inside this Engine
+    # (screamingface_engine.benchmarks.ifeval.vendor), so no single public URL is authoritative.
     revision=REVISION,
     case_count=CASE_COUNT,
     build=_build,

--- a/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
@@ -1,0 +1,149 @@
+"""The Engine owns every word the leaderboard shows about a Benchmark (OME-904).
+
+FEATURE: benchmark descriptions on the leaderboard, with one authoring site.
+STORY: as a leaderboard reader, I see what a benchmark tests without leaving the board.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from screamingface_engine.app import create_app
+from screamingface_engine.benchmarks import Benchmark, BenchmarkRegistry, candidate
+from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
+from screamingface_engine.config import Settings
+from screamingface_engine.testing import InMemoryEventStream
+
+pytestmark = pytest.mark.asyncio
+
+
+def _benchmark(*, focus: str | None = None, dataset_url: str | None = None) -> Benchmark:
+    return Benchmark(
+        id="example-smoke",
+        title="Example Smoke",
+        description="One non-comparable structural probe.",
+        revision="example-smoke-v1",
+        case_count=3,
+        build=lambda selected: candidate(
+            f"Explain why the sky looks blue. Selected cases: {selected}.",
+            web_search=False,
+        ),
+        focus=focus,
+        dataset_url=dataset_url,
+    )
+
+
+async def _catalog(benchmark: Benchmark) -> dict[str, object]:
+    app: FastAPI = create_app(
+        Settings(jwt_secret="s"),
+        stream=InMemoryEventStream(),
+        benchmarks=BenchmarkRegistry((benchmark,)),
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://engine.test",
+    ) as client:
+        entries = (await client.get("/v1/benchmarks")).json()["data"]
+    entry: dict[str, object] = entries[0]
+    return entry
+
+
+async def test_a_declared_focus_and_dataset_link_reach_the_catalog() -> None:
+    entry = await _catalog(
+        _benchmark(
+            focus="Structural probing",
+            dataset_url="https://huggingface.co/datasets/example/smoke",
+        )
+    )
+
+    assert entry["focus"] == "Structural probing"
+    assert entry["dataset_url"] == "https://huggingface.co/datasets/example/smoke"
+
+
+async def test_a_declared_focus_and_dataset_link_reach_the_detail_resource() -> None:
+    benchmark = _benchmark(
+        focus="Structural probing",
+        dataset_url="https://huggingface.co/datasets/example/smoke",
+    )
+
+    resource = benchmark.resource(1)
+
+    assert resource["focus"] == "Structural probing"
+    assert resource["dataset_url"] == "https://huggingface.co/datasets/example/smoke"
+
+
+async def test_a_benchmark_declaring_neither_publishes_neither_key() -> None:
+    # INVARIANT: absent display metadata is an absent key, never a null. A seeded row's
+    # focus/dataset columns are then left untouched rather than blanked by a null.
+    entry = await _catalog(_benchmark())
+
+    assert "focus" not in entry
+    assert "dataset_url" not in entry
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+async def test_a_blank_focus_line_is_refused(blank: str) -> None:
+    with pytest.raises(ValueError, match="focus"):
+        _benchmark(focus=blank)
+
+
+@pytest.mark.parametrize(
+    "reference",
+    ["/datasets/example", "huggingface.co/datasets/example", "ftp://example.invalid/x", ""],
+)
+async def test_a_dataset_link_that_is_not_an_absolute_web_url_is_refused(reference: str) -> None:
+    with pytest.raises(ValueError, match="dataset_url"):
+        _benchmark(dataset_url=reference)
+
+
+async def test_every_installed_benchmark_publishes_a_focus_line() -> None:
+    # STORY: the portal's "Focus" column is filled from the Engine, not hand-copied into a chart.
+    assert {benchmark.id: benchmark.focus for benchmark in BUILTIN_BENCHMARKS} == {
+        "draco": "Research reports with citations",
+        # Same dataset and subject as the canonical board — the judge-pass count is the only
+        # thing that separates them, so that is what a reader needs in the Focus column.
+        "draco-3pass": "Research reports, three judge passes",
+        # The two HealthBench boards share a dataset, so their focus lines have to separate
+        # them at a glance — that is the only place a reader sees the difference.
+        "healthbench-professional": "Clinical safety, full official exam",
+        "healthbench-worst30": "Clinical safety, hardest cases",
+        "ifeval": "Instruction following",
+    }
+
+
+async def test_only_the_benchmarks_with_a_public_dataset_publish_a_link() -> None:
+    # WHY IFEval has none: its dataset is vendored inside the Engine
+    # (screamingface_engine.benchmarks.ifeval.vendor), so no single public URL is authoritative.
+    assert {benchmark.id: benchmark.dataset_url for benchmark in BUILTIN_BENCHMARKS} == {
+        "draco": "https://huggingface.co/datasets/perplexity-ai/draco",
+        "draco-3pass": "https://huggingface.co/datasets/perplexity-ai/draco",
+        "healthbench-professional": "https://huggingface.co/datasets/openai/healthbench",
+        "healthbench-worst30": "https://huggingface.co/datasets/openai/healthbench",
+        "ifeval": None,
+    }
+
+
+async def test_the_catalog_publishes_the_computed_revision_untouched_by_display_metadata() -> None:
+    # INVARIANT: a submission carries the Engine's revision and the board ranks per revision, so
+    # a revision that moves makes every already-recorded submission look incomparable. `revision`
+    # is computed from dataset and protocol constants; editorial text must never reach it, and
+    # the wire value must be that computed value rather than anything derived from metadata.
+    entry = await _catalog(
+        _benchmark(focus="Structural probing", dataset_url="https://example.test/dataset")
+    )
+    plain = await _catalog(_benchmark())
+
+    assert entry["revision"] == plain["revision"] == "example-smoke-v1"
+
+
+async def test_the_catalog_publishes_every_installed_benchmarks_own_revision() -> None:
+    # AIDEV-NOTE: deliberately NOT a table of literal hashes. Pinning them here would recreate
+    # the very failure OME-904 removes — a hand-copied second copy that silently goes stale.
+    # The board no longer holds its own copy either: it seeds `revision` straight from this
+    # catalogue response.
+    for benchmark in BUILTIN_BENCHMARKS:
+        entry = await _catalog(benchmark)
+        assert entry["revision"] == benchmark.revision
+        assert entry["revision"]

--- a/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
@@ -177,3 +177,33 @@ async def test_text_too_long_for_the_board_to_store_is_refused_at_authoring_time
             _benchmark(title=value)
         else:
             _benchmark(revision=value)
+
+
+async def test_the_catalog_keeps_the_field_names_the_leaderboard_seeds_from() -> None:
+    """The catalogue is a PUBLISHED contract; the leaderboard reads these exact names.
+
+    INVARIANT: `apps/scoreboard/src/scoreboard/seed.py` fetches this document at deploy and
+    maps `title` onto its own `display_name` column. Rename or drop one of the required names
+    here and the board stops registering that benchmark — it lands in the seed job's `rejected`
+    list, so the benchmark quietly vanishes from the leaderboard while the Engine's own tests
+    stay green.
+
+    WHY assert it on this side: the two apps have separate virtualenvs and neither can import
+    the other, so no single test can run both halves of the handshake. The producer is the side
+    that can break the contract, so the producer is the side that pins it.
+
+    AIDEV-NOTE: changing anything here means changing `_CatalogEntry` in the Scoreboard's
+    `seed.py` in the same pull request. `focus` and `dataset_url` are optional on both sides,
+    so an older Engine that omits them still seeds correctly.
+    """
+
+    required = {"id", "title", "description", "revision"}
+    optional_display = {"focus", "dataset_url"}
+
+    for benchmark in BUILTIN_BENCHMARKS:
+        entry = await _catalog(benchmark)
+        assert required <= set(entry), f"{benchmark.id} lost a field the leaderboard seeds from"
+        for name in required:
+            assert isinstance(entry[name], str) and entry[name]
+        for name in optional_display & set(entry):
+            assert isinstance(entry[name], str) and entry[name]

--- a/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
@@ -19,12 +19,18 @@ from screamingface_engine.testing import InMemoryEventStream
 pytestmark = pytest.mark.asyncio
 
 
-def _benchmark(*, focus: str | None = None, dataset_url: str | None = None) -> Benchmark:
+def _benchmark(
+    *,
+    focus: str | None = None,
+    dataset_url: str | None = None,
+    title: str = "Example Smoke",
+    revision: str = "example-smoke-v1",
+) -> Benchmark:
     return Benchmark(
         id="example-smoke",
-        title="Example Smoke",
+        title=title,
         description="One non-comparable structural probe.",
-        revision="example-smoke-v1",
+        revision=revision,
         case_count=3,
         build=lambda selected: candidate(
             f"Explain why the sky looks blue. Selected cases: {selected}.",
@@ -147,3 +153,27 @@ async def test_the_catalog_publishes_every_installed_benchmarks_own_revision() -
         entry = await _catalog(benchmark)
         assert entry["revision"] == benchmark.revision
         assert entry["revision"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("focus", "x" * 121),
+        ("title", "x" * 256),
+        ("revision", "x" * 65),
+    ],
+)
+async def test_text_too_long_for_the_board_to_store_is_refused_at_authoring_time(
+    field: str, value: str
+) -> None:
+    # WHY the Engine enforces the board's limits: "one authoring site" means an Engine author
+    # never runs the board's validation. Without a cap here, a 130-character focus line passes
+    # every Engine test and is only discovered at the next deploy, where the board can do
+    # nothing better than skip that benchmark and keep its old text. Fail where it is written.
+    with pytest.raises(ValueError, match=field):
+        if field == "focus":
+            _benchmark(focus=value)
+        elif field == "title":
+            _benchmark(title=value)
+        else:
+            _benchmark(revision=value)

--- a/docs/plan/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/plan/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -1,0 +1,18 @@
+# OME-904 — Implementation plan
+
+1. Add Engine tests proving a `Benchmark` may declare a focus line and a dataset link, that both
+   reach the `/v1/benchmarks` catalogue entry, that a benchmark declaring neither omits the keys,
+   and that declaring them leaves every benchmark's revision unchanged.
+2. Give `Benchmark` optional `focus` and `dataset_url` fields with boundary validation, surface
+   them in the catalogue metadata, and move DRACO's, IFEval's, and the HealthBench challenge's
+   focus lines and dataset links out of the Scoreboard chart into their definitions.
+3. Add Scoreboard seed tests covering the catalogue fetch, the mapping onto seed rows, Engine
+   precedence over a shadowing configured id, an unreachable Engine leaving a populated board
+   untouched, and an unreachable Engine failing when no row carries a revision.
+4. Teach `scoreboard.seed` to fetch the catalogue from `SCOREBOARD_SEED_ENGINE_URL`, merge it
+   ahead of the configured entries, and raise a seed-owned error for every transport, status,
+   and payload failure rather than leaking an HTTP or JSON exception.
+5. Replace the chart's hand-typed benchmark prose with `seedBenchmarks.engineUrl`, keep only the
+   legacy demo entries, and render the new environment variable on the seed job.
+6. Run both stacks' gates, record the outcome in the work ledger, and open the OME-904 pull
+   request describing the single-copy invariant.

--- a/docs/spec/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/spec/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -1,0 +1,57 @@
+# OME-904 — Benchmark descriptions come from the Engine
+
+## Decision
+
+A benchmark's human-readable text — display name, description, focus line, dataset link — is
+owned by the Engine benchmark definition that the text describes, and by nothing else. The
+Scoreboard stops carrying a hand-typed second copy in chart values.
+
+The Engine `Benchmark` gains two optional metadata fields, `focus` and `dataset_url`, so that
+every field the leaderboard displays has exactly one authoring site. They join the existing
+catalogue entry served by `GET /v1/benchmarks`, which is public and requires no credential.
+
+The Scoreboard's seed job — the one-shot container Helm already runs on every install and
+upgrade — fetches that catalogue at deploy and writes one row per published benchmark. Chart
+values keep only two things: which Engine to ask, and the legacy demo entries that predate the
+Engine catalogue and have no Engine counterpart. A deploy-time values override can therefore
+change which Engine is consulted, but can no longer carry, alter, or omit benchmark prose,
+because prose no longer travels through configuration.
+
+Engine-published rows take precedence over configured rows sharing an id. Precedence is what
+makes the Engine the only copy rather than merely the preferred one: a configured entry that
+shadows a published benchmark is ignored and named in the job's output.
+
+When the Engine cannot be reached, the seed job writes the configured legacy rows and leaves
+existing rows untouched — a re-seed refreshes a populated board, so failing a Scoreboard deploy
+on an unrelated service's health buys nothing. It fails loudly in exactly the case where
+silence would publish an empty catalogue: no benchmark row in the database carries a revision,
+which is true only before the first successful seed.
+
+## Invariants
+
+- Benchmark description, focus, and dataset link have one authoring site: the Engine's
+  `Benchmark` definition. No other file in the repository restates them.
+- A seeded row's `revision` equals the Engine's computed revision for that benchmark, because
+  both are read from the same catalogue response in the same request.
+- Seeding stays idempotent: re-running writes the same rows and never duplicates or orphans.
+- The catalogue fetch is unauthenticated and read-only; the seed job holds no Engine credential.
+- An Engine-published benchmark's row wins over a configured entry with the same id, and the
+  shadowed id is reported.
+- Configured entries remain the only source for benchmarks the Engine does not publish.
+- A failed catalogue fetch never blanks or deletes a row that a previous seed wrote.
+- A failed catalogue fetch exits non-zero when no benchmark row carries a revision.
+- An Engine benchmark without a focus line or dataset link seeds those columns as null, and the
+  portal renders its existing em-dash fallback.
+- Adding `focus` and `dataset_url` does not enter any benchmark's revision computation, so no
+  previously recorded submission becomes incomparable.
+
+## Explicit limitations
+
+- The deployed Engine URL is deployment-owned configuration; this change supplies a repository
+  default and reads an override, but does not deploy the Engine.
+- Re-seeding the currently deployed board remains an owner action outside this repository; this
+  change is the durable fix, not the immediate unblock.
+- Legacy demo entries (`livetruth-latest`, `hle`, `livetruth`) keep hand-written values, because
+  no Engine benchmark defines them. They are retained, not adopted.
+- The Scoreboard's own `/v1/benchmarks` response shape is unchanged; only the values it serves
+  stop being null.

--- a/docs/tasks/2026-08-20-OME-904-leaderboard-benchmark-descriptions.md
+++ b/docs/tasks/2026-08-20-OME-904-leaderboard-benchmark-descriptions.md
@@ -1,0 +1,40 @@
+---
+id: OME-904
+linear_url: https://linear.app/openmined/issue/OME-904/show-benchmark-descriptions-on-the-leaderboard-engine-text-as-the-only
+status: in_progress
+type: bug
+priority: 2
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-20
+closed:
+---
+
+# Show benchmark descriptions on the leaderboard — engine text as the only copy
+
+Requested by Irina (2026-08-20). Investigation (verified live 2026-08-20):
+`GET /v1/benchmarks` on the deployed scoreboard returns `description: null` (and
+null focus/dataset_url) for all three benchmarks while `revision` is correct — the
+deployed seed list overrides the repo chart defaults (Helm replaces lists) and
+carries no text. The notebook rendering code is fine; the data is empty. Good 2-3
+line descriptions already exist in the engine benchmark definitions AND hand-copied
+in `apps/scoreboard/charts/scoreboard/values.yaml` — two drifting copies.
+
+Locked decision (owner-approved 2026-08-20): the engine's benchmark text becomes the
+ONLY copy — the scoreboard takes description/focus/dataset link from the engine
+definitions so a deploy override cannot lose the text again. Mechanism: the seed job
+reads the engine catalogue at deploy (`GET {engineUrl}/v1/benchmarks`, public), and the
+engine `Benchmark` gains `focus` + `dataset_url`. Shipped as one PR spanning both apps
+(owner override of the cross-cutting split rule).
+
+Deploy action required: set `seedBenchmarks.engineUrl` in the deploy repo values, or the
+board keeps seeding only the legacy demo entries.
+
+Surfaced during implementation: the revisions pinned in `values.yaml` are STALE relative
+to this checkout's engine (chart `1c58b3085912e304` vs computed `66a463248586b277` for
+draco, and likewise for ifeval and healthbench-worst30). Pre-existing drift, not caused
+here — and the reason the quick unblock would seed stale revisions.
+
+Quick unblock (owner, outside this repo): re-seed the deployed scoreboard with the
+full `values.yaml` entries — seeding is idempotent.
+
+Full body + sf-dark diagram: the Linear issue.

--- a/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -76,7 +76,41 @@ seeds only the configured rows.
   `description`, `focus`, `dataset_url`, and `revision` columns, so S1 does not apply.
 - **Commits:** see the OME-904 branch.
 - **Gates:** `run_gates.py screamingface-engine` ALL GATES GREEN; `run_gates.py scoreboard` ALL
-  GATES GREEN.
+  GATES GREEN. The review round ran with `--skip-append-only` under owner approval (below).
+
+## Review round (PR #657, 2026-08-20)
+
+Eight findings, all verified before any fix — two of them by executing the behaviour rather
+than reading it (`follow_redirects` defaults to False; `.json()` raises `UnicodeDecodeError`,
+not `JSONDecodeError`, on a non-UTF-8 body).
+
+- **Release-breaking:** `httpx` was declared under `[dependency-groups].dev` while the image is
+  built with `uv sync --frozen --no-dev`, so `import httpx` in `scoreboard.seed` would have
+  been a `ModuleNotFoundError` on every deploy. No test could see it, because tests install the
+  dev group. Moved to `[project.dependencies]`, relocked, and pinned by a test that reads
+  `pyproject.toml` — the only kind of test that can defend this.
+- **"Engine is the only copy" held on the happy path only.** With the catalogue unreadable
+  there is nothing to shadow with, so the deploy's own stale entries would have overwritten
+  good rows with null descriptions — OME-904 reproduced by its own fix. Configuration may now
+  never write an entry asserting a `revision` the Engine did not publish this pass, nor one
+  naming an existing Engine-owned row.
+- **The bootstrap guard read the database after writing to it**, so a configured entry carrying
+  a revision satisfied the guard with the row it had just written. The prior state is now read
+  before anything is seeded.
+- **The likeliest misconfiguration was silent** (chart upgraded without `engineUrl`). Those
+  entries are now refused and named loudly.
+- One unreadable catalogue entry rejected the whole batch; entries are now validated
+  independently, and the Engine enforces the board's column widths so over-long text fails
+  where it is written instead of at deploy.
+- Redirects are followed; `UnicodeDecodeError` is caught; the fetch retries transport failures
+  and 5xx (never a 4xx or a mangled body); and `parser.error` no longer wraps the whole run, so
+  an unrelated `ValueError` can no longer surface as a command-line usage error.
+
+Owner-approved prior-test edits (sdlc rule 5, 2026-08-20): 18 lines across two committed test
+files — five mechanical (the fetch returns a `CatalogRead` so it can report unreadable
+entries), eight adding `retry_delay=0` so failure tests do not sleep through the real backoff
+(28s -> 0.07s), three widening a fixture helper, and one changed expectation, because finding 5
+proved batch-rejection wrong. A new test covers the case that must still raise.
 - **Deviations:**
   - The plan's step 1 included pinning each installed benchmark's revision as a literal. That
     test was written, went red, and was replaced rather than satisfied: the three revisions the

--- a/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -173,6 +173,26 @@ Still open, and an owner call because it is CI configuration: the SDK lane is pa
 `packages/**`, so an Engine-only pull request never runs the seam tests. Adding
 `apps/screamingface-engine/**` to that filter would close it.
 
+### Second rebase (2026-08-21)
+
+`main` moved 24 commits ahead and DRACO went the way HealthBench had: refactored into a
+`draco_benchmark()` factory producing two boards (canonical five-pass, plus `draco-3pass` for
+cache-seeded replays). Resolved identically — `focus`/`dataset_url` threaded through the
+factory, both call sites passing them, one shared `DRACO_DATASET_URL` constant. The two boards
+share a dataset and a subject, so the Focus line carries the only difference a reader can see:
+"Research reports with citations" against "Research reports, three judge passes".
+
+Third new benchmark to land mid-branch, which made a testing mistake visible: the recorded-
+response test asserted a hardcoded roster of benchmark ids, so every added board failed it for
+no reason. Replaced (owner-approved, sdlc rule 5) with the invariant it was reaching for —
+every benchmark in the response survives the trip, whatever they are. A test that goes red for
+ordinary work teaches people to edit the test, which is the last reflex you want when it
+eventually goes red for a real one.
+
+Known limit of that trade: a benchmark silently DISAPPEARING from the Engine no longer fails
+this test, because both sides shrink together. It shows up as a deletion in the regenerated
+fixture instead, which is visible in review.
+
 Owner-approved prior-test edits (sdlc rule 5, 2026-08-20): 18 lines across two committed test
 files — five mechanical (the fetch returns a `CatalogRead` so it can report unreadable
 entries), eight adding `retry_delay=0` so failure tests do not sleep through the real backoff

--- a/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -146,8 +146,32 @@ All four verified before acting; the first by executing a request against the li
   case. Correct for a one-shot Job; documented as an AIDEV-NOTE because `seed_from_sources` is
   `async` and would tempt a caller into running it from a live server.
 - **An empty description drops the whole benchmark**, not just its text — no row, no board,
-  submissions refused. Intended, but a much larger consequence than the field suggests, so it
-  is now stated at the field.
+  submissions refused. Owner reversed the original intent (2026-08-20): a missing board is a
+  far worse failure than a plain-looking row, so the consumer now tolerates absent prose and
+  stores it as NULL. Not a placeholder sentence — `leaderboard_view.py` already renders "No
+  description published." for an absent one, and prose written into the database could never
+  be told apart later from prose an author actually wrote. Leniency stops at id/title/revision,
+  without which there is nothing to register or rank. The Engine still REFUSES to define a
+  benchmark without a description: require it where it is written, tolerate it where it is
+  read.
+
+### Testing the contract for real
+
+Filip's "nothing exercises a real Engine response" was the sharpest note, and the obvious fix —
+one test running both halves in process — turned out to be impossible: the two apps have
+separate virtualenvs by design, and the Client SDK's venv carries their source on its path but
+none of their dependencies (not even pydantic), because its local runtime installs those at use
+time. Verified, not assumed.
+
+What was done instead: the producer pins the contract on its own side
+(`test_the_catalog_keeps_the_field_names_the_leaderboard_seeds_from` asserts the catalogue keeps
+the exact field names the board seeds from, and says so), the consumer keeps the recorded real
+response as a fixture, and each half's docstring names the other so a rename finds both. The
+producer is the side that can break the contract, so the producer is the side that pins it.
+
+Still open, and an owner call because it is CI configuration: the SDK lane is path-filtered to
+`packages/**`, so an Engine-only pull request never runs the seam tests. Adding
+`apps/screamingface-engine/**` to that filter would close it.
 
 Owner-approved prior-test edits (sdlc rule 5, 2026-08-20): 18 lines across two committed test
 files — five mechanical (the fetch returns a `CatalogRead` so it can report unreadable

--- a/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -125,6 +125,30 @@ Process lesson: three stacks in this repo import `scoreboard.seed`, and I ran ga
 Changing a signature means grepping for callers across the whole monorepo, not across the app
 that owns the file.
 
+## Second review round (PR #657, 2026-08-20) — approved with four notes
+
+All four verified before acting; the first by executing a request against the live host.
+
+- **The obvious `engineUrl` value silently disables the feature.**
+  `https://fusion.dev.screamingface.ai/v1/benchmarks` answers **HTTP 200 with `content-type:
+  text/html`** — a Cloudflare Access sign-in page, not a 401. Every layer then behaves as
+  designed: status check passes, parse fails, failure is survivable, stale configured entries
+  are refused, job exits zero. Deploy looks clean, text never refreshes. Fixed three ways: the
+  parse error now names the content type and says the address must be in-cluster; the fallback
+  logs at WARNING and states that text was not refreshed; the chart comment records why the
+  public hostname is the wrong value.
+- **Nothing exercised a real Engine response.** Every test fed the parser a payload written in
+  this repo, so they proved the parser agrees with itself — the same shape as the bug being
+  fixed. Added `tests/fixtures/engine_catalog.json`, captured from the actual producer
+  (`catalog_entry()` over the real registry), and a test that parses it. It passed first run,
+  which is the confirmation that was missing rather than a fix.
+- **Blocking I/O inside an async caller** — sync `httpx.Client` + `time.sleep`, ~49s worst
+  case. Correct for a one-shot Job; documented as an AIDEV-NOTE because `seed_from_sources` is
+  `async` and would tempt a caller into running it from a live server.
+- **An empty description drops the whole benchmark**, not just its text — no row, no board,
+  submissions refused. Intended, but a much larger consequence than the field suggests, so it
+  is now stated at the field.
+
 Owner-approved prior-test edits (sdlc rule 5, 2026-08-20): 18 lines across two committed test
 files — five mechanical (the fetch returns a `CatalogRead` so it can report unreadable
 entries), eight adding `retry_delay=0` so failure tests do not sleep through the real backoff

--- a/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -1,0 +1,92 @@
+---
+ticket: OME-904
+stack: python
+status: in_progress
+started: 2026-08-20
+finished:
+---
+
+# OME-904 — Show benchmark descriptions on the leaderboard (engine text as the only copy)
+
+## Intent
+
+The leaderboard prints "No description published." for every benchmark because the
+deployed seed list carries ids + revisions only, and Helm replaces lists wholesale —
+so the descriptions hand-copied into `apps/scoreboard/charts/scoreboard/values.yaml`
+never reach the database. Good text already exists in the Engine benchmark definitions.
+This unit makes the Engine's benchmark catalogue the ONLY copy: the scoreboard seed job
+fetches `GET {engine}/v1/benchmarks` at deploy and writes description / focus /
+dataset_url / revision from it, so a deploy override physically cannot blank the text.
+
+Owner decisions (2026-08-20):
+- Mechanism: seed job fetches the Engine catalogue at deploy (not build-time codegen,
+  not request-time merge).
+- The Engine `Benchmark` gains `focus` + `dataset_url` so all four fields have one copy.
+- Tracked as one ticket / one PR spanning both apps (owner override of the
+  cross-cutting split rule).
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/definition.py` — optional
+  `focus` / `dataset_url` on `Benchmark`, surfaced in `_metadata()`.
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/{draco,ifeval,healthbench}/definition.py`
+  — carry the focus / dataset link text.
+- `apps/scoreboard/src/scoreboard/seed.py` — fetch + map the Engine catalogue, merge with
+  the configured legacy rows.
+- `apps/scoreboard/charts/scoreboard/values.yaml` + `templates/job-seed-benchmarks.yaml`
+  — `seedBenchmarks.engineUrl`, legacy demo rows only.
+- Tests on both sides.
+
+## Test plan
+
+Engine (`tests/unit/test_benchmark_display_metadata.py`): a declared focus line and dataset link
+reach both the catalogue entry and the detail resource; a benchmark declaring neither publishes
+neither key (absent, never null); blank focus and non-http(s) dataset links are refused; the
+three installed benchmarks publish the focus lines and dataset links the board displays, IFEval
+deliberately without one; the published revision is the computed revision and display metadata
+does not move it.
+
+Scoreboard (`tests/unit/test_seed_engine_catalog.py`): a catalogue entry becomes a seed row with
+`title` mapped to `display_name`; an entry without display extras seeds them absent; catalogue
+fields the board does not display are ignored; the catalogue path is appended to the configured
+origin; transport failure, error status, non-JSON body, and a missing displayed field each
+surface as `EngineCatalogUnavailable` rather than an httpx/json exception; an Engine row wins
+over a configured row sharing its id and the shadowed id is reported; a configured row the
+Engine does not publish is kept; the seeded revision is the catalogue revision, never a
+configured literal; an unreachable Engine leaves an already-seeded board untouched and does not
+fail; an unreachable Engine does fail when no row carries a revision; no configured Engine URL
+seeds only the configured rows.
+
+## Acceptance
+
+- No file outside an Engine benchmark definition states a benchmark's description, focus, or
+  dataset link.
+- `helm template` renders `SCOREBOARD_SEED_ENGINE_URL` when `seedBenchmarks.engineUrl` is set
+  and omits it when empty.
+- Both stacks' gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus `apps/scoreboard/src/scoreboard/scores/store.py`
+  (`has_registered_revision`, so the bootstrap check reads the database through the store rather
+  than reaching for the ORM from the seed module) and
+  `apps/scoreboard/charts/scoreboard/README.md`. The before/after diagram is NOT committed
+  (owner decision 2026-08-20): it lives on the Linear issue as an attachment, keeping binaries
+  out of the repository. Source is in the session scratchpad. No migration: `benchmarks` already carries
+  `description`, `focus`, `dataset_url`, and `revision` columns, so S1 does not apply.
+- **Commits:** see the OME-904 branch.
+- **Gates:** `run_gates.py screamingface-engine` ALL GATES GREEN; `run_gates.py scoreboard` ALL
+  GATES GREEN.
+- **Deviations:**
+  - The plan's step 1 included pinning each installed benchmark's revision as a literal. That
+    test was written, went red, and was replaced rather than satisfied: the three revisions the
+    chart pins (`draco 1c58b3085912e304`, `ifeval 0b88a52b5f10a6d9`,
+    `healthbench-worst30 6cd57aee171fbdc4`) do NOT match what this checkout computes
+    (`66a463248586b277`, `1cba769ece27f7ef`, `39cfd96b068f7230`). Pinning literals in a test
+    would have recreated exactly the hand-copied second copy this ticket removes, so the test
+    now asserts the published revision is the benchmark's own computed value, and the board's
+    protection lives where it belongs — the seeded revision comes from the catalogue response.
+  - That mismatch is a PRE-EXISTING drift, surfaced by this work and not caused by it: the
+    deployed board's revisions are stale relative to this checkout's Engine. It also means the
+    ticket's "quick unblock" (re-seed from `values.yaml`) would seed stale revisions. Reported
+    to the owner.

--- a/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
+++ b/docs/work/2026-08-20-OME-904-benchmark-descriptions-from-engine.md
@@ -106,6 +106,25 @@ not `JSONDecodeError`, on a non-UTF-8 body).
   and 5xx (never a 4xx or a mangled body); and `parser.error` no longer wraps the whole run, so
   an unrelated `ValueError` can no longer surface as a command-line usage error.
 
+## CI round (PR #657, 2026-08-20)
+
+CI caught a caller I never looked for: `packages/screamingface/_runtime/server.py:141` imports
+`scoreboard.seed._run`, whose signature this work changed. Pyright reported the missing
+argument, but the signature was the smaller half — that local runtime seeds its board from
+`scoreboard_seed_json(BUILTIN_BENCHMARKS)`, whose rows carry revisions, so under the new
+refusal rule every one of them would have been refused and a local leaderboard would have come
+up EMPTY. A green type-check would still have shipped a broken local stack.
+
+The root cause was the API, not the call site. That path is doing exactly what this ticket
+does — derive the board's catalogue from the Engine registry — in process rather than over
+HTTP, because a local stack runs both in one virtualenv. It had no door. `seed_from_sources`
+and `_run` now take `engine_rows`, the in-process adapter beside the HTTP one, and the local
+projection also carries `focus`/`dataset_url` so a local board matches the deployed one.
+
+Process lesson: three stacks in this repo import `scoreboard.seed`, and I ran gates for two.
+Changing a signature means grepping for callers across the whole monorepo, not across the app
+that owns the file.
+
 Owner-approved prior-test edits (sdlc rule 5, 2026-08-20): 18 lines across two committed test
 files — five mechanical (the fetch returns a `CatalogRead` so it can report unreadable
 entries), eight adding `retry_delay=0` so failure tests do not sleep through the real backoff

--- a/packages/screamingface/src/screamingface/_runtime/bootstrap.py
+++ b/packages/screamingface/src/screamingface/_runtime/bootstrap.py
@@ -26,7 +26,13 @@ def enable_local_providers(environment: MutableMapping[str, str]) -> None:
 
 
 def scoreboard_seed_json(benchmarks: Iterable[BenchmarkDefinition]) -> str:
-    """Project the Engine-owned registry onto Scoreboard's registration contract."""
+    """Project the Engine-owned registry onto Scoreboard's registration contract.
+
+    This is the local twin of what a deployment does over HTTP: the same fields the Engine's
+    ``/v1/benchmarks`` catalogue publishes, read by import because a local stack runs the
+    Engine and the board in one virtualenv (OME-904). Keeping the two projections in step is
+    what makes a local leaderboard look like the deployed one.
+    """
 
     return json.dumps(
         [
@@ -35,6 +41,13 @@ def scoreboard_seed_json(benchmarks: Iterable[BenchmarkDefinition]) -> str:
                 "display_name": benchmark.title,
                 "description": benchmark.description,
                 "revision": benchmark.revision,
+                # Optional in the Engine, so absent stays absent rather than becoming null.
+                **({"focus": focus} if (focus := getattr(benchmark, "focus", None)) else {}),
+                **(
+                    {"dataset_url": dataset_url}
+                    if (dataset_url := getattr(benchmark, "dataset_url", None))
+                    else {}
+                ),
             }
             for benchmark in benchmarks
         ]

--- a/packages/screamingface/src/screamingface/_runtime/server.py
+++ b/packages/screamingface/src/screamingface/_runtime/server.py
@@ -132,13 +132,25 @@ def run_scoreboard(config: RuntimeConfig) -> None:
     import uvicorn  # pyright: ignore[reportMissingImports]
     from scoreboard.config import Settings
     from scoreboard.main import create_app
-    from scoreboard.seed import _run
+    from scoreboard.seed import _run, load_benchmarks_json
     from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 
     # The Engine owns benchmark identity and revision. Deriving the local Scoreboard catalogue
     # from that same registry prevents retired aliases or stale revisions from making a completed
     # local evaluation impossible to publish.
-    asyncio.run(_run(scoreboard_seed_json(BUILTIN_BENCHMARKS)))
+    #
+    # WHY `engine_rows` and not `configured`: these ARE the Engine's benchmarks, read by import
+    # because a local stack runs both in one virtualenv. Handing them in as configuration would
+    # trip the seeder's rule that configuration may not assert a revision the Engine did not
+    # publish — every row would be refused and the local leaderboard would come up empty
+    # (OME-904).
+    asyncio.run(
+        _run(
+            configured=[],
+            engine_url=None,
+            engine_rows=load_benchmarks_json(scoreboard_seed_json(BUILTIN_BENCHMARKS)),
+        )
+    )
     settings = Settings(
         host="127.0.0.1",
         port=9106,

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -85,3 +85,39 @@ def test_scoreboard_seed_is_derived_from_engine_benchmark_identity() -> None:
             "revision": "revision-from-engine",
         }
     ]
+
+
+def test_the_local_projection_carries_the_leaderboard_display_fields() -> None:
+    # INVARIANT: the local board must show what the deployed board shows (OME-904). The Engine
+    # publishes focus and dataset_url in its catalogue; a local stack reads the same registry by
+    # import, so dropping them here would make a local leaderboard quietly poorer than the real
+    # one — the two projections have to stay in step.
+    class Benchmark:
+        id = "draco"
+        title = "DRACO"
+        description = "Research reports"
+        revision = "revision-from-engine"
+        focus = "Research reports with citations"
+        dataset_url = "https://huggingface.co/datasets/perplexity-ai/draco"
+
+    projected = json.loads(scoreboard_seed_json([Benchmark()]))[0]
+
+    assert projected["focus"] == "Research reports with citations"
+    assert projected["dataset_url"] == "https://huggingface.co/datasets/perplexity-ai/draco"
+
+
+def test_the_local_projection_omits_display_fields_a_benchmark_did_not_declare() -> None:
+    # WHY omit rather than send null: the seed contract forbids unknown keys and treats an
+    # absent optional as "leave it alone", which is what an undeclared focus line means.
+    class Benchmark:
+        id = "ifeval"
+        title = "IFEval"
+        description = "Deterministic instruction following"
+        revision = "revision-from-engine"
+        focus = None
+        dataset_url = None
+
+    projected = json.loads(scoreboard_seed_json([Benchmark()]))[0]
+
+    assert "focus" not in projected
+    assert "dataset_url" not in projected


### PR DESCRIPTION
Closes OME-904 — https://linear.app/openmined/issue/OME-904/show-benchmark-descriptions-on-the-leaderboard-engine-text-as-the-only

## TLDR
**The problem**: open the leaderboard and every benchmark has no descriptions. 
<img width="1104" height="484" alt="Screenshot 2026-08-20 at 17 44 27" src="https://github.com/user-attachments/assets/5b7a1f78-314d-437a-934f-9528732ec8d6" />

**Why it was empty**: those descriptions were written — twice. Once in the engine, right next to each benchmark's code. And once again, typed by hand into the scoreboard's deploy settings file.

⚠️ However, neither one reached the scoreboard's Postgre database.

The hand-typed copy lost because our deploy repo supplies its own list of benchmarks, and Helm's rule is that an override replaces a whole list instead of merging into it. So our carefully written list got thrown away and replaced by theirs, which has ids but no descriptions. And the engine's copy lost because nothing ever read it — there was no connection between the engine and the board at all.

💡**The fix**: delete the hand-typed copy. Now, during each deploy, the scoreboard asks the engine directly — "which benchmarks do you have, and what does each one say?" — and saves the answer. One copy, living next to the code it describes, and no way for a deploy setting to blank it out again.


> **Before / after diagram** — how the text travels today vs. after this change: see the [OME-904 issue](https://linear.app/openmined/issue/OME-904/show-benchmark-descriptions-on-the-leaderboard-engine-text-as-the-only). Deliberately not committed; the repo keeps no binaries for it.

## Why it was empty

A benchmark's prose existed **twice**: once in the Engine benchmark definition it describes, once hand-typed into the Scoreboard chart values. In production neither reached the database. The deploy repo supplies its own `seedBenchmarks.benchmarks`, Helm **replaces** lists rather than merging them, and that list carried ids and revisions only — so the chart's copy never entered the pipe at all, and the seed job faithfully wrote `description = NULL`.

## What this changes

The Engine benchmark definition becomes the **only** place a benchmark's text is written.

- `Benchmark` gains optional `focus` and `dataset_url`, so all four fields the board displays have one authoring site. They are validated at construction and published in `GET /v1/benchmarks` only when declared — an absent key, never a null.
- The seed job reads that catalogue at deploy from `seedBenchmarks.engineUrl`. It is public and read-only, so the job holds no Engine credential.
- Chart values keep only which Engine to ask, plus the three legacy demo entries that predate the Engine catalogue and have no Engine definition.
- **Engine rows win** over a configured entry sharing their id, and the shadowed id is named in the job's output. That precedence is what makes the Engine the only copy rather than merely the preferred one — prose reintroduced by a deploy is ignored, not applied.

`revision` rides the same response, so the value the board ranks by and the value the Engine computes can no longer drift apart.

When the Engine is unreachable the job seeds the configured rows, leaves existing rows untouched, and exits **zero** — re-seeding refreshes a populated board, and failing a Scoreboard release on an unrelated service's health costs availability and buys nothing. It exits **non-zero** only when no row carries a revision at all, which is true only before the first successful seed; exiting zero there would publish a board holding nothing but demo entries and call it a success.

## Reviewers: two things worth your attention

**1. The chart's pinned revisions are already stale.** Surfaced by a test written for this ticket, not caused by it:

| benchmark | pinned in `values.yaml` | computed by `main` |
|---|---|---|
| `draco` | `1c58b3085912e304` | `66a463248586b277` |
| `ifeval` | `0b88a52b5f10a6d9` | `1cba769ece27f7ef` |
| `healthbench-worst30` | `6cd57aee171fbdc4` | `39cfd96b068f7230` |

This makes the ticket's suggested quick unblock — re-seed by hand from `values.yaml` — actively harmful: it fills the descriptions while pinning revisions no current Engine will submit against. Deploying this change is the better path. The computed hashes are deliberately **not** pinned in a test either; that would rebuild the hand-copied second copy this PR deletes.

**2. `engineUrl` defaults to empty**, because inventing a hostname in the repo default is a guess. Until the deploy repo sets it, the board seeds only the legacy demos. Happy to add a default if there is a canonical origin.

## Test plan

- `uv run .claude/scripts/run_gates.py screamingface-engine` — ALL GATES GREEN
- `uv run .claude/scripts/run_gates.py scoreboard` — ALL GATES GREEN
- `helm template` verified both ways: `SCOREBOARD_SEED_ENGINE_URL` renders when `engineUrl` is set, and is absent when it is empty.

New tests: `apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py` (catalogue and detail carry the new fields; absent means absent; blank focus and non-`http(s)` links refused; the installed benchmarks publish what the board shows; display metadata never moves a revision) and `apps/scoreboard/tests/unit/test_seed_engine_catalog.py` (field mapping, unknown catalogue fields ignored, URL joining, transport/status/non-JSON/malformed-entry each surfacing as one seed-owned error, Engine precedence, legacy rows kept, seeded revision comes from the catalogue, unreachable-Engine survivable vs. bootstrap failure).

No migration: `benchmarks` already carries `description`, `focus`, `dataset_url`, and `revision`.

## Before / After

### Before

- Trigger: someone opens the leaderboard in the notebook and scans the benchmark list.
- Today: every entry reads "No description published." They cannot tell what DRACO, IFEval, or the HealthBench challenge test without leaving the notebook.
- Cost: the catalogue looks unfinished, and prose someone already wrote is silently lost between two hand-maintained copies that nothing compares.

### After

- Same trigger.
- Now: each benchmark shows its description, focus line, and dataset link, straight from the definition that describes it.
- Win: the board explains itself, and a future deploy cannot blank the text, because there is no second copy left to lose.

### For the next dev

- Adding a benchmark means writing its text in one file, next to the benchmark. There is no chart entry to remember and no revision to re-copy.
- A deploy that reintroduces prose under a published id no longer silently wins; the seed job ignores it and says so in its log.

### Don't regress

- Seeded `revision` matches the Engine's computed revision, now structurally rather than by discipline.
- Seeding stays idempotent; re-running never duplicates or corrupts rows.
- The portal's Focus column and dataset links keep working, including the em-dash fallback for a benchmark that declares neither.
- Legacy demo entries keep their hand-written values — they are retained, not adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

