### PR TITLE
feat(benchmark-tests): Test that provider failures land where each benchmark's failure policy says

### DIFF
--- a/docs/tasks/2026-08-24-OME-962-failure-policy-e2e.md
+++ b/docs/tasks/2026-08-24-OME-962-failure-policy-e2e.md
@@ -1,0 +1,16 @@
+---
+id: OME-962
+linear_url: https://linear.app/openmined/issue/OME-962/test-that-provider-failures-land-where-each-benchmarks-failure-policy
+status: backlog
+type: feature
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-24
+closed:
+---
+
+# Test that provider failures land where each benchmark's failure policy says
+
+Sub-issue of OME-956 (e2e tests for the current benchmarks). Full scope and
+acceptance live in Linear; OME-956's Module Layout section is the source of truth
+for harness file names and contracts.

--- a/docs/work/2026-08-25-OME-962-failure-paths.md
+++ b/docs/work/2026-08-25-OME-962-failure-paths.md
@@ -1,0 +1,105 @@
+---
+ticket: OME-962
+stack: screamingface
+status: done
+started: 2026-08-25
+finished: 2026-08-25
+---
+
+# OME-962 — Rehearse provider failure paths against a scripted fake gateway
+
+## Intent
+
+The e2e replay cache (OME-961) can only replay good news — failed provider calls never
+store a cache entry — so the bad-news paths are unrehearsed. This unit adds a
+`FakeGateway` stand-in (implements the harness `ReplayBackend` port, failure-injection
+only, zero egress) plus hand-authored failure tapes, and proves each provider failure
+(429, 5xx, malformed body, blank completion, judge cut off mid-batch) lands exactly
+where the board's declared failure policy says — e.g. a 429 surfaces as a
+rate-limit/provider error with retryable=True, never as "malformed response".
+Requirement R7 of parent OME-956.
+
+## Planned changes
+
+- `packages/screamingface/tests/e2e/harness/fake_gateway.py` — new: FakeGateway
+  implementing `ReplayBackend`; serves only its Tape; unmatched request fails loudly.
+- `packages/screamingface/tests/e2e/fixtures/failures/*.json` — hand-authored
+  `RecordedExchange` tapes (`provenance.authored=True`), raw provider-shaped bytes.
+- `packages/screamingface/tests/e2e/test_failures.py` — new: engine+SDK vs FakeGateway,
+  asserts each failure lands per declared policy (e2e lane).
+- FakeGateway contract tests live in `test_failures.py`'s default-lane section (NOT in
+  `test_harness_contracts.py` — the sibling OME-964 worktree may touch that file, so
+  the footprint stays in this unit's own files; same style either way).
+- No conftest edits needed; no edits to cache_seeded.py/stack.py/ports.py/tape.py/
+  goldens.py (OME-964 works in the same tree).
+
+## Test plan
+
+- RED-first unit tests: unmatched request → loud error (no default response);
+  authored-flag required on failure fixtures; FakeGateway binds loopback only /
+  cannot egress; serves exactly the recorded bytes+status.
+- RED-first e2e tests (e2e marker + SCREAMINGFACE_TEST_E2E=1 + docker probe):
+  per failure scenario, CaseResult.failures[] carries the declared stage/code/
+  retryable — invariant named in each test.
+- Fixture validation tests (default lane): failure tapes parse as RecordedExchange,
+  authored=True, bodies are raw provider-shaped bytes.
+
+## Acceptance
+
+- Default lane fully green; e2e lane green with the new failure scenarios.
+- Every authored failure shape maps to its declared landing (policy table with
+  file:line evidence from the engine in the report).
+- Zero network egress and zero spend possible by construction.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `packages/screamingface/tests/e2e/harness/fake_gateway.py` (new — FakeGateway,
+    stdlib ThreadingHTTPServer on 127.0.0.1:0, tape-scripted, zero egress by
+    construction)
+  - `packages/screamingface/tests/e2e/fixtures/failures/{rate_limit_429,provider_5xx,
+    malformed_body,blank_completion,judge_cutoff}.tape.json` (new — authored tapes,
+    `provenance.authored=true`, raw gateway-shaped bytes)
+  - `packages/screamingface/tests/e2e/test_failures.py` (new — 11 default-lane
+    FakeGateway/fixture contract tests + 5 e2e scenario tests; FakeGateway unit tests
+    live here instead of `test_harness_contracts.py` to avoid colliding with the
+    OME-964 sibling worktree)
+  - No edits to cache_seeded.py / stack.py / ports.py / tape.py / goldens.py /
+    conftest.py — zero shared-file footprint.
+- **Commits:** uncommitted — pending local owner review
+- **Gates:** ruff check+format clean; pyright 0 errors on the new files; default lane
+  1121 passed / 1 skipped (includes the 12 FakeGateway/fixture contract tests);
+  e2e lane (SCREAMINGFACE_TEST_E2E=1, full `-m e2e`) 9 passed / 5 skipped (board
+  goldens not recorded yet — the honest OME-961 skip) — all 5 failure scenarios proven
+  against the real engine + SDK, plumbing tests green too. Machine setup note: the
+  gitignored `synthetic.manifest.json` had to be regenerated once via the OME-961
+  `generate_synthetic.py` (aigateway venv) before the plumbing fixtures could boot;
+  no tracked file changed (regenerated snapshot/tape are byte-identical).
+- **Deviations:**
+  - FakeGateway is a stdlib `ThreadingHTTPServer`, not uvicorn: the SDK test venv
+    carries no ASGI server, and uvicorn would have meant a pyproject dep change or
+    borrowing another app's venv. Stdlib keeps the footprint to this unit's files and
+    is the stronger zero-egress claim (the module holds no HTTP client at all).
+  - The fake matches tape exchanges by MODEL, not by cache fingerprint — an authored
+    tape cannot pre-compute the gateway `key_hash` of bodies the engine composes at
+    run time; the tape fingerprint stays a row identity only.
+  - The fake also serves `GET /v1/models` as a projection of EXACTLY the tape's models
+    (gateway locked row shape): the SDK's run planning reads the engine catalogue
+    (which proxies that route) before any model call, so the discovery half of the
+    seam is required to even reach the completions seam.
+  - Review nits fixed (owner review, approve-with-nits): (1) every refusal reply now
+    sends `Connection: close` — the unroutable POST branch refuses before reading the
+    body, and on a kept-alive connection the unread bytes would garble the next
+    request and mask the real refusal; closing was chosen over draining because it is
+    simpler and also covers chunked bodies Content-Length cannot measure (pinned by
+    a new contract test: refused POST → close header, follow-up call still served
+    from the tape). (2) `_rehearse` now asserts ALL refusals are empty, not just
+    unmatched-model ones — verified strict against all 5 e2e scenarios; the engine
+    makes zero off-surface requests today, so no tolerated-probe list was needed.
+  - Finding (not fixed here — url4 core is out of scope on benchmark PRs): the
+    connector's failure classification (`code`, `permanent`) is dropped at the url4
+    `on_error="collect"` boundary (`url4/dag/nodes.py::_error_payload` keeps only
+    kind+message), so candidate-stage Failures land with the board default code
+    `case_execution_failed` and `retryable=None`; the gateway-authored MESSAGE is what
+    distinguishes 429/5xx/malformed today. Candidate ticket for url4 if the code/
+    retryable fidelity is wanted end-to-end.

--- a/packages/screamingface/tests/e2e/fixtures/failures/blank_completion.tape.json
+++ b/packages/screamingface/tests/e2e/fixtures/failures/blank_completion.tape.json
@@ -1,0 +1,39 @@
+{
+  "schema": "screamingface.replay-tape.v1",
+  "provenance": {
+    "board": "draco-3pass",
+    "revision": "authored-failure-rehearsal-2026-08",
+    "expression_sha": "42c81d34c07afc4fbb3eeabca171750111a4cc64fc64cdc2bc6aac4839dec27e",
+    "engine_sha": "authored — no engine rendered this tape",
+    "recorded_at": "2026-08-25T00:00:00Z",
+    "run_ref": "hand-authored for OME-962 (see tests/e2e/test_failures.py)",
+    "authored": true
+  },
+  "exchanges": [
+    {
+      "normalized": {
+        "provider": "openrouter",
+        "model": "openrouter/openai/gpt-5.5",
+        "fingerprint": "5a4b940d50b85602e54a65a559a56ee564d22e303bfd7b50068be0bb856550a8"
+      },
+      "request": {
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "body": {
+          "model": "openrouter/openai/gpt-5.5",
+          "messages": [
+            {
+              "role": "user",
+              "content": "AUTHORED blank_completion candidate request for the OME-962 failure rehearsal. The FakeGateway matches by model, not by this body."
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "media_type": "application/json",
+        "body_b64": "eyJpZCI6ImNoYXRjbXBsLW9tZTk2Mi1ibGFuay0xIiwib2JqZWN0IjoiY2hhdC5jb21wbGV0aW9uIiwiY3JlYXRlZCI6MTc4NzI3MDQwMCwibW9kZWwiOiJvcGVuYWkvZ3B0LTUuNSIsImNob2ljZXMiOlt7ImluZGV4IjowLCJtZXNzYWdlIjp7InJvbGUiOiJhc3Npc3RhbnQiLCJjb250ZW50IjoiIn0sImZpbmlzaF9yZWFzb24iOiJsZW5ndGgifV0sInVzYWdlIjp7InByb21wdF90b2tlbnMiOjAsImNvbXBsZXRpb25fdG9rZW5zIjowLCJ0b3RhbF90b2tlbnMiOjB9fQ=="
+      }
+    }
+  ]
+}

--- a/packages/screamingface/tests/e2e/fixtures/failures/judge_cutoff.tape.json
+++ b/packages/screamingface/tests/e2e/fixtures/failures/judge_cutoff.tape.json
@@ -1,0 +1,64 @@
+{
+  "schema": "screamingface.replay-tape.v1",
+  "provenance": {
+    "board": "draco-3pass",
+    "revision": "authored-failure-rehearsal-2026-08",
+    "expression_sha": "42c81d34c07afc4fbb3eeabca171750111a4cc64fc64cdc2bc6aac4839dec27e",
+    "engine_sha": "authored — no engine rendered this tape",
+    "recorded_at": "2026-08-25T00:00:00Z",
+    "run_ref": "hand-authored for OME-962 (see tests/e2e/test_failures.py)",
+    "authored": true
+  },
+  "exchanges": [
+    {
+      "normalized": {
+        "provider": "openrouter",
+        "model": "openrouter/openai/gpt-5.5",
+        "fingerprint": "5b671fc98164c01ea5f7dc97ed65c83268cc2f08dacedf1c23dc879d04537cba"
+      },
+      "request": {
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "body": {
+          "model": "openrouter/openai/gpt-5.5",
+          "messages": [
+            {
+              "role": "user",
+              "content": "AUTHORED judge_cutoff candidate request for the OME-962 failure rehearsal. The FakeGateway matches by model, not by this body."
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "media_type": "application/json",
+        "body_b64": "eyJpZCI6ImNoYXRjbXBsLW9tZTk2Mi1jdXRvZmYtY2FuZGlkYXRlLTEiLCJvYmplY3QiOiJjaGF0LmNvbXBsZXRpb24iLCJjcmVhdGVkIjoxNzg3MjcwNDAwLCJtb2RlbCI6Im9wZW5haS9ncHQtNS41IiwiY2hvaWNlcyI6W3siaW5kZXgiOjAsIm1lc3NhZ2UiOnsicm9sZSI6ImFzc2lzdGFudCIsImNvbnRlbnQiOiJBVVRIT1JFRCBjYW5kaWRhdGUgYW5zd2VyIGZvciB0aGUgT01FLTk2MiBqdWRnZS1jdXRvZmYgcmVoZWFyc2FsOiBhIHNob3J0IHJlc2VhcmNoIHN1bW1hcnkgd2l0aCBhIHNpbmdsZSBjaXRhdGlvbiBbMV0uIn0sImZpbmlzaF9yZWFzb24iOiJzdG9wIn1dLCJ1c2FnZSI6eyJwcm9tcHRfdG9rZW5zIjowLCJjb21wbGV0aW9uX3Rva2VucyI6MCwidG90YWxfdG9rZW5zIjowfX0="
+      }
+    },
+    {
+      "normalized": {
+        "provider": "openrouter",
+        "model": "openrouter/google/gemini-3.1-pro-preview",
+        "fingerprint": "b96dd18bb4c1092f15b06a3dd7e78b1d7c36888c2e5abe6eaaa9b5249d3f27e2"
+      },
+      "request": {
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "body": {
+          "model": "openrouter/google/gemini-3.1-pro-preview",
+          "messages": [
+            {
+              "role": "user",
+              "content": "AUTHORED judge_cutoff judge request for the OME-962 failure rehearsal. The FakeGateway matches by model, not by this body."
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "media_type": "application/json",
+        "body_b64": "eyJpZCI6ImNoYXRjbXBsLW9tZTk2Mi1jdXRvZmYtanVkZ2UtMSIsIm9iamVjdCI6ImNoYXQuY29tcGxldGlvbiIsImNyZWF0ZWQiOjE3ODcyNzA0MDAsIm1vZGVsIjoiZ29vZ2xlL2dlbWluaS0zLjEtcHJvLXByZXZpZXciLCJjaG9pY2VzIjpbeyJpbmRleCI6MCwibWVzc2FnZSI6eyJyb2xlIjoiYXNzaXN0YW50IiwiY29udGVudCI6IntcImV4cGxhbmF0aW9uXCI6IFwiVGhlIHJlc3BvbnNlIGVuZ2FnZXMgdGhlIGNyaXRlcmlvbiBieSBwcmVzZW50aW5nIn0sImZpbmlzaF9yZWFzb24iOiJsZW5ndGgifV0sInVzYWdlIjp7InByb21wdF90b2tlbnMiOjAsImNvbXBsZXRpb25fdG9rZW5zIjowLCJ0b3RhbF90b2tlbnMiOjB9fQ=="
+      }
+    }
+  ]
+}

--- a/packages/screamingface/tests/e2e/fixtures/failures/malformed_body.tape.json
+++ b/packages/screamingface/tests/e2e/fixtures/failures/malformed_body.tape.json
@@ -1,0 +1,39 @@
+{
+  "schema": "screamingface.replay-tape.v1",
+  "provenance": {
+    "board": "draco-3pass",
+    "revision": "authored-failure-rehearsal-2026-08",
+    "expression_sha": "42c81d34c07afc4fbb3eeabca171750111a4cc64fc64cdc2bc6aac4839dec27e",
+    "engine_sha": "authored — no engine rendered this tape",
+    "recorded_at": "2026-08-25T00:00:00Z",
+    "run_ref": "hand-authored for OME-962 (see tests/e2e/test_failures.py)",
+    "authored": true
+  },
+  "exchanges": [
+    {
+      "normalized": {
+        "provider": "openrouter",
+        "model": "openrouter/openai/gpt-5.5",
+        "fingerprint": "da75e6ddbef44ef88cff29897527cf1e9cecc90ad9b9c9922e224ed3e8877545"
+      },
+      "request": {
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "body": {
+          "model": "openrouter/openai/gpt-5.5",
+          "messages": [
+            {
+              "role": "user",
+              "content": "AUTHORED malformed_body candidate request for the OME-962 failure rehearsal. The FakeGateway matches by model, not by this body."
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "media_type": "text/html",
+        "body_b64": "PCFkb2N0eXBlIGh0bWw+PGh0bWw+PGhlYWQ+PHRpdGxlPlNpZ24gaW48L3RpdGxlPjwvaGVhZD48Ym9keT5TaWduIGluIHRvIGNvbnRpbnVlIHRvIHRoZSBnYXRld2F5PC9ib2R5PjwvaHRtbD4="
+      }
+    }
+  ]
+}

--- a/packages/screamingface/tests/e2e/fixtures/failures/provider_5xx.tape.json
+++ b/packages/screamingface/tests/e2e/fixtures/failures/provider_5xx.tape.json
@@ -1,0 +1,39 @@
+{
+  "schema": "screamingface.replay-tape.v1",
+  "provenance": {
+    "board": "draco-3pass",
+    "revision": "authored-failure-rehearsal-2026-08",
+    "expression_sha": "42c81d34c07afc4fbb3eeabca171750111a4cc64fc64cdc2bc6aac4839dec27e",
+    "engine_sha": "authored — no engine rendered this tape",
+    "recorded_at": "2026-08-25T00:00:00Z",
+    "run_ref": "hand-authored for OME-962 (see tests/e2e/test_failures.py)",
+    "authored": true
+  },
+  "exchanges": [
+    {
+      "normalized": {
+        "provider": "openrouter",
+        "model": "openrouter/openai/gpt-5.5",
+        "fingerprint": "c0b843b6ce15ff552e1fe8800f37f7b7e5adab938ac352a774d97cba72308963"
+      },
+      "request": {
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "body": {
+          "model": "openrouter/openai/gpt-5.5",
+          "messages": [
+            {
+              "role": "user",
+              "content": "AUTHORED provider_5xx candidate request for the OME-962 failure rehearsal. The FakeGateway matches by model, not by this body."
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 503,
+        "media_type": "application/json",
+        "body_b64": "eyJkZXRhaWwiOiB7ImNvZGUiOiAicHJvdmlkZXJfdW5hdmFpbGFibGUiLCAibWVzc2FnZSI6ICJUaGUgdXBzdHJlYW0gcHJvdmlkZXIgaXMgdGVtcG9yYXJpbHkgdW5hdmFpbGFibGUuIn19"
+      }
+    }
+  ]
+}

--- a/packages/screamingface/tests/e2e/fixtures/failures/rate_limit_429.tape.json
+++ b/packages/screamingface/tests/e2e/fixtures/failures/rate_limit_429.tape.json
@@ -1,0 +1,39 @@
+{
+  "schema": "screamingface.replay-tape.v1",
+  "provenance": {
+    "board": "draco-3pass",
+    "revision": "authored-failure-rehearsal-2026-08",
+    "expression_sha": "42c81d34c07afc4fbb3eeabca171750111a4cc64fc64cdc2bc6aac4839dec27e",
+    "engine_sha": "authored — no engine rendered this tape",
+    "recorded_at": "2026-08-25T00:00:00Z",
+    "run_ref": "hand-authored for OME-962 (see tests/e2e/test_failures.py)",
+    "authored": true
+  },
+  "exchanges": [
+    {
+      "normalized": {
+        "provider": "openrouter",
+        "model": "openrouter/openai/gpt-5.5",
+        "fingerprint": "15e0c9b98a51c7024b726afc542b96fd347f4aeabaf9db6a884a9e4c6e390e9b"
+      },
+      "request": {
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "body": {
+          "model": "openrouter/openai/gpt-5.5",
+          "messages": [
+            {
+              "role": "user",
+              "content": "AUTHORED rate_limit_429 candidate request for the OME-962 failure rehearsal. The FakeGateway matches by model, not by this body."
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 429,
+        "media_type": "application/json",
+        "body_b64": "eyJkZXRhaWwiOiB7ImNvZGUiOiAicmF0ZV9saW1pdGVkIiwgIm1lc3NhZ2UiOiAiVGhlIHVwc3RyZWFtIHByb3ZpZGVyIGlzIHJhdGUgbGltaXRpbmcgcmVxdWVzdHMuIn19"
+      }
+    }
+  ]
+}

--- a/packages/screamingface/tests/e2e/harness/fake_gateway.py
+++ b/packages/screamingface/tests/e2e/harness/fake_gateway.py
@@ -1,0 +1,298 @@
+"""FakeGateway — the failure-injection replay backend (OME-962, parent R7).
+
+Mental model: a scripted stand-in actor. The cache-seeded gateway (OME-961) can only
+replay good news — a failed provider call never stores a cache row — so the bad-news
+paths are REHEARSED: this backend stands where the AI Gateway stands (the
+``ports.ReplayBackend`` seam) and plays back a hand-authored ``Tape`` of failure
+exchanges verbatim: the 429, the 503, the intercepted HTML page, the token-starved
+blank turn, the truncated judge verdict.
+
+Stages of one rehearsal, in execution order:
+
+1. **Load** — the constructor indexes the tape's exchanges BY MODEL and refuses two
+   tapes outright: one not marked ``provenance.authored=True`` (a rehearsal instrument
+   must never replay something claiming to be a real recording — recordings belong to
+   the cache-seeded gateway), and one holding two exchanges for a single model (row
+   order would then decide which failure injects; ambiguity fails at load, mirroring
+   the tape's own duplicate-identity rule).
+2. **Serve** — ``start()`` binds a stdlib threaded HTTP server to ``127.0.0.1`` port 0
+   and returns the base URL; the engine is pointed at it and never learns more (the
+   seam contract). ``POST /v1/chat/completions`` answers from the tape with the
+   recorded status, media type, and RAW bytes — never re-encoded. ``GET /healthz``
+   answers 200 so the stand-in boots like the real gateway, and ``GET /v1/models``
+   answers the OpenAI-style listing of EXACTLY the tape's models — the SDK's run
+   planning reads the engine's catalogue (which proxies this route) before any model
+   call, and a projection of the tape is still the tape, not an improvised answer.
+3. **Refuse loudly** — anything else gets a named 404 and a row in ``refusals``:
+   an untaped model is ``fake_gateway_unmatched_request`` (the Tape contract —
+   ``lookup`` returns the exchange or ``None``, and ``None`` surfaces as a loud error,
+   deliberately no default response), any other route is ``fake_gateway_unroutable``.
+   Failure injection ONLY: the stand-in never invents an answer and never falls back
+   to anything.
+
+WHY match by MODEL and not by the tape fingerprint: the fingerprint is the gateway's
+own cache ``key_hash`` over the exact request body, and an authored failure tape cannot
+pre-compute it for bodies the ENGINE will compose at run time. The model is the one
+dimension of a scripted failure scenario that is deterministic (the candidate model and
+the board's pinned judge), so an authored tape's fingerprint serves only as the row's
+unique identity, never as a lookup key here.
+
+INVARIANT — zero egress by construction: this module holds no HTTP client at all and
+binds loopback only, so it cannot spend even in a shell with real provider keys
+exported. The strongest form of the harness's clean-environment rule: there is no code
+path that could make an outbound request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Literal
+from urllib.parse import quote
+
+from .tape import RecordedExchange, Tape
+
+_COMPLETIONS_PATH = "/v1/chat/completions"
+_HEALTH_PATH = "/healthz"
+_MODELS_PATH = "/v1/models"
+
+
+@dataclass(frozen=True, slots=True)
+class RefusedRequest:
+    """One request the stand-in refused to answer — the rehearsal's off-script record.
+
+    ``reason`` says which contract the request broke: ``unmatched_model`` is a
+    completions call for a model the tape does not hold; ``unroutable`` is any request
+    outside the taped surface (completions, the health probe, the catalog projection).
+    """
+
+    reason: Literal["unmatched_model", "unroutable"]
+    path: str
+    model: str | None
+
+
+class FakeGateway:
+    """``ReplayBackend`` adapter: an in-process loopback server scripted by one Tape.
+
+    Args:
+        tape: the authored failure tape to play. Must carry
+            ``provenance.authored=True`` and at most one exchange per model —
+            anything else raises ``ValueError`` here, at load, never mid-scenario.
+    """
+
+    def __init__(self, tape: Tape) -> None:
+        self._by_model = _index_by_model(tape)
+        self._refusals: list[RefusedRequest] = []
+        self._lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    # -- the ReplayBackend seam ------------------------------------------------------
+    async def start(self) -> str:
+        return await asyncio.to_thread(self.start_sync)
+
+    async def stop(self) -> None:
+        await asyncio.to_thread(self.stop_sync)
+
+    # The sync twins mirror CacheSeededGateway: the SDK under test is synchronous and
+    # pytest fixtures compose these more honestly than event loops.
+    def start_sync(self) -> str:
+        if self._server is not None:
+            raise RuntimeError("FakeGateway is already started")
+        # Port 0: the OS assigns a free loopback port; the bound address is the truth.
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _handler_for(self))
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name="fake-gateway",
+            daemon=True,  # a leaked thread must never hold a test process open
+        )
+        thread.start()
+        self._server = server
+        self._thread = thread
+        host, port = server.server_address[0], server.server_address[1]
+        return f"http://{host}:{port}"
+
+    def stop_sync(self) -> None:
+        """Tear the server down; idempotent, and safe after a failed start."""
+        server, thread = self._server, self._thread
+        self._server = None
+        self._thread = None
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if thread is not None:
+            thread.join(timeout=10)
+
+    # -- scenario control ------------------------------------------------------------
+    def swap(self, tape: Tape) -> None:
+        """Load the next scenario's tape and clear the refusal record.
+
+        The served base URL stays the same, so one engine boot rehearses every
+        scenario. Validation is identical to construction — a bad tape fails here,
+        before the scenario runs.
+        """
+        by_model = _index_by_model(tape)
+        with self._lock:
+            self._by_model = by_model
+            self._refusals.clear()
+
+    @property
+    def refusals(self) -> tuple[RefusedRequest, ...]:
+        """Every off-script request served the loud error, in arrival order."""
+        with self._lock:
+            return tuple(self._refusals)
+
+    # -- handler callbacks (each request runs on its own server thread) ---------------
+    def _lookup_model(self, model: str | None) -> RecordedExchange | None:
+        with self._lock:
+            return self._by_model.get(model) if model is not None else None
+
+    def _catalog_projection(self) -> bytes:
+        # EXACTLY the tape's models, in the real gateway's locked row shape (aigateway
+        # core/model_capabilities.py::model_row — the SDK's planning requires `id` and
+        # `owned_by`): the discovery half of the seam, derived from the tape's own
+        # normalized identities — never invented.
+        with self._lock:
+            rows = [
+                {
+                    "id": model,
+                    "object": "model",
+                    "owned_by": exchange.normalized.provider,
+                    "supported_parameters": [],
+                    "supported_tools": [],
+                    "unsupported_parameter_behavior": "reject",
+                    "parameter_contract_url": f"/v1/model-parameters?model={quote(model, safe='')}",
+                }
+                for model, exchange in self._by_model.items()
+            ]
+        return json.dumps({"object": "list", "data": rows}).encode()
+
+    def _record_refusal(self, refusal: RefusedRequest) -> None:
+        with self._lock:
+            self._refusals.append(refusal)
+
+
+def _index_by_model(tape: Tape) -> dict[str, RecordedExchange]:
+    # WHY authored is required (not defaulted): a rehearsal must announce itself.
+    # Serving a REAL recording from the stand-in would let a happy-path replay bypass
+    # the cache-seeded gateway's revision guards — the exact fallback R7 forbids.
+    if tape.provenance.authored is not True:
+        raise ValueError(
+            "FakeGateway only plays authored tapes (provenance.authored=True); a real "
+            "recording must replay through the cache-seeded gateway"
+        )
+    by_model: dict[str, RecordedExchange] = {}
+    for exchange in tape.exchanges():
+        model = exchange.normalized.model
+        if model in by_model:
+            raise ValueError(
+                f"tape holds two exchanges for model {model!r} — the fake matches by "
+                f"model, so one model must have exactly one scripted answer"
+            )
+        by_model[model] = exchange
+    return by_model
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """The stand-in's HTTP surface; ``gateway`` is bound per server by ``_handler_for``."""
+
+    gateway: FakeGateway
+
+    # HTTP/1.1 keeps httpx connection reuse working; every reply carries an
+    # explicit Content-Length below, which the protocol version requires.
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib handler naming
+        if self.path == _HEALTH_PATH:
+            self._reply(200, b'{"status":"ok"}', "application/json")
+            return
+        if self.path == _MODELS_PATH:
+            self._reply(200, self.gateway._catalog_projection(), "application/json")
+            return
+        self._refuse_unroutable()
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler naming
+        if self.path != _COMPLETIONS_PATH:
+            self._refuse_unroutable()
+            return
+        model = self._request_model()
+        exchange = self.gateway._lookup_model(model)
+        if exchange is None:
+            self._refuse_unmatched(model)
+            return
+        self._reply(
+            exchange.response.status,
+            bytes(exchange.response.body),
+            exchange.response.media_type,
+        )
+
+    # -- plumbing -------------------------------------------------------------------
+    def _request_model(self) -> str | None:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length)) if length else None
+        except (ValueError, OSError):
+            return None
+        model = body.get("model") if isinstance(body, dict) else None
+        return model if isinstance(model, str) else None
+
+    def _refuse_unmatched(self, model: str | None) -> None:
+        # The Tape contract surfacing as HTTP: lookup returned None, so the answer is
+        # a loud named error — deliberately NO default response.
+        self.gateway._record_refusal(
+            RefusedRequest(reason="unmatched_model", path=self.path, model=model)
+        )
+        self._reply_detail(
+            404,
+            code="fake_gateway_unmatched_request",
+            message=(
+                f"the failure tape holds no exchange for model {model!r} — "
+                f"the FakeGateway never invents an answer"
+            ),
+        )
+
+    def _refuse_unroutable(self) -> None:
+        self.gateway._record_refusal(
+            RefusedRequest(reason="unroutable", path=self.path, model=None)
+        )
+        self._reply_detail(
+            404,
+            code="fake_gateway_unroutable",
+            message=f"the FakeGateway serves only {_COMPLETIONS_PATH} from its tape",
+        )
+
+    def _reply_detail(self, status: int, *, code: str, message: str) -> None:
+        payload = json.dumps({"detail": {"code": code, "message": message}}).encode()
+        # WHY close on every refusal: an off-script POST's body may never have been
+        # read (the unroutable branch refuses before touching rfile), and on a
+        # kept-alive connection those leftover bytes would be parsed as the NEXT
+        # request — garbling it and masking the real refusal. Closing the connection
+        # is simpler than draining and also covers bodies Content-Length cannot
+        # measure (chunked); the client just reconnects.
+        self._reply(status, payload, "application/json", close=True)
+
+    def _reply(self, status: int, body: bytes, media_type: str, *, close: bool = False) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", media_type)
+        self.send_header("Content-Length", str(len(body)))
+        if close:
+            # stdlib's send_header("Connection", "close") also sets close_connection,
+            # so the socket really is torn down after this reply.
+            self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        # Quiet by design: the refusal record is the observable, not stderr.
+        return
+
+
+def _handler_for(gateway: FakeGateway) -> type[BaseHTTPRequestHandler]:
+    """Bind the handler class to one gateway instance (stdlib's class-based wiring)."""
+    return type("_BoundHandler", (_Handler,), {"gateway": gateway})
+
+
+__all__ = ["FakeGateway", "RefusedRequest"]

--- a/packages/screamingface/tests/e2e/test_failures.py
+++ b/packages/screamingface/tests/e2e/test_failures.py
@@ -1,0 +1,468 @@
+"""Failure-path rehearsal against the FakeGateway (OME-962, parent R7).
+
+The cache can only replay good news — a failed provider call never stores a cache row —
+so the bad-news paths are rehearsed here with a scripted stand-in: ``FakeGateway`` plays
+hand-authored failure tapes through the same ``ReplayBackend`` seam the cache-seeded
+gateway uses, and the REAL engine + SDK run a real one-case board against it. Each test
+pins where the engine's DECLARED failure policy says that failure must land.
+
+The declared policy chain, with the code that declares it:
+
+- non-2xx gateway answer → ``ResolutionError`` whose code/message prefer the response's
+  own ``detail`` payload; ``permanent`` is False only for 429/5xx
+  (``runner/connector.py::_raise_for_status``).
+- 2xx non-JSON body → ``aigateway_bad_response``, permanent
+  (``runner/connector.py::_json_or_raise``).
+- parsable turn with neither answer nor tool call → ``aigateway_bad_response``;
+  ``finish_reason=length`` with blank text → ``model_token_cap``
+  (``runner/model_response.py::raise_if_unusable``).
+- a failed CANDIDATE call errors the whole Case row; the board's cases fan out with
+  ``on_error="collect"`` (``benchmarks/protocol.py``), so the row becomes
+  ``{"error": {"kind", "message"}}`` (url4 ``dag/nodes.py::_error_payload``) and DRACO's
+  aggregate maps it to a ``stage="candidate"`` Failure via ``public_error``
+  (``benchmarks/draco/aggregate.py::_row_failure``). The wire row carries no code, so
+  the Failure code is the declared default ``case_execution_failed`` and the
+  gateway-authored MESSAGE is what names the provider failure.
+- a judge that answers but is cut off (truncated verdict JSON) never errors the row:
+  every verdict is bound invalid (``benchmarks/draco/verdict.py::bind``) and the case
+  lands as a ``stage="grading"`` Failure, code ``no_valid_judge_verdict``
+  (``benchmarks/draco/aggregate.py``), with the candidate's output preserved.
+
+Lanes: the FakeGateway/fixture contract tests below are pure-code + loopback-thread and
+run in the DEFAULT lane; the scenario tests boot the real engine subprocess and are
+gated exactly like ``test_replay_plumbing.py`` (``e2e`` marker +
+``SCREAMINGFACE_TEST_E2E=1`` + docker probe) plus prepared draco assets.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import pytest
+from harness._gating import FIXTURES_DIR, require_e2e_stack
+from harness.fake_gateway import FakeGateway
+from harness.stack import EngineProcess
+from harness.tape import TAPE_SCHEMA, LoadedTape, TapeDocument, load_tape
+
+FAILURES_DIR = FIXTURES_DIR / "failures"
+
+#: Both ids are declared engine routes (models/seeds/openrouter.py); the judge id is
+#: DRACO's pinned judge (benchmarks/draco/exam.py::JUDGE_MODEL).
+CANDIDATE_MODEL = "openrouter/openai/gpt-5.5"
+JUDGE_MODEL = "openrouter/google/gemini-3.1-pro-preview"
+
+#: The cheapest judge-bearing board: identical to canonical DRACO but three judge
+#: passes instead of five, so a one-case failure rehearsal spends the fewest calls.
+BOARD = "draco-3pass"
+
+_ASSETS_ENV = "SCREAMINGFACE_E2E_ASSETS"
+_DEFAULT_ASSETS_ROOT = Path("/tmp/screamingface-benchmark-assets")
+
+#: Every authored failure scenario and its tape file. The names are the rehearsal's
+#: vocabulary — each maps one provider failure shape to one declared landing.
+SCENARIO_TAPES = {
+    "rate_limit_429": FAILURES_DIR / "rate_limit_429.tape.json",
+    "provider_5xx": FAILURES_DIR / "provider_5xx.tape.json",
+    "malformed_body": FAILURES_DIR / "malformed_body.tape.json",
+    "blank_completion": FAILURES_DIR / "blank_completion.tape.json",
+    "judge_cutoff": FAILURES_DIR / "judge_cutoff.tape.json",
+}
+
+
+def _authored_tape(
+    *,
+    authored: bool = True,
+    exchanges: list[dict[str, object]] | None = None,
+) -> LoadedTape:
+    """An in-memory failure tape for contract tests — one 429 candidate exchange."""
+    document = {
+        "schema": TAPE_SCHEMA,
+        "provenance": {
+            "board": BOARD,
+            "revision": "authored-failure-rehearsal-2026-08",
+            "expression_sha": "b" * 64,
+            "engine_sha": "authored — no engine rendered this tape",
+            "recorded_at": "2026-08-25T00:00:00Z",
+            "run_ref": "in-memory contract-test tape",
+            "authored": authored,
+        },
+        "exchanges": exchanges if exchanges is not None else [_exchange_429("a" * 64)],
+    }
+    return LoadedTape(TapeDocument.model_validate(document))
+
+
+def _exchange_429(fingerprint: str, model: str = CANDIDATE_MODEL) -> dict[str, object]:
+    import base64
+
+    body = json.dumps(
+        {
+            "detail": {
+                "code": "rate_limited",
+                "message": "The upstream provider is rate limiting requests.",
+            }
+        }
+    ).encode()
+    return {
+        "normalized": {"provider": "openrouter", "model": model, "fingerprint": fingerprint},
+        "request": {
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "body": {"model": model, "messages": []},
+        },
+        "response": {
+            "status": 429,
+            "media_type": "application/json",
+            "body_b64": base64.b64encode(body).decode(),
+        },
+    }
+
+
+# ---- FakeGateway contract (default lane: pure code + a loopback thread) ----
+def test_a_failure_tape_must_declare_itself_authored() -> None:
+    # WHY: the one lie this harness must make impossible is a synthetic fixture
+    # presented as a real recording. The FakeGateway is a rehearsal instrument, so it
+    # refuses any tape that claims to be recorded — real recordings replay through the
+    # cache-seeded gateway, never through the stand-in.
+    with pytest.raises(ValueError, match="authored"):
+        FakeGateway(_authored_tape(authored=False))
+
+
+def test_one_model_cannot_have_two_answers_on_one_tape() -> None:
+    # WHY: the fake matches an incoming call by its MODEL (an authored tape cannot
+    # pre-compute the gateway fingerprint of a body the engine will compose), so two
+    # exchanges for one model would let row order decide which failure injects.
+    # Ambiguity fails at construction, mirroring the tape's duplicate-identity rule.
+    with pytest.raises(ValueError, match="model"):
+        FakeGateway(_authored_tape(exchanges=[_exchange_429("a" * 64), _exchange_429("c" * 64)]))
+
+
+def test_the_fake_serves_exactly_the_recorded_status_and_bytes() -> None:
+    # WHY raw bytes: the tape contract (OME-951 invariant 4) — the stand-in must not
+    # launder the authored provider payload through a decode/re-encode round trip.
+    tape = _authored_tape()
+    gateway = FakeGateway(tape)
+    base_url = gateway.start_sync()
+    try:
+        response = httpx.post(
+            f"{base_url}/v1/chat/completions",
+            json={"model": CANDIDATE_MODEL, "messages": [{"role": "user", "content": "hi"}]},
+            timeout=10.0,
+        )
+    finally:
+        gateway.stop_sync()
+
+    (exchange,) = tape.exchanges()
+    assert response.status_code == 429
+    assert response.content == exchange.response.body
+    assert response.headers["content-type"] == "application/json"
+    assert gateway.refusals == ()
+
+
+def test_a_request_off_the_tape_fails_loudly_with_no_default_response() -> None:
+    # INVARIANT (parent R7): the FakeGateway is failure-injection ONLY — it never
+    # invents an answer for a call its tape does not hold. An unmatched model gets a
+    # loud named error (the stand-in's analogue of the cache-seeded 404 miss) and the
+    # refusal is recorded so a test can prove the rehearsal stayed on-script.
+    gateway = FakeGateway(_authored_tape())
+    base_url = gateway.start_sync()
+    try:
+        response = httpx.post(
+            f"{base_url}/v1/chat/completions",
+            json={"model": "openrouter/never/taped", "messages": []},
+            timeout=10.0,
+        )
+    finally:
+        gateway.stop_sync()
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "fake_gateway_unmatched_request"
+    (refusal,) = gateway.refusals
+    assert refusal.reason == "unmatched_model"
+    assert refusal.model == "openrouter/never/taped"
+
+
+def test_only_the_taped_surface_answers() -> None:
+    # WHY: the stand-in serves ONLY what its tape holds — the chat-completions surface,
+    # a health probe, and a catalogue that PROJECTS the tape's models (run planning
+    # reads it through the engine before any model call; a projection of the tape is
+    # still the tape). Any other route is refused with its own named code, so a test
+    # can tell "the engine asked something off-script" from "the tape missed".
+    gateway = FakeGateway(_authored_tape())
+    base_url = gateway.start_sync()
+    try:
+        health = httpx.get(f"{base_url}/healthz", timeout=10.0)
+        catalog = httpx.get(f"{base_url}/v1/models", timeout=10.0)
+        admin = httpx.get(f"{base_url}/v1/admin/cache/info", timeout=10.0)
+    finally:
+        gateway.stop_sync()
+
+    assert health.status_code == 200
+    assert catalog.status_code == 200
+    # The projection mirrors the gateway's locked /v1/models row shape (id + owned_by
+    # are what the SDK's run planning requires), derived from the tape's identities.
+    (row,) = catalog.json()["data"]
+    assert row["id"] == CANDIDATE_MODEL
+    assert row["owned_by"] == "openrouter"  # from the tape's normalized.provider
+    assert row["object"] == "model"
+    assert row["unsupported_parameter_behavior"] == "reject"
+    assert admin.status_code == 404
+    assert admin.json()["detail"]["code"] == "fake_gateway_unroutable"
+    (refusal,) = gateway.refusals
+    assert refusal.reason == "unroutable"
+
+
+def test_a_refused_post_closes_the_connection_instead_of_garbling_the_next_request() -> None:
+    # WHY: the unroutable branch refuses BEFORE reading the request body, so on a
+    # kept-alive connection the unread bytes would be parsed as the next request's
+    # start-line — garbling an on-script call and masking the real refusal. The fake
+    # therefore closes the connection on every refusal; a follow-up request on a
+    # fresh connection must still be served cleanly from the tape.
+    gateway = FakeGateway(_authored_tape())
+    base_url = gateway.start_sync()
+    try:
+        with httpx.Client(base_url=base_url, timeout=10.0) as client:
+            refused = client.post("/v1/not/a/route", json={"padding": "x" * 4096})
+            followup = client.post(
+                "/v1/chat/completions",
+                json={"model": CANDIDATE_MODEL, "messages": [{"role": "user", "content": "hi"}]},
+            )
+    finally:
+        gateway.stop_sync()
+
+    assert refused.status_code == 404
+    assert refused.headers.get("connection") == "close"
+    assert followup.status_code == 429, followup.text  # served from the tape, ungarbled
+    (refusal,) = gateway.refusals
+    assert refusal.reason == "unroutable"
+
+
+def test_the_fake_binds_loopback_only_and_stop_is_idempotent() -> None:
+    # WHY loopback: zero network egress by construction — the stand-in binds
+    # 127.0.0.1 and holds no HTTP client at all, so it cannot spend even in a shell
+    # with real provider keys exported (the clean-environment rule's sibling).
+    gateway = FakeGateway(_authored_tape())
+    base_url = gateway.start_sync()
+    assert base_url.startswith("http://127.0.0.1:")
+    gateway.stop_sync()
+    gateway.stop_sync()  # must be safe to call twice (ReplayBackend contract)
+
+
+# ---- Authored failure fixtures (default lane: validation on read) ----
+def test_every_rehearsed_scenario_has_an_authored_tape() -> None:
+    # WHY authored=True is asserted per file: provenance is the R11 staleness surface —
+    # a failure fixture must say out loud it is synthetic, or it could be mistaken for
+    # a recording of a real provider incident.
+    for scenario, path in SCENARIO_TAPES.items():
+        assert path.is_file(), f"missing authored failure tape for scenario {scenario}: {path}"
+        tape = load_tape(path)
+        assert tape.provenance.authored is True, f"{scenario} must declare authored=True"
+        assert tape.exchanges(), f"{scenario} tape holds no exchanges"
+
+
+def test_the_provider_error_tapes_carry_the_gateway_authored_detail_envelope() -> None:
+    # WHY this exact shape: the engine reads a non-2xx body's `detail.code`/`.message`
+    # (runner/connector.py::_raise_for_status), and the real gateway authors provider
+    # errors as {"detail": {"code", "message"}} with these exact codes
+    # (aigateway routes/chat_dispatch.py::_litellm_http_exception). The tape must hold
+    # what the engine can actually receive, not an invented error dialect.
+    expectations = {
+        "rate_limit_429": (429, "rate_limited"),
+        "provider_5xx": (503, "provider_unavailable"),
+    }
+    for scenario, (status, code) in expectations.items():
+        (exchange,) = load_tape(SCENARIO_TAPES[scenario]).exchanges()
+        assert exchange.response.status == status
+        assert json.loads(exchange.response.body)["detail"]["code"] == code
+        assert exchange.normalized.model == CANDIDATE_MODEL
+
+
+def test_the_malformed_tape_body_is_not_json_at_all() -> None:
+    # The scenario rehearses a fronting proxy answering 200 with an HTML page — the
+    # exact case runner/connector.py::_json_or_raise names.
+    (exchange,) = load_tape(SCENARIO_TAPES["malformed_body"]).exchanges()
+    assert exchange.response.status == 200
+    with pytest.raises(ValueError):
+        json.loads(exchange.response.body)
+
+
+def test_the_blank_completion_tape_is_a_token_exhausted_empty_turn() -> None:
+    # finish_reason=length + blank text is the one blank-completion shape the engine
+    # classifies specially (model_token_cap, runner/model_response.py) instead of
+    # blaming the gateway.
+    (exchange,) = load_tape(SCENARIO_TAPES["blank_completion"]).exchanges()
+    choice = json.loads(exchange.response.body)["choices"][0]
+    assert choice["finish_reason"] == "length"
+    assert not choice["message"]["content"].strip()
+
+
+def test_the_judge_cutoff_tape_pairs_a_good_candidate_with_a_truncated_judge() -> None:
+    # "Cut off mid-batch" as the engine can actually receive it: the judge ANSWERS
+    # (HTTP 200) but its verdict JSON is truncated by the token budget
+    # (finish_reason=length, non-empty body), so no valid verdict can be bound.
+    tape = load_tape(SCENARIO_TAPES["judge_cutoff"])
+    by_model = {exchange.normalized.model: exchange for exchange in tape.exchanges()}
+    assert set(by_model) == {CANDIDATE_MODEL, JUDGE_MODEL}
+
+    candidate_choice = json.loads(by_model[CANDIDATE_MODEL].response.body)["choices"][0]
+    assert candidate_choice["finish_reason"] == "stop"
+    assert candidate_choice["message"]["content"].strip()
+
+    judge_choice = json.loads(by_model[JUDGE_MODEL].response.body)["choices"][0]
+    assert judge_choice["finish_reason"] == "length"
+    judge_text = judge_choice["message"]["content"]
+    assert judge_text.strip(), "a blank judge turn would land as model_token_cap instead"
+    with pytest.raises(ValueError):
+        json.loads(judge_text)
+
+
+# ---- End-to-end scenarios (e2e lane: real engine + SDK vs the FakeGateway) ----
+@dataclass(frozen=True, slots=True)
+class _FailureStack:
+    """One booted rehearsal stage: swap the cassette, run a scenario, read the report."""
+
+    fake: FakeGateway
+    engine_url: str
+
+
+def _assets_root() -> Path:
+    return Path(os.environ.get(_ASSETS_ENV, str(_DEFAULT_ASSETS_ROOT)))
+
+
+@pytest.fixture(scope="module")
+def failure_stack(tmp_path_factory: pytest.TempPathFactory) -> Iterator[_FailureStack]:
+    """Boot ONCE per module: FakeGateway + real engine, reused by every scenario.
+
+    The gateway seam is stateless between runs — each ``evaluate`` is a fresh engine
+    run, and the fake holds nothing per-run except its refusal record (cleared by
+    ``swap``) — so swapping the cassette between tests cannot leak one scenario into
+    the next, and the slow part (the engine subprocess boot) is paid exactly once.
+    """
+    require_e2e_stack()
+    assets = _assets_root()
+    if not (assets / "draco").is_dir():
+        pytest.skip(
+            f"the failure rehearsal drives the {BOARD} board and needs prepared draco "
+            f"assets at {assets / 'draco'} (run `just stack-prepare` or set {_ASSETS_ENV})"
+        )
+    fake = FakeGateway(load_tape(SCENARIO_TAPES["rate_limit_429"]))
+    engine = EngineProcess(work_dir=tmp_path_factory.mktemp("failure-stack"), assets_dir=assets)
+    base_url = fake.start_sync()
+    try:
+        engine_url = engine.start(base_url)
+        yield _FailureStack(fake=fake, engine_url=engine_url)
+    finally:
+        engine.stop()
+        fake.stop_sync()
+
+
+def _rehearse(stack: _FailureStack, scenario: str):
+    """Play one authored failure tape through a real one-case board run.
+
+    Returns the single CaseResult of the single candidate — the surface where the
+    board's declared failure policy must land.
+    """
+    import screamingface as sf
+
+    stack.fake.swap(load_tape(SCENARIO_TAPES[scenario]))
+    with sf.Client(engine_url=stack.engine_url) as client:
+        report = client.evaluate(
+            sf.Model(CANDIDATE_MODEL), benchmark=BOARD, limit=1, progress=False
+        )
+    # The rehearsal must have stayed on-script: EVERY request the engine made was
+    # answered from the taped surface — no untaped model call (improvisation) and no
+    # off-surface route either (an engine quietly running degraded against 404'd
+    # discovery routes would rehearse a stack that does not exist).
+    assert not stack.fake.refusals, (
+        f"the engine made requests the taped surface does not hold: {stack.fake.refusals}"
+    )
+    candidate = report.candidates.only
+    (case,) = candidate.cases
+    return case
+
+
+@pytest.mark.e2e
+def test_a_provider_429_lands_as_a_candidate_provider_failure_never_malformed(
+    failure_stack: _FailureStack,
+) -> None:
+    # THE R7 invariant: a rate-limited provider surfaces as a candidate-stage provider
+    # failure whose message carries the gateway's own rate-limit wording — never as a
+    # "malformed response", which would send an operator debugging the wrong component.
+    case = _rehearse(failure_stack, "rate_limit_429")
+
+    assert str(case.status) == "failed"
+    (failure,) = case.failures
+    assert failure.stage == "candidate"
+    assert "rate limiting" in failure.message
+    assert "malformed" not in failure.message.lower()
+    # Declared today: the collect row strips the connector's code/permanent, so the
+    # Failure code is DRACO's default for an errored case row (public_error fallback).
+    assert failure.code == "case_execution_failed"
+
+
+@pytest.mark.e2e
+def test_a_provider_5xx_lands_as_a_candidate_provider_failure(
+    failure_stack: _FailureStack,
+) -> None:
+    # Same landing as the 429 (both are the connector's transient class): stage
+    # candidate, message = the gateway-authored provider-unavailable wording.
+    case = _rehearse(failure_stack, "provider_5xx")
+
+    assert str(case.status) == "failed"
+    (failure,) = case.failures
+    assert failure.stage == "candidate"
+    assert "temporarily unavailable" in failure.message
+    assert "malformed" not in failure.message.lower()
+
+
+@pytest.mark.e2e
+def test_a_malformed_gateway_body_lands_as_a_candidate_gateway_fault(
+    failure_stack: _FailureStack,
+) -> None:
+    # A 200 whose body is not JSON at all (an intercepting proxy's HTML page) is the
+    # one failure that SHOULD say "non-JSON"/gateway fault — and must not claim the
+    # provider rate-limited or refused anything.
+    case = _rehearse(failure_stack, "malformed_body")
+
+    assert str(case.status) == "failed"
+    (failure,) = case.failures
+    assert failure.stage == "candidate"
+    assert "non-JSON" in failure.message
+    assert "rate limiting" not in failure.message
+
+
+@pytest.mark.e2e
+def test_a_blank_completion_lands_as_a_token_cap_failure_not_a_gateway_fault(
+    failure_stack: _FailureStack,
+) -> None:
+    # INVARIANT (model_response.py): an all-reasoning `length` turn with blank text is
+    # the MODEL running out of budget — labeling it a gateway fault ("malformed") sends
+    # the reader debugging the wrong component, so the policy names the token cap.
+    case = _rehearse(failure_stack, "blank_completion")
+
+    assert str(case.status) == "failed"
+    (failure,) = case.failures
+    assert failure.stage == "candidate"
+    assert "ran out of tokens" in failure.message
+    assert "malformed" not in failure.message.lower()
+
+
+@pytest.mark.e2e
+def test_a_judge_cut_off_mid_batch_lands_as_grading_never_candidate(
+    failure_stack: _FailureStack,
+) -> None:
+    # THE grading-half invariant: when the candidate answered and only the JUDGE was
+    # cut off, the failure must land at stage="grading" with the candidate's output
+    # preserved on the case — a judge fault must never masquerade as a candidate fault
+    # (that would charge the evaluated model for the evaluator's failure).
+    case = _rehearse(failure_stack, "judge_cutoff")
+
+    assert str(case.status) == "failed"
+    assert case.output, "the candidate's completed answer must be preserved"
+    assert case.failures, "the cut-off judge must be reported, not silently ungraded"
+    assert all(failure.stage == "grading" for failure in case.failures)
+    assert any(failure.code == "no_valid_judge_verdict" for failure in case.failures)


### PR DESCRIPTION
The e2e harness can now rehearse provider disasters: five hand-authored failure tapes play through the real engine + SDK, and each must land exactly where the board's declared failure policy says.

## Before / After

### Before
- Trigger: a provider returns 429/5xx, a malformed body, or cuts a judge off mid-reply during a run
- Today: those paths are untested — failed calls never get a cache entry, so there is nothing to replay — and the on-call debugs a mislabeled error (a 429 surfacing as "malformed response")
- Cost: the engine's worst bugs live exactly where no test looks

### After
- Same trigger, rehearsed in CI by a scripted stand-in gateway
- Now: each authored failure runs through the real pipeline and must land at its declared stage with its declared meaning
- Win: bad news is reported truthfully, proven end-to-end

### Don't regress
- The fake is never a fallback for the happy path — cache-seeded replay stays the only good-news backend
- Zero network egress by construction: FakeGateway is a loopback stdlib server with no HTTP client in the module; no provider keys anywhere

## What's proven (each end-to-end: real engine subprocess + real SDK, draco-3pass, limit=1)

| Authored failure | Must land as |
|---|---|
| HTTP 429 (`rate_limited`) | candidate-stage failure, "provider is rate limiting" |
| HTTP 503 (`provider_unavailable`) | candidate-stage failure, "temporarily unavailable" |
| 200 + HTML body | "non-JSON response body" — never parsed as an answer |
| 200, empty content, `finish_reason=length` | token-cap — explicitly NOT "malformed" |
| judge verdict truncated mid-JSON | `no_valid_judge_verdict` on the **grading** stage, candidate output preserved |

Every scenario also asserts the rehearsal stayed on-script: **all** FakeGateway refusals empty, so a silently-degraded engine (e.g. running against a 404'd route) cannot pass. Off-script refusals reply `Connection: close` so they can't garble a keep-alive connection (owner-review fix, pinned by a contract test).

## Implementation

- `tests/e2e/harness/fake_gateway.py` — `ReplayBackend` adapter scripted by a `Tape`; refuses non-authored tapes; serves recorded raw bytes verbatim; also projects `/v1/models` from exactly the tape's models (the SDK's run planning requires the catalogue).
- `tests/e2e/fixtures/failures/*.tape.json` — authored tapes with the gateway's exact error envelopes (traced to `routes/chat_dispatch.py`).
- `tests/e2e/test_failures.py` — 12 default-lane contract tests + 5 e2e scenarios; every failure-policy claim traced to engine code (`runner/connector.py`, `runner/model_response.py`, `draco/verdict.py`, `draco/aggregate.py`).

Gates: default lane **1121 passed / 1 skipped**; e2e lane **5 scenario + 4 plumbing passed**; ruff + pyright clean. Zero edits to shared harness files. Ledger: `docs/work/2026-08-25-OME-962-failure-paths.md`.

Known finding, deliberately not fixed here (url4 core is out of scope on benchmark PRs): the engine's rich failure classification (`code`, `retryable`) flattens at the url4 `on_error="collect"` boundary — clients distinguish 429 vs malformed only by message today. These tests pin current behavior; a url4 ticket to enrich `_error_payload` would restore full fidelity.

Refs: OME-962

🤖 Generated with [Claude Code](https://claude.com/claude-code)
