### PR TITLE
fix(screamingface): clean up Colab widget styling

### DIFF
--- a/docs/plan/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/plan/2026-08-24-OME-955-colab-widget-styling.md
@@ -21,3 +21,6 @@ spec: ../spec/2026-08-24-OME-955-colab-widget-styling.md
    run the complete ScreamingFace gate suite.
 6. Review `origin/main...HEAD` for SFDS and compatibility regressions, fill the ledger outcome,
    commit, and push the branch. Do not open a PR until the owner requests it.
+7. Review follow-up: delete the unused static panel composition, route runtime and tests through one
+   fragment projection, make the stable table HTML node the sole scroll/focus owner, correct host
+   selector specificity, rerun all gates, and update the draft PR.

--- a/docs/plan/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/plan/2026-08-24-OME-955-colab-widget-styling.md
@@ -1,0 +1,23 @@
+---
+title: Implement Colab notebook surface integration
+ticket: OME-955
+status: approved
+date: 2026-08-24
+spec: ../spec/2026-08-24-OME-955-colab-widget-styling.md
+---
+
+# Implement Colab notebook surface integration
+
+1. Add failing shared-style tests that pin explicit Colab light/dark selectors, exact SFDS token
+   reuse, and preservation of the existing JupyterLab and VS Code selectors.
+2. Replace the inherited no-overflow assertions with approved narrow-table contracts: 820 px
+   minimum width, labelled keyboard-reachable overflow, full-width table, and header-only inset.
+3. Add a failing live-view regression that pins a stable, focusable ipywidgets scroll container
+   whose identity survives `begin`, event, timer, reconcile, and abort renders.
+4. Update the shared style with Colab host selectors, then split the live evaluation view into
+   independently updated header, stable table-scroll container, and terminal content while keeping
+   `evaluation_panel_html` as the canonical static representation.
+5. Run focused style/evaluation/report tests, inspect both light and dark Colab-sized renders, and
+   run the complete ScreamingFace gate suite.
+6. Review `origin/main...HEAD` for SFDS and compatibility regressions, fill the ledger outcome,
+   commit, and push the branch. Do not open a PR until the owner requests it.

--- a/docs/spec/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/spec/2026-08-24-OME-955-colab-widget-styling.md
@@ -1,0 +1,59 @@
+---
+title: Colab notebook surface integration
+ticket: OME-955
+status: approved
+date: 2026-08-24
+---
+
+# Colab notebook surface integration
+
+## Outcome
+
+ScreamingFace evaluation and report surfaces render with the active Colab light or dark theme,
+remain readable in narrow outputs, and do not jump back to the left while live data updates. The
+same HTML keeps the current JupyterLab and VS Code behavior.
+
+## Host theme contract
+
+SFDS v2 remains the only colour and typography source. The shared notebook style applies its exact
+light and dark token sets using host signals in this precedence order:
+
+1. `prefers-color-scheme` is the generic fallback;
+2. Colab output iframes override it with `html[theme="light"]` or `html[theme="dark"]`;
+3. the existing explicit JupyterLab and VS Code selectors remain authoritative in those hosts.
+
+The Colab selector is not guessed: official `googlecolab/colabtools` output CSS uses
+`html[theme=dark]` for its own widgets. Light and dark selectors are both explicit so a light Colab
+notebook never inherits a dark browser or operating-system preference.
+
+Shared host integration stays in `screamingface._ui.style`; individual evaluation and report
+views consume it without duplicating theme logic.
+
+## Evaluation layout contract
+
+- The six-column Candidate table has a readable minimum width of 820 px. Narrow outputs scroll
+  horizontally instead of compressing or overlapping columns.
+- The scroll region is keyboard reachable and labelled as the Candidate evaluation table.
+- Static HTML owns overflow on its table wrapper.
+- The live ipywidgets view owns overflow on a stable `Box` around the table. Header, table HTML,
+  and terminal/error content may update independently, but the scroll-owning DOM node is never
+  replaced, so its `scrollLeft` survives every update without JavaScript, polling, or smoothing.
+- The evaluation header owns its inset. The table remains full-width; no global `.sf-ui` padding
+  is added, so report and other notebook surfaces do not acquire a new indent.
+
+## Boundaries
+
+- No public SDK, Report, Event, Engine, Benchmark, or URL4 contract changes.
+- No new dependency or custom Jupyter widget model.
+- No legacy/alternate responsive table layout and no hidden columns.
+- No inferred or placeholder progress information.
+- Existing SFDS v2 light/dark values, font roles, square geometry, status semantics, and table
+  recipe remain unchanged.
+- Report content and information architecture do not change; it receives only the shared Colab
+  theme correction.
+
+## Accessibility and compatibility
+
+The scroll container is focusable for keyboard users and retains the table's caption. Current
+JupyterLab and VS Code theme selectors stay present and ordered after the Colab selectors. The
+generic media-query fallback remains for other HTML notebook hosts.

--- a/docs/spec/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/spec/2026-08-24-OME-955-colab-widget-styling.md
@@ -19,7 +19,8 @@ SFDS v2 remains the only colour and typography source. The shared notebook style
 light and dark token sets using host signals in this precedence order:
 
 1. `prefers-color-scheme` is the generic fallback;
-2. Colab output iframes override it with `html[theme="light"]` or `html[theme="dark"]`;
+2. Colab output iframes override it with zero-specificity `:where(html[theme="light"])` or
+   `:where(html[theme="dark"])` host qualifiers;
 3. the existing explicit JupyterLab and VS Code selectors remain authoritative in those hosts.
 
 The Colab selector is not guessed: official `googlecolab/colabtools` output CSS uses
@@ -33,11 +34,12 @@ views consume it without duplicating theme logic.
 
 - The six-column Candidate table has a readable minimum width of 820 px. Narrow outputs scroll
   horizontally instead of compressing or overlapping columns.
-- The scroll region is keyboard reachable and labelled as the Candidate evaluation table.
-- Static HTML owns overflow on its table wrapper.
-- The live ipywidgets view owns overflow on a stable `Box` around the table. Header, table HTML,
-  and terminal/error content may update independently, but the scroll-owning DOM node is never
-  replaced, so its `scrollLeft` survives every update without JavaScript, polling, or smoothing.
+- The table is rendered only through the live ipywidgets path; no unused static panel projection is
+  maintained.
+- A stable, focusable `widgets.HTML` node owns horizontal overflow and carries a descriptive
+  tooltip. Its table retains a caption for table semantics. Header, table HTML, and terminal/error
+  content may update independently, but the scroll-owning DOM node is never replaced, so its
+  `scrollLeft` survives every update without JavaScript, polling, or smoothing.
 - The evaluation header owns its inset. The table remains full-width; no global `.sf-ui` padding
   is added, so report and other notebook surfaces do not acquire a new indent.
 
@@ -54,6 +56,6 @@ views consume it without duplicating theme logic.
 
 ## Accessibility and compatibility
 
-The scroll container is focusable for keyboard users and retains the table's caption. Current
-JupyterLab and VS Code theme selectors stay present and ordered after the Colab selectors. The
-generic media-query fallback remains for other HTML notebook hosts.
+The scroll container is the sole table-area focus target and retains the table's caption. Current
+JupyterLab and VS Code theme selectors stay present, ordered later, and carry greater specificity
+than the Colab qualifiers. The generic media-query fallback remains for other HTML notebook hosts.

--- a/docs/tasks/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/tasks/2026-08-24-OME-955-colab-widget-styling.md
@@ -1,0 +1,16 @@
+---
+id: OME-955
+linear_url: https://linear.app/openmined/issue/OME-955/clean-up-colab-widget-styling
+status: in_progress
+type: feature
+priority: medium
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-24
+closed:
+---
+
+# Clean up Colab widget styling
+
+Make ScreamingFace notebook surfaces follow Colab's active theme, keep the live evaluation table
+readable at narrow output widths, preserve horizontal scroll during updates, and own their spacing
+instead of relying on host defaults.

--- a/docs/work/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/work/2026-08-24-OME-955-colab-widget-styling.md
@@ -38,15 +38,30 @@ evaluation table usable at narrow output widths without losing horizontal positi
 - Focused tests and the complete ScreamingFace quality gates pass.
 - Work is committed and pushed without opening a PR.
 
+## Review follow-up
+
+- Remove the unused static `evaluation_panel_html` composition and make tests exercise the same
+  fragments consumed by the live widget.
+- Make the stable `widgets.HTML` table node the sole focusable horizontal-scroll owner; remove the
+  inert nested region/focus target while retaining the table caption and a descriptive tooltip.
+- Give the live widget root a descriptive tooltip and lower Colab selector specificity so the
+  existing JupyterLab and VS Code host selectors remain authoritative.
+- Pin the actual runtime composition, focus ownership, and host precedence with regressions before
+  updating the draft PR.
+
 ## Outcome
 
-- **Actual files:** shared notebook theme tokens, evaluation static HTML, a focused live ipywidgets
-  host, its internal observer import, focused UI/report regressions, and the OME-955 SDLC artifacts.
-- **Commits:** `fix(screamingface): clean up Colab widget styling`
-- **Gates:** 69 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
+- **Actual files:** shared notebook theme tokens, the runtime evaluation fragment projection, a
+  focused live ipywidgets host, its internal observer import, focused UI/report regressions, and the
+  OME-955 SDLC artifacts. Review follow-up removed the dead static panel composition and made the
+  stable table HTML widget the only scroll/focus owner.
+- **Commits:** `fix(screamingface): clean up Colab widget styling`;
+  `fix(screamingface): align Colab widget runtime semantics`
+- **Gates:** 94 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
   formatting, Pyright, the full pytest suite at the 95% coverage floor, notebook checks, package
   build, and distribution validation.
 - **Deviations:** the append-only assertion gate was skipped because this owner-approved ticket
-  intentionally replaces the inherited no-horizontal-overflow contract. The in-app browser had no
-  connected runtime, so deterministic CSS/DOM and real-ipywidgets verification replaced screenshot
-  inspection; owner Colab visual verification remains before PR readiness.
+  intentionally replaces the inherited no-horizontal-overflow contract and the review explicitly
+  corrected tests that targeted a dead static path. The in-app browser had no connected runtime, so
+  deterministic CSS/DOM and real-ipywidgets verification replaced screenshot inspection; owner
+  Colab visual verification remains before PR readiness.

--- a/docs/work/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/work/2026-08-24-OME-955-colab-widget-styling.md
@@ -54,6 +54,8 @@ evaluation table usable at narrow output widths without losing horizontal positi
 - Keep Status to lifecycle plus elapsed time so long grading coverage cannot overflow into Cases.
 - Render incomplete grading coverage as a muted second line beneath the Score it qualifies.
 - Keep fully graded Score cells single-line and preserve the existing Cases execution meaning.
+- Raise the numeric alignment selector above the table-cell base rule so Cases, Score, Cost, and
+  Cache Hit share a right edge in the rendered Colab table.
 
 ## Outcome
 
@@ -64,8 +66,9 @@ evaluation table usable at narrow output widths without losing horizontal positi
   qualifiers beneath Score so Status remains lifecycle plus elapsed time without column overlap.
 - **Commits:** `fix(screamingface): clean up Colab widget styling`;
   `fix(screamingface): align Colab widget runtime semantics`;
-  `fix(screamingface): keep grading coverage with Score`
-- **Gates:** 96 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
+  `fix(screamingface): keep grading coverage with Score`;
+  `fix(screamingface): align numeric evaluation columns`
+- **Gates:** 97 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
   formatting, Pyright, the full pytest suite at the 95% coverage floor, notebook checks, package
   build, and distribution validation.
 - **Deviations:** the append-only assertion gate was skipped because this owner-approved ticket

--- a/docs/work/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/work/2026-08-24-OME-955-colab-widget-styling.md
@@ -49,15 +49,23 @@ evaluation table usable at narrow output widths without losing horizontal positi
 - Pin the actual runtime composition, focus ownership, and host precedence with regressions before
   updating the draft PR.
 
+## Colab visual follow-up
+
+- Keep Status to lifecycle plus elapsed time so long grading coverage cannot overflow into Cases.
+- Render incomplete grading coverage as a muted second line beneath the Score it qualifies.
+- Keep fully graded Score cells single-line and preserve the existing Cases execution meaning.
+
 ## Outcome
 
 - **Actual files:** shared notebook theme tokens, the runtime evaluation fragment projection, a
   focused live ipywidgets host, its internal observer import, focused UI/report regressions, and the
   OME-955 SDLC artifacts. Review follow-up removed the dead static panel composition and made the
-  stable table HTML widget the only scroll/focus owner.
+  stable table HTML widget the only scroll/focus owner. Colab visual follow-up moved result
+  qualifiers beneath Score so Status remains lifecycle plus elapsed time without column overlap.
 - **Commits:** `fix(screamingface): clean up Colab widget styling`;
-  `fix(screamingface): align Colab widget runtime semantics`
-- **Gates:** 94 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
+  `fix(screamingface): align Colab widget runtime semantics`;
+  `fix(screamingface): keep grading coverage with Score`
+- **Gates:** 96 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
   formatting, Pyright, the full pytest suite at the 95% coverage floor, notebook checks, package
   build, and distribution validation.
 - **Deviations:** the append-only assertion gate was skipped because this owner-approved ticket

--- a/docs/work/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/work/2026-08-24-OME-955-colab-widget-styling.md
@@ -1,0 +1,52 @@
+---
+ticket: OME-955
+stack: screamingface
+status: in_progress
+started: 2026-08-24
+finished:
+---
+
+# OME-955 — Clean up Colab widget styling
+
+## Intent
+
+Make shared ScreamingFace notebook styling respect Colab's explicit theme and make the live
+evaluation table usable at narrow output widths without losing horizontal position during updates.
+
+## Planned changes
+
+- Add the missing OME-955 task, approved spec, plan, and ledger artifacts.
+- Update `packages/screamingface/src/screamingface/_ui/style.py` with explicit Colab host selectors.
+- Update the evaluation HTML view with header-owned spacing and a readable table floor, then move
+  the live ipywidgets host into a focused module with a stable scroll container.
+- Add deterministic regressions in the focused shared-style, evaluation, and report test surfaces.
+
+## Test plan
+
+- RED: light and dark Colab selectors override the generic media preference using the unchanged
+  SFDS token sets; JupyterLab and VS Code selectors remain.
+- RED: a narrow Candidate table exposes labelled horizontal overflow, an 820 px floor, and no
+  overlapping/compressed column contract.
+- RED: the live view preserves the identity of its scroll-owning widget across all render phases.
+- GREEN: existing evaluation content, progress, accessibility, report, JupyterLab, and VS Code
+  tests remain unchanged unless the approved narrow-overflow contract directly replaces them.
+
+## Acceptance
+
+- Every observable OME-955 acceptance criterion is pinned by deterministic tests.
+- Light and dark renders use exact SFDS v2 tokens and no raw new visual values.
+- Focused tests and the complete ScreamingFace quality gates pass.
+- Work is committed and pushed without opening a PR.
+
+## Outcome
+
+- **Actual files:** shared notebook theme tokens, evaluation static HTML, a focused live ipywidgets
+  host, its internal observer import, focused UI/report regressions, and the OME-955 SDLC artifacts.
+- **Commits:** `fix(screamingface): clean up Colab widget styling`
+- **Gates:** 69 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
+  formatting, Pyright, the full pytest suite at the 95% coverage floor, notebook checks, package
+  build, and distribution validation.
+- **Deviations:** the append-only assertion gate was skipped because this owner-approved ticket
+  intentionally replaces the inherited no-horizontal-overflow contract. The in-app browser had no
+  connected runtime, so deterministic CSS/DOM and real-ipywidgets verification replaced screenshot
+  inspection; owner Colab visual verification remains before PR readiness.

--- a/packages/screamingface/src/screamingface/_evaluation/progress.py
+++ b/packages/screamingface/src/screamingface/_evaluation/progress.py
@@ -73,7 +73,7 @@ def _notebook_observer(
     """
 
     try:
-        from screamingface._ui.evaluation_view import _NotebookEvaluationView
+        from screamingface._ui.evaluation_widget import _NotebookEvaluationView
 
         return _NotebookEvaluationView(
             candidates,

--- a/packages/screamingface/src/screamingface/_ui/evaluation_state.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_state.py
@@ -71,7 +71,7 @@ class _CandidateProgress:
                 case.grade is not None and case.grade.score is not None
                 for case in self.result.cases
             )
-            qualifier = f"{graded}/{len(self.result.cases)} graded"
+            qualifier = f"{graded} / {len(self.result.cases)} graded"
         elif self.result.failures:
             qualifier = "Warnings"
         else:

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -63,7 +63,7 @@ _STYLE = (
   font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11.5px;color:var(--sf-ink-2);font-variant-numeric:tabular-nums}
 .sf-eval__receipt-success{color:var(--sf-success);font-weight:500}
-.sf-eval__num{text-align:right}
+.sf-eval__table .sf-eval__num{text-align:right}
 .sf-eval__err{margin-top:10px;padding:8px 10px;border-left:2px solid var(--sf-blind);
   background:var(--sf-blind-bg);color:var(--sf-blind);font-family:"IBM Plex Mono",ui-monospace,
   monospace;font-size:12px;white-space:pre-wrap}

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -2,23 +2,17 @@
 
 from __future__ import annotations
 
-import threading
-import time
-from collections.abc import Callable
 from decimal import Decimal
 from html import escape
-from typing import Any
 
-from screamingface._evaluation.model import Candidate
 from screamingface._ui.evaluation_state import _CandidateProgress, _EvaluationProgress
 from screamingface._ui.style import FUSION_GRADIENT, STYLE
-from screamingface.events import Event
-from screamingface.report import Report
 
 _STYLE = (
     STYLE
     + """<style>
-.sf-eval{border:0;padding:4px 0 14px;font-family:"IBM Plex Sans",system-ui,sans-serif}
+.sf-eval{border:0;padding:0 0 14px;font-family:"IBM Plex Sans",system-ui,sans-serif}
+.sf-eval__header{padding:4px 14px 0}
 .sf-eval__title-row{display:flex;align-items:baseline;justify-content:space-between;gap:16px}
 .sf-eval__title{font-size:20px;font-weight:600;line-height:1.2;letter-spacing:-.01em}
 .sf-eval__title-state{flex:0 0 auto;text-align:right;white-space:nowrap;
@@ -30,8 +24,10 @@ _STYLE = (
 .sf-eval__overall-track{height:8px;background:var(--sf-line);overflow:hidden}
 .sf-eval__overall-fill{display:block;height:100%;background-repeat:no-repeat;
   background-position:right center;transition:width .11s linear}
-.sf-eval__table-wrap{margin-top:12px;border:1px solid var(--sf-line)}
-.sf-eval__table{width:100%;table-layout:fixed;border-collapse:collapse;
+.sf-eval__table-wrap{margin-top:12px;border:1px solid var(--sf-line);overflow-x:auto}
+.sf-eval__table-scroll{overflow-x:auto}
+.sf-eval__table-scroll .sf-eval__table-wrap{overflow:visible}
+.sf-eval__table{width:100%;min-width:820px;table-layout:fixed;border-collapse:collapse;
   font-family:"IBM Plex Mono",ui-monospace,monospace;font-size:13px;
   font-variant-numeric:tabular-nums}
 .sf-eval__col--candidate{width:27%}
@@ -84,6 +80,20 @@ def evaluation_panel_html(
     title = escape(benchmark) if benchmark else "Evaluation"
     return (
         f"{_STYLE}<div class='sf-ui sf-eval' aria-label='ScreamingFace evaluation progress'>"
+        f"{_evaluation_header_html(progress, title, check_disclosure)}"
+        f"{_candidate_table_html(progress, elapsed)}"
+        f"{_terminal_html(progress)}"
+        "</div>"
+    )
+
+
+def _evaluation_header_html(
+    progress: _EvaluationProgress,
+    title: str,
+    check_disclosure: str | None,
+) -> str:
+    return (
+        "<div class='sf-eval__header'>"
         "<div class='sf-eval__title-row'>"
         f"<div class='sf-eval__title'>{title}</div>"
         f"{_title_state_html(progress)}"
@@ -91,10 +101,14 @@ def evaluation_panel_html(
         f"{_note_html(check_disclosure)}"
         f"{_overall_progress_html(progress)}"
         f"{_receipt_html(progress)}"
-        f"{_candidate_table_html(progress, elapsed)}"
+        "</div>"
+    )
+
+
+def _terminal_html(progress: _EvaluationProgress) -> str:
+    return (
         f"{_error_html(progress)}"
         f"<div class='sf-eval__announce' aria-live='polite'>{escape(progress.announcement)}</div>"
-        "</div>"
     )
 
 
@@ -209,7 +223,8 @@ def _candidate_table_html(progress: _EvaluationProgress, elapsed: float | None) 
         for name in ("candidate", "status", "cases", "score", "cost", "cache")
     )
     return (
-        "<div class='sf-eval__table-wrap'>"
+        "<div class='sf-eval__table-wrap' role='region' "
+        "aria-label='Candidate evaluation table' tabindex='0'>"
         "<table class='sf-eval__table'>"
         "<caption>Candidate Evaluation progress</caption>"
         f"<colgroup>{columns}</colgroup>"
@@ -311,113 +326,6 @@ def _duration(seconds: float) -> str:
     hours, minutes = divmod(minutes, 60)
     hour_unit = "hr" if hours == 1 else "hrs"
     return f"{hours}{hour_unit} {minutes:02d}min"
-
-
-class _NotebookEvaluationView:
-    _TICK_SECONDS = 1.0
-    _COALESCE_SECONDS = 0.1
-    _MAX_TICK_SECONDS = 6 * 60 * 60
-
-    def __init__(
-        self,
-        candidates: tuple[Candidate, ...],
-        case_count: int | None,
-        benchmark: str | None = None,
-        *,
-        check_disclosure: str | None = None,
-        clock: Callable[[], float] | None = None,
-        tick: bool = True,
-    ) -> None:
-        import ipywidgets as widgets
-
-        self._progress = _EvaluationProgress(candidates=candidates, case_count=case_count)
-        self._benchmark = benchmark
-        self._check_disclosure = check_disclosure
-        self._clock = time.monotonic if clock is None else clock
-        self._started = self._clock()
-        self._lock = threading.Lock()
-        self._done = threading.Event()
-        self._dirty = threading.Event()
-        self._tick = tick
-        self._html: Any = widgets.HTML(value=self._render())
-        self._shown = False
-        self._show()
-        if tick:
-            self._ticker = threading.Thread(
-                target=self._tick_loop,
-                name="screamingface-progress",
-                daemon=True,
-            )
-            self._ticker.start()
-
-    def observe(self, candidate: Candidate, event: Event) -> None:
-        with self._lock:
-            self._progress.observe(
-                candidate,
-                event,
-                elapsed_seconds=self._clock() - self._started,
-            )
-            if not self._tick:
-                self._html.value = self._render()
-        self._dirty.set()
-
-    def begin(self, candidate: Candidate) -> None:
-        with self._lock:
-            self._progress.begin(candidate)
-            if not self._tick:
-                self._html.value = self._render()
-        self._dirty.set()
-
-    def reconcile(self, report: Report) -> None:
-        with self._lock:
-            self._progress.reconcile(report)
-            self._html.value = self._render()
-        self._done.set()
-        self._dirty.set()
-
-    def abort(self, exc: BaseException) -> None:
-        with self._lock:
-            self._progress.abort(exc)
-            self._html.value = self._render()
-        self._done.set()
-        self._dirty.set()
-
-    def close(self) -> None:
-        self._done.set()
-        self._dirty.set()
-
-    def _render(self) -> str:
-        elapsed = None if self._progress.finished else self._clock() - self._started
-        return evaluation_panel_html(
-            self._progress, self._benchmark, elapsed, self._check_disclosure
-        )
-
-    def _tick_loop(self) -> None:
-        deadline = self._started + self._MAX_TICK_SECONDS
-        while not self._done.is_set():
-            dirty = self._dirty.wait(self._TICK_SECONDS)
-            self._dirty.clear()
-            if self._done.is_set():
-                break
-            if dirty and self._done.wait(self._COALESCE_SECONDS):
-                break
-            if self._clock() >= deadline:
-                break
-            try:
-                with self._lock:
-                    if self._progress.finished:
-                        break
-                    self._html.value = self._render()
-            except Exception:
-                break
-
-    def _show(self) -> None:
-        if self._shown:
-            return
-        from IPython.display import display
-
-        display(self._html)
-        self._shown = True
 
 
 __all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -71,19 +71,17 @@ _STYLE = (
 )
 
 
-def evaluation_panel_html(
+def _evaluation_fragments(
     progress: _EvaluationProgress,
     benchmark: str | None = None,
     elapsed: float | None = None,
     check_disclosure: str | None = None,
-) -> str:
+) -> tuple[str, str, str]:
     title = escape(benchmark) if benchmark else "Evaluation"
     return (
-        f"{_STYLE}<div class='sf-ui sf-eval' aria-label='ScreamingFace evaluation progress'>"
-        f"{_evaluation_header_html(progress, title, check_disclosure)}"
-        f"{_candidate_table_html(progress, elapsed)}"
-        f"{_terminal_html(progress)}"
-        "</div>"
+        _STYLE + _evaluation_header_html(progress, title, check_disclosure),
+        _candidate_table_html(progress, elapsed),
+        _terminal_html(progress),
     )
 
 
@@ -223,8 +221,7 @@ def _candidate_table_html(progress: _EvaluationProgress, elapsed: float | None) 
         for name in ("candidate", "status", "cases", "score", "cost", "cache")
     )
     return (
-        "<div class='sf-eval__table-wrap' role='region' "
-        "aria-label='Candidate evaluation table' tabindex='0'>"
+        "<div class='sf-eval__table-wrap'>"
         "<table class='sf-eval__table'>"
         "<caption>Candidate Evaluation progress</caption>"
         f"<colgroup>{columns}</colgroup>"

--- a/packages/screamingface/src/screamingface/_ui/evaluation_view.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_view.py
@@ -57,6 +57,8 @@ _STYLE = (
 .sf-eval__status--timed_out .sf-eval__status-sq{background:var(--sf-danger-solid)}
 .sf-eval__cases{color:var(--sf-ink);white-space:nowrap}
 .sf-eval__unavailable{color:var(--sf-ink-2);white-space:nowrap}
+.sf-eval__score-detail{display:block;margin-top:4px;color:var(--sf-ink-2);font-size:11px;
+  line-height:1.2;white-space:nowrap}
 .sf-eval__receipt{margin-top:7px;min-height:1.45em;
   font-family:"IBM Plex Mono",ui-monospace,monospace;
   font-size:11.5px;color:var(--sf-ink-2);font-variant-numeric:tabular-nums}
@@ -239,7 +241,7 @@ def _candidate_row_html(row: _CandidateProgress, elapsed: float | None) -> str:
         "timed_out": "Timed out",
         "not_run": "Not run",
     }[row.status]
-    details = [row.qualifier] if row.qualifier is not None else []
+    details: list[str] = []
     if row.status == "running" and elapsed is not None:
         started = row.started_elapsed_seconds or 0.0
         details.append(_duration(max(0.0, elapsed - started)))
@@ -253,6 +255,11 @@ def _candidate_row_html(row: _CandidateProgress, elapsed: float | None) -> str:
         if not row.score_available or row.score is None
         else f"{row.score:g}"
     )
+    score_detail = (
+        ""
+        if row.qualifier is None
+        else f"<span class='sf-eval__score-detail'>{escape(row.qualifier)}</span>"
+    )
     cost = "Not reported" if row.cost_usd is None else _money(row.cost_usd)
     cache = _cache_value(row)
     progress_html = _case_progress_html(row)
@@ -262,7 +269,7 @@ def _candidate_row_html(row: _CandidateProgress, elapsed: float | None) -> str:
         f"<td><span class='sf-eval__status sf-eval__status--{row.status}'>"
         f"<span class='sf-eval__status-sq' aria-hidden='true'></span>{status}{suffix}</span></td>"
         f"<td class='sf-eval__num'>{progress_html}</td>"
-        f"<td class='sf-eval__unavailable sf-eval__num'>{escape(score)}</td>"
+        f"<td class='sf-eval__unavailable sf-eval__num'>{escape(score)}{score_detail}</td>"
         f"<td class='sf-eval__unavailable sf-eval__num'>{escape(cost)}</td>"
         f"<td class='sf-eval__unavailable sf-eval__num'>{escape(cache)}</td></tr>"
     )

--- a/packages/screamingface/src/screamingface/_ui/evaluation_widget.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_widget.py
@@ -1,0 +1,158 @@
+"""Stable ipywidgets host for live Evaluation progress."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from html import escape
+from typing import Any
+
+from screamingface._evaluation.model import Candidate
+from screamingface._ui.evaluation_state import _EvaluationProgress
+from screamingface._ui.evaluation_view import (
+    _STYLE,
+    _candidate_table_html,
+    _evaluation_header_html,
+    _terminal_html,
+)
+from screamingface.events import Event
+from screamingface.report import Report
+
+
+class _NotebookEvaluationView:
+    _TICK_SECONDS = 1.0
+    _COALESCE_SECONDS = 0.1
+    _MAX_TICK_SECONDS = 6 * 60 * 60
+
+    def __init__(
+        self,
+        candidates: tuple[Candidate, ...],
+        case_count: int | None,
+        benchmark: str | None = None,
+        *,
+        check_disclosure: str | None = None,
+        clock: Callable[[], float] | None = None,
+        tick: bool = True,
+    ) -> None:
+        import ipywidgets as widgets
+
+        self._progress = _EvaluationProgress(candidates=candidates, case_count=case_count)
+        self._benchmark = benchmark
+        self._check_disclosure = check_disclosure
+        self._clock = time.monotonic if clock is None else clock
+        self._started = self._clock()
+        self._lock = threading.Lock()
+        self._done = threading.Event()
+        self._dirty = threading.Event()
+        self._tick = tick
+        self._header: Any = widgets.HTML(value=self._render_header())
+        self._table: Any = widgets.HTML(value=self._render_table())
+        self._terminal: Any = widgets.HTML(value=self._render_terminal())
+        # INVARIANT: this Box owns scrollLeft and is never replaced. Updating the HTML child may
+        # replace table rows, but Colab keeps the user's horizontal position on this stable node.
+        self._table_scroll: Any = widgets.Box(
+            children=(self._table,),
+            layout=widgets.Layout(overflow="auto", width="100%"),
+            tabbable=True,
+            tooltip="Candidate evaluation table",
+        )
+        self._table_scroll.add_class("sf-eval__table-scroll")
+        self._html: Any = widgets.VBox(children=(self._header, self._table_scroll, self._terminal))
+        self._html.add_class("sf-ui")
+        self._html.add_class("sf-eval")
+        self._shown = False
+        self._show()
+        if tick:
+            self._ticker = threading.Thread(
+                target=self._tick_loop,
+                name="screamingface-progress",
+                daemon=True,
+            )
+            self._ticker.start()
+
+    def observe(self, candidate: Candidate, event: Event) -> None:
+        with self._lock:
+            self._progress.observe(
+                candidate,
+                event,
+                elapsed_seconds=self._clock() - self._started,
+            )
+            if not self._tick:
+                self._refresh()
+        self._dirty.set()
+
+    def begin(self, candidate: Candidate) -> None:
+        with self._lock:
+            self._progress.begin(candidate)
+            if not self._tick:
+                self._refresh()
+        self._dirty.set()
+
+    def reconcile(self, report: Report) -> None:
+        with self._lock:
+            self._progress.reconcile(report)
+            self._refresh()
+        self._done.set()
+        self._dirty.set()
+
+    def abort(self, exc: BaseException) -> None:
+        with self._lock:
+            self._progress.abort(exc)
+            self._refresh()
+        self._done.set()
+        self._dirty.set()
+
+    def close(self) -> None:
+        self._done.set()
+        self._dirty.set()
+
+    def _render_header(self) -> str:
+        title = escape(self._benchmark) if self._benchmark else "Evaluation"
+        return _STYLE + _evaluation_header_html(
+            self._progress,
+            title,
+            self._check_disclosure,
+        )
+
+    def _render_table(self) -> str:
+        elapsed = None if self._progress.finished else self._clock() - self._started
+        return _candidate_table_html(self._progress, elapsed)
+
+    def _render_terminal(self) -> str:
+        return _terminal_html(self._progress)
+
+    def _refresh(self) -> None:
+        self._header.value = self._render_header()
+        self._table.value = self._render_table()
+        self._terminal.value = self._render_terminal()
+
+    def _tick_loop(self) -> None:
+        deadline = self._started + self._MAX_TICK_SECONDS
+        while not self._done.is_set():
+            dirty = self._dirty.wait(self._TICK_SECONDS)
+            self._dirty.clear()
+            if self._done.is_set():
+                break
+            if dirty and self._done.wait(self._COALESCE_SECONDS):
+                break
+            if self._clock() >= deadline:
+                break
+            try:
+                with self._lock:
+                    if self._progress.finished:
+                        break
+                    self._refresh()
+            except Exception:
+                break
+
+    def _show(self) -> None:
+        if self._shown:
+            return
+        from IPython.display import display
+
+        display(self._html)
+        self._shown = True
+
+
+__all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_ui/evaluation_widget.py
+++ b/packages/screamingface/src/screamingface/_ui/evaluation_widget.py
@@ -5,17 +5,11 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Callable
-from html import escape
 from typing import Any
 
 from screamingface._evaluation.model import Candidate
 from screamingface._ui.evaluation_state import _EvaluationProgress
-from screamingface._ui.evaluation_view import (
-    _STYLE,
-    _candidate_table_html,
-    _evaluation_header_html,
-    _terminal_html,
-)
+from screamingface._ui.evaluation_view import _evaluation_fragments
 from screamingface.events import Event
 from screamingface.report import Report
 
@@ -46,19 +40,22 @@ class _NotebookEvaluationView:
         self._done = threading.Event()
         self._dirty = threading.Event()
         self._tick = tick
-        self._header: Any = widgets.HTML(value=self._render_header())
-        self._table: Any = widgets.HTML(value=self._render_table())
-        self._terminal: Any = widgets.HTML(value=self._render_terminal())
-        # INVARIANT: this Box owns scrollLeft and is never replaced. Updating the HTML child may
-        # replace table rows, but Colab keeps the user's horizontal position on this stable node.
-        self._table_scroll: Any = widgets.Box(
-            children=(self._table,),
+        header, table, terminal = self._render_fragments()
+        self._header: Any = widgets.HTML(value=header)
+        # INVARIANT: this HTML widget owns scrollLeft and is never replaced. Value updates replace
+        # its table descendants while Colab keeps the scroll position on this stable root node.
+        self._table: Any = widgets.HTML(
+            value=table,
             layout=widgets.Layout(overflow="auto", width="100%"),
             tabbable=True,
             tooltip="Candidate evaluation table",
         )
-        self._table_scroll.add_class("sf-eval__table-scroll")
-        self._html: Any = widgets.VBox(children=(self._header, self._table_scroll, self._terminal))
+        self._table.add_class("sf-eval__table-scroll")
+        self._terminal: Any = widgets.HTML(value=terminal)
+        self._html: Any = widgets.VBox(
+            children=(self._header, self._table, self._terminal),
+            tooltip="ScreamingFace evaluation progress",
+        )
         self._html.add_class("sf-ui")
         self._html.add_class("sf-eval")
         self._shown = False
@@ -107,25 +104,20 @@ class _NotebookEvaluationView:
         self._done.set()
         self._dirty.set()
 
-    def _render_header(self) -> str:
-        title = escape(self._benchmark) if self._benchmark else "Evaluation"
-        return _STYLE + _evaluation_header_html(
+    def _render_fragments(self) -> tuple[str, str, str]:
+        elapsed = None if self._progress.finished else self._clock() - self._started
+        return _evaluation_fragments(
             self._progress,
-            title,
+            self._benchmark,
+            elapsed,
             self._check_disclosure,
         )
 
-    def _render_table(self) -> str:
-        elapsed = None if self._progress.finished else self._clock() - self._started
-        return _candidate_table_html(self._progress, elapsed)
-
-    def _render_terminal(self) -> str:
-        return _terminal_html(self._progress)
-
     def _refresh(self) -> None:
-        self._header.value = self._render_header()
-        self._table.value = self._render_table()
-        self._terminal.value = self._render_terminal()
+        header, table, terminal = self._render_fragments()
+        self._header.value = header
+        self._table.value = table
+        self._terminal.value = terminal
 
     def _tick_loop(self) -> None:
         deadline = self._started + self._MAX_TICK_SECONDS

--- a/packages/screamingface/src/screamingface/_ui/style.py
+++ b/packages/screamingface/src/screamingface/_ui/style.py
@@ -68,6 +68,8 @@ STYLE = f"""<style>
   font-size:13px;line-height:1.45;
 }}
 @media (prefers-color-scheme:dark){{.sf-ui{{{_DARK}}}}}
+html[theme="light"] .sf-ui{{{_LIGHT}}}
+html[theme="dark"] .sf-ui{{{_DARK}}}
 .jp-mod-theme-dark .sf-ui,[data-jp-theme-light="false"] .sf-ui,
 .vscode-dark .sf-ui,.vscode-high-contrast .sf-ui{{{_DARK}}}
 .jp-mod-theme-light .sf-ui,[data-jp-theme-light="true"] .sf-ui,

--- a/packages/screamingface/src/screamingface/_ui/style.py
+++ b/packages/screamingface/src/screamingface/_ui/style.py
@@ -68,8 +68,8 @@ STYLE = f"""<style>
   font-size:13px;line-height:1.45;
 }}
 @media (prefers-color-scheme:dark){{.sf-ui{{{_DARK}}}}}
-html[theme="light"] .sf-ui{{{_LIGHT}}}
-html[theme="dark"] .sf-ui{{{_DARK}}}
+:where(html[theme="light"]) .sf-ui{{{_LIGHT}}}
+:where(html[theme="dark"]) .sf-ui{{{_DARK}}}
 .jp-mod-theme-dark .sf-ui,[data-jp-theme-light="false"] .sf-ui,
 .vscode-dark .sf-ui,.vscode-high-contrast .sf-ui{{{_DARK}}}
 .jp-mod-theme-light .sf-ui,[data-jp-theme-light="true"] .sf-ui,

--- a/packages/screamingface/tests/test_check_disclosure_display.py
+++ b/packages/screamingface/tests/test_check_disclosure_display.py
@@ -20,10 +20,19 @@ from screamingface._evaluation import progress as progress_module
 from screamingface._evaluation.model import _compiled_candidate, _compiled_operation
 from screamingface._evaluation.progress import _progress_observer
 from screamingface._ui.evaluation_state import _EvaluationProgress
-from screamingface._ui.evaluation_view import evaluation_panel_html
+from screamingface._ui.evaluation_view import _evaluation_fragments
 from screamingface.warnings import EvaluationWarning
 
 _DISCLOSURE = "Benchmark 'draco' may make up to 6 paid check calls (6 per case x 1 cases)"
+
+
+def _runtime_fragments_html(
+    state: _EvaluationProgress,
+    benchmark: str | None,
+    elapsed: float | None,
+    check_disclosure: str | None,
+) -> str:
+    return "".join(_evaluation_fragments(state, benchmark, elapsed, check_disclosure))
 
 
 def _headless_stream() -> io.StringIO:
@@ -115,13 +124,13 @@ def test_no_disclosure_never_warns() -> None:
 
 
 def test_the_panel_renders_the_disclosure_line() -> None:
-    html = evaluation_panel_html(_panel_progress(), "draco", None, "up to 6 paid check <calls>")
+    html = _runtime_fragments_html(_panel_progress(), "draco", None, "up to 6 paid check <calls>")
     assert "sf-eval__note" in html
     assert "check surface · up to 6 paid check &lt;calls&gt;" in html
 
 
 def test_the_panel_omits_the_line_without_a_disclosure() -> None:
-    html = evaluation_panel_html(_panel_progress(), "draco", None, None)
+    html = _runtime_fragments_html(_panel_progress(), "draco", None, None)
     # The class exists in the stylesheet either way; the LINE must not render.
     assert "check surface ·" not in html
     assert "<div class='sf-eval__note'>" not in html

--- a/packages/screamingface/tests/test_evaluation_progress_panel.py
+++ b/packages/screamingface/tests/test_evaluation_progress_panel.py
@@ -10,11 +10,20 @@ from screamingface._ui.evaluation_state import _EvaluationProgress
 from screamingface._ui.evaluation_view import (
     _compact,
     _duration,
+    _evaluation_fragments,
     _money,
-    evaluation_panel_html,
 )
 
 _START = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+
+
+def _runtime_fragments_html(
+    state: _EvaluationProgress,
+    benchmark: str | None = None,
+    elapsed: float | None = None,
+    check_disclosure: str | None = None,
+) -> str:
+    return "".join(_evaluation_fragments(state, benchmark, elapsed, check_disclosure))
 
 
 def candidate(name: str = "opus", model: str = "provider/opus") -> Candidate:
@@ -151,7 +160,7 @@ def test_panel_collapses_live_receipt_before_evidence_exists() -> None:
     opus = candidate()
     state = progress(opus)
 
-    initial = evaluation_panel_html(state)
+    initial = _runtime_fragments_html(state)
     assert "<div class='sf-eval__receipt'" not in initial
     assert ".sf-eval__table-wrap{margin-top:12px" in initial
 
@@ -169,7 +178,7 @@ def test_panel_collapses_live_receipt_before_evidence_exists() -> None:
         ),
     )
 
-    html = evaluation_panel_html(state)
+    html = _runtime_fragments_html(state)
     assert "<div class='sf-eval__receipt'>" in html
     assert "<div class='sf-eval__receipt' aria-hidden='true'>" not in html
     assert "cost $0.25 · 2 model calls · 2.0k in / 500 out" in html
@@ -198,10 +207,10 @@ def test_fully_cached_receipt_tells_the_success_story_without_zero_telemetry() -
             usage=sf.Usage(input_tokens=0, output_tokens=0, cost_usd=Decimal("0")),
         ),
     )
-    assert "fully cached" not in evaluation_panel_html(state)
+    assert "fully cached" not in _runtime_fragments_html(state)
     reconcile_complete(state, opus)
 
-    html = evaluation_panel_html(state)
+    html = _runtime_fragments_html(state)
     receipt = html.split("<div class='sf-eval__receipt'>", 1)[1].split("</div>", 1)[0]
 
     assert "2 model calls · " in receipt
@@ -224,7 +233,7 @@ def test_fully_cached_receipt_requires_cache_evidence_for_every_model_call() -> 
     )
     state.observe(opus, model_span(2, input_tokens=0, output_tokens=0))
 
-    html = evaluation_panel_html(state)
+    html = _runtime_fragments_html(state)
     receipt = html.split("<div class='sf-eval__receipt'>", 1)[1].split("</div>", 1)[0]
 
     assert "fully cached" not in receipt
@@ -332,7 +341,7 @@ def test_panel_escapes_candidate_identity_and_global_errors() -> None:
     state = progress(selected)
     state.abort(RuntimeError("bad <payload>"))
 
-    html = evaluation_panel_html(state, "DRACO <private>")
+    html = _runtime_fragments_html(state, "DRACO <private>")
 
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
@@ -345,7 +354,7 @@ def test_panel_omits_aggregate_cache_band_even_when_evidence_exists() -> None:
     opus = candidate()
     state = progress(opus)
     state.observe(opus, model_span(1, cache_status="bypass", cache_reason="opted_out"))
-    html = evaluation_panel_html(state)
+    html = _runtime_fragments_html(state)
 
     assert "<div class='sf-eval__cache'>" not in html
     assert "no cache activity reported" not in html
@@ -356,7 +365,7 @@ def test_panel_omits_aggregate_cache_band_even_when_evidence_exists() -> None:
 
 
 def test_panel_omits_run_activity_section() -> None:
-    html = evaluation_panel_html(progress())
+    html = _runtime_fragments_html(progress())
 
     assert "<details" not in html
     assert "Run activity" not in html

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -678,6 +678,14 @@ def test_numeric_candidate_columns_are_right_aligned() -> None:
     assert row.count("sf-eval__num") == 4
 
 
+def test_numeric_alignment_rule_beats_the_base_table_cell_rule() -> None:
+    progress = _EvaluationProgress(candidates=(candidate("opus"),), case_count=1)
+
+    html = _runtime_fragments_html(progress, "DRACO")
+
+    assert ".sf-eval__table .sf-eval__num{text-align:right}" in html
+
+
 def test_notebook_surface_uses_current_sfds_v2_tokens() -> None:
     assert "--sf-bg:#fcfdff" in STYLE
     assert "--sf-surface:#f4f6f9" in STYLE

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -868,8 +868,47 @@ def test_partial_result_names_exact_graded_coverage_and_keeps_final_duration() -
     )
 
     html = _runtime_fragments_html(progress, "DRACO")
-    assert "Finished · 1/2 graded · 1m 10s" in html
+    assert "Finished · 1m 10s" in html
+    assert "1 / 2 graded" in html
     assert "Finished · Partial" not in html
+
+
+def test_partial_grading_qualifies_the_score_without_overflowing_status() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=2)
+    progress.reconcile(
+        report_for(
+            opus,
+            score=0.3799,
+            case_count=2,
+            graded_case_count=1,
+            completed_seconds=70,
+        )
+    )
+
+    html = _runtime_fragments_html(progress, "DRACO")
+    row = html.split("<tbody>", 1)[1].split("</tr>", 1)[0]
+    cells = row.split("</td>")
+
+    assert "Finished · 1m 10s" in cells[1]
+    assert "graded" not in cells[1]
+    assert "2 / 2" in cells[2]
+    assert "0.3799" in cells[3]
+    assert "1 / 2 graded" in cells[3]
+    assert "sf-eval__score-detail" in cells[3]
+
+
+def test_fully_graded_score_remains_single_line() -> None:
+    opus = candidate("opus")
+    progress = _EvaluationProgress(candidates=(opus,), case_count=2)
+    progress.reconcile(report_for(opus, score=0.3799, case_count=2))
+
+    html = _runtime_fragments_html(progress, "DRACO")
+    row = html.split("<tbody>", 1)[1].split("</tr>", 1)[0]
+    score_cell = row.split("</td>")[3]
+
+    assert "0.3799" in score_cell
+    assert "sf-eval__score-detail" not in score_cell
 
 
 def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -21,10 +21,19 @@ from screamingface._evaluation.runner import (
     _SyncEventObserver,
 )
 from screamingface._ui.evaluation_state import _EvaluationProgress
-from screamingface._ui.evaluation_view import evaluation_panel_html
+from screamingface._ui.evaluation_view import _evaluation_fragments
 from screamingface._ui.style import _DARK, _LIGHT, FUSION_GRADIENT, STYLE
 
 _START = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+
+
+def _runtime_fragments_html(
+    progress: _EvaluationProgress,
+    benchmark: str | None = None,
+    elapsed: float | None = None,
+    check_disclosure: str | None = None,
+) -> str:
+    return "".join(_evaluation_fragments(progress, benchmark, elapsed, check_disclosure))
 
 
 class _FakeLayout:
@@ -33,8 +42,22 @@ class _FakeLayout:
 
 
 class _FakeHTML:
-    def __init__(self, *, value: str) -> None:
+    def __init__(
+        self,
+        *,
+        value: str,
+        layout: _FakeLayout | None = None,
+        tabbable: bool | None = None,
+        tooltip: str | None = None,
+    ) -> None:
         self.value = value
+        self.layout = layout or _FakeLayout()
+        self.tabbable = tabbable
+        self.tooltip = tooltip
+        self._dom_classes: list[str] = []
+
+    def add_class(self, value: str) -> None:
+        self._dom_classes.append(value)
 
 
 class _FakeBox:
@@ -561,7 +584,7 @@ def test_terminal_engine_evidence_wins_over_workflow_abort_inference() -> None:
 
     assert progress.rows[0].status == "stopped"
 
-    html = evaluation_panel_html(progress, "DRACO", elapsed=20)
+    html = _runtime_fragments_html(progress, "DRACO", elapsed=20)
     table = html.split("<table", 1)[1].split("</table>", 1)[0]
     assert ">Stopped<" in table
     assert "Run stopped" not in table
@@ -605,7 +628,7 @@ def test_candidate_table_uses_the_approved_columns_and_truthful_values() -> None
     progress = _EvaluationProgress(candidates=(opus, gpt), case_count=100)
     progress.observe(opus, span(1, run_id="run_opus"))
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
 
     headers = ["Candidate", "Status", "Cases", "Score", "Cost", "Cache hit"]
     positions = [html.index(f">{header}<") for header in headers]
@@ -629,15 +652,15 @@ def test_candidate_table_uses_the_approved_columns_and_truthful_values() -> None
 def test_candidate_table_owns_the_responsive_scroll_boundary() -> None:
     progress = _EvaluationProgress(candidates=(candidate("opus"),), case_count=1)
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
 
     assert "sf-eval__table-wrap" in html
     assert "overflow-x:auto" in html
     assert ".sf-eval__table-scroll .sf-eval__table-wrap{overflow:visible}" in html
     assert "min-width:820px" in html
-    assert "tabindex='0'" in html
-    assert "role='region'" in html
-    assert "aria-label='Candidate evaluation table'" in html
+    assert "tabindex='0'" not in html
+    assert "role='region'" not in html
+    assert "aria-label='Candidate evaluation table'" not in html
     assert ".sf-eval{border:0;padding:0 0 14px;" in html
     assert ".sf-eval__header{padding:4px 14px 0}" in html
 
@@ -646,7 +669,7 @@ def test_numeric_candidate_columns_are_right_aligned() -> None:
     opus = candidate("opus")
     progress = _EvaluationProgress(candidates=(opus,), case_count=1)
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
 
     for header in ("Cases", "Score", "Cost", "Cache hit"):
         assert f"<th scope='col' class='sf-eval__num'>{header}</th>" in html
@@ -677,8 +700,8 @@ def test_notebook_surface_uses_current_sfds_v2_tokens() -> None:
 
 
 def test_colab_theme_attribute_overrides_the_generic_media_preference() -> None:
-    assert f'html[theme="light"] .sf-ui{{{_LIGHT}}}' in STYLE
-    assert f'html[theme="dark"] .sf-ui{{{_DARK}}}' in STYLE
+    assert f':where(html[theme="light"]) .sf-ui{{{_LIGHT}}}' in STYLE
+    assert f':where(html[theme="dark"]) .sf-ui{{{_DARK}}}' in STYLE
     assert "@media (prefers-color-scheme:dark)" in STYLE
     assert '.jp-mod-theme-dark .sf-ui,[data-jp-theme-light="false"] .sf-ui' in STYLE
     assert ".vscode-dark .sf-ui,.vscode-high-contrast .sf-ui" in STYLE
@@ -691,7 +714,7 @@ def test_candidate_table_matches_current_sfds_table_recipe() -> None:
     progress = _EvaluationProgress(candidates=(opus,), case_count=1)
     progress.abort(RuntimeError("failed"))
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
 
     assert "font-size:13px" in html
     assert "padding:12px 16px" in html
@@ -708,7 +731,7 @@ def test_candidate_table_has_no_inferred_phase_or_whole_table_live_region() -> N
     opus = candidate("opus")
     progress = _EvaluationProgress(candidates=(opus,), case_count=1)
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
 
     assert "Answering" not in html
     assert "Grading" not in html
@@ -735,7 +758,7 @@ def test_running_panel_has_stable_benchmark_title_and_canonical_static_status() 
         ),
     )
 
-    html = evaluation_panel_html(progress, "DRACO", elapsed=45)
+    html = _runtime_fragments_html(progress, "DRACO", elapsed=45)
 
     assert "<div class='sf-eval__title'>DRACO</div>" in html
     assert "<div class='sf-eval__title-state'>evaluating… · 0%</div>" in html
@@ -755,7 +778,7 @@ def test_overall_progress_uses_canonical_sfds_run_treatment() -> None:
     progress.observe(opus, span(1, run_id="run_opus"))
     progress.observe(gpt, span(1, run_id="run_gpt"))
 
-    html = evaluation_panel_html(progress, "DRACO", elapsed=45)
+    html = _runtime_fragments_html(progress, "DRACO", elapsed=45)
 
     assert "Overall progress" not in html
     assert "2 / 200 case runs" not in html
@@ -778,7 +801,7 @@ def test_opaque_url4_replay_keeps_an_unknown_denominator_truthful() -> None:
     progress = _EvaluationProgress(candidates=(opus,), case_count=None)
     progress.observe(opus, span(1, run_id="run_opus"))
 
-    html = evaluation_panel_html(progress, "URL4 replay")
+    html = _runtime_fragments_html(progress, "URL4 replay")
 
     assert "1 case finished" in html
     assert "max='None'" not in html
@@ -805,7 +828,7 @@ def test_aborted_evaluation_headline_does_not_claim_completion() -> None:
 
     progress.abort(KeyboardInterrupt())
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
     assert "Evaluation complete" not in html
     assert "Evaluation ended" not in html
     assert "<div class='sf-eval__title'>DRACO</div>" in html
@@ -822,7 +845,7 @@ def test_reconciled_evaluation_uses_complete_progress_state() -> None:
 
     progress.reconcile(report_for(opus))
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
     assert "<div class='sf-eval__title'>DRACO</div>" in html
     assert "<div class='sf-eval__title-state'>complete · 2s</div>" in html
     assert "complete · 100%" not in html
@@ -844,7 +867,7 @@ def test_partial_result_names_exact_graded_coverage_and_keeps_final_duration() -
         )
     )
 
-    html = evaluation_panel_html(progress, "DRACO")
+    html = _runtime_fragments_html(progress, "DRACO")
     assert "Finished · 1/2 graded · 1m 10s" in html
     assert "Finished · Partial" not in html
 
@@ -884,11 +907,11 @@ def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(
 
     assert "45s" in _widget_text(view._html)
 
-    scroll = view._table_scroll
+    scroll = view._table
     view.abort(RuntimeError("result decode failed"))
 
     assert view._done.is_set()
-    assert view._table_scroll is scroll
+    assert view._table is scroll
     assert "Run failed" in _widget_text(view._html)
     assert "result decode failed" in _widget_text(view._html)
 
@@ -918,7 +941,7 @@ def test_notebook_view_lifecycle_shows_once_and_reconciles_authoritative_report(
     view._show()
     assert displayed == [view._html]
 
-    scroll = view._table_scroll
+    scroll = view._table
     assert scroll.layout.overflow == "auto"
     assert scroll.layout.width == "100%"
     assert scroll.tabbable is True
@@ -928,11 +951,11 @@ def test_notebook_view_lifecycle_shows_once_and_reconciles_authoritative_report(
 
     view.begin(opus)
     assert view._dirty.is_set()
-    assert view._table_scroll is scroll
+    assert view._table is scroll
 
     view.reconcile(report_for(opus))
     assert view._done.is_set()
-    assert view._table_scroll is scroll
+    assert view._table is scroll
     assert "complete · 2s" in _widget_text(view._html)
     assert "Finished · 2s" in _widget_text(view._html)
 
@@ -957,11 +980,74 @@ def test_notebook_view_builds_a_real_focusable_ipywidgets_scroll_container(
     )
 
     assert isinstance(view._html, widgets.VBox)
-    assert isinstance(view._table_scroll, widgets.Box)
-    assert view._table_scroll.layout.overflow == "auto"
-    assert view._table_scroll.layout.width == "100%"
-    assert view._table_scroll.tabbable is True
-    assert view._table_scroll.tooltip == "Candidate evaluation table"
-    assert view._table_scroll.children == (view._table,)
+    assert isinstance(view._table, widgets.HTML)
+    assert view._table.layout.overflow == "auto"
+    assert view._table.layout.width == "100%"
+    assert view._table.tabbable is True
+    assert view._table.tooltip == "Candidate evaluation table"
 
     view.close()
+
+
+def test_live_widget_uses_one_runtime_fragment_projection(monkeypatch: Any) -> None:
+    from screamingface._ui import evaluation_widget
+    from screamingface._ui.evaluation_widget import _NotebookEvaluationView
+
+    monkeypatch.setattr(_NotebookEvaluationView, "_show", lambda self: None)
+    calls: list[tuple[str, float | None]] = []
+
+    def fragments(
+        progress: _EvaluationProgress,
+        benchmark: str | None,
+        elapsed: float | None,
+        check_disclosure: str | None,
+    ) -> tuple[str, str, str]:
+        del progress, check_disclosure
+        calls.append((benchmark or "", elapsed))
+        return "header", "table", "terminal"
+
+    monkeypatch.setattr(evaluation_widget, "_evaluation_fragments", fragments)
+    view = _NotebookEvaluationView(
+        (candidate("opus"),),
+        1,
+        "DRACO",
+        clock=lambda: 100.0,
+        tick=False,
+    )
+
+    assert calls == [("DRACO", 0.0)]
+    assert view._header.value == "header"
+    assert view._table.value == "table"
+    assert view._terminal.value == "terminal"
+
+    view.close()
+
+
+def test_table_html_widget_is_the_only_focusable_scroll_owner(monkeypatch: Any) -> None:
+    import ipywidgets as widgets
+
+    from screamingface._ui.evaluation_widget import _NotebookEvaluationView
+
+    monkeypatch.setattr(_NotebookEvaluationView, "_show", lambda self: None)
+    view = _NotebookEvaluationView(
+        (candidate("opus"),),
+        1,
+        "DRACO",
+        clock=lambda: 100.0,
+        tick=False,
+    )
+
+    assert isinstance(view._table, widgets.HTML)
+    assert view._table.layout.overflow == "auto"
+    assert view._table.tabbable is True
+    assert view._table.tooltip == "Candidate evaluation table"
+    assert "role='region'" not in view._table.value
+    assert "tabindex='0'" not in view._table.value
+    assert view._html.tooltip == "ScreamingFace evaluation progress"
+
+    view.close()
+
+
+def test_colab_theme_qualifiers_cannot_override_explicit_notebook_hosts() -> None:
+    assert f':where(html[theme="light"]) .sf-ui{{{_LIGHT}}}' in STYLE
+    assert f':where(html[theme="dark"]) .sf-ui{{{_DARK}}}' in STYLE

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -22,9 +22,57 @@ from screamingface._evaluation.runner import (
 )
 from screamingface._ui.evaluation_state import _EvaluationProgress
 from screamingface._ui.evaluation_view import evaluation_panel_html
-from screamingface._ui.style import FUSION_GRADIENT, STYLE
+from screamingface._ui.style import _DARK, _LIGHT, FUSION_GRADIENT, STYLE
 
 _START = datetime(2026, 8, 23, 12, 0, tzinfo=UTC)
+
+
+class _FakeLayout:
+    def __init__(self, **values: object) -> None:
+        self.__dict__.update(values)
+
+
+class _FakeHTML:
+    def __init__(self, *, value: str) -> None:
+        self.value = value
+
+
+class _FakeBox:
+    def __init__(
+        self,
+        *,
+        children: tuple[object, ...] = (),
+        layout: _FakeLayout | None = None,
+        tabbable: bool | None = None,
+        tooltip: str | None = None,
+    ) -> None:
+        self.children = children
+        self.layout = layout or _FakeLayout()
+        self.tabbable = tabbable
+        self.tooltip = tooltip
+        self._dom_classes: list[str] = []
+
+    def add_class(self, value: str) -> None:
+        self._dom_classes.append(value)
+
+
+class _FakeVBox(_FakeBox):
+    pass
+
+
+def _fake_widgets() -> SimpleNamespace:
+    return SimpleNamespace(
+        Box=_FakeBox,
+        HTML=_FakeHTML,
+        Layout=_FakeLayout,
+        VBox=_FakeVBox,
+    )
+
+
+def _widget_text(widget: object) -> str:
+    value = getattr(widget, "value", "")
+    children = getattr(widget, "children", ())
+    return str(value) + "".join(_widget_text(child) for child in children)
 
 
 def candidate(name: str) -> Candidate:
@@ -562,13 +610,9 @@ def test_candidate_table_uses_the_approved_columns_and_truthful_values() -> None
     headers = ["Candidate", "Status", "Cases", "Score", "Cost", "Cache hit"]
     positions = [html.index(f">{header}<") for header in headers]
     assert positions == sorted(positions)
+    assert html.count("scope='col'") == len(headers)
     assert "<table" in html
-    assert "sf-eval__table-wrap" in html
-    assert "overflow-x:auto" not in html
-    assert "min-width:820px" not in html
-    assert "tabindex='0'" not in html
     assert "table-layout:fixed" in html
-    assert ".sf-eval{border:0;padding:4px 0 14px;" in html
     widths = {"candidate": 27, "status": 17, "cases": 10, "score": 17, "cost": 14, "cache": 15}
     for name, width in widths.items():
         assert f".sf-eval__col--{name}{{width:{width}%}}" in html
@@ -580,6 +624,22 @@ def test_candidate_table_uses_the_approved_columns_and_truthful_values() -> None
     assert "1 / 100" in html
     assert "Not scored yet" in html
     assert "Not reported" in html
+
+
+def test_candidate_table_owns_the_responsive_scroll_boundary() -> None:
+    progress = _EvaluationProgress(candidates=(candidate("opus"),), case_count=1)
+
+    html = evaluation_panel_html(progress, "DRACO")
+
+    assert "sf-eval__table-wrap" in html
+    assert "overflow-x:auto" in html
+    assert ".sf-eval__table-scroll .sf-eval__table-wrap{overflow:visible}" in html
+    assert "min-width:820px" in html
+    assert "tabindex='0'" in html
+    assert "role='region'" in html
+    assert "aria-label='Candidate evaluation table'" in html
+    assert ".sf-eval{border:0;padding:0 0 14px;" in html
+    assert ".sf-eval__header{padding:4px 14px 0}" in html
 
 
 def test_numeric_candidate_columns_are_right_aligned() -> None:
@@ -614,6 +674,16 @@ def test_notebook_surface_uses_current_sfds_v2_tokens() -> None:
     assert "--sf-line:#35383d" in STYLE
     assert "--sf-line-2:#585c61" in STYLE
     assert "--sf-danger-solid:#ed413f" in STYLE
+
+
+def test_colab_theme_attribute_overrides_the_generic_media_preference() -> None:
+    assert f'html[theme="light"] .sf-ui{{{_LIGHT}}}' in STYLE
+    assert f'html[theme="dark"] .sf-ui{{{_DARK}}}' in STYLE
+    assert "@media (prefers-color-scheme:dark)" in STYLE
+    assert '.jp-mod-theme-dark .sf-ui,[data-jp-theme-light="false"] .sf-ui' in STYLE
+    assert ".vscode-dark .sf-ui,.vscode-high-contrast .sf-ui" in STYLE
+    assert '.jp-mod-theme-light .sf-ui,[data-jp-theme-light="true"] .sf-ui' in STYLE
+    assert ".vscode-light .sf-ui" in STYLE
 
 
 def test_candidate_table_matches_current_sfds_table_recipe() -> None:
@@ -782,13 +852,9 @@ def test_partial_result_names_exact_graded_coverage_and_keeps_final_duration() -
 def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(
     monkeypatch: Any,
 ) -> None:
-    from screamingface._ui.evaluation_view import _NotebookEvaluationView
+    from screamingface._ui.evaluation_widget import _NotebookEvaluationView
 
-    class HTML:
-        def __init__(self, *, value: str) -> None:
-            self.value = value
-
-    monkeypatch.setitem(sys.modules, "ipywidgets", SimpleNamespace(HTML=HTML))
+    monkeypatch.setitem(sys.modules, "ipywidgets", _fake_widgets())
     monkeypatch.setattr(_NotebookEvaluationView, "_show", lambda self: None)
     opus = candidate("opus")
     now = [100.0]
@@ -811,31 +877,29 @@ def test_notebook_view_clock_advances_and_abort_leaves_a_frozen_panel(
         ),
     )
 
-    assert "0s" in view._html.value
+    assert "0s" in _widget_text(view._html)
 
     now[0] += 45
-    view._html.value = view._render()
+    view._refresh()
 
-    assert "45s" in view._html.value
+    assert "45s" in _widget_text(view._html)
 
+    scroll = view._table_scroll
     view.abort(RuntimeError("result decode failed"))
 
     assert view._done.is_set()
-    assert "Run failed" in view._html.value
-    assert "result decode failed" in view._html.value
+    assert view._table_scroll is scroll
+    assert "Run failed" in _widget_text(view._html)
+    assert "result decode failed" in _widget_text(view._html)
 
 
 def test_notebook_view_lifecycle_shows_once_and_reconciles_authoritative_report(
     monkeypatch: Any,
 ) -> None:
-    from screamingface._ui.evaluation_view import _NotebookEvaluationView
+    from screamingface._ui.evaluation_widget import _NotebookEvaluationView
 
-    class HTML:
-        def __init__(self, *, value: str) -> None:
-            self.value = value
-
-    displayed: list[HTML] = []
-    monkeypatch.setitem(sys.modules, "ipywidgets", SimpleNamespace(HTML=HTML))
+    displayed: list[object] = []
+    monkeypatch.setitem(sys.modules, "ipywidgets", _fake_widgets())
     monkeypatch.setitem(
         sys.modules,
         "IPython.display",
@@ -854,13 +918,50 @@ def test_notebook_view_lifecycle_shows_once_and_reconciles_authoritative_report(
     view._show()
     assert displayed == [view._html]
 
+    scroll = view._table_scroll
+    assert scroll.layout.overflow == "auto"
+    assert scroll.layout.width == "100%"
+    assert scroll.tabbable is True
+    assert scroll.tooltip == "Candidate evaluation table"
+    assert scroll._dom_classes == ["sf-eval__table-scroll"]
+    assert view._html._dom_classes == ["sf-ui", "sf-eval"]
+
     view.begin(opus)
     assert view._dirty.is_set()
+    assert view._table_scroll is scroll
 
     view.reconcile(report_for(opus))
     assert view._done.is_set()
-    assert "complete · 2s" in view._html.value
-    assert "Finished · 2s" in view._html.value
+    assert view._table_scroll is scroll
+    assert "complete · 2s" in _widget_text(view._html)
+    assert "Finished · 2s" in _widget_text(view._html)
 
     view.close()
     assert view._done.is_set()
+
+
+def test_notebook_view_builds_a_real_focusable_ipywidgets_scroll_container(
+    monkeypatch: Any,
+) -> None:
+    import ipywidgets as widgets
+
+    from screamingface._ui.evaluation_widget import _NotebookEvaluationView
+
+    monkeypatch.setattr(_NotebookEvaluationView, "_show", lambda self: None)
+    view = _NotebookEvaluationView(
+        (candidate("opus"),),
+        1,
+        "DRACO",
+        clock=lambda: 100.0,
+        tick=False,
+    )
+
+    assert isinstance(view._html, widgets.VBox)
+    assert isinstance(view._table_scroll, widgets.Box)
+    assert view._table_scroll.layout.overflow == "auto"
+    assert view._table_scroll.layout.width == "100%"
+    assert view._table_scroll.tabbable is True
+    assert view._table_scroll.tooltip == "Candidate evaluation table"
+    assert view._table_scroll.children == (view._table,)
+
+    view.close()

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -267,6 +267,13 @@ def test_report_repr_html_is_wired_to_the_panel() -> None:
     assert "sf-report__title" in body(value._repr_html_())
 
 
+def test_report_repr_carries_explicit_colab_theme_overrides() -> None:
+    html = report(candidate("m", 0.5))._repr_html_()
+
+    assert 'html[theme="light"] .sf-ui' in html
+    assert 'html[theme="dark"] .sf-ui' in html
+
+
 def test_report_formatters_keep_artifact_figures_readable() -> None:
     assert _bytes(10) == "10 B"
     assert _bytes(2_048) == "2 KB"

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -270,8 +270,8 @@ def test_report_repr_html_is_wired_to_the_panel() -> None:
 def test_report_repr_carries_explicit_colab_theme_overrides() -> None:
     html = report(candidate("m", 0.5))._repr_html_()
 
-    assert 'html[theme="light"] .sf-ui' in html
-    assert 'html[theme="dark"] .sf-ui' in html
+    assert ':where(html[theme="light"]) .sf-ui' in html
+    assert ':where(html[theme="dark"]) .sf-ui' in html
 
 
 def test_report_formatters_keep_artifact_figures_readable() -> None:


### PR DESCRIPTION
## Summary

- make shared notebook surfaces follow Colab’s explicit light/dark theme while preserving JupyterLab and VS Code precedence
- keep the six-column evaluation table readable at narrow widths with horizontal overflow
- preserve horizontal scroll across live updates with one stable, focusable `widgets.HTML` owner
- keep Status to lifecycle plus elapsed time and place incomplete grading coverage beneath the Score it qualifies
- right-align Cases, Score, Cost, and Cache Hit against a shared numeric edge
- remove the unused static panel projection so tests exercise the fragments shipped by the live widget
- scope evaluation spacing to the header instead of indenting the whole widget

## Test plan

- `python3 .claude/scripts/run_gates.py screamingface --skip-append-only`
- 97 focused evaluation and report tests
- real ipywidgets focus, scroll ownership, fragment composition, update-identity, partial-score layout, and numeric-alignment coverage

## Visual verification

- [x] verify light Colab
- [ ] verify dark Colab
- [ ] attach final screenshots before marking ready

Asana: N/A

Refs: OME-955