### PR TITLE
ci(dev-builds): stamp images with the commit's timestamp (SOURCE_DATE_EPOCH)

### DIFF
--- a/.github/workflows/dev-build-aigateway-ui.yml
+++ b/.github/workflows/dev-build-aigateway-ui.yml
@@ -37,6 +37,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Pin the image's embedded build timestamp to the commit's own timestamp.
+      # WHY: with a warm layer cache, two builds from different commits can
+      # reproduce an IDENTICAL config `created` time (observed 2026-08-21:
+      # #686's chart-only merge tied #684's build to the second), and any
+      # consumer that orders these tags by build time — the deployment
+      # automation that promotes them does exactly that — treats a tie as
+      # not-newer and never ships the new build. Commit time is unique per
+      # merge, monotonic on main, and makes the build reproducible.
+      - id: epoch
+        run: echo "epoch=$(git show -s --format=%ct HEAD)" >> "$GITHUB_OUTPUT"
       - id: sha
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
@@ -56,6 +66,8 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows and this app's Dockerfile,
           # which COPYs apps/aigateway-ui/ from there.

--- a/.github/workflows/dev-build-aigateway.yml
+++ b/.github/workflows/dev-build-aigateway.yml
@@ -22,6 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Pin the image's embedded build timestamp to the commit's own timestamp.
+      # WHY: with a warm layer cache, two builds from different commits can
+      # reproduce an IDENTICAL config `created` time (observed 2026-08-21:
+      # #686's chart-only merge tied #684's build to the second), and any
+      # consumer that orders these tags by build time — the deployment
+      # automation that promotes them does exactly that — treats a tie as
+      # not-newer and never ships the new build. Commit time is unique per
+      # merge, monotonic on main, and makes the build reproducible.
+      - id: epoch
+        run: echo "epoch=$(git show -s --format=%ct HEAD)" >> "$GITHUB_OUTPUT"
       - id: sha
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
@@ -41,6 +51,8 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows (screamingface-engine's
           # Dockerfile COPYs packages/url4 from outside its own directory).

--- a/.github/workflows/dev-build-scoreboard.yml
+++ b/.github/workflows/dev-build-scoreboard.yml
@@ -22,6 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Pin the image's embedded build timestamp to the commit's own timestamp.
+      # WHY: with a warm layer cache, two builds from different commits can
+      # reproduce an IDENTICAL config `created` time (observed 2026-08-21:
+      # #686's chart-only merge tied #684's build to the second), and any
+      # consumer that orders these tags by build time — the deployment
+      # automation that promotes them does exactly that — treats a tie as
+      # not-newer and never ships the new build. Commit time is unique per
+      # merge, monotonic on main, and makes the build reproducible.
+      - id: epoch
+        run: echo "epoch=$(git show -s --format=%ct HEAD)" >> "$GITHUB_OUTPUT"
       - id: sha
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
@@ -41,6 +51,8 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows (screamingface-engine's
           # Dockerfile COPYs packages/url4 from outside its own directory).

--- a/.github/workflows/dev-build-screamingface-engine.yml
+++ b/.github/workflows/dev-build-screamingface-engine.yml
@@ -25,6 +25,16 @@ jobs:
       short: ${{ steps.sha.outputs.short }}
     steps:
       - uses: actions/checkout@v7
+      # Pin the image's embedded build timestamp to the commit's own timestamp.
+      # WHY: with a warm layer cache, two builds from different commits can
+      # reproduce an IDENTICAL config `created` time (observed 2026-08-21:
+      # #686's chart-only merge tied #684's build to the second), and any
+      # consumer that orders these tags by build time — the deployment
+      # automation that promotes them does exactly that — treats a tie as
+      # not-newer and never ships the new build. Commit time is unique per
+      # merge, monotonic on main, and makes the build reproducible.
+      - id: epoch
+        run: echo "epoch=$(git show -s --format=%ct HEAD)" >> "$GITHUB_OUTPUT"
       - id: sha
         run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
@@ -44,6 +54,8 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.epoch }}
         with:
           # Context is the repo root — matches the release workflows (screamingface-engine's
           # Dockerfile COPYs packages/url4 from outside its own directory).
@@ -66,6 +78,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Pin the image's embedded build timestamp to the commit's own timestamp.
+      # WHY: with a warm layer cache, two builds from different commits can
+      # reproduce an IDENTICAL config `created` time (observed 2026-08-21:
+      # #686's chart-only merge tied #684's build to the second), and any
+      # consumer that orders these tags by build time — the deployment
+      # automation that promotes them does exactly that — treats a tie as
+      # not-newer and never ships the new build. Commit time is unique per
+      # merge, monotonic on main, and makes the build reproducible.
+      - id: epoch
+        run: echo "epoch=$(git show -s --format=%ct HEAD)" >> "$GITHUB_OUTPUT"
       - uses: docker/setup-buildx-action@v4
       - uses: docker/login-action@v4.6.0
         with:
@@ -79,6 +101,8 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: az acr login --name acropenmined
       - uses: docker/build-push-action@v7
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.epoch }}
         with:
           context: .
           file: apps/screamingface-engine/Dockerfile.benchmark


### PR DESCRIPTION
## What's happening

Your #686 (the garage `command` fix) merged, built, and reached the registry — and then never deployed. The hosted engine had to be pinned to it by hand. The cause is subtle: with a warm layer cache, two dev builds from **different commits** can reproduce an **identical** image-config `created` timestamp. Observed yesterday: the image for #686 (a chart-only change) carried the exact same build time as #684's image, to the second. The deployment automation that promotes these `main-<sha>` tags selects by **newest build time**, and a tie is not newer — so the new tag was never picked up.

## What changes for you

Nothing in your day-to-day. Each `dev-build-*` workflow gains two things:

- a step that reads the commit's own timestamp (`git show -s --format=%ct HEAD`), and
- `SOURCE_DATE_EPOCH` set on the `docker/build-push-action` steps — BuildKit's standard knob that stamps the image config's `created` field from it.

Build time becomes: unique per merge, monotonic on `main`, and reproducible instead of cache-dependent. Release builds are untouched — this only edits the four dev lanes (the engine workflow gets it in both its engine and benchmark jobs).

## What we need from you

Review and merge. That's it — no secrets, no new permissions, no behavior change beyond the timestamp.

## What's next

After this merges, any future chart-only (or otherwise fully-cached) change deploys unattended like every other merge — no more hand-pins. We'll confirm on the next merge that the promoted tag advances on its own.