### PR TITLE
fix(aigateway): cast Tortoise CharField reads at the Literal alias boundaries

### DIFF
--- a/apps/aigateway/src/aigateway/core/oauth/store.py
+++ b/apps/aigateway/src/aigateway/core/oauth/store.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import cast
 from uuid import UUID
 
 from tortoise.exceptions import DoesNotExist
 
 from aigateway.core.auth.middleware import ANONYMOUS_ACCOUNT_ID
 from aigateway.core.auth.models import Account
+from aigateway.core.profile_models import AuthType
 
 from .identity import AccountIdentity
 from .models import OAuthConnection
-from .schemas import OAuthConnectionResponse
+from .schemas import OAuthConnectionResponse, OAuthConnectionStatus
 
 DEFAULT_CREDENTIAL_ACCOUNT = "default"
 
@@ -373,8 +375,11 @@ def response_from_connection(
         account_id=connection.account_id,
         provider=connection.provider,
         label=connection.label,
-        status=connection.status,
-        auth_type=connection.auth_type,
+        # WHY: tortoise-orm >=1.1.8 types CharField as `str`, which no longer satisfies
+        # these Literal aliases. The columns are bare CharFields, so the narrowing is ours
+        # to assert; the Pydantic response model still rejects a junk value on construction.
+        status=cast(OAuthConnectionStatus, connection.status),
+        auth_type=cast(AuthType, connection.auth_type),
         account=account,
         credential_locator=connection.credential_locator,
         created_at=connection.created_at,

--- a/apps/aigateway/src/aigateway/routes/chat_credentials.py
+++ b/apps/aigateway/src/aigateway/routes/chat_credentials.py
@@ -8,7 +8,7 @@ Phase 1) behind characterization tests; behavior is unchanged.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from fastapi import HTTPException, Request
 
@@ -43,7 +43,10 @@ def auth_mode_for_target(
     disagree about which mode a profile uses.
     """
     if connection is not None:
-        return connection.auth_type or "oauth"
+        # WHY: tortoise-orm >=1.1.8 types CharField as `str`; the stored column is a bare
+        # CharField, so narrowing it back to AuthType is ours to assert. `or "oauth"`
+        # keeps the documented fallback for an empty stored value.
+        return cast(AuthType, connection.auth_type or "oauth")
     if profile is not None:
         return profile.auth_type
     return "oauth"

--- a/docs/work/2026-08-20-OME-912-aigateway-authtype-casts.md
+++ b/docs/work/2026-08-20-OME-912-aigateway-authtype-casts.md
@@ -1,0 +1,69 @@
+---
+ticket: OME-912
+stack: aigateway
+status: done
+started: 2026-08-20
+finished: 2026-08-20
+---
+
+# OME-912 — Cast Tortoise CharField reads at the AuthType Literal boundaries
+
+## Intent
+
+Dependabot PR #640 (`aigateway-python-minor`) is red on `test (3.13)` solely because
+`tortoise-orm 1.1.7 → 1.1.8` gives `fields.CharField(...)` a real `str` type where pyright
+previously inferred `Any`, so values read off a model no longer satisfy `AuthType`
+(`Literal["oauth","api_key"]`). Landing the casts on main first lets Dependabot deliver the
+bump unmodified via `@dependabot rebase`. Sibling of OME-913 (scoreboard); split per D9
+because one issue may carry only one landing leaf.
+
+## Planned changes
+
+- `src/aigateway/core/oauth/store.py` — cast at the `auth_type=` argument (~line 377).
+- `src/aigateway/routes/chat_credentials.py` — cast at the `AuthType` return (~line 46).
+- One further site, to be enumerated from the gate run (the log tail showed "3 errors" but
+  truncated the third).
+- No model, schema or migration change (S1 does not apply).
+
+## Test plan
+
+**Deviation from literal RED/GREEN, stated up front:** `typing.cast` is erased at runtime, so
+no runtime test can distinguish before from after. The failing signal that demands the change
+is the `uv run pyright` gate under tortoise-orm 1.1.8, and that is used as RED:
+
+- RED: pin `tortoise-orm[asyncpg]==1.1.8`, run `uv run pyright` → the 3 `reportArgumentType` /
+  `reportReturnType` errors.
+- GREEN: same command, 0 errors, with the casts in place.
+- Regression: revert the pin to 1.1.7, re-run pyright → still 0 errors, proving the casts are
+  safe to land ahead of the bump.
+- Full existing suite green and unmodified.
+
+## Acceptance
+
+- `uv run pyright` clean under BOTH tortoise-orm 1.1.7 and 1.1.8.
+- All aigateway gates green; no prior test touched.
+- Committed diff contains the casts ONLY — no dependency change.
+
+## Outcome
+
+- **Actual files:** as planned — `src/aigateway/core/oauth/store.py`,
+  `src/aigateway/routes/chat_credentials.py`. No model/schema/migration change.
+- **Commits:** see below.
+- **Gates:** `run_gates.py aigateway` — ALL GATES GREEN (append-only check, ruff check,
+  ruff format --check, pyright, check_no_enterprise, pytest --cov-fail-under=80).
+- **RED/GREEN evidence:**
+  - RED under `tortoise-orm==1.1.8`: 3 errors — `store.py:376` (status),
+    `store.py:377` (auth_type), `chat_credentials.py:46` (return).
+  - GREEN under 1.1.8 with the casts: `0 errors, 0 warnings, 0 informations`.
+  - Regression under 1.1.7 with the casts: `0 errors`.
+- **Deviations:**
+  - The third site was NOT a second `AuthType` boundary as the issue guessed. It is
+    `status=connection.status` at `store.py:376`, a *different* Literal alias
+    (`OAuthConnectionStatus = Literal["pending","active","expired","revoked","error"]`,
+    `core/oauth/schemas.py:13`). Same root cause, second alias — so the fix imports two
+    aliases, not one. Issue description updated to match.
+  - `AuthType` lives in `aigateway.core.profile_models` (not `core/oauth/schemas.py`, which
+    merely re-imports it).
+  - No runtime test added: `typing.cast` is erased at runtime, so no test can distinguish
+    before from after. The `pyright` gate under 1.1.8 is the failing signal that demanded the
+    change and is recorded above — flagged rather than papered over with a vacuous test.


### PR DESCRIPTION
Unblocks Dependabot #640, which is red on `test (3.13)` for exactly one reason. Sibling of #661 (scoreboard); split per D9 because one issue may carry only one landing leaf.

## Root cause

`tortoise-orm 1.1.7 → 1.1.8` types `fields.CharField(...)` as a real `str` where pyright previously inferred `Any`. Values read off `OAuthConnection` then stop satisfying the Literal aliases they feed. `pyright` itself is unchanged by that PR (pinned `>=1.1.393`, not moved in the diff) and main is green, so the bump is the sole cause.

## The three sites

Worth noting the third is **not** a second `AuthType` boundary — it is a different alias:

| Site | Target alias |
|---|---|
| `core/oauth/store.py:376` | `OAuthConnectionStatus` = `Literal["pending","active","expired","revoked","error"]` |
| `core/oauth/store.py:377` | `AuthType` = `Literal["oauth","api_key"]` |
| `routes/chat_credentials.py:46` | `AuthType` (return position) |

These are narrowing assertions, not suppressions: the values flow straight into Pydantic response models, so a junk stored value is still rejected on construction. `chat_credentials.py` keeps its documented `or "oauth"` fallback for an empty stored value.

## Verification

| Condition | pyright |
|---|---|
| tortoise 1.1.8, before | 3 errors |
| tortoise 1.1.8, after | 0 errors |
| tortoise 1.1.7, after | 0 errors |

That last row is the point: the casts land safely **ahead** of the bump, so Dependabot delivers 1.1.8 unmodified via `@dependabot rebase`.

`run_gates.py aigateway` — ALL GATES GREEN. No prior test modified; no dependency change in this diff.

Refs: OME-912