### PR TITLE
feat(screamingface-engine): derive hosted provider availability

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -332,7 +332,9 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
         logging.warning(
             "URL4_CLOUD_RUNNER is 'none' — this App bridges NATS but cannot schedule runs"
         )
-    connections = build_connections(settings)
+    # INVARIANT: deployed availability comes from the signed-in caller's profiles. The provider
+    # catalogue describes capability, not which operator-managed credentials this caller owns.
+    connections = build_connections(settings, listing_source="profiles")
     app = create_app(
         settings,
         stream=stream,

--- a/apps/screamingface-engine/src/screamingface_engine/connections/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/__init__.py
@@ -38,7 +38,7 @@ def _default_client(base_url: str) -> httpx.AsyncClient:
 def build_connections(
     settings: _ConnectionSettings,
     *,
-    listing_source: ListingSource = "connections",
+    listing_source: ListingSource,
     client_factory: Callable[[str], httpx.AsyncClient] = _default_client,
 ) -> Connections | None:
     """Build the AI Gateway adapter, or disable the endpoints when no upstream is configured."""

--- a/apps/screamingface-engine/src/screamingface_engine/connections/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/__init__.py
@@ -7,7 +7,7 @@ from typing import Protocol
 
 import httpx
 
-from screamingface_engine.connections.aigateway import AigatewayConnections
+from screamingface_engine.connections.aigateway import AigatewayConnections, ListingSource
 from screamingface_engine.connections.port import (
     Caller,
     Connection,
@@ -38,13 +38,17 @@ def _default_client(base_url: str) -> httpx.AsyncClient:
 def build_connections(
     settings: _ConnectionSettings,
     *,
+    listing_source: ListingSource = "connections",
     client_factory: Callable[[str], httpx.AsyncClient] = _default_client,
 ) -> Connections | None:
     """Build the AI Gateway adapter, or disable the endpoints when no upstream is configured."""
 
     if not settings.aigateway_base_url:
         return None
-    return AigatewayConnections(client_factory(settings.aigateway_base_url))
+    return AigatewayConnections(
+        client_factory(settings.aigateway_base_url),
+        listing_source=listing_source,
+    )
 
 
 __all__ = [

--- a/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
@@ -91,6 +91,7 @@ class AigatewayConnections:
         )
 
     async def connect(self, caller: Caller, provider: str, api_key: str) -> Connection:
+        self._require_mutable()
         selected_provider = _provider(await self._providers(caller), provider)
         if "api_key" not in selected_provider.auth_methods:
             raise ConnectionMethodUnsupported()
@@ -125,6 +126,7 @@ class AigatewayConnections:
         return _public(row, selected_provider)
 
     async def start_oauth(self, caller: Caller, provider: str) -> OAuthAuthorization:
+        self._require_mutable()
         selected_provider = _provider(await self._providers(caller), provider)
         if "oauth" not in selected_provider.auth_methods:
             raise ConnectionMethodUnsupported()
@@ -141,6 +143,7 @@ class AigatewayConnections:
         return _decode_oauth_authorization(response, provider)
 
     async def disconnect(self, caller: Caller, provider: str) -> Connection:
+        self._require_mutable()
         selected_provider = _provider(await self._providers(caller), provider)
         rows = await self._rows(caller, provider=provider)
         selected = _select(rows, provider)
@@ -162,6 +165,12 @@ class AigatewayConnections:
 
     async def aclose(self) -> None:
         await self._client.aclose()
+
+    def _require_mutable(self) -> None:
+        # INVARIANT: profile-backed hosted reads and caller-managed OAuth writes use separate
+        # Gateway stores. Never accept a credential into state this adapter cannot report or use.
+        if self._listing_source == "profiles":
+            raise ConnectionMethodUnsupported()
 
     async def _providers(self, caller: Caller) -> tuple[_Provider, ...]:
         response = await self._request("GET", _PROVIDERS_PATH, caller)

--- a/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, cast
@@ -21,24 +20,26 @@ from screamingface_engine.connections.port import (
     ConnectionConflict,
     ConnectionMethodUnsupported,
     ConnectionNotFound,
-    ConnectionRateLimited,
-    ConnectionRejected,
     ConnectionStatus,
     ConnectionTimeout,
     ConnectionUnavailable,
     OAuthAuthorization,
 )
+from screamingface_engine.connections.profile_availability import decode_profile_statuses
+from screamingface_engine.connections.provider_id import is_provider_id
+from screamingface_engine.connections.upstream_errors import raise_for_status
 
 logger = logging.getLogger(__name__)
 
 _PROVIDERS_PATH = "/v1/providers"
 _CONNECTIONS_PATH = "/v1/oauth/connections"
+_PROFILES_PATH = "/v1/auth/profiles"
 _API_KEY_PATH = f"{_CONNECTIONS_PATH}/api-key"
 # Inter-service contract: assigning this label explicitly designates a row for ScreamingFace
 # management. Rows under every other label remain outside this adapter's public projection.
 _MANAGED_LABEL = "screamingface"
 _MAX_OAUTH_EXPIRES_IN_SECONDS = 30 * 60
-_PROVIDER_ID = re.compile(r"[a-z0-9][a-z0-9_-]*\Z", re.ASCII)
+ListingSource = Literal["connections", "profiles"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,11 +65,23 @@ class _ConnectionRow:
 class AigatewayConnections:
     """Combine AI Gateway provider capabilities with caller-scoped connection state."""
 
-    def __init__(self, client: httpx.AsyncClient) -> None:
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        listing_source: ListingSource = "connections",
+    ) -> None:
         self._client = client
+        self._listing_source = listing_source
 
     async def list(self, caller: Caller) -> tuple[Connection, ...]:
         providers = await self._providers(caller)
+        if self._listing_source == "profiles":
+            statuses = await self._profile_statuses(caller)
+            return tuple(
+                _profile_connection(provider, statuses.get(provider.id, "not_connected"))
+                for provider in providers
+            )
         rows = await self._rows(caller)
         return tuple(
             _disconnected(provider)
@@ -183,6 +196,12 @@ class AigatewayConnections:
             raise ConnectionBadResponse()
         return [_validate_row(row) for row in rows]
 
+    async def _profile_statuses(self, caller: Caller) -> dict[str, ConnectionStatus]:
+        response = await self._request("GET", _PROFILES_PATH, caller)
+        if response.status_code != 200:
+            raise ConnectionBadResponse()
+        return decode_profile_statuses(_decode_object(response))
+
     async def _request(
         self,
         method: str,
@@ -208,7 +227,7 @@ class AigatewayConnections:
                 "AI Gateway provider-connection transport failure (%s)", type(exc).__name__
             )
             raise ConnectionUnavailable() from exc
-        _raise_for_status(response)
+        raise_for_status(response)
         return response
 
 
@@ -234,6 +253,18 @@ def _disconnected(provider: _Provider) -> Connection:
         display_name=provider.display_name,
         auth_methods=provider.auth_methods,
         status="not_connected",
+    )
+
+
+def _profile_connection(
+    provider: _Provider,
+    status: ConnectionStatus,
+) -> Connection:
+    return Connection(
+        provider=provider.id,
+        display_name=provider.display_name,
+        auth_methods=provider.auth_methods,
+        status=status,
     )
 
 
@@ -273,8 +304,7 @@ def _validate_provider(value: object) -> _Provider:
     methods = value.get("auth_methods")
     if (
         value.get("object") != "provider"
-        or not isinstance(value.get("id"), str)
-        or _PROVIDER_ID.fullmatch(value["id"]) is None
+        or not is_provider_id(value.get("id"))
         or not isinstance(value.get("display_name"), str)
         or not value["display_name"].strip()
         or not isinstance(methods, list)
@@ -372,8 +402,7 @@ def _validate_row(value: object) -> _ConnectionRow:
     if (
         not isinstance(connection_id, str)
         or not _is_uuid(connection_id)
-        or not isinstance(provider, str)
-        or _PROVIDER_ID.fullmatch(provider) is None
+        or not is_provider_id(provider)
         or not isinstance(label, str)
         or not label.strip()
         or not isinstance(status, str)
@@ -408,25 +437,4 @@ def _account_label(value: object) -> str | None:
     return None
 
 
-def _raise_for_status(response: httpx.Response) -> None:
-    status = response.status_code
-    if status < 300:
-        return
-    error = {
-        # Provider capability is checked locally before a credential leaves the Engine.
-        # AI Gateway also uses 400 for malformed credentials, so an upstream 400 is a
-        # rejection—not evidence that the advertised method is unsupported.
-        400: ConnectionRejected,
-        401: ConnectionRejected,
-        403: ConnectionRejected,
-        404: ConnectionNotFound,
-        409: ConnectionConflict,
-        422: ConnectionRejected,
-        429: ConnectionRateLimited,
-        503: ConnectionUnavailable,
-        504: ConnectionTimeout,
-    }.get(status, ConnectionBadResponse)
-    raise error()
-
-
-__all__ = ["AigatewayConnections"]
+__all__ = ["AigatewayConnections", "ListingSource"]

--- a/apps/screamingface-engine/src/screamingface_engine/connections/profile_availability.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/profile_availability.py
@@ -13,7 +13,7 @@ _STATES = frozenset({"pending", "authenticated", "error"})
 
 def decode_profile_statuses(body: dict[str, Any]) -> dict[str, ConnectionStatus]:
     profiles = body.get("profiles")
-    if set(body) != {"profiles"} or not isinstance(profiles, list):
+    if not isinstance(profiles, list):
         raise ConnectionBadResponse()
 
     states_by_provider: dict[str, set[str]] = defaultdict(set)

--- a/apps/screamingface-engine/src/screamingface_engine/connections/profile_availability.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/profile_availability.py
@@ -1,0 +1,40 @@
+"""Strict caller-profile projection for hosted provider availability."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from screamingface_engine.connections.port import ConnectionBadResponse, ConnectionStatus
+from screamingface_engine.connections.provider_id import is_provider_id
+
+_STATES = frozenset({"pending", "authenticated", "error"})
+
+
+def decode_profile_statuses(body: dict[str, Any]) -> dict[str, ConnectionStatus]:
+    profiles = body.get("profiles")
+    if set(body) != {"profiles"} or not isinstance(profiles, list):
+        raise ConnectionBadResponse()
+
+    states_by_provider: dict[str, set[str]] = defaultdict(set)
+    for profile in profiles:
+        if not isinstance(profile, dict):
+            raise ConnectionBadResponse()
+        provider = profile.get("provider")
+        state = profile.get("state")
+        if not is_provider_id(provider) or not isinstance(state, str) or state not in _STATES:
+            raise ConnectionBadResponse()
+        states_by_provider[provider].add(state)
+
+    return {provider: _public_status(states) for provider, states in states_by_provider.items()}
+
+
+def _public_status(states: set[str]) -> ConnectionStatus:
+    if "authenticated" in states:
+        return "connected"
+    if "pending" in states:
+        return "pending"
+    return "error"
+
+
+__all__ = ["decode_profile_statuses"]

--- a/apps/screamingface-engine/src/screamingface_engine/connections/provider_id.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/provider_id.py
@@ -1,0 +1,15 @@
+"""Shared validation for provider identifiers crossing the AI Gateway seam."""
+
+from __future__ import annotations
+
+import re
+from typing import TypeGuard
+
+_PROVIDER_ID = re.compile(r"[a-z0-9][a-z0-9_-]*\Z", re.ASCII)
+
+
+def is_provider_id(value: object) -> TypeGuard[str]:
+    return isinstance(value, str) and _PROVIDER_ID.fullmatch(value) is not None
+
+
+__all__ = ["is_provider_id"]

--- a/apps/screamingface-engine/src/screamingface_engine/connections/upstream_errors.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/upstream_errors.py
@@ -1,0 +1,38 @@
+"""Secret-free translation of AI Gateway HTTP failures."""
+
+from __future__ import annotations
+
+import httpx
+
+from screamingface_engine.connections.port import (
+    ConnectionBadResponse,
+    ConnectionConflict,
+    ConnectionNotFound,
+    ConnectionRateLimited,
+    ConnectionRejected,
+    ConnectionTimeout,
+    ConnectionUnavailable,
+)
+
+
+def raise_for_status(response: httpx.Response) -> None:
+    if response.status_code < 300:
+        return
+    error = {
+        # WHY: capability is checked before credentials leave the Engine, while AI Gateway also
+        # uses 400 for malformed credentials. Upstream 400 is therefore a rejection, not proof
+        # that the advertised method is unsupported.
+        400: ConnectionRejected,
+        401: ConnectionRejected,
+        403: ConnectionRejected,
+        404: ConnectionNotFound,
+        409: ConnectionConflict,
+        422: ConnectionRejected,
+        429: ConnectionRateLimited,
+        503: ConnectionUnavailable,
+        504: ConnectionTimeout,
+    }.get(response.status_code, ConnectionBadResponse)
+    raise error()
+
+
+__all__ = ["raise_for_status"]

--- a/apps/screamingface-engine/src/screamingface_engine/local.py
+++ b/apps/screamingface-engine/src/screamingface_engine/local.py
@@ -168,7 +168,9 @@ def create_local_app(
         max_history=settings.local_max_run_history,
         extra_models=None if catalog is None else (lambda: catalog.admitted_model_ids),
     )
-    connections = build_connections(settings)
+    # INVARIANT: local mode keeps the caller-managed rows that back its BYOK controls; profile
+    # availability is the deployed Engine policy and must not replace this mutable state.
+    connections = build_connections(settings, listing_source="connections")
     app = create_app(
         settings,
         stream=stream,

--- a/apps/screamingface-engine/tests/unit/test_connections_profile_availability.py
+++ b/apps/screamingface-engine/tests/unit/test_connections_profile_availability.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from inspect import Parameter, signature
 
 import httpx
 import pytest
@@ -8,7 +9,11 @@ import pytest
 from screamingface_engine.config import Settings
 from screamingface_engine.connections import build_connections
 from screamingface_engine.connections.aigateway import AigatewayConnections
-from screamingface_engine.connections.port import Caller, ConnectionBadResponse
+from screamingface_engine.connections.port import (
+    Caller,
+    ConnectionBadResponse,
+    ConnectionMethodUnsupported,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -193,3 +198,50 @@ async def test_builder_can_select_profile_availability_without_a_gateway_change(
         ("openrouter", "connected"),
     ]
     await adapter.aclose()
+
+
+async def test_profile_availability_accepts_additive_envelope_fields() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers())
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "profiles": [_profile("openrouter", "authenticated")],
+                "has_more": False,
+            },
+        )
+
+    adapter, _ = _adapter(handler)
+
+    rows = await adapter.list(Caller(ALICE))
+
+    assert [(row.provider, row.status) for row in rows] == [
+        ("anthropic", "not_connected"),
+        ("openrouter", "connected"),
+    ]
+
+
+@pytest.mark.parametrize("operation", ["connect", "start_oauth", "disconnect"])
+async def test_profile_backed_mutations_are_rejected_before_gateway_io(operation: str) -> None:
+    def unexpected(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"hosted mutation reached AI Gateway: {request.method} {request.url}")
+
+    adapter, seen = _adapter(unexpected)
+
+    with pytest.raises(ConnectionMethodUnsupported) as failure:
+        if operation == "connect":
+            await adapter.connect(Caller(ALICE), "openrouter", "must-not-be-sent")
+        elif operation == "start_oauth":
+            await adapter.start_oauth(Caller(ALICE), "openrouter")
+        else:
+            await adapter.disconnect(Caller(ALICE), "openrouter")
+
+    assert failure.value.status == 400
+    assert seen == []
+    assert "must-not-be-sent" not in str(failure.value)
+
+
+async def test_listing_source_is_required_at_the_composition_seam() -> None:
+    assert signature(build_connections).parameters["listing_source"].default is Parameter.empty

--- a/apps/screamingface-engine/tests/unit/test_connections_profile_availability.py
+++ b/apps/screamingface-engine/tests/unit/test_connections_profile_availability.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from screamingface_engine.config import Settings
+from screamingface_engine.connections import build_connections
+from screamingface_engine.connections.aigateway import AigatewayConnections
+from screamingface_engine.connections.port import Caller, ConnectionBadResponse
+
+pytestmark = pytest.mark.asyncio
+
+ALICE = {"X-User-Email": "alice@example.com"}
+BOB = {"X-User-Email": "bob@example.com"}
+
+
+def _provider(provider: str, display_name: str) -> dict[str, object]:
+    return {
+        "object": "provider",
+        "id": provider,
+        "display_name": display_name,
+        "auth_methods": ["api_key"],
+    }
+
+
+def _providers() -> dict[str, object]:
+    return {
+        "object": "list",
+        "data": [
+            _provider("anthropic", "Anthropic"),
+            _provider("openrouter", "OpenRouter"),
+        ],
+    }
+
+
+def _profile(provider: str, state: str) -> dict[str, object]:
+    return {
+        "id": f"private:{provider}:default",
+        "account_id": "private-account",
+        "provider": provider,
+        "name": "default",
+        "account_label": "must-not-leak@example.com",
+        "state": state,
+        "auth_type": "api_key",
+        "defaults": {"system_prompt": "must not leak"},
+    }
+
+
+def _adapter(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[AigatewayConnections, list[httpx.Request]]:
+    seen: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    client = httpx.AsyncClient(
+        base_url="http://aigateway.test",
+        transport=httpx.MockTransport(capture),
+    )
+    return AigatewayConnections(client, listing_source="profiles"), seen
+
+
+async def test_profile_availability_is_caller_scoped_and_secret_free() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json=_providers())
+        email = request.headers["X-User-Email"]
+        provider = "openrouter" if email == "alice@example.com" else "anthropic"
+        return httpx.Response(200, json={"profiles": [_profile(provider, "authenticated")]})
+
+    adapter, seen = _adapter(handler)
+
+    alice = await adapter.list(Caller(ALICE))
+    bob = await adapter.list(Caller(BOB))
+
+    assert [(row.provider, row.status) for row in alice] == [
+        ("anthropic", "not_connected"),
+        ("openrouter", "connected"),
+    ]
+    assert [(row.provider, row.status) for row in bob] == [
+        ("anthropic", "connected"),
+        ("openrouter", "not_connected"),
+    ]
+    assert all(row.auth_method is None and row.account_label is None for row in (*alice, *bob))
+    assert "private-account" not in repr((alice, bob))
+    assert "must-not-leak" not in repr((alice, bob))
+    assert [request.url.path for request in seen] == [
+        "/v1/providers",
+        "/v1/auth/profiles",
+        "/v1/providers",
+        "/v1/auth/profiles",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("states", "expected"),
+    [
+        (("error", "pending", "authenticated"), "connected"),
+        (("error", "pending"), "pending"),
+        (("error",), "error"),
+        ((), "not_connected"),
+    ],
+)
+async def test_profile_state_precedence(states: tuple[str, ...], expected: str) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/providers":
+            return httpx.Response(
+                200,
+                json={"object": "list", "data": [_provider("openrouter", "OpenRouter")]},
+            )
+        return httpx.Response(
+            200,
+            json={"profiles": [_profile("openrouter", state) for state in states]},
+        )
+
+    adapter, _ = _adapter(handler)
+
+    (connection,) = await adapter.list(Caller(ALICE))
+
+    assert connection.status == expected
+
+
+async def test_profiles_for_disabled_providers_do_not_create_catalogue_rows() -> None:
+    adapter, _ = _adapter(
+        lambda request: httpx.Response(
+            200,
+            json=(
+                _providers()
+                if request.url.path == "/v1/providers"
+                else {"profiles": [_profile("disabled-provider", "authenticated")]}
+            ),
+        )
+    )
+
+    rows = await adapter.list(Caller(ALICE))
+
+    assert tuple(row.provider for row in rows) == ("anthropic", "openrouter")
+    assert all(row.status == "not_connected" for row in rows)
+
+
+@pytest.mark.parametrize(
+    "profiles",
+    [
+        None,
+        {},
+        ["not-an-object"],
+        [{"provider": "OpenRouter", "state": "authenticated"}],
+        [{"provider": "openrouter", "state": "unknown"}],
+    ],
+)
+async def test_malformed_profile_availability_is_rejected(profiles: object) -> None:
+    adapter, _ = _adapter(
+        lambda request: httpx.Response(
+            200,
+            json=(_providers() if request.url.path == "/v1/providers" else {"profiles": profiles}),
+        )
+    )
+
+    with pytest.raises(ConnectionBadResponse):
+        await adapter.list(Caller(ALICE))
+
+
+async def test_builder_can_select_profile_availability_without_a_gateway_change() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = (
+            _providers()
+            if request.url.path == "/v1/providers"
+            else {"profiles": [_profile("openrouter", "authenticated")]}
+        )
+        return httpx.Response(200, json=payload)
+
+    def client_factory(base_url: str) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=base_url,
+            transport=httpx.MockTransport(handler),
+        )
+
+    adapter = build_connections(
+        Settings(aigateway_base_url="http://aigateway.test"),
+        listing_source="profiles",
+        client_factory=client_factory,
+    )
+    assert adapter is not None
+
+    rows = await adapter.list(Caller(ALICE))
+
+    assert [(row.provider, row.status) for row in rows] == [
+        ("anthropic", "not_connected"),
+        ("openrouter", "connected"),
+    ]
+    await adapter.aclose()

--- a/docs/plan/2026-08-24-OME-958-hosted-provider-availability.md
+++ b/docs/plan/2026-08-24-OME-958-hosted-provider-availability.md
@@ -1,0 +1,22 @@
+---
+title: Implement hosted provider availability from caller profiles
+ticket: OME-958
+status: approved
+date: 2026-08-24
+spec: ../spec/2026-08-24-OME-958-hosted-provider-availability.md
+---
+
+# Implement hosted provider availability from caller profiles
+
+1. Add adapter tests for caller-specific authenticated profiles, status precedence, malformed
+   profile payloads, identity forwarding, and the unchanged local connection-row path.
+2. Add composition tests pinning deployed Engine to profile listing and local Engine to managed
+   connection listing.
+3. Add a small explicit listing-source input to the AI Gateway adapter and strictly decode the
+   existing `/v1/auth/profiles` response behind it.
+4. Project profile state onto the existing secret-free `Connection` values without changing the
+   REST response model.
+5. Wire production and local composition to their respective sources.
+6. Run focused tests, the full ScreamingFace Engine gate runner, and a direct `origin/main...HEAD`
+   wisdom/confidence review.
+7. Record the outcome, commit with `Refs: OME-958`, and open the Engine PR before starting OME-960.

--- a/docs/plan/2026-08-24-OME-958-hosted-provider-availability.md
+++ b/docs/plan/2026-08-24-OME-958-hosted-provider-availability.md
@@ -20,3 +20,12 @@ spec: ../spec/2026-08-24-OME-958-hosted-provider-availability.md
 6. Run focused tests, the full ScreamingFace Engine gate runner, and a direct `origin/main...HEAD`
    wisdom/confidence review.
 7. Record the outcome, commit with `Refs: OME-958`, and open the Engine PR before starting OME-960.
+
+## Review follow-up
+
+8. Add failing tests proving profile-backed hosted mutation methods reject without any Gateway I/O
+   and profile decoding accepts unrelated envelope fields.
+9. Guard all mutations at the adapter boundary, relax only top-level sibling validation, and make
+   listing-source selection required at the production/local builder seam.
+10. Run focused tests and all Engine gates, update the ledger outcome, commit, and push the draft
+    PR without marking it ready.

--- a/docs/spec/2026-08-24-OME-958-hosted-provider-availability.md
+++ b/docs/spec/2026-08-24-OME-958-hosted-provider-availability.md
@@ -49,9 +49,10 @@ different authentication types and the hosted Client does not manage those crede
 
 ## Failure and privacy contract
 
-Profile payloads are untrusted upstream data. The collection shape, provider identifiers, and
-profile states are validated before projection. A malformed response fails through the existing
-secret-free `ConnectionBadResponse` mapping.
+Profile payloads are untrusted upstream data. The required `profiles` member, provider identifiers,
+and profile states are validated before projection. Unknown sibling members are ignored so an
+additive Gateway envelope change cannot disable the hosted connections route. A malformed required
+member fails through the existing secret-free `ConnectionBadResponse` mapping.
 
 Caller identity forwarding, `Cache-Control: private, no-store`, and `Vary: X-User-Email` remain
 unchanged. Two callers using the same Engine and catalogue may receive different statuses.
@@ -59,7 +60,10 @@ unchanged. Two callers using the same Engine and catalogue may receive different
 ## Compatibility and exclusions
 
 - Local BYOK list/connect/OAuth/disconnect behavior is unchanged.
+- Profile-backed hosted connections are read-only: connect, OAuth-start, and disconnect fail with
+  a safe 4xx before the adapter sends any Gateway request. This prevents the Engine from accepting
+  credentials into the separate OAuth connection store that hosted reads would never report or
+  use.
 - The public Engine response schema and Client wire decoder are unchanged.
 - This unit does not change AI Gateway, URL4, model execution, or benchmark behavior.
-- Direct hosted credential-mutation routes remain the explicit OME-883 limitation; OME-960 keeps
-  those controls absent from the hosted Client UI.
+- OME-960 also keeps hosted mutation controls absent from the Client UI.

--- a/docs/spec/2026-08-24-OME-958-hosted-provider-availability.md
+++ b/docs/spec/2026-08-24-OME-958-hosted-provider-availability.md
@@ -1,0 +1,65 @@
+---
+title: Hosted provider availability from caller profiles
+ticket: OME-958
+status: approved
+date: 2026-08-24
+---
+
+# Hosted provider availability from caller profiles
+
+## Outcome
+
+`GET /v1/connections` on a deployed ScreamingFace Engine truthfully reports which advertised
+providers the signed-in caller can use. Availability comes from the caller's existing AI Gateway
+profiles; local Engine listing continues to reflect the caller-managed `screamingface` connection
+rows used by BYOK controls.
+
+## Ownership and seam
+
+AI Gateway remains authoritative for provider capabilities, profile state, and credential storage.
+Its existing caller-scoped `GET /v1/auth/profiles` route supplies the deployed availability input;
+this work adds no AI Gateway route or schema.
+
+The Engine composition root explicitly selects one listing source when it builds the existing AI
+Gateway connection adapter:
+
+- deployed Engine: caller profiles;
+- local Engine: caller-managed connection rows.
+
+The Engine-facing `Connections` interface and public `/v1/connections` response do not change. The
+source selection is deployment wiring, not an environment guess inside list execution and not a
+Client hint.
+
+## Profile projection
+
+The adapter first loads the enabled provider catalogue, then strictly decodes the caller's profile
+list. It projects profiles only onto providers present in that catalogue; a profile for a disabled
+or unknown provider does not create a public row.
+
+When a provider has multiple profiles, public status uses this deterministic precedence:
+
+1. any `authenticated` profile -> `connected`;
+2. otherwise any `pending` profile -> `pending`;
+3. otherwise any `error` profile -> `error`;
+4. no profile -> `not_connected`.
+
+The projection exposes neither profile identifiers, names, defaults, account labels, nor credential
+material. `auth_method` remains absent because availability may be backed by multiple profiles with
+different authentication types and the hosted Client does not manage those credentials.
+
+## Failure and privacy contract
+
+Profile payloads are untrusted upstream data. The collection shape, provider identifiers, and
+profile states are validated before projection. A malformed response fails through the existing
+secret-free `ConnectionBadResponse` mapping.
+
+Caller identity forwarding, `Cache-Control: private, no-store`, and `Vary: X-User-Email` remain
+unchanged. Two callers using the same Engine and catalogue may receive different statuses.
+
+## Compatibility and exclusions
+
+- Local BYOK list/connect/OAuth/disconnect behavior is unchanged.
+- The public Engine response schema and Client wire decoder are unchanged.
+- This unit does not change AI Gateway, URL4, model execution, or benchmark behavior.
+- Direct hosted credential-mutation routes remain the explicit OME-883 limitation; OME-960 keeps
+  those controls absent from the hosted Client UI.

--- a/docs/tasks/2026-08-24-OME-957-hosted-profile-provider-availability.md
+++ b/docs/tasks/2026-08-24-OME-957-hosted-profile-provider-availability.md
@@ -1,0 +1,16 @@
+---
+id: OME-957
+linear_url: https://linear.app/openmined/issue/OME-957/show-only-profile-enabled-providers-as-connected-on-hosted-engine
+status: in_progress
+type: feature
+priority: high
+labels: [repo, agentic, autonomous]
+created: 2026-08-24
+closed:
+---
+
+# Show only profile-enabled providers as connected on hosted Engine
+
+Cross-cutting parent for replacing the temporary hosted-provider catalogue policy with truthful,
+caller-scoped availability. Engine work is tracked by OME-958; Client presentation is tracked by
+OME-960.

--- a/docs/tasks/2026-08-24-OME-958-hosted-provider-availability.md
+++ b/docs/tasks/2026-08-24-OME-958-hosted-provider-availability.md
@@ -1,0 +1,20 @@
+---
+id: OME-958
+linear_url: https://linear.app/openmined/issue/OME-958/derive-hosted-provider-availability-from-caller-profiles
+status: in_review
+type: feature
+priority: high
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-24
+closed:
+---
+
+# Derive hosted provider availability from caller profiles
+
+Make deployed ScreamingFace Engine connection listing project the signed-in caller's existing AI
+Gateway profiles onto the provider catalogue. Local Engine keeps its caller-managed BYOK rows and
+the public `/v1/connections` response stays unchanged.
+
+Spec: `docs/spec/2026-08-24-OME-958-hosted-provider-availability.md`
+Plan: `docs/plan/2026-08-24-OME-958-hosted-provider-availability.md`
+Ledger: `docs/work/2026-08-24-OME-958-hosted-provider-availability.md`

--- a/docs/tasks/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/tasks/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -1,0 +1,17 @@
+---
+id: OME-960
+linear_url: https://linear.app/openmined/issue/OME-960/render-hosted-provider-statuses-without-byok-controls
+status: backlog
+type: feature
+priority: high
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-24
+closed:
+---
+
+# Render hosted provider statuses without BYOK controls
+
+Queued Client half of OME-957. It will trust the caller-scoped status returned by OME-958 while
+continuing to suppress every hosted BYOK mutation control.
+
+Blocked by OME-958.

--- a/docs/work/2026-08-24-OME-958-hosted-provider-availability.md
+++ b/docs/work/2026-08-24-OME-958-hosted-provider-availability.md
@@ -46,13 +46,38 @@ Engine connection type.
 - No AI Gateway or public `/v1/connections` schema change is introduced.
 - ScreamingFace Engine gates pass at or above their existing coverage threshold.
 
+## Review follow-up
+
+### Planned changes
+
+- Reject connect, OAuth-start, and disconnect before any upstream request when profile-backed
+  hosted listing makes the adapter read-only.
+- Accept unknown sibling fields around the required `profiles` list.
+- Make `listing_source` required at the builder seam so production and local composition cannot
+  silently inherit a default; retain the adapter's legacy default for direct internal use.
+- Add append-only tests for all three hosted mutations, tolerant profile envelopes, and the
+  unchanged mutable local path.
+
+### Test plan
+
+- RED: each hosted mutation raises a safe 4xx connection error and sends zero Gateway requests.
+- RED: profile envelopes with harmless object/paging siblings still project availability.
+- GREEN: existing local list/connect/OAuth/disconnect tests and the full Engine suite remain
+  unchanged.
+
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** the planned composition, adapter, profile projection, shared provider-ID
-  validation, upstream error translation, focused tests, and OME-957/958/960 SDLC artifacts.
-- **Commits:** this implementation commit — `feat(screamingface-engine): derive hosted provider availability`.
+  validation, upstream error translation, hosted read-only mutation guard, focused tests, and
+  OME-957/958/960 SDLC artifacts.
+- **Commits:** `feat(screamingface-engine): derive hosted provider availability`; review follow-up
+  `fix(screamingface-engine): reject hosted provider mutations` (this commit).
 - **Gates:** `run_gates.py screamingface-engine` — ALL GATES GREEN; full suite 2,007 passed,
-  6 skipped; focused connection suite 59 passed; Pyright 0 errors.
+  6 skipped on the initial implementation; review follow-up also passed the complete gate runner
+  and 57 focused adapter tests; Pyright 0 errors.
 - **Deviations:** extracted existing upstream status translation after the initial implementation
-  pushed `aigateway.py` above the 450-line focus limit; final adapter is 440 lines. No AI Gateway
-  or public Engine schema change was required.
+  pushed `aigateway.py` above the 450-line focus limit; final adapter remains within the limit.
+  The follow-up requires `listing_source` at the exported builder seam while retaining the
+  adapter's legacy default for direct internal construction; this preserved every prior test and
+  still makes both production composition omissions fail. No AI Gateway or public Engine success
+  schema change was required.

--- a/docs/work/2026-08-24-OME-958-hosted-provider-availability.md
+++ b/docs/work/2026-08-24-OME-958-hosted-provider-availability.md
@@ -1,0 +1,58 @@
+---
+ticket: OME-958
+stack: screamingface-engine
+status: done
+started: 2026-08-24
+finished: 2026-08-24
+---
+
+# OME-958 — Hosted provider availability from caller profiles
+
+## Intent
+
+Replace deployed Engine's catalogue-shaped provider status with a truthful caller-scoped
+projection of existing AI Gateway profiles, while preserving local BYOK behavior and every public
+Engine connection type.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py` — profile decoding
+  and projection behind an explicit listing source.
+- `apps/screamingface-engine/src/screamingface_engine/connections/profile_availability.py` and
+  `provider_id.py` — focused profile projection and shared provider-ID validation.
+- `apps/screamingface-engine/src/screamingface_engine/connections/upstream_errors.py` — existing
+  secret-free upstream status translation extracted to keep the adapter focused.
+- `apps/screamingface-engine/src/screamingface_engine/connections/__init__.py` — composition input.
+- `apps/screamingface-engine/src/screamingface_engine/app.py` — deployed profile-source wiring.
+- `apps/screamingface-engine/src/screamingface_engine/local.py` — explicit local BYOK-source wiring.
+- `apps/screamingface-engine/tests/unit/test_connections_aigateway.py` — caller/profile contract,
+  precedence, malformed-response, and local-regression tests.
+- `apps/screamingface-engine/tests/unit/test_local_aigateway_connection.py` and focused production
+  composition coverage — source-selection tests.
+- `docs/{tasks,spec,plan,work}/` — required OME-957/958/960 records.
+
+## Test plan
+
+- RED: two callers with different authenticated profiles receive different Connected providers.
+- RED: authenticated, pending, error, and absent profile states project with deterministic
+  precedence; unknown providers cannot enter the catalogue.
+- RED: malformed profile responses fail as `ConnectionBadResponse` without leaking payloads.
+- RED: deployed composition selects profiles; local composition retains managed connection rows.
+- GREEN: existing adapter, REST, local-mode, and full Engine tests remain unchanged and pass.
+
+## Acceptance
+
+- OME-958's Linear acceptance criteria and approved spec are satisfied.
+- No AI Gateway or public `/v1/connections` schema change is introduced.
+- ScreamingFace Engine gates pass at or above their existing coverage threshold.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** the planned composition, adapter, profile projection, shared provider-ID
+  validation, upstream error translation, focused tests, and OME-957/958/960 SDLC artifacts.
+- **Commits:** this implementation commit — `feat(screamingface-engine): derive hosted provider availability`.
+- **Gates:** `run_gates.py screamingface-engine` — ALL GATES GREEN; full suite 2,007 passed,
+  6 skipped; focused connection suite 59 passed; Pyright 0 errors.
+- **Deviations:** extracted existing upstream status translation after the initial implementation
+  pushed `aigateway.py` above the 450-line focus limit; final adapter is 440 lines. No AI Gateway
+  or public Engine schema change was required.


### PR DESCRIPTION
## Summary

- derive deployed Engine provider status from the signed-in caller profiles in AI Gateway
- make profile-backed hosted connections read-only before any Gateway I/O
- preserve local Engine BYOK listing and mutation behavior
- tolerate additive profile-envelope fields while strictly validating the profiles member
- require production and local composition to choose their listing source explicitly
- keep the public /v1/connections success schema unchanged and expose no profile metadata

## Contract

Hosted composition reads the existing caller-scoped /v1/auth/profiles route. AI Gateway and URL4 require no changes. Profile precedence is authenticated → pending → error → absent. Hosted connect, OAuth-start, and disconnect return a safe 4xx instead of accepting credentials into the separate OAuth connection store.

## Test plan

- python3 .claude/scripts/run_gates.py screamingface-engine
- all Engine gates green, including append-only tests, Ruff, format, Pyright, layering, and full coverage tests
- 57 focused adapter tests passed

Asana: none

Refs: OME-958