### PR TITLE
fix(repo): simplify Preview Kubernetes access

### DIFF
--- a/.github/scripts/preview_access.sh
+++ b/.github/scripts/preview_access.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  printf 'Preview access failed: %s\n' "$1" >&2
+  exit 1
+}
+
+pr_number="${1:-}"
+[[ "$pr_number" =~ ^[1-9][0-9]*$ ]] || {
+  printf 'Usage: preview_access.sh PULL_REQUEST_NUMBER\n' >&2
+  exit 2
+}
+
+for required_command in cloudflared curl gh install kubectl mktemp; do
+  command -v "$required_command" >/dev/null 2>&1 || \
+    fail "install $required_command and try again"
+done
+
+readonly kubeconfig_url="https://kube-pr-${pr_number}.preview.dev.screamingface.ai/kubeconfig"
+readonly kubeconfig_path="${PREVIEW_KUBECONFIG:-/tmp/sf-preview-pr-${pr_number}.kubeconfig}"
+temporary_kubeconfig="$(mktemp "/tmp/sf-preview-pr-${pr_number}.kubeconfig.XXXXXX")"
+trap 'rm -f "$temporary_kubeconfig"' EXIT
+
+access_token=""
+if ! access_token="$(cloudflared access token --app="$kubeconfig_url" 2>/dev/null)" || \
+  [[ -z "$access_token" ]]; then
+  printf 'Complete the Cloudflare login in your browser.\n' >&2
+  cloudflared access login --quiet "$kubeconfig_url" 1>&2
+  access_token="$(cloudflared access token --app="$kubeconfig_url")"
+fi
+[[ -n "$access_token" ]] || fail "Cloudflare returned no access token"
+
+if ! github_token="$(gh auth token 2>/dev/null)" || [[ -z "$github_token" ]]; then
+  fail "run gh auth login and try again"
+fi
+
+if ! {
+  printf 'header = "cf-access-token: %s"\n' "$access_token"
+  printf 'header = "X-Preview-Access-Token: %s"\n' "$access_token"
+  printf 'header = "X-GitHub-Token: %s"\n' "$github_token"
+  printf 'output = "%s"\n' "$temporary_kubeconfig"
+  printf 'url = "%s"\n' "$kubeconfig_url"
+} | curl \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --location \
+  --max-redirs 0 \
+  --config -; then
+  fail "the protected kubeconfig request was refused"
+fi
+
+kubectl config view \
+  --kubeconfig "$temporary_kubeconfig" \
+  --minify \
+  >/dev/null || fail "the server returned an invalid kubeconfig"
+
+install -m 600 "$temporary_kubeconfig" "$kubeconfig_path"
+printf '%s\n' "$kubeconfig_path"

--- a/.github/scripts/preview_contract.py
+++ b/.github/scripts/preview_contract.py
@@ -219,22 +219,21 @@ def preview_comment(
                 "",
                 "### Kubernetes access",
                 "",
+                f"Kubeconfig endpoint: https://kube-pr-{number}.preview.dev.screamingface.ai/kubeconfig",
+                "",
+                "This command opens Cloudflare login and prepares `kubectl`.",
+                "It uses a helper from trusted `main`, not from pull-request code.",
+                "",
                 "```bash",
-                f'PREVIEW_KUBECONFIG="/tmp/sf-preview-pr-{number}.kubeconfig"',
-                f'PREVIEW_KUBECONFIG_URL="https://kube-pr-{number}.preview.dev.screamingface.ai/kubeconfig"',
-                'CF_ACCESS_TOKEN="$(cloudflared access token -app="$PREVIEW_KUBECONFIG_URL")"',
-                'GITHUB_TOKEN="$(gh auth token)"',
-                "{",
-                '  printf \'header = "cf-access-token: %s"\\n\' "$CF_ACCESS_TOKEN"',
-                '  printf \'header = "X-Preview-Access-Token: %s"\\n\' "$CF_ACCESS_TOKEN"',
-                '  printf \'header = "X-GitHub-Token: %s"\\n\' "$GITHUB_TOKEN"',
-                '  printf \'url = "%s"\\n\' "$PREVIEW_KUBECONFIG_URL"',
-                '} | curl --fail --silent --show-error --config - > "$PREVIEW_KUBECONFIG"',
-                "unset CF_ACCESS_TOKEN GITHUB_TOKEN",
-                'chmod 600 "$PREVIEW_KUBECONFIG"',
-                'export KUBECONFIG="$PREVIEW_KUBECONFIG"',
+                (
+                    'export KUBECONFIG="$(gh api -H '
+                    "'Accept: application/vnd.github.raw' "
+                    "'repos/ScreamingFace/screamingface/contents/"
+                    ".github/scripts/preview_access.sh?ref=main' "
+                    f'| bash -s -- {number})"'
+                ),
                 "kubectl get pods",
-                "kubectl logs POD_NAME --all-containers --tail=200",
+                "kubectl logs deployment/DEPLOYMENT_NAME --all-containers --tail=200",
                 "```",
                 "",
                 "### Observability",

--- a/.github/scripts/test_preview_access.py
+++ b/.github/scripts/test_preview_access.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER = Path(__file__).with_name("preview_access.sh")
+
+
+def executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body))
+    path.chmod(0o755)
+
+
+def test_helper_logs_in_and_installs_valid_kubeconfig(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    marker = tmp_path / "cloudflare-login"
+    curl_config = tmp_path / "curl-config"
+    kubeconfig = tmp_path / "preview.kubeconfig"
+
+    executable(
+        fake_bin / "cloudflared",
+        """\
+        #!/usr/bin/env python3
+        import os
+        import sys
+        from pathlib import Path
+
+        marker = Path(os.environ["FAKE_CLOUDFLARE_LOGIN"])
+        if sys.argv[1:3] == ["access", "token"]:
+            if not marker.exists():
+                raise SystemExit(1)
+            print("cloudflare-token")
+        elif sys.argv[1:3] == ["access", "login"]:
+            marker.touch()
+        else:
+            raise SystemExit(2)
+        """,
+    )
+    executable(
+        fake_bin / "gh",
+        """\
+        #!/usr/bin/env python3
+        import sys
+
+        if sys.argv[1:] != ["auth", "token"]:
+            raise SystemExit(2)
+        print("github-token")
+        """,
+    )
+    executable(
+        fake_bin / "curl",
+        """\
+        #!/usr/bin/env python3
+        import os
+        import re
+        import sys
+        from pathlib import Path
+
+        config = sys.stdin.read()
+        Path(os.environ["FAKE_CURL_CONFIG"]).write_text(config)
+        output = re.search(r'^output = "([^"]+)"$', config, re.MULTILINE)
+        if output is None:
+            raise SystemExit(2)
+        Path(output.group(1)).write_text(
+            "apiVersion: v1\\nkind: Config\\ncurrent-context: preview\\n"
+        )
+        """,
+    )
+    executable(
+        fake_bin / "kubectl",
+        """\
+        #!/usr/bin/env python3
+        import sys
+
+        if sys.argv[1:3] != ["config", "view"]:
+            raise SystemExit(2)
+        """,
+    )
+
+    environment = {
+        **os.environ,
+        "FAKE_CLOUDFLARE_LOGIN": str(marker),
+        "FAKE_CURL_CONFIG": str(curl_config),
+        "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        "PREVIEW_KUBECONFIG": str(kubeconfig),
+    }
+    result = subprocess.run(
+        ["bash", str(HELPER), "707"],
+        cwd=ROOT,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(kubeconfig)
+    assert "Complete the Cloudflare login" in result.stderr
+    assert marker.exists()
+    assert kubeconfig.stat().st_mode & 0o777 == 0o600
+    request = curl_config.read_text()
+    assert 'header = "cf-access-token: cloudflare-token"' in request
+    assert 'header = "X-Preview-Access-Token: cloudflare-token"' in request
+    assert 'header = "X-GitHub-Token: github-token"' in request
+    assert (
+        'url = "https://kube-pr-707.preview.dev.screamingface.ai/kubeconfig"' in request
+    )
+
+
+def test_helper_requires_a_pull_request_number() -> None:
+    result = subprocess.run(
+        ["bash", str(HELPER)],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "Usage: preview_access.sh PULL_REQUEST_NUMBER" in result.stderr

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -151,6 +151,10 @@ def test_active_comment_contains_access_and_observability_contract() -> None:
     assert "## Preview: active" in comment
     assert "fusion-pr-123.preview.dev.screamingface.ai" in comment
     assert "kube-pr-123.preview.dev.screamingface.ai/kubeconfig" in comment
+    assert "preview_access.sh?ref=main" in comment
+    assert "bash -s -- 123" in comment
+    assert "cloudflared access token" not in comment
+    assert "CF_ACCESS_TOKEN" not in comment
     assert "kubectl logs" in comment
     assert "signoz.pulse.dev.openmined.org/logs-explorer" in comment
     assert 'k8s_namespace_name="sf-preview-pr-123"' in comment

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -10,6 +10,8 @@ on:
       - ".github/workflows/repo-checks.yml"
       - ".github/workflows/preview-*.yml"
       - ".github/scripts/preview_contract.py"
+      - ".github/scripts/preview_access.sh"
+      - ".github/scripts/test_preview_access.py"
       - ".github/scripts/test_preview_contract.py"
       - ".github/dependabot.yml"
       - ".github/dependabot-ignores.yml"
@@ -20,6 +22,8 @@ on:
       - ".github/workflows/repo-checks.yml"
       - ".github/workflows/preview-*.yml"
       - ".github/scripts/preview_contract.py"
+      - ".github/scripts/preview_access.sh"
+      - ".github/scripts/test_preview_access.py"
       - ".github/scripts/test_preview_contract.py"
       - ".github/dependabot.yml"
       - ".github/dependabot-ignores.yml"
@@ -42,7 +46,9 @@ jobs:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
       - name: Test Preview selection, security, and admission
-        run: uv run --project apps/screamingface-engine pytest .github/scripts/test_preview_contract.py -q
+        run: uv run --project apps/screamingface-engine pytest .github/scripts/test_preview_*.py -q
+      - name: Validate Preview access helper
+        run: bash -n .github/scripts/preview_access.sh
 
   loop-parity:
     runs-on: ubuntu-latest

--- a/docs/plan/2026-08-24-ome-965-tenant-preview.md
+++ b/docs/plan/2026-08-24-ome-965-tenant-preview.md
@@ -12,10 +12,12 @@
 8. Run local contract, repository, and workflow validation.
 9. Open and merge the tenant automation pull request after review and green checks.
 10. Open an Engine-only fixture pull request and run the live Preview qualification.
+11. Replace the manual access-token sequence with one trusted access helper.
 
 ## Files
 
 - `.github/scripts/preview_contract.py`
+- `.github/scripts/preview_access.sh`
 - `.github/scripts/test_preview_contract.py`
 - `.github/workflows/preview-images.yml`
 - `.github/workflows/preview-admission.yml`
@@ -30,4 +32,3 @@
 - Workflow contract tests reject `pull_request_target`, fork OIDC, missing exact tags, and missing labels.
 - The sample Engine pull request proves image publication, Argo deployment, Runner Jobs, access,
   observability, and deletion.
-

--- a/docs/spec/2026-08-24-ome-965-tenant-preview.md
+++ b/docs/spec/2026-08-24-ome-965-tenant-preview.md
@@ -36,7 +36,10 @@ their pull-request images, and enters the bounded Preview queue after exact-revi
 ## Developer contract
 
 The maintained pull-request comment shows status, exact revision, selected images, application
-URLs, Kubernetes access commands, and namespace-filtered SigNoz links.
+URLs, one trusted Kubernetes access helper command, and namespace-filtered SigNoz links.
+
+The helper performs Cloudflare login, GitHub author verification, safe download, and kubeconfig
+validation. It comes from trusted `main`, never from pull-request code.
 
 ## Security
 
@@ -44,4 +47,3 @@ URLs, Kubernetes access commands, and namespace-filtered SigNoz links.
 - Azure OIDC runs only when the pull-request head repository equals the base repository.
 - The Preview identity can push only to the disposable Preview registry.
 - The admission workflow runs trusted default-branch code and never checks out pull-request code.
-

--- a/docs/work/2026-08-24-OME-965-tenant-preview.md
+++ b/docs/work/2026-08-24-OME-965-tenant-preview.md
@@ -54,3 +54,5 @@ the pull-request author exact access and observability instructions.
 - **External state:** All required status, component, and image labels exist in the tenant repo.
 - **Deviations:** Linear was unavailable. The owner-authorized OME-965 work item continues
   as the repository-wide Preview automation unit.
+- **Access follow-up:** Replace the error-prone token sequence with a trusted-main helper.
+  The helper handles Cloudflare login, GitHub identity, safe download, and kubeconfig validation.


### PR DESCRIPTION
## Summary

- replace the manual token sequence with one trusted helper command
- open Cloudflare login automatically when the cached token is absent
- validate the downloaded kubeconfig before kubectl uses it
- keep Cloudflare and GitHub tokens out of command arguments

## Tests

- 13 Preview contract tests passed
- Ruff checks passed
- Bash syntax check passed
- Python compilation passed

Refs: OME-965