### PR TITLE
fix(aigateway): map 402 to a dedicated insufficient-credits error

### DIFF
--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/dispatch_errors.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/dispatch_errors.py
@@ -126,15 +126,24 @@ def _embedded_error_exception(status: int | None) -> HTTPException:
     """
     resolved = status if status is not None else 502
     code = "provider_error"
+    message = "OpenRouter reported a provider error"
     if resolved == 401:
         code = "auth_required"
     elif resolved == 400:
         code = "bad_request"
+    elif resolved == 402:
+        # OME-927: OpenRouter reports out-of-credits as a top-level
+        # `payment_required`/402 error embedded in the response body (see
+        # response_errors.py), not a raw HTTP 402 — that shape never reaches
+        # chat_dispatch.py's own status→code mapping, so it needs the same
+        # dedicated code+message here.
+        code = "insufficient_credits"
+        message = "The upstream provider reported insufficient credits."
     elif resolved == 429:
         code = "rate_limited"
     elif resolved >= 500 and status is not None:
         code = "provider_unavailable"
     return _EmbeddedProviderBodyError(
         status_code=resolved,
-        detail={"code": code, "message": "OpenRouter reported a provider error"},
+        detail={"code": code, "message": message},
     )

--- a/apps/aigateway/src/aigateway/routes/chat_dispatch.py
+++ b/apps/aigateway/src/aigateway/routes/chat_dispatch.py
@@ -189,6 +189,10 @@ _PROVIDER_ERROR_MESSAGE = {
     "rate_limited": "The upstream provider is rate limiting requests.",
     "provider_unavailable": "The upstream provider is temporarily unavailable.",
     "provider_error": "The upstream provider returned an error.",
+    # OME-927: a 402 (out of credits) is not a generic provider fault — the
+    # status itself is safe to name (it carries no provider text), so the
+    # dedicated message tells the caller they need to top up, without str(exc).
+    "insufficient_credits": "The upstream provider reported insufficient credits.",
 }
 
 
@@ -212,6 +216,8 @@ def _provider_error_code(status: int, *, validated: bool) -> str:
         return "bad_request"
     if status == 401:
         return "auth_required"
+    if status == 402:
+        return "insufficient_credits"
     if status == 429:
         return "rate_limited"
     if validated and status >= 500:

--- a/apps/aigateway/tests/unit/core/test_litellm_http_exception_sanitize.py
+++ b/apps/aigateway/tests/unit/core/test_litellm_http_exception_sanitize.py
@@ -48,7 +48,7 @@ def _detail(out: HTTPException) -> dict[str, Any]:
     [
         (400, "bad_request"),
         (401, "auth_required"),
-        (402, "provider_error"),
+        (402, "insufficient_credits"),
         (429, "rate_limited"),
         (500, "provider_unavailable"),
         (503, "provider_unavailable"),
@@ -65,6 +65,21 @@ def test_recognized_status_maps_to_code_without_leaking_raw_text(
     # Gateway-authored message only — the raw provider text must never surface.
     assert _SECRET not in detail["message"]
     assert str(detail["message"])  # a non-empty, human-readable message exists
+
+
+def test_402_surfaces_a_dedicated_insufficient_credits_message() -> None:
+    """OME-927: a 402 (out-of-credits) must not read as a generic provider fault.
+
+    FEATURE: insufficient-credits surfacing. Distinct from the parametrized
+    code-mapping check above — this pins the exact client-facing wording so the
+    UI text itself is covered, not merely the machine ``code``.
+    """
+    out = _litellm_http_exception(_FakeLLMError(402, _SECRET))
+    detail = _detail(out)
+    assert out.status_code == 402
+    assert detail["code"] == "insufficient_credits"
+    assert detail["message"] == "The upstream provider reported insufficient credits."
+    assert _SECRET not in detail["message"]
 
 
 def test_malformed_string_status_degrades_to_502_never_raises() -> None:

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_error_policy.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_error_policy.py
@@ -355,7 +355,12 @@ def test_embedded_top_level_error_is_sanitized_and_does_not_invalidate(
         resp = _post_chat(authenticated_client)
 
     assert resp.status_code == 402
-    assert resp.json()["detail"]["code"] == "provider_error"
+    # OME-927: a 402 gets its own dedicated code/message instead of the generic
+    # "provider_error" fallback, so the client can tell the caller to top up.
+    assert resp.json()["detail"]["code"] == "insufficient_credits"
+    assert (
+        resp.json()["detail"]["message"] == "The upstream provider reported insufficient credits."
+    )
     # Raw provider message/metadata is discarded, never echoed.
     assert "Insufficient credits" not in resp.text
     assert "secret-internal-router" not in resp.text

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py
@@ -225,7 +225,7 @@ def test_toplevel_malformed_status_sanitized_to_502_never_500(
     ("status", "expected_status", "expected_code"),
     [
         (400, 400, "bad_request"),
-        (402, 402, "provider_error"),
+        (402, 402, "insufficient_credits"),
         (403, 403, "provider_error"),
         (408, 408, "provider_error"),
         (500, 500, "provider_unavailable"),
@@ -253,6 +253,36 @@ def test_toplevel_billing_and_client_statuses_single_dispatch_sanitized(
     assert calls["n"] == 1
     assert resp.status_code == expected_status
     assert resp.json()["detail"]["code"] == expected_code
+    assert _SECRET not in resp.text
+
+
+def test_toplevel_402_surfaces_a_dedicated_insufficient_credits_message(
+    enabled_openrouter,
+    fast_retries,
+    credential_blobs,
+    authenticated_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OME-927: OpenRouter reports out-of-credits as a top-level ``payment_required``
+    error embedded in a nominal HTTP-200 body (this module's own docstring) — the
+    exact shape the ticket's lead example describes. Pin the client-facing wording
+    through THIS path specifically, since it is a separate status→code mapping
+    (``_embedded_error_exception``) from the generic transport-exception one
+    covered in ``test_litellm_http_exception_sanitize.py``.
+
+    FEATURE: insufficient-credits surfacing.
+    """
+    _create_connection(authenticated_client, "work-or")
+
+    calls = {"n": 0}
+    _counting_wire(lambda: _wire_response(200, _top_level_error(402, _SECRET)), calls, monkeypatch)
+    resp = _post_chat(authenticated_client)
+
+    assert calls["n"] == 1
+    assert resp.status_code == 402
+    detail = resp.json()["detail"]
+    assert detail["code"] == "insufficient_credits"
+    assert detail["message"] == "The upstream provider reported insufficient credits."
     assert _SECRET not in resp.text
 
 

--- a/docs/tasks/2026-08-21-OME-927-insufficient-credits-error.md
+++ b/docs/tasks/2026-08-21-OME-927-insufficient-credits-error.md
@@ -22,4 +22,4 @@ embedded-in-200-body error mapping (`openrouter_provider/dispatch_errors.py`), s
 Canonical artifacts:
 
 - Ledger: `docs/work/2026-08-21-OME-927-insufficient-credits-error.md`
-- PR: (opened once implementation lands)
+- PR: https://github.com/ScreamingFace/screamingface/pull/679 (open, CI pending)

--- a/docs/tasks/2026-08-21-OME-927-insufficient-credits-error.md
+++ b/docs/tasks/2026-08-21-OME-927-insufficient-credits-error.md
@@ -1,0 +1,25 @@
+---
+id: OME-927
+linear_url: https://linear.app/openmined/issue/OME-927/surface-a-meaningful-upstream-error-ideally-the-providers-own-when-a
+status: In Progress
+type: Task
+priority: Medium
+labels: [aigateway, agentic, autonomous]
+created: 2026-08-21
+closed:
+---
+
+# Surface a meaningful upstream error when a run runs out of credits
+
+A run that exhausts upstream provider credits reports a generic
+`candidate · case_execution_failed — The upstream provider returned an error.` instead of
+telling the user they need to top up. Implementing the ticket's Option 2 fallback: map HTTP 402
+to a dedicated `insufficient_credits` code/message in aigateway's error sanitizer — in **both**
+the generic transport-error mapping (`chat_dispatch.py`) and OpenRouter's separate
+embedded-in-200-body error mapping (`openrouter_provider/dispatch_errors.py`), since OpenRouter
+— the ticket's own lead example — reports insufficient-credits through the latter path only.
+
+Canonical artifacts:
+
+- Ledger: `docs/work/2026-08-21-OME-927-insufficient-credits-error.md`
+- PR: (opened once implementation lands)

--- a/docs/work/2026-08-21-OME-927-insufficient-credits-error.md
+++ b/docs/work/2026-08-21-OME-927-insufficient-credits-error.md
@@ -1,0 +1,140 @@
+---
+ticket: OME-927
+stack: aigateway
+status: done
+started: 2026-08-21
+finished: 2026-08-21
+---
+
+# OME-927 — Surface a meaningful upstream error when a run runs out of credits
+
+## Intent
+
+When a run exhausts the upstream provider's credits, the client currently reports
+`candidate · case_execution_failed — The upstream provider returned an error.` — a generic
+string that hides the real cause. Ship the ticket's Option 2 fallback: map HTTP 402
+(insufficient credits) to a dedicated `insufficient_credits` code + message, so the client
+renders `The upstream provider reported insufficient credits.` instead of the generic
+`provider_error` text. Never serialize `str(exc)` (FINDING B invariant stays intact).
+
+## Root-cause tracing (beyond the ticket's own root-cause note)
+
+The ticket's "Root cause" section names one mapping function —
+`apps/aigateway/src/aigateway/routes/chat_dispatch.py::_provider_error_code()` — as the sole
+place a `402` falls through to the generic `provider_error` code. Tracing the actual dispatch
+paths shows there are **two independent status→code mappings**, and the ticket's own primary
+example (OpenRouter) is produced by the *second* one, not the first:
+
+1. `chat_dispatch.py::_provider_error_code()` (called from `_litellm_http_exception`) — the
+   generic path for a genuine LiteLLM/transport exception carrying `status_code`. This is what
+   a raw-HTTP-402 provider (e.g. Anthropic's `billing_error`, which litellm surfaces via a
+   caught exception type) goes through.
+2. `apps/aigateway/src/aigateway/plugins/openrouter_provider/dispatch_errors.py::_embedded_error_exception()`
+   — a **second, separate** status→code mapping, hardcoded in the OpenRouter plugin. OpenRouter
+   reports insufficient-credits as a `payment_required`/`402` error **embedded in an HTTP-200
+   response body** (`response_errors.py::find_converted_error`/`find_raw_error`), not as a raw
+   HTTP 402 status. `plugin.py::chat_completion` routes that embedded error through
+   `_embedded_error_exception(status)`, which has its own independent `if/elif` status ladder
+   that also falls through to `provider_error` for 402 today.
+
+Confirmed by the existing test
+`apps/aigateway/tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py::test_toplevel_billing_and_client_statuses_single_dispatch_sanitized`
+which already parametrizes `(402, 402, "provider_error")` for exactly this embedded-402 shape.
+
+**Consequence:** fixing only `chat_dispatch.py` (as the ticket's own "Suggested fix" section
+describes) would NOT fix the OpenRouter case the ticket cites as its lead example — it would
+only fix a raw-transport 402 from some other provider. Both mappings must be updated together,
+or the fix is incomplete for the primary scenario.
+
+Confirmed the message is safe to reach the client end-to-end:
+`chat_dispatch.py` detail dict → `screamingface_engine/runner/connector.py::_raise_for_status`
+(reads `detail.code`/`detail.message` into `ResolutionError`) →
+`screamingface_engine/benchmarks/aggregation.py::public_error()` (passes through a `code`
+matching `_public_identifier`'s `[A-Za-z0-9_.:-]+` regex) →
+`screamingface_engine/benchmarks/draco/aggregate.py::_row_failure` (stage="candidate") →
+`packages/screamingface/src/screamingface/_ui/report_view.py` (prints `stage · code — message`
+verbatim). `insufficient_credits` is a valid identifier for every hop; no changes needed outside
+`apps/aigateway`.
+
+Verified out of scope / unaffected by this change:
+- `apps/aigateway/src/aigateway/plugins/taxonomy/classify.py::outcome_for_status` — the
+  usage-accounting outcome bucket is derived from the raw HTTP status only, never from the
+  client-facing `code` string, so accounting/taxonomy is untouched.
+- `_should_mark_profile_error_on_dispatch_status` / OAuth-connection-error marking — keyed on
+  the HTTP status (still 402), not on the code string, so credential-health behavior is
+  unchanged.
+- `core/api_key_validation.py` `NO_QUOTA` detection (OpenRouter `payment_required` / Anthropic
+  `billing_error`) — a separate, pre-existing feature (proactive credential health check), not
+  the live-dispatch error path this ticket is about.
+
+## Planned changes
+
+- `apps/aigateway/src/aigateway/routes/chat_dispatch.py`
+  - `_provider_error_code()`: add a `status == 402` branch returning `"insufficient_credits"`.
+  - `_PROVIDER_ERROR_MESSAGE`: add `"insufficient_credits": "The upstream provider reported insufficient credits."`.
+- `apps/aigateway/src/aigateway/plugins/openrouter_provider/dispatch_errors.py`
+  - `_embedded_error_exception()`: add the same `402 → insufficient_credits` branch, with the
+    same client-facing message text (kept as a local literal — this module already authors its
+    own strings independently of `chat_dispatch._PROVIDER_ERROR_MESSAGE`, and unifying that is
+    a larger refactor out of scope here).
+
+## Test plan
+
+- `apps/aigateway/tests/unit/core/test_litellm_http_exception_sanitize.py`: update the existing
+  `(402, "provider_error")` parametrized case to `(402, "insufficient_credits")` — it already
+  asserts no secret leak and a non-empty message, so the parametrize update covers the new
+  branch under the same invariants.
+- `apps/aigateway/tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py`: update
+  the existing `(402, 402, "provider_error")` case in
+  `test_toplevel_billing_and_client_statuses_single_dispatch_sanitized` to
+  `(402, 402, "insufficient_credits")`.
+- New assertions (in one of the above, or a new focused test) confirming the exact client-facing
+  message text `"The upstream provider reported insufficient credits."` is returned for a 402,
+  through both dispatch paths, with no secret/raw-provider-text leak.
+
+## Acceptance
+
+- A raw-transport 402 (any provider) and an OpenRouter embedded-402 both surface
+  `{"code": "insufficient_credits", "message": "The upstream provider reported insufficient credits."}`
+  to the aigateway caller.
+- No other status code's mapping changes (400/401/429/5xx/unclassified all keep their existing
+  code + message).
+- `str(exc)` / raw provider text is never present in the response (existing sanitizer tests
+  keep passing unmodified).
+- Full aigateway gate suite green: ruff check, ruff format --check, pyright,
+  check_no_enterprise.py, pytest (--cov-fail-under=80).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** exactly as planned —
+  `apps/aigateway/src/aigateway/routes/chat_dispatch.py`,
+  `apps/aigateway/src/aigateway/plugins/openrouter_provider/dispatch_errors.py`, plus 3 test
+  files (`tests/unit/core/test_litellm_http_exception_sanitize.py`,
+  `tests/unit/openrouter/test_openrouter_toplevel_conversion_retry.py`,
+  `tests/unit/openrouter/test_openrouter_error_policy.py`).
+- **Commits:** filed as a PR from branch `ome-927-insufficient-credits` off `origin/main`
+  (base `0323a7bc`) — see PR link in the docs/tasks mirror once opened.
+- **Gates:** `uv run .claude/scripts/run_gates.py aigateway --skip-append-only` → ALL GATES
+  GREEN (ruff check, ruff format --check, pyright, check_no_enterprise.py, pytest
+  --cov=aigateway --cov-fail-under=80 — 892 passed). `--skip-append-only` used with explicit
+  user confirmation (see Deviations).
+  **Live verification (beyond the gate suite):** ran the fixed build locally
+  (`AIGW_AUTH_MODE=disabled`, `AIGW_OPENROUTER_ENABLED=true`, scratch SQLite DB, migrations
+  applied), registered a real OpenRouter API key confirmed to carry zero credit, and sent a
+  genuine `/v1/chat/completions` request through it. Response: `HTTP 402`,
+  `{"code": "insufficient_credits", "message": "The upstream provider reported insufficient
+  credits."}` — confirms the fix end-to-end against the real provider, not just mocked tests.
+  Scratch DB and server torn down after the check; no credential persisted anywhere durable.
+- **Deviations:**
+  1. Root-cause tracing found the fix needed **two** source files, not the one the ticket's
+     "Suggested fix" section names — see the ledger's "Root-cause tracing" section above.
+     OpenRouter (the ticket's own lead example) reports insufficient-credits through a
+     *separate* status→code mapping (`openrouter_provider/dispatch_errors.py`) than the one
+     the ticket cites (`chat_dispatch.py`); both were updated together.
+  2. Three **prior** tests asserted the literal `402 → "provider_error"` bug behavior and had
+     to change to `"insufficient_credits"` to reflect the ticket's requested fix. This tripped
+     the repo's automated append-only-test gate (sdlc rule 5), which is a hard STOP by design.
+     Paused and asked the user for explicit confirmation before overriding with
+     `--skip-append-only`; user confirmed "Yes, update all 3" before the gate was re-run.
+  3. One incidental `ruff format` line-length fix in
+     `test_openrouter_error_policy.py` (wrapping a long assert), unrelated to the logic change.


### PR DESCRIPTION
## Summary

- A run that exhausted upstream provider credits surfaced a generic `candidate · case_execution_failed — The upstream provider returned an error.` instead of telling the user they need to top up.
- Adds a `402 → insufficient_credits` branch to **both** of aigateway's independent status→code mappings — `chat_dispatch.py::_provider_error_code` (generic transport exceptions) and `openrouter_provider/dispatch_errors.py::_embedded_error_exception` (OpenRouter's own embedded-in-HTTP-200-body error shape, which is how OpenRouter — the ticket's lead example — actually reports insufficient credits). Root-cause tracing showed the ticket's own "Suggested fix" section named only the first of these; fixing just that one would not have fixed the OpenRouter case it cites.
- Both now return `{"code": "insufficient_credits", "message": "The upstream provider reported insufficient credits."}`. FINDING B (never serialize `str(exc)`) is untouched — the message stays gateway-authored.
- This is the ticket's Option 2 (fallback) fix, not Option 1 (relaying the provider's own sanitized text) — scoped as a small, low-risk PR per the ticket's own acceptance criteria.

## Test plan

- [x] Updated 2 pre-existing parametrized test rows + 1 pre-existing regression test that pinned the literal `402 → "provider_error"` bug behavior (all 3 are exactly the behavior this PR changes — confirmed with the user before overriding the repo's automated append-only-test gate).
- [x] Added 2 new dedicated tests pinning the exact client-facing message text, one per mapping function.
- [x] Full `apps/aigateway` gate suite green: `ruff check`, `ruff format --check`, `pyright`, `check_no_enterprise.py`, `pytest --cov=aigateway --cov-fail-under=80` (892 tests).
- [x] **Live-verified against the real OpenRouter API**: ran the fixed build locally (`AIGW_AUTH_MODE=disabled`), registered a real OpenRouter API key with zero credit, and sent an actual `/v1/chat/completions` request through it — got back `HTTP 402` with the exact `insufficient_credits` code/message, confirming the fix works end-to-end and not only under mocks.

Refs: OME-927