### PR TITLE
chore(screamingface): bump version to 0.1.1.post2

### DIFF
--- a/packages/screamingface/pyproject.toml
+++ b/packages/screamingface/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "screamingface"
-version = "0.1.1.post1"
+version = "0.1.1.post2"
 description = "Evaluate Models and Fusions on URL4-native research benchmarks"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/screamingface/uv.lock
+++ b/packages/screamingface/uv.lock
@@ -3020,7 +3020,7 @@ wheels = [
 
 [[package]]
 name = "screamingface"
-version = "0.1.1.post1"
+version = "0.1.1.post2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Bump the `packages/screamingface` Client SDK version `0.1.1.post1` → `0.1.1.post2` (PEP 440 post-release) so a fresh artifact can be published to PyPI — the existing versions are already uploaded and PyPI is immutable. Mirrors #651 exactly (same two files, version-only).

The `release-screamingface.yml` `verify` job requires the tag version to match `pyproject.toml`, so this must land before the `screamingface-v0.1.1.post2` tag is cut.

`.release-please-manifest.json` is intentionally **not** touched — it stays at `0.1.1`; these `.postN` bumps are managed outside release-please (see OME-824).

## Changes

- `packages/screamingface/pyproject.toml` — `version` → `0.1.1.post2`
- `packages/screamingface/uv.lock` — self-package `version` → `0.1.1.post2` (version-only)

## Test plan

Ran the merge gate's relevant checks locally (`screamingface-tests.yml`):

- `uv lock --check` → passes (exit 0)
- `uv build` → `screamingface-0.1.1.post2.tar.gz` + `-py3-none-any.whl`
- `uv run python scripts/check_distribution.py` → exit 0
- `awk` version guard (release `verify` equivalence) extracts `0.1.1.post2` from `pyproject.toml`