### PR TITLE
Bound the event bridge by a memory budget, not an event count

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/job_env.py
+++ b/apps/screamingface-engine/src/screamingface_engine/job_env.py
@@ -253,6 +253,16 @@ RESULT_HARD_CAP_BYTES = "URL4_CLOUD_RESULT_HARD_CAP_BYTES"
 spilling. The result is already in Runner RAM when checked (string + encoded copy ≈ 2-3× its
 size), so size this to pod memory, not disk."""
 
+BRIDGE_MEMORY_BUDGET_BYTES = "URL4_CLOUD_BRIDGE_MEMORY_BUDGET_BYTES"
+"""Memory ceiling for the runner's event-bridge backlog: past it the run FAILS with
+``BridgeOverflowError`` instead of buffering on. Converted to an event count at 512 B per
+event (see ``runner.executor.EVENT_SIZE_ESTIMATE_BYTES``) — a bound on what the backlog may
+COST, not on how wide a DAG may be (OME-906)."""
+
+DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES = 67_108_864
+"""64 MiB ≈ 131 072 events at the 512 B estimate — 30× the widest burst measured (OME-906)
+and 1/16 of :data:`DEFAULT_RESULT_HARD_CAP_BYTES`, in the same process."""
+
 DEFAULT_RESULT_HARD_CAP_BYTES = 1_073_741_824
 """1 GiB — clears a plausible full-benchmark-scale report while catching runaway output."""
 
@@ -305,6 +315,7 @@ DEPLOY_TIME = frozenset(
         ARTIFACTS_DIR,
         RESULT_INLINE_CAP_BYTES,
         RESULT_HARD_CAP_BYTES,
+        BRIDGE_MEMORY_BUDGET_BYTES,
     }
 )
 """Helm owns these end-to-end. The App writing one would make it two sources of truth again."""
@@ -314,9 +325,11 @@ __all__ = [
     "AIGATEWAY_MODEL",
     "AIGATEWAY_PROFILE",
     "ARTIFACTS_DIR",
+    "BRIDGE_MEMORY_BUDGET_BYTES",
     "CACHE_MAX_AGE_S",
     "CACHE_PARTICIPATE",
     "DEFAULT_ARTIFACTS_DIR",
+    "DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES",
     "DEFAULT_NATS_URL",
     "DEFAULT_RESULT_HARD_CAP_BYTES",
     "DEFAULT_RESULT_INLINE_CAP_BYTES",

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -60,12 +60,26 @@ reader finds the pair by prefix. The soft cap travels WITH the mark because the 
 uninterpretable — 3000 is alarming against a cap of 1024 and impossible against 8192.
 """
 
+EVENT_SIZE_ESTIMATE_BYTES = 512
+"""The per-event cost the bridge's memory budget is divided by to get its hard cap.
+
+Deliberately about DOUBLE the largest measured event (278 B, OME-906), so the real ceiling
+stays under the budget rather than over it. `sys.getsizeof` per event on the hot path would
+cost more than the bound is worth; the estimate only has to be the right order of magnitude.
+"""
+
 
 class BridgeOverflowError(RuntimeError):
-    """Raised by `_Bridge.on_event` when the backlog still exceeds the hard cap after the
-    eviction policy has run — eviction only removes a `Log` when one happens to be buffered,
-    so a backlog made up of non-Log events can grow unchecked past the soft cap all the way
-    to the hard cap, where the streaming consumer is deemed not keeping up with the engine."""
+    """Raised by `_Bridge.on_event` when the backlog still exceeds the cap derived from the
+    bridge's memory budget after the eviction policy has run — eviction only removes a `Log`
+    when one happens to be buffered, so a backlog of non-Log events grows unchecked to the
+    budget cap.
+
+    The message separates the two shapes a full buffer can take: a drain count above zero
+    means ONE DAG burst outran the budget (the engine gathers over `deps` unbounded and emits
+    each node's events before it awaits anything, so a wide fan-in lands in a single
+    event-loop slice); a drain count of zero means the consumer never ran at all.
+    """
 
 
 class _Bridge:
@@ -76,17 +90,26 @@ class _Bridge:
     an incoming non-Log event instead evicts the oldest buffered `Log` to make room (or, if no
     `Log` is buffered, evicts nothing and the buffer grows toward the hard cap) — since a `Log`
     is the only event kind safe to lose without corrupting the run's span/cost accounting.
-    Only past `_HARD_CAP_MULTIPLIER * maxsize` does it give up and raise `BridgeOverflowError`.
+    Only past the hard cap does it give up and raise `BridgeOverflowError`.
+
+    The HARD cap is not a count of events: it is `memory_budget // EVENT_SIZE_ESTIMATE_BYTES`,
+    so an operator bounds what the backlog may COST in bytes, not how wide a DAG may be —
+    the count-derived cap was a ceiling on DAG width (OME-906).
     """
 
-    _HARD_CAP_MULTIPLIER = 8
-
-    def __init__(self, maxsize: int) -> None:
+    def __init__(
+        self,
+        maxsize: int,
+        *,
+        memory_budget: int = job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES,
+    ) -> None:
         self._buf: deque[ObservationEvent] = deque()
         self._max = maxsize
-        self._hard_cap = maxsize * self._HARD_CAP_MULTIPLIER
+        self._budget_bytes = memory_budget
+        self._hard_cap = max(1, memory_budget // EVENT_SIZE_ESTIMATE_BYTES)
         self._dropped = 0
         self._high_water = 0
+        self._drained = 0
         self._closed = False
         self._wake = asyncio.Event()
 
@@ -109,6 +132,17 @@ class _Bridge:
         return self._high_water
 
     @property
+    def drained(self) -> int:
+        """How many events the consumer has taken off the buffer.
+
+        INVARIANT: the honest signal for "is the consumer running at all?" — the overflow
+        message keys on it to tell a wide-DAG burst (drained above zero) from a consumer
+        that never ran (drained zero). A count that merely lagged would say "behind";
+        only zero says "stuck".
+        """
+        return self._drained
+
+    @property
     def backlogged(self) -> bool:
         """Whether the backlog ever passed the SOFT cap.
 
@@ -126,20 +160,36 @@ class _Bridge:
         accounting. Only once the backlog still exceeds the hard cap after that eviction does
         this raise `BridgeOverflowError`.
         """
-        # INVARIANT: _hard_cap > _max (_HARD_CAP_MULTIPLIER > 1) gives the buffer headroom to
-        # grow past the soft cap before it hits the hard cap — NOT a guarantee that a Log is
-        # available to evict. A backlog with no buffered Log at all is exactly the state that
-        # runs out that headroom and raises BridgeOverflowError.
+        # INVARIANT: with the default budget the hard cap sits far above `_max`, giving the
+        # buffer headroom past the soft cap before the budget binds — NOT a guarantee that a
+        # Log is available to evict. A backlog with no buffered Log at all is exactly the
+        # state that runs out that headroom and raises BridgeOverflowError. A budget below
+        # `_max` events' worth makes the hard cap bind first; the policy stays correct, the
+        # soft cap simply never gets to help.
         if len(self._buf) >= self._max:
             if isinstance(event, Log):
                 self._dropped += 1
                 return
             self._evict_oldest_log()
         if len(self._buf) >= self._hard_cap:
+            # WHY keyed on `drained`: a consumer that HAS taken events is running, so a
+            # full buffer is one producer burst wider than the budget — the DAG is the
+            # driver. Zero drained events is the only shape where the consumer itself is
+            # the suspect, and the message must say which of the two fired (OME-906).
+            if self._drained:
+                raise BridgeOverflowError(
+                    f"event backlog exceeded the memory budget "
+                    f"({self._budget_bytes:,} bytes ≈ {self._hard_cap:,} events; "
+                    f"peak {self._high_water}, {self._dropped} Log(s) dropped, "
+                    f"{self._drained:,} event(s) already drained) — one DAG burst wider "
+                    f"than the budget: increase {job_env.BRIDGE_MEMORY_BUDGET_BYTES} "
+                    "or narrow the DAG"
+                )
             raise BridgeOverflowError(
-                f"event backlog exceeded the hard cap ({self._hard_cap} events, "
-                f"peak {self._high_water}, {self._dropped} Log(s) already dropped) "
-                "— the consumer is not keeping up"
+                f"event backlog exceeded the memory budget "
+                f"({self._budget_bytes:,} bytes ≈ {self._hard_cap:,} events; "
+                f"peak {self._high_water}, {self._dropped} Log(s) dropped) and the "
+                "consumer never drained one event — the consumer is stuck, not merely behind"
             )
         self._buf.append(event)
         if len(self._buf) > self._high_water:
@@ -160,6 +210,7 @@ class _Bridge:
     async def drain(self) -> AsyncIterator[ObservationEvent]:
         while True:
             if self._buf:
+                self._drained += 1
                 yield self._buf.popleft()
                 continue
             if self._closed:
@@ -651,6 +702,7 @@ class Url4Executor(Executor):
         queue_cap: int = 1024,
         result_cap: int = job_env.DEFAULT_RESULT_INLINE_CAP_BYTES,
         hard_cap: int = job_env.DEFAULT_RESULT_HARD_CAP_BYTES,
+        memory_budget: int = job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES,
         artifact_store: ArtifactStore | None = None,
         world_aclose: Callable[[], Awaitable[None]] | None = None,
         world_factory: WorldFactory | None = None,
@@ -663,6 +715,10 @@ class Url4Executor(Executor):
         # copy ≈ 2-3× its size), so operators size hard_cap to pod RAM, not disk.
         self._result_cap = result_cap
         self._hard_cap = hard_cap
+        # WHY bytes, not a count: the bridge's hard cap is this budget divided by
+        # `EVENT_SIZE_ESTIMATE_BYTES`, so an operator bounds what the backlog may COST —
+        # a count cap was a ceiling on DAG width (OME-906).
+        self._memory_budget = memory_budget
         self._artifact_store = artifact_store
         self._world_aclose = world_aclose
         self._world_factory = world_factory
@@ -686,7 +742,7 @@ class Url4Executor(Executor):
         # Terminated. Resolving inside `execute` puts config and connect failures inside
         # `run`'s try, where they become Terminated(status="failed") with a real error code.
         await self._resolve_world()
-        bridge = _Bridge(self._queue_cap)
+        bridge = _Bridge(self._queue_cap, memory_budget=self._memory_budget)
         state = _RunState()
 
         async def _drive() -> str:

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -67,6 +67,19 @@ def _int_from_env(env: Mapping[str, str], name: str, default: int) -> int:
         return default
 
 
+def bridge_budget_from_env(env: Mapping[str, str]) -> int:
+    """The Runner's event-bridge memory budget: the bytes the backlog may cost before the
+    run fails with ``BridgeOverflowError`` (OME-906).
+
+    Deploy-time like the result caps, tolerant fallback the same: of the two wrong answers
+    to an unparseable value ("crash every run at boot" vs "run with the shipped default")
+    the default is the one that costs nothing.
+    """
+    return _int_from_env(
+        env, job_env.BRIDGE_MEMORY_BUDGET_BYTES, job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES
+    )
+
+
 def result_delivery_from_env(env: Mapping[str, str]) -> tuple[int, int, ArtifactStore]:
     """The Runner's result-delivery wiring: (inline cap, hard cap, spill store).
 
@@ -265,6 +278,7 @@ def build_executor(
         world_factory=_world,
         result_cap=inline_cap,
         hard_cap=hard_cap,
+        memory_budget=bridge_budget_from_env(env),
         artifact_store=artifact_store,
     )
 

--- a/apps/screamingface-engine/tests/unit/test_runner.py
+++ b/apps/screamingface-engine/tests/unit/test_runner.py
@@ -12,6 +12,7 @@ from screamingface_engine import job_env
 from screamingface_engine.runner.executor import Url4Executor
 from screamingface_engine.runner.main import (
     RunnerConfigError,
+    bridge_budget_from_env,
     build_executor,
     params_from_env,
     result_delivery_from_env,
@@ -478,3 +479,35 @@ def test_result_delivery_from_env_tolerates_unreadable_numbers() -> None:
     )
     assert inline_cap == job_env.DEFAULT_RESULT_INLINE_CAP_BYTES
     assert hard_cap == job_env.DEFAULT_RESULT_HARD_CAP_BYTES
+
+
+# FEATURE: bound the event bridge by memory, not by event count (OME-906). Same
+# env-driven shape as the result caps: a deploy-time knob with a tolerant fallback.
+
+
+def test_bridge_budget_from_env_defaults() -> None:
+    assert bridge_budget_from_env({}) == job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES
+
+
+def test_bridge_budget_from_env_reads_the_name() -> None:
+    assert bridge_budget_from_env({job_env.BRIDGE_MEMORY_BUDGET_BYTES: "1048576"}) == 1_048_576
+
+
+def test_bridge_budget_from_env_tolerates_unreadable_numbers() -> None:
+    assert (
+        bridge_budget_from_env({job_env.BRIDGE_MEMORY_BUDGET_BYTES: "a lot"})
+        == job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES
+    )
+
+
+def test_build_executor_wires_the_bridge_budget_from_env() -> None:
+    # The one hop the `_Bridge` units cannot prove: `build_executor` handing the budget to
+    # the executor. A declared-empty world keeps this synchronous — the world is only
+    # built on first `execute`, which this test never runs.
+    executor = build_executor({job_env.BRIDGE_MEMORY_BUDGET_BYTES: "2048"}, WorldConfig())
+    assert executor._memory_budget == 2048
+
+
+def test_build_executor_defaults_the_bridge_budget() -> None:
+    executor = build_executor({}, WorldConfig())
+    assert executor._memory_budget == job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES

--- a/apps/screamingface-engine/tests/unit/test_url4_executor.py
+++ b/apps/screamingface-engine/tests/unit/test_url4_executor.py
@@ -22,8 +22,9 @@ from screamingface_engine.runner.executor import (
 )
 from screamingface_engine.testing import InMemoryEventStream
 from url4.core.errors import ParseError, ResolutionError
+from url4.dag.nodes import TextNode
 from url4.io.static import StaticIOLayer
-from url4.observe import Log, NodeFinished, NodeStarted, RunStarted, Usage
+from url4.observe import Log, NodeFinished, NodeStarted, ObservationEvent, RunStarted, Usage
 from url4.streaming.interfaces import Completed, ExecStep, Traced
 from url4.streaming.lifecycle import run as publish_run
 from url4.streaming.protocol import (
@@ -325,12 +326,95 @@ def test_bridge_on_event_drop_policy_never_drops_span_usage_lifecycle() -> None:
 
 
 def test_bridge_raises_on_a_span_only_burst_past_the_hard_cap() -> None:
-    bridge = _Bridge(maxsize=2)
+    # WHY the tiny budget: the hard cap is `budget // EVENT_SIZE_ESTIMATE_BYTES`, so a
+    # small budget keeps this unit's burst short instead of buffering the 131 072-event
+    # default cap (OME-906).
+    bridge = _Bridge(maxsize=2, memory_budget=10_240)
     bridge.on_event(RunStarted("t" * 32, "s" * 16, "hash"))
     bridge.on_event(NodeStarted("span-1", None, "WebFetchNode", ""))
     with pytest.raises(BridgeOverflowError):
         for i in range(bridge._hard_cap):
             bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))
+
+
+# FEATURE: bound the event bridge by memory, not by event count (OME-906).
+#
+# The old count cap (`8 x soft cap` = 8 192) was a ceiling on DAG width: the engine fans
+# out over `deps` with an unbounded gather and emits each node's `NodeStarted` before it
+# awaits anything, so a wide fan-in lands its whole event burst in one event-loop slice,
+# before the drain can run at all. These tests pin the budget-bound behaviors the spec
+# requires: a wide DAG completes, the bound follows a byte budget, and the error names
+# which of the two failure shapes fired.
+
+
+def test_the_hard_cap_is_derived_from_the_memory_budget() -> None:
+    bridge = _Bridge(maxsize=2, memory_budget=10_240)
+    assert bridge._hard_cap == 10_240 // 512  # 20 events at 512 B per event
+
+
+def test_a_producer_that_never_stops_fails_at_the_budget() -> None:
+    bridge = _Bridge(maxsize=2, memory_budget=10_240)
+    bridge.on_event(RunStarted("t" * 32, "s" * 16, "hash"))
+    with pytest.raises(BridgeOverflowError):
+        for i in range(25):
+            bridge.on_event(NodeStarted(f"span-{i}", None, "TextNode", ""))
+
+
+@pytest.mark.asyncio
+async def test_overflow_with_drain_progress_names_the_budget_not_the_consumer() -> None:
+    # A drain count above zero is PROOF the consumer runs: the backlog is one burst that
+    # outran the budget, so the message must name the budget and the DAG shape, and must
+    # not accuse the consumer (the old message's claim, disproven by measurement).
+    bridge = _Bridge(maxsize=2, memory_budget=10_240)
+    bridge.on_event(RunStarted("t" * 32, "s" * 16, "hash"))
+    events = cast("AsyncGenerator[ObservationEvent, None]", bridge.drain())
+    await events.__anext__()  # one event drained: the consumer IS running
+    with pytest.raises(BridgeOverflowError) as excinfo:
+        for i in range(25):
+            bridge.on_event(NodeStarted(f"span-{i}", None, "TextNode", ""))
+    await events.aclose()
+    message = str(excinfo.value)
+    assert "URL4_CLOUD_BRIDGE_MEMORY_BUDGET_BYTES" in message
+    assert "DAG" in message
+    assert "consumer" not in message
+
+
+def test_overflow_with_zero_drained_says_the_consumer_never_ran() -> None:
+    # Zero drained events is the ONE case where the old accusation was right: the
+    # consumer never ran at all, which is a stuck consumer, not a wide DAG.
+    bridge = _Bridge(maxsize=2, memory_budget=10_240)
+    with pytest.raises(BridgeOverflowError) as excinfo:
+        for i in range(25):
+            bridge.on_event(NodeStarted(f"span-{i}", None, "TextNode", ""))
+    message = str(excinfo.value)
+    assert "never drained" in message
+    assert "stuck" in message
+
+
+class _WideFanIn:
+    """A node with `width` dependencies: the engine gathers over them unbounded, so the
+    whole width's events land in one event-loop slice before the drain can run."""
+
+    def __init__(self, width: int) -> None:
+        self.deps: dict[str, TextNode] = {f"dep{i}": TextNode("x") for i in range(width)}
+
+    async def resolve(self, inputs, ctx) -> str:
+        return "done"
+
+
+@pytest.mark.asyncio
+async def test_a_wide_dag_burst_completes_instead_of_overflowing() -> None:
+    # RED against the count cap: 9 000 deps put ~18 000 events (NodeStarted plus
+    # NodeFinished per node) in one slice, past the old hard cap of 8 192, and the run
+    # died with BridgeOverflowError. The default budget (64 MiB / 512 B = 131 072
+    # events) holds the same burst — a legitimately wide DAG must complete.
+    executor = Url4Executor(StaticIOLayer())
+
+    frames = await _drain(executor, _WideFanIn(9_000))
+
+    completed = frames[-1]
+    assert isinstance(completed, Completed)
+    assert completed.result.body == "done"
 
 
 class _LoggyNode:
@@ -720,7 +804,10 @@ def test_a_backlog_past_the_soft_cap_is_reported_as_backlogged() -> None:
 
 
 def test_the_overflow_error_names_the_high_water_mark() -> None:
-    bridge = _Bridge(maxsize=2)
+    # WHY the tiny budget: the hard cap is `budget // EVENT_SIZE_ESTIMATE_BYTES` (OME-906),
+    # so a small budget keeps this unit's burst short instead of buffering the 131 072-event
+    # default cap.
+    bridge = _Bridge(maxsize=2, memory_budget=10_240)
     with pytest.raises(BridgeOverflowError) as excinfo:
         for i in range(bridge._hard_cap + 1):
             bridge.on_event(NodeStarted(f"span-{i}", None, "WebFetchNode", ""))

--- a/docs/plan/2026-08-20-OME-906-bridge-memory-budget.md
+++ b/docs/plan/2026-08-20-OME-906-bridge-memory-budget.md
@@ -1,0 +1,66 @@
+# OME-906 — Plan: bound the event bridge by memory, not by event count
+
+- **Spec:** `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md`
+- **Base:** stacked on `OME-906-pipelined-frame-publishing` (PR #667). The spec's §3.2
+  adds the drained counter beside the high-water mark, which PR #667 introduces. Basing
+  this branch on `origin/main` would duplicate that feature and guarantee a conflict.
+  After PR #667 merges, retarget this PR to `main`.
+- **Stack:** `screamingface-engine` only. `url4` is not touched.
+
+## Steps (RED first)
+
+### Step 1 — RED: a wide DAG completes
+
+`tests/unit/test_url4_executor.py`: a node with 9 000 `TextNode` dependencies runs through
+the real `Url4Executor.execute` and the real drain loop, and completes. Today the
+`NodeStarted` burst (about 3 events per node, emitted before any await) exceeds 8 192 and
+raises `BridgeOverflowError`. This is the defect: a legitimate DAG fails.
+
+### Step 2 — RED: the bound is a budget, and the message says what happened
+
+`tests/unit/test_url4_executor.py`, against `_Bridge` directly:
+
+1. A producer that never stops fails at `budget // 512` events, not at 8 192. A small
+   budget (for example 10 240 bytes → 20 events) makes the bound observable.
+2. The same overflow after the drain made progress says the backlog exceeded the memory
+   budget, names the budget and the peak, and does not blame the consumer.
+3. An overflow with a drain count of zero says the consumer never drained — the one case
+   where the old message was the right accusation.
+4. `Log` stays the only event kind ever dropped (existing tests hold; no new code).
+
+### Step 3 — GREEN: the budget plumbing
+
+- `job_env.py`: `BRIDGE_MEMORY_BUDGET_BYTES = "URL4_CLOUD_BRIDGE_MEMORY_BUDGET_BYTES"` and
+  `DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES = 64 MiB`, beside the result caps, in `DEPLOY_TIME`
+  and `__all__`.
+- `runner/executor.py`:
+  - `EVENT_SIZE_ESTIMATE_BYTES = 512` (module constant; the estimate is deliberate —
+    about double the measured 278 B, so the real ceiling stays under budget).
+  - `_Bridge.__init__(maxsize, *, memory_budget)`; `hard_cap = max(1, budget // 512)`.
+    `_HARD_CAP_MULTIPLIER` is removed.
+  - `drain()` counts every event it yields (`drained`).
+  - `on_event` raises with one of two messages, keyed on `drained`: progress made → burst
+    over budget; zero → consumer never drained.
+  - `Url4Executor.__init__(..., memory_budget=job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES)`
+    forwarded to `_Bridge`.
+- `runner/main.py`: `build_executor` reads the name with `_int_from_env` and passes it on,
+  exactly as the result caps travel.
+
+### Step 4 — contracts and gates
+
+- `test_job_env_contract.py` iterates the sets; the new member must stay out of
+  `WRITTEN_BY_APP`. No test change expected.
+- Run the full `screamingface-engine` gate set. No other stack is touched.
+
+### Step 5 — close the unit
+
+- Spec status → implemented; ledger outcome filled; `docs/tasks/` mirror added.
+- Commits: conventional, `Refs: OME-906`; PR stacked on PR #667 with a retarget note.
+
+## Risks
+
+- **A budget below the soft cap (1024 events ≈ 512 KiB)** makes the hard cap bind before
+  soft-cap eviction can run. That is what the operator asked for; the policy stays
+  correct (the hard check raises after the eviction attempt). Documented, not clamped.
+- **The estimate is not a measurement.** Accepted in the spec: order of magnitude is
+  enough, and the default is double the largest measured event.

--- a/docs/spec/2026-08-20-OME-906-bridge-memory-budget.md
+++ b/docs/spec/2026-08-20-OME-906-bridge-memory-budget.md
@@ -1,0 +1,157 @@
+# OME-906 — Bound the event bridge by memory, not by event count
+
+- **Linear:** https://linear.app/openmined/issue/OME-906
+- **Landing:** `apps/screamingface-engine`
+- **Status:** spec — awaiting approval
+- **Supersedes:** `docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md`, whose premise
+  was disproven by measurement. That work shipped on its own merits; it does not fix this.
+
+## 1. The measured problem
+
+`_Bridge.on_event` raises `BridgeOverflowError` when the buffer holds 8192 events. The
+message says "the consumer is not keeping up". **Both the bound and the message describe
+something that is not happening.**
+
+### 1.1 The consumer is never behind
+
+A trace of every produce and consume operation on one run shows 2408 operations in **16**
+alternations: the producer emits hundreds of events with no interruption, then the consumer
+drains all of them with no interruption.
+
+```text
+PCPCPPPPPPPPPPPP…(606 P)…PPCCCCCCCCCC…(606 C)…CCCPCPC
+```
+
+`_Bridge.drain` does not await while its buffer holds anything, and the publish path does
+not suspend either. Therefore the consumer empties the buffer completely every time the
+event loop schedules it. It is not slow. **It cannot run at all while the producer holds
+the loop.**
+
+### 1.2 The publisher is irrelevant
+
+Peak backlog against publish latency, 1500 nodes:
+
+| Publish delay | serial: time / peak | pipelined: time / peak |
+|---|---|---|
+| 0 ms | 0.64 s / 4497 | 0.59 s / 4461 |
+| 0.1 ms | 3.80 s / 4499 | 0.58 s / 4467 |
+| 1 ms | 3.83 s / 4499 | 0.59 s / 4458 |
+| 10 ms | 31.05 s / 4499 | 0.59 s / 4461 |
+
+The delay moves over a 100x range. The peak does not move.
+
+### 1.3 What the cap really bounds
+
+The cap bounds **how many events the engine emits between two chances for the drain to
+run**. Two lines set the burst size:
+
+- `packages/url4/src/url4/dag/executor.py:182` — `_eval` emits `NodeStarted` **before** it
+  awaits anything.
+- `packages/url4/src/url4/dag/executor.py:186` — it then fans out over `node.deps` with a
+  plain `asyncio.gather`, with no bound.
+
+So a DAG of width W puts about W `NodeStarted` events in the buffer in ONE event-loop slice.
+Measured burst against run size:
+
+| N | total events | largest burst |
+|---|---|---|
+| 300 | 1204 | 606 |
+| 600 | 2404 | 1491 |
+| 1200 | 4804 | 3555 |
+| 2400 | 9604 | 7179 |
+
+7179 against 8192 predicts the measured boundary exactly: 2000 nodes pass, 3000 raise.
+
+`DEFAULT_RUN_CONCURRENCY` (32) does not bound this. Its docstring and
+`packages/url4/src/url4/dag/executor.py:391` are explicit — it gates `ctx.io.fetch` through
+a `BoundedIOLayer`, not node resolution.
+
+**The 8192 cap is a ceiling on DAG width.** A 100-Case DRACO Fusion is legitimately about
+3500 nodes wide, so it sits at the limit. Cache hits add the rest: they let many calls
+finish in one coalesced burst, so the trailing `Usage` + `ModelResponse` + `NodeFinished`
+triples also arrive in one slice. That is why the issue's snapshot shows 3465 `NodeStarted`
+for only 561 calls.
+
+### 1.4 The quantity being protected
+
+Measured: `NodeStarted` is 278 B, `NodeFinished` is 232 B. So 8192 events is **2.1 MB**.
+
+The same process accepts a result of `DEFAULT_RESULT_HARD_CAP_BYTES`, which is **1 GiB**. It
+refuses 2.1 MB of telemetry.
+
+## 2. Constraints
+
+| ID | Constraint | Reason |
+|---|---|---|
+| C1 | A legitimately wide DAG must complete | This is the defect |
+| C2 | Memory must stay bounded | The bound's real purpose |
+| C3 | A genuinely stuck consumer must still fail the run | Do not trade one silent failure for another |
+| C4 | No span, cost, result or terminal event is lost | Only a `Log` is safe to discard |
+| C5 | The error message must describe what happened | The current one misdirects |
+
+## 3. Design
+
+Two changes, both in `apps/screamingface-engine/src/screamingface_engine/runner/executor.py`.
+
+### 3.1 Bound the buffer by a memory budget
+
+Replace the count-derived hard cap with a cap derived from a stated memory budget:
+
+```python
+BRIDGE_MEMORY_BUDGET_BYTES = 64 * 1024 * 1024
+EVENT_SIZE_ESTIMATE_BYTES = 512
+```
+
+`hard_cap = BRIDGE_MEMORY_BUDGET_BYTES // EVENT_SIZE_ESTIMATE_BYTES`, about 131 000 events.
+
+WHY an estimate and not real measurement: `sys.getsizeof` per event on the hot path costs
+more than the bound is worth, and the estimate only has to be the right order of magnitude
+to turn a 2 MB ceiling into a 64 MB one. 512 B is deliberately about double the measured
+278 B, so the real ceiling is under budget rather than over it.
+
+WHY 64 MB: it is 30x the widest burst measured here and still small beside the 1 GiB this
+process already accepts for a result. The run mode is a one-shot Job, so the budget is spent
+once and reclaimed on exit.
+
+The budget must be settable from `job_env`, like the result caps, so an operator can lower
+it for a memory-tight pod without a release.
+
+### 3.2 Say what actually happened
+
+The current message blames the consumer. Replace it with the real condition, and add the
+drain-progress fact that distinguishes the two cases:
+
+- If the drain has made progress during this run, the backlog is a legitimate burst that
+  exceeded the budget. Say so, and name the DAG width as the driver.
+- If the drain has made NO progress at all, the consumer really is stuck. Say that.
+
+`_Bridge` already tracks a high-water mark; add a drained counter next to it. The counter is
+also the honest signal C3 asks for: a stuck consumer is one that never drained, not one that
+is merely behind.
+
+### 3.3 Not in scope
+
+- **Bounding the DAG's dep fan-out.** It would keep the buffer small at the source, but it
+  serializes node admission and changes the performance of every run. A separate decision.
+- **Making `_eval` yield before it emits.** Same objection: a hot-path change to every run
+  to fix a bound that is simply set too low.
+- **An asynchronous observer protocol in url4.** The correct long-term shape, and far too
+  large for this.
+
+## 4. Acceptance criteria
+
+1. A DAG whose single burst exceeds 8192 events completes. A deterministic test drives the
+   real `_Bridge` through the real publish loop at a width that raises today.
+2. Memory stays bounded: a producer that never stops still fails at the budget.
+3. A consumer that never drains still fails the run, and the message says the consumer is
+   stuck.
+4. A burst that exceeds the budget fails with a message naming the width and the budget, not
+   the consumer.
+5. Span, cost, result and terminal events are never dropped. Only `Log` is.
+6. The budget is readable from the environment, with the existing result caps as the model.
+
+## 5. Open question for the owner
+
+The 64 MB budget is a judgement call. It is 30x the widest burst measured and 1/16 of the
+result hard cap. If the run pods have a tighter memory limit than that implies, name the
+number and the spec takes it instead.

--- a/docs/spec/2026-08-20-OME-906-bridge-memory-budget.md
+++ b/docs/spec/2026-08-20-OME-906-bridge-memory-budget.md
@@ -2,7 +2,7 @@
 
 - **Linear:** https://linear.app/openmined/issue/OME-906
 - **Landing:** `apps/screamingface-engine`
-- **Status:** spec — awaiting approval
+- **Status:** implemented — stacked on PR #667, awaiting review
 - **Supersedes:** `docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md`, whose premise
   was disproven by measurement. That work shipped on its own merits; it does not fix this.
 

--- a/docs/tasks/2026-08-20-OME-906-bridge-memory-budget.md
+++ b/docs/tasks/2026-08-20-OME-906-bridge-memory-budget.md
@@ -1,0 +1,33 @@
+---
+id: OME-906
+linear_url: https://linear.app/openmined/issue/OME-906/cached-draco-evaluations-overflow-the-runner-event-bridge
+status: in_progress
+type: bug
+priority: 1
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-20
+closed:
+---
+
+# Cached DRACO evaluations overflow the runner event bridge
+
+The ticket blamed a slow consumer; measurement disproved it. The 8 192-event count cap
+bounded DAG WIDTH, not backlog health: the engine fans out over `deps` with an unbounded
+gather and emits each node's `NodeStarted` before it awaits anything, so a wide fan-in
+lands its whole event burst in one event-loop slice, before the drain can run at all. A
+100-Case DRACO Fusion is legitimately ~3 500 nodes wide and sat at the limit. The cap
+defended 2.1 MB in a process that accepts a 1 GiB result.
+
+Fix: bound the bridge by a MEMORY BUDGET (default 64 MiB ≈ 131 072 events at a 512 B
+estimate), readable from `URL4_CLOUD_BRIDGE_MEMORY_BUDGET_BYTES` like the result caps,
+and make the overflow error say which failure shape fired — drain progress above zero is
+one DAG burst wider than the budget; zero drained events is a stuck consumer.
+
+Investigation byproducts shipped separately in PR #667 (pipelined JetStream publishing,
+~50x wall-clock at a 10 ms round trip, and the bridge high-water mark this fix builds
+on): `docs/spec/2026-08-20-OME-906-pipelined-frame-publishing.md` records that history.
+
+Spec `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md`, plan
+`docs/plan/2026-08-20-OME-906-bridge-memory-budget.md`, ledger
+`docs/work/2026-08-20-OME-906-bridge-memory-budget.md`. Stacked on PR #667; retarget to
+`main` after it merges.

--- a/docs/work/2026-08-20-OME-906-bridge-memory-budget.md
+++ b/docs/work/2026-08-20-OME-906-bridge-memory-budget.md
@@ -78,7 +78,9 @@ The six criteria in `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md`.
 - **Gates:** `screamingface-engine` stack — ruff check, ruff format --check, pyright,
   `check_layering.py`, pytest with coverage: 1 890 passed, 5 skipped, 93.57 % (≥ 80 %).
   No other stack touched.
-- **Deviations:** the 64 MB budget stands as specced (owner did not name a tighter
+- **Deviations:** PR #667 and this unit's PR #672 are linked as a native GitHub stack
+  (stack #673, `gh stack link`) — merging #667 auto-rebases/retargets #672 to `main`;
+  no manual retarget. The 64 MB budget stands as specced (owner did not name a tighter
   number; it is env-tunable at deploy time). Open item for the owner: PR #667's
   split-out Linear issue and OME-906's root-cause correction still need Linear MCP,
   which is unavailable in this session — payloads remain blocked on credentials.

--- a/docs/work/2026-08-20-OME-906-bridge-memory-budget.md
+++ b/docs/work/2026-08-20-OME-906-bridge-memory-budget.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-906
+stack: screamingface-engine
+status: planned
+started: 2026-08-20
+finished:
+---
+
+# OME-906 — Bound the event bridge by memory, not by event count
+
+## Intent
+
+`_Bridge` raises `BridgeOverflowError` at 8192 buffered events and blames the consumer. The
+consumer is not the cause. Measurement shows the peak backlog is flat across a 100x range of
+publish latency, and that the buffer holds one uninterrupted producer burst whose size scales
+with DAG width — because `url4/dag/executor.py:182` emits `NodeStarted` before it awaits and
+`:186` fans out over `node.deps` with an unbounded `asyncio.gather`.
+
+So the cap is a ceiling on DAG width. A 100-Case DRACO Fusion is legitimately about 3500
+nodes wide and sits at the limit. The quantity defended is 2.1 MB, in a process that accepts
+a 1 GiB result.
+
+This unit replaces the count bound with a memory budget and makes the error say what
+happened.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/runner/executor.py` — derive the hard
+  cap from `BRIDGE_MEMORY_BUDGET_BYTES`; add a drained counter beside the high-water mark;
+  rewrite the overflow message to distinguish a legitimate burst from a stuck consumer.
+- `apps/screamingface-engine/src/screamingface_engine/job_env.py` — read the budget from the
+  environment, with the existing result caps as the model.
+- Tests in `apps/screamingface-engine/tests/`.
+
+## Test plan
+
+RED first:
+
+- A DAG whose single burst exceeds 8192 events completes through the real bridge and the real
+  publish loop. This test fails today.
+- A producer that never stops fails at the budget, not before it.
+- A consumer that never drains fails the run, with a message that says the consumer is stuck.
+- A burst over budget fails with a message naming the width and the budget.
+- `Log` is still the only event kind ever dropped.
+- The budget is read from the environment and falls back to the default.
+
+## Acceptance
+
+The six criteria in `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md`.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**

--- a/docs/work/2026-08-20-OME-906-bridge-memory-budget.md
+++ b/docs/work/2026-08-20-OME-906-bridge-memory-budget.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-906
 stack: screamingface-engine
-status: planned
+status: in_progress
 started: 2026-08-20
 finished:
 ---
@@ -51,6 +51,34 @@ The six criteria in `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md`.
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:**
-- **Commits:**
-- **Gates:**
-- **Deviations:**
+  - `apps/screamingface-engine/src/screamingface_engine/job_env.py` —
+    `BRIDGE_MEMORY_BUDGET_BYTES` name + `DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES` (64 MiB),
+    `DEPLOY_TIME` + `__all__` membership.
+  - `apps/screamingface-engine/src/screamingface_engine/runner/executor.py` —
+    `EVENT_SIZE_ESTIMATE_BYTES = 512`; `_Bridge(maxsize, *, memory_budget)` with
+    `hard_cap = max(1, budget // 512)`; `_HARD_CAP_MULTIPLIER` removed; `drained` counter
+    in `drain()`; two-variant overflow message keyed on `drained`; `BridgeOverflowError`
+    docstring rewritten; `Url4Executor(memory_budget=...)` plumbed to the bridge.
+  - `apps/screamingface-engine/src/screamingface_engine/runner/main.py` —
+    `bridge_budget_from_env` (tolerant, like the result caps) wired into
+    `build_executor`.
+  - `apps/screamingface-engine/tests/unit/test_url4_executor.py` — RED-first: wide
+    fan-in (9 000 deps) completes through the real engine; budget-derived cap;
+    never-stopping producer fails at the budget; burst message names the budget and
+    the DAG, stuck message says "never drained"; two pre-existing hard-cap tests given
+    explicit small budgets (the default cap moved 8 192 → 131 072 and made them
+    pathological — one took 838 s).
+  - `apps/screamingface-engine/tests/unit/test_runner.py` — env resolution defaults,
+    override, tolerance, and the `build_executor` wiring hop.
+- **Commits:** conventional, `Refs: OME-906`; branch stacked on PR #667
+  (`OME-906-pipelined-frame-publishing`) because the drained counter sits beside the
+  high-water mark that PR introduces — a `main` base would duplicate the feature and
+  guarantee a conflict. Deviation from the branch-from-`origin/main` rule is deliberate
+  and recorded here.
+- **Gates:** `screamingface-engine` stack — ruff check, ruff format --check, pyright,
+  `check_layering.py`, pytest with coverage: 1 890 passed, 5 skipped, 93.57 % (≥ 80 %).
+  No other stack touched.
+- **Deviations:** the 64 MB budget stands as specced (owner did not name a tighter
+  number; it is env-tunable at deploy time). Open item for the owner: PR #667's
+  split-out Linear issue and OME-906's root-cause correction still need Linear MCP,
+  which is unavailable in this session — payloads remain blocked on credentials.


### PR DESCRIPTION
## Summary

**This PR is the real fix for OME-906** — unlike #667, merging it SHOULD close that issue.

The 8 192-event count cap was a ceiling on **DAG width**, not backlog health: the engine
gathers over `deps` unbounded and emits each node's `NodeStarted` before it awaits
anything, so a wide fan-in lands its whole event burst in one event-loop slice, before
the drain can run at all. A 100-Case DRACO Fusion is legitimately ~3 500 nodes wide and
sat at the limit. The cap defended **2.1 MB** in a process that accepts a **1 GiB** result.

Two changes:

1. **The hard cap is now a memory budget.** `budget // 512` events (default 64 MiB ≈
   131 072 events), readable from `URL4_CLOUD_BRIDGE_MEMORY_BUDGET_BYTES` exactly like
   the result caps — an operator bounds what the backlog may **cost**, not how wide a DAG
   may be.
2. **The error says which failure shape fired**, keyed on a new `drained` counter beside
   #667's high-water mark: drain progress above zero is one DAG burst wider than the
   budget (names the knob and the DAG); **zero drained events** is a stuck consumer — the
   one case where the old "consumer is not keeping up" accusation was right.

## Stacked on #667 (GitHub stack #673)

The `drained` counter sits beside the high-water mark **PR #667 introduces**, so this
branch is based on `OME-906-pipelined-frame-publishing`, not `main`. The two PRs are
formally linked as a native GitHub stack: review #667 first — merging it auto-rebases and
auto-retargets this PR to `main` (no manual retarget needed), or merge from this PR to
land both layers in one operation.

## Evidence

- **RED-first:** a 9 000-dep fan-in through the real engine reproduced the production
  failure deterministically (`BridgeOverflowError ... 8192 ... consumer is not keeping up`)
  before the fix, and completes after it.
- A never-stopping producer still fails — at the budget (verified with a 10 240-byte
  budget → 20 events), not at a magic count.
- Local gates (`screamingface-engine` stack): ruff, ruff format, pyright,
  `check_layering.py`, pytest — **1 890 passed, 5 skipped, coverage 93.57 %** (gate 80 %).

## Notes for review

- Two pre-existing hard-cap tests were given explicit small budgets: the default cap
  moved 8 192 → 131 072 and made them pathological (one took **838 s**; now 0.26 s).
- The 64 MB default is the spec's judgement call (30× the widest measured burst, 1/16 of
  the result hard cap); it is deploy-time tunable, so a tighter pod can lower it without
  a release.

Spec `docs/spec/2026-08-20-OME-906-bridge-memory-budget.md` · plan
`docs/plan/2026-08-20-OME-906-bridge-memory-budget.md` · ledger
`docs/work/2026-08-20-OME-906-bridge-memory-budget.md`

Fixes OME-906

