### PR TITLE
chore(repo): repoint release-critical references to the ScreamingFace org

### DIFF
--- a/.github/workflows/release-screamingface.yml
+++ b/.github/workflows/release-screamingface.yml
@@ -6,10 +6,17 @@ name: Release screamingface
 # Auth is PyPI Trusted Publishing (OIDC) — no stored token. Before the first real
 # publish an owner must, one time:
 #   1. reserve the `screamingface` project on PyPI and add a Trusted Publisher →
-#      owner/repo: OpenMined/screamingface, workflow: release-screamingface.yml,
+#      owner/repo: ScreamingFace/screamingface, workflow: release-screamingface.yml,
 #      environment: pypi
 #   2. create the `pypi` GitHub Environment (optionally with required reviewers)
 # Until then verify+build still run (packaging is validated); only publish fails.
+#
+# AIDEV-NOTE (OME-910): the repo moved from the OpenMined org to ScreamingFace. PyPI Trusted
+# Publishing matches the OIDC `repository` claim as an EXACT string and does NOT follow
+# GitHub's org redirect, so an existing publisher entry registered against
+# `OpenMined/screamingface` no longer matches and publish fails with an OIDC mismatch while
+# verify+build stay green. The owner/repo above is the value to set; correcting this comment
+# does not repoint PyPI. Verify the entry in the PyPI console before trusting a release.
 #
 # AIDEV-NOTE: the name `screamingface` is NOT yet reserved on PyPI. Reserve it before
 # announcing the package, or the first tag will build cleanly and fail at the publish step.

--- a/.github/workflows/release-url4.yml
+++ b/.github/workflows/release-url4.yml
@@ -5,9 +5,16 @@ name: Release url4
 # Auth is PyPI Trusted Publishing (OIDC) — no stored token. Before the first real
 # publish an owner must, one time:
 #   1. reserve the `url4` project on PyPI and add a Trusted Publisher →
-#      owner/repo: OpenMined/screamingface, workflow: release-url4.yml, environment: pypi
+#      owner/repo: ScreamingFace/screamingface, workflow: release-url4.yml, environment: pypi
 #   2. create the `pypi` GitHub Environment (optionally with required reviewers)
 # Until then verify+build still run (packaging is validated); only publish fails.
+#
+# AIDEV-NOTE (OME-910): the repo moved from the OpenMined org to ScreamingFace. PyPI Trusted
+# Publishing matches the OIDC `repository` claim as an EXACT string and does NOT follow
+# GitHub's org redirect, so an existing publisher entry registered against
+# `OpenMined/screamingface` no longer matches and publish fails with an OIDC mismatch while
+# verify+build stay green. The owner/repo above is the value to set; correcting this comment
+# does not repoint PyPI. Verify the entry in the PyPI console before trusting a release.
 
 on:
   push:

--- a/docs/work/2026-08-20-OME-910-repoint-org-refs.md
+++ b/docs/work/2026-08-20-OME-910-repoint-org-refs.md
@@ -1,0 +1,66 @@
+---
+ticket: OME-910
+stack: repo
+status: done
+started: 2026-08-20
+finished: 2026-08-20
+---
+
+# OME-910 — Repoint the git remote and release-critical org references
+
+## Intent
+
+The repo was transferred from the `OpenMined` org to `ScreamingFace`. GitHub keeps a
+redirect, so nothing is broken yet — but the redirect is revocable, and PyPI Trusted
+Publishing does not follow it: it matches the OIDC `repository` claim as an exact string.
+Fix the local remote and the two in-repo references a redirect cannot cover, and surface the
+PyPI-console change that only the owner can make.
+
+## Planned changes
+
+- `.git/config` — remote URL (untracked; already done, no branch).
+- `packages/url4/pyproject.toml` — `Repository` / `Issues` project URLs (published PyPI metadata).
+- `.github/workflows/release-url4.yml` — Trusted Publishing setup comment.
+- `.github/workflows/release-screamingface.yml` — same.
+
+Deliberately NOT touched: the ~130 remaining references in README/CONTRIBUTING/docs/
+public-docs/portal (follow-up issue), the CHANGELOGs (correct when written),
+and `OpenMined/sf-installer` (a genuinely different repo, still OpenMined-owned).
+
+## Test plan
+
+No code change — nothing to RED/GREEN. Verification is by inspection and by the repo's own
+workflow linting:
+
+- `git remote -v` resolves to the new URL and `git fetch` succeeds without redirect.
+- No `OpenMined/screamingface` occurrence remains in the four in-scope files.
+- `packages/url4` gates stay green (the pyproject edit must not break the build).
+
+## Acceptance
+
+- The four files above carry `ScreamingFace/screamingface`.
+- `run_gates.py url4` green (pyproject is packaging metadata — the build must still work).
+- The PyPI owner action is recorded on the issue, not silently assumed done.
+
+## Outcome
+
+- **Actual files:** as planned, plus an `AIDEV-NOTE` block added to both release workflows
+  (see Deviations).
+  - `.git/config` (untracked) — remote repointed; all five `.claude/worktrees/` entries AND
+    `screamingface-demo-004` inherit it via `commondir`. `git fetch` verified over the new URL.
+  - `packages/url4/pyproject.toml` — 2 occurrences.
+  - `.github/workflows/release-url4.yml` — 1 + note.
+  - `.github/workflows/release-screamingface.yml` — 1 + note.
+- **Commits:** see below.
+- **Gates:** `run_gates.py url4` — ALL GATES GREEN.
+- **Deviations:**
+  - `screamingface-demo-004` was assumed to be a separate clone needing its own `set-url`. It
+    is a linked worktree of this clone, so it inherited the change — no action was needed.
+  - Added an `AIDEV-NOTE (OME-910)` to both release workflows beyond the planned one-line
+    swap. Correcting the comment does not repoint PyPI, and a reader could easily assume it
+    does; the note states the failure mode explicitly so a release is not trusted on a stale
+    publisher entry.
+- **⚠️ OPEN — OWNER ACTION, not done by this change:** the PyPI Trusted Publisher entries for
+  the `url4` and `screamingface` projects still name `OpenMined/screamingface`. Until an owner
+  repoints them in the PyPI console, both release workflows build and verify green but fail at
+  the publish step with an OIDC mismatch.

--- a/packages/url4/pyproject.toml
+++ b/packages/url4/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://screamingface.ai"
-Repository = "https://github.com/OpenMined/screamingface"
-Issues = "https://github.com/OpenMined/screamingface/issues"
+Repository = "https://github.com/ScreamingFace/screamingface"
+Issues = "https://github.com/ScreamingFace/screamingface/issues"
 
 [project.optional-dependencies]
 # Url4Node.serve() and `url4 serve` — the ASGI app itself is framework-free; only


### PR DESCRIPTION
The repo was **transferred** from `OpenMined` to `ScreamingFace`. GitHub keeps a redirect, so most references still resolve — but one consumer does not follow it.

## Why this is not purely cosmetic

**PyPI Trusted Publishing matches the OIDC `repository` claim as an exact string.** After the transfer that claim is `ScreamingFace/screamingface`, so a publisher entry registered against `OpenMined/screamingface` no longer matches. The failure mode is quiet: `verify` and `build` stay green and only the publish step fails.

## Scope — deliberately narrow

Only what a redirect cannot cover:

- `packages/url4/pyproject.toml` — `Repository` / `Issues`, baked into published PyPI metadata. (`packages/screamingface/pyproject.toml` was already correct.)
- `.github/workflows/release-url4.yml`, `release-screamingface.yml` — the Trusted Publishing setup comments, plus an `AIDEV-NOTE` spelling out that fixing the comment does **not** repoint PyPI.

**Left alone on purpose:** ~130 references in README/CONTRIBUTING/docs/public-docs/portal (follow-up issue); the CHANGELOGs (those links were correct when written); and `OpenMined/sf-installer` in the aigateway release lanes — verified still OpenMined-owned, a genuinely different repo.

## ⚠️ Owner action still open

The PyPI Trusted Publisher entries for the `url4` and `screamingface` projects must be repointed in the PyPI console. This PR documents the correct value; it cannot set it.

`run_gates.py url4` — ALL GATES GREEN.

Refs: OME-910