### PR TITLE
fix(screamingface-engine): garage container needs an explicit command — the image has no Entrypoint

### DIFF
--- a/apps/screamingface-engine/deploy/helm/templates/garage.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/garage.yaml
@@ -105,8 +105,12 @@ spec:
       containers:
         - name: garage
           image: {{ .Values.garage.image | quote }}
-          # The three self-configuration flags (see the header). `server` is the subcommand; the
-          # image's entrypoint is the `garage` binary itself.
+          # The three self-configuration flags (see the header). `command` is NOT optional
+          # decoration: dxflrs/garage:v2.3.0 ships NO Entrypoint — only
+          # `Cmd: ["/garage", "server"]` — so bare `args` would REPLACE that Cmd wholesale and
+          # the kubelet would try to exec the literal string "server"
+          # (`exec: "server": executable file not found in $PATH`, CrashLoopBackOff).
+          command: ["/garage"]
           args:
             - server
             - --single-node


### PR DESCRIPTION
## What's happening

Deploying #683 on the hosted engine surfaced a one-line container bug: the bundled Garage store never starts. `dxflrs/garage:v2.3.0` ships **no Entrypoint** — its image config is only `Cmd: ["/garage", "server"]` (verified against the Docker Hub image config, linux/amd64). The template's bare `args` therefore *replace* that Cmd wholesale, and the kubelet tries to execute the literal string `server`:

```
exec: "server": executable file not found in $PATH
```

Observed live on the hosted engine: `url4-cloud-garage-0` in `RunContainerError` → `CrashLoopBackOff` on every restart. The engine App itself starts and serves fine with the new `backend: s3` configuration — only the store is down, so an over-cap result still has nowhere to land, which is the loss OME-929 exists to close.

## The fix

`command: ["/garage"]` above the existing `args`, restoring the intended `/garage server --single-node …` invocation. The template comment previously asserted "the image's entrypoint is the `garage` binary itself" — it now states the real image contract instead.

Everything else in #683 behaved exactly as documented on our deployment: the values contract, the `existingSecret` path, and the App's startup refusal all worked first try.

## After merge

Nothing needed from the platform side — your merge promotes to the hosted engine unattended (~20 min). We'll confirm the store boots and adopts its key on first boot, then run a full DRACO 3-pass to verify an over-cap Report is finally fetchable end to end.
