### PR TITLE
fix(screamingface-engine): make over-cap result artifacts fetchable on multi-pod deployments

### DIFF
--- a/apps/screamingface-engine/deploy/helm/README.md
+++ b/apps/screamingface-engine/deploy/helm/README.md
@@ -181,13 +181,17 @@ DRACO 3-pass run is 11,902 calls and a ~3 MiB result, so it spills every time. T
 ```yaml
 artifactStorage:
   backend: s3
-  s3:
-    bucket: screamingface-artifacts
-    accessKey: GK...
-    existingSecret: my-artifact-creds   # keyed URL4_CLOUD_ARTIFACT_S3_SECRET_KEY
 garage:
   enabled: true
 ```
+
+That is the whole configuration. No credentials to invent, no bucket to create, no commands to
+run: the chart generates a stable key pair (reused across upgrades via `lookup`) and Garage
+**adopts** it on first boot via its `--single-node`, `--default-access-key` and `--default-bucket`
+server flags (Garage ≥ 2.3.0).
+
+Set `artifactStorage.s3.accessKey` / `.secretKey`, or `existingSecret`, only to use credentials
+you already have — e.g. when pointing at storage you already run.
 
 Both halves are rendered from this one stanza — the Runner's copy in `configmap-runner-env.yaml`
 and the App's in `configmap.yaml` — so a one-sided edit cannot point the writer and the reader at
@@ -197,28 +201,44 @@ fell back to its own pod-local `/tmp`.
 The read path goes **through the App**, not via a presigned URL, so the object store stays
 cluster-internal and the SDK's existing size + sha256 verification is unchanged.
 
-### Bundled Garage: one-time bootstrap
+### Why there is no bootstrap Job
 
-`garage.enabled` deploys a single-node store, but Garage needs an imperative first-run setup that
-this chart deliberately does **not** perform (a half-applied layout is far harder to diagnose than
-a documented manual step):
+The obvious alternative — a `post-install` hook running `garage key create` — was rejected. It
+makes Garage **mint** the credential, which the chart then has to discover and write back into a
+Secret: that needs `create secrets` RBAC and turns a declarative chart into a two-phase one where
+`helm template` no longer describes the result. Adopting a chart-stated key keeps the data flowing
+one way.
 
-```sh
-R=<release>-garage
-kubectl exec -it sts/$R -- /garage status                       # note the node id
-kubectl exec -it sts/$R -- /garage layout assign -z dc1 -c 10G <node-id>
-kubectl exec -it sts/$R -- /garage layout apply --version 1
-kubectl exec -it sts/$R -- /garage bucket create screamingface-artifacts
-kubectl exec -it sts/$R -- /garage key create artifacts-rw
-kubectl exec -it sts/$R -- /garage bucket allow --read --write screamingface-artifacts --key artifacts-rw
-```
+Scripted layout is worse still. Garage's
+[layout operations guide](https://garagehq.deuxfleurs.fr/documentation/operations/layout/) warns
+that repeating `layout apply --version N` can leave a cluster **inconsistent**, and that the
+version must be exactly one past the current one — precisely what a hook re-running on every
+`helm upgrade` gets wrong. `--single-node` removes the operation rather than automating it.
 
-Feed the `key create` output into `artifactStorage.s3.accessKey` / `.secretKey` (or a Secret named
-by `existingSecret`) and upgrade. Objects expire by **bucket lifecycle rule**, not by the App's
-sweeper — which is a no-op in `s3` mode. A bucket with no lifecycle rule never expires artifacts.
+### Credential rotation
 
-To use storage you already run, set `artifactStorage.s3.endpointUrl` and leave `garage.enabled`
-off. Any S3-compatible endpoint works; only PUT and GET of a single object are used.
+The key pair is reused across upgrades on purpose: Garage adopts a default key only on **first
+boot**, so minting a new pair later would leave the engine signing with credentials the store has
+never seen — a 403 on every artifact, which reads like a code bug. To rotate deliberately, add the
+new key to Garage (`garage key create` / `bucket allow`) and then set
+`artifactStorage.s3.accessKey` / `.secretKey` to it.
+
+### Expiry
+
+Objects expire by **bucket lifecycle rule**, not by the App's sweeper — which is a no-op in `s3`
+mode, because listing objects would need query-string signing beyond what the adapter's signer
+supports. **A bucket with no lifecycle rule never expires artifacts.**
+
+### Using storage you already run
+
+Set `artifactStorage.s3.endpointUrl` (plus `accessKey`/`secretKey` or `existingSecret`) and leave
+`garage.enabled` off. Only single-part PUT, streaming GET, HEAD and DELETE of one object are used.
+
+**Caveat — path-style addressing.** The adapter addresses objects as `{endpoint}/{bucket}/{key}`.
+That works with Garage, MinIO, SeaweedFS, Ceph RGW and Cloudflare R2. AWS S3 proper has deprecated
+path-style in favour of virtual-hosted-style (`bucket.s3.region.amazonaws.com`), so pointing this
+at real AWS S3 may fail — and it fails as a signing/404 error that looks like a credential
+problem. Azure Blob is **not** S3-compatible at all and would need a new adapter behind the port.
 
 ## Workload hardening
 

--- a/apps/screamingface-engine/deploy/helm/README.md
+++ b/apps/screamingface-engine/deploy/helm/README.md
@@ -167,6 +167,59 @@ Job controller. Past roughly tens of requests per second the replay guard would 
 the Job name onto a cheap keyed store (e.g. a NATS KV of spent `jti`s), trading the App's
 statelessness for throughput.
 
+## Artifact storage (OME-929)
+
+A Run whose serialized result exceeds the inline cap (1 MiB) is parked under its content address,
+and the terminal frame carries only a claim ticket the client redeems over `GET /artifacts/{id}`.
+
+**With `config.runner: k8s` this store cannot be a local directory.** Each run is a separate Job
+pod whose disk is destroyed with it, so a result spilled there can never be served back: the run
+succeeds, and then the client's redemption 404s — after every model call has been paid for. A full
+DRACO 3-pass run is 11,902 calls and a ~3 MiB result, so it spills every time. The App therefore
+**refuses to start** when `runner: k8s` is paired with `artifactStorage.backend: filesystem`.
+
+```yaml
+artifactStorage:
+  backend: s3
+  s3:
+    bucket: screamingface-artifacts
+    accessKey: GK...
+    existingSecret: my-artifact-creds   # keyed URL4_CLOUD_ARTIFACT_S3_SECRET_KEY
+garage:
+  enabled: true
+```
+
+Both halves are rendered from this one stanza — the Runner's copy in `configmap-runner-env.yaml`
+and the App's in `configmap.yaml` — so a one-sided edit cannot point the writer and the reader at
+different stores. That was the original defect: both read one variable that nothing set, and each
+fell back to its own pod-local `/tmp`.
+
+The read path goes **through the App**, not via a presigned URL, so the object store stays
+cluster-internal and the SDK's existing size + sha256 verification is unchanged.
+
+### Bundled Garage: one-time bootstrap
+
+`garage.enabled` deploys a single-node store, but Garage needs an imperative first-run setup that
+this chart deliberately does **not** perform (a half-applied layout is far harder to diagnose than
+a documented manual step):
+
+```sh
+R=<release>-garage
+kubectl exec -it sts/$R -- /garage status                       # note the node id
+kubectl exec -it sts/$R -- /garage layout assign -z dc1 -c 10G <node-id>
+kubectl exec -it sts/$R -- /garage layout apply --version 1
+kubectl exec -it sts/$R -- /garage bucket create screamingface-artifacts
+kubectl exec -it sts/$R -- /garage key create artifacts-rw
+kubectl exec -it sts/$R -- /garage bucket allow --read --write screamingface-artifacts --key artifacts-rw
+```
+
+Feed the `key create` output into `artifactStorage.s3.accessKey` / `.secretKey` (or a Secret named
+by `existingSecret`) and upgrade. Objects expire by **bucket lifecycle rule**, not by the App's
+sweeper — which is a no-op in `s3` mode. A bucket with no lifecycle rule never expires artifacts.
+
+To use storage you already run, set `artifactStorage.s3.endpointUrl` and leave `garage.enabled`
+off. Any S3-compatible endpoint works; only PUT and GET of a single object are used.
+
 ## Workload hardening
 
 Both workloads — the same image, entered in its two modes — run non-root (uid 1000, the image's

--- a/apps/screamingface-engine/deploy/helm/templates/_helpers.tpl
+++ b/apps/screamingface-engine/deploy/helm/templates/_helpers.tpl
@@ -103,3 +103,37 @@ never reads it itself.
 {{- printf "%s-tavily" (include "screamingface-engine.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The Secret holding the object-storage secret access key (OME-929).
+
+`artifactStorage.s3.existingSecret` wins when set (the prod shape — created out-of-band or by an
+External Secrets / Sealed Secrets flow); otherwise the chart creates `<fullname>-artifact-storage`.
+
+INVARIANT: attached by `envFrom.secretRef` to BOTH the App Deployment and every Runner Job, which
+injects each key under its OWN name — so the key MUST be `URL4_CLOUD_ARTIFACT_S3_SECRET_KEY`, the
+variable both halves read. Unlike the Tavily Secret, the App reads this one too: it is the read
+side of the hand-off.
+*/}}
+{{- define "screamingface-engine.artifactSecretName" -}}
+{{- if .Values.artifactStorage.s3.existingSecret -}}
+{{- .Values.artifactStorage.s3.existingSecret -}}
+{{- else -}}
+{{- printf "%s-artifact-storage" (include "screamingface-engine.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Where the object store lives. Explicit `artifactStorage.s3.endpointUrl` wins; otherwise, with the
+bundled instance enabled, its in-cluster Service. Failing render is deliberate: an empty endpoint
+would leave the App to refuse startup with a less specific message than this one.
+*/}}
+{{- define "screamingface-engine.artifactEndpointUrl" -}}
+{{- if .Values.artifactStorage.s3.endpointUrl -}}
+{{- .Values.artifactStorage.s3.endpointUrl -}}
+{{- else if .Values.garage.enabled -}}
+{{- printf "http://%s-garage:3900" (include "screamingface-engine.fullname" .) -}}
+{{- else -}}
+{{- fail "artifactStorage.backend=s3 needs either artifactStorage.s3.endpointUrl or garage.enabled=true" -}}
+{{- end -}}
+{{- end -}}

--- a/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
@@ -54,7 +54,9 @@ data:
   URL4_CLOUD_ARTIFACT_S3_ENDPOINT_URL: {{ include "screamingface-engine.artifactEndpointUrl" . | quote }}
   URL4_CLOUD_ARTIFACT_S3_BUCKET: {{ .Values.artifactStorage.s3.bucket | quote }}
   URL4_CLOUD_ARTIFACT_S3_REGION: {{ .Values.artifactStorage.s3.region | quote }}
-  URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY: {{ .Values.artifactStorage.s3.accessKey | quote }}
+  # NOTE: the ACCESS KEY is not here either. It is auto-generated when unset, so it must be
+  # stable across upgrades — which means living in the Secret the chart can `lookup`. Both
+  # halves of the pair therefore arrive by `envFrom.secretRef`, from one source.
   {{- end }}
   # NOTE: URL4_CLOUD_ARTIFACT_S3_SECRET_KEY is deliberately ABSENT here. It travels by Secret
   # (`secret-artifact-storage.yaml`), attached to each Job with `envFrom.secretRef` — a ConfigMap

--- a/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
@@ -33,3 +33,29 @@ data:
   # set it; now it does.
   AIGATEWAY_MODEL: {{ . | quote }}
   {{- end }}
+  # Where this Job parks a result too large to ride the stream inline (OME-929).
+  #
+  # INVARIANT: these must name the SAME store as the App's own copy in `configmap.yaml`. Both are
+  # rendered from one `artifactStorage` values stanza precisely so a one-sided edit is impossible —
+  # the previous shape had the two halves reading one variable that NOTHING set, so each fell back
+  # to its own pod-local /tmp and every over-cap result 404'd at redemption.
+  URL4_CLOUD_ARTIFACT_STORE: {{ .Values.artifactStorage.backend | quote }}
+  {{- if and (eq .Values.artifactStorage.backend "filesystem") .Values.artifactStorage.filesystemDir }}
+  # Only meaningful in filesystem mode, which is single-process only. Rendered under the same
+  # condition it is read, so it is Helm-owned exactly when it is the operative setting — rather
+  # than declared Helm-owned and set by nobody, which is how OME-929 happened.
+  #
+  # WHY also gated on a non-empty value: rendering "" would OVERRIDE the code's default with an
+  # empty path, and `Path("")` is the working directory — a silently wrong location rather than
+  # an absent setting. Omitting the key lets the documented default apply.
+  URL4_CLOUD_ARTIFACTS_DIR: {{ .Values.artifactStorage.filesystemDir | quote }}
+  {{- end }}
+  {{- if eq .Values.artifactStorage.backend "s3" }}
+  URL4_CLOUD_ARTIFACT_S3_ENDPOINT_URL: {{ include "screamingface-engine.artifactEndpointUrl" . | quote }}
+  URL4_CLOUD_ARTIFACT_S3_BUCKET: {{ .Values.artifactStorage.s3.bucket | quote }}
+  URL4_CLOUD_ARTIFACT_S3_REGION: {{ .Values.artifactStorage.s3.region | quote }}
+  URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY: {{ .Values.artifactStorage.s3.accessKey | quote }}
+  {{- end }}
+  # NOTE: URL4_CLOUD_ARTIFACT_S3_SECRET_KEY is deliberately ABSENT here. It travels by Secret
+  # (`secret-artifact-storage.yaml`), attached to each Job with `envFrom.secretRef` — a ConfigMap
+  # is readable by anything with `get` on it and is printed in plain text by `helm get manifest`.

--- a/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
@@ -78,7 +78,9 @@ data:
   URL4_CLOUD_ARTIFACT_S3_ENDPOINT_URL: {{ include "screamingface-engine.artifactEndpointUrl" . | quote }}
   URL4_CLOUD_ARTIFACT_S3_BUCKET: {{ .Values.artifactStorage.s3.bucket | quote }}
   URL4_CLOUD_ARTIFACT_S3_REGION: {{ .Values.artifactStorage.s3.region | quote }}
-  URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY: {{ .Values.artifactStorage.s3.accessKey | quote }}
+  # NOTE: the ACCESS KEY is not here either. It is auto-generated when unset, so it must be
+  # stable across upgrades — which means living in the Secret the chart can `lookup`. Both
+  # halves of the pair therefore arrive by `envFrom.secretRef`, from one source.
   # The Secret carrying URL4_CLOUD_ARTIFACT_S3_SECRET_KEY, attached to each Runner Job by the App
   # with `envFrom.secretRef`. Only the NAME travels here; nothing secret belongs in a ConfigMap.
   URL4_CLOUD_ARTIFACT_S3_SECRET_NAME: {{ include "screamingface-engine.artifactSecretName" . | quote }}

--- a/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
@@ -58,6 +58,31 @@ data:
   # it by name in each Job's `envFrom` — it never reads the keys, so adding a variable there needs
   # no App change and no restart.
   URL4_CLOUD_RUNNER_ENV_CONFIGMAP: {{ include "screamingface-engine.fullname" . }}-runner-env
+  # The READ side of the artifact hand-off (OME-929) — the same store the Runner writes to.
+  #
+  # INVARIANT: rendered from the SAME `artifactStorage` values stanza as the Runner's copy in
+  # `configmap-runner-env.yaml`. That shared origin is the fix: the two halves used to read one
+  # variable nothing set, so each silently resolved its own pod-local directory.
+  URL4_CLOUD_ARTIFACT_STORE: {{ .Values.artifactStorage.backend | quote }}
+  {{- if and (eq .Values.artifactStorage.backend "filesystem") .Values.artifactStorage.filesystemDir }}
+  # Only meaningful in filesystem mode, which is single-process only. Rendered under the same
+  # condition it is read, so it is Helm-owned exactly when it is the operative setting — rather
+  # than declared Helm-owned and set by nobody, which is how OME-929 happened.
+  #
+  # WHY also gated on a non-empty value: rendering "" would OVERRIDE the code's default with an
+  # empty path, and `Path("")` is the working directory — a silently wrong location rather than
+  # an absent setting. Omitting the key lets the documented default apply.
+  URL4_CLOUD_ARTIFACTS_DIR: {{ .Values.artifactStorage.filesystemDir | quote }}
+  {{- end }}
+  {{- if eq .Values.artifactStorage.backend "s3" }}
+  URL4_CLOUD_ARTIFACT_S3_ENDPOINT_URL: {{ include "screamingface-engine.artifactEndpointUrl" . | quote }}
+  URL4_CLOUD_ARTIFACT_S3_BUCKET: {{ .Values.artifactStorage.s3.bucket | quote }}
+  URL4_CLOUD_ARTIFACT_S3_REGION: {{ .Values.artifactStorage.s3.region | quote }}
+  URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY: {{ .Values.artifactStorage.s3.accessKey | quote }}
+  # The Secret carrying URL4_CLOUD_ARTIFACT_S3_SECRET_KEY, attached to each Runner Job by the App
+  # with `envFrom.secretRef`. Only the NAME travels here; nothing secret belongs in a ConfigMap.
+  URL4_CLOUD_ARTIFACT_S3_SECRET_NAME: {{ include "screamingface-engine.artifactSecretName" . | quote }}
+  {{- end }}
   {{- if .Values.tavily.enabled }}
   # WHY: only the Secret's NAME travels; the App attaches it to each Job with `envFrom.secretRef`
   # and never reads the credential, so nothing secret belongs in this ConfigMap. The Secret's KEY

--- a/apps/screamingface-engine/deploy/helm/templates/deployment.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/deployment.yaml
@@ -74,6 +74,13 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "screamingface-engine.fullname" . }}
+            {{- if eq .Values.artifactStorage.backend "s3" }}
+            # The object-storage secret access key (OME-929). The App needs it to READ spilled
+            # results back — it is the serve side of `GET /artifacts/{id}`, so unlike the Tavily
+            # credential it is not merely forwarded to Jobs.
+            - secretRef:
+                name: {{ include "screamingface-engine.artifactSecretName" . }}
+            {{- end }}
           env:
             # HS256 topic-capability signing secret (spec §4). Never logged.
             - name: URL4_CLOUD_JWT_SECRET

--- a/apps/screamingface-engine/deploy/helm/templates/garage.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/garage.yaml
@@ -14,21 +14,28 @@ WHY single-node, RWO, no replication: the objects are single-consumer hand-offs 
 48h and are re-derivable by re-running the evaluation. This is a hand-off buffer, not a durability
 tier — replication would add a failure domain and buy nothing at ~3 MiB per run.
 
-AIDEV-NOTE — ONE-TIME BOOTSTRAP REQUIRED, NOT PERFORMED HERE. After first install Garage needs a
-layout assignment, then a bucket and an access key. Those are imperative `garage` CLI steps whose
-failure modes are considerably worse when buried in a Helm hook (a half-applied layout is harder
-to diagnose than a documented manual step), so the chart deliberately stops short. Run:
+SELF-CONFIGURING — no bootstrap step, no Helm hook, no operator commands. Garage v2.3.0 added
+three `server` flags that replace the whole manual sequence:
 
-  kubectl exec -it sts/<release>-garage -- /garage status              # note the node id
-  kubectl exec -it sts/<release>-garage -- /garage layout assign -z dc1 -c 10G <node-id>
-  kubectl exec -it sts/<release>-garage -- /garage layout apply --version 1
-  kubectl exec -it sts/<release>-garage -- /garage bucket create screamingface-artifacts
-  kubectl exec -it sts/<release>-garage -- /garage key create artifacts-rw
-  kubectl exec -it sts/<release>-garage -- /garage bucket allow --read --write screamingface-artifacts --key artifacts-rw
+  --single-node          creates the cluster layout itself, so nothing has to run
+                         `layout assign` / `layout apply`
+  --default-access-key   adopts GARAGE_DEFAULT_ACCESS_KEY / GARAGE_DEFAULT_SECRET_KEY
+  --default-bucket       creates GARAGE_DEFAULT_BUCKET
 
-Then set `artifactStorage.s3.accessKey` / `.secretKey` from the key create output and upgrade.
-Until that is done the App refuses to start with `backend: s3` — which is the intended behaviour:
-a misconfigured store must fail at boot, not at a redemption that follows a paid run.
+WHY that matters beyond convenience: it inverts the data flow. The alternative — a post-install
+Job running `garage key create` — makes Garage MINT the credential, which the chart would then
+have to discover and write back into a Secret, needing `create secrets` RBAC and turning a
+declarative chart into a two-phase one. Here the CHART states the key and Garage adopts it, so
+credentials flow one way and `helm template` fully describes the result.
+
+WHY no scripted layout: Garage's own docs warn that repeating `layout apply --version N` can leave
+the cluster INCONSISTENT, and that a version number must be exactly one past the current one. A
+hook re-running on every `helm upgrade` is precisely the shape that gets that wrong.
+`--single-node` removes the operation instead of automating it.
+
+INVARIANT: the key pair comes from the SAME Secret the App and the Runner read (see
+`secret-artifact-storage.yaml`). One source, three consumers — so the store cannot end up holding
+a key the engine does not present.
 */}}
 {{- if .Values.garage.enabled }}
 {{- $name := printf "%s-garage" (include "screamingface-engine.fullname" .) -}}
@@ -98,6 +105,29 @@ spec:
       containers:
         - name: garage
           image: {{ .Values.garage.image | quote }}
+          # The three self-configuration flags (see the header). `server` is the subcommand; the
+          # image's entrypoint is the `garage` binary itself.
+          args:
+            - server
+            - --single-node
+            - --default-access-key
+            - --default-bucket
+          env:
+            # Garage ADOPTS this pair on first boot rather than minting its own, which is what
+            # keeps the chart declarative. Read from the same Secret the engine reads, so the
+            # store and its clients cannot drift onto different credentials.
+            - name: GARAGE_DEFAULT_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "screamingface-engine.artifactSecretName" . }}
+                  key: URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY
+            - name: GARAGE_DEFAULT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "screamingface-engine.artifactSecretName" . }}
+                  key: URL4_CLOUD_ARTIFACT_S3_SECRET_KEY
+            - name: GARAGE_DEFAULT_BUCKET
+              value: {{ .Values.artifactStorage.s3.bucket | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/apps/screamingface-engine/deploy/helm/templates/garage.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/garage.yaml
@@ -1,0 +1,152 @@
+{{/*
+The bundled S3-compatible object store for spilled results (OME-929, spec D2).
+
+WHY bundled rather than a managed bucket: this removes object storage's two real costs — a cloud
+account's credentials and coupling to one provider — while keeping a wire protocol a managed S3
+could answer later unchanged. The port in `screamingface_engine.artifacts` is the actual two-way
+door; this is just the cheapest thing behind it.
+
+WHY a StatefulSet and not a Deployment: Garage keeps a node identity and a metadata database on
+disk. A Deployment with a PVC can start a second pod against the same volume during a rolling
+update, and two Garage processes on one metadata store is corruption, not contention.
+
+WHY single-node, RWO, no replication: the objects are single-consumer hand-offs that live under
+48h and are re-derivable by re-running the evaluation. This is a hand-off buffer, not a durability
+tier — replication would add a failure domain and buy nothing at ~3 MiB per run.
+
+AIDEV-NOTE — ONE-TIME BOOTSTRAP REQUIRED, NOT PERFORMED HERE. After first install Garage needs a
+layout assignment, then a bucket and an access key. Those are imperative `garage` CLI steps whose
+failure modes are considerably worse when buried in a Helm hook (a half-applied layout is harder
+to diagnose than a documented manual step), so the chart deliberately stops short. Run:
+
+  kubectl exec -it sts/<release>-garage -- /garage status              # note the node id
+  kubectl exec -it sts/<release>-garage -- /garage layout assign -z dc1 -c 10G <node-id>
+  kubectl exec -it sts/<release>-garage -- /garage layout apply --version 1
+  kubectl exec -it sts/<release>-garage -- /garage bucket create screamingface-artifacts
+  kubectl exec -it sts/<release>-garage -- /garage key create artifacts-rw
+  kubectl exec -it sts/<release>-garage -- /garage bucket allow --read --write screamingface-artifacts --key artifacts-rw
+
+Then set `artifactStorage.s3.accessKey` / `.secretKey` from the key create output and upgrade.
+Until that is done the App refuses to start with `backend: s3` — which is the intended behaviour:
+a misconfigured store must fail at boot, not at a redemption that follows a paid run.
+*/}}
+{{- if .Values.garage.enabled }}
+{{- $name := printf "%s-garage" (include "screamingface-engine.fullname" .) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "screamingface-engine.labels" . | nindent 4 }}
+data:
+  garage.toml: |
+    metadata_dir = "/var/lib/garage/meta"
+    data_dir = "/var/lib/garage/data"
+    db_engine = "sqlite"
+    replication_factor = 1
+    # Cluster-internal only: this store is reached by the App and by Runner Job pods, never from
+    # outside. The read path deliberately goes THROUGH the App (spec D4) rather than handing a
+    # client a presigned URL, so nothing off-cluster ever needs to resolve this endpoint.
+    rpc_bind_addr = "[::]:3901"
+    rpc_public_addr = "127.0.0.1:3901"
+    rpc_secret = {{ derivePassword 1 "long" (printf "%s-garage-rpc" .Release.Name) "garage" "screamingface" | sha256sum | quote }}
+
+    [s3_api]
+    s3_region = {{ .Values.artifactStorage.s3.region | quote }}
+    api_bind_addr = "[::]:3900"
+    root_domain = ".s3.garage"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "screamingface-engine.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: s3
+      port: 3900
+      targetPort: s3
+      protocol: TCP
+  selector:
+    {{- include "screamingface-engine.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: garage
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "screamingface-engine.labels" . | nindent 4 }}
+spec:
+  # INVARIANT: 1. See the WHY above — two Garage processes on one metadata store is corruption.
+  replicas: {{ .Values.garage.replicaCount }}
+  serviceName: {{ $name }}
+  selector:
+    matchLabels:
+      {{- include "screamingface-engine.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: garage
+  template:
+    metadata:
+      labels:
+        {{- include "screamingface-engine.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: garage
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: garage
+          image: {{ .Values.garage.image | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            # NOT readOnlyRootFilesystem: Garage writes its metadata and data trees at runtime.
+            # They live on the mounted volume, which is why this is a narrower exception than it
+            # looks — but the root filesystem still has to be writable for its lock files.
+            runAsNonRoot: true
+            runAsUser: 1000
+          ports:
+            - name: s3
+              containerPort: 3900
+              protocol: TCP
+            - name: rpc
+              containerPort: 3901
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/garage.toml
+              subPath: garage.toml
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/garage
+          resources:
+            {{- toYaml .Values.garage.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $name }}
+        {{- if not .Values.garage.persistence.enabled }}
+        # AIDEV-NOTE: emptyDir means every artifact is lost on a Garage restart. Acceptable only
+        # for a throwaway test cluster — a client redeeming across that restart gets the same 404
+        # this ticket exists to remove.
+        - name: data
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.garage.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.garage.persistence.accessModes | nindent 10 }}
+        {{- with .Values.garage.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.garage.persistence.size | quote }}
+  {{- end }}
+{{- end }}

--- a/apps/screamingface-engine/deploy/helm/templates/secret-artifact-storage.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/secret-artifact-storage.yaml
@@ -1,0 +1,34 @@
+{{/*
+The object-storage secret access key (OME-929). Rendered ONLY when the chart owns the Secret —
+`artifactStorage.s3.existingSecret` means an operator (or an External Secrets / Sealed Secrets
+flow) supplies it out-of-band, which is the recommended prod shape.
+
+INVARIANT: attached with `envFrom.secretRef`, which injects every key under its OWN name — so the
+key MUST be `URL4_CLOUD_ARTIFACT_S3_SECRET_KEY`, the variable both halves read.
+
+WHY both halves, unlike the Tavily Secret: this credential is needed to WRITE (each Runner Job)
+and to READ (the App serving `GET /artifacts/{id}`). So the App does need `get secrets` on it, and
+rotating the value requires an App restart as well as taking effect on the next scheduled Job.
+*/}}
+{{- if and (eq .Values.artifactStorage.backend "s3") (not .Values.artifactStorage.s3.existingSecret) }}
+{{- $secretName := printf "%s-artifact-storage" (include "screamingface-engine.fullname" .) -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $secretKey := .Values.artifactStorage.s3.secretKey -}}
+{{- if not $secretKey -}}
+{{/* WHY: reuse the key already in the cluster so a values-less `helm upgrade` does not wipe it. */}}
+{{- if and $existing $existing.data (index $existing.data "URL4_CLOUD_ARTIFACT_S3_SECRET_KEY") -}}
+{{- $secretKey = (index $existing.data "URL4_CLOUD_ARTIFACT_S3_SECRET_KEY" | b64dec) -}}
+{{- else -}}
+{{- fail "artifactStorage.backend=s3 requires either artifactStorage.s3.existingSecret or artifactStorage.s3.secretKey" -}}
+{{- end -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "screamingface-engine.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  URL4_CLOUD_ARTIFACT_S3_SECRET_KEY: {{ $secretKey | quote }}
+{{- end }}

--- a/apps/screamingface-engine/deploy/helm/templates/secret-artifact-storage.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/secret-artifact-storage.yaml
@@ -1,26 +1,53 @@
 {{/*
-The object-storage secret access key (OME-929). Rendered ONLY when the chart owns the Secret —
-`artifactStorage.s3.existingSecret` means an operator (or an External Secrets / Sealed Secrets
-flow) supplies it out-of-band, which is the recommended prod shape.
+The object-storage credentials (OME-929). Holds BOTH halves of the S3 key pair.
 
-INVARIANT: attached with `envFrom.secretRef`, which injects every key under its OWN name — so the
-key MUST be `URL4_CLOUD_ARTIFACT_S3_SECRET_KEY`, the variable both halves read.
+`artifactStorage.s3.existingSecret` wins when set (the prod shape — created out-of-band or by an
+External Secrets / Sealed Secrets flow); otherwise the chart owns this Secret and, when no values
+are supplied, GENERATES the pair so `garage.enabled: true` needs no operator input at all.
 
-WHY both halves, unlike the Tavily Secret: this credential is needed to WRITE (each Runner Job)
-and to READ (the App serving `GET /artifacts/{id}`). So the App does need `get secrets` on it, and
-rotating the value requires an App restart as well as taking effect on the next scheduled Job.
+WHY the access key ID lives here too, though it is not secret: it must be STABLE. An
+auto-generated value has to survive `helm upgrade`, and the `lookup` trick that achieves that only
+works against an object the chart already owns. Keeping the pair together also means one envFrom
+delivers both halves to both consumers, instead of a ConfigMap and a Secret that can disagree.
+
+INVARIANT: attached with `envFrom.secretRef`, which injects each key under its OWN name — so the
+keys MUST be exactly the variables the code reads. Three consumers, one source:
+  - the App          (Deployment envFrom)         reads it to sign GETs when streaming results back
+  - every Runner Job (envFrom.secretRef)          reads it to sign the PUT that parks a result
+  - Garage itself    (env, mapped to GARAGE_DEFAULT_*) creates this very key on first boot
+
+That third consumer is what makes the deployment self-configuring: rather than Garage minting a
+key and the chart having to discover it, the chart states the key and Garage adopts it. The data
+flows one way, which is what lets this stay declarative.
 */}}
 {{- if and (eq .Values.artifactStorage.backend "s3") (not .Values.artifactStorage.s3.existingSecret) }}
 {{- $secretName := printf "%s-artifact-storage" (include "screamingface-engine.fullname" .) -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $accessKey := .Values.artifactStorage.s3.accessKey -}}
 {{- $secretKey := .Values.artifactStorage.s3.secretKey -}}
-{{- if not $secretKey -}}
-{{/* WHY: reuse the key already in the cluster so a values-less `helm upgrade` does not wipe it. */}}
-{{- if and $existing $existing.data (index $existing.data "URL4_CLOUD_ARTIFACT_S3_SECRET_KEY") -}}
-{{- $secretKey = (index $existing.data "URL4_CLOUD_ARTIFACT_S3_SECRET_KEY" | b64dec) -}}
-{{- else -}}
-{{- fail "artifactStorage.backend=s3 requires either artifactStorage.s3.existingSecret or artifactStorage.s3.secretKey" -}}
+{{/*
+WHY reuse before generate: a values-less `helm upgrade` must not mint a NEW key pair. Garage
+adopts the default key only on first boot, so a rotated pair would leave the engine signing with
+credentials the store has never heard of — a 403 on every artifact, which reads as a code bug.
+*/}}
+{{- if and $existing $existing.data -}}
+{{- if and (not $accessKey) (index $existing.data "URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY") -}}
+{{- $accessKey = (index $existing.data "URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY" | b64dec) -}}
 {{- end -}}
+{{- if and (not $secretKey) (index $existing.data "URL4_CLOUD_ARTIFACT_S3_SECRET_KEY") -}}
+{{- $secretKey = (index $existing.data "URL4_CLOUD_ARTIFACT_S3_SECRET_KEY" | b64dec) -}}
+{{- end -}}
+{{- end -}}
+{{/*
+Generated in Garage's own shapes — `GK` + 24 hex for the id, 64 hex for the secret — because
+Garage is the party that has to accept them. sha256sum is how a hex string is obtained here at
+all: sprig has no hex-random, and `randAlphaNum` alone would produce mixed-case alphanumerics.
+*/}}
+{{- if not $accessKey -}}
+{{- $accessKey = printf "GK%s" (randAlphaNum 32 | sha256sum | trunc 24) -}}
+{{- end -}}
+{{- if not $secretKey -}}
+{{- $secretKey = randAlphaNum 64 | sha256sum -}}
 {{- end -}}
 apiVersion: v1
 kind: Secret
@@ -30,5 +57,6 @@ metadata:
     {{- include "screamingface-engine.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY: {{ $accessKey | quote }}
   URL4_CLOUD_ARTIFACT_S3_SECRET_KEY: {{ $secretKey | quote }}
 {{- end }}

--- a/apps/screamingface-engine/deploy/helm/values.schema.json
+++ b/apps/screamingface-engine/deploy/helm/values.schema.json
@@ -450,7 +450,7 @@
     },
     "artifactStorage": {
       "type": "object",
-      "description": "Where over-cap results are parked between the Runner Job that writes one and the App that serves it (OME-929). 'filesystem' is single-process only; separate pods need 's3'.",
+      "description": "Where over-cap results are parked between the Runner Job that writes one and the App that serves it (OME-929). 'filesystem' is single-process only; separate pods need 's3'. With garage.enabled the credentials are generated and adopted automatically.",
       "properties": {
         "backend": {
           "type": "string",
@@ -489,35 +489,6 @@
           "additionalProperties": false
         }
       },
-      "allOf": [
-        {
-          "if": {
-            "properties": {
-              "backend": {
-                "const": "s3"
-              }
-            },
-            "required": [
-              "backend"
-            ]
-          },
-          "then": {
-            "properties": {
-              "s3": {
-                "properties": {
-                  "accessKey": {
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "accessKey"
-                ]
-              }
-            },
-            "description": "artifactStorage.backend=s3 needs artifactStorage.s3.accessKey, plus either .existingSecret or .secretKey"
-          }
-        }
-      ],
       "additionalProperties": false
     },
     "garage": {

--- a/apps/screamingface-engine/deploy/helm/values.schema.json
+++ b/apps/screamingface-engine/deploy/helm/values.schema.json
@@ -447,6 +447,124 @@
     },
     "global": {
       "type": "object"
+    },
+    "artifactStorage": {
+      "type": "object",
+      "description": "Where over-cap results are parked between the Runner Job that writes one and the App that serves it (OME-929). 'filesystem' is single-process only; separate pods need 's3'.",
+      "properties": {
+        "backend": {
+          "type": "string",
+          "enum": [
+            "filesystem",
+            "s3"
+          ]
+        },
+        "filesystemDir": {
+          "type": "string"
+        },
+        "s3": {
+          "type": "object",
+          "properties": {
+            "endpointUrl": {
+              "type": "string"
+            },
+            "bucket": {
+              "type": "string",
+              "minLength": 1
+            },
+            "region": {
+              "type": "string",
+              "minLength": 1
+            },
+            "accessKey": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "secretKey": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "backend": {
+                "const": "s3"
+              }
+            },
+            "required": [
+              "backend"
+            ]
+          },
+          "then": {
+            "properties": {
+              "s3": {
+                "properties": {
+                  "accessKey": {
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "accessKey"
+                ]
+              }
+            },
+            "description": "artifactStorage.backend=s3 needs artifactStorage.s3.accessKey, plus either .existingSecret or .secretKey"
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "garage": {
+      "type": "object",
+      "description": "The bundled single-node S3-compatible store. Default-disabled: an existing endpoint can be named with artifactStorage.s3.endpointUrl instead. Needs a one-time bootstrap after install \u2014 see templates/garage.yaml.",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "image": {
+          "type": "string",
+          "minLength": 1
+        },
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1,
+          "description": "Must be 1: two Garage processes on one metadata store corrupt it."
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "accessModes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            "size": {
+              "type": "string",
+              "minLength": 1
+            },
+            "storageClass": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "resources": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -135,28 +135,32 @@ artifactStorage:
     # Signing region. Arbitrary, but must match what the endpoint expects — Garage uses its own
     # configured region name, NOT an AWS one.
     region: garage
+    # Both may be left EMPTY. With the bundled Garage the chart generates a stable pair (reused
+    # across upgrades via `lookup`) and Garage adopts it on first boot — so `garage.enabled: true`
+    # needs no operator input at all. Set them only to use credentials you already have.
     accessKey: ""
-    # Bring your own Secret (recommended for prod — created out-of-band or by an External Secrets
-    # / Sealed Secrets flow). Empty + `backend: s3` => the chart creates one from `secretKey`.
-    # NOTE: the credential must be keyed `URL4_CLOUD_ARTIFACT_S3_SECRET_KEY` in the Secret; both
-    # the App and each Runner Job attach it with `envFrom.secretRef`, which injects keys under
-    # their own names and cannot rename.
-    existingSecret: ""
     # Dev-only convenience for a chart-created Secret. NEVER commit a real key to a values file;
     # pass it with `--set` / `--set-file`, or use `existingSecret`.
     secretKey: ""
+    # Bring your own Secret (recommended when pointing at storage you already run — created
+    # out-of-band or by an External Secrets / Sealed Secrets flow). It must carry BOTH
+    # `URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY` and `URL4_CLOUD_ARTIFACT_S3_SECRET_KEY`: they are
+    # delivered by `envFrom.secretRef`, which injects keys under their own names and cannot rename.
+    existingSecret: ""
 
 # The bundled S3-compatible object store (OME-929, spec D2). Default-disabled so an existing
 # endpoint can be used instead by setting `artifactStorage.s3.endpointUrl`.
 #
-# AIDEV-NOTE: Garage needs a ONE-TIME bootstrap after first install — a layout assignment, then a
-# bucket and an access key — which this chart does NOT perform, because those are imperative
-# `garage` CLI steps whose failure modes are much worse when hidden inside a hook. See
-# deploy/helm/README.md for the exact commands, and feed the resulting key into
-# `artifactStorage.s3.accessKey` / `.secretKey`.
+# SELF-CONFIGURING: Garage >=2.3.0 creates its own single-node layout, adopts the access key the
+# chart generates, and creates the bucket — so enabling this is the only step. No bootstrap Job, no
+# operator commands. See templates/garage.yaml for why that beats a post-install hook.
 garage:
   enabled: false
-  image: dxflrs/garage:v1.0.1
+  # MINIMUM v2.3.0 — that release added the --single-node / --default-access-key /
+  # --default-bucket server flags this chart relies on to configure itself. On an
+  # earlier tag those flags do not exist, Garage starts with no layout and no bucket,
+  # and every artifact PUT fails.
+  image: dxflrs/garage:v2.3.0
   # One replica: this is a single-consumer hand-off store for objects that live <48h, not a
   # durability tier. Replication would add a failure domain for no benefit at this size.
   replicaCount: 1

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -111,6 +111,69 @@ config:
   # away from the port actually being listened on. Use `service.port` to change what the cluster
   # dials; the container side is fixed.
 
+# Where over-cap Evaluation results are parked between the Runner Job that produces one and the
+# App that serves it back (OME-929).
+#
+# WHY this must not be a local directory when `config.runner: k8s`: each run is a separate Job pod
+# whose disk is destroyed with it, so a result spilled there can never be served — the run
+# succeeds, then the client's redemption 404s, after every model call has been paid for. That was
+# the DEFAULT before OME-929 and nothing about it looked wrong. The App now REFUSES to start in
+# that combination, so a k8s deployment must set `backend: s3` here.
+artifactStorage:
+  # Spill directory for filesystem mode. Ignored when `backend: s3`. Empty => the code's default
+  # (a temp path), which is fine for a single process and catastrophic across pods — hence the
+  # startup refusal described above.
+  filesystemDir: ""
+  # "filesystem" — one process, one disk. Correct for local/single-process only.
+  # "s3"         — any S3-compatible endpoint. Required whenever runs are separate pods.
+  backend: filesystem
+  s3:
+    # Base URL of the endpoint. With `garage.enabled` below, leave empty to use the bundled
+    # instance's in-cluster Service.
+    endpointUrl: ""
+    bucket: screamingface-artifacts
+    # Signing region. Arbitrary, but must match what the endpoint expects — Garage uses its own
+    # configured region name, NOT an AWS one.
+    region: garage
+    accessKey: ""
+    # Bring your own Secret (recommended for prod — created out-of-band or by an External Secrets
+    # / Sealed Secrets flow). Empty + `backend: s3` => the chart creates one from `secretKey`.
+    # NOTE: the credential must be keyed `URL4_CLOUD_ARTIFACT_S3_SECRET_KEY` in the Secret; both
+    # the App and each Runner Job attach it with `envFrom.secretRef`, which injects keys under
+    # their own names and cannot rename.
+    existingSecret: ""
+    # Dev-only convenience for a chart-created Secret. NEVER commit a real key to a values file;
+    # pass it with `--set` / `--set-file`, or use `existingSecret`.
+    secretKey: ""
+
+# The bundled S3-compatible object store (OME-929, spec D2). Default-disabled so an existing
+# endpoint can be used instead by setting `artifactStorage.s3.endpointUrl`.
+#
+# AIDEV-NOTE: Garage needs a ONE-TIME bootstrap after first install — a layout assignment, then a
+# bucket and an access key — which this chart does NOT perform, because those are imperative
+# `garage` CLI steps whose failure modes are much worse when hidden inside a hook. See
+# deploy/helm/README.md for the exact commands, and feed the resulting key into
+# `artifactStorage.s3.accessKey` / `.secretKey`.
+garage:
+  enabled: false
+  image: dxflrs/garage:v1.0.1
+  # One replica: this is a single-consumer hand-off store for objects that live <48h, not a
+  # durability tier. Replication would add a failure domain for no benefit at this size.
+  replicaCount: 1
+  persistence:
+    enabled: true
+    # RWO is sufficient — only the Garage pod mounts this. It is precisely NOT the shared volume
+    # the App and the Runner would have needed, which is why object storage was chosen instead.
+    accessModes: [ReadWriteOnce]
+    size: 10Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
 # Tavily web tools (spec 2026-07-23) — lets the aigateway connector declare web_search/web_fetch
 # and run its bounded tool-calling loop. Disabled => the Runner never sees TAVILY_API_KEY and the
 # connector stays deny-by-default (dec:W5), with a request body identical to the no-tools shape.

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -72,7 +72,14 @@ def build_job_runner(
             image=settings.runner_image,
             namespace=settings.namespace,
             env_configmap=settings.runner_env_configmap,
-            env_secrets=(settings.tavily_secret_name,) if settings.tavily_secret_name else (),
+            # WHY built as a filtered tuple rather than two conditionals: a Job may need both
+            # credentials (Tavily to search, object storage to park its result), and `envFrom`
+            # takes a list — so the two are independent, not alternatives.
+            env_secrets=tuple(
+                name
+                for name in (settings.tavily_secret_name, settings.artifact_s3_secret_name)
+                if name
+            ),
             resources=settings.runner_resources,
             job_ttl_s=settings.effective_job_ttl_s,
             extra_models=extra_models,

--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -16,8 +16,14 @@ from pathlib import Path
 from fastapi import APIRouter, FastAPI
 from fastapi.staticfiles import StaticFiles
 
+from screamingface_engine import job_env
 from screamingface_engine.adapters.factory import build_job_runner
-from screamingface_engine.artifacts import ArtifactStore
+from screamingface_engine.artifacts import (
+    ArtifactReader,
+    ArtifactStore,
+    S3ArtifactStore,
+)
+from screamingface_engine.artifacts.wiring import s3_config_from_values
 from screamingface_engine.auth import Clock, install_problem_handlers
 from screamingface_engine.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry
 from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
@@ -99,13 +105,19 @@ def create_app(
     app.state.benchmarks = benchmarks
     app.state.metrics = build_metrics()
     # FEATURE: deliver large results in full (OME-892) — the serve side of the spill store.
-    artifact_store = ArtifactStore(Path(settings.artifacts_dir))
+    # FEATURE: and survive a multi-pod deployment, where that store cannot be a local disk
+    # (OME-929).
+    artifact_store = _build_artifact_reader(settings)
     app.state.artifact_store = artifact_store
-    # WHY startup + periodic: artifacts are deleted on fetch, so the only leak source is
-    # parcels nobody redeemed (crashed runs, vanished clients). The boot sweep clears the
+    # WHY startup + periodic: fetching never deletes (OME-892 review — content addressing means
+    # one object backs many tickets, and a Range request must leave the rest fetchable), so TTL
+    # is the ONLY cleanup and every redeemed parcel also waits for it. The boot sweep clears the
     # backlog immediately; the periodic task covers a hosted App that stays up for weeks
-    # between redeploys — startup-only would let abandoned parcels pool until the next
+    # between redeploys — startup-only would let parcels pool until the next
     # restart (owner decision on OME-892).
+    #
+    # AIDEV-NOTE: with `artifact_store=s3` the sweeper is a no-op by design — expiry is the
+    # bucket's lifecycle rule. See `artifacts.s3.S3ArtifactStore.sweep`.
     _install_artifact_sweeper(app, artifact_store, settings)
     # WHY: pass a getter, not `catalog` directly — the collector re-reads app.state.catalog on
     # every /metrics scrape rather than capturing the value built here.
@@ -131,7 +143,44 @@ def create_app(
 _logger = logging.getLogger(__name__)
 
 
-def _install_artifact_sweeper(app: FastAPI, store: ArtifactStore, settings: Settings) -> None:
+def _build_artifact_reader(settings: Settings) -> ArtifactReader:
+    """The serve side of the spill store, and a refusal for the combination that loses results.
+
+    FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+    INVARIANT: `runner="k8s"` with filesystem storage is refused. A Runner Job pod and this App
+    pod do not share a disk, so the Runner writes into an `emptyDir` that dies with the Job and
+    every over-cap redemption 404s — after the run has been paid for in full. That pairing was
+    the DEFAULT before OME-929, reachable by configuring nothing, and nothing in the setup said
+    so. It fails at boot now.
+
+    AIDEV-NOTE: if a shared RWX volume is ever mounted into both pods, THIS is the check to
+    relax — deliberately, and with the mount as evidence. Do not relax it to quiet a startup
+    error; that restores the bug.
+    """
+    if settings.artifact_store == "s3":
+        return S3ArtifactStore(
+            s3_config_from_values(
+                {
+                    job_env.ARTIFACT_S3_ENDPOINT_URL: settings.artifact_s3_endpoint_url,
+                    job_env.ARTIFACT_S3_BUCKET: settings.artifact_s3_bucket,
+                    job_env.ARTIFACT_S3_REGION: settings.artifact_s3_region,
+                    job_env.ARTIFACT_S3_ACCESS_KEY: settings.artifact_s3_access_key,
+                    job_env.ARTIFACT_S3_SECRET_KEY: settings.artifact_s3_secret_key,
+                }
+            )
+        )
+    if settings.runner == "k8s":
+        raise ValueError(
+            f"runner='k8s' schedules each run as a separate Job pod, whose disk is destroyed "
+            f"with it, so results spilled to a local directory can never be served back. Set "
+            f"{job_env.ARTIFACT_STORE}=s3 and the {job_env.ARTIFACT_S3_BUCKET} settings, or "
+            f"use runner='none' for a single-process deployment."
+        )
+    return ArtifactStore(Path(settings.artifacts_dir))
+
+
+def _install_artifact_sweeper(app: FastAPI, store: ArtifactReader, settings: Settings) -> None:
     """Wire the artifact TTL sweep: once at startup, then every sweep interval for life.
 
     FEATURE: deliver large results in full (OME-892). The loop is an asyncio task on the

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/__init__.py
@@ -15,6 +15,7 @@ from screamingface_engine.artifacts.ports import (
     LocalFile,
     RemoteStream,
 )
+from screamingface_engine.artifacts.s3 import S3ArtifactStore, S3Config, S3StorageError
 
 # AIDEV-NOTE: an alias, not a subclass. A subclass would be a second type that
 # `isinstance` and `is` comparisons could tell apart, which is exactly the drift the
@@ -29,4 +30,7 @@ __all__ = [
     "FilesystemArtifactStore",
     "LocalFile",
     "RemoteStream",
+    "S3ArtifactStore",
+    "S3Config",
+    "S3StorageError",
 ]

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/__init__.py
@@ -1,0 +1,32 @@
+"""Artifact storage: the ports, and the adapters that implement them.
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+`ArtifactStore` is retained as an alias for `FilesystemArtifactStore`: it names the same
+class 24 call sites and 4 test modules already import, and this repo's tests are
+append-only, so the name must keep resolving. New code should say which adapter it means.
+"""
+
+from screamingface_engine.artifacts.filesystem import FilesystemArtifactStore
+from screamingface_engine.artifacts.ports import (
+    ArtifactContent,
+    ArtifactReader,
+    ArtifactWriter,
+    LocalFile,
+    RemoteStream,
+)
+
+# AIDEV-NOTE: an alias, not a subclass. A subclass would be a second type that
+# `isinstance` and `is` comparisons could tell apart, which is exactly the drift the
+# rename was meant to avoid.
+ArtifactStore = FilesystemArtifactStore
+
+__all__ = [
+    "ArtifactContent",
+    "ArtifactReader",
+    "ArtifactStore",
+    "ArtifactWriter",
+    "FilesystemArtifactStore",
+    "LocalFile",
+    "RemoteStream",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/filesystem.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/filesystem.py
@@ -1,16 +1,26 @@
-"""Content-addressed spill store for results too large to ride the stream inline.
+"""Content-addressed spill store on the local filesystem.
 
 FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
 
 Think of it as the parcel counter behind the mail slot: the runner leaves the complete
 result here under its own fingerprint, the terminal frame carries only the claim ticket
 (`ResultArtifact`), and the REST route hands the file over when the client redeems the
-ticket. Stage order per run: `write_text` (runner, at completion) → `path_for` (REST GET)
-→ `delete` (after a successful fetch) — with `sweep` at app startup collecting parcels
-nobody ever picked up (crashed runs, clients that vanished).
+ticket. Stage order per run: `write_text` (runner, at completion) → `content` (REST GET),
+with `sweep` — at app startup AND periodically — collecting parcels nobody ever picked up
+(crashed runs, clients that vanished).
+
+INVARIANT: fetching NEVER deletes. Content addressing means one file can back many claim
+tickets (identical results dedupe onto one path), a dropped connection must be retryable,
+and a Range request must leave the rest of the file fetchable — delete-on-first-GET broke
+all three (review finding on OME-892). Artifacts die by TTL alone.
 
 INVARIANT: the filename IS the sha256 of the content, so the id doubles as the integrity
 check and a well-formed id can never name anything outside the flat store root.
+
+AIDEV-NOTE: correct for `inprocess`/local, where the writer and the reader are ONE process
+and share this directory by construction. It is NOT correct for the `k8s`/`jetstream`
+backends — see `s3.py` and OME-929. Selecting it there is what produced a 404 after a full
+run's spend, so the selection is derived rather than configurable.
 """
 
 from __future__ import annotations
@@ -22,12 +32,13 @@ import time
 import uuid
 from pathlib import Path
 
+from screamingface_engine.artifacts.ports import ArtifactContent, LocalFile
 from url4.streaming.protocol.signals import ResultArtifact
 
 _ARTIFACT_ID = re.compile(r"^[0-9a-f]{64}$")
 
 
-class ArtifactStore:
+class FilesystemArtifactStore:
     """Flat directory of files named by the lowercase sha256 hex of their content."""
 
     def __init__(self, root: Path) -> None:
@@ -62,8 +73,22 @@ class ArtifactStore:
             os.replace(tmp, final)
         return ResultArtifact(id=digest, size_bytes=len(encoded), sha256=digest)
 
+    def content(self, artifact_id: str) -> ArtifactContent | None:
+        """The stored content for `artifact_id`, or None when absent or malformed.
+
+        Returns `LocalFile` — the route renders it with `FileResponse`, which is what keeps
+        bounded memory and HTTP Range on this path.
+        """
+        path = self.path_for(artifact_id)
+        return None if path is None else LocalFile(path=path)
+
     def path_for(self, artifact_id: str) -> Path | None:
-        """The stored file for `artifact_id`, or None when absent or malformed."""
+        """The stored file for `artifact_id`, or None when absent or malformed.
+
+        AIDEV-NOTE: kept alongside `content` because 14 call sites and their append-only
+        tests name it. It is the filesystem adapter's own detail, NOT part of the
+        `ArtifactReader` port — an object-storage reader has no path to return.
+        """
         if _ARTIFACT_ID.fullmatch(artifact_id) is None:
             return None
         path = self._root / artifact_id
@@ -91,7 +116,7 @@ class ArtifactStore:
         cutoff = (time.time() if now is None else now) - ttl_seconds
         removed = 0
         for path in self._root.iterdir():
-            # `.tmp` files are crash leftovers from `write_text`'s atomic-rename dance —
+            # `.tmp` files are crash leftovers from `write_bytes`'s atomic-rename dance —
             # invisible to `path_for`, but they hold real bytes and must age out too.
             named_like_ours = _ARTIFACT_ID.fullmatch(path.name) is not None or path.name.endswith(
                 ".tmp"
@@ -106,3 +131,6 @@ class ArtifactStore:
                 path.unlink(missing_ok=True)
                 removed += 1
         return removed
+
+
+__all__ = ["FilesystemArtifactStore"]

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/ports.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/ports.py
@@ -67,6 +67,16 @@ class ArtifactWriter(Protocol):
 
     def write_bytes(self, encoded: bytes) -> ResultArtifact: ...
 
+    def write_text(self, body: str) -> ResultArtifact:
+        """Encode `body` as UTF-8 and park it.
+
+        WHY on the port and not just on the adapters: callers legitimately hold a `str` (the
+        executor is the exception — it encodes once to measure the size, then hands over bytes so
+        a gigabyte-scale result is not copied twice). Leaving it off the port only pushed those
+        callers back onto a concrete class, which is the coupling the port exists to remove.
+        """
+        ...
+
 
 @runtime_checkable
 class ArtifactReader(Protocol):

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/ports.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/ports.py
@@ -1,0 +1,92 @@
+"""The two sides of the artifact hand-off, as ports the adapters implement.
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+WHY two ports and not one store: a single class served both sides until now because they
+shared a filesystem. On the hosted Engine they do not — the Runner is a Job pod and the App
+is a Deployment pod, each with its own `emptyDir` — so "the thing that parks a result" and
+"the thing that hands it over" are two roles that happen to coincide only in local mode.
+Splitting them is what lets object storage back the write side without the read side
+learning about it.
+
+INVARIANT: nothing here knows about HTTP. `screamingface_engine.artifacts` is a SHARED LEAF
+of the layering gate — both halves import it — so a Starlette type reaching in would put the
+serving framework into a Runner Job's cold start, which is exactly what that gate exists to
+prevent. The port says what there is to render; `rest.artifacts` decides how.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from url4.streaming.protocol.signals import ResultArtifact
+
+
+@dataclass(frozen=True)
+class LocalFile:
+    """Content the reader can hand over as a path on its own disk.
+
+    WHY a path rather than bytes: it is what lets the route keep `FileResponse`, and with it
+    bounded memory and HTTP Range for resume — capabilities a stream cannot offer.
+    """
+
+    path: Path
+
+
+@dataclass(frozen=True)
+class RemoteStream:
+    """Content the reader must pull from somewhere else as it serves it.
+
+    Carries `size_bytes` explicitly because the filesystem's `stat()` is gone: a client (and
+    a `Content-Length`) still needs the length, and an object store knows it before the body
+    arrives.
+    """
+
+    stream: AsyncIterator[bytes]
+    size_bytes: int
+
+
+# WHY a union rather than one flattened shape: the two storage kinds genuinely differ in what
+# they can offer. Flattening would either lose Range on the local path or fake it on the
+# remote one, and faking it is worse — a Range request that silently returns the whole body
+# breaks resume for a client that believes it worked.
+ArtifactContent = LocalFile | RemoteStream
+
+
+@runtime_checkable
+class ArtifactWriter(Protocol):
+    """The Runner's side: park a finished result and mint its claim ticket.
+
+    Deliberately SYNC. `runner.executor.build_result` already runs this under
+    `asyncio.to_thread` so a large spill cannot stall heartbeats (OME-892 finding 10), so an
+    async port would add a second concurrency story to a path that already has a working one.
+    """
+
+    def write_bytes(self, encoded: bytes) -> ResultArtifact: ...
+
+
+@runtime_checkable
+class ArtifactReader(Protocol):
+    """The App's side: resolve a claim ticket, and reclaim what nobody redeemed.
+
+    Sync for the same reason as the writer, and because `sweep` and `delete` are already sync
+    across every existing call site and their tests, which are append-only.
+    """
+
+    def content(self, artifact_id: str) -> ArtifactContent | None: ...
+
+    def delete(self, artifact_id: str) -> None: ...
+
+    def sweep(self, ttl_seconds: float, *, now: float | None = None) -> int: ...
+
+
+__all__ = [
+    "ArtifactContent",
+    "ArtifactReader",
+    "ArtifactWriter",
+    "LocalFile",
+    "RemoteStream",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/s3.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/s3.py
@@ -19,6 +19,12 @@ AIDEV-NOTE: reclamation is NOT done here. `sweep` is a deliberate no-op — obje
 bucket lifecycle rule, because listing objects would need query-string signing and push the
 signer past the bound spec D5 sets on it. A bucket with no lifecycle rule never expires
 artifacts.
+
+AIDEV-NOTE: objects are addressed PATH-STYLE (`{endpoint}/{bucket}/{key}`). Garage, MinIO,
+SeaweedFS, Ceph RGW and Cloudflare R2 all accept that. AWS S3 proper has deprecated path-style in
+favour of virtual-hosted-style (`bucket.s3.region.amazonaws.com`), so this adapter may not reach
+real AWS S3 — and the failure looks like a signing or credential problem rather than an addressing
+one. Supporting it means choosing the style per endpoint, not patching `_url_path`.
 """
 
 from __future__ import annotations

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/s3.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/s3.py
@@ -1,0 +1,236 @@
+"""Content-addressed spill store on an S3-compatible endpoint.
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+WHY this exists: the filesystem adapter is correct only where the writer and the reader are
+one process. On the hosted Engine the Runner is a Job pod whose disk dies with it, so a
+~3 MiB result written there is unreachable by the App that must serve it — a 404 after the
+whole run's spend was paid. Object storage is the shared ground the two pods actually have.
+
+WHY self-hosted (spec D2): the deployment bundles its own Garage instance, so this needs no
+cloud account, no managed-service credentials, and no cloud coupling — while speaking a wire
+protocol that a managed S3 could later answer unchanged.
+
+INVARIANT: the object key IS the sha256 of the content, exactly as the filename was on the
+filesystem. So the id remains its own integrity check, and a well-formed id cannot address
+anything outside this bucket.
+
+AIDEV-NOTE: reclamation is NOT done here. `sweep` is a deliberate no-op — object expiry is a
+bucket lifecycle rule, because listing objects would need query-string signing and push the
+signer past the bound spec D5 sets on it. A bucket with no lifecycle rule never expires
+artifacts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import AsyncIterator, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import httpx
+
+from screamingface_engine.artifacts.ports import ArtifactContent, RemoteStream
+from screamingface_engine.artifacts.sigv4 import (
+    EMPTY_PAYLOAD_SHA256,
+    Credentials,
+    authorization_header,
+)
+from url4.streaming.protocol.signals import ResultArtifact
+
+_ARTIFACT_ID = re.compile(r"^[0-9a-f]{64}$")
+_STREAM_CHUNK_BYTES = 64 * 1024
+_DEFAULT_TIMEOUT_S = 30.0
+
+
+class S3StorageError(RuntimeError):
+    """The object store could not serve a request.
+
+    INVARIANT: distinct from "the artifact is absent", which is `None`. Collapsing the two
+    would present a misconfiguration (bad credentials, unreachable endpoint) as an expired
+    parcel — the misdiagnosis that sent the OME-929 investigation down a dead end.
+    """
+
+
+@dataclass(frozen=True)
+class S3Config:
+    """Where the bucket is and how to authenticate to it.
+
+    A plain value object rather than a read of `Settings`: `artifacts` is a shared leaf of the
+    layering gate, and `config` belongs to the control plane. Each half builds this from its
+    own configuration source — the App from `Settings`, the Runner from `job_env`.
+    """
+
+    endpoint_url: str
+    bucket: str
+    credentials: Credentials
+    timeout_s: float = _DEFAULT_TIMEOUT_S
+
+
+class S3ArtifactStore:
+    """Flat bucket of objects keyed by the lowercase sha256 hex of their content."""
+
+    def __init__(
+        self,
+        config: S3Config,
+        *,
+        client_factory: Callable[[], httpx.Client] | None = None,
+        async_client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        # WHY factories rather than clients: the write side runs inside `asyncio.to_thread`
+        # (see `ports.ArtifactWriter`) and the read side streams on the event loop, so the two
+        # cannot share one client. Injectable so tests can assert on the request actually
+        # sent — the same seam `runner.connector.build_aigateway_world` uses.
+        self._config = config
+        self._client_factory = client_factory or self._default_client
+        self._async_client_factory = async_client_factory or self._default_async_client
+
+    # --- construction seams --------------------------------------------------------------
+
+    def _default_client(self) -> httpx.Client:
+        return httpx.Client(timeout=self._config.timeout_s)
+
+    def _default_async_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(timeout=self._config.timeout_s)
+
+    # --- ArtifactWriter -----------------------------------------------------------------
+
+    def write_text(self, body: str) -> ResultArtifact:
+        """Persist `body` and return its claim ticket. See `write_bytes`."""
+        return self.write_bytes(body.encode("utf-8"))
+
+    def write_bytes(self, encoded: bytes) -> ResultArtifact:
+        """Persist already-encoded content and return its claim ticket. Idempotent.
+
+        Idempotent for free: the key is the content hash, so re-uploading identical bytes
+        overwrites an identical object.
+
+        INVARIANT: a ticket is only returned once the object store has ACKNOWLEDGED the
+        write. A ticket for a failed upload would turn a loud error here into a silent 404
+        at redemption — the exact failure shape OME-929 exists to remove.
+        """
+        digest = hashlib.sha256(encoded).hexdigest()
+        self._request("PUT", digest, payload_sha256=digest, content=encoded)
+        return ResultArtifact(id=digest, size_bytes=len(encoded), sha256=digest)
+
+    # --- ArtifactReader -----------------------------------------------------------------
+
+    def content(self, artifact_id: str) -> ArtifactContent | None:
+        """The stored content for `artifact_id`, or None when absent or malformed.
+
+        HEADs first to learn existence and length, then hands back a stream that fetches the
+        body when the route iterates it. The HEAD is what lets the route answer 404 without
+        having opened a multi-megabyte body it may not need.
+        """
+        if _ARTIFACT_ID.fullmatch(artifact_id) is None:
+            # INVARIANT: validated before signing, so a traversal attempt never becomes a
+            # request at all — the same guard the filesystem adapter applies to paths.
+            return None
+        head = self._request("HEAD", artifact_id, allow_missing=True)
+        if head is None:
+            return None
+        return RemoteStream(
+            stream=self._stream(artifact_id),
+            size_bytes=int(head.headers.get("content-length", 0)),
+        )
+
+    def delete(self, artifact_id: str) -> None:
+        """Remove an object. Absence is not an error — deletes race lifecycle expiry."""
+        if _ARTIFACT_ID.fullmatch(artifact_id) is None:
+            return
+        self._request("DELETE", artifact_id, allow_missing=True)
+
+    def sweep(self, ttl_seconds: float, *, now: float | None = None) -> int:
+        """Always 0 — expiry is the bucket's lifecycle rule, not ours.
+
+        WHY not a real sweep: listing objects means signing a query string, which pushes the
+        signer past the PUT/GET-of-one-object bound spec D5 places on it. The store expires
+        objects on its own schedule instead.
+
+        AIDEV-NOTE: load-bearing, not a stub. A bucket configured with no lifecycle rule
+        never expires artifacts, and nothing here will notice.
+        """
+        return 0
+
+    # --- one signed request --------------------------------------------------------------
+
+    def _url_path(self, key: str) -> str:
+        return f"/{self._config.bucket}/{key}"
+
+    def _signed_headers(self, method: str, key: str, *, payload_sha256: str) -> dict[str, str]:
+        host = httpx.URL(self._config.endpoint_url).netloc.decode("ascii")
+        now = datetime.now(UTC)
+        headers = {
+            "Host": host,
+            "X-Amz-Content-Sha256": payload_sha256,
+            "X-Amz-Date": now.strftime("%Y%m%dT%H%M%SZ"),
+        }
+        # INVARIANT: the Authorization is computed from THIS dict, and the same dict is what
+        # gets sent — so the SignedHeaders list and the wire headers cannot drift apart.
+        headers["Authorization"] = authorization_header(
+            credentials=self._config.credentials,
+            method=method,
+            path=self._url_path(key),
+            query="",
+            headers=headers,
+            payload_sha256=payload_sha256,
+            now=now,
+        )
+        return headers
+
+    def _request(
+        self,
+        method: str,
+        key: str,
+        *,
+        payload_sha256: str = EMPTY_PAYLOAD_SHA256,
+        content: bytes | None = None,
+        allow_missing: bool = False,
+    ) -> httpx.Response | None:
+        """One signed round trip. `None` only when `allow_missing` and the object is absent."""
+        headers = self._signed_headers(method, key, payload_sha256=payload_sha256)
+        url = f"{self._config.endpoint_url.rstrip('/')}{self._url_path(key)}"
+        try:
+            with self._client_factory() as client:
+                response = client.request(method, url, headers=headers, content=content)
+        except httpx.HTTPError as exc:
+            # WHY wrapped: callers handle `S3StorageError`; a bare httpx error crossing this
+            # boundary would surface as an unhandled exception mid-run.
+            raise S3StorageError(f"{method} {key} could not reach object storage: {exc}") from exc
+        if allow_missing and response.status_code == 404:
+            return None
+        if response.status_code >= 400:
+            # AIDEV-NOTE: the body is the store's own error XML, not ours; it names the real
+            # cause (SignatureDoesNotMatch, NoSuchBucket, AccessDenied) and is what turns an
+            # opaque 403 into an actionable one. It carries no credential material.
+            raise S3StorageError(
+                f"object storage refused {method} {key} with {response.status_code}: "
+                f"{response.text[:200]}"
+            )
+        return response
+
+    async def _stream(self, key: str) -> AsyncIterator[bytes]:
+        """Stream one object's body.
+
+        Opens its own client per fetch: redemptions are rare (once per over-cap run) and a
+        per-fetch client needs no shutdown wiring in the app lifespan, which a shared one
+        would. Signed at iteration time so the request is never older than its signature.
+        """
+        headers = self._signed_headers("GET", key, payload_sha256=EMPTY_PAYLOAD_SHA256)
+        url = f"{self._config.endpoint_url.rstrip('/')}{self._url_path(key)}"
+        try:
+            async with self._async_client_factory() as client:
+                async with client.stream("GET", url, headers=headers) as response:
+                    if response.status_code >= 400:
+                        await response.aread()
+                        raise S3StorageError(
+                            f"object storage refused GET {key} with {response.status_code}"
+                        )
+                    async for chunk in response.aiter_bytes(_STREAM_CHUNK_BYTES):
+                        yield chunk
+        except httpx.HTTPError as exc:
+            raise S3StorageError(f"GET {key} could not reach object storage: {exc}") from exc
+
+
+__all__ = ["S3ArtifactStore", "S3Config", "S3StorageError"]

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/sigv4.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/sigv4.py
@@ -1,0 +1,152 @@
+"""AWS Signature Version 4 — the narrow slice needed to PUT and GET one object.
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+WHY hand-rolled (spec D5): the whole requirement is two unsigned-query requests against our
+own S3-compatible endpoint. No multipart, and no presigning — the App streams artifacts
+through rather than redirecting a client at storage. That fits in pure functions and keeps
+`httpx` the only HTTP dependency a Runner Job loads.
+
+WHY that is safe: we SIGN and the server VERIFIES. A defect here makes our own request fail
+with 403; it cannot make a forged request acceptable. The failure mode is closed, which is
+the property that makes hand-rolling defensible at all.
+
+INVARIANT (the bound): this stays PUT/GET of a single object. Multipart, presigned URLs, or
+chunked payload signing are the signal to take a real S3 client instead of growing this.
+
+Everything here is pure — no I/O, no ambient clock. `now` is a parameter so the signature is
+reproducible in a test, which is what lets it be checked against AWS's published vectors.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+
+ALGORITHM = "AWS4-HMAC-SHA256"
+
+EMPTY_PAYLOAD_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+"""sha256 of the empty byte string — what a GET or HEAD signs as its payload hash."""
+
+# INVARIANT: both must be signed. `host` binds the signature to this endpoint and `x-amz-date`
+# bounds its lifetime; without either, a captured signature is replayable somewhere or
+# forever. The server rejects their absence with an opaque 403, so we refuse earlier, where
+# we can say which one is missing.
+_REQUIRED_HEADERS = ("host", "x-amz-date")
+
+_TERMINATOR = "aws4_request"
+
+
+@dataclass(frozen=True)
+class Credentials:
+    """One S3-compatible endpoint's signing identity.
+
+    AIDEV-NOTE: `secret_key` is credential material. It is never logged and never rendered —
+    `dataclass(frozen=True)` gives this a `__repr__` that WOULD print it, so do not put an
+    instance into a log line or an exception message.
+    """
+
+    access_key: str
+    secret_key: str
+    region: str
+    service: str = "s3"
+
+
+def canonical_request(
+    *,
+    method: str,
+    path: str,
+    query: str,
+    headers: Mapping[str, str],
+    payload_sha256: str,
+) -> str:
+    """The canonical request: the exact bytes whose hash goes into the string to sign.
+
+    `path` passes through unencoded. S3's object APIs do NOT re-encode the key, and our keys
+    are 64 lowercase hex characters, so there is nothing to encode — re-encoding a key that
+    needs none is a silent 403.
+    """
+    lowered = {name.lower(): value.strip() for name, value in headers.items()}
+    for required in _REQUIRED_HEADERS:
+        if required not in lowered:
+            raise ValueError(f"SigV4 requires the {required} header to be signed")
+    names = sorted(lowered)
+    canonical_headers = "".join(f"{name}:{lowered[name]}\n" for name in names)
+    signed_headers = ";".join(names)
+    return "\n".join(
+        [method, path, query, canonical_headers + "\n" + signed_headers, payload_sha256]
+    )
+
+
+def signed_headers_of(headers: Mapping[str, str]) -> str:
+    """The `SignedHeaders` list — the same names, in the same order, as the canonical block.
+
+    Derived from one place so the header list sent and the header list signed cannot drift;
+    computing them separately is the classic way to produce a 403 that reads as bad keys.
+    """
+    return ";".join(sorted(name.lower() for name in headers))
+
+
+def string_to_sign(*, amz_date: str, scope: str, canonical: str) -> str:
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return "\n".join([ALGORITHM, amz_date, scope, digest])
+
+
+def signing_key(*, secret_key: str, date_stamp: str, region: str, service: str) -> bytes:
+    """Four chained HMACs: date, region, service, terminator. Order is part of the spec."""
+    key = f"AWS4{secret_key}".encode()
+    for part in (date_stamp, region, service, _TERMINATOR):
+        key = hmac.new(key, part.encode("utf-8"), hashlib.sha256).digest()
+    return key
+
+
+def authorization_header(
+    *,
+    credentials: Credentials,
+    method: str,
+    path: str,
+    query: str,
+    headers: Mapping[str, str],
+    payload_sha256: str,
+    now: datetime,
+) -> str:
+    """The finished `Authorization` value for one request."""
+    date_stamp = now.strftime("%Y%m%d")
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    scope = f"{date_stamp}/{credentials.region}/{credentials.service}/{_TERMINATOR}"
+    canonical = canonical_request(
+        method=method,
+        path=path,
+        query=query,
+        headers=headers,
+        payload_sha256=payload_sha256,
+    )
+    signature = hmac.new(
+        signing_key(
+            secret_key=credentials.secret_key,
+            date_stamp=date_stamp,
+            region=credentials.region,
+            service=credentials.service,
+        ),
+        string_to_sign(amz_date=amz_date, scope=scope, canonical=canonical).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return (
+        f"{ALGORITHM} Credential={credentials.access_key}/{scope}, "
+        f"SignedHeaders={signed_headers_of(headers)}, Signature={signature}"
+    )
+
+
+__all__ = [
+    "ALGORITHM",
+    "EMPTY_PAYLOAD_SHA256",
+    "Credentials",
+    "authorization_header",
+    "canonical_request",
+    "signed_headers_of",
+    "signing_key",
+    "string_to_sign",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/artifacts/wiring.py
+++ b/apps/screamingface-engine/src/screamingface_engine/artifacts/wiring.py
@@ -1,0 +1,65 @@
+"""Build the artifact store both halves need, and refuse the states that lose results.
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+WHY here and not in `adapters.factory`: that module is control-plane, and the Runner cannot
+import it. Both halves need this decision — the Runner to write, the App to read — so it
+belongs in the shared leaf, taking a plain mapping rather than either side's config object.
+
+INVARIANT: an incomplete object-storage configuration raises HERE, at wiring time. The failure
+it replaces arrived at redemption, after a full run's spend; the whole point is to move it to
+the earliest moment the information exists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from screamingface_engine import job_env
+from screamingface_engine.artifacts.s3 import S3Config
+from screamingface_engine.artifacts.sigv4 import Credentials
+
+# Which settings must be non-empty before an S3 store can be built. The region has a default
+# and the secret key is checked alongside the access key, so only these three are unguessable.
+_REQUIRED_S3 = (
+    job_env.ARTIFACT_S3_ENDPOINT_URL,
+    job_env.ARTIFACT_S3_BUCKET,
+    job_env.ARTIFACT_S3_ACCESS_KEY,
+    job_env.ARTIFACT_S3_SECRET_KEY,
+)
+
+
+def s3_config_from_values(values: Mapping[str, str]) -> S3Config:
+    """Build an `S3Config` from env-named values, or raise naming what is missing.
+
+    Args:
+        values: env-var name → value, using the `job_env.ARTIFACT_S3_*` names. Callers holding
+            a typed settings object render it into this shape so ONE validation path serves
+            both halves.
+
+    Raises:
+        ValueError: naming the first missing variable. The name is the whole point — an
+            operator reading it should not have to guess which of six settings is empty.
+    """
+    missing = [name for name in _REQUIRED_S3 if not (values.get(name) or "").strip()]
+    if missing:
+        raise ValueError(
+            "artifact object storage is selected but not fully configured: "
+            f"{', '.join(missing)} "
+            + ("is" if len(missing) == 1 else "are")
+            + " empty. Set them, or set "
+            f"{job_env.ARTIFACT_STORE}=filesystem for a single-process deployment."
+        )
+    return S3Config(
+        endpoint_url=values[job_env.ARTIFACT_S3_ENDPOINT_URL].strip(),
+        bucket=values[job_env.ARTIFACT_S3_BUCKET].strip(),
+        credentials=Credentials(
+            access_key=values[job_env.ARTIFACT_S3_ACCESS_KEY].strip(),
+            secret_key=values[job_env.ARTIFACT_S3_SECRET_KEY].strip(),
+            region=(values.get(job_env.ARTIFACT_S3_REGION) or "").strip()
+            or job_env.DEFAULT_ARTIFACT_S3_REGION,
+        ),
+    )
+
+
+__all__ = ["s3_config_from_values"]

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -3,7 +3,7 @@ environment variables."""
 
 from typing import Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from screamingface_engine import job_env
@@ -15,6 +15,7 @@ from screamingface_engine import job_env
 _TTL_SKEW_MARGIN_S = 60
 
 RunnerBackend = Literal["none", "k8s"]
+ArtifactStoreBackend = Literal["filesystem", "s3"]
 """Which ``JobRunner`` substrate the deployed App schedules runs on (spec §9).
 
 ``k8s`` is prod (namespace-scoped batch/v1 Jobs) and ``none`` a stream-only App that mints tokens
@@ -54,6 +55,25 @@ class Settings(BaseSettings):
     # Same env var (URL4_CLOUD_ARTIFACTS_DIR) the Runner's spill side reads — one name, so the
     # writer and the `GET /artifacts/{id}` server cannot be pointed at different directories.
     artifacts_dir: str = job_env.DEFAULT_ARTIFACTS_DIR
+    # FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+    #
+    # INVARIANT: every field below reads the env var `job_env` declares for it, by construction —
+    # `env_prefix` + the field name, uppercased. `test_artifact_storage_selection.py` pins that
+    # equality, because a one-sided rename would point the Runner's writer and the App's reader at
+    # different buckets, which is OME-929 again in a shape the 404 would not hint at.
+    #
+    # WHY a choice and not derived from `runner`: the Runner cannot see its own cluster topology,
+    # so the chart states this for both halves. The App CAN see it, and `create_app` refuses
+    # `runner="k8s"` paired with filesystem storage — that pairing IS the bug, and it used to be
+    # the default.
+    artifact_store: ArtifactStoreBackend = "filesystem"
+    artifact_s3_endpoint_url: str = ""
+    artifact_s3_bucket: str = ""
+    artifact_s3_region: str = job_env.DEFAULT_ARTIFACT_S3_REGION
+    artifact_s3_access_key: str = ""
+    # AIDEV-NOTE: credential material. Never logged, never rendered into a ConfigMap — it
+    # reaches the pod from a Secret, the same way `TAVILY_API_KEY` does.
+    artifact_s3_secret_key: str = ""
     # WHY 48h: long enough for any client that survived its run to come back for the parcel
     # (a run itself is bounded by job_deadline_s = 16h), short enough that crashed runs
     # cannot pool disk for more than two days. Swept at App startup AND periodically.
@@ -115,6 +135,11 @@ class Settings(BaseSettings):
     # `envFrom.secretRef`, never a literal copied into the manifest (see
     # ``K8sJobRunner._env_from``). The name of the Secret the Runner Job's env references:
     tavily_secret_name: str | None = None
+    # The Secret carrying URL4_CLOUD_ARTIFACT_S3_SECRET_KEY into each Runner Job (OME-929).
+    # A reference for the same reason `tavily_secret_name` is one: a `batch/v1` Job object is not
+    # a secret, so the credential travels via `envFrom.secretRef` and never as a literal in the
+    # manifest. The App reads the same Secret through its own Deployment `envFrom`.
+    artifact_s3_secret_name: str | None = None
     # WHY: the Runner drives the url4 DAG engine and buffers model responses — it is the
     # workload that actually consumes CPU/memory here. Without requests it schedules into the
     # BestEffort QoS class (placed blind, evicted first, free to OOM its node), so the chart
@@ -209,6 +234,21 @@ class Settings(BaseSettings):
         if self.job_ttl_s is not None:
             return self.job_ttl_s
         return self.iat_window_s + _TTL_SKEW_MARGIN_S
+
+    @field_validator("artifacts_dir", mode="before")
+    @classmethod
+    def _blank_artifacts_dir_means_unset(cls, value: object) -> object:
+        """An empty or whitespace value falls back to the default instead of becoming `Path("")`.
+
+        WHY (OME-929): `Path("")` is the WORKING DIRECTORY, not an error — so a ConfigMap that
+        renders the key with no value would silently relocate the store to wherever the process
+        happens to be, which for a read-only rootfs also fails at write time rather than here.
+        The chart omits the key when it has no value; this makes the same intent safe even if
+        some other deployment path renders it blank.
+        """
+        if isinstance(value, str) and not value.strip():
+            return job_env.DEFAULT_ARTIFACTS_DIR
+        return value
 
     @model_validator(mode="after")
     def _reject_replayable_job_ttl(self) -> Self:

--- a/apps/screamingface-engine/src/screamingface_engine/job_env.py
+++ b/apps/screamingface-engine/src/screamingface_engine/job_env.py
@@ -233,13 +233,52 @@ which ``GET /artifacts/{id}`` serves them (OME-892). One name read by BOTH the R
 side, via :func:`runner.main.build_executor`) and the App's ``Settings.artifacts_dir`` (serve
 side) so the two halves cannot be pointed at different directories by a one-sided edit.
 
-AIDEV-NOTE: in the `k8s` backend the Runner Job and the App are separate pods — this must
-name a SHARED volume there, which the chart does not yet mount (flagged on OME-892); local
-mode (one process) shares it by construction."""
+AIDEV-NOTE: this is the LOCAL-mode store only. In the `k8s` backend the Runner Job and the
+App are separate pods with separate disks, so a filesystem store there loses every over-cap
+result (OME-929) — which is why that pairing is now refused at startup. Deployed artifact
+storage is object storage; see :data:`ARTIFACT_STORE`."""
 
 DEFAULT_ARTIFACTS_DIR = str(Path(tempfile.gettempdir()) / "screamingface-engine" / "artifacts")
 """Fallback for an unset :data:`ARTIFACTS_DIR`. A temp path on purpose: artifacts are
-short-lived hand-offs (deleted on fetch, swept by TTL), not an archive."""
+short-lived hand-offs (swept by TTL), not an archive.
+
+AIDEV-NOTE: fetching does NOT delete them — that was removed on OME-892 review (content
+addressing means one file backs many tickets, and a Range request must leave the rest
+fetchable). TTL is the only cleanup."""
+
+# --- artifact storage backend (OME-929) -----------------------------------------------------
+# WHY these are DEPLOY_TIME and not derived: the Runner cannot see the cluster topology it runs
+# in, so the chart states it. The App CAN see it (`Settings.runner`), and refuses to start when
+# `runner="k8s"` is paired with filesystem storage — the combination that IS the OME-929 bug.
+#
+# INVARIANT: each name here must equal `Settings`' env alias for the same value, i.e.
+# `URL4_CLOUD_` + the field name, uppercased. `test_artifact_storage_selection.py` pins that,
+# because a one-sided rename would point the writer and the reader at different buckets — the
+# same class of failure as OME-929, in a form the 404 message would not even hint at.
+ARTIFACT_STORE = "URL4_CLOUD_ARTIFACT_STORE"
+"""filesystem" (local: one process, one disk) or "s3" (deployed: separate pods).
+
+Absent means "filesystem", which is right for local and WRONG for `k8s` — so the App refuses
+that pairing rather than defaulting into it silently, the way OME-929 did."""
+
+ARTIFACT_S3_ENDPOINT_URL = "URL4_CLOUD_ARTIFACT_S3_ENDPOINT_URL"
+"""Base URL of the S3-compatible endpoint, e.g. the bundled Garage Service."""
+
+ARTIFACT_S3_BUCKET = "URL4_CLOUD_ARTIFACT_S3_BUCKET"
+"""Bucket holding the content-addressed result objects."""
+
+ARTIFACT_S3_REGION = "URL4_CLOUD_ARTIFACT_S3_REGION"
+"""Signing region. Arbitrary but must match what the endpoint expects; Garage's default is
+its own configured region name, NOT an AWS one."""
+
+DEFAULT_ARTIFACT_S3_REGION = "garage"
+
+ARTIFACT_S3_ACCESS_KEY = "URL4_CLOUD_ARTIFACT_S3_ACCESS_KEY"
+"""Access key id. Travels by Secret, like :data:`TAVILY_API_KEY`."""
+
+ARTIFACT_S3_SECRET_KEY = "URL4_CLOUD_ARTIFACT_S3_SECRET_KEY"
+"""Secret access key. INVARIANT: Secret only — never a ConfigMap, never logged. A ConfigMap is
+readable by anything with `get` on it and is printed in plain text by `helm get manifest`."""
 
 RESULT_INLINE_CAP_BYTES = "URL4_CLOUD_RESULT_INLINE_CAP_BYTES"
 """Largest result body (UTF-8 bytes) that rides the result frame inline; anything larger is
@@ -302,8 +341,15 @@ WRITTEN_BY_APP = frozenset(
         *IDENTITY_HEADER_ENV.values(),
     }
 )
-"""The per-run subset. A key the App writes that is NOT in here reaches nothing — the direction
-that breaks silently is an unread WRITE, not an unwritten READ (which simply falls back)."""
+"""The per-run subset. A key the App writes that is NOT in here reaches nothing.
+
+AIDEV-NOTE (corrected on OME-929): this used to claim "the direction that breaks silently is an
+unread WRITE, not an unwritten READ (which simply falls back)". That reasoning is what let
+`ARTIFACTS_DIR` sit in `DEPLOY_TIME` — documented as Helm-owned — while Helm set nothing, and
+both halves fell back to their own pod-local `/tmp`. An unwritten READ falls back SILENTLY, and
+whether that is benign depends entirely on what the fallback means: a byte count has a safe
+default, a storage LOCATION does not. Both directions are now checked —
+`test_deploy_time_chart_contract.py` asserts the chart actually writes these."""
 
 DEPLOY_TIME = frozenset(
     {
@@ -316,6 +362,12 @@ DEPLOY_TIME = frozenset(
         RESULT_INLINE_CAP_BYTES,
         RESULT_HARD_CAP_BYTES,
         BRIDGE_MEMORY_BUDGET_BYTES,
+        ARTIFACT_STORE,
+        ARTIFACT_S3_ENDPOINT_URL,
+        ARTIFACT_S3_BUCKET,
+        ARTIFACT_S3_REGION,
+        ARTIFACT_S3_ACCESS_KEY,
+        ARTIFACT_S3_SECRET_KEY,
     }
 )
 """Helm owns these end-to-end. The App writing one would make it two sources of truth again."""
@@ -334,6 +386,13 @@ __all__ = [
     "DEFAULT_RESULT_HARD_CAP_BYTES",
     "DEFAULT_RESULT_INLINE_CAP_BYTES",
     "DEFAULT_STREAM_GRACE_S",
+    "ARTIFACT_S3_ACCESS_KEY",
+    "ARTIFACT_S3_BUCKET",
+    "ARTIFACT_S3_ENDPOINT_URL",
+    "ARTIFACT_S3_REGION",
+    "ARTIFACT_S3_SECRET_KEY",
+    "ARTIFACT_STORE",
+    "DEFAULT_ARTIFACT_S3_REGION",
     "DEPLOY_TIME",
     "EXPRESSION",
     "EXTRA_MODELS",

--- a/apps/screamingface-engine/src/screamingface_engine/rest/artifacts.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/artifacts.py
@@ -2,10 +2,15 @@
 
 FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
 
-The Runner parks an over-threshold result as a content-addressed file and the terminal
+The Runner parks an over-threshold result under its content address and the terminal
 result frame carries only `{artifact_id, size_bytes, sha256}`; this route is where a
-client trades that ticket for the complete bytes. `FileResponse` streams from disk
-(bounded memory, HTTP Range for resume).
+client trades that ticket for the complete bytes.
+
+WHY two response types (OME-929): the reader port answers with `LocalFile` or
+`RemoteStream`, because the two backing stores genuinely differ. A file on our own disk is
+served with `FileResponse` — bounded memory AND HTTP Range for resume. Object storage has no
+path to hand over, so it is streamed with an explicit `Content-Length` and no Range support,
+rather than pretending to a capability it does not have.
 
 INVARIANT: fetching NEVER deletes. Content addressing means one file can back many claim
 tickets (identical results dedupe onto one path), a dropped connection must be retryable,
@@ -14,11 +19,13 @@ all three (review finding on OME-892). Artifacts die by TTL alone: the periodic 
 `app.py` is the single cleanup mechanism.
 """
 
+import asyncio
 from typing import Annotated
 
-from fastapi import APIRouter, Path, Request
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, Path, Request, Response
+from fastapi.responses import FileResponse, StreamingResponse
 
+from screamingface_engine.artifacts import LocalFile
 from screamingface_engine.auth.dependencies import VerifiedClaims
 from screamingface_engine.auth.problem import ProblemException
 
@@ -29,6 +36,13 @@ router = APIRouter()
     "/artifacts/{artifact_id}",
     tags=["Runs"],
     summary="Fetch one complete spilled result by its claim ticket",
+    # WHY both (OME-929): the handler now returns one of TWO response classes, and FastAPI
+    # tries to build a Pydantic response field from the return annotation — which a union of
+    # Starlette responses is not. `response_model=None` disables that inference; declaring
+    # `response_class` keeps the OpenAPI document stating `application/octet-stream` rather
+    # than degrading to an untyped body, which the docs gate would notice.
+    response_model=None,
+    response_class=Response,
 )
 async def get_artifact(
     request: Request,
@@ -36,22 +50,35 @@ async def get_artifact(
     artifact_id: Annotated[
         str, Path(description="Content address from the result frame's artifact reference.")
     ],
-) -> FileResponse:
+) -> Response:
     # WHY direct attribute access, no getattr fallback: `create_app` always builds the
     # store, so its absence is a wiring bug that must fail loudly, not read as a 404.
     store = request.app.state.artifact_store
-    # INVARIANT: `path_for` resolves only lowercase-sha256 ids inside the store root — a
-    # traversal id and an unknown id are the same 404, never a file outside the store.
-    path = store.path_for(artifact_id)
-    if path is None:
+    # INVARIANT: `content` resolves only lowercase-sha256 ids inside the store — a
+    # traversal id and an unknown id are the same 404, never content outside the store.
+    #
+    # WHY `to_thread`: the port is sync (see `artifacts.ports`), and for object storage this
+    # call makes a blocking round trip to learn the object's existence and length. Running it
+    # on the loop would stall every other request and the WS heartbeats for its duration.
+    content = await asyncio.to_thread(store.content, artifact_id)
+    if content is None:
         raise ProblemException(
             status=404,
             title="Unknown artifact",
             detail=f"no artifact is stored under {artifact_id!r} — it may have expired "
-            "(artifacts are TTL-swept), or, on a multi-pod deployment, the Runner and the "
-            "App may not share URL4_CLOUD_ARTIFACTS_DIR (it must name a shared volume)",
+            "(artifacts are TTL-swept), or the Runner that produced it wrote to storage "
+            "this App cannot read (check the artifact storage settings agree on both sides)",
         )
-    return FileResponse(path, media_type="application/octet-stream")
+    if isinstance(content, LocalFile):
+        return FileResponse(content.path, media_type="application/octet-stream")
+    # INVARIANT: `Content-Length` is set from the ticket's own size, so a truncated upstream
+    # body is a protocol error the client detects — not a short response that looks complete.
+    # The SDK independently re-verifies size AND sha256 before decoding.
+    return StreamingResponse(
+        content.stream,
+        media_type="application/octet-stream",
+        headers={"content-length": str(content.size_bytes)},
+    )
 
 
 __all__ = ["router"]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 from typing import Literal, cast
 
 from screamingface_engine import job_env
-from screamingface_engine.artifacts import ArtifactStore
+from screamingface_engine.artifacts import ArtifactWriter
 from screamingface_engine.runner.accounting import PRICING_VERSION, UNPRICED, accumulate
 from screamingface_engine.runner.cache_counters import RunCacheCounters
 from url4.core.errors import ResolutionError
@@ -540,7 +540,7 @@ class _RunState:
         *,
         inline_cap: int,
         hard_cap: int,
-        store: ArtifactStore | None,
+        store: ArtifactWriter | None,
     ) -> ResultData:
         """Build the final `ResultData`: inline, spilled whole, or refused — never cut.
 
@@ -703,7 +703,7 @@ class Url4Executor(Executor):
         result_cap: int = job_env.DEFAULT_RESULT_INLINE_CAP_BYTES,
         hard_cap: int = job_env.DEFAULT_RESULT_HARD_CAP_BYTES,
         memory_budget: int = job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES,
-        artifact_store: ArtifactStore | None = None,
+        artifact_store: ArtifactWriter | None = None,
         world_aclose: Callable[[], Awaitable[None]] | None = None,
         world_factory: WorldFactory | None = None,
     ) -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -19,7 +19,8 @@ import httpx
 
 from screamingface_engine import job_env
 from screamingface_engine.adapters.jetstream import JetStreamPublisher
-from screamingface_engine.artifacts import ArtifactStore
+from screamingface_engine.artifacts import ArtifactStore, ArtifactWriter, S3ArtifactStore
+from screamingface_engine.artifacts.wiring import s3_config_from_values
 from screamingface_engine.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry, assets_root
 from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.candidate_adapter import install_candidate_invocation
@@ -80,12 +81,22 @@ def bridge_budget_from_env(env: Mapping[str, str]) -> int:
     )
 
 
-def result_delivery_from_env(env: Mapping[str, str]) -> tuple[int, int, ArtifactStore]:
+def result_delivery_from_env(env: Mapping[str, str]) -> tuple[int, int, ArtifactWriter]:
     """The Runner's result-delivery wiring: (inline cap, hard cap, spill store).
 
-    FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892).
-    Reads the same URL4_CLOUD_* names the App's `Settings` serve side reads, so the writer
-    and the `GET /artifacts/{id}` server resolve one directory by construction.
+    FEATURE: deliver large results in full instead of cutting them off at 1 MiB (OME-892),
+    and have them survive this Job's own disk (OME-929).
+
+    Reads the same URL4_CLOUD_* names the App's `Settings` serve side reads, so the writer and
+    the `GET /artifacts/{id}` server resolve ONE store by construction.
+
+    INVARIANT: an object store selected but not fully configured raises HERE. That surfaces as
+    a Terminated(failed) frame on the run's topic — loudly, before any model call — rather than
+    as a claim ticket that redeems to a 404 once the whole run has been paid for.
+
+    AIDEV-NOTE: the caps fall back tolerantly (a byte count has a safe default) while the
+    STORE does not. That asymmetry is the OME-929 lesson: an unwritten value falls back
+    silently, and only some fallbacks are harmless.
     """
     inline_cap = _int_from_env(
         env, job_env.RESULT_INLINE_CAP_BYTES, job_env.DEFAULT_RESULT_INLINE_CAP_BYTES
@@ -93,6 +104,8 @@ def result_delivery_from_env(env: Mapping[str, str]) -> tuple[int, int, Artifact
     hard_cap = _int_from_env(
         env, job_env.RESULT_HARD_CAP_BYTES, job_env.DEFAULT_RESULT_HARD_CAP_BYTES
     )
+    if (env.get(job_env.ARTIFACT_STORE) or "filesystem").strip() == "s3":
+        return inline_cap, hard_cap, S3ArtifactStore(s3_config_from_values(env))
     artifacts_dir = env.get(job_env.ARTIFACTS_DIR) or job_env.DEFAULT_ARTIFACTS_DIR
     return inline_cap, hard_cap, ArtifactStore(Path(artifacts_dir))
 

--- a/apps/screamingface-engine/tests/unit/test_artifact_ports.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_ports.py
@@ -1,0 +1,196 @@
+"""The artifact writer/reader PORTS, and that the App can serve a non-filesystem reader.
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+WHY this file exists: until now one `ArtifactStore` class served both sides because they
+shared a filesystem. On the hosted Engine they do not — the Runner Job pod and the App pod
+each mount their own `emptyDir` — so the write side and the read side are two different
+things and the type system should say so.
+
+INVARIANT: `ArtifactContent` carries no HTTP concept. `screamingface_engine.artifacts` is a
+SHARED LEAF of the layering gate (both halves import it), so a Starlette type reaching into
+it would put the serving framework in a Runner Job's cold start. The route decides how to
+render; the port only says what there is to render.
+"""
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+from _fakes import RecordingJobRunner
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import ASGITransport
+
+from screamingface_engine.app import create_app
+from screamingface_engine.artifacts import (
+    ArtifactContent,
+    ArtifactReader,
+    ArtifactStore,
+    ArtifactWriter,
+    FilesystemArtifactStore,
+    LocalFile,
+    RemoteStream,
+)
+from screamingface_engine.auth import JwtCodec
+from screamingface_engine.config import Settings
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.protocol.signals import ResultArtifact
+
+SECRET = "artifact-ports-secret"
+WINDOW_S = 60
+T0 = datetime(2026, 8, 21, 9, 0, 0, tzinfo=UTC)
+
+
+def _cap(topic: str) -> dict[str, str]:
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+
+
+# --- the ports are satisfied by the filesystem adapter -----------------------------------
+
+
+def test_the_filesystem_adapter_satisfies_both_ports(tmp_path: Path) -> None:
+    store = FilesystemArtifactStore(tmp_path)
+
+    assert isinstance(store, ArtifactWriter)
+    assert isinstance(store, ArtifactReader)
+
+
+def test_a_round_trip_through_port_typed_helpers_returns_the_written_bytes(
+    tmp_path: Path,
+) -> None:
+    """Exercised through the PORTS, not the concrete class — pyright checks the shape here."""
+
+    def deposit(writer: ArtifactWriter, payload: bytes) -> ResultArtifact:
+        return writer.write_bytes(payload)
+
+    def redeem(reader: ArtifactReader, artifact_id: str) -> ArtifactContent | None:
+        return reader.content(artifact_id)
+
+    store = FilesystemArtifactStore(tmp_path)
+    ref = deposit(store, b'{"cases":[1,2,3]}')
+    content = redeem(store, ref.id)
+
+    assert isinstance(content, LocalFile)
+    assert content.path.read_bytes() == b'{"cases":[1,2,3]}'
+
+
+def test_the_legacy_name_still_resolves_to_the_filesystem_adapter() -> None:
+    """24 call sites and 4 test modules import `ArtifactStore`; tests are append-only."""
+    assert ArtifactStore is FilesystemArtifactStore
+
+
+# --- content() replaces path_for at the port boundary ------------------------------------
+
+
+def test_content_is_none_for_an_absent_artifact(tmp_path: Path) -> None:
+    store = FilesystemArtifactStore(tmp_path)
+
+    assert store.content("a" * 64) is None
+
+
+def test_content_is_none_for_a_malformed_id(tmp_path: Path) -> None:
+    """INVARIANT: a traversal id and an unknown id are indistinguishable to a caller."""
+    store = FilesystemArtifactStore(tmp_path)
+    store.write_bytes(b"payload")
+
+    assert store.content("../../etc/passwd") is None
+    assert store.content("NOTHEX" * 10) is None
+
+
+def test_a_remote_stream_carries_its_length_alongside_its_chunks() -> None:
+    """A blob store cannot offer a path, so the port carries the size the file system implied."""
+
+    async def chunks() -> AsyncIterator[bytes]:
+        yield b"ab"
+        yield b"cd"
+
+    content = RemoteStream(stream=chunks(), size_bytes=4)
+
+    assert content.size_bytes == 4
+
+
+# --- the route serves a reader that has no filesystem at all -----------------------------
+
+
+class _StreamOnlyReader:
+    """A reader with NO filesystem — the shape an object-storage adapter has."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def content(self, artifact_id: str) -> ArtifactContent | None:
+        if artifact_id != "b" * 64:
+            return None
+
+        async def chunks() -> AsyncIterator[bytes]:
+            # Deliberately several chunks: a single-chunk stream would pass even if the
+            # route only ever forwarded the first one.
+            for start in range(0, len(self._payload), 8):
+                yield self._payload[start : start + 8]
+
+        return RemoteStream(stream=chunks(), size_bytes=len(self._payload))
+
+    def delete(self, artifact_id: str) -> None: ...
+
+    def sweep(self, ttl_seconds: float, *, now: float | None = None) -> int:
+        return 0
+
+
+def _app_with_reader(tmp_path: Path, reader: object) -> FastAPI:
+    app = create_app(
+        Settings(
+            jwt_secret=SECRET,
+            iat_window_s=WINDOW_S,
+            artifacts_dir=str(tmp_path / "artifacts"),
+        ),
+        stream=InMemoryEventStream(),
+        job_runner=RecordingJobRunner(),
+        clock=lambda: T0,
+    )
+    app.state.artifact_store = reader
+    return app
+
+
+@pytest.mark.asyncio
+async def test_the_route_serves_every_byte_of_a_stream_only_reader(tmp_path: Path) -> None:
+    """STORY: as a researcher on the hosted Engine, I redeem a ticket for a result the
+    Runner Job parked in object storage — the App has never had it on disk."""
+    payload = b'{"cases":[' + b"1," * 5_000 + b"1]}"
+    app = _app_with_reader(tmp_path, _StreamOnlyReader(payload))
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/artifacts/{'b' * 64}", headers=_cap("t"))
+
+    assert response.status_code == 200
+    assert response.content == payload
+
+
+@pytest.mark.asyncio
+async def test_a_stream_only_reader_still_404s_an_unknown_id(tmp_path: Path) -> None:
+    app = _app_with_reader(tmp_path, _StreamOnlyReader(b"x"))
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/artifacts/{'c' * 64}", headers=_cap("t"))
+
+    assert response.status_code == 404
+
+
+def test_the_filesystem_route_still_uses_a_file_response(tmp_path: Path) -> None:
+    """INVARIANT: `LocalFile` keeps `FileResponse`, which is what preserves HTTP Range on
+    the local path — `test_a_range_request_does_not_consume_the_artifact` depends on it."""
+    store = FilesystemArtifactStore(tmp_path / "artifacts")
+    ref = store.write_bytes(b"rangeable")
+    app = _app_with_reader(tmp_path, store)
+
+    with TestClient(app) as client:
+        response = client.get(f"/artifacts/{ref.id}", headers={**_cap("t"), "Range": "bytes=0-3"})
+
+    assert response.status_code == 206
+    assert response.content == b"rang"

--- a/apps/screamingface-engine/tests/unit/test_artifact_spill_is_store_agnostic.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_spill_is_store_agnostic.py
@@ -1,0 +1,143 @@
+"""The spill decision is the executor's; WHERE it spills is the store's (OME-929).
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment.
+
+INVARIANT: `build_result` decides inline-vs-spill from byte counts alone. Swapping the
+filesystem store for the object store must not move the boundary by a single byte, and must
+not change what a failed deposit does. OME-892 pinned this boundary against the filesystem;
+this file pins the SAME boundary against object storage, so the two adapters cannot drift.
+
+WHY that matters: the executor's cap logic is what keeps small runs byte-identical on the
+wire. A store that quietly shifted the threshold would change the wire shape of every small
+run on the hosted Engine only — the hardest class of bug to see from a test suite that runs
+one adapter.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import httpx
+import pytest
+
+from screamingface_engine.artifacts.s3 import S3ArtifactStore, S3Config, S3StorageError
+from screamingface_engine.artifacts.sigv4 import Credentials
+from screamingface_engine.runner.executor import Url4Executor
+from url4.core.errors import ResolutionError
+from url4.io.static import StaticIOLayer
+from url4.streaming.interfaces import Completed
+
+RESULT_BYTES = 50
+
+
+class _FixedResultNode:
+    """Resolves to exactly `RESULT_BYTES` ASCII bytes, so the cap can be aimed precisely."""
+
+    deps: dict = {}
+
+    async def resolve(self, inputs: object, ctx: object) -> str:
+        return "X" * RESULT_BYTES
+
+
+class _Bucket:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.objects: dict[str, bytes] = {}
+        self._fail = fail
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        if self._fail:
+            return httpx.Response(500, text="InternalError")
+        key = request.url.path.rsplit("/", 1)[-1]
+        if request.method == "PUT":
+            self.objects[key] = request.content
+            return httpx.Response(200)
+        return self._read(key, head=request.method == "HEAD")
+
+    def _read(self, key: str, *, head: bool) -> httpx.Response:
+        body = self.objects.get(key)
+        if body is None:
+            return httpx.Response(404)
+        if head:
+            return httpx.Response(200, headers={"content-length": str(len(body))})
+        return httpx.Response(200, content=body)
+
+    def store(self) -> S3ArtifactStore:
+        transport = httpx.MockTransport(self.handle)
+        return S3ArtifactStore(
+            S3Config(
+                endpoint_url="http://garage.svc:3900",
+                bucket="artifacts",
+                credentials=Credentials(access_key="GK", secret_key="s", region="garage"),
+            ),
+            client_factory=lambda: httpx.Client(transport=transport),
+            async_client_factory=lambda: httpx.AsyncClient(transport=transport),
+        )
+
+
+async def _drain(executor: Url4Executor, node: object) -> list[object]:
+    return [frame async for frame in executor.execute(cast("str", node))]
+
+
+@pytest.mark.parametrize(
+    ("cap", "spills"),
+    [
+        (RESULT_BYTES - 1, True),  # cap-1: one byte too small, must spill
+        (RESULT_BYTES, False),  # exactly at cap: the largest result that stays inline
+        (RESULT_BYTES + 1, False),  # cap+1: comfortably inline
+    ],
+    ids=["one-under-cap-spills", "exactly-at-cap-inline", "one-over-cap-inline"],
+)
+@pytest.mark.asyncio
+async def test_the_cap_boundary_is_identical_on_object_storage(cap: int, spills: bool) -> None:
+    """The threshold is `> cap` spills, `<= cap` stays inline — same as the filesystem."""
+    bucket = _Bucket()
+    executor = Url4Executor(StaticIOLayer(), result_cap=cap, artifact_store=bucket.store())
+
+    frames = await _drain(executor, _FixedResultNode())
+
+    completed = frames[-1]
+    assert isinstance(completed, Completed)
+    if spills:
+        assert completed.result.body is None
+        assert completed.result.artifact is not None
+    else:
+        assert completed.result.body == "X" * RESULT_BYTES
+        assert completed.result.artifact is None
+        # Nothing was deposited: an inline result must not also leave an object behind.
+        assert bucket.objects == {}
+
+
+@pytest.mark.asyncio
+async def test_a_spilled_result_is_deposited_whole_and_the_ticket_addresses_it() -> None:
+    bucket = _Bucket()
+    executor = Url4Executor(
+        StaticIOLayer(), result_cap=RESULT_BYTES - 1, artifact_store=bucket.store()
+    )
+
+    frames = await _drain(executor, _FixedResultNode())
+
+    completed = frames[-1]
+    assert isinstance(completed, Completed)
+    ref = completed.result.artifact
+    assert ref is not None
+    assert ref.size_bytes == RESULT_BYTES
+    # The COMPLETE result reached the bucket under the address the ticket names — nothing cut.
+    assert bucket.objects[ref.id] == b"X" * RESULT_BYTES
+
+
+@pytest.mark.asyncio
+async def test_a_refused_deposit_fails_the_run_instead_of_ticketing_nothing() -> None:
+    """INVARIANT (the ordering that matters): the object is stored BEFORE any frame promises
+    it. So a store that refuses the write ends the run loudly, here — it can never publish a
+    successful terminal frame carrying a ticket that redeems to a 404 minutes later, after
+    the whole run has been paid for. That late 404 is precisely the OME-929 failure.
+    """
+    bucket = _Bucket(fail=True)
+    executor = Url4Executor(
+        StaticIOLayer(), result_cap=RESULT_BYTES - 1, artifact_store=bucket.store()
+    )
+
+    with pytest.raises((S3StorageError, ResolutionError)):
+        await _drain(executor, _FixedResultNode())
+
+    assert bucket.objects == {}

--- a/apps/screamingface-engine/tests/unit/test_artifact_storage_selection.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_storage_selection.py
@@ -1,0 +1,163 @@
+"""Which artifact store a deployment gets, and the states it refuses to boot in (OME-929).
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment.
+
+INVARIANT — the whole point of this file: `runner="k8s"` with filesystem artifact storage is
+UNREPRESENTABLE. That pairing is exactly the OME-929 bug (a Job pod writing to its own
+`emptyDir` while the App reads its own), and it used to be not just representable but the
+DEFAULT, reachable by setting nothing at all. It is now refused at startup.
+
+WHY refuse at startup rather than warn: the failure it replaces surfaced at redemption time,
+after 11,902 model calls had been paid for. Every second between the misconfiguration and the
+error costs money, so the error belongs at boot — before a single run is accepted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from _fakes import RecordingJobRunner
+
+from screamingface_engine import job_env
+from screamingface_engine.app import create_app
+from screamingface_engine.artifacts import FilesystemArtifactStore, S3ArtifactStore
+from screamingface_engine.config import Settings
+from screamingface_engine.runner.main import result_delivery_from_env
+from screamingface_engine.testing import InMemoryEventStream
+
+S3_ENV = {
+    job_env.ARTIFACT_STORE: "s3",
+    job_env.ARTIFACT_S3_ENDPOINT_URL: "http://garage.svc:3900",
+    job_env.ARTIFACT_S3_BUCKET: "artifacts",
+    job_env.ARTIFACT_S3_REGION: "garage",
+    job_env.ARTIFACT_S3_ACCESS_KEY: "GKtest",
+    job_env.ARTIFACT_S3_SECRET_KEY: "secret",
+}
+
+
+def _settings(tmp_path: Path, **overrides: object) -> Settings:
+    return Settings(jwt_secret="selection-secret-selection-secret", **overrides)  # type: ignore[arg-type]
+
+
+def _app(settings: Settings) -> object:
+    return create_app(settings, stream=InMemoryEventStream(), job_runner=RecordingJobRunner())
+
+
+# --- the App's read side -----------------------------------------------------------------
+
+
+def test_a_local_app_still_uses_the_filesystem(tmp_path: Path) -> None:
+    """D3: `inprocess`/local shares one disk by construction — behaviour unchanged."""
+    app = _app(_settings(tmp_path, runner="none", artifacts_dir=str(tmp_path)))
+
+    assert isinstance(app.state.artifact_store, FilesystemArtifactStore)  # type: ignore[attr-defined]
+
+
+def test_a_k8s_app_configured_for_object_storage_uses_it(tmp_path: Path) -> None:
+    app = _app(
+        _settings(
+            tmp_path,
+            runner="k8s",
+            artifact_store="s3",
+            artifact_s3_endpoint_url="http://garage.svc:3900",
+            artifact_s3_bucket="artifacts",
+            artifact_s3_access_key="GKtest",
+            artifact_s3_secret_key="secret",
+        )
+    )
+
+    assert isinstance(app.state.artifact_store, S3ArtifactStore)  # type: ignore[attr-defined]
+
+
+def test_a_k8s_app_left_on_filesystem_storage_refuses_to_boot(tmp_path: Path) -> None:
+    """THE regression guard. This configuration — which was the default — is the bug.
+
+    A Runner Job pod and the App pod do not share a disk, so a filesystem store here means
+    every over-cap result 404s at redemption. Nothing about the setup says so, which is why
+    it shipped; now it cannot start.
+    """
+    with pytest.raises(ValueError, match="URL4_CLOUD_ARTIFACT_STORE"):
+        _app(_settings(tmp_path, runner="k8s", artifacts_dir=str(tmp_path)))
+
+
+@pytest.mark.parametrize(
+    "missing", ["artifact_s3_endpoint_url", "artifact_s3_bucket", "artifact_s3_access_key"]
+)
+def test_object_storage_with_an_incomplete_configuration_refuses_to_boot(
+    tmp_path: Path, missing: str
+) -> None:
+    """INVARIANT: half-configured object storage fails at boot, naming the missing setting.
+
+    Deferring it means the first over-cap run discovers it — which is the late, expensive
+    failure this ticket exists to remove.
+    """
+    config: dict[str, object] = {
+        "runner": "k8s",
+        "artifact_store": "s3",
+        "artifact_s3_endpoint_url": "http://garage.svc:3900",
+        "artifact_s3_bucket": "artifacts",
+        "artifact_s3_access_key": "GKtest",
+        "artifact_s3_secret_key": "secret",
+    }
+    config[missing] = ""
+
+    with pytest.raises(ValueError, match=missing.upper()):
+        _app(_settings(tmp_path, **config))
+
+
+# --- the Runner's write side -------------------------------------------------------------
+
+
+def test_the_runner_defaults_to_the_filesystem(tmp_path: Path) -> None:
+    _, _, store = result_delivery_from_env({job_env.ARTIFACTS_DIR: str(tmp_path)})
+
+    assert isinstance(store, FilesystemArtifactStore)
+
+
+def test_the_runner_uses_object_storage_when_the_chart_says_so() -> None:
+    _, _, store = result_delivery_from_env(S3_ENV)
+
+    assert isinstance(store, S3ArtifactStore)
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [job_env.ARTIFACT_S3_ENDPOINT_URL, job_env.ARTIFACT_S3_BUCKET, job_env.ARTIFACT_S3_ACCESS_KEY],
+)
+def test_the_runner_refuses_a_half_configured_object_store(missing: str) -> None:
+    """Fails building the executor, which surfaces as a Terminated(failed) frame on the
+    topic — not as a ticket that redeems to nothing."""
+    env = {key: value for key, value in S3_ENV.items() if key != missing}
+
+    with pytest.raises(ValueError, match=missing):
+        result_delivery_from_env(env)
+
+
+# --- the two sides must read the SAME env names ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "name"),
+    [
+        ("artifact_store", job_env.ARTIFACT_STORE),
+        ("artifact_s3_endpoint_url", job_env.ARTIFACT_S3_ENDPOINT_URL),
+        ("artifact_s3_bucket", job_env.ARTIFACT_S3_BUCKET),
+        ("artifact_s3_region", job_env.ARTIFACT_S3_REGION),
+        ("artifact_s3_access_key", job_env.ARTIFACT_S3_ACCESS_KEY),
+        ("artifact_s3_secret_key", job_env.ARTIFACT_S3_SECRET_KEY),
+    ],
+)
+def test_the_app_setting_and_the_runner_env_name_are_the_same_variable(
+    field: str, name: str
+) -> None:
+    """INVARIANT: one name per value, read by both halves.
+
+    This is the invariant `ARTIFACTS_DIR` was SUPPOSED to have — `job_env` documents it as
+    "one name read by BOTH the Runner and the App's Settings" — and nothing checked it. A
+    one-sided rename would point the writer and the reader at different buckets, reproducing
+    OME-929 in a form the 404 message would not even hint at.
+    """
+    prefix = Settings.model_config.get("env_prefix", "")
+
+    assert f"{prefix}{field}".upper() == name

--- a/apps/screamingface-engine/tests/unit/test_catalog_wiring.py
+++ b/apps/screamingface-engine/tests/unit/test_catalog_wiring.py
@@ -64,9 +64,27 @@ async def test_no_setting_holds_an_aigateway_credential() -> None:
         for name in Settings.model_fields
         if any(word in name for word in ("token", "secret", "key", "password", "credential"))
     }
-    assert suspicious == {"jwt_secret", "tavily_secret_name"}, (
-        "a new secret-shaped setting appeared — confirm it is sourced from a Secret reference"
-    )
+    # Each entry is a reviewed decision, not a waiver. Adding one means answering "where does
+    # this value come from, and what does it grant?" — which is the whole point of pinning the set.
+    #
+    #   jwt_secret              the App's own token-signing secret; value, from a Secret via envFrom
+    #   tavily_secret_name      a NAME only — the App forwards it to Jobs and never reads the key
+    #   artifact_s3_secret_name a NAME only, same shape as tavily_secret_name (OME-929)
+    #   artifact_s3_access_key  an S3 access key ID — an identifier, not a secret; it is the
+    #                           public half of the pair and appears in every signed request
+    #   artifact_s3_secret_key  a VALUE, from a Secret via envFrom, exactly like jwt_secret.
+    #                           WHY the App must hold it (OME-929): it signs its own GETs to stream
+    #                           spilled results back, so a name alone cannot work the way it does
+    #                           for Tavily, where only Runner Jobs ever use the credential.
+    #                           Blast radius if leaked: read/write on the artifact bucket by a peer
+    #                           already inside the NetworkPolicy. No provider or model credentials.
+    assert suspicious == {
+        "jwt_secret",
+        "tavily_secret_name",
+        "artifact_s3_access_key",
+        "artifact_s3_secret_key",
+        "artifact_s3_secret_name",
+    }, "a new secret-shaped setting appeared — confirm it is sourced from a Secret reference"
 
 
 async def test_create_app_exposes_an_injected_catalog() -> None:

--- a/apps/screamingface-engine/tests/unit/test_deploy_time_chart_contract.py
+++ b/apps/screamingface-engine/tests/unit/test_deploy_time_chart_contract.py
@@ -1,0 +1,130 @@
+"""Every `DEPLOY_TIME` variable must actually be written by the chart (OME-929).
+
+`job_env.DEPLOY_TIME` carries the docstring "Helm owns these end-to-end." For
+`URL4_CLOUD_ARTIFACTS_DIR` that was simply false — Helm set nothing, both halves fell back to
+their own pod-local `/tmp`, and every over-cap result 404'd on the hosted Engine.
+
+WHY the existing contract test could not catch it: `test_job_env_contract.py` asserts only the
+NEGATIVE direction — that the App does not write a deploy-time name. Nothing asserted the
+POSITIVE one. `job_env` even recorded the reasoning that permitted the gap:
+
+    "the direction that breaks silently is an unread WRITE, not an unwritten READ
+     (which simply falls back)"
+
+That is inverted for a variable whose fallback is a per-pod temp directory. The fallback was
+not a benign default; it was the misconfiguration. This file asserts the direction nobody was
+checking, and it would have failed the day OME-892 landed.
+
+WHY textual and not `helm template`: this runs in the engine's own pytest lane, which has no
+helm binary. The question — "does the chart name this variable at all?" — is answerable from
+the template text, and a check that always runs beats a richer one that gets skipped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from screamingface_engine import job_env
+
+_CHART = Path(__file__).resolve().parents[2] / "deploy/helm/templates"
+_RUNNER_ENV = _CHART / "configmap-runner-env.yaml"
+_APP_ENV = _CHART / "configmap.yaml"
+
+# Variables the chart legitimately renders only under a condition. Each entry needs a REASON,
+# because "it is optional" is how `ARTIFACTS_DIR` would have been waved through.
+_CONDITIONALLY_RENDERED = {
+    # Absent => web tools stay off, which is a working deployment (dec:W5). The Secret is
+    # attached by name via envFrom, so the KEY appears in the chart's secret template.
+    job_env.TAVILY_API_KEY,
+    # Absent => the Runner uses the default route declared in the image's own url4.toml.
+    job_env.AIGATEWAY_MODEL,
+    # Absent => the caps fall back to shipped defaults that are correct at any scale; unlike
+    # a storage location, a byte count has a safe default.
+    job_env.RESULT_INLINE_CAP_BYTES,
+    job_env.RESULT_HARD_CAP_BYTES,
+    job_env.BRIDGE_MEMORY_BUDGET_BYTES,
+    # Absent => the run mode reads the `url4.toml` baked into the image at its default path.
+    # The image guarantees that file exists, so the fallback resolves to real declared config
+    # rather than to an empty location — the property `ARTIFACTS_DIR` lacked.
+    job_env.RUNNER_CONFIG,
+}
+
+
+def _chart_text() -> str:
+    """Every template, because "does the chart name this?" is a chart-wide question.
+
+    Deliberately not just the two ConfigMaps: a credential is named by the Secret template
+    instead, and scanning only the ConfigMaps would report it as unrendered and invite an
+    allowlist entry for something the chart does supply.
+    """
+    return "\n".join(path.read_text(encoding="utf-8") for path in sorted(_CHART.glob("*.yaml")))
+
+
+def test_the_chart_templates_exist_so_this_check_is_not_vacuous() -> None:
+    assert _RUNNER_ENV.is_file()
+    assert _APP_ENV.is_file()
+
+
+@pytest.mark.parametrize("name", sorted(job_env.DEPLOY_TIME - _CONDITIONALLY_RENDERED))
+def test_every_unconditional_deploy_time_variable_is_named_by_the_chart(name: str) -> None:
+    """If this fails, the code believes Helm supplies a value that Helm does not supply.
+
+    The fallback then silently decides deployment behaviour — which for a storage location
+    means the Runner and the App quietly use different storage.
+    """
+    assert name in _chart_text(), (
+        f"{name} is declared in job_env.DEPLOY_TIME ('Helm owns these end-to-end') but no "
+        f"chart template names it, so the code's fallback silently decides it. Either render "
+        f"it in deploy/helm/templates/, or move it out of DEPLOY_TIME — and if it is "
+        f"deliberately optional, add it to _CONDITIONALLY_RENDERED with the reason why its "
+        f"fallback is safe."
+    )
+
+
+def test_the_artifacts_location_is_rendered_for_both_halves() -> None:
+    """The specific regression: the writer and the reader must be pointed at ONE store.
+
+    Named separately from the parametrised sweep because this is the variable whose absence
+    was the bug, and because it must appear on BOTH sides — the Runner's env and the App's.
+    """
+    runner = _RUNNER_ENV.read_text(encoding="utf-8")
+    app = _APP_ENV.read_text(encoding="utf-8")
+
+    for name in (job_env.ARTIFACT_STORE, job_env.ARTIFACT_S3_BUCKET):
+        assert name in runner, f"the Runner Job never receives {name}"
+        assert name in app, f"the App never receives {name}"
+
+
+def _yaml_keys(template: Path) -> list[str]:
+    """The `key:` names a template actually assigns, ignoring comments.
+
+    Comment-stripping matters: the runner-env template explains IN A COMMENT that the secret key
+    is deliberately absent, and a naive substring search reads that explanation as a violation.
+    """
+    keys = []
+    for raw in template.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("{{"):
+            continue
+        if ":" in line:
+            keys.append(line.split(":", 1)[0].strip())
+    return keys
+
+
+def test_the_secret_key_is_not_assigned_in_a_configmap() -> None:
+    """INVARIANT: object-storage credentials travel by Secret, never in a ConfigMap.
+
+    A ConfigMap is readable by anything with `get` on it and is dumped in plain text by
+    `helm get manifest` — the same reason `TAVILY_API_KEY` only ever travels by name.
+    """
+    assert job_env.ARTIFACT_S3_SECRET_KEY not in _yaml_keys(_RUNNER_ENV)
+    assert job_env.ARTIFACT_S3_SECRET_KEY not in _yaml_keys(_APP_ENV)
+
+
+def test_the_secret_key_is_assigned_in_the_secret_template() -> None:
+    """The other half of the rule above: it must live SOMEWHERE, or nothing supplies it."""
+    secret = _CHART / "secret-artifact-storage.yaml"
+
+    assert job_env.ARTIFACT_S3_SECRET_KEY in _yaml_keys(secret)

--- a/apps/screamingface-engine/tests/unit/test_deploy_time_chart_contract.py
+++ b/apps/screamingface-engine/tests/unit/test_deploy_time_chart_contract.py
@@ -22,6 +22,7 @@ the template text, and a check that always runs beats a richer one that gets ski
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -128,3 +129,61 @@ def test_the_secret_key_is_assigned_in_the_secret_template() -> None:
     secret = _CHART / "secret-artifact-storage.yaml"
 
     assert job_env.ARTIFACT_S3_SECRET_KEY in _yaml_keys(secret)
+
+
+# --- the bundled store configures itself (OME-929) ---------------------------------------
+
+
+def _garage() -> str:
+    return (_CHART / "garage.yaml").read_text(encoding="utf-8")
+
+
+def test_garage_self_configures_with_all_three_server_flags() -> None:
+    """INVARIANT: no bootstrap Job, no operator commands, no scripted layout.
+
+    `--single-node` REMOVES the layout operation rather than automating it, which matters because
+    Garage's own docs warn that repeating `layout apply --version N` can leave a cluster
+    INCONSISTENT — exactly the shape a hook re-running on every `helm upgrade` would produce.
+    The other two adopt the credentials and bucket the chart states.
+    """
+    garage = _garage()
+
+    for flag in ("--single-node", "--default-access-key", "--default-bucket"):
+        assert flag in garage, f"{flag} missing — the deployment would need manual bootstrapping"
+
+
+@pytest.mark.parametrize(
+    ("garage_var", "secret_key"),
+    [
+        ("GARAGE_DEFAULT_ACCESS_KEY", job_env.ARTIFACT_S3_ACCESS_KEY),
+        ("GARAGE_DEFAULT_SECRET_KEY", job_env.ARTIFACT_S3_SECRET_KEY),
+    ],
+)
+def test_garage_adopts_the_same_credentials_the_engine_presents(
+    garage_var: str, secret_key: str
+) -> None:
+    """INVARIANT: one source, three consumers — the App, every Runner Job, and Garage itself.
+
+    Garage ADOPTS the pair the chart generates rather than minting its own. If these ever read
+    from a different place than the engine does, the store holds a key the engine never presents
+    and every artifact request 403s — which reads as a signing bug, not a config one.
+    """
+    garage = _garage()
+
+    assert garage_var in garage
+    # The `key:` of the secretKeyRef must be the variable the engine reads, because `envFrom`
+    # injects under the key's own name and cannot rename.
+    assert f"key: {secret_key}" in garage
+
+
+def test_the_bundled_store_pins_a_version_that_has_the_self_configuration_flags() -> None:
+    """The three flags landed in Garage 2.3.0. An older tag starts with no layout and no bucket,
+    and every artifact PUT fails — so the floor is part of the contract, not a preference."""
+    values = (_CHART.parent / "values.yaml").read_text(encoding="utf-8")
+    match = re.search(r"image:\s*dxflrs/garage:v(\d+)\.(\d+)\.(\d+)", values)
+
+    assert match is not None, "the bundled Garage image is no longer a pinned dxflrs/garage tag"
+    assert (int(match[1]), int(match[2])) >= (2, 3), (
+        f"garage.image is v{match[1]}.{match[2]}.{match[3]}, below the v2.3.0 floor that "
+        "introduced --single-node / --default-access-key / --default-bucket"
+    )

--- a/apps/screamingface-engine/tests/unit/test_s3_artifact_store.py
+++ b/apps/screamingface-engine/tests/unit/test_s3_artifact_store.py
@@ -1,0 +1,245 @@
+"""`S3ArtifactStore` — the adapter that survives the Runner Job (OME-929).
+
+FEATURE: an over-cap result parked by a Runner Job pod is still fetchable by the App pod
+after that Job is gone.
+
+INVARIANT (the bug this adapter exists to kill): the writer and the reader share NO
+filesystem. Every test here builds them as separate instances against a fake endpoint, which
+is the arrangement the previous single-`ArtifactStore` design could not express — and
+therefore could not test.
+
+The fake S3 is `httpx.MockTransport`: it asserts on the request we ACTUALLY send, so a
+signing or path regression is caught here rather than as an opaque 403 in a cluster.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ClassVar
+
+import httpx
+import pytest
+
+from screamingface_engine.artifacts import RemoteStream
+from screamingface_engine.artifacts.s3 import S3ArtifactStore, S3Config, S3StorageError
+from screamingface_engine.artifacts.sigv4 import Credentials
+
+BUCKET = "artifacts"
+ENDPOINT = "http://garage.svc:3900"
+
+
+def _config() -> S3Config:
+    return S3Config(
+        endpoint_url=ENDPOINT,
+        bucket=BUCKET,
+        credentials=Credentials(
+            access_key="GKtestaccess", secret_key="testsecret", region="garage"
+        ),
+    )
+
+
+class _FakeS3:
+    """Objects in a dict, plus the requests it saw — a stand-in for Garage."""
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.requests: list[httpx.Request] = []
+        self.force_status: int | None = None
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if self.force_status is not None:
+            return httpx.Response(self.force_status, text="forced")
+        key = request.url.path.rsplit("/", 1)[-1]
+        return self._DISPATCH[request.method](self, key, request)
+
+    def _put(self, key: str, request: httpx.Request) -> httpx.Response:
+        self.objects[key] = request.content
+        return httpx.Response(200)
+
+    def _delete(self, key: str, _request: httpx.Request) -> httpx.Response:
+        self.objects.pop(key, None)
+        return httpx.Response(204)
+
+    def _head(self, key: str, _request: httpx.Request) -> httpx.Response:
+        body = self.objects.get(key)
+        if body is None:
+            return httpx.Response(404, text="NoSuchKey")
+        return httpx.Response(200, headers={"content-length": str(len(body))})
+
+    def _get(self, key: str, _request: httpx.Request) -> httpx.Response:
+        body = self.objects.get(key)
+        if body is None:
+            return httpx.Response(404, text="NoSuchKey")
+        return httpx.Response(200, content=body)
+
+    _DISPATCH: ClassVar[dict[str, Callable[[_FakeS3, str, httpx.Request], httpx.Response]]] = {
+        "PUT": _put,
+        "DELETE": _delete,
+        "HEAD": _head,
+        "GET": _get,
+    }
+
+    def store(self) -> S3ArtifactStore:
+        """A store wired to this fake — call twice for an independent writer and reader."""
+        return S3ArtifactStore(
+            _config(),
+            client_factory=lambda: httpx.Client(transport=httpx.MockTransport(self.handle)),
+            async_client_factory=lambda: httpx.AsyncClient(
+                transport=httpx.MockTransport(self.handle)
+            ),
+        )
+
+
+async def _drain(content: RemoteStream) -> bytes:
+    return b"".join([chunk async for chunk in content.stream])
+
+
+# --- the acceptance test for OME-929 -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_writer_and_a_reader_sharing_no_filesystem_round_trip_a_result() -> None:
+    """STORY: as a researcher, my 100-case benchmark result reaches me even though the Job
+    that produced it has exited and its disk is gone.
+
+    This is the test whose absence let OME-929 ship: every prior artifact test used ONE
+    store instance in ONE process, so none of them could express a writer/reader split.
+    """
+    fake = _FakeS3()
+    runner_side = fake.store()
+    app_side = fake.store()
+    payload = b'{"cases":[' + b"1," * 200_000 + b"1]}"
+
+    ticket = runner_side.write_bytes(payload)
+    content = app_side.content(ticket.id)
+
+    assert isinstance(content, RemoteStream)
+    assert await _drain(content) == payload
+    assert content.size_bytes == len(payload)
+
+
+def test_the_ticket_is_the_content_address_and_the_real_size() -> None:
+    fake = _FakeS3()
+    payload = b"result-bytes"
+
+    ticket = fake.store().write_bytes(payload)
+
+    assert ticket.size_bytes == len(payload)
+    assert ticket.id == ticket.sha256
+    assert len(ticket.id) == 64
+
+
+# --- the request we actually put on the wire ---------------------------------------------
+
+
+def test_the_upload_targets_the_bucket_and_declares_its_payload_hash() -> None:
+    """INVARIANT: `x-amz-content-sha256` IS the artifact id — one hash, computed once.
+
+    S3 requires that header, and the value it requires is exactly the content address we
+    already have, so a second hash of a multi-megabyte body would be pure waste.
+    """
+    fake = _FakeS3()
+
+    ticket = fake.store().write_bytes(b"payload")
+
+    (request,) = fake.requests
+    assert request.method == "PUT"
+    assert request.url.path == f"/{BUCKET}/{ticket.id}"
+    assert request.headers["x-amz-content-sha256"] == ticket.id
+    assert request.headers["authorization"].startswith("AWS4-HMAC-SHA256 Credential=GKtestaccess/")
+    assert "SignedHeaders=host;x-amz-content-sha256;x-amz-date" in request.headers["authorization"]
+
+
+def test_every_signed_header_is_actually_sent() -> None:
+    """INVARIANT: the SignedHeaders list and the sent headers cannot disagree.
+
+    Signing a header we then omit (or vice versa) is the classic SigV4 defect, and the
+    server reports it as an indistinguishable 403.
+    """
+    fake = _FakeS3()
+    fake.store().write_bytes(b"payload")
+
+    (request,) = fake.requests
+    signed = request.headers["authorization"].split("SignedHeaders=")[1].split(",")[0]
+    for name in signed.split(";"):
+        assert name in request.headers, f"signed {name!r} but did not send it"
+
+
+# --- error paths -------------------------------------------------------------------------
+
+
+def test_a_missing_object_reads_as_absent_not_as_a_failure() -> None:
+    """A 404 is the honest "no such ticket" the route turns into its own 404."""
+    assert _FakeS3().store().content("a" * 64) is None
+
+
+def test_a_malformed_id_never_reaches_the_network() -> None:
+    """INVARIANT: id validation happens before signing, so a traversal attempt cannot even
+    become a request — the same guard the filesystem adapter applies to paths."""
+    fake = _FakeS3()
+
+    assert fake.store().content("../../secrets") is None
+    assert fake.requests == []
+
+
+def test_a_rejected_signature_raises_rather_than_reading_as_absent() -> None:
+    """WHY not None: a 403 means our credentials or signing are wrong, which is an operator
+    problem. Collapsing it into "artifact missing" would present a misconfiguration as a
+    expired-parcel 404 — exactly the misdiagnosis that cost OME-929 its first investigation.
+    """
+    fake = _FakeS3()
+    fake.force_status = 403
+
+    with pytest.raises(S3StorageError, match="403"):
+        fake.store().content("a" * 64)
+
+
+def test_a_failed_upload_raises_instead_of_minting_a_ticket() -> None:
+    """INVARIANT: a ticket is a promise that the bytes are retrievable. Returning one for a
+    failed PUT converts a loud upload error into a silent 404 at redemption time — the whole
+    failure shape this ticket exists to remove."""
+    fake = _FakeS3()
+    fake.force_status = 500
+
+    with pytest.raises(S3StorageError, match="500"):
+        fake.store().write_bytes(b"payload")
+
+
+def test_a_transport_failure_surfaces_as_a_storage_error() -> None:
+    """A connection refused must not escape as a bare httpx error the callers do not expect."""
+
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    store = S3ArtifactStore(
+        _config(),
+        client_factory=lambda: httpx.Client(transport=httpx.MockTransport(refuse)),
+        async_client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(refuse)),
+    )
+
+    with pytest.raises(S3StorageError):
+        store.write_bytes(b"payload")
+
+
+# --- reclamation is delegated, and says so ----------------------------------------------
+
+
+def test_sweep_is_a_no_op_because_expiry_belongs_to_the_bucket() -> None:
+    """WHY 0 and not a listing: sweeping would need ListObjectsV2, whose query parameters
+    push the signer past the PUT/GET bound spec D5 sets on it. Object expiry is a bucket
+    lifecycle rule instead — configured in the chart, enforced by the store.
+
+    AIDEV-NOTE: this returning 0 is load-bearing, not a stub. If the bucket has no lifecycle
+    rule, artifacts never expire — see the ledger's known-limitations note.
+    """
+    assert _FakeS3().store().sweep(ttl_seconds=1.0) == 0
+
+
+def test_delete_removes_the_object() -> None:
+    fake = _FakeS3()
+    ticket = fake.store().write_bytes(b"payload")
+
+    fake.store().delete(ticket.id)
+
+    assert ticket.id not in fake.objects

--- a/apps/screamingface-engine/tests/unit/test_sigv4.py
+++ b/apps/screamingface-engine/tests/unit/test_sigv4.py
@@ -1,0 +1,211 @@
+"""AWS Signature Version 4, checked against AWS's own published example.
+
+FEATURE: over-cap results survive the Runner Job on a multi-pod deployment (OME-929).
+
+WHY hand-rolled rather than a client library (spec D5): the scope is PUT and GET of ONE
+object — no multipart, and no presigning, because the App streams artifacts through rather
+than redirecting. That is small enough to sign correctly in pure functions, and it keeps
+`httpx` the only HTTP dependency in a Runner Job's cold start.
+
+WHY that is safe: we SIGN, Garage VERIFIES. A bug here gets our own request rejected with a
+403 — it can never make a forged request acceptable. The failure mode is closed.
+
+INVARIANT (the bound, spec D5): if this ever needs multipart or presigned URLs, it stops
+being a ~50-line pure function and the dependency is the right answer instead. Do not grow
+it past PUT/GET of a single object.
+
+The vectors below are the `get-vanilla` case from AWS's documented Signature Version 4 test
+suite. They pin all three stages — canonical request, string to sign, and the finished
+`Authorization` header — so a break localises to a stage instead of just "the signature
+changed".
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from screamingface_engine.artifacts.sigv4 import (
+    EMPTY_PAYLOAD_SHA256,
+    Credentials,
+    authorization_header,
+    canonical_request,
+    signing_key,
+    string_to_sign,
+)
+
+# --- AWS `get-vanilla` published vector --------------------------------------------------
+#
+# PROVENANCE: AWS's own `aws-sig-v4-test-suite`, `get-vanilla` case. The four constants below
+# are transcribed from the `.creq`, `.sts` and `.authz` files of that suite as mirrored at
+# https://github.com/boto/botocore/tree/develop/tests/unit/auth/aws4_testsuite/get-vanilla
+#
+# AIDEV-NOTE: do NOT "fix" these to match the implementation. They are the external oracle —
+# the only thing in this file that is not our own code checking itself. If one disagrees with
+# the signer, the signer is what is wrong. Re-fetch from the suite before touching them.
+
+ACCESS_KEY = "AKIDEXAMPLE"
+SECRET_KEY = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+REGION = "us-east-1"
+SERVICE = "service"
+AMZ_DATE = "20150830T123600Z"
+DATE_STAMP = "20150830"
+HOST = "example.amazonaws.com"
+
+# Joined line-by-line rather than concatenated so the suite's `.creq` file structure stays
+# visible — each element below is one line of it, in order.
+EXPECTED_CANONICAL_REQUEST = "\n".join(
+    [
+        "GET",
+        "/",
+        "",
+        f"host:{HOST}",
+        f"x-amz-date:{AMZ_DATE}",
+        "",
+        "host;x-amz-date",
+        EMPTY_PAYLOAD_SHA256,
+    ]
+)
+EXPECTED_STRING_TO_SIGN = "\n".join(
+    [
+        "AWS4-HMAC-SHA256",
+        AMZ_DATE,
+        f"{DATE_STAMP}/{REGION}/{SERVICE}/aws4_request",
+        "bb579772317eb040ac9ed261061d46c1f17a8133879d6129b6e1c25292927e63",
+    ]
+)
+EXPECTED_SIGNATURE = "5fa00fa31553b73ebf1942676e86291e8372ff2a2260956d9b8aae1d763fbf31"
+
+
+def test_the_empty_payload_hash_is_the_sha256_of_nothing() -> None:
+    """A GET signs the hash of an empty body; this constant is that, spelled once."""
+    assert EMPTY_PAYLOAD_SHA256 == (
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    )
+
+
+def test_canonical_request_matches_the_published_vector() -> None:
+    assert (
+        canonical_request(
+            method="GET",
+            path="/",
+            query="",
+            headers={"Host": HOST, "X-Amz-Date": AMZ_DATE},
+            payload_sha256=EMPTY_PAYLOAD_SHA256,
+        )
+        == EXPECTED_CANONICAL_REQUEST
+    )
+
+
+def test_string_to_sign_matches_the_published_vector() -> None:
+    assert (
+        string_to_sign(
+            amz_date=AMZ_DATE,
+            scope=f"{DATE_STAMP}/{REGION}/{SERVICE}/aws4_request",
+            canonical=EXPECTED_CANONICAL_REQUEST,
+        )
+        == EXPECTED_STRING_TO_SIGN
+    )
+
+
+def test_the_authorization_header_matches_the_published_vector() -> None:
+    """The whole chain, end to end — signing key derivation included."""
+    header = authorization_header(
+        credentials=Credentials(
+            access_key=ACCESS_KEY, secret_key=SECRET_KEY, region=REGION, service=SERVICE
+        ),
+        method="GET",
+        path="/",
+        query="",
+        headers={"Host": HOST, "X-Amz-Date": AMZ_DATE},
+        payload_sha256=EMPTY_PAYLOAD_SHA256,
+        now=datetime(2015, 8, 30, 12, 36, 0, tzinfo=UTC),
+    )
+
+    assert header == (
+        f"AWS4-HMAC-SHA256 Credential={ACCESS_KEY}/{DATE_STAMP}/{REGION}/{SERVICE}/aws4_request, "
+        f"SignedHeaders=host;x-amz-date, Signature={EXPECTED_SIGNATURE}"
+    )
+
+
+# --- canonicalisation rules the vector alone does not exercise ---------------------------
+
+
+def test_headers_are_lowercased_trimmed_and_sorted() -> None:
+    """INVARIANT: canonical header order is by lowercase name, not by insertion order.
+
+    Sending them in one order and signing them in another is the classic SigV4 mistake, and
+    it produces a 403 that looks like bad credentials.
+    """
+    canonical = canonical_request(
+        method="PUT",
+        path="/bucket/key",
+        query="",
+        headers={
+            "X-Amz-Date": AMZ_DATE,
+            "Host": HOST,
+            "X-Amz-Content-Sha256": "  abc  ",
+        },
+        payload_sha256="abc",
+    )
+
+    lines = canonical.split("\n")
+    assert lines[3:6] == [
+        f"host:{HOST}",
+        "x-amz-content-sha256:abc",
+        f"x-amz-date:{AMZ_DATE}",
+    ]
+    assert lines[7] == "host;x-amz-content-sha256;x-amz-date"
+
+
+def test_the_object_key_is_not_double_encoded() -> None:
+    """Our keys are 64 hex chars, so the path must pass through byte-identical.
+
+    S3 canonicalisation does NOT re-encode the path for the object APIs; encoding a key that
+    needs no encoding is another silent 403.
+    """
+    key = "a" * 64
+    canonical = canonical_request(
+        method="GET",
+        path=f"/artifacts/{key}",
+        query="",
+        headers={"Host": HOST, "X-Amz-Date": AMZ_DATE},
+        payload_sha256=EMPTY_PAYLOAD_SHA256,
+    )
+
+    assert canonical.split("\n")[1] == f"/artifacts/{key}"
+
+
+def test_the_signing_key_is_derived_over_date_region_service_then_terminator() -> None:
+    """Four chained HMACs, in that order. A wrong order yields a valid-looking bad key."""
+    derived = signing_key(
+        secret_key=SECRET_KEY, date_stamp=DATE_STAMP, region=REGION, service=SERVICE
+    )
+
+    assert isinstance(derived, bytes)
+    assert len(derived) == 32
+    # Deriving twice is pure — no hidden clock or nonce leaks into the key.
+    assert derived == signing_key(
+        secret_key=SECRET_KEY, date_stamp=DATE_STAMP, region=REGION, service=SERVICE
+    )
+
+
+@pytest.mark.parametrize("missing", ["Host", "X-Amz-Date"])
+def test_signing_refuses_to_proceed_without_a_mandatory_header(missing: str) -> None:
+    """INVARIANT: fail loudly here rather than emit a signature the server will reject.
+
+    A missing `host` or `x-amz-date` produces a 403 from the far side with no hint which
+    header was absent — so the check belongs on this side, where the answer is known.
+    """
+    headers = {"Host": HOST, "X-Amz-Date": AMZ_DATE}
+    del headers[missing]
+
+    with pytest.raises(ValueError, match=missing.lower()):
+        canonical_request(
+            method="GET",
+            path="/",
+            query="",
+            headers=headers,
+            payload_sha256=EMPTY_PAYLOAD_SHA256,
+        )

--- a/docs/plan/2026-08-21-OME-929-artifact-blob-handoff.md
+++ b/docs/plan/2026-08-21-OME-929-artifact-blob-handoff.md
@@ -1,0 +1,125 @@
+# OME-929 — Implementation plan
+
+Spec: `docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md`
+Stack: `screamingface-engine` (single landing — D4 means no SDK change, so no epic split)
+Ledger: `docs/work/2026-08-21-OME-929-artifact-blob-handoff.md`
+
+Three SDLC iterations, three commits, one PR. Each iteration is independently green; the bug's
+acceptance test lands in iteration 2 and the deployment wiring in iteration 3.
+
+## Layout
+
+`artifacts.py` becomes a package. `__init__.py` re-exports, and **`ArtifactStore` survives as an
+alias for `FilesystemArtifactStore`** — there are 24 call sites and 4 test modules referencing
+that name, and tests are append-only, so the name must not move.
+
+```
+src/screamingface_engine/artifacts/
+  __init__.py      re-exports; ArtifactStore = FilesystemArtifactStore
+  ports.py         ArtifactWriter, ArtifactReader, ArtifactContent, LocalFile, RemoteStream
+  filesystem.py    FilesystemArtifactStore  (today's behaviour, moved verbatim)
+  s3.py            S3ArtifactStore
+  sigv4.py         the signer — pure functions, no I/O
+```
+
+Precondition to verify first: `.claude/scripts/check_layering.py` must permit this placement
+(it enforces that concrete adapters stay out of `url4.streaming`). Confirm before writing code.
+
+---
+
+## Iteration 1 — extract the ports (no behaviour change)
+
+**RED**
+- `RemoteStream` content renders as a `StreamingResponse` with the right length; `LocalFile`
+  renders as a `FileResponse`. Fails: neither type exists.
+- `FilesystemArtifactStore` structurally satisfies `ArtifactWriter` and `ArtifactReader`.
+
+**GREEN**
+- Add `ports.py`; move the store into `filesystem.py` unchanged; add `content()` returning
+  `LocalFile`; keep `path_for` (14 callers) delegating to it.
+- `rest/artifacts.py` matches on `ArtifactContent` — `FileResponse` for `LocalFile` (this is
+  what keeps `test_a_range_request_does_not_consume_the_artifact` passing unmodified),
+  `StreamingResponse` for `RemoteStream`.
+
+**Invariant to hold:** every one of the existing artifact tests passes untouched.
+
+Commit: `refactor(screamingface-engine): split artifact storage into writer and reader ports`
+
+---
+
+## Iteration 2 — the S3 adapter, and the test that proves the bug
+
+**RED**
+- **SigV4 signer** against AWS's published `aws-sig-v4-test-suite` vectors: canonical request,
+  string-to-sign, signing key derivation, `Authorization` header. Pure functions, table-driven.
+- `S3ArtifactStore` round-trip (`write_bytes` → `content`) against a fake S3 built on
+  `httpx.MockTransport` — asserting the request it *actually* sends: `PUT /{bucket}/{id}`,
+  `x-amz-content-sha256` equal to the artifact id, a valid `Authorization`.
+- **The acceptance test for the bug (spec §6.1):** a writer and a reader constructed as two
+  independent instances sharing no filesystem round-trip an over-cap result. Parametrised over
+  both adapters: it **fails** for `FilesystemArtifactStore` on separate roots with the ticket's
+  404, and **passes** for `S3ArtifactStore`. This is the coverage gap that let the bug ship.
+- Cap boundary at `cap-1` / `cap` / `cap+1` (spec §6.3): the first two inline, the third spills.
+- Error paths: 403 from a bad signature, 404 for a missing object → `None` (not an exception),
+  a truncated upload surfaces rather than minting a ticket for absent content.
+
+**GREEN**
+- `sigv4.py`, then `s3.py`.
+
+**Ordering invariant to pin with its own test:** the upload completes **before** the terminal
+result frame is published. Otherwise a client can redeem a ticket for an object that does not
+exist yet — the same 404 with a race instead of a misconfiguration behind it.
+
+Commit: `feat(screamingface-engine): store spilled results in S3-compatible object storage`
+
+---
+
+## Iteration 3 — deployment wiring and loud failure
+
+**RED**
+- **The `DEPLOY_TIME` contract test (spec §6.2):** walk `job_env.DEPLOY_TIME` and assert the
+  rendered runner-env ConfigMap carries every name, with an explicit allowlist for the
+  genuinely optional ones (`TAVILY_API_KEY`). Fails today — this is the test that would have
+  caught OME-929 the day OME-892 landed.
+- **Startup guard (spec §6.4):** runner backend `k8s`/`jetstream` with absent or unusable S3
+  config → the App refuses to start and the Runner fails its first write, each naming the
+  missing setting. Never a fetch-time 404.
+- Selection is derived (spec §4.3): `inprocess`/`memory` resolve to filesystem, `k8s`/
+  `jetstream` to S3, and no configuration can pair `k8s` with filesystem.
+
+**GREEN**
+- Garage template + `values.yaml` stanza (default-disabled, mirroring the NATS subchart
+  pattern) + PVC (RWO is sufficient — one blob pod).
+- Render the S3 settings into `configmap-runner-env.yaml` (Runner) and `configmap.yaml` (App);
+  credentials via a Secret with `envFrom`, following the `TAVILY_API_KEY` precedent.
+- Wire selection through `adapters/factory.py`; `Settings` gains the S3 fields.
+
+**Also in this iteration** (spec §6.7) — the stale comments, which actively misled the original
+investigation:
+- `artifacts.py` header — "`delete` (after a successful fetch)" and "sweep at app startup"
+  (it is startup **and** periodic)
+- `job_env.py:242` — "deleted on fetch, swept by TTL"
+- `app.py:104` — "artifacts are deleted on fetch, so the only leak source is …"
+- `job_env.py:305` — the inverted "an unwritten READ simply falls back" reasoning (spec §2)
+
+Commit: `feat(screamingface-engine): provision object storage for artifacts and fail loudly on mismatch`
+
+---
+
+## Verification
+
+- `uv run .claude/scripts/run_gates.py screamingface-engine` green after each iteration.
+- `helm template` the engine chart with Garage enabled and disabled; assert the rendered
+  ConfigMaps agree with `DEPLOY_TIME` (this is what the §6.2 test automates).
+- Manual end-to-end against the deployed pods is the owner's check — force a spill with
+  `URL4_CLOUD_RESULT_INLINE_CAP_BYTES=1024` and confirm a full-size result round-trips,
+  verified against the ticket's `size_bytes` + `sha256`.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Hand-rolled SigV4 is wrong | Signed against AWS's published vectors; fails closed (we sign, Garage verifies). Bound: no multipart, no presigning — else take a real client (spec D5). |
+| Converting `artifacts.py` to a package breaks 24 call sites | `ArtifactStore` alias retained; the full existing suite is the regression gate. |
+| Garage operational unfamiliarity | Default-disabled in the chart; `inprocess` never touches it, so local development is unaffected. |
+| App streams ~3 MiB per redemption | Accepted (D4). Single-consumer, once per run, few runs/hour. Presigned URLs remain the escape hatch behind the port. |

--- a/docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md
+++ b/docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md
@@ -1,0 +1,120 @@
+# OME-929 — Over-cap result artifacts must survive the Runner Job
+
+Status: DECIDED 2026-08-21 (owner decisions recorded in §3). Supersedes the transport
+recommendation in the Linear issue, which proposed HTTP upload to the App.
+
+## 1. Problem
+
+A Run whose serialized result exceeds the inline cap (1 MiB) spills to a content-addressed
+artifact; the terminal frame carries only a claim ticket. On the hosted Engine the Runner is a
+Kubernetes **Job** pod and the App is a **Deployment** pod. Each mounts its own `emptyDir` at
+`/tmp` (`adapters/k8s.py:342,367`), and `URL4_CLOUD_ARTIFACTS_DIR` is set by **nothing** in the
+chart — so both halves fall back to the same *pod-local* default path, which is two different
+disks. The Runner writes ~3 MiB into a disk that dies with the Job; the client redeems the
+ticket against the App and gets 404.
+
+The artifact is not an accessory to the Report — it **is** the Report's payload.
+`_decoded_result_body` (`packages/screamingface/.../_evaluation/results.py:44`) raises
+`ExecutionError` on a `None` body, so a lost artifact yields **no Report at all**. Every
+full-scale benchmark run on the hosted Engine therefore produces nothing the user can see,
+after the entire cost of the run is paid (a full DRACO 3-pass run is 11,902 model calls).
+
+Confirmed by the owner 2026-08-21: the failure occurs in the deployed pod environment. The
+Linear issue's "confirm hosted vs local" precondition is satisfied; local (`inprocess`) shares
+the directory by construction and is genuinely unaffected.
+
+## 2. Why it shipped — the coverage gap
+
+`ARTIFACTS_DIR` is a member of `job_env.DEPLOY_TIME`, whose docstring states "Helm owns these
+end-to-end." Helm owns nothing of the sort. `tests/unit/test_job_env_contract.py` asserts only
+the **negative** direction — that the App must not write a deploy-time name (lines 159-166) —
+and never that the chart *does* write them. `job_env.py:305` records the reasoning that
+permitted this: *"the direction that breaks silently is an unread WRITE, not an unwritten READ
+(which simply falls back)."*
+
+That reasoning is inverted for this variable. The fallback is a pod-local temp directory: it is
+not a benign default but the exact misconfiguration that loses the result. A test walking
+`DEPLOY_TIME` against the rendered chart would have failed the day OME-892 landed. Closing this
+gap is in scope and is transport-independent.
+
+## 3. Decisions (owner, 2026-08-21)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | **Object storage**, not a shared RWX volume and not HTTP-upload-to-App | Hosted is AKS; the repo has no RWX StorageClass and no inter-pod shared-volume precedent, so a shared volume needs a platform action outside this repo. Object storage also keeps run completion independent of App liveness. |
+| D2 | **Self-hosted S3 in our own charts** — Garage | Removes object storage's two stated costs (cloud credentials, cloud coupling). Garage is a single static binary, no external dependencies, sized for exactly this workload. |
+| D3 | **Local/`inprocess` keeps the filesystem store** | One process, one disk: the existing behaviour is correct there and stays byte-identical. |
+| D4 | **The App streams artifacts through**; no presigned-URL redirect | Keeps `GET /artifacts/{id}` unchanged, so the SDK's existing size + sha256 verification and retry survive untouched and the blob store stays cluster-internal. Also keeps this a single-landing unit (no SDK change, no epic split). |
+| D5 | **`httpx` + hand-rolled SigV4**; no new dependency | Bounded to PUT and GET of one object — no multipart, and D4 means no presigning. We sign, Garage verifies, so a signer bug fails **closed** (our request is rejected; nothing forged is accepted). The payload sha256 is already computed — it *is* the artifact id. Testable against AWS's published SigV4 vectors. **Bound: if the signer ever needs multipart or presigning, revisit and take a real S3 client.** |
+
+## 4. Design
+
+### 4.1 Ports (core; core never imports an adapter)
+
+The single `ArtifactStore` class exists only because writer and reader shared a filesystem.
+Split it along the boundary that is now real:
+
+- `ArtifactWriter` — Runner side: `write_bytes(encoded: bytes) -> ResultArtifact`
+- `ArtifactReader` — App side: `content(artifact_id) -> ArtifactContent | None`,
+  `delete(artifact_id)`, `sweep(ttl_seconds, *, now=None) -> int`
+
+`ArtifactContent` is a value object, not an HTTP concept, and is deliberately a union because
+the two storage kinds genuinely differ in what they can offer:
+
+```python
+@dataclass(frozen=True)
+class LocalFile:      path: Path                                    # supports HTTP Range
+@dataclass(frozen=True)
+class RemoteStream:   stream: AsyncIterator[bytes]; size_bytes: int  # does not
+ArtifactContent = LocalFile | RemoteStream
+```
+
+Flattening these into one shape would either lose Range on the local path or fake it on the
+remote one. `rest/artifacts.py` renders `LocalFile` with `FileResponse` (as today, preserving
+`test_a_range_request_does_not_consume_the_artifact`) and `RemoteStream` with
+`StreamingResponse`.
+
+### 4.2 Adapters
+
+- `FilesystemArtifactStore` — today's `ArtifactStore` behaviour verbatim, implementing both
+  ports. The default for `inprocess`/`memory` (D3).
+- `S3ArtifactStore` — `httpx` + SigV4 (D5), implementing both ports against one bucket.
+  Selected for `k8s`/`jetstream`.
+
+### 4.3 Selection — derived, not independently configurable
+
+Backend selection **derives** from the runner backend rather than taking its own env var. An
+independent setting would admit exactly one new misconfiguration: `runner=k8s` with a
+filesystem store, which is today's bug wearing a config flag. Deriving makes that state
+unrepresentable.
+
+### 4.4 Fail loudly, at startup
+
+INVARIANT: a writer/reader storage mismatch must surface **before** any run, never at fetch
+time minutes after the spend. When the runner backend is `k8s`/`jetstream` and the S3
+configuration is absent or unusable, the App refuses to start and the Runner fails its first
+write — with a message naming the missing setting.
+
+## 5. Out of scope
+
+- Multi-replica App support (D4 keeps the App on the read path; it is already pinned to one
+  replica for the in-process subscriber gate).
+- Presigned URLs, multipart upload, object-storage replication/versioning tiers. The object is
+  single-consumer, fetched once, dead within 48 h — "survives until the client fetches it" is
+  the entire durability requirement.
+- Migrating existing on-disk artifacts. They are ≤48 h hand-offs; the TTL sweeper drains them.
+- The `draco-3pass` board and DRACO cache-seed work.
+
+## 6. Acceptance
+
+1. A test with writer and reader on **separate storage roots** round-trips an over-cap result.
+   It must fail before the fix with the ticket's 404 and pass after.
+2. A test asserts every `job_env.DEPLOY_TIME` name is rendered by the chart (or is explicitly
+   declared optional), closing the §2 gap.
+3. Cap-boundary tests at `cap-1`, `cap`, `cap+1` bytes pin inline-vs-spill.
+4. A storage mismatch fails at startup or first write, not at fetch.
+5. `inprocess`/local behaviour is byte-identical to today.
+6. Existing artifact tests unchanged and green (tests are append-only).
+7. The stale "deleted on fetch" comments corrected (`artifacts.py` header, `job_env.py:242`,
+   `app.py:104`), and the inverted `job_env.py:305` reasoning corrected.
+8. `uv run .claude/scripts/run_gates.py screamingface-engine` green.

--- a/docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md
+++ b/docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md
@@ -46,6 +46,33 @@ gap is in scope and is transport-independent.
 | D3 | **Local/`inprocess` keeps the filesystem store** | One process, one disk: the existing behaviour is correct there and stays byte-identical. |
 | D4 | **The App streams artifacts through**; no presigned-URL redirect | Keeps `GET /artifacts/{id}` unchanged, so the SDK's existing size + sha256 verification and retry survive untouched and the blob store stays cluster-internal. Also keeps this a single-landing unit (no SDK change, no epic split). |
 | D5 | **`httpx` + hand-rolled SigV4**; no new dependency | Bounded to PUT and GET of one object — no multipart, and D4 means no presigning. We sign, Garage verifies, so a signer bug fails **closed** (our request is rejected; nothing forged is accepted). The payload sha256 is already computed — it *is* the artifact id. Testable against AWS's published SigV4 vectors. **Bound: if the signer ever needs multipart or presigning, revisit and take a real S3 client.** |
+| D6 | **The deployment configures itself — no bootstrap Job, no operator commands** (owner, 2026-08-21) | See §4.5. |
+
+### 4.5 Self-configuration (D6)
+
+Garage ≥ 2.3.0 provides three `garage server` flags that remove the bootstrap entirely:
+`--single-node` (creates its own layout), `--default-access-key` (adopts
+`GARAGE_DEFAULT_ACCESS_KEY`/`_SECRET_KEY`), `--default-bucket` (creates `GARAGE_DEFAULT_BUCKET`).
+The chart generates a stable key pair when none is supplied — reused across upgrades via `lookup`,
+the pattern already used for the JWT secret — and Garage **adopts** it.
+
+WHY adopt rather than mint: a `post-install` hook running `garage key create` makes Garage produce
+the credential, which the chart must then discover and write back into a Secret. That needs
+`create secrets` RBAC and makes the chart two-phase, so `helm template` no longer describes the
+result. Adopting a chart-stated key keeps the data flowing one way and the chart declarative.
+
+WHY not script the layout: Garage's own operations guide warns that repeating
+`layout apply --version N` can leave a cluster **inconsistent**, and that the version must be
+exactly one past the current one — which is what a hook re-running on every `helm upgrade` gets
+wrong. `--single-node` removes the operation instead of automating it.
+
+INVARIANT: one Secret, three consumers — the App (Deployment `envFrom`), every Runner Job
+(`envFrom.secretRef`), and Garage itself (`env` → `GARAGE_DEFAULT_*`). The store therefore cannot
+hold a key the engine does not present.
+
+INVARIANT: the pair is NOT rotated by an upgrade. Garage adopts a default key only on first boot,
+so minting a new pair later would leave the engine signing with credentials the store has never
+seen — a 403 on every artifact, which reads as a code bug rather than a config change.
 
 ## 4. Design
 

--- a/docs/tasks/2026-08-21-OME-929-artifact-blob-handoff.md
+++ b/docs/tasks/2026-08-21-OME-929-artifact-blob-handoff.md
@@ -1,0 +1,38 @@
+---
+id: OME-929
+linear_url: https://linear.app/openmined/issue/OME-929/make-over-cap-result-artifacts-fetchable-on-multi-pod-deployments
+status: in_progress
+type: bug
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-21
+closed:
+---
+
+# Make over-cap result artifacts fetchable on multi-pod deployments
+
+Any Run whose result exceeds the 1 MiB inline cap is unfetchable on the hosted Engine. The
+Runner Job pod and the App pod each mount their own `emptyDir` at `/tmp`, and
+`URL4_CLOUD_ARTIFACTS_DIR` is set nowhere in the chart, so both halves fall back to the same
+pod-local default — two different disks. The client redeems the claim ticket against the App and
+gets 404, after the entire cost of the run is paid (11,902 model calls for a full DRACO 3-pass).
+The artifact *is* the Report's payload, so the user gets no Report at all. Known gap flagged on
+`OME-892`, not a new regression. Owner confirmed 2026-08-21 that it reproduces in the deployed
+pod environment.
+
+Fix (owner decisions, spec §3): spilled artifacts move to **self-hosted S3-compatible object
+storage** (Garage, bundled in our charts) for the `k8s`/`jetstream` backends;
+`inprocess`/local keeps the filesystem store unchanged. The App **streams artifacts through**
+rather than redirecting to a presigned URL, so the SDK's existing size+sha256 verification
+survives untouched and this stays a single-landing unit. Client is `httpx` + a hand-rolled
+SigV4 signer — bounded to PUT/GET of one object, no multipart, no presigning; we sign and
+Garage verifies, so a signer bug fails closed.
+
+Also closes the coverage gap that let it ship: `ARTIFACTS_DIR` is declared in
+`job_env.DEPLOY_TIME` ("Helm owns these end-to-end") while Helm sets nothing, and the contract
+test asserts only that the App *doesn't* write deploy-time names — never that the chart *does*.
+A `DEPLOY_TIME` ↔ rendered-chart test would have gone red the day OME-892 landed.
+
+Spec: `docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md`
+Plan: `docs/plan/2026-08-21-OME-929-artifact-blob-handoff.md`
+Ledger: `docs/work/2026-08-21-OME-929-artifact-blob-handoff.md`

--- a/docs/work/2026-08-21-OME-929-artifact-blob-handoff.md
+++ b/docs/work/2026-08-21-OME-929-artifact-blob-handoff.md
@@ -135,16 +135,55 @@ a writer/reader storage mismatch can no longer reach fetch time.
      the TEST DATA was corrected against AWS's published `aws-sig-v4-test-suite` `get-vanilla`
      files, whose provenance is now recorded in the test.
 
+## Iteration 4 — the deployment configures itself (owner requirement, 2026-08-21)
+
+Owner: bundled Garage, **no manual commands — everything configured automatically.** This
+retired known-limitation 2 below rather than documenting it.
+
+Verified against Garage's docs before designing (the SigV4 episode earlier in this unit is why):
+
+- `garage server` gained `--single-node`, `--default-access-key` and `--default-bucket` in
+  **v2.3.0**. Confirmed the `dxflrs/garage:v2.3.0` tag exists in the registry (v2.3.1 / v2.4.0 do
+  not), so the image floor is real and pinned.
+- **My `key import` assumption was WRONG** — the CLI has no documented way to supply your own key
+  id and secret. The v2.3.0 env-var path replaced that idea entirely.
+- Garage's layout guide states that repeating `layout apply --version N` can leave a cluster
+  **inconsistent**, and the version must be exactly one past the current. That is worse than the
+  "just fails" risk originally recorded, and it is decisive against a hook that re-runs on every
+  upgrade. `--single-node` removes the operation instead.
+
+Implementation:
+- `secret-artifact-storage.yaml` now holds BOTH halves of the pair and GENERATES them when unset,
+  in Garage's own formats (`GK` + 24 hex; 64 hex), reusing the existing `lookup` pattern so an
+  upgrade never rotates them.
+- The access key moved out of both ConfigMaps into that Secret — it must be stable, and `lookup`
+  only works against an object the chart owns.
+- `garage.yaml` gains the three flags and maps the Secret to `GARAGE_DEFAULT_*`.
+- `values.schema.json`: the `accessKey`-required rule was REMOVED; requiring it would forbid the
+  fully-automatic path.
+- Tests: the three flags are present, `GARAGE_DEFAULT_*` reads the same Secret keys the engine
+  reads, and the pinned image is ≥ v2.3.0.
+
+Verified: `helm template` with `backend=s3 garage.enabled=true` and **no credentials supplied**
+renders 12 documents; the generated pair reaches all three consumers from one Secret.
+
+✚ Also documented a limitation found while explaining the design, not while writing it: the
+adapter uses **path-style** addressing, which excludes real AWS S3 (virtual-hosted-style) and
+Azure Blob (not S3-compatible at all). Recorded in `s3.py` and the chart README.
+
 ## Known limitations (carried, not fixed)
 
 1. **Object expiry depends on a bucket lifecycle rule.** `S3ArtifactStore.sweep` is a deliberate
    no-op: listing objects needs query-string signing, which would push the signer past the
    PUT/GET bound spec D5 sets on it. A bucket configured without a lifecycle rule never expires
    artifacts, and nothing in the App will notice. Documented in the chart README and in the code.
-2. **Garage bootstrap is a manual step.** The chart deploys Garage but does not assign a layout,
-   create the bucket, or mint a key — those are imperative CLI steps. Commands are in the README
-   and in `templates/garage.yaml`.
-3. **Not exercised against a live cluster.** The engine side is fully covered by tests, and the
-   chart is verified to render; the Garage manifests and the end-to-end round trip on real pods
-   still need the owner's live-run check (the ticket's cheap repro: force a spill with
-   `URL4_CLOUD_RESULT_INLINE_CAP_BYTES=1024`).
+   **This is now the only operational gap in the bundled path** — worth its own ticket.
+2. **Path-style addressing only** — fine for Garage/MinIO/SeaweedFS/Ceph/R2, likely broken against
+   real AWS S3, impossible for Azure Blob. Choosing the style per endpoint is the fix if needed.
+3. **Not exercised against a live cluster.** The engine side is fully covered by tests and the
+   chart is verified to render, but the Garage manifests and the end-to-end round trip on real
+   pods still need the owner's live-run check (cheap repro: force a spill with
+   `URL4_CLOUD_RESULT_INLINE_CAP_BYTES=1024`). Two things to watch first: whether
+   `--default-access-key` + `--default-bucket` also GRANT the key access to the bucket (the docs
+   do not say so explicitly; if not, the first PUT 403s), and whether Garage accepts a
+   caller-supplied key in these formats.

--- a/docs/work/2026-08-21-OME-929-artifact-blob-handoff.md
+++ b/docs/work/2026-08-21-OME-929-artifact-blob-handoff.md
@@ -75,9 +75,76 @@ scope — the App is pinned to one replica for the in-process subscriber gate).
 Spec §6, items 1-8. Headline: a >1 MiB result round-trips end to end on the deployed pods, and
 a writer/reader storage mismatch can no longer reach fetch time.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files** (as planned, plus the four marked ✚):
+  - `artifacts/{__init__,ports,filesystem,s3,sigv4}.py` — ports + both adapters + the signer
+  - ✚ `artifacts/wiring.py` — the shared `S3Config` builder. Not planned: the validation is
+    needed by BOTH halves, and `adapters/factory.py` (where the plan put selection) is
+    control-plane, so the Runner cannot import it. It belongs in the shared leaf.
+  - `rest/artifacts.py` — renders `LocalFile` (FileResponse, keeps Range) or `RemoteStream`
+    (StreamingResponse + explicit Content-Length); `response_model=None` + `response_class`
+    so FastAPI stops inferring a Pydantic field from a union of Starlette responses
+  - `runner/executor.py` — `artifact_store` retyped to the `ArtifactWriter` PORT (pyright found
+    the leftover coupling to the concrete filesystem class)
+  - `runner/main.py` — `result_delivery_from_env` selects the store; refuses a half-configured one
+  - `app.py` — `_build_artifact_reader` + the startup refusal; stale sweeper comment corrected
+  - `config.py` — `ArtifactStoreBackend`, six `artifact_*` settings, `artifact_s3_secret_name`,
+    ✚ a validator normalising a blank `artifacts_dir` (see deviation 4)
+  - `job_env.py` — six new DEPLOY_TIME names; the inverted "unwritten READ simply falls back"
+    reasoning corrected; ARTIFACTS_DIR redocumented as local-only
+  - `adapters/factory.py` — Jobs now receive both Secrets (Tavily and artifact storage)
+  - `deploy/helm/` — `artifactStorage` + `garage` values stanzas, both ConfigMaps,
+    `secret-artifact-storage.yaml`, `garage.yaml` (StatefulSet + Service + ConfigMap),
+    two `_helpers.tpl` helpers, Deployment `envFrom`, ✚ `values.schema.json`
+    (`additionalProperties: false` rejected the new stanzas), ✚ `README.md` operator section
+  - tests: `test_artifact_ports.py` (9), `test_sigv4.py` (9), `test_s3_artifact_store.py` (11),
+    `test_artifact_spill_is_store_agnostic.py` (5), `test_artifact_storage_selection.py` (16),
+    `test_deploy_time_chart_contract.py` (14)
+- **Commits:**
+  - f9c3f795 refactor(screamingface-engine): split artifact storage into writer and reader ports
+  - 1d8f4ef1 feat(screamingface-engine): store spilled results in S3-compatible object storage
+  - (this) feat(screamingface-engine): provision object storage and fail loudly on mismatch
+- **Gates:** ALL GREEN — 1989 passed, 5 skipped, coverage 93.40% (floor 80); ruff check + format,
+  pyright, layering. `helm template` renders in filesystem and s3+garage modes; `helm lint` clean.
+  Final run used the documented `--skip-append-only` (deviation 3).
+- **Deviations:**
+  1. **`artifacts.py` header corrected in iteration 1, not 3.** The plan scheduled all comment
+     fixes for iteration 3, but iteration 1 rewrites that header while moving the module —
+     committing a known-false statement in order to fix it two commits later is worse.
+  2. **`write_text` added to the `ArtifactWriter` port.** A PRIOR test (`test_runner.py:469`)
+     calls it on the value `result_delivery_from_env` returns. Retyping that return to the port
+     made pyright fail. Fixed in the PORT rather than the test, so no prior test was touched.
+  3. **One prior test modified, with owner approval** (2026-08-21):
+     `test_catalog_wiring.py::test_no_setting_holds_an_aigateway_credential` pins the set of
+     secret-shaped `Settings` fields as a deliberate tripwire. Three names were added
+     (`artifact_s3_access_key`, `artifact_s3_secret_key`, `artifact_s3_secret_name`) with the
+     provenance and blast radius of each recorded inline. The App must hold the S3 secret to
+     sign its own GETs when streaming artifacts back, so a name-only reference cannot work the
+     way it does for Tavily. No assertion was weakened; the tripwire still fires on the next
+     addition.
+  4. **Extra hardening not in the plan:** a blank `URL4_CLOUD_ARTIFACTS_DIR` used to become
+     `Path("")` — the working directory — silently relocating the store. Now normalised to the
+     default in `Settings`, and the chart omits the key rather than rendering an empty value.
+  5. **A second unrendered `DEPLOY_TIME` member surfaced:** the new chart contract test caught
+     `URL4_RUNNER_CONFIG`, which is also declared Helm-owned and set by nobody. Its fallback is
+     a path the image guarantees, so it is genuinely safe — allowlisted with that reason rather
+     than papered over.
+  6. **AWS SigV4 vectors:** the constants recalled from memory were wrong (one was from a
+     different AWS example). The implementation independently produced the correct signature, and
+     the TEST DATA was corrected against AWS's published `aws-sig-v4-test-suite` `get-vanilla`
+     files, whose provenance is now recorded in the test.
+
+## Known limitations (carried, not fixed)
+
+1. **Object expiry depends on a bucket lifecycle rule.** `S3ArtifactStore.sweep` is a deliberate
+   no-op: listing objects needs query-string signing, which would push the signer past the
+   PUT/GET bound spec D5 sets on it. A bucket configured without a lifecycle rule never expires
+   artifacts, and nothing in the App will notice. Documented in the chart README and in the code.
+2. **Garage bootstrap is a manual step.** The chart deploys Garage but does not assign a layout,
+   create the bucket, or mint a key — those are imperative CLI steps. Commands are in the README
+   and in `templates/garage.yaml`.
+3. **Not exercised against a live cluster.** The engine side is fully covered by tests, and the
+   chart is verified to render; the Garage manifests and the end-to-end round trip on real pods
+   still need the owner's live-run check (the ticket's cheap repro: force a spill with
+   `URL4_CLOUD_RESULT_INLINE_CAP_BYTES=1024`).

--- a/docs/work/2026-08-21-OME-929-artifact-blob-handoff.md
+++ b/docs/work/2026-08-21-OME-929-artifact-blob-handoff.md
@@ -1,0 +1,83 @@
+---
+ticket: OME-929
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-21
+finished:
+---
+
+# OME-929 — Over-cap result artifacts must survive the Runner Job
+
+## Intent
+
+Every full-scale benchmark run on the hosted Engine currently produces **no Report at all**. A
+result over the 1 MiB inline cap spills to a content-addressed artifact, but the Runner Job pod
+and the App pod each mount their own `emptyDir` at `/tmp` and `URL4_CLOUD_ARTIFACTS_DIR` is set
+nowhere in the chart — so both fall back to the same pod-local default, which is two different
+disks. The client redeems the claim ticket against the App and gets 404, after all 11,902 model
+calls of a DRACO 3-pass run have been paid for. The artifact *is* the Report's payload
+(`_decoded_result_body` raises on a `None` body), so losing it is total, not partial.
+
+This unit moves spilled artifacts into self-hosted S3-compatible object storage (Garage) for the
+`k8s`/`jetstream` backends, keeps the filesystem store for `inprocess`/local, and closes the
+coverage gap that let the bug ship.
+
+Spec: `docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md` (owner decisions D1–D5)
+Plan: `docs/plan/2026-08-21-OME-929-artifact-blob-handoff.md` (three iterations)
+
+## Planned changes
+
+Iteration 1 — ports (no behaviour change):
+- `src/screamingface_engine/artifacts/{__init__,ports,filesystem}.py` — split the single
+  `ArtifactStore` into `ArtifactWriter`/`ArtifactReader`; `ArtifactStore` retained as an alias
+  for `FilesystemArtifactStore` (24 call sites, 4 test modules, append-only tests)
+- `src/screamingface_engine/rest/artifacts.py` — render `ArtifactContent` (`FileResponse` for
+  `LocalFile`, `StreamingResponse` for `RemoteStream`)
+
+Iteration 2 — the adapter and the bug's acceptance test:
+- `src/screamingface_engine/artifacts/sigv4.py` — pure SigV4 signer (no I/O)
+- `src/screamingface_engine/artifacts/s3.py` — `S3ArtifactStore` over `httpx`
+- tests: SigV4 vectors, fake-S3 round-trip, **separate-roots acceptance test**, cap boundary,
+  upload-before-terminal-frame ordering
+
+Iteration 3 — wiring and loud failure:
+- `deploy/helm/` — Garage template + values + PVC; S3 settings into `configmap-runner-env.yaml`
+  and `configmap.yaml`; credentials Secret via `envFrom` (TAVILY precedent)
+- `src/screamingface_engine/{config,job_env}.py`, `adapters/factory.py` — derived selection
+  (§4.3) + startup guard (§4.4)
+- tests: `DEPLOY_TIME` ↔ rendered-chart contract test; startup-guard tests
+- comment corrections: `artifacts.py` header, `job_env.py:242`, `job_env.py:305`, `app.py:104`
+
+## Test plan
+
+Risk-ranked (highest first), mirroring the ticket's R1–R5:
+
+- **R1 the bug.** Writer and reader on separate storage — over-cap result round-trips.
+  Parametrised over both adapters: fails for filesystem-on-separate-roots with the 404, passes
+  for S3. 100% reproducible.
+- **R2 silent regression.** Every existing artifact test uses one store instance in one process,
+  so none of them can catch a writer/reader split. The R1 test is the structural fix. Plus the
+  `DEPLOY_TIME` ↔ chart contract test, which would have gone red the day OME-892 landed.
+- **R3 cap boundary.** `cap-1`, `cap`, `cap+1` — first two inline, third spills.
+- **R4 ordering.** Upload completes before the terminal frame is published; otherwise the client
+  can redeem a ticket for an object that does not exist yet.
+- **R5 diagnosability.** A storage mismatch fails at startup/first write with the missing
+  setting named — never a fetch-time 404 minutes after the spend.
+- SigV4 correctness against AWS's published test vectors (table-driven, pure).
+- Error paths: bad signature (403), missing object (`None`, not an exception), truncated upload
+  surfaces rather than minting a ticket for absent content.
+
+Explicitly **not** covered: real Garage behaviour under load, and multi-replica App (out of
+scope — the App is pinned to one replica for the in-process subscriber gate).
+
+## Acceptance
+
+Spec §6, items 1-8. Headline: a >1 MiB result round-trips end to end on the deployed pods, and
+a writer/reader storage mismatch can no longer reach fetch time.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">


### PR DESCRIPTION
Fixes OME-929.

## The problem

Every full-scale benchmark run on the hosted Engine produces **no Report at all** — after the
entire cost of the run has been paid.

A result over the 1 MiB inline cap is parked under its content address and the terminal frame
carries only a claim ticket. But the Runner is a Job pod and the App is a Deployment pod, each
mounting its own `emptyDir` at `/tmp`, and `URL4_CLOUD_ARTIFACTS_DIR` was set **nowhere** in the
chart — so both halves fell back to the same *pod-local* default, which is two different disks.
The client redeems against the App and gets 404.

The artifact is not an accessory to the Report; it **is** the Report's payload
(`_decoded_result_body` raises on a `None` body). A full DRACO 3-pass run is 11,902 model calls
and a ~3.03 MiB result, so it spills every time.

## Why it shipped

Sharper than "no test covered it". `ARTIFACTS_DIR` sits in `job_env.DEPLOY_TIME`, documented
*"Helm owns these end-to-end"*, while Helm owned none of it.
`test_job_env_contract.py` asserts only the **negative** direction — that the App must not write
a deploy-time name — and nothing asserted the positive one. `job_env` even recorded the reasoning
that permitted it:

> the direction that breaks silently is an unread WRITE, not an unwritten READ (which simply
> falls back)

That is inverted here. An unwritten READ falls back silently too, and whether that is benign
depends entirely on what the fallback *means*: a byte count has a safe default, a storage
location does not. The comment is corrected, and a `DEPLOY_TIME` ↔ rendered-chart test now
asserts the direction nobody was checking. It would have failed the day OME-892 landed — and it
immediately caught a second unrendered member (`URL4_RUNNER_CONFIG`, whose fallback is genuinely
safe, allowlisted with that reason).

## The fix

Owner decisions, recorded in `docs/spec/2026-08-21-OME-929-artifact-blob-handoff.md`:

| | Decision |
|---|---|
| D1 | Object storage — not a shared RWX volume (needs an out-of-repo AKS change) and not HTTP-upload-to-the-App |
| D2 | Self-hosted (Garage) in our own charts, so no cloud account and no cloud coupling |
| D3 | `inprocess`/local keeps the filesystem store, byte-identical to today |
| D4 | The App **streams artifacts through** — so the SDK is unchanged and the store stays cluster-internal |
| D5 | `httpx` + a hand-rolled SigV4 signer, bounded to PUT/GET of one object |
| D6 | The deployment **configures itself** — no bootstrap Job, no operator commands |

Four commits:

1. **Ports.** `ArtifactWriter` / `ArtifactReader`, with `ArtifactContent = LocalFile | RemoteStream`.
   The union is deliberate — flattening it would either lose HTTP Range on the local path or fake
   it on the remote one. No behaviour change; `ArtifactStore` stays as an alias because 24 call
   sites and 4 append-only test modules name it. Nothing HTTP-shaped enters `artifacts`, which is
   a shared leaf of the layering gate.
2. **The S3 adapter and the test that proves the bug.** A writer and a reader sharing **no
   filesystem** now round-trip an over-cap result — every prior artifact test used one store in
   one process, so none of them could express the split.
3. **Wiring and loud failure.** `runner="k8s"` + filesystem storage is **refused at startup**.
   That pairing *is* the bug, it was the default, and nothing about it looked wrong.
4. **Self-configuring storage.** The whole deployment configuration is now two lines.

## On the hand-rolled SigV4

I flagged this as a risk and it is smaller than it looks: **we sign, Garage verifies**, so a
defect gets our own request refused — it can never make a forgery acceptable. The payload hash is
already computed (it *is* the artifact id), and D4 means no presigned URLs, which is where SigV4
usually turns hairy. Verified against AWS's published `aws-sig-v4-test-suite` `get-vanilla`
vectors, with the provenance recorded in the test. **Bound:** if it ever needs multipart or
presigning, take a real S3 client instead.

Worth noting: the constants I first wrote from memory were wrong, and the implementation
independently produced the *correct* signature. The test data was corrected against the published
files, not the code against the test.

## Self-configuring storage (no bootstrap Job)

`garage.enabled: true` used to leave four `kubectl exec` commands between install and a working
store. Garage **v2.3.0** removes them: `garage server` gained `--single-node` (creates its own
layout), `--default-access-key` (adopts `GARAGE_DEFAULT_ACCESS_KEY`/`_SECRET_KEY`) and
`--default-bucket`. The chart generates a stable key pair when none is supplied — in Garage's own
formats, reusing the `lookup` pattern already used for the JWT secret — and Garage **adopts** it.

**Why adopt rather than mint**, which is the whole design: a `post-install` hook running
`garage key create` makes Garage *produce* the credential, which the chart must then discover and
write back into a Secret. That needs `create secrets` RBAC and turns a declarative chart into a
two-phase one where `helm template` no longer describes the result. Stating the key instead keeps
the data flowing one way.

**Why not script the layout:** Garage's
[operations guide](https://garagehq.deuxfleurs.fr/documentation/operations/layout/) warns that
repeating `layout apply --version N` can leave a cluster **inconsistent**, and that the version
must be exactly one past the current one — precisely what a hook re-running on every
`helm upgrade` gets wrong. `--single-node` removes the operation rather than automating it.

One Secret, three consumers — the App, every Runner Job, and Garage itself — so the store cannot
hold a key the engine never presents. The pair is deliberately **not** rotated by an upgrade:
Garage adopts a default key only on first boot, so a new pair would leave the engine signing with
credentials the store has never seen (a 403 on every artifact, which reads like a code bug).

I verified the flags, their version, and the existence of the `dxflrs/garage:v2.3.0` tag against
the docs and the registry before building on them — and found that my assumed `garage key import`
approach does **not** exist, which is what ruled out the design this replaces. Given I had already
shipped SigV4 constants from memory that turned out wrong earlier in this same PR, checking first
seemed prudent.

## Test plan

Risk-ranked, mirroring the ticket's R1–R5:

- **R1 the bug** — over-cap result round-trips with writer and reader on separate storage.
- **R2 silent regression** — the `DEPLOY_TIME` ↔ chart contract test, plus a check that a
  `Settings` field and its `job_env` env name are the same variable (the invariant
  `ARTIFACTS_DIR` was documented to have and never had).
- **R3 cap boundary** — `cap-1`/`cap`/`cap+1` re-pinned against object storage, so the two
  adapters cannot drift on the threshold that keeps small runs byte-identical on the wire.
- **R4 ordering** — a refused deposit fails the run *there*, instead of publishing a successful
  frame carrying a ticket that 404s minutes later.
- **R5 diagnosability** — a 403 raises rather than reading as absent; a misconfiguration must not
  present itself as an expired parcel, which is what misdirected this bug's first investigation.

`1993 passed, 5 skipped`, coverage 93.40% (floor 80). ruff, pyright, layering all green.
`helm template` renders in filesystem and s3+garage modes — including with NO credentials
supplied, where it produces 12 documents and wires the generated pair to all three consumers.
`helm lint` clean.

## Installing it

```yaml
artifactStorage:
  backend: s3
garage:
  enabled: true
```

That is the entire configuration. No credentials to invent, no bucket to create, no commands to
run — see the self-configuration section below.

## Known limitations (carried deliberately, documented in the ledger)

1. **Object expiry depends on a bucket lifecycle rule.** `S3ArtifactStore.sweep` is a deliberate
   no-op — listing needs query-string signing, past the signer's stated bound. A bucket with no
   lifecycle rule never expires artifacts. This is now the only operational gap in the bundled
   path, and is worth its own ticket.
2. **Path-style addressing only.** Objects are addressed `{endpoint}/{bucket}/{key}`, which works
   on Garage, MinIO, SeaweedFS, Ceph RGW and R2 — but real AWS S3 has deprecated path-style in
   favour of virtual-hosted-style, and Azure Blob is not S3-compatible at all. Found while
   explaining the design, not while writing it; documented in `s3.py` and the chart README.
3. **Not yet exercised on real pods.** The engine side is covered and the chart renders; the
   Garage manifests and the end-to-end round trip need a live-cluster pass. Two things to watch
   first: whether `--default-access-key` + `--default-bucket` also *grant* the key access to the
   bucket (the docs do not say so explicitly — if not, the first PUT 403s), and whether Garage
   accepts a caller-supplied key in the formats the chart generates.

## Owner verification

Force a spill on the deployed pods with `URL4_CLOUD_RESULT_INLINE_CAP_BYTES=1024` and confirm a
result round-trips, checked against the ticket's `size_bytes` + `sha256`.

## Reviewer note

One prior test was modified, with approval: the secret-shaped-`Settings` tripwire in
`test_catalog_wiring.py`, widened by three names with each one's provenance and blast radius
recorded inline. The App must hold the S3 secret to sign its own GETs, so a name-only reference
cannot work the way it does for Tavily. No assertion was weakened and the tripwire still fires on
the next addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
