### PR TITLE
fix(repo): clarify Preview access scope

### DIFF
--- a/.github/scripts/preview_access.sh
+++ b/.github/scripts/preview_access.sh
@@ -57,4 +57,6 @@ kubectl config view \
   >/dev/null || fail "the server returned an invalid kubeconfig"
 
 install -m 600 "$temporary_kubeconfig" "$kubeconfig_path"
+printf 'Preview access is ready for namespace sf-preview-pr-%s.\n' "$pr_number" >&2
+printf 'Cluster-wide commands are blocked.\n' >&2
 printf '%s\n' "$kubeconfig_path"

--- a/.github/scripts/preview_contract.py
+++ b/.github/scripts/preview_contract.py
@@ -24,6 +24,12 @@ LABEL_SLUG = {
     "scoreboard": "scoreboard",
     "engine": "engine",
 }
+DEPLOYMENT_NAMES = {
+    "aigateway": "aigw",
+    "aigatewayUi": "aigw-ui",
+    "scoreboard": "leaderboard",
+    "engine": "url4-cloud",
+}
 COMPONENT_LABELS = {
     name: f"preview-component-{LABEL_SLUG[name]}" for name in COMPONENTS
 }
@@ -184,6 +190,11 @@ def preview_comment(
     namespace = f"sf-preview-pr-{number}"
     component_text = ", ".join(components) or "none"
     image_text = ", ".join(images) or "none"
+    log_commands = [
+        f"kubectl logs deployment/{DEPLOYMENT_NAMES[component]} "
+        "--all-containers --tail=200"
+        for component in components
+    ]
     lines = [
         COMMENT_MARKER,
         f"## Preview: {display_status}",
@@ -233,8 +244,11 @@ def preview_comment(
                     f'| bash -s -- {number})"'
                 ),
                 "kubectl get pods",
-                "kubectl logs deployment/DEPLOYMENT_NAME --all-containers --tail=200",
+                *log_commands,
                 "```",
+                "",
+                f"This kubeconfig only accesses namespace {namespace}.",
+                "Commands with --all-namespaces or -A are blocked.",
                 "",
                 "### Observability",
                 "",

--- a/.github/scripts/test_preview_access.py
+++ b/.github/scripts/test_preview_access.py
@@ -100,6 +100,8 @@ def test_helper_logs_in_and_installs_valid_kubeconfig(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == str(kubeconfig)
     assert "Complete the Cloudflare login" in result.stderr
+    assert "Preview access is ready for namespace sf-preview-pr-707." in result.stderr
+    assert "Cluster-wide commands are blocked." in result.stderr
     assert marker.exists()
     assert kubeconfig.stat().st_mode & 0o777 == 0o600
     request = curl_config.read_text()

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -155,9 +155,37 @@ def test_active_comment_contains_access_and_observability_contract() -> None:
     assert "bash -s -- 123" in comment
     assert "cloudflared access token" not in comment
     assert "CF_ACCESS_TOKEN" not in comment
-    assert "kubectl logs" in comment
+    assert "kubectl logs deployment/url4-cloud --all-containers --tail=200" in comment
+    assert "DEPLOYMENT_NAME" not in comment
+    assert "This kubeconfig only accesses namespace sf-preview-pr-123." in comment
+    assert "Commands with --all-namespaces or -A are blocked." in comment
     assert "signoz.pulse.dev.openmined.org/logs-explorer" in comment
     assert 'k8s_namespace_name="sf-preview-pr-123"' in comment
+
+
+@pytest.mark.parametrize(
+    ("component", "deployment"),
+    [
+        ("aigateway", "aigw"),
+        ("aigatewayUi", "aigw-ui"),
+        ("scoreboard", "leaderboard"),
+        ("engine", "url4-cloud"),
+    ],
+)
+def test_active_comment_uses_the_selected_deployment(
+    component: str, deployment: str
+) -> None:
+    contract = load_contract()
+
+    comment = contract.preview_comment(
+        status="preview",
+        number=123,
+        sha="a" * 40,
+        components=(component,),
+        images=(component,),
+    )
+
+    assert f"kubectl logs deployment/{deployment} " in comment
 
 
 def test_workflows_keep_oidc_away_from_forks_and_serialize_admission() -> None:

--- a/docs/work/2026-08-24-OME-965-tenant-preview.md
+++ b/docs/work/2026-08-24-OME-965-tenant-preview.md
@@ -56,3 +56,4 @@ the pull-request author exact access and observability instructions.
   as the repository-wide Preview automation unit.
 - **Access follow-up:** Replace the error-prone token sequence with a trusted-main helper.
   The helper handles Cloudflare login, GitHub identity, safe download, and kubeconfig validation.
+- **Output follow-up:** Show exact deployment log commands and explain the pull-request namespace limit.


### PR DESCRIPTION
## Summary

- replace the log placeholder with the selected deployment name
- explain that the kubeconfig only accesses its pull-request namespace
- print the namespace limit after the helper succeeds

## Proof

- PR #707 listed pods inside sf-preview-pr-707
- cluster-wide pod listing was denied as designed
- 17 Preview tests passed
- Ruff and Bash checks passed

Refs: OME-965