### PR TITLE
fix(scoreboard): cast Tortoise CharField reads at the Openness Literal boundaries

### DIFF
--- a/apps/scoreboard/src/scoreboard/scores/baseline_store.py
+++ b/apps/scoreboard/src/scoreboard/scores/baseline_store.py
@@ -8,6 +8,8 @@ from pydantic import ValidationError
 from tortoise import BaseDBAsyncClient
 from tortoise.transactions import in_transaction
 
+from scoreboard.classification.openness import Openness
+
 from .models import Baseline, Benchmark
 from .schemas import BaselineImportRow, BaselineSchema
 
@@ -24,7 +26,11 @@ def _baseline_to_schema(model: Baseline) -> BaselineSchema:
         source_url=model.source_url,
         imported_at=model.imported_at,
         metadata=model.metadata,
-        openness_override=model.openness_override,
+        # WHY: tortoise-orm >=1.1.8 types CharField as `str | None`, which no longer
+        # satisfies the schema's `Openness | None`. The DB column is a bare CharField, so
+        # the narrowing is ours to assert; Pydantic still rejects a junk value on
+        # construction, which is what actually enforces the invariant at runtime.
+        openness_override=cast(Openness | None, model.openness_override),
     )
 
 

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -16,6 +16,8 @@ from tortoise.exceptions import FieldError, IntegrityError
 from tortoise.query_api import execute_pypika
 from tortoise.transactions import in_transaction
 
+from scoreboard.classification.openness import Openness
+
 from .models import Benchmark, IdempotencyKey, Score
 from .schemas import BenchmarkSchema, LeaderboardEntry, ScoreSchema, ScoreSubmission
 
@@ -69,7 +71,11 @@ def _score_to_schema(model: Score) -> ScoreSchema:
         client_platform=model.client_platform,
         verified_by_screamingface=model.verified_by_screamingface,
         metadata=model.metadata,
-        openness_override=model.openness_override,
+        # WHY: tortoise-orm >=1.1.8 types CharField as `str | None`, which no longer
+        # satisfies the schema's `Openness | None`. The DB column is a bare CharField, so
+        # the narrowing is ours to assert; Pydantic still rejects a junk value on
+        # construction, which is what actually enforces the invariant at runtime.
+        openness_override=cast(Openness | None, model.openness_override),
         run_cost_usd=model.run_cost_usd,
     )
 

--- a/docs/work/2026-08-20-OME-913-scoreboard-openness-casts.md
+++ b/docs/work/2026-08-20-OME-913-scoreboard-openness-casts.md
@@ -1,0 +1,67 @@
+---
+ticket: OME-913
+stack: scoreboard
+status: done
+started: 2026-08-20
+finished: 2026-08-20
+---
+
+# OME-913 — Cast Tortoise CharField reads at the Openness Literal boundaries
+
+## Intent
+
+Dependabot PR #637 (`scoreboard-python-minor`) is red on `test (3.13)` solely because
+`tortoise-orm 1.1.7 → 1.1.8` gives `fields.CharField(...)` a real `str | None` type where
+pyright previously inferred `Any`. `openness_override` then no longer satisfies the
+`Literal["open","closed"] | None` parameter it feeds. Landing the casts on main first lets
+Dependabot deliver the bump unmodified via `@dependabot rebase`.
+
+## Planned changes
+
+- `src/scoreboard/scores/store.py` — cast at the `openness_override=` schema argument.
+- `src/scoreboard/scores/baseline_store.py` — same.
+- No model, schema or migration change (S1 does not apply — nothing about the DB shape moves).
+
+## Test plan
+
+**Deviation from literal RED/GREEN, stated up front:** `typing.cast` is erased at runtime, so
+no runtime test can distinguish before from after. The failing signal that demands this change
+is the `uv run pyright` gate under tortoise-orm 1.1.8, and that is what is used as RED:
+
+- RED: pin `tortoise-orm[asyncpg]==1.1.8`, run `uv run pyright` → 2 `reportArgumentType`
+  errors at the two sites above.
+- GREEN: same command, 0 errors, with the casts in place.
+- Regression: revert the pin to 1.1.7 and re-run pyright → still 0 errors, proving the casts
+  are safe to land ahead of the bump.
+- The full existing suite must stay green and unmodified.
+
+## Acceptance
+
+- `uv run pyright` clean under BOTH tortoise-orm 1.1.7 and 1.1.8.
+- All scoreboard gates green; no prior test touched.
+- Committed diff contains the casts ONLY — no dependency change (that stays Dependabot's).
+
+## Outcome
+
+- **Actual files:** as planned — `src/scoreboard/scores/store.py`,
+  `src/scoreboard/scores/baseline_store.py`. No model/schema/migration change.
+- **Commits:** see below.
+- **Gates:** `run_gates.py scoreboard` — ALL GATES GREEN (append-only check, ruff check,
+  ruff format --check, pyright, pytest --cov-fail-under=80, portal node tests).
+- **RED/GREEN evidence:**
+  - RED under `tortoise-orm==1.1.8`: 2 × `reportArgumentType` at `baseline_store.py:27`
+    and `store.py:72`.
+  - GREEN under 1.1.8 with the casts: `0 errors, 0 warnings, 0 informations`.
+  - Regression under 1.1.7 with the casts: `0 errors` — confirms the casts land safely
+    ahead of the bump.
+- **Deviations:**
+  - The line number in the issue was `store.py:65`; the real site is `:72` — main moved
+    during the Dependabot sweep before this branch was cut. No behavioural difference.
+  - No runtime test was added. `typing.cast` is erased at runtime, so no test can
+    distinguish before from after; the `pyright` gate under 1.1.8 is the failing signal
+    that demanded the change, and it is recorded above. Flagged rather than papered over
+    with a test that would assert nothing.
+  - Imported `Openness` from `scoreboard.classification.openness` (runtime import, matching
+    the existing precedent at `scores/frontier.py:9`) rather than inlining a `Literal`.
+    Safe: `classification` imports `scores.schemas` only under `TYPE_CHECKING`, so there is
+    no import cycle.


### PR DESCRIPTION
Unblocks Dependabot #637, which is red on `test (3.13)` for exactly one reason.

## Root cause

`tortoise-orm 1.1.7 → 1.1.8` types `fields.CharField(...)` as a real `str | None` where pyright previously inferred `Any`. `openness_override` then stops satisfying the schema's `Literal["open","closed"] | None`. `pyright` itself is unchanged by that PR (pinned `>=1.1.393`, not moved in the diff) and main is green, so the bump is the sole cause.

## Fix

`cast(Openness | None, ...)` at the two schema boundaries, reusing the existing `Openness` alias (`classification/openness.py:16`) rather than inlining a `Literal`. Runtime import is safe — `classification` imports `scores.schemas` only under `TYPE_CHECKING`, and `scores/frontier.py:9` already imports from it.

This is a narrowing assertion, not a suppression: `ScoreSchema.openness_override` is a Pydantic field, so a junk DB value is still rejected on construction.

## Verification

| Condition | pyright |
|---|---|
| tortoise 1.1.8, before | 2 × `reportArgumentType` (`baseline_store.py:27`, `store.py:72`) |
| tortoise 1.1.8, after | 0 errors |
| tortoise 1.1.7, after | 0 errors |

That last row is the point: the casts land safely **ahead** of the bump, so Dependabot delivers 1.1.8 unmodified via `@dependabot rebase`.

`run_gates.py scoreboard` — ALL GATES GREEN. No prior test modified; no dependency change in this diff.

Refs: OME-913