### PR TITLE
fix(screamingface-engine): bake registered benchmark assets

### DIFF
--- a/apps/screamingface-engine/Dockerfile.benchmark
+++ b/apps/screamingface-engine/Dockerfile.benchmark
@@ -55,14 +55,13 @@ WORKDIR /app/apps/screamingface-engine
 # WHY: `uv` is copied in because the base image's uv-created venv has no pip and its runtime
 # stage does not install uv. Reusing the base image's package manager keeps one installer across
 # both Dockerfiles.
-# Keep this digest and the exact datasets version synchronized with DRACO's preparer revision.
-# Changing either changes the bytes that may be baked into an image.
+# Keep this digest and the exact datasets version synchronized with the pinned preparer inputs.
+# Changing either may change the benchmark bytes baked into an image.
 COPY --from=ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 /usr/local/bin/uv /usr/local/bin/uv
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --python /app/apps/screamingface-engine/.venv/bin/python --quiet "datasets==5.0.0"
-RUN mkdir -p /opt/benchmarks/draco \
- && /app/apps/screamingface-engine/.venv/bin/python -m screamingface_engine.benchmarks.draco.prepare \
-      --out /opt/benchmarks/draco
+RUN /app/apps/screamingface-engine/.venv/bin/python \
+      -m screamingface_engine.benchmarks.prepare --root /opt/benchmarks
 
 # --- runtime: the base image + the prepared assets -------------------------------------------
 FROM ${BASE} AS runtime

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
@@ -7,10 +7,19 @@ from screamingface_engine.benchmarks.deployment import (
     BenchmarkDeployment,
     BenchmarkRegistration,
 )
+from screamingface_engine.benchmarks.draco.definition import (
+    ASSET_BUNDLE_ID as DRACO_ASSET_BUNDLE_ID,
+)
 from screamingface_engine.benchmarks.draco.definition import DRACO
 from screamingface_engine.benchmarks.healthbench.definition import (
     HEALTHBENCH_PROFESSIONAL,
     HEALTHBENCH_WORST30,
+)
+from screamingface_engine.benchmarks.healthbench.exam import (
+    ASSET_BUNDLE_ID as HEALTHBENCH_ASSET_BUNDLE_ID,
+)
+from screamingface_engine.benchmarks.ifeval.definition import (
+    ASSET_BUNDLE_ID as IFEVAL_ASSET_BUNDLE_ID,
 )
 from screamingface_engine.benchmarks.ifeval.definition import IFEVAL
 
@@ -35,24 +44,27 @@ def _prepare_healthbench(out: Path) -> None:
     prepare(out)
 
 
-DRACO_ASSETS = BenchmarkAssetBundle(id="draco", prepare=_prepare_draco)
-IFEVAL_ASSETS = BenchmarkAssetBundle(id="ifeval", prepare=_prepare_ifeval)
-HEALTHBENCH_ASSETS = BenchmarkAssetBundle(id="healthbench", prepare=_prepare_healthbench)
+DRACO_ASSETS = BenchmarkAssetBundle(id=DRACO_ASSET_BUNDLE_ID, prepare=_prepare_draco)
+IFEVAL_ASSETS = BenchmarkAssetBundle(id=IFEVAL_ASSET_BUNDLE_ID, prepare=_prepare_ifeval)
+HEALTHBENCH_ASSETS = BenchmarkAssetBundle(
+    id=HEALTHBENCH_ASSET_BUNDLE_ID,
+    prepare=_prepare_healthbench,
+)
 
 # WHY: this composition is the single source for both runtime discovery and image construction.
 # The two HealthBench boards are independent benchmark identities over one physical answer key,
 # so they intentionally share HEALTHBENCH_ASSETS and the deployment prepares it once.
 BUILTIN_DEPLOYMENT = BenchmarkDeployment(
     (
-        BenchmarkRegistration(benchmark=DRACO, assets=(DRACO_ASSETS,)),
-        BenchmarkRegistration(benchmark=IFEVAL, assets=(IFEVAL_ASSETS,)),
+        BenchmarkRegistration(benchmark=DRACO, asset_bundle=DRACO_ASSETS),
+        BenchmarkRegistration(benchmark=IFEVAL, asset_bundle=IFEVAL_ASSETS),
         BenchmarkRegistration(
             benchmark=HEALTHBENCH_WORST30,
-            assets=(HEALTHBENCH_ASSETS,),
+            asset_bundle=HEALTHBENCH_ASSETS,
         ),
         BenchmarkRegistration(
             benchmark=HEALTHBENCH_PROFESSIONAL,
-            assets=(HEALTHBENCH_ASSETS,),
+            asset_bundle=HEALTHBENCH_ASSETS,
         ),
     )
 )

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
@@ -1,24 +1,61 @@
-"""Concrete Benchmarks selected by the URL4 Cloud deployment."""
+"""Concrete Benchmarks and immutable assets selected by this Engine deployment."""
 
+from pathlib import Path
+
+from screamingface_engine.benchmarks.deployment import (
+    BenchmarkAssetBundle,
+    BenchmarkDeployment,
+    BenchmarkRegistration,
+)
 from screamingface_engine.benchmarks.draco.definition import DRACO
 from screamingface_engine.benchmarks.healthbench.definition import (
     HEALTHBENCH_PROFESSIONAL,
     HEALTHBENCH_WORST30,
 )
 from screamingface_engine.benchmarks.ifeval.definition import IFEVAL
-from screamingface_engine.benchmarks.registry import BenchmarkRegistry
 
-# WHY: protocol-neutral registry machinery does not import concrete protocols. This composition
-# module is the single place where this deployment chooses which Benchmark adapters to install.
-# Candidate strategies are client-compiled Recipes, and development projections are not public
-# Benchmarks. This registry contains only complete, independently meaningful benchmark identities.
-BUILTIN_BENCHMARKS = BenchmarkRegistry(
+
+def _prepare_draco(out: Path) -> None:
+    # WHY lazy: image-building code and its optional dataset dependency stay out of the runtime
+    # import graph. The deployment carries the adapter, but imports it only when building assets.
+    from screamingface_engine.benchmarks.draco.prepare import prepare
+
+    prepare(out)
+
+
+def _prepare_ifeval(out: Path) -> None:
+    from screamingface_engine.benchmarks.ifeval.prepare import prepare
+
+    prepare(out)
+
+
+def _prepare_healthbench(out: Path) -> None:
+    from screamingface_engine.benchmarks.healthbench.prepare import prepare
+
+    prepare(out)
+
+
+DRACO_ASSETS = BenchmarkAssetBundle(id="draco", prepare=_prepare_draco)
+IFEVAL_ASSETS = BenchmarkAssetBundle(id="ifeval", prepare=_prepare_ifeval)
+HEALTHBENCH_ASSETS = BenchmarkAssetBundle(id="healthbench", prepare=_prepare_healthbench)
+
+# WHY: this composition is the single source for both runtime discovery and image construction.
+# The two HealthBench boards are independent benchmark identities over one physical answer key,
+# so they intentionally share HEALTHBENCH_ASSETS and the deployment prepares it once.
+BUILTIN_DEPLOYMENT = BenchmarkDeployment(
     (
-        DRACO,
-        IFEVAL,
-        HEALTHBENCH_WORST30,
-        HEALTHBENCH_PROFESSIONAL,
+        BenchmarkRegistration(benchmark=DRACO, assets=(DRACO_ASSETS,)),
+        BenchmarkRegistration(benchmark=IFEVAL, assets=(IFEVAL_ASSETS,)),
+        BenchmarkRegistration(
+            benchmark=HEALTHBENCH_WORST30,
+            assets=(HEALTHBENCH_ASSETS,),
+        ),
+        BenchmarkRegistration(
+            benchmark=HEALTHBENCH_PROFESSIONAL,
+            assets=(HEALTHBENCH_ASSETS,),
+        ),
     )
 )
+BUILTIN_BENCHMARKS = BUILTIN_DEPLOYMENT.benchmarks
 
-__all__ = ["BUILTIN_BENCHMARKS"]
+__all__ = ["BUILTIN_BENCHMARKS", "BUILTIN_DEPLOYMENT"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
@@ -31,29 +31,20 @@ class BenchmarkAssetBundle:
 
 @dataclass(frozen=True, slots=True)
 class BenchmarkRegistration:
-    """One runtime Benchmark plus every asset bundle it requires.
+    """One runtime Benchmark plus the physical asset bundle it requires.
 
-    ``assets`` deliberately has no default: an assetless Benchmark must say ``assets=()`` so a
-    forgotten preparation declaration cannot look like an intentional no-assets protocol.
+    ``asset_bundle`` deliberately has no default. Every registered built-in Benchmark therefore
+    names a preparation path at construction; omission cannot masquerade as an assetless protocol.
     """
 
     benchmark: Benchmark
-    assets: tuple[BenchmarkAssetBundle, ...]
+    asset_bundle: BenchmarkAssetBundle
 
     def __post_init__(self) -> None:
         if not isinstance(self.benchmark, Benchmark):
             raise TypeError("BenchmarkRegistration benchmark must be a Benchmark")
-        if not isinstance(self.assets, tuple):
-            raise TypeError("BenchmarkRegistration assets must be a tuple")
-        selected: set[str] = set()
-        for bundle in self.assets:
-            if not isinstance(bundle, BenchmarkAssetBundle):
-                raise TypeError("BenchmarkRegistration assets must contain BenchmarkAssetBundles")
-            if bundle.id in selected:
-                raise ValueError(
-                    f"Benchmark {self.benchmark.id!r} declares asset bundle {bundle.id!r} twice"
-                )
-            selected.add(bundle.id)
+        if not isinstance(self.asset_bundle, BenchmarkAssetBundle):
+            raise TypeError("BenchmarkRegistration asset_bundle must be a BenchmarkAssetBundle")
 
 
 class BenchmarkDeployment:
@@ -73,11 +64,11 @@ class BenchmarkDeployment:
 
         bundles: dict[str, BenchmarkAssetBundle] = {}
         for registration in selected:
-            for bundle in registration.assets:
-                installed = bundles.get(bundle.id)
-                if installed is not None and installed is not bundle:
-                    raise ValueError(f"conflicting BenchmarkAssetBundles declare id {bundle.id!r}")
-                bundles[bundle.id] = bundle
+            bundle = registration.asset_bundle
+            installed = bundles.get(bundle.id)
+            if installed is not None and installed is not bundle:
+                raise ValueError(f"conflicting BenchmarkAssetBundles declare id {bundle.id!r}")
+            bundles[bundle.id] = bundle
         self._asset_bundles = tuple(bundles[bundle_id] for bundle_id in sorted(bundles))
 
     @property

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
@@ -1,0 +1,113 @@
+"""Compose runtime Benchmarks with the immutable assets their deployment requires."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from screamingface_engine.benchmarks.definition import Benchmark
+from screamingface_engine.benchmarks.registry import BenchmarkRegistry
+
+type BenchmarkAssetPreparer = Callable[[Path], None]
+
+_ASSET_BUNDLE_ID = re.compile(r"[a-z0-9][a-z0-9._-]*")
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkAssetBundle:
+    """One physical directory of immutable assets, shared by one or more Benchmarks."""
+
+    id: str
+    prepare: BenchmarkAssetPreparer
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or _ASSET_BUNDLE_ID.fullmatch(self.id) is None:
+            raise ValueError("BenchmarkAssetBundle id must be one lowercase path-safe identifier")
+        if not callable(self.prepare):
+            raise TypeError("BenchmarkAssetBundle prepare must be callable")
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkRegistration:
+    """One runtime Benchmark plus every asset bundle it requires.
+
+    ``assets`` deliberately has no default: an assetless Benchmark must say ``assets=()`` so a
+    forgotten preparation declaration cannot look like an intentional no-assets protocol.
+    """
+
+    benchmark: Benchmark
+    assets: tuple[BenchmarkAssetBundle, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.benchmark, Benchmark):
+            raise TypeError("BenchmarkRegistration benchmark must be a Benchmark")
+        if not isinstance(self.assets, tuple):
+            raise TypeError("BenchmarkRegistration assets must be a tuple")
+        selected: set[str] = set()
+        for bundle in self.assets:
+            if not isinstance(bundle, BenchmarkAssetBundle):
+                raise TypeError("BenchmarkRegistration assets must contain BenchmarkAssetBundles")
+            if bundle.id in selected:
+                raise ValueError(
+                    f"Benchmark {self.benchmark.id!r} declares asset bundle {bundle.id!r} twice"
+                )
+            selected.add(bundle.id)
+
+
+class BenchmarkDeployment:
+    """One validated deployment of Benchmarks and their build-time assets.
+
+    The runtime consumes ``benchmarks``. The benchmark-image build calls ``prepare_assets``.
+    Both views derive from the same registrations, so the image cannot advertise a Benchmark
+    whose asset requirement was omitted from a parallel Dockerfile list.
+    """
+
+    __slots__ = ("_asset_bundles", "_benchmarks", "_registrations")
+
+    def __init__(self, registrations: Iterable[BenchmarkRegistration]) -> None:
+        selected = tuple(registrations)
+        self._registrations = selected
+        self._benchmarks = BenchmarkRegistry(registration.benchmark for registration in selected)
+
+        bundles: dict[str, BenchmarkAssetBundle] = {}
+        for registration in selected:
+            for bundle in registration.assets:
+                installed = bundles.get(bundle.id)
+                if installed is not None and installed is not bundle:
+                    raise ValueError(f"conflicting BenchmarkAssetBundles declare id {bundle.id!r}")
+                bundles[bundle.id] = bundle
+        self._asset_bundles = tuple(bundles[bundle_id] for bundle_id in sorted(bundles))
+
+    @property
+    def benchmarks(self) -> BenchmarkRegistry:
+        """The runtime registry derived from this deployment's registrations."""
+
+        return self._benchmarks
+
+    @property
+    def registrations(self) -> tuple[BenchmarkRegistration, ...]:
+        """The immutable composition declarations, exposed for deployment audits."""
+
+        return self._registrations
+
+    def prepare_assets(self, root: Path) -> tuple[Path, ...]:
+        """Prepare every unique required bundle beneath ``root``, in stable ID order."""
+
+        root.mkdir(parents=True, exist_ok=True)
+        prepared: list[Path] = []
+        for bundle in self._asset_bundles:
+            out = root / bundle.id
+            out.mkdir(parents=True, exist_ok=True)
+            bundle.prepare(out)
+            prepared.append(out)
+        return tuple(prepared)
+
+
+__all__ = [
+    "BenchmarkAssetBundle",
+    "BenchmarkAssetPreparer",
+    "BenchmarkDeployment",
+    "BenchmarkRegistration",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/definition.py
@@ -18,6 +18,7 @@ from url4 import Node, RelExpr, Text, expr, iterate, render, src, struct
 from url4.peer.server import Url4Node
 
 BENCHMARK_ID = "draco"
+ASSET_BUNDLE_ID = BENCHMARK_ID
 CASE_COUNT = 100
 DATASET = "perplexity-ai/draco"
 DATASET_REVISION = "ce076749809027649ebd331bcb70f42bf720d387"
@@ -182,7 +183,7 @@ def _install(node: Url4Node, assets: Path) -> None:
     # Lazy import keeps the resource-only control-plane path from loading filesystem runtime code.
     from screamingface_engine.benchmarks.draco.runtime import install
 
-    install(node, assets / BENCHMARK_ID)
+    install(node, assets / ASSET_BUNDLE_ID)
 
 
 DRACO = Benchmark(

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/prepare.py
@@ -227,6 +227,20 @@ def write_policy(out: Path) -> Path:
     return path
 
 
+def _prepare(out: Path, limit: int | None) -> dict[str, Any]:
+    return build(
+        load_rows(limit),
+        out,
+        expected_count=CASE_COUNT if limit is None else limit,
+    )
+
+
+def prepare(out: Path) -> None:
+    """Prepare the complete deployable DRACO asset bundle."""
+
+    _prepare(out, None)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="draco-prepare", description=__doc__)
     parser.add_argument("--out", type=Path, default=Path("/opt/benchmarks/draco"))
@@ -234,11 +248,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        summary = build(
-            load_rows(args.limit),
-            args.out,
-            expected_count=CASE_COUNT if args.limit is None else args.limit,
-        )
+        summary = _prepare(args.out, args.limit)
     except PrepareError as exc:
         print(f"prepare failed: {exc}", file=sys.stderr)
         return 1

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/prepare.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Any
 
 from screamingface_engine.benchmarks.draco.definition import (
+    ASSET_BUNDLE_ID,
     CASE_COUNT,
     DATASET,
     DATASET_REVISION,
@@ -47,6 +48,7 @@ from screamingface_engine.benchmarks.draco.definition import (
     RETRIEVAL_POLICY_ID,
 )
 from screamingface_engine.benchmarks.draco.scoring import flatten_criteria
+from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 
 COLUMN_QUESTION = "problem"
 COLUMN_RUBRIC = "answer"
@@ -243,7 +245,11 @@ def prepare(out: Path) -> None:
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="draco-prepare", description=__doc__)
-    parser.add_argument("--out", type=Path, default=Path("/opt/benchmarks/draco"))
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_BENCHMARK_ASSETS_ROOT / ASSET_BUNDLE_ID,
+    )
     parser.add_argument("--limit", type=int, default=None, help="cap the case count (probes)")
     args = parser.parse_args(argv)
 

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/exam.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/exam.py
@@ -48,6 +48,8 @@ from url4.peer.server import Url4Node
 
 type ExamMean = Callable[[Sequence[float]], float | None]
 
+ASSET_BUNDLE_ID = "healthbench"
+
 
 @dataclass(frozen=True, slots=True)
 class Routes:
@@ -302,7 +304,7 @@ def healthbench_benchmark(
 
         # INVARIANT: every board reads the SAME baked asset directory — one immutable
         # answer key, selected from at serve time, never a per-board bake.
-        install_runtime(node, assets / "healthbench", exam)
+        install_runtime(node, assets / ASSET_BUNDLE_ID, exam)
 
     benchmark = Benchmark(
         id=id,

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
@@ -226,12 +226,22 @@ def emit(rows: list[dict[str, Any]], out: Path) -> tuple[int, int]:
     return len(cases), len(WORST30_CASE_IDS)
 
 
+def _prepare(out: Path) -> tuple[int, int]:
+    return emit(load_rows(), out)
+
+
+def prepare(out: Path) -> None:
+    """Prepare the complete HealthBench assets shared by both registered boards."""
+
+    _prepare(out)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
-        total, subset = emit(load_rows(), args.out)
+        total, subset = _prepare(args.out)
     except PrepareError as exc:
         print(f"healthbench prepare failed: {exc}", file=sys.stderr)
         return 1
@@ -246,4 +256,12 @@ if __name__ == "__main__":  # pragma: no cover - CLI entry
     raise SystemExit(main())
 
 
-__all__ = ["PrepareError", "case_messages", "emit", "envelope", "load_rows", "rubric_items"]
+__all__ = [
+    "PrepareError",
+    "case_messages",
+    "emit",
+    "envelope",
+    "load_rows",
+    "prepare",
+    "rubric_items",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/definition.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/definition.py
@@ -16,6 +16,7 @@ from url4 import Node, RelExpr, Text, expr, render, src, struct
 from url4.peer.server import Url4Node
 
 BENCHMARK_ID = "ifeval"
+ASSET_BUNDLE_ID = BENCHMARK_ID
 CASE_COUNT = 541
 DATASET = "google/IFEval"
 DATASET_REVISION = "966cd89545d6b6acfd7638bc708b98261ca58e84"
@@ -100,7 +101,7 @@ def install_ifeval(node: Url4Node, assets: Path) -> None:
     # Lazy import keeps the resource-only control plane from loading verifier runtime deps.
     from screamingface_engine.benchmarks.ifeval.runtime import install
 
-    install(node, assets / BENCHMARK_ID)
+    install(node, assets / ASSET_BUNDLE_ID)
 
 
 IFEVAL = Benchmark(
@@ -126,4 +127,4 @@ IFEVAL = Benchmark(
     ),
 )
 
-__all__ = ["IFEVAL", "install_ifeval"]
+__all__ = ["ASSET_BUNDLE_ID", "IFEVAL", "install_ifeval"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/prepare.py
@@ -48,7 +48,13 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from screamingface_engine.benchmarks.ifeval.definition import CASE_COUNT, DATASET, DATASET_REVISION
+from screamingface_engine.benchmarks.ifeval.definition import (
+    ASSET_BUNDLE_ID,
+    CASE_COUNT,
+    DATASET,
+    DATASET_REVISION,
+)
+from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 
 
 class PrepareError(RuntimeError):
@@ -239,7 +245,11 @@ def prepare(out: Path) -> None:
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="ifeval-prepare", description=__doc__)
-    parser.add_argument("--out", type=Path, default=Path("/opt/benchmarks/ifeval"))
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=DEFAULT_BENCHMARK_ASSETS_ROOT / ASSET_BUNDLE_ID,
+    )
     parser.add_argument("--limit", type=int, default=None, help="cap the case count (probes)")
     args = parser.parse_args(argv)
 

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/prepare.py
@@ -222,6 +222,21 @@ def prepare_nltk(out: Path) -> dict[str, Any]:
     return {"nltk_data": str(target)}
 
 
+def _prepare(out: Path, limit: int | None) -> dict[str, Any]:
+    summary = build(
+        load_rows(limit),
+        out,
+        expected_count=CASE_COUNT if limit is None else limit,
+    )
+    return summary | prepare_nltk(out)
+
+
+def prepare(out: Path) -> None:
+    """Prepare the complete deployable IFEval asset bundle, including NLTK data."""
+
+    _prepare(out, None)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="ifeval-prepare", description=__doc__)
     parser.add_argument("--out", type=Path, default=Path("/opt/benchmarks/ifeval"))
@@ -229,12 +244,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        summary = build(
-            load_rows(args.limit),
-            args.out,
-            expected_count=CASE_COUNT if args.limit is None else args.limit,
-        )
-        summary |= prepare_nltk(args.out)
+        summary = _prepare(args.out, args.limit)
     except PrepareError as exc:
         print(f"prepare failed: {exc}", file=sys.stderr)
         return 1

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
@@ -1,0 +1,34 @@
+"""Prepare every immutable asset bundle required by the built-in Benchmark deployment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from screamingface_engine.benchmarks.builtins import BUILTIN_DEPLOYMENT
+from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
+
+
+def prepare_builtin_assets(root: Path) -> tuple[Path, ...]:
+    """Build all unique assets declared by the built-in deployment."""
+
+    return BUILTIN_DEPLOYMENT.prepare_assets(root)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=DEFAULT_BENCHMARK_ASSETS_ROOT)
+    args = parser.parse_args(argv)
+
+    prepared = prepare_builtin_assets(args.root)
+    print(json.dumps({"root": str(args.root), "bundles": [path.name for path in prepared]}))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - process entrypoint
+    raise SystemExit(main())
+
+
+__all__ = ["prepare_builtin_assets"]

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -38,17 +38,17 @@ def test_deployment_prepares_each_shared_bundle_once_in_stable_directories(
     alpha = BenchmarkAssetBundle(id="alpha", prepare=calls.append)
     deployment = BenchmarkDeployment(
         (
-            BenchmarkRegistration(_benchmark("one"), assets=(shared,)),
-            BenchmarkRegistration(_benchmark("two"), assets=(shared, alpha)),
-            BenchmarkRegistration(_benchmark("assetless"), assets=()),
+            BenchmarkRegistration(_benchmark("one"), asset_bundle=shared),
+            BenchmarkRegistration(_benchmark("two"), asset_bundle=shared),
+            BenchmarkRegistration(_benchmark("three"), asset_bundle=alpha),
         )
     )
 
     prepared = deployment.prepare_assets(tmp_path)
 
     assert tuple(benchmark.id for benchmark in deployment.benchmarks) == (
-        "assetless",
         "one",
+        "three",
         "two",
     )
     assert calls == [tmp_path / "alpha", tmp_path / "shared"]
@@ -63,8 +63,8 @@ def test_conflicting_physical_bundles_cannot_share_a_directory_id() -> None:
     with pytest.raises(ValueError, match="conflicting BenchmarkAssetBundles"):
         BenchmarkDeployment(
             (
-                BenchmarkRegistration(_benchmark("one"), assets=(first,)),
-                BenchmarkRegistration(_benchmark("two"), assets=(second,)),
+                BenchmarkRegistration(_benchmark("one"), asset_bundle=first),
+                BenchmarkRegistration(_benchmark("two"), asset_bundle=second),
             )
         )
 
@@ -77,16 +77,16 @@ def test_asset_bundle_ids_are_safe_directory_names(bundle_id: str) -> None:
 
 def test_builtins_are_registered_with_their_physical_asset_bundles() -> None:
     registrations = {
-        registration.benchmark.id: tuple(bundle.id for bundle in registration.assets)
+        registration.benchmark.id: registration.asset_bundle.id
         for registration in BUILTIN_DEPLOYMENT.registrations
     }
 
     assert BUILTIN_DEPLOYMENT.benchmarks is BUILTIN_BENCHMARKS
     assert registrations == {
-        "draco": ("draco",),
-        "ifeval": ("ifeval",),
-        "healthbench-worst30": ("healthbench",),
-        "healthbench-professional": ("healthbench",),
+        "draco": "draco",
+        "ifeval": "ifeval",
+        "healthbench-worst30": "healthbench",
+        "healthbench-professional": "healthbench",
     }
 
 

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -1,0 +1,98 @@
+"""One deployment declaration drives runtime discovery and image asset preparation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from screamingface_engine.benchmarks.builtins import (
+    BUILTIN_BENCHMARKS,
+    BUILTIN_DEPLOYMENT,
+)
+from screamingface_engine.benchmarks.definition import Benchmark
+from screamingface_engine.benchmarks.deployment import (
+    BenchmarkAssetBundle,
+    BenchmarkDeployment,
+    BenchmarkRegistration,
+)
+from url4 import Text
+
+
+def _benchmark(benchmark_id: str) -> Benchmark:
+    return Benchmark(
+        id=benchmark_id,
+        title=benchmark_id,
+        description=f"{benchmark_id} description",
+        revision="revision-1",
+        case_count=1,
+        build=lambda _selected: Text("protocol"),
+    )
+
+
+def test_deployment_prepares_each_shared_bundle_once_in_stable_directories(
+    tmp_path: Path,
+) -> None:
+    calls: list[Path] = []
+    shared = BenchmarkAssetBundle(id="shared", prepare=calls.append)
+    alpha = BenchmarkAssetBundle(id="alpha", prepare=calls.append)
+    deployment = BenchmarkDeployment(
+        (
+            BenchmarkRegistration(_benchmark("one"), assets=(shared,)),
+            BenchmarkRegistration(_benchmark("two"), assets=(shared, alpha)),
+            BenchmarkRegistration(_benchmark("assetless"), assets=()),
+        )
+    )
+
+    prepared = deployment.prepare_assets(tmp_path)
+
+    assert tuple(benchmark.id for benchmark in deployment.benchmarks) == (
+        "assetless",
+        "one",
+        "two",
+    )
+    assert calls == [tmp_path / "alpha", tmp_path / "shared"]
+    assert prepared == tuple(calls)
+    assert all(path.is_dir() for path in prepared)
+
+
+def test_conflicting_physical_bundles_cannot_share_a_directory_id() -> None:
+    first = BenchmarkAssetBundle(id="shared", prepare=lambda _out: None)
+    second = BenchmarkAssetBundle(id="shared", prepare=lambda _out: None)
+
+    with pytest.raises(ValueError, match="conflicting BenchmarkAssetBundles"):
+        BenchmarkDeployment(
+            (
+                BenchmarkRegistration(_benchmark("one"), assets=(first,)),
+                BenchmarkRegistration(_benchmark("two"), assets=(second,)),
+            )
+        )
+
+
+@pytest.mark.parametrize("bundle_id", ("../escape", "nested/path", "UPPER", "-leading"))
+def test_asset_bundle_ids_are_safe_directory_names(bundle_id: str) -> None:
+    with pytest.raises(ValueError, match="path-safe"):
+        BenchmarkAssetBundle(id=bundle_id, prepare=lambda _out: None)
+
+
+def test_builtins_are_registered_with_their_physical_asset_bundles() -> None:
+    registrations = {
+        registration.benchmark.id: tuple(bundle.id for bundle in registration.assets)
+        for registration in BUILTIN_DEPLOYMENT.registrations
+    }
+
+    assert BUILTIN_DEPLOYMENT.benchmarks is BUILTIN_BENCHMARKS
+    assert registrations == {
+        "draco": ("draco",),
+        "ifeval": ("ifeval",),
+        "healthbench-worst30": ("healthbench",),
+        "healthbench-professional": ("healthbench",),
+    }
+
+
+def test_benchmark_image_invokes_only_the_registered_asset_orchestrator() -> None:
+    dockerfile = Path(__file__).parents[2] / "Dockerfile.benchmark"
+    body = dockerfile.read_text(encoding="utf-8")
+
+    assert "-m screamingface_engine.benchmarks.prepare --root /opt/benchmarks" in body
+    assert "screamingface_engine.benchmarks.draco.prepare" not in body

--- a/docs/plan/2026-08-20-OME-875-benchmark-image-assets.md
+++ b/docs/plan/2026-08-20-OME-875-benchmark-image-assets.md
@@ -1,0 +1,50 @@
+# OME-875 — Implementation plan: registered Benchmark assets
+
+Spec: `docs/spec/2026-08-20-OME-875-benchmark-image-assets.md` · Stack:
+`screamingface-engine` · Branch: `OME-875-benchmark-assets`
+
+> Recorded after the initial implementation commit, following draft-PR review. The refinement
+> steps below reflect the owner-approved design and do not claim retrospective RED-first order.
+
+## 1. Deployment seam
+
+Add `benchmarks/deployment.py` with three concepts:
+
+- `BenchmarkAssetBundle(id, prepare)` validates a path-safe physical bundle identity.
+- `BenchmarkRegistration(benchmark, asset_bundle)` requires exactly one bundle.
+- `BenchmarkDeployment(registrations)` derives the runtime registry, rejects conflicting bundle
+  IDs, deduplicates shared objects, and prepares each unique bundle in stable order.
+
+Keep `BUILTIN_BENCHMARKS` as the runtime-compatible registry derived from
+`BUILTIN_DEPLOYMENT`, so existing callers do not change.
+
+## 2. Family-owned asset identity
+
+Define `ASSET_BUNDLE_ID` beside each family's runtime installation decision:
+
+- DRACO: `ASSET_BUNDLE_ID = BENCHMARK_ID`
+- IFEval: `ASSET_BUNDLE_ID = BENCHMARK_ID`
+- HealthBench: `ASSET_BUNDLE_ID = "healthbench"` in the shared exam module
+
+Use it in the runtime install path, the built-in bundle composition, and individual CLI defaults.
+
+## 3. Preparation interface and image
+
+- Add complete-bundle `prepare(out: Path) -> None` functions without removing probe-capable CLIs.
+- Add `benchmarks.prepare`, which calls `BUILTIN_DEPLOYMENT.prepare_assets(root)`.
+- Replace the DRACO-only Docker command with the single deployment preparation command.
+
+## 4. Verification
+
+- Unit-test bundle validation, exactly-one registration, shared preparation, built-in mappings,
+  and the Docker orchestration invariant.
+- Run `uv run .claude/scripts/run_gates.py screamingface-engine` from the repository root.
+- Push the draft PR and require its deployable-image build to pass.
+- Repeat independent Standards and OME-875 Spec reviews; keep the PR draft until both are clean.
+
+## 5. Review-driven corrections
+
+- Remove speculative assetless/multi-bundle support; present cardinality is exactly one.
+- Eliminate duplicated output-directory strings through family-owned bundle IDs.
+- Move the worktree into `.claude/worktrees/OME-875-benchmark-assets`.
+- Add the task, spec, plan, and work records omitted before the initial commit.

--- a/docs/spec/2026-08-20-OME-875-benchmark-image-assets.md
+++ b/docs/spec/2026-08-20-OME-875-benchmark-image-assets.md
@@ -1,0 +1,80 @@
+# OME-875 — Registered Benchmark asset deployment
+
+Status: approved (owner, 2026-08-20) · Stack: screamingface-engine
+
+> This specification records the design session that preceded implementation in chat. It was
+> committed after the initial draft-PR review exposed the missing repository artifact.
+
+## Problem
+
+`Dockerfile.benchmark` prepares only `/opt/benchmarks/draco`, while the Engine registry advertises
+DRACO, IFEval, HealthBench Worst-30%, and HealthBench Professional. IFEval and HealthBench install
+their routes against files absent from the deployed image, so preflight rejects those evaluations.
+
+The literal repair—three Docker commands—would restore today's files but retain two independently
+maintained declarations: the runtime registry and a Docker preparation list. A future Benchmark
+could repeat the same omission.
+
+## Domain model
+
+The Engine currently has four Benchmark identities and three physical asset bundles:
+
+```text
+draco                    → draco
+ifeval                   → ifeval
+healthbench-worst30      → healthbench
+healthbench-professional → healthbench
+```
+
+- `BenchmarkAssetBundle` is one immutable directory and its build-time preparer.
+- `BenchmarkRegistration` pairs exactly one runtime `Benchmark` with exactly one required bundle.
+- `BenchmarkDeployment` derives the runtime `BenchmarkRegistry`, deduplicates shared bundles, and
+  prepares those bundles beneath the configured root.
+
+Exactly-one cardinality is intentional. There is no assetless or multi-bundle registration until
+a real Benchmark requires one; missing preparation is therefore impossible at construction.
+
+## Asset identity and paths
+
+Each Benchmark family owns one stable, lowercase `ASSET_BUNDLE_ID`. Runtime installation and
+build-time composition import that same value. Bundle output is always
+`assets_root / ASSET_BUNDLE_ID`; no second output-directory field exists.
+
+DRACO and IFEval use their Benchmark ID as the bundle ID. Both HealthBench boards share
+`healthbench`, because they select different exams from the same complete 525-row answer key.
+
+## Build interface
+
+Each existing preparer exposes `prepare(out: Path) -> None`; its individual CLI and optional local
+probe limit remain available. Deployable images use only:
+
+```bash
+python -m screamingface_engine.benchmarks.prepare --root /opt/benchmarks
+```
+
+Preparation always invokes every unique required bundle when the Docker layer rebuilds. There is
+no directory-exists skip, cleanup policy, build-time truncation, or new smoke identity.
+
+## Invariants
+
+- Adding a built-in requires an asset bundle in the same registration expression.
+- Shared bundle identity prepares once; conflicting objects with the same ID fail before download.
+- Bundle IDs are safe single directory names.
+- Runtime imports do not load build-only dataset dependencies; preparer adapters import lazily.
+- DRACO's pinned dataset version, emitted layout, and private rubric routes remain unchanged.
+- Missing/corrupt assets still fail at runtime preflight before paid requests.
+
+## Non-goals
+
+- Independent benchmark-image versioning or deployment.
+- A public or internal `draco-smoke` identity.
+- Runtime asset downloads.
+- General zero/many asset cardinality.
+
+## Acceptance
+
+- Registry discovery remains four Benchmark identities.
+- Image construction prepares exactly `draco`, `healthbench`, and `ifeval` directories.
+- Both HealthBench registrations reference the same bundle object.
+- Unit tests fail if Docker returns to a family-specific preparer invocation.
+- Exact stack gates and the deployable-image CI job pass.

--- a/docs/tasks/2026-08-20-OME-875-benchmark-image-assets.md
+++ b/docs/tasks/2026-08-20-OME-875-benchmark-image-assets.md
@@ -1,0 +1,53 @@
+---
+ticket: OME-875
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-20
+finished:
+---
+
+# OME-875 — Bake every registered Benchmark's assets into the image
+
+## Intent
+
+Make the benchmark image carry the immutable assets for every Benchmark it advertises. The image
+currently prepares DRACO only, so deployed IFEval and HealthBench runs fail pre-spend even though
+their routes appear in discovery. Linear is the authority:
+[OME-875](https://linear.app/openmined/issue/OME-875/bake-every-registered-benchmarks-assets-into-the-benchmark-image-not).
+
+## Planned changes
+
+- Compose runtime Benchmark registration and build-time asset preparation from one declaration.
+- Model the present relationship exactly: each registration requires one physical asset bundle;
+  multiple registrations may share that bundle.
+- Give each Benchmark family one asset-bundle identifier used by both runtime installation and
+  image preparation.
+- Replace the DRACO-only Docker invocation with one built-in preparation command.
+- Keep all existing individual preparer CLIs and runtime missing-asset preflight behavior.
+
+## Test plan
+
+- Assert shared bundles prepare once into stable family-owned directories.
+- Assert conflicting bundle identifiers and unsafe directory identifiers fail before preparation.
+- Assert all four built-ins declare their physical bundle and Docker calls only the orchestrator.
+- Run the exact `screamingface-engine` stack gates and the deployable-image CI build.
+
+## Acceptance
+
+- The built benchmark image contains DRACO, IFEval, and the shared HealthBench assets.
+- A future built-in cannot be registered without naming an asset bundle.
+- HealthBench Professional and Worst-30% prepare the shared 525-row answer key exactly once.
+- DRACO's pinned preparation and missing-asset preflight behavior are unchanged.
+
+## Outcome
+
+- **Actual files:** deployment and preparation modules, built-in composition, the three family
+  definitions/preparers, benchmark Dockerfile, deployment tests, and the four OME-875 records.
+- **Commits:** `33e13f22` initial draft; review-fix commit is the commit carrying this outcome.
+- **Gates:** official `run_gates.py screamingface-engine --skip-append-only` — ALL GATES GREEN;
+  the initial draft-PR deployable-image builds also passed.
+- **Deviations:** these artifacts were added after the first implementation commit when the draft
+  PR review identified that the mandatory agent record had been omitted. They record the approved
+  design honestly rather than claiming to predate the code. The append-only guard was skipped with
+  owner approval because the review fix intentionally replaces the initial commit's zero/many
+  synthetic test with the approved exactly-one contract; no inherited pre-ticket test changed.

--- a/docs/work/2026-08-20-OME-875-benchmark-image-assets.md
+++ b/docs/work/2026-08-20-OME-875-benchmark-image-assets.md
@@ -1,0 +1,52 @@
+---
+ticket: OME-875
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-20
+finished:
+---
+
+# OME-875 — Bake all registered Benchmark assets into the image
+
+## Intent
+
+Make benchmark discovery and image preparation describe the same deployable world. The prior image
+advertised IFEval and HealthBench but prepared DRACO only, causing valid evaluations to fail at
+preflight.
+
+## Planned changes
+
+- Add the deployment/registration/bundle seam described in the approved spec.
+- Normalize existing complete-bundle preparers and add one built-in orchestration CLI.
+- Point Docker at that CLI.
+- Add tests proving shared HealthBench preparation and registration coverage.
+- Apply draft-review corrections for exact-one cardinality and family-owned bundle IDs.
+
+## Test plan
+
+- Focused deployment, preparation, protocol, and local-install tests.
+- Ruff, format, Pyright, and layering checks.
+- Exact stack gate runner with coverage floor.
+- Draft PR deployable-image build and second two-axis review.
+
+## Acceptance
+
+- All registered Benchmark assets exist in the built image.
+- Registration cannot omit an asset bundle.
+- Shared HealthBench assets prepare once.
+- CI and second review are green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `benchmarks/{deployment,prepare,builtins}.py`; the DRACO, IFEval, and
+  HealthBench family definitions/preparers; `Dockerfile.benchmark`;
+  `test_benchmark_deployment.py`; and the four OME-875 records.
+- **Commits:** `33e13f22` — initial draft implementation; the review-fix commit carries this
+  completed code and record.
+- **Gates:** initial local suite 1897 passed, 6 skipped; initial draft-PR image builds passed;
+  official `run_gates.py screamingface-engine --skip-append-only` — ALL GATES GREEN.
+- **Deviations:** worktree and SDLC records were corrected after the initial draft review. This
+  ledger records that ordering explicitly rather than presenting a retrospective plan as prior.
+  The append-only guard was skipped with explicit owner approval because the agreed review fix
+  changes the synthetic deployment test introduced in the initial commit from zero/many asset
+  cardinality to exactly one; no test inherited from before OME-875 was weakened.


### PR DESCRIPTION
Linear: https://linear.app/openmined/issue/OME-875/bake-every-registered-benchmarks-assets-into-the-benchmark-image-not

## Summary

- derive runtime benchmark discovery and image asset preparation from one deployment registration
- require exactly one family-owned asset bundle for every registered Benchmark
- prepare shared HealthBench assets once for both registered HealthBench boards
- replace the DRACO-only Docker step with one built-in asset preparation command
- standardize the three existing preparers behind a complete-bundle prepare interface

## Test plan

- official `uv run .claude/scripts/run_gates.py screamingface-engine --skip-append-only`: ALL GATES GREEN
- focused benchmark/deployment suite: 48 passed
- draft-PR deployable-image build
- two-axis Standards and OME-875 Spec review

The full benchmark image build was not run locally because it downloads every pinned benchmark dataset; the draft-PR deployable-image job exercises it.

## Approved append-only deviation

The append-only guard is skipped with owner approval for the review-fix commit only. The initial OME-875 commit introduced a synthetic test covering zero/many asset bundles; draft review rejected that speculative cardinality, and the approved correction changes that same new test to the exactly-one contract. No test inherited from before OME-875 is changed or weakened.

## SDLC record timing

The task mirror, spec, plan, and ledger were added after the first draft review exposed their omission. They explicitly record this ordering instead of claiming to predate implementation.

Fixes OME-875

