### PR TITLE
feat(screamingface): show live candidate progress

### DIFF
--- a/docs/plan/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/plan/2026-08-23-OME-933-live-evaluation-progress.md
@@ -95,7 +95,8 @@ In `_ui/evaluation_view.py`:
   current/maximum values on the progressbar for accessibility while the table owns visible exact
   Case counts
 - replace the three-cell aggregate usage strip with one evidence-only live receipt ordered as
-  cost, model calls, then tokens in/out; reserve its one-line height before evidence exists
+  cost, model calls, then tokens in/out; omit it before evidence exists so the empty state stays
+  compact
 - render `model calls · fully cached · no tokens billed` only when per-Candidate cache outcomes
   account for every observed model call as a hit and usage/cost evidence does not contradict it;
   suppress zero cost/token telemetry from that receipt while retaining `$0.00` in the table

--- a/docs/plan/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/plan/2026-08-23-OME-933-live-evaluation-progress.md
@@ -1,0 +1,119 @@
+# OME-933 — Live Evaluation progress (implementation plan)
+
+- **Spec:** `docs/spec/2026-08-23-OME-933-live-evaluation-progress.md`
+- **Linear:** https://linear.app/openmined/issue/OME-933/redesign-live-evaluation-progress
+- **Stack:** `screamingface` (`sdlc-python`)
+- **Dependency:** `OME-950`
+
+Implementation starts only after explicit approval of the spec and this plan.
+
+## 1. RED — pin Candidate-scoped state and exact terminal Case counting
+
+Add state tests before production changes for:
+
+- all Candidate rows existing in input order before an Event arrives
+- independent `completed / case_count` for interleaved Candidate Runs
+- the exact `operation == "RelUrlNode"` and `name == "/benchmarks/case-execution"` match
+- successful and error terminal Case spans both counting
+- RemoteFetchNode, model, and unrelated structural spans not counting
+- a 10 Candidate × 100 Case fold reaching 100 independently per row
+- early termination freezing the observed numerator below the denominator
+- per-Candidate usage, cache provenance, model activity, elapsed time, and terminal evidence
+- final CandidateResult reconciliation for score, usage, and Finished qualifiers
+
+Run the focused tests and record RED failures caused by the current aggregate Candidate counter and
+unscoped observer.
+
+The existing progress-panel suite contains assertions for the aggregate panel OME-933 intentionally
+replaces. Revise only those superseded presentation/state assertions; retain unaffected cache,
+Event, escaping, formatter, paid-disclosure, and fail-open coverage. This is the approved contract
+replacement, not a legacy compatibility layer. Add every new invariant append-only.
+
+## 2. GREEN — bind each Run observer to its Candidate
+
+In `_evaluation/runner.py` and `_evaluation/progress.py`:
+
+- define a private built-in Evaluation observer port that accepts `(Candidate, Event)` and has
+  terminal reconciliation/abort methods
+- let the sync and async combined observers bind a small Candidate-scoped callback for each
+  `transport.run`
+- keep one shared lock per Evaluation so interleaved callbacks remain serialized
+- continue passing the original Event alone to the public callback exactly once
+- keep the text observer behavior unchanged while ignoring its bound Candidate context
+- reconcile the built-in observer only after `report_from_outcomes` returns a valid Report
+- on workflow failure, freeze the built-in observer without emitting a synthetic public Event
+
+Cover both the single-Candidate fast path and the multi-Candidate sync/async paths. Pin the existing
+eight-Run concurrency gate and queued Candidates that never start.
+
+## 3. GREEN — replace the aggregate fold with ordered Candidate rows
+
+In `_ui/evaluation_state.py`:
+
+- introduce one Evaluation fold owning ordered per-Candidate row state plus aggregate evidence
+- bind root Started/Terminated evidence to its already-known Candidate rather than matching URLs or
+  models
+- count the exact terminal Case span before filtering structural spans from model-call statistics
+- preserve Run-keyed cache-summary replacement and bypass-reason reconciliation
+- preserve self-scoped Usage accounting without subtree double-counting
+- derive only the approved lifecycle statuses and final qualifiers
+- keep bounded real activity evidence; add no inferred phase or Case identity
+- reconcile final fields from the matching CandidateResult by Candidate identity and validate that
+  every expected Candidate appears once
+
+The fold remains independent of ipywidgets and wall-clock reads so its transitions are deterministic
+and directly testable.
+
+## 4. GREEN — build the SFDS v2 Candidate table and render scheduler
+
+In `_ui/evaluation_view.py`:
+
+- replace the aggregate progress bar with the six-column semantic Candidate table
+- add the sticky header/Candidate column and an internal horizontal-scroll shell; do not add a
+  responsive card/stack alternative
+- show truthful unavailable/final wording and a progress element for each known denominator
+- preserve the paid-check disclosure, aggregate calls/tokens/cost, cache-provenance band, collapsed
+  activity, and conditional global error in the specified order
+- replace whole-panel `aria-live` with a dedicated limited announcement region
+- apply SFDS v2 app-register typography, square/hairline geometry, readable text roles, solid blue
+  activity, semantic status colors, light/dark parity, and reduced-motion behavior
+- remove the old gradient/sweep and small-screen stacked-stat treatment
+- fold Events immediately, coalesce dirty renders around 100 ms, retain the one-second silent clock,
+  and force a final visible render before stopping the scheduler
+
+Render tests must assert structure and semantics rather than brittle full HTML snapshots.
+
+## 5. Regression and contract verification
+
+Add integration tests around the runner and built-in observer for:
+
+- sync and async Candidate scoping under concurrent interleaving
+- public callbacks receiving the same Events once and in their existing accepted order
+- successful Report reconciliation occurring after result decoding
+- invalid result decoding freezing a truthful failed panel while preserving the raised public error
+- user interruption, timeout, Engine terminal failure, and never-started Candidate handling
+- renderer/comm exceptions remaining outside the paid Evaluation failure boundary
+- progress disabled and non-notebook text fallback behavior remaining unchanged
+
+Run the focused progress and Evaluation suites throughout.
+
+## 6. Full gate and delivery
+
+From the repository root run:
+
+```text
+python3 .claude/scripts/run_gates.py screamingface
+```
+
+This covers Ruff, formatting, Pyright, at least 95% package coverage, deterministic notebook checks,
+the package build, and distribution verification.
+
+Then:
+
+- inspect the final diff against the approved spec and the SFDS v2 skill
+- complete the work ledger with exact tests, deviations, and visual owner verification
+- commit with a conventional message and `Refs: OME-933`
+- push the branch and open a draft PR
+- after `OME-950` lands, rebase the branch onto `origin/main` before requesting merge review
+
+Temporary ancestry is a branch-management detail and does not alter the Linear product contract.

--- a/docs/plan/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/plan/2026-08-23-OME-933-live-evaluation-progress.md
@@ -42,6 +42,8 @@ In `_evaluation/runner.py` and `_evaluation/progress.py`:
 - keep the text observer behavior unchanged while ignoring its bound Candidate context
 - reconcile the built-in observer only after `report_from_outcomes` returns a valid Report
 - on workflow failure, freeze the built-in observer without emitting a synthetic public Event
+- mark a Candidate submitted immediately before `transport.run`; derive `Not run` only from that
+  runner-owned fact, never from a missing root Event
 
 Cover both the single-Candidate fast path and the multi-Candidate sync/async paths. Pin the existing
 eight-Run concurrency gate and queued Candidates that never start.
@@ -60,6 +62,7 @@ In `_ui/evaluation_state.py`:
 - keep bounded real activity evidence; add no inferred phase or Case identity
 - reconcile final fields from the matching CandidateResult by Candidate identity and validate that
   every expected Candidate appears once
+- reconcile completed Cases from final CaseResults and preserve live cost when final usage omits it
 
 The fold remains independent of ipywidgets and wall-clock reads so its transitions are deterministic
 and directly testable.
@@ -69,15 +72,46 @@ and directly testable.
 In `_ui/evaluation_view.py`:
 
 - replace the aggregate progress bar with the six-column semantic Candidate table
-- add the sticky header/Candidate column and an internal horizontal-scroll shell; do not add a
-  responsive card/stack alternative
-- show truthful unavailable/final wording and a progress element for each known denominator
-- preserve the paid-check disclosure, aggregate calls/tokens/cost, cache-provenance band, collapsed
-  activity, and conditional global error in the specified order
+- keep the sticky header and use a compact fixed-layout width allocation that fits the notebook
+  without an internal horizontal scrollbar or responsive card/stack alternative
+- remove widget-level horizontal padding so the whole surface aligns with the notebook output edge
+- show only each Candidate's authored display name; omit the redundant full model route
+- keep Status to one line with lifecycle, qualifier, and Running elapsed time; truncate fractional
+  seconds, retain integral seconds below an hour, and show only hours/minutes from one hour onward
+- replace vague `Partial` with the exact `graded/selected graded` count guaranteed by Candidate
+  coverage, and retain final duration from authoritative Candidate Result timestamps
+- use the benchmark name as the stable title; remove the dynamic Evaluation headline and aggregate
+  row-state subtitle
+- use the canonical static square signal with the blue app accent for genuinely Running rows; add
+  no widget-specific animation
+- render one canonical SFDS fusion-gradient overall track from summed completed/planned
+  Candidate-Case runs, including its anchored gradient and `.11s linear` width transition
+- place the compact `state · percent` mono text at the right edge of the benchmark-title row,
+  using `evaluating…`, `complete`, `stopped`, `timed out`, or `failed`; keep the state without a
+  percentage when the denominator is unknown and impose no fixed maximum
+- hide the progress track and redundant 100% after successful reconciliation, replace the state
+  with `complete · duration` using authoritative Candidate Result timestamps, and retain the
+  track for stopped/failed partial work when its denominator is known; keep exact aggregate
+  current/maximum values on the progressbar for accessibility while the table owns visible exact
+  Case counts
+- replace the three-cell aggregate usage strip with one evidence-only live receipt ordered as
+  cost, model calls, then tokens in/out; reserve its one-line height before evidence exists
+- render `model calls · fully cached · no tokens billed` only when per-Candidate cache outcomes
+  account for every observed model call as a hit and usage/cost evidence does not contradict it;
+  suppress zero cost/token telemetry from that receipt while retaining `$0.00` in the table
+- show truthful exact Case text for each known denominator without a redundant progress bar
+- right-align Cases, Score, Cost, and Cache hit using the canonical SFDS numeric-column treatment
+- preserve the paid-check disclosure, aggregate accounting state, per-Candidate cache evidence, and
+  conditional global error; omit aggregate cache and Run activity sections
+- distinguish all-bypass cache evidence as `Bypassed` from genuinely absent outcomes as
+  `Not reported`; compute percentages only over hit/miss traffic
 - replace whole-panel `aria-live` with a dedicated limited announcement region
 - apply SFDS v2 app-register typography, square/hairline geometry, readable text roles, solid blue
   activity, semantic status colors, light/dark parity, and reduced-motion behavior
-- remove the old gradient/sweep and small-screen stacked-stat treatment
+- pin the generated tokens and canonical table recipe from `OpenMined/screamingface-brand`
+  commit `7ea35a12608776ba3f811811578cec9fd5193b4f`; update the shared notebook token bridge
+  centrally where its older palette has drifted
+- remove the old inferred phase/sweep treatment and small-screen stacked-stat treatment
 - fold Events immediately, coalesce dirty renders around 100 ms, retain the one-second silent clock,
   and force a final visible render before stopping the scheduler
 

--- a/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
@@ -65,8 +65,10 @@ No other structural span counts. In particular, a `RemoteFetchNode` with the sam
 path does not count because its operation differs. Model spans cannot stand in for Cases because
 one Case may make zero, one, or many model calls.
 
-If a Run terminates before every terminal Case span is observed, its row preserves the honest
-observed count. The Client does not fabricate the missing completions from the final result.
+While a Run is live, the row preserves only the terminal Case spans actually observed. Once a
+valid final CandidateResult decodes, its complete CaseResults reconcile the terminal display to
+the authoritative selected count. This also clamps opaque URL4 replay if its previously unknown
+denominator is smaller than the observed stream count.
 
 ## State model
 
@@ -87,13 +89,14 @@ the returned body is decoded. On successful reconciliation, `Finished` may carry
 result qualifier using the existing Report contract, in this precedence:
 
 1. `Incomplete` when `score is None`.
-2. `Partial` when `coverage < 1.0`.
+2. Exact numeric grade coverage such as `1/2 graded` when `coverage < 1.0`.
 3. `Warnings` when Candidate failures exist.
 4. No qualifier for a clean result.
 
 An actual terminal Event takes precedence over an inferred workflow outcome. Without one, only an
 explicit user interruption maps to `Stopped` and only an explicit timeout maps to `Timed out`;
-other failures map to `Run failed`. A Candidate with no root start maps to `Not run`.
+other failures map to `Run failed`. `Not run` requires runner-owned evidence that
+`transport.run` was never entered; absence of a root `Started` Event is not treated as proof.
 
 ## Row evidence
 
@@ -101,25 +104,33 @@ The fixed column order is:
 
 1. Candidate
 2. Status
-3. Progress
+3. Cases
 4. Score
 5. Cost
-6. Cache
+6. Cache hit
 
-Before reconciliation, Score reads `Not scored yet`. After reconciliation it shows the decoded
-benchmark-native score, or `Not scored` when the final score is `None`; the Client never computes
-or estimates a score.
+While a row is Queued or Running, Score reads `Not scored yet`. A terminal row without a decoded
+CandidateResult reads `Not scored`, because no score is still pending. After reconciliation it
+shows the decoded benchmark-native score, or `Not scored` when the final score is `None`; the
+Client never computes or estimates a score.
 
 Cost sums accepted self-scoped Usage Events for that Candidate Run and reads `Not reported` until
 evidence exists. Final CandidateResult usage reconciles it after decoding.
 
-Cache uses that Candidate Run's accepted Span provenance and authoritative cache-summary Log:
-`hits / (hits + misses)`, with bypasses excluded from the rate. It reads `Not reported` until
-evidence exists. The existing aggregate cache-provenance band remains below the Evaluation totals.
+Cache hit shows only that Candidate Run's percentage from accepted Span provenance and the
+authoritative cache-summary Log: `hits / (hits + misses)`, with bypasses excluded from the rate.
+It reads `Bypassed` when cache outcomes were reported but every call bypassed, and `Not reported`
+only when no cache outcome evidence exists. Detailed hit/miss/bypass evidence remains available
+through Events and the final Report, not as a second aggregate band in the live widget.
 
-The Status cell may show concise secondary activity from real Events, such as a completed, failed,
-or refused model call and elapsed time. It does not label activity `Answering` or `Grading`, infer a
-current Case, invent typing dots, or animate fake work.
+The Status cell stays on one compact line: primary lifecycle state, optional final qualifier, and
+elapsed time while Running. The live widget does not add a second Run activity section or duplicate
+terminal wording such as `Stopped` plus `Run stopped`. It does not label activity `Answering` or
+`Grading`, infer a current Case, invent typing dots, or animate fake work.
+Elapsed time truncates fractional seconds: seconds are integral, minute durations retain integral
+seconds, and hour durations drop seconds (`42s`, `1m 30s`, `1hr 30min`, `2hrs 45min`).
+Running rows use the monotonic live clock; successfully reconciled rows retain the authoritative
+duration from `CandidateResult.started_at` to `completed_at` instead of dropping elapsed time.
 
 ## Rendering lifecycle
 
@@ -127,42 +138,92 @@ Event folding is immediate and thread-safe. Rendering is coalesced behind a dirt
 burst of Events produces at most roughly one notebook update per 100 ms. During a silent in-flight
 model call, a one-second clock wake refreshes elapsed time so the panel still feels alive.
 
+The benchmark name is the stable heading throughout the run. The panel does not replace it with a
+large dynamic `Evaluating`, `Evaluation complete`, or `Evaluation ended` title, and it does not
+repeat aggregate row-state counts beneath it. Candidate rows already own their exact lifecycle and
+Running elapsed time. Their square status signal uses the static blue app accent for `Running`,
+matching the canonical SFDS status recipe without adding a widget-specific motion pattern.
+
 Final reconciliation or abort forces one synchronous terminal render, stops the clock, and leaves
-the frozen panel visible. A renderer or notebook-comm failure remains decorative and cannot abort
-paid Engine work.
+the frozen panel visible. A compact right-aligned state on the benchmark-title row changes from
+`evaluating… · 72%` to `complete · 1m 10s`, `stopped`, `timed out`, or `failed` using the same
+truthful terminal evidence as the Candidate rows. Successful completion hides the now-redundant
+100% progress track; interrupted or failed partial work retains the track when its denominator is
+known. A renderer or notebook-comm failure remains decorative and cannot abort paid Engine work.
 
 ## Layout and SFDS v2
 
-Below the heading, content appears in this order:
+Content appears in this order:
 
-1. Paid-check disclosure, when applicable.
-2. Candidate table.
-3. Aggregate model calls, tokens, and cost.
-4. Existing aggregate cache-provenance band.
-5. Collapsed Run activity.
+1. Benchmark title with compact overall state right-aligned on the same row.
+2. Paid-check disclosure, when applicable.
+3. Overall Candidate-Case progress, only while the Evaluation is not successfully complete and
+   every Candidate denominator is known.
+4. Compact live receipt, with its height reserved before evidence exists.
+5. Candidate table.
 6. Global error, only when present.
 
-The table is semantic HTML inside its own horizontal-scroll container. It keeps a sticky header and
-sticky Candidate column, a minimum width sufficient for all six columns, and no alternate stacked
-layout. Candidate order never changes; there is no live rank, winner, or comparison treatment.
+Overall progress is `sum(completed Candidate Cases) / sum(planned Candidate Cases)`. It has no
+fixed cap: ten Candidates over 100 Cases is 1,000 Case runs, while twenty Candidates over 2,450
+Cases is 49,000. The UI reuses the canonical SFDS run-progress treatment: an 8px
+gold-to-white-to-blue fusion-gradient fill whose leading edge remains blue, with the branded
+`.11s linear` width transition. The title row's compact mono state reads
+`evaluating… · 72%`. Exact per-Candidate Case counts remain in the table, while the progressbar's
+accessible current and maximum values retain the aggregate count without duplicating it visually.
+The fill may interpolate visually between exact endpoints, but the percentage changes only when
+Case evidence changes. If any denominator is unknown, the bar is omitted rather than estimated,
+while the truthful state remains visible without a percentage. On successful reconciliation, the
+bar and redundant 100% disappear and the state reports `complete` with the authoritative total
+duration from the earliest Candidate start to the latest Candidate completion.
+
+The receipt is one muted mono line beneath the optional progress track, ordered by user value:
+`cost $0.76 · 68 model calls · 202.9k in / 30.2k out`. It exposes only fields with evidence and is
+visually empty before any exists, while reserving its one-line height so the Candidate table does
+not jump when usage first arrives. It replaces the large three-cell aggregate strip without
+changing the underlying live accounting.
+
+After the authoritative Report reconciles, when exact evidence proves every observed model call
+was a hit, with no miss, bypass, unaccounted call, non-zero cost, or non-zero token usage, the
+receipt switches to the success narrative
+`275 model calls · fully cached · no tokens billed`. It suppresses the misleading wall of
+`cost $0.00 · ... · 0 in / 0 out`; the per-Candidate Cost cell still retains `$0.00`.
+
+The semantic table fits all six columns within the available notebook width and does not introduce
+its own horizontal scrollbar. Candidate cells show only the authored display name; the full model
+route is redundant with the Recipe and Report surfaces and consumes the width needed by progress.
+The header remains sticky, long truthful values may wrap, and there is no alternate stacked layout.
+Candidate order never changes; there is no live rank, winner, or comparison treatment.
+The fixed allocation prioritizes Candidate identity, then gives Cost and Cache hit enough room for
+`Not reported`; Cases stays compact because its `x / N` values are short.
+Cases, Score, Cost, and Cache hit use the canonical right-aligned SFDS numeric-column treatment.
+The widget adds no horizontal shell padding because the notebook output cell already owns that
+inset; title, progress, receipt, and table share one output-aligned left edge.
 
 This is the SFDS v2 app register: IBM Plex Sans for prose and status, IBM Plex Mono for figures and
 labels, square geometry, hairline rules, tabular numerals, blue informational activity, semantic
 status colors, readable primary/secondary text roles, and equal light/dark behavior. There is no
-gold, gradient, shadow, rounded card, fake avatar, or decorative low-contrast ink used as text.
+gold or gradient outside the canonical fusion-progress treatment, and no shadow, rounded card,
+fake avatar, or decorative low-contrast ink used as text.
 
-Motion is functional and restrained. Progress fills may transition when motion is allowed; under
-`prefers-reduced-motion: reduce` they update without transition. There is no looping animation.
+The visual source of truth is the generated token sheet and table recipe from
+`OpenMined/screamingface-brand` commit `7ea35a12608776ba3f811811578cec9fd5193b4f`
+(2026-08-18). The shared notebook token bridge uses that revision's app-theme light/dark aliases;
+the table uses its 13px mono body, 11px medium label, 0.1em label tracking, 12×16px wrapped-cell
+spacing, stronger header separator, and 8px status rhythm.
+
+There is no invented phase animation. The overall track uses the canonical SFDS fusion-gradient
+and width transition; exact `completed / total` Case text avoids redundant per-row bars and keeps
+ten-Candidate tables calm and compact.
 
 ## Accessibility
 
 - Use a real `<table>` with a descriptive caption and scoped column headers.
-- Keep the table keyboard-scrollable without turning cells into fake controls.
+- Keep the table and its cells native rather than adding fake controls.
 - Do not place `aria-live` on the changing table or whole panel.
 - Use one separate polite announcement region for Evaluation start, Candidate terminal states, and
   whole-Evaluation completion only.
 - Status cannot rely on color alone: every square indicator has visible text.
-- Progress exposes an accessible name and numeric current/max values.
+- Case progress is exposed as ordinary readable `completed / total` text.
 - Focus is never moved when a Candidate changes state.
 
 ## Compatibility and boundaries
@@ -170,7 +231,8 @@ Motion is functional and restrained. Progress fills may transition when motion i
 - Existing Report and CandidateResult values are unchanged.
 - Existing public Event values, order, replay behavior, and `on_event` callback are unchanged.
 - Existing text progress remains the non-notebook fallback.
-- Existing paid-check disclosure and aggregate cache-provenance behavior remain present.
+- Existing paid-check disclosure and cache-provenance collection remain present; only the
+  redundant aggregate cache/activity rendering is removed from this widget.
 - No Benchmark, screamingface-engine, AIGateway, Scoreboard, or additional URL4 change.
 - No URL4 parsing in the Client.
 - No provisional score, exact live failed/refused Case counter, current Case identity, phase
@@ -187,11 +249,20 @@ Motion is functional and restrained. Progress fills may transition when motion i
 6. Score remains unavailable until CandidateResult decoding and then matches it verbatim.
 7. Queued, Running, Finished, Run failed, Stopped, Timed out, and Not run are covered for sync and
    async Evaluations, including the existing eight-Run concurrency gate.
-8. Cost, cache, aggregate totals, paid-check disclosure, and cache-provenance reconciliation retain
-   their existing evidence rules.
+8. Cost, per-Candidate cache hit, aggregate totals, paid-check disclosure, and cache-provenance
+   reconciliation retain their existing evidence rules; aggregate usage renders as one compact
+   evidence-only receipt and aggregate cache/activity sections are absent.
 9. Public `on_event` receives the same accepted Events once, with no synthetic additions.
-10. Rendering is coalesced, the silent clock advances, one terminal render is forced, and the
-    frozen panel remains visible.
-11. The table horizontally scrolls, preserves keyboard access, uses limited announcements, honors
-    reduced motion, and renders correctly in light and dark themes.
-12. Full `py-screamingface` gates, notebook checks, build, and distribution checks pass.
+10. Rendering is coalesced, the stable benchmark heading and compact progress state remain
+    truthful, the silent clock advances, one terminal render is forced, and the frozen panel
+    remains visible.
+11. The six-column table fits without its own horizontal scroll, hides redundant model routes and
+    progress bars, uses limited announcements, and renders correctly in light and dark.
+12. One overall bar reports exact completed/planned Candidate-Case runs without a fixed cap or
+    invented denominator, using the canonical SFDS gradient, transition, and compact
+    `state · percent` line; accessible values retain the exact aggregate count.
+13. Full `py-screamingface` gates, notebook checks, build, and distribution checks pass.
+14. Shared notebook light/dark tokens and Evaluation table styling match the pinned current
+    `screamingface-brand` revision rather than the older vendored palette snapshot.
+15. A provably fully cached run is described as a success without zero-token telemetry, while any
+    missing, bypassed, missed, or contradictory evidence keeps the ordinary receipt.

--- a/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
@@ -3,7 +3,7 @@
 - **Linear:** https://linear.app/openmined/issue/OME-933/redesign-live-evaluation-progress
 - **Landing:** `packages/screamingface`
 - **Dependency:** `OME-950` supplies relative URL4 route names in ordinary terminal spans
-- **Status:** awaiting implementation approval
+- **Status:** approved 2026-08-23
 
 ## Outcome
 
@@ -18,7 +18,9 @@ schema, Benchmark hook, Engine adapter, URL4 expression, or Client-side scoring 
 
 - One Candidate is one independently submitted Engine Run.
 - Candidate Runs can overlap and their Events can interleave.
-- The Client knows the ordered Candidates and selected Case count before execution starts.
+- The Client knows the ordered Candidates before execution starts. Ordinary Benchmark evaluation
+  also knows the selected Case count; opaque `sf.evaluate(url4)` replay learns it only from the
+  final decoded Report.
 - The transport accepts one Event observer for each Run.
 - The transport's existing Run state validates sequence continuity and suppresses replayed Events
   before invoking that observer.
@@ -50,9 +52,14 @@ event.name == "/benchmarks/case-execution"
 Both `status="ok"` and `status="error"` count because both mean that Case-execution node reached a
 terminal outcome. Failure is evidence about that completion, not a reason to hide the completion.
 
-Each row's denominator is the selected `evaluation.case_count`. `42 / 100` means 42 terminal
-Cases have been observed for that Candidate; it is not Case ID 42 and does not claim which Case is
-currently executing. The display never exceeds its known total.
+For ordinary Benchmark evaluation, each row's denominator is the selected
+`evaluation.case_count`. `42 / 100` means 42 terminal Cases have been observed for that Candidate;
+it is not Case ID 42 and does not claim which Case is currently executing. The display never
+exceeds its known total.
+
+Opaque `sf.evaluate(url4)` replay has no separate selected-count input. It shows the exact observed
+numerator as `42 cases finished` while running, then learns the denominator from the authoritative
+Report. The Client does not parse URL4 to invent execution context.
 
 No other structural span counts. In particular, a `RemoteFetchNode` with the same unqualified
 path does not count because its operation differs. Model spans cannot stand in for Cases because

--- a/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
@@ -1,0 +1,190 @@
+# OME-933 — Live Evaluation progress (spec)
+
+- **Linear:** https://linear.app/openmined/issue/OME-933/redesign-live-evaluation-progress
+- **Landing:** `packages/screamingface`
+- **Dependency:** `OME-950` supplies relative URL4 route names in ordinary terminal spans
+- **Status:** awaiting implementation approval
+
+## Outcome
+
+`sf.evaluate(...)` shows one stable row per Candidate from launch through the authoritative final
+Report. Each row advances independently as terminal benchmark Cases arrive, stays visibly alive
+while work is in flight, and freezes with the final score and evidence when decoding completes.
+
+The design uses only public Events the Client already receives. It adds no progress event, wire
+schema, Benchmark hook, Engine adapter, URL4 expression, or Client-side scoring logic.
+
+## Execution facts
+
+- One Candidate is one independently submitted Engine Run.
+- Candidate Runs can overlap and their Events can interleave.
+- The Client knows the ordered Candidates and selected Case count before execution starts.
+- The transport accepts one Event observer for each Run.
+- The transport's existing Run state validates sequence continuity and suppresses replayed Events
+  before invoking that observer.
+- The Engine publishes a `Span` only when its URL4 node finishes.
+- The shared Benchmark protocol executes one local `/benchmarks/case-execution` node for each
+  selected Case.
+- The final decoded `CandidateResult` is the only authority for score, coverage, failures, usage,
+  and final Candidate classification.
+
+## Candidate identity
+
+The Evaluation runner binds an internal observer to the `Candidate` at the same point that it
+calls `transport.run(candidate, observer)`. The built-in panel therefore receives
+`(Candidate, Event)` without guessing identity from a model name, URL4 text, span source, or
+arrival order.
+
+The public `on_event(event)` callback remains unchanged. It receives each accepted Event once and
+does not receive synthetic progress or reconciliation Events.
+
+## Exact Case progress
+
+A row increments `completed` only for a typed `Span` satisfying both predicates:
+
+```python
+event.operation == "RelUrlNode"
+event.name == "/benchmarks/case-execution"
+```
+
+Both `status="ok"` and `status="error"` count because both mean that Case-execution node reached a
+terminal outcome. Failure is evidence about that completion, not a reason to hide the completion.
+
+Each row's denominator is the selected `evaluation.case_count`. `42 / 100` means 42 terminal
+Cases have been observed for that Candidate; it is not Case ID 42 and does not claim which Case is
+currently executing. The display never exceeds its known total.
+
+No other structural span counts. In particular, a `RemoteFetchNode` with the same unqualified
+path does not count because its operation differs. Model spans cannot stand in for Cases because
+one Case may make zero, one, or many model calls.
+
+If a Run terminates before every terminal Case span is observed, its row preserves the honest
+observed count. The Client does not fabricate the missing completions from the final result.
+
+## State model
+
+Rows stay in input order and use these primary statuses:
+
+| Status | Evidence |
+|---|---|
+| `Queued` | The Candidate exists but its bound observer has not received a root `Started`. |
+| `Running` | Its root Run started and no authoritative CandidateResult has decoded. |
+| `Finished` | Its CandidateResult decoded successfully. |
+| `Run failed` | A terminal failure or Client result-contract failure left no CandidateResult. |
+| `Stopped` | The Run reported `stopped`, or a user interruption stopped an already-started Run. |
+| `Timed out` | The Run or Client explicitly reported a timeout. |
+| `Not run` | Evaluation ended before the Candidate ever started. |
+
+A successful root `Terminated` does not by itself show `Finished`; the row remains `Running` while
+the returned body is decoded. On successful reconciliation, `Finished` may carry one secondary
+result qualifier using the existing Report contract, in this precedence:
+
+1. `Incomplete` when `score is None`.
+2. `Partial` when `coverage < 1.0`.
+3. `Warnings` when Candidate failures exist.
+4. No qualifier for a clean result.
+
+An actual terminal Event takes precedence over an inferred workflow outcome. Without one, only an
+explicit user interruption maps to `Stopped` and only an explicit timeout maps to `Timed out`;
+other failures map to `Run failed`. A Candidate with no root start maps to `Not run`.
+
+## Row evidence
+
+The fixed column order is:
+
+1. Candidate
+2. Status
+3. Progress
+4. Score
+5. Cost
+6. Cache
+
+Before reconciliation, Score reads `Not scored yet`. After reconciliation it shows the decoded
+benchmark-native score, or `Not scored` when the final score is `None`; the Client never computes
+or estimates a score.
+
+Cost sums accepted self-scoped Usage Events for that Candidate Run and reads `Not reported` until
+evidence exists. Final CandidateResult usage reconciles it after decoding.
+
+Cache uses that Candidate Run's accepted Span provenance and authoritative cache-summary Log:
+`hits / (hits + misses)`, with bypasses excluded from the rate. It reads `Not reported` until
+evidence exists. The existing aggregate cache-provenance band remains below the Evaluation totals.
+
+The Status cell may show concise secondary activity from real Events, such as a completed, failed,
+or refused model call and elapsed time. It does not label activity `Answering` or `Grading`, infer a
+current Case, invent typing dots, or animate fake work.
+
+## Rendering lifecycle
+
+Event folding is immediate and thread-safe. Rendering is coalesced behind a dirty signal so a
+burst of Events produces at most roughly one notebook update per 100 ms. During a silent in-flight
+model call, a one-second clock wake refreshes elapsed time so the panel still feels alive.
+
+Final reconciliation or abort forces one synchronous terminal render, stops the clock, and leaves
+the frozen panel visible. A renderer or notebook-comm failure remains decorative and cannot abort
+paid Engine work.
+
+## Layout and SFDS v2
+
+Below the heading, content appears in this order:
+
+1. Paid-check disclosure, when applicable.
+2. Candidate table.
+3. Aggregate model calls, tokens, and cost.
+4. Existing aggregate cache-provenance band.
+5. Collapsed Run activity.
+6. Global error, only when present.
+
+The table is semantic HTML inside its own horizontal-scroll container. It keeps a sticky header and
+sticky Candidate column, a minimum width sufficient for all six columns, and no alternate stacked
+layout. Candidate order never changes; there is no live rank, winner, or comparison treatment.
+
+This is the SFDS v2 app register: IBM Plex Sans for prose and status, IBM Plex Mono for figures and
+labels, square geometry, hairline rules, tabular numerals, blue informational activity, semantic
+status colors, readable primary/secondary text roles, and equal light/dark behavior. There is no
+gold, gradient, shadow, rounded card, fake avatar, or decorative low-contrast ink used as text.
+
+Motion is functional and restrained. Progress fills may transition when motion is allowed; under
+`prefers-reduced-motion: reduce` they update without transition. There is no looping animation.
+
+## Accessibility
+
+- Use a real `<table>` with a descriptive caption and scoped column headers.
+- Keep the table keyboard-scrollable without turning cells into fake controls.
+- Do not place `aria-live` on the changing table or whole panel.
+- Use one separate polite announcement region for Evaluation start, Candidate terminal states, and
+  whole-Evaluation completion only.
+- Status cannot rely on color alone: every square indicator has visible text.
+- Progress exposes an accessible name and numeric current/max values.
+- Focus is never moved when a Candidate changes state.
+
+## Compatibility and boundaries
+
+- Existing Report and CandidateResult values are unchanged.
+- Existing public Event values, order, replay behavior, and `on_event` callback are unchanged.
+- Existing text progress remains the non-notebook fallback.
+- Existing paid-check disclosure and aggregate cache-provenance behavior remain present.
+- No Benchmark, screamingface-engine, AIGateway, Scoreboard, or additional URL4 change.
+- No URL4 parsing in the Client.
+- No provisional score, exact live failed/refused Case counter, current Case identity, phase
+  inference, legacy progress schema, or compatibility fallback before V1.
+
+## Acceptance
+
+1. Ten Candidates over 100 Cases render ten stable rows with independent exact `x / 100` counts.
+2. Interleaved and out-of-order Candidate Events update only their bound row.
+3. Only the exact `(RelUrlNode, /benchmarks/case-execution)` pair advances progress; an error span
+   advances it and a RemoteFetchNode/model/other structural span does not.
+4. Transport replay does not double-count an accepted terminal span.
+5. Early Run termination preserves the observed count and never fabricates 100%.
+6. Score remains unavailable until CandidateResult decoding and then matches it verbatim.
+7. Queued, Running, Finished, Run failed, Stopped, Timed out, and Not run are covered for sync and
+   async Evaluations, including the existing eight-Run concurrency gate.
+8. Cost, cache, aggregate totals, paid-check disclosure, and cache-provenance reconciliation retain
+   their existing evidence rules.
+9. Public `on_event` receives the same accepted Events once, with no synthetic additions.
+10. Rendering is coalesced, the silent clock advances, one terminal render is forced, and the
+    frozen panel remains visible.
+11. The table horizontally scrolls, preserves keyboard access, uses limited announcements, honors
+    reduced motion, and renders correctly in light and dark themes.
+12. Full `py-screamingface` gates, notebook checks, build, and distribution checks pass.

--- a/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/spec/2026-08-23-OME-933-live-evaluation-progress.md
@@ -159,7 +159,7 @@ Content appears in this order:
 2. Paid-check disclosure, when applicable.
 3. Overall Candidate-Case progress, only while the Evaluation is not successfully complete and
    every Candidate denominator is known.
-4. Compact live receipt, with its height reserved before evidence exists.
+4. Compact live receipt, only after cost/call/token evidence exists.
 5. Candidate table.
 6. Global error, only when present.
 
@@ -178,9 +178,9 @@ duration from the earliest Candidate start to the latest Candidate completion.
 
 The receipt is one muted mono line beneath the optional progress track, ordered by user value:
 `cost $0.76 · 68 model calls · 202.9k in / 30.2k out`. It exposes only fields with evidence and is
-visually empty before any exists, while reserving its one-line height so the Candidate table does
-not jump when usage first arrives. It replaces the large three-cell aggregate strip without
-changing the underlying live accounting.
+absent before any exists so an empty placeholder does not create a large visual gap above the
+Candidate table. It replaces the large three-cell aggregate strip without changing the underlying
+live accounting.
 
 After the authoritative Report reconciles, when exact evidence proves every observed model call
 was a hit, with no miss, bypass, unaccounted call, non-zero cost, or non-zero token usage, the

--- a/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
+++ b/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
@@ -34,8 +34,8 @@ the redundant full track and 100% label and shows `complete · duration`; partia
 states retain the known progress evidence.
 
 Running cost, model calls, and tokens remain visible as one compact evidence-only receipt rather
-than three large boxes. Cost appears first. The receipt shows no placeholder values before evidence
-exists, while its one-line height is reserved to prevent the table shifting when evidence arrives.
+than three large boxes. Cost appears first. The receipt is absent before evidence exists so the
+empty state does not leave a large blank band above the Candidate table.
 
 Partial coverage is explicit (`1/2 graded`) rather than a vague `Partial` label. Running and
 finished rows retain per-Candidate duration in Status, using authoritative Candidate Result

--- a/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
+++ b/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
@@ -1,23 +1,23 @@
 ---
 id: OME-933
 linear_url: https://linear.app/openmined/issue/OME-933/redesign-live-evaluation-progress
-status: pick_immediately
+status: in_progress
 type: improvement
 priority: 2
-labels: [py-screamingface, agentic, deferred]
+labels: [py-screamingface, agentic, autonomous]
 created: 2026-08-21
 closed:
 ---
 
 # Redesign live Evaluation progress
 
-Replace the notebook Evaluation panel with a stable SFDS v2 Candidate table driven by the
-Engine's strict `screamingface.evaluation-progress.v1` snapshots and existing public Events.
+Replace the notebook Evaluation panel with a stable SFDS v2 Candidate table driven only by
+existing public Events. Exact Case completion comes from terminal spans whose operation is
+`RelUrlNode` and whose name is `/benchmarks/case-execution`.
 
-The table keeps Candidate, Status, Case, Score, Cost, and Cache columns in fixed Candidate
+The table keeps Candidate, Status, Progress, Score, Cost, and Cache columns in fixed Candidate
 order, uses horizontal scrolling on narrow screens, preserves the aggregate cache-provenance
 band, and never fabricates activity or evidence. The decoded final Candidate Result remains
 authoritative.
 
-Blocked by OME-932. Canonical spec, plan, and ledger will be created in this worktree before
-implementation begins.
+Blocked by OME-950. Canonical spec, plan, and ledger precede implementation.

--- a/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
+++ b/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
@@ -15,10 +15,41 @@ Replace the notebook Evaluation panel with a stable SFDS v2 Candidate table driv
 existing public Events. Exact Case completion comes from terminal spans whose operation is
 `RelUrlNode` and whose name is `/benchmarks/case-execution`.
 
-The table keeps Candidate, Status, Progress, Score, Cost, and Cache columns in fixed Candidate
-order, uses horizontal scrolling on narrow screens, preserves the aggregate cache-provenance
-band, and never fabricates activity or evidence. The decoded final Candidate Result remains
-authoritative.
+The table keeps Candidate, Status, Cases, Score, Cost, and Cache hit columns in fixed Candidate
+order, fits the available notebook width without its own horizontal scrollbar, shows only the
+Candidate display name, omits redundant aggregate cache/Run activity sections, and never
+fabricates activity or evidence. The decoded final Candidate Result remains authoritative.
+
+Cases renders exact `completed / total` text without a redundant per-row progress bar.
+The benchmark name remains the stable heading; Candidate rows own lifecycle and elapsed detail.
+Genuinely Running rows use the canonical static blue SFDS status square without a widget-specific
+animation.
+
+One overall SFDS track reports exact completed Candidate-Case runs over all planned Candidate-Case
+runs. Its denominator is uncapped and it is omitted when the denominator is unknown. It reuses the
+canonical anchored fusion gradient and width transition, while compact `state · percent` text is
+right-aligned on the benchmark-title row. Exact aggregate counts remain on the progressbar for
+accessibility; the Candidate table owns the visible Case fractions. Successful completion removes
+the redundant full track and 100% label and shows `complete · duration`; partial stopped/failed
+states retain the known progress evidence.
+
+Running cost, model calls, and tokens remain visible as one compact evidence-only receipt rather
+than three large boxes. Cost appears first. The receipt shows no placeholder values before evidence
+exists, while its one-line height is reserved to prevent the table shifting when evidence arrives.
+
+Partial coverage is explicit (`1/2 graded`) rather than a vague `Partial` label. Running and
+finished rows retain per-Candidate duration in Status, using authoritative Candidate Result
+timestamps after reconciliation. Numeric table columns are right-aligned for scanning.
+
+Cache hit distinguishes `Bypassed` (reported outcomes but no cacheable request) from
+`Not reported` (no cache outcome evidence). Hit/miss traffic remains a percentage.
+When every observed model call is provably a hit with no contradictory cost/token evidence, the
+receipt reads `model calls · fully cached · no tokens billed` instead of presenting a wall of
+zeroes. The Candidate Cost cell still reports `$0.00`.
+
+Visual styling is pinned to `OpenMined/screamingface-brand` commit `7ea35a1` (2026-08-18),
+including its current shared notebook light/dark aliases and canonical table typography, spacing,
+separators, weights, and semantic state colors.
 
 Ordinary Benchmark evaluation knows the selected Case count up front and renders exact `x / N`.
 Opaque `sf.evaluate(url4)` replay shows its exact observed numerator while running, then learns

--- a/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
+++ b/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
@@ -20,4 +20,8 @@ order, uses horizontal scrolling on narrow screens, preserves the aggregate cach
 band, and never fabricates activity or evidence. The decoded final Candidate Result remains
 authoritative.
 
+Ordinary Benchmark evaluation knows the selected Case count up front and renders exact `x / N`.
+Opaque `sf.evaluate(url4)` replay shows its exact observed numerator while running, then learns
+the denominator from the final Report; the Client does not parse URL4.
+
 Blocked by OME-950. Canonical spec, plan, and ledger precede implementation.

--- a/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
+++ b/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
@@ -1,7 +1,7 @@
 ---
 id: OME-933
 linear_url: https://linear.app/openmined/issue/OME-933/redesign-live-evaluation-progress
-status: in_progress
+status: in_review
 type: improvement
 priority: 2
 labels: [py-screamingface, agentic, autonomous]
@@ -24,4 +24,6 @@ Ordinary Benchmark evaluation knows the selected Case count up front and renders
 Opaque `sf.evaluate(url4)` replay shows its exact observed numerator while running, then learns
 the denominator from the final Report; the Client does not parse URL4.
 
-Blocked by OME-950. Canonical spec, plan, and ledger precede implementation.
+Draft PR: https://github.com/ScreamingFace/screamingface/pull/694
+
+Blocked by OME-950 until its relative-route span name lands.

--- a/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
+++ b/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
@@ -1,7 +1,7 @@
 ---
 id: OME-933
 linear_url: https://linear.app/openmined/issue/OME-933/redesign-live-evaluation-progress
-status: in_review
+status: in_progress
 type: improvement
 priority: 2
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
+++ b/docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md
@@ -1,0 +1,23 @@
+---
+id: OME-933
+linear_url: https://linear.app/openmined/issue/OME-933/redesign-live-evaluation-progress
+status: pick_immediately
+type: improvement
+priority: 2
+labels: [py-screamingface, agentic, deferred]
+created: 2026-08-21
+closed:
+---
+
+# Redesign live Evaluation progress
+
+Replace the notebook Evaluation panel with a stable SFDS v2 Candidate table driven by the
+Engine's strict `screamingface.evaluation-progress.v1` snapshots and existing public Events.
+
+The table keeps Candidate, Status, Case, Score, Cost, and Cache columns in fixed Candidate
+order, uses horizontal scrolling on narrow screens, preserves the aggregate cache-provenance
+band, and never fabricates activity or evidence. The decoded final Candidate Result remains
+authoritative.
+
+Blocked by OME-932. Canonical spec, plan, and ledger will be created in this worktree before
+implementation begins.

--- a/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
@@ -112,8 +112,7 @@ Candidate table already owns exact visible Case fractions. The compact line now 
 Candidate elapsed time now truncates fractional seconds because the panel refreshes once per
 second. It renders integral seconds below an hour and drops seconds at hour scale.
 The final owner-approved table pass replaces vague `Partial` with exact graded coverage, retains
-authoritative final duration, right-aligns numeric columns, and reserves the compact receipt's
-height before usage evidence arrives so the table never jumps.
+authoritative final duration, and right-aligns numeric columns.
 Cache diagnosis found that the local stack intentionally leaves `AIGW_REQUEST_CACHE_ENABLED` off,
 so its model calls report bypass rather than hit/miss. The table now renders `Bypassed` for that
 reported state and reserves `Not reported` for genuinely absent cache outcome evidence.
@@ -124,5 +123,8 @@ The final owner-approved header compaction places live Evaluation state at the r
 benchmark-title row so changing receipt digits never shift it. The canonical progress track stays
 visible only while progress is actionable, including partial stopped/failed runs; successful
 completion removes the redundant full bar and 100% and reports `complete · duration` from
-authoritative Candidate Result timestamps. The receipt remains left-aligned and reserved, and the
-Candidate table remains the canonical detail surface for both one and many Candidates.
+authoritative Candidate Result timestamps. The receipt remains left-aligned, and the Candidate
+table remains the canonical detail surface for both one and many Candidates.
+Live notebook QA then showed that the reserved empty receipt row reads as an oversized dead band
+before any model activity returns. The owner-approved correction omits the receipt entirely until
+real evidence exists, keeping the initial progress track and Candidate table in a compact rhythm.

--- a/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
@@ -1,0 +1,57 @@
+---
+ticket: OME-933
+stack: screamingface
+status: in_progress
+started: 2026-08-23
+finished:
+---
+
+# OME-933 — redesign live Evaluation progress
+
+## Intent
+
+Replace the aggregate notebook progress panel with a truthful, always-alive per-Candidate table.
+Use the existing typed Event stream for activity, cost, cache, lifecycle, and exact terminal Case
+counts; keep final Candidate Results authoritative for scores and outcome classification.
+
+## Planned changes
+
+- `docs/tasks/2026-08-21-OME-933-live-evaluation-progress.md`
+- `docs/spec/2026-08-23-OME-933-live-evaluation-progress.md`
+- `docs/plan/2026-08-23-OME-933-live-evaluation-progress.md`
+- `docs/work/2026-08-23-OME-933-live-evaluation-progress.md`
+- `packages/screamingface/src/screamingface/_evaluation/runner.py`
+- `packages/screamingface/src/screamingface/_ui/evaluation_state.py`
+- `packages/screamingface/src/screamingface/_ui/evaluation_view.py`
+- `packages/screamingface/tests/test_evaluation_progress_panel.py`
+- Additional Client tests only if a contract boundary is not owned by the existing progress suite.
+
+## Test plan
+
+- RED first for Candidate-scoped event routing and exact terminal Case span counting.
+- RED first for 10 Candidates × 100 Cases, concurrent out-of-order completion, replay-safe folding,
+  terminal failures, and final-result reconciliation.
+- RED first for SFDS table structure, horizontal overflow, keyboard access, reduced motion, and
+  light/dark token use.
+- Preserve existing Event callbacks, final Reports, cache provenance, cost accounting, notebook
+  distribution, and all prior progress tests.
+
+## Acceptance
+
+- Every Candidate has one stable row in input order with truthful Status, Progress, Score, Cost,
+  and Cache evidence.
+- Progress counts only `(operation="RelUrlNode", name="/benchmarks/case-execution")` terminal spans
+  and uses the Evaluation's selected Case count as its denominator.
+- Existing Events keep running rows alive; the UI never fabricates phases, delays, values, or Case
+  identities.
+- Scores appear only from successfully decoded final Candidate Results.
+- The app-register SFDS v2 surface remains accessible, readable in light and dark, and horizontally
+  scrollable at narrow widths.
+- The full `screamingface` quality gate passes.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** pending.
+- **Commits:** pending.
+- **Gates:** pending.
+- **Deviations:** pending.

--- a/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
@@ -56,8 +56,7 @@ counts; keep final Candidate Results authoritative for scores and outcome classi
 ## Outcome
 
 - **Actual files:** the spec/task mirror and every production/test file listed above.
-- **Commits:** `f718b42b` (approved spec/plan); implementation is the conventional OME-933 commit
-  containing this completed ledger.
+- **Commits:** `f718b42b` (approved spec/plan), `aa7d3282` (Candidate-scoped implementation).
 - **Gates:** 77 focused progress/evaluation tests passed; 1,043 package tests passed with one
   skip before the final edge-case additions; the complete official `screamingface` gate then
   passed Ruff, Pyright, ≥95% coverage, notebook validation, build, and distribution checks.

--- a/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
@@ -57,10 +57,10 @@ counts; keep final Candidate Results authoritative for scores and outcome classi
 
 - **Actual files:** the spec/task mirror and every production/test file listed above.
 - **Commits:** `f718b42b` (approved spec/plan), `aa7d3282` (Candidate-scoped implementation).
-- **Gates:** the latest compact-header follow-up passes 79 focused progress/evaluation tests,
-  Ruff, Pyright, and the full package suite (1,064 passed, one skipped). The earlier complete
-  official `screamingface` gate also passed ≥95% coverage, notebook validation, build, and
-  distribution checks before the owner's two local notebook edits; those edits remain untouched.
+- **Gates:** the latest follow-up passes 80 focused progress/evaluation tests, Ruff, Pyright, and
+  the full package coverage gate (1,065 passed, one skipped; 95.04%). The earlier complete official
+  `screamingface` gate also passed notebook validation, build, and distribution checks before the
+  owner's local notebook edits; those edits remain untouched.
 - **Deviations:** opaque URL4 replay cannot know its selected denominator before result decoding,
   so it truthfully renders the exact observed numerator until the final Report supplies the total.
   The approved plan intentionally replaced aggregate-panel assertions with Candidate-table

--- a/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-933
 stack: screamingface
-status: in_progress
+status: done
 started: 2026-08-23
-finished:
+finished: 2026-08-23
 ---
 
 # OME-933 — redesign live Evaluation progress
@@ -21,10 +21,14 @@ counts; keep final Candidate Results authoritative for scores and outcome classi
 - `docs/plan/2026-08-23-OME-933-live-evaluation-progress.md`
 - `docs/work/2026-08-23-OME-933-live-evaluation-progress.md`
 - `packages/screamingface/src/screamingface/_evaluation/runner.py`
+- `packages/screamingface/src/screamingface/_evaluation/progress.py`
+- `packages/screamingface/src/screamingface/_evaluation/url4.py`
 - `packages/screamingface/src/screamingface/_ui/evaluation_state.py`
 - `packages/screamingface/src/screamingface/_ui/evaluation_view.py`
+- `packages/screamingface/tests/test_live_candidate_progress.py`
 - `packages/screamingface/tests/test_evaluation_progress_panel.py`
-- Additional Client tests only if a contract boundary is not owned by the existing progress suite.
+- `packages/screamingface/tests/test_progress.py`
+- `packages/screamingface/tests/test_check_disclosure_display.py`
 
 ## Test plan
 
@@ -49,9 +53,16 @@ counts; keep final Candidate Results authoritative for scores and outcome classi
   scrollable at narrow widths.
 - The full `screamingface` quality gate passes.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** pending.
-- **Commits:** pending.
-- **Gates:** pending.
-- **Deviations:** pending.
+- **Actual files:** the spec/task mirror and every production/test file listed above.
+- **Commits:** `f718b42b` (approved spec/plan); implementation is the conventional OME-933 commit
+  containing this completed ledger.
+- **Gates:** 77 focused progress/evaluation tests passed; 1,043 package tests passed with one
+  skip before the final edge-case additions; the complete official `screamingface` gate then
+  passed Ruff, Pyright, ≥95% coverage, notebook validation, build, and distribution checks.
+- **Deviations:** opaque URL4 replay cannot know its selected denominator before result decoding,
+  so it truthfully renders the exact observed numerator until the final Report supplies the total.
+  The approved plan intentionally replaced aggregate-panel assertions with Candidate-table
+  assertions; the append-only detector was skipped only for that recorded contract replacement,
+  while every retained and new test still ran in the full gate.

--- a/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
+++ b/docs/work/2026-08-23-OME-933-live-evaluation-progress.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-933
 stack: screamingface
-status: done
+status: in_progress
 started: 2026-08-23
-finished: 2026-08-23
+finished:
 ---
 
 # OME-933 — redesign live Evaluation progress
@@ -35,33 +35,94 @@ counts; keep final Candidate Results authoritative for scores and outcome classi
 - RED first for Candidate-scoped event routing and exact terminal Case span counting.
 - RED first for 10 Candidates × 100 Cases, concurrent out-of-order completion, replay-safe folding,
   terminal failures, and final-result reconciliation.
-- RED first for SFDS table structure, horizontal overflow, keyboard access, reduced motion, and
-  light/dark token use.
+- RED first for SFDS table structure, six-column width fit, native table semantics, reduced motion,
+  and light/dark token use.
 - Preserve existing Event callbacks, final Reports, cache provenance, cost accounting, notebook
   distribution, and all prior progress tests.
 
 ## Acceptance
 
-- Every Candidate has one stable row in input order with truthful Status, Progress, Score, Cost,
-  and Cache evidence.
+- Every Candidate has one stable row in input order with truthful Status, Cases, Score, Cost,
+  and Cache-hit evidence.
 - Progress counts only `(operation="RelUrlNode", name="/benchmarks/case-execution")` terminal spans
   and uses the Evaluation's selected Case count as its denominator.
 - Existing Events keep running rows alive; the UI never fabricates phases, delays, values, or Case
   identities.
 - Scores appear only from successfully decoded final Candidate Results.
-- The app-register SFDS v2 surface remains accessible, readable in light and dark, and horizontally
-  scrollable at narrow widths.
+- The app-register SFDS v2 surface remains accessible, readable in light and dark, and fits all six
+  columns without its own horizontal scrollbar.
 - The full `screamingface` quality gate passes.
 
 ## Outcome
 
 - **Actual files:** the spec/task mirror and every production/test file listed above.
 - **Commits:** `f718b42b` (approved spec/plan), `aa7d3282` (Candidate-scoped implementation).
-- **Gates:** 77 focused progress/evaluation tests passed; 1,043 package tests passed with one
-  skip before the final edge-case additions; the complete official `screamingface` gate then
-  passed Ruff, Pyright, ≥95% coverage, notebook validation, build, and distribution checks.
+- **Gates:** the latest compact-header follow-up passes 79 focused progress/evaluation tests,
+  Ruff, Pyright, and the full package suite (1,064 passed, one skipped). The earlier complete
+  official `screamingface` gate also passed ≥95% coverage, notebook validation, build, and
+  distribution checks before the owner's two local notebook edits; those edits remain untouched.
 - **Deviations:** opaque URL4 replay cannot know its selected denominator before result decoding,
   so it truthfully renders the exact observed numerator until the final Report supplies the total.
   The approved plan intentionally replaced aggregate-panel assertions with Candidate-table
   assertions; the append-only detector was skipped only for that recorded contract replacement,
   while every retained and new test still ran in the full gate.
+
+## Owner visual-QA follow-up
+
+The first live notebook check showed that the full model route duplicated Candidate identity and
+that the table's forced minimum width created unnecessary horizontal scrolling. The approved
+follow-up removes that secondary route line and lets all six columns fit the notebook width. This
+replaces the earlier horizontal-scroll acceptance rule; no legacy layout fallback is retained.
+The same visual check exposed duplicate terminal text in Status. Status is therefore a single
+compact lifecycle line, while detailed Event activity remains available in the collapsed log.
+Per-row progress bars were also removed after owner review because they duplicated the exact Case
+fraction and consumed width without adding information.
+The per-Candidate Cache header was clarified to Cache hit; its cell stays a percentage while the
+existing aggregate band owns detailed hit, miss, bypass, and reason evidence.
+Terminal rows without a CandidateResult say Not scored rather than the still-pending Not scored
+yet used by Queued and Running rows.
+The owner-approved liveness pass adds an exact state/elapsed subtitle. A subsequent strict-brand
+review removed the custom pulse: Running uses the canonical static blue SFDS status square.
+The same review approved one uncapped overall Candidate-Case progress track. Its first iteration
+used exact summed evidence, a static solid-blue fill, and disappeared when a denominator was
+unavailable.
+Owner visual QA then removed the redundant visible title/count above that track; accessible current
+and maximum values remain on the progressbar itself.
+The next live comparison identified the exact branded target in `screamingface-brand`'s run widget.
+The approved correction replaces the generic blue fill with its anchored SFDS fusion gradient,
+`.11s linear` width transition, and compact `evaluating… · percent · completed/total` line.
+The final header simplification makes the benchmark name the stable title and removes the large
+dynamic Evaluation headline plus the redundant aggregate row-state subtitle. Terminal workflow
+state moves into the compact progress line.
+Owner visual QA replaced the three large usage boxes with one compact evidence-only receipt, with
+running cost first, then model calls and tokens. The empty-prone aggregate cache band and collapsed
+Run activity were removed from the live widget; their underlying Event/Report evidence remains.
+The widget's redundant 14px side padding was removed because Jupyter already owns the output-cell
+inset; every widget element now shares the notebook output edge.
+Final width QA reduced the oversized Cases allocation and reassigned it to Cost and Cache hit so
+their truthful `Not reported` values do not clip.
+The final SFDS fidelity pass uses the generated tokens and table recipe from
+`OpenMined/screamingface-brand` commit `7ea35a12608776ba3f811811578cec9fd5193b4f`
+(2026-08-18). Because the shared notebook token bridge had drifted from that source, the approved
+change updates it centrally and aligns the Evaluation table's typography, spacing, separators,
+weights, and semantic status colors with the same revision.
+Owner visual QA removed the aggregate `completed/total` suffix from the progress label because the
+Candidate table already owns exact visible Case fractions. The compact line now reads
+`evaluating… · percent`; the progressbar retains exact current and maximum accessibility values.
+Candidate elapsed time now truncates fractional seconds because the panel refreshes once per
+second. It renders integral seconds below an hour and drops seconds at hour scale.
+The final owner-approved table pass replaces vague `Partial` with exact graded coverage, retains
+authoritative final duration, right-aligns numeric columns, and reserves the compact receipt's
+height before usage evidence arrives so the table never jumps.
+Cache diagnosis found that the local stack intentionally leaves `AIGW_REQUEST_CACHE_ENABLED` off,
+so its model calls report bypass rather than hit/miss. The table now renders `Bypassed` for that
+reported state and reserves `Not reported` for genuinely absent cache outcome evidence.
+The fully cached receipt is now an evidence-gated success state: all observed model calls must be
+accounted for as hits per Candidate, with no miss, bypass, non-zero usage, or non-zero cost. It
+renders `model calls · fully cached · no tokens billed` and leaves `$0.00` to the Cost column.
+The final owner-approved header compaction places live Evaluation state at the right edge of the
+benchmark-title row so changing receipt digits never shift it. The canonical progress track stays
+visible only while progress is actionable, including partial stopped/failed runs; successful
+completion removes the redundant full bar and 100% and reports `complete · duration` from
+authoritative Candidate Result timestamps. The receipt remains left-aligned and reserved, and the
+Candidate table remains the canonical detail surface for both one and many Candidates.

--- a/packages/screamingface/src/screamingface/_evaluation/progress.py
+++ b/packages/screamingface/src/screamingface/_evaluation/progress.py
@@ -16,6 +16,8 @@ _logger = logging.getLogger(__name__)
 
 
 class _EvaluationObserver(Protocol):
+    def begin(self, candidate: Candidate) -> None: ...
+
     def observe(self, candidate: Candidate, event: Event) -> None: ...
 
     def reconcile(self, report: Report) -> None: ...
@@ -97,6 +99,9 @@ class _ProgressObserver:
     def observe(self, candidate: Candidate, event: Event) -> None:
         del candidate
         self(event)
+
+    def begin(self, candidate: Candidate) -> None:
+        del candidate
 
     def reconcile(self, report: Report) -> None:
         del report

--- a/packages/screamingface/src/screamingface/_evaluation/progress.py
+++ b/packages/screamingface/src/screamingface/_evaluation/progress.py
@@ -5,25 +5,33 @@ from __future__ import annotations
 import logging
 import sys
 import unicodedata
-from collections.abc import Callable
-from typing import TextIO
+from typing import Protocol, TextIO
 
 from screamingface._environment import ipykernel_loaded as _in_notebook
+from screamingface._evaluation.model import Candidate
 from screamingface.events import Event, Log, Span, Started, Terminated
+from screamingface.report import Report
 
 _logger = logging.getLogger(__name__)
+
+
+class _EvaluationObserver(Protocol):
+    def observe(self, candidate: Candidate, event: Event) -> None: ...
+
+    def reconcile(self, report: Report) -> None: ...
+
+    def abort(self, exc: BaseException) -> None: ...
 
 
 def _progress_observer(
     requested: bool | None,
     *,
     stream: TextIO | None = None,
-    total_candidates: int | None = None,
+    candidates: tuple[Candidate, ...] = (),
+    case_count: int | None = None,
     benchmark: str | None = None,
-    candidate_models: tuple[str, ...] = (),
-    candidate_urls: tuple[str, ...] = (),
     check_disclosure: str | None = None,
-) -> Callable[[Event], None] | None:
+) -> _EvaluationObserver | None:
     selected_stream = sys.stderr if stream is None else stream
     in_notebook = _in_notebook()
     enabled = requested is not False and (
@@ -31,10 +39,8 @@ def _progress_observer(
     )
     # In a notebook the live panel is preferred; text remains the fallback everywhere.
     rich = (
-        _notebook_observer(
-            total_candidates, benchmark, candidate_models, candidate_urls, check_disclosure
-        )
-        if enabled and in_notebook
+        _notebook_observer(candidates, case_count, benchmark, check_disclosure)
+        if enabled and in_notebook and candidates
         else None
     )
     # The paid-check disclosure must never be silent (OME-845): the panel is its calm
@@ -52,12 +58,11 @@ def _progress_observer(
 
 
 def _notebook_observer(
-    total_candidates: int | None,
+    candidates: tuple[Candidate, ...],
+    case_count: int | None,
     benchmark: str | None,
-    candidate_models: tuple[str, ...],
-    candidate_urls: tuple[str, ...],
     check_disclosure: str | None = None,
-) -> Callable[[Event], None] | None:
+) -> _EvaluationObserver | None:
     """The live panel, or None when it cannot be built (text progress then carries it).
 
     Building a widget touches ipywidgets' comm layer, which can fail for reasons well
@@ -69,10 +74,9 @@ def _notebook_observer(
         from screamingface._ui.evaluation_view import _NotebookEvaluationView
 
         return _NotebookEvaluationView(
-            total_candidates,
+            candidates,
+            case_count,
             benchmark,
-            candidate_models,
-            candidate_urls,
             check_disclosure=check_disclosure,
         )
     except Exception:
@@ -89,6 +93,16 @@ class _ProgressObserver:
         if message is not None:
             self._stream.write(f"ScreamingFace · {_terminal_text(message)}\n")
             self._stream.flush()
+
+    def observe(self, candidate: Candidate, event: Event) -> None:
+        del candidate
+        self(event)
+
+    def reconcile(self, report: Report) -> None:
+        del report
+
+    def abort(self, exc: BaseException) -> None:
+        del exc
 
 
 def _message(event: Event) -> str | None:

--- a/packages/screamingface/src/screamingface/_evaluation/runner.py
+++ b/packages/screamingface/src/screamingface/_evaluation/runner.py
@@ -79,18 +79,19 @@ def evaluate_sync(
     observer = _sync_event_observer(
         on_event,
         progress,
-        len(evaluation.candidates),
+        tuple(evaluation.candidates),
+        evaluation.case_count,
         benchmark,
-        candidate_models=_candidate_model_ids(tuple(evaluation.candidates)),
-        candidate_urls=tuple(candidate.url4 for candidate in evaluation.candidates),
         check_disclosure=check_disclosure,
     )
     try:
         outcomes = _run_candidates_sync(transport, tuple(evaluation.candidates), observer)
-    except BaseException:
-        _close_event_observer(observer)
+        report = report_from_outcomes(evaluation, outcomes)
+    except BaseException as exc:
+        _abort_event_observer(observer, exc)
         raise
-    return report_from_outcomes(evaluation, outcomes)
+    _reconcile_event_observer(observer, report)
+    return report
 
 
 async def evaluate_async(
@@ -128,18 +129,19 @@ async def evaluate_async(
     observer = _async_event_observer(
         on_event,
         progress,
-        len(evaluation.candidates),
+        tuple(evaluation.candidates),
+        evaluation.case_count,
         benchmark,
-        candidate_models=_candidate_model_ids(tuple(evaluation.candidates)),
-        candidate_urls=tuple(candidate.url4 for candidate in evaluation.candidates),
         check_disclosure=check_disclosure,
     )
     try:
         outcomes = await _run_candidates_async(transport, tuple(evaluation.candidates), observer)
-    except BaseException:
-        _close_event_observer(observer)
+        report = report_from_outcomes(evaluation, outcomes)
+    except BaseException as exc:
+        _abort_event_observer(observer, exc)
         raise
-    return report_from_outcomes(evaluation, outcomes)
+    _reconcile_event_observer(observer, report)
+    return report
 
 
 def _evaluation_options(on_event: object, progress: object) -> None:
@@ -152,20 +154,18 @@ def _evaluation_options(on_event: object, progress: object) -> None:
 def _sync_event_observer(
     callback: Callable[[Event], None] | None,
     progress: bool | None,
-    total_candidates: int | None = None,
+    candidates: tuple[Candidate, ...] = (),
+    case_count: int | None = None,
     benchmark: str | None = None,
-    candidate_models: tuple[str, ...] = (),
-    candidate_urls: tuple[str, ...] = (),
     check_disclosure: str | None = None,
-) -> Callable[[Event], None] | None:
+) -> _SyncEventObserver | None:
     from screamingface._evaluation.progress import _progress_observer
 
     builtin = _progress_observer(
         progress,
-        total_candidates=total_candidates,
+        candidates=candidates,
+        case_count=case_count,
         benchmark=benchmark,
-        candidate_models=candidate_models,
-        candidate_urls=candidate_urls,
         check_disclosure=check_disclosure,
     )
     if builtin is None and callback is None:
@@ -176,20 +176,18 @@ def _sync_event_observer(
 def _async_event_observer(
     callback: Callable[[Event], None | Awaitable[None]] | None,
     progress: bool | None,
-    total_candidates: int | None = None,
+    candidates: tuple[Candidate, ...] = (),
+    case_count: int | None = None,
     benchmark: str | None = None,
-    candidate_models: tuple[str, ...] = (),
-    candidate_urls: tuple[str, ...] = (),
     check_disclosure: str | None = None,
-) -> Callable[[Event], Awaitable[None]] | None:
+) -> _AsyncEventObserver | None:
     from screamingface._evaluation.progress import _progress_observer
 
     builtin = _progress_observer(
         progress,
-        total_candidates=total_candidates,
+        candidates=candidates,
+        case_count=case_count,
         benchmark=benchmark,
-        candidate_models=candidate_models,
-        candidate_urls=candidate_urls,
         check_disclosure=check_disclosure,
     )
     if builtin is None and callback is None:
@@ -200,19 +198,28 @@ def _async_event_observer(
 class _SyncEventObserver:
     def __init__(
         self,
-        builtin: Callable[[Event], None] | None,
+        builtin: object | None,
         callback: Callable[[Event], None] | None,
     ) -> None:
         self._builtin = builtin
         self._callback = callback
         self._lock = Lock()
 
-    def __call__(self, event: Event) -> None:
-        with self._lock:
-            if self._builtin is not None:
-                _observe_progress(self._builtin, event)
-            if self._callback is not None:
-                self._callback(event)
+    def bind(self, candidate: Candidate) -> Callable[[Event], None]:
+        def observe(event: Event) -> None:
+            with self._lock:
+                if self._builtin is not None:
+                    _observe_candidate_progress(self._builtin, candidate, event)
+                if self._callback is not None:
+                    self._callback(event)
+
+        return observe
+
+    def reconcile(self, report: Report) -> None:
+        _reconcile_progress(self._builtin, report)
+
+    def abort(self, exc: BaseException) -> None:
+        _abort_progress(self._builtin, exc)
 
     def close(self) -> None:
         _close_progress(self._builtin)
@@ -221,21 +228,30 @@ class _SyncEventObserver:
 class _AsyncEventObserver:
     def __init__(
         self,
-        builtin: Callable[[Event], None] | None,
+        builtin: object | None,
         callback: Callable[[Event], None | Awaitable[None]] | None,
     ) -> None:
         self._builtin = builtin
         self._callback = callback
         self._lock = asyncio.Lock()
 
-    async def __call__(self, event: Event) -> None:
-        async with self._lock:
-            if self._builtin is not None:
-                _observe_progress(self._builtin, event)
-            if self._callback is not None:
-                returned = self._callback(event)
-                if inspect.isawaitable(returned):
-                    await returned
+    def bind(self, candidate: Candidate) -> Callable[[Event], Awaitable[None]]:
+        async def observe(event: Event) -> None:
+            async with self._lock:
+                if self._builtin is not None:
+                    _observe_candidate_progress(self._builtin, candidate, event)
+                if self._callback is not None:
+                    returned = self._callback(event)
+                    if inspect.isawaitable(returned):
+                        await returned
+
+        return observe
+
+    def reconcile(self, report: Report) -> None:
+        _reconcile_progress(self._builtin, report)
+
+    def abort(self, exc: BaseException) -> None:
+        _abort_progress(self._builtin, exc)
 
     def close(self) -> None:
         _close_progress(self._builtin)
@@ -246,8 +262,14 @@ def _close_event_observer(observer: object) -> None:
         observer.close()
 
 
-def _candidate_model_ids(candidates: tuple[Candidate, ...]) -> tuple[str, ...]:
-    return tuple(dict.fromkeys(model for candidate in candidates for model in candidate.models))
+def _reconcile_event_observer(observer: object, report: Report) -> None:
+    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
+        observer.reconcile(report)
+
+
+def _abort_event_observer(observer: object, exc: BaseException) -> None:
+    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
+        observer.abort(exc)
 
 
 def _close_progress(observer: object) -> None:
@@ -260,11 +282,46 @@ def _close_progress(observer: object) -> None:
         _logger.exception("ScreamingFace progress cleanup failed")
 
 
-def _observe_progress(observer: Callable[[Event], None], event: Event) -> None:
+def _observe_candidate_progress(observer: object, candidate: Candidate, event: Event) -> None:
+    selected = getattr(observer, "observe", None)
+    if not callable(selected):
+        _logger.error("ScreamingFace progress observer has no Candidate observation method")
+        return
+    _observe_progress(selected, candidate, event)
+
+
+def _reconcile_progress(observer: object | None, report: Report) -> None:
+    if observer is None:
+        return
+    reconcile = getattr(observer, "reconcile", None)
+    if not callable(reconcile):
+        return
+    try:
+        reconcile(report)
+    except Exception:
+        _logger.exception("ScreamingFace progress reconciliation failed")
+        _close_progress(observer)
+
+
+def _abort_progress(observer: object | None, exc: BaseException) -> None:
+    if observer is None:
+        return
+    abort = getattr(observer, "abort", None)
+    if not callable(abort):
+        _close_progress(observer)
+        return
+    try:
+        abort(exc)
+    except Exception:
+        _logger.exception("ScreamingFace progress finalization failed")
+        _close_progress(observer)
+
+
+def _observe_progress(observer: Callable[..., object], *values: object) -> None:
     """Keep decorative progress output outside the Evaluation failure boundary."""
 
     try:
-        observer(event)
+        observer(*values)
     except (OSError, ValueError):
         # Closed pipes and notebook streams must not cancel paid Engine work.
         return
@@ -277,11 +334,12 @@ def _observe_progress(observer: Callable[[Event], None], event: Event) -> None:
 def _run_candidates_sync(
     transport: SyncRunTransport,
     candidates: tuple[Candidate, ...],
-    observer: Callable[[Event], None] | None,
+    observer: _SyncEventObserver | None,
 ) -> tuple[tuple[Candidate, _RunOutcome], ...]:
     if len(candidates) == 1:
         candidate = candidates[0]
-        return ((candidate, transport.run(candidate, observer)),)
+        selected_observer = None if observer is None else observer.bind(candidate)
+        return ((candidate, transport.run(candidate, selected_observer)),)
 
     with ThreadPoolExecutor(
         max_workers=min(len(candidates), _MAX_CANDIDATES_IN_FLIGHT),
@@ -290,7 +348,12 @@ def _run_candidates_sync(
         futures = ()
         try:
             futures = tuple(
-                executor.submit(transport.run, candidate, observer) for candidate in candidates
+                executor.submit(
+                    transport.run,
+                    candidate,
+                    None if observer is None else observer.bind(candidate),
+                )
+                for candidate in candidates
             )
             return tuple(
                 (candidate, future.result())
@@ -309,17 +372,19 @@ def _run_candidates_sync(
 async def _run_candidates_async(
     transport: AsyncRunTransport,
     candidates: tuple[Candidate, ...],
-    observer: Callable[[Event], None | Awaitable[None]] | None,
+    observer: _AsyncEventObserver | None,
 ) -> tuple[tuple[Candidate, _RunOutcome], ...]:
     if len(candidates) == 1:
         candidate = candidates[0]
-        return ((candidate, await transport.run(candidate, observer)),)
+        selected_observer = None if observer is None else observer.bind(candidate)
+        return ((candidate, await transport.run(candidate, selected_observer)),)
 
     gate = asyncio.Semaphore(_MAX_CANDIDATES_IN_FLIGHT)
 
     async def run(candidate: Candidate) -> _RunOutcome:
         async with gate:
-            return await transport.run(candidate, observer)
+            selected_observer = None if observer is None else observer.bind(candidate)
+            return await transport.run(candidate, selected_observer)
 
     tasks = tuple(asyncio.create_task(run(candidate)) for candidate in candidates)
     try:

--- a/packages/screamingface/src/screamingface/_evaluation/runner.py
+++ b/packages/screamingface/src/screamingface/_evaluation/runner.py
@@ -205,6 +205,11 @@ class _SyncEventObserver:
         self._callback = callback
         self._lock = Lock()
 
+    def begin(self, candidate: Candidate) -> None:
+        with self._lock:
+            if self._builtin is not None:
+                _begin_candidate_progress(self._builtin, candidate)
+
     def bind(self, candidate: Candidate) -> Callable[[Event], None]:
         def observe(event: Event) -> None:
             with self._lock:
@@ -234,6 +239,11 @@ class _AsyncEventObserver:
         self._builtin = builtin
         self._callback = callback
         self._lock = asyncio.Lock()
+
+    async def begin(self, candidate: Candidate) -> None:
+        async with self._lock:
+            if self._builtin is not None:
+                _begin_candidate_progress(self._builtin, candidate)
 
     def bind(self, candidate: Candidate) -> Callable[[Event], Awaitable[None]]:
         async def observe(event: Event) -> None:
@@ -290,6 +300,14 @@ def _observe_candidate_progress(observer: object, candidate: Candidate, event: E
     _observe_progress(selected, candidate, event)
 
 
+def _begin_candidate_progress(observer: object, candidate: Candidate) -> None:
+    begin = getattr(observer, "begin", None)
+    if not callable(begin):
+        _logger.error("ScreamingFace progress observer has no Candidate begin method")
+        return
+    _observe_progress(begin, candidate)
+
+
 def _reconcile_progress(observer: object | None, report: Report) -> None:
     if observer is None:
         return
@@ -339,22 +357,24 @@ def _run_candidates_sync(
     if len(candidates) == 1:
         candidate = candidates[0]
         selected_observer = None if observer is None else observer.bind(candidate)
+        if observer is not None:
+            observer.begin(candidate)
         return ((candidate, transport.run(candidate, selected_observer)),)
 
     with ThreadPoolExecutor(
         max_workers=min(len(candidates), _MAX_CANDIDATES_IN_FLIGHT),
         thread_name_prefix="screamingface-candidate",
     ) as executor:
+
+        def run(candidate: Candidate) -> _RunOutcome:
+            selected_observer = None if observer is None else observer.bind(candidate)
+            if observer is not None:
+                observer.begin(candidate)
+            return transport.run(candidate, selected_observer)
+
         futures = ()
         try:
-            futures = tuple(
-                executor.submit(
-                    transport.run,
-                    candidate,
-                    None if observer is None else observer.bind(candidate),
-                )
-                for candidate in candidates
-            )
+            futures = tuple(executor.submit(run, candidate) for candidate in candidates)
             return tuple(
                 (candidate, future.result())
                 for candidate, future in zip(candidates, futures, strict=True)
@@ -377,6 +397,8 @@ async def _run_candidates_async(
     if len(candidates) == 1:
         candidate = candidates[0]
         selected_observer = None if observer is None else observer.bind(candidate)
+        if observer is not None:
+            await observer.begin(candidate)
         return ((candidate, await transport.run(candidate, selected_observer)),)
 
     gate = asyncio.Semaphore(_MAX_CANDIDATES_IN_FLIGHT)
@@ -384,6 +406,8 @@ async def _run_candidates_async(
     async def run(candidate: Candidate) -> _RunOutcome:
         async with gate:
             selected_observer = None if observer is None else observer.bind(candidate)
+            if observer is not None:
+                await observer.begin(candidate)
             return await transport.run(candidate, selected_observer)
 
     tasks = tuple(asyncio.create_task(run(candidate)) for candidate in candidates)

--- a/packages/screamingface/src/screamingface/_evaluation/url4.py
+++ b/packages/screamingface/src/screamingface/_evaluation/url4.py
@@ -36,8 +36,9 @@ def evaluate_url4_sync(
     """Execute one already-linked evaluation expression unchanged."""
 
     from screamingface._evaluation.runner import (
-        _close_event_observer,
+        _abort_event_observer,
         _evaluation_options,
+        _reconcile_event_observer,
         _sync_event_observer,
     )
 
@@ -46,17 +47,19 @@ def evaluate_url4_sync(
     observer = _sync_event_observer(
         on_event,
         progress,
-        1,
+        (candidate,),
+        None,
         "URL4 replay",
-        candidate_models=candidate.models,
-        candidate_urls=(candidate.url4,),
     )
     try:
-        outcome = transport.run(candidate, observer)
-    except BaseException:
-        _close_event_observer(observer)
+        bound = None if observer is None else observer.bind(candidate)
+        outcome = transport.run(candidate, bound)
+        report = report_from_url4_outcome(candidate, outcome)
+    except BaseException as exc:
+        _abort_event_observer(observer, exc)
         raise
-    return report_from_url4_outcome(candidate, outcome)
+    _reconcile_event_observer(observer, report)
+    return report
 
 
 async def evaluate_url4_async(
@@ -68,9 +71,10 @@ async def evaluate_url4_async(
     """Asynchronously execute one already-linked evaluation expression unchanged."""
 
     from screamingface._evaluation.runner import (
+        _abort_event_observer,
         _async_event_observer,
-        _close_event_observer,
         _evaluation_options,
+        _reconcile_event_observer,
     )
 
     _evaluation_options(on_event, progress)
@@ -78,17 +82,19 @@ async def evaluate_url4_async(
     observer = _async_event_observer(
         on_event,
         progress,
-        1,
+        (candidate,),
+        None,
         "URL4 replay",
-        candidate_models=candidate.models,
-        candidate_urls=(candidate.url4,),
     )
     try:
-        outcome = await transport.run(candidate, observer)
-    except BaseException:
-        _close_event_observer(observer)
+        bound = None if observer is None else observer.bind(candidate)
+        outcome = await transport.run(candidate, bound)
+        report = report_from_url4_outcome(candidate, outcome)
+    except BaseException as exc:
+        _abort_event_observer(observer, exc)
         raise
-    return report_from_url4_outcome(candidate, outcome)
+    _reconcile_event_observer(observer, report)
+    return report
 
 
 def _candidate_from_url4(value: str) -> Candidate:

--- a/packages/screamingface/src/screamingface/_ui/evaluation_state.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_state.py
@@ -27,6 +27,7 @@ class _CandidateProgress:
     output_tokens: int = 0
     have_tokens: bool = False
     cost_usd: Decimal | None = None
+    submitted: bool = False
     started: bool = False
     terminal_status: str | None = None
     root_sources: set[str] = field(default_factory=set)
@@ -66,12 +67,22 @@ class _CandidateProgress:
         elif self.result.score is None:
             qualifier = "Incomplete"
         elif self.result.coverage < 1.0:
-            qualifier = "Partial"
+            graded = sum(
+                case.grade is not None and case.grade.score is not None
+                for case in self.result.cases
+            )
+            qualifier = f"{graded}/{len(self.result.cases)} graded"
         elif self.result.failures:
             qualifier = "Warnings"
         else:
             qualifier = None
         return qualifier
+
+    @property
+    def duration_seconds(self) -> float | None:
+        if self.result is None:
+            return None
+        return (self.result.completed_at - self.result.started_at).total_seconds()
 
     @property
     def cache_totals(self) -> tuple[int, int, int] | None:
@@ -92,6 +103,24 @@ class _CandidateProgress:
         cacheable = hits + misses
         return None if cacheable == 0 else hits / cacheable
 
+    @property
+    def fully_cached(self) -> bool:
+        totals = self.cache_totals
+        if self.model_calls == 0 or totals is None:
+            return False
+        hits, misses, bypasses = totals
+        cost_consistent = self.cost_usd is None or self.cost_usd == 0
+        tokens_consistent = not self.have_tokens or (
+            self.input_tokens == 0 and self.output_tokens == 0
+        )
+        return (
+            hits == self.model_calls
+            and misses == 0
+            and bypasses == 0
+            and cost_consistent
+            and tokens_consistent
+        )
+
     def observe(self, event: Event, elapsed_seconds: float | None = None) -> None:
         if isinstance(event, Started):
             self._observe_started(event, elapsed_seconds)
@@ -104,9 +133,12 @@ class _CandidateProgress:
         elif isinstance(event, Span):
             self._observe_span(event)
 
+    def begin(self) -> None:
+        self.submitted = True
+        self.activity = "Run submitted"
+
     def _observe_started(self, event: Started, elapsed_seconds: float | None) -> None:
-        if event.url4 != self.candidate.url4:
-            return
+        self.submitted = True
         self.started = True
         self.root_sources.add(event.source)
         self.activity = "Run started"
@@ -198,7 +230,9 @@ class _CandidateProgress:
     def reconcile(self, result: CandidateResult) -> None:
         self.result = result
         self.total_cases = len(result.cases)
-        self.cost_usd = result.usage.cost_usd
+        self.completed_cases = self.total_cases
+        if result.usage.cost_usd is not None:
+            self.cost_usd = result.usage.cost_usd
         if result.usage.input_tokens is not None:
             self.input_tokens = result.usage.input_tokens
             self.have_tokens = True
@@ -210,9 +244,13 @@ class _CandidateProgress:
     def abort(self, exc: BaseException) -> None:
         if self.result is not None or self.status not in {"queued", "running"}:
             return
-        if not self.started:
+        if not self.submitted:
             self.workflow_status = "not_run"
             self.activity = "Not started"
+            return
+        if not self.started:
+            self.workflow_status = "run_failed"
+            self.activity = "Run outcome unavailable"
             return
         if isinstance(exc, KeyboardInterrupt):
             self.workflow_status = "stopped"
@@ -269,9 +307,29 @@ class _EvaluationProgress:
         elif after != before and after not in {"queued", "running"}:
             self.announcement = f"{candidate.name} {after.replace('_', ' ')}"
 
+    def begin(self, candidate: Candidate) -> None:
+        try:
+            row = self._rows_by_name[candidate.name]
+        except KeyError:
+            raise ValueError(f"unknown Evaluation Candidate {candidate.name!r}") from None
+        row.begin()
+
     @property
     def finished(self) -> bool:
         return all(row.status not in {"queued", "running"} for row in self.rows)
+
+    @property
+    def complete(self) -> bool:
+        return all(row.result is not None for row in self.rows)
+
+    @property
+    def duration_seconds(self) -> float | None:
+        if not self.complete:
+            return None
+        results = tuple(row.result for row in self.rows if row.result is not None)
+        started_at = min(result.started_at for result in results)
+        completed_at = max(result.completed_at for result in results)
+        return (completed_at - started_at).total_seconds()
 
     @property
     def model_calls(self) -> int:
@@ -316,6 +374,14 @@ class _EvaluationProgress:
         hits, misses, _ = totals
         cacheable = hits + misses
         return None if cacheable == 0 else hits / cacheable
+
+    @property
+    def fully_cached(self) -> bool:
+        return (
+            self.complete
+            and self.model_calls > 0
+            and all(row.model_calls == 0 or row.fully_cached for row in self.rows)
+        )
 
     @property
     def cache_bypass_breakdown(self) -> tuple[tuple[str, int], ...]:

--- a/packages/screamingface/src/screamingface/_ui/evaluation_state.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_state.py
@@ -1,126 +1,80 @@
-"""Accumulated view of one Evaluation, folded from public Events only.
-
-Deliberately free of ipywidgets and of wall-clock reads: every number here is derived
-from Events the Engine actually sent, so the panel can never show a figure the run did
-not produce, and the fold stays directly testable.
-"""
+"""Candidate-scoped state for the live Evaluation panel."""
 
 from __future__ import annotations
 
-from collections import deque
 from dataclasses import dataclass, field
-from datetime import datetime
 from decimal import Decimal
 from typing import cast
 
+from screamingface._evaluation.model import Candidate
 from screamingface.events import Event, Log, Span, Started, Terminated, Usage
+from screamingface.report import CandidateResult, Report
 
-# A candidate is one Engine run, so terminal Events are the only honest completion
-# signal — model Spans fire many times per candidate and cannot stand in for it.
-_TERMINAL_ORDER = ("failed", "timed_out", "stopped", "succeeded")
-
-# WHY a prefix rather than a fixed key list: the gateway owns the reason vocabulary and publishes
-# one attribute per reason it saw. INVARIANT: the `cache.bypasses` total does not start with this
-# prefix, so the total can never be harvested as a reason bucket.
 _BYPASS_REASON_PREFIX = "cache.bypass."
-
 UNSTATED_BYPASS_REASON = "unstated"
-"""The Engine's bucket for a bypass that named no reason. Kept distinct from its `other` bucket:
-`other` is a cardinality overflow, this is an absent value, and merging them would erase which."""
 
 
 @dataclass(slots=True)
-class _EvaluationProgress:
-    """Running totals for one `evaluate()` call."""
-
-    total_candidates: int | None = None
-    candidate_models: frozenset[str] = field(default_factory=frozenset)
-    candidate_urls: frozenset[str] = field(default_factory=frozenset)
-    root_sources: set[str] = field(default_factory=set)
-    cache_counts: dict[str, tuple[int, int, int]] = field(default_factory=dict)
-    cache_bypass_reasons: dict[str, dict[str, int]] = field(default_factory=dict)
-    completed: int = 0
-    terminal_counts: dict[str, int] = field(default_factory=dict)
+class _CandidateProgress:
+    candidate: Candidate
+    total_cases: int | None
+    completed_cases: int = 0
+    failed_cases: int = 0
     model_calls: int = 0
-    candidate_calls: int = 0
-    benchmark_calls: int = 0
     failed_calls: int = 0
     refusals: int = 0
     input_tokens: int = 0
     output_tokens: int = 0
     have_tokens: bool = False
     cost_usd: Decimal | None = None
-    first_at: datetime | None = None
-    latest_at: datetime | None = None
-    arrival_elapsed_seconds: float | None = None
+    started: bool = False
+    terminal_status: str | None = None
+    root_sources: set[str] = field(default_factory=set)
+    cache_counts: dict[str, tuple[int, int, int]] = field(default_factory=dict)
+    cache_bypass_reasons: dict[str, dict[str, int]] = field(default_factory=dict)
     activity: str | None = None
-    error: str | None = None
-    evaluation_started: bool = False
-    #: Newest-first ring of recent Events, so the panel can show work happening rather
-    #: than a single frozen "last thing". Bounded: a long run emits thousands.
-    feed: deque[tuple[float, str, str]] = field(default_factory=lambda: deque(maxlen=40))
-
-    def observe(self, event: Event, *, elapsed_seconds: float | None = None) -> None:
-        self._stamp(event.timestamp)
-        if elapsed_seconds is not None:
-            self.arrival_elapsed_seconds = max(0.0, elapsed_seconds)
-        if isinstance(event, Started):
-            self._observe_started(event, elapsed_seconds)
-        elif isinstance(event, Log):
-            self._observe_cache_log(event)
-        elif isinstance(event, Span):
-            self._observe_span(event, elapsed_seconds)
-        elif isinstance(event, Usage):
-            self._observe_usage(event)
-        elif isinstance(event, Terminated):
-            self._observe_root_terminated(event, elapsed_seconds)
-
-    @property
-    def running(self) -> bool:
-        return not self.finished
-
-    @property
-    def finished(self) -> bool:
-        """True once every candidate has reported a terminal Event."""
-
-        return self.total_candidates is not None and self.completed >= self.total_candidates
+    result: CandidateResult | None = None
+    workflow_status: str | None = None
+    started_elapsed_seconds: float | None = None
 
     @property
     def status(self) -> str:
-        """Worst terminal status seen, or 'running' while work is outstanding."""
-
-        if not self.finished:
-            return "running"
-        for name in _TERMINAL_ORDER:
-            if self.terminal_counts.get(name):
-                return name
-        return "succeeded"
-
-    @property
-    def fraction(self) -> float | None:
-        """Completed share of candidates, or None when the total is unknown."""
-
-        if not self.total_candidates:
-            return None
-        return min(1.0, self.completed / self.total_candidates)
+        if self.result is not None:
+            status = "finished"
+        elif self.terminal_status == "failed":
+            status = "run_failed"
+        elif self.terminal_status in {"stopped", "timed_out"}:
+            status = self.terminal_status
+        elif self.workflow_status is not None:
+            status = self.workflow_status
+        else:
+            status = "running" if self.started else "queued"
+        return status
 
     @property
-    def elapsed_seconds(self) -> float | None:
-        event_elapsed = (
-            None
-            if self.first_at is None or self.latest_at is None
-            else max(0.0, (self.latest_at - self.first_at).total_seconds())
-        )
-        if self.arrival_elapsed_seconds is None:
-            return event_elapsed
-        if event_elapsed is None:
-            return self.arrival_elapsed_seconds
-        return max(self.arrival_elapsed_seconds, event_elapsed)
+    def score(self) -> float | None:
+        return None if self.result is None else self.result.score
+
+    @property
+    def score_available(self) -> bool:
+        return self.result is not None
+
+    @property
+    def qualifier(self) -> str | None:
+        if self.result is None:
+            qualifier = None
+        elif self.result.score is None:
+            qualifier = "Incomplete"
+        elif self.result.coverage < 1.0:
+            qualifier = "Partial"
+        elif self.result.failures:
+            qualifier = "Warnings"
+        else:
+            qualifier = None
+        return qualifier
 
     @property
     def cache_totals(self) -> tuple[int, int, int] | None:
-        """Latest authoritative hit, miss, and bypass totals across Candidate Runs."""
-
         if not self.cache_counts:
             return None
         return (
@@ -130,104 +84,66 @@ class _EvaluationProgress:
         )
 
     @property
-    def cache_bypass_breakdown(self) -> tuple[tuple[str, int], ...]:
-        """Bypass reasons across every Candidate Run, most frequent first.
-
-        Ties break on the reason name so a live re-render cannot reorder equal counts.
-        AIDEV-NOTE: `other` summed across runs collapses different reason sets — honest per run,
-        imprecise in aggregate. Deliberately not surfaced; explaining it costs more than it buys.
-        """
-
-        totals: dict[str, int] = {}
-        for reasons in self.cache_bypass_reasons.values():
-            for reason, count in reasons.items():
-                totals[reason] = totals.get(reason, 0) + count
-        return tuple(sorted(totals.items(), key=lambda item: (-item[1], item[0])))
-
-    @property
     def cache_hit_rate(self) -> float | None:
-        counts = self.cache_totals
-        if counts is None:
+        totals = self.cache_totals
+        if totals is None:
             return None
-        hits, misses, _ = counts
+        hits, misses, _ = totals
         cacheable = hits + misses
         return None if cacheable == 0 else hits / cacheable
 
-    def _note(
-        self,
-        event: Event,
-        kind: str,
-        text: str,
-        elapsed_seconds: float | None = None,
-    ) -> None:
-        event_offset = (
-            0.0
-            if self.first_at is None
-            else max(0.0, (event.timestamp - self.first_at).total_seconds())
-        )
-        offset = (
-            event_offset
-            if elapsed_seconds is None
-            else max(event_offset, max(0.0, elapsed_seconds))
-        )
-        self.feed.appendleft((offset, kind, text))
-
-    def _stamp(self, moment: datetime) -> None:
-        if self.first_at is None or moment < self.first_at:
-            self.first_at = moment
-        if self.latest_at is None or moment > self.latest_at:
-            self.latest_at = moment
+    def observe(self, event: Event, elapsed_seconds: float | None = None) -> None:
+        if isinstance(event, Started):
+            self._observe_started(event, elapsed_seconds)
+        elif isinstance(event, Log):
+            self._observe_cache_log(event)
+        elif isinstance(event, Usage):
+            self._observe_usage(event)
+        elif isinstance(event, Terminated):
+            self._observe_terminated(event)
+        elif isinstance(event, Span):
+            self._observe_span(event)
 
     def _observe_started(self, event: Started, elapsed_seconds: float | None) -> None:
-        if self.candidate_urls and event.url4 not in self.candidate_urls:
+        if event.url4 != self.candidate.url4:
             return
+        self.started = True
         self.root_sources.add(event.source)
-        self.activity = "Running candidate" if self.total_candidates == 1 else "Running candidates"
-        if not self.evaluation_started:
-            self.evaluation_started = True
-            self._note(event, "start", "evaluation started", elapsed_seconds)
+        self.activity = "Run started"
+        self.started_elapsed_seconds = elapsed_seconds
 
-    def _observe_root_terminated(
-        self,
-        event: Terminated,
-        elapsed_seconds: float | None,
-    ) -> None:
-        if self.candidate_urls and event.source not in self.root_sources:
+    def _observe_terminated(self, event: Terminated) -> None:
+        if event.source not in self.root_sources:
             return
-        self._observe_terminated(event, elapsed_seconds)
+        self.terminal_status = event.status
+        self.activity = (
+            "Run finished"
+            if event.status == "succeeded"
+            else f"Run {event.status.replace('_', ' ')}"
+        )
 
-    def _observe_cache_log(self, event: Log) -> None:
-        names = ("cache.hits", "cache.misses", "cache.bypasses")
-        values = tuple(event.attributes.get(name) for name in names)
-        if not all(isinstance(value, int) and not isinstance(value, bool) for value in values):
-            return
-        self.cache_counts[event.run_id] = cast(tuple[int, int, int], values)
-        # INVARIANT: the summary is a reconciliation, so it REPLACES this run's reason map rather
-        # than adding to it — including replacing it with nothing when the run had no bypasses.
-        # WHY the prefix is safe: `cache.bypasses` (the total) does not start with `cache.bypass.`,
-        # so the total can never be read as a reason bucket.
-        self.cache_bypass_reasons[event.run_id] = {
-            key[len(_BYPASS_REASON_PREFIX) :]: value
-            for key, value in event.attributes.items()
-            if key.startswith(_BYPASS_REASON_PREFIX)
-            and isinstance(value, int)
-            and not isinstance(value, bool)
-        }
+    def _observe_span(self, event: Span) -> None:
+        if event.operation == "RelUrlNode" and event.name == "/benchmarks/case-execution":
+            self._observe_case_span(event)
+        if event.request_model is not None:
+            self._observe_model_span(event)
 
-    def _observe_span(self, event: Span, elapsed_seconds: float | None) -> None:
-        # Structural URL4 spans carry no request_model; only paid model work counts.
-        if event.request_model is None:
-            return
+    def _observe_case_span(self, event: Span) -> None:
+        self.completed_cases += 1
+        if self.total_cases is not None:
+            self.completed_cases = min(self.total_cases, self.completed_cases)
+        if event.status == "error":
+            self.failed_cases += 1
+        unit = "case" if self.completed_cases == 1 else "cases"
+        self.activity = (
+            f"{self.completed_cases} {unit} finished"
+            if self.total_cases is None
+            else f"{self.completed_cases} / {self.total_cases} {unit} finished"
+        )
+
+    def _observe_model_span(self, event: Span) -> None:
         self._observe_cache_status(event)
         self.model_calls += 1
-        if event.request_model in self.candidate_models:
-            self.candidate_calls += 1
-            role = "candidate"
-            self.activity = _calls_activity("Running candidate", self.candidate_calls)
-        else:
-            self.benchmark_calls += 1
-            role = "grading"
-            self.activity = _calls_activity("Grading benchmark", self.benchmark_calls)
         if event.status == "error":
             self.failed_calls += 1
         if event.refusal is not None:
@@ -238,12 +154,28 @@ class _EvaluationProgress:
         if event.output_tokens is not None:
             self.output_tokens += event.output_tokens
             self.have_tokens = True
-        self._note(
-            event,
-            "error" if event.status == "error" else "model",
-            f"{role} · {_span_text(event)}",
-            elapsed_seconds,
+        outcome = (
+            "refused"
+            if event.refusal is not None
+            else "failed"
+            if event.status == "error"
+            else "finished"
         )
+        self.activity = f"Model call {outcome}"
+
+    def _observe_cache_log(self, event: Log) -> None:
+        names = ("cache.hits", "cache.misses", "cache.bypasses")
+        values = tuple(event.attributes.get(name) for name in names)
+        if not all(isinstance(value, int) and not isinstance(value, bool) for value in values):
+            return
+        self.cache_counts[event.run_id] = cast(tuple[int, int, int], values)
+        self.cache_bypass_reasons[event.run_id] = {
+            key[len(_BYPASS_REASON_PREFIX) :]: value
+            for key, value in event.attributes.items()
+            if key.startswith(_BYPASS_REASON_PREFIX)
+            and isinstance(value, int)
+            and not isinstance(value, bool)
+        }
 
     def _observe_cache_status(self, event: Span) -> None:
         if event.cache_status is None:
@@ -253,85 +185,164 @@ class _EvaluationProgress:
         self.cache_counts[event.run_id] = cast(tuple[int, int, int], tuple(counts))
         if event.cache_status != "bypass":
             return
-        # WHY tally live rather than wait for the summary: the band is a diagnostic during the run,
-        # and a bypass storm is worth seeing before the run ends. INVARIANT: a bypass naming no
-        # reason still lands in a bucket, so the breakdown always sums to the bypass total.
         reason = (event.cache_reason or "").strip() or UNSTATED_BYPASS_REASON
         observed = self.cache_bypass_reasons.setdefault(event.run_id, {})
         observed[reason] = observed.get(reason, 0) + 1
 
     def _observe_usage(self, event: Usage) -> None:
-        # 'subtree' repeats what its children already reported — summing both double counts.
-        if event.scope != "self":
+        if event.scope != "self" or event.usage.cost_usd is None:
             return
         amount = event.usage.cost_usd
-        if amount is None:
-            return
         self.cost_usd = amount if self.cost_usd is None else self.cost_usd + amount
 
-    def _observe_terminated(self, event: Terminated, elapsed_seconds: float | None) -> None:
-        self.completed += 1
-        self.terminal_counts[event.status] = self.terminal_counts.get(event.status, 0) + 1
-        if event.error is not None and self.error is None:
-            self.error = event.error.message
-        kind = "done" if event.status == "succeeded" else "error"
-        if not self.finished and self.total_candidates is not None:
-            self.activity = (
-                f"Running candidates · {self.completed}/{self.total_candidates} finished"
-            )
-            terminal = "finished" if event.status == "succeeded" else event.status.replace("_", " ")
-            self._note(
-                event,
-                kind,
-                f"candidate {self.completed}/{self.total_candidates} {terminal}"
-                f"{self._cache_suffix(event.run_id)}",
-                elapsed_seconds,
-            )
+    def reconcile(self, result: CandidateResult) -> None:
+        self.result = result
+        self.total_cases = len(result.cases)
+        self.cost_usd = result.usage.cost_usd
+        if result.usage.input_tokens is not None:
+            self.input_tokens = result.usage.input_tokens
+            self.have_tokens = True
+        if result.usage.output_tokens is not None:
+            self.output_tokens = result.usage.output_tokens
+            self.have_tokens = True
+        self.activity = "Result ready"
+
+    def abort(self, exc: BaseException) -> None:
+        if self.result is not None or self.status not in {"queued", "running"}:
             return
-        terminal = "finished" if self.status == "succeeded" else self.status.replace("_", " ")
-        self.activity = f"Evaluation {terminal}"
-        self._note(
-            event,
-            kind,
-            f"evaluation {terminal}{self._cache_suffix(event.run_id)}",
-            elapsed_seconds,
+        if not self.started:
+            self.workflow_status = "not_run"
+            self.activity = "Not started"
+            return
+        if isinstance(exc, KeyboardInterrupt):
+            self.workflow_status = "stopped"
+            self.activity = "Run stopped"
+        elif isinstance(exc, TimeoutError):
+            self.workflow_status = "timed_out"
+            self.activity = "Run timed out"
+        else:
+            self.workflow_status = "run_failed"
+            self.activity = "Run failed"
+
+
+@dataclass(slots=True, init=False)
+class _EvaluationProgress:
+    case_count: int | None
+    rows: tuple[_CandidateProgress, ...]
+    _rows_by_name: dict[str, _CandidateProgress]
+    error: str | None
+    announcement: str
+
+    def __init__(self, *, candidates: tuple[Candidate, ...], case_count: int | None) -> None:
+        if not candidates:
+            raise ValueError("live Evaluation progress requires at least one Candidate")
+        if case_count is not None and (
+            isinstance(case_count, bool) or not isinstance(case_count, int) or case_count < 1
+        ):
+            raise ValueError("live Evaluation progress case_count must be positive")
+        rows = tuple(
+            _CandidateProgress(candidate=candidate, total_cases=case_count)
+            for candidate in candidates
+        )
+        self.case_count = case_count
+        self.rows = rows
+        self._rows_by_name = {row.candidate.name: row for row in rows}
+        self.error = None
+        self.announcement = ""
+
+    def observe(
+        self,
+        candidate: Candidate,
+        event: Event,
+        *,
+        elapsed_seconds: float | None = None,
+    ) -> None:
+        try:
+            row = self._rows_by_name[candidate.name]
+        except KeyError:
+            raise ValueError(f"unknown Evaluation Candidate {candidate.name!r}") from None
+        before = row.status
+        row.observe(event, elapsed_seconds)
+        after = row.status
+        if isinstance(event, Started) and row.started:
+            self.announcement = "Evaluation started"
+        elif after != before and after not in {"queued", "running"}:
+            self.announcement = f"{candidate.name} {after.replace('_', ' ')}"
+
+    @property
+    def finished(self) -> bool:
+        return all(row.status not in {"queued", "running"} for row in self.rows)
+
+    @property
+    def model_calls(self) -> int:
+        return sum(row.model_calls for row in self.rows)
+
+    @property
+    def failed_calls(self) -> int:
+        return sum(row.failed_calls for row in self.rows)
+
+    @property
+    def input_tokens(self) -> int:
+        return sum(row.input_tokens for row in self.rows)
+
+    @property
+    def output_tokens(self) -> int:
+        return sum(row.output_tokens for row in self.rows)
+
+    @property
+    def have_tokens(self) -> bool:
+        return any(row.have_tokens for row in self.rows)
+
+    @property
+    def cost_usd(self) -> Decimal | None:
+        reported = tuple(row.cost_usd for row in self.rows if row.cost_usd is not None)
+        return None if not reported else sum(reported, Decimal())
+
+    @property
+    def cache_totals(self) -> tuple[int, int, int] | None:
+        reported = tuple(row.cache_totals for row in self.rows if row.cache_totals is not None)
+        if not reported:
+            return None
+        return cast(
+            tuple[int, int, int],
+            tuple(sum(counts[index] for counts in reported) for index in range(3)),
         )
 
-    def _cache_suffix(self, run_id: str) -> str:
-        counts = self.cache_counts.get(run_id)
-        if counts is None:
-            return ""
-        parts = [
-            _cache_count(name, count)
-            for name, count in zip(("hit", "miss", "bypass"), counts, strict=True)
-            if count
-        ]
-        return f" · cache: {', '.join(parts)}" if parts else ""
+    @property
+    def cache_hit_rate(self) -> float | None:
+        totals = self.cache_totals
+        if totals is None:
+            return None
+        hits, misses, _ = totals
+        cacheable = hits + misses
+        return None if cacheable == 0 else hits / cacheable
 
+    @property
+    def cache_bypass_breakdown(self) -> tuple[tuple[str, int], ...]:
+        totals: dict[str, int] = {}
+        for row in self.rows:
+            for reasons in row.cache_bypass_reasons.values():
+                for reason, count in reasons.items():
+                    totals[reason] = totals.get(reason, 0) + count
+        return tuple(sorted(totals.items(), key=lambda item: (-item[1], item[0])))
 
-def _cache_count(name: str, count: int) -> str:
-    plural = {"hit": "hits", "miss": "misses", "bypass": "bypasses"}[name]
-    return f"{count:,} {name if count == 1 else plural}"
+    def reconcile(self, report: Report) -> None:
+        if self.case_count is not None and report.case_count != self.case_count:
+            raise ValueError("final Report has the wrong selected Case count")
+        results = {result.name: result for result in report.candidates}
+        if set(results) != set(self._rows_by_name):
+            raise ValueError("final Report has the wrong Candidates")
+        self.case_count = report.case_count
+        for row in self.rows:
+            row.reconcile(results[row.candidate.name])
+        self.announcement = "Evaluation complete"
 
-
-def _calls_activity(phase: str, count: int) -> str:
-    noun = "model call" if count == 1 else "model calls"
-    return f"{phase} · {count} {noun} completed"
-
-
-def _span_text(event: Span) -> str:
-    """One model call, summarised the way the text observer already words it."""
-
-    parts = [str(event.request_model)]
-    if event.refusal is not None:
-        parts.append("refused")
-    elif event.status == "error":
-        parts.append("failed")
-    if event.start is not None and event.end is not None:
-        parts.append(f"{(event.end - event.start).total_seconds():.1f}s")
-    if event.input_tokens is not None or event.output_tokens is not None:
-        parts.append(f"{event.input_tokens or 0:,}/{event.output_tokens or 0:,} tok")
-    return " · ".join(parts)
+    def abort(self, exc: BaseException) -> None:
+        for row in self.rows:
+            row.abort(exc)
+        message = str(exc).strip()
+        self.error = message or None
+        self.announcement = "Evaluation stopped"
 
 
 __all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -11,79 +11,66 @@ from typing import Any
 
 from screamingface._evaluation.model import Candidate
 from screamingface._ui.evaluation_state import _CandidateProgress, _EvaluationProgress
-from screamingface._ui.style import STYLE
+from screamingface._ui.style import FUSION_GRADIENT, STYLE
 from screamingface.events import Event
 from screamingface.report import Report
 
 _STYLE = (
     STYLE
     + """<style>
-.sf-eval{border:0;padding:4px 14px 14px;font-family:"IBM Plex Sans",system-ui,sans-serif}
-.sf-eval__title{font-size:20px;font-weight:700;line-height:1.2;letter-spacing:-.01em}
-.sf-eval__sub{font-size:13px;color:var(--sf-ink-2);margin-top:3px}
+.sf-eval{border:0;padding:4px 0 14px;font-family:"IBM Plex Sans",system-ui,sans-serif}
+.sf-eval__title-row{display:flex;align-items:baseline;justify-content:space-between;gap:16px}
+.sf-eval__title{font-size:20px;font-weight:600;line-height:1.2;letter-spacing:-.01em}
+.sf-eval__title-state{flex:0 0 auto;text-align:right;white-space:nowrap;
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;color:var(--sf-ink-2);
+  font-variant-numeric:tabular-nums}
 .sf-eval__note{margin-top:10px;padding:7px 10px;border:1px solid var(--sf-line);
   font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px;color:var(--sf-ink-2)}
-.sf-eval__table-wrap{margin-top:14px;overflow-x:auto;border:1px solid var(--sf-line);
-  scrollbar-gutter:stable}
-.sf-eval__table{width:100%;min-width:820px;border-collapse:collapse;
-  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+.sf-eval__overall{margin-top:8px}
+.sf-eval__overall-track{height:8px;background:var(--sf-line);overflow:hidden}
+.sf-eval__overall-fill{display:block;height:100%;background-repeat:no-repeat;
+  background-position:right center;transition:width .11s linear}
+.sf-eval__table-wrap{margin-top:12px;border:1px solid var(--sf-line)}
+.sf-eval__table{width:100%;table-layout:fixed;border-collapse:collapse;
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:13px;
   font-variant-numeric:tabular-nums}
+.sf-eval__col--candidate{width:27%}
+.sf-eval__col--status{width:17%}
+.sf-eval__col--cases{width:10%}
+.sf-eval__col--score{width:17%}
+.sf-eval__col--cost{width:14%}
+.sf-eval__col--cache{width:15%}
 .sf-eval__table caption{position:absolute;width:1px;height:1px;padding:0;margin:-1px;
   overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-.sf-eval__table th,.sf-eval__table td{padding:10px 12px;text-align:left;
-  border-bottom:1px solid var(--sf-line);vertical-align:middle;white-space:nowrap}
+.sf-eval__table th,.sf-eval__table td{padding:12px 16px;text-align:left;
+  border-bottom:1px solid var(--sf-line);vertical-align:middle;overflow-wrap:anywhere}
 .sf-eval__table th{position:sticky;top:0;z-index:2;background:var(--sf-surface);
-  color:var(--sf-ink-2);font-size:11px;text-transform:uppercase;letter-spacing:.08em}
+  color:var(--sf-ink-2);font-size:11px;font-weight:500;text-transform:uppercase;letter-spacing:.1em;
+  border-bottom:1px solid var(--sf-line-2);
+  white-space:nowrap}
+.sf-eval__table tbody tr:hover{background:var(--sf-surface)}
 .sf-eval__table tbody tr:last-child td{border-bottom:0}
-.sf-eval__table th:first-child,.sf-eval__table td:first-child{position:sticky;left:0;z-index:1;
-  background:var(--sf-bg);border-right:1px solid var(--sf-line)}
-.sf-eval__table th:first-child{z-index:3;background:var(--sf-surface)}
-.sf-eval__candidate{font-family:"IBM Plex Sans",system-ui,sans-serif;font-weight:600;
+.sf-eval__candidate{font-family:"IBM Plex Sans",system-ui,sans-serif;font-weight:500;
   color:var(--sf-ink)}
-.sf-eval__candidate-model{display:block;margin-top:2px;font-size:11px;font-weight:400;
-  color:var(--sf-ink-2);font-family:"IBM Plex Mono",ui-monospace,monospace}
-.sf-eval__status{display:inline-flex;align-items:center;gap:7px;color:var(--sf-ink-2);
-  font-family:"IBM Plex Sans",system-ui,sans-serif}
+.sf-eval__status{display:inline-flex;align-items:center;gap:8px;color:var(--sf-ink-2);
+  font-family:"IBM Plex Sans",system-ui,sans-serif;white-space:nowrap}
 .sf-eval__status-sq{width:9px;height:9px;flex:0 0 auto;background:var(--sf-ink-3)}
 .sf-eval__status--running .sf-eval__status-sq{background:var(--sf-accent)}
 .sf-eval__status--finished .sf-eval__status-sq{background:var(--sf-success-solid)}
 .sf-eval__status--run_failed .sf-eval__status-sq,.sf-eval__status--stopped .sf-eval__status-sq,
-.sf-eval__status--timed_out .sf-eval__status-sq{background:var(--sf-blind)}
-.sf-eval__activity{display:block;margin-top:2px;color:var(--sf-ink-2);font-size:11px}
-.sf-eval__progress{display:flex;align-items:center;gap:9px;min-width:150px}
-.sf-eval__progress progress{appearance:none;width:88px;height:6px;border:0;
-  background:var(--sf-line)}
-.sf-eval__progress progress::-webkit-progress-bar{background:var(--sf-line)}
-.sf-eval__progress progress::-webkit-progress-value{background:var(--sf-accent)}
-.sf-eval__progress progress::-moz-progress-bar{background:var(--sf-accent)}
-.sf-eval__progress progress{transition:color .15s ease}
-.sf-eval__unavailable{color:var(--sf-ink-2)}
-.sf-eval__stats{display:grid;grid-template-columns:repeat(3,1fr);border:1px solid var(--sf-line);
-  border-top:0}
-.sf-eval__stat{padding:10px 12px;border-right:1px solid var(--sf-line);min-width:0}
-.sf-eval__stat:last-child{border-right:0}
-.sf-eval__stat-k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
-  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-2)}
-.sf-eval__stat-v{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:18px;
-  margin-top:3px;font-variant-numeric:tabular-nums;color:var(--sf-ink)}
-.sf-eval__cache{border:1px solid var(--sf-line);border-top:0;display:flex;flex-wrap:wrap;
-  align-items:baseline;gap:6px 14px;padding:9px 12px}
-.sf-eval__cache-k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
-  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-2)}
-.sf-eval__cache-v{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:18px;
-  color:var(--sf-ink)}
-.sf-eval__cache-of,.sf-eval__cache-why{font-family:"IBM Plex Mono",ui-monospace,monospace;
-  font-size:11.5px;color:var(--sf-ink-2)}
-.sf-eval__activity-log{margin-top:12px;border:1px solid var(--sf-line);padding:8px 10px;
-  color:var(--sf-ink-2);font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px}
-.sf-eval__activity-log summary{cursor:pointer;color:var(--sf-ink-2)}
-.sf-eval__activity-row{padding:5px 0;border-top:1px solid var(--sf-line)}
+.sf-eval__status--timed_out .sf-eval__status-sq{background:var(--sf-danger-solid)}
+.sf-eval__cases{color:var(--sf-ink);white-space:nowrap}
+.sf-eval__unavailable{color:var(--sf-ink-2);white-space:nowrap}
+.sf-eval__receipt{margin-top:7px;min-height:1.45em;
+  font-family:"IBM Plex Mono",ui-monospace,monospace;
+  font-size:11.5px;color:var(--sf-ink-2);font-variant-numeric:tabular-nums}
+.sf-eval__receipt-success{color:var(--sf-success);font-weight:500}
+.sf-eval__num{text-align:right}
 .sf-eval__err{margin-top:10px;padding:8px 10px;border-left:2px solid var(--sf-blind);
   background:var(--sf-blind-bg);color:var(--sf-blind);font-family:"IBM Plex Mono",ui-monospace,
   monospace;font-size:12px;white-space:pre-wrap}
 .sf-eval__announce{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
   clip:rect(0,0,0,0);white-space:nowrap;border:0}
-@media(prefers-reduced-motion:reduce){.sf-eval__progress progress{transition:none}}
 </style>"""
 )
 
@@ -94,32 +81,138 @@ def evaluation_panel_html(
     elapsed: float | None = None,
     check_disclosure: str | None = None,
 ) -> str:
-    title = "Evaluation complete" if progress.finished else "Evaluating"
-    subtitle = f"Benchmark · {escape(benchmark)}" if benchmark else "Live run status"
+    title = escape(benchmark) if benchmark else "Evaluation"
     return (
         f"{_STYLE}<div class='sf-ui sf-eval' aria-label='ScreamingFace evaluation progress'>"
+        "<div class='sf-eval__title-row'>"
         f"<div class='sf-eval__title'>{title}</div>"
-        f"<div class='sf-eval__sub'>{subtitle}</div>"
+        f"{_title_state_html(progress)}"
+        "</div>"
         f"{_note_html(check_disclosure)}"
+        f"{_overall_progress_html(progress)}"
+        f"{_receipt_html(progress)}"
         f"{_candidate_table_html(progress, elapsed)}"
-        f"{_stats_html(progress)}"
-        f"{_cache_html(progress)}"
-        f"{_activity_html(progress)}"
         f"{_error_html(progress)}"
         f"<div class='sf-eval__announce' aria-live='polite'>{escape(progress.announcement)}</div>"
         "</div>"
     )
 
 
-def _candidate_table_html(progress: _EvaluationProgress, elapsed: float | None) -> str:
-    headers = ("Candidate", "Status", "Progress", "Score", "Cost", "Cache")
-    head = "".join(f"<th scope='col'>{header}</th>" for header in headers)
-    body = "".join(_candidate_row_html(row, elapsed) for row in progress.rows)
+def _overall_progress_html(progress: _EvaluationProgress) -> str:
+    if progress.complete:
+        return ""
+    counts = _overall_counts(progress)
+    if counts is None:
+        return ""
+    completed, total, percent_value = counts
+    percent = f"{percent_value:.6f}".rstrip("0").rstrip(".")
+    background_size = "100" if completed == 0 else f"{10000 / percent_value:.1f}"
     return (
-        "<div class='sf-eval__table-wrap' tabindex='0' "
-        "aria-label='Scrollable Candidate progress table'>"
+        "<div class='sf-eval__overall'>"
+        "<div class='sf-eval__overall-track' role='progressbar' "
+        f"aria-label='Overall Case progress' aria-valuemin='0' aria-valuemax='{total}' "
+        f"aria-valuenow='{completed}'>"
+        f"<span class='sf-eval__overall-fill' style='width:{percent}%;"
+        f"background-size:{background_size}% 100%;background-image:{FUSION_GRADIENT}'></span>"
+        "</div></div>"
+    )
+
+
+def _overall_counts(progress: _EvaluationProgress) -> tuple[int, int, float] | None:
+    totals = tuple(row.total_cases for row in progress.rows)
+    if any(total is None for total in totals):
+        return None
+    total = sum(total for total in totals if total is not None)
+    if total == 0:
+        return None
+    completed = sum(
+        min(row.completed_cases, row.total_cases)
+        for row in progress.rows
+        if row.total_cases is not None
+    )
+    percent_value = completed / total * 100
+    return completed, total, percent_value
+
+
+def _title_state_html(progress: _EvaluationProgress) -> str:
+    state = _overall_state(progress)
+    if progress.duration_seconds is not None:
+        state = f"{state} · {_duration(progress.duration_seconds)}"
+    elif (counts := _overall_counts(progress)) is not None:
+        rounded_percent = int(counts[2] + 0.5)
+        state = f"{state} · {rounded_percent}%"
+    return f"<div class='sf-eval__title-state'>{state}</div>"
+
+
+def _overall_state(progress: _EvaluationProgress) -> str:
+    if progress.complete:
+        state = "complete"
+    elif not progress.finished:
+        state = "evaluating…"
+    else:
+        statuses = {row.status for row in progress.rows}
+        state = next(
+            (
+                label
+                for status, label in (
+                    ("stopped", "stopped"),
+                    ("timed_out", "timed out"),
+                    ("run_failed", "failed"),
+                )
+                if status in statuses
+            ),
+            "ended",
+        )
+    return state
+
+
+def _receipt_html(progress: _EvaluationProgress) -> str:
+    if progress.fully_cached:
+        unit = "model call" if progress.model_calls == 1 else "model calls"
+        return (
+            "<div class='sf-eval__receipt'>"
+            f"{progress.model_calls:,} {unit} · "
+            "<span class='sf-eval__receipt-success'>fully cached</span> · "
+            "no tokens billed</div>"
+        )
+    parts: list[str] = []
+    if progress.cost_usd is not None:
+        parts.append(f"cost {_money(progress.cost_usd)}")
+    if progress.model_calls:
+        unit = "model call" if progress.model_calls == 1 else "model calls"
+        parts.append(f"{progress.model_calls:,} {unit}")
+    if progress.have_tokens:
+        input_tokens = _compact(progress.input_tokens)
+        output_tokens = _compact(progress.output_tokens)
+        parts.append(f"{input_tokens} in / {output_tokens} out")
+    if not parts:
+        return "<div class='sf-eval__receipt' aria-hidden='true'></div>"
+    return f"<div class='sf-eval__receipt'>{' · '.join(parts)}</div>"
+
+
+def _candidate_table_html(progress: _EvaluationProgress, elapsed: float | None) -> str:
+    headers = (
+        ("Candidate", False),
+        ("Status", False),
+        ("Cases", True),
+        ("Score", True),
+        ("Cost", True),
+        ("Cache hit", True),
+    )
+    head = "".join(
+        f"<th scope='col'{" class='sf-eval__num'" if numeric else ''}>{header}</th>"
+        for header, numeric in headers
+    )
+    body = "".join(_candidate_row_html(row, elapsed) for row in progress.rows)
+    columns = "".join(
+        f"<col class='sf-eval__col--{name}'>"
+        for name in ("candidate", "status", "cases", "score", "cost", "cache")
+    )
+    return (
+        "<div class='sf-eval__table-wrap'>"
         "<table class='sf-eval__table'>"
         "<caption>Candidate Evaluation progress</caption>"
+        f"<colgroup>{columns}</colgroup>"
         f"<thead><tr>{head}</tr></thead><tbody>{body}</tbody></table></div>"
     )
 
@@ -134,39 +227,32 @@ def _candidate_row_html(row: _CandidateProgress, elapsed: float | None) -> str:
         "timed_out": "Timed out",
         "not_run": "Not run",
     }[row.status]
-    qualifier = f" · {escape(row.qualifier)}" if row.qualifier is not None else ""
-    activity_text = row.activity
+    details = [row.qualifier] if row.qualifier is not None else []
     if row.status == "running" and elapsed is not None:
         started = row.started_elapsed_seconds or 0.0
-        duration = _duration(max(0.0, elapsed - started))
-        activity_text = f"{activity_text} · {duration}" if activity_text else duration
-    activity = (
-        f"<span class='sf-eval__activity'>{escape(activity_text)}</span>"
-        if activity_text is not None
-        else ""
-    )
-    models = ", ".join(row.candidate.models)
+        details.append(_duration(max(0.0, elapsed - started)))
+    elif row.duration_seconds is not None:
+        details.append(_duration(row.duration_seconds))
+    suffix = "".join(f" · {escape(detail)}" for detail in details)
     score = (
         "Not scored yet"
-        if not row.score_available
+        if not row.score_available and row.status in {"queued", "running"}
         else "Not scored"
-        if row.score is None
+        if not row.score_available or row.score is None
         else f"{row.score:g}"
     )
     cost = "Not reported" if row.cost_usd is None else _money(row.cost_usd)
-    cache = "Not reported" if row.cache_hit_rate is None else f"{row.cache_hit_rate:.1%}"
+    cache = _cache_value(row)
     progress_html = _case_progress_html(row)
     return (
         "<tr>"
-        f"<td><span class='sf-eval__candidate'>{escape(row.candidate.name)}</span>"
-        f"<span class='sf-eval__candidate-model'>{escape(models)}</span></td>"
+        f"<td><span class='sf-eval__candidate'>{escape(row.candidate.name)}</span></td>"
         f"<td><span class='sf-eval__status sf-eval__status--{row.status}'>"
-        f"<span class='sf-eval__status-sq' aria-hidden='true'></span>{status}{qualifier}</span>"
-        f"{activity}</td>"
-        f"<td>{progress_html}</td>"
-        f"<td class='sf-eval__unavailable'>{escape(score)}</td>"
-        f"<td class='sf-eval__unavailable'>{escape(cost)}</td>"
-        f"<td class='sf-eval__unavailable'>{escape(cache)}</td></tr>"
+        f"<span class='sf-eval__status-sq' aria-hidden='true'></span>{status}{suffix}</span></td>"
+        f"<td class='sf-eval__num'>{progress_html}</td>"
+        f"<td class='sf-eval__unavailable sf-eval__num'>{escape(score)}</td>"
+        f"<td class='sf-eval__unavailable sf-eval__num'>{escape(cost)}</td>"
+        f"<td class='sf-eval__unavailable sf-eval__num'>{escape(cache)}</td></tr>"
     )
 
 
@@ -175,66 +261,18 @@ def _case_progress_html(row: _CandidateProgress) -> str:
         unit = "case" if row.completed_cases == 1 else "cases"
         return f"<span class='sf-eval__unavailable'>{row.completed_cases} {unit} finished</span>"
     label = f"{row.completed_cases} / {row.total_cases}"
-    return (
-        f"<span class='sf-eval__progress'><progress value='{row.completed_cases}' "
-        f"max='{row.total_cases}' aria-label='{escape(row.candidate.name)} Case progress'>"
-        f"</progress><span>{label}</span></span>"
-    )
+    return f"<span class='sf-eval__cases'>{label}</span>"
 
 
-def _stats_html(progress: _EvaluationProgress) -> str:
-    calls = "—" if progress.model_calls == 0 else f"{progress.model_calls:,}"
-    if progress.failed_calls:
-        calls = f"{calls} · {progress.failed_calls} failed"
-    tokens = (
-        f"{_compact(progress.input_tokens)} / {_compact(progress.output_tokens)}"
-        if progress.have_tokens
-        else "—"
-    )
-    cost = "—" if progress.cost_usd is None else _money(progress.cost_usd)
-    cells = (("model calls", calls), ("tokens in / out", tokens), ("cost", cost))
-    body = "".join(
-        f"<div class='sf-eval__stat'><div class='sf-eval__stat-k'>{key}</div>"
-        f"<div class='sf-eval__stat-v'>{value}</div></div>"
-        for key, value in cells
-    )
-    return f"<div class='sf-eval__stats'>{body}</div>"
-
-
-def _cache_html(progress: _EvaluationProgress) -> str:
-    rate = progress.cache_hit_rate
-    value = "—" if rate is None else f"{rate:.1%}"
-    counts = progress.cache_totals
-    if counts is None:
-        detail = "no cache activity reported"
-        why = ""
-    else:
-        hits, misses, bypasses = counts
-        detail = f"{hits:,} hit · {misses:,} miss"
-        reasons = " · ".join(
-            f"{escape(reason)} {count:,}" for reason, count in progress.cache_bypass_breakdown
-        )
-        tail = f" — {reasons}" if reasons else ""
-        why = (
-            f"<span class='sf-eval__cache-why'>{bypasses:,} bypassed{tail}</span>"
-            if bypasses
-            else ""
-        )
-    return (
-        "<div class='sf-eval__cache'><span class='sf-eval__cache-k'>cache</span>"
-        f"<span class='sf-eval__cache-v'>{value}</span>"
-        f"<span class='sf-eval__cache-of'>{detail}</span>{why}</div>"
-    )
-
-
-def _activity_html(progress: _EvaluationProgress) -> str:
-    rows = "".join(
-        f"<div class='sf-eval__activity-row'>{escape(row.candidate.name)} · "
-        f"{escape(row.activity)}</div>"
-        for row in progress.rows
-        if row.activity is not None
-    )
-    return f"<details class='sf-eval__activity-log'><summary>Run activity</summary>{rows}</details>"
+def _cache_value(row: _CandidateProgress) -> str:
+    totals = row.cache_totals
+    if totals is None:
+        return "Not reported"
+    hits, misses, bypasses = totals
+    cacheable = hits + misses
+    if cacheable:
+        return f"{hits / cacheable:.1%}"
+    return "Bypassed" if bypasses else "Not reported"
 
 
 def _note_html(check_disclosure: str | None) -> str:
@@ -264,13 +302,15 @@ def _money(value: Decimal) -> str:
 
 
 def _duration(seconds: float) -> str:
-    if seconds < 60:
-        return f"{seconds:.1f}s"
-    minutes, remainder = divmod(int(seconds), 60)
+    whole_seconds = int(seconds)
+    if whole_seconds < 60:
+        return f"{whole_seconds}s"
+    minutes, remainder = divmod(whole_seconds, 60)
     if minutes < 60:
         return f"{minutes}m {remainder:02d}s"
     hours, minutes = divmod(minutes, 60)
-    return f"{hours}h {minutes:02d}m"
+    hour_unit = "hr" if hours == 1 else "hrs"
+    return f"{hours}{hour_unit} {minutes:02d}min"
 
 
 class _NotebookEvaluationView:
@@ -317,6 +357,13 @@ class _NotebookEvaluationView:
                 event,
                 elapsed_seconds=self._clock() - self._started,
             )
+            if not self._tick:
+                self._html.value = self._render()
+        self._dirty.set()
+
+    def begin(self, candidate: Candidate) -> None:
+        with self._lock:
+            self._progress.begin(candidate)
             if not self._tick:
                 self._html.value = self._render()
         self._dirty.set()

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -1,4 +1,4 @@
-"""Live notebook panel for a running `evaluate()`, driven by public Events."""
+"""Live Candidate table for a running Evaluation."""
 
 from __future__ import annotations
 
@@ -9,87 +9,81 @@ from decimal import Decimal
 from html import escape
 from typing import Any
 
-from screamingface._ui.evaluation_state import _EvaluationProgress
-from screamingface._ui.style import FUSION_GRADIENT, STYLE
+from screamingface._evaluation.model import Candidate
+from screamingface._ui.evaluation_state import _CandidateProgress, _EvaluationProgress
+from screamingface._ui.style import STYLE
 from screamingface.events import Event
+from screamingface.report import Report
 
 _STYLE = (
     STYLE
-    + f"""<style>
-.sf-eval{{border:0;border-radius:0;padding:4px 14px 14px}}
-.sf-eval__title{{font-size:20px;font-weight:700;line-height:1.2;letter-spacing:-.01em}}
-.sf-eval__sub{{font-size:13px;color:var(--sf-ink-2);margin-top:3px}}
-/* the track is a well; the fill carries the fusion gradient — square, no radius */
-.sf-eval__track{{position:relative;height:8px;background:var(--sf-line);overflow:hidden;
-  margin-top:14px}}
-.sf-eval__fill{{display:block;height:100%;background-repeat:no-repeat;
-  background-position:center;background-size:100% 100%;background-image:{FUSION_GRADIENT};
-  transition:width .35s ease-out}}
-/* unknown denominator: never fake a fraction — sweep a short band to show liveness */
-.sf-eval__fill--sweep{{width:38%;background-size:100% 100%;
-  animation:sf-eval-sweep 1.5s ease-in-out infinite}}
-@keyframes sf-eval-sweep{{0%{{transform:translateX(-100%)}}100%{{transform:translateX(365%)}}}}
-@media(prefers-reduced-motion:reduce){{.sf-eval__fill--sweep{{animation:none;width:100%}}}}
-.sf-eval__meta{{display:flex;align-items:center;justify-content:space-between;gap:12px;
-  margin-top:8px;font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
-  color:var(--sf-ink-2)}}
-.sf-eval__state{{display:inline-flex;align-items:center;gap:8px;white-space:nowrap}}
-.sf-eval__state .sq{{flex:0 0 auto;width:9px;height:9px;background:var(--sf-ink-3)}}
-.sf-eval__state.running .sq{{background:var(--sf-accent)}}
-.sf-eval__state.succeeded .sq{{background:var(--sf-success-solid)}}
-.sf-eval__state.failed .sq,.sf-eval__state.timed_out .sq,
-.sf-eval__state.stopped .sq{{background:var(--sf-blind)}}
-/* stat table: hairline cells, mono figures, tabular so digits stop jittering as they tick */
-.sf-eval__stats{{display:grid;grid-template-columns:repeat(3,1fr);
-  border:1px solid var(--sf-line);margin-top:14px}}
-.sf-eval__stat{{padding:10px 12px;border-right:1px solid var(--sf-line);min-width:0}}
-.sf-eval__stat:last-child{{border-right:0}}
-.sf-eval__stat-k{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
-  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-3)}}
-.sf-eval__stat-v{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:18px;
-  margin-top:3px;font-variant-numeric:tabular-nums;color:var(--sf-ink);
-  overflow:hidden;text-overflow:ellipsis}}
-/* cache provenance: its own full-width row, because a 4th stat cell is ~206px at the panel's
-   920px cap and the reason breakdown cannot fit there at any width. WHY no `nowrap`: a fixed
-   top-N of reasons is wrong at some width (1 fits at 680px, 2 at 760px, 3 at 920px), so this
-   wraps instead of truncating — an ellipsised diagnostic reads as fact while hiding the number
-   that mattered. Body text is --sf-ink-2: --sf-ink-3 is not a text color and is below AA. */
-.sf-eval__cache{{border:1px solid var(--sf-line);border-top:0;display:flex;flex-wrap:wrap;
-  align-items:baseline;gap:6px 14px;padding:9px 12px}}
-.sf-eval__cache-k{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
-  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-2);flex:0 0 auto}}
-.sf-eval__cache-v{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:18px;
-  font-variant-numeric:tabular-nums;color:var(--sf-ink);flex:0 0 auto}}
-.sf-eval__cache-of{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px;
-  color:var(--sf-ink-2);font-variant-numeric:tabular-nums;flex:0 0 auto}}
-.sf-eval__cache-why{{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px;
-  color:var(--sf-ink-2);font-variant-numeric:tabular-nums;min-width:0}}
-.sf-eval__cache-sep{{color:var(--sf-ink-3)}}
-.sf-eval__act{{margin-top:10px;font-family:"IBM Plex Mono",ui-monospace,monospace;
-  font-size:12px;color:var(--sf-ink-3);white-space:nowrap;overflow:hidden;
-  text-overflow:ellipsis}}
-/* pre-flight spend disclosure: calm and present, never a red banner (OME-845) */
-.sf-eval__note{{margin-top:8px;padding:7px 10px;border:1px solid var(--sf-line);
-  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px;
-  color:var(--sf-ink-2);line-height:1.5}}
-/* the feed: newest first, fixed height — proof of work, not a transcript */
-.sf-eval__feed{{margin-top:12px;border:1px solid var(--sf-line);max-height:132px;
-  overflow:auto}}
-.sf-eval__ev{{display:flex;gap:10px;align-items:baseline;padding:5px 10px;
-  border-bottom:1px solid var(--sf-line);
-  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px}}
-.sf-eval__ev:last-child{{border-bottom:0}}
-.sf-eval__ev-t{{flex:0 0 auto;color:var(--sf-ink-3);font-variant-numeric:tabular-nums}}
-.sf-eval__ev-m{{flex:1 1 auto;color:var(--sf-ink-2);overflow:hidden;
-  text-overflow:ellipsis;white-space:nowrap}}
-.sf-eval__ev--error .sf-eval__ev-m{{color:var(--sf-blind)}}
-.sf-eval__ev--done .sf-eval__ev-m,.sf-eval__ev--start .sf-eval__ev-m{{color:var(--sf-ink)}}
-.sf-eval__err{{margin-top:10px;padding:8px 10px;border-left:2px solid var(--sf-blind);
-  background:var(--sf-blind-bg);color:var(--sf-blind);
-  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;white-space:pre-wrap}}
-@media(max-width:680px){{.sf-eval__stats{{grid-template-columns:1fr}}
-  .sf-eval__stat{{border-right:0;border-bottom:1px solid var(--sf-line)}}
-  .sf-eval__stat:last-child{{border-bottom:0}}}}
+    + """<style>
+.sf-eval{border:0;padding:4px 14px 14px;font-family:"IBM Plex Sans",system-ui,sans-serif}
+.sf-eval__title{font-size:20px;font-weight:700;line-height:1.2;letter-spacing:-.01em}
+.sf-eval__sub{font-size:13px;color:var(--sf-ink-2);margin-top:3px}
+.sf-eval__note{margin-top:10px;padding:7px 10px;border:1px solid var(--sf-line);
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px;color:var(--sf-ink-2)}
+.sf-eval__table-wrap{margin-top:14px;overflow-x:auto;border:1px solid var(--sf-line);
+  scrollbar-gutter:stable}
+.sf-eval__table{width:100%;min-width:820px;border-collapse:collapse;
+  font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:12px;
+  font-variant-numeric:tabular-nums}
+.sf-eval__table caption{position:absolute;width:1px;height:1px;padding:0;margin:-1px;
+  overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.sf-eval__table th,.sf-eval__table td{padding:10px 12px;text-align:left;
+  border-bottom:1px solid var(--sf-line);vertical-align:middle;white-space:nowrap}
+.sf-eval__table th{position:sticky;top:0;z-index:2;background:var(--sf-surface);
+  color:var(--sf-ink-2);font-size:11px;text-transform:uppercase;letter-spacing:.08em}
+.sf-eval__table tbody tr:last-child td{border-bottom:0}
+.sf-eval__table th:first-child,.sf-eval__table td:first-child{position:sticky;left:0;z-index:1;
+  background:var(--sf-bg);border-right:1px solid var(--sf-line)}
+.sf-eval__table th:first-child{z-index:3;background:var(--sf-surface)}
+.sf-eval__candidate{font-family:"IBM Plex Sans",system-ui,sans-serif;font-weight:600;
+  color:var(--sf-ink)}
+.sf-eval__candidate-model{display:block;margin-top:2px;font-size:11px;font-weight:400;
+  color:var(--sf-ink-2);font-family:"IBM Plex Mono",ui-monospace,monospace}
+.sf-eval__status{display:inline-flex;align-items:center;gap:7px;color:var(--sf-ink-2);
+  font-family:"IBM Plex Sans",system-ui,sans-serif}
+.sf-eval__status-sq{width:9px;height:9px;flex:0 0 auto;background:var(--sf-ink-3)}
+.sf-eval__status--running .sf-eval__status-sq{background:var(--sf-accent)}
+.sf-eval__status--finished .sf-eval__status-sq{background:var(--sf-success-solid)}
+.sf-eval__status--run_failed .sf-eval__status-sq,.sf-eval__status--stopped .sf-eval__status-sq,
+.sf-eval__status--timed_out .sf-eval__status-sq{background:var(--sf-blind)}
+.sf-eval__activity{display:block;margin-top:2px;color:var(--sf-ink-2);font-size:11px}
+.sf-eval__progress{display:flex;align-items:center;gap:9px;min-width:150px}
+.sf-eval__progress progress{appearance:none;width:88px;height:6px;border:0;
+  background:var(--sf-line)}
+.sf-eval__progress progress::-webkit-progress-bar{background:var(--sf-line)}
+.sf-eval__progress progress::-webkit-progress-value{background:var(--sf-accent)}
+.sf-eval__progress progress::-moz-progress-bar{background:var(--sf-accent)}
+.sf-eval__progress progress{transition:color .15s ease}
+.sf-eval__unavailable{color:var(--sf-ink-2)}
+.sf-eval__stats{display:grid;grid-template-columns:repeat(3,1fr);border:1px solid var(--sf-line);
+  border-top:0}
+.sf-eval__stat{padding:10px 12px;border-right:1px solid var(--sf-line);min-width:0}
+.sf-eval__stat:last-child{border-right:0}
+.sf-eval__stat-k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
+  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-2)}
+.sf-eval__stat-v{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:18px;
+  margin-top:3px;font-variant-numeric:tabular-nums;color:var(--sf-ink)}
+.sf-eval__cache{border:1px solid var(--sf-line);border-top:0;display:flex;flex-wrap:wrap;
+  align-items:baseline;gap:6px 14px;padding:9px 12px}
+.sf-eval__cache-k{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11px;
+  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-ink-2)}
+.sf-eval__cache-v{font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:18px;
+  color:var(--sf-ink)}
+.sf-eval__cache-of,.sf-eval__cache-why{font-family:"IBM Plex Mono",ui-monospace,monospace;
+  font-size:11.5px;color:var(--sf-ink-2)}
+.sf-eval__activity-log{margin-top:12px;border:1px solid var(--sf-line);padding:8px 10px;
+  color:var(--sf-ink-2);font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:11.5px}
+.sf-eval__activity-log summary{cursor:pointer;color:var(--sf-ink-2)}
+.sf-eval__activity-row{padding:5px 0;border-top:1px solid var(--sf-line)}
+.sf-eval__err{margin-top:10px;padding:8px 10px;border-left:2px solid var(--sf-blind);
+  background:var(--sf-blind-bg);color:var(--sf-blind);font-family:"IBM Plex Mono",ui-monospace,
+  monospace;font-size:12px;white-space:pre-wrap}
+.sf-eval__announce{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;
+  clip:rect(0,0,0,0);white-space:nowrap;border:0}
+@media(prefers-reduced-motion:reduce){.sf-eval__progress progress{transition:none}}
 </style>"""
 )
 
@@ -100,113 +94,114 @@ def evaluation_panel_html(
     elapsed: float | None = None,
     check_disclosure: str | None = None,
 ) -> str:
-    """Render the whole panel for the progress fold's current state.
-
-    `elapsed` lets a live view pass wall-clock seconds. Without it the panel falls back to
-    the span between the first and last Event, which is correct for a finished run but
-    freezes between Events while one is still in flight.
-
-    `check_disclosure` is the paid-check-call ceiling text; when the panel renders it,
-    the Python warning it replaces stays suppressed (OME-845).
-    """
-
+    title = "Evaluation complete" if progress.finished else "Evaluating"
+    subtitle = f"Benchmark · {escape(benchmark)}" if benchmark else "Live run status"
     return (
-        f"{_STYLE}<div class='sf-ui sf-eval' role='status' aria-live='polite' "
-        "aria-label='ScreamingFace evaluation progress'>"
-        f"{_head_html(progress, benchmark)}"
-        f"{_bar_html(progress)}"
-        f"{_meta_html(progress, elapsed)}"
-        f"{_activity_html(progress)}"
+        f"{_STYLE}<div class='sf-ui sf-eval' aria-label='ScreamingFace evaluation progress'>"
+        f"<div class='sf-eval__title'>{title}</div>"
+        f"<div class='sf-eval__sub'>{subtitle}</div>"
         f"{_note_html(check_disclosure)}"
+        f"{_candidate_table_html(progress, elapsed)}"
         f"{_stats_html(progress)}"
         f"{_cache_html(progress)}"
-        f"{_feed_html(progress)}"
-        f"{_error_html(progress)}</div>"
+        f"{_activity_html(progress)}"
+        f"{_error_html(progress)}"
+        f"<div class='sf-eval__announce' aria-live='polite'>{escape(progress.announcement)}</div>"
+        "</div>"
     )
 
 
-def _head_html(progress: _EvaluationProgress, benchmark: str | None) -> str:
-    title = "Evaluation complete" if progress.finished else "Evaluating"
-    sub = f"Benchmark · {escape(benchmark)}" if benchmark else "Live run status"
-    return f"<div class='sf-eval__title'>{title}</div><div class='sf-eval__sub'>{sub}</div>"
-
-
-def _bar_html(progress: _EvaluationProgress) -> str:
-    track = "sf-eval__track"
-    fraction = progress.fraction
-    if fraction is None:
-        # No honest denominator — show liveness, not a made-up percentage.
-        fill = "<span class='sf-eval__fill sf-eval__fill--sweep'></span>"
-        return f"<div class='{track}'>{fill}</div>"
-    percent = fraction * 100
-    fill = f"<span class='sf-eval__fill' style='width:{percent:.1f}%'></span>"
-    return f"<div class='{track}'>{fill}</div>"
-
-
-def _meta_html(progress: _EvaluationProgress, elapsed: float | None = None) -> str:
-    left = _candidate_text(progress)
-    if elapsed is None:
-        elapsed = progress.elapsed_seconds
-    if elapsed is not None:
-        left = f"{left} · {_duration(elapsed)}"
-    status = progress.status
+def _candidate_table_html(progress: _EvaluationProgress, elapsed: float | None) -> str:
+    headers = ("Candidate", "Status", "Progress", "Score", "Cost", "Cache")
+    head = "".join(f"<th scope='col'>{header}</th>" for header in headers)
+    body = "".join(_candidate_row_html(row, elapsed) for row in progress.rows)
     return (
-        f"<div class='sf-eval__meta'><span>{escape(left)}</span>"
-        f"<span class='sf-eval__state {status}'><i class='sq'></i>"
-        f"{escape(status.replace('_', ' '))}</span></div>"
+        "<div class='sf-eval__table-wrap' tabindex='0' "
+        "aria-label='Scrollable Candidate progress table'>"
+        "<table class='sf-eval__table'>"
+        "<caption>Candidate Evaluation progress</caption>"
+        f"<thead><tr>{head}</tr></thead><tbody>{body}</tbody></table></div>"
     )
 
 
-def _candidate_text(progress: _EvaluationProgress) -> str:
-    total = progress.total_candidates
-    if not total:
-        return f"{progress.completed} done"
-    noun = "candidate" if total == 1 else "candidates"
-    return f"{progress.completed}/{total} {noun}"
+def _candidate_row_html(row: _CandidateProgress, elapsed: float | None) -> str:
+    status = {
+        "queued": "Queued",
+        "running": "Running",
+        "finished": "Finished",
+        "run_failed": "Run failed",
+        "stopped": "Stopped",
+        "timed_out": "Timed out",
+        "not_run": "Not run",
+    }[row.status]
+    qualifier = f" · {escape(row.qualifier)}" if row.qualifier is not None else ""
+    activity_text = row.activity
+    if row.status == "running" and elapsed is not None:
+        started = row.started_elapsed_seconds or 0.0
+        duration = _duration(max(0.0, elapsed - started))
+        activity_text = f"{activity_text} · {duration}" if activity_text else duration
+    activity = (
+        f"<span class='sf-eval__activity'>{escape(activity_text)}</span>"
+        if activity_text is not None
+        else ""
+    )
+    models = ", ".join(row.candidate.models)
+    score = (
+        "Not scored yet"
+        if not row.score_available
+        else "Not scored"
+        if row.score is None
+        else f"{row.score:g}"
+    )
+    cost = "Not reported" if row.cost_usd is None else _money(row.cost_usd)
+    cache = "Not reported" if row.cache_hit_rate is None else f"{row.cache_hit_rate:.1%}"
+    progress_html = _case_progress_html(row)
+    return (
+        "<tr>"
+        f"<td><span class='sf-eval__candidate'>{escape(row.candidate.name)}</span>"
+        f"<span class='sf-eval__candidate-model'>{escape(models)}</span></td>"
+        f"<td><span class='sf-eval__status sf-eval__status--{row.status}'>"
+        f"<span class='sf-eval__status-sq' aria-hidden='true'></span>{status}{qualifier}</span>"
+        f"{activity}</td>"
+        f"<td>{progress_html}</td>"
+        f"<td class='sf-eval__unavailable'>{escape(score)}</td>"
+        f"<td class='sf-eval__unavailable'>{escape(cost)}</td>"
+        f"<td class='sf-eval__unavailable'>{escape(cache)}</td></tr>"
+    )
 
 
-def _activity_html(progress: _EvaluationProgress) -> str:
-    activity = progress.activity or "Starting evaluation"
-    return f"<div class='sf-eval__act'>phase · {escape(activity)}</div>"
-
-
-def _note_html(check_disclosure: str | None) -> str:
-    if check_disclosure is None:
-        return ""
-    return f"<div class='sf-eval__note'>check surface · {escape(check_disclosure)}</div>"
+def _case_progress_html(row: _CandidateProgress) -> str:
+    if row.total_cases is None:
+        unit = "case" if row.completed_cases == 1 else "cases"
+        return f"<span class='sf-eval__unavailable'>{row.completed_cases} {unit} finished</span>"
+    label = f"{row.completed_cases} / {row.total_cases}"
+    return (
+        f"<span class='sf-eval__progress'><progress value='{row.completed_cases}' "
+        f"max='{row.total_cases}' aria-label='{escape(row.candidate.name)} Case progress'>"
+        f"</progress><span>{label}</span></span>"
+    )
 
 
 def _stats_html(progress: _EvaluationProgress) -> str:
     calls = "—" if progress.model_calls == 0 else f"{progress.model_calls:,}"
     if progress.failed_calls:
         calls = f"{calls} · {progress.failed_calls} failed"
-    # The direction lives in the label so the figures stay on one line at panel width.
     tokens = (
         f"{_compact(progress.input_tokens)} / {_compact(progress.output_tokens)}"
         if progress.have_tokens
         else "—"
     )
     cost = "—" if progress.cost_usd is None else _money(progress.cost_usd)
-    cells = (
-        ("model calls", calls),
-        ("tokens in / out", tokens),
-        ("cost", cost),
-    )
+    cells = (("model calls", calls), ("tokens in / out", tokens), ("cost", cost))
     body = "".join(
-        f"<div class='sf-eval__stat'><div class='sf-eval__stat-k'>{escape(key)}</div>"
-        f"<div class='sf-eval__stat-v'>{escape(value)}</div></div>"
+        f"<div class='sf-eval__stat'><div class='sf-eval__stat-k'>{key}</div>"
+        f"<div class='sf-eval__stat-v'>{value}</div></div>"
         for key, value in cells
     )
     return f"<div class='sf-eval__stats'>{body}</div>"
 
 
 def _cache_html(progress: _EvaluationProgress) -> str:
-    """The provenance band: what the cache did, and — only when it matters — why it did not.
-
-    INVARIANT: the bypass segment is absent from the markup when no bypass occurred. A healthy run
-    is one number; the band grows only when it has something to report.
-    """
-
     rate = progress.cache_hit_rate
     value = "—" if rate is None else f"{rate:.1%}"
     counts = progress.cache_totals
@@ -216,40 +211,36 @@ def _cache_html(progress: _EvaluationProgress) -> str:
     else:
         hits, misses, bypasses = counts
         detail = f"{hits:,} hit · {misses:,} miss"
-        why = ""
-        if bypasses:
-            # INVARIANT: Engine vocabulary verbatim. The Client never groups, renames or ranks
-            # these by severity — a second copy of the gateway's closed set would drift from
-            # PUBLISHED_CACHE_REASONS, which is published in exactly one place for that reason.
-            reasons = " · ".join(
-                f"{escape(reason)} {count:,}" for reason, count in progress.cache_bypass_breakdown
-            )
-            tail = f" <span class='sf-eval__cache-sep'>—</span> {reasons}" if reasons else ""
-            why = f"<div class='sf-eval__cache-why'>{bypasses:,} bypassed{tail}</div>"
+        reasons = " · ".join(
+            f"{escape(reason)} {count:,}" for reason, count in progress.cache_bypass_breakdown
+        )
+        tail = f" — {reasons}" if reasons else ""
+        why = (
+            f"<span class='sf-eval__cache-why'>{bypasses:,} bypassed{tail}</span>"
+            if bypasses
+            else ""
+        )
     return (
         "<div class='sf-eval__cache'><span class='sf-eval__cache-k'>cache</span>"
-        f"<span class='sf-eval__cache-v'>{escape(value)}</span>"
-        f"<span class='sf-eval__cache-of'>{escape(detail)}</span>{why}</div>"
+        f"<span class='sf-eval__cache-v'>{value}</span>"
+        f"<span class='sf-eval__cache-of'>{detail}</span>{why}</div>"
     )
 
 
-def _feed_html(progress: _EvaluationProgress, limit: int = 12) -> str:
-    """Recent Events, newest first — the panel's proof that work is happening."""
-
-    if not progress.feed:
-        return ""
+def _activity_html(progress: _EvaluationProgress) -> str:
     rows = "".join(
-        f"<div class='sf-eval__ev sf-eval__ev--{escape(kind)}'>"
-        f"<span class='sf-eval__ev-t'>{_offset(offset)}</span>"
-        f"<span class='sf-eval__ev-m'>{escape(text)}</span></div>"
-        for offset, kind, text in list(progress.feed)[:limit]
+        f"<div class='sf-eval__activity-row'>{escape(row.candidate.name)} · "
+        f"{escape(row.activity)}</div>"
+        for row in progress.rows
+        if row.activity is not None
     )
-    return f"<div class='sf-eval__feed'>{rows}</div>"
+    return f"<details class='sf-eval__activity-log'><summary>Run activity</summary>{rows}</details>"
 
 
-def _offset(seconds: float) -> str:
-    minutes, remainder = divmod(int(seconds), 60)
-    return f"{minutes:d}:{remainder:02d}"
+def _note_html(check_disclosure: str | None) -> str:
+    if check_disclosure is None:
+        return ""
+    return f"<div class='sf-eval__note'>check surface · {escape(check_disclosure)}</div>"
 
 
 def _error_html(progress: _EvaluationProgress) -> str:
@@ -283,45 +274,31 @@ def _duration(seconds: float) -> str:
 
 
 class _NotebookEvaluationView:
-    """ipywidgets shell: folds Events into state and repaints one HTML widget.
-
-    Events arrive only when the Engine has something to say, and a single model call can
-    run for minutes. Repainting solely on Events would leave the panel frozen for that
-    whole stretch — indistinguishable from a hang — so a background ticker repaints on a
-    fixed cadence and the clock is read from a monotonic source rather than Event stamps.
-    """
-
-    #: Repaint cadence while work is outstanding. One second reads as a live clock
-    #: without flooding the notebook comm channel.
     _TICK_SECONDS = 1.0
-    #: Backstop for a run that is interrupted before any terminal Event: the ticker is a
-    #: daemon, but this stops it spinning for the life of a long-lived kernel.
+    _COALESCE_SECONDS = 0.1
     _MAX_TICK_SECONDS = 6 * 60 * 60
 
     def __init__(
         self,
-        total_candidates: int | None = None,
+        candidates: tuple[Candidate, ...],
+        case_count: int | None,
         benchmark: str | None = None,
-        candidate_models: tuple[str, ...] = (),
-        candidate_urls: tuple[str, ...] = (),
         *,
         check_disclosure: str | None = None,
         clock: Callable[[], float] | None = None,
         tick: bool = True,
     ) -> None:
-        import ipywidgets as widgets  # noqa: PLC0415 - optional notebook extra
+        import ipywidgets as widgets
 
-        self._progress = _EvaluationProgress(
-            total_candidates=total_candidates,
-            candidate_models=frozenset(candidate_models),
-            candidate_urls=frozenset(candidate_urls),
-        )
+        self._progress = _EvaluationProgress(candidates=candidates, case_count=case_count)
         self._benchmark = benchmark
         self._check_disclosure = check_disclosure
         self._clock = time.monotonic if clock is None else clock
         self._started = self._clock()
         self._lock = threading.Lock()
         self._done = threading.Event()
+        self._dirty = threading.Event()
+        self._tick = tick
         self._html: Any = widgets.HTML(value=self._render())
         self._shown = False
         self._show()
@@ -333,22 +310,36 @@ class _NotebookEvaluationView:
             )
             self._ticker.start()
 
-    def __call__(self, event: Event) -> None:
+    def observe(self, candidate: Candidate, event: Event) -> None:
         with self._lock:
-            self._progress.observe(event, elapsed_seconds=self._clock() - self._started)
-            finished = self._progress.finished
+            self._progress.observe(
+                candidate,
+                event,
+                elapsed_seconds=self._clock() - self._started,
+            )
+            if not self._tick:
+                self._html.value = self._render()
+        self._dirty.set()
+
+    def reconcile(self, report: Report) -> None:
+        with self._lock:
+            self._progress.reconcile(report)
             self._html.value = self._render()
-        if finished:
-            self._done.set()
+        self._done.set()
+        self._dirty.set()
+
+    def abort(self, exc: BaseException) -> None:
+        with self._lock:
+            self._progress.abort(exc)
+            self._html.value = self._render()
+        self._done.set()
+        self._dirty.set()
 
     def close(self) -> None:
-        """Stop repainting and remove a live panel whose Evaluation raised."""
-
         self._done.set()
-        self._html.close()
+        self._dirty.set()
 
     def _render(self) -> str:
-        # A finished run reports the span it actually took; a live one reports wall clock.
         elapsed = None if self._progress.finished else self._clock() - self._started
         return evaluation_panel_html(
             self._progress, self._benchmark, elapsed, self._check_disclosure
@@ -356,23 +347,27 @@ class _NotebookEvaluationView:
 
     def _tick_loop(self) -> None:
         deadline = self._started + self._MAX_TICK_SECONDS
-        while not self._done.wait(self._TICK_SECONDS):
+        while not self._done.is_set():
+            dirty = self._dirty.wait(self._TICK_SECONDS)
+            self._dirty.clear()
+            if self._done.is_set():
+                break
+            if dirty and self._done.wait(self._COALESCE_SECONDS):
+                break
             if self._clock() >= deadline:
-                return
+                break
             try:
                 with self._lock:
                     if self._progress.finished:
-                        return
+                        break
                     self._html.value = self._render()
             except Exception:
-                # Progress is decorative: a dead comm or a closed widget must never
-                # surface on this thread, and must not keep the loop spinning.
-                return
+                break
 
     def _show(self) -> None:
         if self._shown:
             return
-        from IPython.display import display  # noqa: PLC0415 - optional notebook extra
+        from IPython.display import display
 
         display(self._html)
         self._shown = True

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -186,7 +186,7 @@ def _receipt_html(progress: _EvaluationProgress) -> str:
         output_tokens = _compact(progress.output_tokens)
         parts.append(f"{input_tokens} in / {output_tokens} out")
     if not parts:
-        return "<div class='sf-eval__receipt' aria-hidden='true'></div>"
+        return ""
     return f"<div class='sf-eval__receipt'>{' · '.join(parts)}</div>"
 
 

--- a/packages/screamingface/src/screamingface/_ui/style.py
+++ b/packages/screamingface/src/screamingface/_ui/style.py
@@ -5,22 +5,22 @@ from __future__ import annotations
 import re
 
 _LIGHT = (
-    "--sf-bg:#ffffff;--sf-surface:#f6f6f7;--sf-surface-2:#efeff1;"
-    "--sf-ink:#16181d;--sf-ink-2:#585d67;--sf-ink-3:#8b909a;"
-    "--sf-line:#e6e7ea;--sf-line-2:#d4d6db;--sf-gain:#b07d12;--sf-gain-bg:#faf1dd;"
-    "--sf-blind:#b23b3b;--sf-blind-bg:#f6e7e6;"
-    "--sf-accent:#4b91f0;--sf-accent-hover:#3a7ddb;--sf-accent-contrast:#ffffff;"
-    "--sf-success:#14722a;--sf-success-solid:#64e47d;--sf-success-bg:#f0f9f2;"
-    "--sf-warning:#7a5e12;--sf-warning-solid:#efbd41;--sf-warning-bg:#fdf6e6"
+    "--sf-bg:#fcfdff;--sf-surface:#f4f6f9;--sf-surface-2:#eceef0;"
+    "--sf-ink:#3b3c3e;--sf-ink-2:#616265;--sf-ink-3:#b4b6b8;"
+    "--sf-line:#cdcfd2;--sf-line-2:#b4b6b8;--sf-gain:#ec9f3f;--sf-gain-bg:#faf5f0;"
+    "--sf-blind:#6c1c17;--sf-blind-bg:#fff3f2;--sf-danger-solid:#ff0325;"
+    "--sf-accent:#4b91f0;--sf-accent-hover:#4185de;--sf-accent-contrast:#ffffff;"
+    "--sf-success:#004611;--sf-success-solid:#17aa46;--sf-success-bg:#f0f9f2;"
+    "--sf-warning:#66270c;--sf-warning-solid:#f1622d;--sf-warning-bg:#fdf4f1"
 )
 _DARK = (
-    "--sf-bg:#0a0b0d;--sf-surface:#131519;--sf-surface-2:#1a1d22;"
-    "--sf-ink:#e8eaed;--sf-ink-2:#9aa0aa;--sf-ink-3:#686e78;"
-    "--sf-line:#20232a;--sf-line-2:#2c303a;--sf-gain:#e0a23c;--sf-gain-bg:#241c0e;"
-    "--sf-blind:#f0726f;--sf-blind-bg:#2a1715;"
-    "--sf-accent:#75affe;--sf-accent-hover:#8fbeff;--sf-accent-contrast:#0a0b0d;"
-    "--sf-success:#97db9d;--sf-success-solid:#7cdf8c;--sf-success-bg:#0c100d;"
-    "--sf-warning:#e2ca91;--sf-warning-solid:#efbd41;--sf-warning-bg:#151005"
+    "--sf-bg:#05070b;--sf-surface:#0c0f13;--sf-surface-2:#15181c;"
+    "--sf-ink:#e0e5eb;--sf-ink-2:#c7ccd2;--sf-ink-3:#585c61;"
+    "--sf-line:#35383d;--sf-line-2:#585c61;--sf-gain:#e2a35b;--sf-gain-bg:#110e0c;"
+    "--sf-blind:#ffdcd7;--sf-blind-bg:#130d0d;--sf-danger-solid:#ed413f;"
+    "--sf-accent:#6099e7;--sf-accent-hover:#6fa6f0;--sf-accent-contrast:#ffffff;"
+    "--sf-success:#baf2bd;--sf-success-solid:#4aae5e;--sf-success-bg:#0c100d;"
+    "--sf-warning:#ffddd0;--sf-warning-solid:#e36f48;--sf-warning-bg:#130e0c"
 )
 
 # The one sanctioned SFDS gradient (fusion-grad), as the brand repo renders it on a
@@ -28,10 +28,12 @@ _DARK = (
 # plain constant, NOT a custom property on .sf-ui: it stays opt-in per surface so it can
 # only appear where the story earns it — a run in flight, or the leading candidate.
 FUSION_GRADIENT = (
-    "linear-gradient(90deg,#d8860e 0%,#dc9544 8%,#de9f5b 16%,#e2b280 27%,#e7c3a0 34%,"
-    "#ebd4be 40%,#edddcd 43%,#f2e3df 46%,#eeebf3 49%,#e7edf5 52%,#dde6f4 56%,"
-    "#d2dff2 60%,#bfd4f2 65%,#abc8f2 71%,#97bcf3 77%,#83b0f3 84%,#6fa4f3 90%,"
-    "#5a98f3 96%,#4f91f2 100%)"
+    "linear-gradient(100deg,#d8860e 0%,#d98b27 3%,#da9037 6%,#dc9544 10%,#dd9a50 13%,"
+    "#de9f5b 16%,#dfa465 19%,#e0a970 23%,#e2b280 26%,#e5bb90 29%,#e7c3a0 32%,"
+    "#e9ccaf 35%,#ebd4be 39%,#edddcd 42%,#f2e3df 45%,#eeebf3 48%,#e7edf5 52%,"
+    "#dde6f4 55%,#d2dff2 58%,#c8d9f2 61%,#bfd4f2 65%,#b5cef2 68%,#abc8f2 71%,"
+    "#a2c2f2 74%,#97bcf3 77%,#8db6f3 81%,#83b0f3 84%,#79aaf3 87%,#6fa4f3 90%,"
+    "#649ef3 94%,#5a98f3 97%,#4f91f2 100%)"
 )
 
 
@@ -55,14 +57,14 @@ FUSION_GRADIENT_FLOW = _flow(FUSION_GRADIENT)
 
 # The vertical run of the same ramp, for the score cell's left edge band
 # (product-demos/widgets-view/widgets.css .w-rescell-score::before).
-FUSION_GRADIENT_Y = FUSION_GRADIENT.replace("linear-gradient(90deg", "linear-gradient(180deg")
+FUSION_GRADIENT_Y = FUSION_GRADIENT.replace("linear-gradient(100deg", "linear-gradient(180deg")
 
 # INVARIANT: shared surfaces use solid gold; the Fusion gradient is card-scoped.
 STYLE = f"""<style>
 .sf-ui{{
   {_LIGHT};
   max-width:920px;color:var(--sf-ink);background:var(--sf-bg);
-  font-family:system-ui,-apple-system,"Segoe UI",sans-serif;
+  font-family:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
   font-size:13px;line-height:1.45;
 }}
 @media (prefers-color-scheme:dark){{.sf-ui{{{_DARK}}}}}

--- a/packages/screamingface/tests/test_check_disclosure_display.py
+++ b/packages/screamingface/tests/test_check_disclosure_display.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 
 import io
 import warnings
+from typing import Any, cast
 
 import pytest
 
 from screamingface._evaluation import progress as progress_module
+from screamingface._evaluation.model import _compiled_candidate, _compiled_operation
 from screamingface._evaluation.progress import _progress_observer
 from screamingface._ui.evaluation_state import _EvaluationProgress
 from screamingface._ui.evaluation_view import evaluation_panel_html
@@ -27,6 +29,27 @@ _DISCLOSURE = "Benchmark 'draco' may make up to 6 paid check calls (6 per case x
 def _headless_stream() -> io.StringIO:
     # StringIO.isatty() is False — the "no panel, no terminal" environment.
     return io.StringIO()
+
+
+def _panel_progress() -> _EvaluationProgress:
+    operation = _compiled_operation(
+        id="op_model",
+        kind="model",
+        label="model answer",
+        depends_on=(),
+    )
+    return _EvaluationProgress(
+        candidates=(
+            _compiled_candidate(
+                name="model",
+                kind="model",
+                models=("provider/model",),
+                url4="(@)!'model'",
+                operations=(operation,),
+            ),
+        ),
+        case_count=1,
+    )
 
 
 def test_headless_evaluation_still_warns() -> None:
@@ -51,7 +74,8 @@ def test_a_rendering_panel_suppresses_the_warning(monkeypatch: pytest.MonkeyPatc
     # would reintroduce the red banner OME-845 removes.
     taken: dict[str, str | None] = {}
 
-    def fake_notebook_observer(total, benchmark, models, urls, check_disclosure=None):
+    def fake_notebook_observer(candidates, case_count, benchmark, check_disclosure=None):
+        del candidates, case_count, benchmark
         taken["disclosure"] = check_disclosure
         return lambda event: None
 
@@ -59,7 +83,13 @@ def test_a_rendering_panel_suppresses_the_warning(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(progress_module, "_notebook_observer", fake_notebook_observer)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        observer = _progress_observer(None, stream=_headless_stream(), check_disclosure=_DISCLOSURE)
+        observer = _progress_observer(
+            None,
+            stream=_headless_stream(),
+            candidates=cast(Any, (object(),)),
+            case_count=1,
+            check_disclosure=_DISCLOSURE,
+        )
     assert observer is not None
     assert taken["disclosure"] == _DISCLOSURE
 
@@ -85,13 +115,13 @@ def test_no_disclosure_never_warns() -> None:
 
 
 def test_the_panel_renders_the_disclosure_line() -> None:
-    html = evaluation_panel_html(_EvaluationProgress(), "draco", None, "up to 6 paid check <calls>")
+    html = evaluation_panel_html(_panel_progress(), "draco", None, "up to 6 paid check <calls>")
     assert "sf-eval__note" in html
     assert "check surface · up to 6 paid check &lt;calls&gt;" in html
 
 
 def test_the_panel_omits_the_line_without_a_disclosure() -> None:
-    html = evaluation_panel_html(_EvaluationProgress(), "draco", None, None)
+    html = evaluation_panel_html(_panel_progress(), "draco", None, None)
     # The class exists in the stylesheet either way; the LINE must not render.
     assert "check surface ·" not in html
     assert "<div class='sf-eval__note'>" not in html

--- a/packages/screamingface/tests/test_evaluation_progress_panel.py
+++ b/packages/screamingface/tests/test_evaluation_progress_panel.py
@@ -1,14 +1,11 @@
-"""The live evaluate() panel: the Event fold and the HTML it renders."""
-
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from typing import Any
-
-import pytest
+from typing import Any, cast
 
 import screamingface as sf
+from screamingface._evaluation.model import Candidate, _compiled_candidate, _compiled_operation
 from screamingface._ui.evaluation_state import _EvaluationProgress
 from screamingface._ui.evaluation_view import (
     _compact,
@@ -17,16 +14,32 @@ from screamingface._ui.evaluation_view import (
     evaluation_panel_html,
 )
 
-_START = datetime(2026, 8, 7, 12, 0, tzinfo=UTC)
+_START = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
 
 
-def envelope(sequence: int = 1, *, run_id: str = "run_1", offset: float = 0.0) -> dict[str, Any]:
+def candidate(name: str = "opus", model: str = "provider/opus") -> Candidate:
+    operation = _compiled_operation(
+        id=f"op_{name}",
+        kind="model",
+        label=f"{name} answer",
+        depends_on=(),
+    )
+    return _compiled_candidate(
+        name=name,
+        kind="model",
+        models=(model,),
+        url4=f"(@)!'{name}'",
+        operations=(operation,),
+    )
+
+
+def envelope(sequence: int, *, run_id: str = "run_opus") -> dict[str, Any]:
     return {
-        "id": f"event_{sequence}",
+        "id": f"{run_id}_{sequence}",
         "run_id": run_id,
         "sequence": sequence,
-        "timestamp": _START + timedelta(seconds=offset),
-        "source": f"/trace/{run_id}/node/root",
+        "timestamp": _START + timedelta(seconds=sequence),
+        "source": f"/trace/{run_id}/node/{sequence}",
     }
 
 
@@ -36,7 +49,7 @@ def model_span(sequence: int, **overrides: Any) -> sf.events.Span:
         "operation": "chat",
         "start": _START,
         "end": _START + timedelta(seconds=2),
-        "request_model": "anthropic/claude-opus-4.8",
+        "request_model": "provider/opus",
         "input_tokens": 1_000,
         "output_tokens": 250,
     }
@@ -44,424 +57,108 @@ def model_span(sequence: int, **overrides: Any) -> sf.events.Span:
     return sf.events.Span(**envelope(sequence), **values)
 
 
-def test_structural_spans_never_count_as_model_work() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
+def progress(*candidates: Candidate) -> _EvaluationProgress:
+    selected = candidates or (candidate(),)
+    return _EvaluationProgress(candidates=selected, case_count=2)
 
-    progress.observe(
+
+def test_model_spans_accumulate_calls_tokens_failures_and_refusals() -> None:
+    opus = candidate()
+    state = progress(opus)
+
+    state.observe(opus, model_span(1))
+    state.observe(opus, model_span(2, status="error", input_tokens=10, output_tokens=0))
+    state.observe(opus, model_span(3, refusal="declined"))
+
+    row = state.rows[0]
+    assert (row.model_calls, row.failed_calls, row.refusals) == (3, 1, 1)
+    assert (row.input_tokens, row.output_tokens) == (2_010, 500)
+
+
+def test_structural_spans_do_not_count_as_model_work() -> None:
+    opus = candidate()
+    state = progress(opus)
+
+    state.observe(
+        opus,
         sf.events.Span(
             **envelope(1),
             name="TextNode",
             operation="TextNode",
             start=_START,
-            end=_START + timedelta(seconds=1),
-        )
+            end=_START,
+        ),
     )
 
-    assert progress.model_calls == 0
-    assert progress.have_tokens is False
-
-
-def test_model_spans_accumulate_calls_tokens_and_failures() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-
-    progress.observe(model_span(1))
-    progress.observe(model_span(2, status="error", input_tokens=10, output_tokens=0))
-    progress.observe(model_span(3, refusal="declined"))
-
-    assert progress.model_calls == 3
-    assert progress.failed_calls == 1
-    assert progress.refusals == 1
-    assert progress.input_tokens == 2_010
-    assert progress.output_tokens == 500
+    assert state.rows[0].model_calls == 0
 
 
 def test_subtree_usage_is_ignored_so_cost_is_not_double_counted() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-
-    progress.observe(
-        sf.events.Usage(
-            **envelope(1),
-            scope="self",
-            provider="openrouter",
-            model="m",
-            pricing_version="v1",
-            usage=sf.Usage(cost_usd=Decimal("0.25")),
+    opus = candidate()
+    state = progress(opus)
+    for sequence, scope, amount in ((1, "self", "0.25"), (2, "subtree", "99")):
+        state.observe(
+            opus,
+            sf.events.Usage(
+                **envelope(sequence),
+                scope=cast(Any, scope),
+                provider="provider",
+                model="opus",
+                pricing_version="v1",
+                usage=sf.Usage(cost_usd=Decimal(amount)),
+            ),
         )
-    )
-    progress.observe(
-        sf.events.Usage(
-            **envelope(2),
-            scope="subtree",
-            provider="openrouter",
-            model="m",
-            pricing_version="v1",
-            usage=sf.Usage(cost_usd=Decimal("99.00")),
-        )
-    )
 
-    assert progress.cost_usd == Decimal("0.25")
+    assert state.rows[0].cost_usd == Decimal("0.25")
 
 
-def test_progress_tracks_candidates_and_reports_the_worst_terminal_status() -> None:
-    progress = _EvaluationProgress(total_candidates=2)
-
-    progress.observe(sf.events.Terminated(**envelope(1, run_id="run_1"), status="succeeded"))
-    assert progress.running is True
-    assert progress.status == "running"
-    assert progress.fraction == 0.5
-
-    progress.observe(sf.events.Terminated(**envelope(2, run_id="run_2"), status="failed"))
-
-    assert progress.finished is True
-    # A single failure must not be hidden by a sibling candidate that succeeded.
-    assert progress.status == "failed"
-    assert progress.fraction == 1.0
-
-
-def test_elapsed_comes_from_event_timestamps_not_the_wall_clock() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-
-    progress.observe(sf.events.Started(**envelope(1, offset=0), url4="(@)!'hi'"))
-    progress.observe(sf.events.Terminated(**envelope(2, offset=90), status="succeeded"))
-
-    assert progress.elapsed_seconds == 90.0
-
-
-def test_unknown_total_never_renders_a_fabricated_percentage() -> None:
-    progress = _EvaluationProgress(total_candidates=None)
-    progress.observe(model_span(1))
-
-    assert progress.fraction is None
-    assert progress.finished is False
-
-    html = evaluation_panel_html(progress)
-
-    assert "sf-eval__fill--sweep" in html
-    assert "%'" not in html.split("sf-eval__track")[1].split("</div>")[0]
-
-
-def test_panel_renders_live_totals_and_escapes_untrusted_text() -> None:
-    progress = _EvaluationProgress(total_candidates=2)
-    progress.observe(model_span(1, request_model="<script>alert(1)</script>"))
-    progress.observe(
-        sf.events.Usage(
-            **envelope(2),
-            scope="self",
-            provider="openrouter",
-            model="m",
-            pricing_version="v1",
-            usage=sf.Usage(cost_usd=Decimal("1.5")),
-        )
+def test_nested_termination_does_not_change_the_candidate_status() -> None:
+    opus = candidate()
+    state = progress(opus)
+    root = "/trace/run_opus/node/root"
+    state.observe(
+        opus,
+        sf.events.Started(**{**envelope(1), "source": root}, url4=opus.url4),
     )
 
-    html = evaluation_panel_html(progress, "GPQA <Diamond>")
-
-    assert "Evaluating" in html
-    assert "0/2 candidates" in html
-    assert "1.0k / 250" in html
-    assert "$1.50" in html
-    assert "GPQA &lt;Diamond&gt;" in html
-    assert "<script>" not in html
-
-
-def test_panel_switches_to_a_completed_heading_and_surfaces_the_error() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(
-        sf.events.Terminated(
-            **envelope(1),
-            status="failed",
-            error=sf.events.TerminationError(code="boom", message="engine exploded"),
-        )
+    state.observe(
+        opus,
+        sf.events.Terminated(**envelope(2), status="failed"),
     )
 
-    html = evaluation_panel_html(progress, "GPQA")
+    assert state.rows[0].status == "running"
 
-    assert "Evaluation complete" in html
-    assert "sf-eval__state failed" in html
-    assert "engine exploded" in html
-
-
-def test_the_clock_advances_between_events_not_only_on_them() -> None:
-    """A long model call emits no Events; a frozen clock would read as a hang."""
-
-    from screamingface._ui.evaluation_view import _NotebookEvaluationView
-
-    now = [100.0]
-    view = _NotebookEvaluationView(1, "GPQA", clock=lambda: now[0], tick=False)
-    view(sf.events.Started(**envelope(1), url4="(@)!'hi'"))
-    first = view._html.value
-
-    now[0] += 45.0  # time passes; no Event arrives
-    view._html.value = view._render()
-
-    assert "0.0s" in first
-    assert "45.0s" in view._html.value
-
-
-def test_a_finished_run_reports_the_span_it_took_not_the_wall_clock() -> None:
-    from screamingface._ui.evaluation_view import _NotebookEvaluationView
-
-    now = [100.0]
-    view = _NotebookEvaluationView(1, "GPQA", clock=lambda: now[0], tick=False)
-    view(sf.events.Started(**envelope(1, offset=0), url4="(@)!'hi'"))
-    view(sf.events.Terminated(**envelope(2, offset=12), status="succeeded"))
-
-    now[0] += 900.0  # the notebook sits open long after the run ended
-
-    assert "12.0s" in view._render()
-
-
-def test_closing_a_failed_evaluation_stops_the_notebook_ticker() -> None:
-    from screamingface._ui.evaluation_view import _NotebookEvaluationView
-
-    view = _NotebookEvaluationView(1, "GPQA", tick=False)
-
-    view.close()
-
-    assert view._done.is_set()
-
-
-def test_live_figure_formatters_cover_large_small_and_long_running_values() -> None:
-    """The panel stays compact without hiding sub-cent cost or long elapsed time."""
-
-    assert _compact(2_000_000) == "2.0M"
-    assert _money(Decimal("0.005")) == "$0.0050"
-    assert _duration(65) == "1m 05s"
-    assert _duration(3_665) == "1h 01m"
-
-
-def test_panel_surfaces_failed_calls_and_subcent_cost() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1, status="error", input_tokens=2_000_000))
-    progress.observe(
-        sf.events.Usage(
-            **envelope(2),
-            scope="self",
-            provider="openrouter",
-            model="m",
-            pricing_version="v1",
-            usage=sf.Usage(cost_usd=Decimal("0.005")),
-        )
+    state.observe(
+        opus,
+        sf.events.Terminated(**{**envelope(3), "source": root}, status="failed"),
     )
 
-    html = evaluation_panel_html(progress)
-
-    assert "1 · 1 failed" in html
-    assert "2.0M / 250" in html
-    assert "$0.0050" in html
+    assert state.rows[0].status == "run_failed"
 
 
-def test_phase_progress_distinguishes_candidate_work_from_benchmark_grading() -> None:
-    candidate_model = "openrouter/anthropic/claude-opus-4.8"
-    progress = _EvaluationProgress(
-        total_candidates=1,
-        candidate_models=frozenset({candidate_model}),
-    )
+def test_live_cache_rate_excludes_bypasses() -> None:
+    opus = candidate()
+    state = progress(opus)
+    state.observe(opus, model_span(1, cache_status="hit"))
+    state.observe(opus, model_span(2, cache_status="miss"))
+    state.observe(opus, model_span(3, cache_status="bypass", cache_reason="stream"))
 
-    assert "Starting evaluation" in evaluation_panel_html(progress, "Fixture Benchmark")
-
-    progress.observe(sf.events.Started(**envelope(1), url4="(@)!'hi'"))
-    assert progress.activity == "Running candidate"
-
-    progress.observe(model_span(2, request_model=candidate_model))
-    assert progress.activity == "Running candidate · 1 model call completed"
-
-    progress.observe(
-        model_span(
-            3,
-            request_model="openrouter/google/gemini-3.1-pro-preview",
-        )
-    )
-    assert progress.activity == "Grading benchmark · 1 model call completed"
-
-    progress.observe(sf.events.Terminated(**envelope(4), status="succeeded"))
-    html = evaluation_panel_html(progress, "Fixture Benchmark")
-
-    assert progress.activity == "Evaluation finished"
-    assert "phase · Evaluation finished" in html
-    assert "evaluation finished" in html
+    assert state.rows[0].cache_totals == (1, 1, 1)
+    assert state.rows[0].cache_hit_rate == 0.5
+    assert state.cache_bypass_breakdown == (("stream", 1),)
 
 
-def test_evaluation_only_says_finished_after_every_candidate_terminates() -> None:
-    progress = _EvaluationProgress(total_candidates=2)
-
-    progress.observe(sf.events.Terminated(**envelope(1, run_id="run_1"), status="succeeded"))
-
-    assert progress.activity == "Running candidates · 1/2 finished"
-    assert all(text != "evaluation finished" for _, _, text in progress.feed)
-
-    progress.observe(sf.events.Terminated(**envelope(2, run_id="run_2"), status="succeeded"))
-
-    assert progress.activity == "Evaluation finished"
-    assert progress.feed[0][2] == "evaluation finished"
-
-
-def test_parallel_candidate_starts_create_one_evaluation_start_entry() -> None:
-    progress = _EvaluationProgress(total_candidates=2)
-
-    progress.observe(sf.events.Started(**envelope(1, run_id="run_1"), url4="(@)!'one'"))
-    progress.observe(sf.events.Started(**envelope(1, run_id="run_2"), url4="(@)!'two'"))
-
-    assert [text for _, _, text in progress.feed] == ["evaluation started"]
-
-
-def test_live_feed_uses_arrival_time_when_engine_event_timestamps_do_not_advance() -> None:
-    from screamingface._ui.evaluation_view import _NotebookEvaluationView
-
-    now = [100.0]
-    view = _NotebookEvaluationView(2, "DRACO", clock=lambda: now[0], tick=False)
-    view(sf.events.Started(**envelope(1, run_id="run_1"), url4="(@)!'one'"))
-
-    now[0] += 14
-    view(sf.events.Terminated(**envelope(2, run_id="run_1"), status="succeeded"))
-
-    assert "0:14" in view._html.value
-    assert "candidate 1/2 finished" in view._html.value
-
-
-def test_determinate_progress_is_static_and_unavailable_metrics_are_not_zero() -> None:
-    progress = _EvaluationProgress(total_candidates=2)
-    progress.observe(sf.events.Terminated(**envelope(1), status="succeeded"))
-
-    html = evaluation_panel_html(progress)
-
-    assert "width:50.0%" in html
-    assert "sf-eval__fill--live" not in html
-    assert "<div class='sf-eval__stat-v'>—</div>" in html
-
-
-def test_nested_url4_termination_does_not_complete_a_candidate() -> None:
-    candidate_url4 = "(@)!'candidate'"
-    progress = _EvaluationProgress(
-        total_candidates=1,
-        candidate_urls=frozenset({candidate_url4}),
-    )
-    progress.observe(sf.events.Started(**envelope(1), url4=candidate_url4))
-    nested = envelope(2, run_id="run_1")
-    nested["source"] = "/trace/run_1/node/nested"
-
-    progress.observe(
-        sf.events.Terminated(
-            **nested,
-            status="succeeded",
-        )
-    )
-
-    assert progress.completed == 0
-    assert progress.fraction == 0.0
-
-    progress.observe(sf.events.Terminated(**envelope(3), status="succeeded"))
-
-    assert progress.completed == 1
-    assert progress.finished is True
-
-
-def test_candidate_completion_surfaces_the_engine_cache_summary() -> None:
-    candidate_url4 = "(@)!'candidate'"
-    progress = _EvaluationProgress(
-        total_candidates=2,
-        candidate_urls=frozenset({candidate_url4}),
-    )
-    progress.observe(sf.events.Started(**envelope(1), url4=candidate_url4))
-    progress.observe(
+def test_authoritative_cache_summary_replaces_live_counts_and_reasons() -> None:
+    opus = candidate()
+    state = progress(opus)
+    state.observe(opus, model_span(1, cache_status="bypass", cache_reason="stream"))
+    state.observe(
+        opus,
         sf.events.Log(
             **envelope(2),
             severity_number=9,
             severity_text="INFO",
-            body="gateway response cache: 21 hit, 0 miss, 0 bypass",
-            attributes={"cache.hits": 21, "cache.misses": 0, "cache.bypasses": 0},
-        )
-    )
-
-    progress.observe(sf.events.Terminated(**envelope(3), status="succeeded"))
-
-    assert progress.feed[0][2] == "candidate 1/2 finished · cache: 21 hits"
-
-
-def test_model_spans_update_live_cache_counts_and_exclude_bypasses_from_rate() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-
-    progress.observe(model_span(1, cache_status="hit"))
-    progress.observe(model_span(2, cache_status="miss"))
-    progress.observe(model_span(3, cache_status="bypass"))
-
-    assert progress.cache_totals == (1, 1, 1)
-    assert progress.cache_hit_rate == 0.5
-
-    html = evaluation_panel_html(progress)
-    assert "sf-eval__cache" in html
-    assert "50.0%" in html
-    assert "1 hit · 1 miss" in html
-    assert "1 bypassed" in html
-
-
-def test_final_cache_summary_replaces_live_counts_and_runs_still_aggregate() -> None:
-    progress = _EvaluationProgress(total_candidates=2)
-    progress.observe(model_span(1, cache_status="hit"))
-    progress.observe(model_span(2, cache_status="miss"))
-    progress.observe(
-        sf.events.Log(
-            **envelope(3),
-            severity_number=9,
-            severity_text="INFO",
-            body="gateway response cache: 10 hit, 2 miss, 0 bypass",
-            attributes={"cache.hits": 10, "cache.misses": 2, "cache.bypasses": 0},
-        )
-    )
-    progress.observe(
-        sf.events.Span(
-            **envelope(1, run_id="run_2"),
-            name="chat",
-            operation="chat",
-            start=_START,
-            end=_START + timedelta(seconds=1),
-            request_model="openrouter/example/model",
-            cache_status="bypass",
-        )
-    )
-
-    assert progress.cache_counts == {"run_1": (10, 2, 0), "run_2": (0, 0, 1)}
-    assert progress.cache_totals == (10, 2, 1)
-    assert progress.cache_hit_rate == pytest.approx(10 / 12)
-
-
-def test_cache_metric_stays_unavailable_without_hit_or_miss_evidence() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1, cache_status="bypass"))
-    progress.observe(model_span(2, cache_status="bypass"))
-
-    assert progress.cache_totals == (0, 0, 2)
-    assert progress.cache_hit_rate is None
-
-    html = evaluation_panel_html(progress)
-    band = html.split("class='sf-eval__cache'", 1)[1]
-    assert "<span class='sf-eval__cache-v'>—</span>" in band
-    assert "0 hit · 0 miss" in band
-    assert "2 bypassed" in band
-    assert "unstated 2" in band
-
-
-def test_the_stat_row_keeps_three_cells_so_nothing_truncates() -> None:
-    """WHY: a fourth cell is ~206px at the panel's 920px cap — about 32 characters before its
-    label and value — so the diagnostic half would ellipsise at every width the panel gets."""
-
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1, cache_status="hit"))
-
-    html = evaluation_panel_html(progress)
-    assert "grid-template-columns:repeat(3,1fr)" in html
-    assert "repeat(4,1fr)" not in html
-
-
-def test_the_band_reads_bypass_reasons_from_the_authoritative_summary() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-
-    progress.observe(
-        sf.events.Log(
-            **envelope(1),
-            severity_number=9,
-            severity_text="INFO",
-            body="gateway response cache: 6 hit, 3 miss, 91 bypass",
+            body="cache summary",
             attributes={
                 "cache.hits": 6,
                 "cache.misses": 3,
@@ -469,138 +166,91 @@ def test_the_band_reads_bypass_reasons_from_the_authoritative_summary() -> None:
                 "cache.bypass.unsupported_control": 74,
                 "cache.bypass.opted_out": 17,
             },
-        )
+        ),
     )
 
-    assert progress.cache_bypass_breakdown == (("unsupported_control", 74), ("opted_out", 17))
-    html = evaluation_panel_html(progress)
-    assert "91 bypassed" in html
-    assert "unsupported_control 74" in html
-    assert "opted_out 17" in html
-
-
-def test_a_summary_replaces_rather_than_doubles_span_derived_reasons() -> None:
-    """INVARIANT: the summary is a reconciliation, never an addition."""
-
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1, cache_status="bypass", cache_reason="opted_out"))
-    progress.observe(model_span(2, cache_status="bypass", cache_reason="opted_out"))
-
-    assert progress.cache_bypass_breakdown == (("opted_out", 2),)
-
-    progress.observe(
-        sf.events.Log(
-            **envelope(3),
-            severity_number=9,
-            severity_text="INFO",
-            body="gateway response cache: 0 hit, 0 miss, 5 bypass",
-            attributes={
-                "cache.hits": 0,
-                "cache.misses": 0,
-                "cache.bypasses": 5,
-                "cache.bypass.opted_out": 5,
-            },
-        )
+    assert state.rows[0].cache_totals == (6, 3, 91)
+    assert state.cache_bypass_breakdown == (
+        ("unsupported_control", 74),
+        ("opted_out", 17),
     )
 
-    assert progress.cache_bypass_breakdown == (("opted_out", 5),)
 
-
-def test_a_bypass_naming_no_reason_is_counted_as_unstated() -> None:
-    """WHY: the breakdown must always sum to the bypass total, or neither number is trustworthy."""
-
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1, cache_status="bypass"))
-    progress.observe(model_span(2, cache_status="bypass"))
-
-    assert progress.cache_bypass_breakdown == (("unstated", 2),)
-
-    # The strict Event contract is what makes a blank reason unreachable in the fold.
-    with pytest.raises(ValueError, match="cache_reason must be a non-empty string"):
-        model_span(3, cache_status="bypass", cache_reason="   ")
-
-
-def test_unstated_and_other_stay_distinct_buckets() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(
-        sf.events.Log(
-            **envelope(1),
-            severity_number=9,
-            severity_text="INFO",
-            body="gateway response cache: 0 hit, 0 miss, 9 bypass",
-            attributes={
-                "cache.hits": 0,
-                "cache.misses": 0,
-                "cache.bypasses": 9,
-                "cache.bypass.unstated": 4,
-                "cache.bypass.other": 5,
-            },
-        )
-    )
-
-    assert progress.cache_bypass_breakdown == (("other", 5), ("unstated", 4))
-
-
-def test_a_healthy_run_renders_no_bypass_segment_at_all() -> None:
-    """WHY: the band only grows when it has something to report."""
-
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1, cache_status="hit"))
-    progress.observe(model_span(2, cache_status="miss"))
-
-    html = evaluation_panel_html(progress)
-    assert "1 hit · 1 miss" in html
-    assert "bypassed" not in html
-
-
-def test_reason_maps_from_two_runs_aggregate_without_overwriting() -> None:
-    progress = _EvaluationProgress(total_candidates=2)
-    progress.observe(model_span(1, cache_status="bypass", cache_reason="stream"))
-    progress.observe(
+def test_cache_evidence_from_candidates_aggregates_without_overwriting() -> None:
+    opus = candidate()
+    gpt = candidate("gpt", "provider/gpt")
+    state = progress(opus, gpt)
+    state.observe(opus, model_span(1, cache_status="hit"))
+    state.observe(
+        gpt,
         sf.events.Span(
-            **envelope(1, run_id="run_2"),
+            **envelope(1, run_id="run_gpt"),
             name="chat",
             operation="chat",
             start=_START,
-            end=_START + timedelta(seconds=1),
-            request_model="openrouter/example/model",
+            end=_START,
+            request_model="provider/gpt",
             cache_status="bypass",
             cache_reason="metadata",
-        )
+        ),
     )
 
-    assert progress.cache_bypass_breakdown == (("metadata", 1), ("stream", 1))
+    assert state.cache_totals == (1, 0, 1)
+    assert state.cache_bypass_breakdown == (("metadata", 1),)
 
 
-def test_the_band_says_so_when_no_provenance_arrives() -> None:
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1))
+def test_unstated_bypass_reason_remains_distinct_from_other() -> None:
+    opus = candidate()
+    state = progress(opus)
+    state.observe(opus, model_span(1, cache_status="bypass"))
+    state.observe(opus, model_span(2, cache_status="bypass", cache_reason="other"))
 
-    html = evaluation_panel_html(progress)
-    band = html.split("class='sf-eval__cache'")[1].split("</div>")[0]
-    assert "no cache activity reported" in html
-    assert "—" in band
-    assert "%" not in band
+    assert state.cache_bypass_breakdown == (("other", 1), ("unstated", 1))
 
 
-def test_the_band_body_uses_a_contracted_text_token() -> None:
-    """--sf-ink-3 measures 3.20:1 light and 3.83:1 dark against the panel ground: below AA,
-    and SFDS states it is not a text color."""
+def test_panel_escapes_candidate_identity_and_global_errors() -> None:
+    selected = candidate("<script>", "provider/<model>")
+    state = progress(selected)
+    state.abort(RuntimeError("bad <payload>"))
 
-    progress = _EvaluationProgress(total_candidates=1)
-    progress.observe(model_span(1, cache_status="hit"))
+    html = evaluation_panel_html(state, "DRACO <private>")
 
-    html = evaluation_panel_html(progress)
-    band = html.split(".sf-eval__cache-of{")[1].split("}")[0]
-    assert "var(--sf-ink-2)" in band
-    assert "--sf-ink-3" not in band
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html
+    assert "provider/&lt;model&gt;" in html
+    assert "bad &lt;payload&gt;" in html
+    assert "DRACO &lt;private&gt;" in html
 
 
-def test_the_cache_label_uses_the_canonical_contracted_text_role() -> None:
-    """INVARIANT: visible labels use ink-2; ink-3 is decoration, never readable text."""
+def test_cache_band_renders_truthful_empty_and_bypass_states() -> None:
+    opus = candidate()
+    state = progress(opus)
 
-    html = evaluation_panel_html(_EvaluationProgress(total_candidates=1))
-    label = html.split(".sf-eval__cache-k{")[1].split("}")[0]
+    empty = evaluation_panel_html(state)
 
-    assert "color:var(--sf-ink-2)" in label
+    assert "no cache activity reported" in empty
+    assert "bypassed" not in empty
+
+    state.observe(opus, model_span(1, cache_status="bypass", cache_reason="opted_out"))
+    bypassed = evaluation_panel_html(state)
+
+    assert "1 bypassed" in bypassed
+    assert "opted_out 1" in bypassed
+
+
+def test_visible_cache_text_uses_readable_ink_two() -> None:
+    html = evaluation_panel_html(progress())
+    label = html.split(".sf-eval__cache-k{", 1)[1].split("}", 1)[0]
+    body = html.split(".sf-eval__cache-of,", 1)[1].split("}", 1)[0]
+
+    assert "var(--sf-ink-2)" in label
+    assert "var(--sf-ink-2)" in body
     assert "--sf-ink-3" not in label
+    assert "--sf-ink-3" not in body
+
+
+def test_live_figure_formatters_cover_large_small_and_long_values() -> None:
+    assert _compact(2_000_000) == "2.0M"
+    assert _money(Decimal("0.005")) == "$0.0050"
+    assert _duration(65) == "1m 05s"
+    assert _duration(3_665) == "1h 01m"

--- a/packages/screamingface/tests/test_evaluation_progress_panel.py
+++ b/packages/screamingface/tests/test_evaluation_progress_panel.py
@@ -62,6 +62,41 @@ def progress(*candidates: Candidate) -> _EvaluationProgress:
     return _EvaluationProgress(candidates=selected, case_count=2)
 
 
+def reconcile_complete(state: _EvaluationProgress, selected: Candidate) -> None:
+    benchmark = sf.BenchmarkInfo(id="draco", revision="fixture", case_count=2)
+    cases = tuple(
+        sf.CaseResult(
+            case_id=case_id,
+            input="Question",
+            output="Answer",
+            finish_reason="stop",
+            grade=sf.CaseGrade(method="fixture", score=1.0, metrics={}, checks=()),
+            failures=(),
+            metadata={},
+        )
+        for case_id in (1, 2)
+    )
+    result = sf.CandidateResult(
+        benchmark=benchmark,
+        run_id="run_opus",
+        started_at=_START,
+        completed_at=_START + timedelta(seconds=1),
+        name=selected.name,
+        kind=selected.kind,
+        url4=selected.url4,
+        models=selected.models,
+        operations=selected.operations,
+        score=1.0,
+        coverage=1.0,
+        metrics={},
+        cases=cases,
+        members=(),
+        failures=(),
+        usage=sf.Usage(input_tokens=0, output_tokens=0, cost_usd=Decimal("0")),
+    )
+    state.reconcile(sf.Report(benchmark=benchmark, case_count=2, candidates=(result,)))
+
+
 def test_model_spans_accumulate_calls_tokens_failures_and_refusals() -> None:
     opus = candidate()
     state = progress(opus)
@@ -110,6 +145,90 @@ def test_subtree_usage_is_ignored_so_cost_is_not_double_counted() -> None:
         )
 
     assert state.rows[0].cost_usd == Decimal("0.25")
+
+
+def test_panel_reserves_compact_live_receipt_before_evidence_exists() -> None:
+    opus = candidate()
+    state = progress(opus)
+
+    initial = evaluation_panel_html(state)
+    assert "<div class='sf-eval__receipt' aria-hidden='true'></div>" in initial
+    assert ".sf-eval__receipt{margin-top:7px;min-height:1.45em" in initial
+
+    state.observe(opus, model_span(1))
+    state.observe(opus, model_span(2))
+    state.observe(
+        opus,
+        sf.events.Usage(
+            **envelope(3),
+            scope="self",
+            provider="provider",
+            model="opus",
+            pricing_version="v1",
+            usage=sf.Usage(cost_usd=Decimal("0.25")),
+        ),
+    )
+
+    html = evaluation_panel_html(state)
+    assert "<div class='sf-eval__receipt'>" in html
+    assert "<div class='sf-eval__receipt' aria-hidden='true'>" not in html
+    assert "cost $0.25 · 2 model calls · 2.0k in / 500 out" in html
+    assert "sf-eval__stats" not in html
+
+
+def test_fully_cached_receipt_tells_the_success_story_without_zero_telemetry() -> None:
+    opus = candidate()
+    state = progress(opus)
+    state.observe(
+        opus,
+        model_span(1, cache_status="hit", input_tokens=0, output_tokens=0),
+    )
+    state.observe(
+        opus,
+        model_span(2, cache_status="hit", input_tokens=0, output_tokens=0),
+    )
+    state.observe(
+        opus,
+        sf.events.Usage(
+            **envelope(3),
+            scope="self",
+            provider="provider",
+            model="opus",
+            pricing_version="v1",
+            usage=sf.Usage(input_tokens=0, output_tokens=0, cost_usd=Decimal("0")),
+        ),
+    )
+    assert "fully cached" not in evaluation_panel_html(state)
+    reconcile_complete(state, opus)
+
+    html = evaluation_panel_html(state)
+    receipt = html.split("<div class='sf-eval__receipt'>", 1)[1].split("</div>", 1)[0]
+
+    assert "2 model calls · " in receipt
+    assert "fully cached" in receipt
+    assert "no tokens billed" in receipt
+    assert "cost $0.00" not in receipt
+    assert "0 in / 0 out" not in receipt
+    assert "sf-eval__receipt-success" in receipt
+    assert ">$0.00<" in html
+    assert "<div class='sf-eval__title-state'>complete · 1s</div>" in html
+    assert "<div class='sf-eval__overall'>" not in html
+
+
+def test_fully_cached_receipt_requires_cache_evidence_for_every_model_call() -> None:
+    opus = candidate()
+    state = progress(opus)
+    state.observe(
+        opus,
+        model_span(1, cache_status="hit", input_tokens=0, output_tokens=0),
+    )
+    state.observe(opus, model_span(2, input_tokens=0, output_tokens=0))
+
+    html = evaluation_panel_html(state)
+    receipt = html.split("<div class='sf-eval__receipt'>", 1)[1].split("</div>", 1)[0]
+
+    assert "fully cached" not in receipt
+    assert "no tokens billed" not in receipt
 
 
 def test_nested_termination_does_not_change_the_candidate_status() -> None:
@@ -217,40 +336,36 @@ def test_panel_escapes_candidate_identity_and_global_errors() -> None:
 
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
-    assert "provider/&lt;model&gt;" in html
+    assert "provider/&lt;model&gt;" not in html
     assert "bad &lt;payload&gt;" in html
     assert "DRACO &lt;private&gt;" in html
 
 
-def test_cache_band_renders_truthful_empty_and_bypass_states() -> None:
+def test_panel_omits_aggregate_cache_band_even_when_evidence_exists() -> None:
     opus = candidate()
     state = progress(opus)
-
-    empty = evaluation_panel_html(state)
-
-    assert "no cache activity reported" in empty
-    assert "bypassed" not in empty
-
     state.observe(opus, model_span(1, cache_status="bypass", cache_reason="opted_out"))
-    bypassed = evaluation_panel_html(state)
+    html = evaluation_panel_html(state)
 
-    assert "1 bypassed" in bypassed
-    assert "opted_out 1" in bypassed
+    assert "<div class='sf-eval__cache'>" not in html
+    assert "no cache activity reported" not in html
+    assert "1 bypassed" not in html
+    assert "opted_out 1" not in html
+    table = html.split("<table", 1)[1].split("</table>", 1)[0]
+    assert ">Bypassed<" in table
 
 
-def test_visible_cache_text_uses_readable_ink_two() -> None:
+def test_panel_omits_run_activity_section() -> None:
     html = evaluation_panel_html(progress())
-    label = html.split(".sf-eval__cache-k{", 1)[1].split("}", 1)[0]
-    body = html.split(".sf-eval__cache-of,", 1)[1].split("}", 1)[0]
 
-    assert "var(--sf-ink-2)" in label
-    assert "var(--sf-ink-2)" in body
-    assert "--sf-ink-3" not in label
-    assert "--sf-ink-3" not in body
+    assert "<details" not in html
+    assert "Run activity" not in html
 
 
 def test_live_figure_formatters_cover_large_small_and_long_values() -> None:
     assert _compact(2_000_000) == "2.0M"
     assert _money(Decimal("0.005")) == "$0.0050"
+    assert _duration(1.9) == "1s"
     assert _duration(65) == "1m 05s"
-    assert _duration(3_665) == "1h 01m"
+    assert _duration(3_665) == "1hr 01min"
+    assert _duration(9_925) == "2hrs 45min"

--- a/packages/screamingface/tests/test_evaluation_progress_panel.py
+++ b/packages/screamingface/tests/test_evaluation_progress_panel.py
@@ -147,13 +147,13 @@ def test_subtree_usage_is_ignored_so_cost_is_not_double_counted() -> None:
     assert state.rows[0].cost_usd == Decimal("0.25")
 
 
-def test_panel_reserves_compact_live_receipt_before_evidence_exists() -> None:
+def test_panel_collapses_live_receipt_before_evidence_exists() -> None:
     opus = candidate()
     state = progress(opus)
 
     initial = evaluation_panel_html(state)
-    assert "<div class='sf-eval__receipt' aria-hidden='true'></div>" in initial
-    assert ".sf-eval__receipt{margin-top:7px;min-height:1.45em" in initial
+    assert "<div class='sf-eval__receipt'" not in initial
+    assert ".sf-eval__table-wrap{margin-top:12px" in initial
 
     state.observe(opus, model_span(1))
     state.observe(opus, model_span(2))

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -823,3 +823,44 @@ def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(
     assert view._done.is_set()
     assert "Run failed" in view._html.value
     assert "result decode failed" in view._html.value
+
+
+def test_notebook_view_lifecycle_shows_once_and_reconciles_authoritative_report(
+    monkeypatch: Any,
+) -> None:
+    from screamingface._ui.evaluation_view import _NotebookEvaluationView
+
+    class HTML:
+        def __init__(self, *, value: str) -> None:
+            self.value = value
+
+    displayed: list[HTML] = []
+    monkeypatch.setitem(sys.modules, "ipywidgets", SimpleNamespace(HTML=HTML))
+    monkeypatch.setitem(
+        sys.modules,
+        "IPython.display",
+        SimpleNamespace(display=displayed.append),
+    )
+    opus = candidate("opus")
+    view = _NotebookEvaluationView(
+        (opus,),
+        1,
+        "DRACO",
+        clock=lambda: 100.0,
+        tick=False,
+    )
+
+    assert displayed == [view._html]
+    view._show()
+    assert displayed == [view._html]
+
+    view.begin(opus)
+    assert view._dirty.is_set()
+
+    view.reconcile(report_for(opus))
+    assert view._done.is_set()
+    assert "complete · 2s" in view._html.value
+    assert "Finished · 2s" in view._html.value
+
+    view.close()
+    assert view._done.is_set()

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -1,0 +1,537 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+import screamingface as sf
+from screamingface._core.ports import _RunOutcome
+from screamingface._evaluation.model import Candidate, _compiled_candidate, _compiled_operation
+from screamingface._evaluation.runner import (
+    _abort_event_observer,
+    _AsyncEventObserver,
+    _reconcile_event_observer,
+    _run_candidates_async,
+    _run_candidates_sync,
+    _SyncEventObserver,
+)
+from screamingface._ui.evaluation_state import _EvaluationProgress
+from screamingface._ui.evaluation_view import evaluation_panel_html
+
+_START = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+
+
+def candidate(name: str) -> Candidate:
+    operation = _compiled_operation(
+        id=f"op_{name}",
+        kind="model",
+        label=f"{name} answer",
+        depends_on=(),
+    )
+    return _compiled_candidate(
+        name=name,
+        kind="model",
+        models=(f"provider/{name}",),
+        url4=f"(@)!'{name}'",
+        operations=(operation,),
+    )
+
+
+def span(
+    sequence: int,
+    *,
+    run_id: str,
+    operation: str = "RelUrlNode",
+    name: str = "/benchmarks/case-execution",
+    status: str = "ok",
+    request_model: str | None = None,
+    cache_status: str | None = None,
+) -> sf.events.Span:
+    return sf.events.Span(
+        id=f"{run_id}_{sequence}",
+        run_id=run_id,
+        sequence=sequence,
+        timestamp=_START + timedelta(seconds=sequence),
+        source=f"/trace/{run_id}/node/{sequence}",
+        name=name,
+        operation=operation,
+        start=_START,
+        end=_START + timedelta(seconds=1),
+        status=cast(Any, status),
+        request_model=request_model,
+        cache_status=cast(Any, cache_status),
+    )
+
+
+def test_candidate_rows_exist_in_input_order_before_events() -> None:
+    candidates = tuple(candidate(f"candidate-{index}") for index in range(10))
+
+    progress = _EvaluationProgress(candidates=candidates, case_count=100)
+
+    assert [row.candidate.name for row in progress.rows] == [
+        candidate.name for candidate in candidates
+    ]
+    assert [(row.status, row.completed_cases, row.total_cases) for row in progress.rows] == [
+        ("queued", 0, 100)
+    ] * 10
+
+
+def test_interleaved_terminal_case_spans_advance_only_the_bound_candidate() -> None:
+    opus = candidate("opus")
+    gpt = candidate("gpt")
+    progress = _EvaluationProgress(candidates=(opus, gpt), case_count=100)
+
+    progress.observe(opus, span(1, run_id="run_opus"))
+    progress.observe(gpt, span(1, run_id="run_gpt"))
+    progress.observe(opus, span(2, run_id="run_opus", status="error"))
+
+    assert progress.rows[0].completed_cases == 2
+    assert progress.rows[0].failed_cases == 1
+    assert progress.rows[1].completed_cases == 1
+
+
+def test_only_the_local_case_execution_span_advances_case_progress() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=3)
+
+    progress.observe(
+        opus,
+        span(
+            1,
+            run_id="run_opus",
+            operation="RemoteFetchNode",
+        ),
+    )
+    progress.observe(
+        opus,
+        span(
+            2,
+            run_id="run_opus",
+            operation="chat",
+            name="chat",
+            request_model="provider/opus",
+        ),
+    )
+    progress.observe(
+        opus,
+        span(
+            3,
+            run_id="run_opus",
+            name="/benchmarks/aggregate",
+        ),
+    )
+
+    assert progress.rows[0].completed_cases == 0
+
+    progress.observe(opus, span(4, run_id="run_opus"))
+
+    assert progress.rows[0].completed_cases == 1
+
+
+def test_sync_observer_binds_candidate_without_changing_public_callback() -> None:
+    opus = candidate("opus")
+    event = span(1, run_id="run_opus")
+    observed: list[tuple[Candidate, sf.Event]] = []
+    public: list[sf.Event] = []
+
+    class Builtin:
+        def observe(self, selected: Candidate, accepted: sf.Event) -> None:
+            observed.append((selected, accepted))
+
+    observer = _SyncEventObserver(cast(Any, Builtin()), public.append)
+
+    observer.bind(opus)(event)
+
+    assert observed == [(opus, event)]
+    assert public == [event]
+
+
+def test_one_thousand_terminal_spans_reach_exact_independent_totals() -> None:
+    candidates = tuple(candidate(f"candidate-{index}") for index in range(10))
+    progress = _EvaluationProgress(candidates=candidates, case_count=100)
+
+    for case_number in range(1, 101):
+        for index, selected in enumerate(candidates):
+            progress.observe(
+                selected,
+                span(case_number, run_id=f"run_{index}"),
+            )
+
+    assert [row.completed_cases for row in progress.rows] == [100] * 10
+
+
+def test_candidate_cost_and_cache_evidence_remain_scoped_to_its_row() -> None:
+    opus = candidate("opus")
+    gpt = candidate("gpt")
+    progress = _EvaluationProgress(candidates=(opus, gpt), case_count=1)
+
+    progress.observe(
+        opus,
+        sf.events.Usage(
+            id="usage_opus",
+            run_id="run_opus",
+            sequence=1,
+            timestamp=_START,
+            source="/trace/run_opus/node/root",
+            scope="self",
+            provider="provider",
+            model="opus",
+            pricing_version="v1",
+            usage=sf.Usage(cost_usd=Decimal("0.25")),
+        ),
+    )
+    progress.observe(
+        gpt,
+        span(
+            1,
+            run_id="run_gpt",
+            operation="chat",
+            name="chat",
+            request_model="provider/gpt",
+        ),
+    )
+    progress.observe(
+        gpt,
+        span(
+            2,
+            run_id="run_gpt",
+            operation="chat",
+            name="chat",
+            request_model="provider/gpt",
+            cache_status="hit",
+        ),
+    )
+
+    assert progress.rows[0].cost_usd == Decimal("0.25")
+    assert progress.rows[1].cost_usd is None
+    assert progress.rows[0].cache_hit_rate is None
+    assert progress.rows[1].cache_hit_rate == 1.0
+
+
+def outcome(name: str) -> _RunOutcome:
+    return _RunOutcome(
+        run_id=f"run_{name}",
+        started_at=_START,
+        completed_at=_START + timedelta(seconds=1),
+        result_body="{}",
+        media_type="application/json",
+        root_usage=None,
+    )
+
+
+def report_for(selected: Candidate, *, score: float | None = 0.75) -> sf.Report:
+    grade = sf.CaseGrade(method="fixture", score=score, metrics={}, checks=())
+    case = sf.CaseResult(
+        case_id=1,
+        input="Question",
+        output="Answer",
+        finish_reason="stop",
+        grade=grade,
+        failures=(),
+        metadata={},
+    )
+    benchmark = sf.BenchmarkInfo(id="draco", revision="fixture", case_count=100)
+    result = sf.CandidateResult(
+        benchmark=benchmark,
+        run_id=f"run_{selected.name}",
+        started_at=_START,
+        completed_at=_START + timedelta(seconds=2),
+        name=selected.name,
+        kind=selected.kind,
+        url4=selected.url4,
+        models=selected.models,
+        operations=selected.operations,
+        score=score,
+        coverage=1.0 if score is not None else 0.0,
+        metrics={},
+        cases=(case,),
+        members=(),
+        failures=(),
+        usage=sf.Usage(
+            input_tokens=1_000,
+            output_tokens=200,
+            cost_usd=Decimal("0.40"),
+        ),
+    )
+    return sf.Report(benchmark=benchmark, case_count=1, candidates=(result,))
+
+
+def test_sync_candidate_runner_uses_one_bound_observer_per_run() -> None:
+    candidates = (candidate("opus"), candidate("gpt"))
+    observed: list[tuple[str, str]] = []
+
+    class Builtin:
+        def observe(self, selected: Candidate, event: sf.Event) -> None:
+            observed.append((selected.name, event.run_id))
+
+    class Transport:
+        def run(self, selected: Candidate, on_event: object) -> _RunOutcome:
+            assert callable(on_event)
+            on_event(span(1, run_id=f"run_{selected.name}"))
+            return outcome(selected.name)
+
+        def cancel_active(self) -> None:
+            pass
+
+    observer = _SyncEventObserver(cast(Any, Builtin()), None)
+
+    _run_candidates_sync(cast(Any, Transport()), candidates, observer)
+
+    assert sorted(observed) == [("gpt", "run_gpt"), ("opus", "run_opus")]
+
+
+def test_async_candidate_runner_uses_one_bound_observer_per_run() -> None:
+    candidates = (candidate("opus"), candidate("gpt"))
+    observed: list[tuple[str, str]] = []
+
+    class Builtin:
+        def observe(self, selected: Candidate, event: sf.Event) -> None:
+            observed.append((selected.name, event.run_id))
+
+    class Transport:
+        async def run(self, selected: Candidate, on_event: object) -> _RunOutcome:
+            assert callable(on_event)
+            await cast(Any, on_event)(span(1, run_id=f"run_{selected.name}"))
+            return outcome(selected.name)
+
+        async def cancel_active(self) -> None:
+            pass
+
+    observer = _AsyncEventObserver(cast(Any, Builtin()), None)
+
+    asyncio.run(_run_candidates_async(cast(Any, Transport()), candidates, observer))
+
+    assert sorted(observed) == [("gpt", "run_gpt"), ("opus", "run_opus")]
+
+
+def test_final_report_is_the_only_score_and_finished_authority() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+    progress.observe(
+        opus,
+        sf.events.Started(
+            id="started",
+            run_id="run_opus",
+            sequence=1,
+            timestamp=_START,
+            source="/trace/run_opus/node/root",
+            url4=opus.url4,
+        ),
+    )
+    progress.observe(opus, span(2, run_id="run_opus"))
+    progress.observe(
+        opus,
+        sf.events.Terminated(
+            id="terminated",
+            run_id="run_opus",
+            sequence=3,
+            timestamp=_START + timedelta(seconds=2),
+            source="/trace/run_opus/node/root",
+            status="succeeded",
+        ),
+    )
+
+    assert progress.rows[0].status == "running"
+    assert progress.rows[0].score is None
+    assert progress.rows[0].score_available is False
+
+    progress.reconcile(report_for(opus))
+
+    assert progress.rows[0].status == "finished"
+    assert progress.rows[0].score == 0.75
+    assert progress.rows[0].score_available is True
+    assert progress.rows[0].cost_usd == Decimal("0.40")
+
+
+@pytest.mark.parametrize(
+    ("started", "error", "expected"),
+    [
+        (False, RuntimeError("submission failed"), "not_run"),
+        (True, KeyboardInterrupt(), "stopped"),
+        (True, TimeoutError(), "timed_out"),
+        (True, RuntimeError("decode failed"), "run_failed"),
+    ],
+)
+def test_abort_maps_only_explicit_workflow_evidence(
+    started: bool,
+    error: BaseException,
+    expected: str,
+) -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+    if started:
+        progress.observe(
+            opus,
+            sf.events.Started(
+                id="started",
+                run_id="run_opus",
+                sequence=1,
+                timestamp=_START,
+                source="/trace/run_opus/node/root",
+                url4=opus.url4,
+            ),
+        )
+
+    progress.abort(error)
+
+    assert progress.rows[0].status == expected
+
+
+def test_terminal_engine_evidence_wins_over_workflow_abort_inference() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+    root = "/trace/run_opus/node/root"
+    progress.observe(
+        opus,
+        sf.events.Started(
+            id="started",
+            run_id="run_opus",
+            sequence=1,
+            timestamp=_START,
+            source=root,
+            url4=opus.url4,
+        ),
+    )
+    progress.observe(
+        opus,
+        sf.events.Terminated(
+            id="terminated",
+            run_id="run_opus",
+            sequence=2,
+            timestamp=_START + timedelta(seconds=1),
+            source=root,
+            status="stopped",
+        ),
+    )
+
+    progress.abort(RuntimeError("decode failed"))
+
+    assert progress.rows[0].status == "stopped"
+
+
+@pytest.mark.parametrize("phase", ["reconcile", "abort"])
+def test_broken_terminal_progress_phase_still_closes_the_observer(phase: str) -> None:
+    opus = candidate("opus")
+
+    class BrokenProgress:
+        closed = False
+
+        def reconcile(self, report: sf.Report) -> None:
+            del report
+            raise RuntimeError("render failed")
+
+        def abort(self, error: BaseException) -> None:
+            del error
+            raise RuntimeError("render failed")
+
+        def close(self) -> None:
+            self.closed = True
+
+    progress = BrokenProgress()
+    observer = _SyncEventObserver(cast(Any, progress), None)
+
+    if phase == "reconcile":
+        _reconcile_event_observer(observer, report_for(opus))
+    else:
+        _abort_event_observer(observer, RuntimeError("run failed"))
+
+    assert progress.closed is True
+
+
+def test_candidate_table_uses_the_approved_columns_and_truthful_values() -> None:
+    opus = candidate("opus")
+    gpt = candidate("gpt")
+    progress = _EvaluationProgress(candidates=(opus, gpt), case_count=100)
+    progress.observe(opus, span(1, run_id="run_opus"))
+
+    html = evaluation_panel_html(progress, "DRACO")
+
+    headers = ["Candidate", "Status", "Progress", "Score", "Cost", "Cache"]
+    positions = [html.index(f">{header}<") for header in headers]
+    assert positions == sorted(positions)
+    assert "<table" in html
+    assert "sf-eval__table-wrap" in html
+    assert "overflow-x:auto" in html
+    assert "opus" in html
+    assert "gpt" in html
+    assert "1 / 100" in html
+    assert "Not scored yet" in html
+    assert "Not reported" in html
+
+
+def test_candidate_table_has_no_inferred_phase_gradient_or_whole_table_live_region() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+
+    html = evaluation_panel_html(progress, "DRACO")
+
+    assert "Answering" not in html
+    assert "Grading" not in html
+    assert "linear-gradient" not in html
+    assert "sf-eval-sweep" not in html
+    table = html.split("<table", 1)[1].split("</table>", 1)[0]
+    assert "aria-live" not in table
+    assert "prefers-reduced-motion:reduce" in html
+
+
+def test_opaque_url4_replay_keeps_an_unknown_denominator_truthful() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=None)
+    progress.observe(opus, span(1, run_id="run_opus"))
+
+    html = evaluation_panel_html(progress, "URL4 replay")
+
+    assert "1 case finished" in html
+    assert "max='None'" not in html
+    assert "1 /" not in html
+
+
+def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(
+    monkeypatch: Any,
+) -> None:
+    from screamingface._ui.evaluation_view import _NotebookEvaluationView
+
+    class HTML:
+        def __init__(self, *, value: str) -> None:
+            self.value = value
+
+    monkeypatch.setitem(sys.modules, "ipywidgets", SimpleNamespace(HTML=HTML))
+    monkeypatch.setattr(_NotebookEvaluationView, "_show", lambda self: None)
+    opus = candidate("opus")
+    now = [100.0]
+    view = _NotebookEvaluationView(
+        (opus,),
+        1,
+        "DRACO",
+        clock=lambda: now[0],
+        tick=False,
+    )
+    view.observe(
+        opus,
+        sf.events.Started(
+            id="started",
+            run_id="run_opus",
+            sequence=1,
+            timestamp=_START,
+            source="/trace/run_opus/node/root",
+            url4=opus.url4,
+        ),
+    )
+
+    assert "0.0s" in view._html.value
+
+    now[0] += 45
+    view._html.value = view._render()
+
+    assert "45.0s" in view._html.value
+
+    view.abort(RuntimeError("result decode failed"))
+
+    assert view._done.is_set()
+    assert "Run failed" in view._html.value
+    assert "result decode failed" in view._html.value

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -22,6 +22,7 @@ from screamingface._evaluation.runner import (
 )
 from screamingface._ui.evaluation_state import _EvaluationProgress
 from screamingface._ui.evaluation_view import evaluation_panel_html
+from screamingface._ui.style import FUSION_GRADIENT, STYLE
 
 _START = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
 
@@ -224,48 +225,81 @@ def outcome(name: str) -> _RunOutcome:
     )
 
 
-def report_for(selected: Candidate, *, score: float | None = 0.75) -> sf.Report:
-    grade = sf.CaseGrade(method="fixture", score=score, metrics={}, checks=())
-    case = sf.CaseResult(
-        case_id=1,
-        input="Question",
-        output="Answer",
-        finish_reason="stop",
-        grade=grade,
-        failures=(),
-        metadata={},
+def report_for(
+    selected: Candidate,
+    *,
+    score: float | None = 0.75,
+    case_count: int = 1,
+    cost_usd: Decimal | None = Decimal("0.40"),
+    graded_case_count: int | None = None,
+    completed_seconds: int = 2,
+) -> sf.Report:
+    numeric_grades = (
+        (case_count if graded_case_count is None else graded_case_count) if score is not None else 0
+    )
+    cases = tuple(
+        sf.CaseResult(
+            case_id=case_id,
+            input="Question",
+            output="Answer",
+            finish_reason="stop",
+            grade=(
+                sf.CaseGrade(method="fixture", score=score, metrics={}, checks=())
+                if score is None or case_id <= numeric_grades
+                else None
+            ),
+            failures=(
+                ()
+                if score is None or case_id <= numeric_grades
+                else (
+                    sf.Failure(
+                        stage="grading",
+                        code="missing_grade",
+                        message="fixture grade unavailable",
+                        case_id=case_id,
+                        metadata={},
+                    ),
+                )
+            ),
+            metadata={},
+        )
+        for case_id in range(1, case_count + 1)
     )
     benchmark = sf.BenchmarkInfo(id="draco", revision="fixture", case_count=100)
     result = sf.CandidateResult(
         benchmark=benchmark,
         run_id=f"run_{selected.name}",
         started_at=_START,
-        completed_at=_START + timedelta(seconds=2),
+        completed_at=_START + timedelta(seconds=completed_seconds),
         name=selected.name,
         kind=selected.kind,
         url4=selected.url4,
         models=selected.models,
         operations=selected.operations,
         score=score,
-        coverage=1.0 if score is not None else 0.0,
+        coverage=round(numeric_grades / case_count, 4),
         metrics={},
-        cases=(case,),
+        cases=cases,
         members=(),
         failures=(),
         usage=sf.Usage(
             input_tokens=1_000,
             output_tokens=200,
-            cost_usd=Decimal("0.40"),
+            cost_usd=cost_usd,
         ),
     )
-    return sf.Report(benchmark=benchmark, case_count=1, candidates=(result,))
+    return sf.Report(benchmark=benchmark, case_count=case_count, candidates=(result,))
 
 
 def test_sync_candidate_runner_uses_one_bound_observer_per_run() -> None:
     candidates = (candidate("opus"), candidate("gpt"))
+    begun: list[str] = []
     observed: list[tuple[str, str]] = []
 
     class Builtin:
+        def begin(self, selected: Candidate) -> None:
+            begun.append(selected.name)
+
         def observe(self, selected: Candidate, event: sf.Event) -> None:
             observed.append((selected.name, event.run_id))
 
@@ -282,14 +316,19 @@ def test_sync_candidate_runner_uses_one_bound_observer_per_run() -> None:
 
     _run_candidates_sync(cast(Any, Transport()), candidates, observer)
 
+    assert sorted(begun) == ["gpt", "opus"]
     assert sorted(observed) == [("gpt", "run_gpt"), ("opus", "run_opus")]
 
 
 def test_async_candidate_runner_uses_one_bound_observer_per_run() -> None:
     candidates = (candidate("opus"), candidate("gpt"))
+    begun: list[str] = []
     observed: list[tuple[str, str]] = []
 
     class Builtin:
+        def begin(self, selected: Candidate) -> None:
+            begun.append(selected.name)
+
         def observe(self, selected: Candidate, event: sf.Event) -> None:
             observed.append((selected.name, event.run_id))
 
@@ -306,6 +345,7 @@ def test_async_candidate_runner_uses_one_bound_observer_per_run() -> None:
 
     asyncio.run(_run_candidates_async(cast(Any, Transport()), candidates, observer))
 
+    assert sorted(begun) == ["gpt", "opus"]
     assert sorted(observed) == [("gpt", "run_gpt"), ("opus", "run_opus")]
 
 
@@ -348,6 +388,35 @@ def test_final_report_is_the_only_score_and_finished_authority() -> None:
     assert progress.rows[0].cost_usd == Decimal("0.40")
 
 
+def test_final_report_reconciles_case_progress_without_erasing_live_cost() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=None)
+    progress.observe(opus, span(1, run_id="run_opus"))
+    progress.observe(opus, span(2, run_id="run_opus"))
+    progress.observe(opus, span(3, run_id="run_opus"))
+    progress.observe(
+        opus,
+        sf.events.Usage(
+            id="usage",
+            run_id="run_opus",
+            sequence=4,
+            timestamp=_START,
+            source="/trace/run_opus/node/root",
+            scope="self",
+            provider="provider",
+            model="opus",
+            pricing_version="v1",
+            usage=sf.Usage(cost_usd=Decimal("0.25")),
+        ),
+    )
+
+    progress.reconcile(report_for(opus, case_count=2, cost_usd=None))
+
+    row = progress.rows[0]
+    assert (row.completed_cases, row.total_cases) == (2, 2)
+    assert row.cost_usd == Decimal("0.25")
+
+
 @pytest.mark.parametrize(
     ("started", "error", "expected"),
     [
@@ -382,6 +451,37 @@ def test_abort_maps_only_explicit_workflow_evidence(
     assert progress.rows[0].status == expected
 
 
+def test_submitted_candidate_without_lifecycle_evidence_is_not_labelled_not_run() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+
+    progress.begin(opus)
+    progress.abort(RuntimeError("event stream ended"))
+
+    assert progress.rows[0].status == "run_failed"
+    assert progress.rows[0].activity == "Run outcome unavailable"
+
+
+def test_bound_started_event_does_not_depend_on_repeating_the_candidate_url4() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+
+    progress.begin(opus)
+    progress.observe(
+        opus,
+        sf.events.Started(
+            id="started",
+            run_id="run_opus",
+            sequence=1,
+            timestamp=_START,
+            source="/trace/run_opus/node/root",
+            url4="(@)!'wire-normalized-differently'",
+        ),
+    )
+
+    assert progress.rows[0].status == "running"
+
+
 def test_terminal_engine_evidence_wins_over_workflow_abort_inference() -> None:
     opus = candidate("opus")
     progress = _EvaluationProgress(candidates=(opus,), case_count=1)
@@ -412,6 +512,14 @@ def test_terminal_engine_evidence_wins_over_workflow_abort_inference() -> None:
     progress.abort(RuntimeError("decode failed"))
 
     assert progress.rows[0].status == "stopped"
+
+    html = evaluation_panel_html(progress, "DRACO", elapsed=20)
+    table = html.split("<table", 1)[1].split("</table>", 1)[0]
+    assert ">Stopped<" in table
+    assert "Run stopped" not in table
+    assert "sf-eval__activity" not in table
+    assert "<details" not in html
+    assert "Run stopped" not in html
 
 
 @pytest.mark.parametrize("phase", ["reconcile", "abort"])
@@ -451,20 +559,82 @@ def test_candidate_table_uses_the_approved_columns_and_truthful_values() -> None
 
     html = evaluation_panel_html(progress, "DRACO")
 
-    headers = ["Candidate", "Status", "Progress", "Score", "Cost", "Cache"]
+    headers = ["Candidate", "Status", "Cases", "Score", "Cost", "Cache hit"]
     positions = [html.index(f">{header}<") for header in headers]
     assert positions == sorted(positions)
     assert "<table" in html
     assert "sf-eval__table-wrap" in html
-    assert "overflow-x:auto" in html
+    assert "overflow-x:auto" not in html
+    assert "min-width:820px" not in html
+    assert "tabindex='0'" not in html
+    assert "table-layout:fixed" in html
+    assert ".sf-eval{border:0;padding:4px 0 14px;" in html
+    widths = {"candidate": 27, "status": 17, "cases": 10, "score": 17, "cost": 14, "cache": 15}
+    for name, width in widths.items():
+        assert f".sf-eval__col--{name}{{width:{width}%}}" in html
     assert "opus" in html
     assert "gpt" in html
+    assert "provider/opus" not in html
+    assert "provider/gpt" not in html
+    assert "<progress" not in html
     assert "1 / 100" in html
     assert "Not scored yet" in html
     assert "Not reported" in html
 
 
-def test_candidate_table_has_no_inferred_phase_gradient_or_whole_table_live_region() -> None:
+def test_numeric_candidate_columns_are_right_aligned() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+
+    html = evaluation_panel_html(progress, "DRACO")
+
+    for header in ("Cases", "Score", "Cost", "Cache hit"):
+        assert f"<th scope='col' class='sf-eval__num'>{header}</th>" in html
+    assert ".sf-eval__num{text-align:right}" in html
+    row = html.split("<tbody>", 1)[1].split("</tbody>", 1)[0]
+    assert row.count("sf-eval__num") == 4
+
+
+def test_notebook_surface_uses_current_sfds_v2_tokens() -> None:
+    assert "--sf-bg:#fcfdff" in STYLE
+    assert "--sf-surface:#f4f6f9" in STYLE
+    assert "--sf-surface-2:#eceef0" in STYLE
+    assert "--sf-ink:#3b3c3e" in STYLE
+    assert "--sf-ink-2:#616265" in STYLE
+    assert "--sf-ink-3:#b4b6b8" in STYLE
+    assert "--sf-line:#cdcfd2" in STYLE
+    assert "--sf-line-2:#b4b6b8" in STYLE
+    assert "--sf-danger-solid:#ff0325" in STYLE
+    assert "--sf-bg:#05070b" in STYLE
+    assert "--sf-surface:#0c0f13" in STYLE
+    assert "--sf-surface-2:#15181c" in STYLE
+    assert "--sf-ink:#e0e5eb" in STYLE
+    assert "--sf-ink-2:#c7ccd2" in STYLE
+    assert "--sf-ink-3:#585c61" in STYLE
+    assert "--sf-line:#35383d" in STYLE
+    assert "--sf-line-2:#585c61" in STYLE
+    assert "--sf-danger-solid:#ed413f" in STYLE
+
+
+def test_candidate_table_matches_current_sfds_table_recipe() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+    progress.abort(RuntimeError("failed"))
+
+    html = evaluation_panel_html(progress, "DRACO")
+
+    assert "font-size:13px" in html
+    assert "padding:12px 16px" in html
+    assert "border-bottom:1px solid var(--sf-line-2)" in html
+    assert "font-size:11px;font-weight:500" in html
+    assert "letter-spacing:.1em" in html
+    assert ".sf-eval__candidate{font-family:" in html
+    assert "font-weight:500;\n  color:var(--sf-ink)" in html
+    assert "align-items:center;gap:8px" in html
+    assert "background:var(--sf-danger-solid)" in html
+
+
+def test_candidate_table_has_no_inferred_phase_or_whole_table_live_region() -> None:
     opus = candidate("opus")
     progress = _EvaluationProgress(candidates=(opus,), case_count=1)
 
@@ -472,11 +642,65 @@ def test_candidate_table_has_no_inferred_phase_gradient_or_whole_table_live_regi
 
     assert "Answering" not in html
     assert "Grading" not in html
-    assert "linear-gradient" not in html
     assert "sf-eval-sweep" not in html
     table = html.split("<table", 1)[1].split("</table>", 1)[0]
     assert "aria-live" not in table
-    assert "prefers-reduced-motion:reduce" in html
+    assert "<progress" not in html
+
+
+def test_running_panel_has_stable_benchmark_title_and_canonical_static_status() -> None:
+    opus = candidate("opus")
+    gpt = candidate("gpt")
+    progress = _EvaluationProgress(candidates=(opus, gpt), case_count=2)
+    progress.begin(opus)
+    progress.observe(
+        opus,
+        sf.events.Started(
+            id="started",
+            run_id="run_opus",
+            sequence=1,
+            timestamp=_START,
+            source="/trace/run_opus/node/root",
+            url4=opus.url4,
+        ),
+    )
+
+    html = evaluation_panel_html(progress, "DRACO", elapsed=45)
+
+    assert "<div class='sf-eval__title'>DRACO</div>" in html
+    assert "<div class='sf-eval__title-state'>evaluating… · 0%</div>" in html
+    assert ".sf-eval__title-row{display:flex" in html
+    assert "justify-content:space-between" in html
+    assert "DRACO ·" not in html
+    assert "sf-eval__sub" not in html
+    assert ".sf-eval__status--running .sf-eval__status-sq{background:var(--sf-accent)}" in html
+    assert "@keyframes sf-eval-running" not in html
+    assert "animation:sf-eval-running" not in html
+
+
+def test_overall_progress_uses_canonical_sfds_run_treatment() -> None:
+    opus = candidate("opus")
+    gpt = candidate("gpt")
+    progress = _EvaluationProgress(candidates=(opus, gpt), case_count=100)
+    progress.observe(opus, span(1, run_id="run_opus"))
+    progress.observe(gpt, span(1, run_id="run_gpt"))
+
+    html = evaluation_panel_html(progress, "DRACO", elapsed=45)
+
+    assert "Overall progress" not in html
+    assert "2 / 200 case runs" not in html
+    assert "evaluating… · 1%" in html
+    assert "evaluating… · 1% · 2/200" not in html
+    assert "role='progressbar'" in html
+    assert "aria-valuemin='0'" in html
+    assert "aria-valuemax='200'" in html
+    assert "aria-valuenow='2'" in html
+    assert "width:1%" in html
+    assert "background-size:10000.0% 100%" in html
+    assert f"background-image:{FUSION_GRADIENT}" in html
+    assert "transition:width .11s linear" in html
+    overall = html.split("<div class='sf-eval__overall'>", 1)[1].split("</div>", 1)[0]
+    assert "evaluating…" not in overall
 
 
 def test_opaque_url4_replay_keeps_an_unknown_denominator_truthful() -> None:
@@ -489,6 +713,70 @@ def test_opaque_url4_replay_keeps_an_unknown_denominator_truthful() -> None:
     assert "1 case finished" in html
     assert "max='None'" not in html
     assert "1 /" not in html
+    assert "<div class='sf-eval__overall'>" not in html
+    assert "<div class='sf-eval__title-state'>evaluating…</div>" in html
+
+
+def test_aborted_evaluation_headline_does_not_claim_completion() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+    progress.begin(opus)
+    progress.observe(
+        opus,
+        sf.events.Started(
+            id="started",
+            run_id="run_opus",
+            sequence=1,
+            timestamp=_START,
+            source="/trace/run_opus/node/root",
+            url4=opus.url4,
+        ),
+    )
+
+    progress.abort(KeyboardInterrupt())
+
+    html = evaluation_panel_html(progress, "DRACO")
+    assert "Evaluation complete" not in html
+    assert "Evaluation ended" not in html
+    assert "<div class='sf-eval__title'>DRACO</div>" in html
+    assert "stopped · 0%" in html
+    assert "stopped · 0% · 0/1" not in html
+    table = html.split("<table", 1)[1].split("</table>", 1)[0]
+    assert "Not scored yet" not in table
+    assert ">Not scored<" in table
+
+
+def test_reconciled_evaluation_uses_complete_progress_state() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=1)
+
+    progress.reconcile(report_for(opus))
+
+    html = evaluation_panel_html(progress, "DRACO")
+    assert "<div class='sf-eval__title'>DRACO</div>" in html
+    assert "<div class='sf-eval__title-state'>complete · 2s</div>" in html
+    assert "complete · 100%" not in html
+    assert "<div class='sf-eval__overall'>" not in html
+    assert "Finished · 2s" in html
+
+
+def test_partial_result_names_exact_graded_coverage_and_keeps_final_duration() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=2)
+
+    progress.reconcile(
+        report_for(
+            opus,
+            score=0.3799,
+            case_count=2,
+            graded_case_count=1,
+            completed_seconds=70,
+        )
+    )
+
+    html = evaluation_panel_html(progress, "DRACO")
+    assert "Finished · 1/2 graded · 1m 10s" in html
+    assert "Finished · Partial" not in html
 
 
 def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(
@@ -523,12 +811,12 @@ def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(
         ),
     )
 
-    assert "0.0s" in view._html.value
+    assert "0s" in view._html.value
 
     now[0] += 45
     view._html.value = view._render()
 
-    assert "45.0s" in view._html.value
+    assert "45s" in view._html.value
 
     view.abort(RuntimeError("result decode failed"))
 

--- a/packages/screamingface/tests/test_progress.py
+++ b/packages/screamingface/tests/test_progress.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from datetime import UTC, datetime
 from io import StringIO
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -33,7 +33,10 @@ def test_progress_can_be_disabled_or_forced() -> None:
     observer = _progress_observer(True, stream=stream)
     assert observer is not None
 
-    observer(sf.events.Started(**envelope(), url4="(@)!'hello'"))
+    observer.observe(
+        cast(Any, object()),
+        sf.events.Started(**envelope(), url4="(@)!'hello'"),
+    )
 
     assert stream.getvalue() == "ScreamingFace · Evaluation started\n"
 
@@ -76,13 +79,14 @@ def test_progress_neutralizes_terminal_controls_and_multiline_log_spoofing() -> 
     observer = _progress_observer(True, stream=stream)
     assert observer is not None
 
-    observer(
+    observer.observe(
+        cast(Any, object()),
         sf.events.Log(
             **envelope(),
             severity_number=9,
             severity_text="INFO",
             body="safe\x1b]0;forged-title\x07\rforged\nnext\tline",
-        )
+        ),
     )
 
     assert stream.getvalue() == ("ScreamingFace · safe ]0;forged-title forged next line\n")
@@ -120,9 +124,15 @@ def test_sync_evaluate_combines_builtin_and_caller_observers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: list[tuple[str, str]] = []
+
+    class Progress:
+        def observe(self, candidate: object, event: sf.Event) -> None:
+            del candidate
+            observed.append(("progress", event.kind))
+
     monkeypatch.setattr(
         "screamingface._evaluation.progress._progress_observer",
-        lambda requested, **_: lambda event: observed.append(("progress", event.kind)),
+        lambda requested, **_: Progress(),
     )
     callback = _sync_event_observer(
         lambda event: observed.append(("caller", event.kind)),
@@ -130,7 +140,7 @@ def test_sync_evaluate_combines_builtin_and_caller_observers(
     )
     assert callback is not None
 
-    callback(sf.events.Started(**envelope(), url4="(@)!'hello'"))
+    callback.bind(cast(Any, object()))(sf.events.Started(**envelope(), url4="(@)!'hello'"))
 
     assert observed == [("progress", "started"), ("caller", "started")]
 
@@ -140,17 +150,19 @@ def test_sync_builtin_progress_failure_does_not_block_the_caller_observer(
 ) -> None:
     observed: list[str] = []
 
-    def broken_progress(_event: sf.Event) -> None:
-        raise OSError("stdout closed")
+    class BrokenProgress:
+        def observe(self, candidate: object, event: sf.Event) -> None:
+            del candidate, event
+            raise OSError("stdout closed")
 
     monkeypatch.setattr(
         "screamingface._evaluation.progress._progress_observer",
-        lambda requested, **_: broken_progress,
+        lambda requested, **_: BrokenProgress(),
     )
     callback = _sync_event_observer(lambda event: observed.append(event.kind), True)
     assert callback is not None
 
-    callback(sf.events.Started(**envelope(), url4="(@)!'hello'"))
+    callback.bind(cast(Any, object()))(sf.events.Started(**envelope(), url4="(@)!'hello'"))
 
     assert observed == ["started"]
 
@@ -161,8 +173,8 @@ def test_sync_evaluation_failure_closes_live_builtin_progress(
     class Progress:
         closed = False
 
-        def __call__(self, _event: sf.Event) -> None:
-            pass
+        def observe(self, candidate: object, event: sf.Event) -> None:
+            del candidate, event
 
         def close(self) -> None:
             self.closed = True
@@ -184,9 +196,15 @@ async def test_async_evaluate_combines_builtin_and_async_caller_observers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: list[tuple[str, str]] = []
+
+    class Progress:
+        def observe(self, candidate: object, event: sf.Event) -> None:
+            del candidate
+            observed.append(("progress", event.kind))
+
     monkeypatch.setattr(
         "screamingface._evaluation.progress._progress_observer",
-        lambda requested, **_: lambda event: observed.append(("progress", event.kind)),
+        lambda requested, **_: Progress(),
     )
 
     async def caller(event: sf.Event) -> None:
@@ -195,7 +213,7 @@ async def test_async_evaluate_combines_builtin_and_async_caller_observers(
     callback = _async_event_observer(caller, True)
     assert callback is not None
 
-    await callback(sf.events.Started(**envelope(), url4="(@)!'hello'"))
+    await callback.bind(cast(Any, object()))(sf.events.Started(**envelope(), url4="(@)!'hello'"))
 
     assert observed == [("progress", "started"), ("caller", "started")]
 
@@ -206,12 +224,14 @@ async def test_async_builtin_progress_failure_does_not_block_the_caller_observer
 ) -> None:
     observed: list[str] = []
 
-    def broken_progress(_event: sf.Event) -> None:
-        raise OSError("stdout closed")
+    class BrokenProgress:
+        def observe(self, candidate: object, event: sf.Event) -> None:
+            del candidate, event
+            raise OSError("stdout closed")
 
     monkeypatch.setattr(
         "screamingface._evaluation.progress._progress_observer",
-        lambda requested, **_: broken_progress,
+        lambda requested, **_: BrokenProgress(),
     )
 
     async def caller(event: sf.Event) -> None:
@@ -220,7 +240,7 @@ async def test_async_builtin_progress_failure_does_not_block_the_caller_observer
     callback = _async_event_observer(caller, True)
     assert callback is not None
 
-    await callback(sf.events.Started(**envelope(), url4="(@)!'hello'"))
+    await callback.bind(cast(Any, object()))(sf.events.Started(**envelope(), url4="(@)!'hello'"))
 
     assert observed == ["started"]
 
@@ -232,8 +252,8 @@ async def test_async_evaluation_failure_closes_live_builtin_progress(
     class Progress:
         closed = False
 
-        def __call__(self, _event: sf.Event) -> None:
-            pass
+        def observe(self, candidate: object, event: sf.Event) -> None:
+            del candidate, event
 
         def close(self) -> None:
             self.closed = True
@@ -250,7 +270,7 @@ async def test_async_evaluation_failure_closes_live_builtin_progress(
     assert progress.closed is True
 
 
-def test_candidate_model_identity_reaches_builtin_progress(
+def test_candidate_identity_and_case_count_reach_builtin_progress(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     received: dict[str, object] = {}
@@ -264,15 +284,15 @@ def test_candidate_model_identity_reaches_builtin_progress(
         progress_observer,
     )
 
+    candidates = (object(),)
     observer = _sync_event_observer(
         None,
         True,
-        total_candidates=1,
+        candidates=cast(Any, candidates),
+        case_count=100,
         benchmark="draco",
-        candidate_models=("openrouter/anthropic/claude-opus-4.8",),
-        candidate_urls=("(@)!'candidate'",),
     )
 
     assert observer is not None
-    assert received["candidate_models"] == ("openrouter/anthropic/claude-opus-4.8",)
-    assert received["candidate_urls"] == ("(@)!'candidate'",)
+    assert received["candidates"] == candidates
+    assert received["case_count"] == 100

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -380,15 +380,15 @@ def failed_case(case_id: int | str = 153) -> CaseResult:
     )
 
 
-def test_existing_report_warnings_keep_the_distinct_amber_palette() -> None:
+def test_existing_report_warnings_use_the_current_sfds_warning_palette() -> None:
     html = report_html(multi_case_report(case(score=None), score=None, coverage=0.0))
 
-    assert "--sf-warning:#7a5e12" in html
-    assert "--sf-warning-solid:#efbd41" in html
-    assert "--sf-warning-bg:#fdf6e6" in html
-    assert "--sf-warning:#e2ca91" in html
-    assert "--sf-warning-bg:#151005" in html
-    assert "--sf-warning:#9c4828" not in html
+    assert "--sf-warning:#66270c" in html
+    assert "--sf-warning-solid:#f1622d" in html
+    assert "--sf-warning-bg:#fdf4f1" in html
+    assert "--sf-warning:#ffddd0" in html
+    assert "--sf-warning-solid:#e36f48" in html
+    assert "--sf-warning-bg:#130e0c" in html
 
 
 def refused_case(case_id: int = 154) -> CaseResult:


### PR DESCRIPTION
## Summary

- bind each accepted Event to its submitted Candidate without changing the public on_event(event) callback
- replace the aggregate notebook panel with an SFDS v2 Candidate table for Status, exact Case progress, final Score, Cost, and Cache
- reconcile only from the authoritative final Report and freeze truthful stop, timeout, failure, and opaque URL4 replay states

## Boundaries

- Client-only; no Benchmark, Engine, wire-schema, or URL4-expression changes
- exact Case progress counts only terminal (RelUrlNode, /benchmarks/case-execution) spans supplied by OME-950
- no provisional scoring, inferred phases, current Case identity, or legacy fallback

## Verification

- 80 focused progress/evaluation tests
- 1,065 package tests passed with one skip
- package coverage gate passes at 95.04%
- Ruff, format, and Pyright clean
- CI rerunning against main

Refs: OME-933