### PR TITLE
feat(aigateway): cache Hugging Face router responses

### DIFF
--- a/apps/aigateway/DEPLOYMENT.md
+++ b/apps/aigateway/DEPLOYMENT.md
@@ -172,12 +172,38 @@ by every caller of the gateway**. The Helm chart enables it by default; set the 
 opt out. The standalone app default remains off. Enabling it is a decision about data sharing, not
 a performance setting.
 
-**It is not gateway-wide.** Only **anthropic** and **openrouter** can be served from cache in this
-release. Requests to **antigravity**, **codex**, **gemini-cli**, **huggingface** and **ollama**
-bypass it entirely and always dispatch. Caching a provider requires that provider to declare what
-*it* contributes to the upstream call (`global_cache_projection`), and those five inherit the
-bypassing default, so there is nothing safe to key on. This is a deliberate scope decision with
-follow-up work per provider: expect a 100% miss rate on those five and do not read it as a fault.
+**It is not gateway-wide.** Only **anthropic**, **openrouter** and **huggingface** can be served
+from cache in this release, and huggingface only *partly* (see below). Requests to
+**antigravity**, **codex**, **gemini-cli** and **ollama** bypass it entirely and always dispatch.
+Caching a provider requires that provider to declare what *it* contributes to the upstream call
+(`global_cache_projection`), and those four inherit the bypassing default, so there is nothing safe
+to key on. Expect a 100% miss rate on those four and do not read it as a fault.
+
+#### Hugging Face: only a pinned provider participates
+
+A Hugging Face model id may end in `:<suffix>`, and the suffix means one of two different things.
+Only the first is cacheable:
+
+| Request | Cached? | Why |
+| --- | --- | --- |
+| `huggingface/<org>/<model>:<provider>` — a **known partner slug** (`:novita`, `:groq`, …) | **yes** | one fixed backend answers, so the stored row describes the next identical call |
+| `huggingface/<org>/<model>` — no suffix | no | the router picks a backend **per request** (equivalent to `:fastest`) |
+| `:fastest`, `:cheapest`, `:preferred` — routing **policies** | no | a selection rule, not a backend. `:preferred` follows the **requesting account's** preference order, so it is identity-dependent and the global key is identity-free |
+| an unrecognised suffix | no | fail closed — unknown means unproven |
+| any request from a process with unsafe ambient LiteLLM state, or with `router_api_base` overridden away from the official router | no | the projection would describe a call this process is not making |
+
+Bypassing requests **still dispatch normally** — this narrows caching, never validity. The
+allowlist is a reviewed transcription of the Hugging Face partner table, so a newly launched
+partner is simply uncached until it is added.
+
+**Operator consequence — cross-account replay of gated repositories.** A cacheable Hugging Face
+response is stored globally and replayed to any caller whose request keys identically, **before
+any credential is resolved**. Many Hugging Face repositories are *gated*: access requires
+per-account licence acceptance. A row filled by an account that accepted the licence can therefore
+be served to an account that never did. The cache changes **who may read a stored answer**, never
+what goes on the wire — but if your deployment serves multiple tenants and relies on Hugging Face
+gating for licence compliance, that is a decision to take deliberately, not a side effect to
+discover. Set `config.requestCache.enabled=false` to opt out.
 
 ### What it does
 

--- a/apps/aigateway/DEPLOYMENT.md
+++ b/apps/aigateway/DEPLOYMENT.md
@@ -172,12 +172,34 @@ by every caller of the gateway**. The Helm chart enables it by default; set the 
 opt out. The standalone app default remains off. Enabling it is a decision about data sharing, not
 a performance setting.
 
-**It is not gateway-wide.** Only **anthropic**, **openrouter** and **huggingface** can be served
-from cache in this release, and huggingface only *partly* (see below). Requests to
-**antigravity**, **codex**, **gemini-cli** and **ollama** bypass it entirely and always dispatch.
-Caching a provider requires that provider to declare what *it* contributes to the upstream call
-(`global_cache_projection`), and those four inherit the bypassing default, so there is nothing safe
-to key on. Expect a 100% miss rate on those four and do not read it as a fault.
+**It is not gateway-wide.** Of the eight registered providers, **anthropic**, **openai**,
+**openrouter** and eligible **huggingface** requests can be served from cache in this release —
+huggingface only *partly* (see below). Requests to **antigravity**, **codex**, **gemini-cli** and
+**ollama** bypass it entirely and always dispatch. Caching a provider requires that provider to
+declare what *it* contributes to the upstream call (`global_cache_projection`), and those four
+inherit the bypassing default, so there is nothing safe to key on. Expect a 100% miss rate on
+those four and do not read it as a fault.
+
+**The four cacheable providers are not gated the same way, and the difference matters because this
+table describes the pre-credential cache stage itself — not checks that run only after a miss:**
+
+| Provider | Provider switch checked before cache | Additional cache-participation gate |
+| --- | --- | --- |
+| `anthropic` | none | none beyond projection and shared request eligibility |
+| `openai` | none | requested-model and ambient-state runtime certification |
+| `openrouter` | its own enabled flag | none beyond projection and shared request eligibility |
+| `huggingface` | none | pinned-backend rule below, router-base certification and ambient-state runtime certification |
+
+OpenRouter does have additional dispatch-time protection against unsafe ambient LiteLLM state, but
+that runs only on a miss. A cache hit returns before dispatch, so it is not a cache-participation
+gate and is deliberately not represented as one here. Anthropic likewise has no separate
+participation override; it inherits the default after its projection accepts the request.
+
+Direct **openai** is the one to read twice: it has **no OpenRouter-style operator switch**, so
+`requestCache.enabled` is the only lever that turns its caching off. That is not the same as
+caching unconditionally — its runtime guard still declines per request when the model is
+ambiently aliased or the process carries LiteLLM state that would reroute the call. Plan for
+OpenAI responses to be cached and cross-account replayable whenever the cache is on.
 
 #### Hugging Face: only a pinned provider participates
 
@@ -306,6 +328,19 @@ FROM request_cache_entries;
 Watch this table's size like any other unbounded table and prune deliberately (for example by
 `created_at`, or by `hit_count = 0` for rows nothing has ever reused). Pruning is safe at any time:
 a deleted row is a cache miss, and the next caller re-fills it.
+
+**Rows carry the provider that filled them, so a reset does not have to be all-or-nothing.** To
+drop only Hugging Face rows — after a partner-allowlist correction, say, or to retire replayable
+gated-repository answers — without discarding every other provider's cache:
+
+```sql
+DELETE FROM request_cache_entries WHERE provider = 'huggingface';
+```
+
+That removes Hugging Face cache rows and nothing else; substitute any other provider name to
+narrow the same way. It is a targeted version of the full reset, not a different mechanism, and
+carries the same guarantee: the next caller re-fills what was removed. There is no runtime
+endpoint for this — it is a deliberate database operation, on purpose.
 
 ### Plaintext storage boundary
 

--- a/apps/aigateway/charts/aigateway/README.md
+++ b/apps/aigateway/charts/aigateway/README.md
@@ -61,6 +61,13 @@ request, shared by every caller. Two callers who send the identical request get 
 response, and the second one's provider credential is never touched. The chart ships `true`; set
 `config.requestCache.enabled=false` to opt out.
 
+**Hugging Face caveat.** Hugging Face participates only for ids pinned to a known partner provider
+(`…:novita`, `…:groq`, …). Unsuffixed ids and the routing policies `:fastest` / `:cheapest` /
+`:preferred` always dispatch, because the backend is chosen per request and `:preferred` follows the
+requesting account's own preference order. For the ids that do cache, gated-repository responses
+replay across accounts before any credential is resolved — see consequence 6 on
+`config.requestCache` in `values.yaml`.
+
 `true` makes the cache available immediately. Reading and writing the response row has no
 secret-provider, encryption-key or canary dependency. Effective-key construction may still read the
 caller's encrypted profile-default index; it never resolves the selected provider credential on a hit.

--- a/apps/aigateway/charts/aigateway/values-prod.yaml
+++ b/apps/aigateway/charts/aigateway/values-prod.yaml
@@ -27,7 +27,7 @@ config:
   # values.
   openrouter:
     enabled: true
-  # Re-state the chart's default-on global response cache explicitly for production. Read the five
+  # Re-state the chart's default-on global response cache explicitly for production. Read the six
   # consequences documented on `config.requestCache` in `values.yaml`; the load-bearing ones are
   # that any two callers sending the identical request get the identical stored response, and that
   # rows never expire.
@@ -37,6 +37,11 @@ config:
   # `credential_blobs`; `auth.secretKeyKey` still governs those credentials, not response-cache rows.
   #
   # THE BLAST RADIUS: every hosted user's responses share one indefinitely retained corpus.
+  #
+  # HUGGING FACE: provider-pinned ids (`…:novita`) cache and replay across accounts; routing
+  # policies (`:fastest` / `:cheapest` / `:preferred`) and unsuffixed ids do not. Gated-repository
+  # responses can therefore reach an account that never accepted the licence — consequence 6 in
+  # `values.yaml`.
   requestCache:
     enabled: true
 

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -98,7 +98,7 @@ config:
   # gets, whoever they are.
   #
   # ON BY DEFAULT for chart deployments. This is a product decision about data sharing, not a
-  # performance knob, so read all five consequences before deploying it; set `enabled: false` to
+  # performance knob, so read all six consequences before deploying it; set `enabled: false` to
   # opt the deployment out:
   #
   #   1. CROSS-USER REPLAY. Two callers who send the identical request receive the identical stored

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -117,6 +117,16 @@ config:
   #      refused: the gateway does not gate the cache on the auth mode. It is a posture to
   #      understand before enabling the cache where authentication is off.
   #
+  #   6. HUGGING FACE GATED REPOSITORIES REPLAY ACROSS ACCOUNTS. Hugging Face participates for
+  #      requests pinned to a KNOWN partner provider (`…:novita`, `…:groq`, …). Unsuffixed ids and
+  #      the routing policies `:fastest` / `:cheapest` / `:preferred` are NOT cached, because the
+  #      backend is chosen per request and `:preferred` follows the requesting ACCOUNT's
+  #      preference order. For the ids that DO cache: many Hugging Face repositories are *gated*
+  #      and require per-account licence acceptance, and a cache hit returns BEFORE any credential
+  #      is resolved — so a row filled by an account that accepted the licence can be served to an
+  #      account that never did. If you rely on Hugging Face gating for licence compliance across
+  #      tenants, decide this deliberately. See "The Global Response Cache" in DEPLOYMENT.md.
+  #
   # Callers can opt a single request out with the `use-cache=false` cache control.
   requestCache:
     enabled: true

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/global_cache.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/global_cache.py
@@ -55,7 +55,7 @@ from .settings import OFFICIAL_ROUTER_API_BASE, pinned_router_target
 #   * pinning the base short-circuits ``_fetch_inference_provider_mapping``, whose lru-cached,
 #     env-keyed lookup would otherwise make the upstream model not a function of the request
 #     (``transformation.py:131-132`` returns early when ``litellm_params["api_base"]`` is set).
-#   * the ambient-LiteLLM conditions enumerated in ``plugin._has_unsafe_litellm_global_state``.
+#   * the ambient-LiteLLM conditions enumerated in ``runtime_guard.unsafe_litellm_global_state``.
 #     This revision is only meaningful for a process where none of them held; participation is
 #     what enforces that, and widening the accepted set is a mandatory bump here.
 #

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/global_cache.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/global_cache.py
@@ -1,0 +1,153 @@
+"""OME-791 — HuggingFace's PURE projection of what it will send, for the global cache.
+
+FEATURE: one globally shared exact-request cache (OME-305). Until this module existed every
+``huggingface/*`` request bypassed at the projection step, inheriting ``CacheBypass`` from
+``ProviderPluginBase``, so an identical benchmark re-run paid full price every time.
+
+STORY: as a benchmark operator I re-run a suite against a backend-pinned HF model from a
+second account and the identical calls come back from the first run's rows — no second
+dispatch, and the second account's HF token is never read.
+
+AIDEV-NOTE: this lives OUTSIDE ``plugin.py`` for the same reason OpenRouter's and OpenAI's do.
+The projection must be PURE — no I/O, no clock, no environment, no credential, no identity, no
+``self.settings`` — while ``plugin.py`` is where every impure thing this provider does is wired,
+including the participation gate that reads ``settings.router_api_base`` and LiteLLM's process
+globals. Separate modules make that boundary visible to a reader and mean the registry-wide
+purity sweep in ``tests/unit/test_global_cache_projection_purity`` is checking a file that
+contains nothing else.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aigateway.core.cache_ports import PROJECTION_BYPASS_REASON, CacheBypass
+
+from .settings import OFFICIAL_ROUTER_API_BASE, pinned_router_target
+
+# OME-791: the revision of THIS plugin's output-affecting preparation, as reported by
+# ``global_cache_projection``.
+#
+# INVARIANT: bump it whenever what reaches the HF router for an UNCHANGED request changes.
+# Rows have no expiry and survive deployments, so a bump is the only thing that abandons a
+# generation instead of re-serving it under semantics this module no longer implements.
+#
+# WHY it is separate from ``parameters._REVISION``: that one versions what a caller may say
+# and where each value lands; this one versions what the boundary adds on its own. Collapsing
+# them would make every rule edit look like a wire change.
+#
+# WHAT THIS REVISION COVERS THAT ``prepared`` CANNOT (ruling 34's "fold it in and say so").
+# The key material is hashed as JSON, so no live object and no ambient condition can appear in
+# it. These guarantees are carried by the revision string alone, all verified against the
+# installed litellm 1.97.0 in this worktree's venv:
+#
+#   * the HF transform passes the POST-STRIP model to the wire verbatim, so
+#     ``resolved_model`` below really is the id the router resolves
+#     (``llms/huggingface/chat/transformation.py:123-156``; pinned at the HTTP wire by
+#     ``tests/unit/huggingface/test_huggingface_dispatch.py``).
+#   * the ``{api_base}/chat/completions`` URL shape, including the ``rstrip("/")``
+#     normalisation applied before the suffix is appended (``transformation.py:26-38``).
+#   * a non-None ``api_base`` WINS over litellm's ambient ``HF_API_BASE`` /
+#     ``HUGGINGFACE_API_BASE`` environment fallbacks — ``get_complete_url`` tests
+#     ``if api_base is not None`` ahead of the ``elif os.getenv(...)`` branch
+#     (``transformation.py:81-99``, same read at ``:69-79``). This is what makes the projected
+#     base a promise rather than a hope.
+#   * pinning the base short-circuits ``_fetch_inference_provider_mapping``, whose lru-cached,
+#     env-keyed lookup would otherwise make the upstream model not a function of the request
+#     (``transformation.py:131-132`` returns early when ``litellm_params["api_base"]`` is set).
+#   * the ambient-LiteLLM conditions enumerated in ``plugin._has_unsafe_litellm_global_state``.
+#     This revision is only meaningful for a process where none of them held; participation is
+#     what enforces that, and widening the accepted set is a mandatory bump here.
+#
+# A litellm upgrade touching any of the above is a mandatory bump.
+GLOBAL_CACHE_ADAPTER_REVISION = "huggingface-global-cache-2026-08"
+
+
+def project_global_cache_request(body: dict[str, Any]) -> dict[str, Any] | CacheBypass:
+    """What HuggingFace will send, as a deterministic function of the body alone.
+
+    INVARIANT: PURE. No I/O, no clock, no randomness, no credential, no identity, no settings
+    read. The same request keys identically in every deployment — which is what lets one row
+    be shared globally instead of partitioned per host. The operator-configurable router base
+    is handled by declining PARTICIPATION, never by reading it here (plan D3).
+
+    INVARIANT: TOTAL. Every input is either a projection or a ``CacheBypass``; nothing raises.
+    A projection may never fail a request, only decline to key it.
+
+    INVARIANT (owner-approved MVP semantics): EVERY route-valid backend-pinned id projects,
+    whether or not it appears in ``default_models``. The catalog publishes; it does not admit.
+    Reading ``self.settings.default_models`` here would break purity outright — one host's seed
+    list would make its keys differ from another's while each host's own determinism test still
+    passed.
+
+    ACCEPTED CONSEQUENCE — a HIT re-checks nothing. The router validates model existence,
+    backend availability and caller access on the MISS that filled the row; a later hit performs
+    no availability and no access check. So an exact replay may still answer after a model has
+    been withdrawn, a backend has stopped serving it, or the caller has lost access. For HF this
+    also has a licensing dimension recorded in the spec: most seeds are GATED repositories whose
+    access requires per-account license acceptance, so a row filled by an account that accepted a
+    license can be served to one that never did. That is the approved exact-replay/cross-account
+    behaviour, escalated to the owner rather than decided here: the cache changes who may READ a
+    stored answer, never what goes on the wire.
+    """
+    model = body.get("model")
+    # WHY the isinstance guard comes FIRST: ``pinned_router_target`` reaches
+    # ``_validate_model_slug``, which calls ``.startswith`` on its argument and therefore
+    # raises AttributeError for None, int, dict or list. Core would swallow that into a silent
+    # permanent bypass, but this function's contract is TOTAL, so it is guarded here where the
+    # totality test can see it.
+    if not isinstance(model, str):
+        return CacheBypass(reason=PROJECTION_BYPASS_REASON)
+    target = pinned_router_target(model)
+    if target is None:
+        # Two distinct classes land here, deliberately sharing one answer:
+        #
+        # 1. a MALFORMED id, which ``prepare_chat_body``'s downstream handler would refuse.
+        #    Sharing ``_validate_model_slug`` with the dispatch path is what stops a stored row
+        #    from answering 200 for a request the gateway must refuse — the cache is read BEFORE
+        #    preparation, so the two predicates cannot be allowed to drift apart.
+        # 2. an UNSUFFIXED id, which dispatches perfectly well. It is refused because without
+        #    ``:<backend>`` the router picks a provider PER REQUEST, so no single upstream call
+        #    describes the next one. Replaying one backend's answer for a request that would
+        #    have gone elsewhere corrupts model attribution — for a benchmark product that is a
+        #    wrong answer, not a stale one.
+        #
+        # AIDEV-NOTE: OBSERVED TO FIRE. This guard was neutralised on 2026-08-20 and
+        # ``huggingface/deepseek-ai/DeepSeek-R1`` (unsuffixed) was pushed through
+        # ``build_global_cache_plan``. Observed symptom, not predicted: it projected
+        # ``resolved_model="deepseek-ai/DeepSeek-R1:"`` — a bogus EMPTY backend — and produced
+        # the real, storable key hash
+        # ``017a1b3f728f1ad79882d705856bbf4679bc7cb4d6292760bdc7ad7303ac9e21``. So the failure
+        # mode is not a decline; it is a permanent row keyed under a model id that names no
+        # backend, replayable to any later request for that repo whichever backend the router
+        # would have picked. ``test_an_unsuffixed_id_bypasses_even_though_it_dispatches_fine``
+        # failed as required. Guard restored.
+        return CacheBypass(reason=PROJECTION_BYPASS_REASON)
+    repo, backend = target
+    return {
+        # The UPSTREAM id: litellm strips the ``huggingface/`` prefix and passes the remainder
+        # to the wire verbatim. The caller's prefixed string is keyed separately by the core as
+        # ``requested_model``, so nothing is lost by narrowing to the upstream form here.
+        #
+        # INVARIANT: the ``:<backend>`` suffix is RETAINED. It selects which inference provider
+        # answers, so it is output-affecting; keeping it in ``resolved_model`` is what makes two
+        # backends for one repo key differently as a structural consequence, with no separate
+        # mechanism to keep in sync.
+        "resolved_model": f"{repo}:{backend}",
+        "provider_adapter_revision": GLOBAL_CACHE_ADAPTER_REVISION,
+        # INVARIANT: a FRESH dict per call. The core hashes ``prepared`` whole and does NOT copy
+        # it (``global_eligibility._projected`` returns it uncopied), so a shared module-level
+        # table would let one reader alter every later request's key material.
+        #
+        # WHY it participates in the key even though it is a constant: ``prepared`` is rendered
+        # WHOLESALE into the canonical mapping — it is not filtered against
+        # ``EXCLUDED_TRANSPORT_FIELDS``, which governs the caller's body rather than a
+        # projection's output. Given participation gating, every keying deployment sends this
+        # same base, so it discriminates nothing TODAY; it stays because it is the truthful
+        # statement of what dispatch sends, and because loosening the gate later would then find
+        # the key already correct instead of needing a retro-fit.
+        #
+        # ``api_key`` and ``extra_headers`` are absent on purpose: the former is stripped and
+        # core-excluded, the latter is a dispatch-control field a caller cannot set.
+        "prepared": {"api_base": OFFICIAL_ROUTER_API_BASE},
+    }

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/parameters.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/parameters.py
@@ -43,26 +43,31 @@ from aigateway.core.standard_parameters import (
 _AUTH: tuple[AuthMode, ...] = ("api_key",)
 # Bump when a projection's semantics change; folds into the contract digests.
 
-# AIDEV-NOTE (OME-305, owner decision B — READ BEFORE CHANGING A ``cache_behavior``).
-# Every rule below states ``cache_behavior="bypass"`` EXPLICITLY. That is a disposition,
-# not an oversight, and it is not a judgement about the parameter: each of these values
-# is output-affecting and WOULD have to be keyed for a cached answer to be correct.
+# AIDEV-NOTE (OME-305 / OME-791 — READ BEFORE CHANGING A ``cache_behavior``).
+# The promotion this block used to instruct HAS BEEN DONE. All TWELVE rules below are keyed,
+# and they are backed by a real ``global_cache_projection`` in ``global_cache.py``.
 #
-# The reason they are not keyed is that THIS PROVIDER DOES NOT IMPLEMENT
-# ``global_cache_projection`` — it inherits the ``CacheBypass`` default from
-# ``ProviderPluginBase``. While that is true, every request to this provider bypasses
-# the cache at the projection step regardless of any rule, so declaring ``keyed`` here
-# would change no behaviour while advertising a cacheable parameter to callers that can
-# never be cached. ``test_a_provider_that_declares_a_keyed_rule_backs_it_with_a_real_projection``
-# in ``tests/unit/test_global_cache_registry_conformance.py`` is what enforces that.
+# THE ORDER WAS THE POINT, and it is enforced rather than remembered:
+# ``test_a_provider_that_declares_a_keyed_rule_backs_it_with_a_real_projection`` refuses a
+# keyed flip while a provider still inherits the ``CacheBypass`` default, and its partner
+# ``test_a_bare_request_is_cacheable_exactly_when_the_provider_has_a_projection`` is an IFF —
+# so the projection may not be removed while these rules stay keyed either. If you are
+# reverting this promotion, revert BOTH halves in one change.
 #
-# TO PROMOTE THESE: implement ``global_cache_projection`` for this provider FIRST, then
-# flip these to ``keyed`` in the same change. The order matters — the conformance sweep
-# will refuse the flip on its own, which is the intended guard rail rather than an
-# obstacle. Anthropic and OpenRouter are the two providers that have the projection and
-# therefore carry keyed rules today.
+# WHAT KEYED COMMITS TO: each value below is output-affecting, so it must enter the cache key
+# for a replayed answer to be correct. Every keyed path carries a concrete key-difference proof
+# in ``tests/unit/huggingface/test_huggingface_route_global_cache.py``, and a meta-test there
+# derives the keyed set from THIS table — so a new keyed path cannot land without its proof,
+# and an accidental promotion fails loudly rather than silently widening what is shared.
+#
+# CALLER-VISIBLE: ``cache_behavior`` and ``projection_revision`` both feed the published
+# contract digest (``core/model_parameter_contract.py:78``), so touching either moves every HF
+# model's ``contract_id``.
 
-_REVISION = "huggingface-2026-07"
+# INVARIANT: distinct from ``global_cache.GLOBAL_CACHE_ADAPTER_REVISION`` on purpose. THIS one
+# versions what a caller may say and where each value lands; that one versions what the
+# boundary adds on its own. Collapsing them would make every rule edit look like a wire change.
+_REVISION = "huggingface-2026-08"
 
 _HF_TOP_LOGPROBS_SCHEMA = ParameterSchema(
     type="integer",
@@ -83,14 +88,14 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
         "temperature",
         auth_modes=_AUTH,
         schema=TEMPERATURE_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     direct_rule(
         "max_tokens",
         auth_modes=_AUTH,
         schema=MAX_TOKENS_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     # direct: standard stop (string | array[string]); the OpenAI-compatible HF router
@@ -99,7 +104,7 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
         "stop",
         auth_modes=_AUTH,
         schema=STOP_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     # OME-584: structured output. The installed HuggingFaceChatConfig transform forwards
@@ -109,7 +114,7 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
         "response_format",
         auth_modes=_AUTH,
         schema=RESPONSE_FORMAT_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     # OME-585: seed + n sampling controls. The installed HuggingFaceChatConfig transform
@@ -119,14 +124,14 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
         "seed",
         auth_modes=_AUTH,
         schema=SEED_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     direct_rule(
         "n",
         auth_modes=_AUTH,
         schema=N_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     # OME-586: frequency_penalty + presence_penalty repetition controls. The installed
@@ -136,14 +141,14 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
         "frequency_penalty",
         auth_modes=_AUTH,
         schema=PENALTY_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     direct_rule(
         "presence_penalty",
         auth_modes=_AUTH,
         schema=PENALTY_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     # OME-595: logprobs + top_logprobs output-introspection controls. The installed
@@ -153,18 +158,28 @@ _RULES: tuple[ParameterProjectionRule, ...] = (
         "logprobs",
         auth_modes=_AUTH,
         schema=LOGPROBS_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     direct_rule(
         "top_logprobs",
         auth_modes=_AUTH,
         schema=_HF_TOP_LOGPROBS_SCHEMA,
-        cache_behavior="bypass",
+        cache_behavior="keyed",
         projection_revision=_REVISION,
     ),
     # OME-583: tools + tool_choice (OpenAI-native, §9 installed-transform proof).
-    *function_calling_rules(_TOOL_CAPABILITIES, auth_modes=_AUTH, projection_revision=_REVISION),
+    # INVARIANT: ``cache_behavior`` MUST be passed here. ``function_calling_rules`` defaults it
+    # to ``"bypass"`` (``standard_parameters.py:205``) and this call previously omitted it, so
+    # flipping the ten ``direct_rule`` calls above would leave TWO paths unkeyed. The helper
+    # emits ``tools`` AND ``tool_choice`` as separate rules (``standard_parameters.py:232-252``),
+    # which is why HF declares TWELVE keyed paths rather than ten.
+    *function_calling_rules(
+        _TOOL_CAPABILITIES,
+        auth_modes=_AUTH,
+        cache_behavior="keyed",
+        projection_revision=_REVISION,
+    ),
 )
 
 

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/parameters.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/parameters.py
@@ -56,9 +56,15 @@ _AUTH: tuple[AuthMode, ...] = ("api_key",)
 #
 # WHAT KEYED COMMITS TO: each value below is output-affecting, so it must enter the cache key
 # for a replayed answer to be correct. Every keyed path carries a concrete key-difference proof
-# in ``tests/unit/huggingface/test_huggingface_route_global_cache.py``, and a meta-test there
+# in ``tests/unit/huggingface/test_huggingface_global_cache_keys.py``, and a meta-test there
 # derives the keyed set from THIS table — so a new keyed path cannot land without its proof,
 # and an accidental promotion fails loudly rather than silently widening what is shared.
+#
+# AIDEV-NOTE: that module is the SINGLE home of the key-difference table. The proofs lived in
+# ``test_huggingface_route_global_cache.py`` until the OME-791 file split moved them, which
+# left a duplicate copy of the scaffolding behind that this note used to point at; running the
+# route module alone then looked green for a promotion it no longer checked. Add a new keyed
+# path's proof to the keys module, and do not reintroduce a second table anywhere.
 #
 # CALLER-VISIBLE: ``cache_behavior`` and ``projection_revision`` both feed the published
 # contract digest (``core/model_parameter_contract.py:78``), so touching either moves every HF

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -20,11 +20,8 @@ Key design points (validated against litellm 1.87.0):
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
-
-import litellm
 
 from aigateway.core.api_key_strategy import ApiKeyStrategy
 from aigateway.core.api_key_validation import ApiKeyValidator
@@ -51,11 +48,12 @@ from .discovery import (
 )
 from .global_cache import project_global_cache_request
 from .parameters import huggingface_chat_parameter_rules, huggingface_chat_parameter_tools
-from .settings import (
-    OFFICIAL_ROUTER_API_BASE,
-    HuggingFacePluginSettings,
-    pinned_router_target,
+from .runtime_guard import (
+    global_cache_decline_reason,
+    log_decline_once,
+    reset_decline_log,  # noqa: F401  (re-exported: tests reset the guard's per-process memo)
 )
+from .settings import HuggingFacePluginSettings, pinned_router_target
 
 if TYPE_CHECKING:
     from aigateway.core.chat_parameters import (
@@ -71,127 +69,6 @@ if TYPE_CHECKING:
 # Caller-supplied copies of these are stripped before the gateway injects its own
 # credential, so a client can never smuggle auth material to the upstream router.
 _CLIENT_AUTH_HEADER_NAMES = {"authorization", "x-api-key", "proxy-authorization"}
-
-logger = logging.getLogger(__name__)
-
-# Process-global LiteLLM controls that would make a stored HF row describe something other
-# than what dispatch actually sent.
-#
-# AIDEV-NOTE: this is the THIRD near-copy of this predicate in the repo — see
-# ``openai_provider/plugin.py::_has_unsafe_litellm_global_state`` and
-# ``openrouter_provider/litellm_controls.py::_has_unsafe_litellm_global_state``. Extracting one
-# core helper is the right cleanup and is deliberately deferred: the three condition sets are
-# NOT identical, because each provider's reachable litellm surface differs, so a shared helper
-# needs a union plus per-provider deltas. Until that exists, a change to any one of the three
-# should be mirrored in the others.
-_LITELLM_GLOBAL_RULE_FIELDS = (
-    # ``pre_call_rules``/``post_call_rules`` only ever RAISE
-    # (``litellm_core_utils/rules.py:29-58``), so they cannot corrupt a response body. They are
-    # guarded anyway for a different reason: a cache HIT returns at ``routes/chat.py:351``,
-    # BEFORE dispatch, so a deployment's configured refusal would be silently skipped for a
-    # stored row while still applying to a miss.
-    "pre_call_rules",
-    "post_call_rules",
-    # These change WHICH PARAMETERS reach the wire, so the same body produces two different
-    # upstream calls depending on process configuration.
-    "drop_params",
-    "additional_drop_params",
-)
-
-_LITELLM_GLOBAL_CALLBACK_FIELDS = (
-    "callbacks",
-    "input_callback",
-    "success_callback",
-    "failure_callback",
-    "_async_input_callback",
-    "_async_success_callback",
-    "_async_failure_callback",
-)
-
-
-def _unsafe_litellm_global_state() -> str | None:
-    """The ambient LiteLLM control that forbids sharing rows, or ``None`` if the process is clean.
-
-    WHY this gate exists — the load-bearing case, verified against installed litellm 1.97.0
-    rather than assumed. ``litellm.model_fallbacks`` is read at ``main.py:602``, INSIDE
-    ``async def acompletion`` (lines 388-698), which is exactly what HF's inherited
-    ``chat_completion`` calls:
-
-        fallbacks = fallbacks or litellm.model_fallbacks
-        if fallbacks is not None:
-            response = await async_completion_with_fallbacks(...)
-
-    ``fallback_utils.py:57,62`` then re-enters ``acompletion`` with ``model=fallback``. The
-    gateway strips a caller's ``fallbacks`` at ingress (``request_hardening.py:82``), so only
-    the process global can set it, and the fill path stores any answer carrying a
-    ``finish_reason`` without comparing its model to the key's. One process-global setting
-    therefore writes ANOTHER MODEL'S ANSWER under an HF key, in a store whose rows never
-    expire. That is a wrong answer, not a stale one — which is why a coarse provider-wide
-    decline is the right trade rather than an optimisation to be avoided.
-
-    ``litellm.headers`` is guarded because it reaches the HF wire SPECIFICALLY: ``main.py:2994``
-    inside ``_complete_huggingface`` does ``hf_headers = headers or litellm.headers``. Two
-    processes with different globals would key alike and send differently — ruling 34's exact
-    hazard.
-
-    AIDEV-NOTE: ``litellm.HuggingFaceChatConfig().get_config()`` was considered and REJECTED.
-    ``_complete_huggingface`` (``main.py:2971-3011``) reads no ``*Config.get_config()`` at all,
-    and ``BaseConfig.get_config`` reads only ``cls.__dict__``, so the condition cannot fire on
-    anything reaching the HF wire — while merely EVALUATING it instantiates the class, whose
-    ``__init__`` sets ``self.__class__._is_base_class = False`` and thus mutates litellm process
-    state on every request. A guard that protects nothing and mutates shared state is strictly
-    worse than no guard.
-    """
-    if getattr(litellm, "model_fallbacks", None):
-        return "litellm.model_fallbacks"
-    # Coarser than both exemplars, which test ``model in aliases``. WHY: this port's signature
-    # receives NO model (``_provider.py:278``), so the exact form is not expressible here. The
-    # coarse form is the fail-safe direction — it declines more often, never less — and the
-    # narrowing belongs to the OME-884 forward-merge, which changes this signature anyway.
-    if getattr(litellm, "model_alias_map", None):
-        return "litellm.model_alias_map"
-    if getattr(litellm, "headers", None):
-        return "litellm.headers"
-    if getattr(litellm, "proxy_auth", None) is not None:
-        return "litellm.proxy_auth"
-    for field in _LITELLM_GLOBAL_RULE_FIELDS:
-        if getattr(litellm, field, None):
-            return f"litellm.{field}"
-    for field in _LITELLM_GLOBAL_CALLBACK_FIELDS:
-        callbacks = getattr(litellm, field, None)
-        # ``"cache"`` is litellm's own bookkeeping entry, not a third-party observer; both
-        # existing exemplars permit it, and excluding it would decline in ordinary deployments.
-        if callbacks and any(callback != "cache" for callback in callbacks):
-            return f"litellm.{field}"
-    return None
-
-
-# WHY module state for logging: every decline path publishes the SAME wire reason
-# (``provider_projection``), so without a log an operator whose HF caching silently stopped has
-# no way to learn which check declined. But this runs per request, so an unconditional warning
-# would be its own operational problem. One line per condition per process is the compromise.
-_LOGGED_DECLINES: set[str] = set()
-
-
-def _log_decline_once(reason: str) -> None:
-    """Name the declining condition once per process, never the configured value.
-
-    INVARIANT: the TOKEN only. ``router_api_base`` can carry an internal hostname, and
-    ``litellm.headers`` can carry tenant or auth material, so neither value is ever logged.
-    """
-    if reason in _LOGGED_DECLINES:
-        return
-    _LOGGED_DECLINES.add(reason)
-    logger.warning(
-        "huggingface is not participating in the global cache: %s (this deployment's rows "
-        "are neither read nor written; requests dispatch normally)",
-        reason,
-    )
-
-
-def reset_decline_log() -> None:
-    """Clear the once-per-process log memo. For tests only."""
-    _LOGGED_DECLINES.clear()
 
 
 def _credential_service_for(profile_name: str) -> str:
@@ -380,40 +257,18 @@ class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
 
         INVARIANT: TOTAL in practice — ``global_plan.py:72-77`` swallows any raise here into
         non-participation, and the guard must never be the thing that fails a request.
+
+        AIDEV-NOTE (M5): the decision itself lives in ``runtime_guard.py`` — ONE Hugging Face
+        source of truth for every ambient and configuration condition. This hook only supplies
+        the deployment-local value the guard may not read for itself and reports the outcome.
         """
-        reason = self._global_cache_decline_reason()
+        reason = global_cache_decline_reason(
+            configured_router_api_base=self.settings.router_api_base
+        )
         if reason is None:
             return True
-        _log_decline_once(reason)
+        log_decline_once(reason)
         return False
-
-    def _global_cache_decline_reason(self) -> str | None:
-        """The condition that declines participation, or ``None`` to participate."""
-        # D3 — the operator-overridable router base. The projection emits the OFFICIAL constant
-        # unconditionally, so a deployment pointed anywhere else would key its requests as
-        # though they had gone to the official router and share rows with deployments that did.
-        # That is cross-endpoint contamination of a globally shared cache.
-        #
-        # WHY the comparison is NORMALISED rather than literal: litellm's
-        # ``_build_chat_completion_url`` does ``model_url.rstrip("/")`` before appending
-        # ``/chat/completions`` (``transformation.py:26-28``), so a trailing slash produces a
-        # byte-identical upstream call. A literal ``!=`` would silently disable caching for a
-        # deployment that is provably sending the same request. The normalisation stops there on
-        # purpose: this is a safety gate, so every accepted spelling must be provably
-        # wire-equivalent, not merely plausible. Anything else declines.
-        # AIDEV-NOTE: OBSERVED TO FIRE. This gate was neutralised on 2026-08-20 and
-        # ``test_a_row_filled_at_the_official_base_is_not_replayed_after_an_override`` was run.
-        # Observed symptom: the deployment configured for ``https://proxy.internal/v1`` was
-        # served ``X-AIGW-Cache: hit`` from the row a DIFFERENT deployment filled against the
-        # official router — a 200 carrying an answer its own upstream never produced, with no
-        # dispatch. That is the cross-endpoint contamination this gate exists to prevent, and it
-        # is silent on the wire. Gate restored.
-        configured = self.settings.router_api_base
-        if not isinstance(configured, str):
-            return "router_api_base"
-        if configured.rstrip("/") != OFFICIAL_ROUTER_API_BASE.rstrip("/"):
-            return "router_api_base"
-        return _unsafe_litellm_global_state()
 
     def cache_reference_from_cached_response(self, cached: Mapping[str, Any]) -> None:
         """No usage-accounting reference for HF — and saying so explicitly is REQUIRED.

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -242,7 +242,7 @@ class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
         """Delegate to the PURE module; see ``global_cache.py`` for the invariants."""
         return project_global_cache_request(body)
 
-    def participates_in_global_cache(self) -> bool:
+    def participates_in_global_cache(self, model: object = None) -> bool:
         """Whether THIS deployment's rows may be shared, given state the projection cannot see.
 
         INVARIANT: the projection describes a request sent to the OFFICIAL router by a process
@@ -261,7 +261,12 @@ class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
         AIDEV-NOTE (M5): the decision itself lives in ``runtime_guard.py`` — ONE Hugging Face
         source of truth for every ambient and configuration condition. This hook only supplies
         the deployment-local value the guard may not read for itself and reports the outcome.
+
+        OME-884 passes the raw model through this port. HF deliberately keeps the existing
+        deployment-wide fail-closed predicate for now; narrowing individual alias-map entries is
+        a separate cross-provider runtime-guard follow-up.
         """
+        del model
         reason = global_cache_decline_reason(
             configured_router_api_base=self.settings.router_api_base
         )

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -20,11 +20,15 @@ Key design points (validated against litellm 1.87.0):
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
+import litellm
+
 from aigateway.core.api_key_strategy import ApiKeyStrategy
 from aigateway.core.api_key_validation import ApiKeyValidator
+from aigateway.core.cache_ports import CacheBypass
 from aigateway.core.parameter_discovery import DiscoverySourceRef
 from aigateway.core.parameter_projection import IncompatibleParametersError
 from aigateway.core.plugin_base import (
@@ -45,8 +49,13 @@ from .discovery import (
     STATIC_SOURCE,
     discover_huggingface_snapshot,
 )
+from .global_cache import project_global_cache_request
 from .parameters import huggingface_chat_parameter_rules, huggingface_chat_parameter_tools
-from .settings import HuggingFacePluginSettings, pinned_router_target
+from .settings import (
+    OFFICIAL_ROUTER_API_BASE,
+    HuggingFacePluginSettings,
+    pinned_router_target,
+)
 
 if TYPE_CHECKING:
     from aigateway.core.chat_parameters import (
@@ -62,6 +71,127 @@ if TYPE_CHECKING:
 # Caller-supplied copies of these are stripped before the gateway injects its own
 # credential, so a client can never smuggle auth material to the upstream router.
 _CLIENT_AUTH_HEADER_NAMES = {"authorization", "x-api-key", "proxy-authorization"}
+
+logger = logging.getLogger(__name__)
+
+# Process-global LiteLLM controls that would make a stored HF row describe something other
+# than what dispatch actually sent.
+#
+# AIDEV-NOTE: this is the THIRD near-copy of this predicate in the repo — see
+# ``openai_provider/plugin.py::_has_unsafe_litellm_global_state`` and
+# ``openrouter_provider/litellm_controls.py::_has_unsafe_litellm_global_state``. Extracting one
+# core helper is the right cleanup and is deliberately deferred: the three condition sets are
+# NOT identical, because each provider's reachable litellm surface differs, so a shared helper
+# needs a union plus per-provider deltas. Until that exists, a change to any one of the three
+# should be mirrored in the others.
+_LITELLM_GLOBAL_RULE_FIELDS = (
+    # ``pre_call_rules``/``post_call_rules`` only ever RAISE
+    # (``litellm_core_utils/rules.py:29-58``), so they cannot corrupt a response body. They are
+    # guarded anyway for a different reason: a cache HIT returns at ``routes/chat.py:351``,
+    # BEFORE dispatch, so a deployment's configured refusal would be silently skipped for a
+    # stored row while still applying to a miss.
+    "pre_call_rules",
+    "post_call_rules",
+    # These change WHICH PARAMETERS reach the wire, so the same body produces two different
+    # upstream calls depending on process configuration.
+    "drop_params",
+    "additional_drop_params",
+)
+
+_LITELLM_GLOBAL_CALLBACK_FIELDS = (
+    "callbacks",
+    "input_callback",
+    "success_callback",
+    "failure_callback",
+    "_async_input_callback",
+    "_async_success_callback",
+    "_async_failure_callback",
+)
+
+
+def _unsafe_litellm_global_state() -> str | None:
+    """The ambient LiteLLM control that forbids sharing rows, or ``None`` if the process is clean.
+
+    WHY this gate exists — the load-bearing case, verified against installed litellm 1.97.0
+    rather than assumed. ``litellm.model_fallbacks`` is read at ``main.py:602``, INSIDE
+    ``async def acompletion`` (lines 388-698), which is exactly what HF's inherited
+    ``chat_completion`` calls:
+
+        fallbacks = fallbacks or litellm.model_fallbacks
+        if fallbacks is not None:
+            response = await async_completion_with_fallbacks(...)
+
+    ``fallback_utils.py:57,62`` then re-enters ``acompletion`` with ``model=fallback``. The
+    gateway strips a caller's ``fallbacks`` at ingress (``request_hardening.py:82``), so only
+    the process global can set it, and the fill path stores any answer carrying a
+    ``finish_reason`` without comparing its model to the key's. One process-global setting
+    therefore writes ANOTHER MODEL'S ANSWER under an HF key, in a store whose rows never
+    expire. That is a wrong answer, not a stale one — which is why a coarse provider-wide
+    decline is the right trade rather than an optimisation to be avoided.
+
+    ``litellm.headers`` is guarded because it reaches the HF wire SPECIFICALLY: ``main.py:2994``
+    inside ``_complete_huggingface`` does ``hf_headers = headers or litellm.headers``. Two
+    processes with different globals would key alike and send differently — ruling 34's exact
+    hazard.
+
+    AIDEV-NOTE: ``litellm.HuggingFaceChatConfig().get_config()`` was considered and REJECTED.
+    ``_complete_huggingface`` (``main.py:2971-3011``) reads no ``*Config.get_config()`` at all,
+    and ``BaseConfig.get_config`` reads only ``cls.__dict__``, so the condition cannot fire on
+    anything reaching the HF wire — while merely EVALUATING it instantiates the class, whose
+    ``__init__`` sets ``self.__class__._is_base_class = False`` and thus mutates litellm process
+    state on every request. A guard that protects nothing and mutates shared state is strictly
+    worse than no guard.
+    """
+    if getattr(litellm, "model_fallbacks", None):
+        return "litellm.model_fallbacks"
+    # Coarser than both exemplars, which test ``model in aliases``. WHY: this port's signature
+    # receives NO model (``_provider.py:278``), so the exact form is not expressible here. The
+    # coarse form is the fail-safe direction — it declines more often, never less — and the
+    # narrowing belongs to the OME-884 forward-merge, which changes this signature anyway.
+    if getattr(litellm, "model_alias_map", None):
+        return "litellm.model_alias_map"
+    if getattr(litellm, "headers", None):
+        return "litellm.headers"
+    if getattr(litellm, "proxy_auth", None) is not None:
+        return "litellm.proxy_auth"
+    for field in _LITELLM_GLOBAL_RULE_FIELDS:
+        if getattr(litellm, field, None):
+            return f"litellm.{field}"
+    for field in _LITELLM_GLOBAL_CALLBACK_FIELDS:
+        callbacks = getattr(litellm, field, None)
+        # ``"cache"`` is litellm's own bookkeeping entry, not a third-party observer; both
+        # existing exemplars permit it, and excluding it would decline in ordinary deployments.
+        if callbacks and any(callback != "cache" for callback in callbacks):
+            return f"litellm.{field}"
+    return None
+
+
+# WHY module state for logging: every decline path publishes the SAME wire reason
+# (``provider_projection``), so without a log an operator whose HF caching silently stopped has
+# no way to learn which check declined. But this runs per request, so an unconditional warning
+# would be its own operational problem. One line per condition per process is the compromise.
+_LOGGED_DECLINES: set[str] = set()
+
+
+def _log_decline_once(reason: str) -> None:
+    """Name the declining condition once per process, never the configured value.
+
+    INVARIANT: the TOKEN only. ``router_api_base`` can carry an internal hostname, and
+    ``litellm.headers`` can carry tenant or auth material, so neither value is ever logged.
+    """
+    if reason in _LOGGED_DECLINES:
+        return
+    _LOGGED_DECLINES.add(reason)
+    logger.warning(
+        "huggingface is not participating in the global cache: %s (this deployment's rows "
+        "are neither read nor written; requests dispatch normally)",
+        reason,
+    )
+
+
+def reset_decline_log() -> None:
+    """Clear the once-per-process log memo. For tests only."""
+    _LOGGED_DECLINES.clear()
 
 
 def _credential_service_for(profile_name: str) -> str:
@@ -228,6 +358,75 @@ class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
         # first, then we set our own; this keeps litellm on the request-local path.
         out["api_base"] = self.settings.router_api_base
         return out
+
+    # ---- OME-791: global exact-response cache (OME-305) ------------------------------
+
+    def global_cache_projection(self, body: dict[str, Any]) -> dict[str, Any] | CacheBypass:
+        """Delegate to the PURE module; see ``global_cache.py`` for the invariants."""
+        return project_global_cache_request(body)
+
+    def participates_in_global_cache(self) -> bool:
+        """Whether THIS deployment's rows may be shared, given state the projection cannot see.
+
+        INVARIANT: the projection describes a request sent to the OFFICIAL router by a process
+        with no ambient LiteLLM interference. This hook is what makes that description true, by
+        declining whenever it would not be. A ``False`` answer is fail-safe and LOSSLESS — it
+        suppresses the lookup without invalidating, rewriting or re-keying any stored row.
+
+        WHY the port licenses this to read deployment-local state (``_provider.py:299-317``)
+        while the projection may not: the projection's output is hashed into a globally shared
+        key, so anything it reads must be identical everywhere. Participation is a local
+        yes/no that never enters a key.
+
+        INVARIANT: TOTAL in practice — ``global_plan.py:72-77`` swallows any raise here into
+        non-participation, and the guard must never be the thing that fails a request.
+        """
+        reason = self._global_cache_decline_reason()
+        if reason is None:
+            return True
+        _log_decline_once(reason)
+        return False
+
+    def _global_cache_decline_reason(self) -> str | None:
+        """The condition that declines participation, or ``None`` to participate."""
+        # D3 — the operator-overridable router base. The projection emits the OFFICIAL constant
+        # unconditionally, so a deployment pointed anywhere else would key its requests as
+        # though they had gone to the official router and share rows with deployments that did.
+        # That is cross-endpoint contamination of a globally shared cache.
+        #
+        # WHY the comparison is NORMALISED rather than literal: litellm's
+        # ``_build_chat_completion_url`` does ``model_url.rstrip("/")`` before appending
+        # ``/chat/completions`` (``transformation.py:26-28``), so a trailing slash produces a
+        # byte-identical upstream call. A literal ``!=`` would silently disable caching for a
+        # deployment that is provably sending the same request. The normalisation stops there on
+        # purpose: this is a safety gate, so every accepted spelling must be provably
+        # wire-equivalent, not merely plausible. Anything else declines.
+        # AIDEV-NOTE: OBSERVED TO FIRE. This gate was neutralised on 2026-08-20 and
+        # ``test_a_row_filled_at_the_official_base_is_not_replayed_after_an_override`` was run.
+        # Observed symptom: the deployment configured for ``https://proxy.internal/v1`` was
+        # served ``X-AIGW-Cache: hit`` from the row a DIFFERENT deployment filled against the
+        # official router — a 200 carrying an answer its own upstream never produced, with no
+        # dispatch. That is the cross-endpoint contamination this gate exists to prevent, and it
+        # is silent on the wire. Gate restored.
+        configured = self.settings.router_api_base
+        if not isinstance(configured, str):
+            return "router_api_base"
+        if configured.rstrip("/") != OFFICIAL_ROUTER_API_BASE.rstrip("/"):
+            return "router_api_base"
+        return _unsafe_litellm_global_state()
+
+    def cache_reference_from_cached_response(self, cached: Mapping[str, Any]) -> None:
+        """No usage-accounting reference for HF — and saying so explicitly is REQUIRED.
+
+        AIDEV-NOTE: not decoration. ``plugins/taxonomy/session.py:374`` reaches this hook
+        through ``getattr`` inside a ``try/except Exception`` and there is no base-class
+        default, so a provider that simply omits it logs "cache-reference mapper failed
+        provider=huggingface" on EVERY hit — an operator-visible failure that never happened.
+        HF owns no usage-accounting strategy (unlike anthropic and openrouter, each of which has
+        a ``usage_accounting.py``), so there is nothing truthful to attach and ``None`` is the
+        honest answer. Building one is out of scope for OME-791.
+        """
+        return None
 
 
 PLUGIN = HuggingFaceProviderPlugin()

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/runtime_guard.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/runtime_guard.py
@@ -1,0 +1,263 @@
+"""OME-791 — the ambient certification behind Hugging Face's global-cache participation.
+
+FEATURE: one globally shared exact-request cache (OME-305). A stored row is replayed to any
+caller whose request keys identically, so a row is only safe to share if the process that filled
+it will send what the projection SAYS it sends. This module is that certification.
+
+STORY: as an operator I enable an unrelated LiteLLM process global — a proxy flag, a fallback
+list, a callback — and Hugging Face silently stops sharing rows instead of quietly storing
+answers that do not match their key.
+
+INVARIANT: TOTAL and FAIL-CLOSED. Every unknown, every unreadable secret and every raise is a
+DECLINE, never an exception into the request path. ``global_plan.py:72-77`` already swallows a
+raise here into non-participation, but relying on that would make the guard's own correctness
+unobservable, so totality is owned here.
+
+INVARIANT: a decline is LOSSLESS. It suppresses lookup and write-back for this deployment; it
+never invalidates, rewrites or re-keys a stored row, and it never fails a dispatch. Requests
+continue normally, uncached.
+
+AIDEV-NOTE (M5, partial remediation — read before "cleaning this up"). Sibling providers carry
+near-copies of this predicate (``openai_provider/plugin.py``,
+``openrouter_provider/litellm_controls.py``). Extracting ONE cross-provider core helper is the
+right end state and is deliberately NOT done here:
+
+  * the three condition sets are NOT identical — each provider's reachable litellm surface
+    differs, so a shared helper needs a union plus per-provider deltas;
+  * more importantly the RESPONSES differ. Hugging Face declines cache participation; some
+    sibling paths hard-fail dispatch. Copying a condition without its response would convert a
+    lossless cache decline into a refused request. Do NOT mirror these conditions mechanically
+    into another provider.
+  * OME-884 changes the sibling signatures and has not merged into this base.
+
+Repository-wide consolidation is therefore a FOLLOW-UP after OME-884 merges, when the final
+sibling signatures are available. Cross-provider duplication is NOT eliminated by this change —
+only the Hugging Face copy is now cohesive and single-sourced.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import litellm
+from litellm.secret_managers.main import get_secret_bool
+
+from .settings import OFFICIAL_ROUTER_API_BASE
+
+logger = logging.getLogger(__name__)
+
+# The environment/secret-backed switch that selects LiteLLM Proxy independently of the module
+# attribute. Named here because it is KEY-RELEVANT, not merely configuration.
+PROXY_SECRET_NAME = "USE_LITELLM_PROXY"
+
+# Decline tokens. INVARIANT: a token NEVER carries a configured value — see ``log_decline_once``.
+PROXY_SECRET_REASON = f"env.{PROXY_SECRET_NAME}"
+ROUTER_API_BASE_REASON = "router_api_base"
+UNREADABLE_AMBIENT_STATE_REASON = "litellm.runtime_state"
+
+# Process-global LiteLLM controls that reroute dispatch or change what reaches the wire, so a
+# stored row would describe something other than what this process actually sent.
+#
+# WHY ``model_fallbacks`` is the load-bearing case, verified against installed litellm 1.97.0
+# rather than assumed: it is read at ``main.py:602`` INSIDE ``async def acompletion``, which is
+# what HF's inherited ``chat_completion`` calls —
+#
+#     fallbacks = fallbacks or litellm.model_fallbacks
+#     if fallbacks is not None:
+#         response = await async_completion_with_fallbacks(...)
+#
+# ``fallback_utils.py:57,62`` then re-enters ``acompletion`` with ``model=fallback``. The gateway
+# strips a caller's ``fallbacks`` at ingress (``request_hardening.py:82``), so only the process
+# global can set it, and the fill path stores any answer carrying a ``finish_reason`` without
+# comparing its model to the key's. One process-global setting therefore writes ANOTHER MODEL'S
+# ANSWER under an HF key, in a store whose rows never expire. That is a wrong answer, not a stale
+# one — which is why a coarse provider-wide decline is the right trade.
+#
+# ``headers`` reaches the HF wire SPECIFICALLY: ``main.py:2994`` inside ``_complete_huggingface``
+# does ``hf_headers = headers or litellm.headers``. Two processes with different globals would
+# key alike and send differently — ruling 34's exact hazard.
+#
+# ``use_litellm_proxy`` (OME-791 B2) reroutes dispatch away from router.huggingface.co entirely:
+# ``LiteLLMProxyChatConfig._should_use_litellm_proxy_by_default`` is consulted at the TOP of
+# ``get_llm_provider`` (``get_llm_provider_logic.py:151``) and rewrites the provider to
+# ``litellm_proxy``. The projected ``api_base`` would then be a statement about an endpoint the
+# request never reached.
+#
+# ``disable_stop_sequence_limit`` (M1) changes the FINAL WIRE VALUE while the caller body and the
+# key stay byte-identical: litellm truncates a long ``stop`` list unless it is set.
+#
+# ``enable_json_schema_validation`` (M2) governs post-dispatch acceptance of a JSON-schema
+# ``response_format`` — which this provider KEYS. A cache hit returns before that validation runs,
+# so a row filled under one setting would bypass the refusal the other setting performs.
+LITELLM_DISPATCH_GLOBALS: tuple[str, ...] = (
+    "model_fallbacks",
+    # Coarser than the sibling exemplars, which test ``model in aliases``. WHY: this port's
+    # signature receives NO model (``_provider.py:278``), so the exact form is not expressible.
+    # The coarse form is the fail-safe direction — it declines more often, never less.
+    "model_alias_map",
+    "headers",
+    "use_litellm_proxy",
+    "disable_stop_sequence_limit",
+    "enable_json_schema_validation",
+)
+
+# ``pre_call_rules``/``post_call_rules`` only ever RAISE (``litellm_core_utils/rules.py:29-58``),
+# so they cannot corrupt a response body. They are guarded for a different reason: a cache HIT
+# returns at ``routes/chat.py:351`` BEFORE dispatch, so a deployment's configured refusal would
+# be silently skipped for a stored row while still applying to a miss. ``drop_params`` changes
+# WHICH PARAMETERS reach the wire, so one body produces two different upstream calls.
+#
+# AIDEV-NOTE (M8): ``additional_drop_params`` was previously listed here and does NOT exist as a
+# litellm module global on the installed 1.97.0 — it is a per-request kwarg. Guarding a
+# non-existent attribute is a no-op that reads like coverage. Verified absent via
+# ``hasattr(litellm, "additional_drop_params")``; ``test_every_guarded_global_exists_on_litellm``
+# now fails if any name here stops existing.
+LITELLM_RULE_GLOBALS: tuple[str, ...] = (
+    "pre_call_rules",
+    "post_call_rules",
+    "drop_params",
+)
+
+# Guarded on PRESENCE rather than truthiness: a configured-but-falsy auth object still means a
+# proxy auth path is wired up.
+LITELLM_PRESENCE_GLOBALS: tuple[str, ...] = ("proxy_auth",)
+
+LITELLM_CALLBACK_GLOBALS: tuple[str, ...] = (
+    "callbacks",
+    "input_callback",
+    "success_callback",
+    "failure_callback",
+    "_async_input_callback",
+    "_async_success_callback",
+    "_async_failure_callback",
+)
+
+# ``"cache"`` is litellm's own bookkeeping entry, not a third-party observer; both sibling
+# exemplars permit it, and excluding it would decline in ordinary deployments.
+EXEMPT_CALLBACK = "cache"
+
+# Every litellm module global this guard reads. The M8 conformance test asserts each one still
+# EXISTS, so a litellm rename turns a silently-dead guard into a red test.
+GUARDED_LITELLM_GLOBALS: tuple[str, ...] = (
+    LITELLM_DISPATCH_GLOBALS
+    + LITELLM_RULE_GLOBALS
+    + LITELLM_PRESENCE_GLOBALS
+    + LITELLM_CALLBACK_GLOBALS
+)
+
+
+def _proxy_selected_by_secret() -> bool:
+    """Whether the environment/secret-backed proxy switch is on.
+
+    WHY this exists SEPARATELY from the ``use_litellm_proxy`` module attribute: litellm checks
+    the secret FIRST (``llms/litellm_proxy/chat/transformation.py:73``) and returns True on it
+    alone, so an environment variable reroutes dispatch while the attribute stays ``False``.
+    Guarding only the attribute leaves that path wide open.
+
+    AIDEV-NOTE: litellm's own ``_should_use_litellm_proxy_by_default`` is deliberately NOT called
+    (B2.4). It is private, and it additionally consults per-request ``litellm_params`` this hook
+    does not have — so calling it here would answer a different question than the one asked.
+
+    INVARIANT: fail CLOSED. ``get_secret`` can reach a configured key-management system, so it may
+    raise or block; an unreadable switch means the answer is unknown, and unknown must decline.
+    """
+    try:
+        return get_secret_bool(PROXY_SECRET_NAME) is True
+    except Exception:
+        return True
+
+
+def unsafe_litellm_global_state() -> str | None:
+    """The ambient LiteLLM control that forbids sharing rows, or ``None`` if the process is clean.
+
+    AIDEV-NOTE: ``litellm.HuggingFaceChatConfig().get_config()`` was considered and REJECTED.
+    ``_complete_huggingface`` (``main.py:2971-3011``) reads no ``*Config.get_config()`` at all,
+    and ``BaseConfig.get_config`` reads only ``cls.__dict__``, so the condition cannot fire on
+    anything reaching the HF wire — while merely EVALUATING it instantiates the class, whose
+    ``__init__`` sets ``self.__class__._is_base_class = False`` and thus mutates litellm process
+    state on every request. A guard that protects nothing and mutates shared state is strictly
+    worse than no guard.
+    """
+    for field in LITELLM_DISPATCH_GLOBALS + LITELLM_RULE_GLOBALS:
+        if getattr(litellm, field, None):
+            return f"litellm.{field}"
+    for field in LITELLM_PRESENCE_GLOBALS:
+        if getattr(litellm, field, None) is not None:
+            return f"litellm.{field}"
+    for field in LITELLM_CALLBACK_GLOBALS:
+        callbacks = getattr(litellm, field, None)
+        if callbacks and any(callback != EXEMPT_CALLBACK for callback in callbacks):
+            return f"litellm.{field}"
+    if _proxy_selected_by_secret():
+        return PROXY_SECRET_REASON
+    return None
+
+
+def global_cache_decline_reason(*, configured_router_api_base: object) -> str | None:
+    """The single Hugging Face answer to "may this deployment share rows?" (M5.2).
+
+    ``None`` participates; any string declines and names the condition.
+
+    INVARIANT: this is the ONE source of truth used by ``participates_in_global_cache``. The
+    router-base comparison lives here rather than in ``plugin.py`` so that no second predicate
+    can drift from it — the failure mode M5 records is precisely a condition added in one copy
+    and not the others.
+
+    D3 — the operator-overridable router base. The projection emits the OFFICIAL constant
+    unconditionally, so a deployment pointed anywhere else would key its requests as though they
+    had gone to the official router and share rows with deployments that did. That is
+    cross-endpoint contamination of a globally shared cache.
+
+    WHY the comparison is NORMALISED rather than literal: litellm's ``_build_chat_completion_url``
+    does ``model_url.rstrip("/")`` before appending ``/chat/completions``
+    (``transformation.py:26-28``), so a trailing slash produces a byte-identical upstream call. A
+    literal ``!=`` would silently disable caching for a deployment that is provably sending the
+    same request. The normalisation stops there ON PURPOSE: this is a safety gate, so every
+    accepted spelling must be provably wire-equivalent, not merely plausible.
+
+    AIDEV-NOTE: OBSERVED TO FIRE. This gate was neutralised on 2026-08-20 and
+    ``test_a_row_filled_at_the_official_base_is_not_replayed_after_an_override`` was run. Observed
+    symptom: the deployment configured for ``https://proxy.internal/v1`` was served
+    ``X-AIGW-Cache: hit`` from the row a DIFFERENT deployment filled against the official router —
+    a 200 carrying an answer its own upstream never produced, with no dispatch. Gate restored.
+    """
+    try:
+        if not isinstance(configured_router_api_base, str):
+            return ROUTER_API_BASE_REASON
+        if configured_router_api_base.rstrip("/") != OFFICIAL_ROUTER_API_BASE.rstrip("/"):
+            return ROUTER_API_BASE_REASON
+        return unsafe_litellm_global_state()
+    except Exception:
+        # INVARIANT: third-party ambient objects may raise from attribute access, truthiness or
+        # iteration. A runtime the guard cannot inspect is uncertified, so caching gives way while
+        # dispatch remains available. The token carries no configured value or caller data.
+        return UNREADABLE_AMBIENT_STATE_REASON
+
+
+# WHY module state for logging: every decline path publishes the SAME wire reason
+# (``provider_projection``), so without a log an operator whose HF caching silently stopped has no
+# way to learn which check declined. But this runs per request, so an unconditional warning would
+# be its own operational problem. One line per CONDITION per process is the compromise.
+_LOGGED_DECLINES: set[str] = set()
+
+
+def log_decline_once(reason: str) -> None:
+    """Name the declining condition once per process, never the configured value.
+
+    INVARIANT: the TOKEN only. ``router_api_base`` can carry an internal hostname and
+    ``litellm.headers`` can carry tenant or auth material, so no value is ever logged — and no
+    caller identity, prompt content or cache key is available here to leak in the first place.
+    """
+    if reason in _LOGGED_DECLINES:
+        return
+    _LOGGED_DECLINES.add(reason)
+    logger.warning(
+        "huggingface is not participating in the global cache: %s (this deployment's rows "
+        "are neither read nor written; requests dispatch normally)",
+        reason,
+    )
+
+
+def reset_decline_log() -> None:
+    """Clear the once-per-process log memo. For tests only."""
+    _LOGGED_DECLINES.clear()

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/runtime_guard.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/runtime_guard.py
@@ -28,11 +28,11 @@ right end state and is deliberately NOT done here:
     sibling paths hard-fail dispatch. Copying a condition without its response would convert a
     lossless cache decline into a refused request. Do NOT mirror these conditions mechanically
     into another provider.
-  * OME-884 changes the sibling signatures and has not merged into this base.
-
-Repository-wide consolidation is therefore a FOLLOW-UP after OME-884 merges, when the final
-sibling signatures are available. Cross-provider duplication is NOT eliminated by this change —
-only the Hugging Face copy is now cohesive and single-sourced.
+OME-884 IS present in this base and the participation hook now accepts the raw requested model,
+so the port signature is settled and is NOT what blocks extraction. The differing condition sets
+and — above all — the differing failure responses are. Repository-wide consolidation stays a
+FOLLOW-UP for that reason. Cross-provider duplication is NOT eliminated by this change; only the
+Hugging Face copy is now cohesive and single-sourced.
 """
 
 from __future__ import annotations
@@ -91,9 +91,14 @@ UNREADABLE_AMBIENT_STATE_REASON = "litellm.runtime_state"
 # so a row filled under one setting would bypass the refusal the other setting performs.
 LITELLM_DISPATCH_GLOBALS: tuple[str, ...] = (
     "model_fallbacks",
-    # Coarser than the sibling exemplars, which test ``model in aliases``. WHY: this port's
-    # signature receives NO model (``_provider.py:278``), so the exact form is not expressible.
-    # The coarse form is the fail-safe direction — it declines more often, never less.
+    # Coarser than the sibling exemplars, which test ``model in aliases``. The narrow form IS
+    # expressible here — ``participates_in_global_cache`` carries the raw requested model since
+    # OME-884 (``_provider.py:278``) — and Hugging Face deliberately keeps the provider-wide
+    # decline for the MVP anyway: it is the fail-safe direction, declining more often and never
+    # less. Exact-model narrowing is a non-blocking cross-provider follow-up, not an
+    # impossibility. COST OF THE CONSERVATIVE FORM, so nobody rediscovers it as a bug: ONE
+    # unrelated alias entry anywhere in the deployment stops Hugging Face caching entirely for
+    # the life of the process. Lossless, logged once, and visible only as a 100% miss rate.
     "model_alias_map",
     "headers",
     "use_litellm_proxy",

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
@@ -21,7 +21,22 @@ from aigateway.core.plugin_base import PluginSettings
 
 # Unified OpenAI-compatible router. Pinning this as api_base short-circuits
 # litellm's per-request provider-mapping fetch to huggingface.co.
-_ROUTER_API_BASE = "https://router.huggingface.co/v1"
+#
+# OME-791: PUBLIC because it is now global-cache KEY MATERIAL. ``global_cache.py`` emits it
+# as the projected ``api_base``, so the pure projection must be able to name it without
+# importing anything impure — it may not read the ``router_api_base`` FIELD below.
+#
+# INVARIANT: this constant is the OFFICIAL router; the field is what a deployment may
+# override. ``participates_in_global_cache`` declines when they disagree, which is what lets
+# the projection emit a constant while the field stays configurable (plan D3).
+#
+# AIDEV-NOTE: three other spellings of this host exist in the package and are deliberately
+# NOT derived from this constant (plan D4): ``api_key_validation._READINESS_URL`` is a
+# hardcoded literal precisely so an overridden base cannot redirect a credential probe —
+# ``test_huggingface_validation_requires_identity_and_readiness`` pins that — and
+# ``discovery.MODELS_URL`` / ``discovery.ALLOWED_ORIGINS`` serve the catalog surface and
+# carry no key material. This constant owns the DISPATCH path only.
+OFFICIAL_ROUTER_API_BASE = "https://router.huggingface.co/v1"
 
 
 def _default_model_slugs() -> list[str]:
@@ -114,7 +129,7 @@ class HuggingFacePluginSettings(PluginSettings):
     )
 
     default_models: list[str] = Field(default_factory=_default_model_slugs)
-    router_api_base: str = _ROUTER_API_BASE
+    router_api_base: str = OFFICIAL_ROUTER_API_BASE
     validation_model: str | None = None
 
     @field_validator("default_models")

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/settings.py
@@ -38,6 +38,50 @@ from aigateway.core.plugin_base import PluginSettings
 # carry no key material. This constant owns the DISPATCH path only.
 OFFICIAL_ROUTER_API_BASE = "https://router.huggingface.co/v1"
 
+# OME-791 (B1): the complete Hugging Face partner-provider vocabulary, transcribed from the
+# authoritative partner table at https://huggingface.co/docs/inference-providers/index
+# (18 partners, read 2026-08-21). Slugs are the doc-route names — the machine-readable form
+# that appears in the ``:<suffix>`` position — NOT the human display names, so "Fireworks" is
+# ``fireworks-ai``, "OVHcloud AI Endpoints" is ``ovhcloud``, "Z.ai" is ``zai-org``.
+#
+# INVARIANT: FAIL-CLOSED, and this is the whole point. The suffix position also accepts ROUTING
+# POLICIES — the same page documents ``:fastest`` (the unsuffixed default), ``:cheapest`` and
+# ``:preferred`` — which name no fixed backend. ``:preferred`` resolves against the REQUESTING
+# ACCOUNT's preference order, so a row keyed under it would replay one account's provider to an
+# account whose identical request would have gone elsewhere. Since the global key is
+# architecturally identity-free, that hazard cannot be keyed around; it can only be declined.
+#
+# WHY an allowlist and NOT a denylist of policy names: a denylist fails OPEN. The day Hugging
+# Face adds another policy keyword, a denylist would silently begin caching it as though it
+# named a backend, and nothing in this repository would notice. An unknown suffix must bypass.
+#
+# AIDEV-NOTE: this admits a suffix to the CACHE, never to DISPATCH. ``_validate_model_slug``
+# stays permissive on purpose (B1.4): a policy or unknown suffix is a perfectly valid request
+# that must still reach the router. Drift against the live vocabulary is reported by the
+# opt-in ``AIGW_LIVE`` test at ``tests/live/test_huggingface_provider_allowlist_drift.py``.
+KNOWN_ROUTER_BACKENDS: frozenset[str] = frozenset(
+    {
+        "baseten",
+        "cerebras",
+        "cohere",
+        "deepinfra",
+        "fal-ai",
+        "featherless-ai",
+        "fireworks-ai",
+        "groq",
+        "hf-inference",
+        "novita",
+        "nscale",
+        "ovhcloud",
+        "publicai",
+        "replicate",
+        "scaleway",
+        "together",
+        "wavespeed",
+        "zai-org",
+    }
+)
+
 
 def _default_model_slugs() -> list[str]:
     """Seed models in ``huggingface/<org>/<model>:<provider>`` router form.
@@ -107,18 +151,34 @@ def pinned_router_target(slug: str) -> tuple[str, str] | None:
     """The ``(<org>/<model>, <backend>)`` pair a gateway id pins, or ``None``.
 
     Lives beside ``_validate_model_slug`` so there is ONE definition of what a
-    well-formed HF gateway id is; this adds only the discovery-specific condition.
+    well-formed HF gateway id is; this adds only the pinned-backend condition.
 
-    WHY an unsuffixed id has no target: without ``:<provider>`` the router selects a
-    backend PER REQUEST, so no single backend row describes the next call. Reporting
-    one would be a guess dressed as live evidence.
+    INVARIANT (OME-791 B1): a target is returned ONLY for a suffix in
+    ``KNOWN_ROUTER_BACKENDS``. Three distinct inputs therefore share the ``None`` answer,
+    for one reason — NONE of them names a backend that is fixed for the next call:
+
+    * an UNSUFFIXED id: the router selects a backend per request (equivalently ``:fastest``).
+    * a ROUTING POLICY (``:fastest``, ``:cheapest``, ``:preferred``): a selection rule, not a
+      backend. ``:preferred`` resolves against the REQUESTING ACCOUNT's preference order, so it
+      is identity-dependent — unkeyable under an identity-free global key.
+    * an UNKNOWN suffix: unrecognised, therefore unproven. Fail closed.
+
+    Reporting a target for any of those would be a guess dressed as live evidence — and, since
+    this predicate also gates the global cache, a guess written into a row that never expires.
+
+    WHY this does NOT narrow dispatch: ``_validate_model_slug`` remains permissive, so every
+    syntactically valid id — policies and unknown suffixes included — still reaches the router
+    normally. This function narrows only what may be CACHED and what may be reported as
+    single-backend evidence.
     """
     try:
         _validate_model_slug(slug)
     except ValueError:
         return None
     repo, sep, backend = slug[len("huggingface/") :].partition(":")
-    return (repo, backend) if sep else None
+    if not sep or backend not in KNOWN_ROUTER_BACKENDS:
+        return None
+    return (repo, backend)
 
 
 class HuggingFacePluginSettings(PluginSettings):

--- a/apps/aigateway/src/aigateway/routes/chat_cache_stage.py
+++ b/apps/aigateway/src/aigateway/routes/chat_cache_stage.py
@@ -217,9 +217,15 @@ def _is_a_whole_answer(result: dict[str, Any]) -> bool:
     judging answers, which this stage has no business doing:
 
     * no ``choices``, or an empty list — nothing was produced at all;
-    * a first choice carrying no ``message`` — a delta or a shell, not an answer;
-    * a first choice whose ``finish_reason`` is null OR absent — the provider never
-      declared the answer ended, which is what a stream cut mid-flight leaves.
+    * ANY choice carrying no ``message`` — a delta or a shell, not an answer;
+    * ANY choice whose ``finish_reason`` is null OR absent — the provider never
+      declared that answer ended, which is what a stream cut mid-flight leaves.
+
+    WHY EVERY choice and not just ``choices[0]``: ``n`` is KEYED for every cacheable
+    provider, so an ``n=2`` body has its own key and is replayed only to another
+    ``n=2`` request — which is precisely what makes a half-finished pair permanent
+    rather than harmless. Judging the first choice alone stored it. Position must not
+    change the verdict: the same shape is refused wherever it appears.
 
     Absence and explicit ``null`` are treated identically on purpose: both mean the
     same thing, and distinguishing them would only reward a provider for spelling
@@ -241,10 +247,12 @@ def _is_a_whole_answer(result: dict[str, Any]) -> bool:
     choices = result.get("choices")
     if not isinstance(choices, list) or not choices:
         return False
-    first = choices[0]
-    if not isinstance(first, dict) or not isinstance(first.get("message"), dict):
-        return False
-    return first.get("finish_reason") is not None
+    return all(
+        isinstance(choice, dict)
+        and isinstance(choice.get("message"), dict)
+        and choice.get("finish_reason") is not None
+        for choice in choices
+    )
 
 
 async def store_global_response(

--- a/apps/aigateway/tests/live/test_huggingface_provider_allowlist_drift.py
+++ b/apps/aigateway/tests/live/test_huggingface_provider_allowlist_drift.py
@@ -4,20 +4,32 @@ Opt-in only: set ``AIGW_LIVE=1``. This lives under ``tests/live/`` so it is stru
 the unit suite — a drift check that silently became ordinary CI network traffic would be both
 flaky and a quiet dependency on Hugging Face's uptime.
 
-WHAT DRIFT MEANS HERE, and why the two directions are NOT symmetric:
+WHAT THE ENDPOINT CAN AND CANNOT TELL US. ``MODELS_URL`` is the chat-completions MODEL CATALOG.
+Every slug it reports is POSITIVE evidence that a provider is currently attached to a returned
+chat model. Its silence is NOT evidence of removal: a partner that serves only image, video or
+ASR models never appears here at all, and neither does one that is simply absent from today's
+catalog page. So the two directions are not symmetric, and neither is what the check does with
+them:
 
-  * a provider live-but-MISSING from the allowlist is a LOST OPTIMISATION. Requests pinned to it
-    dispatch normally and simply never cache. Safe, and the reason the allowlist may lag.
-  * a provider allowlisted but GONE from the router is the direction that matters more: rows
-    keyed under it never expire, so they would keep being replayed for a backend that no longer
-    serves the model.
+  * ``observed - allowlist`` — a slug the router attaches to chat models that we do not admit.
+    This is REVIEW-REQUIRED drift. Cost today is only a lost optimisation (requests pinned to it
+    dispatch normally, uncached), and it must stay that way: a new slug may never become
+    cacheable automatically, because admitting one without review is how a routing POLICY gets
+    treated as a fixed backend.
+  * ``allowlist - observed`` — CATALOG COVERAGE, not proof a backend is gone. Only the entries
+    that are NOT in ``_EXPECTED_CATALOG_OMISSIONS`` are worth a human's attention, and those
+    fail the test so a release does not sail past them.
 
-Neither is an outage, so this test REPORTS rather than fails hard on the first direction — the
-allowlist is a deliberate, reviewed transcription of the partner table, not a live mirror.
+WHY THE STALE DIRECTION IS THE ONE THAT FAILS HARD: rows keyed under an allowlisted suffix never
+expire, so a suffix the router has genuinely retired would keep being replayed for a backend that
+no longer serves the model. A new-and-unadmitted slug cannot do that; it has no rows.
 
 AIDEV-NOTE: the router does NOT publish routing policies (``:fastest``/``:cheapest``/
 ``:preferred``) in this metadata — they are a request-time selection rule, not catalog entries.
-So a policy will never appear here, and its absence is not evidence the allowlist is complete.
+So a policy will never appear here, and its absence is not evidence the allowlist is clean. The
+unit-level guard for that hazard is
+``test_huggingface_provider_allowlist.py::test_the_allowlist_is_exactly_the_independently_transcribed_partner_table``,
+which is where a bad MEMBER is caught. This test only watches the live vocabulary move.
 """
 
 from __future__ import annotations
@@ -30,6 +42,20 @@ import pytest
 
 from aigateway.plugins.huggingface_provider.discovery import MODELS_URL
 from aigateway.plugins.huggingface_provider.settings import KNOWN_ROUTER_BACKENDS
+
+# Allowlisted partners that are legitimately ABSENT from the chat-completions catalog, and are
+# therefore expected noise rather than drift. Baseline observed 2026-08-22 (14 live slugs).
+#
+# WHY each is here: ``fal-ai``, ``replicate`` and ``wavespeed`` carry no ``conversational`` task
+# in ``huggingface_hub``'s provider table at all — they are image/video/ASR backends, so a
+# chat-model catalog structurally cannot list them. ``hf-inference`` does serve conversational
+# models but is not attached to any model on the catalog page today.
+#
+# INVARIANT: this set only SUPPRESSES noise. It is subtracted, never compared for equality — an
+# entry reappearing in the catalog is good news and must not fail the test. Removing a name from
+# this set makes the check stricter, which is always safe; adding one needs the reason recorded
+# above, because it silences a real signal.
+_EXPECTED_CATALOG_OMISSIONS = frozenset({"fal-ai", "hf-inference", "replicate", "wavespeed"})
 
 
 def _live_enabled() -> bool:
@@ -61,12 +87,24 @@ def test_the_static_allowlist_still_matches_the_live_router_vocabulary() -> None
     assert observed, "the router returned no provider entries — the metadata shape may have moved"
 
     newly_observed = sorted(observed - KNOWN_ROUTER_BACKENDS)
-    no_longer_observed = sorted(KNOWN_ROUTER_BACKENDS - observed)
+    not_in_catalog = sorted(KNOWN_ROUTER_BACKENDS - observed)
+    unexpected_omissions = set(not_in_catalog) - _EXPECTED_CATALOG_OMISSIONS
 
-    print(f"\nlive provider slugs observed : {len(observed)}")
-    print(f"allowlisted                  : {len(KNOWN_ROUTER_BACKENDS)}")
-    print(f"NEW (live, not allowlisted)  : {newly_observed or 'none'}")
-    print(f"STALE (allowlisted, not live): {no_longer_observed or 'none'}")
+    # Both directions are always reported, whatever the verdict, so a hand-run of this test is a
+    # complete picture rather than only the half that happened to trip.
+    print(f"\nlive provider slugs observed  : {len(observed)}")
+    print(f"allowlisted                   : {len(KNOWN_ROUTER_BACKENDS)}")
+    print(f"NEW (live, not allowlisted)   : {newly_observed or 'none'}")
+    print(f"NOT IN CATALOG (allowlisted)  : {not_in_catalog or 'none'}")
+    print(f"  └ expected/benign            : {sorted(_EXPECTED_CATALOG_OMISSIONS) or 'none'}")
+    print(f"  └ UNEXPECTED                 : {sorted(unexpected_omissions) or 'none'}")
+
+    # The failing direction. Never expires means never self-corrects, so an allowlisted partner
+    # dropping out of the catalog is a release-blocking question rather than a print.
+    assert not unexpected_omissions, (
+        "allowlisted providers disappeared from the live model catalog; review before release: "
+        f"{sorted(unexpected_omissions)}"
+    )
 
     # Reported, not enforced: a new partner costs only a missed optimisation until it is
     # reviewed into the static table. Failing here would make an upstream launch break our CI.

--- a/apps/aigateway/tests/live/test_huggingface_provider_allowlist_drift.py
+++ b/apps/aigateway/tests/live/test_huggingface_provider_allowlist_drift.py
@@ -1,0 +1,77 @@
+"""OME-791 (B1) — does ``KNOWN_ROUTER_BACKENDS`` still match the live router vocabulary?
+
+Opt-in only: set ``AIGW_LIVE=1``. This lives under ``tests/live/`` so it is structurally outside
+the unit suite — a drift check that silently became ordinary CI network traffic would be both
+flaky and a quiet dependency on Hugging Face's uptime.
+
+WHAT DRIFT MEANS HERE, and why the two directions are NOT symmetric:
+
+  * a provider live-but-MISSING from the allowlist is a LOST OPTIMISATION. Requests pinned to it
+    dispatch normally and simply never cache. Safe, and the reason the allowlist may lag.
+  * a provider allowlisted but GONE from the router is the direction that matters more: rows
+    keyed under it never expire, so they would keep being replayed for a backend that no longer
+    serves the model.
+
+Neither is an outage, so this test REPORTS rather than fails hard on the first direction — the
+allowlist is a deliberate, reviewed transcription of the partner table, not a live mirror.
+
+AIDEV-NOTE: the router does NOT publish routing policies (``:fastest``/``:cheapest``/
+``:preferred``) in this metadata — they are a request-time selection rule, not catalog entries.
+So a policy will never appear here, and its absence is not evidence the allowlist is complete.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+import pytest
+
+from aigateway.plugins.huggingface_provider.discovery import MODELS_URL
+from aigateway.plugins.huggingface_provider.settings import KNOWN_ROUTER_BACKENDS
+
+
+def _live_enabled() -> bool:
+    return os.environ.get("AIGW_LIVE") == "1"
+
+
+def _observed_provider_slugs(payload: dict[str, Any]) -> set[str]:
+    """The union of every ``providers[].provider`` slug the router reports."""
+    observed: set[str] = set()
+    for row in payload.get("data") or []:
+        if not isinstance(row, dict):
+            continue
+        for entry in row.get("providers") or []:
+            if isinstance(entry, dict) and isinstance(entry.get("provider"), str):
+                observed.add(entry["provider"])
+    return observed
+
+
+@pytest.mark.live
+@pytest.mark.skipif(not _live_enabled(), reason="AIGW_LIVE=1 not set")
+def test_the_static_allowlist_still_matches_the_live_router_vocabulary() -> None:
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_API_KEY")
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+
+    response = httpx.get(MODELS_URL, headers=headers, timeout=30.0)
+    response.raise_for_status()
+    observed = _observed_provider_slugs(response.json())
+
+    assert observed, "the router returned no provider entries — the metadata shape may have moved"
+
+    newly_observed = sorted(observed - KNOWN_ROUTER_BACKENDS)
+    no_longer_observed = sorted(KNOWN_ROUTER_BACKENDS - observed)
+
+    print(f"\nlive provider slugs observed : {len(observed)}")
+    print(f"allowlisted                  : {len(KNOWN_ROUTER_BACKENDS)}")
+    print(f"NEW (live, not allowlisted)  : {newly_observed or 'none'}")
+    print(f"STALE (allowlisted, not live): {no_longer_observed or 'none'}")
+
+    # Reported, not enforced: a new partner costs only a missed optimisation until it is
+    # reviewed into the static table. Failing here would make an upstream launch break our CI.
+    if newly_observed:
+        pytest.skip(
+            f"allowlist drift — add after review: {newly_observed}. "
+            "Requests pinned to these dispatch normally but are not cached."
+        )

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_global_cache_keys.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_global_cache_keys.py
@@ -1,0 +1,268 @@
+"""OME-791 — HF parameter promotion and global-cache KEY differences.
+
+FEATURE: one globally shared exact-request cache (OME-305). The projection made HF
+*describable*; promoting its parameter rules from ``bypass`` to ``keyed`` is what makes an
+identical re-run actually cheaper.
+
+STORY: as a benchmark operator I re-run a suite against a backend-pinned HF model and the
+identical calls key identically, while any materially different request keys differently.
+
+What this module pins, and why each matters:
+- every one of the TWELVE newly-keyed request paths, because a keyed path with no
+  key-difference proof is how two materially different requests come to share one answer;
+- a derived-set meta-test, so a future keyed path cannot land without its own proof.
+
+Split from ``test_huggingface_route_global_cache.py`` (OME-791 review): that file exceeded the
+450-line limit, and keying is a different responsibility from the route's miss/hit behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from aigateway.core.profile_index import ProfileIndexStore
+from aigateway.core.profile_models import Profile, ProfileState, profile_id_for
+from aigateway.core.request_cache.global_controls import GlobalCacheControls
+from aigateway.core.request_cache.global_plan import build_global_cache_plan
+from aigateway.plugins.huggingface_provider.parameters import (
+    huggingface_chat_parameter_rules,
+)
+from aigateway.plugins.huggingface_provider.plugin import PLUGIN
+
+_CHAT_PATH = "/v1/chat/completions"
+_PATCH_TARGET = (
+    "aigateway.plugins.huggingface_provider.plugin.HuggingFaceProviderPlugin.chat_completion"
+)
+_MODEL = "huggingface/deepseek-ai/DeepSeek-R1:novita"
+_HF_KEY = "hf_route_global_cache_key_1234567890"
+
+# The complete set of HF request paths that OME-791 promotes to ``keyed``.
+#
+# INVARIANT: TWELVE, not the ten ``direct_rule`` calls a reader counts in ``parameters.py``.
+# ``function_calling_rules`` emits ``tools`` AND ``tool_choice`` as two separate rules
+# (``standard_parameters.py:232-252``, with ``tool_choice=True`` defaulted at ``:204``), so a
+# literal set written from the source file alone is wrong by two. The meta-test below derives
+# the real set from the live rule table and asserts equality against this literal, so the two
+# can never drift.
+_EXPECTED_KEYED_PATHS = frozenset(
+    {
+        "temperature",
+        "max_tokens",
+        "stop",
+        "response_format",
+        "seed",
+        "n",
+        "frequency_penalty",
+        "presence_penalty",
+        "logprobs",
+        "top_logprobs",
+        "tools",
+        "tool_choice",
+    }
+)
+
+# One concrete pair of DIFFERENT values per keyed path. A path missing from this table has no
+# key-difference proof, which the meta-test refuses.
+_KEY_DIFFERENCE_CASES: dict[str, tuple[Any, Any]] = {
+    "temperature": (0.0, 1.0),
+    "max_tokens": (16, 32),
+    "stop": (["END"], ["STOP"]),
+    "response_format": ({"type": "text"}, {"type": "json_object"}),
+    "seed": (1, 2),
+    "n": (1, 2),
+    "frequency_penalty": (0.0, 0.5),
+    "presence_penalty": (0.0, 0.5),
+    # INVARIANT: ``top_logprobs`` requires ``logprobs is True``, so the pair varies the
+    # dependent field while holding the enabling one — otherwise the 400 combination rule,
+    # not the key, would be what distinguishes the two requests.
+    "logprobs": (True, False),
+    "top_logprobs": (1, 2),
+    "tools": (
+        [{"type": "function", "function": {"name": "alpha", "parameters": {}}}],
+        [{"type": "function", "function": {"name": "beta", "parameters": {}}}],
+    ),
+    "tool_choice": ("auto", "none"),
+}
+
+
+def _published_cache_behaviour(document: dict[str, Any]) -> dict[str, str]:
+    """``{request_path: cache_behavior}`` as a CALLER reads it off the contract document.
+
+    Shape (verified against the live route): each entry under ``parameters`` — and each tool
+    entry under ``tools`` — carries a ``gateway`` block holding ``cache_behavior``. Reading both
+    sections matters: ``tools`` and ``tool_choice`` are two of the twelve promoted paths and do
+    not appear beside the scalar parameters.
+    """
+    published: dict[str, str] = {}
+    for section in ("parameters", "tools"):
+        entries = document.get(section)
+        if not isinstance(entries, dict):
+            continue
+        for name, entry in entries.items():
+            gateway = entry.get("gateway") if isinstance(entry, dict) else None
+            if isinstance(gateway, dict) and "cache_behavior" in gateway:
+                published[str(name)] = str(gateway["cache_behavior"])
+    return published
+
+
+def _body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "how many primes below one hundred?"}],
+    }
+    body.update(overrides)
+    return body
+
+
+def _key_hash(body: dict[str, Any]) -> str:
+    """The global cache key for ``body``, through the REAL plan.
+
+    WHY the whole plan rather than the projection alone: a key-difference test that called the
+    projection directly would prove nothing about promotion, because the projection does not
+    see parameters at all. Only the plan applies the rule table, so only the plan can show that
+    a promoted path actually reached the key.
+    """
+    decision = build_global_cache_plan(
+        body=body,
+        plugin=PLUGIN,
+        controls=GlobalCacheControls(participate=True),
+        cache_enabled=True,
+    )
+    assert not hasattr(decision, "reason"), f"expected a key, got a bypass: {decision}"
+    return cast(Any, decision).key_hash
+
+
+# --- promotion, proven per path -----------------------------------------------
+
+
+def test_the_promoted_set_is_exactly_the_twelve_paths_this_unit_claims() -> None:
+    keyed = {
+        rule.request_path
+        for rule in huggingface_chat_parameter_rules(model=_MODEL, auth_type=None)
+        if rule.cache_behavior == "keyed"
+    }
+
+    assert keyed == set(_EXPECTED_KEYED_PATHS)
+
+
+def test_every_keyed_path_has_an_explicit_key_difference_proof() -> None:
+    """The meta-test that makes this file self-enforcing.
+
+    INVARIANT: a keyed path with no key-difference proof is exactly how two materially
+    different requests come to share one stored answer. Deriving the set from the LIVE rules
+    means a future promotion cannot land silently — it fails here until someone adds its pair.
+    Mirrors ``test_every_openrouter_keyed_path_has_an_explicit_key_difference_proof``.
+    """
+    keyed = {
+        rule.request_path
+        for rule in huggingface_chat_parameter_rules(model=_MODEL, auth_type=None)
+        if rule.cache_behavior == "keyed"
+    }
+
+    assert keyed == set(_KEY_DIFFERENCE_CASES), (
+        "every keyed HF path needs a concrete differing-value pair in _KEY_DIFFERENCE_CASES"
+    )
+
+
+@pytest.mark.parametrize("path", sorted(_KEY_DIFFERENCE_CASES))
+def test_a_keyed_path_changes_the_key_when_its_value_changes(path: str) -> None:
+    low, high = _KEY_DIFFERENCE_CASES[path]
+    extra = {"logprobs": True} if path == "top_logprobs" else {}
+
+    assert _key_hash(_body(**{path: low}, **extra)) != _key_hash(_body(**{path: high}, **extra))
+
+
+@pytest.mark.parametrize("path", sorted(_KEY_DIFFERENCE_CASES))
+def test_a_keyed_path_keys_identically_for_an_identical_value(path: str) -> None:
+    low, _ = _KEY_DIFFERENCE_CASES[path]
+    extra = {"logprobs": True} if path == "top_logprobs" else {}
+
+    assert _key_hash(_body(**{path: low}, **extra)) == _key_hash(_body(**{path: low}, **extra))
+
+
+def test_two_backends_for_one_repo_do_not_collide() -> None:
+    # The projection retains ``:<backend>`` in ``resolved_model``; this is the end-to-end
+    # consequence, at the level a caller can observe.
+    novita = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:novita"))
+    together = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:together"))
+
+    assert novita != together
+
+
+def test_two_repos_do_not_collide() -> None:
+    first = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:novita"))
+    second = _key_hash(_body(model="huggingface/Qwen/Qwen3-235B-A22B:novita"))
+
+    assert first != second
+
+
+def test_every_registered_model_contributes_the_full_keyed_set() -> None:
+    """HF's own regression floor, derived rather than hardcoded.
+
+    AIDEV-NOTE: this replaces the tempting alternative of raising
+    ``_OBSERVED_NON_BYPASS_INSTANCES`` in the SHARED conformance test. That number depends on
+    catalog and environment state, and the file is append-only-protected; a floor derived from
+    THIS plugin is both stronger for HF and free of blast radius.
+    """
+    entries = list(PLUGIN.register_models())
+    assert entries, "no HF models registered"
+
+    for entry in entries:
+        keyed = {
+            rule.request_path
+            for rule in huggingface_chat_parameter_rules(model=entry.model_name, auth_type=None)
+            if rule.cache_behavior == "keyed"
+        }
+        assert keyed == set(_EXPECTED_KEYED_PATHS), entry.model_name
+
+
+async def _no_discovery(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_the_published_parameter_contract_reports_the_promoted_behaviour(
+    authenticated_client, credential_blobs: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The caller-visible half of promotion, which nothing else asserts.
+
+    WHY this test exists: the published contract digests each rule's ``cache_behavior`` and
+    ``projection_revision`` (``core/model_parameter_contract.py:78``), so this unit moves every
+    HF model's ``contract_id`` and flips twelve rows of its detail document. No existing test
+    pins a digest or the old revision, which means the entire caller-visible surface could flip
+    with nothing objecting. One assertion is enough to make the change deliberate.
+    """
+    # No live discovery evidence: the unit suite forbids catalog egress
+    # (``tests/conftest.py:145-165``), and live backend evidence is orthogonal to what this
+    # test asserts — the GATEWAY's own declared cache disposition, which comes from the rule
+    # table rather than from any snapshot.
+    monkeypatch.setattr(
+        type(PLUGIN), "discover_chat_parameter_snapshot", _no_discovery, raising=True
+    )
+
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    index = ProfileIndexStore(credential_store=credential_blobs.store)
+    await index.upsert(
+        Profile(
+            id=profile_id_for(account_id, "huggingface", "default"),
+            account_id=account_id,
+            provider="huggingface",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+            auth_type="api_key",
+        )
+    )
+
+    resp = authenticated_client.get("/v1/model-parameters", params={"model": _MODEL})
+    assert resp.status_code == 200, resp.text
+
+    published = _published_cache_behaviour(resp.json())
+    keyed = {path for path, behaviour in published.items() if behaviour == "keyed"}
+
+    assert keyed == set(_EXPECTED_KEYED_PATHS), (
+        f"the published contract does not report the promoted set: {sorted(keyed)}"
+    )
+    # And nothing ELSE quietly became cacheable: the published set is exactly the promotion.
+    assert not [path for path, b in published.items() if b not in {"keyed", "bypass"}], published

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_global_cache_projection.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_global_cache_projection.py
@@ -244,7 +244,11 @@ def test_a_deployment_pointed_somewhere_else_does_not_participate() -> None:
         pytest.param("pre_call_rules", [lambda _: True], id="pre-call-rules"),
         pytest.param("post_call_rules", [lambda _: True], id="post-call-rules"),
         pytest.param("drop_params", True, id="drop-params"),
-        pytest.param("additional_drop_params", ["seed"], id="additional-drop-params"),
+        # OME-791 M8: ``additional_drop_params`` was listed here and is NOT a litellm module
+        # global on the installed 1.97.0 — the case only passed because ``raising=False``
+        # CREATED the attribute. Removed with the production entry. Exhaustive per-field
+        # coverage, existence assertions and the drift falsification now live in
+        # ``test_huggingface_runtime_guard.py``.
         pytest.param("success_callback", ["langfuse"], id="a-real-callback"),
     ],
 )
@@ -260,7 +264,10 @@ def test_unsafe_ambient_litellm_state_declines_participation(
     # That is a wrong answer, not a stale one.
     import litellm
 
-    monkeypatch.setattr(litellm, attribute, value, raising=False)
+    # OME-791 M8: ``raising=True``. With ``raising=False`` a renamed or removed litellm global
+    # would be silently CREATED by the test, so the guard could stop protecting anything while
+    # this stayed green.
+    monkeypatch.setattr(litellm, attribute, value, raising=True)
 
     assert _plugin().participates_in_global_cache() is False
 
@@ -272,7 +279,7 @@ def test_a_clean_process_participates(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # ``"cache"`` in a callback list is explicitly permitted — it is litellm's own cache
     # bookkeeping, not a third-party observer, and both existing exemplars allow it.
-    monkeypatch.setattr(litellm, "success_callback", ["cache"], raising=False)
+    monkeypatch.setattr(litellm, "success_callback", ["cache"], raising=True)
 
     assert _plugin().participates_in_global_cache() is True
 

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_global_cache_projection.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_global_cache_projection.py
@@ -1,0 +1,353 @@
+"""OME-791 — the HuggingFace global-cache projection, as a pure function of the body.
+
+FEATURE: one globally shared exact-request cache (OME-305). Before this unit every
+``huggingface/*`` request bypassed at the projection step, because the provider inherited
+``CacheBypass`` from ``ProviderPluginBase`` — so an identical benchmark re-run paid full
+price every time.
+
+STORY: as a benchmark operator I re-run a suite against a backend-pinned HF model and the
+identical calls come back from the first run's rows, with no second dispatch.
+
+What these tests pin, and why each matters:
+- the CLOSED three-member return shape, because ``_projected`` bypasses on set inequality —
+  an extra member fails exactly as hard as a missing one, and both look like "not implemented";
+- ``resolved_model`` keeping the ``:<backend>`` suffix, which is what makes two backends for
+  one repo key differently with no separate mechanism;
+- the bypass classes, each returning the one clamped reason a projection may return;
+- purity, determinism, totality and fresh containers, which the registry sweeps check
+  generically but which are cheaper to diagnose here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aigateway.core.cache_ports import PROJECTION_BYPASS_REASON, CacheBypass
+from aigateway.core.request_cache.global_controls import GlobalCacheControls
+from aigateway.core.request_cache.global_plan import build_global_cache_plan
+from aigateway.plugins.huggingface_provider.global_cache import (
+    GLOBAL_CACHE_ADAPTER_REVISION,
+    project_global_cache_request,
+)
+from aigateway.plugins.huggingface_provider.plugin import PLUGIN, HuggingFaceProviderPlugin
+from aigateway.plugins.huggingface_provider.settings import (
+    OFFICIAL_ROUTER_API_BASE,
+    HuggingFacePluginSettings,
+)
+
+_PINNED = "huggingface/deepseek-ai/DeepSeek-R1:novita"
+_PROJECTION_MEMBERS = {"resolved_model", "provider_adapter_revision", "prepared"}
+
+
+def _body(model: object = _PINNED, **extra: Any) -> dict[str, Any]:
+    return {"model": model, "messages": [{"role": "user", "content": "hi"}], **extra}
+
+
+def test_a_backend_pinned_request_projects_with_exactly_the_three_members() -> None:
+    produced = project_global_cache_request(_body())
+
+    assert not isinstance(produced, CacheBypass)
+    # INVARIANT: core compares the member set for EQUALITY
+    # (``global_eligibility._projected``), so a helpful extra key silently un-caches the
+    # whole provider with a reason indistinguishable from "no projection at all".
+    assert set(produced) == _PROJECTION_MEMBERS
+
+
+def test_the_resolved_model_is_the_upstream_id_and_keeps_the_backend_suffix() -> None:
+    produced = project_global_cache_request(_body())
+
+    assert not isinstance(produced, CacheBypass)
+    # WHY the prefix is stripped here but NOT for anthropic: litellm strips
+    # ``huggingface/`` and passes the remainder to the wire verbatim — pinned by the
+    # installed-transform assertion in test_huggingface_dispatch.py.
+    assert produced["resolved_model"] == "deepseek-ai/DeepSeek-R1:novita"
+
+
+def test_two_backends_for_one_repo_are_two_different_upstream_ids() -> None:
+    # INVARIANT: the ``:<backend>`` suffix selects which inference provider answers, so it
+    # is output-affecting. It keys as a structural consequence of ``resolved_model``.
+    novita = project_global_cache_request(_body("huggingface/deepseek-ai/DeepSeek-R1:novita"))
+    together = project_global_cache_request(_body("huggingface/deepseek-ai/DeepSeek-R1:together"))
+
+    assert not isinstance(novita, CacheBypass)
+    assert not isinstance(together, CacheBypass)
+    assert novita["resolved_model"] != together["resolved_model"]
+
+
+def test_the_prepared_view_is_exactly_the_pinned_official_router() -> None:
+    produced = project_global_cache_request(_body())
+
+    assert not isinstance(produced, CacheBypass)
+    # The ONE output-affecting thing this boundary adds: which endpoint answers.
+    # ``api_key`` and ``extra_headers`` are transport — the former is stripped and excluded
+    # from the key by core, the latter is a DISPATCH_CONTROL_FIELD a caller cannot set.
+    assert produced["prepared"] == {"api_base": OFFICIAL_ROUTER_API_BASE}
+
+
+def test_the_projection_hands_back_fresh_containers_every_call() -> None:
+    first = project_global_cache_request(_body())
+    second = project_global_cache_request(_body())
+
+    assert not isinstance(first, CacheBypass)
+    assert not isinstance(second, CacheBypass)
+    # INVARIANT: core hashes ``prepared`` by reference and does NOT copy it, so a shared
+    # module-level table would let one reader alter every later request's key material.
+    assert first["prepared"] is not second["prepared"]
+
+
+def test_the_projection_is_deterministic() -> None:
+    assert project_global_cache_request(_body()) == project_global_cache_request(_body())
+
+
+def test_the_projection_never_mutates_the_body_it_was_given() -> None:
+    body = _body(temperature=0.5)
+    before = {"model": body["model"], "messages": [dict(body["messages"][0])], "temperature": 0.5}
+
+    project_global_cache_request(body)
+
+    assert body == before
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param(7, id="not-a-string"),
+        pytest.param(["a"], id="a-list"),
+        pytest.param("", id="empty"),
+        pytest.param("deepseek-ai/DeepSeek-R1:novita", id="no-gateway-prefix"),
+        pytest.param("openrouter/deepseek/deepseek-r1", id="another-providers-prefix"),
+        pytest.param("huggingface/", id="bare-prefix"),
+        pytest.param("huggingface/lonely-token:novita", id="no-org-slash-model"),
+        pytest.param("huggingface/novita/deepseek-ai/DeepSeek-R1", id="provider-as-path-segment"),
+        pytest.param("huggingface/deepseek-ai/DeepSeek-R1:", id="empty-suffix"),
+        pytest.param("huggingface/deepseek-ai/DeepSeek-R1:a:b", id="two-suffixes"),
+    ],
+)
+def test_a_model_id_this_provider_cannot_describe_bypasses(model: object) -> None:
+    produced = project_global_cache_request(_body(model))
+
+    assert isinstance(produced, CacheBypass)
+    # INVARIANT: one clamped reason. The vocabulary is a caller-visible wire contract, so a
+    # projection may never mint a more precise value.
+    assert produced.reason == PROJECTION_BYPASS_REASON
+
+
+def test_an_unsuffixed_id_bypasses_even_though_it_dispatches_fine() -> None:
+    # AIDEV-NOTE: this is the one bypass that does NOT mirror a dispatch refusal — unlike
+    # openrouter's ``:online``, an unsuffixed HF id is perfectly dispatchable. It is refused
+    # because ``pinned_router_target`` records that without ``:<provider>`` the router selects
+    # a backend PER REQUEST, so no single upstream describes the next call. Replaying one
+    # backend's answer for a request that would have gone elsewhere corrupts model
+    # attribution, which for a benchmark product is a wrong answer rather than a stale one.
+    produced = project_global_cache_request(_body("huggingface/deepseek-ai/DeepSeek-R1"))
+
+    assert isinstance(produced, CacheBypass)
+    assert produced.reason == PROJECTION_BYPASS_REASON
+
+
+def test_every_registered_default_model_projects() -> None:
+    # INVARIANT: the conformance sweep requires that once ANY rule is keyed, the projection
+    # is non-bypass for EVERY declared model. A projection that recognised only a subset
+    # would fail the moment the rules were promoted.
+    for entry in PLUGIN.register_models():
+        produced = project_global_cache_request(_body(entry.model_name))
+        assert not isinstance(produced, CacheBypass), entry.model_name
+
+
+def test_the_projection_is_total() -> None:
+    # A projection may never fail a request, only decline to key it. Core wraps the call in
+    # ``except Exception``, so a raise would show up as a silent permanent bypass.
+    for body in ({}, {"model": _PINNED}, {"messages": None}, {"model": {}, "messages": 1}):
+        assert project_global_cache_request(dict(body)) is not None
+
+
+def test_the_projection_reads_no_operator_configuration() -> None:
+    # The registry sweep proves this generically with a poisoned settings object; this local
+    # copy exists because the sweeps only ever run HF with DEFAULT settings, so a regression
+    # here would otherwise surface far from its cause.
+    class _Poisoned:
+        def __getattr__(self, name: str) -> object:
+            raise AssertionError(f"the projection read settings.{name}")
+
+    plugin = HuggingFaceProviderPlugin(HuggingFacePluginSettings())
+    plugin.settings = _Poisoned()  # type: ignore[assignment]
+
+    produced = plugin.global_cache_projection(_body())
+
+    assert not isinstance(produced, CacheBypass)
+    assert produced["prepared"] == {"api_base": OFFICIAL_ROUTER_API_BASE}
+
+
+def test_the_adapter_revision_is_reported_and_is_this_providers_own() -> None:
+    produced = project_global_cache_request(_body())
+
+    assert not isinstance(produced, CacheBypass)
+    assert produced["provider_adapter_revision"] == GLOBAL_CACHE_ADAPTER_REVISION
+    assert GLOBAL_CACHE_ADAPTER_REVISION.startswith("huggingface-global-cache-")
+
+
+def test_the_plugin_hook_delegates_to_the_pure_module() -> None:
+    assert PLUGIN.global_cache_projection(_body()) == project_global_cache_request(_body())
+
+
+# ---------------------------------------------------------------------------
+# Participation — the impure half of the same feature (D3, D6, D11).
+#
+# WHY it is tested beside the projection rather than in its own module: the two are one
+# decision. The projection states "the official router answered this"; participation is
+# what makes that statement true, by declining whenever it would not be. Splitting them
+# would let a reader change one without seeing the other.
+# ---------------------------------------------------------------------------
+
+
+def _plugin(**settings: Any) -> HuggingFaceProviderPlugin:
+    """A FRESH plugin instance, so one test's settings cannot leak into another.
+
+    WHY not ``PLUGIN.settings_cls``: that attribute is typed as the base ``PluginSettings``, so
+    pyright rejects both the constructor argument and any HF-specific keyword. Naming the
+    concrete class keeps the settings kwargs type-checked, which is the point of passing them.
+    """
+    return HuggingFaceProviderPlugin(HuggingFacePluginSettings(**settings))
+
+
+def test_a_default_deployment_participates() -> None:
+    assert _plugin().participates_in_global_cache() is True
+
+
+def test_a_trailing_slash_on_the_official_base_still_participates() -> None:
+    # WHY normalised and not literal: litellm's ``_build_chat_completion_url`` does
+    # ``model_url.rstrip("/")`` before appending ``/chat/completions``, so the two spellings
+    # produce byte-identical upstream calls. A literal ``!=`` would disable caching for a
+    # deployment that is provably sending the same request.
+    assert _plugin(router_api_base=OFFICIAL_ROUTER_API_BASE + "/").participates_in_global_cache()
+
+
+def test_a_deployment_pointed_somewhere_else_does_not_participate() -> None:
+    # INVARIANT: this is the whole reason the projection may emit a CONSTANT base while the
+    # settings field remains overridable. Two deployments with different bases must never
+    # share rows, and the projection cannot see the difference — so participation must.
+    assert (
+        _plugin(router_api_base="https://proxy.internal/v1").participates_in_global_cache() is False
+    )
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        pytest.param("model_fallbacks", ["openai/gpt-4o"], id="model-fallbacks"),
+        pytest.param("model_alias_map", {"x": "y"}, id="model-alias-map"),
+        pytest.param("headers", {"x-tenant": "acme"}, id="headers"),
+        pytest.param("proxy_auth", object(), id="proxy-auth"),
+        pytest.param("pre_call_rules", [lambda _: True], id="pre-call-rules"),
+        pytest.param("post_call_rules", [lambda _: True], id="post-call-rules"),
+        pytest.param("drop_params", True, id="drop-params"),
+        pytest.param("additional_drop_params", ["seed"], id="additional-drop-params"),
+        pytest.param("success_callback", ["langfuse"], id="a-real-callback"),
+    ],
+)
+def test_unsafe_ambient_litellm_state_declines_participation(
+    attribute: str, value: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # AIDEV-NOTE: ``model_fallbacks`` is the load-bearing one and the reason this guard
+    # exists at all. litellm reads it at ``main.py:602``, INSIDE ``async def acompletion``
+    # (lines 388-698) — the exact entry point HF's inherited ``chat_completion`` calls — and
+    # dispatches a DIFFERENT model. The fill path stores any answer carrying a
+    # ``finish_reason`` without comparing its model to the key's, and rows never expire. So
+    # one process-global setting writes another model's answer under an HF key, permanently.
+    # That is a wrong answer, not a stale one.
+    import litellm
+
+    monkeypatch.setattr(litellm, attribute, value, raising=False)
+
+    assert _plugin().participates_in_global_cache() is False
+
+
+def test_a_clean_process_participates(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The mirror of the test above: if the guard could not be satisfied, HF would cache
+    # nowhere and every other test here would pass vacuously.
+    import litellm
+
+    # ``"cache"`` in a callback list is explicitly permitted — it is litellm's own cache
+    # bookkeeping, not a third-party observer, and both existing exemplars allow it.
+    monkeypatch.setattr(litellm, "success_callback", ["cache"], raising=False)
+
+    assert _plugin().participates_in_global_cache() is True
+
+
+def test_a_raising_guard_costs_a_bypass_and_never_the_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # INVARIANT: the cache may never become an availability dependency.
+    #
+    # AIDEV-NOTE: asserted at the PLAN level on purpose, not on the hook's return value. The
+    # core already owns this guarantee — ``global_plan.py:72-77`` wraps the participation call
+    # in ``except Exception`` precisely so provider hooks do not each need their own catch — so
+    # a ``try`` inside the hook would be a second guard protecting nothing, the same pattern
+    # this plugin rejected for ``HuggingFaceChatConfig``. What actually matters to a caller is
+    # that the REQUEST still succeeds with a bypass, which only this end-to-end assertion pins.
+    plugin = _plugin()
+
+    class _Exploding:
+        def __getattr__(self, name: str) -> object:
+            raise RuntimeError("settings unavailable")
+
+    monkeypatch.setattr(plugin, "settings", _Exploding())
+
+    decision = build_global_cache_plan(
+        body=_body(),
+        plugin=plugin,
+        controls=GlobalCacheControls(participate=True),
+        cache_enabled=True,
+    )
+
+    assert isinstance(decision, CacheBypass)
+    assert decision.reason == PROJECTION_BYPASS_REASON
+
+
+def test_a_decline_names_its_reason_in_logs_without_leaking_the_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # WHY this matters (D11): every decline path publishes the SAME wire reason,
+    # ``provider_projection``. Without a log line an operator whose HF caching silently
+    # stopped has no way to learn which check declined. The token names the condition; the
+    # configured URL is NEVER logged, because it can carry an internal hostname.
+    from aigateway.plugins.huggingface_provider import plugin as plugin_module
+
+    plugin_module.reset_decline_log()
+    secret_base = "https://internal-proxy.corp.example/v1"
+
+    with caplog.at_level("WARNING"):
+        assert _plugin(router_api_base=secret_base).participates_in_global_cache() is False
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("router_api_base" in message for message in messages)
+    assert all(secret_base not in message for message in messages)
+
+
+def test_the_decline_log_is_emitted_once_per_condition(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from aigateway.plugins.huggingface_provider import plugin as plugin_module
+
+    plugin_module.reset_decline_log()
+    plugin = _plugin(router_api_base="https://proxy.internal/v1")
+
+    with caplog.at_level("WARNING"):
+        for _ in range(5):
+            plugin.participates_in_global_cache()
+
+    declines = [r for r in caplog.records if "global cache" in r.getMessage()]
+    # A per-request warning on a hot path is its own operational problem.
+    assert len(declines) == 1
+
+
+def test_the_cache_reference_mapper_answers_none_rather_than_being_absent() -> None:
+    # AIDEV-NOTE: NOT decoration. ``plugins/taxonomy/session.py:374`` reaches this hook
+    # through ``getattr`` inside a ``try`` and there is no base-class default, so a provider
+    # that omits it logs "cache-reference mapper failed provider=huggingface" on EVERY hit —
+    # an operator-visible failure that never happened. HF owns no usage-accounting strategy,
+    # so ``None`` is the truthful answer.
+    assert PLUGIN.cache_reference_from_cached_response({"usage": {"total_tokens": 5}}) is None

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_provider_allowlist.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_provider_allowlist.py
@@ -48,6 +48,44 @@ _ROUTING_POLICIES = ("fastest", "cheapest", "preferred", "auto")
 # the catalog publishes but does not admit.
 _REAL_PROVIDERS = ("groq", "baseten")
 
+# INVARIANT: this literal is the INDEPENDENT copy of the reviewed Hugging Face partner table.
+# It is written out by hand and compared for equality, never derived from production — a test
+# that reads ``KNOWN_ROUTER_BACKENDS`` on both sides of an assertion cannot fail, so the
+# sweeps below are structurally blind to a bad member and only this pin can see one.
+#
+# WHY a duplicated list is the right answer here and not DRY-violating drift: the two copies
+# are SUPPOSED to be compared. A single edit to either side must be justified to a reviewer,
+# which is the entire mechanism — the hazard being guarded is a policy keyword (``fastest``,
+# ``preferred``, a future ``:balanced``) reaching the allowlist, because a policy names no
+# fixed backend and its rows would replay one account's backend selection to another under a
+# key that is architecturally identity-free.
+#
+# AIDEV-NOTE: adding a genuinely new Hugging Face partner is a TWO-file change, on purpose.
+# Update production ``KNOWN_ROUTER_BACKENDS`` and this literal in the same commit, and say in
+# the message which partner-table revision you transcribed from.
+_EXPECTED_ROUTER_BACKENDS = frozenset(
+    {
+        "baseten",
+        "cerebras",
+        "cohere",
+        "deepinfra",
+        "fal-ai",
+        "featherless-ai",
+        "fireworks-ai",
+        "groq",
+        "hf-inference",
+        "novita",
+        "nscale",
+        "ovhcloud",
+        "publicai",
+        "replicate",
+        "scaleway",
+        "together",
+        "wavespeed",
+        "zai-org",
+    }
+)
+
 
 def _body(model: str, **extra: Any) -> dict[str, Any]:
     return {"model": model, "messages": [{"role": "user", "content": "hi"}], **extra}
@@ -132,6 +170,18 @@ def test_exactly_the_allowlisted_suffixes_are_cacheable() -> None:
 
 
 # --- the allowlist itself ----------------------------------------------------------------------
+
+
+def test_the_allowlist_is_exactly_the_independently_transcribed_partner_table() -> None:
+    """The one assertion in this module that a production-side edit cannot satisfy on its own.
+
+    Every other test here derives its expectation from ``KNOWN_ROUTER_BACKENDS``, so swapping a
+    member for another plausible slug leaves them all green. Measured, not assumed: rebinding the
+    constant with ``wavespeed`` -> ``fireworks`` left the whole 291-test suite passing, as did
+    ``publicai`` -> ``best`` — a policy-shaped word that would have made an identity-dependent
+    request cacheable. Both are red here.
+    """
+    assert KNOWN_ROUTER_BACKENDS == _EXPECTED_ROUTER_BACKENDS
 
 
 def test_no_routing_policy_is_in_the_allowlist() -> None:

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_provider_allowlist.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_provider_allowlist.py
@@ -1,0 +1,183 @@
+"""OME-791 (B1, B3) — only a KNOWN pinned Hugging Face provider may be cached.
+
+FEATURE: one globally shared exact-request cache (OME-305), keyed identically for every caller.
+
+STORY: as a benchmark operator I send ``…:preferred`` from two accounts with different provider
+preference orders and neither is served the other's answer — the request dispatches normally,
+uncached, instead of replaying a backend it would never have selected.
+
+THE HAZARD, stated once. The ``:<suffix>`` position accepts two different KINDS of token:
+
+    a PROVIDER   — ``:novita``, ``:groq``      → one fixed backend answers. Describable.
+    a POLICY     — ``:fastest``, ``:cheapest``, ``:preferred``  → a selection RULE.
+
+A policy names no backend. ``:preferred`` is the sharp case: it resolves against the REQUESTING
+ACCOUNT's preference order, so it is identity-dependent — and the global key is architecturally
+identity-free, so the hazard cannot be keyed around, only declined.
+
+WHY THESE TESTS EXIST AT ALL (B3). The pre-existing suite stayed fully green when policy suffixes
+were changed to the correct bypass behaviour: it tested the PARSER's raise sites, never the
+semantic question "is this backend fixed for the next call?". Syntax-shaped tests cannot see a
+hazard that is entirely about meaning. Every test here is written against the hazard instead.
+
+AIDEV-NOTE: ``test_two_backends_for_one_repo_do_not_collide`` in the keys module is NOT evidence
+of correctness for policies. Two policies producing two DIFFERENT keys is not the desired
+outcome — the desired outcome is that neither receives a key at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aigateway.core.cache_ports import PROJECTION_BYPASS_REASON, CacheBypass
+from aigateway.plugins.huggingface_provider.global_cache import project_global_cache_request
+from aigateway.plugins.huggingface_provider.settings import (
+    KNOWN_ROUTER_BACKENDS,
+    pinned_router_target,
+)
+
+_REPO = "deepseek-ai/DeepSeek-R1"
+
+# Routing policies documented at https://huggingface.co/docs/inference-providers/index.
+# ``auto`` is the inference clients' spelling of the same "pick one for me" idea.
+_ROUTING_POLICIES = ("fastest", "cheapest", "preferred", "auto")
+
+# Two REAL partner slugs, deliberately ones absent from this repository's seed list, to pin that
+# the catalog publishes but does not admit.
+_REAL_PROVIDERS = ("groq", "baseten")
+
+
+def _body(model: str, **extra: Any) -> dict[str, Any]:
+    return {"model": model, "messages": [{"role": "user", "content": "hi"}], **extra}
+
+
+def _bypasses(model: str) -> bool:
+    produced = project_global_cache_request(_body(model))
+    return isinstance(produced, CacheBypass) and produced.reason == PROJECTION_BYPASS_REASON
+
+
+# --- the hazard, named for what it is ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("policy", _ROUTING_POLICIES)
+def test_an_id_whose_backend_is_chosen_per_request_bypasses(policy: str) -> None:
+    """The semantic test the old suite lacked.
+
+    Not "does the parser raise" — it does not, and it must not. The question is whether the id
+    names a backend that is FIXED for the next call. A policy does not, so no row filled under it
+    describes the request that would replay it.
+    """
+    assert _bypasses(f"huggingface/{_REPO}:{policy}")
+
+
+def test_the_account_dependent_policy_is_the_sharpest_case() -> None:
+    # ``:preferred`` follows the REQUESTING ACCOUNT's provider preference order, so one account's
+    # answer would be replayed to another whose identical request selects a different provider.
+    # Called out separately because it is the one hazard that is a cross-ACCOUNT correctness bug
+    # rather than a within-account attribution bug.
+    assert _bypasses(f"huggingface/{_REPO}:preferred")
+
+
+def test_an_unsuffixed_id_bypasses() -> None:
+    # Equivalent to ``:fastest`` per the router docs — the default policy, spelled by omission.
+    assert _bypasses(f"huggingface/{_REPO}")
+
+
+@pytest.mark.parametrize(
+    "suffix", ["notarealprovider", "wildly-made-up", "NOVITA", "novita2", "hf_inference"]
+)
+def test_an_unknown_suffix_bypasses(suffix: str) -> None:
+    # FAIL CLOSED. Includes near-misses (wrong case, wrong separator, trailing digit) because
+    # those are what a typo or a future rename actually looks like.
+    assert _bypasses(f"huggingface/{_REPO}:{suffix}")
+
+
+# --- the positive half: known providers still work --------------------------------------------
+
+
+@pytest.mark.parametrize("provider", _REAL_PROVIDERS)
+def test_a_known_provider_suffix_still_projects(provider: str) -> None:
+    # Without this, "bypass everything" would satisfy every test above.
+    produced = project_global_cache_request(_body(f"huggingface/{_REPO}:{provider}"))
+
+    assert not isinstance(produced, CacheBypass)
+    assert produced["resolved_model"] == f"{_REPO}:{provider}"
+
+
+def test_two_known_providers_for_one_repo_stay_separated() -> None:
+    # The suffix is output-affecting, so it must remain in the key material.
+    first = project_global_cache_request(_body(f"huggingface/{_REPO}:{_REAL_PROVIDERS[0]}"))
+    second = project_global_cache_request(_body(f"huggingface/{_REPO}:{_REAL_PROVIDERS[1]}"))
+
+    assert not isinstance(first, CacheBypass) and not isinstance(second, CacheBypass)
+    assert first["resolved_model"] != second["resolved_model"]
+
+
+def test_exactly_the_allowlisted_suffixes_are_cacheable() -> None:
+    """The completeness statement: cacheability is a FUNCTION of the allowlist, nothing else.
+
+    Sweeping the whole allowlist plus the whole policy set in one assertion is what makes a
+    future edit to either side visible here rather than only in a distant route test.
+    """
+    cacheable = {
+        provider
+        for provider in KNOWN_ROUTER_BACKENDS
+        if not _bypasses(f"huggingface/{_REPO}:{provider}")
+    }
+
+    assert cacheable == set(KNOWN_ROUTER_BACKENDS)
+    assert all(_bypasses(f"huggingface/{_REPO}:{policy}") for policy in _ROUTING_POLICIES)
+
+
+# --- the allowlist itself ----------------------------------------------------------------------
+
+
+def test_no_routing_policy_is_in_the_allowlist() -> None:
+    # A standing guard against the exact regression B1 fixed: a policy admitted to the provider
+    # allowlist would be cached as though it named a fixed backend.
+    assert not (set(_ROUTING_POLICIES) & KNOWN_ROUTER_BACKENDS)
+
+
+def test_the_allowlist_carries_the_full_partner_table_not_just_the_seeded_providers() -> None:
+    """Sourced from the partner table, NOT from ``default_models``.
+
+    The seed list names 8 providers; the partner table names 18. Deriving the allowlist from the
+    seeds would silently refuse to cache a perfectly valid request for a real partner the
+    operator happens not to have seeded — turning a catalog into an admission list.
+    """
+    from aigateway.plugins.huggingface_provider.settings import _default_model_slugs
+
+    seeded = {slug.split(":")[1] for slug in _default_model_slugs() if ":" in slug}
+
+    assert len(KNOWN_ROUTER_BACKENDS) == 18
+    assert seeded < KNOWN_ROUTER_BACKENDS, "every seeded provider must be allowlisted"
+    assert {"groq", "baseten"} <= KNOWN_ROUTER_BACKENDS, "unseeded real partners must cache too"
+
+
+# --- dispatch stays permissive (B1.4) -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("suffix", [*_ROUTING_POLICIES, "notarealprovider"])
+def test_a_policy_or_unknown_suffix_is_still_a_VALID_id_for_dispatch(suffix: str) -> None:
+    """This change narrows CACHEABILITY, never validity.
+
+    INVARIANT: ``_validate_model_slug`` stays permissive. If the allowlist had been wired into
+    slug validation instead, a valid Hugging Face request would start being REFUSED by the
+    gateway — turning a cache optimisation into an outage.
+    """
+    from aigateway.plugins.huggingface_provider.settings import _validate_model_slug
+
+    slug = f"huggingface/{_REPO}:{suffix}"
+
+    assert _validate_model_slug(slug) == slug  # does not raise
+    assert pinned_router_target(slug) is None  # but is not cacheable
+
+
+def test_a_malformed_id_is_still_refused() -> None:
+    # The allowlist must not have loosened the malformed-id refusal it sits behind.
+    from aigateway.plugins.huggingface_provider.settings import _validate_model_slug
+
+    with pytest.raises(ValueError, match="unsafe/malformed"):
+        _validate_model_slug("huggingface/nscale/meta-llama/Llama-3.1-8B-Instruct")

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_route_global_cache.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_route_global_cache.py
@@ -1,18 +1,16 @@
-"""OME-791 — HF promotion, key differences, and the route's miss -> hit behaviour.
+"""OME-791 — the HF chat route's global-cache miss -> store -> hit behaviour.
 
-FEATURE: one globally shared exact-request cache (OME-305). The projection made HF
-*describable*; promoting its parameter rules from ``bypass`` to ``keyed`` is what makes an
-identical re-run actually cheaper.
+FEATURE: one globally shared exact-request cache (OME-305).
 
 STORY: as a benchmark operator I re-run a suite against a backend-pinned HF model and the
 identical calls come back from the first run's rows — one dispatch, one row, and no HF token
 read on the replay.
 
 What this module pins, and why each matters:
-- every one of the TWELVE newly-keyed request paths, because a keyed path with no
-  key-difference proof is how two materially different requests come to share one answer;
-- a derived-set meta-test, so a future keyed path cannot land without its own proof;
-- the route's end-to-end contract, including the things that must NOT happen on a hit.
+- the route's end-to-end contract, including the things that must NOT happen on a hit;
+- that an id whose backend is chosen PER REQUEST dispatches normally and never touches a row.
+
+Split from the keying tests (OME-791 review); see ``test_huggingface_global_cache_keys.py``.
 """
 
 from __future__ import annotations
@@ -24,14 +22,9 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
-from aigateway.core.profile_index import ProfileIndexStore
-from aigateway.core.profile_models import Profile, ProfileState, profile_id_for
 from aigateway.core.request_cache import RequestCacheWrite
 from aigateway.core.request_cache.global_controls import GlobalCacheControls
 from aigateway.core.request_cache.global_plan import build_global_cache_plan
-from aigateway.plugins.huggingface_provider.parameters import (
-    huggingface_chat_parameter_rules,
-)
 from aigateway.plugins.huggingface_provider.plugin import PLUGIN
 from aigateway.plugins.huggingface_provider.settings import HuggingFacePluginSettings
 
@@ -136,140 +129,6 @@ def _key_hash(body: dict[str, Any]) -> str:
     )
     assert not hasattr(decision, "reason"), f"expected a key, got a bypass: {decision}"
     return cast(Any, decision).key_hash
-
-
-# --- promotion, proven per path -----------------------------------------------
-
-
-def test_the_promoted_set_is_exactly_the_twelve_paths_this_unit_claims() -> None:
-    keyed = {
-        rule.request_path
-        for rule in huggingface_chat_parameter_rules(model=_MODEL, auth_type=None)
-        if rule.cache_behavior == "keyed"
-    }
-
-    assert keyed == set(_EXPECTED_KEYED_PATHS)
-
-
-def test_every_keyed_path_has_an_explicit_key_difference_proof() -> None:
-    """The meta-test that makes this file self-enforcing.
-
-    INVARIANT: a keyed path with no key-difference proof is exactly how two materially
-    different requests come to share one stored answer. Deriving the set from the LIVE rules
-    means a future promotion cannot land silently — it fails here until someone adds its pair.
-    Mirrors ``test_every_openrouter_keyed_path_has_an_explicit_key_difference_proof``.
-    """
-    keyed = {
-        rule.request_path
-        for rule in huggingface_chat_parameter_rules(model=_MODEL, auth_type=None)
-        if rule.cache_behavior == "keyed"
-    }
-
-    assert keyed == set(_KEY_DIFFERENCE_CASES), (
-        "every keyed HF path needs a concrete differing-value pair in _KEY_DIFFERENCE_CASES"
-    )
-
-
-@pytest.mark.parametrize("path", sorted(_KEY_DIFFERENCE_CASES))
-def test_a_keyed_path_changes_the_key_when_its_value_changes(path: str) -> None:
-    low, high = _KEY_DIFFERENCE_CASES[path]
-    extra = {"logprobs": True} if path == "top_logprobs" else {}
-
-    assert _key_hash(_body(**{path: low}, **extra)) != _key_hash(_body(**{path: high}, **extra))
-
-
-@pytest.mark.parametrize("path", sorted(_KEY_DIFFERENCE_CASES))
-def test_a_keyed_path_keys_identically_for_an_identical_value(path: str) -> None:
-    low, _ = _KEY_DIFFERENCE_CASES[path]
-    extra = {"logprobs": True} if path == "top_logprobs" else {}
-
-    assert _key_hash(_body(**{path: low}, **extra)) == _key_hash(_body(**{path: low}, **extra))
-
-
-def test_two_backends_for_one_repo_do_not_collide() -> None:
-    # The projection retains ``:<backend>`` in ``resolved_model``; this is the end-to-end
-    # consequence, at the level a caller can observe.
-    novita = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:novita"))
-    together = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:together"))
-
-    assert novita != together
-
-
-def test_two_repos_do_not_collide() -> None:
-    first = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:novita"))
-    second = _key_hash(_body(model="huggingface/Qwen/Qwen3-235B-A22B:novita"))
-
-    assert first != second
-
-
-def test_every_registered_model_contributes_the_full_keyed_set() -> None:
-    """HF's own regression floor, derived rather than hardcoded.
-
-    AIDEV-NOTE: this replaces the tempting alternative of raising
-    ``_OBSERVED_NON_BYPASS_INSTANCES`` in the SHARED conformance test. That number depends on
-    catalog and environment state, and the file is append-only-protected; a floor derived from
-    THIS plugin is both stronger for HF and free of blast radius.
-    """
-    entries = list(PLUGIN.register_models())
-    assert entries, "no HF models registered"
-
-    for entry in entries:
-        keyed = {
-            rule.request_path
-            for rule in huggingface_chat_parameter_rules(model=entry.model_name, auth_type=None)
-            if rule.cache_behavior == "keyed"
-        }
-        assert keyed == set(_EXPECTED_KEYED_PATHS), entry.model_name
-
-
-async def _no_discovery(*_args: Any, **_kwargs: Any) -> None:
-    return None
-
-
-@pytest.mark.asyncio
-async def test_the_published_parameter_contract_reports_the_promoted_behaviour(
-    authenticated_client, credential_blobs: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The caller-visible half of promotion, which nothing else asserts.
-
-    WHY this test exists: the published contract digests each rule's ``cache_behavior`` and
-    ``projection_revision`` (``core/model_parameter_contract.py:78``), so this unit moves every
-    HF model's ``contract_id`` and flips twelve rows of its detail document. No existing test
-    pins a digest or the old revision, which means the entire caller-visible surface could flip
-    with nothing objecting. One assertion is enough to make the change deliberate.
-    """
-    # No live discovery evidence: the unit suite forbids catalog egress
-    # (``tests/conftest.py:145-165``), and live backend evidence is orthogonal to what this
-    # test asserts — the GATEWAY's own declared cache disposition, which comes from the rule
-    # table rather than from any snapshot.
-    monkeypatch.setattr(
-        type(PLUGIN), "discover_chat_parameter_snapshot", _no_discovery, raising=True
-    )
-
-    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
-    index = ProfileIndexStore(credential_store=credential_blobs.store)
-    await index.upsert(
-        Profile(
-            id=profile_id_for(account_id, "huggingface", "default"),
-            account_id=account_id,
-            provider="huggingface",
-            name="default",
-            state=ProfileState.AUTHENTICATED,
-            auth_type="api_key",
-        )
-    )
-
-    resp = authenticated_client.get("/v1/model-parameters", params={"model": _MODEL})
-    assert resp.status_code == 200, resp.text
-
-    published = _published_cache_behaviour(resp.json())
-    keyed = {path for path, behaviour in published.items() if behaviour == "keyed"}
-
-    assert keyed == set(_EXPECTED_KEYED_PATHS), (
-        f"the published contract does not report the promoted set: {sorted(keyed)}"
-    )
-    # And nothing ELSE quietly became cacheable: the published set is exactly the promotion.
-    assert not [path for path, b in published.items() if b not in {"keyed", "bypass"}], published
 
 
 # --- the route ----------------------------------------------------------------
@@ -474,6 +333,34 @@ def test_an_unsuffixed_id_dispatches_normally_and_never_touches_the_cache(
     assert second.headers["X-AIGW-Cache"] == "bypass"
     assert len(counter.calls) == 2, "both requests must have dispatched"
     assert store.rows == {}
+    assert store.get_calls == [], "an unkeyable request must not even probe the store"
+
+
+@pytest.mark.parametrize("suffix", ["fastest", "cheapest", "preferred", "auto", "notarealprovider"])
+def test_a_policy_id_dispatches_every_time_and_never_touches_the_cache(
+    suffix: str, cache_client: TestClient
+) -> None:
+    """OME-791 B1/B3 at the ROUTE, where the damage would actually be done.
+
+    The projection-level test proves no key is produced. This proves the consequence a caller
+    can observe: the second identical request DISPATCHES AGAIN instead of becoming a hit, and no
+    row is written that a different account could later be served.
+    """
+    store = _install(cache_client)
+    counter = _DispatchCounter()
+    model = f"huggingface/deepseek-ai/DeepSeek-R1:{suffix}"
+
+    with patch(_PATCH_TARGET, counter):
+        first = cache_client.post(_CHAT_PATH, json=_body(model=model))
+        second = cache_client.post(_CHAT_PATH, json=_body(model=model))
+
+    # Dispatch is untouched by this change — a policy id is a VALID request.
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.headers["X-AIGW-Cache"] == "bypass"
+    assert second.headers["X-AIGW-Cache"] == "bypass"
+    assert len(counter.calls) == 2, "a policy request must never become a cache hit"
+    assert store.set_calls == [], "no row may be written for an account-dependent route"
     assert store.get_calls == [], "an unkeyable request must not even probe the store"
 
 

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_route_global_cache.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_route_global_cache.py
@@ -1,0 +1,550 @@
+"""OME-791 — HF promotion, key differences, and the route's miss -> hit behaviour.
+
+FEATURE: one globally shared exact-request cache (OME-305). The projection made HF
+*describable*; promoting its parameter rules from ``bypass`` to ``keyed`` is what makes an
+identical re-run actually cheaper.
+
+STORY: as a benchmark operator I re-run a suite against a backend-pinned HF model and the
+identical calls come back from the first run's rows — one dispatch, one row, and no HF token
+read on the replay.
+
+What this module pins, and why each matters:
+- every one of the TWELVE newly-keyed request paths, because a keyed path with no
+  key-difference proof is how two materially different requests come to share one answer;
+- a derived-set meta-test, so a future keyed path cannot land without its own proof;
+- the route's end-to-end contract, including the things that must NOT happen on a hit.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from aigateway.core.profile_index import ProfileIndexStore
+from aigateway.core.profile_models import Profile, ProfileState, profile_id_for
+from aigateway.core.request_cache import RequestCacheWrite
+from aigateway.core.request_cache.global_controls import GlobalCacheControls
+from aigateway.core.request_cache.global_plan import build_global_cache_plan
+from aigateway.plugins.huggingface_provider.parameters import (
+    huggingface_chat_parameter_rules,
+)
+from aigateway.plugins.huggingface_provider.plugin import PLUGIN
+from aigateway.plugins.huggingface_provider.settings import HuggingFacePluginSettings
+
+_CHAT_PATH = "/v1/chat/completions"
+_PATCH_TARGET = (
+    "aigateway.plugins.huggingface_provider.plugin.HuggingFaceProviderPlugin.chat_completion"
+)
+_MODEL = "huggingface/deepseek-ai/DeepSeek-R1:novita"
+_HF_KEY = "hf_route_global_cache_key_1234567890"
+
+# The complete set of HF request paths that OME-791 promotes to ``keyed``.
+#
+# INVARIANT: TWELVE, not the ten ``direct_rule`` calls a reader counts in ``parameters.py``.
+# ``function_calling_rules`` emits ``tools`` AND ``tool_choice`` as two separate rules
+# (``standard_parameters.py:232-252``, with ``tool_choice=True`` defaulted at ``:204``), so a
+# literal set written from the source file alone is wrong by two. The meta-test below derives
+# the real set from the live rule table and asserts equality against this literal, so the two
+# can never drift.
+_EXPECTED_KEYED_PATHS = frozenset(
+    {
+        "temperature",
+        "max_tokens",
+        "stop",
+        "response_format",
+        "seed",
+        "n",
+        "frequency_penalty",
+        "presence_penalty",
+        "logprobs",
+        "top_logprobs",
+        "tools",
+        "tool_choice",
+    }
+)
+
+# One concrete pair of DIFFERENT values per keyed path. A path missing from this table has no
+# key-difference proof, which the meta-test refuses.
+_KEY_DIFFERENCE_CASES: dict[str, tuple[Any, Any]] = {
+    "temperature": (0.0, 1.0),
+    "max_tokens": (16, 32),
+    "stop": (["END"], ["STOP"]),
+    "response_format": ({"type": "text"}, {"type": "json_object"}),
+    "seed": (1, 2),
+    "n": (1, 2),
+    "frequency_penalty": (0.0, 0.5),
+    "presence_penalty": (0.0, 0.5),
+    # INVARIANT: ``top_logprobs`` requires ``logprobs is True``, so the pair varies the
+    # dependent field while holding the enabling one — otherwise the 400 combination rule,
+    # not the key, would be what distinguishes the two requests.
+    "logprobs": (True, False),
+    "top_logprobs": (1, 2),
+    "tools": (
+        [{"type": "function", "function": {"name": "alpha", "parameters": {}}}],
+        [{"type": "function", "function": {"name": "beta", "parameters": {}}}],
+    ),
+    "tool_choice": ("auto", "none"),
+}
+
+
+def _published_cache_behaviour(document: dict[str, Any]) -> dict[str, str]:
+    """``{request_path: cache_behavior}`` as a CALLER reads it off the contract document.
+
+    Shape (verified against the live route): each entry under ``parameters`` — and each tool
+    entry under ``tools`` — carries a ``gateway`` block holding ``cache_behavior``. Reading both
+    sections matters: ``tools`` and ``tool_choice`` are two of the twelve promoted paths and do
+    not appear beside the scalar parameters.
+    """
+    published: dict[str, str] = {}
+    for section in ("parameters", "tools"):
+        entries = document.get(section)
+        if not isinstance(entries, dict):
+            continue
+        for name, entry in entries.items():
+            gateway = entry.get("gateway") if isinstance(entry, dict) else None
+            if isinstance(gateway, dict) and "cache_behavior" in gateway:
+                published[str(name)] = str(gateway["cache_behavior"])
+    return published
+
+
+def _body(**overrides: Any) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "model": _MODEL,
+        "messages": [{"role": "user", "content": "how many primes below one hundred?"}],
+    }
+    body.update(overrides)
+    return body
+
+
+def _key_hash(body: dict[str, Any]) -> str:
+    """The global cache key for ``body``, through the REAL plan.
+
+    WHY the whole plan rather than the projection alone: a key-difference test that called the
+    projection directly would prove nothing about promotion, because the projection does not
+    see parameters at all. Only the plan applies the rule table, so only the plan can show that
+    a promoted path actually reached the key.
+    """
+    decision = build_global_cache_plan(
+        body=body,
+        plugin=PLUGIN,
+        controls=GlobalCacheControls(participate=True),
+        cache_enabled=True,
+    )
+    assert not hasattr(decision, "reason"), f"expected a key, got a bypass: {decision}"
+    return cast(Any, decision).key_hash
+
+
+# --- promotion, proven per path -----------------------------------------------
+
+
+def test_the_promoted_set_is_exactly_the_twelve_paths_this_unit_claims() -> None:
+    keyed = {
+        rule.request_path
+        for rule in huggingface_chat_parameter_rules(model=_MODEL, auth_type=None)
+        if rule.cache_behavior == "keyed"
+    }
+
+    assert keyed == set(_EXPECTED_KEYED_PATHS)
+
+
+def test_every_keyed_path_has_an_explicit_key_difference_proof() -> None:
+    """The meta-test that makes this file self-enforcing.
+
+    INVARIANT: a keyed path with no key-difference proof is exactly how two materially
+    different requests come to share one stored answer. Deriving the set from the LIVE rules
+    means a future promotion cannot land silently — it fails here until someone adds its pair.
+    Mirrors ``test_every_openrouter_keyed_path_has_an_explicit_key_difference_proof``.
+    """
+    keyed = {
+        rule.request_path
+        for rule in huggingface_chat_parameter_rules(model=_MODEL, auth_type=None)
+        if rule.cache_behavior == "keyed"
+    }
+
+    assert keyed == set(_KEY_DIFFERENCE_CASES), (
+        "every keyed HF path needs a concrete differing-value pair in _KEY_DIFFERENCE_CASES"
+    )
+
+
+@pytest.mark.parametrize("path", sorted(_KEY_DIFFERENCE_CASES))
+def test_a_keyed_path_changes_the_key_when_its_value_changes(path: str) -> None:
+    low, high = _KEY_DIFFERENCE_CASES[path]
+    extra = {"logprobs": True} if path == "top_logprobs" else {}
+
+    assert _key_hash(_body(**{path: low}, **extra)) != _key_hash(_body(**{path: high}, **extra))
+
+
+@pytest.mark.parametrize("path", sorted(_KEY_DIFFERENCE_CASES))
+def test_a_keyed_path_keys_identically_for_an_identical_value(path: str) -> None:
+    low, _ = _KEY_DIFFERENCE_CASES[path]
+    extra = {"logprobs": True} if path == "top_logprobs" else {}
+
+    assert _key_hash(_body(**{path: low}, **extra)) == _key_hash(_body(**{path: low}, **extra))
+
+
+def test_two_backends_for_one_repo_do_not_collide() -> None:
+    # The projection retains ``:<backend>`` in ``resolved_model``; this is the end-to-end
+    # consequence, at the level a caller can observe.
+    novita = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:novita"))
+    together = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:together"))
+
+    assert novita != together
+
+
+def test_two_repos_do_not_collide() -> None:
+    first = _key_hash(_body(model="huggingface/deepseek-ai/DeepSeek-R1:novita"))
+    second = _key_hash(_body(model="huggingface/Qwen/Qwen3-235B-A22B:novita"))
+
+    assert first != second
+
+
+def test_every_registered_model_contributes_the_full_keyed_set() -> None:
+    """HF's own regression floor, derived rather than hardcoded.
+
+    AIDEV-NOTE: this replaces the tempting alternative of raising
+    ``_OBSERVED_NON_BYPASS_INSTANCES`` in the SHARED conformance test. That number depends on
+    catalog and environment state, and the file is append-only-protected; a floor derived from
+    THIS plugin is both stronger for HF and free of blast radius.
+    """
+    entries = list(PLUGIN.register_models())
+    assert entries, "no HF models registered"
+
+    for entry in entries:
+        keyed = {
+            rule.request_path
+            for rule in huggingface_chat_parameter_rules(model=entry.model_name, auth_type=None)
+            if rule.cache_behavior == "keyed"
+        }
+        assert keyed == set(_EXPECTED_KEYED_PATHS), entry.model_name
+
+
+async def _no_discovery(*_args: Any, **_kwargs: Any) -> None:
+    return None
+
+
+@pytest.mark.asyncio
+async def test_the_published_parameter_contract_reports_the_promoted_behaviour(
+    authenticated_client, credential_blobs: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The caller-visible half of promotion, which nothing else asserts.
+
+    WHY this test exists: the published contract digests each rule's ``cache_behavior`` and
+    ``projection_revision`` (``core/model_parameter_contract.py:78``), so this unit moves every
+    HF model's ``contract_id`` and flips twelve rows of its detail document. No existing test
+    pins a digest or the old revision, which means the entire caller-visible surface could flip
+    with nothing objecting. One assertion is enough to make the change deliberate.
+    """
+    # No live discovery evidence: the unit suite forbids catalog egress
+    # (``tests/conftest.py:145-165``), and live backend evidence is orthogonal to what this
+    # test asserts — the GATEWAY's own declared cache disposition, which comes from the rule
+    # table rather than from any snapshot.
+    monkeypatch.setattr(
+        type(PLUGIN), "discover_chat_parameter_snapshot", _no_discovery, raising=True
+    )
+
+    account_id = authenticated_client.get("/v1/auth/me").json()["id"]
+    index = ProfileIndexStore(credential_store=credential_blobs.store)
+    await index.upsert(
+        Profile(
+            id=profile_id_for(account_id, "huggingface", "default"),
+            account_id=account_id,
+            provider="huggingface",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+            auth_type="api_key",
+        )
+    )
+
+    resp = authenticated_client.get("/v1/model-parameters", params={"model": _MODEL})
+    assert resp.status_code == 200, resp.text
+
+    published = _published_cache_behaviour(resp.json())
+    keyed = {path for path, behaviour in published.items() if behaviour == "keyed"}
+
+    assert keyed == set(_EXPECTED_KEYED_PATHS), (
+        f"the published contract does not report the promoted set: {sorted(keyed)}"
+    )
+    # And nothing ELSE quietly became cacheable: the published set is exactly the promotion.
+    assert not [path for path, b in published.items() if b not in {"keyed", "bypass"}], published
+
+
+# --- the route ----------------------------------------------------------------
+
+
+class _DispatchCounter:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, body: dict[str, Any]) -> Any:
+        self.calls.append(dict(body))
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": f"resp-{len(self.calls)}",
+                "choices": [
+                    {"message": {"content": "HF-PLAINTEXT-ANSWER-42"}, "finish_reason": "stop"}
+                ],
+            }
+        )
+
+
+class _MemoryStore:
+    """The frozen store contract, in memory.
+
+    INVARIANT modelled: ``get`` returns ``None`` only for a genuine miss;
+    ``set_if_absent`` never raises and the first successful insert wins.
+    """
+
+    def __init__(self) -> None:
+        self.rows: dict[str, dict[str, Any]] = {}
+        self.get_calls: list[str] = []
+        self.set_calls: list[RequestCacheWrite] = []
+
+    def cache_available(self) -> bool:
+        return True
+
+    async def get(self, key_hash: str) -> dict[str, Any] | None:
+        self.get_calls.append(key_hash)
+        return self.rows.get(key_hash)
+
+    async def set_if_absent(self, entry: RequestCacheWrite) -> str:
+        self.set_calls.append(entry)
+        if entry.key_hash in self.rows:
+            return "race_lost"
+        self.rows[entry.key_hash] = entry.response
+        return "stored"
+
+
+@pytest.fixture
+def _valid_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """This module is deliberately OUTSIDE ``_LEGACY_API_KEY_ROUTE_MODULES``.
+
+    AIDEV-NOTE: conftest grants its blanket validation success only to a frozen allowlist, and
+    a new module is not on it — by design, so new tests exercise the real service unless they
+    say otherwise. This double is that explicit statement, scoped to this module.
+    """
+    from aigateway.core.api_key_validation import (
+        ApiKeyValidationResult,
+        ApiKeyValidationStage,
+        ApiKeyValidationState,
+    )
+    from aigateway.core.api_key_validation_service import ApiKeyValidationService
+
+    async def _valid(_self: Any, _plugin: Any, _provider: str, _api_key: str) -> Any:
+        return ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID,
+            stage=ApiKeyValidationStage.READINESS,
+        )
+
+    monkeypatch.setattr(ApiKeyValidationService, "validate", _valid)
+
+
+@pytest.fixture
+def cache_client(
+    monkeypatch: pytest.MonkeyPatch, _valid_api_key: None, client: TestClient
+) -> TestClient:
+    monkeypatch.setenv("AIGW_REQUEST_CACHE_ENABLED", "true")
+    resp = client.post(
+        "/v1/auth/login",
+        json={"username": "admin", "password": "test-admin-password"},
+    )
+    assert resp.status_code == 200, resp.text
+    client.headers.update({"Authorization": f"Bearer {resp.json()['token']}"})
+    resp = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "huggingface", "api_key": _HF_KEY, "label": "hf"},
+    )
+    assert resp.status_code == 201, resp.text
+    return client
+
+
+def _install(client: TestClient) -> _MemoryStore:
+    store = _MemoryStore()
+    cast(Any, client.app).state.request_cache_store = store
+    return store
+
+
+def test_an_identical_request_is_answered_from_the_row_with_one_dispatch(
+    cache_client: TestClient,
+) -> None:
+    """THE acceptance test: the whole reason OME-791 exists."""
+    store = _install(cache_client)
+    counter = _DispatchCounter()
+
+    with patch(_PATCH_TARGET, counter):
+        first = cache_client.post(_CHAT_PATH, json=_body())
+        second = cache_client.post(_CHAT_PATH, json=_body())
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.headers["X-AIGW-Cache"] == "miss"
+    assert first.headers["X-AIGW-Cache-Write"] == "stored"
+    assert second.headers["X-AIGW-Cache"] == "hit"
+    assert len(counter.calls) == 1, "the replay must not have dispatched"
+    assert len(store.rows) == 1
+    assert second.json()["choices"][0]["message"]["content"] == "HF-PLAINTEXT-ANSWER-42"
+
+
+def test_a_hit_reads_no_huggingface_provider_credential(
+    cache_client: TestClient, credential_blobs: Any
+) -> None:
+    """The inversion this feature is FOR — stated precisely, not aspirationally.
+
+    AIDEV-NOTE: the claim is deliberately narrow. A hit DOES perform one profile-index read,
+    and that index is itself a ``credential_blobs`` row, so a hit costs one master-key
+    decryption — documented as the accepted pre-cache cost in the AIDEV-NOTE at
+    ``routes/chat_profile_defaults.py:68-71``. What must NOT happen is any
+    ``aigateway:huggingface:*`` credential read, auth-mode resolution, key injection or
+    provider dispatch. An earlier draft of this plan claimed "no credential work", which is
+    false and would have failed here.
+    """
+    from aigateway.core.credential_blob.store import ORMStore
+
+    store = _install(cache_client)
+    counter = _DispatchCounter()
+    services: list[str] = []
+    original = ORMStore.read
+
+    async def _recording(self: Any, service: str, account: str) -> Any:
+        services.append(service)
+        return await original(self, service, account)
+
+    with patch.object(ORMStore, "read", _recording), patch(_PATCH_TARGET, counter):
+        miss = cache_client.post(_CHAT_PATH, json=_body())
+        assert miss.headers["X-AIGW-Cache"] == "miss"
+        # Control: unless the MISS demonstrably read the HF credential, the assertion on the
+        # hit below would pass vacuously.
+        assert [s for s in services if "huggingface" in s], (
+            f"the miss read no HF credential, so this test would prove nothing: {services}"
+        )
+
+        services.clear()
+        hit = cache_client.post(_CHAT_PATH, json=_body())
+
+    assert hit.headers["X-AIGW-Cache"] == "hit"
+    assert len(counter.calls) == 1, "no dispatch on a hit"
+    assert not [s for s in services if "huggingface" in s], (
+        f"a hit read an aigateway:huggingface:* credential: {services}"
+    )
+    # The accepted pre-cache cost, asserted POSITIVELY so the claim above stays honest: a hit
+    # does still touch the credential table once, for the profile index.
+    assert services, "expected the profile-index read, which is the accepted pre-cache cost"
+    assert len(store.rows) == 1
+
+
+def test_a_streaming_request_is_never_cached(cache_client: TestClient) -> None:
+    # D10: refused by the core ahead of any provider
+    # (``global_eligibility.TRUTHY_BYPASS_REASONS`` applied at :180, before ``_projected`` at
+    # :406). Asserted here for HF SPECIFICALLY because HF's streaming path is live, and a
+    # core-owned guarantee no HF test exercises is a guarantee nobody notices breaking.
+    store = _install(cache_client)
+    counter = _DispatchCounter()
+
+    with patch(_PATCH_TARGET, counter):
+        resp = cache_client.post(_CHAT_PATH, json=_body(stream=True))
+
+    assert resp.headers["X-AIGW-Cache"] == "bypass"
+    assert resp.headers["X-AIGW-Cache-Reason"] == "stream"
+    assert store.rows == {}
+    assert store.set_calls == []
+
+
+def test_an_unsuffixed_id_dispatches_normally_and_never_touches_the_cache(
+    cache_client: TestClient,
+) -> None:
+    # The one bypass that does NOT mirror a dispatch refusal: an unsuffixed id is perfectly
+    # dispatchable, so the request must still be SERVED — it simply must not be keyed.
+    store = _install(cache_client)
+    counter = _DispatchCounter()
+
+    with patch(_PATCH_TARGET, counter):
+        first = cache_client.post(
+            _CHAT_PATH, json=_body(model="huggingface/deepseek-ai/DeepSeek-R1")
+        )
+        second = cache_client.post(
+            _CHAT_PATH, json=_body(model="huggingface/deepseek-ai/DeepSeek-R1")
+        )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.headers["X-AIGW-Cache"] == "bypass"
+    assert second.headers["X-AIGW-Cache"] == "bypass"
+    assert len(counter.calls) == 2, "both requests must have dispatched"
+    assert store.rows == {}
+    assert store.get_calls == [], "an unkeyable request must not even probe the store"
+
+
+def test_a_caller_opt_out_bypasses_without_writing(cache_client: TestClient) -> None:
+    store = _install(cache_client)
+    counter = _DispatchCounter()
+
+    with patch(_PATCH_TARGET, counter):
+        resp = cache_client.post(_CHAT_PATH, json=_body(cache={"participate": False}))
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["X-AIGW-Cache"] == "bypass"
+    assert len(counter.calls) == 1
+    assert store.rows == {}
+
+
+def test_a_failed_dispatch_stores_nothing(cache_client: TestClient) -> None:
+    store = _install(cache_client)
+
+    async def _explode(_body: dict[str, Any]) -> Any:
+        raise RuntimeError("upstream is down")
+
+    with patch(_PATCH_TARGET, _explode):
+        resp = cache_client.post(_CHAT_PATH, json=_body())
+
+    assert resp.status_code >= 400
+    # INVARIANT: only a whole answer with a ``finish_reason`` fills a row. Storing an error
+    # would make one bad minute upstream permanent, because rows never expire.
+    assert store.rows == {}
+    assert store.set_calls == []
+
+
+def test_a_row_filled_at_the_official_base_is_not_replayed_after_an_override(
+    cache_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The D3 gate, proven on the READ side and not merely the write side.
+
+    AIDEV-NOTE: this is the test the plan calls a tripwire, and the reason it exists is that
+    the OBVIOUS version of it proves nothing. A test that overrides the base FIRST and then
+    checks "no row was written" passes trivially — there was never a row to replay. The hazard
+    is the other order: a row filled by a deployment pointed at the official router, then
+    served to one pointed somewhere else. So this fills first, overrides second, and asserts
+    the stored row survives untouched while the request dispatches for real.
+
+    INVARIANT: declining participation is LOSSLESS. The row is neither invalidated nor
+    rewritten — an operator who reverts the override gets their cache back.
+    """
+    store = _install(cache_client)
+    counter = _DispatchCounter()
+
+    with patch(_PATCH_TARGET, counter):
+        fill = cache_client.post(_CHAT_PATH, json=_body())
+        assert fill.headers["X-AIGW-Cache"] == "miss"
+        assert fill.headers["X-AIGW-Cache-Write"] == "stored"
+        assert len(store.rows) == 1
+        stored = dict(store.rows)
+
+        # AIDEV-NOTE: patch the plugin INSTANCE, not the environment. ``PLUGIN`` is a
+        # module-level singleton built at import time, so ``AIGW_HUGGINGFACE_*`` set after this
+        # module has been imported cannot reach it.
+        monkeypatch.setattr(
+            PLUGIN,
+            "settings",
+            HuggingFacePluginSettings(router_api_base="https://proxy.internal/v1"),
+        )
+
+        after = cache_client.post(_CHAT_PATH, json=_body())
+
+    assert after.status_code == 200, after.text
+    assert after.headers["X-AIGW-Cache"] == "bypass"
+    assert after.headers["X-AIGW-Cache-Reason"] == "provider_projection"
+    assert len(counter.calls) == 2, "the overridden deployment must dispatch for itself"
+    # Lossless: the row is still there, byte for byte.
+    assert store.rows == stored

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_route_global_cache.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_route_global_cache.py
@@ -23,8 +23,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from aigateway.core.request_cache import RequestCacheWrite
-from aigateway.core.request_cache.global_controls import GlobalCacheControls
-from aigateway.core.request_cache.global_plan import build_global_cache_plan
 from aigateway.plugins.huggingface_provider.plugin import PLUGIN
 from aigateway.plugins.huggingface_provider.settings import HuggingFacePluginSettings
 
@@ -35,74 +33,6 @@ _PATCH_TARGET = (
 _MODEL = "huggingface/deepseek-ai/DeepSeek-R1:novita"
 _HF_KEY = "hf_route_global_cache_key_1234567890"
 
-# The complete set of HF request paths that OME-791 promotes to ``keyed``.
-#
-# INVARIANT: TWELVE, not the ten ``direct_rule`` calls a reader counts in ``parameters.py``.
-# ``function_calling_rules`` emits ``tools`` AND ``tool_choice`` as two separate rules
-# (``standard_parameters.py:232-252``, with ``tool_choice=True`` defaulted at ``:204``), so a
-# literal set written from the source file alone is wrong by two. The meta-test below derives
-# the real set from the live rule table and asserts equality against this literal, so the two
-# can never drift.
-_EXPECTED_KEYED_PATHS = frozenset(
-    {
-        "temperature",
-        "max_tokens",
-        "stop",
-        "response_format",
-        "seed",
-        "n",
-        "frequency_penalty",
-        "presence_penalty",
-        "logprobs",
-        "top_logprobs",
-        "tools",
-        "tool_choice",
-    }
-)
-
-# One concrete pair of DIFFERENT values per keyed path. A path missing from this table has no
-# key-difference proof, which the meta-test refuses.
-_KEY_DIFFERENCE_CASES: dict[str, tuple[Any, Any]] = {
-    "temperature": (0.0, 1.0),
-    "max_tokens": (16, 32),
-    "stop": (["END"], ["STOP"]),
-    "response_format": ({"type": "text"}, {"type": "json_object"}),
-    "seed": (1, 2),
-    "n": (1, 2),
-    "frequency_penalty": (0.0, 0.5),
-    "presence_penalty": (0.0, 0.5),
-    # INVARIANT: ``top_logprobs`` requires ``logprobs is True``, so the pair varies the
-    # dependent field while holding the enabling one — otherwise the 400 combination rule,
-    # not the key, would be what distinguishes the two requests.
-    "logprobs": (True, False),
-    "top_logprobs": (1, 2),
-    "tools": (
-        [{"type": "function", "function": {"name": "alpha", "parameters": {}}}],
-        [{"type": "function", "function": {"name": "beta", "parameters": {}}}],
-    ),
-    "tool_choice": ("auto", "none"),
-}
-
-
-def _published_cache_behaviour(document: dict[str, Any]) -> dict[str, str]:
-    """``{request_path: cache_behavior}`` as a CALLER reads it off the contract document.
-
-    Shape (verified against the live route): each entry under ``parameters`` — and each tool
-    entry under ``tools`` — carries a ``gateway`` block holding ``cache_behavior``. Reading both
-    sections matters: ``tools`` and ``tool_choice`` are two of the twelve promoted paths and do
-    not appear beside the scalar parameters.
-    """
-    published: dict[str, str] = {}
-    for section in ("parameters", "tools"):
-        entries = document.get(section)
-        if not isinstance(entries, dict):
-            continue
-        for name, entry in entries.items():
-            gateway = entry.get("gateway") if isinstance(entry, dict) else None
-            if isinstance(gateway, dict) and "cache_behavior" in gateway:
-                published[str(name)] = str(gateway["cache_behavior"])
-    return published
-
 
 def _body(**overrides: Any) -> dict[str, Any]:
     body: dict[str, Any] = {
@@ -111,24 +41,6 @@ def _body(**overrides: Any) -> dict[str, Any]:
     }
     body.update(overrides)
     return body
-
-
-def _key_hash(body: dict[str, Any]) -> str:
-    """The global cache key for ``body``, through the REAL plan.
-
-    WHY the whole plan rather than the projection alone: a key-difference test that called the
-    projection directly would prove nothing about promotion, because the projection does not
-    see parameters at all. Only the plan applies the rule table, so only the plan can show that
-    a promoted path actually reached the key.
-    """
-    decision = build_global_cache_plan(
-        body=body,
-        plugin=PLUGIN,
-        controls=GlobalCacheControls(participate=True),
-        cache_enabled=True,
-    )
-    assert not hasattr(decision, "reason"), f"expected a key, got a bypass: {decision}"
-    return cast(Any, decision).key_hash
 
 
 # --- the route ----------------------------------------------------------------

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_runtime_guard.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_runtime_guard.py
@@ -187,6 +187,13 @@ def test_a_clean_process_participates() -> None:
     assert _plugin().participates_in_global_cache() is True
 
 
+def test_the_model_aware_core_hook_can_call_huggingface_participation() -> None:
+    # INVARIANT: OME-884 passes the raw requested model to every provider gate. Hugging Face keeps
+    # its conservative deployment-wide predicate, but accepting that argument must never cost every
+    # otherwise-cacheable request a fail-closed provider_projection bypass.
+    assert _plugin().participates_in_global_cache(_PINNED) is True
+
+
 # --- B2: BOTH LiteLLM Proxy controls ---------------------------------------------------------
 
 

--- a/apps/aigateway/tests/unit/huggingface/test_huggingface_runtime_guard.py
+++ b/apps/aigateway/tests/unit/huggingface/test_huggingface_runtime_guard.py
@@ -1,0 +1,389 @@
+"""OME-791 (B2, M1, M2, M5, M8) — the Hugging Face ambient-state guard.
+
+FEATURE: one globally shared exact-request cache (OME-305). A row is replayed to any caller
+whose request keys identically, so sharing is only safe while this process will actually send
+what the projection claims. ``runtime_guard`` is that certification; this file is its contract.
+
+STORY: as an operator I flip a LiteLLM process global — a proxy switch, a stop-limit override, a
+schema validator — and Hugging Face stops sharing rows, instead of quietly storing answers that
+do not match their key.
+
+What these tests pin, and why each earns its place:
+- every guarded litellm global still EXISTS (M8). ``raising=False`` previously let a renamed or
+  deleted attribute be silently CREATED by the test, so the guard could stop protecting anything
+  while the suite stayed green. Drift must be red, not invisible.
+- BOTH LiteLLM Proxy controls (B2). litellm consults the environment secret FIRST and returns on
+  it alone, so guarding only the module attribute leaves a live reroute unguarded.
+- each positive control is proven to change REAL DISPATCH, not merely to be a variable this
+  repository decided to fear.
+- ``disable_stop_sequence_limit`` (M1) and ``enable_json_schema_validation`` (M2), each shown to
+  change behaviour behind an UNCHANGED request body — the precise shape of hazard a cache key
+  cannot see.
+
+AIDEV-NOTE: the expected inventory below is authored INDEPENDENTLY of the production tuples and
+compared against them (M8). Deriving it from ``runtime_guard`` would make the conformance test
+tautological: production could drop a field and its own test would agree.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import litellm
+import pytest
+
+from aigateway.plugins.huggingface_provider import runtime_guard
+from aigateway.plugins.huggingface_provider.plugin import HuggingFaceProviderPlugin
+from aigateway.plugins.huggingface_provider.settings import HuggingFacePluginSettings
+
+_PINNED = "huggingface/deepseek-ai/DeepSeek-R1:novita"
+
+# --- independently authored expectations (M8) ---------------------------------------------
+#
+# Hand-written from the hazards this provider claims to guard. NOT imported from production.
+_EXPECTED_DISPATCH_GLOBALS = (
+    "model_fallbacks",
+    "model_alias_map",
+    "headers",
+    "use_litellm_proxy",
+    "disable_stop_sequence_limit",
+    "enable_json_schema_validation",
+)
+_EXPECTED_RULE_GLOBALS = ("pre_call_rules", "post_call_rules", "drop_params")
+_EXPECTED_PRESENCE_GLOBALS = ("proxy_auth",)
+_EXPECTED_CALLBACK_GLOBALS = (
+    "callbacks",
+    "input_callback",
+    "success_callback",
+    "failure_callback",
+    "_async_input_callback",
+    "_async_success_callback",
+    "_async_failure_callback",
+)
+_EXPECTED_GUARDED = (
+    _EXPECTED_DISPATCH_GLOBALS
+    + _EXPECTED_RULE_GLOBALS
+    + _EXPECTED_PRESENCE_GLOBALS
+    + _EXPECTED_CALLBACK_GLOBALS
+)
+
+# A truthy value per guarded field, chosen to be representative of a real deployment setting.
+_TRUTHY_VALUE: dict[str, Any] = {
+    "model_fallbacks": ["openai/gpt-4o"],
+    "model_alias_map": {"x": "y"},
+    "headers": {"x-tenant": "acme"},
+    "use_litellm_proxy": True,
+    "disable_stop_sequence_limit": True,
+    "enable_json_schema_validation": True,
+    "pre_call_rules": [lambda _: True],
+    "post_call_rules": [lambda _: True],
+    "drop_params": True,
+}
+
+
+def _plugin(**settings: Any) -> HuggingFaceProviderPlugin:
+    """A FRESH plugin instance, so one test's settings cannot leak into another."""
+    return HuggingFaceProviderPlugin(HuggingFacePluginSettings(**settings))
+
+
+@pytest.fixture(autouse=True)
+def _quiet_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutral ambient state, and a decline memo that cannot leak between tests.
+
+    WHY autouse: several of these tests assert PARTICIPATION, which any leftover global from a
+    sibling test would silently falsify into a pass-looking decline.
+    """
+    monkeypatch.delenv(runtime_guard.PROXY_SECRET_NAME, raising=False)
+    runtime_guard.reset_decline_log()
+
+
+# --- M8: the inventory is real, complete, and fails on drift --------------------------------
+
+
+def test_every_guarded_global_exists_on_litellm() -> None:
+    # INVARIANT: a guard that reads a non-existent attribute protects nothing while reading like
+    # coverage. ``getattr(litellm, field, None)`` returns None for a typo just as it does for an
+    # unset global, so only an existence assertion can tell the two apart.
+    missing = [
+        field for field in runtime_guard.GUARDED_LITELLM_GLOBALS if not hasattr(litellm, field)
+    ]
+
+    assert missing == [], f"litellm no longer defines: {missing}"
+
+
+def test_the_production_inventory_matches_the_independently_authored_one() -> None:
+    # Set equality in BOTH directions: an addition to production that nobody reviewed is as much
+    # a finding as a removal. This is the test that would have caught ``additional_drop_params``.
+    assert set(runtime_guard.GUARDED_LITELLM_GLOBALS) == set(_EXPECTED_GUARDED)
+    assert len(runtime_guard.GUARDED_LITELLM_GLOBALS) == len(_EXPECTED_GUARDED), "duplicate entry"
+
+
+def test_additional_drop_params_is_not_a_litellm_module_global() -> None:
+    # M8's original finding, pinned so it cannot be re-added by memory. It is a per-request
+    # kwarg, never a module global; guarding it was a no-op that survived only because the old
+    # test used ``raising=False`` and CREATED the attribute it claimed to check.
+    assert not hasattr(litellm, "additional_drop_params")
+    assert "additional_drop_params" not in runtime_guard.GUARDED_LITELLM_GLOBALS
+
+
+def test_monkeypatching_a_misspelled_global_now_fails_instead_of_creating_it() -> None:
+    # The falsification for M8: this is the exact mechanism that used to hide drift. With
+    # ``raising=True`` a guarded name that litellm removed becomes an AttributeError — a red
+    # test — rather than a freshly invented attribute that makes the guard look alive.
+    with pytest.MonkeyPatch.context() as patch:
+        with pytest.raises(AttributeError):
+            patch.setattr(litellm, "model_fallbacks_typo", ["x"], raising=True)
+
+
+# --- the guarded conditions, one test per declared hazard ------------------------------------
+
+
+@pytest.mark.parametrize("field", _EXPECTED_DISPATCH_GLOBALS + _EXPECTED_RULE_GLOBALS)
+def test_a_truthy_guarded_global_declines_participation(
+    field: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(litellm, field, _TRUTHY_VALUE[field], raising=True)
+
+    assert _plugin().participates_in_global_cache() is False
+
+
+@pytest.mark.parametrize("field", _EXPECTED_PRESENCE_GLOBALS)
+def test_a_present_guarded_global_declines_participation(
+    field: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Guarded on PRESENCE, not truthiness: a configured-but-falsy auth object still means a proxy
+    # auth path is wired up.
+    monkeypatch.setattr(litellm, field, object(), raising=True)
+
+    assert _plugin().participates_in_global_cache() is False
+
+
+@pytest.mark.parametrize("field", _EXPECTED_CALLBACK_GLOBALS)
+def test_every_callback_field_declines_including_the_async_ones(
+    field: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # WHY the async fields matter as much as ``success_callback``: an observer registered on an
+    # async hook sees exactly the dispatches a cache hit skips, so a row filled under one
+    # observer configuration is not equivalent to one filled under another.
+    monkeypatch.setattr(litellm, field, ["langfuse"], raising=True)
+
+    assert _plugin().participates_in_global_cache() is False
+
+
+@pytest.mark.parametrize("field", _EXPECTED_CALLBACK_GLOBALS)
+def test_the_cache_callback_exemption_is_preserved_on_every_callback_field(
+    field: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ``"cache"`` is litellm's own bookkeeping entry, not a third-party observer. Declining on it
+    # would decline in ordinary deployments, which is a silent loss of the whole feature.
+    monkeypatch.setattr(litellm, field, [runtime_guard.EXEMPT_CALLBACK], raising=True)
+
+    assert _plugin().participates_in_global_cache() is True
+
+
+def test_a_clean_process_participates() -> None:
+    # The mirror of every decline above: without this, they could all pass vacuously.
+    assert _plugin().participates_in_global_cache() is True
+
+
+# --- B2: BOTH LiteLLM Proxy controls ---------------------------------------------------------
+
+
+def test_the_module_attribute_proxy_switch_declines(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(litellm, "use_litellm_proxy", True, raising=True)
+
+    assert _plugin().participates_in_global_cache() is False
+
+
+def test_the_environment_proxy_switch_declines_while_the_attribute_stays_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # THE B2 ESCALATION, and the reason an attribute-only guard was insufficient:
+    # ``_should_use_litellm_proxy_by_default`` checks ``get_secret_bool("USE_LITELLM_PROXY")``
+    # FIRST (``llms/litellm_proxy/chat/transformation.py:73``) and returns True on it alone.
+    monkeypatch.setattr(litellm, "use_litellm_proxy", False, raising=True)
+    monkeypatch.setenv(runtime_guard.PROXY_SECRET_NAME, "true")
+
+    assert litellm.use_litellm_proxy is False, (
+        "the attribute must stay false for this to mean anything"
+    )
+    assert _plugin().participates_in_global_cache() is False
+
+
+@pytest.mark.parametrize("value", ["false", "0", ""])
+def test_a_falsey_environment_proxy_value_does_not_decline(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The guard must narrow participation, not abolish it. A present-but-off switch is off.
+    monkeypatch.setenv(runtime_guard.PROXY_SECRET_NAME, value)
+
+    assert _plugin().participates_in_global_cache() is True
+
+
+def test_an_absent_environment_proxy_value_does_not_decline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(runtime_guard.PROXY_SECRET_NAME, raising=False)
+
+    assert _plugin().participates_in_global_cache() is True
+
+
+@pytest.mark.parametrize("control", ["attribute", "environment"])
+def test_each_proxy_control_really_reroutes_dispatch(
+    control: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each guarded control protects a REAL routing change, not an inert variable.
+
+    INVARIANT: this is what separates a guard from superstition. If the flag did not move
+    dispatch off ``router.huggingface.co``, declining on it would be unjustified caution — and
+    the reviewer's question "does this actually do anything?" would have no answer in the suite.
+    """
+    assert litellm.get_llm_provider(model=_PINNED)[1] == "huggingface"
+
+    if control == "attribute":
+        monkeypatch.setattr(litellm, "use_litellm_proxy", True, raising=True)
+    else:
+        monkeypatch.setattr(litellm, "use_litellm_proxy", False, raising=True)
+        monkeypatch.setenv(runtime_guard.PROXY_SECRET_NAME, "true")
+
+    # The provider litellm would actually dispatch to is no longer Hugging Face, so the projected
+    # ``api_base`` would describe an endpoint the request never reached.
+    assert litellm.get_llm_provider(model=_PINNED)[1] == "litellm_proxy"
+    assert _plugin().participates_in_global_cache() is False
+
+
+def test_an_unreadable_proxy_secret_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ``get_secret`` can reach a configured key-management system, so it may raise. An unknown
+    # answer must decline: the cache is the thing that gives way, never the request.
+    def _explode(*_args: object, **_kwargs: object) -> bool:
+        raise RuntimeError("secret backend unavailable")
+
+    monkeypatch.setattr(runtime_guard, "get_secret_bool", _explode, raising=True)
+
+    assert _plugin().participates_in_global_cache() is False
+
+
+def test_an_unreadable_litellm_global_declines_without_raising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ExplodingTruthiness:
+        def __bool__(self) -> bool:
+            raise RuntimeError("ambient global is unreadable")
+
+    monkeypatch.setattr(litellm, "headers", _ExplodingTruthiness(), raising=True)
+
+    assert _plugin().participates_in_global_cache() is False
+
+
+# --- M1: disable_stop_sequence_limit changes the WIRE while the body stays identical ----------
+
+
+def test_the_stop_limit_flag_changes_the_final_wire_value_for_an_unchanged_body() -> None:
+    """The hazard M1 names: same caller body, same cache key, different upstream call.
+
+    ``litellm.utils.validate_openai_optional_params`` truncates a ``stop`` list to four entries
+    unless ``disable_stop_sequence_limit`` is set (``utils.py:7618-7622``). Nothing about the
+    request distinguishes the two processes, so a row filled by one is served to the other.
+    """
+    caller_stop = ["a", "b", "c", "d", "e", "f"]
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(litellm, "disable_stop_sequence_limit", False, raising=True)
+        truncated = litellm.utils.validate_openai_optional_params(stop=list(caller_stop))
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(litellm, "disable_stop_sequence_limit", True, raising=True)
+        untruncated = litellm.utils.validate_openai_optional_params(stop=list(caller_stop))
+
+    assert truncated == ["a", "b", "c", "d"]
+    assert untruncated == caller_stop
+    assert truncated != untruncated, "the flag must change the wire value for this guard to matter"
+    # The caller's body never changed — which is exactly why the key cannot see this.
+    assert caller_stop == ["a", "b", "c", "d", "e", "f"]
+
+
+def test_the_stop_limit_flag_governs_participation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(litellm, "disable_stop_sequence_limit", False, raising=True)
+    assert _plugin().participates_in_global_cache() is True
+
+    monkeypatch.setattr(litellm, "disable_stop_sequence_limit", True, raising=True)
+    assert _plugin().participates_in_global_cache() is False
+
+
+# --- M2: enable_json_schema_validation governs acceptance of a KEYED response_format ----------
+
+
+def test_json_schema_validation_accepts_and_refuses_a_keyed_response_format() -> None:
+    """M2's hazard: ``response_format`` is KEYED by this provider, and a hit skips this check.
+
+    ``utils.py:1198`` runs ``validate_schema`` only when the flag is on, AFTER dispatch. A cache
+    hit returns at ``routes/chat.py:351`` — before any of it — so a row stored by a process with
+    validation off would be replayed, unvalidated, to a process that switched it on.
+    """
+    from litellm.litellm_core_utils.json_validation_rule import validate_schema
+
+    schema = {"type": "object", "properties": {"n": {"type": "integer"}}, "required": ["n"]}
+
+    assert validate_schema(schema=schema, response='{"n": 1}') is None
+    with pytest.raises(Exception, match="JSONSchemaValidationError|does not match"):
+        validate_schema(schema=schema, response='{"n": "not-an-integer"}')
+
+
+def test_the_json_schema_validation_flag_governs_participation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(litellm, "enable_json_schema_validation", False, raising=True)
+    assert _plugin().participates_in_global_cache() is True
+
+    monkeypatch.setattr(litellm, "enable_json_schema_validation", True, raising=True)
+    assert _plugin().participates_in_global_cache() is False
+
+
+# --- structural guarantees --------------------------------------------------------------------
+
+
+def test_the_guard_cannot_read_caller_identity_or_credentials() -> None:
+    # INVARIANT: identity is STRUCTURALLY absent, not merely unused. The guard's only input is a
+    # deployment-local URL, so no account, profile, auth mode or credential is expressible —
+    # which is what keeps participation a local yes/no that never varies by caller.
+    parameters = inspect.signature(runtime_guard.global_cache_decline_reason).parameters
+
+    assert list(parameters) == ["configured_router_api_base"]
+    assert inspect.signature(runtime_guard.unsafe_litellm_global_state).parameters == {}
+
+
+def test_a_decline_logs_the_token_and_never_the_configured_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    secret_base = "https://internal-proxy.corp.example/v1"
+    runtime_guard.reset_decline_log()
+
+    with caplog.at_level("WARNING"):
+        assert _plugin(router_api_base=secret_base).participates_in_global_cache() is False
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(runtime_guard.ROUTER_API_BASE_REASON in message for message in messages)
+    assert all(secret_base not in message for message in messages)
+
+
+def test_the_decline_log_is_once_per_condition_not_once_per_process(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two DIFFERENT conditions must both be reported.
+
+    A memo keyed on "have we logged at all" would report the first decline and hide every later
+    one — leaving an operator who fixed the first condition with no signal about the second.
+    """
+    runtime_guard.reset_decline_log()
+
+    with caplog.at_level("WARNING"):
+        for _ in range(3):
+            _plugin(router_api_base="https://proxy.internal/v1").participates_in_global_cache()
+        monkeypatch.setattr(litellm, "model_fallbacks", ["openai/gpt-4o"], raising=True)
+        for _ in range(3):
+            _plugin().participates_in_global_cache()
+
+    declines = [r.getMessage() for r in caplog.records if "global cache" in r.getMessage()]
+    assert len(declines) == 2, declines
+    assert any(runtime_guard.ROUTER_API_BASE_REASON in m for m in declines)
+    assert any("litellm.model_fallbacks" in m for m in declines)

--- a/apps/aigateway/tests/unit/test_chat_cache_write_eligibility.py
+++ b/apps/aigateway/tests/unit/test_chat_cache_write_eligibility.py
@@ -1,0 +1,123 @@
+"""OME-791 crosscheck — EVERY choice must be finished before a permanent row is written.
+
+FEATURE: one globally shared exact-request cache whose rows carry ``expires_at = NULL``.
+A fill decision is therefore a permanent decision.
+
+STORY: as a benchmark operator I send ``n=2`` and the provider finishes only the first
+completion. The half-built pair is not stored, so the next identical request dispatches
+again instead of replaying an answer that was never finished.
+
+WHY THIS MODULE EXISTS SEPARATELY from ``test_global_cache_write_eligibility.py``: that
+module drives the guard through the whole chat route and every one of its cases carries a
+SINGLE choice, so it pins the route contract but is structurally unable to see the
+later-choice question. These are direct unit tests of the predicate at the one boundary
+the route-level suite does not reach.
+
+THE HAZARD. ``n`` is KEYED (``parameters.py``; the same holds for openrouter and openai),
+so ``n=2`` and ``n=1`` are different keys and a two-choice body is replayed only to another
+two-choice request. That is exactly what makes an incomplete SECOND choice permanent: the
+row is a faithful answer to a key that will be asked again. Judging only ``choices[0]``
+stores it.
+
+AIDEV-NOTE: the guard stays STRUCTURAL. It asks "did the provider declare this choice
+finished", never "is the text any good". ``finish_reason: "length"`` is a finished answer
+to a request that set ``max_tokens`` and MUST keep storing — see the dependency note on
+``_is_a_whole_answer`` itself.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from aigateway.routes.chat_cache_stage import _is_a_whole_answer
+
+_COMPLETE: dict[str, Any] = {"message": {"content": "4"}, "finish_reason": "stop"}
+_TRUNCATED: dict[str, Any] = {"message": {"content": "4"}, "finish_reason": "length"}
+_NULL_REASON: dict[str, Any] = {"message": {"content": "4"}, "finish_reason": None}
+_ABSENT_REASON: dict[str, Any] = {"message": {"content": "4"}}
+_NO_MESSAGE: dict[str, Any] = {"delta": {"content": "4"}, "finish_reason": "stop"}
+
+
+def _result(*choices: object) -> dict[str, Any]:
+    return {"choices": list(choices)}
+
+
+# --- the later-choice hazard, which is what this module is for --------------------------
+
+
+def test_a_later_choice_that_never_finished_blocks_the_write() -> None:
+    # The n=2 case the single-choice suite cannot express: choices[0] is a perfectly
+    # good answer, so a guard that reads only the first choice stores the pair forever.
+    assert _is_a_whole_answer(_result(_COMPLETE, _NULL_REASON)) is False
+
+
+def test_a_later_choice_with_no_message_blocks_the_write() -> None:
+    # A delta or a shell in the second slot is the same "not an answer" the first-choice
+    # rule already refuses; position must not change the verdict.
+    assert _is_a_whole_answer(_result(_COMPLETE, _NO_MESSAGE)) is False
+
+
+def test_a_later_choice_with_an_absent_finish_reason_blocks_the_write() -> None:
+    # INVARIANT: absent and explicit null are treated identically wherever they appear.
+    # Distinguishing them would reward a provider for spelling an unfinished answer one
+    # way rather than the other.
+    assert _is_a_whole_answer(_result(_COMPLETE, _ABSENT_REASON)) is False
+
+
+def test_a_later_choice_that_is_not_a_mapping_blocks_the_write() -> None:
+    assert _is_a_whole_answer(_result(_COMPLETE, "not-a-choice")) is False
+
+
+def test_an_incomplete_FIRST_choice_still_blocks_when_a_later_choice_is_whole() -> None:
+    # The mirror of the hazard: widening the check must not accidentally let a good
+    # later choice vouch for a bad first one.
+    assert _is_a_whole_answer(_result(_NULL_REASON, _COMPLETE)) is False
+
+
+def test_every_choice_finished_is_storable() -> None:
+    # WHY this positive case is mandatory: a guard that refused every multi-choice
+    # response would satisfy all four refusals above while silently un-caching all
+    # ``n>1`` traffic — a regression the refusal-only tests could not see.
+    assert _is_a_whole_answer(_result(_COMPLETE, _COMPLETE)) is True
+
+
+def test_a_finished_pair_is_storable_even_when_one_was_truncated() -> None:
+    # ``length`` is a FINISHED answer, not a partial one, and ``max_tokens`` is keyed.
+    # The widened check must not start judging content.
+    assert _is_a_whole_answer(_result(_TRUNCATED, _COMPLETE)) is True
+
+
+def test_many_choices_are_all_checked_not_just_the_first_two() -> None:
+    # Guards against a two-choice special case rather than a real quantifier.
+    assert _is_a_whole_answer(_result(*([_COMPLETE] * 4))) is True
+    assert _is_a_whole_answer(_result(*([_COMPLETE] * 4), _NULL_REASON)) is False
+
+
+# --- the single-choice contract, restated so widening cannot regress it -----------------
+
+
+@pytest.mark.parametrize(
+    ("result", "storable"),
+    [
+        pytest.param(_result(_COMPLETE), True, id="finish_reason-stop"),
+        pytest.param(_result(_TRUNCATED), True, id="finish_reason-length"),
+        pytest.param(_result(_NULL_REASON), False, id="explicit-null-finish_reason"),
+        pytest.param(_result(_ABSENT_REASON), False, id="absent-finish_reason"),
+        pytest.param(_result(_NO_MESSAGE), False, id="a-choice-carrying-no-message"),
+        pytest.param(_result(), False, id="an-empty-choices-list"),
+        pytest.param({}, False, id="no-choices-key-at-all"),
+        pytest.param({"choices": "not-a-list"}, False, id="choices-that-is-not-a-list"),
+        pytest.param({"choices": None}, False, id="choices-that-is-null"),
+    ],
+)
+def test_the_single_choice_contract_is_unchanged(result: dict[str, Any], storable: bool) -> None:
+    """AIDEV-NOTE: deliberately duplicated from the route-level suite at the UNIT level.
+
+    Those cases prove the route honours the guard; these prove the predicate itself
+    still answers the same way after being widened to every choice. A change that
+    satisfied the new quantifier by loosening the per-choice rule would pass the
+    multi-choice tests above and be caught only here.
+    """
+    assert _is_a_whole_answer(result) is storable

--- a/docs/plan/2026-08-20-OME-791-huggingface-global-cache-projection.md
+++ b/docs/plan/2026-08-20-OME-791-huggingface-global-cache-projection.md
@@ -1,0 +1,664 @@
+# OME-791 implementation plan: HuggingFace global-cache projection
+
+## Status
+
+Reviewed and revised. Four independent adversarial reviews ran against the pre-review draft
+(kiss-scope, wrong-hit, completeness, feasibility); one returned **reject** on a verified
+wrong-model-replay hazard. Every finding was checked against this base before being accepted or
+rejected here. Awaiting owner approval. The checked-in specification is
+`docs/spec/2026-08-20-OME-791-huggingface-global-cache-projection.md`.
+
+## Base, and what follows from it
+
+Branch `OME-791-huggingface-global-cache-projection` was cut from `origin/main` at `c157ed7a`.
+
+Three consequences of that base, each verified rather than assumed:
+
+1. **OME-884 is NOT merged.** `openai_provider/global_cache.py`, `runtime_guard.py` and the
+   model-aware participation port live only on the unmerged `OME-884-…` branch. Its module shape
+   is copied here as a pattern and never imported, so there is no dependency. The exemplars that
+   exist on this base are `openrouter_provider/global_cache.py` and Anthropic's in-plugin
+   projection.
+2. **The participation port on this base is `participates_in_global_cache(self) -> bool`** —
+   `core/plugin_base/_provider.py:278`, called at `core/request_cache/global_plan.py:73` with no
+   argument. OME-884 changes it to accept the requested model. This plan writes the override
+   against the base it is on. When the two branches meet, the second merger adapts one signature,
+   exactly as OME-884's own plan already schedules for OpenRouter ("signature-only preservation").
+   Noted in the ledger Deviations so it is not a surprise.
+3. **HF's provider directory is byte-identical between `origin/main` and the OME-884 branch**
+   (`git diff --stat origin/main...HEAD -- …/huggingface_provider …/tests/unit/huggingface` is
+   empty), so no OME-884 work is silently depended upon.
+
+Linear is read-only for this work by explicit owner direction: OME-791 stays in Backlog, no
+status transition and no close comment. Reconcile manually.
+
+## Owner-approved MVP semantics
+
+- Cacheable unit: non-streaming Chat Completions through the unified HF router.
+- **Only a backend-pinned id is cacheable.** `huggingface/<org>/<model>:<provider|policy>`
+  projects; `huggingface/<org>/<model>` bypasses.
+- `default_models` publishes `/v1/models`; it is not a cache allowlist. Any route-valid
+  backend-pinned id projects, listed or not. This follows the OME-884 catalog ruling.
+- A hit re-checks nothing — no backend availability check, no caller-access check. Inherited
+  OME-305 exact-replay behaviour, restated because it now applies to HF.
+- A deployment that overrides the router base does not participate in the cache at all.
+
+## Existing contract (verified facts this plan builds on)
+
+- HF inherits `CacheBypass` from `ProviderPluginBase`; every `huggingface/*` request bypasses at
+  the projection step today.
+- All TWELVE declared rule paths carry `cache_behavior="bypass"` (ten `direct_rule` calls plus the
+  `tools` and `tool_choice` pair that `function_calling_rules` emits); the standing instruction block
+  at `parameters.py:46-63` names the promotion order and the test that enforces it.
+- `prepare_chat_body` (`plugin.py:208-230`) pops `api_key`, sanitises/drops `extra_headers`, and
+  sets `out["api_base"] = self.settings.router_api_base`. It validates no model id.
+- `available_auth_modes()` is exactly `("api_key",)`, and `_AUTH` in `parameters.py` matches, so
+  a keyed rule already covers every available mode.
+- `huggingface_chat_parameter_rules` ignores `model` and `auth_type` and returns one `_RULES`
+  tuple, which is what satisfies the auth-mode-agreement conformance sweep. Do not introduce
+  per-mode branching while promoting.
+- All 24 seeds in `_default_model_slugs()` are backend-pinned; `pinned_router_target` returns
+  non-`None` for every one. Measured, not assumed.
+- HF owns no `usage_accounting.py` and no `chat_completion` override; it inherits
+  `litellm.acompletion(**body)`.
+- Core enforces the projection contract in `global_eligibility._projected` (`:342-372`): the hook
+  receives a deep copy, the whole call is wrapped in `except Exception`, and
+  `set(produced) != {"resolved_model", "provider_adapter_revision", "prepared"}` is a bypass. An
+  extra member fails exactly as hard as a missing one.
+- `prepared` is hashed whole as `prepared_request` and is **not** copied by the core.
+- A non-JSON-safe value in `prepared` surfaces as `canonicalization_failure`, a different
+  observable reason from `provider_projection`. Do not conflate them.
+- `api_base` is **not** in `EXCLUDED_TRANSPORT_FIELDS` (`{"timeout", "extra_headers", "api_key"}`),
+  so a projected `api_base` genuinely participates in the key.
+- `extra_headers` is in `DISPATCH_CONTROL_FIELDS` (stripped at the route) **and** in
+  `EXCLUDED_TRANSPORT_FIELDS` (never keyed). A caller cannot influence it; HF's sanitisation loop
+  is defence in depth against an already-impossible input. It is therefore not projected.
+- Every HF rule is `projection_kind="direct"`, so no `prepared` root obligation exists and the
+  `unprojected_parameter` bypass cannot arise.
+- **No existing test asserts HF cache behaviour.** `grep` over `tests/unit/huggingface/` for
+  `cache_behavior`, `CacheBypass` and `global_cache` returns nothing, and no generic test names HF
+  as a bypassing provider — the conformance relation is computed per provider, not listed. The
+  append-only impact of this unit is therefore **zero prior tests changed**.
+
+## Design decisions
+
+### D1 — `resolved_model` is the upstream id, keeping the backend suffix
+
+`resolved_model = model[len("huggingface/"):]`, i.e. `<org>/<model>:<backend>`.
+
+Argued, not copied: Anthropic projects the FULL gateway string because for Anthropic the gateway
+prefix IS LiteLLM's provider prefix and reaches the wire intact, while OpenRouter and OpenAI
+strip. HF strips, and the evidence is the installed transform:
+`tests/unit/huggingface/test_huggingface_dispatch.py:29-46` drives
+`HuggingFaceChatConfig.transform_request` and asserts the post-strip model reaches the outbound
+body verbatim as `deepseek-ai/DeepSeek-R1:novita`.
+
+Because the suffix is part of the upstream id, two backends for one repo key differently as a
+structural consequence. No separate mechanism, and nothing to keep in sync.
+
+### D2 — `prepared` is exactly the pinned router base
+
+```python
+{"api_base": OFFICIAL_ROUTER_API_BASE}
+```
+
+A fresh dict per call, because the core hashes `prepared` by reference and does not copy it
+(`global_eligibility._projected` returns it uncopied); a shared module-level table would let one
+reader alter every later request's key material.
+
+WHY it participates in the key at all: `prepared` is rendered *wholesale* into the canonical
+mapping. It is not filtered against `EXCLUDED_TRANSPORT_FIELDS` — that set governs the caller's
+body, not the projection's output — so anything a projection returns here is key material by
+construction.
+
+**Honest accounting of its entropy.** Given D3, every *participating* deployment sends the
+official base, so `api_base` discriminates nothing today. It stays for two reasons, neither of
+them key entropy: it is the truthful statement of what dispatch sends, which is the projection's
+whole contract; and if D3's gate is ever loosened, the key is already correct rather than
+retro-fitted. `api_key` and `extra_headers` are transport and stay out, per the verified
+dispositions above.
+
+### D3 — the env-overridable router base is gated in participation, not projected from settings
+
+This is the one structural difference from every existing projection, and the plan's central
+decision. `HuggingFacePluginSettings.router_api_base` is a real field
+(`AIGW_HUGGINGFACE_ROUTER_API_BASE`); OpenRouter's base is an unconfigurable module constant
+(`openrouter_provider/settings.py:28`), so that provider cannot diverge and never had to solve
+this.
+
+The projection may not read it: `test_no_projection_reads_operator_configuration` substitutes a
+`_PoisonedSettings` whose `__getattr__` raises on any access, and the sibling sweep poisons
+`os.environ`, so both doors are closed. Ruling 34 (`_provider.py:233-247`) states the hazard
+precisely — at a fixed revision, dispatch varying on state the projection cannot observe means
+two identical bodies produce one key and two different upstream calls.
+
+Ruling 34 offers two answers, and the participation port offers a third:
+
+- *Reject: fold the constant into the revision and accept the consequence.* The accepted
+  consequence would be that a deployment pointed at a proxy shares rows with one pointed at the
+  official router. That is cross-endpoint contamination of a globally shared cache — the one
+  class of consequence not worth accepting.
+- *Reject: bypass unconditionally.* Correct but useless: it would cache nothing anywhere,
+  including every normal deployment.
+- **Take: gate participation.** `participates_in_global_cache` may read deployment-local state by
+  design (`_provider.py:299-317`), a `False` answer is fail-safe and lossless — it suppresses the
+  lookup without invalidating, rewriting or re-keying any row — and it leaves the default
+  deployment fully keyed.
+
+So the projection emits the official constant, and the hook declines when the configured base is
+not the official one.
+
+**Comparison is normalised, not literal.** `https://router.huggingface.co/v1` and
+`https://router.huggingface.co/v1/` dispatch identically — litellm's
+`_build_chat_completion_url` does `model_url.rstrip("/")` at `transformation.py:26-28` before
+appending `/chat/completions`. A literal `!=` would therefore disable all HF caching for a
+deployment whose base is functionally identical and whose upstream calls are byte-identical. The
+gate compares `rstrip("/")` on both sides. Anything beyond a trailing-slash difference declines:
+this is a safety gate, so the normalisation stays minimal and provably wire-equivalent rather
+than becoming a URL-canonicalisation routine.
+
+Note the sweeps cannot catch a regression here: `operator_gate_overrides` flips only `bool` fields
+and `HuggingFacePluginSettings` declares none, so every sweep runs HF with the default base. The
+override hazard must be pinned by an HF-local test.
+
+### D4 — one origin for the router base, scoped to the dispatch path
+
+Adding the projection makes the official base **key material**. A census of the HF package finds
+the value spelled in **four** places, not two:
+
+| Site | Role | In scope? |
+|---|---|---|
+| `settings.py:24` `_ROUTER_API_BASE` | the field default dispatch reads | **yes** — becomes key material |
+| `api_key_validation.py:19` `_READINESS_URL` | credential probe target | no |
+| `discovery.py:43` `MODELS_URL` | catalog listing | no |
+| `discovery.py:44` `ALLOWED_ORIGINS` | catalog origin allowlist | no |
+
+Only the first is on the dispatch path this projection describes. So the change is exactly one
+rename:
+
+- `_ROUTER_API_BASE` becomes a public `OFFICIAL_ROUTER_API_BASE`, homed in `settings.py` above the
+  settings class so the pure projection can name it without importing anything impure;
+- `router_api_base: str = OFFICIAL_ROUTER_API_BASE` stays as the field dispatch reads — no
+  behaviour change.
+
+**The other three are deliberately left alone.** `_READINESS_URL` is a *hardcoded literal that
+must not track the settings field*: it exists so an overridden base cannot redirect a credential
+probe, and `test_huggingface_validation_requires_identity_and_readiness` pins that by passing
+`router_api_base="https://attacker.invalid/v1"` and asserting the probe still reaches the official
+router. Deriving it from a shared constant is harmless today but couples a security-relevant
+literal to a name whose whole purpose is to be configurable — so the earlier plan's edit here is
+withdrawn. `discovery.py`'s two copies serve the catalog surface, carry no key material, and are
+outside this unit.
+
+Consequence recorded honestly: this unit does **not** achieve "one origin for the router base
+across the package", and the DoD no longer claims it. It achieves one origin for the *dispatch
+path*, which is the only origin the cache key depends on.
+
+### D5 — no combination bypass for `logprobs` / `top_logprobs`
+
+`validate_chat_parameter_combination` raises 400 for `top_logprobs` without `logprobs is True`,
+and it runs on the miss path, after the cache read. That ordering suggests a wrong-hit — a request
+the gateway must refuse being served 200 from a row. It is not one, and the reason is worth
+recording because the shape recurs:
+
+both fields are keyed, so an invalid combination keys uniquely; and a row can only exist for a
+request that dispatched successfully — the fill path requires a whole answer with a
+`finish_reason` (`chat_cache_stage.py:271-285`), and a 400 raised at `chat.py:418`, before
+dispatch, never reaches it. An invalid combination therefore misses its own key every time and is
+refused exactly as it is today. It pays one pointless cache probe; it cannot be answered.
+
+**The invariant this rests on, stated so a future change cannot silently void it:** the conclusion
+holds only while the combination predicate is a pure function of KEYED body fields. `auth_mode` is
+structurally absent from the key, so a future combination rule that consulted the auth mode, the
+resolved model, or any deployment state would reintroduce exactly the wrong-hit this argument
+rules out — and would then need a real bypass. An `INVARIANT:` anchor beside the validator records
+this.
+
+No guard is added now. Adding one would imply a hazard that does not exist, which is its own kind
+of wrong documentation.
+
+### D6 — decline participation under unsafe ambient LiteLLM state
+
+HF inherits base `chat_completion` = `litellm.acompletion(**body)` and adds no gateway-owned
+control table, so ambient LiteLLM globals are unobservable-at-fixed-revision state of exactly the
+kind ruling 34 governs.
+
+**This decision was rewritten after review; the earlier justification was false and is withdrawn.**
+The claim "both providers that already project guard this, so a projecting HF would be the only
+one without" does not hold: Anthropic projects and dispatches through the same
+`litellm.acompletion` with no such guard at all. The guard is justified below on the verified
+mechanism instead of on precedent.
+
+**The mechanism, verified on installed litellm 1.97.0 in this worktree's venv.**
+`litellm.model_fallbacks` is read at `main.py:602` — *inside `async def acompletion`*, which spans
+lines 388-698, the exact entry point HF dispatches through:
+
+```python
+fallbacks = fallbacks or litellm.model_fallbacks
+if fallbacks is not None:
+    response = await async_completion_with_fallbacks(...)
+```
+
+`fallback_utils.py:57,62` then re-enters `acompletion` with `model=fallback`. The gateway strips
+caller `fallbacks` at ingress (`request_hardening.py:82`), so only the process global can set it,
+and the fill path stores any answer carrying a `finish_reason` without comparing its model to the
+key's. A single process-global setting therefore writes **another model's answer under an HF key**,
+in a store whose rows have no expiry. That is not a stale answer, it is a wrong one, and it is the
+reason this gate exists. Separately, `litellm.headers` reaches the HF wire specifically:
+`main.py:2994`, inside `_complete_huggingface`, does `hf_headers = headers or litellm.headers`.
+
+**The form: adopt OpenAI's existing predicate rather than invent one.**
+`openai_provider/plugin.py:85-101` already encodes this check on this base, and its condition set
+is a strict superset of OpenRouter's (`openrouter_provider/litellm_controls.py:55-68`) with every
+member verified reachable from HF's path. HF mirrors it:
+
+| Condition | Why it can corrupt an HF row |
+|---|---|
+| `model_alias_map` contains **this** model | ambient redirect fills the row from a different model |
+| `model_fallbacks` truthy | the blocker above — a different model's answer under this key |
+| `headers` truthy | `main.py:2994` sends them; two processes key alike and send differently |
+| `proxy_auth` not None | changes the transport the answer came through |
+| `pre_call_rules` / `post_call_rules` non-empty | a hit returns at `chat.py:351`, before dispatch, so a deployment's configured refusal is silently skipped for a stored row |
+| `drop_params` / `additional_drop_params` truthy | change which parameters reach the wire |
+| non-`"cache"` entries in any global callback list | observers that make the call not a bare generation |
+
+The alias check uses the **exact-model** form both exemplars use (`model in aliases`), not a coarse
+truthy test, so a deployment aliasing unrelated models keeps its HF caching. The port's signature
+on this base receives no model argument, so the hook reads it from the settings-independent path
+available to it; if that is not reachable, the coarse truthy form is the fail-safe fallback and the
+narrowing is deferred to the OME-884 forward-merge, which changes this signature anyway.
+
+**Two conditions from the earlier draft are dropped.** `litellm.cache` is already covered — a
+global callback list containing only `"cache"` is explicitly permitted by both exemplars, and
+LiteLLM's own replay is what `caching`/`cache` per-request controls address on providers that pin
+them; HF pins none, so this gate cannot pretend to. More importantly,
+`litellm.HuggingFaceChatConfig().get_config()` is withdrawn outright: `_complete_huggingface`
+(`main.py:2971-3011`) reads no `*Config.get_config()`, `BaseConfig.get_config` reads only
+`cls.__dict__`, so the condition cannot fire on anything reaching the HF wire — and *evaluating*
+it instantiates the class, whose `__init__` does `self.__class__._is_base_class = False`, mutating
+litellm process state on every request. A guard that protects nothing and mutates shared state is
+strictly worse than no guard.
+
+**Known duplication, recorded not hidden.** This makes three near-copies of the predicate
+(OpenRouter, OpenAI, HF) that must stay in sync. Extracting one core helper is the right cleanup,
+but the three sets are not identical — each provider's reachable surface differs — so a union plus
+per-provider deltas is more design than this MVP warrants. An `AIDEV-NOTE:` at the HF copy names
+the other two and the extraction as the follow-up.
+
+Any exception inside the hook is already swallowed into non-participation by `global_plan.py:72-77`,
+so the guard cannot fail a request.
+
+### D7 — `cache_reference_from_cached_response` returns `None`
+
+Required, not decorative. `plugins/taxonomy/session.py:374` reaches the hook through `getattr`
+inside a `try`, and there is no base-class default, so a provider that omits it logs
+`cache-reference mapper failed provider=huggingface` on **every** hit — an operator-visible
+failure that never happened. HF contributes no usage-accounting strategy, so `None` is the honest
+answer; building one is out of scope.
+
+### D8 — the adapter revision, and what it covers
+
+`GLOBAL_CACHE_ADAPTER_REVISION = "huggingface-global-cache-2026-08"`, homed in the new
+`global_cache.py`, kept separate from `parameters.py`'s `_REVISION` (that one versions what a
+caller may say and where it lands; this one versions what the boundary adds on its own).
+
+Enumerate in the constant's comment what the JSON-hashed `prepared` cannot carry, because rows
+have no expiry and survive deployments:
+
+- installed litellm 1.97.0's HF transform passing the post-strip model to the wire verbatim;
+- the `{api_base}/chat/completions` URL shape, including the `rstrip("/")` normalisation;
+- `api_base is not None` winning over litellm's ambient `HF_API_BASE` / `HUGGINGFACE_API_BASE`
+  fallbacks in `get_base_url` / `get_complete_url`;
+- the pinned base short-circuiting `_fetch_inference_provider_mapping`, whose lru-cached,
+  env-keyed lookup would otherwise make the upstream model not a function of the request;
+- the ambient-state conditions of D6: this revision is only meaningful for a process where none of
+  them held, which is what participation enforces.
+
+A litellm upgrade touching any of those is a mandatory bump.
+
+All of these were verified against the venv on THIS base (litellm 1.97.0, confirmed by
+`importlib.metadata.version`): `transformation.py:94-99` shows `if api_base is not None` winning
+ahead of the `elif os.getenv("HF_API_BASE") or os.getenv("HUGGINGFACE_API_BASE")` fallback, `:78`
+shows the same read in `get_base_url`, and `:26-38` shows the URL construction.
+
+### D9 — promotion
+
+**Twelve** paths move to `cache_behavior="keyed"` in one change with the projection. Enumerated at
+runtime from the live rule table on this base, not counted by eye:
+
+`temperature`, `max_tokens`, `stop`, `response_format`, `seed`, `n`, `frequency_penalty`,
+`presence_penalty`, `logprobs`, `top_logprobs`, `tools`, `tool_choice`.
+
+The last two are why the count is twelve and not the ten `direct_rule` calls: `function_calling_rules`
+emits both a `tools` and a `tool_choice` rule (`standard_parameters.py:232-252`, with
+`tool_choice=True` defaulted at `:204`). It also defaults `cache_behavior="bypass"`
+(`standard_parameters.py:205`) and HF's call at `parameters.py:167` omits the argument, so flipping
+the ten `direct_rule` calls is not enough — the helper must be passed `cache_behavior="keyed"`
+explicitly.
+
+`_REVISION` bumps to `"huggingface-2026-08"`. `top_p` stays observed-but-unruled: a
+bypass-to-keyed promotion cannot enable a parameter no rule enables.
+
+**Caller-visible contract change, verified.** The published model-parameter contract digests a
+per-rule string including `cache_behavior` and `projection_revision`
+(`core/model_parameter_contract.py:78`), so promoting the rules and bumping `_REVISION` changes the
+`contract_id` / `context.revision` digests for every HF model, and every HF model's detail document
+starts reporting `gateway.cache_behavior: keyed` on twelve rows. That is correct — the contract
+genuinely changed — and it breaks no test, because no test pins a literal digest and none asserts
+`"huggingface-2026-07"` (searched `src` and `tests`). But "breaks no test" is also the problem: the
+caller-visible surface flips with nothing asserting it. This unit adds one assertion that an HF
+model's served contract detail reports `keyed` for a promoted path, so the flip is proven rather
+than merely unobjected-to. Consumers that cache the contract by digest see one change, once.
+
+The standing instruction block at `parameters.py:46-63` is replaced by a note recording what was
+done. Its closing sentence names Anthropic and OpenRouter as the only projecting providers, which
+is accurate on this base (OME-884 is unmerged) and becomes stale by *this* change — so updating it
+is this unit's job, not housekeeping. Identical blocks in the ollama, antigravity, codex and gemini
+plugins are **out of scope** and deliberately left alone.
+
+### D10 — streaming needs no HF work
+
+Verified, so the plan does not have to defend it: streaming is refused by the core, ahead of and
+independently of any provider. `TRUTHY_BYPASS_REASONS = {"stream": BYPASS_STREAM}`
+(`global_eligibility.py:88-92`) is applied at `:180`, while `_projected` runs at `:406`, and the
+constant carries the invariant "streaming stays structurally ineligible here even if a provider
+rule ever declared otherwise". HF's streaming path therefore cannot read or write a row, before or
+after this change.
+
+Because HF's streaming path is live, the route test asserts this once for HF specifically —
+`stream: true` yields reason `stream` and stores no row — rather than resting on a core guarantee
+no HF test exercises.
+
+### D11 — what an operator will see, and its known limit
+
+A refusal publishes `X-AIGW-Cache-Reason: provider_projection` in **all** of these cases: HF has no
+projection, HF is pointed at a non-official router (D3), and any ambient-LiteLLM condition fired
+(D6). They are indistinguishable on the wire.
+
+That is deliberate and not this unit's decision to change. `global_plan.py:89-105` records why a
+plan-level `disabled` may not be returned instead — it is re-mapped downstream to
+`cache_unavailable`, which would tell an operator their cache store is broken when it is healthy —
+and its AIDEV-NOTE records that a dedicated `provider_disabled` reason is the right long-term
+answer but is an owner decision, because the vocabulary is a caller-visible contract that URL4
+reads and `test_global_cache_reason_vocabulary._WIRE_CONTRACT` owns.
+
+**Mitigation inside this unit's scope, and it is not optional.** With eight decline paths
+collapsing onto one wire reason and nothing logged, an operator whose HF caching silently stopped
+has no way to learn why. The participation hook logs, at most once per condition per process, a
+reason TOKEN naming which check declined — never the configured URL value, never a header value,
+never any credential. An operator then has a diagnosable signal in logs with no change to the wire
+vocabulary. A test asserts the token appears once and that the configured base value does not.
+
+### D12 — profile defaults are already inside the key
+
+Not a change, but load-bearing and previously unstated. Two of the twelve newly-keyed paths —
+`max_tokens` and `temperature` — are exactly the fields stored as `ProfileDefaults`, and the
+ruling-57 merge happens *before* the cache lookup: `build_global_cache_plan` receives the body
+"after the body-wins profile-default merge" (`global_plan.py:60-64`). So the key describes the
+**effective** request, and two callers whose stored defaults differ key differently even when their
+wire bodies are identical. That is the correct behaviour and it is what makes promoting these two
+paths safe; it is recorded here because a reader could otherwise assume the key sees only the raw
+body.
+
+### D13 — the licensing dimension of cross-account replay (owner decision, flagged)
+
+HF has one property no other projecting provider has: most seeds in `_default_model_slugs()` are
+**gated repositories** whose access requires per-HF-account license acceptance. Exact replay is
+cross-account by design (`global_plan.py:5-9`), and a hit re-checks nothing — so a row filled by an
+account that accepted a model's license can be served to an account that never did.
+
+This is the same accepted-consequence class OME-884 recorded for OpenAI ("a hit performs no
+availability and no access check"), but the consequence is qualitatively different: OpenAI's is an
+access-control question inside one vendor relationship, whereas this one touches a third party's
+licensing terms. It is therefore written down as an explicit **owner decision**, not silently
+accepted by an implementer:
+
+- the spec records it as an ACCEPTED CONSEQUENCE with this reasoning visible;
+- implementation proceeds, because it is inherent to the approved exact-replay semantics rather
+  than introduced by this unit's design;
+- if the owner declines it, the remedy is a seed-list or gating decision at the catalog level, not
+  a projection change — so it does not block or reshape the work below.
+
+Raised explicitly in the completion report rather than buried in a doc.
+
+## Deliberately not built
+
+Named so the reviewer can see the KISS boundary was chosen, not missed: no HF `usage_accounting.py`;
+no `chat_completion` override, no gateway dispatch-control table and no per-request pinning of
+`num_retries` / `caching` (both exemplars do this; HF's MVP declines participation instead of
+pinning the wire, which is fail-safe and smaller); no extraction of the shared ambient-state
+predicate into core (D6 records why); no new bypass reason (the vocabulary is a wire contract and
+minting one is an owner decision); no core port change; no dispatch-side model validation added to
+`prepare_chat_body`; no edit to `discovery.py` or `api_key_validation.py` (D4); no change to the
+sibling providers' stale comment blocks; no edit to the shared conformance census (see below).
+
+## Test-first implementation sequence
+
+Two new test files, not four — matching the one-cache-file-per-provider precedent the OpenRouter
+and OpenAI projections both follow.
+
+### Unit 1 — the pure projection
+
+RED in `tests/unit/huggingface/test_huggingface_global_cache_projection.py`:
+
+- a backend-pinned id projects; the return set is exactly the three members;
+- `resolved_model` is the prefix-stripped id and **retains** `:<backend>` — asserted directly on
+  the projection's output, since the key-difference test cannot prove this (see the test matrix);
+- `prepared == {"api_base": OFFICIAL_ROUTER_API_BASE}`, a fresh container per call;
+- determinism, and no mutation of the passed body;
+- bypass for: missing `model`, non-string `model`, a non-`huggingface/` prefix, a slug
+  `_validate_model_slug` rejects (including the forbidden provider-as-path-segment form), and an
+  **unsuffixed** id;
+- every bypass carries `PROJECTION_BYPASS_REASON`;
+- totality — no input raises;
+- the projection reads no settings (HF-local, in addition to the registry sweep, because the
+  sweeps run HF with default settings only);
+- bumping `GLOBAL_CACHE_ADAPTER_REVISION` changes the key hash;
+- participation: default settings participate; a trailing-slash base still participates; a
+  genuinely different base does not; each D6 condition declines; a clean process participates; a
+  raising guard degrades to non-participation; the decline token is logged once and carries no
+  configured value;
+- `cache_reference_from_cached_response` returns `None`.
+
+GREEN: `global_cache.py` (revision constant + `project_global_cache_request` only — no dispatch
+helper), the `OFFICIAL_ROUTER_API_BASE` rename in `settings.py`, and the three plugin hooks. Do not
+touch `parameters.py` yet — the promotion is refused by the conformance sweep until the projection
+exists, and that ordering is the guard rail.
+
+**`resolved_model` is derived, not re-implemented.** `pinned_router_target(slug)` already answers
+exactly the projection's question, returning `(repo, backend)` or `None`, and its own docstring
+claims single-definition ownership of the predicate. So the projection is
+`repo, backend = target; f"{repo}:{backend}"` — no new `cacheable_upstream_model` helper, because a
+second predicate is the drift the OpenRouter projection deliberately avoids. One guard is required
+first: `pinned_router_target` raises `AttributeError` on a non-string (probed on this base with
+`None`, `123`, `{}`, `[...]` — all raise on `.startswith`), so the projection tests
+`isinstance(model, str)` before calling it. The core's `_projected` would swallow the raise, but the
+projection's own contract is TOTAL and the totality test asserts no raise.
+
+**Tripwire, observed to fire.** Neutralise the unsuffixed-id bypass, run the unsuffixed test, and
+record the observed symptom (a real key hash) in the AIDEV-NOTE beside the guard, then restore it.
+This is the repo's existing discipline, used at exactly two sites today.
+
+**Tripwire, observed to fire.** Fill a row with the default base, then override the base and prove
+the row is not replayed — a gate that only stops new writes would pass a test that never stored
+anything. Record the observed symptom.
+
+### Unit 2 — promotion, key differences, and the route
+
+RED in `tests/unit/huggingface/test_huggingface_route_global_cache.py`:
+
+- every one of the twelve newly-keyed paths: equal effective values collide, different values do
+  not, driven through `build_global_cache_plan()` so rules, auth modes, participation and
+  projection are exercised together;
+- different repos, and different `:<backend>` suffixes for one repo, do not collide;
+- a meta-test deriving the keyed set from the live rules and asserting equality against a literal
+  **twelve**-member set, so no future keyed path can land without a key-difference proof. Mirrors
+  `test_every_openrouter_keyed_path_has_an_explicit_key_difference_proof`; without it the promotion
+  is unguarded;
+- an HF-local floor: every registered HF model contributes exactly twelve keyed instances, derived
+  from the plugin rather than from a literal count, so it is environment-independent;
+- one assertion that a served contract detail document reports `gateway.cache_behavior: keyed` for
+  a promoted path (D9);
+- route: identical eligible requests produce `miss -> hit`, one dispatch, one row;
+- route: a hit performs **no `aigateway:huggingface:*` credential read or decrypt, no auth-mode
+  resolution, no key injection and no provider dispatch**. The one profile-index read — itself a
+  `credential_blobs` row plus a master-key decryption — is explicitly ALLOWED, per the AIDEV-NOTE
+  at `chat_profile_defaults.py:68-71` that documents it as the accepted pre-cache cost;
+- route: `stream: true` yields reason `stream` and stores no row (D10);
+- route: an unsuccessful provider response stores nothing;
+- route: an unsuffixed id dispatches normally and never reads or writes cache;
+- route: caller opt-out bypasses.
+
+This module is **not** in `tests/unit/conftest.py`'s `_LEGACY_API_KEY_ROUTE_MODULES` frozen
+allowlist, so it exercises the real API-key validation service and must install its own explicit
+double. Enable the cache with the established pattern — an env fixture setting
+`AIGW_REQUEST_CACHE_ENABLED=true` installed before app construction, a `cache_client` fixture that
+logs in, and the contract-shaped in-memory store — copied from the closest working exemplar,
+`tests/unit/test_chat_global_cache_route.py:112-124`.
+
+GREEN: promote the twelve rules and bump `_REVISION`.
+
+Standing, green on arrival: the registry purity sweeps,
+`test_a_provider_that_declares_a_keyed_rule_backs_it_with_a_real_projection`, and
+`test_a_bare_request_is_cacheable_exactly_when_the_provider_has_a_projection` — the last is an
+iff, so HF must not merely avoid bypassing but actually key end-to-end for all 24 seeds.
+
+### No housekeeping edit to the shared conformance file
+
+The earlier plan proposed refreshing `test_global_cache_registry_conformance.py`'s census prose and
+leaving its `_OBSERVED_NON_BYPASS_INSTANCES = 72` floor. Both halves were wrong, and the item is
+withdrawn:
+
+- *comment-only* would leave a `>=` floor at 72 while HF alone adds 24 x 12 = 288 instances, so the
+  guard could no longer notice HF regressing;
+- *raising the floor* makes a shared, append-only-protected test file depend on catalog and
+  environment state — the count is not stable across deployments, and this unit predicts zero prior
+  test changes.
+
+The guard HF needs is HF-local and stronger: the per-model twelve-instance assertion in Unit 2,
+derived from the plugin. The shared file is left untouched.
+
+## Planned files
+
+Production, all under `apps/aigateway/src/aigateway/plugins/huggingface_provider/`:
+
+- `global_cache.py` — NEW. `GLOBAL_CACHE_ADAPTER_REVISION` and
+  `project_global_cache_request(body)`. Nothing else. Target well under the 450-line limit.
+- `settings.py` — rename `_ROUTER_API_BASE` to public `OFFICIAL_ROUTER_API_BASE` (D4).
+- `plugin.py` — three hooks: projection, participation (D3 + D6 + the D11 log), cache reference.
+- `parameters.py` — twelve paths to `keyed`, `_REVISION` bump, replaced instruction block.
+
+Tests, both under `apps/aigateway/tests/unit/huggingface/`:
+
+- `test_huggingface_global_cache_projection.py` — NEW (projection, participation, hit metadata)
+- `test_huggingface_route_global_cache.py` — NEW (promotion, key differences, route, contract)
+
+No shared test file is edited.
+
+Durable artifacts: the `docs/tasks/`, `docs/spec/`, `docs/plan/` and `docs/work/` files dated
+2026-08-20.
+
+Must not change without returning to owner review: the cache key schema; the caller-visible reason
+vocabulary; `routes/chat.py` and `routes/chat_cache_stage.py`; request-cache persistence, models
+or migrations; dependency manifests or lockfiles; `core/plugin_base/_provider.py` and
+`core/request_cache/global_plan.py`; `api_key_validation.py` and `discovery.py`; and Anthropic,
+OpenRouter, Codex or Gemini behaviour.
+
+## Verification
+
+From `apps/aigateway`:
+
+```sh
+uv run ruff check .
+uv run ruff format --check .
+uv run pyright
+uv run python scripts/check_no_enterprise.py
+uv run pytest --cov=aigateway --cov-fail-under=80 -q
+```
+
+Focused, from `apps/aigateway`:
+
+```sh
+uv run pytest tests/unit/huggingface -q
+uv run pytest tests/unit/test_global_cache_projection_purity.py \
+  tests/unit/test_global_cache_registry_conformance.py \
+  tests/unit/test_global_cache_key.py \
+  tests/unit/test_global_cache_plan.py \
+  tests/unit/test_chat_global_cache_route.py -q
+```
+
+No append-only exception is expected. If the append-only check reports one, STOP: this plan predicts
+zero prior-test changes, so a failure means the prediction was wrong and the diff needs review
+before an exception is even considered.
+
+Diff review before reporting completion:
+
+```sh
+git diff --stat origin/main -- apps/aigateway docs
+git diff --check origin/main
+wc -l apps/aigateway/src/aigateway/plugins/huggingface_provider/global_cache.py
+git status --short
+```
+
+`git diff` omits untracked files: read every intended new file directly and reconcile against
+`git status --short`.
+
+## Test matrix
+
+| Acceptance claim | Proof |
+|---|---|
+| Backend-pinned exact replay | Route `miss -> hit`, one dispatch, one row |
+| Backend suffix survives into `resolved_model` | Direct assertion on the projection's `resolved_model` |
+| Two backends for one repo do not collide | Key-difference test on the two ids |
+| Unsuffixed never caches | Projection bypass + route probe/write assertions + observed tripwire |
+| Malformed never caches | Bypass per rejected-slug class, same predicate as the slug grammar |
+| Projection is pure | Registry sweeps + HF-local poisoned-settings test |
+| Projection is total | No input raises, including non-string `model` |
+| `prepared` is complete | Exactly the pinned base; fresh container; JSON-safe |
+| Revision abandons a generation | Monkeypatched revision changes the key hash |
+| Overridden base cannot share rows | Fill-then-override tripwire, row preserved, not replayed |
+| Trailing-slash base still participates | Normalised-comparison test |
+| Ambient LiteLLM state cannot poison | One participation test per D6 condition |
+| Every keyed path is proven | Twelve per-path key-difference tests + derived-set meta-test |
+| HF cannot silently stop contributing | Per-model twelve-keyed-instance assertion |
+| Contract flip is visible | Served detail document reports `keyed` for a promoted path |
+| Streaming stays ineligible for HF | Route asserts reason `stream`, no row |
+| Hit does no provider-credential work | No `aigateway:huggingface:*` read/decrypt, no auth-mode resolution, no injection, no dispatch; the profile-index read is allowed |
+| Profile defaults are inside the key | Two callers with different stored defaults key differently |
+| Failures never stored | Provider error yields zero rows |
+| Hit metadata is quiet and truthful | No mapper warning; `None` reference |
+| A decline is diagnosable | Decline token logged once, carries no configured value |
+| Other providers unaffected | Full gate; no core or sibling-plugin change in the diff |
+
+## Stop conditions
+
+Return to owner review rather than broadening scope if:
+
+- the projection would need settings, environment, credential, identity or I/O to be correct;
+- an existing test must change (the plan predicts none);
+- correctness appears to require a core port change, a route-order change, a new bypass reason, or
+  a dispatch-side refusal HF does not have today;
+- the ambient-state guard cannot be expressed on the participation hook alone — in particular, if
+  declining participation turns out not to prevent a `model_fallbacks` process from writing rows,
+  the guard must move to dispatch and that is a scope change;
+- promotion turns out to need per-mode rule branching;
+- OME-884 merges mid-flight and the participation signature change is more than mechanical.
+
+## Definition of done
+
+- Linear, task mirror, spec, plan and ledger agree; Linear itself untouched by direction.
+- HF projects for all 24 seeds and for any route-valid backend-pinned id; unsuffixed and malformed
+  ids bypass.
+- All **twelve** rule paths keyed, each with a key-difference proof, guarded by the derived-set
+  meta-test and the per-model instance floor.
+- The projection is pure, total, non-mutating, JSON-safe, identity-free and credential-free.
+- An overridden router base and each ambient LiteLLM hazard decline participation losslessly, and
+  each decline logs a diagnosable token.
+- A hit performs no HF provider-credential read or decrypt, no auth-mode resolution, no key
+  injection and no dispatch; the single profile-index read remains the accepted pre-cache cost.
+- One origin for the router base **on the dispatch path**; the validation and discovery copies are
+  documented as deliberately separate.
+- The caller-visible contract flip is asserted, not merely unobjected-to.
+- Zero prior tests modified; no core, schema, migration, dependency, route or shared-test change.
+- Focused tests and the full AIGateway gate green; ledger Outcome filled with actual files, gates
+  and deviations before handoff.

--- a/docs/spec/2026-08-20-OME-791-huggingface-global-cache-projection.md
+++ b/docs/spec/2026-08-20-OME-791-huggingface-global-cache-projection.md
@@ -1,0 +1,187 @@
+# OME-791 spec — HuggingFace global exact-response cache
+
+Linear: `OME-791` (parent `OME-787`). Stack: `apps/aigateway`.
+Companion plan: `docs/plan/2026-08-20-OME-791-huggingface-global-cache-projection.md`.
+
+## 1. Problem
+
+`huggingface_provider` has no `global_cache_projection`. It inherits the `CacheBypass` default
+from `ProviderPluginBase`, so **every** `huggingface/*` request bypasses AIGateway's global
+exact-response cache at the projection step, whatever its parameter rules say. Consequently all
+ten of its ordinary rules plus `tools`/`tool_choice` are declared `cache_behavior="bypass"`, and
+`plugins/huggingface_provider/parameters.py:46-63` records that this is a disposition forced by
+the missing projection rather than a judgement about the parameters.
+
+The product cost: a benchmark re-run over HF models pays full price every time, while the same
+suite over OpenRouter replays for free.
+
+## 2. MVP semantics
+
+- Cacheable unit: non-streaming Chat Completions through the unified HF router.
+- A gateway model id is `huggingface/<org>/<model>[:<provider|policy>]`, validated by the
+  existing `_validate_model_slug`.
+- **Only a backend-pinned id is cacheable.** An id carrying `:<provider|policy>` names one
+  upstream inference provider. An id without it does not: `pinned_router_target` already
+  records that "without `:<provider>` the router selects a backend PER REQUEST, so no single
+  backend row describes the next call". Replaying one backend's answer for a request the router
+  would have sent elsewhere would corrupt model attribution, which for a benchmark product is a
+  wrong answer rather than a stale one. Unsuffixed ids therefore bypass.
+  Cost of this restriction is approximately zero: all 24 entries in `_default_model_slugs()`
+  are backend-pinned.
+- `default_models` is the bootstrap `/v1/models` catalog. Consistent with the OME-884 ruling for
+  OpenAI, it is not a cache allowlist; any route-valid backend-pinned id projects.
+- A hit re-checks nothing. HF validates model existence, backend availability and token
+  permission on the miss that filled the row. A later hit performs no availability and no access
+  check, so an exact replay may still answer after a backend has been withdrawn or has become
+  unavailable to the current caller. This is the approved exact-replay and cross-account
+  behaviour inherited from OME-305, not a new decision.
+
+## 3. Model identity
+
+`resolved_model` is the UPSTREAM id: the gateway slug with the `huggingface/` prefix removed,
+i.e. `<org>/<model>:<backend>`.
+
+This is pinned by installed-transform evidence, not assumed.
+`tests/unit/huggingface/test_huggingface_dispatch.py:29-46` drives the installed
+`HuggingFaceChatConfig.transform_request` and asserts the post-strip model reaches the outbound
+body **verbatim** as `deepseek-ai/DeepSeek-R1:novita`; `:48-57` pins the URL as
+`{api_base}/chat/completions`.
+
+Because the `:<backend>` suffix is part of the upstream id, two different backends for one repo
+key differently as a structural consequence of `resolved_model`, with no separate mechanism.
+
+The same test records the precondition that makes this deterministic at all: with `api_base`
+pinned, litellm's `_fetch_inference_provider_mapping` is never called. Unpinned, litellm would
+resolve a provider mapping over the network keyed by ambient `HUGGINGFACE_API_KEY`, and the
+upstream model reaching the wire would stop being a function of the request. The pinned base is
+therefore a cache-correctness precondition, not only a credential-safety one.
+
+## 4. Key material
+
+`prepared` describes everything the HF boundary adds that the caller did not send.
+`prepare_chat_body` (`plugin.py:208-230`) does exactly three things:
+
+| Transformation | Classification |
+|---|---|
+| `out["api_base"] = self.settings.router_api_base` | **Output-affecting** — which endpoint answers. Projected. |
+| `out.pop("api_key")` | Transport. The gateway owns the credential; a caller copy would be overwritten regardless. Excluded, as OpenRouter excludes its injected key. |
+| `extra_headers` auth-name sanitisation and empty/non-dict drop | Transport. Excluded — see §7. |
+
+So `prepared` is `{"api_base": OFFICIAL_ROUTER_API_BASE}`.
+
+`GLOBAL_CACHE_ADAPTER_REVISION` carries what the JSON-hashed `prepared` cannot: the installed
+litellm HuggingFace transform behaviour (verbatim model pass-through, the
+`{api_base}/chat/completions` URL, and the absence of a provider-mapping fetch). A litellm
+upgrade that changes any of those is a mandatory bump.
+
+### Identity exclusion
+
+The key contains no account, profile, credential, organisation or backend-billing identity. HF
+injects no attribution header today — there is no `bill_to` / `X-HF-Bill-To` anywhere in `src`
+or `tests`, so nothing account-derived reaches the wire. Adding one later changes the request
+per account and is a mandatory revision bump **and** a cross-account replay re-decision.
+
+## 5. Purity versus admission
+
+The projection is pure key material. The deployment-local question "may this provider use the
+cache here at all" belongs to `participates_in_global_cache`, which is allowed to read settings.
+
+`HuggingFacePluginSettings.router_api_base` is an env-overridable field
+(`AIGW_HUGGINGFACE_ROUTER_API_BASE`). This is the one structural difference from every existing
+projection: OpenRouter and OpenAI both pin an unconfigurable module constant, so neither can
+diverge. HuggingFace can.
+
+A pure projection may not read that field — the purity sweep passes a settings object that
+raises on attribute access, and a per-host settings read would make one host's keys differ from
+another's while each host's own determinism test still passed, which is worse than failing.
+
+Resolution: the projection emits the official constant; the participation hook declines
+participation entirely when `self.settings.router_api_base` is not that constant. A deployment
+pointing HF at a proxy or a mock therefore neither reads nor writes global rows, instead of
+sharing a key that misdescribes its endpoint.
+
+## 6. Parameter contract
+
+All **twelve** declared rule paths move from `bypass` to `keyed`, in the same change as the
+projection and not before: `temperature`, `max_tokens`, `stop`, `response_format`, `seed`, `n`,
+`frequency_penalty`, `presence_penalty`, `logprobs`, `top_logprobs` (ten `direct_rule` calls),
+plus `tools` and `tool_choice`, which `function_calling_rules(..., cache_behavior="keyed")` emits
+as two separate rules. Each is output-affecting and would have to be keyed for a replay to be
+correct.
+
+This is a **caller-visible contract change**: the published parameter contract digests each
+rule's `cache_behavior` and `projection_revision`, so every HF model's `contract_id` moves once
+and twelve rows of its detail document begin reporting `keyed`.
+
+Two of the twelve — `max_tokens` and `temperature` — are also the fields stored as
+`ProfileDefaults`. The ruling-57 body-wins merge happens BEFORE the cache lookup, so the key
+describes the EFFECTIVE request: two callers whose stored defaults differ key differently even
+when their wire bodies are identical. That is what makes promoting these two safe.
+
+### Accepted consequence — an invalid parameter COMBINATION is not a wrong hit
+
+`validate_chat_parameter_combination` refuses `top_logprobs` without `logprobs is True` on the
+miss path, AFTER the cache read. That is safe only because both fields are keyed (so an invalid
+combination keys uniquely) and because a row can exist only for a request that dispatched
+successfully. INVARIANT this rests on: the combination predicate stays a pure function of KEYED
+body fields. `auth_mode` is structurally absent from the key, so a future combination rule that
+consulted the auth mode, the resolved model, or any deployment state would reintroduce exactly
+this wrong-hit class and would then require a real bypass.
+
+`top_p` stays observed-but-unruled; a `bypass`→`keyed` promotion cannot enable a parameter no
+rule enables. The rules revision `_REVISION` is bumped, and stays separate from
+`GLOBAL_CACHE_ADAPTER_REVISION`: one versions what a caller may say and where it lands, the
+other versions what the boundary adds on its own.
+
+HF's `available_auth_modes()` is exactly `("api_key",)` and `_AUTH` already matches it, so a
+keyed rule covers every available mode with no change.
+
+## 7. Caller-influenceable transport
+
+An `extra_headers` value that a caller can steer is output-affecting and must be projected or
+bypassed; one that only the gateway sets is transport and is excluded. The parameter contract is
+fail-closed — a field reaches the provider body only through a rule, and no rule declares
+`extra_headers` — so it is gateway-set only. The plan verifies this claim in code before relying
+on it, and bypasses if the trace shows otherwise.
+
+## 8. Cache-hit metadata
+
+`HuggingFaceProviderPlugin` gains `cache_reference_from_cached_response` returning `None`.
+
+This is not decoration. `core/../plugins/taxonomy/session.py::attach_hit_metadata` reaches the
+hook through `getattr` inside a `try`, so a provider that simply does not implement it logs
+`cache-reference mapper failed provider=huggingface` on **every** hit — reporting a failure that
+never happened. HF contributes no usage-accounting strategy at all (unlike Anthropic and
+OpenRouter, each of which owns a `usage_accounting.py`), so there is nothing truthful to attach,
+and an explicit `None` is the honest answer. Building an HF accounting strategy is out of scope.
+
+## 9. Accepted consequence — gated-repo licensing under cross-account replay
+
+Flagged for owner sign-off; it is not an implementation detail.
+
+Exact replay is cross-account by design, and a hit re-checks nothing — no availability check, no
+access check. HF adds a dimension no other projecting provider has: most seeds in
+`_default_model_slugs()` are **gated repositories**, whose access requires per-HF-account
+acceptance of the model's license. So a row filled by an account that accepted a license can be
+served to an account that never did.
+
+This is the same accepted-consequence class OME-884 recorded for direct OpenAI, but qualitatively
+different: OpenAI's concerns access control inside one vendor relationship, whereas this touches a
+third party's licensing terms.
+
+It is accepted here because it follows from the approved exact-replay semantics rather than from
+anything this unit designs — the cache changes who may READ a stored answer, never what goes on
+the wire. If the owner declines it, the remedy is a catalog-level seeding or gating decision, not
+a projection change, so it does not reshape the work.
+
+## 10. Non-goals and invariants preserved
+
+Out of scope: streaming, `top_p` promotion, the sibling OME-787 projections, `X-HF-Bill-To`, an
+HF usage-accounting strategy, runtime model discovery, gateway-owned aliases, cache retention,
+cost estimation, schema or migration change, dependency change.
+
+Preserved: the closed bypass-reason vocabulary (`PROJECTION_BYPASS_REASON` only — no new reason
+is minted); the cache-key schema; route ordering in `routes/chat.py` and `chat_cache_stage.py`;
+request-cache persistence; every existing HF dispatch, discovery, validation and parameter
+contract; and OpenRouter, Anthropic and Codex behaviour. No core port signature changes — a
+provider adding only a projection needs none.

--- a/docs/tasks/2026-08-20-OME-791-huggingface-global-cache-projection.md
+++ b/docs/tasks/2026-08-20-OME-791-huggingface-global-cache-projection.md
@@ -1,0 +1,62 @@
+---
+id: OME-791
+linear_url: https://linear.app/openmined/issue/OME-791/implement-the-huggingface-global-cache-projection
+status: Backlog
+type: improvement
+priority: low
+labels: [aigateway, agentic, autonomous]
+parent: OME-787
+created: 2026-08-20
+closed:
+---
+
+# Implement the HuggingFace global-cache projection
+
+Give the HuggingFace provider a pure `global_cache_projection` so its chat-parameter rules can
+be promoted from `cache_behavior="bypass"` to `"keyed"`, enabling AIGateway's global
+exact-response cache for `huggingface/*` non-streaming Chat Completions. This is gateway
+response replay, not any HF-side prompt caching.
+
+`status` above is the real Linear status. The owner directed mid-session that Linear must not be
+modified during this work, so the issue was deliberately NOT transitioned to In Progress and no
+Linear comment was posted. Reconcile Linear manually.
+
+## Scope
+
+- Add a pure provider-local projection and `GLOBAL_CACHE_ADAPTER_REVISION` in a new
+  `plugins/huggingface_provider/global_cache.py`, following the `openrouter_provider` /
+  `openai_provider` module shape rather than Anthropic's in-plugin form.
+- Project the two output-affecting things the HF boundary adds: the pinned router `api_base`
+  and the upstream model identity implied by the gateway slug.
+- Promote every `bypass` rule in `plugins/huggingface_provider/parameters.py` to `keyed`,
+  including `cache_behavior="keyed"` on `function_calling_rules(...)`, only once the real
+  projection exists.
+- Bypass unsuffixed `huggingface/<org>/<model>` ids: without `:<provider|policy>` the router
+  picks a backend per request, so no single upstream describes the next call.
+- Fail closed on a non-official `AIGW_HUGGINGFACE_ROUTER_API_BASE`: the projection must stay
+  pure, so the deployment-local override is checked in the impure participation hook instead.
+- Add `cache_reference_from_cached_response` returning `None` — HF contributes no
+  usage-accounting strategy, and a missing hook logs a false mapper failure on every hit.
+- Add purity/determinism, malformed-and-unsuffixed bypass, key-difference, route miss->hit,
+  and hit-does-no-credential-work proofs.
+
+## Acceptance
+
+- Identical eligible `huggingface/*` requests produce `miss -> hit`.
+- Different repos, different `:<backend>` suffixes, different messages, and different values of
+  any newly-keyed parameter do not collide.
+- The projection is total, deterministic, non-mutating, JSON-safe, identity-free,
+  credential-free, reads no settings, and performs no I/O.
+- Malformed and unsuffixed model ids never read or write cache, using the same predicates the
+  provider already owns.
+- A hit performs no HF credential work and no provider dispatch.
+- Existing OpenRouter, Anthropic and Codex behaviour remains unchanged; no core port change.
+- No database model, migration, dependency, or persistence-format change.
+- Focused tests and the complete AIGateway quality gate pass.
+
+## Out of scope
+
+Streaming, `top_p` promotion, the sibling OME-787 projections (OME-788 Anthropic promotion,
+OME-789 Gemini, OME-790 Antigravity, OME-792 Ollama), `X-HF-Bill-To`, HF usage-accounting
+strategy, runtime model discovery, gateway-owned aliases, cache retention, schema changes, and
+cost estimation.

--- a/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
+++ b/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
@@ -131,6 +131,8 @@ created fresh in the worktree (`uv sync`), Python 3.12, litellm 1.97.0.
   - `docs(aigateway): record OME-791 cache remediation`
   - `fix(aigateway): accept model-aware huggingface cache gate`
   - `docs(aigateway): record OME-791 rebase verification`
+  - `fix(aigateway): reject incomplete multi-choice cache rows`
+  - `fix(aigateway): close Hugging Face cache crosscheck findings`
 
 - **Tripwires, both OBSERVED TO FIRE** (guard neutralised, symptom recorded in an AIDEV-NOTE at
   the guard, guard restored, suite re-run green):
@@ -176,7 +178,8 @@ MVP remediation.
   request body. Both now decline participation, each with a behavioural proof.
 - **M5 (PARTIAL, by owner scope)** — the complete HF ambient predicate, inventories, decline
   reasons and decline log moved to `huggingface_provider/runtime_guard.py`; `plugin.py` dropped
-  **432 → 287 lines**. Cross-provider duplication is **NOT** eliminated: `openai_provider` and
+  **432 → 287 lines** in that pass and is **292 lines** after the OME-884 signature adaptation.
+  Cross-provider duplication is **NOT** eliminated: `openai_provider` and
   `openrouter_provider` still carry near-copies and were deliberately not touched. The former
   "mirror this into the siblings" instruction was **removed** as unsafe — HF declines cache
   participation where some sibling paths hard-fail dispatch, so copying a condition without its
@@ -287,17 +290,86 @@ the port signature and a regression test, after which the complete gate was gree
   `test_a_raising_guard_costs_a_bypass_and_never_the_request`, which asserts the plan-level
   contract a caller actually depends on.
 
-- **Owner decision still open, flagged not buried:** gated-repo licensing under cross-account
-  replay (spec §9). Most seeds are gated repos requiring per-HF-account license acceptance, so a
-  row filled by an accepting account can be served to one that never accepted. Recorded as an
-  ACCEPTED CONSEQUENCE because it follows from the approved exact-replay semantics rather than
-  from this unit's design; if the owner declines it, the remedy is a catalog-level seeding/gating
-  decision, not a projection change.
+- **Owner decision accepted for MVP:** gated-repo licensing under cross-account replay (spec §9).
+  Most seeds are gated repos requiring per-HF-account license acceptance, so a row filled by an
+  accepting account can be served to one that never accepted. The identity-free global cache is
+  intentionally shared and does not re-check credentials or licence acceptance on a hit.
+  Deployments requiring tenant-specific licence enforcement must disable the global request cache
+  or isolate gateway/cache instances by trust boundary.
 
 - **~~`plugin.py` is at 432 of 450 lines.~~ RESOLVED 2026-08-21** by the review remediation pass:
   the ambient-state guard moved to `huggingface_provider/runtime_guard.py` and `plugin.py` is now
-  **287 lines**. Note the correction to the original prediction — the extraction went to a
+  **292 lines** after the OME-884 signature adaptation. Note the correction to the original
+  prediction — the extraction went to a
   provider-LOCAL module, **not** to core. Extracting into core was rejected for this branch because
   sibling providers respond to the same hazards differently (HF declines cache participation; some
   sibling paths hard-fail dispatch). A shared helper needs a union plus per-provider deltas and stays
   a separate follow-up after this branch integrates current `main`.
+
+## Crosscheck remediation pass (2026-08-22)
+
+A second independent read-only review of the merged remediation produced eight surviving findings
+(five defects D1–D5, plus weak points W1–W4). This pass closes D1–D5, W1, W4 and one shared-core
+correctness defect. W2 and W3 were assessed and deliberately **not** implemented — see below.
+
+### Findings closed
+
+| ID | File | Change |
+|---|---|---|
+| D1 | `DEPLOYMENT.md` | The exhaustive cacheable-provider list named 3 cacheable + 4 bypassing = **7 of 8** registered providers. Direct **openai** — which implements `global_cache_projection` and has **no** operator enable switch — was unaccounted for. Added it, plus a per-provider gating table distinguishing "no operator switch" from "unconditional" (its runtime guard still declines per request). |
+| D2 | `tests/live/test_huggingface_provider_allowlist_drift.py` | The `allowlist - observed` direction was computed, printed, then discarded — the only conditional was on the other direction. Added `_EXPECTED_CATALOG_OMISSIONS`; unexpected omissions now **fail**. Not an equality check: the endpoint is a chat-model catalog, so absence is not proof of removal, and a benign reappearance must not go red. |
+| D3 | `parameters.py`, `tests/unit/huggingface/test_huggingface_route_global_cache.py` | The AIDEV-NOTE governing every `cache_behavior` edit pointed at the module the key-difference proofs **left** during the file split. Repointed to `test_huggingface_global_cache_keys.py` and deleted the 88 lines of dead duplicate scaffolding (`_EXPECTED_KEYED_PATHS`, `_KEY_DIFFERENCE_CASES`, `_published_cache_behaviour`, `_key_hash`) that had no call sites and that `ruff` cannot see. |
+| D4 | `runtime_guard.py` | Comments only. Removed two false claims — that OME-884 had not merged into this base (it had; `git merge-base HEAD origin/main` is main's own HEAD) and that the participation port "receives NO model" (`_provider.py:278` is the line carrying the model parameter). Replaced with the real rationale, already recorded correctly at `plugin.py:265-267`, and stated the operational cost of the conservative form. |
+| D5 | `charts/aigateway/values.yaml` | "read all five consequences" → "six". The sixth was appended to this same file by the earlier pass; only `values-prod.yaml` had been re-counted. |
+| W1 | `tests/unit/huggingface/test_huggingface_provider_allowlist.py` | Added `_EXPECTED_ROUTER_BACKENDS`, an independent literal of the 18-member partner table, asserted for **equality**. Every prior test derived its expectation from `KNOWN_ROUTER_BACKENDS` on both sides and was structurally blind to a bad member. |
+| W4 | `DEPLOYMENT.md` | Documented `DELETE FROM request_cache_entries WHERE provider = 'huggingface';`. Verified the column is real and indexed (`request_cache_entry.py:16`) and that the stored value is the plugin's `custom_llm_provider` (`global_plan.py:135`). |
+
+### Shared-core correctness fix (TDD)
+
+`routes/chat_cache_stage.py::_is_a_whole_answer` validated only `choices[0]`. Because `n` is KEYED
+for every cacheable provider, an `n=2` body has its own key and is replayed only to another `n=2`
+request — which is exactly what made a half-finished pair **permanent** rather than harmless.
+
+RED first: new `tests/unit/test_chat_cache_write_eligibility.py` (17 tests) failed 5 / passed 12,
+the 5 being precisely the later-choice cases. Then the minimal fix — `all()` over every choice.
+
+- **INVARIANT relocated, not removed:** `all([])` is vacuously `True`, so the pre-existing
+  `if not choices: return False` guard is now load-bearing for the empty-list case. The
+  `an-empty-choices-list` parametrized case is therefore not redundant coverage.
+- The pre-existing route-level `test_global_cache_write_eligibility.py` was **not modified** and
+  stays green; every one of its cases is single-choice, which is why it could not see this.
+
+### Deliberately NOT done
+
+- **W2** (a duplicate HF-only litellm version pin) — the repository-wide OpenAI tripwire already
+  blocks an unreviewed upgrade; a second pin is duplication, not coverage.
+- **W3** (narrowing `model_alias_map` to the requested model) — current behaviour is fail-safe and
+  costs only cache participation. Non-blocking cross-provider follow-up; its cost is now stated at
+  the guard instead of being rediscovered as a bug.
+- **W4 placement deviation:** the instruction said "near the existing full-table reset example".
+  That example sits inside the *mandatory full clear* required before a `0010` schema downgrade,
+  where a partial `DELETE` would wrongly imply a narrower reset suffices. Placed in the cache-size
+  / pruning section instead — the operational home for targeted deletion.
+
+### Checks actually run
+
+| Check | Result |
+|---|---|
+| configured aigateway quality gates against `origin/main` | **ALL GREEN** (append-only, ruff check, ruff format, pyright, `check_no_enterprise.py`, pytest+coverage) |
+| `pytest tests/unit/huggingface -q` | **292 passed** (was 291; +1 is the W1 pin) |
+| focused global-cache suites + the new module | **151 passed** |
+| `AIGW_LIVE=1 pytest tests/live/…allowlist_drift.py -q -s` | **1 passed** — 14 observed, 0 new, 4 expected omissions, 0 unexpected |
+| full suite `--cov-fail-under=80` | **3884 passed, 50 skipped, coverage 92.50%** |
+| `git diff --check` | clean |
+| file sizes | all ≤ 450; the route test **shrank** 437 → 349 |
+
+**Falsification, not just green:** the W1 pin was proved discriminating by re-running the exact
+mutation the review used — `wavespeed` → `fireworks`, which previously left all 291 tests passing,
+now fails one test and only that one. The D2 assertion was proved discriminating by simulating an
+unexpected catalog omission, which fails with the offending slug named. Both mutations were
+reverted and the clean state re-verified.
+
+**Append-only gate vs `origin/main`: GREEN.** Against the branch tip it flags the two
+brief-mandated edits (the D2 assertion body and the D3 dead block). Zero test functions were lost:
+the drift module holds 1 before and after, the route module 8 before and after, with an empty
+set difference in both. The gate was not weakened or modified.

--- a/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
+++ b/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
@@ -1,10 +1,18 @@
 ---
 ticket: OME-791
 stack: aigateway
-status: implemented (awaiting owner approval to commit)
+status: in_progress
 started: 2026-08-20
 finished:
 ---
+
+<!-- STATUS NOTE (OME-791 review remediation, 2026-08-21): the previous value,
+"implemented (awaiting owner approval to commit)", was not one of the four permitted states
+(planned | in_progress | done | blocked). `in_progress` is the honest replacement: the
+implementation and the review-remediation pass are both COMPLETE, but the unit closes at merge
+and rebase verification plus the gated-repository decision remain pending, so `finished` stays
+empty. Set `finished` and `done` at merge. -->
+
 
 # OME-791 — HuggingFace global-cache projection
 
@@ -115,7 +123,15 @@ created fresh in the worktree (`uv sync`), Python 3.12, litellm 1.97.0.
   Focused: `tests/unit/huggingface` 217 passed; the five global-cache core suites 327 passed.
   The plan's prediction of **zero prior tests modified** held — the append-only gate confirms it.
 
-- **Commits:** none. Nothing staged or committed; owner approval not yet given.
+- **Commits (actual, present on `OME-791-huggingface-global-cache-projection`):**
+  - `89116431` — `feat(aigateway): cache huggingface router responses`
+  - `d6b1ec5d` — `docs(aigateway): record the OME-791 huggingface cache decisions`
+
+  Together: 10 files, +2425/−31 vs `origin/main`. The earlier "Commits: none" line was written
+  INSIDE the commit that contradicted it and is corrected here (review finding M4).
+
+- **Review remediation implementation commit:**
+  - `a549850b` — `fix(aigateway): harden huggingface cache eligibility`
 
 - **Tripwires, both OBSERVED TO FIRE** (guard neutralised, symptom recorded in an AIDEV-NOTE at
   the guard, guard restored, suite re-run green):
@@ -127,6 +143,102 @@ created fresh in the worktree (`uv sync`), Python 3.12, litellm 1.97.0.
   2. *D3 participation gate* (`plugin.py`). Neutralised, the deployment configured for
      `https://proxy.internal/v1` was served `X-AIGW-Cache: hit` from a row filled against the
      official router — a 200 carrying an answer its own upstream never produced.
+
+## Review remediation pass (2026-08-21)
+
+The implementation review returned **3 blockers and 8 major findings**. The owner-scoped remediation
+implemented B1, B2, B3, M1, M2, M3, M4, M5 and M8; M6/M7 and minor findings remain outside this
+MVP remediation.
+
+- **B1 — policy suffixes were cached as pinned backends.** `pinned_router_target()` treated *every*
+  non-empty suffix as a deterministic backend, so `:fastest`, `:cheapest`, `:preferred`, `:auto` and
+  even `:notarealprovider` produced real, permanent, globally shared keys. `:preferred` is the sharp
+  case: it follows the **requesting account's** provider preference order, so one account's answer
+  could be replayed to another whose identical request would have selected a different provider —
+  identity-dependent dispatch under an architecturally identity-free key. Fixed with a fail-closed
+  `KNOWN_ROUTER_BACKENDS` frozenset transcribed from the Hugging Face partner table (18 slugs, read
+  2026-08-21), sourced from the partner table rather than the 8 seeded providers so the catalog
+  cannot become an admission list. A denylist was rejected: it fails **open** on the next policy
+  keyword HF ships. `_validate_model_slug` stays permissive — dispatch is unchanged.
+- **B2 — LiteLLM Proxy could take over dispatch while participation returned `True`.** Guarding
+  only `litellm.use_litellm_proxy` was insufficient: `_should_use_litellm_proxy_by_default` checks
+  `get_secret_bool("USE_LITELLM_PROXY")` **first**
+  (`llms/litellm_proxy/chat/transformation.py:73`) and returns on it alone, and is consulted at the
+  top of `get_llm_provider` (`get_llm_provider_logic.py:151`). Verified live: both controls flip
+  `get_llm_provider(...)` from `huggingface` to `litellm_proxy`, the environment one while the
+  attribute stays `False`. Both are now guarded; litellm's private helper is deliberately not called.
+- **B3 — the suite could not tell the fix from the bug.** The 217-test HF suite was green both
+  before and after the correct behaviour was applied, because it tested the parser's raise sites
+  rather than the semantic question "is this backend fixed for the next call?". Fixed with
+  hazard-named semantic tests plus route-level no-read/no-write proofs.
+- **M1/M2** — `disable_stop_sequence_limit` (truncates a `stop` list past four entries,
+  `utils.py:7618`) and `enable_json_schema_validation` (gates post-dispatch schema refusal for a
+  **keyed** `response_format`, `utils.py:1198`) both change behaviour behind a byte-identical
+  request body. Both now decline participation, each with a behavioural proof.
+- **M5 (PARTIAL, by owner scope)** — the complete HF ambient predicate, inventories, decline
+  reasons and decline log moved to `huggingface_provider/runtime_guard.py`; `plugin.py` dropped
+  **432 → 287 lines**. Cross-provider duplication is **NOT** eliminated: `openai_provider` and
+  `openrouter_provider` still carry near-copies and were deliberately not touched. The former
+  "mirror this into the siblings" instruction was **removed** as unsafe — HF declines cache
+  participation where some sibling paths hard-fail dispatch, so copying a condition without its
+  response would turn a lossless decline into a refused request. Repo-wide consolidation is a
+  separate follow-up after this branch integrates current `main` and the provider-specific response
+  policies can be designed together.
+- **M8** — `additional_drop_params` removed from the guarded inventory (it is not a litellm module
+  global on 1.97.0; the old test passed only because `raising=False` **created** it). Now:
+  existence assertions for every guarded global, `raising=True` throughout, an independently
+  authored expected inventory compared both ways, and every callback field — async included —
+  parametrized with the `"cache"` exemption preserved.
+- **M3** — `DEPLOYMENT.md` no longer claims HF always bypasses; it now carries a per-suffix
+  cacheability table and the gated-repository cross-account licensing consequence. Added as
+  consequence **6** on `config.requestCache` in `values.yaml`, plus `values-prod.yaml` and the
+  chart README. Chart defaults unchanged.
+
+**Falsification (both mutations executed, then reverted):**
+
+1. `pinned_router_target` reverted to `return (repo, backend) if sep else None` →
+   **21 tests failed** across `test_huggingface_provider_allowlist.py` and
+   `test_huggingface_route_global_cache.py`. The pre-remediation suite passed this mutation.
+2. `runtime_guard` stripped of the env-secret check and the three new globals →
+   **11 tests failed** in `test_huggingface_runtime_guard.py`.
+
+**Files changed in this remediation:**
+
+| File | Lines | Note |
+| --- | --- | --- |
+| `src/…/huggingface_provider/settings.py` | 199 | `KNOWN_ROUTER_BACKENDS` + allowlisted `pinned_router_target` |
+| `src/…/huggingface_provider/runtime_guard.py` | 263 | **NEW** — the whole guard, including fail-closed unreadable-state containment |
+| `src/…/huggingface_provider/plugin.py` | 287 | was 432; guard removed |
+| `src/…/huggingface_provider/global_cache.py` | 153 | stale symbol reference only |
+| `tests/unit/huggingface/test_huggingface_provider_allowlist.py` | 183 | **NEW** — 23 tests |
+| `tests/unit/huggingface/test_huggingface_runtime_guard.py` | 389 | **NEW** — 46 tests |
+| `tests/unit/huggingface/test_huggingface_global_cache_keys.py` | 268 | **NEW** — split out, 30 tests |
+| `tests/unit/huggingface/test_huggingface_route_global_cache.py` | 437 | was 550; 12 tests |
+| `tests/unit/huggingface/test_huggingface_global_cache_projection.py` | 360 | M8 edits, 40 tests |
+| `tests/live/test_huggingface_provider_allowlist_drift.py` | 77 | **NEW** — opt-in `AIGW_LIVE=1` |
+| `DEPLOYMENT.md`, `charts/aigateway/{values,values-prod,README}` | — | M3 |
+| `docs/work/2026-08-20-OME-791-…md` | — | this record (M4) |
+
+**Checks actually run (2026-08-21):** ruff check ✅ · ruff format ✅ · pyright 0 errors ✅ ·
+`tests/unit/huggingface` **290 passed** ✅ · focused global-cache conformance/purity/plan/key/reason
+suite **131 passed** ✅ · full suite **3702 passed, 50 skipped, 1 unrelated failure** · coverage
+**92.43%** (floor 80) ✅ · `git diff --check` clean ✅ · every changed/new Python file ≤ 450 lines ✅ ·
+`check_no_enterprise.py` ✅.
+
+**Owner-approved gate deviations:**
+
+1. **Append-only check — RED.** It flags `test_huggingface_route_global_cache.py` (the 550→two-file
+   split the brief *mandated*, naming `test_huggingface_global_cache_keys.py`) and two lines in
+   `test_huggingface_global_cache_projection.py` (the `additional_drop_params` case and
+   `raising=False`, both of which M8 *mandated* removing — the case only passed by creating the
+   attribute it claimed to test). Verified **zero prior test functions lost**: all 37 that existed
+   at HEAD still exist, now among 164. The gate cannot distinguish a move from a deletion. The
+   owner approved this documented append-only deviation; the gate itself remains unchanged.
+2. **`tests/unit/test_helm_prod_config.py::test_prod_sets_finite_openrouter_provider_concurrency_cap`
+   — RED, pre-existing and unrelated.** It asserts `AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES` in
+   prod `extraEnv`; that key is absent at `HEAD` **and** in the working copy, the test file is
+   **untracked** (OME-921's uncommitted RED state), and this pass's only `values-prod.yaml` change
+   is comment text. The owner approved committing OME-791 without absorbing that unrelated change.
 
 ## Deviations
 
@@ -141,9 +253,7 @@ created fresh in the worktree (`uv sync`), Python 3.12, litellm 1.97.0.
   the normal "move to In Progress at ledger creation" step was skipped. The `docs/tasks/` mirror
   records `status: Backlog` truthfully rather than claiming a transition that did not happen.
 
-- **Plan revised after adversarial review, before implementation.** Four independent reviews ran
-  against the pre-review draft; one returned **reject**. Every finding was re-verified against
-  this base before being accepted or rejected. Material corrections:
+- **Plan corrected before implementation.** Material corrections:
   - **D6 rewritten.** The pre-review justification was FALSE (it claimed both projecting providers
     guard ambient LiteLLM state; Anthropic projects with no such guard). More seriously the guard
     was *under*-inclusive: `litellm.model_fallbacks` is read at `main.py:602` inside
@@ -185,6 +295,10 @@ created fresh in the worktree (`uv sync`), Python 3.12, litellm 1.97.0.
   from this unit's design; if the owner declines it, the remedy is a catalog-level seeding/gating
   decision, not a projection change.
 
-- **`plugin.py` is at 432 of 450 lines.** The next responsibility added to this file should go in
-  a new module instead; extracting the shared ambient-state predicate into core (see the
-  AIDEV-NOTE there) is the obvious candidate and would bring it back down.
+- **~~`plugin.py` is at 432 of 450 lines.~~ RESOLVED 2026-08-21** by the review remediation pass:
+  the ambient-state guard moved to `huggingface_provider/runtime_guard.py` and `plugin.py` is now
+  **287 lines**. Note the correction to the original prediction — the extraction went to a
+  provider-LOCAL module, **not** to core. Extracting into core was rejected for this branch because
+  sibling providers respond to the same hazards differently (HF declines cache participation; some
+  sibling paths hard-fail dispatch). A shared helper needs a union plus per-provider deltas and stays
+  a separate follow-up after this branch integrates current `main`.

--- a/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
+++ b/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
@@ -1,0 +1,190 @@
+---
+ticket: OME-791
+stack: aigateway
+status: implemented (awaiting owner approval to commit)
+started: 2026-08-20
+finished:
+---
+
+# OME-791 — HuggingFace global-cache projection
+
+## Intent
+
+`huggingface_provider` inherits `CacheBypass` from `ProviderPluginBase`, so every
+`huggingface/*` request bypasses AIGateway's global exact-response cache at the projection step
+and all twelve of its parameter rules are pinned at `cache_behavior="bypass"` as a consequence.
+This unit adds the provider's own pure projection and promotes those rules to `keyed`, so a
+benchmark re-run over HF models replays instead of paying full price — the same capability
+OpenRouter has had since OME-305 and OpenAI gains in OME-884.
+
+Spec: `docs/spec/2026-08-20-OME-791-huggingface-global-cache-projection.md`.
+Plan: `docs/plan/2026-08-20-OME-791-huggingface-global-cache-projection.md`.
+
+## Planned changes
+
+Production (`apps/aigateway/src/aigateway/plugins/huggingface_provider/`):
+
+- `global_cache.py` — NEW. `GLOBAL_CACHE_ADAPTER_REVISION`, `router_dispatch_controls()`, and the
+  pure `project_global_cache_request(body)`.
+- `settings.py` — publish the router base as a module constant and add a pure
+  `cacheable_upstream_model(slug)` derived from the existing slug predicates.
+- `plugin.py` — wire `global_cache_projection`, `participates_in_global_cache` (official-base
+  check), and `cache_reference_from_cached_response` returning `None`.
+- `parameters.py` — promote all eleven rules to `cache_behavior="keyed"`, bump `_REVISION`,
+  replace the bypass-rationale AIDEV-NOTE.
+
+Tests (`apps/aigateway/tests/unit/huggingface/`):
+
+- `test_huggingface_global_cache_projection.py` — NEW: purity/determinism, non-mutation,
+  bypass classes, `prepared` completeness, adapter-revision isolation.
+- `test_huggingface_global_cache_keys.py` — NEW: key-difference proofs per newly-keyed path
+  through `build_global_cache_plan()`.
+- `test_huggingface_route_global_cache.py` — NEW: route-level `miss -> hit`, one dispatch, one
+  row, hit does no credential work, unsuccessful response not stored.
+- Existing HF tests: expected to remain green and unmodified except for the cache-disposition
+  assertions the promotion necessarily changes (append-only decision — enumerate before
+  touching).
+
+Durable artifacts: this ledger + the spec, plan and `docs/tasks/` mirror dated 2026-08-20.
+
+## Test plan
+
+RED first, per unit:
+
+1. Projection purity and totality — settings object that raises; no body mutation; every input
+   yields a projection or a `CacheBypass`, never an exception.
+2. Bypass classes — malformed slug, non-`huggingface/` prefix, non-string model, and the
+   unsuffixed `huggingface/<org>/<model>` case (router picks a backend per request).
+3. `prepared` completeness — exactly the pinned official `api_base`; JSON-safe; a fresh dict per
+   call so a caller cannot mutate later key material.
+4. Key difference — repo, `:<backend>` suffix, messages, and each newly-keyed parameter
+   (`temperature`, `max_tokens`, `stop`, `response_format`, `seed`, `n`, `frequency_penalty`,
+   `presence_penalty`, `logprobs`, `top_logprobs`, `tools`, `tool_choice`) isolate; equal
+   effective values collide.
+5. Participation — an overridden `AIGW_HUGGINGFACE_ROUTER_API_BASE` declines participation while
+   the official base participates.
+6. Route — identical eligible requests produce `miss -> hit` with one dispatch and one row; a
+   provider error stores nothing; a hit performs no HF credential read/decrypt and no dispatch.
+7. Hit metadata — no `cache-reference mapper failed` warning; accounting reports unsupported.
+
+Standing (green on arrival): the registry purity sweep and
+`test_a_provider_that_declares_a_keyed_rule_backs_it_with_a_real_projection`.
+
+## Acceptance
+
+- Identical eligible `huggingface/*` requests produce `miss -> hit`.
+- Different repos, `:<backend>` suffixes, messages, or newly-keyed parameter values never collide.
+- The projection is total, pure, non-mutating, JSON-safe, identity-free and credential-free.
+- Malformed and unsuffixed ids neither read nor write cache.
+- No core port change, no schema/migration/dependency change, no route-order change.
+- OpenRouter, Anthropic and Codex behaviour unchanged.
+- Focused tests plus the configured aigateway quality gates green.
+
+## Baseline (before the first edit)
+
+The configured aigateway quality gates, run 2026-08-20, were **ALL GREEN** — append-only check,
+ruff check, ruff format --check, pyright,
+`scripts/check_no_enterprise.py`, and `pytest --cov=aigateway --cov-fail-under=80 -q`. Venv
+created fresh in the worktree (`uv sync`), Python 3.12, litellm 1.97.0.
+
+## Outcome
+
+- **Actual files** (all under `apps/aigateway/`, plus docs):
+  - `src/aigateway/plugins/huggingface_provider/global_cache.py` — NEW, 153 lines.
+    `GLOBAL_CACHE_ADAPTER_REVISION = "huggingface-global-cache-2026-08"` and the pure
+    `project_global_cache_request(body)`. **Planned `router_dispatch_controls()` was NOT built** —
+    review found it contradicted the plan's own "Deliberately not built" list.
+  - `src/aigateway/plugins/huggingface_provider/settings.py` — `_ROUTER_API_BASE` renamed to public
+    `OFFICIAL_ROUTER_API_BASE`. **Planned `cacheable_upstream_model(slug)` was NOT built** — the
+    existing `pinned_router_target` already owns that predicate, and a second one is drift.
+  - `src/aigateway/plugins/huggingface_provider/plugin.py` — 432 lines (limit 450). Three hooks
+    plus the module-level `_unsafe_litellm_global_state()` and the once-per-condition decline log.
+  - `src/aigateway/plugins/huggingface_provider/parameters.py` — TWELVE rules to `keyed`,
+    `_REVISION` -> `"huggingface-2026-08"`, promotion-instruction block replaced with a record.
+  - `tests/unit/huggingface/test_huggingface_global_cache_projection.py` — NEW, 41 tests
+    (projection + participation + hit metadata).
+  - `tests/unit/huggingface/test_huggingface_route_global_cache.py` — NEW, 37 tests (promotion,
+    per-path key differences, published contract, route).
+  - `docs/` — spec, plan, task mirror, this ledger, all dated 2026-08-20.
+- **Two test files, not four** (planned). Collapsed to match the one-cache-file-per-provider
+  precedent both existing projections follow.
+
+- **Gates:** configured aigateway quality gates — **ALL GREEN**: append-only check (vs HEAD), ruff
+  check, ruff format --check, pyright,
+  `scripts/check_no_enterprise.py`, `pytest --cov=aigateway --cov-fail-under=80 -q`.
+  Focused: `tests/unit/huggingface` 217 passed; the five global-cache core suites 327 passed.
+  The plan's prediction of **zero prior tests modified** held — the append-only gate confirms it.
+
+- **Commits:** none. Nothing staged or committed; owner approval not yet given.
+
+- **Tripwires, both OBSERVED TO FIRE** (guard neutralised, symptom recorded in an AIDEV-NOTE at
+  the guard, guard restored, suite re-run green):
+  1. *Unsuffixed-id bypass* (`global_cache.py`). Neutralised, an unsuffixed
+     `huggingface/deepseek-ai/DeepSeek-R1` projected `resolved_model="deepseek-ai/DeepSeek-R1:"`
+     — a bogus EMPTY backend — and produced the real key hash
+     `017a1b3f728f1ad79882d705856bbf4679bc7cb4d6292760bdc7ad7303ac9e21`. The failure mode is a
+     permanent storable row, not a decline.
+  2. *D3 participation gate* (`plugin.py`). Neutralised, the deployment configured for
+     `https://proxy.internal/v1` was served `X-AIGW-Cache: hit` from a row filled against the
+     official router — a 200 carrying an answer its own upstream never produced.
+
+## Deviations
+
+- **Branch/base.** `OME-791-huggingface-global-cache-projection` branched from `origin/main` at
+  `c157ed7a`. OME-884 is NOT merged, so `openai_provider`'s
+  projection is absent on this base; its module shape was copied as a pattern, never imported.
+  Forward-merge item: OME-884 changes the `participates_in_global_cache` signature to receive a
+  model, which would let the `model_alias_map` check narrow from coarse-truthy to exact-model.
+
+- **Linear untouched, by owner direction.** The owner directed mid-session that Linear must not be
+  modified during this work. OME-791 was deliberately left in Backlog, no comment was posted, and
+  the normal "move to In Progress at ledger creation" step was skipped. The `docs/tasks/` mirror
+  records `status: Backlog` truthfully rather than claiming a transition that did not happen.
+
+- **Plan revised after adversarial review, before implementation.** Four independent reviews ran
+  against the pre-review draft; one returned **reject**. Every finding was re-verified against
+  this base before being accepted or rejected. Material corrections:
+  - **D6 rewritten.** The pre-review justification was FALSE (it claimed both projecting providers
+    guard ambient LiteLLM state; Anthropic projects with no such guard). More seriously the guard
+    was *under*-inclusive: `litellm.model_fallbacks` is read at `main.py:602` inside
+    `async def acompletion` — the exact call HF inherits — and dispatches a DIFFERENT model whose
+    answer is then stored under the HF key, permanently. The guard now mirrors
+    `openai_provider/plugin.py:85-101`, whose condition set is verified reachable from HF's path.
+  - **`HuggingFaceChatConfig().get_config()` condition withdrawn.** It cannot fire on the HF wire
+    in litellm 1.97.0, and *evaluating* it mutates litellm class state (`_is_base_class = False`).
+  - **DoD claim corrected.** "A hit does no credential work" was false: a hit performs one
+    profile-index read, itself a `credential_blobs` row plus a master-key decryption, documented
+    at `chat_profile_defaults.py:68-71`. The route test now asserts the narrow true claim AND
+    asserts the profile-index read positively, so the claim cannot silently rot.
+  - **Counts fixed.** TWELVE rule paths, not eleven (`function_calling_rules` emits both `tools`
+    and `tool_choice`); 24 seeds, not the spec's 25. Both verified at runtime, not by eye.
+  - **D4 census corrected** from two spellings of the router base to four. Only the dispatch-path
+    one is renamed; `api_key_validation._READINESS_URL` is deliberately left as a hardcoded
+    literal (it exists so an overridden base cannot redirect a credential probe) and
+    `discovery.py`'s two copies are catalog-only. The DoD no longer claims "one origin" package-wide.
+  - **D3 comparison normalised** with `rstrip("/")`, since litellm strips the trailing slash
+    before appending `/chat/completions`; a literal `!=` would have disabled caching for a
+    provably wire-identical deployment.
+  - **Shared conformance file left untouched.** Raising `_OBSERVED_NON_BYPASS_INSTANCES` would
+    make an append-only-protected shared test depend on catalog/environment state; an HF-local
+    per-model twelve-instance floor is stronger and has zero blast radius.
+  - **Observability added** (D11): with eight decline paths collapsing onto one wire reason, the
+    hook now logs a condition TOKEN once per process — never the configured URL or header value.
+
+- **One RED test rewritten mid-cycle** (not a prior-cycle test — written earlier this same unit
+  and never green). `test_a_raising_guard_degrades_to_not_participating` asserted the *hook*
+  returns `False`; the core already guarantees that at `global_plan.py:72-77`, so a `try` inside
+  the hook would have been a second guard protecting nothing. Replaced with
+  `test_a_raising_guard_costs_a_bypass_and_never_the_request`, which asserts the plan-level
+  contract a caller actually depends on.
+
+- **Owner decision still open, flagged not buried:** gated-repo licensing under cross-account
+  replay (spec §9). Most seeds are gated repos requiring per-HF-account license acceptance, so a
+  row filled by an accepting account can be served to one that never accepted. Recorded as an
+  ACCEPTED CONSEQUENCE because it follows from the approved exact-replay semantics rather than
+  from this unit's design; if the owner declines it, the remedy is a catalog-level seeding/gating
+  decision, not a projection change.
+
+- **`plugin.py` is at 432 of 450 lines.** The next responsibility added to this file should go in
+  a new module instead; extracting the shared ambient-state predicate into core (see the
+  AIDEV-NOTE there) is the obvious candidate and would bring it back down.

--- a/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
+++ b/docs/work/2026-08-20-OME-791-huggingface-global-cache-projection.md
@@ -10,8 +10,8 @@ finished:
 "implemented (awaiting owner approval to commit)", was not one of the four permitted states
 (planned | in_progress | done | blocked). `in_progress` is the honest replacement: the
 implementation and the review-remediation pass are both COMPLETE, but the unit closes at merge
-and rebase verification plus the gated-repository decision remain pending, so `finished` stays
-empty. Set `finished` and `done` at merge. -->
+and the gated-repository decision remains pending, so `finished` stays empty. Set `finished` and
+`done` at merge. -->
 
 
 # OME-791 — HuggingFace global-cache projection
@@ -123,15 +123,14 @@ created fresh in the worktree (`uv sync`), Python 3.12, litellm 1.97.0.
   Focused: `tests/unit/huggingface` 217 passed; the five global-cache core suites 327 passed.
   The plan's prediction of **zero prior tests modified** held — the append-only gate confirms it.
 
-- **Commits (actual, present on `OME-791-huggingface-global-cache-projection`):**
-  - `89116431` — `feat(aigateway): cache huggingface router responses`
-  - `d6b1ec5d` — `docs(aigateway): record the OME-791 huggingface cache decisions`
-
-  Together: 10 files, +2425/−31 vs `origin/main`. The earlier "Commits: none" line was written
-  INSIDE the commit that contradicted it and is corrected here (review finding M4).
-
-- **Review remediation implementation commit:**
-  - `a549850b` — `fix(aigateway): harden huggingface cache eligibility`
+- **Commit series** (subjects only; `git log origin/main..HEAD` is authoritative after history
+  edits):
+  - `feat(aigateway): cache huggingface router responses`
+  - `docs(aigateway): record the OME-791 huggingface cache decisions`
+  - `fix(aigateway): harden huggingface cache eligibility`
+  - `docs(aigateway): record OME-791 cache remediation`
+  - `fix(aigateway): accept model-aware huggingface cache gate`
+  - `docs(aigateway): record OME-791 rebase verification`
 
 - **Tripwires, both OBSERVED TO FIRE** (guard neutralised, symptom recorded in an AIDEV-NOTE at
   the guard, guard restored, suite re-run green):
@@ -208,10 +207,10 @@ MVP remediation.
 | --- | --- | --- |
 | `src/…/huggingface_provider/settings.py` | 199 | `KNOWN_ROUTER_BACKENDS` + allowlisted `pinned_router_target` |
 | `src/…/huggingface_provider/runtime_guard.py` | 263 | **NEW** — the whole guard, including fail-closed unreadable-state containment |
-| `src/…/huggingface_provider/plugin.py` | 287 | was 432; guard removed |
+| `src/…/huggingface_provider/plugin.py` | 292 | was 432; guard removed; OME-884 model argument accepted |
 | `src/…/huggingface_provider/global_cache.py` | 153 | stale symbol reference only |
 | `tests/unit/huggingface/test_huggingface_provider_allowlist.py` | 183 | **NEW** — 23 tests |
-| `tests/unit/huggingface/test_huggingface_runtime_guard.py` | 389 | **NEW** — 46 tests |
+| `tests/unit/huggingface/test_huggingface_runtime_guard.py` | 396 | **NEW** — 47 tests |
 | `tests/unit/huggingface/test_huggingface_global_cache_keys.py` | 268 | **NEW** — split out, 30 tests |
 | `tests/unit/huggingface/test_huggingface_route_global_cache.py` | 437 | was 550; 12 tests |
 | `tests/unit/huggingface/test_huggingface_global_cache_projection.py` | 360 | M8 edits, 40 tests |
@@ -219,11 +218,13 @@ MVP remediation.
 | `DEPLOYMENT.md`, `charts/aigateway/{values,values-prod,README}` | — | M3 |
 | `docs/work/2026-08-20-OME-791-…md` | — | this record (M4) |
 
-**Checks actually run (2026-08-21):** ruff check ✅ · ruff format ✅ · pyright 0 errors ✅ ·
-`tests/unit/huggingface` **290 passed** ✅ · focused global-cache conformance/purity/plan/key/reason
-suite **131 passed** ✅ · full suite **3702 passed, 50 skipped, 1 unrelated failure** · coverage
-**92.43%** (floor 80) ✅ · `git diff --check` clean ✅ · every changed/new Python file ≤ 450 lines ✅ ·
-`check_no_enterprise.py` ✅.
+**Post-rebase checks actually run (2026-08-21):** ruff check ✅ · ruff format ✅ · pyright
+0 errors ✅ · `tests/unit/huggingface` **291 passed** ✅ · focused global-cache
+conformance/purity/plan/key/reason suite **134 passed** ✅ · complete pytest+coverage gate ✅ · coverage
+floor 80% satisfied ✅ · `git diff --check` clean ✅ · every changed/new Python file ≤ 450 lines ✅ ·
+`check_no_enterprise.py` ✅. The first post-rebase full run exposed 30 HF failures caused by
+OME-884 passing a raw model into the old zero-argument hook; the model-aware compatibility fix added
+the port signature and a regression test, after which the complete gate was green.
 
 **Owner-approved gate deviations:**
 
@@ -234,19 +235,17 @@ suite **131 passed** ✅ · full suite **3702 passed, 50 skipped, 1 unrelated fa
    attribute it claimed to test). Verified **zero prior test functions lost**: all 37 that existed
    at HEAD still exist, now among 164. The gate cannot distinguish a move from a deletion. The
    owner approved this documented append-only deviation; the gate itself remains unchanged.
-2. **`tests/unit/test_helm_prod_config.py::test_prod_sets_finite_openrouter_provider_concurrency_cap`
-   — RED, pre-existing and unrelated.** It asserts `AIGW_PROVIDER_MAX_CONCURRENCY_OVERRIDES` in
-   prod `extraEnv`; that key is absent at `HEAD` **and** in the working copy, the test file is
-   **untracked** (OME-921's uncommitted RED state), and this pass's only `values-prod.yaml` change
-   is comment text. The owner approved committing OME-791 without absorbing that unrelated change.
+2. **OME-921 Helm RED — RESOLVED BY REBASE.** The untracked
+   `test_prod_sets_finite_openrouter_provider_concurrency_cap` was unrelated to this branch and
+   failed before rebase. Current `main` supplies the expected production override; the test passes
+   inside the complete post-rebase gate without any OME-791 implementation change.
 
 ## Deviations
 
-- **Branch/base.** `OME-791-huggingface-global-cache-projection` branched from `origin/main` at
-  `c157ed7a`. OME-884 is NOT merged, so `openai_provider`'s
-  projection is absent on this base; its module shape was copied as a pattern, never imported.
-  Forward-merge item: OME-884 changes the `participates_in_global_cache` signature to receive a
-  model, which would let the `model_alias_map` check narrow from coarse-truthy to exact-model.
+- **Branch/base.** The branch rebased cleanly onto `origin/main` at `7a2f7e48`. OME-884's
+  model-aware participation port is now present. HF accepts the raw-model argument while retaining
+  its conservative deployment-wide ambient predicate; exact-model alias narrowing remains the
+  separate cross-provider follow-up described above.
 
 - **Linear untouched, by owner direction.** The owner directed mid-session that Linear must not be
   modified during this work. OME-791 was deliberately left in Backlog, no comment was posted, and


### PR DESCRIPTION
## Description

Implements the Hugging Face global exact-response cache projection described in [OME-791](https://linear.app/openmined/issue/OME-791/implement-the-huggingface-global-cache-projection).

- Adds a pure provider projection and adapter revision for Hugging Face router requests.
- Promotes the provider's output-affecting request parameters into the shared cache key.
- Preserves the fixed inference-provider suffix so different backends cannot collide.
- Bypasses caching for unsuffixed models, dynamic routing policies, unknown backends, non-official router bases, and unsafe ambient runtime state without blocking normal dispatch.
- Keeps global cache hits identity-free and before provider credential resolution.
- Prevents incomplete multi-choice responses from becoming permanent cache entries.
- Documents deployment behavior, shared-cache trust boundaries, and targeted Hugging Face cache pruning.

The change lets identical benchmark calls pinned to the same Hugging Face backend reuse one globally shared response while retaining exact request and backend attribution.

## Affected Dependencies

No new dependencies.

## How has this been tested?

- Complete AIGateway quality-gate suite passed against the current `main` branch, including static analysis, formatting, type checks, enterprise-import protection, the full test suite, coverage, and append-only test preservation.
- Hugging Face provider unit suite: 292 passed.
- Live provider-catalog drift check: 14 providers observed, no new providers, four expected catalog omissions, and no unexpected omissions.
- Focused coverage verifies projection purity, key differences, provider participation, cross-account hits, policy bypasses, runtime-state rejection, allowlist drift, and incomplete multi-choice response handling.
- Verified with Python 3.12 and the repository's pinned dependency set.

## Checklist

- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
