### PR TITLE
feat(screamingface-engine): add the draco-3pass DRACO board for cache-seeded replays

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
@@ -1,6 +1,6 @@
 """Concrete Benchmarks selected by the URL4 Cloud deployment."""
 
-from screamingface_engine.benchmarks.draco.definition import DRACO
+from screamingface_engine.benchmarks.draco.definition import DRACO, DRACO_3PASS
 from screamingface_engine.benchmarks.healthbench.definition import (
     HEALTHBENCH_PROFESSIONAL,
     HEALTHBENCH_WORST30,
@@ -15,6 +15,7 @@ from screamingface_engine.benchmarks.registry import BenchmarkRegistry
 BUILTIN_BENCHMARKS = BenchmarkRegistry(
     (
         DRACO,
+        DRACO_3PASS,
         IFEVAL,
         HEALTHBENCH_WORST30,
         HEALTHBENCH_PROFESSIONAL,

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/definition.py
@@ -1,245 +1,119 @@
-"""DRACO as one Engine-owned Benchmark definition."""
+"""The DRACO boards this Engine serves, and what makes them different.
+
+Both sit the SAME 100-case dataset (``perplexity-ai/draco``) over the SAME rubric
+answer key — one Judge (Gemini-3.1-Pro Preview), one grading chain. They differ in
+exactly one place:
+
+    board         judge passes   grading
+    ────────────  ─────────────  ──────────────────────────────────────────────────
+    draco         5              the official five-pass reproduction (the paper
+                                 judges every answer five times for stability)
+    draco-3pass   3              the cache-seeded replay — the draco-cache-seed
+                                 archive covers grading rounds 1-3 only, so this
+                                 board re-runs the archived candidates fully from
+                                 the shared response cache
+
+Everything else is shared and cannot drift: the dataset and judge pinning live in
+``exam.py``, and the revision math, route layout, and url4 expression tree live in
+``exam.py`` too. Each board below is one call to ``draco_benchmark``.
+
+INVARIANT: canonical ``draco``'s revision is FROZEN at ``66a463248586b277``
+(``test_draco_3pass_definition.py``). Its routes carry it and the scoreboard seeds it,
+so an accidental change would orphan every existing submission. The 3-pass board is a
+separate identity by construction — a different revision is a different benchmark, so
+its scores are never compared against the five-pass ones (OME-775).
+
+References:
+    - DRACO (protocol authority): https://github.com/perplexity-ai/draco
+    - Dataset: https://huggingface.co/datasets/perplexity-ai/draco
+"""
 
 from __future__ import annotations
 
-import hashlib
-from pathlib import Path
-
-from screamingface_engine.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
-from screamingface_engine.benchmarks.definition import Benchmark, CheckSurface, candidate
-from screamingface_engine.benchmarks.draco.prompts import JUDGE_INSTRUCTIONS
-from screamingface_engine.benchmarks.draco.verdict import call as criterion_verdict
-from screamingface_engine.benchmarks.protocol import (
-    EVALUATION_PROTOCOL_REVISION,
-    build_evaluation_protocol,
-    preserve_candidate_outcome,
+from screamingface_engine.benchmarks.draco.exam import (
+    CASE_COUNT,
+    CHECK_CRITERION,
+    DATASET,
+    DATASET_PREPARER_REVISION,
+    DATASET_REVISION,
+    EXCLUDED_DOMAINS,
+    JUDGE_MODEL,
+    JUDGE_PARAMS,
+    RETRIEVAL_POLICY_ID,
+    draco_benchmark,
 )
-from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
-from url4.peer.server import Url4Node
 
-BENCHMARK_ID = "draco"
-CASE_COUNT = 100
-DATASET = "perplexity-ai/draco"
-DATASET_REVISION = "ce076749809027649ebd331bcb70f42bf720d387"
-DATASET_PREPARER_REVISION = "datasets-5.0.0"
-PROTOCOL_REVISION = "five-pass-reproduction-v1"
-# The paper pins Gemini-3-Pro Preview, which Google shut down on 2026-03-09. Google designated
-# Gemini-3.1-Pro Preview as its replacement, so this reproduction uses that successor model.
-JUDGE_MODEL = "openrouter/google/gemini-3.1-pro-preview"
-JUDGE_PASSES = 5
-JUDGE_SEEDS = tuple(range(1, JUDGE_PASSES + 1))
-RETRIEVAL_POLICY_ID = "draco/reproduction"
-EXCLUDED_DOMAINS = (
-    "arxiv.org",
-    "huggingface.co",
-    "openrouter.ai",
-    "paperswithcode.com",
-    "alphaxiv.org",
-    "semanticscholar.org",
-    "research.perplexity.ai",
-)
-JUDGE_PARAMS = (
-    # The same model is also a DRACO Candidate. Its route can retrieve, but Grading cannot. The
-    # Runner consumes this control and sends no search field or tools to AI Gateway, so the Judge
-    # request remains eligible for the exact-response cache.
-    ("web_search", "false"),
-    ("temperature", "0.2"),
-    # The official low-reasoning setting is added once AI Gateway exposes a validated
-    # OpenRouter parameter for it. Unknown fields fail closed, so guessing here breaks every
-    # judge call rather than producing a documented protocol deviation.
-    ("max_tokens", "4096"),
-)
-REVISION = hashlib.sha256(
-    "\n".join(
-        (
-            DATASET,
-            DATASET_REVISION,
-            DATASET_PREPARER_REVISION,
-            PROTOCOL_REVISION,
-            EVALUATION_PROTOCOL_REVISION,
-            CANDIDATE_RESULT_SCHEMA,
-            RETRIEVAL_POLICY_ID,
-            repr(EXCLUDED_DOMAINS),
-            JUDGE_MODEL,
-            str(JUDGE_PASSES),
-            repr(JUDGE_SEEDS),
-            repr(JUDGE_PARAMS),
-            JUDGE_INSTRUCTIONS,
-        )
-    ).encode()
-).hexdigest()[:16]
-# The pass criterion of the mid-run check surface (OME-829/830). Declared here rather
-# than imported from check_policy, which reads this module for the judge pinning.
-CHECK_CRITERION = "draco-pass.v1"
-ROUTE_PREFIX = f"/benchmarks/{BENCHMARK_ID}/{REVISION}"
-CASES_ROUTE = f"{ROUTE_PREFIX}/cases"
-TASKS_ROUTE = f"{ROUTE_PREFIX}/tasks"
-VERDICT_ROUTE = f"{ROUTE_PREFIX}/criterion-verdict"
-CRITERION_EVALUATION_ROUTE = f"{ROUTE_PREFIX}/criterion-evaluation"
-CASE_EVALUATION_ROUTE = f"{ROUTE_PREFIX}/case-evaluation"
-AGGREGATE_ROUTE = f"{ROUTE_PREFIX}/aggregate"
-# The mid-run check surface (OME-829). The pass criterion is protocol semantics, so it
-# rides in the path: a different criterion is a different route, visible in the manifest
-# and in every Candidate url4 compiled against it.
-CHECK_SURFACE_ROUTE = f"{ROUTE_PREFIX}/check-surface/{CHECK_CRITERION}"
-
-
-def _build(case_count: int) -> Node:
-    candidate_invocation = candidate(
-        "$item.input",
-        web_search=True,
-        web_search_exclude=EXCLUDED_DOMAINS,
-    )
-    judge_calls = tuple(
-        src(
-            criterion_verdict(
-                RelExpr(
-                    path=_model_route(JUDGE_MODEL),
-                    # Every dynamic value is local to this iteration item. The model sees only
-                    # the official prompt fields; the Engine binds the known criterion id after
-                    # the reply, so grading never trusts a model-generated identifier.
-                    context=_judge_context(),
-                    intent=Text(_url4_text(JUDGE_INSTRUCTIONS)),
-                    # Stable pass seeds create five independent cache slots. Repeated benchmark
-                    # runs may reuse those slots, but one run can never collapse five Judge
-                    # passes into one cached response.
-                    params=(*JUDGE_PARAMS, ("seed", str(run))),
-                ),
-                "$item.criterion_id",
-                case_id="$item.case_id",
-                sequence=run,
-                route=VERDICT_ROUTE,
-            ),
-            name=f"verdict_{run}",
-            weight=0.0,
-        )
-        for run in range(1, JUDGE_PASSES + 1)
-    )
-    criterion_evaluation = expr(
-        src("$item.case_record", name="case_record", weight=0.0),
-        src("$item.check_record", name="check_record", weight=0.0),
-        *judge_calls,
-        src(
-            RelExpr(
-                path=CRITERION_EVALUATION_ROUTE,
-                context=render(
-                    struct(
-                        {
-                            "case": "$case_record",
-                            "check": "$check_record",
-                            **{
-                                f"evidence_{run}": f"$verdict_{run}"
-                                for run in range(1, JUDGE_PASSES + 1)
-                            },
-                        }
-                    )
-                ),
-                intent=Text("$item.case_id"),
-            ),
-            name="criterion_evaluation",
-            weight=0.0,
-        ),
-        intent=Text("$criterion_evaluation"),
-    )
-    criteria = iterate(
-        RelExpr(
-            path=TASKS_ROUTE,
-            # This collection boundary invokes the Candidate exactly once, then returns the
-            # criterion tasks plus Engine-bound Case/Check records for lossless aggregation.
-            context="$candidate_invocation",
-            intent=Text("$item.case_id"),
-        ),
-        body=(src(criterion_evaluation, name="evaluated", weight=0.0),),
-        intent=Text("$evaluated"),
-    )
-    case_evaluation = expr(
-        src(criteria, name="criteria", weight=0.0),
-        src(
-            RelExpr(
-                path=CASE_EVALUATION_ROUTE,
-                context="$criteria",
-                intent=Text("$item.case_id"),
-            ),
-            name="case_evaluation",
-            weight=0.0,
-        ),
-        intent=Text("$case_evaluation"),
-    )
-    return build_evaluation_protocol(
-        cases_route=CASES_ROUTE,
-        case_evaluation=preserve_candidate_outcome(
-            candidate_invocation=candidate_invocation,
-            grading=case_evaluation,
-            case_id="$item.id",
-        ),
-        selected_case_count=case_count,
-        available_case_count=CASE_COUNT,
-        aggregate_route=AGGREGATE_ROUTE,
-    )
-
-
-def _install(node: Url4Node, assets: Path) -> None:
-    # Lazy import keeps the resource-only control-plane path from loading filesystem runtime code.
-    from screamingface_engine.benchmarks.draco.runtime import install
-
-    install(node, assets / BENCHMARK_ID)
-
-
-DRACO = Benchmark(
-    id=BENCHMARK_ID,
+# ── Board 1 — the canonical five-pass reproduction ──────────────────────────────────
+CANONICAL_EXAM, DRACO = draco_benchmark(
+    id="draco",
     title="DRACO",
     description=(
         "A 100-task DRACO reproduction with official score arithmetic. It uses the successor "
         "Judge model, provider-default reasoning, mixed native/Tavily retrieval, and a host-only "
-        "approximation of the reference blocklist, so its scores are not paper-identical."
+        "approximation of the reference blocklist, so its scores are not paper-identical. Every "
+        "answer is judged five times — the paper's stability protocol."
     ),
-    revision=REVISION,
-    case_count=CASE_COUNT,
-    build=_build,
-    install=_install,
-    check_surface=CheckSurface(
-        check_route=CHECK_SURFACE_ROUTE,
-        feedback_intent="feedback",
-        expected_check_cost="paid",
-    ),
+    judge_passes=5,
+    protocol_revision="five-pass-reproduction-v1",
 )
 
+# ── Board 2 — the three-pass cache-seeded replay ────────────────────────────────────
+THREE_PASS_EXAM, DRACO_3PASS = draco_benchmark(
+    id="draco-3pass",
+    title="DRACO 3-Pass",
+    description=(
+        "The DRACO 100-case reproduction judged three times per answer instead of five. "
+        "Identical dataset, criteria, Judge, and retrieval policy to the canonical board — "
+        "only the judge-pass count differs. The draco-cache-seed archive covers exactly "
+        "these three passes, so re-running its candidates is served fully from the shared "
+        "response cache; scores carry their own benchmark revision and are not compared "
+        "against five-pass results."
+    ),
+    judge_passes=3,
+    protocol_revision="three-pass-reproduction-v1",
+)
 
-def _model_route(model: str) -> str:
-    return "/" + model.removeprefix("/")
+# ── canonical aliases (kept for the runtime and the tests that import them) ─────────
+# These are the canonical board's values, re-exported so pre-factory callers keep
+# working unchanged. The runtime now reads the exam instead; only legacy imports touch
+# these.
+BENCHMARK_ID = CANONICAL_EXAM.id
+REVISION = CANONICAL_EXAM.revision
+JUDGE_PASSES = CANONICAL_EXAM.judge_passes
+JUDGE_SEEDS = tuple(range(1, JUDGE_PASSES + 1))
+ROUTE_PREFIX = CANONICAL_EXAM.routes.prefix
+CASES_ROUTE = CANONICAL_EXAM.routes.cases
+TASKS_ROUTE = CANONICAL_EXAM.routes.tasks
+VERDICT_ROUTE = CANONICAL_EXAM.routes.verdict
+CRITERION_EVALUATION_ROUTE = CANONICAL_EXAM.routes.criterion_evaluation
+CASE_EVALUATION_ROUTE = CANONICAL_EXAM.routes.case_evaluation
+AGGREGATE_ROUTE = CANONICAL_EXAM.routes.aggregate
+CHECK_SURFACE_ROUTE = CANONICAL_EXAM.routes.check_surface
 
-
-def _judge_context() -> str:
-    return " ".join(
-        (
-            "<criterion_type>",
-            "$item.criterion_type",
-            "</criterion_type>",
-            "<criterion>",
-            "$item.criterion",
-            "</criterion>",
-            "<query>",
-            "$item.question",
-            "</query>",
-            "<response>",
-            "$item.answer",
-            "</response>",
-        )
-    )
-
-
-def _url4_text(value: str) -> str:
-    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
-    normalized = normalized.replace("\n", "\u2028").replace("\t", " ")
-    unsupported = next(
-        (character for character in normalized if character < " " or character == "\x7f"),
-        None,
-    )
-    if unsupported is not None:
-        raise ValueError(
-            f"Benchmark prompt contains unsupported control character U+{ord(unsupported):04X}"
-        )
-    return normalized.replace("$", "$$")
-
-
-__all__ = ["DRACO"]
+__all__ = [
+    "AGGREGATE_ROUTE",
+    "BENCHMARK_ID",
+    "CASE_COUNT",
+    "CASE_EVALUATION_ROUTE",
+    "CASES_ROUTE",
+    "CANONICAL_EXAM",
+    "CHECK_CRITERION",
+    "CHECK_SURFACE_ROUTE",
+    "CRITERION_EVALUATION_ROUTE",
+    "DATASET",
+    "DATASET_PREPARER_REVISION",
+    "DATASET_REVISION",
+    "DRACO",
+    "DRACO_3PASS",
+    "EXCLUDED_DOMAINS",
+    "JUDGE_MODEL",
+    "JUDGE_PARAMS",
+    "JUDGE_PASSES",
+    "JUDGE_SEEDS",
+    "RETRIEVAL_POLICY_ID",
+    "REVISION",
+    "ROUTE_PREFIX",
+    "TASKS_ROUTE",
+    "THREE_PASS_EXAM",
+    "VERDICT_ROUTE",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py
@@ -1,0 +1,387 @@
+"""How ANY DRACO board is built — identity, addresses, and the one expression tree.
+
+Think of it as printing an exam paper from a template. The template is fixed: the same
+100-case dataset (``perplexity-ai/draco``), the same criteria, the same Judge
+(Gemini-3.1-Pro Preview), the same grading chain. What the printer varies per board is
+exactly two things:
+
+    how many times the Judge grades each criterion   (``judge_passes``)
+    what it calls itself                             (``id`` — which decides every route address)
+
+Everything else is derived. ``draco_revision`` fingerprints the whole board identity
+into a 16-hex revision; ``Routes`` hangs the seven protocol routes plus the check
+surface under ``/benchmarks/<id>/<revision>/``; ``build_draco_protocol`` writes the
+url4 expression tree. ``draco_benchmark`` is the one call a board module makes.
+
+INVARIANT: two boards built here share the baked assets and differ ONLY where the
+knobs above differ. A board's revision changes if ANY hashed input changes, so an
+expression addressed to an old revision physically cannot resolve against a new exam.
+
+INVARIANT (frozen canonical): the canonical board keeps the pre-factory revision —
+``draco_revision`` reproduces the original hash tuple byte-for-byte, so ``draco``'s
+routes, scoreboard seeds, and every published submission stay exactly where they are.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from screamingface_engine.benchmarks.contract import CANDIDATE_RESULT_SCHEMA
+from screamingface_engine.benchmarks.definition import Benchmark, CheckSurface, candidate
+from screamingface_engine.benchmarks.draco.prompts import JUDGE_INSTRUCTIONS
+from screamingface_engine.benchmarks.draco.verdict import call as criterion_verdict
+from screamingface_engine.benchmarks.protocol import (
+    EVALUATION_PROTOCOL_REVISION,
+    build_evaluation_protocol,
+    preserve_candidate_outcome,
+)
+from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
+from url4.peer.server import Url4Node
+
+# --- the shared pins: the dataset, the judge, and the retrieval policy ----------------
+
+DATASET = "perplexity-ai/draco"
+DATASET_REVISION = "ce076749809027649ebd331bcb70f42bf720d387"
+DATASET_PREPARER_REVISION = "datasets-5.0.0"
+CASE_COUNT = 100
+# The paper pins Gemini-3-Pro Preview, which Google shut down on 2026-03-09. Google designated
+# Gemini-3.1-Pro Preview as its replacement, so this reproduction uses that successor model.
+JUDGE_MODEL = "openrouter/google/gemini-3.1-pro-preview"
+RETRIEVAL_POLICY_ID = "draco/reproduction"
+EXCLUDED_DOMAINS = (
+    "arxiv.org",
+    "huggingface.co",
+    "openrouter.ai",
+    "paperswithcode.com",
+    "alphaxiv.org",
+    "semanticscholar.org",
+    "research.perplexity.ai",
+)
+JUDGE_PARAMS = (
+    # The same model is also a DRACO Candidate. Its route can retrieve, but Grading cannot. The
+    # Runner consumes this control and sends no search field or tools to AI Gateway, so the Judge
+    # request remains eligible for the exact-response cache.
+    ("web_search", "false"),
+    ("temperature", "0.2"),
+    # The official low-reasoning setting is added once AI Gateway exposes a validated
+    # OpenRouter parameter for it. Unknown fields fail closed, so guessing here breaks every
+    # judge call rather than producing a documented protocol deviation.
+    ("max_tokens", "4096"),
+)
+# The pass criterion of the mid-run check surface (OME-829/830). Declared here rather
+# than imported from check_policy, which reads this module for the judge pinning.
+CHECK_CRITERION = "draco-pass.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class Routes:
+    """The seven addresses one board answers on, all under its own revision prefix."""
+
+    prefix: str
+    cases: str
+    tasks: str
+    verdict: str
+    criterion_evaluation: str
+    case_evaluation: str
+    aggregate: str
+    check_surface: str
+
+    @classmethod
+    def for_exam(cls, benchmark_id: str, revision: str) -> Routes:
+        prefix = f"/benchmarks/{benchmark_id}/{revision}"
+        return cls(
+            prefix=prefix,
+            cases=f"{prefix}/cases",
+            tasks=f"{prefix}/tasks",
+            verdict=f"{prefix}/criterion-verdict",
+            criterion_evaluation=f"{prefix}/criterion-evaluation",
+            case_evaluation=f"{prefix}/case-evaluation",
+            aggregate=f"{prefix}/aggregate",
+            check_surface=f"{prefix}/check-surface/{CHECK_CRITERION}",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DracoExam:
+    """One DRACO board identity: how many judge passes, at which addresses.
+
+    This is what the runtime needs to serve a board — it carries no metadata a human
+    reads (that lives on the ``Benchmark``), only what the protocol handlers consume.
+    """
+
+    id: str
+    revision: str
+    routes: Routes
+    judge_passes: int
+
+
+def draco_revision(*, protocol_revision: str, judge_passes: int) -> str:
+    """Fingerprint one board identity into the 16 hex characters its routes carry.
+
+    Everything a Candidate's score depends on goes in: the dataset pin, the preparer
+    that turned it into assets, the shared evaluation protocol, the Candidate result
+    schema, the retrieval policy, the judge pinning, the judge-instruction bytes — plus
+    the two per-board inputs (protocol revision and pass count, which also decides the
+    pass seeds). Change any of them and every route address moves, which is the only
+    safe way to change an exam.
+
+    INVARIANT (frozen): the tuple below reproduces the original canonical hash
+    byte-for-byte — same order, same repr() shapes — so the canonical board's revision
+    survives the factory refactor untouched (pinned by test_draco_3pass_definition.py).
+    """
+
+    judge_seeds = tuple(range(1, judge_passes + 1))
+    return hashlib.sha256(
+        "\n".join(
+            (
+                DATASET,
+                DATASET_REVISION,
+                DATASET_PREPARER_REVISION,
+                protocol_revision,
+                EVALUATION_PROTOCOL_REVISION,
+                CANDIDATE_RESULT_SCHEMA,
+                RETRIEVAL_POLICY_ID,
+                repr(EXCLUDED_DOMAINS),
+                JUDGE_MODEL,
+                str(judge_passes),
+                repr(judge_seeds),
+                repr(JUDGE_PARAMS),
+                JUDGE_INSTRUCTIONS,
+            )
+        ).encode()
+    ).hexdigest()[:16]
+
+
+def build_draco_protocol(routes: Routes, case_count: int, judge_passes: int) -> Node:
+    """Build the whole benchmark as one url4 expression tree (a recipe, not a run).
+
+    The shape is canonical DRACO's: one Candidate invocation per Case, then one Judge
+    call per criterion per pass — ``judge_passes`` verdicts per criterion, each on its
+    own stable seed so the passes occupy independent cache slots (a run can never
+    collapse them into one cached response). The criterion evaluation folds the
+    ``judge_passes`` evidence records into one Engine-bound record, the case evaluation
+    rolls criteria up, and the aggregate reduces every Case row into the Candidate
+    Result.
+
+    ``case_count`` < ``CASE_COUNT`` slices to a partial run (the SDK's ``limit=N``);
+    equality means the full set. Every route is revision-pinned.
+    """
+
+    candidate_invocation = candidate(
+        "$item.input",
+        web_search=True,
+        web_search_exclude=EXCLUDED_DOMAINS,
+    )
+    judge_calls = tuple(
+        src(
+            criterion_verdict(
+                RelExpr(
+                    path=_model_route(JUDGE_MODEL),
+                    # Every dynamic value is local to this iteration item. The model sees only
+                    # the official prompt fields; the Engine binds the known criterion id after
+                    # the reply, so grading never trusts a model-generated identifier.
+                    context=_judge_context(),
+                    intent=Text(_url4_text(JUDGE_INSTRUCTIONS)),
+                    # Stable pass seeds create independent cache slots. Repeated benchmark
+                    # runs may reuse those slots, but one run can never collapse judge
+                    # passes into one cached response.
+                    params=(*JUDGE_PARAMS, ("seed", str(run))),
+                ),
+                "$item.criterion_id",
+                case_id="$item.case_id",
+                sequence=run,
+                route=routes.verdict,
+            ),
+            name=f"verdict_{run}",
+            weight=0.0,
+        )
+        for run in range(1, judge_passes + 1)
+    )
+    criterion_evaluation = expr(
+        src("$item.case_record", name="case_record", weight=0.0),
+        src("$item.check_record", name="check_record", weight=0.0),
+        *judge_calls,
+        src(
+            RelExpr(
+                path=routes.criterion_evaluation,
+                context=render(
+                    struct(
+                        {
+                            "case": "$case_record",
+                            "check": "$check_record",
+                            **{
+                                f"evidence_{run}": f"$verdict_{run}"
+                                for run in range(1, judge_passes + 1)
+                            },
+                        }
+                    )
+                ),
+                intent=Text("$item.case_id"),
+            ),
+            name="criterion_evaluation",
+            weight=0.0,
+        ),
+        intent=Text("$criterion_evaluation"),
+    )
+    criteria = iterate(
+        RelExpr(
+            path=routes.tasks,
+            # This collection boundary invokes the Candidate exactly once, then returns the
+            # criterion tasks plus Engine-bound Case/Check records for lossless aggregation.
+            context="$candidate_invocation",
+            intent=Text("$item.case_id"),
+        ),
+        body=(src(criterion_evaluation, name="evaluated", weight=0.0),),
+        intent=Text("$evaluated"),
+    )
+    case_evaluation = expr(
+        src(criteria, name="criteria", weight=0.0),
+        src(
+            RelExpr(
+                path=routes.case_evaluation,
+                context="$criteria",
+                intent=Text("$item.case_id"),
+            ),
+            name="case_evaluation",
+            weight=0.0,
+        ),
+        intent=Text("$case_evaluation"),
+    )
+    return build_evaluation_protocol(
+        cases_route=routes.cases,
+        case_evaluation=preserve_candidate_outcome(
+            candidate_invocation=candidate_invocation,
+            grading=case_evaluation,
+            case_id="$item.id",
+        ),
+        selected_case_count=case_count,
+        available_case_count=CASE_COUNT,
+        aggregate_route=routes.aggregate,
+    )
+
+
+def draco_benchmark(
+    *,
+    id: str,
+    title: str,
+    description: str,
+    judge_passes: int,
+    protocol_revision: str,
+) -> tuple[DracoExam, Benchmark]:
+    """Wire one DRACO board: identity → addresses → expression → private routes.
+
+    Args:
+        id: the public benchmark id; it becomes the first path segment of every route.
+        title: the human name shown in the catalogue.
+        description: the catalogue description — it must say how many judge passes this
+            board runs, because that is the difference a reader cannot see anywhere else.
+        judge_passes: how many times the Judge grades each answer (the pass seeds
+            derive from it).
+        protocol_revision: this board's own protocol version string (hashed).
+
+    Returns:
+        ``(exam, benchmark)`` — the ``DracoExam`` for the runtime's private routes, and
+        the public ``Benchmark`` the registry publishes. The board module exports both:
+        the runtime needs the first, the catalogue the second.
+    """
+
+    revision = draco_revision(
+        protocol_revision=protocol_revision,
+        judge_passes=judge_passes,
+    )
+    exam = DracoExam(
+        id=id,
+        revision=revision,
+        routes=Routes.for_exam(id, revision),
+        judge_passes=judge_passes,
+    )
+
+    def build(selected_case_count: int) -> Node:
+        return build_draco_protocol(exam.routes, selected_case_count, exam.judge_passes)
+
+    def install(node: Url4Node, assets: Path) -> None:
+        # Lazy import keeps the resource-only control-plane path from loading filesystem
+        # runtime code (healthbench precedent).
+        from screamingface_engine.benchmarks.draco.runtime import install as install_runtime
+
+        # INVARIANT: every board reads the SAME baked asset directory — one immutable
+        # case/rubric set, never a per-board bake.
+        install_runtime(node, assets / "draco", exam)
+
+    benchmark = Benchmark(
+        id=id,
+        title=title,
+        description=description,
+        revision=revision,
+        case_count=CASE_COUNT,
+        build=build,
+        install=install,
+        # The mid-run check is a real Judge call over the case rubric, so a corrective
+        # loop's check budget is paid (same surface as canonical).
+        check_surface=CheckSurface(
+            check_route=exam.routes.check_surface,
+            feedback_intent="feedback",
+            expected_check_cost="paid",
+        ),
+    )
+    return exam, benchmark
+
+
+def _model_route(model: str) -> str:
+    return "/" + model.removeprefix("/")
+
+
+def _judge_context() -> str:
+    # The U+2028 LINE SEPARATOR between fields is part of the request payload — and
+    # therefore of the judge cache key. It must stay byte-identical to the original
+    # canonical prompt or the archived draco-cache-seed rows would never match.
+    return "\u2028".join(
+        (
+            "<criterion_type>",
+            "$item.criterion_type",
+            "</criterion_type>",
+            "<criterion>",
+            "$item.criterion",
+            "</criterion>",
+            "<query>",
+            "$item.question",
+            "</query>",
+            "<response>",
+            "$item.answer",
+            "</response>",
+        )
+    )
+
+
+def _url4_text(value: str) -> str:
+    normalized = value.replace("\r\n", "\n").replace("\r", "\n")
+    normalized = normalized.replace("\n", "\u2028").replace("\t", " ")
+    unsupported = next(
+        (character for character in normalized if character < " " or character == "\x7f"),
+        None,
+    )
+    if unsupported is not None:
+        raise ValueError(
+            f"Benchmark prompt contains unsupported control character U+{ord(unsupported):04X}"
+        )
+    return normalized.replace("$", "$$")
+
+
+__all__ = [
+    "CASE_COUNT",
+    "CHECK_CRITERION",
+    "DATASET",
+    "DATASET_PREPARER_REVISION",
+    "DATASET_REVISION",
+    "DracoExam",
+    "EXCLUDED_DOMAINS",
+    "JUDGE_MODEL",
+    "JUDGE_PARAMS",
+    "RETRIEVAL_POLICY_ID",
+    "Routes",
+    "build_draco_protocol",
+    "draco_benchmark",
+    "draco_revision",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/runtime.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/runtime.py
@@ -1,4 +1,9 @@
-"""Install canonical DRACO's private assets and functions into one Runner world."""
+"""Install one DRACO board's private assets and functions into a Runner world.
+
+The board's routes and judge-pass count come from the :class:`DracoExam` the board
+module passes in — the same dataset assets serve every board, and only the
+addresses and the evidence cardinality differ.
+"""
 
 from __future__ import annotations
 
@@ -15,19 +20,10 @@ from screamingface_engine.benchmarks.draco.case_evaluation import (
     bind_criterion_evaluation,
 )
 from screamingface_engine.benchmarks.draco.check_policy import DRACO_CHECK
-from screamingface_engine.benchmarks.draco.definition import (
-    AGGREGATE_ROUTE,
-    BENCHMARK_ID,
+from screamingface_engine.benchmarks.draco.exam import (
     CASE_COUNT,
-    CASE_EVALUATION_ROUTE,
-    CASES_ROUTE,
-    CHECK_SURFACE_ROUTE,
-    CRITERION_EVALUATION_ROUTE,
     JUDGE_MODEL,
-    JUDGE_PASSES,
-    REVISION,
-    TASKS_ROUTE,
-    VERDICT_ROUTE,
+    DracoExam,
 )
 from screamingface_engine.benchmarks.draco.verdict import bind, binding_key
 from screamingface_engine.benchmarks.evaluation import (
@@ -42,37 +38,38 @@ from screamingface_engine.benchmarks.rubric_check import check_surface
 from url4.peer.server import Request, Url4Node
 
 
-def install(node: Url4Node, root: Path) -> None:
-    """Register the routes referenced by canonical DRACO."""
+def install(node: Url4Node, root: Path, exam: DracoExam) -> None:
+    """Register the routes referenced by one DRACO board."""
     cases_json, selected_cases, rubrics = _protocol_assets(root)
-    node.data(CASES_ROUTE, cases_json, media_type="application/json")
-    node.endpoint(TASKS_ROUTE)(_task_rows(root))
+    node.data(exam.routes.cases, cases_json, media_type="application/json")
+    node.endpoint(exam.routes.tasks)(_task_rows(root))
     # The mid-run check surface the corrective loop consumes. It closes over `node` so the
     # judge route resolves per request — installation must still work in a world that holds
     # no model routes at all (every benchmark-only test builds one).
-    node.endpoint(CHECK_SURFACE_ROUTE)(
+    node.endpoint(exam.routes.check_surface)(
         check_surface(
             node,
             root,
             DRACO_CHECK,
         )
     )
-    node.endpoint(VERDICT_ROUTE)(_criterion_verdict)
-    node.endpoint(CRITERION_EVALUATION_ROUTE)(_criterion_evaluation)
-    node.endpoint(CASE_EVALUATION_ROUTE)(
+    node.endpoint(exam.routes.verdict)(_criterion_verdict)
+    node.endpoint(exam.routes.criterion_evaluation)(_criterion_evaluation(exam.judge_passes))
+    node.endpoint(exam.routes.case_evaluation)(
         case_evaluation_endpoint(
             label="DRACO Case evaluation",
             item_name="Criterion evaluation",
             bind=bind_case_evaluation,
         )
     )
-    node.endpoint(AGGREGATE_ROUTE)(
+    node.endpoint(exam.routes.aggregate)(
         aggregate_endpoint(
             label="DRACO",
             available_case_count=len(selected_cases),
             aggregate=_aggregate(
                 selected_cases,
                 rubrics,
+                exam,
             ),
         )
     )
@@ -81,12 +78,12 @@ def install(node: Url4Node, root: Path) -> None:
 def _protocol_assets(
     root: Path,
 ) -> tuple[str, list[dict[str, object]], dict[int, dict[str, Any]]]:
-    """Load and validate canonical DRACO before registering any route."""
+    """Load and validate DRACO's shared assets before registering any route."""
 
     raw = _read(root / "cases.json", "DRACO cases")
     selected = _parse_cases(raw)
     if len(selected) != CASE_COUNT:
-        raise _unavailable(f"expected {CASE_COUNT} canonical DRACO cases, got {len(selected)}")
+        raise _unavailable(f"expected {CASE_COUNT} DRACO cases, got {len(selected)}")
     try:
         rubrics = protocol_assets.validate_protocol_assets(root, selected)
     except (OSError, ValueError) as exc:
@@ -164,51 +161,62 @@ def _criterion_verdict(request: Request) -> str:
     return compact_json(record)
 
 
-def _criterion_evaluation(request: Request) -> str:
-    try:
-        case_id = tasks.positive_case_id(request.intent)
-        payload = json_object(request.context, "DRACO Criterion evaluation")
-        expected = (
-            "case",
-            "check",
-            *(f"evidence_{sequence}" for sequence in range(1, JUDGE_PASSES + 1)),
-        )
-        if tuple(payload) != expected:
-            raise ValueError(
-                "DRACO Criterion evaluation fields must be case, check, and consecutive "
-                "evidence_1..evidence_N"
+def _criterion_evaluation(judge_passes: int):
+    """One criterion-evaluation handler bound to its board's judge-pass count.
+
+    The protocol posts exactly ``judge_passes`` evidence records per criterion, so the
+    handler demands exactly those field names — a five-pass expression cannot resolve
+    against a three-pass board's route and vice versa (every route is revision-pinned).
+    """
+
+    def handle(request: Request) -> str:
+        try:
+            case_id = tasks.positive_case_id(request.intent)
+            payload = json_object(request.context, "DRACO Criterion evaluation")
+            expected = (
+                "case",
+                "check",
+                *(f"evidence_{sequence}" for sequence in range(1, judge_passes + 1)),
             )
-        raw_case = json_object(payload["case"], "Case record")
-        case_record = raw_case or None
-        check_record = json_object(payload["check"], "Check record")
-        evidence = [
-            json_object(payload[field], field)
-            for field in expected
-            if field.startswith("evidence_")
-        ]
-        result = bind_criterion_evaluation(
-            case_id,
-            case_record,
-            check_record,
-            evidence,
-        )
-    except (TypeError, ValueError) as exc:
-        raise _unavailable(str(exc)) from exc
-    return compact_json(result)
+            if tuple(payload) != expected:
+                raise ValueError(
+                    "DRACO Criterion evaluation fields must be case, check, and consecutive "
+                    "evidence_1..evidence_N"
+                )
+            raw_case = json_object(payload["case"], "Case record")
+            case_record = raw_case or None
+            check_record = json_object(payload["check"], "Check record")
+            evidence = [
+                json_object(payload[field], field)
+                for field in expected
+                if field.startswith("evidence_")
+            ]
+            result = bind_criterion_evaluation(
+                case_id,
+                case_record,
+                check_record,
+                evidence,
+            )
+        except (TypeError, ValueError) as exc:
+            raise _unavailable(str(exc)) from exc
+        return compact_json(result)
+
+    return handle
 
 
 def _aggregate(
     selected_cases: list[dict[str, object]],
     rubrics: dict[int, dict[str, Any]],
+    exam: DracoExam,
 ):
     def aggregate(case_evaluations: str, selected_case_count: int) -> dict[str, Any]:
         return scoring.aggregate(
             case_evaluations,
             rubrics,
-            BENCHMARK_ID,
+            exam.id,
             selected_cases=selected_cases[:selected_case_count],
-            judge_passes=JUDGE_PASSES,
-            benchmark_revision=REVISION,
+            judge_passes=exam.judge_passes,
+            benchmark_revision=exam.revision,
         )
 
     return aggregate
@@ -221,7 +229,7 @@ def _parse_cases(raw: str) -> list[dict[str, object]]:
             raise ValueError("expected a JSON array of objects")
         return cases
     except (TypeError, ValueError) as exc:
-        raise _unavailable(f"could not read canonical DRACO cases: {exc}") from exc
+        raise _unavailable(f"could not read DRACO cases: {exc}") from exc
 
 
 def _read(path: Path, label: str) -> str:

--- a/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
@@ -26,11 +26,13 @@ from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
 
 
-def test_public_catalogue_contains_exactly_the_four_product_benchmarks() -> None:
-    # OME-903 added the professional board beside the worst-30% challenge; both are
-    # complete, independently meaningful benchmark identities over one baked answer key.
+def test_public_catalogue_contains_exactly_the_five_product_benchmarks() -> None:
+    # OME-903 added the professional board beside the worst-30% challenge; the 3-pass DRACO
+    # board joined the canonical one; all are complete, independently meaningful benchmark
+    # identities over one baked answer key.
     assert tuple(benchmark.id for benchmark in BUILTIN_BENCHMARKS) == (
         "draco",
+        "draco-3pass",
         "healthbench-professional",
         "healthbench-worst30",
         "ifeval",

--- a/apps/screamingface-engine/tests/unit/test_draco_3pass_definition.py
+++ b/apps/screamingface-engine/tests/unit/test_draco_3pass_definition.py
@@ -1,0 +1,345 @@
+"""The draco-3pass board: same benchmark, three judge passes, its own identity.
+
+The draco-cache-seed archive covers grading rounds 1-3 only, so this board runs exactly
+those three passes — re-running the archived candidates is served fully from the shared
+response cache. The canonical five-pass board stays untouched and keeps its frozen
+revision.
+
+INVARIANT: the two boards differ in exactly one place — judge passes. The dataset,
+criteria, Judge, prompts, and retrieval policy are shared and cannot drift; a different
+revision is a different benchmark, so three-pass scores are never compared against
+five-pass ones (OME-775).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from benchmark_support import install_benchmarks
+
+from screamingface_engine.benchmarks.case_execution import case_execution_payload
+from screamingface_engine.benchmarks.contract import encode_candidate_invocation
+from screamingface_engine.benchmarks.draco import aggregate as agg
+from screamingface_engine.benchmarks.draco.case_evaluation import (
+    bind_case_evaluation,
+    bind_criterion_evaluation,
+)
+from screamingface_engine.benchmarks.draco.definition import (
+    CANONICAL_EXAM,
+    DRACO,
+    DRACO_3PASS,
+    JUDGE_MODEL,
+    THREE_PASS_EXAM,
+)
+from screamingface_engine.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
+from screamingface_engine.benchmarks.registry import BenchmarkRegistry
+from url4 import render
+from url4.peer.server import Url4Node
+
+# INVARIANT: the canonical board's address may not move by accident. Every route it
+# serves carries this hash and the scoreboard seeds it; a refactor that reshuffles the
+# revision math must land on the SAME value (healthbench-worst30 precedent).
+CANONICAL_REVISION = "66a463248586b277"
+
+
+def _url4(benchmark, limit: int | None = None) -> str:
+    return str(benchmark.resource(limit)["url4"])
+
+
+# --- identity ---------------------------------------------------------------------
+
+
+def test_the_canonical_revision_is_frozen_against_refactors() -> None:
+    assert DRACO.revision == CANONICAL_REVISION
+    assert CANONICAL_EXAM.revision == CANONICAL_REVISION
+
+
+def test_the_three_pass_board_has_its_own_identity() -> None:
+    assert DRACO_3PASS.id == "draco-3pass"
+    assert DRACO_3PASS.title == "DRACO 3-Pass"
+    assert DRACO_3PASS.case_count == 100
+    assert THREE_PASS_EXAM.judge_passes == 3
+    assert DRACO_3PASS.revision != DRACO.revision
+
+
+def test_the_three_pass_routes_are_revision_pinned_and_separate() -> None:
+    assert THREE_PASS_EXAM.revision in _url4(DRACO_3PASS)
+    prefix = THREE_PASS_EXAM.routes.prefix
+    assert prefix == f"/benchmarks/draco-3pass/{THREE_PASS_EXAM.revision}"
+    canonical_routes = {
+        CANONICAL_EXAM.routes.cases,
+        CANONICAL_EXAM.routes.tasks,
+        CANONICAL_EXAM.routes.verdict,
+        CANONICAL_EXAM.routes.criterion_evaluation,
+        CANONICAL_EXAM.routes.case_evaluation,
+        CANONICAL_EXAM.routes.aggregate,
+        CANONICAL_EXAM.routes.check_surface,
+    }
+    three_pass_routes = {
+        THREE_PASS_EXAM.routes.cases,
+        THREE_PASS_EXAM.routes.tasks,
+        THREE_PASS_EXAM.routes.verdict,
+        THREE_PASS_EXAM.routes.criterion_evaluation,
+        THREE_PASS_EXAM.routes.case_evaluation,
+        THREE_PASS_EXAM.routes.aggregate,
+        THREE_PASS_EXAM.routes.check_surface,
+    }
+    assert all(route.startswith(prefix) for route in three_pass_routes)
+    assert not (canonical_routes & three_pass_routes)
+
+
+def test_the_catalogue_serves_both_boards() -> None:
+    entry = DRACO_3PASS.catalog_entry()
+    assert entry["id"] == "draco-3pass"
+    assert entry["case_count"] == 100
+    check = entry["check_surface"]
+    assert isinstance(check, dict)
+    assert check["check_route"].startswith(f"/benchmarks/draco-3pass/{THREE_PASS_EXAM.revision}")
+
+
+# ── protocol shape ------------------------------------------------------------------
+
+
+def test_the_three_pass_protocol_renders_exactly_three_verdicts() -> None:
+    expression = render(DRACO_3PASS.build(1))
+
+    assert expression.count("/" + JUDGE_MODEL) == 3
+    assert expression.count("web_search=false") == 3
+    for seed in range(1, 4):
+        assert expression.count(f"&seed={seed}") == 1
+    assert "&seed=4" not in expression
+    for field in ("evidence_1", "evidence_2", "evidence_3"):
+        assert expression.count(f"{field}: ") == 1
+    assert "evidence_4:" not in expression
+
+
+def test_the_three_pass_limit_slices_cases_not_judging_strength() -> None:
+    full = render(DRACO_3PASS.build(DRACO_3PASS.case_count))
+    one_case = render(DRACO_3PASS.build(1))
+
+    # The verdict calls live in the per-criterion iteration TEMPLATE, so their count is
+    # the pass count (3), not passes × cases — the case count only slices the selection.
+    assert full.count("/" + JUDGE_MODEL) == 3
+    assert one_case.count("/" + JUDGE_MODEL) == 3
+    assert one_case.count("iteration.slice=0:1") == 1
+
+
+# ── installation --------------------------------------------------------------------
+
+
+def _draco_assets(root: Path) -> None:
+    assets = root / "draco"
+    (assets / "criteria").mkdir(parents=True)
+    (assets / "rubrics").mkdir()
+    cases = [{"id": case_id, "input": f"Question {case_id}"} for case_id in range(1, 101)]
+    (assets / "cases.json").write_text(json.dumps(cases), encoding="utf-8")
+    criterion = '[{"id":"c1","requirement":"Be correct","criterion_type":"positive"}]'
+    rubric = '{"sections":[{"id":"accuracy","criteria":[{"id":"c1","weight":1}]}]}'
+    for case_id in range(1, 101):
+        (assets / "criteria" / f"{case_id}.json").write_text(criterion, encoding="utf-8")
+        (assets / "rubrics" / f"{case_id}.json").write_text(rubric, encoding="utf-8")
+
+
+def test_both_boards_install_and_validate_on_one_world(tmp_path: Path) -> None:
+    _draco_assets(tmp_path)
+    node = Url4Node("test")
+    install_benchmarks(
+        node,
+        tmp_path,
+        benchmarks=BenchmarkRegistry((DRACO, DRACO_3PASS)),
+    )
+
+    registered = set(node.processor_routes())
+    for route in (
+        CANONICAL_EXAM.routes.tasks,
+        CANONICAL_EXAM.routes.verdict,
+        CANONICAL_EXAM.routes.criterion_evaluation,
+        CANONICAL_EXAM.routes.case_evaluation,
+        CANONICAL_EXAM.routes.aggregate,
+        CANONICAL_EXAM.routes.check_surface,
+        THREE_PASS_EXAM.routes.tasks,
+        THREE_PASS_EXAM.routes.verdict,
+        THREE_PASS_EXAM.routes.criterion_evaluation,
+        THREE_PASS_EXAM.routes.case_evaluation,
+        THREE_PASS_EXAM.routes.aggregate,
+        THREE_PASS_EXAM.routes.check_surface,
+    ):
+        assert route in registered
+    # The cases routes are DATA routes, not endpoints — same accessor the registry uses.
+    data = getattr(node, "_data", {})
+    assert CANONICAL_EXAM.routes.cases in data
+    assert THREE_PASS_EXAM.routes.cases in data
+
+
+def test_the_three_pass_install_rejects_evidence_that_is_not_three_wide(
+    tmp_path: Path,
+) -> None:
+    _draco_assets(tmp_path)
+    node = Url4Node("test")
+    install_benchmarks(
+        node,
+        tmp_path,
+        benchmarks=BenchmarkRegistry((DRACO_3PASS,)),
+    )
+
+    # The canonical board's expression (five evidence slots) must not resolve against
+    # the three-pass board's criterion-evaluation route: every route is revision-pinned,
+    # so the canonical protocol literally addresses a different path.
+    assert CANONICAL_EXAM.routes.criterion_evaluation not in node.processor_routes()
+
+
+# ── aggregation -----------------------------------------------------------------------
+
+
+_RUBRIC = {
+    "sections": [
+        {
+            "id": "Factual Accuracy",
+            "criteria": [
+                {"id": "a1", "weight": 2, "requirement": "cites a source"},
+                {"id": "a2", "weight": 1, "requirement": "states the date"},
+                {"id": "a3", "weight": -3, "requirement": "invents a statistic"},
+            ],
+        },
+        {"id": "Presentation", "criteria": [{"id": "b1", "weight": 1, "requirement": "is terse"}]},
+    ]
+}
+
+
+def _selected_cases(*case_ids: int) -> list[dict[str, object]]:
+    return [{"id": case_id, "input": f"Question {case_id}"} for case_id in case_ids]
+
+
+def _verdict(cid: str, status: str, sequence: int = 1) -> dict[str, object]:
+    raw = json.dumps({"explanation": "evidence", "criterion_status": status})
+    return {
+        "schema": "screamingface.criterion-verdict.v1",
+        "case_id": 1,
+        "criterion_id": cid,
+        "sequence": sequence,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": True,
+        "explanation": "evidence",
+        "criterion_status": status,
+        "raw_output": raw,
+    }
+
+
+def _three_pass_row() -> dict[str, object]:
+    evidence = {
+        cid: [_verdict(cid, status, sequence) for sequence, status in enumerate(statuses, 1)]
+        for cid, statuses in {
+            "a1": ["MET"] * 3,
+            "a2": ["MET"] * 3,
+            "a3": ["UNMET"] * 3,
+            "b1": ["MET"] * 3,
+        }.items()
+    }
+    case_record = {
+        "schema": CASE_SCHEMA,
+        "case_id": 1,
+        "input": "Question 1",
+        "status": "completed",
+        "answer": "Answer 1",
+        "output": "Answer 1",
+        "finish_reason": "stop",
+        "refusal": None,
+        "execution": None,
+        "metadata": {},
+    }
+    criteria = []
+    for index, criterion_id in enumerate(("a1", "a2", "a3", "b1")):
+        criteria.append(
+            bind_criterion_evaluation(
+                1,
+                case_record if index == 0 else None,
+                {
+                    "schema": CHECK_SCHEMA,
+                    "case_id": 1,
+                    "criterion_id": criterion_id,
+                    "criterion_type": "negative" if criterion_id == "a3" else "positive",
+                    "requirement": f"Requirement {criterion_id}",
+                },
+                evidence[criterion_id],
+            )
+        )
+    return case_execution_payload(
+        1,
+        encode_candidate_invocation("Answer 1", "stop", None),
+        [bind_case_evaluation(1, criteria)],
+    )
+
+
+def test_three_pass_aggregate_carries_the_variant_identity() -> None:
+    result = agg.aggregate(
+        json.dumps([_three_pass_row()]),
+        rubrics={1: _RUBRIC},
+        benchmark_id="draco-3pass",
+        selected_cases=_selected_cases(1),
+        judge_passes=3,
+        benchmark_revision=THREE_PASS_EXAM.revision,
+    )
+
+    assert result["benchmark_id"] == "draco-3pass"
+    assert result["benchmark_revision"] == THREE_PASS_EXAM.revision
+    assert result["metrics"]["n_runs"] == 3
+    assert result["score"] == 1.0
+
+
+def _four_pass_row() -> dict[str, object]:
+    evidence = {
+        "a1": [
+            _verdict("a1", "MET", sequence)
+            for sequence in (1, 2, 3, 4)  # four passes — the protocol never produces this
+        ],
+        "a2": [_verdict("a2", "MET", n) for n in (1, 2, 3)],
+        "a3": [_verdict("a3", "UNMET", n) for n in (1, 2, 3)],
+        "b1": [_verdict("b1", "MET", n) for n in (1, 2, 3)],
+    }
+    case_record = {
+        "schema": CASE_SCHEMA,
+        "case_id": 1,
+        "input": "Question 1",
+        "status": "completed",
+        "answer": "Answer 1",
+        "output": "Answer 1",
+        "finish_reason": "stop",
+        "refusal": None,
+        "execution": None,
+        "metadata": {},
+    }
+    criteria = []
+    for index, criterion_id in enumerate(("a1", "a2", "a3", "b1")):
+        criteria.append(
+            bind_criterion_evaluation(
+                1,
+                case_record if index == 0 else None,
+                {
+                    "schema": CHECK_SCHEMA,
+                    "case_id": 1,
+                    "criterion_id": criterion_id,
+                    "criterion_type": "negative" if criterion_id == "a3" else "positive",
+                    "requirement": f"Requirement {criterion_id}",
+                },
+                evidence[criterion_id],
+            )
+        )
+    return case_execution_payload(
+        1,
+        encode_candidate_invocation("Answer 1", "stop", None),
+        [bind_case_evaluation(1, criteria)],
+    )
+
+
+def test_a_fourth_pass_aborts_as_protocol_corruption() -> None:
+    with pytest.raises(agg.AggregateError, match="more than 3 Judge Evidence"):
+        agg.aggregate(
+            json.dumps([_four_pass_row()]),
+            rubrics={1: _RUBRIC},
+            benchmark_id="draco-3pass",
+            selected_cases=_selected_cases(1),
+            judge_passes=3,
+        )

--- a/apps/screamingface-engine/tests/unit/test_draco_case_evaluation_route.py
+++ b/apps/screamingface-engine/tests/unit/test_draco_case_evaluation_route.py
@@ -13,6 +13,7 @@ from screamingface_engine.benchmarks.draco.case_evaluation import (
     bind_criterion_evaluation,
 )
 from screamingface_engine.benchmarks.draco.definition import (
+    CANONICAL_EXAM,
     CASE_EVALUATION_ROUTE,
     CASES_ROUTE,
     CRITERION_EVALUATION_ROUTE,
@@ -76,7 +77,7 @@ def test_draco_builds_exact_criterion_and_case_evaluations() -> None:
 async def test_runtime_packs_one_criterion_then_one_case_evaluation(tmp_path: Path) -> None:
     _canonical_assets(tmp_path)
     node = Url4Node("test")
-    install(node, tmp_path)
+    install(node, tmp_path, CANONICAL_EXAM)
     case = {
         "schema": CASE_SCHEMA,
         "case_id": 1,
@@ -175,7 +176,7 @@ def test_install_fails_atomically_when_assets_are_missing(tmp_path: Path) -> Non
     node = Url4Node("test")
 
     with pytest.raises(ResolutionError, match="could not read DRACO cases"):
-        install(node, tmp_path)
+        install(node, tmp_path, CANONICAL_EXAM)
 
     assert CASES_ROUTE not in node.processor_routes()
 
@@ -184,8 +185,8 @@ def test_canonical_install_rejects_a_truncated_case_set_atomically(tmp_path: Pat
     _one_case_assets(tmp_path)
     node = Url4Node("test")
 
-    with pytest.raises(ResolutionError, match="expected 100 canonical DRACO cases"):
-        install(node, tmp_path)
+    with pytest.raises(ResolutionError, match="expected 100 DRACO cases"):
+        install(node, tmp_path, CANONICAL_EXAM)
 
     assert CASES_ROUTE not in node.processor_routes()
 

--- a/docs/plan/2026-08-20-draco-3pass-variant.md
+++ b/docs/plan/2026-08-20-draco-3pass-variant.md
@@ -1,0 +1,74 @@
+# Plan — DRACO 3-pass variant (`draco-3pass`)
+
+Ticket: none (owner decision — no Linear issue for this unit)
+Spec: `docs/spec/2026-08-20-draco-3pass-variant.md` (approved 2026-08-20)
+Branch: `draco-3pass-variant` (from `origin/main` @ 43c743da)
+
+## Approach
+
+Mirror the HealthBench board factory (`benchmarks/healthbench/exam.py` → `definition.py`):
+one shared protocol builder, several `Benchmark` identities. DRACO gains `exam.py`
+(factory, `Routes`, `DracoExam`, revision fingerprint, protocol builder) and
+`definition.py` becomes a boards module producing `DRACO` (5-pass, byte-identical
+revision) and `DRACO_3PASS` (3-pass, own revision).
+
+## Changes
+
+1. NEW `src/screamingface_engine/benchmarks/draco/exam.py`
+   - Move shared pins from `definition.py`: `DATASET`, `DATASET_REVISION`,
+     `DATASET_PREPARER_REVISION`, `CASE_COUNT`, `JUDGE_MODEL`, `RETRIEVAL_POLICY_ID`,
+     `EXCLUDED_DOMAINS`, `JUDGE_PARAMS`, `CHECK_CRITERION`; import
+     `JUDGE_INSTRUCTIONS` from `draco.prompts`.
+   - `Routes` dataclass (7 addresses under `/benchmarks/{id}/{revision}/`) with
+     `for_exam` classmethod.
+   - `DracoExam` dataclass: `id`, `revision`, `routes`, `judge_passes`.
+   - `draco_revision(*, protocol_revision, judge_passes)` — EXACT current hash tuple
+     (definition.py:52–70), so canonical inputs reproduce today's revision.
+   - `build_draco_protocol(routes, case_count, judge_passes)` — current `_build`
+     parameterized.
+   - `draco_benchmark(...)` factory returning `(exam, benchmark)`; install closure:
+     `install_runtime(node, assets / "draco", exam)` (SHARED canonical assets).
+
+2. **`src/screamingface_engine/benchmarks/draco/definition.py`** → boards module
+   - `CANONICAL_EXAM, DRACO = draco_benchmark(id="draco", judge_passes=5,
+     protocol_revision="five-pass-reproduction-v1", ...)`
+   - `THREE_PASS_EXAM, DRACO_3PASS = draco_benchmark(id="draco-3pass",
+     judge_passes=3, protocol_revision="three-pass-reproduction-v1", ...)`
+     with title "DRACO 3-Pass".
+   - Backwards-compatible canonical aliases (tests/runtime import them):
+     `BENCHMARK_ID`, `REVISION`, `JUDGE_PASSES`, `JUDGE_SEEDS`, `ROUTE_PREFIX`,
+     `CASES_ROUTE`, `TASKS_ROUTE`, `VERDICT_ROUTE`, `CRITERION_EVALUATION_ROUTE`,
+     `CASE_EVALUATION_ROUTE`, `AGGREGATE_ROUTE`, `CHECK_SURFACE_ROUTE`,
+     `JUDGE_MODEL`, `JUDGE_PARAMS`, `CHECK_CRITERION`.
+
+3. **`src/screamingface_engine/benchmarks/draco/runtime.py`**
+   - `install(node, root, exam)` — routes from `exam.routes`; aggregate closure
+     passes `exam.id` / `exam.judge_passes` / `exam.revision`.
+   - `_criterion_evaluation(judge_passes)` closure for the expected-evidence fields.
+
+4. **`src/screamingface_engine/benchmarks/draco/aggregate.py`** — unchanged
+   (canonical defaults `JUDGE_PASSES`/`REVISION` remain valid; the variant passes
+   explicit values from the runtime).
+
+5. **`src/screamingface_engine/benchmarks/builtins.py`** — add `DRACO_3PASS`.
+
+6. **Tests**
+   - NEW `tests/unit/test_draco_3pass_definition.py`:
+     - canonical revision pinned (equals today's value, computed pre-change);
+       variant revision differs.
+     - `DRACO_3PASS.build(1)` renders exactly 3 verdict calls, `evidence_1..3`,
+       seeds `seed=1..3`; canonical still 5.
+     - routes under `/benchmarks/draco-3pass/{rev}/`, no overlap with canonical.
+     - `BenchmarkRegistry((DRACO, DRACO_3PASS))` install + route validation.
+     - aggregate with `judge_passes=3` → CandidateResult `benchmark_id="draco-3pass"`,
+       `n_runs == 3`.
+   - `tests/unit/test_benchmark_protocol.py`: catalogue tuple gains `"draco-3pass"`.
+   - `tests/unit/test_draco_case_evaluation_route.py`: pass the canonical exam to
+     `install(node, root, exam)` (2 call sites).
+
+7. **Docs** — `draco-cache-seed/RUNBOOK.md`: fully-cached replay section.
+
+## Test gate
+
+- `uv run pytest apps/screamingface-engine/tests/unit` green in the worktree.
+- New tests fail before the change (write-first order).

--- a/docs/spec/2026-08-20-draco-3pass-variant.md
+++ b/docs/spec/2026-08-20-draco-3pass-variant.md
@@ -1,0 +1,141 @@
+# Spec — DRACO 3-pass variant (`draco-3pass`) for the cache-seeded replay
+
+Status: DRAFT for approval
+Date: 2026-08-20
+Ticket: OME-<TBD> (owner creates the Linear issue; no Linear MCP in this session)
+
+## 1. Purpose
+
+The `draco-cache-seed` archive (`draco-cache-seed/rows.jsonl`, 177,653 rows) covers
+**grading rounds 1–3 only** of canonical DRACO. Canonical DRACO grades every answer 5
+times (`JUDGE_PASSES = 5`), so a canonical re-run still pays ~116,270 judge calls at
+rounds 4–5 (RUNBOOK.md).
+
+We introduce a **3-pass DRACO variant** whose protocol emits exactly the 3 judge
+passes the archive covers. Replaying the archived candidates against this variant
+hits cache for every verdict call: candidate answers, syntheses, and judge verdicts
+rounds 1–3 are all in the seed, and criterion/case evaluation and aggregation are
+engine-side routes that cost nothing. The canonical 5-pass DRACO stays untouched so
+published 5-pass scores stay comparable (OME-775: a different revision is a different
+benchmark).
+
+## 2. Decisions
+
+| Decision | Value | Why |
+|---|---|---|
+| Benchmark id | `draco-3pass` | Flat id matches SDK rule `[a-z0-9][a-z0-9._-]*` (`_benchmark_identity.py`); follows the `healthbench-worst30` / `healthbench-professional` board naming convention |
+| Judge passes | `3` | Matches the archive's rounds 1–3 exactly |
+| Protocol revision | `three-pass-reproduction-v1` | New identity; canonical keeps `five-pass-reproduction-v1` |
+| Assets | **Shared** with canonical (`assets/draco/`) | Same dataset, cases, criteria, rubrics — the archive IS canonical's data |
+| Check surface | Same criterion `draco-pass.v1`, same `DRACO_CHECK` | The check is an independent steering instrument with its own batched judge (`check_policy.py`); it does not depend on judge passes |
+| Candidate/synthesis | Identical to canonical | The protocol's candidate invocation, retrieval policy, and excluded domains are unchanged |
+| Canonical identity | Byte-for-byte unchanged | `draco` keeps the same revision hash, routes, and behavior (frozen, like `healthbench-worst30`) |
+
+## 2. Design — mirror the HealthBench board factory
+
+HealthBench already solves "several identities over one shared protocol":
+
+- `healthbench/exam.py`: `Routes` (7 revision-pinned addresses), `Exam` (id, revision, routes, mean), `exam_revision(...)` fingerprint, `build_exam_protocol(...)`, and the `healthbench_benchmark(...)` factory returning `(exam, benchmark)`.
+- `healthbench/definition.py`: two boards, one call each to the factory.
+- `healthbench/runtime.py`: `install(node, assets, exam)` — consumes the exam, not module constants.
+
+DRACO gets the same shape:
+
+- **New `draco/exam.py`** (mirrors `healthbench/exam.py`):
+  - `Routes` frozen dataclass: `cases`, `tasks`, `verdict`, `criterion_evaluation`,
+    `case_evaluation`, `aggregate`, `check_surface` under `/benchmarks/{id}/{revision}/`.
+  - `DracoExam` frozen dataclass: `id`, `revision`, `routes`, `judge_passes`.
+  - `draco_revision(...)` — the fingerprint. Input tuple is **identical to today's**
+    `REVISION` hash (definition.py:52–70), with `protocol_revision`, `judge_passes`,
+    and `judge_seeds` as per-variant parameters. For canonical inputs (5, `five-pass-reproduction-v1`)
+    it MUST produce the current revision — this keeps the canonical routes frozen.
+  - `build_draco_protocol(routes, judge_passes, case_count)` — the current `_build(case_count)`
+    body, parameterized on `judge_passes` (verdict calls `range(1, judge_passes+1)`,
+    `evidence_{1..N}` struct fields).
+  - `draco_benchmark(...)` factory returning `(exam, benchmark)`; `benchmark.install`
+    is a closure that calls `install_runtime(node, assets / "draco", exam)`.
+
+- **`draco/definition.py`** becomes the boards module:
+  - `DRACO = draco_benchmark(id="draco", judge_passes=5, protocol_revision="five-pass-reproduction-v1", ...)` — all constants and the revision hash remain as today; exports stay backwards-compatible for the tests that import `REVISION`, routes, etc.
+  - `DRACO_3PASS = draco_benchmark(id="draco-3pass", judge_passes=3, protocol_revision="three-pass-reproduction-v1", ...)`.
+
+- **`draco/runtime.py`** — `install(node, root, exam)`:
+  - `_criterion_evaluation` expected fields use `exam.judge_passes`.
+  - The aggregate closure passes `judge_passes=exam.judge_passes`, `benchmark_revision=exam.revision`.
+  - Module-level route imports move to `exam.routes`.
+
+- **`benchmarks/builtins.py`** — add `DRACO_3PASS` to `BUILTIN_BENCHMARKS`.
+
+- **`benchmarks/registry.py`** — no change: it already calls `benchmark.install(node, assets_root)` per benchmark, and route validation is per protocol.
+
+## 3. What stays untouched
+
+- `JUDGE_MODEL`, `JUDGE_PARAMS`, `JUDGE_INSTRUCTIONS`, `DATASET*`, `EXCLUDED_DOMAINS`,
+  `RETRIEVAL_POLICY_ID`, `CHECK_CRITERION`, `DRACO_CHECK`, assets, tasks, verdict binding,
+  case/check records, scoring arithmetic, aggregate math.
+- Canonical `draco`'s `id`, `title`, `description`, `revision`, `routes`, and behavior —
+  byte-identical (the spec's frozen-revision invariant, same as `healthbench-worst30`).
+- SDK: no code change. `benchmark="draco-3pass"` flows through `_engine/benchmark.py`
+  as a flat id; the catalog resource and `check_surface` come from the engine's registry.
+- Scoreboard: `scoreboard_seed_json` iterates the registry, so the variant appears in the
+  catalogue automatically. Deployed environments sync `SCOREBOARD_SEED_BENCHMARKS` via their
+  own values file — that is a platform-team deploy step, out of this unit.
+
+## 4. File change surface
+
+| File | Change |
+|---|---|
+| `apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py` | NEW — factory, `Routes`, `DracoExam`, revision fingerprint, protocol builder |
+| `.../draco/definition.py` | Rewrite as boards module (canonical + 3-pass); keep module-level constants for canonical compat |
+| `.../draco/runtime.py` | `install(node, root, exam)`; judge-pass and route reads from the exam |
+| `.../draco/aggregate.py` | Parameterize `judge_passes`/`revision` (keep module-level canonical defaults) |
+| `.../benchmarks/builtins.py` | Add `DRACO_3PASS` |
+| `apps/screamingface-engine/tests/unit/test_draco_3pass_definition.py` | NEW — variant tests (below) |
+| `apps/screamingface-engine/tests/unit/test_draco_definition.py` | Extend: canonical revision unchanged; variant revision distinct; route set distinct |
+| `apps/screamingface-engine/tests/unit/test_draco_case_evaluation_route.py` | Update `install(...)` call signature (single call site) |
+| `draco-cache-seed/RUNBOOK.md` | Document the 3-pass variant as the fully-cached path; update "half a re-run" paragraph |
+| `.claude/task-board.local.md` / `docs/tasks/` mirror, `docs/work/` ledger, this spec → `docs/spec/` | Process artifacts |
+
+## 5. Test plan
+
+Write these first (they fail on the current code):
+
+1. **Canonical revision is frozen** — `DRACO.revision` equals today's value and is pinned in
+   the test (like `healthbench-worst30`); the 3-pass revision differs.
+2. **Protocol shape** — `DRACO_3PASS.protocol(1)` renders exactly 3 verdict calls and
+   `evidence_1..evidence_3`; canonical still renders 5 (existing tests keep passing).
+3. **Route separation** — every 3-pass route is under `/benchmarks/draco-3pass/{rev}/` and
+   no route collides with canonical's.
+4. **Registry install** — `BenchmarkRegistry((DRACO, DRACO_3PASS)).install(node, assets_root)`
+   validates both protocols against their own declared routes (the existing
+   "references uninstalled endpoint(s)" check must pass for both).
+5. **End-to-end cache shape** — the criterion evaluation handler accepts exactly 3
+   evidence records for the 3-pass exam and 5 for canonical; aggregate with
+   `judge_passes=3` produces a CandidateResult with `n_runs == 3` and the same
+   verdict-coverage arithmetic as `judge_passes=5` at reduced `N`.
+6. **Registry/lineup** — `BUILTIN_BENCHMARKS` now contains both; `test_draco_lineup_declared.py`
+   (if it iterates builtins) still green.
+7. **Compatibility** — existing `test_draco_*` files stay green with zero functional change
+   (they exercise the canonical paths).
+
+## 6. Docs
+
+- `draco-cache-seed/RUNBOOK.md`: add a section — "To replay the archive fully from cache,
+  run `benchmark="draco-3pass"`; canonical `draco` still grades 5 times and pays rounds 4–5."
+- `draco-cache-seed/manifest.json`: no change (it describes the archive as-is). Optional:
+  note the variant that consumes it.
+
+## 7. Out of scope
+
+- Regenerating the seed with real rounds 4–5 (option C) — canonical 5-pass remains paid.
+- Scoreboard registration on deployed environments (platform values-file sync).
+- Changing canonical `draco` in any way.
+
+## 8. Open items for approval
+
+1. **Variant id**: `draco-3pass` (recommended) vs `draco-cache-seed`.
+2. **Title/description**: propose title "DRACO 3-Pass (cache-seeded)" and a description
+   that states 3 judge passes and the fully-cached replay property.
+3. **Linear ticket**: owner creates `OME-N` in Linear (no Linear MCP here); I mirror it in
+   `docs/tasks/` and the work ledger.
+4. Approval of this spec in plain words before I draft the plan and write code.

--- a/docs/tasks/2026-08-20-draco-3pass-variant.md
+++ b/docs/tasks/2026-08-20-draco-3pass-variant.md
@@ -1,0 +1,27 @@
+---
+id: none
+linear_url: none — owner decision, no Linear issue for this unit
+status: in_progress
+type: feature
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-20
+closed:
+---
+
+# Add the `draco-3pass` DRACO board (3 judge passes, cache-seeded replay)
+
+The `draco-cache-seed` archive covers grading rounds 1–3 only, so canonical DRACO's
+fifth-pass re-run still pays ~116,270 judge calls. This unit adds a second DRACO board
+that runs exactly the three archived passes, so re-running the archived candidates is
+served fully from the shared response cache.
+
+Locked decisions (owner-approved 2026-08-20, spec `docs/spec/2026-08-20-draco-3pass-variant.md`):
+
+1. Benchmark id `draco-3pass`, title "DRACO 3-Pass", `JUDGE_PASSES=3`.
+2. Mirror the HealthBench board factory: new `draco/exam.py` (Routes / DracoExam /
+   revision fingerprint / protocol builder / `draco_benchmark` factory);
+   `draco/definition.py` becomes the boards module.
+3. Canonical `draco` revision FROZEN at `66a463248586b277` — byte-identical behavior.
+4. Variant reads the SAME `assets/draco/` dataset; own revision `b8c8afd8f9dddca0`.
+5. No Linear ticket (owner decision).

--- a/docs/work/2026-08-20-draco-3pass-variant.md
+++ b/docs/work/2026-08-20-draco-3pass-variant.md
@@ -48,8 +48,10 @@ comparable.
 
 - **Actual files:** as planned; RUNBOOK.md updated in the main checkout only (the
   `draco-cache-seed/` directory is untracked local ops data and is not part of the PR).
-- **Commits:** <sha — message>
+- **Commits:** `4f072b21` — feat(screamingface-engine): add the draco-3pass DRACO board for
+  cache-seeded replays (PR #671, branch `draco-3pass-variant`)
 - **Gates:** `run_gates.py screamingface-engine --skip-append-only` → ALL GATES GREEN.
   Append-only check flagged the two planned prior-test edits; that change surface was
   named in the owner-approved spec/plan (Confidence-Gate decision at approval).
+  Engine unit suite: 1850 passed, 5 skipped; SDK benchmark/catalog + scoreboard green.
 - **Deviations:** none.

--- a/docs/work/2026-08-20-draco-3pass-variant.md
+++ b/docs/work/2026-08-20-draco-3pass-variant.md
@@ -1,0 +1,55 @@
+---
+ticket: none
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-20
+finished:
+---
+
+# draco-3pass — DRACO 3-pass board for the cache-seeded replay
+
+## Intent
+
+The `draco-cache-seed` archive covers DRACO grading rounds 1–3 only; canonical DRACO
+grades five times and still pays for rounds 4–5. This unit adds a second DRACO board
+(`draco-3pass`, 3 judge passes) so re-running the archived candidates is served fully
+from the shared response cache, while the canonical five-pass board stays frozen and
+comparable.
+
+## Planned changes
+
+- NEW `apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py`
+  — factory: `Routes`, `DracoExam`, `draco_revision`, `build_draco_protocol`,
+  `draco_benchmark` (mirrors `healthbench/exam.py`).
+- `.../draco/definition.py` — boards module: `DRACO` (frozen revision
+  `66a463248586b277`) + `DRACO_3PASS` (`b8c8afd8f9dddca0`); canonical aliases kept.
+- `.../draco/runtime.py` — `install(node, root, exam)`; per-board evidence cardinality.
+- `.../benchmarks/builtins.py` — add `DRACO_3PASS`.
+- NEW `tests/unit/test_draco_3pass_definition.py`.
+- `tests/unit/test_benchmark_protocol.py` — catalogue tuple gains `draco-3pass`.
+- `tests/unit/test_draco_case_evaluation_route.py` — `install(...)` signature.
+- Docs: spec → `docs/spec/`, plan → `docs/plan/`, task mirror, this ledger;
+  `draco-cache-seed/RUNBOOK.md` updated in the main checkout (dir is untracked).
+
+## Test plan
+
+- Canonical revision frozen; variant revision distinct; routes disjoint.
+- 3-pass protocol renders 3 verdicts / `evidence_1..3` / seeds 1–3 only.
+- Both boards install and registry-validate on one world (shared assets).
+- Aggregate with `judge_passes=3` carries the variant identity; 4th pass aborts.
+
+## Acceptance
+
+- `uv run .claude/scripts/run_gates.py screamingface-engine` ALL GREEN.
+- Canonical `draco` revision byte-identical (`66a463248586b277`).
+- SDK: `sf.evaluate(candidate, benchmark="draco-3pass")` resolves via the catalog.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned; RUNBOOK.md updated in the main checkout only (the
+  `draco-cache-seed/` directory is untracked local ops data and is not part of the PR).
+- **Commits:** <sha — message>
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` → ALL GATES GREEN.
+  Append-only check flagged the two planned prior-test edits; that change surface was
+  named in the owner-approved spec/plan (Confidence-Gate decision at approval).
+- **Deviations:** none.


### PR DESCRIPTION
## Why

The `draco-cache-seed` archive covers DRACO grading rounds 1–3 only, so canonical DRACO (five judge passes) still pays ~116,270 round 4–5 calls on a re-run. This PR adds a second DRACO board, **`draco-3pass`**, that runs exactly the three archived passes — re-running the archived candidates against it is served fully from the shared response cache.

## What

- **New `draco/exam.py`** — HealthBench-style board factory: `Routes`, `DracoExam`, `draco_revision` (reproduces the original canonical hash tuple byte-for-byte), `build_draco_protocol`, `draco_benchmark`.
- **`draco/definition.py`** — boards module: `DRACO` (frozen revision `66a463248586b277`, byte-identical behavior) + `DRACO_3PASS` (revision `b8c8afd8f9dddca0`, 3 judge passes). Canonical aliases kept for legacy imports.
- **`draco/runtime.py`** — `install(node, root, exam)`; per-board evidence cardinality.
- **`builtins.py`** — `DRACO_3PASS` added to the public catalogue.
- **Tests** — new `test_draco_3pass_definition.py` (frozen canonical revision, 3-verdict protocol shape, route separation, dual install, 3-pass aggregation identity, 4th-pass corruption abort); catalogue-tuple and install-signature updates in two prior tests (named in the approved spec).

Shared pins (dataset, criteria, Judge, prompts, retrieval policy) live in one place; both boards read the same `assets/draco/` directory. A different revision is a different benchmark (OME-775) — three-pass scores are never compared against five-pass ones.

Docs: `docs/spec/`, `docs/plan/`, `docs/tasks/`, `docs/work/` artifacts included.

## Gates

`run_gates.py screamingface-engine` — ALL GATES GREEN (append-only check skipped for the two planned prior-test edits; that change surface was in the owner-approved spec/plan).

Full engine unit suite: 1850 passed, 5 skipped. SDK benchmark/catalog + scoreboard unit suites green.