### PR TITLE
fix(screamingface-engine): serialize benchmark cases

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/protocol.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/protocol.py
@@ -86,10 +86,12 @@ def build_evaluation_protocol(
     if any(not isinstance(binding, Node) for binding in bindings):
         raise TypeError("bindings must contain only URL4 Nodes")
 
+    # INVARIANT: Case admission covers the complete spawned row; nested Case work keeps its cap.
     case_evaluations = iterate(
         cases_route,
         body=(src(case_evaluation, name="evaluated", weight=0.0),),
         intent=Text("$evaluated"),
+        concurrency=1,
         slice=(None if selected_case_count == available_case_count else (0, selected_case_count)),
         on_error="collect",
     )

--- a/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 
@@ -21,7 +22,7 @@ from screamingface_engine.benchmarks.protocol import (
     build_evaluation_protocol,
     preserve_candidate_outcome,
 )
-from url4 import RelExpr, Text, render, src
+from url4 import RelExpr, Text, expr, render, src, struct
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
 
@@ -114,6 +115,79 @@ async def test_protocol_preserves_selected_order_and_collects_a_case_failure() -
 
 
 @pytest.mark.asyncio
+async def test_protocol_evaluates_only_one_complete_case_at_a_time() -> None:
+    node = Url4Node("benchmark-sequential-cases")
+    node.data(
+        "/example/cases",
+        json.dumps([{"id": "case-1"}, {"id": "case-2"}, {"id": "case-3"}]),
+        media_type="application/json",
+    )
+    active_cases: set[str] = set()
+    active_branches = max_active_cases = max_active_branches = 0
+
+    @node.endpoint("/example/case-branch")
+    async def case_branch(request: Request) -> str:
+        nonlocal active_branches, max_active_branches, max_active_cases
+        active_cases.add(request.context)
+        active_branches += 1
+        max_active_cases = max(max_active_cases, len(active_cases))
+        max_active_branches = max(max_active_branches, active_branches)
+        try:
+            await asyncio.sleep(0.01)
+            return request.intent
+        finally:
+            active_branches -= 1
+
+    @node.endpoint("/example/complete-case")
+    def complete_case(request: Request) -> str:
+        payload = json.loads(request.context)
+        active_cases.remove(payload["case_id"])
+        return json.dumps({"case_id": payload["case_id"]})
+
+    @node.endpoint("/example/aggregate")
+    def aggregate(request: Request) -> str:
+        return request.context
+
+    case_evaluation = expr(
+        src(
+            RelExpr(path="/example/case-branch", context="$item.id", intent=Text("left")),
+            name="left",
+            weight=0.0,
+        ),
+        src(
+            RelExpr(path="/example/case-branch", context="$item.id", intent=Text("right")),
+            name="right",
+            weight=0.0,
+        ),
+        src(
+            RelExpr(
+                path="/example/complete-case",
+                context=render(struct({"case_id": "$item.id", "left": "$left", "right": "$right"})),
+                intent=Text(""),
+            ),
+            name="completed",
+            weight=0.0,
+        ),
+        intent=Text("$completed"),
+    )
+    protocol = build_evaluation_protocol(
+        cases_route="/example/cases",
+        case_evaluation=case_evaluation,
+        selected_case_count=3,
+        available_case_count=3,
+        aggregate_route="/example/aggregate",
+    )
+    rendered = render(protocol)
+
+    await node.evaluate(rendered)
+
+    # INVARIANT: whole Cases are serial, while independent work inside one Case stays parallel.
+    assert max_active_cases == 1
+    assert max_active_branches == 2
+    assert "iteration.concurrency=1" in rendered
+
+
+@pytest.mark.asyncio
 async def test_case_execution_preserves_candidate_invocation_when_grading_fails() -> None:
     node = Url4Node("benchmark-case-execution")
 
@@ -161,11 +235,11 @@ def test_protocol_rejects_an_impossible_case_selection() -> None:
 @pytest.mark.parametrize(
     ("benchmark", "expected_sha256"),
     (
-        (DRACO, "6a9e0deb13a9e88868dc5452cce46527f89236be2aa34da3fbaa7afb413ecefa"),
-        (IFEVAL, "c01431240e88cbe76fcbebfa3cab9fb36f36f70e8fa28807a070bbe5fb3f21eb"),
+        (DRACO, "fe91990b18cf4672d9eccc412fca7bf533de1cb33de38bee589d37302c04d8dc"),
+        (IFEVAL, "c272779623671772ad8c2629e320e283837f34e3b270c693643285174794e4f8"),
         (
             HEALTHBENCH_WORST30,
-            "a5a729e1fcc53c7bb4c506f8a29a577ad4c68e983dcc32c6a9edcd33a443054c",
+            "963cbe2cbffed4ff4123adf6b667af4191ab5337f774bbd43e0ec547d3f6b3e9",
         ),
     ),
 )

--- a/docs/plan/2026-08-21-OME-931-sequential-benchmark-cases.md
+++ b/docs/plan/2026-08-21-OME-931-sequential-benchmark-cases.md
@@ -1,0 +1,42 @@
+# OME-931 — Implementation plan
+
+- **Spec:** `docs/spec/2026-08-21-OME-931-sequential-benchmark-cases.md`
+- **Linear:** https://linear.app/openmined/issue/OME-931/evaluate-benchmark-cases-sequentially
+- **Branch:** `OME-931-sequential-benchmark-cases`
+- **Stack:** `screamingface-engine` (`sdlc-python`)
+
+## 1. RED — prove complete Cases do not overlap
+
+In `apps/screamingface-engine/tests/unit/test_benchmark_protocol.py`, add an asynchronous fixture
+endpoint that records active Case evaluations across several rows. Run the focused test against
+the unmodified protocol and require `max_active == 1`; confirm it fails because the default outer
+map admits multiple rows.
+
+Also pin the intended rendered directive on the shared protocol. Keep the existing order and
+failure-policy assertions intact.
+
+## 2. GREEN — bind the outer Case map
+
+In `apps/screamingface-engine/src/screamingface_engine/benchmarks/protocol.py`:
+
+- pass `concurrency=1` to the shared outer `iterate(...)`.
+
+Make no URL4 runtime, benchmark-specific builder, or benchmark-revision changes. Revision is the
+identity of the thing measured; this unit changes only operational scheduling.
+
+## 3. Reconcile deliberate identities
+
+Run the benchmark protocol and definition tests. Update only the old expectations that are
+explicit byte/revision pins for this approved protocol change:
+
+- canonical rendered URL4 SHA-256 values.
+
+Do not change the frozen DRACO or HealthBench revision values, weaken structural assertions, or
+change unrelated expectations.
+
+## 4. Verify and deliver
+
+- Run the focused shared protocol and benchmark definition tests.
+- Run `uv run .claude/scripts/run_gates.py screamingface-engine` from the repository root.
+- Complete the ledger outcome, commit with `Refs: OME-931`, push, and open a PR.
+- Add the close-discipline evidence to Linear; leave final Done transition to merge automation.

--- a/docs/spec/2026-08-21-OME-931-sequential-benchmark-cases.md
+++ b/docs/spec/2026-08-21-OME-931-sequential-benchmark-cases.md
@@ -1,0 +1,46 @@
+# OME-931 — Sequential outer benchmark Case evaluation
+
+- **Linear:** https://linear.app/openmined/issue/OME-931/evaluate-benchmark-cases-sequentially
+- **Landing:** `apps/screamingface-engine`
+- **Related discovery:** `OME-887` provisional-score latency
+
+## Problem
+
+The shared benchmark protocol currently leaves its outer Case iteration at URL4's default map
+concurrency. A multi-Case evaluation can therefore spread work across many Cases before any one
+Case has completed candidate invocation, grading, and Case-result construction. That delays the
+first complete Case outcome and multiplies Case-level resource pressure.
+
+## Required behavior
+
+The outer Case iteration MUST set `iteration.concurrency=1`. The semaphore covers the complete
+spawned row expression, so the next Case begins only after the current Case returns or raises.
+
+This bound is intentionally scoped:
+
+- Nested iterations and fan-out inside the active Case retain their existing concurrency.
+- Separate benchmark runs retain independent schedulers and can execute concurrently.
+- Fetching the Case collection, resolving shared bindings, and final aggregation remain outside
+  the Case semaphore.
+- Per-Case `on_error=collect`, selection slicing, and ordered result collection remain unchanged.
+
+## Design
+
+Add `concurrency=1` to the one shared `iterate(...)` call in
+`screamingface_engine.benchmarks.protocol.build_evaluation_protocol`. Do not change URL4: its
+`MapNode` already holds the per-map semaphore across the entire spawned row subtree.
+
+Keep `EVALUATION_PROTOCOL_REVISION` unchanged. Benchmark revision identifies the dataset and
+scoring contract — the thing measured — while Case admission is an operational scheduling
+choice. The rendered URL4 recipe changes and its byte pins must move, but existing scores remain
+comparable and the Scoreboard's registered benchmark revisions must not move.
+
+## Acceptance criteria
+
+1. A deterministic shared-protocol test observes a maximum of one active Case endpoint.
+2. The generated outer iteration renders `iteration.concurrency=1`.
+3. Failure collection, selected order, and aggregation output remain unchanged.
+4. IFEval, DRACO, and both HealthBench boards retain their existing benchmark revisions.
+5. Canonical rendered URL4 SHA-256 pins move to the sequential recipes.
+6. No URL4 package or Scoreboard code changes.
+7. The full `screamingface-engine` gate passes.

--- a/docs/tasks/2026-08-21-OME-931-sequential-benchmark-cases.md
+++ b/docs/tasks/2026-08-21-OME-931-sequential-benchmark-cases.md
@@ -1,0 +1,23 @@
+---
+id: OME-931
+linear_url: https://linear.app/openmined/issue/OME-931/evaluate-benchmark-cases-sequentially
+status: in_progress
+type: improvement
+priority: 3
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-21
+closed:
+---
+
+# Evaluate benchmark cases sequentially
+
+Run the shared Engine benchmark protocol's outer Case iteration with URL4
+`iteration.concurrency=1`. One complete Case evaluation therefore finishes or fails before the
+next Case begins, while nested work inside a Case and separate benchmark runs retain their own
+concurrency.
+
+Canonical artifacts:
+
+- Spec: `docs/spec/2026-08-21-OME-931-sequential-benchmark-cases.md`
+- Plan: `docs/plan/2026-08-21-OME-931-sequential-benchmark-cases.md`
+- Ledger: `docs/work/2026-08-21-OME-931-sequential-benchmark-cases.md`

--- a/docs/work/2026-08-21-OME-931-sequential-benchmark-cases.md
+++ b/docs/work/2026-08-21-OME-931-sequential-benchmark-cases.md
@@ -1,0 +1,59 @@
+---
+ticket: OME-931
+stack: screamingface-engine
+status: done
+started: 2026-08-21
+finished: 2026-08-21
+---
+
+# OME-931 — evaluate benchmark cases sequentially
+
+## Intent
+
+Make progress and resource use Case-oriented by admitting only one outer benchmark Case at a
+time. URL4 already provides the required per-iteration bound; the Engine-owned shared benchmark
+protocol must select it explicitly.
+
+## Planned changes
+
+- `docs/tasks/2026-08-21-OME-931-sequential-benchmark-cases.md`
+- `docs/spec/2026-08-21-OME-931-sequential-benchmark-cases.md`
+- `docs/plan/2026-08-21-OME-931-sequential-benchmark-cases.md`
+- `docs/work/2026-08-21-OME-931-sequential-benchmark-cases.md`
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/protocol.py`
+- `apps/screamingface-engine/tests/unit/test_benchmark_protocol.py`
+- `apps/screamingface-engine/tests/unit/test_benchmark_protocol.py` canonical URL4 byte pins.
+
+## Test plan
+
+- RED: execute several Cases through the shared protocol with an asynchronous endpoint and prove
+  that no two complete Case subtrees overlap.
+- Assert the rendered protocol carries exactly the outer `iteration.concurrency=1` directive.
+- Preserve selected Case order and failure collection.
+- Update deliberate URL4 byte pins while proving benchmark revisions remain unchanged.
+- Run focused benchmark protocol/definition tests, then the full `screamingface-engine` gate.
+
+## Acceptance
+
+- At most one outer Case evaluation is active per benchmark run.
+- A Case's candidate invocation, grading, and result construction complete or fail before the
+  next Case begins.
+- Nested concurrency inside one Case and concurrency across separate runs are unchanged.
+- Registered built-in benchmark revisions remain unchanged because the scoring contract is
+  unchanged; their rendered URL4 recipe hashes move.
+- The full Engine quality gate passes.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** all planned files — four SDLC artifacts, the shared Engine benchmark
+  protocol, and its unit test. No URL4 or Scoreboard files changed.
+- **Commits:** pending — `fix(screamingface-engine): serialize benchmark cases`, landing with
+  this ledger update.
+- **Gates:** focused protocol/definition set: 37 passed; full Engine gate GREEN — ruff check,
+  ruff format, pyright, layering, and pytest. Independent full test evidence: 1993 passed,
+  6 skipped, 93.38% coverage (80% required).
+- **Deviations:** the initial design proposed advancing `EVALUATION_PROTOCOL_REVISION`. Frozen
+  identity tests and the benchmark-registration spec established that benchmark revision names
+  the thing measured, not operational scheduling, so revisions remain stable and only rendered
+  URL4 SHA pins moved. The append-only precheck was skipped with the owner's explicit approval
+  to update those three exact byte pins; every substantive quality gate ran unchanged and green.


### PR DESCRIPTION
## Summary

- set URL4 iteration.concurrency=1 on the shared outer benchmark Case map
- prove complete Cases execute sequentially while independent branches inside one Case remain parallel
- keep benchmark revisions stable because scoring semantics are unchanged
- update the canonical rendered URL4 SHA-256 pins for DRACO, IFEval, and HealthBench Worst-30%
- add the required task mirror, work ledger, spec, and plan

## Test plan

- RED evidence: the new regression observed 3 simultaneously active Cases before the directive
- focused protocol and benchmark-definition suite: 37 passed
- full Engine suite: 1993 passed, 6 skipped, 93.38% coverage
- full Engine gates: ruff, ruff format, pyright, layering, and pytest/coverage all green
- append-only precheck waived with owner approval solely to update the three exact canonical URL4 hash literals

## Screenshots

Not applicable — no UI change.

Fixes OME-931
