### PR TITLE
chore(screamingface): bump version to 0.1.1.post3

### DIFF
--- a/packages/screamingface/pyproject.toml
+++ b/packages/screamingface/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "screamingface"
-version = "0.1.1.post2"
+version = "0.1.1.post3"
 description = "Evaluate Models and Fusions on URL4-native research benchmarks"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/screamingface/uv.lock
+++ b/packages/screamingface/uv.lock
@@ -3020,7 +3020,7 @@ wheels = [
 
 [[package]]
 name = "screamingface"
-version = "0.1.1.post2"
+version = "0.1.1.post3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- bump the screamingface package version from 0.1.1.post2 to 0.1.1.post3
- keep the package lock metadata aligned

## Verification

- uv lock --check
- uv build
- distribution validation