### PR TITLE
feat(engine): warn attached client when a Runner Job cannot be scheduled (OME-948)

### DIFF
--- a/.claude/scripts/check_layering.py
+++ b/.claude/scripts/check_layering.py
@@ -10,7 +10,8 @@ One image ships two modes, and the whole point of that shape is a rule about wha
     (serve)         (run)                       runs it — and the two halves stay disjoint.
 
   Control plane: app · rest · ws · auth · catalog · connections · config · metrics · ops · reaper
-                 schemas · adapters.k8s · adapters.factory  (FastAPI, uvicorn, the k8s client)
+                 schemas · adapters.k8s · adapters.factory · run_stall  (FastAPI, uvicorn,
+                 the k8s client)
   Run mode:      runner.executor (the url4 engine) · runner.connector · runner.main
 
   Shared leaves, importable by BOTH: job_env · subjects · adapters.jetstream · world_config
@@ -60,6 +61,9 @@ CONTROL_PLANE = {
     # Runner Job import the control plane's orphan reaper. It watches WS subscriber counts and
     # calls the job runner from the serving process; it belongs to the control plane.
     "reaper",
+    # WHY named here (OME-948): same argument as `reaper` — an unlisted module would be a
+    # shared leaf, letting a Runner Job import the control plane's run-stall watcher.
+    "run_stall",
     "rest",
     "schemas",
     "ws",

--- a/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
@@ -17,6 +17,11 @@ data:
   # replica is streaming and stop healthy runs. Multi-replica needs a shared subscriber gate
   # (NATS consumer interest) before this can be scaled out. 0 disables the reaper.
   URL4_CLOUD_ORPHAN_GRACE_S: {{ .Values.config.orphanGraceS | quote }}
+  # How long a run may stay stuck as `scheduled` before the App warns its client that the
+  # runner is at capacity (OME-948). 0 disables the watch. Advisory-only: it never stops or
+  # reschedules the run. INVARIANT: like the reaper, the live-topic set is IN-PROCESS, so
+  # `replicaCount: 1` is load-bearing for it too.
+  URL4_CLOUD_RUN_STALL_WARN_AFTER_S: {{ .Values.config.runStallWarnAfterS | quote }}
   # The run substrate the App schedules on (spec §9). `k8s` is what makes this chart functional —
   # without it the App bridges NATS but answers every `GET /?q=` with 503.
   URL4_CLOUD_RUNNER: {{ .Values.runner.backend | quote }}

--- a/apps/screamingface-engine/deploy/helm/values.schema.json
+++ b/apps/screamingface-engine/deploy/helm/values.schema.json
@@ -62,6 +62,11 @@
           "minimum": 0,
           "description": "Seconds a run may keep going with no WebSocket subscriber before the App stops it (OME-890); 0 disables the reaper. INVARIANT: the audience count is in-process, so replicaCount must stay 1 while this is non-zero \u2014 a second replica would answer \"nobody is listening\" for runs another replica is streaming. Keep it above uvicorn's WS ping window (~40s), which is what closes a partitioned client's socket in the first place."
         },
+        "runStallWarnAfterS": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Seconds a run may stay stuck as `scheduled` (Job exists, no Pod ever created) before the App warns its attached client that the runner service is at capacity (OME-948); 0 disables the watch. A Pending Pod counts as active, so normal pod delays never look stalled. Advisory only: the watch never stops or reschedules the run. INVARIANT: the live-topic set is in-process, so replicaCount must stay 1 while this is non-zero."
+        },
         "aigatewayBaseUrl": {
           "type": "string"
         },

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -99,6 +99,12 @@ config:
   # detection it depends on. This bounds SPEND on runs whose client died; `jobDeadlineS` above
   # remains the backstop.
   orphanGraceS: 120
+  # Seconds a run may stay stuck as `scheduled` (Job exists, no Pod ever created) before the
+  # App warns its attached client that the runner service is at capacity (OME-948). A Pending
+  # Pod counts as active, so image pulls and normal creation latency never look stalled; 60s of
+  # `scheduled` genuinely means the Pod was refused. 0 disables the watch. Advisory only — it
+  # never stops or reschedules the run.
+  runStallWarnAfterS: 60
   # Overrides the default model route declared in the Runner image's url4.toml. Empty => the
   # image's own default. Must be one of the models that url4.toml declares.
   aigatewayModel: ""

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py
@@ -15,7 +15,7 @@ from typing import Protocol
 from kubernetes.client import ApiException
 
 from screamingface_engine import job_env
-from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.ports import IdentityAwareJobRunner, RunnerScheduleUnavailable
 from url4.streaming.interfaces import JobAlreadyExists, JobStatus, job_name
 from url4.streaming.protocol import CachePolicy
 from url4.streaming.trace import valid_traceparent
@@ -196,6 +196,15 @@ class K8sJobRunner(IdentityAwareJobRunner):
         except ApiException as exc:
             if exc.status == _CONFLICT:
                 raise JobAlreadyExists(name) from exc
+            # OME-948: a transient substrate refusal is a retry-later, not a crash. Map it to
+            # the engine-local `RunnerScheduleUnavailable`, which the REST layer renders as the
+            # same generic 503 + Retry-After as a full local runner. `JobRunnerAtCapacity` is
+            # deliberately NOT reused — its own contract says a cluster-backed runner never
+            # raises it. A permanent 4xx is an engine manifest bug and propagates unchanged
+            # (today's behavior: surfaces as 500).
+            status = exc.status
+            if status is not None and (status == 429 or status >= 500):
+                raise RunnerScheduleUnavailable(f"runner schedule refused: {status}") from exc
             raise
         return name
 

--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -38,6 +38,7 @@ from screamingface_engine.metrics import (
     build_metrics,
     register_catalog_metrics,
     register_reaper_metrics,
+    register_stall_metrics,
 )
 from screamingface_engine.ops import router as ops_router
 from screamingface_engine.reaper import RunReaper
@@ -49,6 +50,7 @@ from screamingface_engine.rest import (
     connection_router,
 )
 from screamingface_engine.rest import router as rest_router
+from screamingface_engine.run_stall import RunStallWatcher
 from screamingface_engine.schemas import customize_openapi
 from screamingface_engine.ws import ConnectionRegistry
 from screamingface_engine.ws import router as ws_router
@@ -77,7 +79,11 @@ def healthz() -> dict[str, str]:
     return {"status": "ok"}
 
 
-def create_app(
+# WHY `noqa: PLR0915` (composition root): every installed watcher/feature is one honest call
+# in this builder — the orphan reaper, then the run-stall watch. Shrinking statements would
+# mean hiding an installer behind a forwarding helper, which is the layer this file exists to
+# avoid. The repo's idiom for entry points that legitimately grow is a named suppression.
+def create_app(  # noqa: PLR0915
     settings: Settings | None = None,
     *,
     stream: EventConsumer | None = None,
@@ -128,6 +134,9 @@ def create_app(
     app.state.interest = interest if interest is not None else registry
     # FEATURE: tie a run's lifetime to its audience (OME-890).
     _install_orphan_reaper(app, registry, job_runner, settings)
+    # FEATURE: surface a generic capacity warning when a Runner Job cannot be scheduled
+    # (OME-948).
+    _install_run_stall_watch(app, registry, job_runner, settings)
     if clock is not None:
         app.state.clock = clock
     install_problem_handlers(app)
@@ -280,6 +289,82 @@ def _install_orphan_reaper(
 
     async def _stop() -> None:
         task = app.state.reaper_task
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    app.router.on_startup.append(_start)
+    app.router.on_shutdown.append(_stop)
+
+
+def _install_run_stall_watch(
+    app: FastAPI,
+    registry: ConnectionRegistry,
+    job_runner: JobRunner | None,
+    settings: Settings,
+) -> None:
+    """Wire the run-stall watch: warn a run whose Job never gets a Pod, on a cadence.
+
+    FEATURE: surface a generic capacity warning when a Runner Job cannot be scheduled (OME-948).
+    Modelled on `_install_orphan_reaper` — the policy object owns no task, the loop is an
+    asyncio task on the App's own event loop, and shutdown cancels it so nothing outlives the
+    App. No sweep at startup, unlike the artifact sweeper: nothing can be stuck before a run has
+    been scheduled, so a boot sweep would have nothing to look at.
+
+    INVARIANT: k8s-only. Local mode cannot stall silently — an in-process run either runs or
+    fails fast at accept time (`JobRunnerAtCapacity` → 503) — so a non-k8s runner never gets
+    the task, and no background work appears on every local boot.
+
+    INVARIANT: the watcher is handed `registry` — the REAL one — never `app.state.interest`,
+    for the same reason as the reaper: a gate that answers "nobody is listening" for every
+    topic would warn-and-drop every run in the process.
+    """
+    app.state.stall_watcher = None
+    app.state.stall_task = None
+    # WHY registered unconditionally, and via a getter: the collector reads whatever
+    # `app.state.stall_watcher` holds at scrape time, so a stream-only App exposes no stall
+    # series rather than a stale zero, and `/metrics` never depends on wiring order.
+    register_stall_metrics(app.state.metrics, lambda: app.state.stall_watcher)
+    if job_runner is None or settings.runner != "k8s" or settings.run_stall_warn_after_s <= 0:
+        # WHY the early return: a non-k8s runner cannot stall silently, and an operator may turn
+        # the watch off with `URL4_CLOUD_RUN_STALL_WARN_AFTER_S=0`. Either way, no task is
+        # created — the many tests that inject no runner must not grow a background task.
+        return
+    watcher = RunStallWatcher(
+        job_runner,
+        registry,
+        warn_after_s=settings.run_stall_warn_after_s,
+    )
+    app.state.stall_watcher = watcher
+
+    async def _sweep_forever() -> None:
+        while True:
+            await asyncio.sleep(watcher.tick_s)
+            # INVARIANT: one failed sweep must not kill the watcher. An unhandled exception here
+            # would end the task silently and every stuck run would stay silent until the 16h
+            # ceiling — worse than the bug this fixes, because it would LOOK fixed. Log and
+            # keep the cadence. `CancelledError` is a BaseException and still propagates, so
+            # shutdown is unaffected.
+            try:
+                await watcher.sweep()
+            except Exception:
+                _logger.exception("run-stall sweep failed; retrying next interval")
+
+    async def _start() -> None:
+        app.state.stall_task = asyncio.get_running_loop().create_task(_sweep_forever())
+        # AIDEV-NOTE: the single-replica assumption is LOGGED, not merely noted in the chart. The
+        # live-topic set lives in this process's memory, so a second replica would warn about
+        # runs another replica is streaming — advisory-only, but duplicate WARNs would read as
+        # noise. Multi-replica needs the same shared SubscriberGate the reaper waits on.
+        _logger.info(
+            "run-stall watch armed warn_after_s=%.0f tick_s=%.0f (assumes a single replica)",
+            settings.run_stall_warn_after_s,
+            watcher.tick_s,
+        )
+
+    async def _stop() -> None:
+        task = app.state.stall_task
         if task is not None:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -93,6 +93,16 @@ class Settings(BaseSettings):
     # INVARIANT: this bounds SPEND, not correctness — job_deadline_s (16h) remains the backstop.
     # Raising it costs money per orphaned run; lowering it risks stopping a live one.
     orphan_grace_s: float = Field(default=120.0, ge=0.0)
+    # FEATURE: surface a generic capacity warning when a Runner Job cannot be scheduled
+    # (OME-948).
+    #
+    # WHY 60s: a Job whose Pod cannot be created retries `FailedCreate` with backoff and shows
+    # `scheduled` (no active Pod, no terminal condition) the whole time; a Pending Pod counts as
+    # `active`, so image pulls and normal creation latency never look stalled. 60s of
+    # `scheduled` therefore genuinely means "no Pod has ever been created". The watch warns the
+    # attached client once per stall episode; it never touches the run itself. 0 disables the
+    # watch (the sweep loop is skipped entirely).
+    run_stall_warn_after_s: float = Field(default=60.0, ge=0.0)
     # INVARIANT: stateless iat window (seconds) — start rejected when now - iat exceeds it (§4).
     iat_window_s: int = 60
     # WHY: sync-hold cap; a run outliving it degrades to 202 async (spec §5).

--- a/apps/screamingface-engine/src/screamingface_engine/metrics.py
+++ b/apps/screamingface-engine/src/screamingface_engine/metrics.py
@@ -195,3 +195,34 @@ class _ReaperCollector:
 def register_reaper_metrics(metrics: Metrics, get_reaper: Callable[[], Any]) -> None:
     """Register a `_ReaperCollector` for `get_reaper` on `metrics.registry`."""
     metrics.registry.register(_ReaperCollector(get_reaper))
+
+
+class _StallCollector:
+    """A `prometheus_client` custom collector for the run-stall watcher's counters (OME-948)."""
+
+    def __init__(self, get_watcher: Callable[[], Any]) -> None:
+        self._get_watcher = get_watcher
+
+    def collect(self) -> Iterable[Any]:
+        """Called by `prometheus_client` once per `/metrics` scrape."""
+        watcher = self._get_watcher()
+        if watcher is None:
+            return
+        yield CounterMetricFamily(
+            "screamingface_engine_run_stalls_warned",
+            "Runs warned that their Runner Job could not be scheduled (at capacity).",
+            value=watcher.warned_total,
+        )
+        # WHY a gauge beside the counter: a value that never returns to zero is the only signal
+        # that distinguishes "the sweep task died" from "no stalls happened" — the same argument
+        # as the reaper's `armed` gauge.
+        yield GaugeMetricFamily(
+            "screamingface_engine_run_stalls_stuck",
+            "Runs currently tracked as stuck (Job scheduled but no Pod has ever been created).",
+            value=float(watcher.stuck_count),
+        )
+
+
+def register_stall_metrics(metrics: Metrics, get_watcher: Callable[[], Any]) -> None:
+    """Register a `_StallCollector` for `get_watcher` on `metrics.registry`."""
+    metrics.registry.register(_StallCollector(get_watcher))

--- a/apps/screamingface-engine/src/screamingface_engine/ports.py
+++ b/apps/screamingface-engine/src/screamingface_engine/ports.py
@@ -69,3 +69,15 @@ class IdentityAwareJobRunner(JobRunner):
         identity: Mapping[str, str] | None = None,
         cache: CachePolicy | None = None,
     ) -> str: ...
+
+
+class RunnerScheduleUnavailable(Exception):
+    """The scheduler could not accept this run NOW — retry later, unchanged.
+
+    The substrate-transient sibling of :class:`JobRunnerAtCapacity`, but engine-local rather
+    than a url4 port type, for one reason: `JobRunnerAtCapacity`'s own contract says a
+    cluster-backed runner NEVER raises it ("lets the scheduler absorb the load"), and a k8s
+    apiserver refusal is exactly the case that contract excludes. This type is raised by
+    adapters on a transient substrate failure (apiserver 5xx/429) and mapped by the REST layer
+    to the same generic retryable 503 + `Retry-After` the capacity branch already produces.
+    """

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -28,7 +28,7 @@ from screamingface_engine.auth import (
     new_topic,
 )
 from screamingface_engine.config import Settings
-from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.ports import IdentityAwareJobRunner, RunnerScheduleUnavailable
 from screamingface_engine.rest.cache_header import parse_cache_control
 from screamingface_engine.rest.cache_policy import resolve
 from screamingface_engine.rest.interest import SubscriberGate
@@ -204,6 +204,16 @@ async def _schedule(
             status=503,
             title="Service Unavailable",
             detail="the runner is at capacity — retry shortly",
+            headers={"Retry-After": "1"},
+        ) from exc
+    except RunnerScheduleUnavailable as exc:
+        # OME-948: a transient substrate refusal at schedule time gets the same generic retryable
+        # answer as a full local runner — never a naked 500. The detail is deliberately generic;
+        # the adapter's cause is logged, not echoed.
+        raise ProblemException(
+            status=503,
+            title="Service Unavailable",
+            detail="the runner could not schedule this run — retry later",
             headers={"Retry-After": "1"},
         ) from exc
 
@@ -385,6 +395,7 @@ _START_RESPONSES: dict[int | str, dict[str, Any]] = {
     400: _problem("The url4 expression query parameter `q` is required."),
     409: _problem("A run already exists for this topic (single-shot)."),
     428: _problem("Attach a WebSocket to the topic before starting the run."),
+    503: _problem("The runner is at capacity or could not schedule the run — retry later."),
     502: _problem("The run failed."),
     504: _problem("The run exceeded its 16 h deadline."),
 }

--- a/apps/screamingface-engine/src/screamingface_engine/run_stall.py
+++ b/apps/screamingface-engine/src/screamingface_engine/run_stall.py
@@ -1,0 +1,207 @@
+"""Warns a run's attached client when its Job is stuck in ``scheduled`` past a bound.
+
+FEATURE: surface a generic capacity warning when a Runner Job cannot be scheduled (OME-948).
+
+STORY: as a researcher whose evaluation was accepted but whose Runner Pod can never be created
+(the namespace is at its ResourceQuota, or any other scheduling refusal), I am told the runner
+service is at capacity instead of staring at a silently non-progressing run for up to 16 hours.
+
+WHY this module exists: ``_map_status`` in the k8s adapter already reports the honest state —
+``scheduled`` means the Job exists, no Pod is active, and no terminal condition has fired — and
+nobody reads it. The run is accepted (HTTP 202), the Runner process never starts, the App's
+``EventConsumer`` is read-only, and the WS bridge keeps heartbeating, so the client waits with
+no information until ``activeDeadlineSeconds``. A run that was accepted and never executes is
+exactly the case ``notices.warn`` exists for (see its module docstring). This module closes that
+gap with the notice channel the App already owns.
+
+INVARIANTS:
+
+- The message is GENERIC — "the runner service is at capacity". Detection is symptom-based
+  (``scheduled`` persisting), never cause-based (quota names, namespaces, Pod names), so the
+  same notice covers quota refusals, node pressure, and any future scheduling failure.
+- Advisory-only. A failed probe or a wrong verdict can cost a missing or late WARNING, and
+  nothing else: this module never stops, reschedules, or otherwise touches the run.
+- k8s-only by WIRING, never by code: the module is substrate-blind (it reads only
+  ``JobStatus`` from the port). ``app.py`` installs it only when ``settings.runner == "k8s"``;
+  local mode cannot stall silently and never wires it.
+- The stall clock is MONOTONIC (NTP-jump-safe, the reaper's invariant); the frame's ``time`` is
+  a datetime — two questions, two seams.
+
+AIDEV-NOTE: POLICY ONLY — no FastAPI, no task ownership, and deliberately no import from ``ws``.
+The sweep loop lives in ``app.py::_install_run_stall_watch``, beside the orphan reaper it is
+modelled on. The audience's ``AudienceListener`` slot stays the reaper's alone: this watcher
+POLLS the registry's topic snapshot rather than listening, which is what keeps the two modules
+decoupled and the single-listener invariant intact.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from datetime import datetime
+from typing import Protocol
+
+from screamingface_engine import notices
+from url4.streaming.interfaces import JobStatus
+from url4.streaming.protocol import OutboundFrame
+
+_logger = logging.getLogger(__name__)
+
+_MIN_TICK_S = 1.0
+_TICKS_PER_BOUND = 8
+"""How many sweeps fit inside one stall bound. WHY derived rather than a second setting: warn
+latency is `bound` to `bound + bound/8`, so an operator tunes ONE knob and gets a bounded
+overshoot — the same shape as the orphan reaper's `_TICKS_PER_GRACE`."""
+
+STALL_MESSAGE = (
+    "the runner could not schedule compute for this run (the runner service is at capacity). "
+    "The run has not started — stop it and retry later."
+)
+"""The generic, user-facing notice body. INVARIANT: no internals — see the module docstring."""
+
+Clock = Callable[[], float]
+"""Monotonic elapsed-time source for the stall bound (NTP-jump-safe; see the module docstring)."""
+
+FrameClock = Callable[[], datetime]
+"""Wall-clock source for the WARN frame's ``time`` — the seam `_converge_cache` feeds too."""
+
+
+class RunStatus(Protocol):
+    """The one runner question the watch needs, and deliberately nothing else.
+
+    ``not_found`` already answers "the Job is gone", so there is no ``exists`` here — a terminal
+    or absent Job is none of the watcher's business. The real ``K8sJobRunner.status`` satisfies
+    this structurally.
+    """
+
+    async def status(self, topic: str) -> JobStatus: ...
+
+
+class StallAudience(Protocol):
+    """The registry-shaped collaborator: the live topic snapshot to watch and the notice sink.
+
+    Both live on the REAL ``ConnectionRegistry`` (never the ``interest`` DI seam — the same
+    invariant as the orphan reaper, for the same reason: a gate that answers "nobody is
+    listening" for every topic would stop every run in the process).
+    """
+
+    def topics(self) -> frozenset[str]: ...
+
+    def notify(self, topic: str, frame: OutboundFrame) -> None: ...
+
+
+class RunStallWatcher:
+    """Warns each live topic whose Job has been stuck in ``scheduled`` past the bound, once.
+
+    INVARIANT: a run that STARTED, SUCCEEDED, FAILED or went ``timed_out`` is dropped from
+    tracking the moment any non-``scheduled`` status is observed — a healthy run must never be
+    warned, and a stalled one that heals must not carry its old clock into a later stall.
+
+    INVARIANT: a topic that leaves the audience (its last socket detached) is PRUNED — a later
+    reconnect starts a fresh stall clock, so an old ``first_seen`` can never fire an instant
+    warn against a run that has meanwhile progressed.
+
+    INVARIANT: one WARN per stall EPISODE. The ``warned`` set is cleared when the topic leaves
+    ``scheduled`` or the audience — re-warnings happen only for genuinely new stall episodes.
+    """
+
+    def __init__(
+        self,
+        runner: RunStatus,
+        audience: StallAudience,
+        *,
+        warn_after_s: float,
+        clock: Clock = time.monotonic,
+        frame_clock: FrameClock = datetime.now,
+        tick_s: float | None = None,
+    ) -> None:
+        self._runner = runner
+        self._audience = audience
+        self._warn_after_s = warn_after_s
+        self._clock = clock
+        self._frame_clock = frame_clock
+        self._tick_s = (
+            tick_s if tick_s is not None else max(_MIN_TICK_S, warn_after_s / _TICKS_PER_BOUND)
+        )
+        #: monotonic time a topic was first observed stuck; the stall clock.
+        self._first_seen: dict[str, float] = {}
+        #: topics already warned for their CURRENT stall episode.
+        self._warned: set[str] = set()
+        self._warned_total = 0
+
+    @property
+    def tick_s(self) -> float:
+        """Seconds between sweeps. The loop in `app.py` reads its cadence from here."""
+        return self._tick_s
+
+    @property
+    def stuck_count(self) -> int:
+        """Topics currently being tracked as stuck (warned or not yet warned).
+
+        WHY exposed: it is the `/metrics` gauge, and a value that never returns to zero is how
+        an operator sees that the watch has stopped working — a silently dead sweep otherwise
+        looks exactly like "no stalls happened" (same argument as the reaper's ``armed_count``).
+        """
+        return len(self._first_seen)
+
+    @property
+    def warned_total(self) -> int:
+        """Runs warned for an unschedulable Job, since boot."""
+        return self._warned_total
+
+    async def sweep(self) -> tuple[str, ...]:
+        """Warn every live topic whose stall bound has closed; return the topics warned.
+
+        Split from the loop that calls it so tests drive the policy against an injected clock
+        with no sleeps at all.
+
+        INVARIANT: a per-topic ``status()`` failure is tolerated — logged, that topic skipped
+        for this tick, its tracking KEPT (a transient probe failure must neither warn nor
+        forget; the next tick retries). The reaper's philosophy, verbatim: a failed probe
+        re-arms rather than gives up.
+        """
+        live = self._audience.topics()
+        now = self._clock()
+        warned: list[str] = []
+        for topic in live:
+            try:
+                status = await self._runner.status(topic)
+            except Exception:
+                # WHY a broad catch: the probe is a network round trip and can raise any
+                # transport/API error the substrate's client raises — enumerating them all
+                # here would couple the policy to the substrate. The reaper's stop path is
+                # the same shape. A failed probe must never kill the sweep loop.
+                _logger.warning(
+                    "run-stall status probe failed topic=%s; will retry", topic, exc_info=True
+                )
+                continue
+            if status != "scheduled":
+                self._first_seen.pop(topic, None)
+                self._warned.discard(topic)
+                continue
+            self._first_seen.setdefault(topic, now)
+            if topic not in self._warned and now - self._first_seen[topic] >= self._warn_after_s:
+                self._audience.notify(
+                    topic,
+                    notices.warn(topic, self._frame_clock, STALL_MESSAGE, {}),
+                )
+                self._warned.add(topic)
+                self._warned_total += 1
+                warned.append(topic)
+        # INVARIANT: prune topics that left the audience (a socket detached). A stale
+        # ``first_seen`` would otherwise make a reconnect warn instantly against an old clock.
+        for stale in set(self._first_seen) - live:
+            self._first_seen.pop(stale, None)
+            self._warned.discard(stale)
+        return tuple(warned)
+
+
+__all__ = [
+    "STALL_MESSAGE",
+    "Clock",
+    "FrameClock",
+    "RunStatus",
+    "RunStallWatcher",
+    "StallAudience",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/ws/registry.py
+++ b/apps/screamingface-engine/src/screamingface_engine/ws/registry.py
@@ -104,6 +104,16 @@ class ConnectionRegistry:
         session = self._sessions.get(topic)
         return session is not None and session.subscribers > 0
 
+    def topics(self) -> frozenset[str]:
+        """A snapshot of every topic with a live connection.
+
+        FEATURE: run-stall watch (OME-948). A snapshot, never a live view: the sweep awaits a
+        status probe per topic, so the set must be stable for the duration of a sweep — a socket
+        closing mid-sweep must not raise during iteration. A topic that vanished simply reads
+        `not_found` on its probe and is dropped by the watcher's own pruning.
+        """
+        return frozenset(self._sessions)
+
     def declare_cache_policy(self, topic: str, policy: CachePolicy | None) -> bool:
         """Record ``policy`` as ``topic``'s cache intent — FIRST ATTACH WINS (spec §5.2).
 

--- a/apps/screamingface-engine/tests/integration/test_run_stall_spine.py
+++ b/apps/screamingface-engine/tests/integration/test_run_stall_spine.py
@@ -1,0 +1,168 @@
+"""End to end: a run whose Job can never start delivers one generic WARN to the attached client.
+
+FEATURE: surface a generic capacity warning when a Runner Job cannot be scheduled (OME-948).
+
+STORY: as a researcher whose evaluation was accepted but whose Runner Pod can never be created
+(the namespace is at its quota), I am told the runner service is at capacity instead of staring
+at a silently non-progressing run for up to 16 hours.
+
+WHY this file exists beside the unit tests: `test_run_stall.py` proves the policy against
+fakes and `test_app_factory.py` proves the wiring gate. Neither proves the SPINE — that a REAL
+WebSocket attached to the real registry and bridge receives the WARN frame the watcher pushed
+through `notify`, and that the `/metrics` surface reports the stall. That is what this covers,
+assembled the same way `test_orphan_reaper_spine.py` assembles its local-mode App — except the
+runner is a fake that reports every run as `scheduled` forever, because a k8s scheduler refusal
+is exactly the state a real local runner cannot produce.
+
+AIDEV-NOTE: these tests wait on CONDITIONS with a deadline, never on a fixed sleep. The watch's
+sweep runs on the App's own event loop inside `TestClient`'s portal, so the test thread cannot
+await it directly; the observable it polls instead is `/metrics`, the same surface an operator
+uses. `run_stall_warn_after_s` is set small so a sweep tick actually lands during the test —
+`_TICKS_PER_GRACE` floors the tick at 1s, so budget just over a second per warn.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable, Iterator, Mapping
+
+import pytest
+from fastapi.testclient import TestClient
+
+from screamingface_engine.app import create_app
+from screamingface_engine.config import Settings
+from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.run_stall import STALL_MESSAGE
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.interfaces import JobStatus
+
+SECRET = "s" * 32
+
+# Small enough that a 1s sweep tick closes the stall window during the test, large enough that a
+# pod-creation latency of a few seconds would never be mistaken for a stall in production terms.
+SHORT_BOUND_S = 0.2
+
+_WAIT_TIMEOUT_S = 10.0
+_POLL_S = 0.02
+
+
+class _StuckRunner(IdentityAwareJobRunner):
+    """Every run is accepted and then never gets a Pod — `scheduled` forever."""
+
+    async def schedule(
+        self,
+        topic: str,
+        url4: str,
+        deadline_s: int,
+        *,
+        traceparent: str | None = None,
+        credential: str | None = None,
+        profile: str | None = None,
+        identity: Mapping[str, str] | None = None,
+        cache: object | None = None,
+    ) -> str:
+        return topic
+
+    async def stop(self, topic: str) -> None: ...
+
+    async def exists(self, topic: str) -> bool:
+        return False
+
+    async def status(self, topic: str) -> JobStatus:
+        return "scheduled"
+
+
+@pytest.fixture
+def stuck() -> Iterator[TestClient]:
+    settings = Settings(
+        jwt_secret=SECRET,
+        runner="k8s",
+        run_stall_warn_after_s=SHORT_BOUND_S,
+        # `runner="k8s"` refuses a filesystem artifact store (OME-929), so the site-backed
+        # tests must declare the object store; nothing here ever touches the network.
+        artifact_store="s3",
+        artifact_s3_endpoint_url="http://minio:9000",
+        artifact_s3_bucket="tests",
+        artifact_s3_region="us-east-1",
+        artifact_s3_access_key="test",
+        artifact_s3_secret_key="test",
+        # The run never completes, so a sync hold would block for the full default 30s. Every
+        # test starts with `Prefer: respond-async`; this is the safety net.
+        sync_max_wait_s=0.2,
+    )
+    app = create_app(
+        settings,
+        stream=InMemoryEventStream(),
+        job_runner=_StuckRunner(),
+    )
+    with TestClient(app) as client:
+        yield client
+
+
+def _cap(token: str) -> dict[str, str]:
+    return {"URL4-Capability": token}
+
+
+def _async_start(token: str) -> dict[str, str]:
+    return {"URL4-Capability": token, "Prefer": "respond-async"}
+
+
+def _token(client: TestClient) -> str:
+    response = client.post("/token")
+    assert response.status_code == 200
+    return str(response.json()["token"])
+
+
+def _attach(ws: object) -> None:
+    ws.send_text(  # type: ignore[attr-defined]
+        json.dumps(
+            {
+                "specversion": "1.0",
+                "id": "attach-1",
+                "source": "/test",
+                "type": "ai.url4.attach",
+                "data": {},
+            }
+        )
+    )
+
+
+def _metric(client: TestClient, name: str) -> float:
+    """One metric's current value, read from the real `/metrics` surface."""
+    for line in client.get("/metrics").text.splitlines():
+        if line.startswith(f"{name} "):
+            return float(line.rsplit(" ", 1)[1])
+    return 0.0
+
+
+def _warned(client: TestClient) -> float:
+    # prometheus_client appends `_total` to counter families on the wire.
+    return _metric(client, "screamingface_engine_run_stalls_warned_total")
+
+
+def _wait_until(predicate: Callable[[], bool], what: str) -> None:
+    deadline = time.monotonic() + _WAIT_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(_POLL_S)
+    raise AssertionError(f"timed out after {_WAIT_TIMEOUT_S}s waiting for {what}")
+
+
+def test_a_stuck_run_delivers_one_generic_warn_to_the_attached_client(stuck: TestClient) -> None:
+    token = _token(stuck)
+    with stuck.websocket_connect(f"/ws?ticket={token}") as ws:
+        _attach(ws)
+        response = stuck.get("/?q='hi'!'go'", headers=_async_start(token))
+        assert response.status_code == 202
+
+        # The notice fires one sweep tick after the stall bound closes, on the App's loop.
+        _wait_until(lambda: _warned(stuck) >= 1.0, "the stall warn to fire")
+        # The notice was already queued to THIS socket at warn time; drain until the WARN frame.
+        for _ in range(8):
+            frame = json.loads(ws.receive_text())
+            if frame["type"] == "ai.url4.log" and frame["data"]["severity_text"] == "WARN":
+                assert frame["data"]["body"] == STALL_MESSAGE
+                return
+        raise AssertionError("the attached client never received the WARN log frame")

--- a/apps/screamingface-engine/tests/unit/test_app_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_app_factory.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import UTC, datetime
 
 import httpx
@@ -8,7 +9,10 @@ from screamingface_engine import cli
 from screamingface_engine.app import create_app
 from screamingface_engine.auth import JwtCodec
 from screamingface_engine.config import Settings
+from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.run_stall import RunStallWatcher
 from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.interfaces import JobStatus
 
 pytestmark = pytest.mark.asyncio
 
@@ -71,3 +75,71 @@ def test_prod_cli_serves_the_env_wired_factory(monkeypatch: pytest.MonkeyPatch) 
 
     assert recorded["app"] == "screamingface_engine.app:create_app_from_env"
     assert recorded["factory"] is True
+
+
+class _FakeRunner(IdentityAwareJobRunner):
+    """A structural fake the wiring gate needs: a non-None runner that is not k8s-backed."""
+
+    async def schedule(
+        self,
+        topic: str,
+        url4: str,
+        deadline_s: int,
+        *,
+        traceparent: str | None = None,
+        credential: str | None = None,
+        profile: str | None = None,
+        identity: Mapping[str, str] | None = None,
+        cache: object | None = None,
+    ) -> str:
+        return topic
+
+    async def stop(self, topic: str) -> None: ...
+
+    async def exists(self, topic: str) -> bool:
+        return False
+
+    async def status(self, topic: str) -> JobStatus:
+        return "not_found"
+
+
+def _k8s_settings() -> Settings:
+    """Settings that pass the App's boot-time fences: `runner="k8s"` refuses a filesystem
+    artifact store (OME-929 — a Job pod's disk dies with it), so the k8s wiring tests must
+    declare the object store. No network is touched at construction.
+    """
+    return Settings(
+        jwt_secret=SECRET,
+        iat_window_s=WINDOW_S,
+        runner="k8s",
+        artifact_store="s3",
+        artifact_s3_endpoint_url="http://minio:9000",
+        artifact_s3_bucket="tests",
+        artifact_s3_region="us-east-1",
+        artifact_s3_access_key="test",
+        artifact_s3_secret_key="test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_stall_watch_is_absent_outside_k8s() -> None:
+    app = create_app(
+        Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S),
+        stream=InMemoryEventStream(),
+        job_runner=_FakeRunner(),
+    )
+    # Local mode cannot stall silently (an in-process run fails fast or 503s at accept), so the
+    # watch must not be wired — a useless background task on every local boot would be the smell.
+    assert app.state.stall_watcher is None
+
+
+@pytest.mark.asyncio
+async def test_run_stall_watch_is_present_for_a_k8s_runner() -> None:
+    app = create_app(
+        _k8s_settings(),
+        stream=InMemoryEventStream(),
+        job_runner=_FakeRunner(),
+    )
+    watcher = app.state.stall_watcher
+    assert isinstance(watcher, RunStallWatcher)
+    assert watcher.tick_s >= 1.0

--- a/apps/screamingface-engine/tests/unit/test_run_stall.py
+++ b/apps/screamingface-engine/tests/unit/test_run_stall.py
@@ -1,0 +1,214 @@
+"""Policy tests for the run-stall watcher (OME-948) — fake clock, fake runner, fake audience.
+
+The spine (`test_run_stall_spine.py`) proves a REAL WebSocket client receives the WARN frame
+through the real registry and bridge. This module proves the POLICY: when a run warns — only for
+a Job stuck in `scheduled` past the bound, and only once per stall episode — and that a probe
+failure or a detached audience never corrupts the watch state.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from screamingface_engine.run_stall import STALL_MESSAGE, RunStallWatcher
+from url4.streaming.interfaces import JobStatus
+
+#: The notice is generic by contract — no quota names, no namespace or Pod identifiers, no
+#: internals a caller cannot act on. These tokens must never appear in the body.
+_FORBIDDEN = ("quota", "ns-ceiling", "url4-", "namespace", "pod ")
+
+
+class _FakeRunner:
+    """One scripted `JobStatus` per topic; `status` can be made to raise on demand."""
+
+    def __init__(self, statuses: dict[str, JobStatus] | None = None) -> None:
+        self.statuses: dict[str, JobStatus] = statuses or {}
+        self.raise_on: set[str] = set()
+
+    async def status(self, topic: str) -> JobStatus:
+        if topic in self.raise_on:
+            raise RuntimeError(f"probe failed for {topic}")
+        return self.statuses.get(topic, "not_found")
+
+
+class _FakeAudience:
+    """The registry-shaped collaborator: a topic snapshot and a notify recorder."""
+
+    def __init__(self) -> None:
+        self.live: set[str] = set()
+        self.frames: list[tuple[str, Any]] = []
+
+    def topics(self) -> frozenset[str]:
+        return frozenset(self.live)
+
+    def notify(self, topic: str, frame: Any) -> None:
+        self.frames.append((topic, frame))
+
+
+class _Clock:
+    """A mutable monotonic clock the tests advance explicitly."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _watcher(
+    runner: _FakeRunner,
+    audience: _FakeAudience,
+    clock: _Clock,
+    *,
+    warn_after_s: float = 60.0,
+) -> RunStallWatcher:
+    return RunStallWatcher(
+        runner,
+        audience,
+        warn_after_s=warn_after_s,
+        clock=clock,
+        frame_clock=lambda: datetime(2026, 8, 22, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_warn_before_the_bound_and_exactly_once_after() -> None:
+    runner = _FakeRunner({"t": "scheduled"})
+    audience = _FakeAudience()
+    audience.live.add("t")
+    clock = _Clock()
+    watcher = _watcher(runner, audience, clock, warn_after_s=60.0)
+
+    # First sweep starts the stall clock; nothing is due yet.
+    assert await watcher.sweep() == ()
+    clock.advance(59.0)
+    assert await watcher.sweep() == ()
+    # Elapsed == the bound is the pinned boundary: it warns.
+    clock.advance(1.0)
+    assert await watcher.sweep() == ("t",)
+    assert len(audience.frames) == 1
+    assert watcher.warned_total == 1
+    # Warned once per episode: a later sweep never repeats it.
+    clock.advance(3600.0)
+    assert await watcher.sweep() == ()
+    assert len(audience.frames) == 1
+    assert watcher.warned_total == 1
+
+
+@pytest.mark.asyncio
+async def test_running_and_terminal_never_warn_and_clear_tracking() -> None:
+    runner = _FakeRunner({"t": "scheduled"})
+    audience = _FakeAudience()
+    audience.live.add("t")
+    clock = _Clock()
+    watcher = _watcher(runner, audience, clock)
+
+    await watcher.sweep()
+    assert watcher.stuck_count == 1
+    runner.statuses["t"] = "running"
+    clock.advance(3600.0)
+    assert await watcher.sweep() == ()
+    assert watcher.stuck_count == 0
+    assert audience.frames == []
+
+    runner.statuses["t"] = "failed"
+    await watcher.sweep()
+    assert watcher.stuck_count == 0
+
+
+@pytest.mark.asyncio
+async def test_coming_back_to_scheduled_restarts_the_clock() -> None:
+    runner = _FakeRunner({"t": "scheduled"})
+    audience = _FakeAudience()
+    audience.live.add("t")
+    clock = _Clock()
+    watcher = _watcher(runner, audience, clock, warn_after_s=10.0)
+
+    await watcher.sweep()  # tracked at t=1000
+    runner.statuses["t"] = "running"
+    clock.advance(1000.0)
+    await watcher.sweep()  # cleared
+    runner.statuses["t"] = "scheduled"
+    # A fresh stall episode must sit a full fresh bound — the old clock does not carry over.
+    assert await watcher.sweep() == ()
+    clock.advance(9.0)
+    assert await watcher.sweep() == ()
+    clock.advance(1.0)
+    assert await watcher.sweep() == ("t",)
+
+
+@pytest.mark.asyncio
+async def test_a_probe_failure_is_tolerated_and_keeps_tracking() -> None:
+    runner = _FakeRunner({"t": "scheduled"})
+    audience = _FakeAudience()
+    audience.live.add("t")
+    clock = _Clock()
+    watcher = _watcher(runner, audience, clock, warn_after_s=10.0)
+
+    await watcher.sweep()  # tracked at t=1000
+    clock.advance(10.0)
+    runner.raise_on.add("t")
+    # A failed probe costs a missing or late warning, never a crash and never forgotten state.
+    assert await watcher.sweep() == ()
+    assert watcher.stuck_count == 1
+    runner.raise_on.discard("t")
+    assert await watcher.sweep() == ("t",)
+    assert watcher.warned_total == 1
+
+
+@pytest.mark.asyncio
+async def test_a_topic_leaving_the_audience_is_pruned_and_reconnect_restarts() -> None:
+    runner = _FakeRunner({"t": "scheduled"})
+    audience = _FakeAudience()
+    audience.live.add("t")
+    clock = _Clock()
+    watcher = _watcher(runner, audience, clock, warn_after_s=10.0)
+
+    await watcher.sweep()  # tracked at t=1000
+    clock.advance(3600.0)
+    audience.live.discard("t")  # the last socket detached
+    assert await watcher.sweep() == ()
+    assert watcher.stuck_count == 0  # pruned: a reconnect must not inherit a stale clock
+    audience.live.add("t")
+    assert await watcher.sweep() == ()  # fresh first_seen; no instant warn
+    clock.advance(10.0)
+    assert await watcher.sweep() == ("t",)
+
+
+@pytest.mark.asyncio
+async def test_an_empty_audience_is_a_noop() -> None:
+    watcher = _watcher(_FakeRunner(), _FakeAudience(), _Clock())
+    assert await watcher.sweep() == ()
+    assert watcher.stuck_count == 0
+    assert watcher.warned_total == 0
+
+
+@pytest.mark.asyncio
+async def test_the_notice_is_a_warn_log_with_the_generic_body() -> None:
+    runner = _FakeRunner({"t": "scheduled"})
+    audience = _FakeAudience()
+    audience.live.add("t")
+    clock = _Clock()
+    watcher = _watcher(runner, audience, clock, warn_after_s=0.0)
+
+    await watcher.sweep()
+    assert len(audience.frames) == 1
+    topic, frame = audience.frames[0]
+    assert topic == "t"
+    assert frame.type == "ai.url4.log"
+    assert frame.data.severity_text == "WARN"
+    assert frame.data.body == STALL_MESSAGE
+    lowered = frame.data.body.lower()
+    for token in _FORBIDDEN:
+        assert token not in lowered
+
+
+def test_the_sweep_cadence_derives_from_the_bound_with_a_floor() -> None:
+    assert _watcher(_FakeRunner(), _FakeAudience(), _Clock(), warn_after_s=60.0).tick_s == 7.5
+    assert _watcher(_FakeRunner(), _FakeAudience(), _Clock(), warn_after_s=4.0).tick_s == 1.0

--- a/apps/screamingface-engine/tests/unit/test_runners_k8s.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_k8s.py
@@ -6,6 +6,7 @@ from kubernetes.client import ApiException
 
 from screamingface_engine import job_env
 from screamingface_engine.adapters.k8s import K8sJobRunner
+from screamingface_engine.ports import RunnerScheduleUnavailable
 from url4.streaming.interfaces import JobAlreadyExists, JobRunner, job_name
 
 pytestmark = pytest.mark.asyncio
@@ -245,12 +246,35 @@ async def test_status_reraises_non_404_api_errors() -> None:
         await runner.status(TOPIC)
 
 
-async def test_schedule_reraises_non_409_api_errors() -> None:
-    class Boom(FakeBatchV1):
+async def test_schedule_maps_transient_api_errors_to_runner_schedule_unavailable() -> None:
+    """OME-948: a transient apiserver refusal is a retry-later, not a crash (503 on the wire)."""
+
+    class Boom500(FakeBatchV1):
         def create_namespaced_job(
             self, namespace: str, body, *, _request_timeout: float | None = None
         ) -> FakeCreatedJob:
             raise ApiException(status=500)
+
+    class Boom429(FakeBatchV1):
+        def create_namespaced_job(
+            self, namespace: str, body, *, _request_timeout: float | None = None
+        ) -> FakeCreatedJob:
+            raise ApiException(status=429)
+
+    for boom in (Boom500(), Boom429()):
+        runner = _runner(boom)
+        with pytest.raises(RunnerScheduleUnavailable):
+            await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+
+
+async def test_schedule_reraises_a_permanent_4xx_api_error() -> None:
+    """A permanent 4xx is an engine manifest bug, not a capacity signal — unchanged."""
+
+    class Boom(FakeBatchV1):
+        def create_namespaced_job(
+            self, namespace: str, body, *, _request_timeout: float | None = None
+        ) -> FakeCreatedJob:
+            raise ApiException(status=400)
 
     runner = _runner(Boom())
     with pytest.raises(ApiException):

--- a/docs/diagrams/OME-948-run-stall-capacity-notice.md
+++ b/docs/diagrams/OME-948-run-stall-capacity-notice.md
@@ -1,0 +1,145 @@
+# OME-948 — Run-stall capacity warning: mechanism diagrams
+
+Mermaid views of how the Engine detects a Runner Job that can never start and surfaces a
+generic capacity warning to the attached client, plus the schedule-time 503 hardening.
+
+- **Linear:** https://linear.app/openmined/issue/OME-948/surface-a-generic-capacity-warning-when-a-runner-job-cannot-be
+- **Spec:** `docs/spec/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- **Plan:** `docs/plan/2026-08-22-OME-948-run-stall-capacity-notice.md`
+
+## 1. Component map — where the mechanism lives
+
+```mermaid
+flowchart TD
+    SDK["Researcher / SDK<br/>(packages/screamingface · Client)<br/>~8 candidate runs in flight"]
+
+    subgraph ENGINE["screamingface-engine — control plane (FastAPI App)"]
+        REST["REST run lifecycle<br/>POST /token · GET /?q=… · DELETE /"]
+        WSB["WS bridge (/ws)<br/>attach · heartbeat · outbound frames"]
+        REG["ConnectionRegistry<br/>topics() snapshot · notify()"]
+        WATCH["RunStallWatcher (policy)<br/>sweep() every tick<br/>tick = max(1s, warnAfter / 8)"]
+        WIRING["_install_run_stall_watch<br/>wired ONLY when runner='k8s'"]
+        K8["K8sJobRunner<br/>create / status / delete Job"]
+        MET["/metrics<br/>run_stalls_stuck · run_stalls_warned_total"]
+    end
+
+    subgraph CLUSTER["Kubernetes — sf-fusion namespace"]
+        QUOTA["ResourceQuota 'ns-ceiling'<br/>4 CPU / 6 GiB — already 100% used"]
+        JOB["Runner Job url4-…<br/>status.active = 0<br/>→ reports 'scheduled'"]
+        POD["Runner Pod 500m / 1Gi<br/>NEVER created — FailedCreate"]
+    end
+
+    SDK -->|"1· mint token"| REST
+    SDK -->|"2· attach WS (subscriber)"| WSB
+    SDK -->|"3· start run — 202"| REST
+    REST -->|"4· schedule()"| K8
+    K8 -->|"5· create Job"| JOB
+    JOB -.->|"6· pod refused by quota"| QUOTA
+    QUOTA -.->|"status stays 'scheduled'"| JOB
+
+    WIRING -->|"wires the sweep loop"| WATCH
+    WATCH -->|"7· status(topic) per live topic"| K8
+    K8 -->|"read Job"| JOB
+    WATCH -->|"8· stuck past bound → notice"| REG
+    REG -->|"9· deliver to attached sockets"| WSB
+    WSB -->|"10· Log frame → console"| SDK
+    WATCH -->|"counters"| MET
+    MET -. "gauge shows live stuck" .-> OPS["operator / dashboard"]
+
+    style WATCH fill:#fff3bf,stroke:#f08c00
+    style JOB fill:#ffe8e8,stroke:#e03131
+```
+
+**The one-sentence story:** the SDK drives a run; Kubernetes refuses the pod (quota), leaving
+the Job stuck at `scheduled`; the RunStallWatcher notices the stall and pushes a generic WARN
+through the App's only voice — the notice channel — instead of the client staring at silence
+for up to 16 h.
+
+## 2. Sequence — the two paths that matter
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant S as SDK Client
+    participant A as Engine REST
+    participant W as WS Bridge
+    participant R as RunStallWatcher
+    participant J as K8sAdapter
+    participant K as Kubernetes (sf)
+    participant U as User
+
+    Note over S,A: path 1 — the stall becomes visible
+    S->>A: POST /token (capability)
+    S->>W: connect /ws?ticket=…
+    W->>W: registry.add(topic) — subscriber gate opens
+    S->>A: GET /?q=… Prefer: respond-async
+    A->>J: schedule(topic, expr, deadline)
+    J->>K: create Job url-…
+    A-->>S: 202 Accepted + Location
+    Note over K: quota at 100% CPU — pod refused (FailedCreate), status.active=0
+    loop every tick (max(1s, warnAfter/8))
+        R->>J: status(topic) for each live topic
+        J-->>R: "scheduled"
+    end
+    Note over R: "scheduled" persisted ≥ warnAfter (60s)<br/>and not yet warned this episode
+    R->>W: registry.notify(topic, WARN LogEvent)
+    W-->>S: ai.url4.log · severity=WARN<br/>"the runner service is at capacity…"
+    S->>U: Log event → console line + evaluation feed
+    U->>A: DELETE / (user stops the run)
+
+    Note over S,A: path 2 — refused at schedule time
+    S->>A: GET /?q=… (another run)
+    A->>J: schedule()
+    J->>K: create Job
+    K-->>J: ApiException 500/429 (transient)
+    J->>J: raise RunnerScheduleUnavailable (engine-local)
+    A-->>S: 503 problem + Retry-After: 1<br/>"the runner could not schedule this run — retry later"
+    Note over A,J: a 4xx would propagate unchanged — that is an engine manifest bug, not capacity
+```
+
+## 3. The watcher's decision logic (per sweep, per topic)
+
+```mermaid
+flowchart TD
+    SW["sweep() — every tick<br/>tick = max(1s, warnAfter_s/8)"] --> SNAP["live = registry.topics()<br/>(snapshot)"]
+    SNAP --> LOOP{"for each topic"}
+    LOOP --> PROBE["status = runner.status(topic)"]
+    PROBE -->|"probe raised ⚠"| TOL["log · skip this tick<br/>tracking KEPT —<br/>never warn on a broken probe"]
+    PROBE -->|"= 'scheduled'"| FIRST{"first_seen exists?"}
+    FIRST -->|no| SET["first_seen[topic] = now"]
+    FIRST -->|yes| BOUND{"now − first_seen<br/>≥ warnAfter?"}
+    SET --> BOUND
+    BOUND -->|"no — still young"| NEXT["next tick"]
+    BOUND -->|"yes"| ONCE{"warned this episode?"}
+    ONCE -->|"no"| WARN["notify(topic, WARN LogEvent)<br/>generic body — no internals"]
+    WARN --> MARK["warned = add(topic)<br/>warned_total += 1"]
+    ONCE -->|"yes"| SILENT["stay silent"]
+    PROBE -->|"anything else<br/>(running · failed ·<br/>succeeded · timed_out · not_found)"| DROP["drop tracking<br/>pop first_seen · discard warned"]
+    DROP --> PRUNE
+    MARK --> PRUNE["after loop: prune topics no longer in snapshot<br/>(reconnect restarts the stall clock)"]
+    SILENT --> PRUNE
+    PRUNE --> MET["metrics:<br/>stuck_count gauge · warned_total counter"]
+
+    style PROBE fill:#ffe8e8,stroke:#e03131
+    style WARN fill:#d3f9d8,stroke:#2f9e44
+```
+
+**Invariants the diagram encodes:**
+
+- Warn **at most once per stall episode** — a run healed is forgotten instantly (no stale clock).
+- A probe failure **costs at most a late warning**, never a crash or a corrupted decision.
+- A topic whose client detached is **pruned**, so a reconnect starts a fresh stall clock instead
+  of warning instantly against an old one.
+- The message is **generic** — symptom-based detection ("scheduled" persisting), never
+  cause-based — so the same notice covers quota refusals, node pressure, and any future
+  scheduling failure. It carries no internals (no "quota", namespace, or Pod names).
+
+## Accuracy notes
+
+- The notice reaches the client through the SDK's existing `Log` rendering (console line +
+  evaluation feed). Rendering *generic* log bodies in the rich TUI panel is the documented
+  client-side follow-up and is not shown here.
+- The 60 s bound, the `max(1, bound/8)` cadence, and the `"scheduled"` predicate match
+  `run_stall.py` / `app.py` verbatim; the knob is `URL4_CLOUD_RUN_STALL_WARN_AFTER_S`
+  (chart: `config.runStallWarnAfterS`).
+- Advisory-only by design: the watch never stops, reschedules, or otherwise touches a run.

--- a/docs/plan/2026-08-22-OME-948-run-stall-capacity-notice.md
+++ b/docs/plan/2026-08-22-OME-948-run-stall-capacity-notice.md
@@ -1,0 +1,120 @@
+# OME-948 — Implementation plan
+
+- **Spec:** `docs/spec/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- **Linear:** https://linear.app/openmined/issue/OME-948/surface-a-generic-capacity-warning-when-a-runner-job-cannot-be
+- **Branch:** `OME-948-run-stall-capacity-notice`
+- **Stack:** `screamingface-engine` (`sdlc-python`)
+
+## 1. RED — the policy proves a stuck run is warnable and warnable once
+
+In `apps/screamingface-engine/tests/unit/test_run_stall.py`, build the policy against fakes
+(an injected monotonic clock, a fake runner returning a scripted `JobStatus` per topic, a fake
+`topics()` set, and a `notify` recorder):
+
+- A topic whose status is `scheduled` from the first sweep: no warn until the elapsed time passes
+  `run_stall_warn_after_s` (injected), then exactly one warn; further sweeps do not re-warn.
+- A topic that transitions `scheduled` → `running`: tracking dropped, no warn ever.
+- A topic that transitions to a terminal status (`failed`/`timed_out`/`succeeded`): tracking
+  dropped.
+- A topic that is `running` or terminal from the start: never tracked, never warned.
+- `scheduled` younger than the bound: no warn; the next sweep after the bound warns (boundary
+  pinned at equality: elapsed `==` `run_stall_warn_after_s` warns).
+- A topic whose `status()` call raises: tolerated — no warn, tracking kept, the next sweep
+  retries; other topics in the same sweep still get their turn.
+- `topics()` empty: sweep is a no-op.
+- Assert the emitted frame is the generic `LogEvent` (WARN) whose `data.body` contains the
+  generic message and whose attributes carry no internal names.
+
+Run against the unmodified code: these fail for lack of the module — the RED state.
+
+## 2. GREEN — `run_stall.py` policy module
+
+In `apps/screamingface-engine/src/screamingface_engine/run_stall.py`:
+
+- TWO collaborator Protocols, mirroring the `RunReaper` style (`Audience`/`RunControl`): the
+  runner as `async status(topic) -> JobStatus` (its only needed method), and the registry as
+  `topics() -> frozenset[str]` + `notify(topic, frame)`. No FastAPI, no WS imports, no
+  `run_stall`-side kubernetes anything — the module is substrate-blind and k8s-only by
+  WIRING, never by code.
+- TWO clock seams: monotonic `Callable[[], float]` (default `time.monotonic`) for the stall
+  bound; `Callable[[], datetime]` (default `datetime.now(UTC)`) for the WARN frame's `time`.
+  `_TICKS_PER_GRACE`-style derived cadence (`max(1.0, warn_after_s / 8)`).
+- `RunStallWatcher` with `sweep()` returning the topics warned this sweep; per-topic
+  `first_seen_stuck` and a `warned` set; `stuck_count` / `warned_total` properties for metrics;
+  per-topic `status()` failure tolerated (log, keep tracking, neither warn nor forget);
+  iteration over a snapshot of `topics()` so a mid-sweep registry mutation cannot raise.
+- The warn frame is built with the existing `notices.warn(topic, clock, message, attributes)`.
+- Module docstring documents the INVARIANTs: generic message only; symptom-based detection;
+  advisory-only — a watcher failure can never affect the run itself.
+
+## 3. GREEN — wire into the App + settings + metrics + chart
+
+In `apps/screamingface-engine/src/screamingface_engine/ws/registry.py`:
+
+- Add `topics() -> frozenset[str]`, a snapshot view over `_sessions` — the watch's bounded topic
+  set (live audience), and the ONLY registry change.
+
+In `apps/screamingface-engine/src/screamingface_engine/app.py`:
+
+- Add `_install_run_stall_watch(app, registry, job_runner, settings)` modeled on
+  `_install_orphan_reaper`: skip when `job_runner is None` or `settings.runner != "k8s"`;
+  startup task + shutdown cancel; per-tick exceptions logged and tolerated; the watcher is
+  handed the REAL registry (never the `interest` DI seam) — same invariant as the reaper.
+- Register `engine_stuck_runs` gauge and `engine_stuck_warned_total` counter via a getter
+  (mirror `register_reaper_metrics` in `metrics.py`).
+
+In `apps/screamingface-engine/src/screamingface_engine/config.py`:
+
+- `run_stall_warn_after_s: float = 60.0` with env `URL4_CLOUD_RUN_STALL_WARN_AFTER_S`.
+
+In `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py`:
+
+- `_schedule_blocking`: `except ApiException as exc:` → raise `RunnerScheduleUnavailable` (the
+  new engine-local exception in `ports.py`) when `exc.status >= 500 or exc.status == 429`;
+  re-raise unchanged otherwise. `JobRunnerAtCapacity` is NOT reused — its own docstring forbids
+  cluster-backed runners from raising it.
+
+In `apps/screamingface-engine/src/screamingface_engine/ports.py`:
+
+- Add `class RunnerScheduleUnavailable(Exception)` — engine-local, substrate-transient, with a
+  docstring noting why the url4 port type is not reused.
+
+In `apps/screamingface-engine/src/screamingface_engine/rest/routes.py`:
+
+- `_schedule`: `except RunnerScheduleUnavailable` → `ProblemException(503, "the runner could not
+  schedule this run — retry later", headers={"Retry-After": "1"})`, mirroring the existing
+  `JobRunnerAtCapacity` branch. Doc-only: add the already-real 503 to `_START_RESPONSES`.
+
+In `.claude/scripts/check_layering.py`:
+
+- Register `run_stall` in `CONTROL_PLANE` (and the header comment's module list) — a new
+  control-plane root module; the gate fails without it.
+
+In `apps/screamingface-engine/deploy/helm/`:
+
+- `values.yaml` (`config.runStallWarnAfterS: 60`), `templates/configmap.yaml`
+  (`URL4_CLOUD_RUN_STALL_WARN_AFTER_S`), `values.schema.json` (the new key) — the
+  `orphanGraceS` pattern verbatim, so the knob is settable in the deployed topology.
+
+## 4. Integration spine + regression
+
+- `tests/integration/test_run_stall_spine.py` (modeled on `test_orphan_reaper_spine.py`): fake
+  runner returning `scheduled`, real App via `create_app` with `Settings(runner="k8s")`, a real
+  WS client attach; advance a fake clock past the bound, drive a sweep, assert the socket
+  receives exactly one WARN `Log` frame with the generic body.
+- `test_app.py`: the watch is absent when `settings.runner != "k8s"` (local mode untouched).
+- `tests/unit/test_runners_k8s.py` (the canonical k8s-adapter suite with its shared fakes):
+  `ApiException` 500/429 → `RunnerScheduleUnavailable`; the old
+  `test_schedule_reraises_non_409_api_errors` characterization (500 propagated) is updated to
+  the new contract — a permanent 4xx (400) still propagates unchanged.
+- `metrics`: stuck gauge returns to zero after terminal; counter increments once per warned run.
+
+## 5. Verify and deliver
+
+- Run the focused `test_run_stall.py`, `test_run_stall_spine.py`, `test_app.py`,
+  `test_runners_k8s.py` suites.
+- Run `uv run .claude/scripts/run_gates.py screamingface-engine` from the repository root
+  (ruff, pyright, `check_layering.py`, pytest ≥ 80%).
+- Complete the ledger outcome, commit with `Refs: OME-948`, push, and open a PR.
+- Add the close-discipline evidence to Linear; leave the final Done transition to merge
+  automation.

--- a/docs/spec/2026-08-22-OME-948-run-stall-capacity-notice.md
+++ b/docs/spec/2026-08-22-OME-948-run-stall-capacity-notice.md
@@ -1,0 +1,146 @@
+# OME-948 — Surface a generic capacity warning when a Runner Job cannot be scheduled
+
+- **Linear:** https://linear.app/openmined/issue/OME-948/surface-a-generic-capacity-warning-when-a-runner-job-cannot-be
+- **Landing:** `apps/screamingface-engine`
+- **Related discovery:** `OME-947` (`sf-fusion` `ns-ceiling` quota blocks Runner Job pods — the
+  failure this unit makes visible); `OME-908` (fair-scheduling — the deeper admission fix, out of
+  scope here)
+
+## Problem
+
+When a Runner Job is accepted but its Pod can never be created — e.g. the `sf-fusion` namespace
+is at its `ns-ceiling` ResourceQuota (OME-947) — the run stalls silently:
+
+- The engine returns HTTP 202 (`_schedule` → `K8sJobRunner.schedule` succeeds; quota applies to
+  *pods*, not to the Job object).
+- Kubernetes retries Pod creation (`FailedCreate`), `Job.status.active` stays 0, and
+  `_map_status` reports the honest state: **`scheduled`** (Job exists, no active Pod, no
+  terminal condition).
+- Nothing publishes to the run's stream — the Runner process never starts, and the App's
+  `EventConsumer` is read-only ("the App never publishes to the broker"). The WS bridge keeps
+  heartbeating (`ws_heartbeat_s=15s`), so the client's 120s receive-timeout never fires.
+- The user waits with no information until `activeDeadlineSeconds` (16h) eventually fires
+  `DeadlineExceeded` — and even then nothing consumes the `timed_out` state.
+
+A run that was accepted and never executes is exactly the case the notice channel exists for:
+"something the caller was promised was dropped … indistinguishable from a bug in the gateway"
+(module docstring, `screamingface_engine/notices.py`).
+
+## Required behavior
+
+1. The engine MUST detect a run whose Job is stuck in `scheduled` for at least a grace window
+   (`run_stall_warn_after_s`, default 60s; warn at elapsed `>=` the bound).
+2. On detection, the engine MUST send **one generic `warn` notice per run** to the run's attached
+   client via the existing notice channel (`notices.warn` → `ConnectionRegistry.notify` → WS
+   bridge → `Log` frame → SDK `_evaluation/progress.py::_message` renders "ScreamingFace ·
+   <body>").
+3. The message MUST be generic — "the runner service is at capacity", no quota names, no
+   internal detail — because the detection is symptom-based (Pod never starts), not cause-based
+   (quota), so the same notice covers node pressure and any other scheduling refusal.
+4. Detection MUST NOT false-positive on normal Pod-creation latency or image pulls: a Pending
+   Pod counts toward `Job.status.active`, so `scheduled` with `active == 0` persisting past the
+   grace window genuinely means "no Pod has ever been created".
+5. The watch is Kubernetes-only. Local mode (`InProcessJobRunner`) cannot stall silently — it
+   runs immediately or fails fast at accept time (`JobRunnerAtCapacity` → 503) — so the watch is
+   wired only when `settings.runner == "k8s"`.
+6. Schedule-time transient substrate failures MUST surface as a generic retryable **503** problem.
+   The translation is honest about the port contract: `JobRunnerAtCapacity`'s own docstring says a
+   cluster-backed runner NEVER raises it ("lets the scheduler absorb the load"), so it is NOT
+   reused. Instead `ports.py` — the module `rest/routes.py` and `adapters/k8s.py` already share —
+   gains one engine-local exception, `RunnerScheduleUnavailable`. `K8sJobRunner._schedule_blocking`
+   maps `ApiException` with `status >= 500 or status == 429` to it; `rest/routes.py::_schedule`
+   catches it → `503 + Retry-After: 1` with the generic detail "the runner could not schedule
+   this run — retry later". A 4xx `ApiException` is an engine manifest bug and keeps today's
+   behavior (surfaces as 500). The REST layer gains NO kubernetes import — `kubernetes` stays
+   confined to `adapters/`, and `url4.streaming` gains no new type.
+7. A per-topic `status()` failure during a sweep MUST be tolerated: log, skip that topic for
+   this tick, keep its tracking state (neither warn nor forget) — the reaper's "a failed stop
+   re-arms, never gives up" philosophy. A failed probe can cost a missing or late warning, and
+   nothing else: the watch is advisory-only and MUST NOT affect the run itself.
+8. Known limitation (accepted for v1): the notice is delivered to sockets attached at warn time;
+   a client that RECONNECTS mid-stall does not see it. Fixing that needs re-warn-on-arrival, and
+   `ConnectionRegistry.listen()` holds exactly one `AudienceListener` (the reaper's) —
+   multi-listener registry surgery is out of scope. Tripwire: if reconnect-during-stall proves
+   common in practice, revisit.
+
+## Design
+
+A new policy module `screamingface_engine/run_stall.py`, shaped exactly like the existing
+`RunReaper` (policy-only, no FastAPI/WS imports, `sweep()` split from the loop so tests drive the
+policy with fakes and an injected clock).
+
+- **Collaborators (narrow structural Protocols, satisfied structurally — TWO collaborators, not
+  three):**
+  - the runner: `status(topic) -> JobStatus` — the ONE method the watch needs (`not_found`
+    already covers "the Job is gone"; simpler than the reaper's two-method `RunControl`). The
+    real `K8sJobRunner.status` satisfies it.
+  - the registry: `topics() -> frozenset[str]` + `notify(topic, frame)` — both live on the REAL
+    `ConnectionRegistry` (never the `interest` DI seam — the same invariant as the reaper).
+    `topics()` is a NEW ~4-line snapshot view over `_sessions` and is the only registry change.
+- **Clock seams (two, deliberately):** a monotonic `Callable[[], float]` (default
+  `time.monotonic`) for the stall bound — the reaper's NTP-jump invariant, verbatim — and a
+  `Callable[[], datetime]` (default `datetime.now(UTC)`) for the WARN frame's `time`, the same
+  seam `_converge_cache` feeds from `app.state.clock`. Elapsed time and frame time are different
+  questions; one clock cannot honestly answer both.
+- **Policy state:** per-topic `first_seen_stuck` (monotonic) and a `warned` set. `sweep()` reads
+  `status(topic)` per live topic; `scheduled` persists → track; once elapsed >= grace and not yet
+  warned → `notify(warn)` once; any other status → drop tracking (a run that started, succeeded,
+  or went terminal is none of the watcher's business). Iteration takes a snapshot of `topics()`
+  so a registry mutated mid-sweep (a socket closing) cannot raise during iteration — a topic
+  that vanished reads `not_found` next tick and is dropped.
+- **Message:** `"the runner could not schedule compute for this run (the runner service is at
+  capacity). The run has not started — stop it and retry later."` — generic, no internals.
+- **Wiring:** `app.py::create_app` installs the sweep loop like `_install_orphan_reaper`
+  (startup task, shutdown cancel, per-tick exception tolerated) gated on `settings.runner ==
+  "k8s"` and `job_runner is not None`; registers two metrics via getter — `engine_stuck_runs`
+  (gauge, returns to zero) and `engine_stuck_warned_total` (counter) — mirroring
+  `register_reaper_metrics`.
+- **New knob:** `Settings.run_stall_warn_after_s: float = 60.0` (env
+  `URL4_CLOUD_RUN_STALL_WARN_AFTER_S`). One knob; the sweep cadence derives from it like
+  `_TICKS_PER_GRACE` in the reaper (default `warn_after_s / 8`, min 1s). The knob is
+  chart-exposed like every deploy knob (`values.yaml: config.runStallWarnAfterS` →
+  `configmap.yaml` env entry → `values.schema.json`) — without the chart entries it could not
+  be set in the deployed topology, the only topology with the bug.
+- **Load bound (envelope):** one `read_namespaced_job` per live topic per tick. At the local
+  ceiling (32 topics) and the derived ~15s tick that is ≈ 2 API reads/s worst case, each a
+  `to_thread` call with the adapter's existing 10s request timeout — bounded and trivial.
+- **Schedule-time hardening (honest about the port contract):** `ports.py` gains one
+  engine-local exception, `RunnerScheduleUnavailable` — `JobRunnerAtCapacity` is NOT reused
+  because its own docstring forbids cluster-backed runners from raising it. `K8sJobRunner
+  ._schedule_blocking` adds one `except ApiException` — `status >= 500 or status == 429` →
+  raise `RunnerScheduleUnavailable` from it; re-raise anything else unchanged. `rest/routes.py
+  ::_schedule` adds the matching `except RunnerScheduleUnavailable` → `503 + Retry-After: 1`
+  ("the runner could not schedule this run — retry later"), mirroring the `JobRunnerAtCapacity`
+  branch. The REST layer gains no kubernetes import; `url4.streaming` gains no new type.
+  (Doc-only: add the already-real 503 to `_START_RESPONSES`.)
+
+### Explicitly not changing
+
+- The wire protocol (`url4.streaming`), terminal-frame semantics, or the App's read-only broker
+  posture — the notice channel is the only voice the App has, by design.
+- The `screamingface` SDK transport — the existing `Log` rendering already surfaces the message.
+  (Client-side TUI rendering of generic warnings beyond the plain `Log` path is a separate
+  client-side nicety, not this unit.)
+- Admission/backpressure policy (OME-908) and the quota/request-size fixes (OME-947 options 1–2).
+- Warn-then-auto-stop of the stalled run (follow-up ticket).
+
+## Acceptance criteria
+
+1. A spine integration test (modeled on `test_orphan_reaper_spine.py`) proves a fake stuck
+   runner yields exactly one `Log` WARN frame on the attached WebSocket with the generic body.
+2. Unit tests of the policy with an injected clock: warn only once the elapsed monotonic time is
+   `>= run_stall_warn_after_s` (boundary pinned at equality); warn at most once per run; no warn
+   while status is `running`/`succeeded`/`failed`/`timed_out` or for `scheduled` younger than the
+   bound; tracking state cleaned up on any non-stuck status; a per-topic `status()` failure is
+   tolerated without warning or forgetting.
+3. `test_app.py` proves the watch is absent when `settings.runner != "k8s"`.
+4. `K8sJobRunner` maps `ApiException` (`status >= 500 or 429`) to the engine-local
+   `RunnerScheduleUnavailable` (defined in `ports.py`), and `rest/routes.py::_schedule` maps it to
+   a generic `503 + Retry-After: 1`; 409 (`JobAlreadyExists`) and permanent 4xx behavior
+   unchanged; the REST layer gains no kubernetes import and `url4.streaming` gains no new type.
+5. Metrics `engine_stuck_runs` returns to zero and `engine_stuck_warned_total` increments once
+   per warned run.
+6. The message body contains no internals (no "quota", "ns-ceiling", namespace or Pod names).
+7. The full `screamingface-engine` gate passes — ruff, pyright, `check_layering.py` (with
+   `run_stall` registered as a control-plane module), and pytest coverage ≥ 80% for
+   `screamingface_engine`.

--- a/docs/tasks/2026-08-22-OME-948-run-stall-capacity-notice.md
+++ b/docs/tasks/2026-08-22-OME-948-run-stall-capacity-notice.md
@@ -1,0 +1,25 @@
+---
+id: OME-948
+linear_url: https://linear.app/openmined/issue/OME-948/surface-a-generic-capacity-warning-when-a-runner-job-cannot-be
+status: in_progress
+type: improvement
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-22
+closed:
+---
+
+# Surface a generic capacity warning when a Runner Job cannot be scheduled
+
+When a Runner Job is accepted but its Pod can never be created (the `sf-fusion` `ns-ceiling`
+quota — OME-947 — or any other scheduling refusal), the run stalls silently for up to 16h with
+no user-visible signal. The Engine detects a Job stuck in `scheduled` past a grace window and
+sends one generic `warn` notice to the run's attached client through the existing notice
+channel, and maps schedule-time Kubernetes API failures from a naked 500 to a generic retryable
+503.
+
+Canonical artifacts:
+
+- Spec: `docs/spec/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- Plan: `docs/plan/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- Ledger: `docs/work/2026-08-22-OME-948-run-stall-capacity-notice.md`

--- a/docs/work/2026-08-22-OME-948-run-stall-capacity-notice.md
+++ b/docs/work/2026-08-22-OME-948-run-stall-capacity-notice.md
@@ -107,7 +107,7 @@ generic and covers any cause of Pod-creation failure.
     canonical suite with the shared fakes)
   - `apps/screamingface-engine/tests/unit/test_app_factory.py` (wiring-gate tests)
   - `apps/screamingface-engine/tests/integration/test_run_stall_spine.py`
-- **Commits:** <sha — message>
+- **Commits:** `dbc11162` — feat(engine): warn attached client when a Runner Job cannot be scheduled
 - **Gates:** ruff clean · format clean · pyright 0 errors · `check_layering.py` OK · pytest
   2006 passed / 5 skipped, coverage 92.14% ≥ 80%
 - **Deviations:** module renamed `runner_stall` → `run_stall` (layering-test prefix collision);

--- a/docs/work/2026-08-22-OME-948-run-stall-capacity-notice.md
+++ b/docs/work/2026-08-22-OME-948-run-stall-capacity-notice.md
@@ -1,0 +1,117 @@
+---
+ticket: OME-948
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-22
+finished:
+---
+
+# OME-948 — Surface a generic capacity warning when a Runner Job cannot be scheduled
+
+## Intent
+
+Make a silently-stalled run visible: when the Engine accepts a run but its Runner Pod can never
+be created (namespace quota — OME-947 — or any scheduling refusal), the attached client gets one
+generic WARN notice through the existing notice channel instead of waiting hours with no
+information. Also map schedule-time Kubernetes API failures from a naked 500 to a generic
+retryable 503. Detection is symptom-based ("Job stuck in `scheduled`"), so the notice stays
+generic and covers any cause of Pod-creation failure.
+
+## Planned changes
+
+- `docs/tasks/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- `docs/spec/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- `docs/plan/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- `docs/work/2026-08-22-OME-948-run-stall-capacity-notice.md`
+- `apps/screamingface-engine/src/screamingface_engine/run_stall.py` (new policy module,
+  `RunReaper`-shaped: two collaborator Protocols, monotonic + datetime clock seams, `sweep()`
+  split from the loop)
+- `apps/screamingface-engine/src/screamingface_engine/ws/registry.py` (`topics()` snapshot view
+  over `_sessions` — the only registry change)
+- `apps/screamingface-engine/src/screamingface_engine/app.py` (`_install_run_stall_watch`,
+  gated on `settings.runner == "k8s"`; startup/shutdown task; metrics registration)
+- `apps/screamingface-engine/src/screamingface_engine/config.py`
+  (`run_stall_warn_after_s: float = 60.0`, env `URL4_CLOUD_RUN_STALL_WARN_AFTER_S`)
+- `apps/screamingface-engine/src/screamingface_engine/ports.py` (`RunnerScheduleUnavailable`
+  — engine-local; `JobRunnerAtCapacity` NOT reused, its docstring forbids cluster runners)
+- `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py` (`_schedule_blocking`:
+  transient `ApiException` (≥500 or 429) → `RunnerScheduleUnavailable`; 409 and permanent 4xx
+  unchanged)
+- `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` (`_schedule`:
+  `except RunnerScheduleUnavailable` → generic 503 + `Retry-After: 1`; `_START_RESPONSES`
+  gains the already-real 503 doc entry)
+- `apps/screamingface-engine/src/screamingface_engine/metrics.py`
+  (`engine_stuck_runs` gauge, `engine_stuck_warned_total` counter, getter-based)
+- `.claude/scripts/check_layering.py` (register `run_stall` in `CONTROL_PLANE` + header list)
+- `apps/screamingface-engine/deploy/helm/values.yaml`,
+  `apps/screamingface-engine/deploy/helm/values.schema.json`,
+  `apps/screamingface-engine/deploy/helm/templates/configmap.yaml`
+  (`config.runStallWarnAfterS` → `URL4_CLOUD_RUN_STALL_WARN_AFTER_S`, the `orphanGraceS`
+  pattern — without these the knob is unsettable in the deployed topology)
+- `apps/screamingface-engine/tests/unit/test_run_stall.py` (policy with fake clock/fakes)
+- `apps/screamingface-engine/tests/unit/test_runners_k8s.py` (the canonical k8s suite: the
+  old `test_schedule_reraises_non_409_api_errors` characterization is updated — 500/429 →
+  `RunnerScheduleUnavailable`, a permanent 4xx still propagates)
+- `apps/screamingface-engine/tests/integration/test_run_stall_spine.py` (WS receives one WARN
+  frame; modeled on `test_orphan_reaper_spine.py`)
+- `apps/screamingface-engine/tests/unit/test_app.py` (watch absent when runner != k8s)
+
+## Test plan
+
+- RED: policy tests written first against fakes fail for lack of `run_stall`; the spine test
+  proves a stuck run yields exactly one WARN `Log` frame on the WS with the generic body.
+- Boundaries: warn only after `run_stall_warn_after_s`; never twice; no warn for
+  `running`/terminal or young `scheduled`; tracking cleaned up on non-stuck status.
+- Error paths: `ApiException` → 503 problem; `JobAlreadyExists` → 409 and
+  `JobRunnerAtCapacity` → 503 unchanged; per-tick sweep failure logged and tolerated.
+- Invariant protected: the notice body carries no internal names (no "quota", namespace, Pod
+  names); watch never wired in local mode; the real registry (not the `interest` DI seam) is
+  the audience source.
+
+## Acceptance
+
+- A stuck run (k8s, `scheduled` past the bound) delivers exactly one generic WARN notice to the
+  attached client.
+- A healthy or terminal run never receives a notice.
+- Schedule-time k8s failures surface as a generic retryable 503, not a 500.
+- `engine_stuck_runs` returns to zero; `engine_stuck_warned_total` counts warned runs.
+- Local mode is unaffected (no watch, no new knobs engaged).
+- Full `screamingface-engine` gate passes (ruff, pyright, `check_layering.py`, pytest ≥ 80%).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** spec/plan/tasks/work as planned, plus:
+  - `apps/screamingface-engine/src/screamingface_engine/run_stall.py` (planned as `runner_stall.py`
+    — renamed: the layering test's run-mode-leak predicate matches `screamingface_engine.runner*`,
+    and `run_stall` also matches the env knob name)
+  - `apps/screamingface-engine/src/screamingface_engine/ws/registry.py` (`topics()` snapshot view)
+  - `apps/screamingface-engine/src/screamingface_engine/ports.py` (`RunnerScheduleUnavailable`)
+  - `apps/screamingface-engine/src/screamingface_engine/app.py` (`_install_run_stall_watch`,
+    `# noqa: PLR0915` on `create_app` — composition root at the statement limit)
+  - `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py` (transient `ApiException`
+    ≥500/429 → `RunnerScheduleUnavailable`)
+  - `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` (`except
+    RunnerScheduleUnavailable` → 503 + Retry-After; `_START_RESPONSES` gains the 503 entry)
+  - `apps/screamingface-engine/src/screamingface_engine/config.py`
+    (`run_stall_warn_after_s: float = 60.0`)
+  - `apps/screamingface-engine/src/screamingface_engine/metrics.py` (`_StallCollector`,
+    `register_stall_metrics`)
+  - `.claude/scripts/check_layering.py` (register `run_stall` in CONTROL_PLANE + header list)
+  - `apps/screamingface-engine/deploy/helm/{values.yaml,values.schema.json,templates/configmap.yaml}`
+    (`config.runStallWarnAfterS`)
+  - `apps/screamingface-engine/tests/unit/test_run_stall.py` (policy; planned as
+    `test_runner_stall.py`, renamed with the module)
+  - `apps/screamingface-engine/tests/unit/test_runners_k8s.py` (the old
+    `test_schedule_reraises_non_409_api_errors` characterization updated to the new contract;
+    the planned separate `test_k8s_schedule_failures.py` was NOT created — its cases live in the
+    canonical suite with the shared fakes)
+  - `apps/screamingface-engine/tests/unit/test_app_factory.py` (wiring-gate tests)
+  - `apps/screamingface-engine/tests/integration/test_run_stall_spine.py`
+- **Commits:** <sha — message>
+- **Gates:** ruff clean · format clean · pyright 0 errors · `check_layering.py` OK · pytest
+  2006 passed / 5 skipped, coverage 92.14% ≥ 80%
+- **Deviations:** module renamed `runner_stall` → `run_stall` (layering-test prefix collision);
+  adapter-translation tests folded into `test_runners_k8s.py` instead of a new file; `create_app`
+  carries a justified `# noqa: PLR0915` (one added installer call crossed the 26-statement
+  limit); schedule-time mapping uses the engine-local `RunnerScheduleUnavailable` (the plan's
+  earlier draft reused `JobRunnerAtCapacity`, whose port docstring forbids cluster runners).


### PR DESCRIPTION
Closes **OME-948** — https://linear.app/openmined/issue/OME-948/surface-a-generic-capacity-warning-when-a-runner-job-cannot-be

## What

Make a silently-stalled run visible. When the Engine accepts a run but its Runner Pod can never be created (namespace at its ResourceQuota — OME-947 — or any scheduling refusal), the Job stays `scheduled` forever and the client waits with no information for up to 16h. This adds:

1. **`RunStallWatcher`** (`run_stall.py`, `RunReaper`-shaped policy + sweep loop in `create_app`, k8s-only by wiring): polls each live topic's `JobStatus` once per derived tick; past `run_stall_warn_after_s` (default 60s) it sends **one generic WARN notice per stall episode** through the existing notice channel (`notices.warn` → `ConnectionRegistry.notify` → WS bridge → `Log` frame → SDK renders "ScreamingFace · <body>"). Message is symptom-generic — "the runner service is at capacity" — no quota/namespace/Pod names. Advisory-only: never stops or reschedules a run.
2. **Schedule-time hardening**: `K8sJobRunner` maps transient `ApiException` (≥500 or 429) to the engine-local `RunnerScheduleUnavailable` (ports.py) → REST renders the same 503 + `Retry-After` a full local runner gets. `JobRunnerAtCapacity` is deliberately not reused (its port contract forbids cluster runners). A permanent 4xx still propagates.
3. Chart-exposed knob `config.runStallWarnAfterS` → `URL4_CLOUD_RUN_STALL_WARN_AFTER_S`; metrics `screamingface_engine_run_stalls_warned` / `_stuck`.

## Fences respected

- App's read-only broker posture: notices are the only App→client voice (unchanged).
- Registry keeps its single `AudienceListener` slot (the reaper's); the watcher polls `topics()` instead of listening.
- No `url4.streaming` changes; REST layer gains no kubernetes import; layering gate updated (`run_stall` registered in CONTROL_PLANE).

## Gates (all green)

ruff clean · format clean · pyright 0 errors · `check_layering.py` OK · pytest 2006 passed / 5 skipped, coverage 92.14% ≥ 80%

Refs: OME-948
