### PR TITLE
feat(aigateway): admin cache-snapshot upload (OME-952)

### DIFF
--- a/apps/aigateway/pyproject.toml
+++ b/apps/aigateway/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "asyncpg==0.31.0",
     "aiosqlite==0.22.1",
     "cryptography==50.0.0",
+    "python-multipart>=0.0.20",
 ]
 
 [project.scripts]

--- a/apps/aigateway/src/aigateway/config.py
+++ b/apps/aigateway/src/aigateway/config.py
@@ -142,6 +142,14 @@ class Settings(BaseSettings):
         default=1_000_000, gt=0, validation_alias="AIGW_REQUEST_CACHE_MAX_RESPONSE_BYTES"
     )
 
+    # Admin cache-snapshot upload cap (OME-952): the COMPRESSED archive size accepted by
+    # POST /v1/admin/cache/snapshots. Deliberately on the compressed bytes — that is what
+    # crosses the wire and fills the spool directory — and deliberately generous: the DRACO
+    # corpus is ~35 MB gzipped today and snapshots grow with the table.
+    cache_upload_max_bytes: int = Field(
+        default=268_435_456, gt=0, validation_alias="AIGW_CACHE_UPLOAD_MAX_BYTES"
+    )
+
     # Bounded public-catalog discovery behind /v1/model-parameters (OME-479 §5.2,
     # §5.3). Enabled by default: the evidence it gathers can only RESTRICT what a
     # contract claims, so running without it is the more permissive state, not the

--- a/apps/aigateway/src/aigateway/core/admin_schemas.py
+++ b/apps/aigateway/src/aigateway/core/admin_schemas.py
@@ -123,3 +123,56 @@ class SetAdminApiKeyRequest(BaseModel):
 class PatchAdminProfileRequest(BaseModel):
     defaults: ProfileDefaults | None = None
     account_label: str | None = None
+
+
+# --- response-cache admin (OME-952) ---------------------------------------------------------------
+
+
+class AdminCacheInfoOut(BaseModel):
+    """Live state of the global response cache, for the console's cache section.
+
+    ``revisions`` are the constants every cache key embeds; a snapshot manifest that disagrees
+    with them would load rows the gateway can never serve, which is why the console shows the
+    live values beside the upload form.
+    """
+
+    serving: bool
+    row_count: int
+    revisions: dict[str, str]
+
+
+class AdminCacheJobOut(BaseModel):
+    """One snapshot load attempt, as the console lists and polls it."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    state: str
+    """``validating`` → ``loading`` → ``merging`` → ``complete`` | ``failed`` | ``refused``."""
+
+    mode: str
+    """``merge`` (create-or-replace) or ``replace`` (wholesale contents swap)."""
+
+    actor: str
+    created_at: datetime
+    finished_at: datetime | None = None
+    staged_rows: int | None = None
+    live_before: int | None = None
+    live_after: int | None = None
+    inserted_rows: int | None = None
+    """Merge mode only, best-effort: derived from the before/after counts, not row RETURNING."""
+
+    updated_rows: int | None = None
+    manifest_present: bool = False
+    forced: bool = False
+    """A revision mismatch was overridden with ``force`` — visible on the job and the audit line."""
+
+    warnings: list[str] = Field(default_factory=list)
+    refusal: str | None = None
+    """Machine code naming why a ``refused`` job was refused; see the spec's refusal contract."""
+
+    error: str | None = None
+
+
+class AdminCacheJobList(BaseModel):
+    jobs: list[AdminCacheJobOut]

--- a/apps/aigateway/src/aigateway/core/request_cache/bulk_loader.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/bulk_loader.py
@@ -1,0 +1,212 @@
+"""Postgres bulk loader for cache snapshots: stage via COPY, then merge or replace (OME-952).
+
+This is the SQL-direct half of the admin upload. A snapshot's COPY block is re-fed to Postgres
+through asyncpg's COPY protocol — the server re-reads its own dump format, so no value is ever
+parsed, unescaped, or re-serialised by this process (spec invariants 1 and 4).
+
+WHY Tortoise is bypassed for the load: the ORM lane (``set_if_absent``) is row-by-row and
+create-only by design, built for the request path. A snapshot is ~190k already-final rows whose
+per-row guarantees (key validity, payload shape) were established by the gateway that wrote
+them; moving them is a bulk COPY plus one set-based merge, seconds rather than minutes.
+
+MERGE keeps the live row's identity and serving history (``id``, ``created_at``, ``hit_count``,
+``last_hit_at``) and replaces only the content columns — the same create-or-replace discipline
+as ``set_if_absent``: a stored answer may be replaced by its snapshot version, never removed.
+REPLACE is a wholesale contents swap behind the caller's loss acknowledgement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import BinaryIO, Final, Literal, NamedTuple, Protocol
+
+from tortoise import Tortoise
+from tortoise.backends.asyncpg.client import AsyncpgDBClient
+
+from .snapshot import CopyBlockSource, open_snapshot_stream
+
+_TABLE: Final = "request_cache_entries"
+_STAGING: Final = "request_cache_entries_staging"
+_BATCH_BYTES: Final = 1 << 20  # 1 MiB per asyncpg chunk — enough for throughput, small in memory.
+
+# Column lists for the final INSERT statements. The staging side names every column (the dump
+# carries all of them); on the merge target `id` is generated (`gen_random_uuid()`: snapshot
+# ids belong to the deployment that wrote them, and fresh ids make cross-deployment id
+# collisions impossible) and `updated_at` reads `now()` — the row changed here.
+_MERGE_INSERT_COLUMNS: Final = (
+    "id, key_hash, prompt_hash, provider, model, response_json, response_size_bytes, "
+    "created_at, updated_at, expires_at, last_hit_at, hit_count"
+)
+_REPLACE_COLUMNS: Final = (
+    "id, key_hash, prompt_hash, provider, model, response_json, response_size_bytes, "
+    "created_at, updated_at, expires_at, last_hit_at, hit_count"
+)
+
+_MERGE_SQL: Final = f"""
+INSERT INTO {_TABLE} ({_MERGE_INSERT_COLUMNS})
+SELECT gen_random_uuid(), s.key_hash, s.prompt_hash, s.provider, s.model, s.response_json,
+       s.response_size_bytes, s.created_at, now(), s.expires_at, s.last_hit_at, s.hit_count
+  FROM {_STAGING} AS s
+ON CONFLICT (key_hash) DO UPDATE SET
+    prompt_hash         = EXCLUDED.prompt_hash,
+    provider            = EXCLUDED.provider,
+    model               = EXCLUDED.model,
+    response_json       = EXCLUDED.response_json,
+    response_size_bytes = EXCLUDED.response_size_bytes,
+    expires_at          = EXCLUDED.expires_at,
+    updated_at          = now()
+"""
+
+_REPLACE_SQL: Final = (
+    f"INSERT INTO {_TABLE} ({_REPLACE_COLUMNS}) SELECT {_REPLACE_COLUMNS} FROM {_STAGING} AS s"
+)
+
+
+class CacheUploadUnsupportedDatabase(RuntimeError):
+    """The active database is not Postgres, so the COPY protocol path cannot run."""
+
+
+class StagedRowCountMismatch(RuntimeError):
+    """The staged row count disagrees with the manifest's declared ``row_count``."""
+
+    def __init__(self, staged: int, declared: int) -> None:
+        self.staged = staged
+        self.declared = declared
+        super().__init__(f"staged {staged} rows but the manifest declared {declared}")
+
+
+class ReplaceGuardBlocked(RuntimeError):
+    """Replace would discard live rows written after the snapshot was taken."""
+
+    def __init__(self, live: int, staged: int) -> None:
+        self.live = live
+        self.staged = staged
+        super().__init__(
+            f"the live table holds {live} rows but the snapshot carries {staged}; "
+            f"{live - staged} row(s) newer than the snapshot would be destroyed"
+        )
+
+
+class LoadOutcome(NamedTuple):
+    staged_rows: int
+    live_before: int
+    live_after: int
+
+
+class _PhaseCallback(Protocol):
+    async def __call__(self, phase: Literal["loading", "merging"]) -> None: ...
+
+
+def _postgres_client() -> AsyncpgDBClient:
+    client = Tortoise.get_connection("default")
+    if not isinstance(client, AsyncpgDBClient):
+        raise CacheUploadUnsupportedDatabase(
+            "the cache snapshot loader speaks Postgres COPY; this deployment's database is "
+            f"{type(client).__name__}"
+        )
+    return client
+
+
+async def load_snapshot(
+    path: Path,
+    *,
+    mode: Literal["merge", "replace"],
+    expected_rows: int | None,
+    acknowledge_loss: bool,
+    on_phase: _PhaseCallback | None = None,
+) -> LoadOutcome:
+    """Stage, verify, and load one snapshot file into the live cache table.
+
+    Raises before ANY live-table write: :class:`NoCopyBlock` / :class:`CopyHeaderMismatch`
+    (no honest load possible), :class:`StagedRowCountMismatch` (manifest lied about its rows),
+    :class:`ReplaceGuardBlocked` (replace would lose newer rows, unacknowledged). The caller
+    maps each to the job's ``refused`` state.
+    """
+    if on_phase is not None:
+        await on_phase("loading")
+
+    client = _postgres_client()
+    staged_rows = 0
+
+    async with client.acquire_connection() as raw:
+        # A staging twin, created once and TRUNCATEd per run: no indexes, no constraints, no
+        # defaults — the dump supplies every column, and a bare copy of the column shape loads
+        # fastest. Dropping it between runs would trade a CREATE per upload for nothing.
+        await raw.execute(f"CREATE TABLE IF NOT EXISTS {_STAGING} (LIKE {_TABLE})")
+        await raw.execute(f"TRUNCATE {_STAGING}")
+
+        stream: BinaryIO = open_snapshot_stream(path)
+        # The `finally` closes the (possibly gzip-wrapped) stream on every exit; the raw file
+        # beneath a gzip wrapper is closed by the wrapper itself.
+        try:
+            source = CopyBlockSource(stream)
+            await asyncio.to_thread(source.header)
+            staged_rows = await _copy_stream_into_staging(raw, source)
+        finally:
+            await asyncio.to_thread(stream.close)
+
+        if expected_rows is not None and staged_rows != expected_rows:
+            raise StagedRowCountMismatch(staged_rows, expected_rows)
+
+        live_before: int = await raw.fetchval(f"SELECT count(*) FROM {_TABLE}")  # type: ignore[assignment]
+
+        if mode == "replace" and live_before > staged_rows and not acknowledge_loss:
+            raise ReplaceGuardBlocked(live_before, staged_rows)
+
+        if on_phase is not None:
+            await on_phase("merging")
+
+        # One transaction for the load: readers see the old contents until commit (MVCC), and
+        # a mid-load failure leaves the live table untouched rather than half-replaced.
+        async with raw.transaction():
+            if mode == "merge":
+                await raw.execute(_MERGE_SQL)
+            else:
+                await raw.execute(f"TRUNCATE {_TABLE}")
+                await raw.execute(_REPLACE_SQL)
+            live_after: int = await raw.fetchval(f"SELECT count(*) FROM {_TABLE}")  # type: ignore[assignment]
+
+        await raw.execute(f"TRUNCATE {_STAGING}")
+
+    return LoadOutcome(staged_rows=staged_rows, live_before=live_before, live_after=live_after)
+
+
+def _read_batch(source: CopyBlockSource) -> bytes:
+    """Accumulate data lines into ~1 MiB, newline-terminated, bytes verbatim (thread-side)."""
+    buffer = bytearray()
+    for line in source.data_lines():
+        buffer += line
+        if len(buffer) >= _BATCH_BYTES:
+            break
+    return bytes(buffer)
+
+
+async def _copy_stream_into_staging(raw: object, source: CopyBlockSource) -> int:
+    """Feed the block to Postgres COPY; return the row count actually delivered."""
+    rows = 0
+
+    async def chunks() -> AsyncIterator[bytes]:
+        nonlocal rows
+        while True:
+            # gzip reads are blocking; keep them off the event loop the gateway serves on.
+            chunk = await asyncio.to_thread(_read_batch, source)
+            if not chunk:
+                return
+            rows += chunk.count(b"\n")
+            yield chunk
+
+    await raw.copy_to_table(  # type: ignore[attr-defined]
+        _STAGING, source=chunks(), timeout=600
+    )
+    return rows
+
+
+__all__ = [
+    "CacheUploadUnsupportedDatabase",
+    "LoadOutcome",
+    "ReplaceGuardBlocked",
+    "StagedRowCountMismatch",
+    "load_snapshot",
+]

--- a/apps/aigateway/src/aigateway/core/request_cache/revisions.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/revisions.py
@@ -1,0 +1,40 @@
+"""Core-owned registry of the adapter revision constants cache keys embed (OME-952).
+
+A global cache key is a hash over the request PLUS revision constants: the parameter contract
+(``global_keys.PARAMETER_CONTRACT_REVISION``, core's own) and each provider adapter's
+projection revision (a PLUGIN constant). A snapshot produced under different constants would
+load cleanly and then NEVER be served — a 100% miss with no error anywhere — which is why the
+admin upload compares revisions before loading anything (spec invariant 8).
+
+WHY a registry rather than an import: core must not import plugins (hexagonal rule), so the
+plugin side registers its constant here at plugin load — the same direction of dependence the
+provider registry itself uses. ``main.load_plugins`` imports every provider package, so by the
+time any route can run, the registrations are in place.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .global_keys import PARAMETER_CONTRACT_REVISION
+
+_ADAPTER_REVISIONS: dict[str, str] = {}
+
+#: The key under which the parameter-contract constant is reported. Final because both the
+#: manifest (OME-954) and the seed generator write it verbatim.
+PARAMETER_CONTRACT_KEY: Final = "parameter_contract"
+
+
+def register_adapter_revision(name: str, revision: str) -> None:
+    """Record one provider adapter's cache-key revision. Called at plugin load."""
+    _ADAPTER_REVISIONS[name] = revision
+
+
+def active_adapter_revisions() -> dict[str, str]:
+    """A copy of the registered adapter revisions (safe to hand to callers)."""
+    return dict(_ADAPTER_REVISIONS)
+
+
+def active_cache_revisions() -> dict[str, str]:
+    """Every revision constant a snapshot's manifest must agree with, keyed by manifest name."""
+    return {PARAMETER_CONTRACT_KEY: PARAMETER_CONTRACT_REVISION, **_ADAPTER_REVISIONS}

--- a/apps/aigateway/src/aigateway/core/request_cache/snapshot.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/snapshot.py
@@ -1,0 +1,208 @@
+"""Slice a ``snapshot-cache`` pg_dump down to its COPY block (OME-952).
+
+A snapshot is a gzip'd single-table ``pg_dump`` of ``public.request_cache_entries``: a fixed
+prologue, one ``COPY ... FROM stdin;`` header, the rows in COPY text format, a ``\\.`` terminator,
+and a fixed epilogue. The loader (see :mod:`.bulk_loader`) re-feeds exactly the row lines to
+Postgres through its own COPY protocol, which is why this module works at the BYTE level and
+never decodes a value: a value may contain any byte the dump format escapes, and the only
+guarantee that survives a decode/re-encode round trip is the one we never make.
+
+INVARIANT — nothing here parses SQL. The header is recognised by shape, the data lines are
+yielded verbatim, and the epilogue (``CREATE TABLE``, indexes, constraints) is discarded
+unread. The dump's own DDL must never reach the server through this path.
+"""
+
+from __future__ import annotations
+
+import gzip
+from collections.abc import Iterator
+from pathlib import Path
+from typing import BinaryIO, Final
+
+from pydantic import BaseModel, Field, field_validator
+
+# The table's column order, as pg_dump writes it — which is the DATABASE's column order, pinned
+# by the migrations and verified against a live deployment (OME-952 plan). The loader feeds
+# ``copy_to_table`` with THIS tuple, so no upload-derived identifier ever reaches a COPY
+# command; a dump whose header disagrees is refused rather than re-interpreted.
+CANONICAL_COLUMNS: Final[tuple[str, ...]] = (
+    "id",
+    "key_hash",
+    "prompt_hash",
+    "provider",
+    "model",
+    "response_json",
+    "response_size_bytes",
+    "created_at",
+    "updated_at",
+    "expires_at",
+    "last_hit_at",
+    "hit_count",
+)
+
+_TABLE_NAME: Final = "request_cache_entries"
+_HEADER_PREFIX: Final = f"COPY public.{_TABLE_NAME} (".encode()
+_HEADER_SUFFIX: Final = b" FROM stdin;"
+_GZIP_MAGIC: Final = b"\x1f\x8b"
+
+
+class NoCopyBlock(ValueError):
+    """The stream contains no COPY block for the request-cache table."""
+
+
+class CopyHeaderMismatch(ValueError):
+    """A COPY block was found but its column layout is not this gateway's."""
+
+    def __init__(self, columns: tuple[str, ...]) -> None:
+        self.columns = columns
+        super().__init__(
+            f"the snapshot's COPY header lists {len(columns)} column(s) in an order this "
+            "gateway does not share; the rows could not be loaded honestly"
+        )
+
+
+def open_snapshot_stream(path: Path) -> BinaryIO:
+    """Open a snapshot for reading, transparently gunzipping when the magic bytes say so.
+
+    ``snapshot-cache`` writes gzip; a plain ``pg_dump`` output is accepted too because the
+    bytes are indistinguishable to every later stage — detection by magic, never by filename.
+    """
+    raw = path.open("rb")
+    try:
+        head = raw.read(2)
+        raw.seek(0)
+        if head == _GZIP_MAGIC:
+            return gzip.open(raw, "rb")  # type: ignore[return-value]
+        return raw
+    except Exception:
+        raw.close()
+        raise
+
+
+class CopyBlockSource:
+    """Line-level cursor over one dump's COPY block.
+
+    :meth:`header` scans forward to the ``COPY public.request_cache_entries (...) FROM stdin;``
+    line and returns its column list — parsed from the HEADER only, which pg_dump generates
+    from the table definition, never from row data. :meth:`data_lines` then yields the row
+    lines up to the ``\\.`` terminator, newline-terminated, bytes verbatim.
+    """
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self._lines: Iterator[bytes] = iter(stream)
+        self._block_exhausted = False
+
+    def header(self) -> tuple[str, ...]:
+        for line in self._lines:
+            if not line.startswith(_HEADER_PREFIX):
+                continue
+            clean = line.rstrip(b"\r\n")
+            if not clean.endswith(_HEADER_SUFFIX):
+                # A COPY line for our table that is not a data header (e.g. a comment quoting
+                # one) is not something pg_dump produces; treat it as an unrecognised shape.
+                continue
+            body = clean[len(_HEADER_PREFIX) : -len(_HEADER_SUFFIX)]
+            if not body.endswith(b")"):
+                raise CopyHeaderMismatch(())  # pragma: no cover - hand-crafted input only
+            body = body[:-1]
+            try:
+                columns = tuple(name.strip() for name in body.decode("ascii").split(","))
+            except UnicodeDecodeError as exc:  # pragma: no cover - hand-crafted input only
+                raise CopyHeaderMismatch(()) from exc
+            if any(not name for name in columns):
+                raise CopyHeaderMismatch(columns)
+            if columns != CANONICAL_COLUMNS:
+                raise CopyHeaderMismatch(columns)
+            return columns
+        raise NoCopyBlock(f"no COPY block for public.{_TABLE_NAME} in the snapshot")
+
+    def data_lines(self) -> Iterator[bytes]:
+        """Yield COPY data lines, each newline-terminated, through the ``\\.`` terminator.
+
+        A raw newline can never occur INSIDE a COPY text value (newlines are escaped as
+        ``\\n`` by the dump), so splitting on ``b"\\n"`` splits rows exactly. The terminator
+        itself is consumed and not yielded. pg_dump always terminates rows with a newline;
+        a final line without one (hand-made input) is terminated here, because the COPY wire
+        format needs row separators.
+
+        LATCHED CLOSED: the loader reads this in BATCHES, and a batch boundary can fall past
+        the terminator. A fresh call here must never resume into the dump's epilogue (pg_dump
+        18 even appends ``\\unrestrict`` directives there) — those lines are not data, and
+        feeding them to COPY was a real defect: the epilogue's leading blank line parsed as
+        a row whose first field was empty. After the terminator, this yields nothing.
+        """
+        if self._block_exhausted:
+            return
+        for line in self._lines:
+            if line.rstrip(b"\r\n") == b"\\.":
+                self._block_exhausted = True
+                return
+            yield line if line.endswith(b"\n") else line + b"\n"
+
+
+class SnapshotManifest(BaseModel):
+    """The sidecar ``snapshot-cache`` emits beside the archive (OME-954's contract).
+
+    Present ⇒ the loader can PROVE the rows were keyed by the same revision constants this
+    gateway hashes with. Absent ⇒ the load proceeds with ``revisions_unverified`` — an honest
+    warning, not a refusal, because snapshots taken before manifests existed are still valid
+    dumps of this table.
+    """
+
+    schema: str  # noqa: A003 - the manifest's own field name
+    generated_at: str
+    row_count: int = Field(ge=0)
+    sha256: str
+    revisions: dict[str, str]
+
+    @field_validator("schema")
+    @classmethod
+    def _known_schema(cls, value: str) -> str:
+        if value != "screamingface.cache-snapshot.v1":
+            raise ValueError(f"unknown manifest schema: {value!r}")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def _hex_digest(cls, value: str) -> str:
+        if len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+            raise ValueError("sha256 must be a 64-character lowercase hex digest")
+        return value
+
+    @field_validator("revisions")
+    @classmethod
+    def _nonempty(cls, value: dict[str, str]) -> dict[str, str]:
+        if not value:
+            raise ValueError("revisions must name at least one constant")
+        return value
+
+
+def parse_manifest(raw: bytes) -> SnapshotManifest:
+    """Strict parse: any shape or content problem raises ``ValueError``.
+
+    The manifest is operator-supplied input, so it is validated as hard as the rows are: a
+    manifest that lies about its own checksum or row count must be refused as ``manifest_invalid``
+    rather than silently downgrade the verification it exists to provide.
+    """
+    from pydantic import ValidationError
+
+    try:
+        return SnapshotManifest.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ValueError(f"manifest is not a valid cache-snapshot v1 document: {exc}") from exc
+
+
+def digest_matches(actual_hex: str, manifest: SnapshotManifest) -> bool:
+    return actual_hex == manifest.sha256
+
+
+__all__ = [
+    "CANONICAL_COLUMNS",
+    "CopyBlockSource",
+    "CopyHeaderMismatch",
+    "NoCopyBlock",
+    "SnapshotManifest",
+    "digest_matches",
+    "open_snapshot_stream",
+    "parse_manifest",
+]

--- a/apps/aigateway/src/aigateway/core/request_cache/upload_job.py
+++ b/apps/aigateway/src/aigateway/core/request_cache/upload_job.py
@@ -1,0 +1,266 @@
+"""The admin cache-upload job runner: one slot, owned task, honest records (OME-952).
+
+The upload route spools the file synchronously (a Starlette ``UploadFile`` dies with its
+request) and hands the PATH here; everything that can refuse a snapshot — checksum, row count,
+revision mismatch, the replace guard — runs inside the job and lands as the terminal state
+``refused`` with a machine code, because the upload itself was accepted (spec contract).
+
+INVARIANTS
+- ONE load job per process at a time; a second upload while one runs raises
+  :class:`CacheUploadBusy`, which the route answers 409 (spec invariant 5).
+- The spawned task is OWNED: the runner holds the reference for its lifetime, so the event
+  loop's weak reference to nameless tasks cannot let it be collected mid-load.
+- Job records live on ``app.state`` only — a restart forgets reports, never data (spec
+  limitation, accepted). The durable truth is the table plus the audit log.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections import deque
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+from .bulk_loader import (
+    CacheUploadUnsupportedDatabase,
+    LoadOutcome,
+    ReplaceGuardBlocked,
+    StagedRowCountMismatch,
+    load_snapshot,
+)
+from .revisions import active_cache_revisions
+from .snapshot import (
+    CopyHeaderMismatch,
+    NoCopyBlock,
+    SnapshotManifest,
+    digest_matches,
+    parse_manifest,
+)
+
+MAX_UPLOAD_BYTES_DEFAULT = 256 * 1024 * 1024
+_HISTORY_LIMIT = 50
+
+
+class CacheUploadBusy(RuntimeError):
+    """Another load job is running; only one may run per deployment at a time."""
+
+
+# Refusal codes are API surface (the console renders them); new ones are additive.
+REFUSAL_CODES = (
+    "manifest_invalid",
+    "checksum_mismatch",
+    "revision_mismatch",
+    "upload_too_large",
+    "no_copy_block",
+    "column_layout_mismatch",
+    "row_count_mismatch",
+    "newer_rows_would_be_lost",
+    "unsupported_database",
+)
+
+
+@dataclass
+class CacheJobRecord:
+    """One load attempt's observable history. Serialized to ``AdminCacheJobOut``."""
+
+    id: uuid.UUID
+    actor: str
+    mode: Literal["merge", "replace"]
+    created_at: datetime
+    state: str = "validating"
+    finished_at: datetime | None = None
+    staged_rows: int | None = None
+    live_before: int | None = None
+    live_after: int | None = None
+    inserted_rows: int | None = None
+    updated_rows: int | None = None
+    manifest_present: bool = False
+    forced: bool = False
+    warnings: list[str] = field(default_factory=list)
+    refusal: str | None = None
+    error: str | None = None
+
+    def out_counts(self, outcome: LoadOutcome) -> None:
+        """Fill the counters from a finished load. Merge additionally splits inserted/updated.
+
+        The split is derived from counts, not per-row RETURNING: ``inserted = live_after -
+        live_before`` because merge only adds keys that were absent, and every other staged
+        row landed on the update path. A concurrent delete between the two counts can blur
+        the split by a row — the spec records it as best-effort, and it is.
+        """
+        self.staged_rows = outcome.staged_rows
+        self.live_before = outcome.live_before
+        self.live_after = outcome.live_after
+        if self.mode == "merge":
+            inserted = max(outcome.live_after - outcome.live_before, 0)
+            self.inserted_rows = inserted
+            self.updated_rows = max(outcome.staged_rows - inserted, 0)
+
+
+Loader = Callable[..., Awaitable[LoadOutcome]]
+RevisionSource = Callable[[], dict[str, str]]
+
+
+@dataclass(frozen=True)
+class UploadAcceptance:
+    """What the route validated synchronously, passed to the runner as trusted input."""
+
+    upload_path: Path
+    sha256_hex: str
+    actual_bytes: int
+    manifest_raw: bytes | None
+    mode: Literal["merge", "replace"]
+    force: bool
+    acknowledge_loss: bool
+    actor: str
+
+
+class CacheUploadRunner:
+    """Runs cache-snapshot loads one at a time and remembers their records."""
+
+    def __init__(
+        self,
+        *,
+        loader: Loader = load_snapshot,
+        revisions: RevisionSource = active_cache_revisions,
+        max_upload_bytes: int = MAX_UPLOAD_BYTES_DEFAULT,
+        history_limit: int = _HISTORY_LIMIT,
+    ) -> None:
+        self._loader = loader
+        self._revisions = revisions
+        self.max_upload_bytes = max_upload_bytes
+        self._history_limit = history_limit
+        self._jobs: deque[CacheJobRecord] = deque(maxlen=history_limit)
+        self._task: asyncio.Task[None] | None = None
+
+    # --- queries --------------------------------------------------------------------------------
+
+    def jobs(self) -> list[CacheJobRecord]:
+        return list(self._jobs)
+
+    def get(self, job_id: uuid.UUID) -> CacheJobRecord | None:
+        return next((job for job in self._jobs if job.id == job_id), None)
+
+    def busy(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    # --- one load -------------------------------------------------------------------------------
+
+    def start(self, acceptance: UploadAcceptance) -> CacheJobRecord:
+        """Accept one upload and begin its load. Raises :class:`CacheUploadBusy` if occupied."""
+        if self.busy():
+            raise CacheUploadBusy("a cache snapshot load is already running on this gateway")
+        record = CacheJobRecord(
+            id=uuid.uuid4(),
+            actor=acceptance.actor,
+            mode=acceptance.mode,
+            created_at=datetime.now(UTC),
+        )
+        self._jobs.append(record)
+        # OWNED reference: kept on self until done, so the loop's weak task refs cannot
+        # drop it mid-load. Exceptions never escape _run — it always reaches a terminal state.
+        self._task = asyncio.create_task(self._run(record, acceptance))
+        return record
+
+    async def _run(self, record: CacheJobRecord, acceptance: UploadAcceptance) -> None:
+        manifest: SnapshotManifest | None = None
+        try:
+            if acceptance.actual_bytes > self.max_upload_bytes:
+                self._refuse(record, "upload_too_large")
+                return
+
+            if acceptance.manifest_raw is not None:
+                record.manifest_present = True
+                try:
+                    manifest = parse_manifest(acceptance.manifest_raw)
+                except ValueError as exc:
+                    self._refuse(record, "manifest_invalid", detail=str(exc))
+                    return
+                if not digest_matches(acceptance.sha256_hex, manifest):
+                    self._refuse(record, "checksum_mismatch")
+                    return
+                mismatched = {
+                    name: {"manifest": value, "gateway": self._revisions().get(name)}
+                    for name, value in manifest.revisions.items()
+                    if self._revisions().get(name) != value
+                }
+                if mismatched:
+                    if not acceptance.force:
+                        self._refuse(record, "revision_mismatch", detail=str(mismatched))
+                        return
+                    record.forced = True
+                    record.warnings.append("revision_mismatch_forced")
+            else:
+                record.warnings.append("revisions_unverified")
+
+            try:
+                outcome = await self._loader(
+                    acceptance.upload_path,
+                    mode=acceptance.mode,
+                    expected_rows=manifest.row_count if manifest is not None else None,
+                    acknowledge_loss=acceptance.acknowledge_loss,
+                    on_phase=_phase_recorder(record),
+                )
+            except (
+                NoCopyBlock,
+                CopyHeaderMismatch,
+                StagedRowCountMismatch,
+                ReplaceGuardBlocked,
+                CacheUploadUnsupportedDatabase,
+            ) as exc:
+                code = _REFUSAL_FOR[type(exc)]
+                self._refuse(record, code, detail=str(exc))
+                return
+            except Exception as exc:  # noqa: BLE001 - the job boundary; recorded, not hidden
+                record.state = "failed"
+                record.error = f"{type(exc).__name__}: {exc}"
+                record.finished_at = datetime.now(UTC)
+                return
+
+            record.out_counts(outcome)
+            record.state = "complete"
+            record.finished_at = datetime.now(UTC)
+        finally:
+            try:
+                acceptance.upload_path.unlink(missing_ok=True)
+            except OSError:  # pragma: no cover - best-effort temp cleanup
+                pass
+
+    @staticmethod
+    def _refuse(record: CacheJobRecord, code: str, *, detail: str | None = None) -> None:
+        record.state = "refused"
+        record.refusal = code
+        record.error = detail
+        record.finished_at = datetime.now(UTC)
+
+
+_REFUSAL_FOR: dict[type[Exception], str] = {
+    NoCopyBlock: "no_copy_block",
+    CopyHeaderMismatch: "column_layout_mismatch",
+    StagedRowCountMismatch: "row_count_mismatch",
+    ReplaceGuardBlocked: "newer_rows_would_be_lost",
+    CacheUploadUnsupportedDatabase: "unsupported_database",
+}
+
+
+def _phase_recorder(
+    record: CacheJobRecord,
+) -> Callable[[Literal["loading", "merging"]], Awaitable[None]]:
+    async def on_phase(phase: Literal["loading", "merging"]) -> None:
+        record.state = phase
+
+    return on_phase
+
+
+__all__ = [
+    "CacheUploadBusy",
+    "CacheUploadRunner",
+    "CacheJobRecord",
+    "MAX_UPLOAD_BYTES_DEFAULT",
+    "REFUSAL_CODES",
+    "UploadAcceptance",
+]

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -39,6 +39,7 @@ from .core.pending_auth import PendingAuthTable
 from .core.profile_index import ProfileIndexStore
 from .core.registry import ProviderRegistry
 from .core.request_cache.store import ConfiguredCacheAvailability, TortoiseRequestCacheStore
+from .core.request_cache.upload_job import CacheUploadRunner
 from .core.secrets.factory import build_secret_store, set_active_secret_store
 from .core.usage_accounting.hooks import build_accounting_handler
 from .db import close_db, init_db
@@ -46,6 +47,7 @@ from .plugins.taxonomy.plugin import TaxonomyPlugin
 from .routes import (
     accounts,
     admin,
+    admin_cache,
     api_key_validation,
     auth,
     auth_session,
@@ -377,6 +379,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.pending_auth = PendingAuthTable(ttl_seconds=600)
     app.state.discovery_runtime = _build_discovery_runtime(settings)
+    # OME-952: the admin cache-snapshot upload runner. app-state-only by the same reasoning
+    # as `admitted_models` above: job REPORTS are deployment-lifetime, the loaded data and
+    # the audit log are the durable truth.
+    app.state.cache_upload_runner = CacheUploadRunner(
+        max_upload_bytes=settings.cache_upload_max_bytes
+    )
     # OME-879: dynamic-admission state. Deliberately app-state-only (deployment
     # lifetime): a restart forgets every admission and nothing is persisted.
     app.state.admitted_models = {}
@@ -391,6 +399,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     app.include_router(accounts.router)
     app.include_router(admin.router)
     _describe_admin_security(app)
+    app.include_router(admin_cache.router)
     app.include_router(api_key_validation.router)
     app.include_router(auth.router)
     app.include_router(oauth_connections.router)

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/global_cache.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/global_cache.py
@@ -65,6 +65,15 @@ from .settings import (
 # for models without built-in search, one that erred rather than answering.
 GLOBAL_CACHE_ADAPTER_REVISION = "openrouter-global-cache-2026-08d"
 
+# OME-952: register the revision with the core-owned registry the admin cache-snapshot
+# upload compares manifests against. Plugins import core (never the reverse), and this
+# module is imported by ``plugin.py`` at load time, so the registration is in place before
+# any route can run. Registering HERE keeps the constant single-sourced: the registry and
+# the projection report the same name.
+from aigateway.core.request_cache.revisions import register_adapter_revision  # noqa: E402
+
+register_adapter_revision("openrouter_adapter", GLOBAL_CACHE_ADAPTER_REVISION)
+
 
 def project_global_cache_request(body: dict[str, Any]) -> dict[str, Any] | CacheBypass:
     """What this provider will send, as a deterministic function of the body.

--- a/apps/aigateway/src/aigateway/routes/admin_cache.py
+++ b/apps/aigateway/src/aigateway/routes/admin_cache.py
@@ -1,0 +1,187 @@
+"""Admin routes for the response-cache snapshot upload (OME-952).
+
+Four routes, all behind :class:`CurrentAdmin` and audited by the admin router's
+``AdminAuditRoute`` — a cache load mutates state EVERY caller of the gateway shares, so every
+attempt (including refusals) is logged with its actor, exactly like the account routes.
+
+Synchronous refusals (4xx before any job exists): malformed multipart fields (422 by FastAPI),
+an unknown mode (400), a non-Postgres database (400), an upload already over the size cap
+(413), and a load already running (409). Everything else is judged inside the job, because
+the honest answer for a 40 MB gzip archive is a ``202`` plus a pollable record, not a request
+that blocks for the load's duration.
+
+The upload is spooled to a temp file BEFORE the job starts: a Starlette ``UploadFile`` is
+request-scoped, and the job outlives the response. Spooling also fixes the digest — the
+sha256 the manifest check compares — and enforces the size cap on ACTUAL bytes, not the
+``Content-Length`` a client may understate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from pathlib import Path
+from uuid import UUID
+
+from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
+from tortoise import Tortoise
+from tortoise.backends.asyncpg.client import AsyncpgDBClient
+
+from ..core.admin_schemas import AdminCacheInfoOut, AdminCacheJobList, AdminCacheJobOut
+from ..core.auth.admin import CurrentAdmin
+from ..core.request_cache.models import RequestCacheEntry
+from ..core.request_cache.revisions import active_cache_revisions
+from ..core.request_cache.upload_job import (
+    CacheUploadBusy,
+    CacheUploadRunner,
+    UploadAcceptance,
+)
+from .admin import AdminAuditRoute
+
+router = APIRouter(prefix="/v1/admin/cache", tags=["Admin"], route_class=AdminAuditRoute)
+
+_SPOOL_CHUNK = 1 << 20
+_MANIFEST_CAP = 64 * 1024  # a manifest is a few hundred bytes; 64 KiB is already a lie
+_MODES = ("merge", "replace")
+
+
+def _note_actor(request: Request, admin: CurrentAdmin) -> None:
+    request.state.admin_actor = admin.username
+
+
+def _runner(request: Request) -> CacheUploadRunner:
+    return request.app.state.cache_upload_runner
+
+
+def _postgres_active() -> bool:
+    return isinstance(Tortoise.get_connection("default"), AsyncpgDBClient)
+
+
+async def _spool(upload: UploadFile, destination: Path, cap: int) -> tuple[str, int]:
+    """Copy the upload to ``destination`` under ``cap`` bytes; return (sha256 hex, size).
+
+    Reads are chunked: the file never sits in memory whole, and the cap stops a mislabelled
+    upload before it fills the disk a temp directory shares with the database.
+    """
+    digest = hashlib.sha256()
+    total = 0
+    with destination.open("wb") as sink:
+        while chunk := await upload.read(_SPOOL_CHUNK):
+            total += len(chunk)
+            if total > cap:
+                sink.close()
+                destination.unlink(missing_ok=True)
+                raise HTTPException(
+                    status_code=413,
+                    detail={
+                        "code": "cache_upload_too_large",
+                        "max_bytes": cap,
+                        "message": (
+                            f"the upload exceeds the {cap} byte snapshot cap (got at least {total})"
+                        ),
+                    },
+                )
+            sink.write(chunk)
+            digest.update(chunk)
+    return digest.hexdigest(), total
+
+
+@router.get("/info", response_model=AdminCacheInfoOut)
+async def cache_info(request: Request, admin: CurrentAdmin) -> AdminCacheInfoOut:
+    _note_actor(request, admin)
+    store = request.app.state.request_cache_store
+    return AdminCacheInfoOut(
+        serving=store.cache_available(),
+        row_count=await RequestCacheEntry.all().count(),
+        revisions=active_cache_revisions(),
+    )
+
+
+@router.post("/snapshots", status_code=202, response_model=AdminCacheJobOut)
+async def upload_snapshot(
+    request: Request,
+    admin: CurrentAdmin,
+    snapshot: UploadFile = File(..., description="gzip'd single-table pg_dump of the cache"),
+    manifest: UploadFile | None = File(
+        None, description="the .manifest.json snapshot-cache emitted beside the archive"
+    ),
+    mode: str = Form("merge"),
+    force: bool = Form(False),
+    acknowledge_loss: bool = Form(False),
+) -> AdminCacheJobOut:
+    _note_actor(request, admin)
+    runner = _runner(request)
+
+    if mode not in _MODES:
+        raise HTTPException(
+            status_code=400,
+            detail={"code": "cache_upload_bad_mode", "mode": mode, "modes": list(_MODES)},
+        )
+    if not _postgres_active():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "cache_upload_unsupported_database",
+                "message": "snapshot loads speak Postgres COPY; this database is not Postgres",
+            },
+        )
+
+    handle, name = tempfile.mkstemp(prefix="cache-snapshot-", suffix=".sql.gz")
+    os.close(handle)
+    path = Path(name)
+    try:
+        sha256_hex, actual_bytes = await _spool(snapshot, path, runner.max_upload_bytes)
+        manifest_raw = await manifest.read(_MANIFEST_CAP + 1) if manifest is not None else None
+        if manifest_raw is not None and len(manifest_raw) > _MANIFEST_CAP:
+            raise HTTPException(
+                status_code=413,
+                detail={"code": "cache_manifest_too_large", "max_bytes": _MANIFEST_CAP},
+            )
+        try:
+            record = runner.start(
+                UploadAcceptance(
+                    upload_path=path,
+                    sha256_hex=sha256_hex,
+                    actual_bytes=actual_bytes,
+                    manifest_raw=manifest_raw,
+                    mode=mode,  # type: ignore[arg-type]  # checked against _MODES above
+                    force=force,
+                    acknowledge_loss=acknowledge_loss,
+                    actor=admin.username,
+                )
+            )
+        except CacheUploadBusy as exc:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "cache_load_in_progress",
+                    "message": "one snapshot load runs at a time; poll the running job",
+                },
+            ) from exc
+    except HTTPException:
+        # The spooled file is the job's to delete once accepted; on any synchronous refusal
+        # it is ours, and it must not linger in /tmp.
+        path.unlink(missing_ok=True)
+        raise
+    return AdminCacheJobOut.model_validate(record, from_attributes=True)
+
+
+@router.get("/snapshots/jobs", response_model=AdminCacheJobList)
+async def list_cache_jobs(request: Request, admin: CurrentAdmin) -> AdminCacheJobList:
+    _note_actor(request, admin)
+    return AdminCacheJobList(
+        jobs=[
+            AdminCacheJobOut.model_validate(job, from_attributes=True)
+            for job in _runner(request).jobs()
+        ]
+    )
+
+
+@router.get("/snapshots/jobs/{job_id}", response_model=AdminCacheJobOut)
+async def get_cache_job(request: Request, admin: CurrentAdmin, job_id: UUID) -> AdminCacheJobOut:
+    _note_actor(request, admin)
+    job = _runner(request).get(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail={"code": "cache_job_not_found"})
+    return AdminCacheJobOut.model_validate(job, from_attributes=True)

--- a/apps/aigateway/tests/integration/test_cache_snapshot_upload_postgres.py
+++ b/apps/aigateway/tests/integration/test_cache_snapshot_upload_postgres.py
@@ -1,0 +1,300 @@
+"""Postgres evidence for the admin cache-snapshot loader (OME-952).
+
+The COPY/merge engine is pinned HERE, against the dialect it exists for, because every
+property it guarantees is a Postgres property: the COPY text round trip (byte-identical
+``response_json`` after re-feeding a real ``pg_dump``), the merge's column split (content
+from the snapshot, identity and serving history from the live row), the replace guard, and
+the staging lifecycle. The unit modules pin the DECISIONS around these; this module pins the
+behaviour itself, using a genuine ``pg_dump`` of a populated table as its fixture — no
+hand-crafted approximation of the format, the format.
+
+Run with: ``AIGW_TEST_PG=1 uv run pytest -m needs_postgres``
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from collections.abc import AsyncIterator, Generator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from urllib.parse import quote
+
+import asyncpg  # type: ignore[import-untyped]
+import pytest
+from testcontainers.postgres import PostgresContainer  # type: ignore[import-untyped]
+
+from aigateway.core.request_cache.bulk_loader import (
+    ReplaceGuardBlocked,
+    StagedRowCountMismatch,
+    load_snapshot,
+)
+from aigateway.core.request_cache.models import RequestCacheEntry
+from aigateway.core.request_cache.store import RequestCacheWrite, TortoiseRequestCacheStore
+from aigateway.core.request_cache.upload_job import CacheUploadRunner, UploadAcceptance
+from aigateway.db import close_db, init_db
+
+pytestmark = pytest.mark.needs_postgres
+
+_APP_DIR = Path(__file__).resolve().parents[2]
+
+
+def _database_url(postgres: PostgresContainer) -> str:
+    return (
+        f"postgres://{postgres.username}:{quote(postgres.password, safe='')}"
+        f"@{postgres.get_container_host_ip()}:{postgres.get_exposed_port(5432)}"
+        f"/{postgres.dbname}"
+    )
+
+
+def _migrate(database_url: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "tortoise", "-c", "aigateway.db.TORTOISE_CONFIG", "migrate"],
+        cwd=_APP_DIR,
+        env={**os.environ, "AIGATEWAY_DATABASE_URL": database_url},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture(scope="module")
+def migrated_postgres() -> Generator[str, None, None]:
+    if os.environ.get("AIGW_TEST_PG") != "1":
+        pytest.skip("AIGW_TEST_PG=1 not set")
+    with PostgresContainer("postgres:16-alpine", driver=None) as postgres:
+        database_url = _database_url(postgres)
+        _migrate(database_url)
+        yield database_url
+
+
+@asynccontextmanager
+async def _db(database_url: str) -> AsyncIterator[TortoiseRequestCacheStore]:
+    await close_db()
+    await init_db(database_url)
+    raw = await asyncpg.connect(database_url)  # type: ignore[arg-type]
+    try:
+        await RequestCacheEntry.all().delete()
+        await raw.execute("DROP TABLE IF EXISTS request_cache_entries_staging")
+        yield TortoiseRequestCacheStore()
+    finally:
+        await raw.close()
+        await close_db()
+
+
+def _write(
+    key_hash: str, response: dict, *, model: str = "openrouter/openai/gpt-5.5"
+) -> RequestCacheWrite:
+    payload = json.dumps(response, separators=(",", ":"), ensure_ascii=False)
+    return RequestCacheWrite(
+        key_hash=key_hash,
+        prompt_hash="p" * 64,
+        provider="openrouter",
+        model=model,
+        response=response,
+        response_size_bytes=len(payload.encode()),
+    )
+
+
+HOSTILE_PAYLOAD = {
+    "id": "cmpl-x",
+    "choices": [
+        {
+            "message": {
+                "content": (
+                    'line1\nline2\twith tabs and \\ backslash and "quotes" and unicode: déjà 🚀'
+                ),
+            }
+        }
+    ],
+    "usage": {"total_tokens": 42, "cost": 0.000717},
+}
+
+
+def _dump_table(database_url: str, out: Path) -> int:
+    """A genuine single-table pg_dump — the fixture IS the production snapshot format.
+
+    The row count is taken with the SAME slicer the loader uses, so the fixture and the
+    production path cannot disagree about what a data line is.
+    """
+    subprocess.run(
+        [
+            "pg_dump",
+            "--data-only",
+            "--no-owner",
+            "--no-privileges",
+            "-t",
+            "request_cache_entries",
+            "--file",
+            str(out),
+            database_url,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    from aigateway.core.request_cache.snapshot import CopyBlockSource, open_snapshot_stream
+
+    with open_snapshot_stream(out) as stream:
+        source = CopyBlockSource(stream)
+        source.header()
+        return sum(1 for _ in source.data_lines())
+
+
+@pytest.mark.asyncio
+async def test_a_real_pg_dump_round_trips_and_merges(migrated_postgres, tmp_path) -> None:
+    async with _db(migrated_postgres) as store:
+        # Three rows live here; the dump we will reload is taken after they exist.
+        for key, response in (
+            ("a" * 64, {"v": 1}),
+            ("b" * 64, HOSTILE_PAYLOAD),
+            ("c" * 64, {"v": 3}),
+        ):
+            await store.set_if_absent(_write(key, response))
+
+        dump = tmp_path / "snapshot.sql"
+        rows = _dump_table(migrated_postgres, dump)
+        assert rows >= 3
+
+        # Simulate the source deployment DIVERGING from ours: after the snapshot, we add a
+        # local-only row and mutate one the snapshot also holds.
+        await store.set_if_absent(_write("d" * 64, {"v": 4, "local": True}))
+        await RequestCacheEntry.filter(key_hash="a" * 64).update(model="openrouter/other/model")
+
+        outcome = await load_snapshot(
+            dump,
+            mode="merge",
+            expected_rows=None,
+            acknowledge_loss=False,
+        )
+        assert outcome.staged_rows >= 3
+        assert outcome.live_before == 4
+        assert outcome.live_after == 4  # nothing new: every dumped key already existed
+
+        # Merge semantics: content from the snapshot, identity/history local.
+        overwritten = await RequestCacheEntry.get(key_hash="a" * 64)
+        assert overwritten.model == "openrouter/openai/gpt-5.5"  # snapshot wins on content
+        assert overwritten.hit_count == 0  # local history survives
+        kept = await RequestCacheEntry.get(key_hash="d" * 64)
+        assert kept is not None  # merge never deletes a live row
+
+        # Byte-identity: the hostile payload crossed a dump + COPY round trip untouched.
+        hostile = await RequestCacheEntry.get(key_hash="b" * 64)
+        decoded = json.loads(hostile.response_json)
+        assert (
+            decoded["choices"][0]["message"]["content"]
+            == HOSTILE_PAYLOAD["choices"][0]["message"]["content"]
+        )
+
+        # Staging is cleaned out behind the load.
+        raw = await asyncpg.connect(migrated_postgres)  # type: ignore[arg-type]
+        try:
+            staged = await raw.fetchval("SELECT count(*) FROM request_cache_entries_staging")
+        finally:
+            await raw.close()
+        assert staged == 0
+
+
+@pytest.mark.asyncio
+async def test_merge_inserts_new_keys_with_fresh_ids(migrated_postgres, tmp_path) -> None:
+    async with _db(migrated_postgres) as store:
+        await store.set_if_absent(_write("a" * 64, {"v": 1}))
+        dump = tmp_path / "snapshot.sql"
+        _dump_table(migrated_postgres, dump)
+        await RequestCacheEntry.all().delete()  # simulate a cold deployment receiving the snapshot
+
+        outcome = await load_snapshot(
+            dump, mode="merge", expected_rows=None, acknowledge_loss=False
+        )
+        assert outcome.live_before == 0
+        assert outcome.live_after == outcome.staged_rows
+        assert await RequestCacheEntry.all().count() == outcome.staged_rows
+
+
+@pytest.mark.asyncio
+async def test_replace_refuses_to_lose_newer_rows_until_acknowledged(
+    migrated_postgres, tmp_path
+) -> None:
+    async with _db(migrated_postgres) as store:
+        await store.set_if_absent(_write("a" * 64, {"v": 1}))
+        dump = tmp_path / "snapshot.sql"
+        _dump_table(migrated_postgres, dump)
+        await store.set_if_absent(_write("b" * 64, {"v": "written after the snapshot"}))
+
+        with pytest.raises(ReplaceGuardBlocked) as guard:
+            await load_snapshot(dump, mode="replace", expected_rows=None, acknowledge_loss=False)
+        assert guard.value.live == 2 and guard.value.staged == 1
+        assert await RequestCacheEntry.all().count() == 2  # refused: nothing changed
+
+        outcome = await load_snapshot(
+            dump, mode="replace", expected_rows=None, acknowledge_loss=True
+        )
+        assert outcome.live_after == 1
+        only = await RequestCacheEntry.get(key_hash="a" * 64)
+        assert only is not None
+
+
+@pytest.mark.asyncio
+async def test_a_manifest_row_count_mismatch_refuses_before_any_live_write(
+    migrated_postgres, tmp_path
+) -> None:
+    async with _db(migrated_postgres) as store:
+        await store.set_if_absent(_write("a" * 64, {"v": 1}))
+        dump = tmp_path / "snapshot.sql"
+        _dump_table(migrated_postgres, dump)
+        with pytest.raises(StagedRowCountMismatch):
+            await load_snapshot(dump, mode="merge", expected_rows=999, acknowledge_loss=False)
+        assert await RequestCacheEntry.all().count() == 1
+
+
+@pytest.mark.asyncio
+async def test_the_runner_end_to_end_against_real_postgres(migrated_postgres, tmp_path) -> None:
+    """The route's runner, the route's digest source, real COPY: the whole unit in one flow."""
+    async with _db(migrated_postgres) as store:
+        await store.set_if_absent(_write("a" * 64, {"v": 1}))
+        dump = tmp_path / "snapshot.sql"
+        rows = _dump_table(migrated_postgres, dump)
+
+        digest = hashlib.sha256(dump.read_bytes()).hexdigest()
+        manifest = json.dumps(
+            {
+                "schema": "screamingface.cache-snapshot.v1",
+                "generated_at": "2026-08-23",
+                "row_count": rows,
+                "sha256": digest,
+                "revisions": {
+                    "parameter_contract": "aigw-parameter-contract-2026-08b",
+                    "openrouter_adapter": "openrouter-global-cache-2026-08d",
+                },
+            }
+        ).encode()
+
+        # Importing the plugin registers its adapter revision exactly as production wiring
+        # (main.load_plugins) does — the manifest check must see the deployed constants.
+        import aigateway.plugins.openrouter_provider.global_cache  # noqa: F401
+        from aigateway.core.request_cache.revisions import active_cache_revisions
+
+        assert active_cache_revisions()["openrouter_adapter"]
+        runner = CacheUploadRunner(revisions=active_cache_revisions)
+        record = runner.start(
+            UploadAcceptance(
+                upload_path=dump,
+                sha256_hex=digest,
+                actual_bytes=dump.stat().st_size,
+                manifest_raw=manifest,
+                mode="merge",
+                force=False,
+                acknowledge_loss=False,
+                actor="admin@openmined.org",
+            )
+        )
+        task = runner._task
+        assert task is not None
+        await asyncio.wait_for(asyncio.gather(task), timeout=60)
+        assert record.state == "complete", record.error
+        assert record.manifest_present is True
+        assert record.staged_rows == rows

--- a/apps/aigateway/tests/unit/test_cache_snapshot_slicing.py
+++ b/apps/aigateway/tests/unit/test_cache_snapshot_slicing.py
@@ -1,0 +1,171 @@
+"""Slicing evidence for the cache-snapshot loader (OME-952).
+
+The slicer is the trust boundary of the whole feature: everything downstream (staging COPY,
+merge SQL) consumes what these functions yield. Pinned here — the header is recognised by
+shape and column layout, data lines pass through byte-identical, the terminator ends the
+block, and the epilogue never yields. A hand-made hostile "dump" whose epilogue carries SQL
+reaches the loader as nothing at all.
+"""
+
+from __future__ import annotations
+
+import gzip
+from io import BytesIO
+
+import pytest
+
+from aigateway.core.request_cache.snapshot import (
+    CANONICAL_COLUMNS,
+    CopyBlockSource,
+    CopyHeaderMismatch,
+    NoCopyBlock,
+    SnapshotManifest,
+    open_snapshot_stream,
+    parse_manifest,
+)
+
+_HEADER_LINE = (
+    "COPY public.request_cache_entries (" + ", ".join(CANONICAL_COLUMNS) + ") FROM stdin;\n"
+)
+
+
+def _dump(*rows: bytes, header: str = _HEADER_LINE, epilogue: bytes = b"") -> BytesIO:
+    return BytesIO(
+        b"--\n-- Name: request_cache_entries; Type: TABLE DATA\n--\n\n"
+        + header.encode()
+        + b"".join(rows)
+        + b"\\.\n"
+        + epilogue
+    )
+
+
+def test_header_returns_the_canonical_columns() -> None:
+    source = CopyBlockSource(_dump(b"one row\n"))
+    assert source.header() == CANONICAL_COLUMNS
+
+
+def test_a_dump_for_a_different_table_has_no_block() -> None:
+    source = CopyBlockSource(BytesIO(b"COPY public.other_table (id) FROM stdin;\n1\n\\.\n"))
+    with pytest.raises(NoCopyBlock):
+        source.header()
+
+
+def test_a_column_layout_that_is_not_ours_is_refused_not_reinterpreted() -> None:
+    reordered = ", ".join((CANONICAL_COLUMNS[1], CANONICAL_COLUMNS[0], *CANONICAL_COLUMNS[2:]))
+    source = CopyBlockSource(
+        _dump(b"row\n", header=f"COPY public.request_cache_entries ({reordered}) FROM stdin;\n")
+    )
+    with pytest.raises(CopyHeaderMismatch):
+        source.header()
+
+
+def test_data_lines_pass_through_byte_identical_and_stop_at_the_terminator() -> None:
+    # A payload with every COPY text escape: tab, newline, backslash, quotes, unicode, and
+    # the NULL marker \N in a nullable column. None of it may be touched. Built as str and
+    # encoded once: a real tab separates columns, two-character escapes travel as written.
+    row_text = (
+        'uuid1\tk1\tp1\topenrouter\tm1\t{\\n  "a": "x\\\\y\\t"}\t123\t'
+        "2026-01-01 00:00:00+00\t2026-01-01 00:00:00+00\t\\N\t\\N\t0\n"
+    )
+    row = row_text.encode()
+    hostile_epilogue = (
+        b"\n\n--\n-- Name: request_cache_entries_pkey; Type: CONSTRAINT\n--\n"
+        b"ALTER TABLE ONLY public.request_cache_entries ADD CONSTRAINT pkey PRIMARY KEY (id);\n"
+    )
+    source = CopyBlockSource(_dump(row, b"uuid2\tk2\\t\\N\n", epilogue=hostile_epilogue))
+    source.header()
+    lines = list(source.data_lines())
+    assert lines == [row, b"uuid2\tk2\\t\\N\n"]
+
+
+def test_a_final_line_without_a_newline_is_terminated() -> None:
+    # pg_dump always terminates rows; hand input might not. The COPY wire format needs row
+    # separators, so the slicer supplies the missing one and nothing else.
+    stream = BytesIO(_HEADER_LINE.encode() + b"uuid1\tk1" + b"\n\\.\n")
+    source = CopyBlockSource(stream)
+    source.header()
+    assert list(source.data_lines()) == [b"uuid1\tk1\n"]
+
+
+def test_an_empty_table_yields_no_lines() -> None:
+    source = CopyBlockSource(_dump())
+    source.header()
+    assert list(source.data_lines()) == []
+
+
+def test_open_snapshot_stream_detects_gzip_by_magic_not_name(tmp_path) -> None:
+    payload = _HEADER_LINE.encode() + b"\\.\n"
+    gz = tmp_path / "snapshot.sql.gz"
+    gz.write_bytes(gzip.compress(payload))
+    plain = tmp_path / "snapshot.sql"
+    plain.write_bytes(payload)
+
+    with open_snapshot_stream(gz) as stream:
+        assert stream.read() == payload
+    with open_snapshot_stream(plain) as stream:
+        assert stream.read() == payload
+
+
+# --- manifest -----------------------------------------------------------------------------------
+
+
+def _manifest_dict(**overrides: object) -> dict:
+    base = {
+        "schema": "screamingface.cache-snapshot.v1",
+        "generated_at": "2026-08-22",
+        "row_count": 197130,
+        "sha256": "a" * 64,
+        "revisions": {"parameter_contract": "aigw-parameter-contract-2026-08b"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_a_valid_manifest_parses() -> None:
+    manifest = parse_manifest(
+        b'{"schema": "screamingface.cache-snapshot.v1", "generated_at": "2026-08-22",'
+        b' "row_count": 12, "sha256": "' + b"f" * 64 + b'",'
+        b' "revisions": {"parameter_contract": "x"}}'
+    )
+    assert manifest.row_count == 12
+    assert isinstance(manifest, SnapshotManifest)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"schema": "screamingface.cache-snapshot.v2"},
+        {"row_count": -1},
+        {"sha256": "XYZ"},  # not hex, wrong length
+        {"sha256": "A" * 64},  # uppercase is not the digest form
+        {"revisions": {}},
+        {"revisions": {"k": 1}},
+    ],
+)
+def test_a_manifest_that_lies_about_its_shape_is_invalid(overrides: dict) -> None:
+    import json
+
+    with pytest.raises(ValueError):
+        parse_manifest(json.dumps(_manifest_dict(**overrides)).encode())
+
+
+def test_non_json_is_invalid() -> None:
+    with pytest.raises(ValueError):
+        parse_manifest(b"not json at all")
+
+
+def test_batches_past_the_terminator_never_leak_the_epilogue() -> None:
+    """Regression: the loader reads in batches; a fresh batch after the terminator must be
+    empty, not the dump's epilogue (blank line + comments + `\\unrestrict` in pg_dump 18).
+    Feeding the epilogue to COPY parsed its leading blank line as a row (empty uuid)."""
+    from aigateway.core.request_cache.bulk_loader import _read_batch
+
+    epilogue = b"\n\n-- PostgreSQL database dump complete\n--\n\n\\unrestrict tok123\n"
+    source = CopyBlockSource(_dump(b"row-1\nrow-2\n", epilogue=epilogue))
+    source.header()
+    first = _read_batch(source)
+    second = _read_batch(source)
+    third = _read_batch(source)
+    assert first == b"row-1\nrow-2\n"
+    assert second == b""
+    assert third == b""

--- a/apps/aigateway/tests/unit/test_cache_upload_job_runner.py
+++ b/apps/aigateway/tests/unit/test_cache_upload_job_runner.py
@@ -1,0 +1,284 @@
+"""The cache-upload job runner's state machine, with a fake loader (OME-952).
+
+Every branch here maps to a refusal code the console renders, so the branches are the API:
+checksum, row-count, revision mismatch (and its forced override), the replace guard, the size
+cap, and the slicer's own refusals. The loader is stubbed because its behaviour is pinned
+against real Postgres in `tests/integration/test_cache_snapshot_upload_postgres.py`; what this
+module owns is the DECISIONS around it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aigateway.core.request_cache.bulk_loader import (
+    LoadOutcome,
+    ReplaceGuardBlocked,
+    StagedRowCountMismatch,
+)
+from aigateway.core.request_cache.snapshot import CopyHeaderMismatch, NoCopyBlock
+from aigateway.core.request_cache.upload_job import (
+    CacheJobRecord,
+    CacheUploadBusy,
+    CacheUploadRunner,
+    UploadAcceptance,
+)
+
+_LIVE = {
+    "parameter_contract": "aigw-parameter-contract-2026-08b",
+    "openrouter_adapter": "openrouter-global-cache-2026-08d",
+}
+_SHA = "b" * 64
+
+
+class FakeLoader:
+    """Records the call and answers with a scriptable outcome or exception."""
+
+    def __init__(
+        self,
+        outcome: LoadOutcome | None = None,
+        raises: Exception | None = None,
+    ) -> None:
+        self.outcome = outcome or LoadOutcome(staged_rows=10, live_before=5, live_after=10)
+        self.raises = raises
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, path: Path, **kwargs: Any) -> LoadOutcome:
+        self.calls.append({"path": path, **kwargs})
+        if self.raises is not None:
+            raise self.raises
+        return self.outcome
+
+
+def _manifest_raw(**overrides: Any) -> bytes:
+    payload: dict[str, Any] = {
+        "schema": "screamingface.cache-snapshot.v1",
+        "generated_at": "2026-08-22",
+        "row_count": 10,
+        "sha256": _SHA,
+        "revisions": dict(_LIVE),
+    }
+    payload.update(overrides)
+    return json.dumps(payload).encode()
+
+
+def _acceptance(
+    tmp_path: Path,
+    *,
+    manifest_raw: bytes | None = None,
+    mode: str = "merge",
+    force: bool = False,
+    acknowledge_loss: bool = False,
+    actual_bytes: int = 1024,
+) -> UploadAcceptance:
+    upload = tmp_path / "snapshot.sql.gz"
+    upload.write_bytes(b"payload")
+    return UploadAcceptance(
+        upload_path=upload,
+        sha256_hex=_SHA,
+        actual_bytes=actual_bytes,
+        manifest_raw=manifest_raw,
+        mode=mode,  # type: ignore[arg-type]
+        force=force,
+        acknowledge_loss=acknowledge_loss,
+        actor="admin@openmined.org",
+    )
+
+
+def _runner(loader: FakeLoader, max_bytes: int = 1024 * 1024) -> CacheUploadRunner:
+    return CacheUploadRunner(
+        loader=loader,  # type: ignore[arg-type]
+        revisions=lambda: dict(_LIVE),
+        max_upload_bytes=max_bytes,
+    )
+
+
+async def _start_and_wait(
+    runner: CacheUploadRunner, acceptance: UploadAcceptance
+) -> CacheJobRecord:
+    record = runner.start(acceptance)
+    task = runner._task
+    assert task is not None
+    await asyncio.wait_for(asyncio.gather(task), timeout=5)
+    return record
+
+
+# --- happy paths -------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_verified_manifest_loads_with_counters_and_clean_state(tmp_path) -> None:
+    loader = FakeLoader(
+        LoadOutcome(staged_rows=100, live_before=40, live_after=90)
+    )  # 50 keys were new, 50 replaced
+    runner = _runner(loader)
+    record = await _start_and_wait(runner, _acceptance(tmp_path, manifest_raw=_manifest_raw()))
+
+    assert record.state == "complete"
+    assert record.manifest_present is True
+    assert record.staged_rows == 100
+    assert record.inserted_rows == 50
+    assert record.updated_rows == 50
+    assert record.finished_at is not None
+    assert not record.warnings
+    # The spooled file is the job's to remove once terminal.
+    # The spooled upload is deleted once the job is terminal.
+    assert not Path(str(loader.calls[0]["path"])).exists()
+
+
+@pytest.mark.asyncio
+async def test_a_manifestless_load_warns_revisions_unverified(tmp_path) -> None:
+    loader = FakeLoader()
+    runner = _runner(loader)
+    record = await _start_and_wait(runner, _acceptance(tmp_path))
+
+    assert record.state == "complete"
+    assert record.warnings == ["revisions_unverified"]
+    assert loader.calls[0]["expected_rows"] is None
+
+
+# --- refusals ----------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_checksum_mismatch_refuses_before_any_load(tmp_path) -> None:
+    loader = FakeLoader()
+    runner = _runner(loader)
+    record = await _start_and_wait(
+        runner,
+        _acceptance(tmp_path, manifest_raw=_manifest_raw(sha256="c" * 64)),
+    )
+    assert record.state == "refused"
+    assert record.refusal == "checksum_mismatch"
+    assert loader.calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_revision_mismatch_refuses_unless_forced(tmp_path) -> None:
+    loader = FakeLoader()
+    runner = _runner(loader)
+    stale = _manifest_raw(
+        revisions={**_LIVE, "openrouter_adapter": "openrouter-global-cache-2026-08a"}
+    )
+    record = await _start_and_wait(runner, _acceptance(tmp_path, manifest_raw=stale))
+    assert record.refusal == "revision_mismatch"
+    assert loader.calls == []
+
+    loader2 = FakeLoader()
+    runner2 = _runner(loader2)
+    forced = await _start_and_wait(runner2, _acceptance(tmp_path, manifest_raw=stale, force=True))
+    assert forced.state == "complete"
+    assert forced.forced is True
+    assert forced.warnings == ["revision_mismatch_forced"]
+
+
+@pytest.mark.asyncio
+async def test_a_row_count_mismatch_refused_by_the_loader_maps_to_its_code(tmp_path) -> None:
+    loader = FakeLoader(raises=StagedRowCountMismatch(staged=9, declared=10))
+    runner = _runner(loader)
+    record = await _start_and_wait(runner, _acceptance(tmp_path, manifest_raw=_manifest_raw()))
+    assert record.refusal == "row_count_mismatch"
+    assert record.staged_rows is None
+
+
+@pytest.mark.asyncio
+async def test_the_replace_guard_maps_to_its_code(tmp_path) -> None:
+    loader = FakeLoader(raises=ReplaceGuardBlocked(live=200, staged=100))
+    runner = _runner(loader)
+    record = await _start_and_wait(
+        runner, _acceptance(tmp_path, mode="replace", manifest_raw=_manifest_raw())
+    )
+    assert record.refusal == "newer_rows_would_be_lost"
+    assert "100 row(s) newer" in (record.error or "")
+
+
+@pytest.mark.parametrize(
+    ("raises", "code"),
+    [
+        (NoCopyBlock("missing"), "no_copy_block"),
+        (CopyHeaderMismatch(("a",)), "column_layout_mismatch"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_slicer_refusals_map_to_their_codes(tmp_path, raises, code) -> None:
+    runner = _runner(FakeLoader(raises=raises))
+    record = await _start_and_wait(runner, _acceptance(tmp_path))
+    assert record.refusal == code
+
+
+@pytest.mark.asyncio
+async def test_a_bad_manifest_refuses_as_invalid(tmp_path) -> None:
+    runner = _runner(FakeLoader())
+    record = await _start_and_wait(runner, _acceptance(tmp_path, manifest_raw=b"{not json"))
+    assert record.refusal == "manifest_invalid"
+
+
+@pytest.mark.asyncio
+async def test_an_oversized_upload_refuses_without_touching_the_loader(tmp_path) -> None:
+    loader = FakeLoader()
+    runner = _runner(loader, max_bytes=128)
+    record = await _start_and_wait(
+        runner, _acceptance(tmp_path, actual_bytes=1024, manifest_raw=None)
+    )
+    assert record.refusal == "upload_too_large"
+    assert loader.calls == []
+
+
+@pytest.mark.asyncio
+async def test_an_unexpected_loader_failure_lands_as_failed_not_refused(tmp_path) -> None:
+    runner = _runner(FakeLoader(raises=RuntimeError("disk vanished")))
+    record = await _start_and_wait(runner, _acceptance(tmp_path))
+    assert record.state == "failed"
+    assert record.refusal is None
+    assert "disk vanished" in (record.error or "")
+
+
+# --- the single slot ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_second_upload_while_one_runs_is_busy(tmp_path) -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_loader(path: Path, **kwargs: Any) -> LoadOutcome:
+        started.set()
+        await release.wait()
+        return LoadOutcome(staged_rows=1, live_before=0, live_after=1)
+
+    runner = CacheUploadRunner(loader=slow_loader, revisions=lambda: dict(_LIVE))
+    first = runner.start(_acceptance(tmp_path))
+    await started.wait()
+    with pytest.raises(CacheUploadBusy):
+        runner.start(_acceptance(tmp_path))
+    release.set()
+    await asyncio.sleep(0)
+    while not first.finished_at:
+        await asyncio.sleep(0)
+
+    # After completion the slot frees, and the busy record joins the history.
+    second = runner.start(_acceptance(tmp_path))
+    while not second.finished_at:
+        await asyncio.sleep(0)
+    assert [job.state for job in runner.jobs()] == ["complete", "complete"]
+
+
+@pytest.mark.asyncio
+async def test_history_is_bounded(tmp_path) -> None:
+    loader = FakeLoader(LoadOutcome(staged_rows=0, live_before=0, live_after=0))
+    runner = CacheUploadRunner(
+        loader=loader,  # type: ignore[arg-type]
+        revisions=lambda: dict(_LIVE),
+        history_limit=2,
+    )
+    for _ in range(3):
+        record = await _start_and_wait(runner, _acceptance(tmp_path))
+    assert len(runner.jobs()) == 2
+    assert runner.get(record.id) is record
+    assert runner.get(uuid.uuid4()) is None

--- a/apps/aigateway/tests/unit/test_cache_upload_routes.py
+++ b/apps/aigateway/tests/unit/test_cache_upload_routes.py
@@ -1,0 +1,260 @@
+"""Route-level evidence for the admin cache-snapshot upload (OME-952).
+
+What is pinned here is the ROUTE layer: the admin gate applies to every route exactly as it
+does to the account routes, the synchronous refusals answer their HTTP codes (400 mode /
+400 dialect / 413 size / 409 busy), the upload hands the runner a spooled file plus a digest,
+and the job/job-list endpoints serialize records with the fields the console polls. The load
+itself is the runner's decision (pinned in `test_cache_upload_job_runner.py`) and Postgres's
+behaviour (pinned in the integration module).
+
+The fixture database is SQLite, so every upload test patches the route module's Postgres
+guard — the guard's own answer is pinned unpatched in `test_the_dialect_guard_answers_400`.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from datetime import UTC, datetime
+from ipaddress import ip_network
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import aigateway.routes.admin_cache as admin_cache
+from aigateway.core.request_cache.bulk_loader import LoadOutcome
+from aigateway.core.request_cache.upload_job import (
+    CacheJobRecord,
+    CacheUploadBusy,
+    CacheUploadRunner,
+    UploadAcceptance,
+)
+
+ADMIN = "admin@openmined.org"
+POD_NETWORK = ip_network("10.0.0.0/8")
+
+
+class ImmediateLoader:
+    """Completes synchronously, capturing the spooled bytes at call time (they are deleted)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, path: Path, **kwargs: Any) -> LoadOutcome:
+        self.calls.append({"path": path, "content": path.read_bytes(), **kwargs})
+        return LoadOutcome(staged_rows=1, live_before=0, live_after=1)
+
+
+def _runner() -> tuple[CacheUploadRunner, ImmediateLoader]:
+    loader = ImmediateLoader()
+    return (
+        CacheUploadRunner(
+            loader=loader,
+            revisions=lambda: {"parameter_contract": "aigw-parameter-contract-2026-08b"},
+        ),
+        loader,
+    )
+
+
+def _admin_client(client: TestClient, runner: CacheUploadRunner | None = None) -> TestClient:
+    client.app.state.settings.auth_mode = "cloudflare_headers"
+    client.app.state.settings.allowed_networks = (POD_NETWORK,)
+    client.app.state.settings.admin_emails = frozenset({ADMIN})
+    if runner is not None:
+        client.app.state.cache_upload_runner = runner
+    return TestClient(client.app, client=("10.1.2.3", 50000))
+
+
+def _headers() -> dict[str, str]:
+    return {"X-User-Email": ADMIN}
+
+
+def _files(payload: bytes = b"--\npayload\n") -> list[tuple[str, tuple[str, bytes, str]]]:
+    import gzip
+
+    return [("snapshot", ("snap.sql.gz", gzip.compress(payload), "application/gzip"))]
+
+
+def _poll_terminal(runner: CacheUploadRunner, job_id: uuid.UUID) -> CacheJobRecord:
+    """Wait for the app-loop-driven job to finish; the record is shared state."""
+    for _ in range(10_000):
+        job = runner.get(job_id)
+        assert job is not None
+        if job.finished_at is not None:
+            return job
+        time.sleep(0.001)
+    raise AssertionError("job never reached a terminal state")
+
+
+# --- auth --------------------------------------------------------------------------------------
+
+
+def test_every_cache_route_requires_an_admin(client) -> None:
+    unauthenticated = TestClient(client.app, client=("10.1.2.3", 50000))
+    for method, path in (
+        ("get", "/v1/admin/cache/info"),
+        ("get", "/v1/admin/cache/snapshots/jobs"),
+        ("post", "/v1/admin/cache/snapshots"),
+        ("get", f"/v1/admin/cache/snapshots/jobs/{uuid.uuid4()}"),
+    ):
+        if method == "post":
+            resp = unauthenticated.post(path, files=_files(), headers=_headers())
+        else:
+            resp = unauthenticated.get(path, headers=_headers())
+        assert resp.status_code in (401, 403, 503), (method, path, resp.status_code)
+
+
+def test_a_non_admin_is_refused_exactly_like_the_account_routes(client) -> None:
+    admin_client = _admin_client(client, _runner()[0])
+    resp = admin_client.get("/v1/admin/cache/info", headers={"X-User-Email": "stranger@x.org"})
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "This account is not an administrator of this gateway."
+
+
+# --- info --------------------------------------------------------------------------------------
+
+
+def test_info_reports_serving_state_count_and_live_revisions(client) -> None:
+    admin_client = _admin_client(client, _runner()[0])
+    resp = admin_client.get("/v1/admin/cache/info", headers=_headers())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["serving"] is False  # the client fixture's default setting is cache-off
+    assert body["row_count"] == 0
+    assert body["revisions"]["parameter_contract"] == "aigw-parameter-contract-2026-08b"
+    assert body["revisions"]["openrouter_adapter"] == "openrouter-global-cache-2026-08d"
+
+
+# --- upload ------------------------------------------------------------------------------------
+
+
+def test_an_upload_spools_the_archive_and_records_the_job(client, monkeypatch) -> None:
+    monkeypatch.setattr(admin_cache, "_postgres_active", lambda: True)
+    import gzip
+
+    runner, loader = _runner()
+    admin_client = _admin_client(client, runner)
+    resp = admin_client.post(
+        "/v1/admin/cache/snapshots",
+        files=_files(b"payload-bytes"),
+        data={"mode": "merge"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 202, resp.text
+    job = resp.json()
+    assert job["actor"] == ADMIN
+    record = _poll_terminal(runner, uuid.UUID(job["id"]))
+    assert record.state == "complete"
+    # The spool holds the upload VERBATIM (the loader opens/gunzips it itself), and deletes
+    # it once terminal.
+    assert gzip.decompress(loader.calls[0]["content"]) == b"payload-bytes"
+    assert not Path(loader.calls[0]["path"]).exists()
+
+
+def test_an_unknown_mode_is_a_400(client, monkeypatch) -> None:
+    monkeypatch.setattr(admin_cache, "_postgres_active", lambda: True)
+    admin_client = _admin_client(client, _runner()[0])
+    resp = admin_client.post(
+        "/v1/admin/cache/snapshots",
+        files=_files(),
+        data={"mode": "append"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "cache_upload_bad_mode"
+
+
+def test_a_snapshot_over_the_cap_is_a_413(client, monkeypatch) -> None:
+    monkeypatch.setattr(admin_cache, "_postgres_active", lambda: True)
+    runner, _ = _runner()
+    runner.max_upload_bytes = 8
+    admin_client = _admin_client(client, runner)
+    resp = admin_client.post(
+        "/v1/admin/cache/snapshots",
+        files=_files(b"this payload is far beyond eight bytes"),
+        headers=_headers(),
+    )
+    assert resp.status_code == 413
+    assert resp.json()["detail"]["code"] == "cache_upload_too_large"
+
+
+def test_a_running_load_makes_a_second_upload_409(client, monkeypatch) -> None:
+    monkeypatch.setattr(admin_cache, "_postgres_active", lambda: True)
+
+    class BusyRunner:
+        max_upload_bytes = 1024 * 1024
+
+        def start(self, acceptance: UploadAcceptance) -> None:
+            raise CacheUploadBusy("occupied")
+
+        def jobs(self) -> list[CacheJobRecord]:
+            return []
+
+        def get(self, job_id: uuid.UUID) -> CacheJobRecord | None:
+            return None
+
+        def busy(self) -> bool:
+            return True
+
+    client.app.state.settings.auth_mode = "cloudflare_headers"
+    client.app.state.settings.allowed_networks = (POD_NETWORK,)
+    client.app.state.settings.admin_emails = frozenset({ADMIN})
+    client.app.state.cache_upload_runner = BusyRunner()  # type: ignore[assignment]
+    admin_client = TestClient(client.app, client=("10.1.2.3", 50000))
+    resp = admin_client.post("/v1/admin/cache/snapshots", files=_files(), headers=_headers())
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "cache_load_in_progress"
+
+
+def test_the_dialect_guard_answers_400_on_non_postgres(client) -> None:
+    admin_client = _admin_client(client, _runner()[0])
+    resp = admin_client.post("/v1/admin/cache/snapshots", files=_files(), headers=_headers())
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["code"] == "cache_upload_unsupported_database"
+
+
+# --- jobs --------------------------------------------------------------------------------------
+
+
+def test_jobs_list_and_job_by_id_serialize_the_record(client) -> None:
+    runner, _ = _runner()
+    record = CacheJobRecord(
+        id=uuid.uuid4(),
+        actor=ADMIN,
+        mode="merge",
+        created_at=datetime.now(UTC),
+        state="complete",
+        staged_rows=10,
+        live_before=4,
+        live_after=10,
+        inserted_rows=6,
+        updated_rows=4,
+        warnings=["revisions_unverified"],
+    )
+    runner._jobs.append(record)
+    admin_client = _admin_client(client, runner)
+
+    listed = admin_client.get("/v1/admin/cache/snapshots/jobs", headers=_headers())
+    assert listed.status_code == 200
+    assert listed.json()["jobs"][0]["id"] == str(record.id)
+    assert listed.json()["jobs"][0]["warnings"] == ["revisions_unverified"]
+
+    one = admin_client.get(f"/v1/admin/cache/snapshots/jobs/{record.id}", headers=_headers())
+    assert one.status_code == 200
+    assert one.json()["inserted_rows"] == 6
+
+    missing = admin_client.get(f"/v1/admin/cache/snapshots/jobs/{uuid.uuid4()}", headers=_headers())
+    assert missing.status_code == 404
+    assert missing.json()["detail"]["code"] == "cache_job_not_found"
+
+
+@pytest.mark.parametrize(
+    "refusal", ["checksum_mismatch", "revision_mismatch", "newer_rows_would_be_lost"]
+)
+def test_refusal_codes_round_trip_through_the_job_record(client, refusal) -> None:
+    """The console renders `refusal` verbatim — the codes are API and must not be renamed."""
+    from aigateway.core.request_cache.upload_job import REFUSAL_CODES
+
+    assert refusal in REFUSAL_CODES

--- a/apps/aigateway/uv.lock
+++ b/apps/aigateway/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "python-multipart" },
     { name = "tortoise-orm", extra = ["asyncpg"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -44,6 +45,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyjwt", specifier = "==2.13.0" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "tortoise-orm", extras = ["asyncpg"], specifier = "==1.1.8" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.52.1" },
 ]
@@ -1616,6 +1618,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]

--- a/docs/plan/2026-08-23-OME-952-cache-snapshot-upload.md
+++ b/docs/plan/2026-08-23-OME-952-cache-snapshot-upload.md
@@ -1,0 +1,61 @@
+# OME-952 — aigateway cache-snapshot upload (plan)
+
+Implements `docs/spec/2026-08-22-OME-951-admin-cache-snapshot-upload.md` (approved) — gateway half.
+
+## Recon-derived decisions (beyond the spec)
+
+- **Live-table ground truth (PG16)**: no DB-side defaults for `id`/`created_at`/`updated_at`;
+  column order equals model-definition order; uniques: `id` pkey + `key_hash`. Therefore the
+  merge INSERT generates ids with core `gen_random_uuid()` (never carries snapshot ids — kills
+  the cross-deployment id-collision class) and sets `updated_at = now()` on both insert and
+  update. Spec's illustrative SQL is extended with `updated_at`; intent unchanged.
+- **COPY feeding**: `tortoise.backends.asyncpg` client exposes `acquire_connection()` → raw
+  `asyncpg.Connection`; `copy_to_table(source=<async gen>, columns=<ours>)` sends bytes verbatim.
+  The dump's COPY-header column list must match our canonical list EXACTLY (order included) —
+  refusals otherwise; our identifiers (never upload-derived ones) reach the COPY command.
+  The `\.` terminator is stripped by the slicer; asyncpg ends the stream with CopyDone.
+- **Blocking gzip reads** happen in `asyncio.to_thread` chunk reads feeding the async generator.
+- **Hexagonal**: core may not import the openrouter plugin. New core registry
+  `core/request_cache/revisions.py`; the plugin registers its adapter revision at plugin load
+  (plugins→core is the allowed direction; same wiring pattern as the provider registry).
+- **Sync vs async validation**: busy-slot (409), dialect (400), multipart shape (422),
+  content-length over cap (413) are synchronous HTTP errors. Everything else (checksum, row
+  count, revision, no-copy-block, real size cap, replace guard) runs inside the job and lands
+  as terminal state `refused` — the spec's contract.
+- **python-multipart** added as a dependency (FastAPI multipart parsing).
+
+## Files
+
+- `config.py` — `cache_upload_max_bytes` (default 256 MiB, `AIGW_CACHE_UPLOAD_MAX_BYTES`).
+- `core/request_cache/revisions.py` (new) — core-owned adapter-revision registry +
+  `active_cache_revisions()` incl. `PARAMETER_CONTRACT_REVISION`.
+- `plugins/openrouter_provider/global_cache.py` — one registration call at import.
+- `core/request_cache/snapshot.py` (new) — pure parsing: COPY-header/columns parser, byte-level
+  block slicer, gzip magic, `SnapshotManifest` model + strict validation.
+- `core/request_cache/bulk_loader.py` (new) — `PostgresCacheSnapshotLoader`: staging
+  create/truncate, asyncpg COPY load, single-transaction merge/replace with counters.
+- `core/request_cache/upload_job.py` (new) — `CacheUploadRunner` (single in-flight slot,
+  owned task, bounded history) + `CacheJobRecord`.
+- `core/admin_schemas.py` — `AdminCacheInfoOut`, `AdminCacheJobOut`, `AdminCacheJobList`.
+- `routes/admin_cache.py` (new) — 4 routes; `AdminAuditRoute`; `CurrentAdmin`.
+- `main.py` — wire runner on `app.state.cache_upload_runner`; include router.
+- `pyproject.toml` — `python-multipart`.
+
+## Tests
+
+- `tests/unit/test_cache_snapshot_slicing.py` — header parse (order variants, wrong table,
+  no block, early EOF), terminator handling, escaped payload passthrough, gzip magic,
+  manifest validation (schema tag, hex sha, row_count, revisions).
+- `tests/unit/test_cache_upload_job_runner.py` — fake loader: full happy path with counters;
+  refused paths (checksum, row-count, revision mismatch, `force` override recorded, replace
+  guard with/without acknowledgement, size cap, no block); busy slot; failure state.
+- `tests/unit/test_cache_upload_routes.py` — auth gates per the account-route pattern;
+  409/400/413 sync refusals; job/job-list serialization via the stubbed runner.
+- `tests/integration/test_cache_snapshot_upload_postgres.py` — testcontainers PG (pattern of
+  `test_global_cache_store_postgres.py`): real dump fixture; COPY loads; merge keeps
+  lifecycle columns, replaces content, byte-identical `response_json`; replace path; staging
+  cleanup; concurrent single-slot. Marked `needs_postgres`.
+
+## Gates
+
+`uv run ruff check && uv run ruff format --check && uv run pyright && uv run python scripts/check_no_enterprise.py && uv run pytest --cov=aigateway --cov-fail-under=80 -q`

--- a/docs/work/2026-08-23-OME-952-cache-snapshot-upload.md
+++ b/docs/work/2026-08-23-OME-952-cache-snapshot-upload.md
@@ -1,0 +1,35 @@
+---
+ticket: OME-952
+stack: aigateway
+status: in_review
+started: 2026-08-23
+finished:
+---
+
+# OME-952 — aigateway: cache-snapshot upload routes and loader
+
+## Intent
+
+Implement the gateway half of the approved OME-951 spec: admin routes that accept a
+`snapshot-cache` pg_dump, an async single-slot job runner, a COPY/merge Postgres loader, and
+the revision guard — never executing uploaded SQL.
+
+## Planned changes
+
+See `docs/plan/2026-08-23-OME-952-cache-snapshot-upload.md` (9 files + 4 test modules).
+
+## Test plan
+
+See the plan's Tests section: slicing unit tests, job-runner state machine with fake loader,
+route auth/serialization tests, Postgres integration test (testcontainers).
+
+## Acceptance
+
+Spec acceptance criteria 1–8, 10–11 (12 belongs to OME-954's manifest emission).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus the regression test for the slicer's terminator latch
+- **Commits:** (see PR)
+- **Gates:** ruff clean · pyright clean · check_no_enterprise OK · pytest 3755 passed / 54 skipped, coverage 92.28% · AIGW_TEST_PG=1 integration 5 passed
+- **Deviations:** (1) merge SQL includes `id` in the target list with `gen_random_uuid()` and sets `updated_at = now()` — the live table has NO db-side defaults (verified against the running cluster), so the INSERT must generate them. (2) Two defects found and fixed by the Postgres integration run: the slicer leaked the dump epilogue into COPY across batch boundaries (pg_dump 18 epilogue parses as an empty-uuid row), and the merge column list was one short. Both carry regression tests.


### PR DESCRIPTION
## What

Gateway half of the OME-951 spec (approved):

- **Routes** `GET /v1/admin/cache/info`, `POST /v1/admin/cache/snapshots` (multipart, 202), `GET /v1/admin/cache/snapshots/jobs[/{id}]` — all behind `CurrentAdmin`, audited via `AdminAuditRoute`.
- **Job runner** (`app.state.cache_upload_runner`): single in-flight slot (second upload → 409), owned task, bounded history, states `validating → loading → merging → complete | failed | refused` with counters, warnings, and machine refusal codes.
- **Loader** (`core/request_cache/bulk_loader.py`): staging table + asyncpg COPY (bytes verbatim — uploaded SQL is never executed), then one-transaction **merge** (`ON CONFLICT (key_hash) DO UPDATE`, content from snapshot, local `id`/`created_at`/`hit_count`/`last_hit_at` survive, fresh `gen_random_uuid()` ids — the live table has no DB-side defaults) or guarded **replace** (refuses when live > staged without `acknowledge_loss`).
- **Revision guard**: manifest sha256 + row-count + revision constants vs the live gateway (`core/request_cache/revisions.py` registry; the OpenRouter plugin registers its adapter constant at load — hexagonal direction preserved). Mismatch → refused; `force` override recorded on job + audit line.
- **Schemas**: `AdminCacheInfoOut`/`AdminCacheJobOut`/`AdminCacheJobList` in `admin_schemas.py` for the typed console client.
- Config: `AIGW_CACHE_UPLOAD_MAX_BYTES` (default 256 MiB). Dep: `python-multipart`.

## Notable defects the integration run caught (both fixed + regression-tested)

1. The slicer leaked the dump **epilogue** into COPY across batch boundaries — pg_dump 18's epilogue (blank line → `uuid \\` error) — fixed with a closed-latch on the terminator.
2. Merge INSERT column count mismatch — live table has **no DB-side defaults** for `id` (verified against the running cluster), so ids are generated in SQL.

## Gates

`ruff` clean · `pyright` clean · `check_no_enterprise` OK · `pytest` **3755 passed / 54 skipped, cov 92.28%** · `AIGW_TEST_PG=1` integration **5/5** (testcontainers Postgres 16, genuine `pg_dump` fixtures)

Depends on spec PR #696 (docs only). OME-953 (console UI) stacks on this branch.

Refs: OME-952