### PR TITLE
fix(repo): publish access for active Previews

### DIFF
--- a/.github/scripts/preview_contract.py
+++ b/.github/scripts/preview_contract.py
@@ -180,18 +180,19 @@ def preview_comment(
     components: Sequence[str],
     images: Sequence[str],
 ) -> str:
+    display_status = "active" if status == "preview" else status
     namespace = f"sf-preview-pr-{number}"
     component_text = ", ".join(components) or "none"
     image_text = ", ".join(images) or "none"
     lines = [
         COMMENT_MARKER,
-        f"## Preview: {status}",
+        f"## Preview: {display_status}",
         "",
         f"- Revision: `{sha}`",
         f"- Components: `{component_text}`",
         f"- Images: `{image_text}`",
     ]
-    if status == "active":
+    if display_status == "active":
         routes: list[str] = []
         if {"aigateway", "aigatewayUi", "engine"} & set(components):
             routes.append(

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -141,13 +141,14 @@ def test_active_comment_contains_access_and_observability_contract() -> None:
     contract = load_contract()
 
     comment = contract.preview_comment(
-        status="active",
+        status="preview",
         number=123,
         sha="a" * 40,
         components=("engine",),
         images=("engine",),
     )
 
+    assert "## Preview: active" in comment
     assert "fusion-pr-123.preview.dev.screamingface.ai" in comment
     assert "kube-pr-123.preview.dev.screamingface.ai/kubeconfig" in comment
     assert "kubectl logs" in comment


### PR DESCRIPTION
## Summary

- render admitted `preview` state as `active`
- publish application routes, scoped kubeconfig commands, and SigNoz links
- cover the real admission label in the contract test

## Test plan

- Preview contract: 11 passed
- Ruff check and format: passed
- verify sample PR #707 receives the maintained access comment

Refs: OME-965