### PR TITLE
fix(engine): apply scheduling to Runner Jobs

### DIFF
--- a/apps/screamingface-engine/deploy/helm/README.md
+++ b/apps/screamingface-engine/deploy/helm/README.md
@@ -132,6 +132,8 @@ What the App schedules:
   at `/tmp` (required by `readOnlyRootFilesystem`)
 - `resources` from `runner.resources` — without them the Runner schedules **BestEffort**: placed
   blind, evicted first, free to OOM the node it shares
+- `nodeSelector` and `tolerations` from the chart's top-level placement values — the Runner and
+  Engine Deployment therefore use the same operator-owned node pool and taint policy
 - `ttlSecondsAfterFinished` — see the invariant below
 
 > **INVARIANT — the TTL floor.** The Job's deterministic *name* is the stateless single-use replay

--- a/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap.yaml
@@ -35,6 +35,14 @@ data:
   # verbatim instead of being flattened into a per-field env sprawl.
   URL4_CLOUD_RUNNER_RESOURCES: {{ toJson . | quote }}
   {{- end }}
+  {{- if .Values.nodeSelector }}
+  # Runner Jobs and the Engine Deployment use the same operator-owned node placement.
+  URL4_CLOUD_RUNNER_NODE_SELECTOR: {{ toJson .Values.nodeSelector | quote }}
+  {{- end }}
+  {{- if .Values.tolerations }}
+  # JSON preserves the Kubernetes toleration structure for each generated Runner Job.
+  URL4_CLOUD_RUNNER_TOLERATIONS: {{ toJson .Values.tolerations | quote }}
+  {{- end }}
   {{- with .Values.runner.jobTtlSeconds }}
   # Optional EXTENSION of how long a finished Runner Job is kept. Unset => the App derives the
   # floor: iatWindowS + a 60s clock-skew margin. It may only ever be raised — the Job's name is

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -385,6 +385,8 @@ runner:
 # after `helm dependency build`; otherwise reuse an existing NATS via `config.natsUrl`.
 nats:
   enabled: false
+  # The dependency schema requires a string even while the dependency is disabled.
+  fullnameOverride: ""
   # Passed through to the nats-io/k8s subchart when enabled. JetStream is required by the bus.
   config:
     jetstream:

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -81,6 +81,8 @@ def build_job_runner(
                 if name
             ),
             resources=settings.runner_resources,
+            node_selector=settings.runner_node_selector,
+            tolerations=settings.runner_tolerations,
             job_ttl_s=settings.effective_job_ttl_s,
             extra_models=extra_models,
         )

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py
@@ -124,6 +124,8 @@ class K8sJobRunner(IdentityAwareJobRunner):
         env_configmap: str | None = None,
         env_secrets: Sequence[str] = (),
         resources: Mapping[str, Mapping[str, str]] | None = None,
+        node_selector: Mapping[str, str] | None = None,
+        tolerations: Sequence[Mapping[str, object]] = (),
         job_ttl_s: int | None = None,
         request_timeout_s: float | None = None,
         extra_models: Callable[[], Sequence[str]] | None = None,
@@ -136,6 +138,10 @@ class K8sJobRunner(IdentityAwareJobRunner):
         self._env_configmap = env_configmap
         self._env_secrets = list(env_secrets)
         self._resources = resources
+        # WHY snapshots: deployment settings can be caller-owned mutable objects. A later
+        # mutation must not redirect future Jobs or remove a required taint boundary.
+        self._node_selector = dict(node_selector or {})
+        self._tolerations = [dict(toleration) for toleration in tolerations]
         self._job_ttl_s = job_ttl_s
         # WHY a callable and not a snapshot (OME-880): the admitted-model overlay grows while
         # the app runs, and a model admitted a second ago must reach the very next Job.
@@ -346,6 +352,20 @@ class K8sJobRunner(IdentityAwareJobRunner):
             container["envFrom"] = env_from
         if self._resources is not None:
             container["resources"] = {k: dict(v) for k, v in self._resources.items()}
+        pod_spec: dict[str, object] = {
+            "restartPolicy": "Never",
+            "enableServiceLinks": False,
+            "automountServiceAccountToken": False,
+            "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
+            "containers": [container],
+            "volumes": [{"name": "tmp", "emptyDir": {}}],
+        }
+        # INVARIANT: the operator owns placement through Helm. The adapter transports those
+        # Kubernetes-native values without embedding Preview or another environment's policy.
+        if self._node_selector:
+            pod_spec["nodeSelector"] = dict(self._node_selector)
+        if self._tolerations:
+            pod_spec["tolerations"] = [dict(toleration) for toleration in self._tolerations]
         spec: dict[str, object] = {
             "backoffLimit": 0,
             # WHY this is NOT `deadline_s`: the run self-terminates at `JOB_DEADLINE_S`, publishes
@@ -358,14 +378,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
             ),
             "template": {
                 "metadata": {"labels": RUNNER_LABELS},
-                "spec": {
-                    "restartPolicy": "Never",
-                    "enableServiceLinks": False,
-                    "automountServiceAccountToken": False,
-                    "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
-                    "containers": [container],
-                    "volumes": [{"name": "tmp", "emptyDir": {}}],
-                },
+                "spec": pod_spec,
             },
         }
         if self._job_ttl_s is not None:

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -146,6 +146,10 @@ class Settings(BaseSettings):
     # supplies the numbers. Shape is the k8s `resources` block verbatim, e.g.
     # {"requests": {"cpu": "200m", "memory": "256Mi"}, "limits": {"memory": "1Gi"}}.
     runner_resources: dict[str, dict[str, str]] | None = None
+    # INVARIANT: Runner Jobs use the same operator-owned placement as the Engine Deployment.
+    # The chart supplies Kubernetes-native structures, so this code stays environment-neutral.
+    runner_node_selector: dict[str, str] = Field(default_factory=dict)
+    runner_tolerations: list[dict[str, object]] = Field(default_factory=list)
     # --- model catalog (OME-625). The catalog endpoint forwards the CALLER's
     # credential, so there is deliberately NO credential setting here:
     # screamingface-engine holds no aigateway secret. `aigateway_base_url` above is

--- a/apps/screamingface-engine/tests/unit/test_deploy_time_chart_contract.py
+++ b/apps/screamingface-engine/tests/unit/test_deploy_time_chart_contract.py
@@ -131,6 +131,16 @@ def test_the_secret_key_is_assigned_in_the_secret_template() -> None:
     assert job_env.ARTIFACT_S3_SECRET_KEY in _yaml_keys(secret)
 
 
+def test_runner_scheduling_is_serialized_from_deployment_values() -> None:
+    """INVARIANT: the control plane and every Runner Job share one placement source."""
+    app = _APP_ENV.read_text(encoding="utf-8")
+
+    assert "URL4_CLOUD_RUNNER_NODE_SELECTOR" in app
+    assert "toJson .Values.nodeSelector" in app
+    assert "URL4_CLOUD_RUNNER_TOLERATIONS" in app
+    assert "toJson .Values.tolerations" in app
+
+
 # --- the bundled store configures itself (OME-929) ---------------------------------------
 
 

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -76,3 +76,31 @@ def test_k8s_runner_is_built_from_settings() -> None:
 def test_unknown_runner_is_rejected_at_settings_construction() -> None:
     with pytest.raises(ValueError):
         Settings(runner="kubernetes")  # type: ignore[arg-type]
+
+
+def test_k8s_runner_receives_deployment_scheduling() -> None:
+    settings = Settings(
+        runner="k8s",
+        runner_node_selector={"openmined.org/pool": "preview"},
+        runner_tolerations=[
+            {
+                "key": "workload",
+                "operator": "Equal",
+                "value": "preview",
+                "effect": "NoSchedule",
+            }
+        ],
+    )
+
+    runner = build_job_runner(settings, k8s_client_factory=_FakeBatchApi)
+
+    assert isinstance(runner, K8sJobRunner)
+    assert runner._node_selector == {"openmined.org/pool": "preview"}
+    assert runner._tolerations == [
+        {
+            "key": "workload",
+            "operator": "Equal",
+            "value": "preview",
+            "effect": "NoSchedule",
+        }
+    ]

--- a/apps/screamingface-engine/tests/unit/test_runners_k8s.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_k8s.py
@@ -407,3 +407,41 @@ async def test_the_pod_outlives_its_own_stream_reclamation() -> None:
 
     assert float(env[job_env.JOB_DEADLINE_S]) == 60
     assert spec["activeDeadlineSeconds"] > 60 + grace
+
+
+async def test_runner_job_carries_configured_scheduling() -> None:
+    client = FakeBatchV1()
+    node_selector = {"openmined.org/pool": "preview"}
+    tolerations = [
+        {
+            "key": "workload",
+            "operator": "Equal",
+            "value": "preview",
+            "effect": "NoSchedule",
+        }
+    ]
+    runner = K8sJobRunner(
+        client,
+        image="runner:test",
+        node_selector=node_selector,
+        tolerations=tolerations,
+    )
+    node_selector["openmined.org/pool"] = "default"
+    tolerations[0]["value"] = "default"
+    name = await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+    pod = _pod(client, name)
+    assert pod["nodeSelector"] == {"openmined.org/pool": "preview"}
+    assert pod["tolerations"] == [
+        {"key": "workload", "operator": "Equal", "value": "preview", "effect": "NoSchedule"}
+    ]
+    assert pod["automountServiceAccountToken"] is False
+
+
+async def test_runner_job_omits_empty_scheduling() -> None:
+    client = FakeBatchV1()
+    name = await K8sJobRunner(client, image="runner:test").schedule(
+        TOPIC, "chat(hi)", deadline_s=60
+    )
+    pod = _pod(client, name)
+    assert "nodeSelector" not in pod
+    assert "tolerations" not in pod

--- a/docs/plan/2026-08-24-ome-965-runner-scheduling.md
+++ b/docs/plan/2026-08-24-ome-965-runner-scheduling.md
@@ -1,0 +1,19 @@
+# OME-965 — Runner Job scheduling plan
+
+## Implementation
+
+1. Add failing adapter tests for configured and empty scheduling values.
+2. Add failing factory tests for settings propagation.
+3. Add failing chart contract tests for JSON scheduling settings.
+4. Add typed Runner scheduling settings.
+5. Pass the settings through the factory.
+6. Copy the settings into each Runner Pod specification.
+7. Render the existing Helm scheduling values into the Engine ConfigMap.
+8. Update the Engine chart documentation.
+9. Run the ScreamingFace Engine gate suite.
+
+## Safety
+
+The chart owns environment-specific values. The adapter only transports and
+applies their Kubernetes-native structure. Empty defaults preserve existing
+deployments.

--- a/docs/spec/2026-08-24-ome-965-runner-scheduling.md
+++ b/docs/spec/2026-08-24-ome-965-runner-scheduling.md
@@ -1,0 +1,29 @@
+# OME-965 — Runner Job scheduling specification
+
+## Problem
+
+`K8sJobRunner` creates Pods without node selectors or tolerations. A deployment
+can schedule the Engine control plane on a dedicated node pool, but its Runner
+Jobs do not inherit that placement.
+
+The Preview platform requires `openmined.org/pool=preview` and the
+`workload=preview:NoSchedule` toleration. Admission rejects Runner Jobs that do
+not carry both fields.
+
+## Decision
+
+The existing top-level Helm `nodeSelector` and `tolerations` values define
+scheduling for both the Engine control plane and its Runner Jobs.
+
+The chart serializes both values as JSON settings. The factory passes them to
+`K8sJobRunner`. The adapter copies them into each Runner Pod specification.
+
+The Engine code stays environment-neutral. It does not contain Preview labels,
+taints, or toleration values.
+
+## Constraints
+
+- Empty scheduling values must omit both Job fields.
+- The adapter must copy caller-owned mappings and lists.
+- Runner Jobs must keep `automountServiceAccountToken: false`.
+- No RBAC, Secret, image, or public API contract changes.

--- a/docs/tasks/2026-08-24-ome-965-runner-scheduling.md
+++ b/docs/tasks/2026-08-24-ome-965-runner-scheduling.md
@@ -1,0 +1,25 @@
+---
+id: OME-965
+linear_url: https://linear.app/openmined/issue/OME-965
+status: in_review
+type: Bug
+priority: High
+labels: [screamingface-engine, autonomous, agentic]
+created: 2026-08-24
+closed:
+---
+
+# Apply Engine scheduling to Runner Jobs
+
+## Goal
+
+Make each Kubernetes Runner Job inherit the Engine deployment's node selector
+and tolerations. This lets Preview Runner Pods pass admission and schedule on
+the isolated Preview node pool.
+
+## Acceptance
+
+- Runner Jobs use configured node selectors and tolerations.
+- Deployments with empty scheduling values keep the current Job shape.
+- Runner Jobs continue to disable ServiceAccount token automount.
+- Engine and Helm contract tests pass.

--- a/docs/work/2026-08-24-OME-965-runner-scheduling.md
+++ b/docs/work/2026-08-24-OME-965-runner-scheduling.md
@@ -1,0 +1,51 @@
+---
+ticket: OME-965
+stack: screamingface-engine
+status: done
+started: 2026-08-24
+finished: 2026-08-24
+---
+
+# OME-965 — apply Engine scheduling to Runner Jobs
+
+## Intent
+
+Pass deployment-owned node selectors and tolerations into every Kubernetes
+Runner Job. This closes the Preview scheduling failure without hardcoding
+platform policy in tenant code.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/config.py`
+- `apps/screamingface-engine/src/screamingface_engine/adapters/factory.py`
+- `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py`
+- `apps/screamingface-engine/deploy/helm/templates/configmap.yaml`
+- `apps/screamingface-engine/deploy/helm/values.yaml`
+- `apps/screamingface-engine/deploy/helm/README.md`
+- `apps/screamingface-engine/tests/unit/test_runners_k8s.py`
+- `apps/screamingface-engine/tests/unit/test_runners_factory.py`
+- `apps/screamingface-engine/tests/unit/test_deploy_time_chart_contract.py`
+- task, specification, plan, and work records for `OME-965`
+
+## Test plan
+
+- Prove configured node selectors and tolerations reach the Runner Pod.
+- Prove empty scheduling settings omit both fields.
+- Prove the factory passes both settings to the adapter.
+- Prove Helm renders both values as JSON settings.
+- Run the complete ScreamingFace Engine gate suite.
+
+## Acceptance
+
+- Preview Runner Jobs pass required scheduling fields to Kubernetes.
+- Environment-neutral deployments keep their current Job shape.
+- No prior test changes or security weakening occur.
+
+## Outcome
+
+- **Actual files:** all planned files, plus `deploy/helm/values.yaml` to repair the existing
+  disabled-NATS schema default that blocked Helm rendering
+- **Commits:** this change — `fix(engine): apply scheduling to Runner Jobs`
+- **Gates:** focused suite: 55 passed; complete `screamingface-engine` gate: all green
+- **Deviations:** the full gate exposed a pre-existing `nats.fullnameOverride: null` render
+  failure. The chart now supplies the empty string required by its existing schema.


### PR DESCRIPTION
## Summary

- pass the chart node selector and tolerations into Engine settings
- apply those settings to every generated Kubernetes Runner Job
- preserve empty defaults and disabled ServiceAccount token mounts
- repair the disabled NATS chart default required for Helm schema validation
- add task, specification, plan, work, adapter, factory, and chart tests

## Test plan

- `uv run .claude/scripts/run_gates.py screamingface-engine`
- result: all gates green
- focused chart and Runner suite: 55 passed

Refs: OME-965