### PR TITLE
feat(screamingface): say whether a refused case was declined by the provider or refused by the model

### DIFF
--- a/docs/tasks/2026-08-24-OME-959-say-refusal-kind.md
+++ b/docs/tasks/2026-08-24-OME-959-say-refusal-kind.md
@@ -1,0 +1,16 @@
+---
+id: OME-959
+linear_url: https://linear.app/openmined/issue/OME-959/say-whether-a-refused-case-was-declined-by-the-provider-or-refused-by
+status: backlog
+type: feature
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-24
+closed:
+---
+
+# Say whether a refused case was declined by the provider or refused by the model
+
+Sub-issue of OME-956 (e2e tests for the current benchmarks). Full scope and
+acceptance live in Linear; OME-956's Module Layout section is the source of truth
+for harness file names and contracts.

--- a/docs/work/2026-08-24-OME-959-refusal-kind.md
+++ b/docs/work/2026-08-24-OME-959-refusal-kind.md
@@ -88,3 +88,4 @@ Failing tests first, each naming its invariant:
   `test_public_interface.py` with a snapshot pinning class-defined properties, so
   `refusal_kind` will appear in the snapshot — whichever branch merges second must
   regenerate it (owner-review confirmed).
+- **Review follow-up (2026-08-25):** the five classification tests collapsed into one parametrized signal-table test (owner-requested); count unchanged at 11.

--- a/docs/work/2026-08-24-OME-959-refusal-kind.md
+++ b/docs/work/2026-08-24-OME-959-refusal-kind.md
@@ -1,0 +1,90 @@
+---
+ticket: OME-959
+stack: screamingface
+status: in_progress
+started: 2026-08-24
+finished:
+---
+
+# OME-959 — Say whether a refused case was declined by the provider or refused by the model
+
+## Intent
+
+A refused Case in a client `Report` carries one ambiguous `refusal: str | None`; a
+reader cannot tell a provider that declined to serve the call apart from a model that
+answered by refusing. The Engine already emits the split on the wire — this unit reads
+it client-side, without touching the wire format or the `scored/refused/failed` status
+semantics.
+
+## Wire evidence (decision gate: signal IS on the wire)
+
+The Engine classifies a refused turn in
+`apps/screamingface-engine/src/screamingface_engine/runner/model_response.py:50`:
+`finish_reason == "content_filter" or refusal is not None` → `provider_refusal`
+(OME-745). The bound `ModelOutcome(finish_reason, refusal)` is carried verbatim onto
+the `screamingface.candidate-result.v1` Case
+(`benchmarks/invocation.py:45-59` → `benchmarks/contract.py:135-136` `CaseResult
+.finish_reason/.refusal` → `benchmarks/aggregation.py:278-311 refused_case_result`).
+So a refused Case on the wire TODAY distinguishes the two kinds by its raw fields:
+
+- provider declined: `finish_reason == "content_filter"` (filter turns normally carry
+  null refusal text — invariant comment at `model_response.py:49`)
+- model refused: non-null `refusal` (the provider `message.refusal` field — the
+  model's own refusal message), `finish_reason` typically `"stop"` or null
+
+No explicit kind field exists on the wire; the classification is a deterministic
+function of the two fields the client already decodes
+(`packages/screamingface/src/screamingface/_evaluation/results.py:256-268`).
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/case_result.py` — `RefusalKind` type
+  alias + derived read-only property `CaseResult.refusal_kind` (no new wire field,
+  no `to_dict` change: absence stays absence, old payloads load unchanged).
+- `packages/screamingface/tests/test_case_refusal_kind.py` — new test module
+  (per-concern module layout, keeps prior test files untouched).
+
+## Test plan
+
+Failing tests first, each naming its invariant:
+
+- a `content_filter` refused payload reads as the provider declining
+- a `refusal`-field refused payload reads as the model refusing
+- both signals present → provider declined (mirrors the Engine's own check order)
+- a refused payload with neither signal (older Engine) loads with kind `None` — never
+  a crash, never a guess
+- a failed Case with a provider error (e.g. a 402) has no refusal kind — a provider
+  402 must not read as a model refusal
+- a scored Case has no refusal kind
+- `to_dict()` is byte-identical to the wire payload — the derived kind is never
+  serialized, so saved reports and old readers are untouched
+- a locally built refused CaseResult derives the kind the same way
+
+## Acceptance
+
+- A refused case in a client `Report` states which of the two kinds it was,
+  round-tripping from the real engine payload shape.
+- `scored/refused/failed` semantics unchanged; full screamingface suite green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** exactly as planned —
+  `packages/screamingface/src/screamingface/case_result.py` (+26 lines: `RefusalKind`
+  alias + derived `CaseResult.refusal_kind` property, nothing serialized) and
+  `packages/screamingface/tests/test_case_refusal_kind.py` (11 new tests, RED-first:
+  10 failed before the property existed, the byte-identical-export test passed by
+  construction).
+- **Commits:** uncommitted — pending local owner review
+- **Gates:** ALL GREEN — ruff check ✓ · ruff format --check ✓ · pyright ✓ (0 errors) ·
+  `pytest --cov=screamingface --cov-fail-under=95 -q` ✓ **1076 passed, 1 skipped**
+  (was 1066 collected; coverage 95.05%) · check_notebooks.py ✓ · uv build ✓ ·
+  check_distribution.py ✓.
+- **Deviations:** none in scope. One ruff-shaped adjustment: the property folds its
+  last two returns into one conditional expression (PLR0911 caps returns at 3).
+  Surface note for the sibling ticket pinning the public SDK surface: `sf.CaseResult`
+  gains the read-only `refusal_kind` property (and `screamingface.case_result` gains
+  the `RefusalKind` alias); `sf.__all__` is unchanged. Merge-order with the
+  surface-pinning ticket (OME-963) IS load-bearing: that branch replaces
+  `test_public_interface.py` with a snapshot pinning class-defined properties, so
+  `refusal_kind` will appear in the snapshot — whichever branch merges second must
+  regenerate it (owner-review confirmed).

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -27,6 +27,10 @@ type CheckOutcome = Literal["MET", "UNMET"]
 # `benchmarks/contract.py` CaseStatus.
 type CaseStatus = Literal["scored", "refused", "failed"]
 type StopReason = Literal["passed", "max_rounds"]
+# Which side refused a refused Case — derived from the two provider-verbatim signals
+# the Engine's runner classifies a refusal from (OME-745, `runner/model_response.py`);
+# never carried on the wire.
+type RefusalKind = Literal["provider_declined", "model_refusal"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -332,6 +336,28 @@ class CaseResult:
     @property
     def metadata(self) -> Mapping[str, object]:
         return self._metadata
+
+    @property
+    def refusal_kind(self) -> RefusalKind | None:
+        """Which side refused: the provider declined, or the model answered by refusing.
+
+        The Engine classifies a refused turn from two provider-verbatim signals it
+        already publishes on every Case (OME-745, the Engine's
+        `runner/model_response.py`): a ``content_filter`` finish reason means the
+        provider's filter terminated the call, and a non-null ``refusal`` carries the
+        model's own refusal message. This property is the client's ONE reading of
+        that split, checked in the Engine classifier's own order — ``content_filter``
+        first, so a filtered turn that also carries refusal text still reads as the
+        provider declining. ``None`` for any non-refused Case, and for a refused Case
+        whose payload carries neither signal (older Engines) — unknown, never a
+        guess. Derived, never serialized: ``to_dict`` stays byte-identical.
+        """
+
+        if self.status != "refused":
+            return None
+        if self.finish_reason == "content_filter":
+            return "provider_declined"
+        return "model_refusal" if self.refusal is not None else None
 
     @property
     def conversation(self) -> tuple[tuple[str, str], ...] | None:

--- a/packages/screamingface/tests/test_case_refusal_kind.py
+++ b/packages/screamingface/tests/test_case_refusal_kind.py
@@ -1,0 +1,165 @@
+"""A refused Case states which side refused: the provider declined, or the model.
+
+INVARIANT defended: the Engine's runner classifies a refused turn from two
+provider-verbatim signals it already publishes on every Case (OME-745,
+`runner/model_response.py`): a `content_filter` finish reason means the provider's
+filter terminated the call; a non-null `refusal` field carries the model's own
+refusal message. The client derives `refusal_kind` from exactly those wire fields —
+never from answer text, never serialized, and never guessed when neither signal is
+present (older payloads stay loadable with kind `None`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import screamingface as sf
+from screamingface._evaluation.results import _case_result
+
+
+def _refused_payload(finish_reason: str | None, refusal: str | None) -> dict[str, Any]:
+    return {
+        "status": "refused",
+        "case_id": 1,
+        "input": "A clinical question",
+        "output": None,
+        "finish_reason": finish_reason,
+        "refusal": refusal,
+        "stop_reason": None,
+        "rounds_executed": None,
+        "grade": {"method": "rubric", "score": 0.0, "metrics": {}, "checks": []},
+        "failures": [],
+        "metadata": {},
+    }
+
+
+def test_a_content_filter_decline_reads_as_the_provider_declining() -> None:
+    # WHY: `finish_reason == "content_filter"` is the provider's filter terminating
+    # the call — the exact signal the Engine's runner classifies a refusal from —
+    # and filter turns normally carry null refusal text.
+    case = _case_result(_refused_payload("content_filter", None))
+
+    assert case.refusal_kind == "provider_declined"
+
+
+def test_a_provider_refusal_field_reads_as_the_model_refusing() -> None:
+    # WHY: a non-null `refusal` is the provider `message.refusal` field — the
+    # model's own refusal message — so the model answered by refusing.
+    case = _case_result(_refused_payload("stop", "I can't help with that request."))
+
+    assert case.refusal_kind == "model_refusal"
+
+
+def test_a_refusal_message_without_a_finish_reason_still_reads_as_the_model() -> None:
+    # WHY: not every provider reports a finish reason with the refusal field
+    # (OME-745 captured them independently); the model's message alone decides.
+    case = _case_result(_refused_payload(None, "I can't help with that request."))
+
+    assert case.refusal_kind == "model_refusal"
+
+
+def test_both_signals_present_read_as_the_provider_declining() -> None:
+    # WHY: mirrors the Engine classifier's own check order (`content_filter` first)
+    # — a filtered turn was terminated by the provider even when refusal text
+    # tagged along.
+    case = _case_result(_refused_payload("content_filter", "exact refusal"))
+
+    assert case.refusal_kind == "provider_declined"
+
+
+def test_an_old_payload_without_either_signal_loads_with_unknown_kind() -> None:
+    # WHY: pre-OME-745 saved reports carry neither signal — they must still load,
+    # and the kind is unknown, never a crash and never a guess.
+    case = _case_result(_refused_payload(None, None))
+
+    assert case.status == "refused"
+    assert case.refusal_kind is None
+
+
+def test_a_provider_402_failure_is_no_kind_of_refusal() -> None:
+    # WHY: a provider that errors (e.g. a 402) produces a FAILED Case — it must not
+    # read as a model refusal, or as any refusal at all.
+    payload: dict[str, Any] = {
+        "status": "failed",
+        "case_id": 1,
+        "input": "A question",
+        "output": None,
+        "finish_reason": None,
+        "refusal": None,
+        "stop_reason": None,
+        "rounds_executed": None,
+        "grade": None,
+        "failures": [
+            {
+                "stage": "candidate",
+                "code": "provider_error",
+                "message": "402 Payment Required",
+                "retryable": True,
+                "case_id": 1,
+                "metadata": {},
+            }
+        ],
+        "metadata": {},
+    }
+
+    assert _case_result(payload).refusal_kind is None
+
+
+def test_a_scored_case_has_no_refusal_kind() -> None:
+    # WHY: `content_filter` never reaches a scored Case in practice, but the kind
+    # is a reading of REFUSED Cases only — status semantics stay untouched.
+    payload = _refused_payload("stop", None)
+    payload.update(status="scored", output="Four.")
+    payload["grade"] = {"method": "rubric", "score": 1.0, "metrics": {}, "checks": []}
+
+    assert _case_result(payload).refusal_kind is None
+
+
+def test_the_derived_kind_is_never_serialized() -> None:
+    # WHY: no wire change — `to_dict()` stays byte-identical to the payload, so
+    # saved reports round-trip unchanged and old readers see nothing new.
+    payload = _refused_payload("content_filter", None)
+
+    exported = _case_result(payload).to_dict()
+
+    assert exported == payload
+    assert "refusal_kind" not in exported
+
+
+def test_a_locally_built_refused_case_derives_the_same_kind() -> None:
+    # WHY: the kind is a pure function of the Case fields, so a directly
+    # constructed value and a wire-decoded one can never disagree.
+    case = sf.CaseResult(
+        status="refused",
+        case_id=1,
+        input="A clinical question",
+        output=None,
+        finish_reason="content_filter",
+        grade=sf.CaseGrade(method="rubric", score=0.0, metrics={}, checks=()),
+        failures=(),
+        metadata={},
+    )
+
+    assert case.refusal_kind == "provider_declined"
+
+
+@pytest.mark.parametrize(
+    ("finish_reason", "refusal", "kind"),
+    [
+        ("content_filter", None, "provider_declined"),
+        ("stop", "I can't help with that request.", "model_refusal"),
+    ],
+)
+def test_the_kind_survives_a_save_and_reload_round_trip(
+    finish_reason: str | None, refusal: str | None, kind: str
+) -> None:
+    # WHY: the acceptance path — a refused Case round-tripping from the real
+    # engine payload shape states which of the two kinds it was, on both sides
+    # of a save/reload.
+    payload = _refused_payload(finish_reason, refusal)
+
+    reloaded = _case_result(_case_result(payload).to_dict())
+
+    assert reloaded.refusal_kind == kind

--- a/packages/screamingface/tests/test_case_refusal_kind.py
+++ b/packages/screamingface/tests/test_case_refusal_kind.py
@@ -35,47 +35,56 @@ def _refused_payload(finish_reason: str | None, refusal: str | None) -> dict[str
     }
 
 
-def test_a_content_filter_decline_reads_as_the_provider_declining() -> None:
-    # WHY: `finish_reason == "content_filter"` is the provider's filter terminating
-    # the call — the exact signal the Engine's runner classifies a refusal from —
-    # and filter turns normally carry null refusal text.
-    case = _case_result(_refused_payload("content_filter", None))
-
-    assert case.refusal_kind == "provider_declined"
-
-
-def test_a_provider_refusal_field_reads_as_the_model_refusing() -> None:
-    # WHY: a non-null `refusal` is the provider `message.refusal` field — the
-    # model's own refusal message — so the model answered by refusing.
-    case = _case_result(_refused_payload("stop", "I can't help with that request."))
-
-    assert case.refusal_kind == "model_refusal"
-
-
-def test_a_refusal_message_without_a_finish_reason_still_reads_as_the_model() -> None:
-    # WHY: not every provider reports a finish reason with the refusal field
-    # (OME-745 captured them independently); the model's message alone decides.
-    case = _case_result(_refused_payload(None, "I can't help with that request."))
-
-    assert case.refusal_kind == "model_refusal"
-
-
-def test_both_signals_present_read_as_the_provider_declining() -> None:
-    # WHY: mirrors the Engine classifier's own check order (`content_filter` first)
-    # — a filtered turn was terminated by the provider even when refusal text
-    # tagged along.
-    case = _case_result(_refused_payload("content_filter", "exact refusal"))
-
-    assert case.refusal_kind == "provider_declined"
-
-
-def test_an_old_payload_without_either_signal_loads_with_unknown_kind() -> None:
-    # WHY: pre-OME-745 saved reports carry neither signal — they must still load,
-    # and the kind is unknown, never a crash and never a guess.
-    case = _case_result(_refused_payload(None, None))
+@pytest.mark.parametrize(
+    ("finish_reason", "refusal", "kind"),
+    [
+        pytest.param(
+            "content_filter",
+            None,
+            "provider_declined",
+            id="content-filter-is-the-provider-declining",
+        ),
+        pytest.param(
+            "stop",
+            "I can't help with that request.",
+            "model_refusal",
+            id="a-refusal-message-is-the-model-refusing",
+        ),
+        pytest.param(
+            None,
+            "I can't help with that request.",
+            "model_refusal",
+            id="the-message-alone-decides-without-a-finish-reason",
+        ),
+        pytest.param(
+            "content_filter",
+            "exact refusal",
+            "provider_declined",
+            id="both-signals-present-the-provider-wins",
+        ),
+        pytest.param(
+            None,
+            None,
+            None,
+            id="a-pre-OME-745-payload-loads-with-unknown-kind",
+        ),
+    ],
+)
+def test_the_kind_follows_the_engine_classifiers_signal_table(
+    finish_reason: str | None, refusal: str | None, kind: str | None
+) -> None:
+    # WHY: one row per line of the Engine classifier's own truth table
+    # (`runner/model_response.py`, OME-745): `content_filter` means the provider's
+    # filter terminated the call and is checked FIRST (so a filtered turn with
+    # refusal text tagging along still reads as the provider declining); a
+    # non-null `refusal` — the model's own refusal message — alone decides even
+    # without a finish reason (OME-745 captured the two independently); and a
+    # pre-OME-745 payload carrying neither signal still loads, with the kind
+    # unknown — never a crash and never a guess.
+    case = _case_result(_refused_payload(finish_reason, refusal))
 
     assert case.status == "refused"
-    assert case.refusal_kind is None
+    assert case.refusal_kind == kind
 
 
 def test_a_provider_402_failure_is_no_kind_of_refusal() -> None:


### PR DESCRIPTION
Refused benchmark cases now say **which kind** of refusal happened: the provider declined to serve the call, or the model itself answered by refusing.

## Before / After

### Before
- Trigger: a dev opens a report to see why a case scored zero
- Today: the case just says "refused" with one free-text string — no way to tell a provider that declined to serve the call from a model that answered by refusing
- Cost: wrong diagnosis (a gateway/billing problem read as model behavior, or vice versa), and no e2e golden can freeze without baking the ambiguity in (OME-956 R10)

### After
- Same trigger
- Now: `CaseResult.refusal_kind` states `provider_declined` or `model_refusal`
- Win: refusals are debuggable at a glance, and the e2e goldens (OME-964) can freeze safely

### Don't regress
- `scored/refused/failed` status semantics unchanged; old saved reports load exactly as before

## Why no wire change

The engine already emits the two raw signals on every refused case (OME-745): `finish_reason == "content_filter"` marks a provider-declined turn, a non-null `refusal` carries the model's own refusal message. The split is therefore a **derived read-only property** on the client's `CaseResult`, mirroring the engine classifier's exact precedence (`content_filter` checked first). `to_dict()` stays byte-identical — zero contract churn, automatic backward compatibility.

## Implementation

- `case_result.py` (+26): `RefusalKind` literal alias + `CaseResult.refusal_kind` property, gated on `status == "refused"`, `None` when neither signal is present (old payloads).
- 11 invariant-named tests (`test_case_refusal_kind.py`), e.g. "a provider 402 failure is no kind of refusal".
- Gates: 1076 passed / 1 skipped, coverage 95.05%, ruff + pyright + build clean.
- Ledger: `docs/work/2026-08-24-OME-959-refusal-kind.md`.

**Merge-order note:** #716 pins class properties in its surface snapshot — whichever of the two PRs merges second regenerates that snapshot (`UPDATE_SURFACE_SNAPSHOT=1`).

Refs: OME-959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
