### PR TITLE
fix(screamingface): always deliver connection-panel completions

### DIFF
--- a/docs/tasks/2026-08-21-OME-926-connection-panel-completion-dispatch.md
+++ b/docs/tasks/2026-08-21-OME-926-connection-panel-completion-dispatch.md
@@ -1,0 +1,34 @@
+---
+id: OME-926
+linear_url: https://linear.app/openmined/issue/OME-926/keep-sfconnect-from-getting-stuck-on-checking-when-a-notebook-event
+status: In Review
+priority: High
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-21
+closed:
+---
+
+# Keep sf.connect() from getting stuck on "checking" when a notebook event loop changes
+
+In Google Colab the documented no-argument `sf.connect()` can sit forever on
+"ScreamingFace Hosted Engine · checking". The same Cloudflare Access discovery completes in
+~0.2s in standard Jupyter against the same healthy hosted Engine.
+
+Root cause, confirmed on the issue with a deterministic harness
+(`worker_finished=True, captured_loop_closed=True, access_check_pending=True`):
+`ConnectionPanel.widget()` caches the asyncio loop live at render time, then posts the
+discovery result back with `loop.call_soon_threadsafe(...)` from a daemon thread. When the
+notebook host has closed or replaced that loop, the call raises `RuntimeError`, which is
+swallowed with a bare `return` — the completion never lands and `access_check_pending`
+stays `True`. `access_status()` then reports `checking` forever, and the "Checking…" button
+is rendered disabled, so the user has no way out.
+
+The same "the captured loop is still alive" assumption is repeated in login completion and
+the cross-panel auth broadcast, which is why the fix is one shared completion dispatcher
+rather than three patches. Colab churns its event loop where Jupyter does not; the fix
+removes the dependency on loop identity instead of branching on the host.
+
+Canonical artifacts:
+
+- Ledger: `docs/work/2026-08-21-OME-926-connection-panel-completion-dispatch.md`
+- PR: (pending)

--- a/docs/work/2026-08-21-OME-926-connection-panel-completion-dispatch.md
+++ b/docs/work/2026-08-21-OME-926-connection-panel-completion-dispatch.md
@@ -1,0 +1,123 @@
+---
+ticket: OME-926
+stack: screamingface
+status: done
+started: 2026-08-21
+finished: 2026-08-21
+---
+
+# OME-926 — one completion dispatcher for ConnectionPanel background work
+
+## Intent
+
+`sf.connect()` in Colab can remain forever on "checking". `ConnectionPanel` caches the
+asyncio loop live at `widget()` time and posts every background completion back to *that*
+loop via `call_soon_threadsafe`; when the notebook host has closed or replaced it, the call
+raises `RuntimeError` which is swallowed with a bare `return`, so `access_check_pending`
+never clears. Replace loop-identity dependence with one dispatcher that always runs the
+completion, so Colab and Jupyter expose the same user-visible transitions.
+
+FEATURE: hosted-Engine connection panel (`sf.connect()`).
+STORY: as a Colab user, I run `sf.connect()` and reach Log in / provider rows / a readable
+error — never a permanent "checking".
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_ui/connections.py`
+  - new `_dispatch(callback, *args)` helper: live loop resolved **at post time** →
+    else cached `self._loop` if open → else run inline on the calling thread.
+    INVARIANT: every path ends with the completion actually running.
+  - route `_start_access_check_thread` (:309-336), `_start_login_thread` (:354-377) and
+    `_auth_state_changed` (:395-404) through it; audit `_start_oauth` (:226-236) and keep
+    its behaviour.
+  - drop the silent `weakref` completion drop (:323-325).
+  - `_repr_html_` (:146-152) must not render a stuck `checking` — it never starts the probe.
+- `packages/screamingface/src/screamingface/_ui/connection_view.py` — stop rendering the
+  "Checking…" button `disabled = True` (:242-245), so a hung probe stays recoverable.
+- `packages/screamingface/tests/test_connection_panel.py` — tests (append-only).
+
+Out of scope per the issue: Cloudflare auth, provider-connection contracts, other widgets.
+`sf.connect()` stays non-blocking. No schema/model change, so S1 does not apply.
+
+## Test plan
+
+RED first, reusing `_panel`/`_text`/`_wait_for_button`/`_buttons` (:66-150) and
+`_SharedAuthClient` (:110-149); styled after
+`test_unexpected_login_failure_does_not_leave_panel_waiting` (:816-834). No prior test is
+modified.
+
+- **Regression guard:** render the real controller, close/replace the rendering loop before
+  Access discovery completes, assert the panel leaves "checking".
+- Access-required / unprotected-Engine / discovery-**error** each reach the right terminal
+  state (the error path is currently untested).
+- Login completion cannot remain on "Cancel" solely because the rendering loop changed.
+- Module-level `sf.connect()` entrypoint (`_default_client.py:121-171`), not just the
+  internal helper — explicitly required by the issue's acceptance.
+- `_repr_html_` while `access_check_pending` does not render a stuck `checking`.
+- Existing Jupyter connection + OAuth tests stay green and unmodified.
+
+Baseline before this unit: `Checking…`, `checking`, `access_check_pending`,
+`_start_access_check`, `_complete_access_check` appear **nowhere** in `tests/`.
+
+## Acceptance
+
+- The regression guard fails before the fix and passes after.
+- All six issue acceptance bullets covered by a test.
+- `uv run .claude/scripts/run_gates.py screamingface` green, including
+  `--cov-fail-under=95`, the notebook determinism check, and the distribution check.
+
+## Outcome
+
+- **Actual files:**
+  - NEW `src/screamingface/_ui/loop_dispatch.py` (80) — `_CompletionDispatcher`. Planned as
+    an inline `_dispatch` helper; extracted on owner approval because the inline version
+    pushed `connections.py` to 485 lines against the loop's ≤450 rule (it was already 454
+    on `origin/main`). Now 439.
+  - `src/screamingface/_ui/connections.py` — three call sites routed through the
+    dispatcher; both `except RuntimeError: return` swallows deleted; the dead `loop`
+    parameter dropped from both thread starters; `_start_access_check` re-renders after
+    marking the probe started.
+  - `src/screamingface/_ui/connection_state.py` — `checking` requires
+    `access_check_pending AND access_check_started`.
+  - `tests/test_connection_panel.py` — 8 tests added (+1 prior test retargeted, below).
+  - `src/screamingface/_runtime/server.py` — unplanned, owner-approved: see Deviations.
+
+- **Commits:** see PR.
+
+- **Gates:** `run_gates.py screamingface --skip-append-only` — ALL GATES GREEN.
+  1017 passed, 1 skipped; coverage 95.40% (gate 95%). ruff · ruff format · pyright ·
+  notebook determinism · `uv build` · distribution check all green.
+
+- **Deviations:**
+  1. **Dispatcher extracted to its own module** rather than inlined — owner-approved, to
+     satisfy the ≤450-line rule. Gives the issue's "one completion-dispatch mechanism" a
+     named home.
+  2. **One prior test modified** — `panel._loop = stale_loop` →
+     `panel._dispatcher.adopt(stale_loop)` in the OAuth live-loop test (~:363). Injection
+     handle only; scenario and every assertion unchanged, still passing. Raised as a rule-5
+     Confidence-Gate decision and approved before editing. Gates therefore run with
+     `--skip-append-only`, the runner's documented path.
+  3. **`_runtime/server.py:177` typed `app: Any`** — unrelated to OME-926 and outside the
+     issue's scope, fixed here on owner approval. `app: object` typechecked only while
+     uvicorn was absent; CI installs `--extra notebook` (uvicorn lives in `runtime`) so CI
+     never saw it, while the local gate runner installs uvicorn and failed on clean
+     `origin/main`. A local gate red on main trains people to ignore it, so it was worth
+     clearing. **Latent gate-fidelity gap remains: the local runner and CI do not install
+     the same extras.** Worth its own issue.
+  4. **Retry affordance NOT implemented.** The plan floated making the disabled "Checking…"
+     button clickable. Dropped: the issue's acceptance is scoped to completions that have
+     *finished* ("never remain pending after the background operation has completed"), which
+     the dispatcher fully satisfies. A genuinely hung probe is a different defect, and a
+     live button needs retry machinery nothing yet demands (YAGNI). `disabled = True` stands.
+  5. **`weakref` completion drop left alone.** The plan listed removing it; on reading, a
+     GC'd or `_closed` panel has nothing to render, so returning there is correct. Only the
+     `RuntimeError` path was the bug.
+
+- **Not reproduced locally in Colab.** The regression guard reproduces the reported state
+  deterministically (render on a loop, close it, then release the probe), which is what the
+  issue's acceptance asks for. A real Colab pass is still worth doing — see Owner-verify.
+
+- **Latent, unfixed (flagged per plan):** `AsyncClient._access_required` is `async def`
+  (`client.py:473-475`) but `_start_access_check` only checks `callable(...)`, so a coroutine
+  would read truthy ⇒ "access required", never awaited. Unreachable today —
+  `ConnectionPanel` is only built from the sync `Client` (`client.py:288-294`).

--- a/docs/work/2026-08-21-OME-926-connection-panel-completion-dispatch.md
+++ b/docs/work/2026-08-21-OME-926-connection-panel-completion-dispatch.md
@@ -70,54 +70,78 @@ Baseline before this unit: `Checking…`, `checking`, `access_check_pending`,
 
 - **Actual files:**
   - NEW `src/screamingface/_ui/loop_dispatch.py` (80) — `_CompletionDispatcher`. Planned as
-    an inline `_dispatch` helper; extracted on owner approval because the inline version
-    pushed `connections.py` to 485 lines against the loop's ≤450 rule (it was already 454
-    on `origin/main`). Now 439.
+    an inline helper; extracted on owner approval because inlining pushed
+    `connections.py` to 485 lines against the loop's ≤450 rule (already 454 on
+    `origin/main`). Now 440.
   - `src/screamingface/_ui/connections.py` — three call sites routed through the
     dispatcher; both `except RuntimeError: return` swallows deleted; the dead `loop`
     parameter dropped from both thread starters; `_start_access_check` re-renders after
     marking the probe started.
   - `src/screamingface/_ui/connection_state.py` — `checking` requires
-    `access_check_pending AND access_check_started`.
-  - `tests/test_connection_panel.py` — 8 tests added (+1 prior test retargeted, below).
+    `access_check_pending AND access_check_started`; hosts `_sync_access_probe`.
+  - `tests/test_connection_panel.py` — 9 tests added (+1 prior test retargeted).
   - `src/screamingface/_runtime/server.py` — unplanned, owner-approved: see Deviations.
 
-- **Commits:** see PR.
+- **Commits:** `6f8540ac` server.py typing · `47d260a7` completion dispatcher ·
+  `f6536f30` async-probe guard. PR #680.
 
 - **Gates:** `run_gates.py screamingface --skip-append-only` — ALL GATES GREEN.
-  1017 passed, 1 skipped; coverage 95.40% (gate 95%). ruff · ruff format · pyright ·
-  notebook determinism · `uv build` · distribution check all green.
+  1018 passed, 1 skipped; coverage ≥95% (gate 95%).
+
+- **VERIFIED IN COLAB.** The owner ran the branch in Google Colab: the panel left
+  "checking" and reached "login required" with a Log in button. This also retires the
+  open risk that the inline-completion path might not repaint from a worker thread — it
+  does.
 
 - **Deviations:**
   1. **Dispatcher extracted to its own module** rather than inlined — owner-approved, to
      satisfy the ≤450-line rule. Gives the issue's "one completion-dispatch mechanism" a
      named home.
   2. **One prior test modified** — `panel._loop = stale_loop` →
-     `panel._dispatcher.adopt(stale_loop)` in the OAuth live-loop test (~:363). Injection
-     handle only; scenario and every assertion unchanged, still passing. Raised as a rule-5
-     Confidence-Gate decision and approved before editing. Gates therefore run with
-     `--skip-append-only`, the runner's documented path.
-  3. **`_runtime/server.py:177` typed `app: Any`** — unrelated to OME-926 and outside the
-     issue's scope, fixed here on owner approval. `app: object` typechecked only while
-     uvicorn was absent; CI installs `--extra notebook` (uvicorn lives in `runtime`) so CI
-     never saw it, while the local gate runner installs uvicorn and failed on clean
-     `origin/main`. A local gate red on main trains people to ignore it, so it was worth
-     clearing. **Latent gate-fidelity gap remains: the local runner and CI do not install
-     the same extras.** Worth its own issue.
-  4. **Retry affordance NOT implemented.** The plan floated making the disabled "Checking…"
-     button clickable. Dropped: the issue's acceptance is scoped to completions that have
-     *finished* ("never remain pending after the background operation has completed"), which
-     the dispatcher fully satisfies. A genuinely hung probe is a different defect, and a
-     live button needs retry machinery nothing yet demands (YAGNI). `disabled = True` stands.
+     `panel._dispatcher.adopt(stale_loop)` in the OAuth live-loop test. Injection handle
+     only; scenario and every assertion unchanged. Raised as a rule-5 Confidence-Gate
+     decision and approved before editing. Gates therefore run `--skip-append-only`.
+  3. **`_runtime/server.py` typed `app: Any`** — unrelated to OME-926, owner-approved.
+     **Correction to an earlier claim in this ledger:** this was first justified as
+     needed to make the local gates pass. That was wrong. The pyright error appeared only
+     in a *stale shared-checkout venv* that had uvicorn installed from an earlier
+     `--extra runtime` run; a clean venv (and CI, which installs only `--extra notebook`)
+     never saw it. The annotation is genuinely wrong on its own merits — `object`
+     satisfies none of `uvicorn.Config`'s `app` types — so the fix stands, but it was
+     never gate-blocking. The commit message was rewritten to say so.
+  4. **Retry affordance NOT implemented.** The plan floated making the disabled
+     "Checking…" button clickable. Dropped: the issue's acceptance covers completions that
+     have *finished*, which the dispatcher fully satisfies. A hung probe is a different
+     defect and a live button needs retry machinery nothing yet demands (YAGNI).
   5. **`weakref` completion drop left alone.** The plan listed removing it; on reading, a
-     GC'd or `_closed` panel has nothing to render, so returning there is correct. Only the
-     `RuntimeError` path was the bug.
+     GC'd or `_closed` panel has nothing to render, so returning there is correct. Only
+     the `RuntimeError` path was the bug.
+  6. **Async-probe guard bundled into this unit** rather than filed separately —
+     owner-approved. `AsyncClient._access_required` is `async def` while
+     `_start_access_check` checked only `callable(...)`, so the coroutine read truthy ⇒
+     "access required" for every Engine, never awaited. `_sync_access_probe` now also
+     gates on `iscoroutinefunction`, and both the initial state and the check resolve
+     through it so they cannot disagree. Unreachable today (`ConnectionPanel` is built
+     only from the sync `Client`).
 
-- **Not reproduced locally in Colab.** The regression guard reproduces the reported state
-  deterministically (render on a loop, close it, then release the probe), which is what the
-  issue's acceptance asks for. A real Colab pass is still worth doing — see Owner-verify.
+- **Process error, recorded:** several `git stash push/pop` cycles were used to compare
+  against `origin/main`. Stashes are shared across worktrees, and one `pop` applied an
+  unrelated pre-existing stash (`codex-preserve-before-main-pull-2026-08-20`) into this
+  worktree, leaving conflict markers in `client.py` and `tests/test_leaderboards.py`.
+  Recovered with no loss: that stash was never dropped (a conflicted apply preserves it)
+  and remains at `stash@{0}`; this branch's commits were already on `origin`. **Do not use
+  bare `git stash` to diff against a base in this repo — use `git worktree` or
+  `git show`/`git diff <ref>` instead.**
 
-- **Latent, unfixed (flagged per plan):** `AsyncClient._access_required` is `async def`
-  (`client.py:473-475`) but `_start_access_check` only checks `callable(...)`, so a coroutine
-  would read truthy ⇒ "access required", never awaited. Unreachable today —
-  `ConnectionPanel` is only built from the sync `Client` (`client.py:288-294`).
+- **Discovered, NOT in scope — needs its own issue:** clicking **Log in** in Colab opens
+  nothing. `_present_access_authorization` (`_access/contract.py:101`) `print()`s the
+  authorization URL — from a worker thread inside a widget callback, so it is invisible in
+  Colab — and then calls `webbrowser.open` only when `_running_in_notebook()` is False.
+  That check requires the shell class module to start with `ipykernel`
+  (`_access/contract.py:180-188`), but Colab's is `google.colab._shell`, so Colab tries to
+  open a browser **on the Colab VM**. The real fix is a presenter seam so the panel renders
+  the URL as a link rather than writing it to stdout. Workaround: call `client.login()`
+  directly in a cell.
+
+- **Latent, unfixed:** none remaining from the plan — the `AsyncClient` coroutine trap
+  listed there was fixed here (Deviation 6).

--- a/packages/screamingface/src/screamingface/_runtime/server.py
+++ b/packages/screamingface/src/screamingface/_runtime/server.py
@@ -174,7 +174,11 @@ def run_scoreboard(config: RuntimeConfig) -> None:
     )
 
 
-def _server(app: object, port: int, name: str) -> Server:
+def _server(app: Any, port: int, name: str) -> Server:
+    # WHY: the ASGI app comes from _build_apps via the optional "runtime" extra, so its
+    # static type is unavailable whenever that extra is not installed (as in CI). `object`
+    # typechecked only while uvicorn was absent — with the extra installed, pyright
+    # rejected it against uvicorn.Config's ASGIApplication parameter.
     import uvicorn  # pyright: ignore[reportMissingImports]
 
     return _EmbeddedServer(

--- a/packages/screamingface/src/screamingface/_ui/connection_state.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_state.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import inspect
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 if TYPE_CHECKING:
     from screamingface.connections import Connection
@@ -44,6 +46,22 @@ class _ConnectionPanelState:
 def _user_message(error: Exception) -> str:
     message = getattr(error, "user_message", None)
     return message if isinstance(message, str) else str(error)
+
+
+def _sync_access_probe(client: object) -> Callable[[], bool] | None:
+    """The client's synchronous Access probe, or None when it has none usable here.
+
+    WHY: ``AsyncClient._access_required`` is ``async def``. Calling it returns a coroutine
+    — which is truthy — so a bare ``callable()`` check reports "access required" for every
+    Engine and leaves the coroutine un-awaited. ConnectionPanel is a synchronous surface,
+    so an async probe is treated as absent rather than mis-read.
+    INVARIANT: only a probe that returns a real bool synchronously is ever invoked.
+    """
+
+    probe = getattr(client, "_access_required", None)
+    if not callable(probe) or inspect.iscoroutinefunction(probe):
+        return None
+    return cast(Callable[[], bool], probe)
 
 
 __all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_ui/connection_state.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_state.py
@@ -27,7 +27,10 @@ class _ConnectionPanelState:
     flows: dict[str, object] = field(default_factory=dict)
 
     def access_status(self, *, authenticated: bool, authenticating: bool) -> str:
-        if self.access_check_pending:
+        # INVARIANT: "checking" means a probe is in flight. A pending-but-unstarted
+        # check has nothing driving it (the static _repr_html_ path never starts one),
+        # so it must report the resolved state rather than a status nothing will clear.
+        if self.access_check_pending and self.access_check_started:
             status = "checking"
         elif self.access_pending or authenticating:
             status = "waiting"

--- a/packages/screamingface/src/screamingface/_ui/connections.py
+++ b/packages/screamingface/src/screamingface/_ui/connections.py
@@ -8,7 +8,11 @@ import weakref
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
 
-from screamingface._ui.connection_state import _ConnectionPanelState, _user_message
+from screamingface._ui.connection_state import (
+    _ConnectionPanelState,
+    _sync_access_probe,
+    _user_message,
+)
 from screamingface._ui.connection_view import (
     _NotebookConnectionView,
     _provider_status,
@@ -89,9 +93,7 @@ class ConnectionPanel:
             # reports that it does not require Cloudflare Access.
             provider_mutations_enabled=not hosted,
             access_check_pending=(
-                hosted
-                and not client.authenticated
-                and callable(getattr(client, "_access_required", None))
+                hosted and not client.authenticated and _sync_access_probe(client) is not None
             ),
         )
         if not hosted or client.authenticated:
@@ -284,8 +286,8 @@ class ConnectionPanel:
     def _start_access_check(self) -> None:
         if not self._state.access_check_pending or self._state.access_check_started:
             return
-        check = getattr(self._client, "_access_required", None)
-        if not callable(check):
+        check = _sync_access_probe(self._client)
+        if check is None:
             self._state.access_check_pending = False
             self._render_rows()
             return
@@ -293,11 +295,10 @@ class ConnectionPanel:
         # WHY: "checking" is only shown once the probe is in flight, so the row has to be
         # re-rendered here — the view was built before the check started.
         self._render_rows()
-        typed_check = cast(Callable[[], bool], check)
         if self._dispatcher.loop is None:
-            self._run_access_check_sync(typed_check)
+            self._run_access_check_sync(check)
             return
-        self._start_access_check_thread(typed_check)
+        self._start_access_check_thread(check)
 
     def _run_access_check_sync(self, check: Callable[[], bool]) -> None:
         try:

--- a/packages/screamingface/src/screamingface/_ui/connections.py
+++ b/packages/screamingface/src/screamingface/_ui/connections.py
@@ -15,6 +15,7 @@ from screamingface._ui.connection_view import (
     static_panel_html,
 )
 from screamingface._ui.engine_origin import _is_hosted_engine
+from screamingface._ui.loop_dispatch import _CompletionDispatcher
 from screamingface.errors import ScreamingFaceError
 
 if TYPE_CHECKING:
@@ -101,7 +102,7 @@ class ConnectionPanel:
         self._tasks: dict[str, asyncio.Task[None]] = {}
         self._access_check_thread: threading.Thread | None = None
         self._login_thread: threading.Thread | None = None
-        self._loop: asyncio.AbstractEventLoop | None = None
+        self._dispatcher = _CompletionDispatcher()
         self._unsubscribe_auth: Callable[[], None] | None = None
         self._view: _NotebookConnectionView | None = None
         self._closed = False
@@ -128,10 +129,7 @@ class ConnectionPanel:
         return self._state.connections
 
     def widget(self) -> Widget:
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self._loop = None
+        self._dispatcher.capture()
         subscribe = getattr(self._client, "_subscribe_auth", None)
         if callable(subscribe) and self._unsubscribe_auth is None:
             typed_subscribe = cast(
@@ -229,10 +227,10 @@ class ConnectionPanel:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            loop = self._loop
+            loop = self._dispatcher.loop
         if loop is None or loop.is_closed():
             return
-        self._loop = loop
+        self._dispatcher.adopt(loop)
         self._tasks[provider] = loop.create_task(self._poll_oauth(provider, flow))
 
     async def _poll_oauth(self, provider: str, flow: object) -> None:
@@ -270,7 +268,7 @@ class ConnectionPanel:
             self._render_rows()
             return
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
         except RuntimeError:
             self._attempt(self._login_access)
             if self._client.authenticated:
@@ -281,7 +279,7 @@ class ConnectionPanel:
 
         self._state.access_pending = True
         self._render_rows()
-        self._start_login_thread(loop)
+        self._start_login_thread()
 
     def _start_access_check(self) -> None:
         if not self._state.access_check_pending or self._state.access_check_started:
@@ -292,11 +290,14 @@ class ConnectionPanel:
             self._render_rows()
             return
         self._state.access_check_started = True
+        # WHY: "checking" is only shown once the probe is in flight, so the row has to be
+        # re-rendered here — the view was built before the check started.
+        self._render_rows()
         typed_check = cast(Callable[[], bool], check)
-        if self._loop is None:
+        if self._dispatcher.loop is None:
             self._run_access_check_sync(typed_check)
             return
-        self._start_access_check_thread(typed_check, self._loop)
+        self._start_access_check_thread(typed_check)
 
     def _run_access_check_sync(self, check: Callable[[], bool]) -> None:
         try:
@@ -306,11 +307,7 @@ class ConnectionPanel:
         else:
             self._complete_access_check(required, None)
 
-    def _start_access_check_thread(
-        self,
-        check: Callable[[], bool],
-        loop: asyncio.AbstractEventLoop,
-    ) -> None:
+    def _start_access_check_thread(self, check: Callable[[], bool]) -> None:
         panel_ref = weakref.ref(self)
 
         def run() -> None:
@@ -323,10 +320,7 @@ class ConnectionPanel:
             panel = panel_ref()
             if panel is None or panel._closed:
                 return
-            try:
-                loop.call_soon_threadsafe(panel._complete_access_check, required, error)
-            except RuntimeError:
-                return
+            panel._dispatcher(panel._complete_access_check, required, error)
 
         self._access_check_thread = threading.Thread(
             target=run,
@@ -351,7 +345,7 @@ class ConnectionPanel:
                 self._set_notice(_user_message(exc))
         self._render_rows()
 
-    def _start_login_thread(self, loop: asyncio.AbstractEventLoop) -> None:
+    def _start_login_thread(self) -> None:
         client = self._client
         panel_ref = weakref.ref(self)
 
@@ -364,10 +358,7 @@ class ConnectionPanel:
             panel = panel_ref()
             if panel is None or panel._closed:
                 return
-            try:
-                loop.call_soon_threadsafe(panel._complete_login_access, error)
-            except RuntimeError:
-                return
+            panel._dispatcher(panel._complete_login_access, error)
 
         self._login_thread = threading.Thread(
             target=run,
@@ -395,13 +386,7 @@ class ConnectionPanel:
     def _auth_state_changed(self) -> None:
         if self._closed:
             return
-        if self._loop is not None:
-            try:
-                self._loop.call_soon_threadsafe(self._apply_auth_state)
-            except RuntimeError:
-                return
-        else:
-            self._apply_auth_state()
+        self._dispatcher(self._apply_auth_state)
 
     def _apply_auth_state(self) -> None:
         if self._closed:

--- a/packages/screamingface/src/screamingface/_ui/loop_dispatch.py
+++ b/packages/screamingface/src/screamingface/_ui/loop_dispatch.py
@@ -1,0 +1,80 @@
+"""Delivery of panel background completions, independent of notebook loop churn."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+
+class _CompletionDispatcher:
+    """Runs a panel's background completions whatever became of the rendering loop.
+
+    INVARIANT: a dispatched callback ALWAYS runs. Discarding a completion because no
+    event loop would accept it is what stranded ``sf.connect()`` on "checking" forever
+    in Colab (OME-926) — the worker had the answer in hand and threw it away.
+
+    AIDEV-NOTE: this is the single completion-dispatch mechanism for the connection
+    panel. Never reintroduce a bare ``except RuntimeError: return`` around
+    ``call_soon_threadsafe`` at a call site; route the completion through here instead.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop | None:
+        """The loop completions are currently posted to, or None to run them inline."""
+
+        return self._loop
+
+    def capture(self) -> None:
+        """Adopt the loop live on this thread — called when the panel renders."""
+
+        self._loop = self._running_loop()
+
+    def adopt(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Adopt a loop resolved by a caller that already knows the live one."""
+
+        self._loop = loop
+
+    def usable(self) -> asyncio.AbstractEventLoop | None:
+        """The loop that should take a completion now, or None to run it inline.
+
+        WHY: a notebook host may close OR silently replace the loop that was live when
+        the widget rendered, and an abandoned loop accepts ``call_soon_threadsafe``
+        without ever running the callback. Requiring ``is_running()`` rejects both the
+        closed and the abandoned loop, so the only loops we post to are ones that will
+        actually drain the callback.
+        """
+
+        for candidate in (self._running_loop(), self._loop):
+            if candidate is not None and not candidate.is_closed() and candidate.is_running():
+                return candidate
+        return None
+
+    def __call__(self, callback: Callable[..., None], *args: Any) -> None:
+        """Deliver ``callback`` — via a live loop where there is one, else inline."""
+
+        loop = self.usable()
+        if loop is None:
+            callback(*args)
+            return
+        try:
+            loop.call_soon_threadsafe(callback, *args)
+        except RuntimeError:
+            # WHY: the loop can pass the checks above and still reject the post — it may
+            # close in that window. Running inline keeps the panel truthful.
+            callback(*args)
+        else:
+            self._loop = loop
+
+    @staticmethod
+    def _running_loop() -> asyncio.AbstractEventLoop | None:
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
+
+__all__: list[str] = []

--- a/packages/screamingface/tests/test_connection_panel.py
+++ b/packages/screamingface/tests/test_connection_panel.py
@@ -1161,3 +1161,47 @@ def test_access_discovery_resolves_when_the_widget_renders_without_a_loop() -> N
     assert "login required" in text
     assert [button.description for button in _buttons(root)] == ["Log in"]
     root.close()
+
+
+def test_an_async_access_probe_is_never_read_as_a_result() -> None:
+    # INVARIANT: an ``async def _access_required`` must never be invoked as if it were
+    # synchronous. A coroutine object is truthy, so its return value would report "access
+    # required" for every Engine while the coroutine itself was silently never awaited.
+    #
+    # WHY the assertion is a warning check: an un-awaited coroutine never executes its
+    # body, so no counter inside the probe can observe the call. The leaked coroutine is
+    # the only observable, and it surfaces as a RuntimeWarning when it is collected.
+    import gc
+    import warnings
+
+    class AsyncProbeClient:
+        engine_url = "https://fusion.dev.screamingface.ai"
+        authenticated = False
+        authenticating = False
+
+        def __init__(self) -> None:
+            self.connections = _EmptyConnections()
+
+        async def _access_required(self) -> bool:
+            return False
+
+    client = AsyncProbeClient()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        panel = _panel(client)
+        root = panel.widget()
+        gc.collect()
+
+    never_awaited = [
+        entry
+        for entry in caught
+        if issubclass(entry.category, RuntimeWarning) and "never awaited" in str(entry.message)
+    ]
+    assert never_awaited == []
+
+    text = _text(root)
+    assert "checking" not in text
+    assert "login required" in text
+    assert [button.description for button in _buttons(root)] == ["Log in"]
+    root.close()

--- a/packages/screamingface/tests/test_connection_panel.py
+++ b/packages/screamingface/tests/test_connection_panel.py
@@ -360,7 +360,7 @@ async def test_panel_starts_oauth_and_polls_without_blocking_the_notebook() -> N
     # Jupyter can dispatch a later widget click on a different loop from the one that
     # rendered it. The OAuth poller must use the loop active for the click.
     stale_loop = asyncio.new_event_loop()
-    panel._loop = stale_loop
+    panel._dispatcher.adopt(stale_loop)
 
     started = time.monotonic()
     _button(root, "OAuth").click()
@@ -934,4 +934,230 @@ def test_loopback_provider_rows_keep_byok_controls(engine_url: str) -> None:
     root = panel.widget()
 
     assert [button.description for button in _buttons(root)] == ["Connect"]
+    root.close()
+
+
+def _render_on_a_disposable_loop(panel: sf.ConnectionPanel) -> widgets.Widget:
+    """Render on a loop that is then closed, reproducing the Colab lifecycle.
+
+    WHY: Colab may close or replace the asyncio loop that was live when the widget
+    rendered. The panel must not depend on that loop still existing when a background
+    completion arrives. A plain ``asyncio.run`` cannot be nested inside an async test,
+    so these cases stay synchronous.
+    """
+
+    async def render() -> widgets.Widget:
+        return panel.widget()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(render())
+    finally:
+        loop.close()
+
+
+def _settle(root: widgets.Widget, *, until: Callable[[str], bool]) -> str:
+    for _ in range(200):
+        text = _text(root)
+        if until(text):
+            return text
+        time.sleep(0.01)
+    return _text(root)
+
+
+class _GatedAccessClient:
+    """Holds Access discovery open until the test releases it."""
+
+    engine_url = "https://fusion.dev.screamingface.ai"
+    authenticated = False
+    authenticating = False
+
+    def __init__(self, *, required: bool = True, error: Exception | None = None) -> None:
+        self.connections = _EmptyConnections()
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self._required = required
+        self._error = error
+
+    def _access_required(self) -> bool:
+        self.started.set()
+        assert self.release.wait(1)
+        if self._error is not None:
+            raise self._error
+        return self._required
+
+
+def test_access_discovery_still_lands_when_the_rendering_loop_closed() -> None:
+    # STORY: as a Colab user, sf.connect() reaches "Log in" instead of a permanent "checking".
+    client = _GatedAccessClient(required=True)
+    panel = _panel(client)
+
+    root = _render_on_a_disposable_loop(panel)
+    assert client.started.wait(1)
+    assert "checking" in _text(root)
+
+    client.release.set()
+    text = _settle(root, until=lambda value: "checking" not in value)
+
+    assert "checking" not in text
+    assert "login required" in text
+    assert [button.description for button in _buttons(root)] == ["Log in"]
+    root.close()
+
+
+def test_unprotected_engine_discovery_lands_when_the_rendering_loop_closed() -> None:
+    connection = sf.Connection(
+        provider="openrouter",
+        display_name="OpenRouter",
+        auth_methods=("api_key",),
+        status="not_connected",
+        auth_method=None,
+        account_label=None,
+    )
+
+    class Connections:
+        def list(self) -> tuple[sf.Connection, ...]:
+            return (connection,)
+
+    client = _GatedAccessClient(required=False)
+    client.connections = cast(Any, Connections())
+    panel = _panel(client)
+
+    root = _render_on_a_disposable_loop(panel)
+    assert client.started.wait(1)
+    client.release.set()
+    text = _settle(root, until=lambda value: "OpenRouter" in value)
+
+    assert "OpenRouter" in text
+    assert "checking" not in text
+    assert "Hosted Engine" not in text
+    root.close()
+
+
+def test_access_discovery_error_lands_when_the_rendering_loop_closed() -> None:
+    client = _GatedAccessClient(error=RuntimeError("Engine unreachable during discovery"))
+    panel = _panel(client)
+
+    root = _render_on_a_disposable_loop(panel)
+    assert client.started.wait(1)
+    client.release.set()
+    text = _settle(root, until=lambda value: "checking" not in value)
+
+    assert "Engine unreachable during discovery" in text
+    assert "checking" not in text
+    assert [button.description for button in _buttons(root)] == ["Log in"]
+    root.close()
+
+
+def test_login_completion_lands_when_the_rendering_loop_closed() -> None:
+    # INVARIANT: login completion never strands the panel on "Cancel" because the
+    # rendering loop changed.
+    client = _SharedAuthClient()
+    panel = _panel(client)
+
+    # WHY: Access login is long-lived — the user leaves for a browser — so the loop live
+    # when "Log in" was clicked is the one most likely to be gone by completion. Render
+    # AND click on that loop, then close it, so the login thread is holding a dead loop.
+    async def render_and_click() -> widgets.Widget:
+        root = panel.widget()
+        _button(root, "Log in").click()
+        return root
+
+    loop = asyncio.new_event_loop()
+    try:
+        root = loop.run_until_complete(render_and_click())
+    finally:
+        loop.close()
+
+    assert client.started.wait(1)
+    assert [button.description for button in _buttons(root)] == ["Cancel"]
+
+    client.release.set()
+    _settle(root, until=lambda value: "Log out" in value)
+
+    assert [button.description for button in _buttons(root)] == ["Log out"]
+    root.close()
+
+
+def test_module_level_connect_reaches_a_terminal_state_after_the_loop_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # WHY: the issue's acceptance requires the documented module-level entrypoint to be
+    # covered, not only the internal ConnectionPanel helper.
+    client = _GatedAccessClient(required=True)
+    monkeypatch.setattr("screamingface._default_client.default_client", lambda: cast(Any, client))
+
+    async def render() -> widgets.Widget:
+        return sf.connect().widget()
+
+    loop = asyncio.new_event_loop()
+    try:
+        root = loop.run_until_complete(render())
+    finally:
+        loop.close()
+
+    assert client.started.wait(1)
+    client.release.set()
+    text = _settle(root, until=lambda value: "checking" not in value)
+
+    assert "checking" not in text
+    assert [button.description for button in _buttons(root)] == ["Log in"]
+    root.close()
+
+
+def test_static_html_does_not_claim_checking_when_no_probe_is_running() -> None:
+    # INVARIANT: "checking" means a probe is in flight. _repr_html_ never starts one,
+    # so it must render the resolved state instead of a status nothing will clear.
+    client = _GatedAccessClient(required=True)
+    panel = _panel(client)
+
+    html = panel._repr_html_()
+
+    assert "checking" not in html
+    assert "login required" in html
+    assert not client.started.is_set()
+
+
+def test_completion_runs_inline_when_a_live_loop_rejects_the_post() -> None:
+    # WHY: a loop can pass the is_running() check and still reject the post — it may be
+    # closed in the window between the two. The completion must land anyway.
+    class _RacingLoop:
+        def is_closed(self) -> bool:
+            return False
+
+        def is_running(self) -> bool:
+            return True
+
+        def call_soon_threadsafe(self, callback: Callable[..., None], *args: Any) -> None:
+            del callback, args
+            raise RuntimeError("Event loop is closed")
+
+    client = _GatedAccessClient(required=True)
+    panel = _panel(client)
+
+    root = _render_on_a_disposable_loop(panel)
+    assert client.started.wait(1)
+    panel._dispatcher.adopt(cast(Any, _RacingLoop()))
+    client.release.set()
+    text = _settle(root, until=lambda value: "checking" not in value)
+
+    assert "checking" not in text
+    assert [button.description for button in _buttons(root)] == ["Log in"]
+    root.close()
+
+
+def test_access_discovery_resolves_when_the_widget_renders_without_a_loop() -> None:
+    # WHY: a plain script or an older kernel renders with no running loop at all, so the
+    # probe runs synchronously; that branch must still reach a terminal state.
+    client = _GatedAccessClient(required=True)
+    client.release.set()
+    panel = _panel(client)
+
+    root = panel.widget()
+
+    assert client.started.is_set()
+    text = _text(root)
+    assert "checking" not in text
+    assert "login required" in text
+    assert [button.description for button in _buttons(root)] == ["Log in"]
     root.close()


### PR DESCRIPTION
Fixes OME-926.

## Summary

`sf.connect()` could sit forever on "checking" in Colab. The Cloudflare Access probe runs
on a daemon thread and posts its result back to the asyncio loop that was live when
`widget()` rendered. When the notebook host has closed or replaced that loop,
`call_soon_threadsafe` raises `RuntimeError` — and both worker threads swallowed it with a
bare `return`. The probe had already succeeded in ~0.2s; **the answer was in hand and
thrown away**, so `access_check_pending` never cleared. The "Checking…" button is rendered
`disabled`, so there was no way out.

The same "the captured loop is still alive" assumption was copy-pasted in three places,
which is why this replaces them with **one** dispatcher rather than patching each:

| Site | Before |
|---|---|
| `_start_access_check_thread` | cached loop; `RuntimeError` swallowed |
| `_start_login_thread` | same — could strand the panel on "Cancel" |
| `_auth_state_changed` | same, for the cross-panel auth broadcast |

`_CompletionDispatcher` (new, `_ui/loop_dispatch.py`) resolves a live loop **at post time**
instead of trusting the cached one, requires `is_running()` so an *abandoned* loop cannot
silently absorb the callback, and otherwise runs the completion inline. **A completion is
never discarded.**

Colab and Jupyter differ here only in loop lifecycle — Colab churns the loop, Jupyter
doesn't — so no host branching is introduced. There is still no Colab-specific code.

Also in scope: `"checking"` now requires the probe to have actually *started*. The static
`_repr_html_` path never starts one, so it was rendering a status nothing could ever clear
— an independent stuck-on-checking path with no event loop involved.

`_start_oauth`'s existing live-loop mitigation is preserved exactly; its regression test
still passes.

## ✅ Verified in Colab

Run on a real Colab notebook: the panel left "checking" and reached **login required** with
a Log in button. This also retires the one open risk I had flagged — that the inline
completion path might not repaint from a worker thread. It does.

## Commits

| | |
|---|---|
| `6f8540ac` | types `_runtime/server.py`'s ASGI app. **Unrelated to OME-926** — `object` satisfies none of `uvicorn.Config`'s `app` types, so the annotation was simply wrong, but it is *not* gate-blocking (pyright only sees uvicorn when the optional `runtime` extra is installed, and CI installs only `--extra notebook`). Easy to drop from this PR. |
| `47d260a7` | the completion dispatcher — the actual OME-926 fix. |
| `042e243d` | `AsyncClient._access_required` is `async def` but the panel checked only `callable(...)`, so the coroutine read truthy ⇒ "access required" for every Engine, never awaited. Unreachable today; a trap for whoever wires the panel to `AsyncClient`. |

## Test plan

Coverage before this PR was **zero** — `Checking…`, `checking`, `access_check_pending`,
`_start_access_check`, `_complete_access_check` appeared nowhere in `tests/`.

9 tests added, each verified RED against `origin/main` first:

- **The regression guard** — render on a loop, close it, release the probe, assert the
  panel leaves "checking".
- Access-required / unprotected-Engine / discovery-**error** each reach the right terminal
  state (the error path was untested).
- Login completion cannot remain on "Cancel" because the rendering loop changed.
- The documented module-level `sf.connect()` entrypoint, not just the internal helper.
- `_repr_html_` does not claim "checking" when nothing is driving a probe.
- A live loop that rejects the post (close race), and rendering with no loop at all.
- An `async def` probe is never invoked as if synchronous (asserted via the leaked-coroutine
  warning, since an un-awaited coroutine never runs its own body).

`run_gates.py screamingface --skip-append-only` — **ALL GATES GREEN**. 1018 passed,
1 skipped; coverage ≥95%.

## Reviewer notes

- **One prior test modified** — `panel._loop = stale_loop` →
  `panel._dispatcher.adopt(stale_loop)` in the OAuth live-loop test. Injection handle only;
  scenario and every assertion unchanged. Raised as a rule-5 Confidence-Gate decision and
  approved before editing, hence `--skip-append-only`.
- **Follow-up filed: OME-930** — clicking **Log in** in Colab still opens nothing. Separate
  pre-existing defect: the authorization URL is `print`ed from a worker thread inside a
  widget callback (invisible in Colab), and `_running_in_notebook()` doesn't recognise
  Colab, so `webbrowser.open` fires on the Colab VM. Needs a presenter seam, not a patch.
- **Not implemented deliberately:** a retry affordance on the "Checking…" button. The
  issue's acceptance covers completions that have *finished*, which the dispatcher fully
  satisfies; a hung probe is a different defect and a live button needs retry machinery
  nothing yet demands.

Ledger: `docs/work/2026-08-21-OME-926-connection-panel-completion-dispatch.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)