### PR TITLE
feat(screamingface): show hosted provider availability

### DIFF
--- a/docs/plan/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/plan/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -1,0 +1,20 @@
+---
+title: Implement hosted provider status presentation
+ticket: OME-960
+status: approved
+date: 2026-08-24
+spec: ../spec/2026-08-24-OME-960-hosted-provider-presentation.md
+---
+
+# Implement hosted provider status presentation
+
+1. Replace the inherited hosted-all-connected assertion with failing tests for connected,
+   unavailable, and non-terminal/error provider states across widget text, static HTML, and repr.
+2. Pin the absence of every hosted provider mutation control and preserve the existing loopback
+   BYOK behavior.
+3. Update the shared provider presentation helper so hosted rows trust Engine status, derive the
+   `Unavailable` label for `not_connected`, and claim ScreamingFace availability only when
+   connected.
+4. Run the focused connection-panel tests and the complete ScreamingFace gate suite.
+5. Review the `origin/main...HEAD` diff, fill the ledger outcome, and commit locally. Do not open a
+   Client PR until the owner explicitly requests it.

--- a/docs/plan/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/plan/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -18,3 +18,12 @@ spec: ../spec/2026-08-24-OME-960-hosted-provider-presentation.md
 4. Run the focused connection-panel tests and the complete ScreamingFace gate suite.
 5. Review the `origin/main...HEAD` diff, fill the ledger outcome, and commit locally. Do not open a
    Client PR until the owner explicitly requests it.
+
+## Review follow-up
+
+6. Replace the weak substring assertions with exact hosted status-cell assertions for every
+   non-connected wire state.
+7. Consolidate hosted/local wire-state, label/class, and source decisions into one presentation
+   projection; remove the second branching helper.
+8. Collapse every hosted non-connected wire state to the quiet SFDS `Unavailable` presentation,
+   rerun focused and full gates, commit, and update draft PR #703.

--- a/docs/spec/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/spec/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -1,0 +1,43 @@
+---
+title: Hosted provider status presentation
+ticket: OME-960
+status: approved
+date: 2026-08-24
+---
+
+# Hosted provider status presentation
+
+## Outcome
+
+The Client connection panel shows the hosted Engine's caller-scoped provider availability instead
+of presenting every advertised provider as connected. A user can tell which hosted providers are
+available without being offered credentials controls that belong only to local BYOK operation.
+
+## Presentation contract
+
+The Engine's `Connection.status` remains the source of truth. Hosted rows project that wire state
+into concise user-facing language:
+
+- `connected` -> `Connected`, with source `Available via ScreamingFace`;
+- `not_connected` -> `Unavailable`, with no availability source claim;
+- `pending`, `needs_reauth`, and `error` retain their existing truthful status wording and make no
+  availability source claim.
+
+Static HTML and ipywidgets use the same presentation helper. The plain representation exposes the
+same projected status, so it cannot claim a provider is connected when the visual panel does not.
+
+## Boundaries
+
+- Hosted rows expose no Connect, Disconnect, API-key, OAuth, Save, or Cancel controls.
+- Hosted account labels remain hidden.
+- Local loopback BYOK status, account labels, and mutation controls remain byte-for-byte in scope
+  and behavior.
+- The public `Connection` model, Engine response schema, authentication flow, and provider
+  catalogue do not change.
+- The Client change remains blocked from merge until OME-958 makes hosted status authoritative.
+
+## Compatibility decision
+
+OME-960 intentionally reverses OME-883's unreleased presentation rule that forced every hosted
+provider to `Connected`. The inherited test encoding that rule is updated rather than retained as
+a compatibility fallback; the owner explicitly approved truthful caller-scoped availability.

--- a/docs/spec/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/spec/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -19,12 +19,17 @@ The Engine's `Connection.status` remains the source of truth. Hosted rows projec
 into concise user-facing language:
 
 - `connected` -> `Connected`, with source `Available via ScreamingFace`;
-- `not_connected` -> `Unavailable`, with no availability source claim;
-- `pending`, `needs_reauth`, and `error` retain their existing truthful status wording and make no
-  availability source claim.
+- `not_connected`, `pending`, `needs_reauth`, and `error` -> `Unavailable`, with no availability
+  source claim.
 
-Static HTML and ipywidgets use the same presentation helper. The plain representation exposes the
-same projected status, so it cannot claim a provider is connected when the visual panel does not.
+The non-connected wire states describe operator-owned credential lifecycle details. They are not
+actionable for a hosted caller, so the Client exposes only the caller-relevant availability fact.
+Local BYOK rows continue to expose their exact wire status because the local caller owns and can
+repair those credentials.
+
+One presentation projection owns status class/label and source together. Static HTML, ipywidgets,
+and plain representation all use that projection, so no rendering path can leak a different wire
+state or make an independent availability claim.
 
 ## Boundaries
 

--- a/docs/tasks/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/tasks/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -1,7 +1,7 @@
 ---
 id: OME-960
 linear_url: https://linear.app/openmined/issue/OME-960/render-hosted-provider-statuses-without-byok-controls
-status: backlog
+status: in_progress
 type: feature
 priority: high
 labels: [py-screamingface, agentic, autonomous]
@@ -11,7 +11,5 @@ closed:
 
 # Render hosted provider statuses without BYOK controls
 
-Queued Client half of OME-957. It will trust the caller-scoped status returned by OME-958 while
-continuing to suppress every hosted BYOK mutation control.
-
-Blocked by OME-958.
+Trust the caller-scoped provider status returned by OME-958 while continuing to suppress every
+hosted BYOK mutation control. The Engine dependency landed in PR #702.

--- a/docs/work/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/work/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -24,7 +24,7 @@ provider mutation controls local-only.
 
 - Connected hosted providers remain Connected and carry the ScreamingFace availability source.
 - Hosted providers reported `not_connected` render Unavailable, never Connected.
-- Hosted pending/error states are preserved without availability claims.
+- Hosted pending/error/reauth states collapse to the caller-relevant Unavailable presentation.
 - Static HTML, widget text, and repr agree.
 - Hosted mutation controls remain absent; local loopback BYOK controls remain unchanged.
 
@@ -36,11 +36,30 @@ provider mutation controls local-only.
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:** task/spec/plan/ledger artifacts; shared connection-panel presentation and
-  SFDS status styling; focused hosted presentation coverage in `test_connection_panel.py`.
-- **Commits:** `feat(screamingface): show hosted provider availability` (this commit).
-- **Gates:** 38 focused connection-panel tests passed; complete `screamingface` gate runner passed
-  Ruff, format, Pyright, 95% coverage pytest, notebook checks, build, and distribution checks.
+- **Actual files:** task/spec/plan/ledger artifacts; one shared connection-panel presentation
+  projection; SFDS status styling; focused hosted presentation coverage in
+  `test_connection_panel.py`.
+- **Commits:** `feat(screamingface): show hosted provider availability`; review follow-up
+  `fix(screamingface): hide hosted credential lifecycle states` (this commit).
+- **Gates:** 39 focused connection-panel tests passed; complete `screamingface` gate runner passed
+  Ruff, format, Pyright, 95% coverage pytest, notebook checks, build, and distribution checks after
+  the review follow-up.
 - **Deviations:** the append-only test check was skipped after it correctly identified the
   intentional, owner-approved replacement of OME-883's obsolete all-hosted-connected assertion.
-  No test guard or gate configuration was changed.
+  It was skipped again for the reviewer-requested replacement of the weak pending/error substring
+  assertion with an exact cell contract. No test guard or gate configuration was changed.
+
+## Review follow-up
+
+### Planned changes
+
+- Strengthen hosted status tests to assert the exact status cell, class, label, source, and repr.
+- Replace the split `_provider_status`/`_provider_presentation` decisions with one projection.
+- Render every hosted non-connected Engine state as quiet, unactionable `Unavailable` while
+  preserving exact local BYOK states.
+
+### Test plan
+
+- RED: `pending`, `error`, and `needs_reauth` must produce the exact same hosted Unavailable cell as
+  `not_connected`, without availability source or raw wire vocabulary in repr.
+- GREEN: connected hosted and all local BYOK presentation/control tests remain unchanged.

--- a/docs/work/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/work/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -40,10 +40,17 @@ provider mutation controls local-only.
   projection; SFDS status styling; focused hosted presentation coverage in
   `test_connection_panel.py`.
 - **Commits:** `feat(screamingface): show hosted provider availability`; review follow-up
-  `fix(screamingface): hide hosted credential lifecycle states` (this commit).
+  `fix(screamingface): hide hosted credential lifecycle states`; final dead-branch cleanup
+  `refactor(screamingface): remove dead unavailable label branch` (this commit).
 - **Gates:** 39 focused connection-panel tests passed; complete `screamingface` gate runner passed
   Ruff, format, Pyright, 95% coverage pytest, notebook checks, build, and distribution checks after
   the review follow-up.
+- **Review verification:** the latest pushed head already asserted the exact hosted Unavailable
+  status cell for `error` in both widget and static HTML output; removed only the genuinely dead
+  generic-label branch identified by the follow-up review.
+- **Dependency verification:** rebased onto `origin/main` after Engine PR #702 merged; resolved the
+  task-mirror conflict by retaining the active Client scope and removing the obsolete blocker.
+  All focused tests and the complete ScreamingFace gate runner passed again after the rebase.
 - **Deviations:** the append-only test check was skipped after it correctly identified the
   intentional, owner-approved replacement of OME-883's obsolete all-hosted-connected assertion.
   It was skipped again for the reviewer-requested replacement of the weak pending/error substring
@@ -57,6 +64,8 @@ provider mutation controls local-only.
 - Replace the split `_provider_status`/`_provider_presentation` decisions with one projection.
 - Render every hosted non-connected Engine state as quiet, unactionable `Unavailable` while
   preserving exact local BYOK states.
+- Remove the now-dead `unavailable` case from the generic status-label helper; hosted presentation
+  supplies its explicit caller-facing label through the projection.
 
 ### Test plan
 

--- a/docs/work/2026-08-24-OME-960-hosted-provider-presentation.md
+++ b/docs/work/2026-08-24-OME-960-hosted-provider-presentation.md
@@ -1,0 +1,46 @@
+---
+ticket: OME-960
+stack: screamingface
+status: in_progress
+started: 2026-08-24
+finished:
+---
+
+# OME-960 — Render hosted provider statuses without BYOK controls
+
+## Intent
+
+Make hosted provider availability truthful for the signed-in caller while keeping credentials and
+provider mutation controls local-only.
+
+## Planned changes
+
+- Add the OME-960 task, spec, plan, and ledger artifacts.
+- Update `packages/screamingface/tests/test_connection_panel.py` test-first.
+- Update the shared presentation logic and status styling in
+  `packages/screamingface/src/screamingface/_ui/connection_view.py`.
+
+## Test plan
+
+- Connected hosted providers remain Connected and carry the ScreamingFace availability source.
+- Hosted providers reported `not_connected` render Unavailable, never Connected.
+- Hosted pending/error states are preserved without availability claims.
+- Static HTML, widget text, and repr agree.
+- Hosted mutation controls remain absent; local loopback BYOK controls remain unchanged.
+
+## Acceptance
+
+- The observable Client behavior matches the approved OME-960 spec.
+- Focused tests and the full ScreamingFace quality gates pass.
+- The work is committed locally without opening a PR.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** task/spec/plan/ledger artifacts; shared connection-panel presentation and
+  SFDS status styling; focused hosted presentation coverage in `test_connection_panel.py`.
+- **Commits:** `feat(screamingface): show hosted provider availability` (this commit).
+- **Gates:** 38 focused connection-panel tests passed; complete `screamingface` gate runner passed
+  Ruff, format, Pyright, 95% coverage pytest, notebook checks, build, and distribution checks.
+- **Deviations:** the append-only test check was skipped after it correctly identified the
+  intentional, owner-approved replacement of OME-883's obsolete all-hosted-connected assertion.
+  No test guard or gate configuration was changed.

--- a/packages/screamingface/src/screamingface/_ui/connection_view.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_view.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from html import escape
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, assert_never
 
 from screamingface._ui.connection_state import _ConnectionPanelState
 from screamingface._ui.engine_origin import _is_screamingface_engine
@@ -434,30 +435,45 @@ def _source_html(text: str | None) -> str:
     return f"<span class='sf-connections__source'>{escape(text) if text else '—'}</span>"
 
 
+@dataclass(frozen=True, slots=True)
+class _ProviderPresentation:
+    status_class: str
+    status_label: str
+    source: str | None
+
+
 def _provider_presentation(
     connection: Connection,
     *,
     provider_mutations_enabled: bool,
-) -> tuple[str, str | None]:
-    status = _provider_status(
-        connection,
-        provider_mutations_enabled=provider_mutations_enabled,
-    )
+) -> _ProviderPresentation:
     if provider_mutations_enabled:
-        return status, connection.account_label
-    # Hosted status is caller-scoped availability supplied by the Engine. Claim managed
-    # availability only for a provider the caller can actually use.
-    return status, "Available via ScreamingFace" if status == "connected" else None
+        return _ProviderPresentation(
+            status_class=connection.status,
+            status_label=_status_label(connection.status),
+            source=connection.account_label,
+        )
 
-
-def _provider_status(connection: Connection, *, provider_mutations_enabled: bool) -> str:
-    if not provider_mutations_enabled and connection.status == "not_connected":
-        return "unavailable"
-    return connection.status
+    # INVARIANT: hosted callers see only availability they can act on. Profile lifecycle states
+    # belong to the operator, so they must not leak into the caller-facing label or styling.
+    match connection.status:
+        case "connected":
+            return _ProviderPresentation(
+                status_class="connected",
+                status_label="Connected",
+                source="Available via ScreamingFace",
+            )
+        case "not_connected" | "pending" | "needs_reauth" | "error":
+            return _ProviderPresentation(
+                status_class="unavailable",
+                status_label="Unavailable",
+                source=None,
+            )
+    assert_never(connection.status)
 
 
 def _meta_html(connection: Connection, *, provider_mutations_enabled: bool) -> str:
-    status, source = _provider_presentation(
+    presentation = _provider_presentation(
         connection,
         provider_mutations_enabled=provider_mutations_enabled,
     )
@@ -467,8 +483,8 @@ def _meta_html(connection: Connection, *, provider_mutations_enabled: bool) -> s
         f"{_icon_html(connection.provider, connection.display_name)}"
         f"<span class='sf-connections__provider'>{escape(connection.display_name)}</span>"
         "</span>"
-        f"{_status_html(status)}"
-        f"{_source_html(source)}</div>"
+        f"{_status_html(presentation.status_class, label=presentation.status_label)}"
+        f"{_source_html(presentation.source)}</div>"
     )
 
 
@@ -513,10 +529,10 @@ def _status_label(status: str) -> str:
     return words.capitalize() if status in {"connected", "authenticated", "unavailable"} else words
 
 
-def _status_html(status: str) -> str:
+def _status_html(status: str, *, label: str | None = None) -> str:
     return (
         f"<div class='sf-connections__status {status}'><i class='sq'></i>"
-        f"{escape(_status_label(status))}</div>"
+        f"{escape(_status_label(status) if label is None else label)}</div>"
     )
 
 

--- a/packages/screamingface/src/screamingface/_ui/connection_view.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_view.py
@@ -526,7 +526,7 @@ def _status_label(status: str) -> str:
     """Capitalise decisive states; transitional and diagnostic states stay quiet."""
 
     words = status.replace("_", " ")
-    return words.capitalize() if status in {"connected", "authenticated", "unavailable"} else words
+    return words.capitalize() if status in {"connected", "authenticated"} else words
 
 
 def _status_html(status: str, *, label: str | None = None) -> str:

--- a/packages/screamingface/src/screamingface/_ui/connection_view.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_view.py
@@ -110,7 +110,8 @@ _STYLE = (
   background:var(--sf-blind)}
 /* an inactive row recedes (the whole label dims) while a live one stays full ink — state
    reads from weight+square, never from hue alone, so a colour-blind reader still gets it */
-.sf-connections__status.not_connected,.sf-connections__status.login_required{
+.sf-connections__status.not_connected,.sf-connections__status.unavailable,
+.sf-connections__status.login_required{
   color:var(--sf-ink-3)}
 .sf-connections__source{font-size:14px;color:var(--sf-ink-3);white-space:nowrap;overflow:hidden;
   text-overflow:ellipsis}
@@ -444,15 +445,15 @@ def _provider_presentation(
     )
     if provider_mutations_enabled:
         return status, connection.account_label
-    # On a hosted Engine the connection rows are caller-scoped BYOK state, not the
-    # operator-managed credentials used for execution. Every provider the hosted Engine
-    # advertises is therefore presented as managed availability; its caller status must not
-    # make a deployment credential look unavailable.
-    return status, "Available via ScreamingFace"
+    # Hosted status is caller-scoped availability supplied by the Engine. Claim managed
+    # availability only for a provider the caller can actually use.
+    return status, "Available via ScreamingFace" if status == "connected" else None
 
 
 def _provider_status(connection: Connection, *, provider_mutations_enabled: bool) -> str:
-    return connection.status if provider_mutations_enabled else "connected"
+    if not provider_mutations_enabled and connection.status == "not_connected":
+        return "unavailable"
+    return connection.status
 
 
 def _meta_html(connection: Connection, *, provider_mutations_enabled: bool) -> str:
@@ -506,10 +507,10 @@ def _access_meta_html(status: str, engine_url: str) -> str:
 
 
 def _status_label(status: str) -> str:
-    """Live states are capitalised; an inactive state stays lowercase and recedes."""
+    """Capitalise decisive states; transitional and diagnostic states stay quiet."""
 
     words = status.replace("_", " ")
-    return words.capitalize() if status in {"connected", "authenticated"} else words
+    return words.capitalize() if status in {"connected", "authenticated", "unavailable"} else words
 
 
 def _status_html(status: str) -> str:

--- a/packages/screamingface/src/screamingface/_ui/connections.py
+++ b/packages/screamingface/src/screamingface/_ui/connections.py
@@ -13,7 +13,7 @@ from screamingface._ui.connection_state import (
 )
 from screamingface._ui.connection_view import (
     _NotebookConnectionView,
-    _provider_status,
+    _provider_presentation,
     static_panel_html,
 )
 from screamingface._ui.engine_origin import _is_hosted_engine
@@ -173,7 +173,10 @@ class ConnectionPanel:
         provider_mutations_enabled = self._state.provider_mutations_enabled
         statuses = ", ".join(
             f"{item.provider}="
-            f"{_provider_status(item, provider_mutations_enabled=provider_mutations_enabled)}"
+            + _provider_presentation(
+                item,
+                provider_mutations_enabled=provider_mutations_enabled,
+            ).status_class
             for item in self._state.connections
         )
         access = (

--- a/packages/screamingface/tests/test_connection_panel.py
+++ b/packages/screamingface/tests/test_connection_panel.py
@@ -912,8 +912,8 @@ def test_authenticated_hosted_provider_rows_show_caller_availability_without_con
     root.close()
 
 
-@pytest.mark.parametrize("status", ["pending", "needs_reauth", "error"])
-def test_hosted_provider_non_available_status_is_preserved_without_source(status: str) -> None:
+@pytest.mark.parametrize("status", ["not_connected", "pending", "needs_reauth", "error"])
+def test_hosted_non_connected_wire_states_project_to_unavailable(status: str) -> None:
     connection = sf.Connection(
         provider="future",
         display_name="Future Provider",
@@ -925,13 +925,16 @@ def test_hosted_provider_non_available_status_is_preserved_without_source(status
     panel = _hosted_panel(connection)
     root = panel.widget()
 
-    expected = status.replace("_", " ")
+    expected_cell = (
+        "<div class='sf-connections__status unavailable'><i class='sq'></i>Unavailable</div>"
+    )
+    widget_text = _text(root)
     html = panel._repr_html_()
-    assert expected in _text(root)
-    assert expected in html
-    assert "Available via ScreamingFace" not in _text(root)
+    assert widget_text.count(expected_cell) == 1
+    assert html.count(expected_cell) == 1
+    assert "Available via ScreamingFace" not in widget_text
     assert "Available via ScreamingFace" not in html
-    assert f"future={status}" in repr(panel)
+    assert "future=unavailable" in repr(panel)
     assert [button.description for button in _buttons(root)] == ["Log out"]
     root.close()
 

--- a/packages/screamingface/tests/test_connection_panel.py
+++ b/packages/screamingface/tests/test_connection_panel.py
@@ -95,6 +95,20 @@ def _panel(client: object) -> sf.ConnectionPanel:
     return sf.ConnectionPanel(cast(Any, client))
 
 
+def _hosted_panel(*connections: sf.Connection) -> sf.ConnectionPanel:
+    class Connections:
+        def list(self) -> tuple[sf.Connection, ...]:
+            return connections
+
+    class HostedClient:
+        engine_url = "https://fusion.dev.screamingface.ai"
+        authenticated = True
+        authenticating = False
+        connections = Connections()
+
+    return _panel(HostedClient())
+
+
 async def _wait_for_button(widget: widgets.Widget, description: str) -> None:
     for _ in range(100):
         if [button.description for button in _buttons(widget)] == [description]:
@@ -861,7 +875,7 @@ def test_non_screamingface_hosted_engine_shows_a_neutral_label_without_the_mark(
     root.close()
 
 
-def test_authenticated_hosted_provider_rows_show_managed_availability_without_controls() -> None:
+def test_authenticated_hosted_provider_rows_show_caller_availability_without_controls() -> None:
     connected = sf.Connection(
         provider="openrouter",
         display_name="OpenRouter",
@@ -878,34 +892,47 @@ def test_authenticated_hosted_provider_rows_show_managed_availability_without_co
         auth_method=None,
         account_label=None,
     )
-
-    class Connections:
-        def list(self) -> tuple[sf.Connection, ...]:
-            return (connected, caller_disconnected)
-
-    class HostedClient:
-        engine_url = "https://fusion.dev.screamingface.ai"
-        authenticated = True
-        authenticating = False
-        connections = Connections()
-
-    panel = _panel(HostedClient())
+    panel = _hosted_panel(connected, caller_disconnected)
     root = panel.widget()
 
     text = _text(root)
     html = panel._repr_html_()
     representation = repr(panel)
     assert [button.description for button in _buttons(root)] == ["Log out"]
-    assert "Available via ScreamingFace" in text
-    assert "Available via ScreamingFace" in html
-    assert text.count("Connected") == 2
-    assert "unavailable" not in text
-    assert "unavailable" not in html
+    assert text.count("Available via ScreamingFace") == 1
+    assert html.count("Available via ScreamingFace") == 1
+    assert text.count("Connected") == 1
+    assert "Unavailable" in text
+    assert "Unavailable" in html
     assert "private-account@example.com" not in text
     assert "private-account@example.com" not in html
     assert "openrouter=connected" in representation
-    assert "anthropic=connected" in representation
+    assert "anthropic=unavailable" in representation
     assert "not_connected" not in representation
+    root.close()
+
+
+@pytest.mark.parametrize("status", ["pending", "needs_reauth", "error"])
+def test_hosted_provider_non_available_status_is_preserved_without_source(status: str) -> None:
+    connection = sf.Connection(
+        provider="future",
+        display_name="Future Provider",
+        auth_methods=("oauth",),
+        status=cast(Any, status),
+        auth_method=None,
+        account_label=None,
+    )
+    panel = _hosted_panel(connection)
+    root = panel.widget()
+
+    expected = status.replace("_", " ")
+    html = panel._repr_html_()
+    assert expected in _text(root)
+    assert expected in html
+    assert "Available via ScreamingFace" not in _text(root)
+    assert "Available via ScreamingFace" not in html
+    assert f"future={status}" in repr(panel)
+    assert [button.description for button in _buttons(root)] == ["Log out"]
     root.close()
 
 


### PR DESCRIPTION
## Summary

- trust the hosted Engine caller-scoped provider availability instead of forcing every provider to Connected
- show Connected only for connected; project not_connected, pending, needs_reauth, and error to the quiet Unavailable state
- retain Available via ScreamingFace only for connected hosted providers
- keep every hosted API-key, OAuth, connect, and disconnect control hidden
- centralize status class, user label, and source in one presentation projection
- preserve local loopback BYOK wire states, presentation, and controls

## Dependency

Engine PR #702 is merged. This branch is rebased directly onto the merged Engine contract.

## Test plan

- 39 focused connection-panel tests passed after the rebase
- exact status-cell tests cover every hosted non-connected wire state across static HTML, ipywidgets, and repr
- complete screamingface gate runner passed Ruff, format, Pyright, 95% coverage tests, notebook checks, build, and distribution checks after the rebase
- hosted owner smoke test passed against fusion.dev.screamingface.ai
- append-only check skipped only for owner/reviewer-approved replacements of OME-883 old all-hosted-connected assertion and the weak raw-status substring assertion; no gate configuration changed

## Screenshots

Owner verified the hosted connection panel against the development Engine.

Asana: none

Refs: OME-960