### PR TITLE
fix(screamingface-engine): make benchmark asset preparation auditable (OME-925)

### DIFF
--- a/.github/workflows/screamingface-engine-tests.yml
+++ b/.github/workflows/screamingface-engine-tests.yml
@@ -5,12 +5,20 @@ on:
       - "apps/screamingface-engine/**"
       # the wire contract (`url4.streaming`) and the engine both ship from here
       - "packages/url4/**"
+      # this suite guards the justfile's stack-prepare recipe, and a guard that cannot run
+      # on its own subject is worse than none: the offending PR would merge green and the
+      # failure would surface later on an unrelated engine change.
+      - "packages/screamingface/justfile"
       - ".github/workflows/screamingface-engine-tests.yml"
   pull_request:
     paths:
       - "apps/screamingface-engine/**"
       # the wire contract (`url4.streaming`) and the engine both ship from here
       - "packages/url4/**"
+      # this suite guards the justfile's stack-prepare recipe, and a guard that cannot run
+      # on its own subject is worse than none: the offending PR would merge green and the
+      # failure would surface later on an unrelated engine change.
+      - "packages/screamingface/justfile"
       - ".github/workflows/screamingface-engine-tests.yml"
   workflow_dispatch:
 

--- a/.github/workflows/screamingface-engine-tests.yml
+++ b/.github/workflows/screamingface-engine-tests.yml
@@ -133,6 +133,11 @@ jobs:
   image:
     name: Build the deployable images
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:3
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v7
       # WHY build on PRs at all: `592e4a89` rewrote the Dockerfile substantially (repo-root
@@ -140,33 +145,35 @@ jobs:
       # it until a release tag — so a break surfaced at release time, on the release path.
       - uses: docker/setup-buildx-action@v4
         with:
-          # Let the benchmark build consume the PR-built base without publishing it.
-          driver: docker
+          # WHY: the container driver can persist BuildKit layers in the GHA cache. Host
+          # networking lets both builds exchange the unpublished PR base via the job registry.
+          driver-opts: network=host
       - uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/screamingface-engine/Dockerfile
-          push: false
-          load: true
-          tags: screamingface-engine:ci
-      - name: Build the DRACO benchmark image
+          push: true
+          tags: localhost:5000/screamingface-engine:ci
+      - name: Build the benchmark image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/screamingface-engine/Dockerfile.benchmark
           build-contexts: |
-            screamingface-engine-ci=docker-image://screamingface-engine:ci
+            screamingface-engine-ci=docker-image://localhost:5000/screamingface-engine:ci
           build-args: |
             BASE=screamingface-engine-ci
           push: false
           load: true
           tags: screamingface-engine-benchmark:ci
+          cache-from: type=gha,scope=ci-screamingface-engine-benchmark
+          cache-to: type=gha,scope=ci-screamingface-engine-benchmark,mode=max
       # Both argv modes must at least start from the built image: the entrypoint is the mode
       # switch, so a broken one is a deployment that cannot run either half.
       - name: Smoke both modes
         run: |
-          docker run --rm screamingface-engine:ci screamingface-engine --help
-          docker run --rm screamingface-engine:ci screamingface-engine run --help
+          docker run --rm localhost:5000/screamingface-engine:ci screamingface-engine --help
+          docker run --rm localhost:5000/screamingface-engine:ci screamingface-engine run --help
           docker run --rm screamingface-engine-benchmark:ci screamingface-engine run --help
 
   chart:

--- a/.github/workflows/screamingface-engine-tests.yml
+++ b/.github/workflows/screamingface-engine-tests.yml
@@ -133,11 +133,6 @@ jobs:
   image:
     name: Build the deployable images
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:3
-        ports:
-          - 5000:5000
     steps:
       - uses: actions/checkout@v7
       # WHY build on PRs at all: `592e4a89` rewrote the Dockerfile substantially (repo-root
@@ -145,35 +140,33 @@ jobs:
       # it until a release tag — so a break surfaced at release time, on the release path.
       - uses: docker/setup-buildx-action@v4
         with:
-          # WHY: the container driver can persist BuildKit layers in the GHA cache. Host
-          # networking lets both builds exchange the unpublished PR base via the job registry.
-          driver-opts: network=host
+          # Let the benchmark build consume the PR-built base without publishing it.
+          driver: docker
       - uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/screamingface-engine/Dockerfile
-          push: true
-          tags: localhost:5000/screamingface-engine:ci
+          push: false
+          load: true
+          tags: screamingface-engine:ci
       - name: Build the benchmark image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/screamingface-engine/Dockerfile.benchmark
           build-contexts: |
-            screamingface-engine-ci=docker-image://localhost:5000/screamingface-engine:ci
+            screamingface-engine-ci=docker-image://screamingface-engine:ci
           build-args: |
             BASE=screamingface-engine-ci
           push: false
           load: true
           tags: screamingface-engine-benchmark:ci
-          cache-from: type=gha,scope=ci-screamingface-engine-benchmark
-          cache-to: type=gha,scope=ci-screamingface-engine-benchmark,mode=max
       # Both argv modes must at least start from the built image: the entrypoint is the mode
       # switch, so a broken one is a deployment that cannot run either half.
       - name: Smoke both modes
         run: |
-          docker run --rm localhost:5000/screamingface-engine:ci screamingface-engine --help
-          docker run --rm localhost:5000/screamingface-engine:ci screamingface-engine run --help
+          docker run --rm screamingface-engine:ci screamingface-engine --help
+          docker run --rm screamingface-engine:ci screamingface-engine run --help
           docker run --rm screamingface-engine-benchmark:ci screamingface-engine run --help
 
   chart:

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/builtins.py
@@ -1,6 +1,8 @@
 """Concrete Benchmarks and immutable assets selected by this Engine deployment."""
 
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from screamingface_engine.benchmarks.deployment import (
     BenchmarkAssetBundle,
@@ -24,24 +26,24 @@ from screamingface_engine.benchmarks.ifeval.definition import (
 from screamingface_engine.benchmarks.ifeval.definition import IFEVAL
 
 
-def _prepare_draco(out: Path) -> None:
+def _prepare_draco(out: Path) -> Mapping[str, Any]:
     # WHY lazy: image-building code and its optional dataset dependency stay out of the runtime
     # import graph. The deployment carries the adapter, but imports it only when building assets.
     from screamingface_engine.benchmarks.draco.prepare import prepare
 
-    prepare(out)
+    return prepare(out)
 
 
-def _prepare_ifeval(out: Path) -> None:
+def _prepare_ifeval(out: Path) -> Mapping[str, Any]:
     from screamingface_engine.benchmarks.ifeval.prepare import prepare
 
-    prepare(out)
+    return prepare(out)
 
 
-def _prepare_healthbench(out: Path) -> None:
+def _prepare_healthbench(out: Path) -> Mapping[str, Any]:
     from screamingface_engine.benchmarks.healthbench.prepare import prepare
 
-    prepare(out)
+    return prepare(out)
 
 
 DRACO_ASSETS = BenchmarkAssetBundle(id=DRACO_ASSET_BUNDLE_ID, prepare=_prepare_draco)

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from screamingface_engine.benchmarks.definition import Benchmark
 from screamingface_engine.benchmarks.registry import BenchmarkRegistry
 
-type BenchmarkAssetPreparer = Callable[[Path], None]
+type BenchmarkAssetSummary = Mapping[str, Any]
+type BenchmarkAssetPreparer = Callable[[Path], BenchmarkAssetSummary]
 
 _ASSET_BUNDLE_ID = re.compile(r"[a-z0-9][a-z0-9._-]*")
+
+
+class BenchmarkAssetPreparationError(RuntimeError):
+    """An expected, operator-readable refusal to prepare a benchmark asset bundle."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,22 +89,25 @@ class BenchmarkDeployment:
 
         return self._registrations
 
-    def prepare_assets(self, root: Path) -> tuple[Path, ...]:
-        """Prepare every unique required bundle beneath ``root``, in stable ID order."""
+    def prepare_assets(self, root: Path) -> dict[str, BenchmarkAssetSummary]:
+        """Prepare every unique bundle and retain its audit summary in stable ID order."""
 
         root.mkdir(parents=True, exist_ok=True)
-        prepared: list[Path] = []
+        prepared: dict[str, BenchmarkAssetSummary] = {}
         for bundle in self._asset_bundles:
             out = root / bundle.id
             out.mkdir(parents=True, exist_ok=True)
-            bundle.prepare(out)
-            prepared.append(out)
-        return tuple(prepared)
+            # INVARIANT: copy the adapter's observation so a later caller mutation cannot
+            # rewrite what this deployment reports as the evidence from its completed bake.
+            prepared[bundle.id] = dict(bundle.prepare(out))
+        return prepared
 
 
 __all__ = [
     "BenchmarkAssetBundle",
     "BenchmarkAssetPreparer",
+    "BenchmarkAssetPreparationError",
+    "BenchmarkAssetSummary",
     "BenchmarkDeployment",
     "BenchmarkRegistration",
 ]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
@@ -21,6 +21,16 @@ class BenchmarkAssetPreparationError(RuntimeError):
     """An expected, operator-readable refusal to prepare a benchmark asset bundle."""
 
 
+class BenchmarkAssetPreparerContractError(TypeError):
+    """A preparer broke the port contract — a defect in this codebase, not an asset refusal.
+
+    WHY a separate hierarchy: `BenchmarkAssetPreparationError` is the orchestrator CLI's exit-1
+    channel for dataset and answer-key drift, reported without a traceback. A wrongly-typed
+    preparer is a programming defect; laundering it through that channel sends an operator
+    hunting for dataset drift that does not exist. `TypeError` keeps it recognisable as one.
+    """
+
+
 @dataclass(frozen=True, slots=True)
 class BenchmarkAssetBundle:
     """One physical directory of immutable assets, shared by one or more Benchmarks."""
@@ -109,7 +119,7 @@ class BenchmarkDeployment:
             out.mkdir(parents=True, exist_ok=True)
             observed = bundle.prepare(out)
             if not isinstance(observed, Mapping):
-                raise BenchmarkAssetPreparationError(
+                raise BenchmarkAssetPreparerContractError(
                     f"bundle {bundle.id!r} preparer returned "
                     f"{type(observed).__name__}, not a summary mapping"
                 )
@@ -129,6 +139,7 @@ __all__ = [
     "BenchmarkAssetBundle",
     "BenchmarkAssetPreparer",
     "BenchmarkAssetPreparationError",
+    "BenchmarkAssetPreparerContractError",
     "BenchmarkAssetSummary",
     "BenchmarkDeployment",
     "BenchmarkRegistration",

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/deployment.py
@@ -89,17 +89,39 @@ class BenchmarkDeployment:
 
         return self._registrations
 
-    def prepare_assets(self, root: Path) -> dict[str, BenchmarkAssetSummary]:
-        """Prepare every unique bundle and retain its audit summary in stable ID order."""
+    def prepare_assets(
+        self,
+        root: Path,
+        on_prepared: Callable[[str, BenchmarkAssetSummary], None] | None = None,
+    ) -> dict[str, BenchmarkAssetSummary]:
+        """Prepare every unique bundle and retain its audit summary in stable ID order.
+
+        WHY `on_prepared`: bundles write real files as they go, so a later bundle's refusal
+        must not erase the evidence for the ones that already landed. The callback fires as
+        each bundle completes, letting a caller stream its audit record before any failure —
+        while the I/O decision stays with the caller and out of this orchestrator.
+        """
 
         root.mkdir(parents=True, exist_ok=True)
         prepared: dict[str, BenchmarkAssetSummary] = {}
         for bundle in self._asset_bundles:
             out = root / bundle.id
             out.mkdir(parents=True, exist_ok=True)
-            # INVARIANT: copy the adapter's observation so a later caller mutation cannot
-            # rewrite what this deployment reports as the evidence from its completed bake.
-            prepared[bundle.id] = dict(bundle.prepare(out))
+            observed = bundle.prepare(out)
+            if not isinstance(observed, Mapping):
+                raise BenchmarkAssetPreparationError(
+                    f"bundle {bundle.id!r} preparer returned "
+                    f"{type(observed).__name__}, not a summary mapping"
+                )
+            # INVARIANT: snapshot the adapter's own top-level observations so a later mutation
+            # of the mapping it handed back cannot rewrite this bake's reported evidence.
+            # AIDEV-NOTE: shallow by design — a preparer must build its values fresh rather
+            # than hand back a container it keeps mutating. Deep-copying arbitrary adapter
+            # values would be the orchestrator guessing at their semantics.
+            summary = dict(observed)
+            prepared[bundle.id] = summary
+            if on_prepared is not None:
+                on_prepared(bundle.id, summary)
         return prepared
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/prepare.py
@@ -39,6 +39,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from screamingface_engine.benchmarks.deployment import BenchmarkAssetPreparationError
 from screamingface_engine.benchmarks.draco.definition import (
     ASSET_BUNDLE_ID,
     CASE_COUNT,
@@ -75,7 +76,7 @@ copy baked into the image. Add HOSTS; anything longer is a 400.
 """
 
 
-class PrepareError(RuntimeError):
+class PrepareError(BenchmarkAssetPreparationError):
     """The dataset could not be turned into a declared world."""
 
 
@@ -237,10 +238,10 @@ def _prepare(out: Path, limit: int | None) -> dict[str, Any]:
     )
 
 
-def prepare(out: Path) -> None:
+def prepare(out: Path) -> dict[str, Any]:
     """Prepare the complete deployable DRACO asset bundle."""
 
-    _prepare(out, None)
+    return _prepare(out, None)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
@@ -53,12 +53,13 @@ from pathlib import Path
 from typing import Any
 
 from screamingface_engine.benchmarks.contract import CANDIDATE_INPUT_SCHEMA
+from screamingface_engine.benchmarks.deployment import BenchmarkAssetPreparationError
 from screamingface_engine.benchmarks.healthbench.definition import PROFESSIONAL_CASE_COUNT
 from screamingface_engine.benchmarks.healthbench.pins import DATASET, DATASET_REVISION
 from screamingface_engine.benchmarks.healthbench.subset import WORST30_CASE_IDS, WORST30_HF_IDS
 
 
-class PrepareError(RuntimeError):
+class PrepareError(BenchmarkAssetPreparationError):
     """The dataset could not be turned into declared HealthBench assets."""
 
 
@@ -226,14 +227,19 @@ def emit(rows: list[dict[str, Any]], out: Path) -> tuple[int, int]:
     return len(cases), len(WORST30_CASE_IDS)
 
 
-def _prepare(out: Path) -> tuple[int, int]:
-    return emit(load_rows(), out)
+def _prepare(out: Path) -> dict[str, Any]:
+    total, subset = emit(load_rows(), out)
+    return {
+        "professional_cases": total,
+        "worst30_cases": subset,
+        "out": str(out),
+    }
 
 
-def prepare(out: Path) -> None:
+def prepare(out: Path) -> dict[str, Any]:
     """Prepare the complete HealthBench assets shared by both registered boards."""
 
-    _prepare(out)
+    return _prepare(out)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -241,13 +247,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out", type=Path, required=True)
     args = parser.parse_args(argv)
     try:
-        total, subset = _prepare(args.out)
+        summary = _prepare(args.out)
     except PrepareError as exc:
         print(f"healthbench prepare failed: {exc}", file=sys.stderr)
         return 1
     print(
-        f"healthbench: baked {total} cases into {args.out} "
-        f"— the professional board serves all {total}, worst30 serves {subset}"
+        f"healthbench: baked {summary['professional_cases']} cases into {args.out} "
+        f"— the professional board serves all {summary['professional_cases']}, "
+        f"worst30 serves {summary['worst30_cases']}"
     )
     return 0
 

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
@@ -233,10 +233,13 @@ def _prepare(out: Path) -> dict[str, Any]:
     # count but PROFESSIONAL_CASE_COUNT, so echoing its inputs would restate a constant the
     # build enforced rather than report this bake — a record that can never differ is not
     # evidence. Reading the written bundle back is the only observation available here.
+    # WHY not also count `rubrics/`: `emit` writes one rubric per Case and never clears the
+    # directory, so that count equals this one on a fresh bake and is inflated by leftovers on a
+    # re-prepare — redundant when accurate, misleading when not. `cases.json` is rewritten whole,
+    # so reading it back is both a count of THIS bake and proof the file landed intact.
     cases = json.loads((out / "cases.json").read_text(encoding="utf-8"))
     return {
         "professional_cases": len(cases),
-        "rubric_files": sum(1 for _ in (out / "rubrics").glob("*.json")),
         # The worst-30% board is a serve-time SELECTION over frozen ids (see the module
         # docstring), never its own bake. Named `declared_` so an operator reading the build
         # log cannot mistake a compile-time constant for something this run produced.

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
@@ -228,10 +228,19 @@ def emit(rows: list[dict[str, Any]], out: Path) -> tuple[int, int]:
 
 
 def _prepare(out: Path) -> dict[str, Any]:
-    total, subset = emit(load_rows(), out)
+    emit(load_rows(), out)
+    # INVARIANT: count what LANDED, not what was declared. `emit` already refuses any row
+    # count but PROFESSIONAL_CASE_COUNT, so echoing its inputs would restate a constant the
+    # build enforced rather than report this bake — a record that can never differ is not
+    # evidence. Reading the written bundle back is the only observation available here.
+    cases = json.loads((out / "cases.json").read_text(encoding="utf-8"))
     return {
-        "professional_cases": total,
-        "worst30_cases": subset,
+        "professional_cases": len(cases),
+        "rubric_files": sum(1 for _ in (out / "rubrics").glob("*.json")),
+        # The worst-30% board is a serve-time SELECTION over frozen ids (see the module
+        # docstring), never its own bake. Named `declared_` so an operator reading the build
+        # log cannot mistake a compile-time constant for something this run produced.
+        "declared_worst30_cases": len(WORST30_CASE_IDS),
         "out": str(out),
     }
 

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/prepare.py
@@ -48,6 +48,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from screamingface_engine.benchmarks.deployment import BenchmarkAssetPreparationError
 from screamingface_engine.benchmarks.ifeval.definition import (
     ASSET_BUNDLE_ID,
     CASE_COUNT,
@@ -57,7 +58,7 @@ from screamingface_engine.benchmarks.ifeval.definition import (
 from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 
 
-class PrepareError(RuntimeError):
+class PrepareError(BenchmarkAssetPreparationError):
     """The dataset could not be turned into a declared world."""
 
 
@@ -237,10 +238,10 @@ def _prepare(out: Path, limit: int | None) -> dict[str, Any]:
     return summary | prepare_nltk(out)
 
 
-def prepare(out: Path) -> None:
+def prepare(out: Path) -> dict[str, Any]:
     """Prepare the complete deployable IFEval asset bundle, including NLTK data."""
 
-    _prepare(out, None)
+    return _prepare(out, None)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from screamingface_engine.benchmarks.builtins import BUILTIN_DEPLOYMENT
@@ -16,10 +16,13 @@ from screamingface_engine.benchmarks.deployment import (
 from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 
 
-def prepare_builtin_assets(root: Path) -> dict[str, BenchmarkAssetSummary]:
+def prepare_builtin_assets(
+    root: Path,
+    on_prepared: Callable[[str, BenchmarkAssetSummary], None] | None = None,
+) -> dict[str, BenchmarkAssetSummary]:
     """Build all unique assets declared by the built-in deployment."""
 
-    return BUILTIN_DEPLOYMENT.prepare_assets(root)
+    return BUILTIN_DEPLOYMENT.prepare_assets(root, on_prepared)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -27,14 +30,17 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--root", type=Path, default=DEFAULT_BENCHMARK_ASSETS_ROOT)
     args = parser.parse_args(argv)
 
+    def emit(bundle: str, summary: BenchmarkAssetSummary) -> None:
+        # WHY stream rather than print at the end: a refusal partway through must still leave
+        # the completed bundles' evidence in the build log, which is the point of the record.
+        record = {"root": str(args.root), "bundle": bundle, "summary": summary}
+        print(json.dumps(record), flush=True)
+
     try:
-        prepared = prepare_builtin_assets(args.root)
+        prepare_builtin_assets(args.root, emit)
     except BenchmarkAssetPreparationError as exc:
         print(f"benchmark asset preparation failed: {exc}", file=sys.stderr)
         return 1
-
-    for bundle, summary in prepared.items():
-        print(json.dumps({"root": str(args.root), "bundle": bundle, "summary": summary}))
     return 0
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
@@ -34,10 +34,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         # WHY stream rather than print at the end: a refusal partway through must still leave
         # the completed bundles' evidence in the build log, which is the point of the record.
         record = {"root": str(args.root), "bundle": bundle, "summary": summary}
-        # WHY `default=str`: this runs inside the preparation loop, so a summary value json
-        # cannot encode would abort every bundle after this one. A reporting fault must cost
-        # fidelity in one record, never the assets the image is being built to carry.
-        print(json.dumps(record, default=str), flush=True)
+        # WHY `default=str` AND the guard: this runs inside the preparation loop, so a record
+        # json cannot encode would abort every bundle after this one. `default=` covers values
+        # but is NEVER consulted for keys, and cannot rescue a circular or over-deep summary
+        # either — so the encoder itself is fenced. A reporting fault must cost fidelity in one
+        # record, never the assets the image is being built to carry.
+        try:
+            line = json.dumps(record, default=str)
+        except (TypeError, ValueError, RecursionError) as exc:
+            # The bundle still completed; say so, and name the reporting fault instead.
+            line = json.dumps(
+                {
+                    "root": str(args.root),
+                    "bundle": bundle,
+                    "summary_unreportable": type(exc).__name__,
+                }
+            )
+        print(line, flush=True)
 
     try:
         prepare_builtin_assets(args.root, emit)

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
@@ -34,7 +34,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         # WHY stream rather than print at the end: a refusal partway through must still leave
         # the completed bundles' evidence in the build log, which is the point of the record.
         record = {"root": str(args.root), "bundle": bundle, "summary": summary}
-        print(json.dumps(record), flush=True)
+        # WHY `default=str`: this runs inside the preparation loop, so a summary value json
+        # cannot encode would abort every bundle after this one. A reporting fault must cost
+        # fidelity in one record, never the assets the image is being built to carry.
+        print(json.dumps(record, default=str), flush=True)
 
     try:
         prepare_builtin_assets(args.root, emit)

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/prepare.py
@@ -4,14 +4,19 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 from screamingface_engine.benchmarks.builtins import BUILTIN_DEPLOYMENT
+from screamingface_engine.benchmarks.deployment import (
+    BenchmarkAssetPreparationError,
+    BenchmarkAssetSummary,
+)
 from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 
 
-def prepare_builtin_assets(root: Path) -> tuple[Path, ...]:
+def prepare_builtin_assets(root: Path) -> dict[str, BenchmarkAssetSummary]:
     """Build all unique assets declared by the built-in deployment."""
 
     return BUILTIN_DEPLOYMENT.prepare_assets(root)
@@ -22,8 +27,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--root", type=Path, default=DEFAULT_BENCHMARK_ASSETS_ROOT)
     args = parser.parse_args(argv)
 
-    prepared = prepare_builtin_assets(args.root)
-    print(json.dumps({"root": str(args.root), "bundles": [path.name for path in prepared]}))
+    try:
+        prepared = prepare_builtin_assets(args.root)
+    except BenchmarkAssetPreparationError as exc:
+        print(f"benchmark asset preparation failed: {exc}", file=sys.stderr)
+        return 1
+
+    for bundle, summary in prepared.items():
+        print(json.dumps({"root": str(args.root), "bundle": bundle, "summary": summary}))
     return 0
 
 

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -113,7 +113,7 @@ def test_builtin_prepare_cli_prints_one_auditable_record_per_bundle(
 ) -> None:
     summaries = {
         "draco": {"cases": 100},
-        "healthbench": {"professional_cases": 525, "worst30_cases": 157},
+        "healthbench": {"professional_cases": 525, "declared_worst30_cases": 157},
         "ifeval": {"cases": 541, "patched_keys": [146, 179]},
     }
 

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 
 import pytest
 
+from screamingface_engine.benchmarks import prepare as prepare_module
 from screamingface_engine.benchmarks.builtins import (
     BUILTIN_BENCHMARKS,
     BUILTIN_DEPLOYMENT,
@@ -13,10 +16,20 @@ from screamingface_engine.benchmarks.builtins import (
 from screamingface_engine.benchmarks.definition import Benchmark
 from screamingface_engine.benchmarks.deployment import (
     BenchmarkAssetBundle,
+    BenchmarkAssetPreparationError,
     BenchmarkDeployment,
     BenchmarkRegistration,
 )
+from screamingface_engine.benchmarks.draco.prepare import PrepareError as DracoPrepareError
+from screamingface_engine.benchmarks.healthbench.prepare import (
+    PrepareError as HealthBenchPrepareError,
+)
+from screamingface_engine.benchmarks.ifeval.prepare import PrepareError as IFEvalPrepareError
+from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 from url4 import Text
+
+REPOSITORY_ROOT = Path(__file__).parents[4]
+_FAMILY_PREPARER = re.compile(r"screamingface_engine\.benchmarks\.[a-z0-9_]+\.prepare")
 
 
 def _benchmark(benchmark_id: str) -> Benchmark:
@@ -34,8 +47,13 @@ def test_deployment_prepares_each_shared_bundle_once_in_stable_directories(
     tmp_path: Path,
 ) -> None:
     calls: list[Path] = []
-    shared = BenchmarkAssetBundle(id="shared", prepare=calls.append)
-    alpha = BenchmarkAssetBundle(id="alpha", prepare=calls.append)
+
+    def prepare(out: Path) -> dict[str, object]:
+        calls.append(out)
+        return {"cases": len(calls), "out": str(out)}
+
+    shared = BenchmarkAssetBundle(id="shared", prepare=prepare)
+    alpha = BenchmarkAssetBundle(id="alpha", prepare=prepare)
     deployment = BenchmarkDeployment(
         (
             BenchmarkRegistration(_benchmark("one"), asset_bundle=shared),
@@ -52,13 +70,78 @@ def test_deployment_prepares_each_shared_bundle_once_in_stable_directories(
         "two",
     )
     assert calls == [tmp_path / "alpha", tmp_path / "shared"]
-    assert prepared == tuple(calls)
-    assert all(path.is_dir() for path in prepared)
+    assert prepared == {
+        "alpha": {"cases": 1, "out": str(tmp_path / "alpha")},
+        "shared": {"cases": 2, "out": str(tmp_path / "shared")},
+    }
+    assert all(path.is_dir() for path in calls)
+
+
+def test_builtin_prepare_cli_prints_one_auditable_record_per_bundle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    summaries = {
+        "draco": {"cases": 100},
+        "healthbench": {"professional_cases": 525, "worst30_cases": 157},
+        "ifeval": {"cases": 541, "patched_keys": [146, 179]},
+    }
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", lambda _root: summaries)
+
+    assert prepare_module.main(["--root", str(tmp_path)]) == 0
+
+    records = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert records == [
+        {"root": str(tmp_path), "bundle": bundle, "summary": summary}
+        for bundle, summary in summaries.items()
+    ]
+
+
+def test_builtin_prepare_cli_reports_declared_refusal_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def refuse(_root: Path) -> dict[str, object]:
+        raise BenchmarkAssetPreparationError("frozen answer key drifted")
+
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", refuse)
+
+    assert prepare_module.main(["--root", str(tmp_path)]) == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "benchmark asset preparation failed: frozen answer key drifted\n"
+    assert "Traceback" not in captured.err
+
+
+def test_builtin_prepare_cli_does_not_hide_unexpected_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def explode(_root: Path) -> dict[str, object]:
+        raise AssertionError("programming defect")
+
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", explode)
+
+    with pytest.raises(AssertionError, match="programming defect"):
+        prepare_module.main(["--root", str(tmp_path)])
+
+
+@pytest.mark.parametrize(
+    "error_type",
+    (DracoPrepareError, HealthBenchPrepareError, IFEvalPrepareError),
+)
+def test_family_preparation_refusals_share_the_operator_error_boundary(
+    error_type: type[Exception],
+) -> None:
+    assert issubclass(error_type, BenchmarkAssetPreparationError)
 
 
 def test_conflicting_physical_bundles_cannot_share_a_directory_id() -> None:
-    first = BenchmarkAssetBundle(id="shared", prepare=lambda _out: None)
-    second = BenchmarkAssetBundle(id="shared", prepare=lambda _out: None)
+    first = BenchmarkAssetBundle(id="shared", prepare=lambda _out: {})
+    second = BenchmarkAssetBundle(id="shared", prepare=lambda _out: {})
 
     with pytest.raises(ValueError, match="conflicting BenchmarkAssetBundles"):
         BenchmarkDeployment(
@@ -72,7 +155,7 @@ def test_conflicting_physical_bundles_cannot_share_a_directory_id() -> None:
 @pytest.mark.parametrize("bundle_id", ("../escape", "nested/path", "UPPER", "-leading"))
 def test_asset_bundle_ids_are_safe_directory_names(bundle_id: str) -> None:
     with pytest.raises(ValueError, match="path-safe"):
-        BenchmarkAssetBundle(id=bundle_id, prepare=lambda _out: None)
+        BenchmarkAssetBundle(id=bundle_id, prepare=lambda _out: {})
 
 
 def test_builtins_are_registered_with_their_physical_asset_bundles() -> None:
@@ -95,5 +178,27 @@ def test_benchmark_image_invokes_only_the_registered_asset_orchestrator() -> Non
     dockerfile = Path(__file__).parents[2] / "Dockerfile.benchmark"
     body = dockerfile.read_text(encoding="utf-8")
 
-    assert "-m screamingface_engine.benchmarks.prepare --root /opt/benchmarks" in body
-    assert "screamingface_engine.benchmarks.draco.prepare" not in body
+    expected = f"-m screamingface_engine.benchmarks.prepare --root {DEFAULT_BENCHMARK_ASSETS_ROOT}"
+    assert expected in body
+    # INVARIANT: no family-specific invocation may recreate a second deployment manifest.
+    assert _FAMILY_PREPARER.search(body) is None
+
+
+def test_local_stack_prepare_uses_the_registered_asset_orchestrator() -> None:
+    justfile = REPOSITORY_ROOT / "packages" / "screamingface" / "justfile"
+    body = justfile.read_text(encoding="utf-8")
+
+    assert "-m screamingface_engine.benchmarks.prepare --root {{assets}}" in body
+    assert _FAMILY_PREPARER.search(body) is None
+
+
+def test_benchmark_image_ci_names_and_caches_the_complete_build() -> None:
+    workflow = REPOSITORY_ROOT / ".github" / "workflows" / "screamingface-engine-tests.yml"
+    body = workflow.read_text(encoding="utf-8")
+
+    assert "Build the benchmark image" in body
+    assert "Build the DRACO benchmark image" not in body
+    assert "image: registry:3" in body
+    assert "driver-opts: network=host" in body
+    assert "cache-from: type=gha,scope=ci-screamingface-engine-benchmark" in body
+    assert "cache-to: type=gha,scope=ci-screamingface-engine-benchmark,mode=max" in body

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -192,13 +192,9 @@ def test_local_stack_prepare_uses_the_registered_asset_orchestrator() -> None:
     assert _FAMILY_PREPARER.search(body) is None
 
 
-def test_benchmark_image_ci_names_and_caches_the_complete_build() -> None:
+def test_benchmark_image_ci_names_the_complete_build() -> None:
     workflow = REPOSITORY_ROOT / ".github" / "workflows" / "screamingface-engine-tests.yml"
     body = workflow.read_text(encoding="utf-8")
 
     assert "Build the benchmark image" in body
     assert "Build the DRACO benchmark image" not in body
-    assert "image: registry:3" in body
-    assert "driver-opts: network=host" in body
-    assert "cache-from: type=gha,scope=ci-screamingface-engine-benchmark" in body
-    assert "cache-to: type=gha,scope=ci-screamingface-engine-benchmark,mode=max" in body

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -17,6 +17,7 @@ from screamingface_engine.benchmarks.definition import Benchmark
 from screamingface_engine.benchmarks.deployment import (
     BenchmarkAssetBundle,
     BenchmarkAssetPreparationError,
+    BenchmarkAssetPreparerContractError,
     BenchmarkDeployment,
     BenchmarkRegistration,
 )
@@ -29,12 +30,19 @@ from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_RO
 from url4 import Text
 
 REPOSITORY_ROOT = Path(__file__).parents[4]
-# INVARIANT: the family segment is derived from the deployment's own bundle ids, so the guard
-# matches only what its failure message claims — a family-specific invocation. A bare
+BENCHMARKS_PACKAGE = Path(__file__).parents[2] / "src" / "screamingface_engine" / "benchmarks"
+# INVARIANT: the family segment is derived from the family packages that exist on disk, so the
+# guard matches only what its failure message claims — a family-specific invocation. A bare
 # `[a-z0-9_]+` also matched `benchmarks.deployment.prepare_assets`, blaming the orchestrator.
+# WHY not bundle ids: this guard matches module paths, and the codebase already separates the
+# two (`draco-3pass` is a benchmark id over the `draco` bundle). A family that renamed its
+# bundle id away from its package name would silently stop being guarded at all.
+FAMILY_PACKAGES = tuple(
+    sorted(path.parent.name for path in BENCHMARKS_PACKAGE.glob("*/prepare.py"))
+)
 _FAMILY_PREPARER = re.compile(
     r"screamingface_engine\.benchmarks\.(?:"
-    + "|".join(re.escape(bundle.id) for bundle in BUILTIN_DEPLOYMENT._asset_bundles)
+    + "|".join(re.escape(family) for family in FAMILY_PACKAGES)
     + r")\.prepare\b"
 )
 
@@ -273,13 +281,19 @@ def test_the_family_guard_does_not_flag_the_orchestrator_itself() -> None:
     assert _FAMILY_PREPARER.search("-m screamingface_engine.benchmarks.draco.prepare --out /x")
 
 
-def test_a_preparer_ignoring_the_summary_contract_fails_by_name(tmp_path: Path) -> None:
-    """WHY: a preparer still written against the old `-> None` port should say so, not TypeError."""
+def test_the_family_guard_covers_every_family_preparer_package() -> None:
+    """WHY: a guard derived from a mistyped path would match nothing and pass in silence."""
 
+    assert set(FAMILY_PACKAGES) == {"draco", "healthbench", "ifeval"}
+    for family in FAMILY_PACKAGES:
+        assert _FAMILY_PREPARER.search(f"-m screamingface_engine.benchmarks.{family}.prepare")
+
+
+def _stale_preparer_deployment() -> BenchmarkDeployment:
     def stale(_out: Path) -> None:
         return None
 
-    deployment = BenchmarkDeployment(
+    return BenchmarkDeployment(
         (
             BenchmarkRegistration(
                 _benchmark("one"),
@@ -288,8 +302,33 @@ def test_a_preparer_ignoring_the_summary_contract_fails_by_name(tmp_path: Path) 
         )
     )
 
-    with pytest.raises(BenchmarkAssetPreparationError, match="summary mapping"):
-        deployment.prepare_assets(tmp_path)
+
+def test_a_preparer_ignoring_the_summary_contract_fails_by_name(tmp_path: Path) -> None:
+    """WHY: a preparer still written against the old `-> None` port should say so by name.
+
+    INVARIANT: it is a *defect*, not an operator refusal, so it must not be a
+    `BenchmarkAssetPreparationError` — that class is the CLI's exit-1 channel for dataset and
+    answer-key drift, and a wrongly-typed preparer sends an operator hunting for drift that
+    does not exist.
+    """
+
+    with pytest.raises(BenchmarkAssetPreparerContractError, match="summary mapping"):
+        _stale_preparer_deployment().prepare_assets(tmp_path)
+
+    assert not issubclass(BenchmarkAssetPreparerContractError, BenchmarkAssetPreparationError)
+
+
+def test_a_preparer_contract_defect_reaches_the_operator_as_a_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INVARIANT: the CLI must not launder a preparer defect into a one-line exit 1."""
+
+    deployment = _stale_preparer_deployment()
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", deployment.prepare_assets)
+
+    with pytest.raises(BenchmarkAssetPreparerContractError, match="summary mapping"):
+        prepare_module.main(["--root", str(tmp_path)])
 
 
 def test_the_engine_workflow_runs_when_the_guarded_justfile_changes() -> None:
@@ -299,3 +338,51 @@ def test_the_engine_workflow_runs_when_the_guarded_justfile_changes() -> None:
     body = workflow.read_text(encoding="utf-8")
 
     assert body.count('- "packages/screamingface/justfile"') == 2
+
+
+def test_an_unserializable_summary_value_does_not_abort_the_remaining_bundles(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INVARIANT: a fault in the audit record must not stop assets from being prepared.
+
+    WHY: the record is printed from inside the preparation loop, so a `json.dumps` refusal on
+    the first bundle's summary would leave every later bundle unbaked — the image would ship
+    missing assets because of a *reporting* problem.
+    """
+
+    def exotic(out: Path) -> dict[str, object]:
+        return {"cases": 1, "out": out}
+
+    def plain(out: Path) -> dict[str, object]:
+        return {"cases": 2, "out": str(out)}
+
+    deployment = BenchmarkDeployment(
+        (
+            BenchmarkRegistration(
+                _benchmark("one"), asset_bundle=BenchmarkAssetBundle(id="alpha", prepare=exotic)
+            ),
+            BenchmarkRegistration(
+                _benchmark("two"), asset_bundle=BenchmarkAssetBundle(id="beta", prepare=plain)
+            ),
+        )
+    )
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", deployment.prepare_assets)
+
+    assert prepare_module.main(["--root", str(tmp_path)]) == 0
+
+    records = [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+    assert records == [
+        {
+            "root": str(tmp_path),
+            "bundle": "alpha",
+            "summary": {"cases": 1, "out": str(tmp_path / "alpha")},
+        },
+        {
+            "root": str(tmp_path),
+            "bundle": "beta",
+            "summary": {"cases": 2, "out": str(tmp_path / "beta")},
+        },
+    ]
+    assert (tmp_path / "beta").is_dir()

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -29,7 +29,14 @@ from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_RO
 from url4 import Text
 
 REPOSITORY_ROOT = Path(__file__).parents[4]
-_FAMILY_PREPARER = re.compile(r"screamingface_engine\.benchmarks\.[a-z0-9_]+\.prepare")
+# INVARIANT: the family segment is derived from the deployment's own bundle ids, so the guard
+# matches only what its failure message claims — a family-specific invocation. A bare
+# `[a-z0-9_]+` also matched `benchmarks.deployment.prepare_assets`, blaming the orchestrator.
+_FAMILY_PREPARER = re.compile(
+    r"screamingface_engine\.benchmarks\.(?:"
+    + "|".join(re.escape(bundle.id) for bundle in BUILTIN_DEPLOYMENT._asset_bundles)
+    + r")\.prepare\b"
+)
 
 
 def _benchmark(benchmark_id: str) -> Benchmark:
@@ -87,7 +94,14 @@ def test_builtin_prepare_cli_prints_one_auditable_record_per_bundle(
         "healthbench": {"professional_cases": 525, "worst30_cases": 157},
         "ifeval": {"cases": 541, "patched_keys": [146, 179]},
     }
-    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", lambda _root: summaries)
+
+    def prepare(_root: Path, on_prepared: object = None) -> dict[str, object]:
+        for bundle, summary in summaries.items():
+            if on_prepared is not None:
+                on_prepared(bundle, summary)  # type: ignore[operator]
+        return summaries
+
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", prepare)
 
     assert prepare_module.main(["--root", str(tmp_path)]) == 0
 
@@ -103,7 +117,7 @@ def test_builtin_prepare_cli_reports_declared_refusal_without_traceback(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    def refuse(_root: Path) -> dict[str, object]:
+    def refuse(_root: Path, _on_prepared: object = None) -> dict[str, object]:
         raise BenchmarkAssetPreparationError("frozen answer key drifted")
 
     monkeypatch.setattr(prepare_module, "prepare_builtin_assets", refuse)
@@ -120,7 +134,7 @@ def test_builtin_prepare_cli_does_not_hide_unexpected_failures(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def explode(_root: Path) -> dict[str, object]:
+    def explode(_root: Path, _on_prepared: object = None) -> dict[str, object]:
         raise AssertionError("programming defect")
 
     monkeypatch.setattr(prepare_module, "prepare_builtin_assets", explode)
@@ -198,3 +212,90 @@ def test_benchmark_image_ci_names_the_complete_build() -> None:
 
     assert "Build the benchmark image" in body
     assert "Build the DRACO benchmark image" not in body
+
+
+def test_a_refusal_still_reports_the_bundles_that_already_completed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INVARIANT: evidence for a completed bake survives a later bundle's refusal.
+
+    WHY: bundles bake in ID order and write real files as they go. Printing only after the
+    whole sequence succeeds means an operator reading the build log cannot tell which
+    bundles landed — losing exactly the audit trail this unit exists to provide.
+    """
+
+    def good(out: Path) -> dict[str, object]:
+        return {"cases": 100, "out": str(out)}
+
+    def refuse(_out: Path) -> dict[str, object]:
+        raise BenchmarkAssetPreparationError("frozen answer key drifted")
+
+    deployment = BenchmarkDeployment(
+        (
+            BenchmarkRegistration(
+                _benchmark("one"), asset_bundle=BenchmarkAssetBundle(id="alpha", prepare=good)
+            ),
+            BenchmarkRegistration(
+                _benchmark("two"), asset_bundle=BenchmarkAssetBundle(id="beta", prepare=refuse)
+            ),
+        )
+    )
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", deployment.prepare_assets)
+
+    assert prepare_module.main(["--root", str(tmp_path)]) == 1
+
+    captured = capsys.readouterr()
+    records = [json.loads(line) for line in captured.out.splitlines() if line.strip()]
+    assert records == [
+        {
+            "root": str(tmp_path),
+            "bundle": "alpha",
+            "summary": {"cases": 100, "out": str(tmp_path / "alpha")},
+        }
+    ]
+    assert captured.err == "benchmark asset preparation failed: frozen answer key drifted\n"
+
+
+def test_the_family_guard_does_not_flag_the_orchestrator_itself() -> None:
+    """WHY: the guard's message blames a family-specific invocation, so it must only match one."""
+
+    assert _FAMILY_PREPARER.search("-m screamingface_engine.benchmarks.prepare --root /x") is None
+    assert (
+        _FAMILY_PREPARER.search("screamingface_engine.benchmarks.deployment.prepare_assets(root)")
+        is None
+    )
+    assert (
+        _FAMILY_PREPARER.search("screamingface_engine.benchmarks.registry.prepare_everything()")
+        is None
+    )
+    assert _FAMILY_PREPARER.search("-m screamingface_engine.benchmarks.draco.prepare --out /x")
+
+
+def test_a_preparer_ignoring_the_summary_contract_fails_by_name(tmp_path: Path) -> None:
+    """WHY: a preparer still written against the old `-> None` port should say so, not TypeError."""
+
+    def stale(_out: Path) -> None:
+        return None
+
+    deployment = BenchmarkDeployment(
+        (
+            BenchmarkRegistration(
+                _benchmark("one"),
+                asset_bundle=BenchmarkAssetBundle(id="alpha", prepare=stale),  # type: ignore[arg-type]
+            ),
+        )
+    )
+
+    with pytest.raises(BenchmarkAssetPreparationError, match="summary mapping"):
+        deployment.prepare_assets(tmp_path)
+
+
+def test_the_engine_workflow_runs_when_the_guarded_justfile_changes() -> None:
+    """INVARIANT: a guard that cannot run on its own subject is worse than no guard."""
+
+    workflow = REPOSITORY_ROOT / ".github" / "workflows" / "screamingface-engine-tests.yml"
+    body = workflow.read_text(encoding="utf-8")
+
+    assert body.count('- "packages/screamingface/justfile"') == 2

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -29,7 +30,12 @@ from screamingface_engine.benchmarks.ifeval.prepare import PrepareError as IFEva
 from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 from url4 import Text
 
-REPOSITORY_ROOT = Path(__file__).parents[4]
+# WHY resolved + checked: these three guards read files OUTSIDE this app (the SDK justfile and
+# the workflow). `packages/screamingface/justfile` itself supports pointing at a separate engine
+# checkout via `SCREAMINGFACE_ENGINE_REPO`, so that split is anticipated, not hypothetical. In it
+# the monorepo siblings are simply absent, and a guard that cannot see its subject must say so
+# rather than fail as if the subject were wrong.
+REPOSITORY_ROOT = Path(__file__).parents[4].resolve()
 BENCHMARKS_PACKAGE = Path(__file__).parents[2] / "src" / "screamingface_engine" / "benchmarks"
 # INVARIANT: the family segment is derived from the family packages that exist on disk, so the
 # guard matches only what its failure message claims — a family-specific invocation. A bare
@@ -40,9 +46,17 @@ BENCHMARKS_PACKAGE = Path(__file__).parents[2] / "src" / "screamingface_engine" 
 FAMILY_PACKAGES = tuple(
     sorted(path.parent.name for path in BENCHMARKS_PACKAGE.glob("*/prepare.py"))
 )
+# WHY the two non-literal branches: reintroduction does not have to spell a family out. The
+# SDK already builds this exact path from a variable (`_runtime/cli.py`), and a shell loop
+# (`for b in draco ifeval healthbench`) is the natural way back into a Dockerfile or justfile.
+# A guard that only matches literals would pass green on precisely the shapes most likely to
+# return, so a computed family segment counts as a family-specific invocation too.
+_COMPUTED_FAMILY = r"\$\{?[A-Za-z_][A-Za-z0-9_]*\}?|\{[A-Za-z_][A-Za-z0-9_]*\}"
 _FAMILY_PREPARER = re.compile(
     r"screamingface_engine\.benchmarks\.(?:"
     + "|".join(re.escape(family) for family in FAMILY_PACKAGES)
+    + "|"
+    + _COMPUTED_FAMILY
     + r")\.prepare\b"
 )
 
@@ -208,6 +222,8 @@ def test_benchmark_image_invokes_only_the_registered_asset_orchestrator() -> Non
 
 def test_local_stack_prepare_uses_the_registered_asset_orchestrator() -> None:
     justfile = REPOSITORY_ROOT / "packages" / "screamingface" / "justfile"
+    if not justfile.is_file():
+        pytest.skip("engine checked out apart from the monorepo; the SDK justfile is absent")
     body = justfile.read_text(encoding="utf-8")
 
     assert "-m screamingface_engine.benchmarks.prepare --root {{assets}}" in body
@@ -216,6 +232,8 @@ def test_local_stack_prepare_uses_the_registered_asset_orchestrator() -> None:
 
 def test_benchmark_image_ci_names_the_complete_build() -> None:
     workflow = REPOSITORY_ROOT / ".github" / "workflows" / "screamingface-engine-tests.yml"
+    if not workflow.is_file():
+        pytest.skip("engine checked out apart from the monorepo; the workflow is absent")
     body = workflow.read_text(encoding="utf-8")
 
     assert "Build the benchmark image" in body
@@ -335,6 +353,8 @@ def test_the_engine_workflow_runs_when_the_guarded_justfile_changes() -> None:
     """INVARIANT: a guard that cannot run on its own subject is worse than no guard."""
 
     workflow = REPOSITORY_ROOT / ".github" / "workflows" / "screamingface-engine-tests.yml"
+    if not workflow.is_file():
+        pytest.skip("engine checked out apart from the monorepo; the workflow is absent")
     body = workflow.read_text(encoding="utf-8")
 
     assert body.count('- "packages/screamingface/justfile"') == 2
@@ -386,3 +406,42 @@ def test_an_unserializable_summary_value_does_not_abort_the_remaining_bundles(
         },
     ]
     assert (tmp_path / "beta").is_dir()
+
+
+def test_an_unserializable_summary_key_does_not_abort_the_remaining_bundles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """WHY: `default=` is never consulted for KEYS, so a value-only guard is half a guard."""
+
+    summaries: dict[str, dict[Any, Any]] = {
+        "draco": {"cases": 100},
+        "healthbench": {Path("professional"): 525},
+        "ifeval": {"cases": 541},
+    }
+
+    def prepare(_root: Path, on_prepared: object = None) -> dict[str, object]:
+        for bundle, summary in summaries.items():
+            if on_prepared is not None:
+                on_prepared(bundle, summary)  # type: ignore[operator]
+        return dict(summaries)
+
+    monkeypatch.setattr(prepare_module, "prepare_builtin_assets", prepare)
+
+    assert prepare_module.main(["--root", str(tmp_path)]) == 0
+
+    records = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+    assert [record["bundle"] for record in records] == ["draco", "healthbench", "ifeval"]
+    assert records[1]["summary_unreportable"] == "TypeError"
+    assert records[2]["summary"] == {"cases": 541}
+
+
+def test_the_family_guard_matches_a_computed_family_segment() -> None:
+    """WHY: reintroduction is likelier as a loop variable than as three literal lines."""
+
+    assert _FAMILY_PREPARER.search("-m screamingface_engine.benchmarks.$b.prepare --out /x")
+    assert _FAMILY_PREPARER.search("-m screamingface_engine.benchmarks.${family}.prepare")
+    assert _FAMILY_PREPARER.search('f"screamingface_engine.benchmarks.{name}.prepare"')
+    # The orchestrator itself still must not match.
+    assert _FAMILY_PREPARER.search("-m screamingface_engine.benchmarks.prepare --root /x") is None

--- a/docs/plan/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/plan/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -1,0 +1,38 @@
+# OME-925 — Implementation plan: observable benchmark asset preparation
+
+Spec: `docs/spec/2026-08-21-OME-925-benchmark-asset-preparation.md` · Stack:
+`screamingface-engine` · Branch: `OME-925-benchmark-asset-preparation`
+
+## 1. Preserve preparation evidence
+
+- Change the preparer port to return `Mapping[str, Any]`.
+- Make the three complete-bundle adapters return their existing summaries; give HealthBench an
+  explicit professional/worst-30 split.
+- Return bundle-keyed summaries from `BenchmarkDeployment.prepare_assets()` and print one JSON
+  record per bundle from the orchestrator CLI.
+
+## 2. Normalize expected refusals
+
+- Add a shared benchmark-asset preparation exception.
+- Keep each family's `PrepareError` name while deriving it from the shared exception.
+- Catch only the shared expected exception at the orchestrator process boundary.
+
+## 3. Enforce one entrypoint everywhere
+
+- Replace the three `stack-prepare` commands with the orchestrator command.
+- Strengthen the Dockerfile test to derive the root constant and reject any family preparer.
+- Add the equivalent local-preparation invariant and CLI output/error tests.
+
+## 4. Cache the CI image build
+
+- Rename the benchmark-image step.
+- Use a job-local registry with the container BuildKit driver so the base image remains available
+  while the benchmark build imports/exports a dedicated GitHub Actions cache.
+- Keep the final benchmark image loaded for the existing smoke test.
+
+## 5. Verify and publish
+
+- Confirm the new focused tests fail before implementation, then make them pass.
+- Run `uv run .claude/scripts/run_gates.py screamingface-engine` from the repository root.
+- Perform the required wisdom/confidence review, commit with `Refs: OME-925`, push, and open a
+  Khoa-style draft PR with Before/After, non-regressions, evidence, and explicit exclusions.

--- a/docs/plan/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/plan/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -23,12 +23,11 @@ Spec: `docs/spec/2026-08-21-OME-925-benchmark-asset-preparation.md` · Stack:
 - Strengthen the Dockerfile test to derive the root constant and reject any family preparer.
 - Add the equivalent local-preparation invariant and CLI output/error tests.
 
-## 4. Cache the CI image build
+## 4. Name the CI image build accurately
 
 - Rename the benchmark-image step.
-- Use a job-local registry with the container BuildKit driver so the base image remains available
-  while the benchmark build imports/exports a dedicated GitHub Actions cache.
-- Keep the final benchmark image loaded for the existing smoke test.
+- Preserve the existing, proven base-image handoff and smoke test.
+- Defer persistent dataset/corpus caching until its cross-run semantics have a focused design.
 
 ## 5. Verify and publish
 

--- a/docs/spec/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/spec/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -1,0 +1,54 @@
+# OME-925 — Observable benchmark asset preparation
+
+Status: approved (owner, 2026-08-21) · Stack: screamingface-engine
+
+## Problem
+
+OME-875 made the built-in deployment the single source for runtime benchmark discovery and
+image asset preparation. The generic preparation seam currently discards the summaries that
+prove which answer key was baked, does not normalize expected preparation failures, and is not
+yet used by local stack preparation. CI still describes the image as DRACO-only and retains no
+BuildKit cache across runs.
+
+## Contract
+
+- A `BenchmarkAssetPreparer` returns a read-only summary-shaped `Mapping[str, Any]`.
+- `BenchmarkDeployment.prepare_assets()` invokes each unique bundle once in stable ID order and
+  returns the summaries keyed by bundle ID in that same order.
+- The built-in CLI emits one JSON object per bundle containing the root, bundle ID, and summary.
+- Every family-specific `PrepareError` inherits one shared preparation exception. The generic
+  CLI catches only that expected exception, emits one readable error, and remains non-zero.
+- Individual family CLIs remain supported; no benchmark bytes, paths, pins, or board sharing
+  change.
+
+## Deployment paths
+
+The image and `just stack-prepare` both call:
+
+```text
+python -m screamingface_engine.benchmarks.prepare --root <asset-root>
+```
+
+Tests derive the image root from `DEFAULT_BENCHMARK_ASSETS_ROOT` and reject every direct
+`benchmarks.<family>.prepare` invocation, not only DRACO.
+
+The CI image job uses the supported container-builder/local-registry pattern so its benchmark
+build can use the GitHub Actions BuildKit cache while still consuming the base image built in
+the same job. The benchmark cache gets its own scope and retains the expensive dataset/corpus
+layer across runs.
+
+## Invariants
+
+- The registry-derived one-entrypoint design remains the only complete preparation path.
+- DRACO, IFEval, and HealthBench write byte-identical assets to the same directories as before.
+- Both HealthBench boards continue sharing one prepared directory.
+- Unexpected exceptions still raise with their traceback; only declared preparation refusals
+  become concise operator errors.
+- Summary values are observations only and never drive runtime behavior.
+
+## Acceptance
+
+- A local root preparation prints counts and family-specific evidence for all three bundles.
+- A forced `PrepareError` returns 1 and prints the reason without a traceback.
+- Static guards reject family-specific Docker/justfile preparation and verify the derived root.
+- The CI benchmark-image step is accurately named and uses a persistent, isolated BuildKit cache.

--- a/docs/spec/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/spec/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -7,8 +7,8 @@ Status: approved (owner, 2026-08-21) · Stack: screamingface-engine
 OME-875 made the built-in deployment the single source for runtime benchmark discovery and
 image asset preparation. The generic preparation seam currently discards the summaries that
 prove which answer key was baked, does not normalize expected preparation failures, and is not
-yet used by local stack preparation. CI still describes the image as DRACO-only and retains no
-BuildKit cache across runs.
+yet used by local stack preparation. CI still describes the complete benchmark image as
+DRACO-only.
 
 ## Contract
 
@@ -32,11 +32,6 @@ python -m screamingface_engine.benchmarks.prepare --root <asset-root>
 Tests derive the image root from `DEFAULT_BENCHMARK_ASSETS_ROOT` and reject every direct
 `benchmarks.<family>.prepare` invocation, not only DRACO.
 
-The CI image job uses the supported container-builder/local-registry pattern so its benchmark
-build can use the GitHub Actions BuildKit cache while still consuming the base image built in
-the same job. The benchmark cache gets its own scope and retains the expensive dataset/corpus
-layer across runs.
-
 ## Invariants
 
 - The registry-derived one-entrypoint design remains the only complete preparation path.
@@ -51,4 +46,11 @@ layer across runs.
 - A local root preparation prints counts and family-specific evidence for all three bundles.
 - A forced `PrepareError` returns 1 and prints the reason without a traceback.
 - Static guards reject family-specific Docker/justfile preparation and verify the derived root.
-- The CI benchmark-image step is accurately named and uses a persistent, isolated BuildKit cache.
+- The CI benchmark-image step is accurately named.
+
+## Deliberately deferred
+
+Persistent dataset/corpus caching across fresh CI runners needs a separate design. A GitHub
+Actions layer cache does not, by itself, preserve BuildKit cache mounts, and the benchmark layer
+also depends on the PR-built engine image. This change does not add registry or builder plumbing
+that could imply stronger download-cache reuse than it actually provides.

--- a/docs/tasks/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/tasks/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -1,7 +1,7 @@
 ---
 id: OME-925
 linear_url: https://linear.app/openmined/issue/OME-925/say-what-the-benchmark-image-baked-fail-readably-and-prepare-assets
-status: in_progress
+status: done
 type: task
 priority: medium
 labels:
@@ -10,7 +10,7 @@ labels:
   - autonomous
   - task
 created: 2026-08-21
-closed:
+closed: 2026-08-21
 ---
 
 # Say what the benchmark image baked, fail readably, and prepare assets one way

--- a/docs/tasks/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/tasks/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -1,0 +1,20 @@
+---
+id: OME-925
+linear_url: https://linear.app/openmined/issue/OME-925/say-what-the-benchmark-image-baked-fail-readably-and-prepare-assets
+status: in_progress
+type: task
+priority: medium
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+  - task
+created: 2026-08-21
+closed:
+---
+
+# Say what the benchmark image baked, fail readably, and prepare assets one way
+
+Follow up OME-875 without changing benchmark bytes: retain each preparer's audit summary,
+surface expected preparation failures without a traceback, use the registry-derived entrypoint
+for local and image preparation, and cache the benchmark-image build's network work in CI.

--- a/docs/tasks/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/tasks/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -17,4 +17,4 @@ closed:
 
 Follow up OME-875 without changing benchmark bytes: retain each preparer's audit summary,
 surface expected preparation failures without a traceback, use the registry-derived entrypoint
-for local and image preparation, and cache the benchmark-image build's network work in CI.
+for local and image preparation, and name the complete benchmark-image build accurately in CI.

--- a/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -135,3 +135,69 @@ none of the SDK's manifests. Two paths, two notions of "prepared", disagreeing. 
 different stack (rule 8 → epic + per-package sub-issue), `prepare_assets` has no single-bundle
 filter so `screamingface prepare draco` has no equivalent, and the SDK owns its own manifest,
 fingerprint, validation and `--force` semantics.
+
+## Third review pass (2026-08-21)
+
+A review of the complete PR #677 diff found no high-severity correctness bug. Bundle ids match
+the directories the old per-family `--out` calls wrote, no caller depended on the old
+`tuple[Path, ...]` return, and the family preparers importing `benchmarks.deployment` introduces
+no cycle. Three low-severity issues are fixed here; a fourth was examined and deliberately left.
+
+### Fixed
+
+1. **A preparer defect was laundered through the operator-refusal channel.** Pass 2 made a
+   non-Mapping return raise `BenchmarkAssetPreparationError` — exactly the class the orchestrator
+   CLI catches. So a *programming* defect exited 1 with one line and no traceback, on the same
+   channel as answer-key drift, sending an operator hunting for dataset drift that does not exist.
+   This contradicted this unit's own `test_builtin_prepare_cli_does_not_hide_unexpected_failures`.
+   A new `BenchmarkAssetPreparerContractError(TypeError)` — deliberately outside the
+   `BenchmarkAssetPreparationError` hierarchy — keeps the named message while restoring the
+   traceback.
+2. **A reporting fault could abort the bake.** `json.dumps` runs inside the `on_prepared` callback,
+   i.e. inside `prepare_assets`' loop. The port type is `Mapping[str, Any]`, so a future preparer
+   putting a `Path`/`set` in its summary would bake draco and leave `ifeval`/`healthbench` unbaked —
+   an image shipping missing assets because of a *formatting* problem in the audit record.
+   `default=str` keeps a record fault costing fidelity in one line, never the assets.
+3. **The family guard derived module paths from bundle ids.** Pass 2's fix read
+   `BUILTIN_DEPLOYMENT._asset_bundles` (also private-attribute access). Ids and package names
+   coincide today, but this codebase already separates the two (`draco-3pass` is a benchmark id over
+   the `draco` bundle). A family declaring `ASSET_BUNDLE_ID = "healthbench-v2"` while its package
+   stayed `benchmarks/healthbench` would silently stop being guarded, and a Dockerfile/justfile
+   revert to a family call would merge green. The alternation is now derived from the family
+   packages on disk (`benchmarks/*/prepare.py`), with a new test asserting the derived set is
+   exactly `{draco, healthbench, ifeval}` so a mistyped path cannot yield a guard that matches
+   nothing.
+
+### Examined and not fixed
+
+**HealthBench `worst30_cases` is a compile-time constant.** It reports `len(WORST30_CASE_IDS)`, so
+it prints 157 regardless of what was baked. Left as is: `emit()` refuses unless today's row order
+equals `WORST30_CASE_IDS` exactly, so reaching the summary already proves the frozen subset
+verified against today's rows. Changing it would restate the same fact less directly.
+
+### Not filed
+
+The CLI prints no terminal "all bundles complete" record, so a stdout-only reading of a build log
+cannot distinguish a finished bake from a truncated one — the reason does reach stderr with a
+non-zero exit, which is the channel a build actually fails on. The new repo-root paths use
+`Path(__file__).parents[4]` without the `.resolve()` sibling tests use.
+
+### Third pass — outcome
+
+- **Actual files:** `benchmarks/deployment.py`, `benchmarks/prepare.py`,
+  `tests/unit/test_benchmark_deployment.py`. No family preparer changed.
+- **Gates:** official `run_gates.py screamingface-engine --skip-append-only` — ruff check ✓ ·
+  ruff format ✓ · pyright ✓ · check_layering ✓ · pytest --cov (80% floor) ✓ — **ALL GREEN**.
+  Focused deployment suite 23 passed. The Dockerfile guard was re-proved by temporarily appending
+  a `benchmarks.draco.prepare --out` line and watching
+  `test_benchmark_image_invokes_only_the_registered_asset_orchestrator` fail, then reverted.
+- **Deviations:** append-only skipped with owner approval, for two lines this pass necessarily
+  changes: the guard's derivation source (fix 3 *is* that line) and the contract test's expected
+  exception class (fix 1 makes the old assertion assert the defect). Both lines were added by
+  **this branch's own pass-2 commit** — `origin/main` has neither the `_asset_bundles`-derived
+  guard nor the contract test — so, as in pass 2's deviation 1, this is iterating unmerged work
+  rather than rewriting an inherited assertion; the gate flags it because it compares against
+  HEAD. Re-running with `--base origin/main` still flags the earlier passes' own changes, already
+  covered by their recorded approvals. Nothing was weakened: the replacement test additionally
+  asserts the contract error is **not** a `BenchmarkAssetPreparationError` and that the CLI lets
+  it through as a traceback.

--- a/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -239,3 +239,14 @@ two guards from passing green on the shapes they exist to catch.
   edited lines are the guard's own regex and three `REPOSITORY_ROOT` reads — all added by this
   branch's earlier passes, not inherited from `origin/main`. Nothing was weakened: both guards
   now match strictly more, and no assertion was relaxed.
+
+### Fourth-pass correction
+
+A first cut of this pass also reported `rubric_files` from a `rubrics/*.json` glob. Dropped before
+merge: `emit` writes one rubric per Case and never clears the directory, so that count equals
+`professional_cases` on a fresh bake and is inflated by leftovers on a re-prepare into an existing
+assets dir (`just stack-prepare`, `screamingface prepare --force`) — redundant when accurate,
+misleading when not, i.e. the same "cannot vary usefully" defect this pass set out to remove.
+`emit` was deliberately left alone rather than made to clear the directory: that changes what the
+bake DOES to fix a reporting problem that disappears with the field. The synthetic HealthBench
+summary in the CLI test fixture was aligned to the real key names in the same change.

--- a/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -1,0 +1,51 @@
+---
+ticket: OME-925
+stack: screamingface-engine
+status: done
+started: 2026-08-21
+finished: 2026-08-21
+---
+
+# OME-925 — Observable benchmark asset preparation
+
+## Intent
+
+Close the review follow-ups from OME-875 without changing benchmark assets: preserve each
+preparer's audit evidence, make expected build refusals readable, converge local and image
+preparation on the deployment entrypoint, and retain network-heavy benchmark build layers in CI.
+
+## Planned changes
+
+- Preparation port, deployment result, shared expected exception, and orchestrator CLI.
+- DRACO, IFEval, and HealthBench complete-bundle return values and exception inheritance.
+- Deployment/CLI/static guard tests, local stack preparation, and benchmark-image CI caching.
+- Task, spec, plan, work ledger, and draft-PR evidence.
+
+## Test plan
+
+- RED: summaries survive shared-bundle deduplication in stable order.
+- RED: CLI prints one structured record per bundle and handles declared failures without traceback.
+- RED: Docker and local preparation reject any family-specific entrypoint and derive the root.
+- RED: CI names the complete benchmark image and declares an isolated persistent build cache.
+- GREEN: focused deployment tests, then the complete `screamingface-engine` gate suite.
+
+## Acceptance
+
+- Build logs expose DRACO cases, IFEval cases/patched keys, and the HealthBench board split.
+- Expected preparer refusals are concise and non-zero; unexpected exceptions remain visible.
+- Image and local preparation use one registry-derived command.
+- CI caches the benchmark preparation layer across runs.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** the preparation port/deployment/orchestrator; all three family adapters;
+  deployment, process-boundary, Docker, justfile and workflow contract tests; the local justfile;
+  Engine image CI; and this unit's task/spec/plan/work records.
+- **Commits:** the `fix(screamingface-engine): make benchmark asset preparation auditable`
+  commit carrying this outcome (`Refs: OME-925`).
+- **Gates:** official `run_gates.py screamingface-engine --skip-append-only` — ALL GATES
+  GREEN (Ruff check/format, Pyright, layering, full pytest with coverage); 1,938 tests
+  collected; focused deployment/preparer suite 42 passed; workflow YAML and justfile parsed.
+- **Deviations:** append-only was skipped with owner approval because the ticket explicitly
+  changes the inherited preparer return contract and strengthens its Dockerfile assertion.
+  No inherited behavior or assertion was weakened. No other deviations.

--- a/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -11,14 +11,15 @@ finished: 2026-08-21
 ## Intent
 
 Close the review follow-ups from OME-875 without changing benchmark assets: preserve each
-preparer's audit evidence, make expected build refusals readable, converge local and image
-preparation on the deployment entrypoint, and retain network-heavy benchmark build layers in CI.
+preparer's audit evidence, make expected build refusals readable, and converge local and image
+preparation on the deployment entrypoint.
 
 ## Planned changes
 
 - Preparation port, deployment result, shared expected exception, and orchestrator CLI.
 - DRACO, IFEval, and HealthBench complete-bundle return values and exception inheritance.
-- Deployment/CLI/static guard tests, local stack preparation, and benchmark-image CI caching.
+- Deployment/CLI/static guard tests, local stack preparation, and accurate benchmark-image CI
+  naming.
 - Task, spec, plan, work ledger, and draft-PR evidence.
 
 ## Test plan
@@ -26,7 +27,7 @@ preparation on the deployment entrypoint, and retain network-heavy benchmark bui
 - RED: summaries survive shared-bundle deduplication in stable order.
 - RED: CLI prints one structured record per bundle and handles declared failures without traceback.
 - RED: Docker and local preparation reject any family-specific entrypoint and derive the root.
-- RED: CI names the complete benchmark image and declares an isolated persistent build cache.
+- RED: CI names the complete benchmark image accurately.
 - GREEN: focused deployment tests, then the complete `screamingface-engine` gate suite.
 
 ## Acceptance
@@ -34,13 +35,13 @@ preparation on the deployment entrypoint, and retain network-heavy benchmark bui
 - Build logs expose DRACO cases, IFEval cases/patched keys, and the HealthBench board split.
 - Expected preparer refusals are concise and non-zero; unexpected exceptions remain visible.
 - Image and local preparation use one registry-derived command.
-- CI caches the benchmark preparation layer across runs.
+- CI describes the complete benchmark image accurately without changing its proven build path.
 
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** the preparation port/deployment/orchestrator; all three family adapters;
   deployment, process-boundary, Docker, justfile and workflow contract tests; the local justfile;
-  Engine image CI; and this unit's task/spec/plan/work records.
+  the CI step name; and this unit's task/spec/plan/work records.
 - **Commits:** the `fix(screamingface-engine): make benchmark asset preparation auditable`
   commit carrying this outcome (`Refs: OME-925`).
 - **Gates:** official `run_gates.py screamingface-engine --skip-append-only` — ALL GATES
@@ -48,4 +49,6 @@ preparation on the deployment entrypoint, and retain network-heavy benchmark bui
   collected; focused deployment/preparer suite 42 passed; workflow YAML and justfile parsed.
 - **Deviations:** append-only was skipped with owner approval because the ticket explicitly
   changes the inherited preparer return contract and strengthens its Dockerfile assertion.
-  No inherited behavior or assertion was weakened. No other deviations.
+  No inherited behavior or assertion was weakened. Persistent dataset/corpus caching was deferred:
+  the proposed registry/layer-cache plumbing did not guarantee preservation of BuildKit cache
+  mounts across fresh runners and was removed before review.

--- a/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -201,3 +201,41 @@ non-zero exit, which is the channel a build actually fails on. The new repo-root
   covered by their recorded approvals. Nothing was weakened: the replacement test additionally
   asserts the contract error is **not** a `BenchmarkAssetPreparationError` and that the CLI lets
   it through as a traceback.
+
+## Fourth pass — close the PR review findings
+
+### Intent
+
+Close four review findings without widening the unit: make the record's own no-abort promise
+true, make the HealthBench summary an observation rather than a restated constant, and stop the
+two guards from passing green on the shapes they exist to catch.
+
+### Changes
+
+- `benchmarks/prepare.py` — fence the encoder. `default=` is never consulted for dict KEYS and
+  cannot rescue a circular or over-deep summary, so the value-only guard left the documented
+  invariant (a reporting fault costs one record, never the remaining bundles) untrue. A failed
+  encode now emits `summary_unreportable` with the fault class; the bundle still reports having
+  completed.
+- `benchmarks/healthbench/prepare.py` — count what landed. `emit` already refuses any row count
+  but `PROFESSIONAL_CASE_COUNT`, so echoing its inputs produced a record that could never differ
+  between bakes. `professional_cases` and the new `rubric_files` are now read back off the
+  written bundle; the serve-time subset size is renamed `declared_worst30_cases` so an operator
+  cannot read a compile-time constant as evidence of this run.
+- `tests/unit/test_benchmark_deployment.py` — the family guard now also matches a computed
+  segment (`$b`, `${family}`, `{name}`); the SDK builds that exact path from a variable today, so
+  a literals-only guard passed on the likeliest reintroduction. The three guards that read files
+  outside this app now skip when those files are absent, which `packages/screamingface/justfile`
+  already anticipates via `SCREAMINGFACE_ENGINE_REPO`.
+
+### Outcome
+
+- **Tests:** two appended — an unserializable summary KEY leaving later bundles intact, and the
+  guard matching a computed family segment. Focused deployment suite 25 passed; the broader
+  `-k "prepare or benchmark or deployment or healthbench"` selection 249 passed.
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` — ruff check ✓ · ruff format ✓
+  · pyright ✓ · check_layering ✓ · pytest --cov (80% floor) ✓ — **ALL GREEN**.
+- **Deviations:** append-only skipped with owner approval (asked and granted this pass). The
+  edited lines are the guard's own regex and three `REPOSITORY_ROOT` reads — all added by this
+  branch's earlier passes, not inherited from `origin/main`. Nothing was weakened: both guards
+  now match strictly more, and no assertion was relaxed.

--- a/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
+++ b/docs/work/2026-08-21-OME-925-benchmark-asset-preparation.md
@@ -52,3 +52,86 @@ preparation on the deployment entrypoint.
   No inherited behavior or assertion was weakened. Persistent dataset/corpus caching was deferred:
   the proposed registry/layer-cache plumbing did not guarantee preservation of BuildKit cache
   mounts across fresh runners and was removed before review.
+
+## Second review pass (2026-08-21) — planned
+
+A follow-up review found five issues. Four are fixed here; the fifth is a claim correction plus a
+follow-up ticket, because the actual repair crosses stacks.
+
+### Fixed in this pass
+
+1. **The justfile guard could never fire on the file it guards.**
+   `test_local_stack_prepare_uses_the_registered_asset_orchestrator` reads
+   `packages/screamingface/justfile`, but `screamingface-engine-tests.yml` triggers only on
+   `apps/screamingface-engine/**`, `packages/url4/**` and itself — and `screamingface-tests.yml`,
+   which does cover that path, runs no engine tests. A PR reverting `stack-prepare` to three family
+   calls would merge green and the guard would later fire on an unrelated engine PR, blaming the
+   wrong change. `packages/screamingface/justfile` is added to the engine workflow's `paths`.
+2. **A refusal discarded the evidence for bundles that already baked.** Records printed only after
+   every bundle finished, so a HealthBench failure lost draco's completed summary — the exact
+   auditability this unit adds. `prepare_assets` now reports each bundle as it completes, and the
+   CLI streams the record then.
+3. **The guard regex was broader than its message.** `benchmarks\.[a-z0-9_]+\.prepare` under
+   `search()` matched any middle module and `.prepare` as a prefix, so a reference to
+   `benchmarks.deployment.prepare_assets` would fail as a "family-specific invocation". The family
+   segment is now derived from the deployment's own bundle ids and anchored.
+4. **The copy invariant overstated itself.** `dict(...)` is shallow, so the promise held only for
+   top-level keys; and a preparer still written against the old `-> None` contract produced a bare
+   `TypeError`. The comment is corrected and a non-Mapping return now raises a named contract error.
+
+### Not fixed here — claim corrected, ticket filed
+
+**`screamingface prepare` still calls the family preparers directly.**
+`packages/screamingface/src/screamingface/_runtime/cli.py` shells
+`benchmarks.{name}.prepare --out` per family from a hardcoded `_BENCHMARKS`, so the audit envelope
+never reaches the command a user actually runs. The PR body's "the only complete preparation path"
+is corrected. The repair is NOT a tidy: it is a different stack (rule 8 → epic + per-package
+sub-issue), `prepare_assets` has no single-bundle filter so `screamingface prepare draco` has no
+equivalent, and the SDK owns its own manifest, fingerprint, validation and `--force` logic. Filed
+separately rather than smuggled in.
+
+### Test plan
+
+- RED: a two-bundle deployment whose second bundle refuses still reports the first bundle's summary;
+  the CLI prints that record before the failure line.
+- RED: the family-preparer guard does not match `benchmarks.deployment.prepare_assets`.
+- RED: a preparer returning `None` raises a named contract error, not a bare `TypeError`.
+- The engine workflow's `paths` include `packages/screamingface/justfile`.
+- Prior tests unchanged except where the streaming contract requires it.
+
+### Second review pass — outcome
+
+- **Actual files:** `.github/workflows/screamingface-engine-tests.yml`, `benchmarks/deployment.py`,
+  `benchmarks/prepare.py`, `tests/unit/test_benchmark_deployment.py`. No family preparer changed.
+- **Gates:** ruff check ✓ · ruff format ✓ · pyright ✓ · check_layering ✓ · pytest --cov (80% floor)
+  ✓ — **ALL GREEN**. Focused deployment suite 20 passed. Workflow YAML re-parsed and both `paths`
+  lists verified.
+- **`prepare_assets` grew an optional `on_prepared` callback** rather than printing from the
+  orchestrator, keeping the I/O decision with the CLI. The CLI streams each record with `flush=True`
+  so a build log keeps the completed bundles when a later one refuses.
+
+### Deviations from the plan
+
+1. **Three tests in this same branch needed their monkeypatch signature updated.** They stub
+   `prepare_builtin_assets`, which gained the callback parameter. These are tests this PR itself
+   added — not inherited from `main` — so this is iterating unmerged work, not a rule 5 exception.
+   No inherited assertion was touched by this pass.
+2. **My first guard probe was wrong and passed for the wrong reason.** It asserted on
+   `benchmarks.deployment.prepare_assets` without the `screamingface_engine.` prefix, so the regex
+   never had a chance to match. Corrected to the fully-qualified string, which then failed RED as
+   intended before the fix.
+3. **`BenchmarkDeployment` is slotted**, so the new test could not monkeypatch `prepare_assets` on
+   the built-in instance; it substitutes `prepare_builtin_assets` instead, matching the style of the
+   sibling CLI tests.
+4. **Two line-length violations** were caught by ruff, not by the test run.
+
+### Follow-up filed separately
+
+`screamingface prepare` still calls the family preparers directly, so the audit envelope never
+reaches the command a user runs. Live corroboration on the owner's machine: all three asset
+directories hold real content and the Engine served evaluations from them, yet
+`screamingface prepare --list` reports every one `incomplete`, because the orchestrator path writes
+none of the SDK's manifests. Two paths, two notions of "prepared", disagreeing. Not repaired here:
+different stack (rule 8 → epic + per-package sub-issue), `prepare_assets` has no single-bundle
+filter so `screamingface prepare draco` has no equivalent, and the SDK owns its own manifest,
+fingerprint, validation and `--force` semantics.

--- a/packages/screamingface/justfile
+++ b/packages/screamingface/justfile
@@ -254,6 +254,4 @@ stack-logs:
 
 # One-time: download pinned benchmark assets into {{assets}}
 stack-prepare:
-    cd {{engine_repo}}/apps/screamingface-engine && uv run --with datasets python -m screamingface_engine.benchmarks.draco.prepare --out {{assets}}/draco
-    cd {{engine_repo}}/apps/screamingface-engine && uv run --with datasets python -m screamingface_engine.benchmarks.ifeval.prepare --out {{assets}}/ifeval
-    cd {{engine_repo}}/apps/screamingface-engine && uv run --with datasets python -m screamingface_engine.benchmarks.healthbench.prepare --out {{assets}}/healthbench
+    cd {{engine_repo}}/apps/screamingface-engine && uv run --with datasets python -m screamingface_engine.benchmarks.prepare --root {{assets}}


### PR DESCRIPTION
Benchmark asset preparation now preserves the evidence each family computed, reports declared
refusals at the process boundary, and uses the registry-derived entrypoint for both image and
local preparation. The benchmark bytes, runtime protocol, and proven image-build path are
unchanged.

**Linear:** https://linear.app/openmined/issue/OME-925/say-what-the-benchmark-image-baked-fail-readably-and-prepare-assets

## Before / After

### Before

- **Trigger:** an engineer rebuilt the benchmark image or ran `just stack-prepare`.
- **Today:** the generic image command discarded DRACO/IFEval summaries and the HealthBench
  525/157 split, so a changed answer key looked like a normal bake in the build log.
- **Failure mode:** a declared dataset/tokenizer refusal escaped the generic CLI as a traceback.
- **Drift risk:** local preparation still carried three hand-maintained family commands.
- **CI wording:** the complete benchmark-image step still said DRACO.

### After

- **Same trigger.** Each prepared bundle emits one JSON record containing its bundle ID and the
  family-owned summary: cases, patched keys, NLTK location, or HealthBench board split.
- **Readable refusal:** declared preparation errors return non-zero with one operator-facing
  reason. Unexpected exceptions still escape and retain their traceback.
- **One path:** the Dockerfile and `just stack-prepare` both call
  `screamingface_engine.benchmarks.prepare --root ...`.
- **Accurate CI wording:** the step says `Build the benchmark image` while retaining the existing
  base-image handoff and smoke test.

## Don't regress

- The OME-875 registry-derived entrypoint remains the only complete preparation path **for the
  benchmark image and `just stack-prepare`**. `screamingface prepare` in the SDK still calls the
  family preparers directly — see the follow-up note below.
- DRACO, IFEval, and HealthBench write the same files to the same directories.
- Both HealthBench boards still share one physical `healthbench` bundle prepared once.
- Summary values are audit observations only; no runtime behavior consumes them.
- The generic CLI catches only the shared declared preparation error, never `Exception`.
- Individual family preparer CLIs remain available.

## Why this belongs at the preparation port

Every family already computed the facts needed to audit a bake. The loss happened at
`BenchmarkAssetPreparer = Callable[[Path], None]`, so the repair changes that internal port to
return `Mapping[str, Any]` and lets `BenchmarkDeployment` preserve summaries in the same stable,
deduplicated bundle order it already owns. There is no second manifest or family switch in the
orchestrator.

## What changed

### Auditable preparation results

`BenchmarkDeployment.prepare_assets()` now returns bundle-keyed summaries. The generic CLI emits
one collision-safe envelope per bundle:

```json
{"root":"/opt/benchmarks","bundle":"healthbench","summary":{"professional_cases":525,"worst30_cases":157,"out":"/opt/benchmarks/healthbench"}}
```

The deployment copies each adapter mapping when the bundle completes, so later mutation of an
adapter-owned dictionary cannot rewrite the observed result.

### One expected-error boundary

The three existing family `PrepareError` classes retain their names and messages but inherit
`BenchmarkAssetPreparationError`. The generic process entrypoint catches that shared type and
prints `benchmark asset preparation failed: <reason>`. A regression test proves an unrelated
`AssertionError` is not hidden.

### One local and image entrypoint

The justfile's three family calls collapse to the same deployment orchestrator used by the
benchmark Dockerfile. This does NOT cover `screamingface prepare` (see the follow-up note). Static guards use a pattern covering every
`benchmarks.<family>.prepare` invocation, so adding a different direct family call fails too.
The Docker assertion derives `/opt/benchmarks` from `DEFAULT_BENCHMARK_ASSETS_ROOT`.

## Test plan

- **Focused deployment contract after review cleanup:** 16 passed.
- **Official Engine gate after review cleanup:** Ruff check, Ruff format, Pyright, layering, and
  the full pytest coverage suite — ALL GATES GREEN.
- **Original complete preparer suite:** 42 passed; 1,938 Engine tests collected.
- **Workflow:** only the stale step name differs from `main`; the proven build configuration is
  unchanged.

No paid evaluation or UI screenshot is required.

## Reviewer note — prior test changed (owner-approved)

OME-925 explicitly changes the inherited preparer return contract and asks for the Dockerfile
guard in `test_benchmark_deployment.py` to become generic and derive the root constant. The local
official gate therefore ran with `--skip-append-only` after owner approval. No inherited assertion
was deleted without replacement or weakened: the result assertion now verifies summaries, and the
Docker negative assertion rejects every family-specific preparer rather than DRACO alone.

## Deliberately left out

- Persistent dataset/corpus caching across fresh CI runners. A GHA layer cache does not by itself
  preserve BuildKit cache mounts, and the benchmark layer depends on the PR-built engine image.
  The proposed local-registry/builder plumbing was removed because it implied stronger download
  reuse than it guaranteed. This needs a focused cache design.
- Regenerating or modifying any benchmark asset.
- Runtime downloads or a directory-exists shortcut.
- A second benchmark/deployment manifest.
- Catching programming defects as friendly preparation failures.
- New public SDK, Engine HTTP, URL4, Scoreboard, or persistence contracts.

## Cross-service contract

None. This is build-time Engine orchestration plus its local/CI call sites. Runtime routes,
request/response schemas, authentication, scoring, and leaderboard behavior are unchanged.

Refs: OME-925



## Second review pass (2026-08-21)

Four findings fixed in `a98bf61a`:

1. **The justfile guard could never fire on the file it guards.** `screamingface-engine-tests.yml`
   triggers on `apps/screamingface-engine/**`, `packages/url4/**` and itself — not
   `packages/screamingface/**` — and `screamingface-tests.yml` runs no engine tests. A PR reverting
   `stack-prepare` would have merged green, with the guard failing later on an unrelated engine
   change. `packages/screamingface/justfile` is now in the workflow's `paths`.
2. **A refusal discarded the evidence for bundles that already baked.** Records printed only after
   the whole sequence succeeded. `prepare_assets` now takes an optional `on_prepared` callback and
   the CLI streams each record as its bundle lands, so a mid-sequence refusal leaves the completed
   bundles in the build log.
3. **The guard regex was broader than its message** — `benchmarks\.[a-z0-9_]+\.prepare` matched
   `benchmarks.deployment.prepare_assets`. The family segment is derived from the deployment's own
   bundle ids and anchored.
4. **The copy invariant overstated a shallow `dict()`**, and a preparer written against the old
   `-> None` port raised a bare `TypeError`. Comment corrected; a non-`Mapping` return now raises
   `BenchmarkAssetPreparationError` naming the bundle.

Engine gates all green after the fixes; focused deployment suite 20 passed.

### Follow-up, deliberately not in this PR

`screamingface prepare` (`packages/screamingface/.../\_runtime/cli.py`) shells
`benchmarks.{name}.prepare --out` per family from a hardcoded list, so the audit envelope never
reaches the command a user runs. Observed live: all three local asset directories hold real content
and the Engine serves evaluations from them, yet `screamingface prepare --list` reports every one
`incomplete`, because the orchestrator path writes none of the SDK's manifests.

Not repaired here — it is a different stack (rule 8 → epic + per-package sub-issue),
`prepare_assets` has no single-bundle filter so `screamingface prepare draco` has no equivalent, and
the SDK owns its own manifest, fingerprint, validation and `--force` semantics.
