### PR TITLE
docs(repo): record the 2026-08-20 Dependabot backlog sweep

### DIFF
--- a/docs/tasks/2026-08-20-OME-910-repoint-org-refs.md
+++ b/docs/tasks/2026-08-20-OME-910-repoint-org-refs.md
@@ -1,0 +1,29 @@
+---
+id: OME-910
+linear_url: https://linear.app/openmined/issue/OME-910/repoint-the-git-remote-and-release-critical-org-references-after-the
+status: In Review
+type: Task
+priority: High
+labels: [repo, agentic, autonomous, task]
+created: 2026-08-20
+closed:
+---
+
+# Repoint the git remote and release-critical org references
+
+The repo was transferred from the `OpenMined` org to `ScreamingFace`. GitHub keeps a redirect,
+so most references still resolve — but PyPI Trusted Publishing matches the OIDC `repository`
+claim as an exact string and does not follow it, so the `url4` and `screamingface` release
+lanes fail at the publish step while verify and build stay green.
+
+Scope is deliberately narrow: `.git/config` (untracked), the published PyPI project URLs in
+`packages/url4/pyproject.toml`, and the Trusted Publishing setup comments in the two release
+workflows. Docs, portal and public-docs references are `OME-914`; the CHANGELOGs are left
+alone because their links were correct when written.
+
+Repointing the PyPI publisher entries is an owner action in the PyPI console and remains open.
+
+Canonical artifacts:
+
+- Ledger: `docs/work/2026-08-20-OME-910-repoint-org-refs.md`
+- PR: #663

--- a/docs/tasks/2026-08-20-OME-911-dependabot-backlog-sweep.md
+++ b/docs/tasks/2026-08-20-OME-911-dependabot-backlog-sweep.md
@@ -1,0 +1,26 @@
+---
+id: OME-911
+linear_url: https://linear.app/openmined/issue/OME-911/dependabot-backlog-sweep-close-the-obsolete-url4-cloud-pr-and-land-the
+status: In Progress
+type: Task
+priority: High
+labels: [repo, agentic, autonomous, task]
+created: 2026-08-20
+closed:
+---
+
+# Dependabot backlog sweep after the ScreamingFace org transfer
+
+Eleven open Dependabot PRs. Close what is structurally dead, land what is green, and hand the
+genuinely-blocked ones to their own work items rather than force-merging or closing them.
+Repeat of `OME-734` under epic `OME-733`.
+
+`#641` was closed as obsolete rather than rebased: `apps/url4-cloud` no longer exists on main
+(renamed to `apps/screamingface-engine` by `9b888579`), and `#645` is its green successor.
+
+`#640` and `#637` were left for `OME-912` / `OME-913` — both were red for one shared reason,
+a tortoise-orm 1.1.8 typing regression, not a flake.
+
+Canonical artifacts:
+
+- Ledger: `docs/work/2026-08-20-OME-911-dependabot-backlog-sweep.md`

--- a/docs/tasks/2026-08-20-OME-912-aigateway-authtype-casts.md
+++ b/docs/tasks/2026-08-20-OME-912-aigateway-authtype-casts.md
@@ -1,0 +1,25 @@
+---
+id: OME-912
+linear_url: https://linear.app/openmined/issue/OME-912/aigateway-cast-tortoise-charfield-reads-at-the-authtype-literal
+status: In Review
+type: Task
+priority: High
+labels: [aigateway, agentic, autonomous, task]
+created: 2026-08-20
+closed:
+---
+
+# aigateway: cast Tortoise CharField reads at the Literal alias boundaries
+
+`tortoise-orm 1.1.8` types `fields.CharField(...)` as a real `str` where pyright previously
+inferred `Any`, so values read off `OAuthConnection` stop satisfying `AuthType` and
+`OAuthConnectionStatus`. Three sites; landing the casts ahead of the bump lets Dependabot
+`#640` deliver 1.1.8 unmodified.
+
+Sibling of `OME-913` (scoreboard) — split per D9, since one issue may carry only one landing
+leaf.
+
+Canonical artifacts:
+
+- Ledger: `docs/work/2026-08-20-OME-912-aigateway-authtype-casts.md`
+- PR: #662

--- a/docs/tasks/2026-08-20-OME-913-scoreboard-openness-casts.md
+++ b/docs/tasks/2026-08-20-OME-913-scoreboard-openness-casts.md
@@ -1,0 +1,23 @@
+---
+id: OME-913
+linear_url: https://linear.app/openmined/issue/OME-913/scoreboard-cast-tortoise-charfield-reads-at-the-openness-literal
+status: Done
+type: Task
+priority: High
+labels: [scoreboard, agentic, autonomous, task]
+created: 2026-08-20
+closed: 2026-08-20
+---
+
+# scoreboard: cast Tortoise CharField reads at the Openness Literal boundaries
+
+`tortoise-orm 1.1.8` types `fields.CharField(...)` as `str | None`, so `openness_override`
+stops satisfying the schema's `Literal["open","closed"] | None`. Two sites; landing the casts
+ahead of the bump lets Dependabot `#637` deliver 1.1.8 unmodified.
+
+Verified green under both 1.1.7 and 1.1.8 — that pairing is what makes it safe to land first.
+
+Canonical artifacts:
+
+- Ledger: `docs/work/2026-08-20-OME-913-scoreboard-openness-casts.md`
+- PR: #661 (merged)

--- a/docs/work/2026-08-20-OME-911-dependabot-backlog-sweep.md
+++ b/docs/work/2026-08-20-OME-911-dependabot-backlog-sweep.md
@@ -1,0 +1,70 @@
+---
+ticket: OME-911
+stack: repo
+status: done
+started: 2026-08-20
+finished: 2026-08-20
+---
+
+# OME-911 — Dependabot backlog sweep after the ScreamingFace org transfer
+
+## Intent
+
+Eleven open Dependabot PRs had accumulated. Clear the backlog: close what is structurally
+dead, land what is green, and hand the two genuinely-blocked PRs to their own work items
+rather than force-merging or closing them. Repeat of OME-734 under epic OME-733.
+
+## Planned changes
+
+No source changes. PR-state actions only, plus this ledger.
+
+- Close #641 (`apps/url4-cloud` — tree renamed away by `9b888579`; superseded by #645).
+- Merge, in order: #554, #550 (uvicorn floor — first, they share `pyproject.toml`/`uv.lock`
+  with #640/#637), then #557, #636, #632, #645, #638, #639.
+- Leave #640 / #637 for OME-912 / OME-913, then `@dependabot rebase` and merge.
+
+## Test plan
+
+Not a code unit — no RED/GREEN. The gate is each PR's own CI:
+
+- Re-check `mergeStateStatus == CLEAN` immediately before each merge (the earlier survey is
+  a snapshot; main moves).
+- After the sweep, `main` stays green on the lanes these PRs touch.
+- `.claude/scripts/audit_dependabot_ignores.py` still passes — the 1:1 invariant between
+  `dependabot.yml` and `dependabot-ignores.yml` must survive the sweep.
+
+## Acceptance
+
+- No open PR authored by `app/dependabot` except #640/#637 pending their sub-issues.
+- #641 closed with the supersession reason recorded on the PR.
+- No `--admin` merge; nothing merged ahead of green CI.
+
+## Outcome
+
+- **Actual files:** this ledger, plus the four `docs/tasks/` mirrors for this batch
+  (see Deviations).
+- **Result — 11 PRs resolved:**
+
+  | PR | Outcome |
+  |----|---------|
+  | #641 | Closed as obsolete, reason recorded on the PR |
+  | #554 #550 | Merged (uvicorn floor, first — they share files with #640/#637) |
+  | #557 | Merged — last two `@v4` action pins in the repo |
+  | #636 #632 #645 #638 #639 | Merged |
+  | #640 #637 | Held for OME-912 / OME-913, then `@dependabot rebase` |
+
+- **Gates:** each PR's own CI, re-checked `CLEAN` immediately before its merge. No `--admin`,
+  nothing merged ahead of green CI. `run_gates.py` was run per-app on the two repair branches
+  (scoreboard, aigateway) — both ALL GATES GREEN.
+- **Deviations:**
+  - The first merge attempt read `#550` as `UNKNOWN/UNKNOWN` and skipped it. That is GitHub
+    recomputing mergeability asynchronously after `#554` landed, not a real block — the
+    remaining merges were done through a poll-until-`CLEAN` loop instead of firing blind.
+    Worth remembering: a single `gh pr view` right after a merge is not a reliable gate.
+  - `docs/tasks/` mirrors for all four tickets in this batch (OME-910/911/912/913) are
+    committed here rather than one-per-PR. They were missed at filing time; OME-913's PR had
+    already merged, and adding pure-bookkeeping files to the two open code PRs would have
+    restarted their CI for no engineering reason. Consolidating them in this sweep unit — the
+    batch's bookkeeping unit — was the cheaper correction.
+  - Line numbers quoted in OME-912/OME-913 at filing time drifted (`store.py:65` → `:72`)
+    because main moved during the sweep. No behavioural difference.


### PR DESCRIPTION
Bookkeeping for the Dependabot triage. No source changes.

## What happened to the eleven open PRs

| PR | Outcome |
|----|---------|
| #641 | **Closed as obsolete** — `apps/url4-cloud` no longer exists on main (renamed to `apps/screamingface-engine` by `9b888579`); #645 is its green successor |
| #554 #550 | Merged first — uvicorn floor, sharing `pyproject.toml`/`uv.lock` with #640/#637 |
| #557 | Merged — the last two `@v4` action pins in the repo |
| #636 #632 #645 #638 #639 | Merged |
| #640 #637 | Held for #662 / #661 — both red for one shared reason, not a flake |

#640 and #637 were **not** force-merged or closed. They were red because `tortoise-orm 1.1.8` types `CharField` as a real `str` where pyright previously inferred `Any`, breaking five `Literal` boundaries across the two apps. Fixed properly in #661 (merged) and #662, after which Dependabot delivers the bumps unmodified via `@dependabot rebase`.

## Also here

The `docs/tasks/` mirrors for this batch (OME-910/911/912/913), which were missed at filing time. They are consolidated here rather than split across the code PRs — OME-913's PR had already merged, and pushing bookkeeping files to the open code PRs would have restarted their CI for no engineering reason.

Refs: OME-911