### PR TITLE
feat(screamingface-engine): expose generic run Log seam

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/run_logs.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/run_logs.py
@@ -1,0 +1,169 @@
+"""Benchmark adapter for the generic Runner run-Log scope."""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import Literal
+
+from screamingface_engine.benchmarks.registry import BenchmarkRegistry
+from screamingface_engine.run_log_contract import (
+    LogScalar,
+    StructuredLogEmitter,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class _BenchmarkRunRecorder:
+    """Own one execution's Benchmark claim and opaque structured-Log emitter."""
+
+    __slots__ = (
+        "_active",
+        "_closed_warned",
+        "_conflict_warned",
+        "_disabled",
+        "_emit",
+        "_owner",
+        "_registry",
+        "_unknown_warned",
+    )
+
+    def __init__(
+        self,
+        registry: BenchmarkRegistry,
+        emit: StructuredLogEmitter,
+    ) -> None:
+        self._registry = registry
+        self._emit = emit
+        self._owner: str | None = None
+        self._active = True
+        self._disabled = False
+        self._closed_warned = False
+        self._conflict_warned = False
+        self._unknown_warned = False
+
+    def emit(
+        self,
+        benchmark_id: str,
+        body: str,
+        attributes: Mapping[str, LogScalar],
+    ) -> None:
+        if not self._claim(benchmark_id):
+            return
+        try:
+            self._emit(body, attributes)
+        except Exception as exc:  # noqa: BLE001 - the concrete adapter is observational too
+            _logger.warning(
+                "Benchmark run Log adapter emission failed (%s)",
+                type(exc).__name__,
+            )
+
+    def _claim(self, benchmark_id: str) -> bool:
+        allowed = False
+        if not self._active:
+            self._warn_closed_once()
+        elif self._disabled:
+            pass
+        elif type(benchmark_id) is not str or self._registry.get(benchmark_id) is None:
+            self._warn_unknown_once()
+        elif self._owner is None:
+            self._owner = benchmark_id
+            allowed = True
+        elif self._owner == benchmark_id:
+            allowed = True
+        elif self._owner != benchmark_id:
+            self._disabled = True
+            self._warn_conflict_once()
+        return allowed
+
+    def close(self) -> None:
+        self._active = False
+
+    def _warn_closed_once(self) -> None:
+        if not self._closed_warned:
+            _logger.warning("closed Benchmark run Log recorder ignored")
+            self._closed_warned = True
+
+    def _warn_unknown_once(self) -> None:
+        if not self._unknown_warned:
+            _logger.warning("unknown Benchmark run Log claim ignored")
+            self._unknown_warned = True
+
+    def _warn_conflict_once(self) -> None:
+        if not self._conflict_warned:
+            # INVARIANT: never interpolate either ID. A conflict is actionable without copying
+            # producer-controlled identity or any Benchmark payload into operator diagnostics.
+            _logger.warning("conflicting Benchmark run Log claims; instrumentation disabled")
+            self._conflict_warned = True
+
+
+_current_recorder: contextvars.ContextVar[_BenchmarkRunRecorder | None] = contextvars.ContextVar(
+    "screamingface_engine_benchmark_run_log_recorder", default=None
+)
+
+
+class _BenchmarkRunScope(AbstractContextManager[None]):
+    __slots__ = ("_recorder", "_token")
+
+    def __init__(self, recorder: _BenchmarkRunRecorder) -> None:
+        self._recorder = recorder
+        self._token: contextvars.Token[_BenchmarkRunRecorder | None] | None = None
+
+    def __enter__(self) -> None:
+        self._token = _current_recorder.set(self._recorder)
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Literal[False]:
+        self._recorder.close()
+        if self._token is not None:
+            _current_recorder.reset(self._token)
+            self._token = None
+        return False
+
+
+class BenchmarkRunLogAdapter:
+    """Adapt the immutable Benchmark registry onto the generic Runner run-scope port."""
+
+    __slots__ = ("_registry",)
+
+    def __init__(self, registry: BenchmarkRegistry) -> None:
+        self._registry = registry
+
+    def open_run_scope(
+        self,
+        rendered_url4: str,
+        emit_structured_log: StructuredLogEmitter,
+    ) -> AbstractContextManager[None] | None:
+        # WHY opaque: Benchmark ownership comes from the operation that actually runs. Inferring it
+        # from syntax would couple progress to URL4 formatting and fail on equivalent expressions.
+        del rendered_url4
+        if not len(self._registry):
+            return None
+        return _BenchmarkRunScope(_BenchmarkRunRecorder(self._registry, emit_structured_log))
+
+
+def emit_benchmark_run_log(
+    benchmark_id: str,
+    body: str,
+    attributes: Mapping[str, LogScalar],
+) -> None:
+    """Submit one Benchmark-owned record when called inside an active Engine execution.
+
+    A call outside a run is an inert capability probe, not an error. A child task that retained a
+    recorder beyond scope close is different: the recorder observes that stale use and refuses it.
+    """
+
+    recorder = _current_recorder.get()
+    if recorder is not None:
+        recorder.emit(benchmark_id, body, attributes)
+
+
+__all__ = ["BenchmarkRunLogAdapter", "emit_benchmark_run_log"]

--- a/apps/screamingface-engine/src/screamingface_engine/run_log_contract.py
+++ b/apps/screamingface-engine/src/screamingface_engine/run_log_contract.py
@@ -13,7 +13,8 @@ class StructuredLogEmitter(Protocol):
     """Synchronous, non-blocking submission into one execution's existing bridge.
 
     Calls must remain on the event-loop thread that received the emitter. Off-thread calls are
-    invalid and are ignored by the Runner rather than mutating its non-thread-safe bridge.
+    invalid and are ignored by the Runner rather than mutating its non-thread-safe bridge; repeated
+    violations produce at most one operator diagnostic per emitter.
     Attribute floats must be finite; non-finite values are rejected as malformed records.
     """
 

--- a/apps/screamingface-engine/src/screamingface_engine/run_log_contract.py
+++ b/apps/screamingface-engine/src/screamingface_engine/run_log_contract.py
@@ -10,13 +10,23 @@ type LogScalar = str | int | float | bool | None
 
 
 class StructuredLogEmitter(Protocol):
-    """Synchronous, non-blocking submission into one execution's existing bridge."""
+    """Synchronous, non-blocking submission into one execution's existing bridge.
+
+    Calls must remain on the event-loop thread that received the emitter. Off-thread calls are
+    invalid and are ignored by the Runner rather than mutating its non-thread-safe bridge.
+    Attribute floats must be finite; non-finite values are rejected as malformed records.
+    """
 
     def __call__(self, body: str, attributes: Mapping[str, LogScalar]) -> None: ...
 
 
 class RunLogScopeFactory(Protocol):
-    """The one generic lifecycle operation an observational adapter implements."""
+    """The one generic lifecycle operation an observational adapter implements.
+
+    The returned context manager owns partial-acquisition rollback: when its ``__enter__`` raises,
+    it must unwind anything already acquired before re-raising because the Runner will not call
+    ``__exit__`` afterward, following Python's context-manager protocol.
+    """
 
     def open_run_scope(
         self,

--- a/apps/screamingface-engine/src/screamingface_engine/run_log_contract.py
+++ b/apps/screamingface-engine/src/screamingface_engine/run_log_contract.py
@@ -1,0 +1,28 @@
+"""Dependency-free interface for optional run-scoped structured Logs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager
+from typing import Protocol
+
+type LogScalar = str | int | float | bool | None
+
+
+class StructuredLogEmitter(Protocol):
+    """Synchronous, non-blocking submission into one execution's existing bridge."""
+
+    def __call__(self, body: str, attributes: Mapping[str, LogScalar]) -> None: ...
+
+
+class RunLogScopeFactory(Protocol):
+    """The one generic lifecycle operation an observational adapter implements."""
+
+    def open_run_scope(
+        self,
+        rendered_url4: str,
+        emit_structured_log: StructuredLogEmitter,
+    ) -> AbstractContextManager[None] | None: ...
+
+
+__all__ = ["LogScalar", "RunLogScopeFactory", "StructuredLogEmitter"]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -24,6 +24,11 @@ from screamingface_engine import job_env
 from screamingface_engine.artifacts import ArtifactWriter
 from screamingface_engine.runner.accounting import PRICING_VERSION, UNPRICED, accumulate
 from screamingface_engine.runner.cache_counters import RunCacheCounters
+from screamingface_engine.runner.run_logs import (
+    RunLogScope,
+    RunLogScopeFactory,
+    StructuredLog,
+)
 from url4.core.errors import ResolutionError
 from url4.dag import run as url4_run
 from url4.io.layer import IOLayer
@@ -82,6 +87,13 @@ class BridgeOverflowError(RuntimeError):
     """
 
 
+type BridgeEvent = ObservationEvent | StructuredLog
+
+
+def _is_log_event(event: BridgeEvent) -> bool:
+    return isinstance(event, (Log, StructuredLog))
+
+
 class _Bridge:
     """A bounded async event queue between the engine's synchronous `url4.observe` callback
     and the async streaming loop draining it.
@@ -103,7 +115,7 @@ class _Bridge:
         *,
         memory_budget: int = job_env.DEFAULT_BRIDGE_MEMORY_BUDGET_BYTES,
     ) -> None:
-        self._buf: deque[ObservationEvent] = deque()
+        self._buf: deque[BridgeEvent] = deque()
         self._max = maxsize
         self._budget_bytes = memory_budget
         self._hard_cap = max(1, memory_budget // EVENT_SIZE_ESTIMATE_BYTES)
@@ -151,7 +163,7 @@ class _Bridge:
         """
         return self._high_water > self._max
 
-    def on_event(self, event: ObservationEvent) -> None:
+    def on_event(self, event: BridgeEvent) -> None:
         """Called synchronously by the engine for every observation event.
 
         Policy at the soft cap (`maxsize`): a `Log` is dropped outright (counted in
@@ -167,7 +179,7 @@ class _Bridge:
         # `_max` events' worth makes the hard cap bind first; the policy stays correct, the
         # soft cap simply never gets to help.
         if len(self._buf) >= self._max:
-            if isinstance(event, Log):
+            if _is_log_event(event):
                 self._dropped += 1
                 return
             self._evict_oldest_log()
@@ -198,7 +210,7 @@ class _Bridge:
 
     def _evict_oldest_log(self) -> None:
         for i, buffered in enumerate(self._buf):
-            if isinstance(buffered, Log):
+            if _is_log_event(buffered):
                 del self._buf[i]
                 self._dropped += 1
                 return
@@ -207,7 +219,7 @@ class _Bridge:
         self._closed = True
         self._wake.set()
 
-    async def drain(self) -> AsyncIterator[ObservationEvent]:
+    async def drain(self) -> AsyncIterator[BridgeEvent]:
         while True:
             if self._buf:
                 self._drained += 1
@@ -341,7 +353,7 @@ class _RunState:
         self._subtree_cost: Decimal | None = None
         self._subtree_unpriced = False
 
-    def map(self, event: ObservationEvent) -> list[Traced]:
+    def map(self, event: BridgeEvent) -> list[Traced]:
         """Fold one observation event into run state, returning the wire frames it produces.
 
         Dispatches on event type: `RunStarted` records the trace/root ids (no frame);
@@ -357,11 +369,11 @@ class _RunState:
             self.spans[event.span_id] = _SpanState(
                 event.node_kind, event.detail, datetime.now(UTC), event.parent_span_id
             )
-        elif isinstance(event, Log):
+        elif isinstance(event, (Log, StructuredLog)):
             # The engine attributes each log line to the span that emitted it; carry that through
             # so a consumer can tell WHICH node logged. A span-less line (logged outside any
             # node) legitimately has none and falls back to the run root.
-            return [Traced(payload=_log_frame(event), span=self._span_ref(event.span_id))]
+            return [self._map_log(event)]
         elif isinstance(event, Usage):
             self._fold_usage(event)
         elif isinstance(event, ModelResponse):
@@ -369,6 +381,14 @@ class _RunState:
         elif isinstance(event, NodeFinished):
             return self._finish(event)
         return []
+
+    def _map_log(self, event: Log | StructuredLog) -> Traced:
+        if isinstance(event, StructuredLog):
+            return Traced(
+                payload=LogData.at("INFO", event.body, event.attributes),
+                span=None,
+            )
+        return Traced(payload=_log_frame(event), span=self._span_ref(event.span_id))
 
     def _span_ref(self, span_id: str | None) -> SpanRef | None:
         """A `SpanRef` for a live span, or None when the frame belongs to the run itself.
@@ -706,6 +726,7 @@ class Url4Executor(Executor):
         artifact_store: ArtifactWriter | None = None,
         world_aclose: Callable[[], Awaitable[None]] | None = None,
         world_factory: WorldFactory | None = None,
+        run_log_scope_factory: RunLogScopeFactory | None = None,
     ) -> None:
         self._io = io
         self._queue_cap = queue_cap
@@ -722,6 +743,7 @@ class Url4Executor(Executor):
         self._artifact_store = artifact_store
         self._world_aclose = world_aclose
         self._world_factory = world_factory
+        self._run_log_scope_factory = run_log_scope_factory
 
     async def execute(
         self, url4: str, *, trace: TraceContext | None = None
@@ -747,15 +769,7 @@ class Url4Executor(Executor):
 
         async def _drive() -> str:
             try:
-                if trace is not None:
-                    return await url4_run(
-                        url4,
-                        self._io,
-                        observer=bridge,
-                        trace_id=trace.trace_id,
-                        root_span_id=trace.root_span_id,
-                    )
-                return await url4_run(url4, self._io, observer=bridge)
+                return await self._run_with_log_scope(url4, bridge, trace)
             finally:
                 bridge.close()
 
@@ -786,6 +800,30 @@ class Url4Executor(Executor):
             elif not task.cancelled():
                 task.exception()
             await self._aclose_world()
+
+    async def _run_with_log_scope(
+        self,
+        rendered_url4: str,
+        bridge: _Bridge,
+        trace: TraceContext | None,
+    ) -> str:
+        async def invoke() -> str:
+            if trace is not None:
+                return await url4_run(
+                    rendered_url4,
+                    self._io,
+                    observer=bridge,
+                    trace_id=trace.trace_id,
+                    root_span_id=trace.root_span_id,
+                )
+            return await url4_run(rendered_url4, self._io, observer=bridge)
+
+        with RunLogScope(
+            self._run_log_scope_factory,
+            rendered_url4,
+            bridge.on_event,
+        ):
+            return await invoke()
 
     async def _resolve_world(self) -> None:
         """Build the world on first execute. Idempotent; a failure leaves nothing to close.

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -76,8 +76,8 @@ cost more than the bound is worth; the estimate only has to be the right order o
 
 class BridgeOverflowError(RuntimeError):
     """Raised by `_Bridge.on_event` when the backlog still exceeds the cap derived from the
-    bridge's memory budget after the eviction policy has run — eviction only removes a `Log`
-    when one happens to be buffered, so a backlog of non-Log events grows unchecked to the
+    bridge's memory budget after the eviction policy has run — eviction only removes a log-like
+    event when one happens to be buffered, so a backlog of non-log events grows unchecked to the
     budget cap.
 
     The message separates the two shapes a full buffer can take: a drain count above zero
@@ -95,14 +95,14 @@ def _is_log_event(event: BridgeEvent) -> bool:
 
 
 class _Bridge:
-    """A bounded async event queue between the engine's synchronous `url4.observe` callback
-    and the async streaming loop draining it.
+    """A bounded async event queue between synchronous run-event producers and the async
+    streaming loop draining them.
 
-    Buffers up to `maxsize` events; beyond that, an incoming `Log` is dropped outright, while
-    an incoming non-Log event instead evicts the oldest buffered `Log` to make room (or, if no
-    `Log` is buffered, evicts nothing and the buffer grows toward the hard cap) — since a `Log`
-    is the only event kind safe to lose without corrupting the run's span/cost accounting.
-    Only past the hard cap does it give up and raise `BridgeOverflowError`.
+    Buffers up to `maxsize` events; beyond that, an incoming log-like event (`Log` or
+    `StructuredLog`) is dropped outright, while any other event instead evicts the oldest
+    buffered log-like event to make room (or, if none is buffered, evicts nothing and the buffer
+    grows toward the hard cap). Logs are the only events safe to lose without corrupting the
+    run's span/cost accounting. Only past the hard cap does it raise `BridgeOverflowError`.
 
     The HARD cap is not a count of events: it is `memory_budget // EVENT_SIZE_ESTIMATE_BYTES`,
     so an operator bounds what the backlog may COST in bytes, not how wide a DAG may be —
@@ -164,17 +164,16 @@ class _Bridge:
         return self._high_water > self._max
 
     def on_event(self, event: BridgeEvent) -> None:
-        """Called synchronously by the engine for every observation event.
+        """Called synchronously for every URL4 observation or injected structured Log.
 
-        Policy at the soft cap (`maxsize`): a `Log` is dropped outright (counted in
-        `dropped`); anything else evicts the oldest buffered `Log` to make room, since a
-        `Log` is the only event kind safe to lose without corrupting the run's span/cost
-        accounting. Only once the backlog still exceeds the hard cap after that eviction does
-        this raise `BridgeOverflowError`.
+        Policy at the soft cap (`maxsize`): a log-like event is dropped outright (counted in
+        `dropped`); anything else evicts the oldest buffered log-like event to make room. Only
+        once the backlog still exceeds the hard cap after that eviction does this raise
+        `BridgeOverflowError`.
         """
         # INVARIANT: with the default budget the hard cap sits far above `_max`, giving the
         # buffer headroom past the soft cap before the budget binds — NOT a guarantee that a
-        # Log is available to evict. A backlog with no buffered Log at all is exactly the
+        # log-like event is available to evict. A backlog with no buffered log at all is exactly the
         # state that runs out that headroom and raises BridgeOverflowError. A budget below
         # `_max` events' worth makes the hard cap bind first; the policy stays correct, the
         # soft cap simply never gets to help.
@@ -357,10 +356,11 @@ class _RunState:
         """Fold one observation event into run state, returning the wire frames it produces.
 
         Dispatches on event type: `RunStarted` records the trace/root ids (no frame);
-        `NodeStarted` opens a span (no frame); `Log` maps straight to a `Traced` log frame;
-        `Usage` folds token counts into the owning span and the run totals (no frame);
-        `NodeFinished` closes the span and returns its `SpanData` frame, plus a `CostUsageData`
-        frame when the span carried usage. Any other event type produces nothing.
+        `NodeStarted` opens a span (no frame); `Log` maps to its emitting span while injected
+        `StructuredLog` maps to the run root; `Usage` folds token counts into the owning span and
+        the run totals (no frame); `NodeFinished` closes the span and returns its `SpanData` frame,
+        plus a `CostUsageData` frame when the span carried usage. Any other event type produces
+        nothing.
         """
         if isinstance(event, RunStarted):
             self.trace_id = event.trace_id
@@ -370,9 +370,8 @@ class _RunState:
                 event.node_kind, event.detail, datetime.now(UTC), event.parent_span_id
             )
         elif isinstance(event, (Log, StructuredLog)):
-            # The engine attributes each log line to the span that emitted it; carry that through
-            # so a consumer can tell WHICH node logged. A span-less line (logged outside any
-            # node) legitimately has none and falls back to the run root.
+            # INVARIANT: URL4 Logs retain their emitting span; injected StructuredLogs deliberately
+            # attach to the run root because their semantic identity lives in attributes.
             return [self._map_log(event)]
         elif isinstance(event, Usage):
             self._fold_usage(event)

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -25,6 +25,7 @@ from screamingface_engine.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry,
 from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.candidate_adapter import install_candidate_invocation
 from screamingface_engine.benchmarks.ensemble import install_corrective_runtime
+from screamingface_engine.benchmarks.run_logs import BenchmarkRunLogAdapter
 from screamingface_engine.runner.connector import AigatewayConfig, build_aigateway_world
 from screamingface_engine.runner.executor import Url4Executor, World, deny_by_default_world
 from screamingface_engine.world_config import WorldConfig, WorldConfigError, load_config
@@ -293,6 +294,7 @@ def build_executor(
         hard_cap=hard_cap,
         memory_budget=bridge_budget_from_env(env),
         artifact_store=artifact_store,
+        run_log_scope_factory=BenchmarkRunLogAdapter(benchmarks),
     )
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
@@ -1,0 +1,170 @@
+"""Generic run-scoped structured Log interface and local validation."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Literal, Protocol
+
+_logger = logging.getLogger(__name__)
+
+type LogScalar = str | int | float | bool | None
+
+
+@dataclass(frozen=True, slots=True)
+class StructuredLog:
+    """One validated Runner-local input for an ordinary root Log frame."""
+
+    body: str
+    attributes: dict[str, LogScalar]
+
+
+class StructuredLogEmitter(Protocol):
+    """Synchronous, non-blocking submission into one execution's existing bridge."""
+
+    def __call__(self, body: str, attributes: Mapping[str, LogScalar]) -> None: ...
+
+
+class RunLogScopeFactory(Protocol):
+    """The one generic lifecycle operation an observational adapter implements."""
+
+    def open_run_scope(
+        self,
+        rendered_url4: str,
+        emit_structured_log: StructuredLogEmitter,
+    ) -> AbstractContextManager[None] | None: ...
+
+
+class RunLogEmitter:
+    """Validate, snapshot, and synchronously submit Logs while one scope is alive.
+
+    WHY this implementation sits behind ``StructuredLogEmitter``: producers should learn only
+    ``emit(body, attributes)``. Validation, expiry, diagnostics, and bridge input ownership remain
+    local to the Runner adapter and cannot be inconsistently recreated by every producer.
+    """
+
+    __slots__ = ("_active", "_expired_warned", "_submit")
+
+    def __init__(self, submit: Callable[[StructuredLog], None]) -> None:
+        self._submit = submit
+        self._active = True
+        self._expired_warned = False
+
+    def __call__(self, body: str, attributes: Mapping[str, LogScalar]) -> None:
+        if not self._active:
+            if not self._expired_warned:
+                _logger.warning("run Log expired emitter ignored")
+                self._expired_warned = True
+            return
+        record = self._validate(body, attributes)
+        if record is None:
+            return
+        try:
+            self._submit(record)
+        except Exception as exc:  # noqa: BLE001 - this observational seam is fail-open by contract
+            _logger.warning(
+                "run Log submission failed (%s)",
+                type(exc).__name__,
+            )
+
+    def close(self) -> None:
+        self._active = False
+
+    @staticmethod
+    def _validate(body: object, attributes: object) -> StructuredLog | None:
+        try:
+            if type(body) is not str or not body or not isinstance(attributes, Mapping):
+                raise _InvalidStructuredLog
+            snapshot: dict[str, LogScalar] = {}
+            for key, value in attributes.items():
+                # INVARIANT: exact built-in scalar types only. Pydantic coercion would turn a
+                # producer defect into a plausible-looking wire claim; membership over arbitrary
+                # JSON would raise TypeError for arrays/objects (the OME-928 regression shape).
+                if type(key) is not str or (
+                    value is not None and type(value) not in {str, int, float, bool}
+                ):
+                    raise _InvalidStructuredLog
+                snapshot[key] = value
+        except _InvalidStructuredLog:
+            _logger.warning("run Log submission rejected")
+        except Exception as exc:  # noqa: BLE001 - hostile Mapping implementations are input here
+            _logger.warning("run Log submission rejected (%s)", type(exc).__name__)
+        else:
+            return StructuredLog(body=body, attributes=snapshot)
+        return None
+
+
+class _InvalidStructuredLog(ValueError):
+    """Internal control flow for a record outside the flat scalar contract."""
+
+
+class RunLogScope(AbstractContextManager[None]):
+    """Contain one optional adapter scope without exposing lifecycle complexity to Runner."""
+
+    __slots__ = ("_emitter", "_factory", "_inner", "_rendered_url4")
+
+    def __init__(
+        self,
+        factory: RunLogScopeFactory | None,
+        rendered_url4: str,
+        submit: Callable[[StructuredLog], None],
+    ) -> None:
+        self._factory = factory
+        self._rendered_url4 = rendered_url4
+        self._emitter = RunLogEmitter(submit)
+        self._inner: AbstractContextManager[None] | None = None
+
+    def __enter__(self) -> None:
+        inner = self._open()
+        if inner is not None:
+            try:
+                inner.__enter__()
+            except Exception as exc:  # noqa: BLE001 - observational entry is fail-open
+                _log_scope_failure("entry", exc)
+            else:
+                self._inner = inner
+                return
+        self._emitter.close()
+
+    def _open(self) -> AbstractContextManager[None] | None:
+        if self._factory is None:
+            return None
+        try:
+            return self._factory.open_run_scope(self._rendered_url4, self._emitter)
+        except Exception as exc:  # noqa: BLE001 - observational setup is fail-open
+            _log_scope_failure("setup", exc)
+            return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> Literal[False]:
+        try:
+            if self._inner is not None:
+                try:
+                    self._inner.__exit__(exc_type, exc_value, traceback)
+                except Exception as exc:  # noqa: BLE001 - observational teardown is fail-open
+                    _log_scope_failure("teardown", exc)
+        finally:
+            # INVARIANT: teardown may emit its last record; expiry happens only AFTER exit.
+            self._emitter.close()
+        # An observational adapter can neither suppress nor replace execution failure.
+        return False
+
+
+def _log_scope_failure(phase: str, error: Exception) -> None:
+    # INVARIANT: URL4 and Log payloads can contain private Benchmark material. Diagnostics name
+    # only the stable seam phase and exception class; exception messages are never interpolated.
+    _logger.warning("run Log scope %s failed (%s)", phase, type(error).__name__)
+
+
+__all__ = [
+    "LogScalar",
+    "RunLogScopeFactory",
+    "StructuredLogEmitter",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
@@ -7,11 +7,15 @@ from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Literal, Protocol
+from typing import Literal
+
+from screamingface_engine.run_log_contract import (
+    LogScalar,
+    RunLogScopeFactory,
+    StructuredLogEmitter,
+)
 
 _logger = logging.getLogger(__name__)
-
-type LogScalar = str | int | float | bool | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,22 +24,6 @@ class StructuredLog:
 
     body: str
     attributes: dict[str, LogScalar]
-
-
-class StructuredLogEmitter(Protocol):
-    """Synchronous, non-blocking submission into one execution's existing bridge."""
-
-    def __call__(self, body: str, attributes: Mapping[str, LogScalar]) -> None: ...
-
-
-class RunLogScopeFactory(Protocol):
-    """The one generic lifecycle operation an observational adapter implements."""
-
-    def open_run_scope(
-        self,
-        rendered_url4: str,
-        emit_structured_log: StructuredLogEmitter,
-    ) -> AbstractContextManager[None] | None: ...
 
 
 class RunLogEmitter:

--- a/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
@@ -39,6 +39,8 @@ class RunLogEmitter:
     __slots__ = (
         "_active",
         "_expired_warned",
+        "_off_thread_lock",
+        "_off_thread_warned",
         "_owner_thread_id",
         "_submit",
     )
@@ -46,6 +48,8 @@ class RunLogEmitter:
     def __init__(self, submit: Callable[[StructuredLog], None]) -> None:
         self._submit = submit
         self._owner_thread_id = threading.get_ident()
+        self._off_thread_lock = threading.Lock()
+        self._off_thread_warned = False
         self._active = True
         self._expired_warned = False
 
@@ -53,7 +57,11 @@ class RunLogEmitter:
         # INVARIANT: `_Bridge` owns an asyncio.Event and a deque with no cross-thread
         # synchronization. Reject at this outer seam before any of that state can be touched.
         if threading.get_ident() != self._owner_thread_id:
-            _logger.warning("run Log off-thread submission ignored")
+            with self._off_thread_lock:
+                should_warn = not self._off_thread_warned
+                self._off_thread_warned = True
+            if should_warn:
+                _logger.warning("run Log off-thread submission ignored")
             return
         if not self._active:
             if not self._expired_warned:

--- a/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/run_logs.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import math
+import threading
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
@@ -34,14 +36,25 @@ class RunLogEmitter:
     local to the Runner adapter and cannot be inconsistently recreated by every producer.
     """
 
-    __slots__ = ("_active", "_expired_warned", "_submit")
+    __slots__ = (
+        "_active",
+        "_expired_warned",
+        "_owner_thread_id",
+        "_submit",
+    )
 
     def __init__(self, submit: Callable[[StructuredLog], None]) -> None:
         self._submit = submit
+        self._owner_thread_id = threading.get_ident()
         self._active = True
         self._expired_warned = False
 
     def __call__(self, body: str, attributes: Mapping[str, LogScalar]) -> None:
+        # INVARIANT: `_Bridge` owns an asyncio.Event and a deque with no cross-thread
+        # synchronization. Reject at this outer seam before any of that state can be touched.
+        if threading.get_ident() != self._owner_thread_id:
+            _logger.warning("run Log off-thread submission ignored")
+            return
         if not self._active:
             if not self._expired_warned:
                 _logger.warning("run Log expired emitter ignored")
@@ -68,11 +81,13 @@ class RunLogEmitter:
                 raise _InvalidStructuredLog
             snapshot: dict[str, LogScalar] = {}
             for key, value in attributes.items():
-                # INVARIANT: exact built-in scalar types only. Pydantic coercion would turn a
-                # producer defect into a plausible-looking wire claim; membership over arbitrary
-                # JSON would raise TypeError for arrays/objects (the OME-928 regression shape).
-                if type(key) is not str or (
-                    value is not None and type(value) not in {str, int, float, bool}
+                # INVARIANT: exact built-in scalar types and finite floats only. Pydantic coercion
+                # would turn a producer defect into a plausible-looking wire claim; its JSON
+                # encoder also rewrites nan and infinities to null, erasing their original meaning.
+                if (
+                    type(key) is not str
+                    or (value is not None and type(value) not in {str, int, float, bool})
+                    or (type(value) is float and not math.isfinite(value))
                 ):
                     raise _InvalidStructuredLog
                 snapshot[key] = value
@@ -153,6 +168,9 @@ def _log_scope_failure(phase: str, error: Exception) -> None:
 
 __all__ = [
     "LogScalar",
+    "RunLogEmitter",
+    "RunLogScope",
     "RunLogScopeFactory",
+    "StructuredLog",
     "StructuredLogEmitter",
 ]

--- a/apps/screamingface-engine/tests/unit/test_benchmark_run_logs.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_run_logs.py
@@ -1,0 +1,293 @@
+"""Dormant Benchmark adapter for the generic run Log seam (OME-934)."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+from collections.abc import Mapping
+from pathlib import Path
+
+import httpx
+import pytest
+
+from screamingface_engine.benchmarks import Benchmark, BenchmarkRegistry
+from screamingface_engine.benchmarks.run_logs import (
+    BenchmarkRunLogAdapter,
+    emit_benchmark_run_log,
+)
+from screamingface_engine.runner.main import build_executor
+from screamingface_engine.runner.run_logs import LogScalar, StructuredLogEmitter
+from screamingface_engine.testing import InMemoryEventStream
+from screamingface_engine.world_config import AigatewaySection, ModelSpec, WorldConfig
+from url4 import RelExpr, render, text
+from url4.peer.server import Request, Url4Node
+from url4.streaming.interfaces import Completed, Traced
+from url4.streaming.lifecycle import run as publish_run
+from url4.streaming.protocol import LogData, LogEvent, TerminatedEvent
+
+_SRC = Path(__file__).resolve().parents[2] / "src/screamingface_engine"
+
+
+def _benchmark(benchmark_id: str) -> Benchmark:
+    return Benchmark(
+        id=benchmark_id,
+        title=f"{benchmark_id} benchmark",
+        description="A structural run-Log adapter probe.",
+        revision="probe-v1",
+        case_count=1,
+        build=lambda _selected: text("unused"),
+    )
+
+
+def _capture() -> tuple[
+    list[tuple[str, dict[str, LogScalar]]],
+    StructuredLogEmitter,
+]:
+    records: list[tuple[str, dict[str, LogScalar]]] = []
+
+    def emit(body: str, attributes: Mapping[str, LogScalar]) -> None:
+        records.append((body, dict(attributes)))
+
+    return records, emit
+
+
+def test_registered_benchmark_claim_activates_an_otherwise_inert_scope() -> None:
+    registry = BenchmarkRegistry((_benchmark("alpha"),))
+    adapter = BenchmarkRunLogAdapter(registry)
+    records, emit = _capture()
+    scope = adapter.open_run_scope("(((deliberately-not-parsed", emit)
+    assert scope is not None
+
+    with scope:
+        emit_benchmark_run_log("alpha", "benchmark observation", {"observed": 1})
+
+    assert records == [("benchmark observation", {"observed": 1})]
+
+
+def test_zero_claims_and_unknown_claim_are_silent_on_the_run_stream(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = BenchmarkRegistry((_benchmark("alpha"),))
+    adapter = BenchmarkRunLogAdapter(registry)
+    records, emit = _capture()
+    caplog.set_level(logging.WARNING)
+    scope = adapter.open_run_scope("opaque", emit)
+    assert scope is not None
+
+    with scope:
+        emit_benchmark_run_log("unknown", "must not publish", {"observed": 1})
+
+    assert records == []
+    assert "unknown Benchmark run Log claim ignored" in caplog.text
+    assert "must not publish" not in caplog.text
+
+
+def test_conflicting_benchmark_owner_disables_the_recorder_without_choosing_first(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = BenchmarkRegistry((_benchmark("alpha"), _benchmark("beta")))
+    adapter = BenchmarkRunLogAdapter(registry)
+    records, emit = _capture()
+    caplog.set_level(logging.WARNING)
+    scope = adapter.open_run_scope("opaque", emit)
+    assert scope is not None
+
+    with scope:
+        emit_benchmark_run_log("alpha", "first", {"observed": 1})
+        emit_benchmark_run_log("beta", "conflict", {"observed": 2})
+        emit_benchmark_run_log("alpha", "disabled", {"observed": 3})
+
+    assert records == [("first", {"observed": 1})]
+    assert "conflicting Benchmark run Log claims; instrumentation disabled" in caplog.text
+    assert "alpha" not in caplog.text
+    assert "beta" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_concurrent_scopes_are_task_local() -> None:
+    registry = BenchmarkRegistry((_benchmark("alpha"), _benchmark("beta")))
+    adapter = BenchmarkRunLogAdapter(registry)
+    both_started = asyncio.Event()
+    started = 0
+
+    async def run(benchmark_id: str) -> list[tuple[str, dict[str, LogScalar]]]:
+        nonlocal started
+        records, emit = _capture()
+        scope = adapter.open_run_scope("same opaque URL4", emit)
+        assert scope is not None
+        with scope:
+            started += 1
+            if started == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=1)
+            emit_benchmark_run_log(
+                benchmark_id,
+                f"{benchmark_id} observation",
+                {"owner": benchmark_id},
+            )
+        return records
+
+    alpha, beta = await asyncio.gather(run("alpha"), run("beta"))
+
+    assert alpha == [("alpha observation", {"owner": "alpha"})]
+    assert beta == [("beta observation", {"owner": "beta"})]
+
+
+def test_nested_scope_restores_the_outer_recorder() -> None:
+    registry = BenchmarkRegistry((_benchmark("alpha"), _benchmark("beta")))
+    adapter = BenchmarkRunLogAdapter(registry)
+    outer, emit_outer = _capture()
+    inner, emit_inner = _capture()
+    outer_scope = adapter.open_run_scope("outer", emit_outer)
+    inner_scope = adapter.open_run_scope("inner", emit_inner)
+    assert outer_scope is not None and inner_scope is not None
+
+    with outer_scope:
+        emit_benchmark_run_log("alpha", "outer before", {"step": 1})
+        with inner_scope:
+            emit_benchmark_run_log("beta", "inner", {"step": 2})
+        emit_benchmark_run_log("alpha", "outer after", {"step": 3})
+
+    assert outer == [("outer before", {"step": 1}), ("outer after", {"step": 3})]
+    assert inner == [("inner", {"step": 2})]
+
+
+@pytest.mark.asyncio
+async def test_child_task_retaining_closed_recorder_cannot_publish_late(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = BenchmarkRegistry((_benchmark("alpha"),))
+    adapter = BenchmarkRunLogAdapter(registry)
+    records, emit = _capture()
+    release = asyncio.Event()
+    caplog.set_level(logging.WARNING)
+
+    async def late() -> None:
+        await release.wait()
+        emit_benchmark_run_log("alpha", "late private body", {"late": True})
+
+    scope = adapter.open_run_scope("opaque", emit)
+    assert scope is not None
+    with scope:
+        task = asyncio.create_task(late())
+    release.set()
+    await task
+
+    assert records == []
+    assert "closed Benchmark run Log recorder ignored" in caplog.text
+    assert "late private body" not in caplog.text
+
+
+def _progress_benchmark() -> Benchmark:
+    benchmark_id = "progress-probe"
+    route = "/benchmarks/progress-probe/run"
+
+    def install(node: Url4Node, _root: Path) -> None:
+        async def run(_request: Request) -> str:
+            emit_benchmark_run_log(
+                benchmark_id,
+                "benchmark probe",
+                {"probe.completed": 1},
+            )
+            return "probe result"
+
+        node.endpoint(route)(run)
+
+    return Benchmark(
+        id=benchmark_id,
+        title="Progress Probe",
+        description="A production-composition progress transport probe.",
+        revision="progress-probe-v1",
+        case_count=1,
+        build=lambda _selected: RelExpr(path=route, context="case", intent=text("run")),
+        install=install,
+    )
+
+
+def _world_config() -> WorldConfig:
+    return WorldConfig(
+        aigateway=AigatewaySection(
+            base_url="http://aigateway.test",
+            default_model="provider/model",
+            models=(ModelSpec(id="provider/model"),),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_production_composition_delivers_benchmark_record_on_sequenced_log_stream(
+    tmp_path: Path,
+) -> None:
+    benchmark = _progress_benchmark()
+    registry = BenchmarkRegistry((benchmark,))
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(500)),
+        base_url="http://aigateway.test",
+    )
+    executor = build_executor(
+        {},
+        _world_config(),
+        client=client,
+        benchmarks=registry,
+        benchmark_assets_root=tmp_path,
+    )
+    stream = InMemoryEventStream()
+    topic = "ome-934-composition"
+
+    try:
+        await publish_run(stream, executor, topic, render(benchmark.protocol(1)))
+    finally:
+        await client.aclose()
+
+    frames = []
+    async for frame in stream.subscribe(topic, from_sequence=1):
+        frames.append(frame)
+        if isinstance(frame, TerminatedEvent):
+            break
+    logs = [
+        frame
+        for frame in frames
+        if isinstance(frame, LogEvent) and frame.data.body == "benchmark probe"
+    ]
+    assert len(logs) == 1
+    assert logs[0].data.attributes == {"probe.completed": 1}
+    sequences = [int(frame.sequence) for frame in frames if frame.sequence is not None]
+    assert sequences == sorted(sequences)
+    assert len(sequences) == len(set(sequences))
+
+
+@pytest.mark.asyncio
+async def test_production_composition_with_empty_registry_emits_no_new_log() -> None:
+    executor = build_executor({}, WorldConfig())
+
+    frames = [frame async for frame in executor.execute(render(text("unchanged")))]
+
+    assert not any(
+        isinstance(frame, Traced) and isinstance(frame.payload, LogData) for frame in frames
+    )
+    assert isinstance(frames[-1], Completed)
+    assert frames[-1].result.body == "unchanged"
+
+
+def _imported_modules(path: Path) -> set[str]:
+    modules: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"), filename=str(path))):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
+            modules.add(node.module)
+    return modules
+
+
+def test_only_composition_root_imports_concrete_benchmark_run_log_adapter() -> None:
+    adapter_module = "screamingface_engine.benchmarks.run_logs"
+    runner = _SRC / "runner"
+
+    offenders = [
+        path.relative_to(_SRC)
+        for path in runner.glob("*.py")
+        if path.name != "main.py" and adapter_module in _imported_modules(path)
+    ]
+
+    assert offenders == []

--- a/apps/screamingface-engine/tests/unit/test_benchmark_run_logs.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_run_logs.py
@@ -291,3 +291,35 @@ def test_only_composition_root_imports_concrete_benchmark_run_log_adapter() -> N
     ]
 
     assert offenders == []
+
+
+def _recursive_concrete_adapter_importers(runner: Path) -> list[Path]:
+    adapter_module = "screamingface_engine.benchmarks.run_logs"
+    composition_root = runner / "main.py"
+    return [
+        path
+        for path in runner.rglob("*.py")
+        if path != composition_root and adapter_module in _imported_modules(path)
+    ]
+
+
+def test_recursive_layering_guard_exempts_only_the_root_composition_module(
+    tmp_path: Path,
+) -> None:
+    runner = tmp_path / "runner"
+    nested = runner / "nested"
+    nested.mkdir(parents=True)
+    import_line = "import screamingface_engine.benchmarks.run_logs\n"
+    (runner / "main.py").write_text(import_line, encoding="utf-8")
+    nested_main = nested / "main.py"
+    nested_main.write_text(import_line, encoding="utf-8")
+
+    assert _recursive_concrete_adapter_importers(runner) == [nested_main]
+
+
+def test_runner_tree_imports_concrete_benchmark_adapter_only_at_composition_root() -> None:
+    runner = _SRC / "runner"
+
+    offenders = [path.relative_to(_SRC) for path in _recursive_concrete_adapter_importers(runner)]
+
+    assert offenders == []

--- a/apps/screamingface-engine/tests/unit/test_run_log_seam.py
+++ b/apps/screamingface-engine/tests/unit/test_run_log_seam.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
@@ -11,9 +12,11 @@ from typing import cast
 import pytest
 
 import screamingface_engine.runner.executor as executor_module
+import screamingface_engine.runner.run_logs as run_logs_module
 from screamingface_engine.runner.executor import BridgeEvent, Url4Executor, _Bridge
 from screamingface_engine.runner.run_logs import (
     LogScalar,
+    RunLogEmitter,
     RunLogScopeFactory,
     StructuredLog,
     StructuredLogEmitter,
@@ -366,3 +369,56 @@ def test_run_scope_factory_interface_has_one_method() -> None:
     }
 
     assert public == {"open_run_scope"}
+
+
+def test_run_log_module_exports_its_complete_public_interface() -> None:
+    assert set(run_logs_module.__all__) == {
+        "LogScalar",
+        "RunLogEmitter",
+        "RunLogScope",
+        "RunLogScopeFactory",
+        "StructuredLog",
+        "StructuredLogEmitter",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "non_finite",
+    [float("nan"), float("inf"), float("-inf")],
+    ids=["nan", "positive-infinity", "negative-infinity"],
+)
+async def test_non_finite_float_drops_the_complete_record(
+    caplog: pytest.LogCaptureFixture,
+    non_finite: float,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    executor = Url4Executor(
+        _io(),
+        run_log_scope_factory=_MalformedFactory(non_finite),
+    )
+
+    frames = await _drain(executor)
+
+    assert [log.body for log in _logs(frames)] == ["valid"]
+    assert "run Log submission rejected" in caplog.text
+    assert isinstance(frames[-1], Completed)
+
+
+@pytest.mark.asyncio
+async def test_off_thread_submission_is_dropped_before_it_reaches_the_bridge(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    submitted: list[StructuredLog] = []
+    emitter = RunLogEmitter(submitted.append)
+    caplog.set_level(logging.WARNING)
+
+    await asyncio.to_thread(
+        emitter,
+        "private off-thread body",
+        {"progress.completed": 1},
+    )
+
+    assert submitted == []
+    assert "off-thread submission ignored" in caplog.text
+    assert "private off-thread body" not in caplog.text

--- a/apps/screamingface-engine/tests/unit/test_run_log_seam.py
+++ b/apps/screamingface-engine/tests/unit/test_run_log_seam.py
@@ -422,3 +422,23 @@ async def test_off_thread_submission_is_dropped_before_it_reaches_the_bridge(
     assert submitted == []
     assert "off-thread submission ignored" in caplog.text
     assert "private off-thread body" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_repeated_off_thread_submissions_warn_only_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    submitted: list[StructuredLog] = []
+    emitter = RunLogEmitter(submitted.append)
+    caplog.set_level(logging.WARNING)
+
+    await asyncio.to_thread(emitter, "first private body", {"progress.completed": 1})
+    await asyncio.to_thread(emitter, "second private body", {"progress.completed": 2})
+
+    warnings = [
+        record for record in caplog.records if "off-thread submission ignored" in record.message
+    ]
+    assert submitted == []
+    assert len(warnings) == 1
+    assert "first private body" not in caplog.text
+    assert "second private body" not in caplog.text

--- a/apps/screamingface-engine/tests/unit/test_run_log_seam.py
+++ b/apps/screamingface-engine/tests/unit/test_run_log_seam.py
@@ -1,0 +1,368 @@
+"""Generic run-scoped structured Log seam (OME-934)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import cast
+
+import pytest
+
+import screamingface_engine.runner.executor as executor_module
+from screamingface_engine.runner.executor import BridgeEvent, Url4Executor, _Bridge
+from screamingface_engine.runner.run_logs import (
+    LogScalar,
+    RunLogScopeFactory,
+    StructuredLog,
+    StructuredLogEmitter,
+)
+from url4.io.static import StaticIOLayer
+from url4.observe import NodeStarted
+from url4.streaming.interfaces import Completed, ExecStep, Traced
+from url4.streaming.protocol import LogData
+
+
+async def _drain(
+    executor: Url4Executor,
+    expression: str = "https://example.test!go",
+) -> list[ExecStep]:
+    return [frame async for frame in executor.execute(expression)]
+
+
+def _io() -> StaticIOLayer:
+    return StaticIOLayer(fetch_map={"https://example.test": "source"})
+
+
+def _logs(frames: list[ExecStep]) -> list[LogData]:
+    return [
+        frame.payload
+        for frame in frames
+        if isinstance(frame, Traced) and isinstance(frame.payload, LogData)
+    ]
+
+
+class _Scope(AbstractContextManager[None]):
+    def __init__(
+        self,
+        *,
+        events: list[str],
+        emit: StructuredLogEmitter,
+        exit_error: Exception | None = None,
+    ) -> None:
+        self._events = events
+        self._emit = emit
+        self._exit_error = exit_error
+        self.exit_exception: type[BaseException] | None = None
+
+    def __enter__(self) -> None:
+        self._events.append("enter")
+        self._emit("scope entered", {"scope.phase": "enter", "scope.count": 1})
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        self.exit_exception = exc_type
+        self._events.append("exit")
+        self._emit("scope exited", {"scope.phase": "exit"})
+        if self._exit_error is not None:
+            raise self._exit_error
+        # INVARIANT: an observational scope cannot suppress an execution failure.
+        return True
+
+
+class _Factory(RunLogScopeFactory):
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        decline: bool = False,
+        exit_error: Exception | None = None,
+    ) -> None:
+        self.events = events
+        self.decline = decline
+        self.exit_error = exit_error
+        self.urls: list[str] = []
+        self.emitter: StructuredLogEmitter | None = None
+        self.scope: _Scope | None = None
+
+    def open_run_scope(
+        self,
+        rendered_url4: str,
+        emit_structured_log: StructuredLogEmitter,
+    ) -> AbstractContextManager[None] | None:
+        self.events.append("open")
+        self.urls.append(rendered_url4)
+        self.emitter = emit_structured_log
+        if self.decline:
+            return None
+        self.scope = _Scope(
+            events=self.events,
+            emit=emit_structured_log,
+            exit_error=self.exit_error,
+        )
+        return self.scope
+
+
+@pytest.mark.asyncio
+async def test_scope_gets_exact_url4_and_surrounds_only_run_before_bridge_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    expression = "https://example.test/a%20b(context)!intent"
+
+    async def world() -> tuple[StaticIOLayer, None]:
+        events.append("world")
+        return StaticIOLayer(), None
+
+    async def run(
+        rendered_url4: str,
+        _io: object,
+        **_kwargs: object,
+    ) -> str:
+        events.append("run")
+        assert rendered_url4 is expression
+        return "result"
+
+    monkeypatch.setattr(executor_module, "url4_run", run)
+    factory = _Factory(events)
+    executor = Url4Executor(world_factory=world, run_log_scope_factory=factory)
+
+    frames = await _drain(executor, expression)
+
+    assert events == ["world", "open", "enter", "run", "exit"]
+    assert factory.urls == [expression]
+    assert [log.body for log in _logs(frames)] == ["scope entered", "scope exited"]
+    assert _logs(frames)[0].attributes == {"scope.phase": "enter", "scope.count": 1}
+    assert all(log.severity_text == "INFO" for log in _logs(frames))
+    assert isinstance(frames[-1], Completed)
+    assert frames[-1].result.body == "result"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("factory", [None, _Factory([], decline=True)])
+async def test_missing_or_declining_factory_keeps_execution_silent_and_unchanged(
+    factory: RunLogScopeFactory | None,
+) -> None:
+    executor = Url4Executor(_io(), run_log_scope_factory=factory)
+
+    frames = await _drain(executor)
+
+    assert _logs(frames) == []
+    assert isinstance(frames[-1], Completed)
+    assert frames[-1].result.body == "go\n\nsource"
+
+
+class _SetupFailureFactory(RunLogScopeFactory):
+    def open_run_scope(
+        self,
+        rendered_url4: str,
+        emit_structured_log: StructuredLogEmitter,
+    ) -> AbstractContextManager[None] | None:
+        del rendered_url4, emit_structured_log
+        raise RuntimeError("private prompt must not be logged")
+
+
+@pytest.mark.asyncio
+async def test_factory_setup_failure_is_private_and_cannot_change_the_result(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    executor = Url4Executor(_io(), run_log_scope_factory=_SetupFailureFactory())
+
+    frames = await _drain(executor)
+
+    assert isinstance(frames[-1], Completed)
+    assert frames[-1].result.body == "go\n\nsource"
+    assert "run Log scope setup failed (RuntimeError)" in caplog.text
+    assert "private prompt" not in caplog.text
+
+
+class _EntryFailureFactory(RunLogScopeFactory):
+    def open_run_scope(
+        self,
+        rendered_url4: str,
+        emit_structured_log: StructuredLogEmitter,
+    ) -> AbstractContextManager[None] | None:
+        del rendered_url4, emit_structured_log
+
+        class _EntryFailureScope(AbstractContextManager[None]):
+            exited = False
+
+            def __enter__(self) -> None:
+                raise RuntimeError("private entry payload")
+
+            def __exit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc_value: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                self.exited = True
+
+        self.scope = _EntryFailureScope()
+        return self.scope
+
+
+@pytest.mark.asyncio
+async def test_scope_entry_failure_does_not_enter_teardown_or_change_execution(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    factory = _EntryFailureFactory()
+    executor = Url4Executor(_io(), run_log_scope_factory=factory)
+
+    frames = await _drain(executor)
+
+    assert isinstance(frames[-1], Completed)
+    assert frames[-1].result.body == "go\n\nsource"
+    assert not factory.scope.exited
+    assert "run Log scope entry failed (RuntimeError)" in caplog.text
+    assert "private entry payload" not in caplog.text
+
+
+class _ExecutionFailure(RuntimeError):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_scope_exit_cannot_suppress_or_replace_the_original_execution_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    original = _ExecutionFailure("original execution failure")
+
+    async def fail(*_args: object, **_kwargs: object) -> str:
+        raise original
+
+    monkeypatch.setattr(executor_module, "url4_run", fail)
+    caplog.set_level(logging.WARNING)
+    factory = _Factory([], exit_error=RuntimeError("private teardown payload"))
+    executor = Url4Executor(_io(), run_log_scope_factory=factory)
+
+    with pytest.raises(_ExecutionFailure) as exc_info:
+        await _drain(executor)
+
+    assert exc_info.value is original
+    assert factory.scope is not None
+    assert factory.scope.exit_exception is _ExecutionFailure
+    assert "run Log scope teardown failed (RuntimeError)" in caplog.text
+    assert "private teardown payload" not in caplog.text
+
+
+class _MalformedFactory(RunLogScopeFactory):
+    def __init__(self, value: object) -> None:
+        self._value = value
+
+    def open_run_scope(
+        self,
+        rendered_url4: str,
+        emit_structured_log: StructuredLogEmitter,
+    ) -> AbstractContextManager[None] | None:
+        del rendered_url4
+
+        class _MalformedScope(AbstractContextManager[None]):
+            def __enter__(self) -> None:
+                emit_structured_log("valid", {"valid": True})
+                malformed = cast("Mapping[str, LogScalar]", {"invalid": self_value})
+                emit_structured_log("must be dropped whole", malformed)
+
+            def __exit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc_value: BaseException | None,
+                traceback: TracebackType | None,
+            ) -> None:
+                return None
+
+        self_value = self._value
+        return _MalformedScope()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("malformed", [[], {}, {"nested": []}])
+async def test_malformed_record_is_dropped_whole_without_coercion_or_execution_failure(
+    caplog: pytest.LogCaptureFixture,
+    malformed: object,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    executor = Url4Executor(
+        _io(),
+        run_log_scope_factory=_MalformedFactory(malformed),
+    )
+
+    frames = await _drain(executor)
+
+    assert [log.body for log in _logs(frames)] == ["valid"]
+    assert "run Log submission rejected" in caplog.text
+    assert "array" not in caplog.text
+    assert isinstance(frames[-1], Completed)
+
+
+@pytest.mark.asyncio
+async def test_retained_emitter_becomes_inert_and_warns_at_most_once_after_scope_close(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING)
+    factory = _Factory([])
+    executor = Url4Executor(_io(), run_log_scope_factory=factory)
+
+    await _drain(executor)
+    assert factory.emitter is not None
+    factory.emitter("late one", {"late": 1})
+    factory.emitter("late two", {"late": 2})
+
+    expired = [record for record in caplog.records if "expired emitter" in record.message]
+    assert len(expired) == 1
+    assert "late one" not in caplog.text
+    assert "late two" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bridge_submission_failure_is_fail_open_and_payload_private(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    original = _Bridge.on_event
+
+    def fail_injected(self: _Bridge, event: BridgeEvent) -> None:
+        if isinstance(event, StructuredLog):
+            raise RuntimeError("private submitted body")
+        original(self, event)
+
+    monkeypatch.setattr(_Bridge, "on_event", fail_injected)
+    caplog.set_level(logging.WARNING)
+    executor = Url4Executor(_io(), run_log_scope_factory=_Factory([]))
+
+    frames = await _drain(executor)
+
+    assert isinstance(frames[-1], Completed)
+    assert _logs(frames) == []
+    assert "run Log submission failed (RuntimeError)" in caplog.text
+    assert "private submitted body" not in caplog.text
+
+
+def test_injected_log_has_the_existing_evictable_log_policy() -> None:
+    bridge = _Bridge(maxsize=1)
+    bridge.on_event(StructuredLog("progress", {"cases.completed": 1}))
+
+    bridge.on_event(NodeStarted("span", None, "TextNode", ""))
+
+    assert bridge.dropped == 1
+    assert bridge.high_water == 1
+
+
+def test_run_scope_factory_interface_has_one_method() -> None:
+    # The deletion test for a deep seam: adapters learn one lifecycle operation, while validation,
+    # failure containment, ordering, and transport remain hidden behind it.
+    public = {
+        name
+        for name, value in vars(RunLogScopeFactory).items()
+        if isinstance(value, Callable) and not name.startswith("_")
+    }
+
+    assert public == {"open_run_scope"}

--- a/docs/plan/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/plan/2026-08-22-OME-934-run-log-seam.md
@@ -4,35 +4,77 @@ Spec: `docs/spec/2026-08-22-OME-934-run-log-seam.md`
 Stack: `screamingface-engine`
 Ledger: `docs/work/2026-08-22-OME-934-run-log-seam.md`
 
-Production code starts only after explicit owner approval.
+Production code starts only after explicit owner approval in plain words. Each iteration follows
+the `sdlc-python` RED → GREEN → review loop and appends coverage rather than weakening inherited
+tests.
 
-## Iteration 1 — port and isolation
-
-### RED
-
-- Optional factory sees the exact rendered URL4 once.
-- Its context surrounds exactly one run.
-- Concurrent runs receive distinct emitters and state.
-- No factory preserves byte-identical result and errors.
-
-### GREEN
-
-- Define the smallest generic run-scope and scalar structured-Log port.
-- Add optional injection to the Runner adapter and composition root.
-- Keep generic modules free of Benchmark imports.
-
-## Iteration 2 — bridge delivery and failure containment
+## Iteration 1 — define the generic run-scope port
 
 ### RED
 
-- Emitted Logs use existing bridge ordering and protocol mapping.
-- Setup, emission, and teardown failures cannot replace the URL4 result or exception.
-- Existing bridge pressure policy remains unchanged.
+- The optional factory sees the exact URL4 once.
+- A synchronous context surrounds only `url4_run`, after world resolution and before bridge close.
+- A missing or declining factory preserves the existing result and error behavior.
+- Concurrent and nested executions receive isolated state and restore the outer scope.
 
 ### GREEN
 
-- Adapt the emitter to the existing Log observation/bridge path.
-- Contain only observational failures and retain diagnostics without recursive publication.
+- Define the smallest generic factory, scope, structured-Log emitter, and scalar types in the
+  Runner adapter layer.
+- Add one optional factory dependency to `Url4Executor`.
+- Keep the port internal Python dependency injection: no env, HTTP, Client, or URL4 option.
+
+## Iteration 2 — deliver through the existing bridge
+
+### RED
+
+- A valid record enters the existing bridge immediately and maps to an INFO `LogData` with its flat
+  scalar attributes intact.
+- It shares existing ordering, root attachment, eviction, drop accounting, and lifecycle sequence.
+- Malformed records are dropped whole.
+- Setup, entry, emission, exit, and expired-emitter failures cannot replace success or the original
+  URL4 exception.
+- Operator diagnostics cannot recurse or disclose URL4 or submitted payloads.
+
+### GREEN
+
+- Add one Runner-local structured-Log bridge input; do not widen `url4.observe.Log`.
+- Validate before enqueueing and treat the input as an evictable ordinary Log.
+- Make emitters inert on scope close.
+- Contain observational failures at the seam and report only safe internal diagnostics.
+
+## Iteration 3 — wire the dormant Benchmark adapter
+
+### RED
+
+- `build_executor` injects one adapter derived from its existing `BenchmarkRegistry`.
+- The adapter opens inert run-local state and emits nothing without a Benchmark-owned claim.
+- A registered claim can use the generic emitter; unknown and conflicting claims are ignored or
+  disable instrumentation without changing evaluation.
+- Nested and concurrent Benchmark scopes cannot cross-talk.
+- Generic executor modules cannot import `screamingface_engine.benchmarks`.
+
+### GREEN
+
+- Implement the adapter and task-local recorder under `screamingface_engine/benchmarks`.
+- Validate claims against the existing immutable registry; add no second registry.
+- Wire the adapter only in the existing composition root.
+- Add the layering guard for port → adapter dependency direction.
+
+## Iteration 4 — prove production composition and regressions
+
+### RED
+
+- A `build_executor` test drives the fully composed path and observes an injected record in the
+  existing sequenced Log stream.
+- Default/non-Benchmark execution emits no new record.
+- Existing successful results, URL4 failures, cancellation, early consumer exit, bridge pressure,
+  cache summaries, and world teardown retain their contracts.
+
+### GREEN
+
+- Add only the minimum composition fixture needed to activate the dormant recorder.
+- Keep all ScreamingFace progress schema and terminal Case semantics out of OME-934.
 
 ## Verification
 
@@ -40,5 +82,11 @@ Production code starts only after explicit owner approval.
 uv run .claude/scripts/run_gates.py screamingface-engine
 ```
 
-Before PR, compare exact results/errors and inspect the diff to confirm no `benchmarks` consumer,
-generated URL4, or `packages/url4` change.
+Before commit and PR-ready review:
+
+- confirm `git diff origin/main -- packages/url4 packages/screamingface` is empty;
+- confirm no generated/discovered URL4 fixture changed;
+- confirm generic executor modules contain no Benchmark import or schema vocabulary;
+- run the focused executor, Benchmark adapter, composition, and layering suites;
+- run the complete ScreamingFace Engine gate; and
+- inspect the final diff against every invariant in the approved specification.

--- a/docs/plan/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/plan/2026-08-22-OME-934-run-log-seam.md
@@ -4,9 +4,8 @@ Spec: `docs/spec/2026-08-22-OME-934-run-log-seam.md`
 Stack: `screamingface-engine`
 Ledger: `docs/work/2026-08-22-OME-934-run-log-seam.md`
 
-Production code starts only after explicit owner approval in plain words. Each iteration follows
-the `sdlc-python` RED → GREEN → review loop and appends coverage rather than weakening inherited
-tests.
+Owner implementation approval received 2026-08-22. Each iteration follows the `sdlc-python`
+RED → GREEN → review loop and appends coverage rather than weakening inherited tests.
 
 ## Iteration 1 — define the generic run-scope port
 

--- a/docs/plan/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/plan/2026-08-22-OME-934-run-log-seam.md
@@ -1,0 +1,44 @@
+# OME-934 — Implementation plan
+
+Spec: `docs/spec/2026-08-22-OME-934-run-log-seam.md`
+Stack: `screamingface-engine`
+Ledger: `docs/work/2026-08-22-OME-934-run-log-seam.md`
+
+Production code starts only after explicit owner approval.
+
+## Iteration 1 — port and isolation
+
+### RED
+
+- Optional factory sees the exact rendered URL4 once.
+- Its context surrounds exactly one run.
+- Concurrent runs receive distinct emitters and state.
+- No factory preserves byte-identical result and errors.
+
+### GREEN
+
+- Define the smallest generic run-scope and scalar structured-Log port.
+- Add optional injection to the Runner adapter and composition root.
+- Keep generic modules free of Benchmark imports.
+
+## Iteration 2 — bridge delivery and failure containment
+
+### RED
+
+- Emitted Logs use existing bridge ordering and protocol mapping.
+- Setup, emission, and teardown failures cannot replace the URL4 result or exception.
+- Existing bridge pressure policy remains unchanged.
+
+### GREEN
+
+- Adapt the emitter to the existing Log observation/bridge path.
+- Contain only observational failures and retain diagnostics without recursive publication.
+
+## Verification
+
+```text
+uv run .claude/scripts/run_gates.py screamingface-engine
+```
+
+Before PR, compare exact results/errors and inspect the diff to confirm no `benchmarks` consumer,
+generated URL4, or `packages/url4` change.

--- a/docs/plan/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/plan/2026-08-22-OME-934-run-log-seam.md
@@ -18,8 +18,8 @@ RED → GREEN → review loop and appends coverage rather than weakening inherit
 
 ### GREEN
 
-- Define the smallest generic factory, scope, structured-Log emitter, and scalar types in the
-  Runner adapter layer.
+- Define the smallest generic factory, structured-Log emitter, and scalar types in a
+  dependency-free app-owned port leaf; keep lifecycle implementation in the Runner adapter.
 - Add one optional factory dependency to `Url4Executor`.
 - Keep the port internal Python dependency injection: no env, HTTP, Client, or URL4 option.
 

--- a/docs/spec/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/spec/2026-08-22-OME-934-run-log-seam.md
@@ -1,7 +1,7 @@
 # OME-934 — Generic run-scoped structured Log seam
 
-Status: READY FOR IMPLEMENTATION APPROVAL 2026-08-22. The owner approved the issue split and the
-grilled architecture. Production implementation still requires explicit approval in plain words.
+Status: APPROVED 2026-08-22. The owner approved the issue split, grilled architecture, and OME-934
+implementation in plain words.
 
 ## Purpose
 

--- a/docs/spec/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/spec/2026-08-22-OME-934-run-log-seam.md
@@ -81,6 +81,7 @@ Instrumentation is observational and fail-open:
   than coercing or partially publishing it;
 - a factory may decline by returning `None` without a diagnostic;
 - an expired emitter is inert and may produce at most one operator diagnostic;
+- off-thread submissions are inert and may produce at most one operator diagnostic per emitter;
 - diagnostics use the normal internal logger, never this Log seam, so reporting a seam failure
   cannot recurse; and
 - diagnostics identify only a stable seam phase and safe exception information. They never include

--- a/docs/spec/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/spec/2026-08-22-OME-934-run-log-seam.md
@@ -1,56 +1,133 @@
 # OME-934 — Generic run-scoped structured Log seam
 
-Status: DRAFT 2026-08-22. The issue split is approved; production implementation awaits explicit
-approval of this specification and plan.
+Status: READY FOR IMPLEMENTATION APPROVAL 2026-08-22. The owner approved the issue split and the
+grilled architecture. Production implementation still requires explicit approval in plain words.
 
 ## Purpose
 
-Allow an injected observational component to establish run-local state from the exact rendered URL4
-and emit ordinary structured Logs through the existing Runner bridge.
+Allow one injected observational adapter to establish state for exactly one Engine execution and
+submit ordinary structured Logs through that execution's existing Runner bridge. Finish the
+production composition path now so a later Benchmark change can add live progress semantics
+without another generic Runner or URL4 change.
 
-## Contract
+## Boundary
 
-The Runner accepts one optional generic run-scope factory:
+OME-934 owns:
+
+- one generic Runner run-scope port;
+- lifecycle integration around exactly one `url4_run`;
+- validation and same-bridge delivery of injected structured Logs;
+- one Benchmark adapter wired by the existing production composition root;
+- an inert, task-local Benchmark recorder that future Benchmark operations can activate; and
+- unit, composition, isolation, failure-containment, and layering tests for that complete path.
+
+OME-934 does not publish `screamingface.evaluation-progress.v1`. OME-932 will add the terminal Case
+signals and provisional-score semantics in `screamingface_engine/benchmarks/*`.
+
+## Generic Runner contract
+
+The `Url4Executor` accepts at most one optional run-scope factory:
 
 ```text
-open_run_scope(rendered_url4, emit_structured_log) -> context manager
+open_run_scope(rendered_url4, emit_structured_log) -> context manager | None
 ```
 
-The context surrounds exactly one `url4_run`. The emitter accepts an opaque body and scalar
-attributes and submits an ordinary Log to the run's existing `_Bridge`.
+- `rendered_url4` is the exact input string, passed once. The Runner neither parses nor rewrites it.
+- The factory and returned context manager are synchronous and perform no I/O or paid work.
+- Returning `None` declines instrumentation for that execution.
+- The scope opens after world resolution and surrounds only `url4_run`.
+- Scope teardown completes before the bridge closes, so teardown may submit its final Log.
+- `emit_structured_log` is synchronous, non-blocking, and event-loop-local.
+- The emitter accepts a non-empty string body plus flat attributes whose values already satisfy
+  `LogData`: `str | int | float | bool | None`.
+- A valid submission enters the same `_Bridge` immediately and is mapped to an ordinary INFO
+  `LogData` on the run root. There is no second queue, poller, sequence, wire type, or Client path.
 
-## Extension capacity
+An injected Log is a Runner-local bridge input, not a new `url4.observe.Log` shape. This preserves
+`packages/url4` unchanged while retaining the existing wire Log contract and ordering.
 
-The seam is intentionally schema-agnostic. A future Benchmark-owned producer can publish
-namespaced lifecycle records for Answering, Judging, Grading, terminal Case accounting,
-provisional scores, or another scalar progress fact without changing the Runner, URL4 expression,
-or wire discriminator. The producer and Client own the record schema; the Runner only transports
-an ordinary structured Log.
+## Benchmark adapter
 
-This is not a universal event bus:
+The composition root constructs one adapter from the same immutable `BenchmarkRegistry` already
+used to install Benchmarks and injects it through the generic Runner port.
 
-- attributes retain the existing `LogData` scalar value contract;
-- existing URL4 spans and `cost.usage` remain their own first-class signal types rather than being
-  copied into Logs;
-- Logs retain the bridge's existing lossy-under-pressure policy, so correctness-sensitive progress
-  uses complete cumulative snapshots and reconciles from the authoritative final result;
-- a future requirement for guaranteed delivery, nested payloads, or a new first-class wire event is
-  a separate protocol decision rather than an expansion of this seam.
+The adapter opens an inert run-local recorder for every execution. It does not inspect the URL4
+syntax. A Benchmark-owned operation may claim that recorder with its registered Benchmark ID and
+submit a structured Log. Until that happens, the adapter emits nothing.
 
-## Invariants
+- An unknown Benchmark ID declines the signal.
+- The first registered Benchmark ID owns the recorder for that execution.
+- A signal claiming a different Benchmark ID disables instrumentation for that execution; it never
+  mixes counters or scores and never selects a winner by registration order.
+- Zero claims is the normal behavior for a non-Benchmark execution.
+- Nested scopes restore the outer recorder when the inner execution closes.
+- A retained emitter or recorder becomes inert after its scope closes and cannot contaminate a
+  later execution.
 
-- The factory and scope are optional; absence preserves current behaviour.
-- Every execution receives its own scope/emitter; concurrent runs cannot cross-talk.
-- Setup, emission, and teardown are observational and fail-open.
-- Logs retain existing sequence, run subject, transport, and eviction behaviour.
-- Runner code imports no Benchmark module and recognizes no ScreamingFace schema.
-- Generated URL4, URL4 execution, results, paid work, errors, and `packages/url4` are unchanged.
-- No Benchmark progress producer is included in this PR.
+There is no second progress registry. Existing `BenchmarkRegistry` construction remains the sole
+static validation of Benchmark identity.
+
+## Failure and diagnostic contract
+
+Instrumentation is observational and fail-open:
+
+- factory setup, context entry, submission, context exit, and Benchmark-adapter failures cannot
+  replace a URL4 result or its existing exception;
+- a malformed body, attribute key, or attribute value drops the complete submitted record rather
+  than coercing or partially publishing it;
+- a factory may decline by returning `None` without a diagnostic;
+- an expired emitter is inert and may produce at most one operator diagnostic;
+- diagnostics use the normal internal logger, never this Log seam, so reporting a seam failure
+  cannot recurse; and
+- diagnostics identify only a stable seam phase and safe exception information. They never include
+  rendered URL4, Log bodies, attributes, prompts, answers, rubrics, or other payload material.
+
+Static composition defects still fail at startup through their existing contracts. Fail-open
+behavior is not a way to hide an invalid `BenchmarkRegistry` or broken Engine configuration.
+
+## Delivery and reliability
+
+Injected Logs have the existing ordinary-Log policy:
+
+- they attach to the execution root; semantic identity belongs in attributes;
+- they receive the same run subject and lifecycle sequence as every other streamed frame;
+- they are immediately eligible for the bridge's existing Log eviction policy under pressure; and
+- they provide no correctness guarantee beyond ordinary Logs.
+
+OME-932 must therefore publish complete cumulative snapshots. The authoritative final evaluation
+result remains the reconciliation source if an intermediate or final progress Log is evicted.
+
+## Privacy and schema ownership
+
+The generic seam validates only the body and flat scalar attribute shape. It recognizes no
+ScreamingFace schema and performs no domain-specific redaction.
+
+OME-932 owns an exact producer whitelist for `screamingface.evaluation-progress.v1`. Its tests must
+forbid Case IDs, prompts, inputs, answers, attachments, rubrics, judge explanations, provider
+errors, model identity, and private metadata. The Client ignores ordinary Logs whose schema it does
+not recognize.
+
+## Architecture invariants
+
+- Generic executor modules depend only on the generic run-scope port.
+- Only the production composition root imports and wires the concrete Benchmark adapter.
+- Runner code recognizes no Benchmark, Candidate, model, grading, or progress vocabulary.
+- URL4 source, rendered expressions, execution graphs, protocol/revision/cache identity, results,
+  paid calls, public errors, and `packages/url4` remain unchanged.
+- Spans and `cost.usage` remain their existing first-class signals rather than being copied into
+  Logs.
+- This is one optional seam, not a generic instrumentation registry or universal event bus.
 
 ## Acceptance
 
-1. Exact rendered URL4 is passed once to the factory.
-2. An emitted structured Log arrives through the existing bridge in normal order.
-3. Concurrent and nested test runs remain isolated.
-4. Missing, declining, malformed, or failing instrumentation cannot alter the run.
-5. Existing Runner/protocol gates and layering checks pass.
+1. The exact URL4 is handed to one synchronous run scope around only `url4_run`.
+2. A valid injected record arrives through the existing bridge as an ordered INFO `LogData`.
+3. Existing Log eviction treats injected Logs identically to URL4 Logs.
+4. Missing, declining, malformed, expired, or failing instrumentation cannot alter execution.
+5. Concurrent and nested runs remain isolated and restore the correct outer state.
+6. The Benchmark adapter is wired through `build_executor`, remains inert without a Benchmark
+   claim, and rejects unknown or conflicting ownership without affecting evaluation.
+7. A composition-path test proves the production registry adapter reaches the sequenced Log stream.
+8. A layering test proves the executor imports no Benchmark module or concrete adapter.
+9. Existing result, error, Runner, protocol, and Engine gates remain green.
+10. No progress schema, URL4 change, Client change, wire change, or `packages/url4` change lands.

--- a/docs/spec/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/spec/2026-08-22-OME-934-run-log-seam.md
@@ -1,0 +1,56 @@
+# OME-934 — Generic run-scoped structured Log seam
+
+Status: DRAFT 2026-08-22. The issue split is approved; production implementation awaits explicit
+approval of this specification and plan.
+
+## Purpose
+
+Allow an injected observational component to establish run-local state from the exact rendered URL4
+and emit ordinary structured Logs through the existing Runner bridge.
+
+## Contract
+
+The Runner accepts one optional generic run-scope factory:
+
+```text
+open_run_scope(rendered_url4, emit_structured_log) -> context manager
+```
+
+The context surrounds exactly one `url4_run`. The emitter accepts an opaque body and scalar
+attributes and submits an ordinary Log to the run's existing `_Bridge`.
+
+## Extension capacity
+
+The seam is intentionally schema-agnostic. A future Benchmark-owned producer can publish
+namespaced lifecycle records for Answering, Judging, Grading, terminal Case accounting,
+provisional scores, or another scalar progress fact without changing the Runner, URL4 expression,
+or wire discriminator. The producer and Client own the record schema; the Runner only transports
+an ordinary structured Log.
+
+This is not a universal event bus:
+
+- attributes retain the existing `LogData` scalar value contract;
+- existing URL4 spans and `cost.usage` remain their own first-class signal types rather than being
+  copied into Logs;
+- Logs retain the bridge's existing lossy-under-pressure policy, so correctness-sensitive progress
+  uses complete cumulative snapshots and reconciles from the authoritative final result;
+- a future requirement for guaranteed delivery, nested payloads, or a new first-class wire event is
+  a separate protocol decision rather than an expansion of this seam.
+
+## Invariants
+
+- The factory and scope are optional; absence preserves current behaviour.
+- Every execution receives its own scope/emitter; concurrent runs cannot cross-talk.
+- Setup, emission, and teardown are observational and fail-open.
+- Logs retain existing sequence, run subject, transport, and eviction behaviour.
+- Runner code imports no Benchmark module and recognizes no ScreamingFace schema.
+- Generated URL4, URL4 execution, results, paid work, errors, and `packages/url4` are unchanged.
+- No Benchmark progress producer is included in this PR.
+
+## Acceptance
+
+1. Exact rendered URL4 is passed once to the factory.
+2. An emitted structured Log arrives through the existing bridge in normal order.
+3. Concurrent and nested test runs remain isolated.
+4. Missing, declining, malformed, or failing instrumentation cannot alter the run.
+5. Existing Runner/protocol gates and layering checks pass.

--- a/docs/spec/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/spec/2026-08-22-OME-934-run-log-seam.md
@@ -110,6 +110,8 @@ not recognize.
 ## Architecture invariants
 
 - Generic executor modules depend only on the generic run-scope port.
+- The generic port is a dependency-free app-owned leaf; the Benchmark adapter never imports the
+  Runner implementation.
 - Only the production composition root imports and wires the concrete Benchmark adapter.
 - Runner code recognizes no Benchmark, Candidate, model, grading, or progress vocabulary.
 - URL4 source, rendered expressions, execution graphs, protocol/revision/cache identity, results,

--- a/docs/spec/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/spec/2026-08-22-OME-934-run-log-seam.md
@@ -34,12 +34,16 @@ open_run_scope(rendered_url4, emit_structured_log) -> context manager | None
 
 - `rendered_url4` is the exact input string, passed once. The Runner neither parses nor rewrites it.
 - The factory and returned context manager are synchronous and perform no I/O or paid work.
+- A returned context manager must unwind partial acquisition inside a failing `__enter__`; Python
+  does not call `__exit__` after entry fails, and neither does the Runner's fail-open wrapper.
 - Returning `None` declines instrumentation for that execution.
 - The scope opens after world resolution and surrounds only `url4_run`.
 - Scope teardown completes before the bridge closes, so teardown may submit its final Log.
-- `emit_structured_log` is synchronous, non-blocking, and event-loop-local.
+- `emit_structured_log` is synchronous, non-blocking, and event-loop-thread-local. An off-thread
+  call is invalid and is dropped before it can mutate the Runner bridge.
 - The emitter accepts a non-empty string body plus flat attributes whose values already satisfy
-  `LogData`: `str | int | float | bool | None`.
+  the JSON wire meaning of `LogData`: `str | int | finite float | bool | None`. `nan` and positive
+  or negative infinity are malformed rather than being serialized as `null`.
 - A valid submission enters the same `_Bridge` immediately and is mapped to an ordinary INFO
   `LogData` on the run root. There is no second queue, poller, sequence, wire type, or Client path.
 

--- a/docs/tasks/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/tasks/2026-08-22-OME-934-run-log-seam.md
@@ -1,0 +1,19 @@
+---
+id: OME-934
+linear_url: https://linear.app/openmined/issue/OME-934/expose-generic-run-scoped-structured-log-seam
+status: in_progress
+type: improvement
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-22
+closed:
+---
+
+# Expose generic run-scoped structured Log seam
+
+Add one optional injected Runner run scope that receives the exact rendered URL4 and an opaque
+structured-Log emitter backed by the existing bridge.
+
+The seam is generic, fail-open, concurrency-isolated, and contains no Benchmark or progress
+semantics. It changes neither generated URL4 nor `packages/url4`. OME-932 is its first consumer
+and lands in a separate PR.

--- a/docs/tasks/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/tasks/2026-08-22-OME-934-run-log-seam.md
@@ -1,7 +1,7 @@
 ---
 id: OME-934
 linear_url: https://linear.app/openmined/issue/OME-934/expose-generic-run-scoped-structured-log-seam
-status: in_progress
+status: in_review
 type: improvement
 priority: 2
 labels: [screamingface-engine, agentic, autonomous]

--- a/docs/tasks/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/tasks/2026-08-22-OME-934-run-log-seam.md
@@ -14,6 +14,8 @@ closed:
 Add one optional injected Runner run scope that receives the exact rendered URL4 and an opaque
 structured-Log emitter backed by the existing bridge.
 
-The seam is generic, fail-open, concurrency-isolated, and contains no Benchmark or progress
-semantics. It changes neither generated URL4 nor `packages/url4`. OME-932 is its first consumer
-and lands in a separate PR.
+The seam is generic, fail-open, and concurrency-isolated. OME-934 also wires one dormant
+`BenchmarkRegistry` adapter and task-local recorder through the production composition root, while
+keeping generic executor code free of Benchmark imports. It publishes no progress schema or
+semantic record. It changes neither generated URL4 nor `packages/url4`; OME-932 adds terminal Case
+and provisional-score semantics under `benchmarks/*` in a separate PR.

--- a/docs/work/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/work/2026-08-22-OME-934-run-log-seam.md
@@ -18,7 +18,8 @@ through one dormant Benchmark adapter so the first consumer requires no second c
 
 - `docs/spec/2026-08-22-OME-934-run-log-seam.md`
 - `docs/plan/2026-08-22-OME-934-run-log-seam.md`
-- one generic Runner port, local structured-Log bridge input, and executor lifecycle integration
+- one dependency-free generic port, local structured-Log bridge input, and Runner lifecycle
+  implementation
 - one task-local Benchmark recorder and registry adapter wired only at the composition root
 - focused isolation, ordering, failure, composition, regression, and layering tests
 
@@ -41,7 +42,19 @@ through one dormant Benchmark adapter so the first consumer requires no second c
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:** pending
-- **Commits:** pending
-- **Gates:** pending
-- **Deviations:** pending
+- **Actual files:** added the dependency-free port in
+  `apps/screamingface-engine/src/screamingface_engine/run_log_contract.py`; generic lifecycle,
+  validation, expiry, and bridge delivery in `runner/run_logs.py` + `runner/executor.py`; the
+  task-local registry adapter in `benchmarks/run_logs.py`; production composition in
+  `runner/main.py`; 22 focused behavioral tests across `test_run_log_seam.py` and
+  `test_benchmark_run_logs.py`; and the approved spec/plan/task/work artifacts.
+- **Commits:** `83d9de64` — `docs: finalize OME-934 run log seam design`; `f204d2df` —
+  `feat(screamingface-engine): add generic run Log scope`; the Benchmark adapter, production
+  wiring, and this outcome land in this branch's final implementation commit.
+- **Gates:** focused generic suite 55 passed; focused adapter/composition/regression suite 132
+  passed; `python3 .claude/scripts/run_gates.py screamingface-engine` passed Ruff check, Ruff
+  format, Pyright, layering, append-only verification, and the complete coverage suite twice.
+- **Deviations:** the dependency-free factory/emitter/scalar port vocabulary moved from the Runner
+  implementation module into an app-owned shared leaf after the layering gate correctly rejected
+  a Benchmark adapter importing `screamingface_engine.runner`. Runner lifecycle implementation
+  remains in `runner/run_logs.py`; no scope or external contract changed.

--- a/docs/work/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/work/2026-08-22-OME-934-run-log-seam.md
@@ -40,6 +40,37 @@ through one dormant Benchmark adapter so the first consumer requires no second c
 - Owner approved the revised specification, plan, and implementation on 2026-08-22 before
   production code began.
 
+## Follow-up iteration — review hardening
+
+### Intent
+
+Close the approved PR review findings without expanding the seam: preserve exact scalar meaning,
+make its event-loop affinity enforceable, state standard failed-entry cleanup ownership, keep
+documentation and exports honest, and make the layering guard recursive.
+
+### Planned changes
+
+- Reject `nan` and positive/negative infinity as malformed structured-Log attributes.
+- State and enforce that the emitter may run only on its owning event-loop thread.
+- Document that a returned context manager must unwind partial acquisition inside a failing
+  `__enter__`, because the Runner will not call `__exit__` afterward.
+- Correct root-versus-span log documentation and align `runner.run_logs.__all__` with its public
+  names.
+- Recursively guard the complete Runner tree against concrete Benchmark-adapter imports.
+
+### Test plan
+
+- RED parametrized wire-seam tests for all non-finite float values and whole-record rejection.
+- RED cross-thread submission test proving the record is dropped without touching the bridge.
+- RED contract/export assertions and a nested Runner-package layering fixture.
+- Focused run-log suites, then the complete `screamingface-engine` quality gate.
+
+### Acceptance
+
+- Invalid or off-thread submissions remain observational and cannot change execution.
+- The generic port carries every lifecycle/threading constraint an adapter author must know.
+- Existing URL4 Logs, wire types, bridge ordering, and Benchmark behavior remain unchanged.
+
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** added the dependency-free port in
@@ -58,3 +89,19 @@ through one dormant Benchmark adapter so the first consumer requires no second c
   implementation module into an app-owned shared leaf after the layering gate correctly rejected
   a Benchmark adapter importing `screamingface_engine.runner`. Runner lifecycle implementation
   remains in `runner/run_logs.py`; no scope or external contract changed.
+
+### Follow-up outcome
+
+- **Actual files:** hardened scalar and thread-affinity validation in `runner/run_logs.py`; made
+  adapter lifecycle requirements explicit in `run_log_contract.py` and the approved spec; corrected
+  root/log-like documentation in `runner/executor.py`; and appended finite-value, cross-thread,
+  export, and recursive-layering coverage to the two existing OME-934 test modules.
+- **Tests:** each behavioral change was observed RED before implementation; the complete focused
+  run-log suite passed with 28 tests.
+- **Gates:** `python3 .claude/scripts/run_gates.py screamingface-engine` passed append-only
+  verification, Ruff check, Ruff format, Pyright, layering, and the complete coverage suite.
+- **Deviations:** the append-only gate refused an in-place strengthening of the existing flat
+  layering test, so that test remains byte-identical and a separate recursive guard now covers the
+  complete Runner tree. No production scope or contract was weakened.
+- **Commit:** the follow-up hardening lands in this branch's next `fix(screamingface-engine)`
+  commit with `Refs: OME-934`.

--- a/docs/work/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/work/2026-08-22-OME-934-run-log-seam.md
@@ -11,25 +11,30 @@ finished:
 ## Intent
 
 Specify the smallest generic Runner port needed for observational features to emit structured Logs
-without importing their domain semantics into Runner code.
+without importing their domain semantics into Runner code, and finish its production composition
+through one dormant Benchmark adapter so the first consumer requires no second core change.
 
 ## Planned changes
 
 - `docs/spec/2026-08-22-OME-934-run-log-seam.md`
 - `docs/plan/2026-08-22-OME-934-run-log-seam.md`
-- one generic Runner port and executor/composition wiring fixed by the approved plan
-- focused isolation, ordering, failure, and layering tests
+- one generic Runner port, local structured-Log bridge input, and executor lifecycle integration
+- one task-local Benchmark recorder and registry adapter wired only at the composition root
+- focused isolation, ordering, failure, composition, regression, and layering tests
 
 ## Test plan
 
-- RED tests for exact URL4 handoff, ordinary Log delivery, concurrent isolation, and fail-open
-  setup/emission/teardown.
-- Regression fixtures for unchanged result, URL4 identity, existing Events, and errors.
-- Layering test prohibiting Benchmark imports.
+- RED tests for exact URL4 handoff, same-bridge Log delivery, scalar validation, nested/concurrent
+  isolation, ownership refusal, expired emitters, and fail-open setup/emission/teardown.
+- Production `build_executor` proof for the wired but semantically dormant Benchmark adapter.
+- Regression fixtures for unchanged result, URL4 identity, existing Events, errors, cancellation,
+  early consumer exit, bridge pressure, and world teardown.
+- Layering test allowing the concrete adapter only at the composition root.
 
 ## Acceptance
 
-- No Benchmark schema or semantics outside `/benchmarks`.
+- No Benchmark schema or semantics in generic Runner modules.
+- No `screamingface.evaluation-progress.v1` records in OME-934.
 - No generated URL4 or `packages/url4` change.
 - No production code before explicit approval of this issue's spec and plan.
 

--- a/docs/work/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/work/2026-08-22-OME-934-run-log-seam.md
@@ -36,7 +36,8 @@ through one dormant Benchmark adapter so the first consumer requires no second c
 - No Benchmark schema or semantics in generic Runner modules.
 - No `screamingface.evaluation-progress.v1` records in OME-934.
 - No generated URL4 or `packages/url4` change.
-- No production code before explicit approval of this issue's spec and plan.
+- Owner approved the revised specification, plan, and implementation on 2026-08-22 before
+  production code began.
 
 ## Outcome (fill at the end — required before COMMIT)
 

--- a/docs/work/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/work/2026-08-22-OME-934-run-log-seam.md
@@ -1,0 +1,41 @@
+---
+ticket: OME-934
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-22
+finished:
+---
+
+# OME-934 — expose generic run-scoped structured Log seam
+
+## Intent
+
+Specify the smallest generic Runner port needed for observational features to emit structured Logs
+without importing their domain semantics into Runner code.
+
+## Planned changes
+
+- `docs/spec/2026-08-22-OME-934-run-log-seam.md`
+- `docs/plan/2026-08-22-OME-934-run-log-seam.md`
+- one generic Runner port and executor/composition wiring fixed by the approved plan
+- focused isolation, ordering, failure, and layering tests
+
+## Test plan
+
+- RED tests for exact URL4 handoff, ordinary Log delivery, concurrent isolation, and fail-open
+  setup/emission/teardown.
+- Regression fixtures for unchanged result, URL4 identity, existing Events, and errors.
+- Layering test prohibiting Benchmark imports.
+
+## Acceptance
+
+- No Benchmark schema or semantics outside `/benchmarks`.
+- No generated URL4 or `packages/url4` change.
+- No production code before explicit approval of this issue's spec and plan.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** pending
+- **Commits:** pending
+- **Gates:** pending
+- **Deviations:** pending

--- a/docs/work/2026-08-22-OME-934-run-log-seam.md
+++ b/docs/work/2026-08-22-OME-934-run-log-seam.md
@@ -105,3 +105,32 @@ documentation and exports honest, and make the layering guard recursive.
   complete Runner tree. No production scope or contract was weakened.
 - **Commit:** the follow-up hardening lands in this branch's next `fix(screamingface-engine)`
   commit with `Refs: OME-934`.
+
+## Follow-up iteration — rate-limit off-thread diagnostics
+
+### Intent
+
+Keep repeated invalid worker-thread submissions fail-open without flooding the operator log.
+
+### Planned changes and test plan
+
+- Append a RED regression test proving repeated off-thread calls produce one safe diagnostic.
+- Add the same one-shot guard already used by expired-emitter rejection.
+- Rerun the focused run-log suite and complete `screamingface-engine` quality gate.
+
+### Acceptance
+
+- Every off-thread record remains dropped before bridge access.
+- At most one off-thread diagnostic is written per run-scoped emitter, without payload disclosure.
+
+### Outcome
+
+- **Implementation:** added a thread-safe one-shot diagnostic guard used only by invalid off-thread
+  calls; the normal event-loop submission path remains lock-free.
+- **Tests:** the appended regression observed two warnings RED, then passed with one; the complete
+  focused OME-934 suite passed with 30 tests.
+- **Gates:** `python3 .claude/scripts/run_gates.py screamingface-engine` passed append-only
+  verification, Ruff check, Ruff format, Pyright, layering, and the complete coverage suite.
+- **Deviations:** none.
+- **Commit:** this rate-limit correction lands in the branch's next
+  `fix(screamingface-engine)` commit with `Refs: OME-934`.


### PR DESCRIPTION
## Summary

Implements the complete OME-934 production seam:

- one generic synchronous, fail-open run-scope structured-Log port;
- same-bridge delivery using the existing Log ordering and eviction policy;
- one dormant BenchmarkRegistry adapter wired only at the composition root; and
- task-local ownership, nesting, expiry, privacy, composition, regression, and layering coverage.

The executor remains unaware of Benchmarks, models, grading, and ScreamingFace schemas. The Benchmark adapter does not parse URL4 and emits nothing until a registered Benchmark operation claims its run-local recorder.

## What changed

- Added a dependency-free app-owned port for the factory, scalar attributes, and emitter.
- Added Runner-owned lifecycle containment, strict no-coercion validation, expiry, safe diagnostics, and a Runner-local bridge input.
- Extended the existing bridge so injected records are ordinary evictable INFO Logs with the same root attachment and sequence.
- Added a Benchmark adapter that validates claims against the existing immutable registry, isolates concurrent/nested runs, and disables ambiguous ownership.
- Wired that adapter through build_executor.
- Added 22 focused behavioral tests, including a production composition proof through the sequenced Log stream.

## Deliberately unchanged

- rendered URL4 and its execution graph
- packages/url4
- public wire discriminators and Client contracts
- results, paid work, cache identity, spans, cost events, and existing errors
- runtime progress behavior

OME-932 will add cumulative terminal Case counts and provisional-score records under screamingface_engine/benchmarks/* in a separate PR. OME-934 emits no screamingface.evaluation-progress.v1 record.

## Test plan

- [x] generic seam focused suite: 55 passed
- [x] adapter/composition/regression focused suite: 132 passed
- [x] append-only test guard
- [x] Ruff check
- [x] Ruff format check
- [x] Pyright
- [x] Engine layering gate
- [x] complete Engine pytest + coverage gate
- [x] no packages/url4 or packages/screamingface diff
- [x] no UI changes

## Cross-service notes

No cross-service contract changes. OME-933 remains the later Client consumer of OME-932 ordinary Logs.

**Asana:** N/A

Refs: OME-934