### PR TITLE
fix(repo): add Preview debug commands

### DIFF
--- a/.github/scripts/preview_contract.py
+++ b/.github/scripts/preview_contract.py
@@ -30,6 +30,18 @@ DEPLOYMENT_NAMES = {
     "scoreboard": "leaderboard",
     "engine": "url4-cloud",
 }
+POD_LABEL_NAMES = {
+    "aigateway": "aigateway",
+    "aigatewayUi": "aigateway-ui",
+    "scoreboard": "scoreboard",
+    "engine": "url4-cloud",
+}
+COMPONENT_TITLES = {
+    "aigateway": "AI Gateway",
+    "aigatewayUi": "AI Gateway UI",
+    "scoreboard": "Scoreboard",
+    "engine": "Engine",
+}
 COMPONENT_LABELS = {
     name: f"preview-component-{LABEL_SLUG[name]}" for name in COMPONENTS
 }
@@ -190,11 +202,42 @@ def preview_comment(
     namespace = f"sf-preview-pr-{number}"
     component_text = ", ".join(components) or "none"
     image_text = ", ".join(images) or "none"
-    log_commands = [
-        f"kubectl logs deployment/{DEPLOYMENT_NAMES[component]} "
-        "--all-containers --tail=200"
-        for component in components
+    debug_commands = [
+        "# Show pod status, restarts, IP addresses, and nodes.",
+        f"kubectl --namespace {namespace} get pods -o wide",
+        "",
+        "# Show recent warning events.",
+        (
+            f"kubectl --namespace {namespace} get events "
+            "--field-selector type=Warning --sort-by=.metadata.creationTimestamp"
+        ),
     ]
+    for component in components:
+        title = COMPONENT_TITLES[component]
+        deployment = DEPLOYMENT_NAMES[component]
+        pod_label = POD_LABEL_NAMES[component]
+        debug_commands.extend(
+            [
+                "",
+                f"# Describe the {title} pods.",
+                (
+                    f"kubectl --namespace {namespace} describe pods "
+                    f"--selector app.kubernetes.io/name={pod_label}"
+                ),
+                "",
+                f"# Show the latest {title} logs.",
+                (
+                    f"kubectl --namespace {namespace} logs deployment/{deployment} "
+                    "--all-containers --tail=200"
+                ),
+                "",
+                f"# Follow {title} logs. Press Ctrl+C to stop.",
+                (
+                    f"kubectl --namespace {namespace} logs --follow "
+                    f"deployment/{deployment} --all-containers --tail=50"
+                ),
+            ]
+        )
     lines = [
         COMMENT_MARKER,
         f"## Preview: {display_status}",
@@ -243,18 +286,35 @@ def preview_comment(
                     ".github/scripts/preview_access.sh?ref=main' "
                     f'| bash -s -- {number})"'
                 ),
-                "kubectl get pods",
-                *log_commands,
                 "```",
                 "",
                 f"This kubeconfig only accesses namespace {namespace}.",
                 "Commands with --all-namespaces or -A are blocked.",
                 "",
+                "### Reconnect from a new terminal",
+                "",
+                "The kubeconfig remains on this machine. Its token lasts one hour.",
+                "Run the Kubernetes access command again after the token expires.",
+                "",
+                "```bash",
+                f"export KUBECONFIG=/tmp/sf-preview-pr-{number}.kubeconfig",
+                f"kubectl --namespace {namespace} get pods",
+                "```",
+                "",
+                "### Quick debug",
+                "",
+                "Pod suffixes change after restarts.",
+                "These commands use the pull-request namespace, stable labels, and stable deployment names.",
+                "",
+                "```bash",
+                *debug_commands,
+                "```",
+                "",
                 "### Observability",
                 "",
-                f"[Open SigNoz logs](https://signoz.pulse.dev.openmined.org/logs-explorer?query=k8s_namespace_name%3D%22{namespace}%22)",
+                f"[Open SigNoz logs](https://signoz.pulse.dev.openmined.org/logs-explorer?query=k8s.namespace.name%3D%22{namespace}%22)",
                 "",
-                f'Filter: `k8s_namespace_name="{namespace}"`',
+                f'Filter: `k8s.namespace.name="{namespace}"`',
             ]
         )
     return "\n".join(lines) + "\n"

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -155,25 +155,40 @@ def test_active_comment_contains_access_and_observability_contract() -> None:
     assert "bash -s -- 123" in comment
     assert "cloudflared access token" not in comment
     assert "CF_ACCESS_TOKEN" not in comment
-    assert "kubectl logs deployment/url4-cloud --all-containers --tail=200" in comment
+    assert (
+        "kubectl --namespace sf-preview-pr-123 logs deployment/url4-cloud "
+        "--all-containers --tail=200" in comment
+    )
+    assert (
+        "kubectl --namespace sf-preview-pr-123 logs --follow "
+        "deployment/url4-cloud --all-containers --tail=50" in comment
+    )
+    assert (
+        "kubectl --namespace sf-preview-pr-123 describe pods "
+        "--selector app.kubernetes.io/name=url4-cloud" in comment
+    )
+    assert "kubectl --namespace sf-preview-pr-123 get pods -o wide" in comment
+    assert "export KUBECONFIG=/tmp/sf-preview-pr-123.kubeconfig" in comment
+    assert "Its token lasts one hour." in comment
     assert "DEPLOYMENT_NAME" not in comment
     assert "This kubeconfig only accesses namespace sf-preview-pr-123." in comment
     assert "Commands with --all-namespaces or -A are blocked." in comment
     assert "signoz.pulse.dev.openmined.org/logs-explorer" in comment
-    assert 'k8s_namespace_name="sf-preview-pr-123"' in comment
+    assert 'k8s.namespace.name="sf-preview-pr-123"' in comment
+    assert "k8s_namespace_name" not in comment
 
 
 @pytest.mark.parametrize(
-    ("component", "deployment"),
+    ("component", "deployment", "pod_label"),
     [
-        ("aigateway", "aigw"),
-        ("aigatewayUi", "aigw-ui"),
-        ("scoreboard", "leaderboard"),
-        ("engine", "url4-cloud"),
+        ("aigateway", "aigw", "aigateway"),
+        ("aigatewayUi", "aigw-ui", "aigateway-ui"),
+        ("scoreboard", "leaderboard", "scoreboard"),
+        ("engine", "url4-cloud", "url4-cloud"),
     ],
 )
 def test_active_comment_uses_the_selected_deployment(
-    component: str, deployment: str
+    component: str, deployment: str, pod_label: str
 ) -> None:
     contract = load_contract()
 
@@ -185,7 +200,11 @@ def test_active_comment_uses_the_selected_deployment(
         images=(component,),
     )
 
-    assert f"kubectl logs deployment/{deployment} " in comment
+    assert (
+        f"kubectl --namespace sf-preview-pr-123 logs deployment/{deployment} "
+        in comment
+    )
+    assert f"--selector app.kubernetes.io/name={pod_label}" in comment
 
 
 def test_workflows_keep_oidc_away_from_forks_and_serialize_admission() -> None:

--- a/docs/plan/2026-08-24-ome-965-tenant-preview.md
+++ b/docs/plan/2026-08-24-ome-965-tenant-preview.md
@@ -13,6 +13,7 @@
 9. Open and merge the tenant automation pull request after review and green checks.
 10. Open an Engine-only fixture pull request and run the live Preview qualification.
 11. Replace the manual access-token sequence with one trusted access helper.
+12. Add copy-ready debug commands and the correct SigNoz namespace field.
 
 ## Files
 

--- a/docs/spec/2026-08-24-ome-965-tenant-preview.md
+++ b/docs/spec/2026-08-24-ome-965-tenant-preview.md
@@ -36,10 +36,16 @@ their pull-request images, and enters the bounded Preview queue after exact-revi
 ## Developer contract
 
 The maintained pull-request comment shows status, exact revision, selected images, application
-URLs, one trusted Kubernetes access helper command, and namespace-filtered SigNoz links.
+URLs, one trusted Kubernetes access helper command, reconnect steps, copy-ready debug commands,
+and namespace-filtered SigNoz links.
 
 The helper performs Cloudflare login, GitHub author verification, safe download, and kubeconfig
 validation. It comes from trusted `main`, never from pull-request code.
+
+Debug commands use the exact pull-request namespace, stable deployment names, and stable pod
+labels. SigNoz filters use the `k8s.namespace.name` field.
+
+The downloaded kubeconfig stays on the developer machine. Its Kubernetes token lasts one hour.
 
 ## Security
 

--- a/docs/work/2026-08-24-OME-965-tenant-preview.md
+++ b/docs/work/2026-08-24-OME-965-tenant-preview.md
@@ -57,3 +57,5 @@ the pull-request author exact access and observability instructions.
 - **Access follow-up:** Replace the error-prone token sequence with a trusted-main helper.
   The helper handles Cloudflare login, GitHub identity, safe download, and kubeconfig validation.
 - **Output follow-up:** Show exact deployment log commands and explain the pull-request namespace limit.
+- **Debug follow-up:** Add reconnect, pod status, warning event, describe, recent log, and live log commands.
+  Use `k8s.namespace.name` for the SigNoz namespace filter.


### PR DESCRIPTION
## Summary

- add copy-ready reconnect and debug commands to the maintained Preview comment
- scope every command to the exact pull-request namespace
- use stable deployment names and pod labels after pod restarts
- correct the SigNoz filter to k8s.namespace.name
- explain the one-hour Kubernetes token lifetime

## Tests

- 17 Preview tests passed
- Ruff and Bash checks passed
- PR #707 pod, event, describe, and log commands passed live
- PR #707 developer RBAC permits events and pod logs

Refs: OME-965