### PR TITLE
fix(screamingface-engine): repair HealthBench preparation summary

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py
@@ -266,7 +266,7 @@ def main(argv: list[str] | None = None) -> int:
     print(
         f"healthbench: baked {summary['professional_cases']} cases into {args.out} "
         f"— the professional board serves all {summary['professional_cases']}, "
-        f"worst30 serves {summary['worst30_cases']}"
+        f"worst30 serves {summary['declared_worst30_cases']}"
     )
     return 0
 

--- a/apps/screamingface-engine/tests/unit/test_healthbench_prepare.py
+++ b/apps/screamingface-engine/tests/unit/test_healthbench_prepare.py
@@ -140,3 +140,20 @@ def test_a_dataset_that_gained_a_row_fails_the_build(tmp_path: Path) -> None:
     )
     with pytest.raises(PrepareError, match="525"):
         emit(rows, tmp_path)
+
+
+def test_cli_summary_keys_match_real_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "screamingface_engine.benchmarks.healthbench.prepare.load_rows",
+        _synthetic_rows,
+    )
+
+    assert main(["--out", str(tmp_path)]) == 0
+    assert capsys.readouterr().out == (
+        f"healthbench: baked 525 cases into {tmp_path} "
+        "— the professional board serves all 525, worst30 serves 157\n"
+    )

--- a/apps/screamingface-engine/tests/unit/test_healthbench_prepare.py
+++ b/apps/screamingface-engine/tests/unit/test_healthbench_prepare.py
@@ -17,6 +17,7 @@ from screamingface_engine.benchmarks.healthbench.prepare import (
     PrepareError,
     case_messages,
     emit,
+    main,
     rubric_items,
 )
 from screamingface_engine.benchmarks.healthbench.subset import (
@@ -25,6 +26,27 @@ from screamingface_engine.benchmarks.healthbench.subset import (
 )
 
 _TOTAL_ROWS = 525
+
+
+def test_cli_renders_the_current_preparation_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "screamingface_engine.benchmarks.healthbench.prepare._prepare",
+        lambda _out: {
+            "professional_cases": 525,
+            "declared_worst30_cases": 157,
+            "out": str(tmp_path),
+        },
+    )
+
+    assert main(["--out", str(tmp_path)]) == 0
+    assert capsys.readouterr().out == (
+        f"healthbench: baked 525 cases into {tmp_path} "
+        "— the professional board serves all 525, worst30 serves 157\n"
+    )
 
 
 def _synthetic_rows() -> list[dict[str, object]]:

--- a/docs/plan/2026-08-25-OME-980-healthbench-summary.md
+++ b/docs/plan/2026-08-25-OME-980-healthbench-summary.md
@@ -1,0 +1,21 @@
+# OME-980 — Implementation plan: HealthBench preparation success summary
+
+Spec: `docs/spec/2026-08-25-OME-980-healthbench-summary.md` · Stack:
+`screamingface-engine` · Branch: `OME-980-healthbench-summary`
+
+## 1. Pin the regression
+
+- Add a HealthBench-specific CLI test that patches `_prepare()` with the current summary mapping.
+- Assert that `main()` returns zero and renders the professional and declared worst-30 counts.
+- Keep this test family-specific because preparer signatures differ between benchmark families.
+
+## 2. Repair the lookup
+
+- Update the stale `worst30_cases` read to `declared_worst30_cases`.
+- Do not rename the preparer's audit field or change benchmark preparation behavior.
+
+## 3. Verify and publish
+
+- Run the focused test through RED and GREEN.
+- Run `python3 .claude/scripts/run_gates.py screamingface-engine`.
+- Complete the work ledger, review the diff, commit with `Refs: OME-980`, push, and open a draft PR.

--- a/docs/spec/2026-08-25-OME-980-healthbench-summary.md
+++ b/docs/spec/2026-08-25-OME-980-healthbench-summary.md
@@ -1,0 +1,23 @@
+# OME-980 — HealthBench preparation success summary
+
+Status: approved (owner, 2026-08-25) · Stack: screamingface-engine
+
+## Problem
+
+HealthBench preparation completes successfully, but its family CLI then reads the removed
+`worst30_cases` summary key. The preparer now truthfully exposes the compile-time selection as
+`declared_worst30_cases`, so rendering the success message raises `KeyError` after the assets have
+already been written.
+
+## Contract
+
+- `_prepare()` continues returning `declared_worst30_cases`; the honest audit name is not reverted.
+- `main()` reads that key when rendering its success message.
+- The success path returns zero and reports both the professional-case and declared worst-30 counts.
+- Dataset bytes, benchmark selection, registry behavior, and runtime evaluation do not change.
+
+## Acceptance
+
+- A HealthBench-specific CLI regression test exercises the real summary shape.
+- The test fails on `origin/main` with the stale-key `KeyError` and passes after the lookup repair.
+- The complete `screamingface-engine` quality gates pass.

--- a/docs/tasks/2026-08-25-OME-980-healthbench-summary.md
+++ b/docs/tasks/2026-08-25-OME-980-healthbench-summary.md
@@ -1,0 +1,20 @@
+---
+id: OME-980
+linear_url: https://linear.app/openmined/issue/OME-980/fix-the-healthbench-preparation-success-summary
+status: in_progress
+type: task
+priority: high
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+  - task
+created: 2026-08-25
+closed:
+---
+
+# Fix the HealthBench preparation success summary
+
+Keep the audit field named `declared_worst30_cases` and repair the family CLI's stale lookup so
+successful HealthBench asset preparation reports its counts instead of raising `KeyError` after
+the assets have already been written.

--- a/docs/work/2026-08-25-OME-980-healthbench-summary.md
+++ b/docs/work/2026-08-25-OME-980-healthbench-summary.md
@@ -1,0 +1,43 @@
+---
+ticket: OME-980
+stack: screamingface-engine
+status: done
+started: 2026-08-25
+finished: 2026-08-25
+---
+
+# OME-980 — HealthBench preparation success summary
+
+## Intent
+
+Repair the post-preparation HealthBench CLI crash while preserving the honest
+`declared_worst30_cases` audit field and every benchmark/runtime contract.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/prepare.py`
+- `apps/screamingface-engine/tests/unit/test_healthbench_prepare.py`
+- This unit's task, spec, plan, and work records.
+
+## Test plan
+
+- RED: the family CLI receives the current summary mapping and raises the stale-key `KeyError`.
+- GREEN: it returns zero and reports the professional and declared worst-30 counts.
+- Run the complete `screamingface-engine` gate suite.
+
+## Acceptance
+
+- Successful HealthBench preparation no longer crashes while rendering its summary.
+- The current summary key is pinned by a regression test.
+- No asset, selection, or runtime benchmark behavior changes.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** the HealthBench family preparer's CLI lookup, its focused unit test, and this
+  unit's task/spec/plan/work records.
+- **Commits:** `fix(screamingface-engine): repair HealthBench preparation summary`
+  (`Refs: OME-980`).
+- **Gates:** focused HealthBench prepare suite — 8 passed; official
+  `run_gates.py screamingface-engine` — append-only, Ruff check/format, Pyright, layering, and full
+  pytest/coverage all green.
+- **Deviations:** none.

--- a/docs/work/2026-08-25-OME-980-healthbench-summary.md
+++ b/docs/work/2026-08-25-OME-980-healthbench-summary.md
@@ -41,3 +41,11 @@ Repair the post-preparation HealthBench CLI crash while preserving the honest
   `run_gates.py screamingface-engine` — append-only, Ruff check/format, Pyright, layering, and full
   pytest/coverage all green.
 - **Deviations:** none.
+
+## Review follow-up
+
+The first CLI test stubbed `_prepare()` with the same mapping expected by `main()`, so a future
+summary-key rename could make production fail post-bake while leaving the test green. An appended
+regression test now stubs only `load_rows()` and drives the CLI through the real `_prepare()`.
+Replaying the original stale lookup makes this test fail with the expected `KeyError`; restoring
+the fix returns the full Engine gate suite to green, including the append-only check.


### PR DESCRIPTION
HealthBench asset preparation no longer crashes after a successful bake while rendering its CLI summary.

## Before / After

### Before
- `_prepare()` correctly returned the honest audit field `declared_worst30_cases`.
- `main()` still read the removed `worst30_cases` key and raised `KeyError` after writing the assets.

### After
- The CLI reads `declared_worst30_cases` and exits successfully.
- A HealthBench-specific regression test pins the current summary mapping and rendered counts.

### Don’t regress
- The audit field keeps its honest `declared_` name.
- No dataset bytes, benchmark selection, registry behavior, or runtime evaluation changes.

## Verification

- Focused HealthBench prepare suite: 8 passed.
- Full `screamingface-engine` gates: append-only, Ruff, Pyright, layering, and pytest/coverage all green.

Refs: OME-980