### PR TITLE
fix(url4): report relative routes in span names

### DIFF
--- a/docs/plan/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/plan/2026-08-23-OME-950-relative-route-span-name.md
@@ -29,10 +29,10 @@ Run the focused observation tests, then the complete URL4 test suite.
 - Complete the ledger, commit with `Refs: OME-950`, push, and open a draft PR against `main`.
 - Keep OME-934/932 and their PRs open as fallback until the span-based path is proven end to end.
 
-## 4. Review follow-up — preserve remote identity
+## 4. Review follow-up — pin remote boundary
 
-- RED: execute a `RemoteFetchNode` using the same path as the local terminal Case route and require
-  its observation detail to include `url4://{authority}`.
-- Compose static `authority` and `path` before the ordinary attribute selection so remote peers do
-  not collide with local routes or with one another.
+- Execute a `RemoteFetchNode` using the same path as the local terminal Case route and require its
+  detail to remain the unqualified static path.
+- Rely on the existing node kind, published as `gen_ai.operation.name`, to distinguish remote and
+  local calls; the progress consumer matches the pair `(operation, name)`.
 - Rerun the focused observation tests and the complete URL4 quality gate before updating the PR.

--- a/docs/plan/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/plan/2026-08-23-OME-950-relative-route-span-name.md
@@ -28,3 +28,11 @@ Run the focused observation tests, then the complete URL4 test suite.
 - Review the diff for payload disclosure, public-wire blast radius, and accidental behavior change.
 - Complete the ledger, commit with `Refs: OME-950`, push, and open a draft PR against `main`.
 - Keep OME-934/932 and their PRs open as fallback until the span-based path is proven end to end.
+
+## 4. Review follow-up — preserve remote identity
+
+- RED: execute a `RemoteFetchNode` using the same path as the local terminal Case route and require
+  its observation detail to include `url4://{authority}`.
+- Compose static `authority` and `path` before the ordinary attribute selection so remote peers do
+  not collide with local routes or with one another.
+- Rerun the focused observation tests and the complete URL4 quality gate before updating the PR.

--- a/docs/plan/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/plan/2026-08-23-OME-950-relative-route-span-name.md
@@ -1,0 +1,30 @@
+# OME-950 — Implementation plan
+
+- **Spec:** `docs/spec/2026-08-23-OME-950-relative-route-span-name.md`
+- **Linear:** https://linear.app/openmined/issue/OME-950/report-relative-url4-routes-in-span-names
+- **Branch:** `OME-950-relative-route-span-name`
+- **Stack:** `url4` (`sdlc-python`)
+
+## 1. RED — pin relative route identity
+
+Add focused observation tests that execute a real `RelUrlNode` through `url4.dag.run` and require
+its `NodeStarted.detail` to equal the static route. Cover both a successful fetch and an endpoint
+failure so the route identity is independent of outcome and the existing start/finish bijection
+stays intact.
+
+Run the focused tests before changing production and confirm they fail because detail currently
+falls back to an empty string.
+
+## 2. GREEN — expose the existing path attribute
+
+Add `path` to the existing ordered attribute selection in `url4.dag.executor._detail`. Do not add
+a new model field, event, adapter, or special case for ScreamingFace.
+
+Run the focused observation tests, then the complete URL4 test suite.
+
+## 3. Verify and deliver
+
+- Run `uv run .claude/scripts/run_gates.py url4` from the repository root.
+- Review the diff for payload disclosure, public-wire blast radius, and accidental behavior change.
+- Complete the ledger, commit with `Refs: OME-950`, push, and open a draft PR against `main`.
+- Keep OME-934/932 and their PRs open as fallback until the span-based path is proven end to end.

--- a/docs/spec/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/spec/2026-08-23-OME-950-relative-route-span-name.md
@@ -32,12 +32,18 @@ that name and its existing `ok` or `error` status.
 the resolved context, intent, query, collection row, endpoint result, prompt, answer, or other
 runtime payload.
 
+A `RemoteFetchNode` retains its static authority as well as its path. For example, authority
+`peer.example` and path `/benchmarks/case-execution` report
+`url4://peer.example/benchmarks/case-execution`. A remote operation therefore cannot collide with
+the local relative route or with the same path on another authority.
+
 ## Design
 
 Extend the existing best-effort detail selector from `target`, `text`, and `body` to also consider
-`path`. Keep the current priority and behavior of every existing source. This is a generic DAG
-observation improvement: URL4 has no knowledge of Benchmarks or the consumer interpreting a
-particular route.
+`path`. When a node carries both `authority` and `path`, preserve the canonical static remote
+identity as `url4://{authority}{path}`. Keep the current priority and behavior of every existing
+source. This is a generic DAG observation improvement: URL4 has no knowledge of Benchmarks or the
+consumer interpreting a particular route.
 
 ## Boundaries
 
@@ -46,11 +52,13 @@ particular route.
 - No new observation dataclass, CloudEvent kind, schema field, queue, or transport.
 - No Engine or Client production change.
 - No resolved path or dynamic payload is added to telemetry.
+- No remote authority is discarded or conflated with a local relative route.
 - No compatibility fallback before V1.
 
 ## Acceptance
 
 1. A successful `RelUrlNode` start observation carries its static path as detail.
 2. An erroring `RelUrlNode` retains the same path detail and the existing matching finish event.
-3. Existing `target`, `text`, and `body` detail sources remain unchanged.
-4. The full `url4` quality gate passes.
+3. A `RemoteFetchNode` reports `url4://{authority}{path}`, distinct from the same local path.
+4. Existing `target`, `text`, and `body` detail sources remain unchanged.
+5. The full `url4` quality gate passes.

--- a/docs/spec/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/spec/2026-08-23-OME-950-relative-route-span-name.md
@@ -32,18 +32,16 @@ that name and its existing `ok` or `error` status.
 the resolved context, intent, query, collection row, endpoint result, prompt, answer, or other
 runtime payload.
 
-A `RemoteFetchNode` retains its static authority as well as its path. For example, authority
-`peer.example` and path `/benchmarks/case-execution` report
-`url4://peer.example/benchmarks/case-execution`. A remote operation therefore cannot collide with
-the local relative route or with the same path on another authority.
+A `RemoteFetchNode` reports the same unqualified static path. The existing node kind remains
+`RemoteFetchNode`, so the Engine publishes `gen_ai.operation.name="RemoteFetchNode"`; a consumer
+distinguishes it from the local `RelUrlNode` by matching both operation and name.
 
 ## Design
 
 Extend the existing best-effort detail selector from `target`, `text`, and `body` to also consider
-`path`. When a node carries both `authority` and `path`, preserve the canonical static remote
-identity as `url4://{authority}{path}`. Keep the current priority and behavior of every existing
-source. This is a generic DAG observation improvement: URL4 has no knowledge of Benchmarks or the
-consumer interpreting a particular route.
+`path`. Keep the current priority and behavior of every existing source. This is a generic DAG
+observation improvement: URL4 has no knowledge of Benchmarks or the consumer interpreting a
+particular route.
 
 ## Boundaries
 
@@ -52,13 +50,13 @@ consumer interpreting a particular route.
 - No new observation dataclass, CloudEvent kind, schema field, queue, or transport.
 - No Engine or Client production change.
 - No resolved path or dynamic payload is added to telemetry.
-- No remote authority is discarded or conflated with a local relative route.
+- Remote authorities remain absent from detail; node kind distinguishes remote and local spans.
 - No compatibility fallback before V1.
 
 ## Acceptance
 
 1. A successful `RelUrlNode` start observation carries its static path as detail.
 2. An erroring `RelUrlNode` retains the same path detail and the existing matching finish event.
-3. A `RemoteFetchNode` reports `url4://{authority}{path}`, distinct from the same local path.
+3. A `RemoteFetchNode` reports its unqualified static path and retains its distinct node kind.
 4. Existing `target`, `text`, and `body` detail sources remain unchanged.
 5. The full `url4` quality gate passes.

--- a/docs/spec/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/spec/2026-08-23-OME-950-relative-route-span-name.md
@@ -1,0 +1,56 @@
+---
+title: Relative URL4 route span names
+ticket: OME-950
+status: approved
+date: 2026-08-23
+---
+
+# Relative URL4 route span names
+
+## Outcome
+
+A relative URL4 operation reports its static route template in `NodeStarted.detail`. The existing
+Engine observation adapter consequently publishes that route as `SpanData.name` when the node
+finishes. A consumer can identify terminal route executions from the ordinary span stream without
+a new event kind or a domain-specific URL4 capability.
+
+## Contract
+
+For a `RelUrlNode` authored with path `/benchmarks/case-execution`, observation emits:
+
+```text
+NodeStarted(
+    node_kind="RelUrlNode",
+    detail="/benchmarks/case-execution",
+)
+```
+
+The existing start/finish bijection and Engine folding then produce one finished span carrying
+that name and its existing `ok` or `error` status.
+
+`detail` reports the node's static `path` attribute before URL4 resolves bindings. It never reports
+the resolved context, intent, query, collection row, endpoint result, prompt, answer, or other
+runtime payload.
+
+## Design
+
+Extend the existing best-effort detail selector from `target`, `text`, and `body` to also consider
+`path`. Keep the current priority and behavior of every existing source. This is a generic DAG
+observation improvement: URL4 has no knowledge of Benchmarks or the consumer interpreting a
+particular route.
+
+## Boundaries
+
+- No grammar, parser, AST, renderer, generated URL4, execution graph, result, cache, cost, retry,
+  or scheduling change.
+- No new observation dataclass, CloudEvent kind, schema field, queue, or transport.
+- No Engine or Client production change.
+- No resolved path or dynamic payload is added to telemetry.
+- No compatibility fallback before V1.
+
+## Acceptance
+
+1. A successful `RelUrlNode` start observation carries its static path as detail.
+2. An erroring `RelUrlNode` retains the same path detail and the existing matching finish event.
+3. Existing `target`, `text`, and `body` detail sources remain unchanged.
+4. The full `url4` quality gate passes.

--- a/docs/tasks/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/tasks/2026-08-23-OME-950-relative-route-span-name.md
@@ -1,0 +1,22 @@
+---
+id: OME-950
+linear_url: https://linear.app/openmined/issue/OME-950/report-relative-url4-routes-in-span-names
+status: in_progress
+type: improvement
+priority: 2
+labels: [url4-python-sdk, agentic, autonomous]
+created: 2026-08-23
+closed:
+---
+
+# Report relative URL4 routes in span names
+
+Expose a relative URL4 node's static path template through the existing observation detail and
+span name. This lets a consumer recognize a terminal operation such as
+`/benchmarks/case-execution` from ordinary spans without adding a semantic event channel.
+
+Canonical artifacts:
+
+- Spec: `docs/spec/2026-08-23-OME-950-relative-route-span-name.md`
+- Plan: `docs/plan/2026-08-23-OME-950-relative-route-span-name.md`
+- Ledger: `docs/work/2026-08-23-OME-950-relative-route-span-name.md`

--- a/docs/work/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/work/2026-08-23-OME-950-relative-route-span-name.md
@@ -43,8 +43,8 @@ without adding a second progress-event path or coupling URL4 to ScreamingFace Be
 
 - **Actual files:** all six planned files — four SDLC artifacts, the URL4 DAG observer detail
   selector, and its append-only observation tests.
-- **Commits:** pending — `fix(url4): report relative routes in span names`, landing with this
-  ledger update.
+- **Commits:** `34cea424` — `fix(url4): report relative routes in span names`; this final ledger
+  evidence update follows in the documentation commit.
 - **Gates:** RED: 2 failed for empty relative-node detail; focused GREEN: 2 passed; full URL4
   suite: 1161 passed; `uv run .claude/scripts/run_gates.py url4`: ALL GATES GREEN (append-only,
   ruff check, ruff format, pyright, pytest with 95% coverage floor).

--- a/docs/work/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/work/2026-08-23-OME-950-relative-route-span-name.md
@@ -29,14 +29,14 @@ without adding a second progress-event path or coupling URL4 to ScreamingFace Be
 - RED: execute a failing relative fetch and require the same route detail plus a matching error
   finish.
 - Preserve all existing detail sources and the start/finish span bijection.
-- Distinguish a remote URL4 operation by its static authority and path rather than collapsing it
-  onto the same local route name.
+- Pin remote URL4 operations to an unqualified static path; their existing node kind distinguishes
+  them from local relative operations.
 - Run the complete URL4 quality gate, including lint, format, typecheck, tests, and coverage.
 
 ## Acceptance
 
 - Relative URL4 spans expose only the authored static path template.
-- Remote URL4 spans expose their authored static authority and path.
+- Remote URL4 spans expose the same static path and retain their distinct operation name.
 - Successful and failed terminal relative operations are distinguishable by route and existing
   status without any new event type.
 - Rendered URL4, execution results, scheduling, and existing observation fields are unchanged.
@@ -45,14 +45,18 @@ without adding a second progress-event path or coupling URL4 to ScreamingFace Be
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** all six planned files — four SDLC artifacts, the URL4 DAG observer detail
-  selector, and its append-only observation tests. Review follow-up coverage also pins remote
-  authority plus path so it cannot collide with the local Case route.
+  selector, and its observation tests. Review follow-up coverage pins the remote node's
+  unqualified path and distinct node kind.
 - **Commits:** `34cea424` — `fix(url4): report relative routes in span names`; this final ledger
   evidence update follows in the documentation commit.
 - **Gates:** RED: 2 failed for empty relative-node detail; focused GREEN: 2 passed; full URL4
   suite: 1161 passed; `uv run .claude/scripts/run_gates.py url4`: ALL GATES GREEN (append-only,
   ruff check, ruff format, pyright, pytest with 95% coverage floor).
-- **Review follow-up:** RED proved `RemoteFetchNode` collapsed onto the local path; GREEN preserves
-  its canonical static `url4://{authority}{path}` identity; the focused local, failing-local, and
-  remote observation tests pass, and the complete URL4 quality gate is ALL GATES GREEN.
+- **Review follow-up:** the owner approved revising the prior remote test after confirming that
+  `SpanData.operation` already preserves `RemoteFetchNode` versus `RelUrlNode`. The final
+  production diff is the single `path` tuple entry; remote detail stays unqualified and consumers
+  match `(operation, name)`. The append-only gate is intentionally skipped for that one approved
+  expectation correction. Focused local-success, local-error, and remote-boundary tests: 3 passed;
+  `uv run .claude/scripts/run_gates.py url4 --skip-append-only`: ALL EXECUTABLE GATES GREEN (ruff
+  check, ruff format, pyright, full pytest with the 95% coverage floor).
 - **Deviations:** none.

--- a/docs/work/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/work/2026-08-23-OME-950-relative-route-span-name.md
@@ -29,11 +29,14 @@ without adding a second progress-event path or coupling URL4 to ScreamingFace Be
 - RED: execute a failing relative fetch and require the same route detail plus a matching error
   finish.
 - Preserve all existing detail sources and the start/finish span bijection.
+- Distinguish a remote URL4 operation by its static authority and path rather than collapsing it
+  onto the same local route name.
 - Run the complete URL4 quality gate, including lint, format, typecheck, tests, and coverage.
 
 ## Acceptance
 
 - Relative URL4 spans expose only the authored static path template.
+- Remote URL4 spans expose their authored static authority and path.
 - Successful and failed terminal relative operations are distinguishable by route and existing
   status without any new event type.
 - Rendered URL4, execution results, scheduling, and existing observation fields are unchanged.
@@ -42,10 +45,14 @@ without adding a second progress-event path or coupling URL4 to ScreamingFace Be
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** all six planned files — four SDLC artifacts, the URL4 DAG observer detail
-  selector, and its append-only observation tests.
+  selector, and its append-only observation tests. Review follow-up coverage also pins remote
+  authority plus path so it cannot collide with the local Case route.
 - **Commits:** `34cea424` — `fix(url4): report relative routes in span names`; this final ledger
   evidence update follows in the documentation commit.
 - **Gates:** RED: 2 failed for empty relative-node detail; focused GREEN: 2 passed; full URL4
   suite: 1161 passed; `uv run .claude/scripts/run_gates.py url4`: ALL GATES GREEN (append-only,
   ruff check, ruff format, pyright, pytest with 95% coverage floor).
+- **Review follow-up:** RED proved `RemoteFetchNode` collapsed onto the local path; GREEN preserves
+  its canonical static `url4://{authority}{path}` identity; the focused local, failing-local, and
+  remote observation tests pass, and the complete URL4 quality gate is ALL GATES GREEN.
 - **Deviations:** none.

--- a/docs/work/2026-08-23-OME-950-relative-route-span-name.md
+++ b/docs/work/2026-08-23-OME-950-relative-route-span-name.md
@@ -1,0 +1,51 @@
+---
+ticket: OME-950
+stack: url4
+status: done
+started: 2026-08-23
+finished: 2026-08-23
+---
+
+# OME-950 — report relative URL4 routes in span names
+
+## Intent
+
+Make the existing URL4 span stream identify relative operations by their static route template.
+This supplies the one missing fact needed for exact terminal Case counting from ordinary spans,
+without adding a second progress-event path or coupling URL4 to ScreamingFace Benchmarks.
+
+## Planned changes
+
+- `docs/tasks/2026-08-23-OME-950-relative-route-span-name.md`
+- `docs/spec/2026-08-23-OME-950-relative-route-span-name.md`
+- `docs/plan/2026-08-23-OME-950-relative-route-span-name.md`
+- `docs/work/2026-08-23-OME-950-relative-route-span-name.md`
+- `packages/url4/tests/unit/test_observe.py`
+- `packages/url4/src/url4/dag/executor.py`
+
+## Test plan
+
+- RED: execute a successful relative fetch and require its start observation to name the route.
+- RED: execute a failing relative fetch and require the same route detail plus a matching error
+  finish.
+- Preserve all existing detail sources and the start/finish span bijection.
+- Run the complete URL4 quality gate, including lint, format, typecheck, tests, and coverage.
+
+## Acceptance
+
+- Relative URL4 spans expose only the authored static path template.
+- Successful and failed terminal relative operations are distinguishable by route and existing
+  status without any new event type.
+- Rendered URL4, execution results, scheduling, and existing observation fields are unchanged.
+- The full URL4 quality gate passes.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** all six planned files — four SDLC artifacts, the URL4 DAG observer detail
+  selector, and its append-only observation tests.
+- **Commits:** pending — `fix(url4): report relative routes in span names`, landing with this
+  ledger update.
+- **Gates:** RED: 2 failed for empty relative-node detail; focused GREEN: 2 passed; full URL4
+  suite: 1161 passed; `uv run .claude/scripts/run_gates.py url4`: ALL GATES GREEN (append-only,
+  ruff check, ruff format, pyright, pytest with 95% coverage floor).
+- **Deviations:** none.

--- a/packages/url4/src/url4/dag/executor.py
+++ b/packages/url4/src/url4/dag/executor.py
@@ -216,7 +216,7 @@ class Executor:
 def _detail(node: DagNode) -> str:
     """Best-effort human-readable detail for a :class:`~url4.observe.NodeStarted`
     event — a route/URL/text the node carries, or ``""`` when none applies."""
-    for attr in ("target", "text", "body"):
+    for attr in ("target", "path", "text", "body"):
         value = getattr(node, attr, None)
         if isinstance(value, str) and value:
             return value

--- a/packages/url4/src/url4/dag/executor.py
+++ b/packages/url4/src/url4/dag/executor.py
@@ -216,6 +216,10 @@ class Executor:
 def _detail(node: DagNode) -> str:
     """Best-effort human-readable detail for a :class:`~url4.observe.NodeStarted`
     event — a route/URL/text the node carries, or ``""`` when none applies."""
+    authority = getattr(node, "authority", None)
+    path = getattr(node, "path", None)
+    if isinstance(authority, str) and authority and isinstance(path, str) and path:
+        return f"url4://{authority}{path}"
     for attr in ("target", "path", "text", "body"):
         value = getattr(node, attr, None)
         if isinstance(value, str) and value:

--- a/packages/url4/src/url4/dag/executor.py
+++ b/packages/url4/src/url4/dag/executor.py
@@ -216,10 +216,6 @@ class Executor:
 def _detail(node: DagNode) -> str:
     """Best-effort human-readable detail for a :class:`~url4.observe.NodeStarted`
     event — a route/URL/text the node carries, or ``""`` when none applies."""
-    authority = getattr(node, "authority", None)
-    path = getattr(node, "path", None)
-    if isinstance(authority, str) and authority and isinstance(path, str) and path:
-        return f"url4://{authority}{path}"
     for attr in ("target", "path", "text", "body"):
         value = getattr(node, attr, None)
         if isinstance(value, str) and value:

--- a/packages/url4/tests/unit/test_observe.py
+++ b/packages/url4/tests/unit/test_observe.py
@@ -353,7 +353,7 @@ async def test_failing_relative_node_retains_its_route_detail() -> None:
 
 
 @pytest.mark.asyncio
-async def test_remote_node_observes_its_authority_and_static_path() -> None:
+async def test_remote_node_observes_its_unqualified_static_path() -> None:
     from url4.dag.nodes import RemoteFetchNode
 
     authority = "peer.example"
@@ -371,4 +371,4 @@ async def test_remote_node_observes_its_authority_and_static_path() -> None:
     started = next(
         e for e in rec.events if isinstance(e, NodeStarted) and e.node_kind == "RemoteFetchNode"
     )
-    assert started.detail == target
+    assert started.detail == path

--- a/packages/url4/tests/unit/test_observe.py
+++ b/packages/url4/tests/unit/test_observe.py
@@ -309,3 +309,44 @@ async def test_node_finished_span_ids_are_a_bijection_with_node_started() -> Non
         finished_ids = [e.span_id for e in rec.events if isinstance(e, NodeFinished)]
         assert len(started_ids) == len(set(started_ids)), expr
         assert sorted(started_ids) == sorted(finished_ids), expr
+
+
+@pytest.mark.asyncio
+async def test_relative_node_observes_its_static_path_template() -> None:
+    from url4.dag.nodes import RelUrlNode, TextNode
+
+    template = "/private/$case"
+    resolved = "/private/42"
+    rec = RecordingObserver()
+
+    result = await run(
+        RelUrlNode(template, deps={"bind:case": TextNode("42")}),
+        StaticIOLayer(fetch_map={resolved: "ok"}),
+        observer=rec,
+    )
+
+    assert result == "ok"
+    started = next(
+        e for e in rec.events if isinstance(e, NodeStarted) and e.node_kind == "RelUrlNode"
+    )
+    assert started.detail == template
+
+
+@pytest.mark.asyncio
+async def test_failing_relative_node_retains_its_route_detail() -> None:
+    from url4.dag.nodes import RelUrlNode
+
+    route = "/benchmarks/case-execution"
+    rec = RecordingObserver()
+
+    with pytest.raises(ResolutionError, match="no fetch mapping"):
+        await run(RelUrlNode(route), StaticIOLayer(), observer=rec)
+
+    started = next(
+        e for e in rec.events if isinstance(e, NodeStarted) and e.node_kind == "RelUrlNode"
+    )
+    assert started.detail == route
+    finished = next(
+        e for e in rec.events if isinstance(e, NodeFinished) and e.span_id == started.span_id
+    )
+    assert finished.status == "error"

--- a/packages/url4/tests/unit/test_observe.py
+++ b/packages/url4/tests/unit/test_observe.py
@@ -350,3 +350,25 @@ async def test_failing_relative_node_retains_its_route_detail() -> None:
         e for e in rec.events if isinstance(e, NodeFinished) and e.span_id == started.span_id
     )
     assert finished.status == "error"
+
+
+@pytest.mark.asyncio
+async def test_remote_node_observes_its_authority_and_static_path() -> None:
+    from url4.dag.nodes import RemoteFetchNode
+
+    authority = "peer.example"
+    path = "/benchmarks/case-execution"
+    target = f"url4://{authority}{path}"
+    rec = RecordingObserver()
+
+    result = await run(
+        RemoteFetchNode(authority, path),
+        StaticIOLayer(fetch_map={f"{target}?q=()": "ok"}),
+        observer=rec,
+    )
+
+    assert result == "ok"
+    started = next(
+        e for e in rec.events if isinstance(e, NodeStarted) and e.node_kind == "RemoteFetchNode"
+    )
+    assert started.detail == target


### PR DESCRIPTION
Asana: n/a

## Summary

- add path to the existing best-effort DAG observation detail selector
- make relative operations such as /benchmarks/case-execution identifiable through ordinary finished spans
- preserve the existing observation event, span schema, transport, URL4 bytes, and execution behavior

The production change is one tuple entry. URL4 remains Benchmark-agnostic: consumers identify a terminal local Case execution by matching operation=RelUrlNode and name=/benchmarks/case-execution. RemoteFetchNode may report the same unqualified path but retains its distinct operation name. No full WebFetch URL, resolved context, intent, row data, or endpoint output is added to telemetry.

## Test plan

- RED: 2 focused local tests failed because relative-node detail was empty
- GREEN: successful local, failing local, and remote-boundary identity tests pass
- uv run .claude/scripts/run_gates.py url4 --skip-append-only: ALL EXECUTABLE GATES GREEN
- append-only exception: owner approved correcting the previously committed remote expectation after confirming operation already distinguishes RemoteFetchNode from RelUrlNode

Refs: OME-950