### PR TITLE
feat(repo): automate pull-request Preview environments

### DIFF
--- a/.github/scripts/preview_contract.py
+++ b/.github/scripts/preview_contract.py
@@ -1,0 +1,423 @@
+"""Select Preview inputs and manage the bounded Preview lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import NamedTuple
+
+COMPONENTS = ("aigateway", "aigatewayUi", "scoreboard", "engine")
+STATUS_LABELS = frozenset(
+    {"preview-building", "preview-queued", "preview", "preview-expired"}
+)
+LABEL_SLUG = {
+    "aigateway": "aigateway",
+    "aigatewayUi": "aigateway-ui",
+    "scoreboard": "scoreboard",
+    "engine": "engine",
+}
+COMPONENT_LABELS = {
+    name: f"preview-component-{LABEL_SLUG[name]}" for name in COMPONENTS
+}
+IMAGE_LABELS = {name: f"preview-image-{LABEL_SLUG[name]}" for name in COMPONENTS}
+MANAGED_LABELS = (
+    STATUS_LABELS
+    | frozenset(COMPONENT_LABELS.values())
+    | frozenset(IMAGE_LABELS.values())
+)
+COMMENT_MARKER = "<!-- screamingface-preview -->"
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+
+
+class Selection(NamedTuple):
+    components: tuple[str, ...]
+    images: tuple[str, ...]
+
+
+class PullState(NamedTuple):
+    number: int
+    labels: frozenset[str]
+    preview_since: datetime | None
+    queued_since: datetime
+    draft: bool = False
+
+
+class AdmissionPlan(NamedTuple):
+    expire: tuple[int, ...]
+    promote: tuple[int, ...]
+
+
+def _starts(path: str, prefixes: Sequence[str]) -> bool:
+    return any(path.startswith(prefix) for prefix in prefixes)
+
+
+def _is_file(path: str, names: Sequence[str]) -> bool:
+    return path in names
+
+
+def _select_path(path: str) -> Selection:
+    if path == ".dockerignore":
+        return Selection(COMPONENTS, COMPONENTS)
+
+    rules = {
+        "aigateway": {
+            "chart": ("apps/aigateway/charts/aigateway/",),
+            "prefix": ("apps/aigateway/src/",),
+            "files": (
+                "apps/aigateway/Dockerfile",
+                "apps/aigateway/pyproject.toml",
+                "apps/aigateway/uv.lock",
+            ),
+        },
+        "aigatewayUi": {
+            "chart": ("apps/aigateway-ui/charts/aigateway-ui/",),
+            "prefix": ("apps/aigateway-ui/src/", "apps/aigateway-ui/public/"),
+            "files": (
+                "apps/aigateway-ui/Dockerfile",
+                "apps/aigateway-ui/package.json",
+                "apps/aigateway-ui/package-lock.json",
+                "apps/aigateway-ui/next.config.ts",
+                "apps/aigateway-ui/next.config.js",
+            ),
+        },
+        "scoreboard": {
+            "chart": ("apps/scoreboard/charts/scoreboard/",),
+            "prefix": (
+                "apps/scoreboard/src/",
+                "apps/scoreboard/portal/",
+                "apps/scoreboard/artifacts/",
+            ),
+            "files": (
+                "apps/scoreboard/Dockerfile",
+                "apps/scoreboard/pyproject.toml",
+                "apps/scoreboard/uv.lock",
+            ),
+        },
+        "engine": {
+            "chart": ("apps/screamingface-engine/deploy/helm/",),
+            "prefix": ("apps/screamingface-engine/src/", "packages/url4/"),
+            "files": (
+                "apps/screamingface-engine/Dockerfile",
+                "apps/screamingface-engine/Dockerfile.benchmark",
+                "apps/screamingface-engine/pyproject.toml",
+                "apps/screamingface-engine/uv.lock",
+                "apps/screamingface-engine/url4.toml",
+            ),
+        },
+    }
+    for component, rule in rules.items():
+        if _starts(path, rule["prefix"]) or _is_file(path, rule["files"]):
+            return Selection((component,), (component,))
+        if _starts(path, rule["chart"]):
+            return Selection((component,), ())
+    return Selection((), ())
+
+
+def classify_paths(paths: Sequence[str]) -> Selection:
+    """Return ordered runtime and image selections for changed paths."""
+    components: set[str] = set()
+    images: set[str] = set()
+    for path in paths:
+        selected = _select_path(path)
+        components.update(selected.components)
+        images.update(selected.images)
+    return Selection(
+        tuple(name for name in COMPONENTS if name in components),
+        tuple(name for name in COMPONENTS if name in images),
+    )
+
+
+def preview_tag(number: int, sha: str) -> str:
+    if number < 1 or not SHA_PATTERN.fullmatch(sha):
+        raise ValueError(
+            "Preview tag needs a positive pull request and a 40-character SHA"
+        )
+    return f"pr-{number}-{sha[:7]}"
+
+
+def plan_admission(
+    pulls: Sequence[PullState],
+    now: datetime,
+    max_active: int = 3,
+    max_age: timedelta = timedelta(hours=72),
+) -> AdmissionPlan:
+    expire = tuple(
+        pull.number
+        for pull in pulls
+        if "preview" in pull.labels
+        and pull.preview_since is not None
+        and now - pull.preview_since > max_age
+    )
+    active = sum(
+        "preview" in pull.labels and pull.number not in expire for pull in pulls
+    )
+    queue = sorted(
+        (
+            pull
+            for pull in pulls
+            if "preview-queued" in pull.labels
+            and "no-preview" not in pull.labels
+            and not pull.draft
+        ),
+        key=lambda pull: (pull.queued_since, pull.number),
+    )
+    promote = tuple(pull.number for pull in queue[: max(0, max_active - active)])
+    return AdmissionPlan(expire, promote)
+
+
+def preview_comment(
+    status: str,
+    number: int,
+    sha: str,
+    components: Sequence[str],
+    images: Sequence[str],
+) -> str:
+    namespace = f"sf-preview-pr-{number}"
+    component_text = ", ".join(components) or "none"
+    image_text = ", ".join(images) or "none"
+    lines = [
+        COMMENT_MARKER,
+        f"## Preview: {status}",
+        "",
+        f"- Revision: `{sha}`",
+        f"- Components: `{component_text}`",
+        f"- Images: `{image_text}`",
+    ]
+    if status == "active":
+        routes: list[str] = []
+        if {"aigateway", "aigatewayUi", "engine"} & set(components):
+            routes.append(
+                f"- AI Gateway: https://aigw-pr-{number}.preview.dev.screamingface.ai"
+            )
+        if "aigatewayUi" in components:
+            routes.append(
+                f"- AI Gateway UI: https://console-pr-{number}.preview.dev.screamingface.ai"
+            )
+        if "scoreboard" in components:
+            routes.append(
+                f"- Scoreboard: https://leaderboard-pr-{number}.preview.dev.screamingface.ai"
+            )
+        if "engine" in components:
+            routes.append(
+                f"- Fusion: https://fusion-pr-{number}.preview.dev.screamingface.ai"
+            )
+        lines.extend(
+            [
+                "",
+                "### Applications",
+                "",
+                *routes,
+                "",
+                "### Kubernetes access",
+                "",
+                "```bash",
+                f'PREVIEW_KUBECONFIG="/tmp/sf-preview-pr-{number}.kubeconfig"',
+                f'PREVIEW_KUBECONFIG_URL="https://kube-pr-{number}.preview.dev.screamingface.ai/kubeconfig"',
+                'CF_ACCESS_TOKEN="$(cloudflared access token -app="$PREVIEW_KUBECONFIG_URL")"',
+                'GITHUB_TOKEN="$(gh auth token)"',
+                "{",
+                '  printf \'header = "cf-access-token: %s"\\n\' "$CF_ACCESS_TOKEN"',
+                '  printf \'header = "X-Preview-Access-Token: %s"\\n\' "$CF_ACCESS_TOKEN"',
+                '  printf \'header = "X-GitHub-Token: %s"\\n\' "$GITHUB_TOKEN"',
+                '  printf \'url = "%s"\\n\' "$PREVIEW_KUBECONFIG_URL"',
+                '} | curl --fail --silent --show-error --config - > "$PREVIEW_KUBECONFIG"',
+                "unset CF_ACCESS_TOKEN GITHUB_TOKEN",
+                'chmod 600 "$PREVIEW_KUBECONFIG"',
+                'export KUBECONFIG="$PREVIEW_KUBECONFIG"',
+                "kubectl get pods",
+                "kubectl logs POD_NAME --all-containers --tail=200",
+                "```",
+                "",
+                "### Observability",
+                "",
+                f"[Open SigNoz logs](https://signoz.pulse.dev.openmined.org/logs-explorer?query=k8s_namespace_name%3D%22{namespace}%22)",
+                "",
+                f'Filter: `k8s_namespace_name="{namespace}"`',
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _parse_time(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+class GitHub:
+    def __init__(self) -> None:
+        self.repo = os.environ["GITHUB_REPOSITORY"]
+        self.token = os.environ["GITHUB_TOKEN"]
+        self.api = os.environ.get("GITHUB_API_URL", "https://api.github.com")
+
+    def request(self, method: str, path: str, data: object | None = None) -> object:
+        body = None if data is None else json.dumps(data).encode()
+        request = urllib.request.Request(
+            f"{self.api}/repos/{self.repo}{path}",
+            data=body,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "screamingface-preview",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request) as response:
+                content = response.read()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace")
+            raise RuntimeError(
+                f"GitHub API {method} {path}: {error.code}: {detail}"
+            ) from error
+        return json.loads(content) if content else {}
+
+    def pull(self, number: int) -> dict:
+        return self.request("GET", f"/pulls/{number}")  # type: ignore[return-value]
+
+    def pulls(self) -> list[dict]:
+        return self.request("GET", "/pulls?state=open&per_page=100")  # type: ignore[return-value]
+
+    def events(self, number: int) -> list[dict]:
+        return self.request("GET", f"/issues/{number}/events?per_page=100")  # type: ignore[return-value]
+
+    def set_managed_labels(self, number: int, wanted: set[str]) -> None:
+        pull = self.pull(number)
+        current = {item["name"] for item in pull["labels"]}
+        labels = sorted((current - MANAGED_LABELS) | wanted)
+        self.request("PUT", f"/issues/{number}/labels", {"labels": labels})
+
+    def upsert_comment(self, number: int, body: str) -> None:
+        comments = self.request("GET", f"/issues/{number}/comments?per_page=100")
+        for comment in comments:  # type: ignore[union-attr]
+            if COMMENT_MARKER in comment["body"]:
+                self.request(
+                    "PATCH", f"/issues/comments/{comment['id']}", {"body": body}
+                )
+                return
+        self.request("POST", f"/issues/{number}/comments", {"body": body})
+
+
+def _pull_selection(pull: dict) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    labels = {item["name"] for item in pull["labels"]}
+    components = tuple(name for name in COMPONENTS if COMPONENT_LABELS[name] in labels)
+    images = tuple(name for name in COMPONENTS if IMAGE_LABELS[name] in labels)
+    return components, images
+
+
+def _update(number: int, sha: str, status: str, selection: Selection) -> None:
+    github = GitHub()
+    pull = github.pull(number)
+    if pull["head"]["sha"] != sha:
+        print(f"Ignore stale revision {sha}; current revision is {pull['head']['sha']}")
+        return
+    wanted = {COMPONENT_LABELS[name] for name in selection.components}
+    wanted.update(IMAGE_LABELS[name] for name in selection.images)
+    if status in STATUS_LABELS:
+        wanted.add(status)
+    github.set_managed_labels(number, wanted)
+    github.upsert_comment(number, preview_comment(status, number, sha, *selection))
+
+
+def reconcile() -> None:
+    github = GitHub()
+    now = datetime.now(UTC)
+    raw_pulls = github.pulls()
+    pulls: list[PullState] = []
+    for pull in raw_pulls:
+        labels = frozenset(item["name"] for item in pull["labels"])
+        events = github.events(pull["number"])
+        added = {
+            name: [
+                _parse_time(event["created_at"])
+                for event in events
+                if event["event"] == "labeled"
+                and event.get("label", {}).get("name") == name
+            ]
+            for name in ("preview", "preview-queued")
+        }
+        created = _parse_time(pull["created_at"])
+        pulls.append(
+            PullState(
+                pull["number"],
+                labels,
+                max(added["preview"], default=None),
+                max(added["preview-queued"], default=created),
+                pull["draft"],
+            )
+        )
+    plan = plan_admission(pulls, now)
+    by_number = {pull["number"]: pull for pull in raw_pulls}
+    for number in plan.expire:
+        pull = by_number[number]
+        components, images = _pull_selection(pull)
+        _update(
+            number,
+            pull["head"]["sha"],
+            "preview-expired",
+            Selection(components, images),
+        )
+    for number in plan.promote:
+        pull = by_number[number]
+        components, images = _pull_selection(pull)
+        _update(number, pull["head"]["sha"], "preview", Selection(components, images))
+
+
+def _selection(value: argparse.Namespace) -> Selection:
+    return Selection(
+        tuple(json.loads(value.components)), tuple(json.loads(value.images))
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    classify = subparsers.add_parser("classify")
+    classify.add_argument("--paths", type=Path, required=True)
+    classify.add_argument("--number", type=int, required=True)
+    classify.add_argument("--sha", required=True)
+    classify.add_argument("--output", type=Path, required=True)
+    for name in ("prepare", "ready", "failed", "disable"):
+        command = subparsers.add_parser(name)
+        command.add_argument("--number", type=int, required=True)
+        command.add_argument("--sha", required=True)
+        command.add_argument("--components", default="[]")
+        command.add_argument("--images", default="[]")
+    subparsers.add_parser("reconcile")
+    args = parser.parse_args()
+    if args.command == "classify":
+        selection = classify_paths(args.paths.read_text().splitlines())
+        matrix = [name for name in selection.images if name != "engine"]
+        outputs = {
+            "components": json.dumps(selection.components, separators=(",", ":")),
+            "images": json.dumps(selection.images, separators=(",", ":")),
+            "matrix": json.dumps(matrix, separators=(",", ":")),
+            "engine": str("engine" in selection.images).lower(),
+            "any": str(bool(selection.components)).lower(),
+            "tag": preview_tag(args.number, args.sha),
+        }
+        with args.output.open("a") as output:
+            for name, value in outputs.items():
+                output.write(f"{name}={value}\n")
+    elif args.command == "reconcile":
+        reconcile()
+    else:
+        selection = _selection(args)
+        status = {
+            "prepare": "preview-building",
+            "ready": "preview-queued",
+            "failed": "failed",
+            "disable": "disabled",
+        }[args.command]
+        _update(args.number, args.sha, status, selection)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -163,7 +163,7 @@ def test_workflows_keep_oidc_away_from_forks_and_serialize_admission() -> None:
     assert "pull_request:" in images
     assert "AZURE_PREVIEW_CLIENT_ID" in images
     assert "head.repo.full_name == github.repository" in images
-    assert "acropenminedpreview.azurecr.io" in images
+    assert "  REGISTRY: acropenminedpreview.azurecr.io" in images.splitlines()
     assert "preview-building" in images
     assert '"$BASE_SHA...$HEAD_SHA"' in images
     assert "workflow_run:" in admission

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -165,6 +165,7 @@ def test_workflows_keep_oidc_away_from_forks_and_serialize_admission() -> None:
     assert "head.repo.full_name == github.repository" in images
     assert "acropenminedpreview.azurecr.io" in images
     assert "preview-building" in images
+    assert '"$BASE_SHA...$HEAD_SHA"' in images
     assert "workflow_run:" in admission
     assert "schedule:" in admission
     assert "screamingface-preview-admission" in admission

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = Path(__file__).with_name("preview_contract.py")
+
+
+def load_contract():
+    spec = importlib.util.spec_from_file_location("preview_contract", CONTRACT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_engine_source_and_shared_url4_select_only_engine_images() -> None:
+    contract = load_contract()
+
+    selection = contract.classify_paths(
+        [
+            "apps/screamingface-engine/src/screamingface_engine/config.py",
+            "packages/url4/src/url4/parser.py",
+        ]
+    )
+
+    assert selection.components == ("engine",)
+    assert selection.images == ("engine",)
+
+
+def test_chart_only_selects_runtime_without_an_image() -> None:
+    contract = load_contract()
+
+    selection = contract.classify_paths(
+        ["apps/aigateway/charts/aigateway/templates/deployment.yaml"]
+    )
+
+    assert selection.components == ("aigateway",)
+    assert selection.images == ()
+
+
+def test_tests_and_docs_do_not_select_a_runtime() -> None:
+    contract = load_contract()
+
+    selection = contract.classify_paths(
+        [
+            "apps/aigateway/tests/unit/test_health.py",
+            "apps/scoreboard/README.md",
+            "apps/screamingface-engine/docs/architecture.md",
+        ]
+    )
+
+    assert selection.components == ()
+    assert selection.images == ()
+
+
+def test_root_dockerignore_selects_every_runtime_and_image() -> None:
+    contract = load_contract()
+
+    selection = contract.classify_paths([".dockerignore"])
+
+    assert selection.components == ("aigateway", "aigatewayUi", "scoreboard", "engine")
+    assert selection.images == ("aigateway", "aigatewayUi", "scoreboard", "engine")
+
+
+def test_ui_uses_the_infrastructure_label_slug() -> None:
+    contract = load_contract()
+
+    assert contract.COMPONENT_LABELS["aigatewayUi"] == "preview-component-aigateway-ui"
+    assert contract.IMAGE_LABELS["aigatewayUi"] == "preview-image-aigateway-ui"
+
+
+def test_old_and_new_rename_paths_are_both_classified() -> None:
+    contract = load_contract()
+
+    selection = contract.classify_paths(
+        [
+            "apps/aigateway/src/aigateway/old.py",
+            "apps/scoreboard/src/scoreboard/new.py",
+        ]
+    )
+
+    assert selection.components == ("aigateway", "scoreboard")
+    assert selection.images == ("aigateway", "scoreboard")
+
+
+def test_preview_tag_requires_exact_pr_and_sha() -> None:
+    contract = load_contract()
+
+    assert contract.preview_tag(42, "a" * 40) == "pr-42-aaaaaaa"
+    with pytest.raises(ValueError):
+        contract.preview_tag(0, "a" * 40)
+    with pytest.raises(ValueError):
+        contract.preview_tag(42, "not-a-sha")
+
+
+def test_admission_expires_first_then_promotes_oldest_queue() -> None:
+    contract = load_contract()
+    now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+    pulls = [
+        contract.PullState(1, frozenset({"preview"}), now - timedelta(hours=73), now),
+        contract.PullState(2, frozenset({"preview"}), now - timedelta(hours=1), now),
+        contract.PullState(3, frozenset({"preview"}), now - timedelta(hours=1), now),
+        contract.PullState(
+            4, frozenset({"preview-queued"}), None, now - timedelta(hours=2)
+        ),
+        contract.PullState(
+            5, frozenset({"preview-queued"}), None, now - timedelta(hours=1)
+        ),
+    ]
+
+    plan = contract.plan_admission(pulls, now)
+
+    assert plan.expire == (1,)
+    assert plan.promote == (4,)
+
+
+def test_disabled_and_draft_requests_never_promote() -> None:
+    contract = load_contract()
+    now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+    pulls = [
+        contract.PullState(
+            1,
+            frozenset({"preview-queued", "no-preview"}),
+            None,
+            now,
+        ),
+        contract.PullState(2, frozenset({"preview-queued"}), None, now, draft=True),
+    ]
+
+    plan = contract.plan_admission(pulls, now)
+
+    assert plan.promote == ()
+
+
+def test_active_comment_contains_access_and_observability_contract() -> None:
+    contract = load_contract()
+
+    comment = contract.preview_comment(
+        status="active",
+        number=123,
+        sha="a" * 40,
+        components=("engine",),
+        images=("engine",),
+    )
+
+    assert "fusion-pr-123.preview.dev.screamingface.ai" in comment
+    assert "kube-pr-123.preview.dev.screamingface.ai/kubeconfig" in comment
+    assert "kubectl logs" in comment
+    assert "signoz.pulse.dev.openmined.org/logs-explorer" in comment
+    assert 'k8s_namespace_name="sf-preview-pr-123"' in comment
+
+
+def test_workflows_keep_oidc_away_from_forks_and_serialize_admission() -> None:
+    images = (ROOT / ".github/workflows/preview-images.yml").read_text()
+    admission = (ROOT / ".github/workflows/preview-admission.yml").read_text()
+
+    assert "pull_request_target" not in images
+    assert "pull_request:" in images
+    assert "AZURE_PREVIEW_CLIENT_ID" in images
+    assert "head.repo.full_name == github.repository" in images
+    assert "acropenminedpreview.azurecr.io" in images
+    assert "preview-building" in images
+    assert "workflow_run:" in admission
+    assert "schedule:" in admission
+    assert "screamingface-preview-admission" in admission
+    assert "cancel-in-progress: false" in admission

--- a/.github/workflows/preview-admission.yml
+++ b/.github/workflows/preview-admission.yml
@@ -1,0 +1,30 @@
+name: Preview admission
+
+on:
+  workflow_run:
+    workflows: ["Preview images"]
+    types: [completed]
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: screamingface-preview-admission
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Expire active requests and admit the oldest queued requests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/preview_contract.py reconcile

--- a/.github/workflows/preview-images.yml
+++ b/.github/workflows/preview-images.yml
@@ -63,7 +63,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git fetch --no-tags origin "$HEAD_SHA"
-          git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" > /tmp/preview-paths
+          git diff --name-only --no-renames "$BASE_SHA...$HEAD_SHA" > /tmp/preview-paths
       - id: classify
         name: Select affected Preview images
         env:

--- a/.github/workflows/preview-images.yml
+++ b/.github/workflows/preview-images.yml
@@ -1,0 +1,232 @@
+name: Preview images
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled, closed]
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: screamingface-preview-images-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: acropenminedpreview.azurecr.io
+
+jobs:
+  disable:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.action == 'closed' || github.event.pull_request.draft ||
+      contains(github.event.pull_request.labels.*.name, 'no-preview'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Remove the Preview request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          python3 .github/scripts/preview_contract.py disable
+          --number "$PR_NUMBER" --sha "$HEAD_SHA"
+
+  plan:
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.action != 'closed' && !github.event.pull_request.draft &&
+      !contains(github.event.pull_request.labels.*.name, 'no-preview')
+    runs-on: ubuntu-latest
+    outputs:
+      components: ${{ steps.classify.outputs.components }}
+      images: ${{ steps.classify.outputs.images }}
+      matrix: ${{ steps.classify.outputs.matrix }}
+      engine: ${{ steps.classify.outputs.engine }}
+      any: ${{ steps.classify.outputs.any }}
+      tag: ${{ steps.classify.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Read both sides of renamed paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --no-tags origin "$HEAD_SHA"
+          git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" > /tmp/preview-paths
+      - id: classify
+        name: Select affected Preview images
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          python3 .github/scripts/preview_contract.py classify
+          --paths /tmp/preview-paths --number "$PR_NUMBER" --sha "$HEAD_SHA"
+          --output "$GITHUB_OUTPUT"
+      - name: Mark the request preview-building
+        if: steps.classify.outputs.any == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMPONENTS: ${{ steps.classify.outputs.components }}
+          IMAGES: ${{ steps.classify.outputs.images }}
+        run: >-
+          python3 .github/scripts/preview_contract.py prepare
+          --number "$PR_NUMBER" --sha "$HEAD_SHA"
+          --components "$COMPONENTS" --images "$IMAGES"
+      - name: Disable an empty Preview
+        if: steps.classify.outputs.any != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >-
+          python3 .github/scripts/preview_contract.py disable
+          --number "$PR_NUMBER" --sha "$HEAD_SHA"
+
+  images:
+    needs: plan
+    if: needs.plan.outputs.any == 'true' && needs.plan.outputs.matrix != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        component: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_PREVIEW_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign in to the Preview registry
+        run: az acr login --name acropenminedpreview
+      - uses: docker/setup-buildx-action@v4
+      - name: Select image inputs
+        id: image
+        env:
+          COMPONENT: ${{ matrix.component }}
+        run: |
+          case "$COMPONENT" in
+            aigateway)
+              echo "file=apps/aigateway/Dockerfile" >> "$GITHUB_OUTPUT"
+              echo "repository=screamingface-aigateway" >> "$GITHUB_OUTPUT"
+              ;;
+            aigatewayUi)
+              echo "file=apps/aigateway-ui/Dockerfile" >> "$GITHUB_OUTPUT"
+              echo "repository=screamingface-aigateway-ui" >> "$GITHUB_OUTPUT"
+              ;;
+            scoreboard)
+              echo "file=apps/scoreboard/Dockerfile" >> "$GITHUB_OUTPUT"
+              echo "repository=screamingface-scoreboard" >> "$GITHUB_OUTPUT"
+              ;;
+            *) exit 2 ;;
+          esac
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ steps.image.outputs.file }}
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.image.outputs.repository }}:${{ needs.plan.outputs.tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=preview-${{ matrix.component }}
+          cache-to: type=gha,mode=max,scope=preview-${{ matrix.component }}
+
+  engine:
+    needs: plan
+    if: needs.plan.outputs.engine == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_PREVIEW_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Sign in to the Preview registry
+        run: az acr login --name acropenminedpreview
+      - uses: docker/setup-buildx-action@v4
+      - name: Build Engine
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/screamingface-engine/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/screamingface-engine:${{ needs.plan.outputs.tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=preview-engine
+          cache-to: type=gha,mode=max,scope=preview-engine
+      - name: Build Engine benchmark from the exact Engine image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/screamingface-engine/Dockerfile.benchmark
+          build-args: BASE=${{ env.REGISTRY }}/screamingface-engine:${{ needs.plan.outputs.tag }}
+          push: true
+          tags: ${{ env.REGISTRY }}/screamingface-engine-benchmark:${{ needs.plan.outputs.tag }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.event.pull_request.head.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=preview-engine-benchmark
+          cache-to: type=gha,mode=max,scope=preview-engine-benchmark
+
+  finish:
+    needs: [plan, images, engine]
+    if: always() && needs.plan.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Queue the exact revision
+        if: >-
+          needs.plan.result == 'success' &&
+          (needs.images.result == 'success' || needs.images.result == 'skipped') &&
+          (needs.engine.result == 'success' || needs.engine.result == 'skipped')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMPONENTS: ${{ needs.plan.outputs.components }}
+          IMAGES: ${{ needs.plan.outputs.images }}
+        run: >-
+          python3 .github/scripts/preview_contract.py ready
+          --number "$PR_NUMBER" --sha "$HEAD_SHA"
+          --components "$COMPONENTS" --images "$IMAGES"
+      - name: Record a failed build
+        if: >-
+          needs.plan.result != 'success' ||
+          (needs.images.result != 'success' && needs.images.result != 'skipped') ||
+          (needs.engine.result != 'success' && needs.engine.result != 'skipped')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMPONENTS: ${{ needs.plan.outputs.components }}
+          IMAGES: ${{ needs.plan.outputs.images }}
+        run: >-
+          python3 .github/scripts/preview_contract.py failed
+          --number "$PR_NUMBER" --sha "$HEAD_SHA"
+          --components "$COMPONENTS" --images "$IMAGES"

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -8,6 +8,9 @@ on:
       - ".claude/skills/sdlc-**"
       - ".claude/scripts/**"
       - ".github/workflows/repo-checks.yml"
+      - ".github/workflows/preview-*.yml"
+      - ".github/scripts/preview_contract.py"
+      - ".github/scripts/test_preview_contract.py"
       - ".github/dependabot.yml"
       - ".github/dependabot-ignores.yml"
   pull_request:
@@ -15,6 +18,9 @@ on:
       - ".claude/skills/sdlc-**"
       - ".claude/scripts/**"
       - ".github/workflows/repo-checks.yml"
+      - ".github/workflows/preview-*.yml"
+      - ".github/scripts/preview_contract.py"
+      - ".github/scripts/test_preview_contract.py"
       - ".github/dependabot.yml"
       - ".github/dependabot-ignores.yml"
   # WHY a schedule: the ignore audit checks state that changes when UPSTREAM ships, not when we
@@ -29,6 +35,15 @@ permissions:
   contents: read
 
 jobs:
+  preview-contract:
+    name: Preview contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+      - name: Test Preview selection, security, and admission
+        run: uv run --project apps/screamingface-engine pytest .github/scripts/test_preview_contract.py -q
+
   loop-parity:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,25 @@ human contributors.** As a human, the list above is the whole contract: issue â†
 conventional commits â†’ PR. The agent contract is documented in
 [`.claude/README.md`](.claude/README.md).
 
+## Pull-request Preview environments
+
+A same-repository pull request receives a Preview only when it changes a deployable runtime.
+The automation builds only affected images. Engine changes also build the Engine benchmark image.
+
+The maintained `Preview` pull-request comment shows the current state and exact revision.
+It also shows application links, Kubernetes commands, and SigNoz links after admission.
+
+Preview states use these labels:
+
+- `preview-building`: Required images are not ready.
+- `preview-queued`: Images are ready, and the request waits for a slot.
+- `preview`: Argo CD deploys the request.
+- `preview-expired`: The 72-hour active period ended.
+- `no-preview`: The author disabled the Preview.
+
+Only three Preview environments can be active. The oldest ready request receives the next slot.
+Close the pull request to delete its Preview. Pull-request code receives no Kubernetes credential.
+
 ## Releases
 
 | Stack | How |

--- a/docs/plan/2026-08-24-ome-965-tenant-preview.md
+++ b/docs/plan/2026-08-24-ome-965-tenant-preview.md
@@ -1,0 +1,33 @@
+# OME-965 — tenant Preview automation plan
+
+## Implementation
+
+1. Add failing classification and lifecycle contract tests.
+2. Add a standard-library Preview contract helper.
+3. Add the same-repository selective image workflow.
+4. Add the serialized queue and expiry workflow.
+5. Add repository checks for workflow contracts.
+6. Add the developer workflow to contributing guidance.
+7. Create the managed GitHub labels.
+8. Run local contract, repository, and workflow validation.
+9. Open and merge the tenant automation pull request after review and green checks.
+10. Open an Engine-only fixture pull request and run the live Preview qualification.
+
+## Files
+
+- `.github/scripts/preview_contract.py`
+- `.github/scripts/test_preview_contract.py`
+- `.github/workflows/preview-images.yml`
+- `.github/workflows/preview-admission.yml`
+- `.github/workflows/repo-checks.yml`
+- `CONTRIBUTING.md`
+- specification, plan, and work records
+
+## Verification
+
+- Path classification covers happy, boundary, rename, chart-only, shared-package, and root inputs.
+- Lifecycle planning enforces three slots and 72-hour expiry.
+- Workflow contract tests reject `pull_request_target`, fork OIDC, missing exact tags, and missing labels.
+- The sample Engine pull request proves image publication, Argo deployment, Runner Jobs, access,
+  observability, and deletion.
+

--- a/docs/spec/2026-08-24-ome-965-tenant-preview.md
+++ b/docs/spec/2026-08-24-ome-965-tenant-preview.md
@@ -1,0 +1,47 @@
+# OME-965 — tenant Preview automation specification
+
+## Result
+
+A same-repository pull request selects only affected deployable components, publishes only
+their pull-request images, and enters the bounded Preview queue after exact-revision readiness.
+
+## Selection contract
+
+- AI Gateway, AI Gateway UI, Scoreboard, and Engine use independent component and image labels.
+- A chart-only change selects its runtime component without rebuilding its image.
+- Tests and documentation alone select no Preview runtime.
+- `packages/url4/` selects the Engine runtime and builds Engine plus its benchmark image.
+- A root `.dockerignore` change selects every runtime and all five images.
+- Rename detection considers both old and new paths.
+
+## Supply contract
+
+- Only same-repository, non-draft pull requests can use the Azure Preview identity.
+- Images publish to `acropenminedpreview.azurecr.io` with tag `pr-<number>-<sha7>`.
+- The benchmark image uses the exact pull-request Engine image as its base.
+- The workflow records the full 40-character revision in OCI labels and its maintained comment.
+- Pull-request automation receives no Kubernetes credential.
+
+## Lifecycle contract
+
+- `preview-building` means required images are not ready.
+- `preview-queued` means images are ready but no slot is available.
+- `preview` authorizes Argo discovery.
+- `preview-expired` records automatic removal after 72 hours.
+- `no-preview` disables Preview automation.
+- At most three open pull requests carry `preview`.
+- A serialized default-branch reconciler promotes queued requests and expires active requests.
+- Close, merge, draft conversion, fork origin, and empty selection remove managed Preview labels.
+
+## Developer contract
+
+The maintained pull-request comment shows status, exact revision, selected images, application
+URLs, Kubernetes access commands, and namespace-filtered SigNoz links.
+
+## Security
+
+- The image workflow uses `pull_request`, never `pull_request_target`.
+- Azure OIDC runs only when the pull-request head repository equals the base repository.
+- The Preview identity can push only to the disposable Preview registry.
+- The admission workflow runs trusted default-branch code and never checks out pull-request code.
+

--- a/docs/work/2026-08-24-OME-965-tenant-preview.md
+++ b/docs/work/2026-08-24-OME-965-tenant-preview.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-965
 stack: repo
-status: in_progress
+status: done
 started: 2026-08-24
-finished:
+finished: 2026-08-24
 ---
 
 # OME-965 — implement tenant Preview automation
@@ -45,7 +45,12 @@ the pull-request author exact access and observability instructions.
 
 ## Outcome
 
-- **Actual files:** pending
-- **Commits:** pending
-- **Gates:** pending
-- **Deviations:** pending
+- **Actual files:** The planned helper, tests, workflows, checks, contributor guide, and
+  work artifacts changed.
+- **Commits:** `test: define tenant preview contract` and
+  `feat: automate tenant preview environments`.
+- **Gates:** 11 contract tests pass. Ruff check, Ruff format, Python compilation,
+  YAML parsing, and `git diff --check` pass.
+- **External state:** All required status, component, and image labels exist in the tenant repo.
+- **Deviations:** Linear was unavailable. The owner-authorized OME-965 work item continues
+  as the repository-wide Preview automation unit.

--- a/docs/work/2026-08-24-OME-965-tenant-preview.md
+++ b/docs/work/2026-08-24-OME-965-tenant-preview.md
@@ -1,0 +1,51 @@
+---
+ticket: OME-965
+stack: repo
+status: in_progress
+started: 2026-08-24
+finished:
+---
+
+# OME-965 — implement tenant Preview automation
+
+## Intent
+
+Complete the tenant-owned half of pull-request Preview environments. Build only changed images,
+publish them through the dedicated Azure identity, manage the bounded Preview lifecycle, and give
+the pull-request author exact access and observability instructions.
+
+## Planned changes
+
+- `.github/scripts/preview_contract.py`
+- `.github/scripts/test_preview_contract.py`
+- `.github/workflows/preview-images.yml`
+- `.github/workflows/preview-admission.yml`
+- `.github/workflows/repo-checks.yml`
+- `CONTRIBUTING.md`
+- `docs/spec/2026-08-24-ome-965-tenant-preview.md`
+- `docs/plan/2026-08-24-ome-965-tenant-preview.md`
+- this ledger
+
+## Test plan
+
+- Run the Preview contract unit tests.
+- Run repository checks.
+- Validate workflow YAML and security invariants.
+- Run one Engine-only live fixture after the automation merges.
+
+## Acceptance
+
+- Only same-repository pull requests receive Preview registry access.
+- Only affected deployable images build.
+- Engine selection builds the paired benchmark image from the exact Engine image.
+- Exact-revision readiness precedes the `preview` label.
+- Three-slot admission and 72-hour expiry are serialized.
+- The pull-request comment contains URLs, access commands, and SigNoz filters.
+- The fixture Preview creates, qualifies, and deletes without manual cluster changes.
+
+## Outcome
+
+- **Actual files:** pending
+- **Commits:** pending
+- **Gates:** pending
+- **Deviations:** pending


### PR DESCRIPTION
## Summary

- select AI Gateway, AI Gateway UI, Scoreboard, and Engine independently
- publish only changed pull-request images to the dedicated Preview registry
- build the Engine benchmark from the exact pull-request Engine image
- serialize three-slot admission and 72-hour expiry
- publish application, Kubernetes, and SigNoz access in one maintained comment
- deny fork OIDC and give pull-request code no Kubernetes credential

## Test plan

- `uv run --project apps/screamingface-engine pytest .github/scripts/test_preview_contract.py -q`
- result: 11 passed
- Ruff check and format: passed
- Python compilation, YAML parsing, and diff checks: passed

Refs: OME-965