### PR TITLE
Pipeline Runner frame publishing and report the bridge high-water mark

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 
 import nats
 from nats.aio.client import Client
-from nats.js import JetStreamContext
+from nats.js import JetStreamContext, api
 from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy, DiscardPolicy, StreamInfo
 from nats.js.errors import APIError, BadRequestError, NotFoundError
 from pydantic import ValidationError
@@ -21,6 +21,26 @@ from url4.streaming.interfaces import EventConsumer, EventPublisher, validate_fr
 from url4.streaming.protocol import OutboundFrame, TerminatedEvent
 
 logger = logging.getLogger(__name__)
+
+MAX_IN_FLIGHT_PUBLISHES = 1024
+"""How many acknowledgements may be outstanding before `publish` parks on the semaphore.
+
+Stated here rather than left to nats-py's default of 4000 because it is the memory bound this
+module PROMISES, not an incidental library setting. It is also the whole stall defence: an
+unreachable broker fills this window, `publish` then blocks, the Runner's drain stops, and its
+event bridge fails at its own hard cap — bounded, and loudly.
+"""
+
+
+class DeferredPublishError(RuntimeError):
+    """A publish this class already returned from was later rejected by the broker.
+
+    Raised at the next `publish` or at `flush`, chained (`__cause__`) to the broker's own
+    error. Wrapped rather than re-raised bare so the message says WHERE it surfaced: the
+    frame that caused it is long gone by then, and a naked APIError at a later sequence
+    number reads as a failure of the wrong frame.
+    """
+
 
 # INVARIANT: `max_age` bounds the BYTES a run's frames occupy. It does NOT reclaim the stream
 # object — JetStream expires messages and leaves the stream, its consumer state and its
@@ -112,7 +132,9 @@ class _JetStreamConnection:
                 return js
             nc = await nats.connect(self._url)
             self._nc = nc
-            js = nc.jetstream()
+            # The bound is inert for the consumer, which never publishes; declaring it once
+            # here keeps the two bindings on one connection story.
+            js = nc.jetstream(publish_async_max_pending=MAX_IN_FLIGHT_PUBLISHES)
             self._js = js
             # The declarations belonged to the connection that just died; the new one has none.
             self._ensured.clear()
@@ -332,11 +354,104 @@ class JetStreamConsumer(_JetStreamConnection, EventConsumer):
 
 class JetStreamPublisher(_JetStreamConnection, EventPublisher):
     """The App-side publisher. Only the mock runner writes to a topic in a real deployment —
-    the real Runner has its own copy, because the two deployables may not import each other."""
+    the real Runner has its own copy, because the two deployables may not import each other.
+
+    Publishes are PIPELINED: `publish` returns once the frame is written to the connection,
+    and `flush` waits for the acknowledgements.
+
+    WHY (OME-906): awaiting one acknowledgement per frame capped the drain at one broker round
+    trip per frame, while the engine produced observation events at CPU speed. A cached DRACO
+    burst therefore overflowed the Runner's event bridge — which cannot push back, because the
+    engine's observer callback is synchronous — and a correct Evaluation failed.
+
+    INVARIANT: exactly ONE task calls `publish`. `publish_async` writes to the connection
+    inside the call, so a single caller hands the broker the frames in call order, and the
+    broker assigns its stream sequence from that order. Two tasks void it, and the SDK finds
+    gaps by exactly that sequence. This is also why the pipeline lives HERE and not in the
+    lifecycle: a task per frame would bound the window just as well and lose the ordering.
+    """
+
+    def __init__(
+        self,
+        nats_url: str,
+        *,
+        stream_max_age_s: float = DEFAULT_STREAM_MAX_AGE_S,
+        stream_max_bytes: int = DEFAULT_STREAM_MAX_BYTES,
+        orphan_grace_s: float = DEFAULT_ORPHAN_GRACE_S,
+        never_started_s: float = DEFAULT_NEVER_STARTED_S,
+    ) -> None:
+        # Forwarded explicitly rather than through `**kwargs`: the base takes one `int` among
+        # its floats, so a single widened annotation cannot type-check, and the alternative
+        # was a `type: ignore` over the whole call.
+        super().__init__(
+            nats_url,
+            stream_max_age_s=stream_max_age_s,
+            stream_max_bytes=stream_max_bytes,
+            orphan_grace_s=orphan_grace_s,
+            never_started_s=never_started_s,
+        )
+        # A dict used as an ORDERED set. Insertion order is publish order, and `_reap` keeps
+        # the first failure — meaning the one on the earliest-published frame. A plain `set`
+        # iterates by hash, which made "first" whichever future it happened to yield and only
+        # showed up as a test that passed alone and failed in suite order.
+        self._acks: dict[asyncio.Future[api.PubAck], None] = {}
+        self._deferred_failure: BaseException | None = None
 
     async def publish(self, topic: str, event: OutboundFrame) -> None:
         js = await self._jetstream()
-        await js.publish(subject_for(topic), encode(event))
+        # Fail fast: a broker that started rejecting stops the run now, rather than after the
+        # whole in-flight window drains.
+        self._reap()
+        self._raise_deferred()
+        ack = await js.publish_async(subject_for(topic), encode(event))
+        self._acks[ack] = None
+
+    async def flush(self) -> None:
+        if self._acks:
+            await asyncio.wait(tuple(self._acks))
+        self._reap()
+        self._raise_deferred()
+
+    def _reap(self) -> None:
+        """Harvest every settled acknowledgement: drop it and keep the first rejection.
+
+        WHY reaping rather than an `add_done_callback`: a callback runs through
+        `loop.call_soon`, so a failure recorded there is not yet visible to a `flush` that
+        happens not to await — correctness would depend on callback scheduling order. Reading
+        the futures directly makes both paths deterministic.
+
+        INVARIANT: `_acks` stays bounded. Every `publish` reaps before it adds, and `flush`
+        reaps all, so it never outgrows the in-flight window
+        (`MAX_IN_FLIGHT_PUBLISHES`) that nats-py's own semaphore enforces.
+
+        Reading `exception()` here is also what stops asyncio's "exception was never
+        retrieved" warning on a future nothing awaits.
+        """
+        for ack in tuple(self._acks):
+            if not ack.done():
+                continue
+            del self._acks[ack]
+            if ack.cancelled():
+                # No broker verdict. Treating teardown as a rejection would fail a run on
+                # the shutdown path.
+                continue
+            exc = ack.exception()
+            if exc is not None and self._deferred_failure is None:
+                self._deferred_failure = exc
+
+    def _raise_deferred(self) -> None:
+        """Report a recorded failure once, then forget it.
+
+        INVARIANT: clearing is required, not tidiness. `run` reaches its `failed` arm through
+        this raise, and that arm publishes AND flushes the terminal frame — if the failure
+        persisted, that flush would raise too and the subscriber would wait forever for the
+        one frame it is guaranteed.
+        """
+        exc, self._deferred_failure = self._deferred_failure, None
+        if exc is not None:
+            raise DeferredPublishError(
+                "a JetStream publish was rejected after it returned"
+            ) from exc
 
 
-__all__ = ["JetStreamConsumer", "JetStreamPublisher"]
+__all__ = ["DeferredPublishError", "JetStreamConsumer", "JetStreamPublisher"]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -51,6 +51,15 @@ from url4.streaming.protocol.taxonomy import CostBreakdown
 
 _logger = logging.getLogger(__name__)
 
+BRIDGE_HIGH_WATER = "bridge.high_water"
+BRIDGE_SOFT_CAP = "bridge.soft_cap"
+"""Attribute keys for the bridge's closing diagnostic.
+
+Named as one `bridge.*` family, exactly as `RunCacheCounters` names its `cache.*` keys, so a
+reader finds the pair by prefix. The soft cap travels WITH the mark because the mark alone is
+uninterpretable — 3000 is alarming against a cap of 1024 and impossible against 8192.
+"""
+
 
 class BridgeOverflowError(RuntimeError):
     """Raised by `_Bridge.on_event` when the backlog still exceeds the hard cap after the
@@ -77,12 +86,36 @@ class _Bridge:
         self._max = maxsize
         self._hard_cap = maxsize * self._HARD_CAP_MULTIPLIER
         self._dropped = 0
+        self._high_water = 0
         self._closed = False
         self._wake = asyncio.Event()
 
     @property
     def dropped(self) -> int:
         return self._dropped
+
+    @property
+    def soft_cap(self) -> int:
+        return self._max
+
+    @property
+    def high_water(self) -> int:
+        """The deepest this backlog ever got.
+
+        INVARIANT: a MARK, never a gauge — draining does not lower it. A figure that fell
+        back with the queue would read as healthy on every run that recovered, which is
+        every run an operator would still want to know about.
+        """
+        return self._high_water
+
+    @property
+    def backlogged(self) -> bool:
+        """Whether the backlog ever passed the SOFT cap.
+
+        The threshold worth reporting: below it the eviction policy never engaged, so there
+        is nothing to say — and `_closing_logs` must stay silent when that is true.
+        """
+        return self._high_water > self._max
 
     def on_event(self, event: ObservationEvent) -> None:
         """Called synchronously by the engine for every observation event.
@@ -105,9 +138,12 @@ class _Bridge:
         if len(self._buf) >= self._hard_cap:
             raise BridgeOverflowError(
                 f"event backlog exceeded the hard cap ({self._hard_cap} events, "
-                f"{self._dropped} Log(s) already dropped) — the consumer is not keeping up"
+                f"peak {self._high_water}, {self._dropped} Log(s) already dropped) "
+                "— the consumer is not keeping up"
             )
         self._buf.append(event)
+        if len(self._buf) > self._high_water:
+            self._high_water = len(self._buf)
         self._wake.set()
 
     def _evict_oldest_log(self) -> None:
@@ -520,28 +556,54 @@ class _RunState:
         return "mixed", "mixed"
 
 
-def _closing_logs(dropped: int, counters: RunCacheCounters) -> list[Traced]:
+def _closing_logs(bridge: _Bridge, counters: RunCacheCounters) -> list[Traced]:
     """The log frames a run emits about ITSELF, after its last span and before `Completed`.
 
-    Both are statements about the whole run rather than about any node, so both carry
-    ``span=None`` and neither can be made until every event has been folded. Extracted from
+    All are statements about the whole run rather than about any node, so all carry
+    ``span=None`` and none can be made until every event has been folded. Extracted from
     `Url4Executor.execute` so the generator stays a straight line — the run loop's shape is what
     a reader checks for correctness, and a growing tail of end-of-run bookkeeping obscures it.
 
     Args:
-        dropped: Log events the bridge discarded under backpressure.
+        bridge: The run's event bridge, for its dropped count and its high-water mark.
         counters: The run's cache tallies.
 
     Returns:
-        Only the frames that have something to say. A run that dropped nothing and touched no
-        cache — the overwhelming majority, since most expressions call no gateway at all —
-        produces neither, rather than two lines reporting that nothing happened.
+        Only the frames that have something to say. A run that dropped nothing, never
+        backlogged, and touched no cache — the overwhelming majority, since most expressions
+        call no gateway at all — produces none, rather than three lines reporting that
+        nothing happened.
     """
     frames: list[Traced] = []
-    if dropped:
+    if bridge.dropped:
         frames.append(
             Traced(
-                payload=LogData.at("WARN", f"dropped {dropped} log event(s) (telemetry overflow)"),
+                payload=LogData.at(
+                    "WARN", f"dropped {bridge.dropped} log event(s) (telemetry overflow)"
+                ),
+                span=None,
+            )
+        )
+    # FEATURE: bridge high-water reporting (OME-906). Emitted only PAST the soft cap: a run
+    # that never queued has nothing to report, and an always-on line would bury the signal in
+    # the runs that are fine. The pair answers "how close did this run come?" — which the
+    # overflow error can only answer for runs that already failed.
+    #
+    # WHY not Prometheus: same two reasons as `RunCacheCounters` — the run mode is a one-shot
+    # Job with no scrape endpoint, and `check_layering.py` forbids `runner.*` to import
+    # `screamingface_engine.metrics`. The run's own telemetry stream is the only channel.
+    if bridge.backlogged:
+        frames.append(
+            Traced(
+                payload=LogData.at(
+                    "WARN",
+                    f"event backlog peaked at {bridge.high_water} events "
+                    f"(soft cap {bridge.soft_cap})",
+                    {
+                        BRIDGE_HIGH_WATER: bridge.high_water,
+                        BRIDGE_SOFT_CAP: bridge.soft_cap,
+                    },
+                ),
                 span=None,
             )
         )
@@ -647,7 +709,7 @@ class Url4Executor(Executor):
                 for frame in state.map(ev):
                     yield frame
             result_str = await task
-            for frame in _closing_logs(bridge.dropped, state.cache_counters):
+            for frame in _closing_logs(bridge, state.cache_counters):
                 yield frame
             # WHY to_thread: for a spilled result this hashes and writes up to hard_cap
             # bytes — synchronous disk work that would otherwise stall the very loop that

--- a/apps/screamingface-engine/src/screamingface_engine/testing/mock_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/testing/mock_runner.py
@@ -169,6 +169,10 @@ async def publish_mock_run(stream: EventPublisher, topic: str, url4: str) -> Non
     await stream.ensure_stream(topic)
     for event in build_run(topic, url4):
         await stream.publish(topic, event)
+    # A publisher may defer its acknowledgements, and this function's only caller exits the
+    # process right after it returns — without the barrier the mock run's frames could still
+    # be in flight when the connection closes.
+    await stream.flush()
 
 
 def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule, spec §11)

--- a/apps/screamingface-engine/tests/unit/_fakes.py
+++ b/apps/screamingface-engine/tests/unit/_fakes.py
@@ -81,6 +81,19 @@ class _JetStreamEventStream(EventStream):
 
     async def publish(self, topic: str, event: OutboundFrame) -> None:
         await self._publisher.publish(topic, event)
+        # WHY flush here (OME-906): `JetStreamPublisher.publish` now DEFERS its
+        # acknowledgement, so it returns before the broker has confirmed the frame. The shared
+        # contract suite publishes and then reads, and it must mean the same thing for both
+        # parameters — `InMemoryEventStream.publish` is durable on return, so this composite
+        # makes itself durable on return too.
+        #
+        # AIDEV-NOTE: this deliberately DIVERGES from the Runner, which flushes once at the
+        # outcome boundary rather than per frame — that is the whole point of the pipeline. The
+        # contract suite asserts sequence, replay and purge semantics, not durability timing;
+        # the timing is covered by `test_jetstream_pipelining.py`. Do not "fix" this to match
+        # production, and do not add a flush to the contract suite instead: that would make
+        # every adapter's contract depend on a barrier only one of them needs.
+        await self._publisher.flush()
 
     def subscribe(
         self, topic: str, from_sequence: int | None = None

--- a/apps/screamingface-engine/tests/unit/test_jetstream_pipelining.py
+++ b/apps/screamingface-engine/tests/unit/test_jetstream_pipelining.py
@@ -1,0 +1,203 @@
+"""`JetStreamPublisher` pipelines its publishes; `flush` is the durability barrier.
+
+FEATURE: a cached DRACO burst must not overflow the Runner event bridge (OME-906). Awaiting
+one broker acknowledgement per frame capped the drain at one round trip per frame — roughly
+1000 frames/s — while the engine produced observation events at CPU speed. The bridge between
+them cannot push back, because the engine's observer callback is synchronous, so it overflowed
+its hard cap on a run that was entirely correct.
+
+The unit suite has no broker, so these tests replace `_jetstream` with a fake context. The
+real-broker behaviour is covered by the NATS-gated conformance parameters in `_fakes.py`.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from screamingface_engine.adapters.jetstream import (
+    DeferredPublishError,
+    JetStreamPublisher,
+)
+from url4.streaming.protocol import LogData, LogEvent, OutboundFrame, SpanData, SpanEvent
+
+TOPIC = "pipelining-topic"
+
+
+class _FakeJetStream:
+    """The slice of `JetStreamContext` the publisher uses, with acknowledgements under test
+    control so a test can assert on the deferred window rather than on timing."""
+
+    def __init__(self) -> None:
+        self.subjects: list[str] = []
+        self.futures: list[asyncio.Future[object]] = []
+
+    async def publish_async(self, subject: str, payload: bytes) -> asyncio.Future[object]:
+        self.subjects.append(subject)
+        future: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+        self.futures.append(future)
+        return future
+
+    def settle_all(self) -> None:
+        for future in self.futures:
+            if not future.done():
+                future.set_result(object())
+
+
+def _publisher(fake: _FakeJetStream) -> JetStreamPublisher:
+    publisher = JetStreamPublisher("nats://unused:4222")
+
+    async def _fake_jetstream() -> _FakeJetStream:
+        return fake
+
+    # WHY monkeypatch the seam rather than the socket: the pipelining contract is about WHEN
+    # this class waits, which is observable at the JetStream boundary and nowhere below it.
+    publisher._jetstream = _fake_jetstream  # type: ignore[assignment,method-assign]
+    return publisher
+
+
+def _log(n: int) -> LogEvent:
+    return LogEvent(
+        id=f"e{n}",
+        source="/trace/t/node/root",
+        subject="t",
+        data=LogData.at("INFO", f"msg-{n}"),
+    )
+
+
+def _span(n: int) -> SpanEvent:
+    return SpanEvent(
+        id=f"s{n}",
+        source="/trace/t/node/n",
+        subject="t",
+        data=SpanData(name="chat", operation="chat", start=datetime(2026, 8, 20, tzinfo=UTC)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_publish_does_not_wait_for_the_acknowledgement() -> None:
+    # INVARIANT: this is the whole fix. `publish` returns with the acknowledgement still
+    # outstanding, so the drain rate stops being one broker round trip per frame.
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+
+    await publisher.publish(TOPIC, _log(0))
+
+    assert len(fake.futures) == 1
+    assert not fake.futures[0].done(), "publish must not have awaited the acknowledgement"
+
+
+@pytest.mark.asyncio
+async def test_many_frames_publish_without_a_single_acknowledgement() -> None:
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+
+    for i in range(50):
+        await publisher.publish(TOPIC, _span(i))
+
+    assert len(fake.subjects) == 50
+    assert not any(f.done() for f in fake.futures)
+
+
+@pytest.mark.asyncio
+async def test_the_frames_reach_the_transport_in_call_order() -> None:
+    """INVARIANT: order is why the pipeline lives in the transport and not in the caller.
+    A task per frame would reach the socket in an unknown order, and the consumer finds gaps
+    by the sequence the broker assigns from that order."""
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+    frames: list[OutboundFrame] = [_log(i) for i in range(5)]
+
+    for frame in frames:
+        await publisher.publish(TOPIC, frame)
+
+    assert len(fake.subjects) == 5
+    assert fake.subjects == [fake.subjects[0]] * 5, "one topic means one subject"
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_acknowledgement_raises_on_the_next_publish() -> None:
+    # STORY: as an operator, a broker that starts rejecting must stop the run promptly —
+    # not after the whole in-flight window has drained.
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+    await publisher.publish(TOPIC, _log(0))
+    fake.futures[0].set_exception(RuntimeError("maximum messages exceeded"))
+    await asyncio.sleep(0)  # let the done callback run
+
+    with pytest.raises(DeferredPublishError) as excinfo:
+        await publisher.publish(TOPIC, _log(1))
+
+    assert "maximum messages exceeded" in str(excinfo.value.__cause__)
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_acknowledgement_raises_at_the_flush() -> None:
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+    await publisher.publish(TOPIC, _log(0))
+    fake.futures[0].set_exception(RuntimeError("no stream response"))
+
+    with pytest.raises(DeferredPublishError):
+        await publisher.flush()
+
+
+@pytest.mark.asyncio
+async def test_the_flush_reports_a_failure_once_and_then_clears_it() -> None:
+    """INVARIANT: every exit from a run still publishes its terminal frame. If `flush` kept
+    re-raising, the `failed` arm's own publish-and-flush would raise too and the subscriber
+    would wait forever for a frame that never came."""
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+    await publisher.publish(TOPIC, _log(0))
+    fake.futures[0].set_exception(RuntimeError("rejected"))
+
+    with pytest.raises(DeferredPublishError):
+        await publisher.flush()
+
+    await publisher.flush()  # must not raise the same failure again
+
+
+@pytest.mark.asyncio
+async def test_the_flush_waits_for_the_pending_acknowledgements() -> None:
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+    for i in range(3):
+        await publisher.publish(TOPIC, _log(i))
+
+    flushing = asyncio.ensure_future(publisher.flush())
+    await asyncio.sleep(0)
+    assert not flushing.done(), "flush returned while acknowledgements were still outstanding"
+
+    fake.settle_all()
+    await asyncio.wait_for(flushing, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_only_the_first_failure_is_reported() -> None:
+    # WHY the first: it is the one that explains the run. A later rejection is usually the
+    # same broker condition observed again.
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+    for i in range(2):
+        await publisher.publish(TOPIC, _log(i))
+    fake.futures[0].set_exception(RuntimeError("first"))
+    fake.futures[1].set_exception(RuntimeError("second"))
+
+    with pytest.raises(DeferredPublishError) as excinfo:
+        await publisher.flush()
+
+    assert "first" in str(excinfo.value.__cause__)
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_acknowledgement_is_not_a_failure() -> None:
+    # A cancelled future carries no broker verdict. Treating it as a rejection would fail a
+    # run on teardown, which is the shutdown path, not a defect.
+    fake = _FakeJetStream()
+    publisher = _publisher(fake)
+    await publisher.publish(TOPIC, _log(0))
+    fake.futures[0].cancel()
+    await asyncio.sleep(0)
+
+    await publisher.flush()

--- a/apps/screamingface-engine/tests/unit/test_publish_durability.py
+++ b/apps/screamingface-engine/tests/unit/test_publish_durability.py
@@ -1,0 +1,142 @@
+"""The two-phase publish contract: ordered hand-off, then an explicit durability barrier.
+
+FEATURE: a cached DRACO burst must not overflow the Runner event bridge (OME-906). The
+Runner used to await one broker acknowledgement per frame, which capped the drain at one
+round trip per frame while the engine produced events at CPU speed. `EventPublisher` now
+separates "the transport took the frame, in order" from "the broker made it durable", and
+the lifecycle waits for durability only where it decides the outcome of the run.
+
+These tests pin the CONTRACT, not one adapter: `flush` must default to doing nothing, the
+lifecycle must flush before it declares an outcome, and a deferred failure surfacing at the
+flush must fail the run the same way an immediate publish failure always has.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+from _fakes import MockExecutor
+
+from url4.streaming.interfaces import EventPublisher, ExecStep, Executor, TraceContext
+from url4.streaming.lifecycle import run as publish_run
+from url4.streaming.protocol import OutboundFrame, ResultEvent, TerminatedEvent
+
+TOPIC = "durability-topic"
+
+
+class _TracingPublisher(EventPublisher):
+    """Records `publish` and `flush` as one ordered trace, so a test can assert the barrier
+    lands between the frames rather than merely that it ran."""
+
+    def __init__(self, *, flush_raises: BaseException | None = None) -> None:
+        self.trace: list[str] = []
+        self.published: list[OutboundFrame] = []
+        self._flush_raises = flush_raises
+        self.flushes = 0
+
+    async def ensure_stream(self, topic: str) -> None:
+        return None
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None:
+        self.published.append(event)
+        self.trace.append(f"publish:{type(event).__name__}")
+
+    async def flush(self) -> None:
+        self.flushes += 1
+        self.trace.append("flush")
+        # Only the FIRST flush raises: an adapter reports a deferred failure once and then
+        # discards it, so the termination path can still get its own frame out.
+        if self._flush_raises is not None and self.flushes == 1:
+            raise self._flush_raises
+
+
+class _CancellingExecutor(Executor):
+    async def execute(
+        self, url4: str, *, trace: TraceContext | None = None
+    ) -> AsyncIterator[ExecStep]:
+        raise asyncio.CancelledError
+        yield  # pragma: no cover - unreachable, makes this an async generator
+
+
+def _terminal(pub: _TracingPublisher) -> TerminatedEvent:
+    return next(f for f in pub.published if isinstance(f, TerminatedEvent))
+
+
+def test_the_port_flush_defaults_to_doing_nothing() -> None:
+    """INVARIANT: `flush` is NOT abstract. Every existing adapter and test fake is durable
+    when `publish` returns, so making it abstract would break all of them for nothing."""
+
+    class _Minimal(EventPublisher):
+        async def ensure_stream(self, topic: str) -> None:
+            return None
+
+        async def publish(self, topic: str, event: OutboundFrame) -> None:
+            return None
+
+    assert asyncio.run(_Minimal().flush()) is None
+
+
+@pytest.mark.asyncio
+async def test_the_run_flushes_after_the_result_and_before_the_terminal_frame() -> None:
+    # INVARIANT: the barrier sits where the OUTCOME is decided. A flush after the terminal
+    # frame instead of before it would let a run publish "succeeded" over a stream whose
+    # span frames were never acknowledged.
+    pub = _TracingPublisher()
+
+    await publish_run(pub, MockExecutor(), TOPIC, "'hi' -> claude")
+
+    assert "flush" in pub.trace
+    result_at = pub.trace.index("publish:ResultEvent")
+    terminal_at = pub.trace.index("publish:TerminatedEvent")
+    first_flush_at = pub.trace.index("flush")
+    assert result_at < first_flush_at < terminal_at
+
+
+@pytest.mark.asyncio
+async def test_the_terminal_frame_is_flushed_before_the_run_returns() -> None:
+    pub = _TracingPublisher()
+
+    await publish_run(pub, MockExecutor(), TOPIC, "'hi' -> claude")
+
+    assert pub.trace[-1] == "flush", (
+        f"the terminal frame must be durable before `run` returns, trace ended {pub.trace[-3:]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_deferred_failure_surfacing_at_the_flush_fails_the_run() -> None:
+    # STORY: as an operator, a run whose span frames never reached the broker must report
+    # `failed`, not `succeeded` over a stream with a hole in it.
+    pub = _TracingPublisher(flush_raises=RuntimeError("ack rejected"))
+
+    await publish_run(pub, MockExecutor(), TOPIC, "'hi' -> claude")
+
+    terminal = _terminal(pub)
+    assert terminal.data.status == "failed"
+    assert terminal.data.error is not None
+    assert "ack rejected" in terminal.data.error.message
+
+
+@pytest.mark.asyncio
+async def test_a_failed_flush_still_lets_the_terminal_frame_out() -> None:
+    """INVARIANT: every exit path from `run` publishes a terminal frame. A deferred failure
+    reported at the first flush must not also take out the frame that reports it."""
+    pub = _TracingPublisher(flush_raises=RuntimeError("ack rejected"))
+
+    await publish_run(pub, MockExecutor(), TOPIC, "'hi' -> claude")
+
+    assert isinstance(pub.published[-1], TerminatedEvent)
+    assert not any(isinstance(f, ResultEvent) and f is pub.published[-1] for f in pub.published)
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_run_still_terminates_as_stopped() -> None:
+    # WHY here: `_terminate` gained a flush, and the cancellation arm suppresses failures
+    # from it. This pins that the added barrier did not turn a `stopped` run into a `failed`
+    # one, which is the one regression the new call could plausibly cause.
+    pub = _TracingPublisher()
+
+    with pytest.raises(asyncio.CancelledError):
+        await publish_run(pub, _CancellingExecutor(), TOPIC, "'hi' -> claude")
+
+    assert _terminal(pub).data.status == "stopped"

--- a/apps/screamingface-engine/tests/unit/test_url4_executor.py
+++ b/apps/screamingface-engine/tests/unit/test_url4_executor.py
@@ -9,10 +9,14 @@ from typing import cast
 import pytest
 
 from screamingface_engine.artifacts import ArtifactStore
+from screamingface_engine.runner.cache_counters import RunCacheCounters
 from screamingface_engine.runner.executor import (
+    BRIDGE_HIGH_WATER,
+    BRIDGE_SOFT_CAP,
     BridgeOverflowError,
     Url4Executor,
     _Bridge,
+    _closing_logs,
     _RunState,
     deny_by_default_world,
 )
@@ -669,3 +673,110 @@ async def test_hard_cap_governs_even_when_knobs_are_inverted(tmp_path: Path) -> 
 
     assert excinfo.value.code == "result_too_large"
     assert "30" in str(excinfo.value)
+
+
+def test_the_bridge_records_its_high_water_mark() -> None:
+    # FEATURE: bridge high-water reporting (OME-906). A run that overflowed told an operator
+    # only THAT it overflowed; a run that came close told them nothing at all. The mark is
+    # the difference between "this is fine" and "this is one cached Fusion from failing".
+    bridge = _Bridge(maxsize=4)
+    for i in range(3):
+        bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))
+
+    assert bridge.high_water == 3
+
+
+@pytest.mark.asyncio
+async def test_the_high_water_mark_is_a_mark_not_a_gauge() -> None:
+    # INVARIANT: draining does NOT lower it. The peak is the diagnostic; a mark that fell
+    # back with the queue would read as healthy on every run that recovered.
+    bridge = _Bridge(maxsize=4)
+    for i in range(3):
+        bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))
+    bridge.close()
+
+    drained = [event async for event in bridge.drain()]
+
+    assert len(drained) == 3
+    assert bridge.high_water == 3
+
+
+def test_a_backlog_within_the_soft_cap_is_not_reported_as_backlogged() -> None:
+    bridge = _Bridge(maxsize=4)
+    for i in range(4):
+        bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))
+
+    assert bridge.high_water == 4
+    assert not bridge.backlogged
+
+
+def test_a_backlog_past_the_soft_cap_is_reported_as_backlogged() -> None:
+    bridge = _Bridge(maxsize=4)
+    for i in range(6):
+        bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))
+
+    assert bridge.high_water == 6
+    assert bridge.backlogged
+
+
+def test_the_overflow_error_names_the_high_water_mark() -> None:
+    bridge = _Bridge(maxsize=2)
+    with pytest.raises(BridgeOverflowError) as excinfo:
+        for i in range(bridge._hard_cap + 1):
+            bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))
+
+    # Asserts the PHRASE, not just the number: the hard cap is already in this message, and
+    # at the moment of the raise the peak equals it — so a bare digit check passes on a
+    # message that never learned to report the mark.
+    assert f"peak {bridge.high_water}" in str(excinfo.value)
+
+
+def _backlogged_bridge(*, events: int, maxsize: int = 4) -> _Bridge:
+    """A bridge whose backlog is made of NON-Log events, which is the shape that matters.
+
+    A Log-only burst pins the buffer AT the soft cap — `on_event` drops an incoming Log
+    outright rather than appending it — so it never raises the mark and is already reported by
+    the dropped-count line. Only lossless events climb toward the hard cap, which is the
+    condition OME-906 exists to make visible.
+    """
+    bridge = _Bridge(maxsize=maxsize)
+    for i in range(events):
+        bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))
+    return bridge
+
+
+def test_a_backlogged_run_reports_its_high_water_mark_in_a_closing_log() -> None:
+    bridge = _backlogged_bridge(events=9, maxsize=4)
+
+    frames = _closing_logs(bridge, RunCacheCounters())
+
+    marks = [
+        f.payload
+        for f in frames
+        if isinstance(f.payload, LogData) and BRIDGE_HIGH_WATER in (f.payload.attributes or {})
+    ]
+    assert len(marks) == 1
+    attributes = marks[0].attributes or {}
+    assert attributes[BRIDGE_HIGH_WATER] == 9
+    assert attributes[BRIDGE_SOFT_CAP] == 4
+    # INVARIANT: a run-level statement, so it belongs to no span.
+    assert all(f.span is None for f in frames)
+
+
+def test_a_run_that_never_backlogged_reports_no_high_water_log() -> None:
+    # WHY: `_closing_logs` stays silent when there is nothing to say — most expressions call
+    # no gateway and never queue. An always-on line would make the signal worthless.
+    bridge = _backlogged_bridge(events=3, maxsize=4)
+
+    frames = _closing_logs(bridge, RunCacheCounters())
+
+    assert frames == []
+
+
+def test_a_backlog_exactly_at_the_soft_cap_is_not_yet_worth_reporting() -> None:
+    # Boundary: `backlogged` is strictly GREATER than the soft cap. Reaching the cap is the
+    # eviction policy working as designed, not a diagnosis.
+    bridge = _backlogged_bridge(events=4, maxsize=4)
+
+    assert bridge.high_water == 4
+    assert _closing_logs(bridge, RunCacheCounters()) == []

--- a/docs/plan/2026-08-20-OME-906-pipelined-frame-publishing.md
+++ b/docs/plan/2026-08-20-OME-906-pipelined-frame-publishing.md
@@ -1,0 +1,268 @@
+# OME-906 — Implementation plan
+
+- **Spec:** `docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md`
+- **Linear:** https://linear.app/openmined/issue/OME-906
+- **Branch:** `OME-906-pipelined-frame-publishing`
+- **Stacks:** `url4` (`packages/url4`) and `screamingface-engine`
+  (`apps/screamingface-engine`). Both use the `sdlc-python` skill.
+
+## Order of work
+
+The `url4` package holds the port. The engine holds the only override. Therefore the port
+comes first. Each step is RED first, then GREEN.
+
+| Step | Stack | Subject |
+|---|---|---|
+| 1 | url4 | Add `flush` to the `EventPublisher` port |
+| 2 | url4 | Call `flush` at the two outcome boundaries |
+| 3 | screamingface-engine | Record the bridge high-water mark |
+| 4 | screamingface-engine | Make `JetStreamPublisher` pipeline its publishes |
+| 5 | screamingface-engine | Add the DRACO-shaped regression test |
+
+## Step 1 — The port method
+
+**File:** `packages/url4/src/url4/streaming/interfaces/stream.py`
+
+Add one method to `EventPublisher`, after `publish` and before `close`:
+
+```python
+    async def flush(self) -> None:
+        """Wait until every frame published so far is durable.
+
+        Raises the first deferred failure, then DISCARDS the remaining deferred state, so
+        the termination path's own flush does not raise an error already reported.
+
+        Does nothing by default: an adapter whose `publish` is durable when it returns has
+        nothing to wait for. Only a deferring adapter overrides this.
+        """
+        return None
+```
+
+Extend the `publish` docstring with the two new rules:
+
+- The frames reach the broker in call order. An adapter can defer the acknowledgement to
+  `flush`.
+- The caller must use exactly one task. Concurrent callers break the order guarantee.
+
+**RED first.** `packages/url4/tests/` gets these tests:
+
+- A minimal `EventPublisher` subclass that implements only the abstract methods. Assert
+  that `await pub.flush()` returns `None`. This test covers the default body. The `url4`
+  gate needs 95 percent coverage, so the default body needs a caller.
+- Assert that `EventPublisher` stays abstract for `ensure_stream` and `publish`. `flush`
+  must not become abstract.
+
+**Do not** make `flush` abstract. An abstract method breaks every existing implementation
+and every test fake.
+
+## Step 2 — The lifecycle barrier
+
+**File:** `packages/url4/src/url4/streaming/lifecycle.py`
+
+In `_publish_execution`, after the `ResultEvent` publish, add:
+
+```python
+    await stream.flush()
+```
+
+Add a comment that states why the call is at this place: the outcome of the run is decided
+after this line, so the durability must be known before it.
+
+In `_terminate`, after the `TerminatedEvent` publish, add the same call.
+
+**RED first.** `packages/url4/tests/` gets these tests:
+
+- A fake publisher that counts calls. Assert `flush` runs after the result frame and
+  before the terminal frame.
+- A fake publisher whose `flush` raises. Assert `run` publishes
+  `Terminated(status="failed")` with the error, and that `run` does not report success.
+- A fake publisher that records the order of every call. Assert the terminal frame is
+  published, then flushed.
+
+**Watch the arms.** `run` has one arm for each way a run ends. The arm for
+`asyncio.CancelledError` must keep its current behavior. Check that the new `flush` in
+`_terminate` does not change the `stopped` outcome.
+
+## Step 3 — The bridge high-water mark
+
+**File:** `apps/screamingface-engine/src/screamingface_engine/runner/executor.py`
+
+In `_Bridge.__init__`, add `self._high_water = 0`.
+
+In `on_event`, after `self._buf.append(event)`, add:
+
+```python
+        if len(self._buf) > self._high_water:
+            self._high_water = len(self._buf)
+```
+
+Add a `high_water` property beside `dropped`.
+
+Add the mark to the `BridgeOverflowError` message.
+
+**File:** the same module, function `_closing_logs`
+
+Change the signature to accept the high-water mark. Emit a log frame only if the mark
+passed the soft cap. The function's docstring requires silence when there is nothing to
+report, so a mark below the soft cap emits nothing.
+
+Use the attribute key style of `RunCacheCounters` for the new attribute.
+
+**RED first.** `apps/screamingface-engine/tests/unit/test_url4_executor.py` gets these
+tests:
+
+- A burst that stays below the soft cap. Assert no high-water log frame.
+- A burst that passes the soft cap. Assert one log frame with the correct value.
+- Assert the `BridgeOverflowError` message holds the mark.
+
+## Step 4 — The adapter pipeline
+
+**File:** `apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py`
+
+`_JetStreamConnection._jetstream` must build the context with the explicit bound:
+
+```python
+self._nc.jetstream(publish_async_max_pending=_MAX_IN_FLIGHT)
+```
+
+`nats.aio.client.NATS.jetstream(**opts)` forwards the keyword. This is verified against
+`nats-py` 2.15.0.
+
+Replace `JetStreamPublisher.publish` and add `flush`:
+
+```python
+class JetStreamPublisher(_JetStreamConnection, EventPublisher):
+    """...
+
+    Publishes are PIPELINED: `publish` returns when the frame is written to the
+    connection, and `flush` waits for the acknowledgements.
+
+    WHY (OME-906): a cached DRACO burst makes span events faster than one broker round
+    trip for each frame can drain. The bridge upstream cannot apply backpressure, because
+    the engine's observer callback is synchronous. Therefore the bridge overflowed its
+    hard cap on a run that was correct.
+
+    INVARIANT: exactly ONE task calls `publish`. `publish_async` writes to the connection
+    inside the call, so one task gives the broker the frames in call order. Two tasks void
+    that order, and the SDK finds gaps by the stream sequence the broker then assigns.
+    """
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None:
+        js = await self._jetstream()
+        self._raise_deferred()
+        ack = await js.publish_async(subject_for(topic), encode(event))
+        ack.add_done_callback(self._record_failure)
+
+    async def flush(self) -> None:
+        js = await self._jetstream()
+        await js.publish_async_completed()
+        self._raise_deferred()
+```
+
+`_record_failure` keeps the first failure only, and reads the exception:
+
+```python
+    def _record_failure(self, ack: asyncio.Future[api.PubAck]) -> None:
+        if ack.cancelled():
+            return
+        # Reading the exception HERE also stops the "exception was never retrieved"
+        # warning on a future that nothing awaits.
+        exc = ack.exception()
+        if exc is not None and self._deferred_failure is None:
+            self._deferred_failure = exc
+```
+
+`_raise_deferred` raises and clears:
+
+```python
+    def _raise_deferred(self) -> None:
+        exc, self._deferred_failure = self._deferred_failure, None
+        if exc is not None:
+            raise PublishFailedError("a deferred JetStream publish was rejected") from exc
+```
+
+Keep no list of pending futures. Such a list grows with the run and is itself an unbounded
+queue. `nats-py` already holds the pending set.
+
+Decide the home of `PublishFailedError` during the step. Check first whether an existing
+engine error type fits. Do not add a new type if one exists.
+
+**RED first.** `apps/screamingface-engine/tests/unit/test_event_stream_adapters.py` gets
+these tests. Replace `_jetstream` with a fake context. The unit suite has no broker.
+
+- `publish` does not wait for the acknowledgement. Assert it returns while the future is
+  pending.
+- The order is kept. Publish several frames. Assert the fake received the subjects in call
+  order.
+- A rejected acknowledgement raises on the next `publish`.
+- A rejected acknowledgement raises on `flush`.
+- `flush` clears the failure. A second `flush` does not raise again.
+- `flush` waits for the pending acknowledgements.
+- A cancelled acknowledgement future is ignored.
+
+Keep the existing port-conformance tests.
+
+## Step 5 — The DRACO regression
+
+**File:** a new test module under `apps/screamingface-engine/tests/integration/`
+
+`InMemoryEventStream` publishes for free. It can never reproduce this defect. Therefore
+the test needs a publisher fake with a delay.
+
+Build two fakes:
+
+- `_SerialPublisher`: `publish` waits 1 ms and is then durable. This fake models the old
+  behavior.
+- `_PipelinedPublisher`: `publish` returns at once and records the frame. `flush` waits
+  for the recorded frames. This fake models the new contract.
+
+Build a DRACO-shaped executor: a 100-Case protocol, a Fusion of three member Models and
+one synthesizer, and immediate cache-hit responses. Target 700 or more model calls.
+
+Assert with `_PipelinedPublisher`:
+
+- `lifecycle.run` completes. It does not raise `BridgeOverflowError`.
+- The frame order is `Started`, then the span and cost frames, then
+  `CostUsage(scope="subtree")`, then `Result`, then `Terminated(succeeded)`.
+- Every span frame is present. Count the spans against the node count.
+
+Assert with a fake whose `publish` never returns:
+
+- The run fails.
+- The buffer length stays at or below the hard cap.
+
+Do **not** assert that `_SerialPublisher` still overflows. Such a test fixes unwanted
+behavior in place.
+
+## Gates
+
+Run both stacks. The changed paths trigger both CI lanes.
+
+```sh
+# packages/url4
+cd packages/url4
+uv run ruff check && uv run ruff format --check && uv run pyright
+uv run pytest --cov=url4 --cov-fail-under=95 -q
+
+# apps/screamingface-engine
+cd apps/screamingface-engine
+uv run ruff check && uv run ruff format --check && uv run pyright
+uv run pytest -q
+```
+
+Also run the layering check. Step 3 touches `screamingface_engine.runner`, which must not
+import `screamingface_engine.metrics`.
+
+## Risks
+
+| Risk | Control |
+|---|---|
+| The `url4` coverage gate is 95 percent. The new default `flush` body needs a caller. | Step 1 adds a direct test of the default body. |
+| A new `flush` in `_terminate` could change the `stopped` outcome. | Step 2 tests the cancellation arm. |
+| The adapter tests have no broker. | Replace `_jetstream` with a fake. This matches the current test design, which asserts only port conformance against a real address. |
+| `nats-py` behavior could change. | The version is pinned at 2.15.0 in `uv.lock`. The plan cites the verified call sites. |
+
+## Definition of done
+
+All six acceptance criteria of OME-906 hold. Both gate sets are green. The work ledger
+records the commits and the gate output.

--- a/docs/plan/2026-08-20-OME-906-pipelined-frame-publishing.md
+++ b/docs/plan/2026-08-20-OME-906-pipelined-frame-publishing.md
@@ -1,4 +1,9 @@
-# OME-906 — Implementation plan
+# Implementation plan — pipelined frame publishing
+
+> **Steps 1 to 4 are delivered. Step 5 is NOT, and must not be attempted as written.** The
+> reproduction it asks for disproved the spec's premise: pipelining does not raise the
+> overflow ceiling. See the correction at the top of the spec and the evidence in the work
+> ledger. The real fix needs its own spec and plan.
 
 - **Spec:** `docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md`
 - **Linear:** https://linear.app/openmined/issue/OME-906
@@ -264,5 +269,9 @@ import `screamingface_engine.metrics`.
 
 ## Definition of done
 
-All six acceptance criteria of OME-906 hold. Both gate sets are green. The work ledger
-records the commits and the gate output.
+**Not met, and correctly so.** Steps 1 to 4 are delivered with both gate sets green. Step 5
+stopped the unit: it showed that acceptance criteria 1, 2, 3 and 5 of OME-906 cannot be met
+by this design, because the design targets the wrong mechanism.
+
+Delivered here: the two-phase publish contract (a 50x wall-clock gain at a 10 ms round trip)
+and the bridge high-water mark (acceptance criterion 6). Everything else stays open.

--- a/docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md
+++ b/docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md
@@ -1,8 +1,29 @@
-# OME-906 — Pipelined frame publishing for the Runner event bridge
+# Pipelined frame publishing for the Runner event bridge
 
-- **Linear:** https://linear.app/openmined/issue/OME-906
+- **Linear:** https://linear.app/openmined/issue/OME-906 (investigation origin — NOT closed by this)
 - **Landing:** `apps/screamingface-engine` and `packages/url4`
-- **Status:** spec — approved for planning
+- **Status:** delivered — but see the correction below
+
+> ## CORRECTION — read this first
+>
+> Sections 1 to 4 record the design as it was approved. The premise of section 1 was
+> **measured to be wrong** during implementation.
+>
+> The bridge backlog does NOT depend on how fast the publisher drains it. Across a 100x
+> range of publish latency (0 ms to 10 ms per frame) the peak backlog stays flat. The cap
+> bounds how many events the engine emits **between two chances for the drain to run**, and
+> `url4/dag/executor.py:182` emits `NodeStarted` before it awaits anything while `:186` fans
+> out over `node.deps` with an unbounded `asyncio.gather`. A DAG of width W therefore
+> buffers about W events in ONE event-loop slice. The cap is a ceiling on DAG width.
+>
+> The full evidence is in
+> `docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md`.
+>
+> **What this spec delivered is still correct and still valuable on its own terms:** a
+> two-phase publish contract that cuts wall-clock time by about 50x at a 10 ms round trip,
+> and the high-water reporting that made the real cause measurable. It does NOT fix
+> OME-906. Acceptance criteria 1, 2, 3 and 5 in section 8 remain open, and the real fix
+> needs its own spec.
 
 ## 1. Problem
 
@@ -73,6 +94,10 @@ The solution must obey these constraints.
 C2 is the strongest constraint. It removes most candidate designs.
 
 ## 3. Rejected options
+
+> Row 1 of this table is wrong. See the correction above: raising the cap is the correct
+> direction, because the cap is the binding constraint and the publisher is not. 8192
+> buffered events measure 2.1 MB, in a process that accepts a 1 GiB result.
 
 | Option | Reason for rejection |
 |---|---|

--- a/docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md
+++ b/docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md
@@ -1,0 +1,227 @@
+# OME-906 — Pipelined frame publishing for the Runner event bridge
+
+- **Linear:** https://linear.app/openmined/issue/OME-906
+- **Landing:** `apps/screamingface-engine` and `packages/url4`
+- **Status:** spec — approved for planning
+
+## 1. Problem
+
+A DRACO Evaluation fails when many model calls return from the cache in a burst. The run
+stops with this error:
+
+```text
+ExecutionError: event backlog exceeded the hard cap
+(8192 events, 0 Log(s) already dropped) — the consumer is not keeping up
+```
+
+The run is correct. The system rejects it because of a throughput mismatch.
+
+### 1.1 The three stages
+
+The Runner moves events through three stages. Each stage has a different speed.
+
+| Stage | Code | Speed |
+|---|---|---|
+| Producer | `url4.dag.run` calls `_Bridge.on_event` | CPU speed |
+| Buffer | `_Bridge` deque, soft cap 1024, hard cap 8192 | — |
+| Consumer | `_publish_execution` publishes one frame, then waits | One broker round trip per frame |
+
+The producer is synchronous. `_Bridge.on_event` cannot use `await`. Therefore the buffer
+cannot tell the producer to stop. The buffer can only discard an event or raise an error.
+
+### 1.2 Why the cache burst causes the failure
+
+Model latency usually holds the producer back. The cache removes that delay. The DAG then
+makes events at CPU speed. The consumer still pays one broker round trip for each frame.
+
+The measured reproduction shows the gap. 622 calls make 4228 frames. At 1 ms for each
+round trip, the consumer needs approximately 4 seconds. The producer needs some
+milliseconds. The buffer fills.
+
+### 1.3 Why the relief mechanism does not help
+
+`_Bridge.on_event` can discard only a `Log` event. All other event types are lossless.
+The buffer at the moment of failure held these events:
+
+| Event type | Count | Can be discarded |
+|---|---|---|
+| `NodeStarted` | 3465 | no |
+| `NodeFinished` | 3605 | no |
+| `Usage` | 561 | no |
+| `ModelResponse` | 561 | no |
+| **Total** | **8192** | — |
+
+The buffer held no `Log` event. Therefore `_evict_oldest_log` removed nothing.
+
+Span lifecycle events are 7070 of the 8192 events. Model events are 1122. Therefore a
+change that only groups `Usage` events recovers less than 7 percent. Such a change does
+not correct the failure.
+
+## 2. Constraints
+
+The solution must obey these constraints.
+
+| ID | Constraint | Reason |
+|---|---|---|
+| C1 | The drain rate must not depend on the broker round trip | This is the defect |
+| C2 | The frames must stay in order | The SDK finds gaps with the broker stream sequence |
+| C3 | No span, cost, result or terminal frame is lost | Only a `Log` is safe to discard |
+| C4 | A failed acknowledgement must fail the Evaluation | A hole in the stream must not report success |
+| C5 | The memory must stay bounded if the publisher stalls | Protects the process |
+| C6 | The high-water mark must be visible | Operators need the diagnosis |
+
+C2 is the strongest constraint. It removes most candidate designs.
+
+## 3. Rejected options
+
+| Option | Reason for rejection |
+|---|---|
+| Increase the 8192 cap | The cap is not the limit. The throughput ratio is the limit. A larger cap moves the failure to a larger Evaluation. |
+| Group the `Usage` events | Span lifecycle events are 86 percent of the buffer. This option recovers less than 7 percent. |
+| Put many frames in one broker message | The SDK expects one CloudEvent for each message. Its gap logic uses the per-message sequence. This option breaks the SDK contract. |
+| Make the bridge apply backpressure | `_Bridge.on_event` is synchronous. It cannot wait. To block it stops the event loop that drains it. A correct version needs an asynchronous observer in the url4 engine. That change is large. It is out of scope. |
+| Start one task for each frame in the lifecycle | Concurrent tasks reach the socket in an unknown order. The broker then assigns the stream sequence out of order. This option breaks C2. |
+
+The last row is important. **The pipeline must exist in the transport, not in the caller.**
+
+## 4. Design
+
+`nats-py` 2.15 supplies the necessary primitive. `JetStreamContext.publish_async` does
+three things:
+
+1. It waits on a semaphore. The semaphore bounds the frames in flight. This satisfies C5.
+2. It writes to the connection inside the call. One task therefore writes in call order.
+   This satisfies C2.
+3. It returns a future for the acknowledgement. This satisfies C4.
+
+`publish_async_completed` waits for all pending acknowledgements. It is the barrier.
+
+The design separates two ideas that `publish` holds together today:
+
+- The transport accepted the frame, and the order is correct.
+- The broker made the frame durable.
+
+```text
+Before:  drain -> publish -> wait for the broker -> drain -> ...
+         one frame in flight. Throughput = 1 / round trip.
+
+After:   drain -> publish -> drain -> publish -> ...
+         up to N frames in flight, in order.
+         flush() waits for all acknowledgements at the outcome boundary.
+```
+
+The consumer then runs at CPU speed. The buffer stays shallow. This satisfies C1.
+
+### 4.1 Port contract
+
+`packages/url4/src/url4/streaming/interfaces/stream.py` gets one new method.
+
+`publish(topic, event)` keeps its signature. Its contract becomes:
+
+- The frames reach the broker in call order.
+- An adapter can defer the acknowledgement to `flush`.
+- The caller must use exactly one task. Concurrent callers break the order guarantee.
+- The method raises an error if an earlier deferred publish failed. This stops a broken
+  run early.
+
+`flush()` is new:
+
+- It waits until every frame published before it is durable.
+- It raises the first deferred failure. Then it discards the remaining deferred state.
+  A later `flush` on the termination path therefore does not raise the same error twice.
+- Its default body does nothing. An adapter that is durable when `publish` returns needs
+  no override.
+
+The default body makes the blast radius zero. `InMemoryEventStream.publish` appends to an
+in-process log. It is durable when it returns. The test fakes are also in-process. Only
+`JetStreamPublisher` overrides `flush`.
+
+### 4.2 Lifecycle barrier
+
+`packages/url4/src/url4/streaming/lifecycle.py` gets two calls to `flush`.
+
+The first call is at the end of `_publish_execution`, after the result frame. The
+docstring of that function states that an error from it selects the outcome arm in `run`.
+A failed `flush` therefore reaches the existing failure arm. The arm publishes
+`Terminated(status="failed")`. C4 needs no new control flow.
+
+The second call is in `_terminate`, after it publishes the terminal frame. The terminal
+frame is then durable before `run` returns.
+
+### 4.3 JetStream adapter
+
+`apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py` changes
+`JetStreamPublisher`:
+
+- `publish` calls `publish_async`. It adds a done callback to the returned future. It
+  does not wait for the acknowledgement.
+- `flush` calls `publish_async_completed`. Then it raises any recorded failure.
+- The done callback records the first failure only. The first failure explains the run.
+  The callback also reads the exception. This stops the "exception was never retrieved"
+  warning.
+- The adapter keeps no list of pending futures. Such a list is itself an unbounded queue.
+  `nats-py` already tracks the pending set.
+- The adapter states its own bound. It builds the context with
+  `publish_async_max_pending=1024`. The bound is a promise of this class. It is not a
+  library default.
+
+### 4.4 The stall timeout is not used
+
+`publish_async` accepts `wait_stall`. This design does not use it, for two reasons.
+
+1. The hard cap of the bridge already bounds an endless stall. The frames in flight fill.
+   `publish_async` then waits on the semaphore. The drain stops. The buffer reaches 8192.
+   `BridgeOverflowError` follows. The memory is bounded and the run fails. C5 holds.
+2. `nats-py` converts `asyncio.CancelledError` to `TooManyStalledMsgsError` on that path.
+   A cancelled run would then report `failed` instead of `stopped`.
+
+## 5. Failure behavior
+
+| Situation | Result |
+|---|---|
+| Cache burst, healthy broker | The buffer stays shallow. The Evaluation completes. |
+| One acknowledgement is rejected in the middle of a run | The next `publish` raises. The failure arm publishes `Terminated(failed)`. |
+| The last acknowledgement is rejected | The `flush` at the end raises. The same arm runs. |
+| The broker never answers | The frames in flight fill. The drain stops. The buffer reaches the hard cap. The run fails. The memory is bounded at 1024 in flight plus 8192 buffered. |
+| The run is cancelled | `CancelledError` leaves the semaphore wait. The existing `stopped` arm runs. |
+| Local in-memory adapter | `publish` is already durable. `flush` does nothing. The behavior does not change. |
+
+`BridgeOverflowError` stays. It now reports only a true stall. Its message is then correct.
+
+## 6. Observability
+
+`RunCacheCounters` sets the precedent. Its docstring gives two reasons against Prometheus.
+Both reasons apply here:
+
+1. The run mode is a one-shot Job. It has no scrape endpoint.
+2. `.claude/scripts/check_layering.py` forbids `screamingface_engine.runner.*` to import
+   `screamingface_engine.metrics`.
+
+Therefore the bridge reports through the telemetry stream of the run:
+
+- `_Bridge` keeps a high-water mark. `on_event` updates it.
+- The `BridgeOverflowError` message states the high-water mark.
+- `_closing_logs` emits the high-water mark only if the run passed the soft cap. The
+  docstring of that function requires silence when there is nothing to report. A mark
+  below 1024 is not worth a log line.
+
+## 7. Out of scope
+
+- Write the bridge overflow to disk. The Linear issue asks for bounded memory and a
+  failure. It does not ask for unlimited buffering.
+- Make the url4 observer protocol asynchronous. This is the correct long-term shape. Its
+  blast radius is too large for this correction.
+- Drain the buffer in batches. No measurement supports this change.
+
+## 8. Acceptance criteria
+
+The criteria come from OME-906:
+
+1. A deterministic regression test covers a DRACO-shaped cache burst with a delayed
+   publisher.
+2. A 100-Case DRACO Fusion Evaluation with 700 or more immediate cached Judge responses
+   completes. It does not raise `BridgeOverflowError`.
+3. The started, span, cost, result and terminal frames stay in order. None is lost.
+4. A failed acknowledgement fails the Evaluation with a correct terminal error.
+5. The memory stays bounded when the publisher stalls without end.
+6. The bridge records the high-water mark for operational diagnosis.

--- a/docs/tasks/2026-08-20-pipelined-frame-publishing.md
+++ b/docs/tasks/2026-08-20-pipelined-frame-publishing.md
@@ -1,0 +1,37 @@
+---
+id: OME-906
+linear_url: https://linear.app/openmined/issue/OME-906
+asana_url:
+status: in_progress
+type: task
+priority: 1
+labels: []
+created: 2026-08-20
+closed:
+---
+
+# Cached DRACO evaluations overflow the Runner event bridge
+
+The Runner publishes one frame for each broker round trip. A cached DRACO burst makes
+events far faster. Therefore the bridge overflows its 8192-event hard cap and a correct
+Evaluation fails.
+
+The correction pipelines the publishes with a bounded number of acknowledgements in
+flight, and adds a durability barrier at the outcome boundary of the run.
+
+- Spec: `docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md`
+- Plan: `docs/plan/2026-08-20-OME-906-pipelined-frame-publishing.md`
+- Ledger: `docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md`
+
+## Owner actions outstanding
+
+OME-906 carries **no labels**. The card requires a landing leaf, one `actor` and one
+`who-acts`. The Linear MCP plugin is not active in this session, and the card forbids any
+other transport for mutations. Proposed set:
+
+- landing: `screamingface-engine` (the deployable that shows the defect; the landing group
+  is single-select, so `url4-python-sdk` cannot also apply)
+- actor: `agentic`
+- who-acts: `autonomous`
+
+The state also needs the move to *in progress*.

--- a/docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md
+++ b/docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-906
 stack: url4, screamingface-engine
-status: in_progress
+status: blocked
 started: 2026-08-20
 finished:
 ---
@@ -61,9 +61,79 @@ The six criteria of OME-906:
 - The memory stays bounded when the publisher stalls without end.
 - The bridge records the high-water mark.
 
-## Outcome (fill at the end — required before COMMIT)
+## BLOCKED — the measured root cause is not the one in the issue
 
-- **Actual files:**
-- **Commits:**
-- **Gates:**
+Steps 1 to 4 of the plan are committed and green. Step 5, the DRACO regression, stopped the
+unit: the reproduction shows that pipelined publishing does NOT raise the overflow ceiling.
+
+### What was measured
+
+A DRACO-shaped fan-out (N cache-hit case nodes under one fusion root, each reporting usage
+and a `hit` model response) driven through the REAL `_Bridge` and the REAL
+`lifecycle.run` publish loop. Two publisher fakes: `serial` waits per frame, the old shape;
+`pipelined` writes through and waits at the barrier, the new shape.
+
+**Peak backlog against publish latency, N = 1500, node I/O 1 ms:**
+
+| Publish delay | serial: time / peak | pipelined: time / peak |
+|---|---|---|
+| 0 ms | 0.64 s / 4497 | 0.59 s / 4461 |
+| 0.1 ms | 3.80 s / 4499 | 0.58 s / 4467 |
+| 1 ms | 3.83 s / 4499 | 0.59 s / 4458 |
+| 10 ms | 31.05 s / 4499 | 0.59 s / 4461 |
+
+The publish delay moves over a 100x range. **The peak does not move.**
+
+**Peak against run size, publish delay 0, node I/O 1 ms:**
+
+| N | frames | peak | result |
+|---|---|---|---|
+| 500 | 1007 | 1224 | ok |
+| 1000 | 2007 | 2700 | ok |
+| 2000 | 4007 | 5964 | ok |
+| 3000 | 5470 | — | `BridgeOverflowError` |
+
+Peak is approximately 3N — near the whole event count of the run — and it overflows on run
+SIZE alone, with a publisher that costs nothing.
+
+### What this means
+
+- The issue states the cause is "cached model responses produce events much faster than the
+  serial publish path drains them". The drain rate is not the governing term. The bridge
+  holds nearly every event a run emits, because the drain task cannot interleave with a
+  fan-out producer on the same event loop, whatever the publisher costs.
+- Acceptance criterion 2 is therefore NOT met by the committed work. A run of DRACO's size
+  (about 3500 nodes, 8192 events) still overflows.
+- The committed work is still worth keeping on its own merits: 31 s to 0.59 s at a 10 ms
+  round trip is a 50x wall-clock gain, and the high-water mark from step 3 is what made this
+  measurable at all. Neither is the fix the issue asks for.
+- "Raise the 8192 cap", which the issue rejects as a delay tactic, is no longer obviously
+  wrong. The cap is the binding constraint and the publisher is not. 8192 buffered
+  `ObservationEvent`s is a few MB; a count-based cap chosen against an unmeasured cause is
+  the thing to revisit, ideally as a memory bound.
+
+### Outcome so far
+
+- **Actual files:** `packages/url4/src/url4/streaming/interfaces/stream.py`,
+  `packages/url4/src/url4/streaming/lifecycle.py`,
+  `apps/screamingface-engine/src/screamingface_engine/runner/executor.py`,
+  `apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py`,
+  `apps/screamingface-engine/src/screamingface_engine/testing/mock_runner.py`,
+  tests: `tests/unit/test_publish_durability.py`,
+  `tests/unit/test_jetstream_pipelining.py`, `tests/unit/test_url4_executor.py`,
+  `tests/unit/_fakes.py`.
+- **Commits:** `ea829212` port + lifecycle barrier · `a7437086` high-water mark ·
+  `32b5ba7d` adapter pipelining.
+- **Gates:** url4 ALL GREEN; screamingface-engine ALL GREEN (1880 passed, 5 skipped).
 - **Deviations:**
+  1. `url4/streaming/*` is omitted from url4's own coverage and its tests live in the engine
+     suite by design, so the plan's "tests in packages/url4/tests/" was wrong. All tests
+     went to `apps/screamingface-engine/tests/`.
+  2. Failures are harvested by reaping settled futures, not by `add_done_callback`. A
+     callback runs through `loop.call_soon`, so a `flush` that does not await would miss it.
+  3. `_acks` is an insertion-ordered dict, not a set. A set made "first failure" mean
+     whichever future hash order yielded — it passed alone and failed in suite order.
+  4. `_JetStreamEventStream.publish` in `tests/unit/_fakes.py` gained a flush. That is a
+     prior fixture, so it was an approved rule-5 change, landed with
+     `run_gates.py --skip-append-only` once.
+  5. Step 5 not done — see above.

--- a/docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md
+++ b/docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md
@@ -1,0 +1,69 @@
+---
+ticket: OME-906
+stack: url4, screamingface-engine
+status: in_progress
+started: 2026-08-20
+finished:
+---
+
+# OME-906 — Pipelined frame publishing for the Runner event bridge
+
+## Intent
+
+A DRACO Evaluation fails when many model calls return from the cache at once. The Runner
+publishes one frame for each broker round trip. The engine makes events at CPU speed.
+Therefore the bridge between them overflows its hard cap and the Evaluation stops. The
+Evaluation was correct.
+
+This unit separates two ideas that `EventPublisher.publish` holds together: the transport
+accepted the frame in order, and the broker made the frame durable. The adapter then keeps
+a bounded number of acknowledgements in flight, and the lifecycle waits for them at the
+boundary where it decides the outcome of the run.
+
+## Planned changes
+
+- `packages/url4/src/url4/streaming/interfaces/stream.py` — add `EventPublisher.flush`
+  with a default body that does nothing. Extend the `publish` contract.
+- `packages/url4/src/url4/streaming/lifecycle.py` — call `flush` at the end of
+  `_publish_execution` and after the terminal frame in `_terminate`.
+- `apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py` — make
+  `JetStreamPublisher` use `publish_async`, record the first failed acknowledgement, and
+  implement `flush`. Set `publish_async_max_pending` explicitly.
+- `apps/screamingface-engine/src/screamingface_engine/runner/executor.py` — record the
+  `_Bridge` high-water mark. Report it in the overflow message and in `_closing_logs`.
+- Tests in `packages/url4/tests/`, `apps/screamingface-engine/tests/unit/` and
+  `apps/screamingface-engine/tests/integration/`.
+
+## Test plan
+
+Written RED first, per step:
+
+1. The default `flush` returns `None`. `flush` is not abstract.
+2. `flush` runs after the result frame. A raising `flush` produces
+   `Terminated(status="failed")`. Cancellation still produces `stopped`.
+3. The bridge high-water mark appears in the overflow message. `_closing_logs` reports it
+   only above the soft cap.
+4. `publish` does not wait for its acknowledgement. The call order is kept. A rejected
+   acknowledgement raises on the next `publish` and on `flush`. A second `flush` does not
+   raise the same error. A cancelled future is ignored.
+5. A DRACO-shaped burst of 700 or more cached calls completes against a pipelined
+   publisher fake. The frames stay in order and none is lost. A publisher that never
+   answers fails the run with a bounded buffer.
+
+## Acceptance
+
+The six criteria of OME-906:
+
+- A deterministic regression covers a DRACO-shaped cache burst with a delayed publisher.
+- A 100-Case DRACO Fusion Evaluation with 700 or more cached Judge responses completes.
+- The started, span, cost, result and terminal frames stay in order and lossless.
+- A failed acknowledgement fails the Evaluation with a correct terminal error.
+- The memory stays bounded when the publisher stalls without end.
+- The bridge records the high-water mark.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**

--- a/docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md
+++ b/docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md
@@ -96,6 +96,48 @@ The publish delay moves over a 100x range. **The peak does not move.**
 Peak is approximately 3N — near the whole event count of the run — and it overflows on run
 SIZE alone, with a publisher that costs nothing.
 
+### The confirmed root cause
+
+`_Bridge`'s hard cap does not bound a sustained backlog. It bounds **how many events the
+engine emits between two chances for the drain to run**.
+
+The trace shows why. One run of 2408 operations alternates only **16** times: the producer
+emits hundreds of events with no interruption, then the consumer drains all of them with no
+interruption. `_Bridge.drain` never awaits while its buffer is non-empty, and the publish
+path does not suspend either, so the consumer always empties the buffer completely once the
+loop schedules it. The consumer is not behind. It cannot run at all during a burst.
+
+The burst comes from the DAG:
+
+- `url4/dag/executor.py:182` — `_eval` emits `NodeStarted` **before** it awaits anything.
+- `url4/dag/executor.py:186` — it then fans out over `node.deps` with a plain
+  `asyncio.gather`, with no bound.
+
+So a DAG of width W pushes about W `NodeStarted` events into the buffer in ONE event-loop
+slice. The measured burst grows linearly with the run and equals the peak:
+
+| N | total events | largest burst |
+|---|---|---|
+| 300 | 1204 | 606 |
+| 600 | 2404 | 1491 |
+| 1200 | 4804 | 3555 |
+| 2400 | 9604 | 7179 |
+
+7179 against a cap of 8192 predicts exactly the boundary measured earlier: N = 2000 passes,
+N = 3000 raises.
+
+`DEFAULT_RUN_CONCURRENCY` (32) does not help. Its docstring and
+`url4/dag/executor.py:391` are explicit: it bounds `ctx.io.fetch` calls through a
+`BoundedIOLayer`. It does not bound node resolution or the observation events they emit.
+
+Cache hits matter only at the margin. They let many calls finish in one coalesced burst, so
+the trailing `Usage` + `ModelResponse` + `NodeFinished` triples also arrive in a single
+slice, on top of the width. That matches the issue's own snapshot: 3465 `NodeStarted` for
+561 calls.
+
+**The 8192 cap is therefore a ceiling on DAG WIDTH.** A 100-Case DRACO Fusion is legitimately
+about 3500 nodes wide, so it sits right at the limit.
+
 ### What this means
 
 - The issue states the cause is "cached model responses produce events much faster than the
@@ -107,10 +149,16 @@ SIZE alone, with a publisher that costs nothing.
 - The committed work is still worth keeping on its own merits: 31 s to 0.59 s at a 10 ms
   round trip is a 50x wall-clock gain, and the high-water mark from step 3 is what made this
   measurable at all. Neither is the fix the issue asks for.
-- "Raise the 8192 cap", which the issue rejects as a delay tactic, is no longer obviously
-  wrong. The cap is the binding constraint and the publisher is not. 8192 buffered
-  `ObservationEvent`s is a few MB; a count-based cap chosen against an unmeasured cause is
-  the thing to revisit, ideally as a memory bound.
+- "Raise the 8192 cap", which the issue rejects as a delay tactic, is the correct direction.
+  The cap is the binding constraint, the publisher is not, and the quantity it protects is
+  tiny: 8192 buffered events measure **2.1 MB** (278 B and 232 B per event, measured). The
+  same process accepts a result of `DEFAULT_RESULT_HARD_CAP_BYTES` = **1 GiB**. It refuses
+  2.1 MB of telemetry.
+- The message "the consumer is not keeping up" is wrong by construction. The consumer always
+  drains the buffer completely once scheduled. A genuinely stuck consumer shows as NO drain
+  progress, which is a different and detectable signal — and the right thing for a bound to
+  watch.
+- The issue's Root cause and Suggested direction sections both need correcting.
 
 ### Outcome so far
 

--- a/packages/url4/src/url4/streaming/interfaces/stream.py
+++ b/packages/url4/src/url4/streaming/interfaces/stream.py
@@ -11,7 +11,33 @@ class EventPublisher(ABC):
 
     @abstractmethod
     async def publish(self, topic: str, event: OutboundFrame) -> None:
-        pass
+        """Hand one frame to the transport.
+
+        The frames reach the broker in CALL ORDER. An adapter MAY defer the durability
+        acknowledgement to :meth:`flush` — so a return from here means "accepted, in
+        order", not yet "durable".
+
+        INVARIANT: exactly ONE task calls this per topic. A deferring adapter can only
+        order the writes it performs itself, and the consumer finds gaps by the sequence
+        the broker assigns from that order, so concurrent callers void both guarantees.
+
+        Raises when a PREVIOUSLY deferred publish has since failed, so a broken transport
+        stops a run promptly instead of after the whole in-flight window drains.
+        """
+
+    async def flush(self) -> None:
+        """Wait until every frame published so far is durable.
+
+        Raises the first deferred failure, then DISCARDS the remaining deferred state, so
+        the termination path's own flush does not re-raise an error already reported —
+        every exit from a run must still get its terminal frame out.
+
+        Does nothing by default: an adapter whose :meth:`publish` is already durable when
+        it returns has nothing to wait for. Only a DEFERRING adapter overrides this, which
+        is why this is not abstract — making it so would break every in-process adapter
+        and test fake to serve one broker-backed implementation.
+        """
+        return None
 
     async def close(self) -> None:
         pass

--- a/packages/url4/src/url4/streaming/lifecycle.py
+++ b/packages/url4/src/url4/streaming/lifecycle.py
@@ -104,6 +104,11 @@ async def _terminate(
         topic,
         TerminatedEvent(**seq.next(root_tp), data=TerminatedData(status=status, error=error)),
     )
+    # The terminal frame is the one frame a subscriber is guaranteed, so `run` must not
+    # return while it is still only queued. Each arm in `run` keeps its own policy for a
+    # raise from here — the cancellation arm suppresses it, exactly as it already did for a
+    # failing publish.
+    await stream.flush()
 
 
 def _trace_fields(
@@ -163,6 +168,14 @@ async def _publish_execution(
     subtree = completed.subtree_cost.model_copy(update={"scope": "subtree"})
     await stream.publish(topic, CostUsageEvent(**seq.next(root_tp), data=subtree))
     await stream.publish(topic, ResultEvent(**seq.next(root_tp), data=completed.result))
+    # INVARIANT: durability is settled BEFORE the outcome is. A publisher may defer its
+    # acknowledgements (see `EventPublisher.publish`), so without this barrier `run` could
+    # publish `succeeded` over a stream that silently lost a span frame — and a consumer
+    # cannot tell that from a complete one.
+    #
+    # WHY here rather than in `run`: this function raises to select `run`'s outcome arm, so
+    # a deferred failure reported here reaches the `failed` arm with no new control flow.
+    await stream.flush()
 
 
 async def run(


### PR DESCRIPTION
## Summary

Two independent improvements that came out of the OME-906 investigation. **This PR does not
fix OME-906 and must not close it** — the investigation disproved the issue's stated root
cause, and the real fix is specced separately.

1. **A two-phase publish contract.** `EventPublisher.publish` conflated "the transport took
   the frame, in order" with "the broker made it durable". `flush` now separates them, and
   `JetStreamPublisher` pipelines through `publish_async` with a bounded in-flight window.
   Worth **~50x wall-clock** at a 10 ms round trip (31.05 s → 0.59 s on a 1500-node run).
2. **Bridge high-water reporting.** `_Bridge` records its peak backlog, names it in the
   overflow error, and reports it with its soft cap in a closing log frame. This is the
   instrument that made the real root cause measurable.

## What the investigation found

The issue attributes the overflow to serial ack-per-frame publishing. Measurement says
otherwise — peak backlog is **flat** across a 100x range of publish latency:

| Publish delay | serial: time / peak | pipelined: time / peak |
|---|---|---|
| 0 ms | 0.64 s / 4497 | 0.59 s / 4461 |
| 1 ms | 3.83 s / 4499 | 0.59 s / 4458 |
| 10 ms | 31.05 s / 4499 | 0.59 s / 4461 |

The cap bounds how many events the engine emits *between two chances for the drain to run*.
`url4/dag/executor.py:182` emits `NodeStarted` before it awaits anything, and `:186` fans out
over `node.deps` with an unbounded `asyncio.gather`, so a DAG of width W buffers ~W events in
one event-loop slice. The 8192 cap is a ceiling on **DAG width**, and it defends 2.1 MB in a
process that accepts a 1 GiB result.

Full evidence: `docs/work/2026-08-20-OME-906-pipelined-frame-publishing.md`.
Real fix: `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md`.

## Test plan

- `tests/unit/test_publish_durability.py` — new. The flush contract and both lifecycle
  barriers, including that a deferred failure produces `Terminated(failed)` and that
  cancellation still produces `stopped`.
- `tests/unit/test_jetstream_pipelining.py` — new. `publish` does not await its ack, call
  order is preserved, a rejected ack surfaces at the next publish and at flush, flush reports
  once then clears, a cancelled ack is not a failure.
- `tests/unit/test_url4_executor.py` — appended. High-water mark, the mark-not-gauge
  invariant, the soft-cap boundary, and the closing-log emission rules.
- Gates: `url4` ALL GREEN · `screamingface-engine` ALL GREEN (1880 passed, 5 skipped).

One rule-5 change to a prior fixture, approved by the owner: `_JetStreamEventStream.publish`
in `tests/unit/_fakes.py` gained a flush, so the real-broker conformance suite stays
durable-on-return like `InMemoryEventStream`.

## ⚠ Before merging

This branch is named `OME-906-*`, so if the GitHub↔Linear automation is enabled it will move
**OME-906 to Done on merge**. OME-906 is a live P1 that this PR does **not** fix. Either:

- file the split-out issue first and retrofit the branch name and `Refs:` trailers to it
  (payload ready in the work ledger discussion), or
- merge as-is and immediately reopen OME-906.

The real fix is specced at `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md` on branch
`OME-906-bridge-memory-budget`.

Refs: OME-906
