### PR TITLE
fix(screamingface): apply Colab theme detection everywhere

### DIFF
--- a/docs/plan/2026-08-25-OME-984-colab-theme-detection.md
+++ b/docs/plan/2026-08-25-OME-984-colab-theme-detection.md
@@ -1,0 +1,21 @@
+# OME-984 — Implementation plan: shared notebook theme detection
+
+Spec: `docs/spec/2026-08-25-OME-984-colab-theme-detection.md` · Stack: screamingface ·
+Branch: `OME-984-colab-theme-detection`
+
+## 1. Pin every independent theme block
+
+- Add one parameterized contract test for shared widgets, Leaderboards, both notice variants, and
+  both provider-logo variants.
+- Confirm only the shared widget block currently passes the Colab selector contract.
+
+## 2. Centralize host detection
+
+- Extract the repeated browser/Colab/JupyterLab/VS Code selector matrix into one internal helper.
+- Reuse it without changing any surface's light or dark declarations.
+
+## 3. Verify and publish
+
+- Run focused Leaderboard, notice, connection, and theme-contract tests.
+- Run `python3 .claude/scripts/run_gates.py screamingface`.
+- Complete the ledger, review the generated CSS ordering, commit, push, and open a draft PR.

--- a/docs/spec/2026-08-25-OME-984-colab-theme-detection.md
+++ b/docs/spec/2026-08-25-OME-984-colab-theme-detection.md
@@ -1,0 +1,24 @@
+# OME-984 — Colab theme detection for every notebook surface
+
+Status: approved (owner, 2026-08-25) · Stack: screamingface
+
+## Problem
+
+OME-955 made the shared `.sf-ui` token block follow Colab's explicit `html[theme]` state, but
+Leaderboards, notices, and connection provider-logo variants own independent theme rules. They can
+still follow the browser or OS preference and render dark inside light Colab, or the reverse.
+
+## Contract
+
+- One internal helper generates the browser fallback, Colab, JupyterLab, and VS Code theme matrix.
+- Shared widgets, Leaderboards, notices, and provider-logo variants use that matrix.
+- Each surface retains its existing SFDS light and dark declarations exactly.
+- Explicit host themes override the browser fallback; JupyterLab and VS Code behavior remains
+  authoritative where their selectors are present.
+
+## Acceptance
+
+- Every independent notebook theme block contains explicit light and dark Colab selectors.
+- Leaderboards, notices, and connection logos follow Colab's active theme.
+- No visual token, data, API, or runtime behavior changes.
+- Focused and complete ScreamingFace quality gates pass.

--- a/docs/tasks/2026-08-25-OME-984-colab-theme-detection.md
+++ b/docs/tasks/2026-08-25-OME-984-colab-theme-detection.md
@@ -1,0 +1,19 @@
+---
+id: OME-984
+linear_url: https://linear.app/openmined/issue/OME-984/apply-colab-theme-detection-to-every-notebook-surface
+status: in_progress
+type: task
+priority: medium
+labels:
+  - py-screamingface
+  - agentic
+  - autonomous
+  - task
+created: 2026-08-25
+closed:
+---
+
+# Apply Colab theme detection to every notebook surface
+
+Bring Leaderboards, client notices, and connection provider logos under the same host-theme
+selection contract already used by shared ScreamingFace notebook surfaces.

--- a/docs/work/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/work/2026-08-24-OME-955-colab-widget-styling.md
@@ -57,18 +57,31 @@ evaluation table usable at narrow output widths without losing horizontal positi
 - Raise the numeric alignment selector above the table-cell base rule so Cases, Score, Cost, and
   Cache Hit share a right edge in the rendered Colab table.
 
+## Theme ownership follow-up
+
+- Generate the browser, Colab, JupyterLab, and VS Code theme matrix from one shared helper while
+  retaining each surface's existing light/dark SFDS values.
+- Apply the shared matrix to the independent Leaderboard and notice token blocks and to the
+  connection panel's provider-logo variants.
+- Pin every independent notebook theme selector with one parameterized contract test.
+
 ## Outcome
 
-- **Actual files:** shared notebook theme tokens, the runtime evaluation fragment projection, a
+- **Actual files:** shared notebook theme tokens and host-rule generator, the runtime evaluation
+  fragment projection, a
   focused live ipywidgets host, its internal observer import, focused UI/report regressions, and the
   OME-955 SDLC artifacts. Review follow-up removed the dead static panel composition and made the
   stable table HTML widget the only scroll/focus owner. Colab visual follow-up moved result
   qualifiers beneath Score so Status remains lifecycle plus elapsed time without column overlap.
+  Theme follow-up brought Leaderboards, notices, and connection provider logos under the same host
+  matrix without changing their visual tokens.
 - **Commits:** `fix(screamingface): clean up Colab widget styling`;
   `fix(screamingface): align Colab widget runtime semantics`;
   `fix(screamingface): keep grading coverage with Score`;
-  `fix(screamingface): align numeric evaluation columns`
-- **Gates:** 97 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
+  `fix(screamingface): align numeric evaluation columns`;
+  `fix(screamingface): unify notebook theme detection`
+- **Gates:** 101 focused Leaderboard/notice/connection/theme-contract tests pass; complete
+  `screamingface` gate passes Ruff,
   formatting, Pyright, the full pytest suite at the 95% coverage floor, notebook checks, package
   build, and distribution validation.
 - **Deviations:** the append-only assertion gate was skipped because this owner-approved ticket

--- a/docs/work/2026-08-24-OME-955-colab-widget-styling.md
+++ b/docs/work/2026-08-24-OME-955-colab-widget-styling.md
@@ -57,31 +57,18 @@ evaluation table usable at narrow output widths without losing horizontal positi
 - Raise the numeric alignment selector above the table-cell base rule so Cases, Score, Cost, and
   Cache Hit share a right edge in the rendered Colab table.
 
-## Theme ownership follow-up
-
-- Generate the browser, Colab, JupyterLab, and VS Code theme matrix from one shared helper while
-  retaining each surface's existing light/dark SFDS values.
-- Apply the shared matrix to the independent Leaderboard and notice token blocks and to the
-  connection panel's provider-logo variants.
-- Pin every independent notebook theme selector with one parameterized contract test.
-
 ## Outcome
 
-- **Actual files:** shared notebook theme tokens and host-rule generator, the runtime evaluation
-  fragment projection, a
+- **Actual files:** shared notebook theme tokens, the runtime evaluation fragment projection, a
   focused live ipywidgets host, its internal observer import, focused UI/report regressions, and the
   OME-955 SDLC artifacts. Review follow-up removed the dead static panel composition and made the
   stable table HTML widget the only scroll/focus owner. Colab visual follow-up moved result
   qualifiers beneath Score so Status remains lifecycle plus elapsed time without column overlap.
-  Theme follow-up brought Leaderboards, notices, and connection provider logos under the same host
-  matrix without changing their visual tokens.
 - **Commits:** `fix(screamingface): clean up Colab widget styling`;
   `fix(screamingface): align Colab widget runtime semantics`;
   `fix(screamingface): keep grading coverage with Score`;
-  `fix(screamingface): align numeric evaluation columns`;
-  `fix(screamingface): unify notebook theme detection`
-- **Gates:** 101 focused Leaderboard/notice/connection/theme-contract tests pass; complete
-  `screamingface` gate passes Ruff,
+  `fix(screamingface): align numeric evaluation columns`
+- **Gates:** 97 focused evaluation/report tests pass; complete `screamingface` gate passes Ruff,
   formatting, Pyright, the full pytest suite at the 95% coverage floor, notebook checks, package
   build, and distribution validation.
 - **Deviations:** the append-only assertion gate was skipped because this owner-approved ticket

--- a/docs/work/2026-08-25-OME-984-colab-theme-detection.md
+++ b/docs/work/2026-08-25-OME-984-colab-theme-detection.md
@@ -1,0 +1,44 @@
+---
+ticket: OME-984
+stack: screamingface
+status: done
+started: 2026-08-25
+finished: 2026-08-25
+---
+
+# OME-984 — Colab theme detection for every notebook surface
+
+## Intent
+
+Complete OME-955's host-theme contract for the independent notebook style blocks it did not cover,
+without changing their SFDS values or their visible design.
+
+## Planned changes
+
+- Shared notebook theme-rule generation.
+- Leaderboard, notice, and connection-logo theme wiring.
+- One cross-surface theme contract test.
+- This unit's task, spec, plan, and work records.
+
+## Test plan
+
+- RED: five independent Leaderboard/notice/logo selectors lack Colab light and dark rules.
+- GREEN: all six theme blocks use the shared host matrix.
+- Focused presentation tests and the complete ScreamingFace gate suite remain green.
+
+## Acceptance
+
+- Colab's explicit theme wins over the browser fallback on every notebook surface.
+- JupyterLab and VS Code behavior remains unchanged.
+- No visual token values change.
+
+## Outcome
+
+- **Actual files:** shared theme-rule generation; Leaderboard, notice, and connection-logo wiring;
+  a parameterized six-block contract test; and this unit's task/spec/plan/work records.
+- **Commits:** `fix(screamingface): unify notebook theme detection`; OME-984 artifact follow-up.
+- **Gates:** 101 focused tests passed; complete `screamingface` gate passed Ruff, formatting,
+  Pyright, full pytest at the 95% coverage floor, notebook checks, package build, and distribution
+  validation.
+- **Deviations:** implementation was first completed on the already-merged OME-955 branch; it was
+  relocated unchanged onto this fresh `origin/main` worktree before opening a PR.

--- a/packages/screamingface/src/screamingface/_ui/connection_view.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_view.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Protocol, assert_never
 from screamingface._ui.connection_state import _ConnectionPanelState
 from screamingface._ui.engine_origin import _is_screamingface_engine
 from screamingface._ui.provider_icons import provider_icon_html
-from screamingface._ui.style import STYLE
+from screamingface._ui.style import STYLE, _theme_rules
 
 if TYPE_CHECKING:
     from screamingface.connections import Connection
@@ -83,22 +83,19 @@ _STYLE = (
 .sf-tile-icon--logo{width:auto;height:auto;background:none;border:0}
 .sf-tile-icon--logo svg{display:block;width:1.35em;height:1.35em}
 .sf-tile-icon--logo .sf-icon-dark{display:none}
-@media(prefers-color-scheme:dark){.sf-tile-icon--logo .sf-icon-light{display:none}
-  .sf-tile-icon--logo .sf-icon-dark{display:block}}
-.jp-mod-theme-dark .sf-tile-icon--logo .sf-icon-light,
-[data-jp-theme-light="false"] .sf-tile-icon--logo .sf-icon-light,
-.vscode-dark .sf-tile-icon--logo .sf-icon-light,
-.vscode-high-contrast .sf-tile-icon--logo .sf-icon-light{display:none}
-.jp-mod-theme-dark .sf-tile-icon--logo .sf-icon-dark,
-[data-jp-theme-light="false"] .sf-tile-icon--logo .sf-icon-dark,
-.vscode-dark .sf-tile-icon--logo .sf-icon-dark,
-.vscode-high-contrast .sf-tile-icon--logo .sf-icon-dark{display:block}
-.jp-mod-theme-light .sf-tile-icon--logo .sf-icon-light,
-[data-jp-theme-light="true"] .sf-tile-icon--logo .sf-icon-light,
-.vscode-light .sf-tile-icon--logo .sf-icon-light{display:block}
-.jp-mod-theme-light .sf-tile-icon--logo .sf-icon-dark,
-[data-jp-theme-light="true"] .sf-tile-icon--logo .sf-icon-dark,
-.vscode-light .sf-tile-icon--logo .sf-icon-dark{display:none}
+"""
+    + _theme_rules(
+        ".sf-tile-icon--logo .sf-icon-light",
+        "display:block",
+        "display:none",
+    )
+    + "\n"
+    + _theme_rules(
+        ".sf-tile-icon--logo .sf-icon-dark",
+        "display:none",
+        "display:block",
+    )
+    + """
 .sf-connections__provider{font-weight:600;font-size:14px;white-space:nowrap;overflow:hidden;
   text-overflow:ellipsis;min-width:0}
 .sf-connections__status{display:inline-flex;align-items:center;gap:8px;font-size:14px;

--- a/packages/screamingface/src/screamingface/_ui/leaderboard_style.py
+++ b/packages/screamingface/src/screamingface/_ui/leaderboard_style.py
@@ -1,45 +1,35 @@
 """SFDS widget styling for public Leaderboard notebook surfaces."""
 
-from screamingface._ui.style import FUSION_GRADIENT_FLOW
+from screamingface._ui.style import FUSION_GRADIENT_FLOW, _theme_rules
+
+_LIGHT = (
+    "--sf-lb-bg:#fcfdff;--sf-lb-surface:#f4f6f9;--sf-lb-surface-2:#eceef0;"
+    "--sf-lb-ink:#3b3c3e;--sf-lb-ink-2:#828386;--sf-lb-ink-3:#b4b6b8;"
+    "--sf-lb-line:#cdcfd2;--sf-lb-line-2:#b4b6b8;"
+    "--sf-lb-accent:#4b91f0;--sf-lb-accent-hover:#4185de;"
+    "--sf-lb-accent-text:#4e85ca;--sf-lb-accent-contrast:#fff"
+)
+_DARK = (
+    "--sf-lb-bg:#05070b;--sf-lb-surface:#0c0f13;--sf-lb-surface-2:#15181c;"
+    "--sf-lb-ink:#e0e5eb;--sf-lb-ink-2:#aeb2b8;--sf-lb-ink-3:#585c61;"
+    "--sf-lb-line:#35383d;--sf-lb-line-2:#585c61;"
+    "--sf-lb-accent:#5a93e0;--sf-lb-accent-hover:#68a0e9;"
+    "--sf-lb-accent-text:#87b4f0;--sf-lb-accent-contrast:#fff"
+)
 
 # This surface follows the product register in screamingface-brand:
 # product-demos/widgets-view/widgets.css and components/style.css. Tokens are
 # repeated here so rich notebook output is self-contained and theme-aware.
-LEADERBOARD_STYLE = """<style>
+LEADERBOARD_STYLE = (
+    """<style>
 .sf-lb{
-  --sf-lb-bg:#fcfdff;--sf-lb-surface:#f4f6f9;--sf-lb-surface-2:#eceef0;
-  --sf-lb-ink:#3b3c3e;--sf-lb-ink-2:#828386;--sf-lb-ink-3:#b4b6b8;
-  --sf-lb-line:#cdcfd2;--sf-lb-line-2:#b4b6b8;
-  --sf-lb-accent:#4b91f0;--sf-lb-accent-hover:#4185de;
-  --sf-lb-accent-text:#4e85ca;--sf-lb-accent-contrast:#fff;
+  __LIGHT__;
   --sf-lb-fusion:__FUSION__;
   max-width:920px;color:var(--sf-lb-ink);background:var(--sf-lb-bg);
   font-family:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
   font-size:13px;line-height:1.38;
 }
-@media(prefers-color-scheme:dark){.sf-lb{
-  --sf-lb-bg:#05070b;--sf-lb-surface:#0c0f13;--sf-lb-surface-2:#15181c;
-  --sf-lb-ink:#e0e5eb;--sf-lb-ink-2:#aeb2b8;--sf-lb-ink-3:#585c61;
-  --sf-lb-line:#35383d;--sf-lb-line-2:#585c61;
-  --sf-lb-accent:#5a93e0;--sf-lb-accent-hover:#68a0e9;
-  --sf-lb-accent-text:#87b4f0;--sf-lb-accent-contrast:#fff;
-}}
-.jp-mod-theme-dark .sf-lb,[data-jp-theme-light="false"] .sf-lb,
-.vscode-dark .sf-lb,.vscode-high-contrast .sf-lb{
-  --sf-lb-bg:#05070b;--sf-lb-surface:#0c0f13;--sf-lb-surface-2:#15181c;
-  --sf-lb-ink:#e0e5eb;--sf-lb-ink-2:#aeb2b8;--sf-lb-ink-3:#585c61;
-  --sf-lb-line:#35383d;--sf-lb-line-2:#585c61;
-  --sf-lb-accent:#5a93e0;--sf-lb-accent-hover:#68a0e9;
-  --sf-lb-accent-text:#87b4f0;--sf-lb-accent-contrast:#fff;
-}
-.jp-mod-theme-light .sf-lb,[data-jp-theme-light="true"] .sf-lb,
-.vscode-light .sf-lb{
-  --sf-lb-bg:#fcfdff;--sf-lb-surface:#f4f6f9;--sf-lb-surface-2:#eceef0;
-  --sf-lb-ink:#3b3c3e;--sf-lb-ink-2:#828386;--sf-lb-ink-3:#b4b6b8;
-  --sf-lb-line:#cdcfd2;--sf-lb-line-2:#b4b6b8;
-  --sf-lb-accent:#4b91f0;--sf-lb-accent-hover:#4185de;
-  --sf-lb-accent-text:#4e85ca;--sf-lb-accent-contrast:#fff;
-}
+__THEME_RULES__
 .sf-lb,.sf-lb *{box-sizing:border-box}
 .sf-lb__head{display:flex;flex-direction:column;align-items:flex-start;gap:4px;
   margin-bottom:16px}
@@ -140,6 +130,9 @@ LEADERBOARD_STYLE = """<style>
   .sf-lb__controls{flex-wrap:wrap}.sf-lb__checkbox{margin-left:0}
   .sf-lb-list__row{grid-template-columns:1fr}.sf-lb-list__meta{justify-content:flex-start}
 }
-</style>""".replace("__FUSION__", FUSION_GRADIENT_FLOW)
+</style>""".replace("__LIGHT__", _LIGHT)
+    .replace("__THEME_RULES__", _theme_rules(".sf-lb", _LIGHT, _DARK))
+    .replace("__FUSION__", FUSION_GRADIENT_FLOW)
+)
 
 __all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_ui/notice_view.py
+++ b/packages/screamingface/src/screamingface/_ui/notice_view.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from html import escape
 
 from screamingface._notices import ClientNotice
+from screamingface._ui.style import _theme_rules
 
 _WARNING_LIGHT = (
     "--sf-notice-ink:#9c4828;--sf-notice-solid:#f1622d;"
@@ -33,18 +34,8 @@ _STYLE = f"""<style>
 }}
 .sf-notice--warning{{{_WARNING_LIGHT}}}
 .sf-notice--info{{{_INFO_LIGHT}}}
-@media (prefers-color-scheme:dark){{
-  .sf-notice--warning{{{_WARNING_DARK}}}
-  .sf-notice--info{{{_INFO_DARK}}}
-}}
-.jp-mod-theme-dark .sf-notice--warning,[data-jp-theme-light="false"] .sf-notice--warning,
-.vscode-dark .sf-notice--warning,.vscode-high-contrast .sf-notice--warning{{{_WARNING_DARK}}}
-.jp-mod-theme-dark .sf-notice--info,[data-jp-theme-light="false"] .sf-notice--info,
-.vscode-dark .sf-notice--info,.vscode-high-contrast .sf-notice--info{{{_INFO_DARK}}}
-.jp-mod-theme-light .sf-notice--warning,[data-jp-theme-light="true"] .sf-notice--warning,
-.vscode-light .sf-notice--warning{{{_WARNING_LIGHT}}}
-.jp-mod-theme-light .sf-notice--info,[data-jp-theme-light="true"] .sf-notice--info,
-.vscode-light .sf-notice--info{{{_INFO_LIGHT}}}
+{_theme_rules(".sf-notice--warning", _WARNING_LIGHT, _WARNING_DARK)}
+{_theme_rules(".sf-notice--info", _INFO_LIGHT, _INFO_DARK)}
 .sf-notice__mark{{width:8px;height:8px;margin-top:5px;background:var(--sf-notice-solid)}}
 .sf-notice__title{{font-weight:600;line-height:1.35}}
 .sf-notice__body{{line-height:1.45;margin-top:2px}}

--- a/packages/screamingface/src/screamingface/_ui/style.py
+++ b/packages/screamingface/src/screamingface/_ui/style.py
@@ -59,6 +59,32 @@ FUSION_GRADIENT_FLOW = _flow(FUSION_GRADIENT)
 # (product-demos/widgets-view/widgets.css .w-rescell-score::before).
 FUSION_GRADIENT_Y = FUSION_GRADIENT.replace("linear-gradient(100deg", "linear-gradient(180deg")
 
+
+def _theme_rules(selector: str, light: str, dark: str) -> str:
+    dark_hosts = ",".join(
+        (
+            f".jp-mod-theme-dark {selector}",
+            f'[data-jp-theme-light="false"] {selector}',
+            f".vscode-dark {selector}",
+            f".vscode-high-contrast {selector}",
+        )
+    )
+    light_hosts = ",".join(
+        (
+            f".jp-mod-theme-light {selector}",
+            f'[data-jp-theme-light="true"] {selector}',
+            f".vscode-light {selector}",
+        )
+    )
+    return (
+        f"@media (prefers-color-scheme:dark){{{selector}{{{dark}}}}}\n"
+        f':where(html[theme="light"]) {selector}{{{light}}}\n'
+        f':where(html[theme="dark"]) {selector}{{{dark}}}\n'
+        f"{dark_hosts}{{{dark}}}\n"
+        f"{light_hosts}{{{light}}}"
+    )
+
+
 # INVARIANT: shared surfaces use solid gold; the Fusion gradient is card-scoped.
 STYLE = f"""<style>
 .sf-ui{{
@@ -67,13 +93,7 @@ STYLE = f"""<style>
   font-family:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
   font-size:13px;line-height:1.45;
 }}
-@media (prefers-color-scheme:dark){{.sf-ui{{{_DARK}}}}}
-:where(html[theme="light"]) .sf-ui{{{_LIGHT}}}
-:where(html[theme="dark"]) .sf-ui{{{_DARK}}}
-.jp-mod-theme-dark .sf-ui,[data-jp-theme-light="false"] .sf-ui,
-.vscode-dark .sf-ui,.vscode-high-contrast .sf-ui{{{_DARK}}}
-.jp-mod-theme-light .sf-ui,[data-jp-theme-light="true"] .sf-ui,
-.vscode-light .sf-ui{{{_LIGHT}}}
+{_theme_rules(".sf-ui", _LIGHT, _DARK)}
 .sf-ui,.sf-ui *{{box-sizing:border-box}}
 </style>"""
 

--- a/packages/screamingface/tests/test_notebook_theme_contract.py
+++ b/packages/screamingface/tests/test_notebook_theme_contract.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from screamingface._ui.connection_view import _STYLE as CONNECTION_STYLE
+from screamingface._ui.leaderboard_style import LEADERBOARD_STYLE
+from screamingface._ui.notice_view import _STYLE as NOTICE_STYLE
+from screamingface._ui.style import STYLE
+
+
+@pytest.mark.parametrize(
+    ("css", "selector"),
+    [
+        (STYLE, ".sf-ui"),
+        (LEADERBOARD_STYLE, ".sf-lb"),
+        (NOTICE_STYLE, ".sf-notice--warning"),
+        (NOTICE_STYLE, ".sf-notice--info"),
+        (CONNECTION_STYLE, ".sf-tile-icon--logo .sf-icon-light"),
+        (CONNECTION_STYLE, ".sf-tile-icon--logo .sf-icon-dark"),
+    ],
+)
+def test_every_notebook_theme_block_honours_colab(
+    css: str,
+    selector: str,
+) -> None:
+    assert f':where(html[theme="light"]) {selector}' in css
+    assert f':where(html[theme="dark"]) {selector}' in css


### PR DESCRIPTION
Colab now controls the theme of every ScreamingFace notebook surface, including the independent Leaderboard, notice, and connection-logo style blocks.

## Before / After

### Before
- OME-955 fixed the shared `.sf-ui` block.
- Leaderboards, notices, and provider-logo variants still followed the browser or OS preference and could render dark inside light Colab.

### After
- One internal helper generates the browser fallback, Colab, JupyterLab, and VS Code selector matrix.
- Every independent notebook theme block uses it.
- Existing SFDS light and dark token values are unchanged.

### Don’t regress
- Explicit host themes override the browser fallback.
- JupyterLab and VS Code selectors remain authoritative.
- No data, API, or runtime behavior changes.

## Verification

- Focused Leaderboard/notice/connection/theme-contract suite: 101 passed.
- Full `screamingface` gates: Ruff, formatting, Pyright, pytest at 95% coverage, notebook checks, wheel build, and distribution validation all green.

Refs: OME-984