### PR TITLE
feat(scoreboard): retire the legacy news demo benchmarks

### DIFF
--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -118,27 +118,41 @@ Leaving `config.authMode` at its default (`disabled`) keeps today's behavior —
 
 The app chart runs `python -m scoreboard.seed` after install and upgrade. Seed data comes from `.Values.seedBenchmarks.benchmarks` and is passed through `SCOREBOARD_SEED_BENCHMARKS_JSON`.
 
-The default seed registers HLE plus the Livetruth public datasets:
+**The default seeds nothing.** `benchmarks` is `[]` and `engineUrl` is empty, so a fresh install registers no benchmark at all and `GET /v1/benchmarks` returns an empty list. The legacy `hle` / `livetruth` / `livetruth-latest` demo entries were removed in OME-986; they were leftovers from the previous SF project.
+
+A real deployment gets its benchmarks from the Engine, by pointing `engineUrl` at the Engine's **in-cluster** address:
+
+```yaml
+seedBenchmarks:
+  enabled: true
+  engineUrl: http://screamingface-engine.screamingface.svc.cluster.local:8000
+  benchmarks: []
+```
+
+To register a benchmark the Engine does not publish — a local smoke target, say — list it explicitly:
 
 ```yaml
 seedBenchmarks:
   enabled: true
   benchmarks:
-    - id: livetruth-latest
-      display_name: News Livetruth Latest
-      description: OpenMined Livetruth latest demo dataset
-      dataset_url: https://scoreboard.screamingface.ai/livetruth-latest.jsonl
-    - id: hle
-      display_name: News Hallucinations
-      description: OpenMined HLE benchmark
-      dataset_url: https://github.com/openmined/HLE.jsonl
-    - id: livetruth
-      display_name: News Livetruth
-      description: OpenMined Livetruth benchmark
-      dataset_url: https://scoreboard.screamingface.ai/livetruth-masking.dataset.jsonl
+    - id: smoke
+      display_name: Smoke
+      description: Local smoke target, not an Engine benchmark
 ```
 
-Re-running the Job is safe because benchmark registration is an upsert. Disable seeding with `--set seedBenchmarks.enabled=false`.
+An entry whose id the Engine also publishes is ignored and named in the Job's output; the Engine is the only place a published benchmark's text is written (OME-904).
+
+Re-running the Job is safe because benchmark registration is an upsert.
+
+**Seeding never deletes.** Removing an entry from this list stops it being recreated; it does not remove a row that already exists, which stays and is still served. To remove one:
+
+```bash
+python -m scoreboard.retire_benchmark --benchmark <id> --yes
+```
+
+It refuses while any score or baseline references the benchmark, and refuses an Engine-published one unless you also pass `--include-engine-owned` — which is only correct once the Engine has stopped publishing it, since otherwise the next seed recreates it.
+
+Disable seeding with `--set seedBenchmarks.enabled=false`.
 
 ## Smoke Checks
 
@@ -150,15 +164,15 @@ curl -fsS http://scoreboard.40.76.107.241.nip.io/healthz
 curl -fsS http://scoreboard.40.76.107.241.nip.io/v1/benchmarks
 ```
 
-Submit a smoke score with an idempotency key. If `config.authMode=cloudflare_headers` is set, add `-H "X-User-Email: <email>"` (and submit from an allowed peer) or this 401s:
+Submit a smoke score with an idempotency key. **`benchmark_id` must name a benchmark this deployment actually registered** — the default seed list is empty, so pick one from the `/v1/benchmarks` call above or seed a `smoke` entry as shown under Benchmark Seeding. Submitting to an unregistered id returns 404. If `config.authMode=cloudflare_headers` is set, add `-H "X-User-Email: <email>"` (and submit from an allowed peer) or this 401s:
 
 ```bash
 curl -fsS -X POST http://scoreboard.40.76.107.241.nip.io/v1/scores \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: score-007-smoke-1" \
-  -d '{"version":1,"benchmark_id":"hle","spec_id":"score-007-smoke","url4_expression":"url4://smoke","submitted_by":"score-007","score":0.5,"total_questions":2,"ran_with_providers":["smoke"],"client":{"name":"curl","version":"0.1.0","platform":"k3s"}}'
+  -d '{"version":1,"benchmark_id":"smoke","spec_id":"score-007-smoke","url4_expression":"url4://smoke","submitted_by":"score-007","score":0.5,"total_questions":2,"ran_with_providers":["smoke"],"client":{"name":"curl","version":"0.1.0","platform":"k3s"}}'
 
-curl -fsS http://scoreboard.40.76.107.241.nip.io/v1/leaderboard/hle
+curl -fsS http://scoreboard.40.76.107.241.nip.io/v1/leaderboard/smoke
 ```
 
 The SCORE-007 initial task mentions POSTing from SF desktop, but current D-SCORE-006 in this repo is AIGateway desktop login, not scoreboard score publishing. Use the public API smoke above until a desktop submission task exists.

--- a/apps/scoreboard/charts/scoreboard/README.md
+++ b/apps/scoreboard/charts/scoreboard/README.md
@@ -24,7 +24,9 @@ The post-install/post-upgrade seed Job runs `python -m scoreboard.seed`. Re-runn
 
 Each benchmark's text — display name, description, focus line, dataset link — is read at deploy from the Engine named by `.Values.seedBenchmarks.engineUrl`, over its public `GET /v1/benchmarks` catalog. That Engine definition is the only place the text is written, so `revision` cannot drift from the Engine's computed value and a values override cannot blank the prose (OME-904). Set `engineUrl` per deployment; leaving it empty seeds only the configured entries.
 
-`.Values.seedBenchmarks.benchmarks` is passed as JSON alongside it and carries only the retained legacy demo entries, which have no Engine definition. An entry whose id the Engine also publishes is ignored, and the Job names it in its output.
+`.Values.seedBenchmarks.benchmarks` is passed as JSON alongside it and is **empty by default** — the legacy demo entries it used to carry were retired in OME-986. Use it only for a benchmark the Engine does not publish, such as a local smoke target. An entry whose id the Engine also publishes is ignored, and the Job names it in its output.
+
+Seeding never deletes: removing an entry stops it being recreated but leaves any existing row in place. Remove one with `python -m scoreboard.retire_benchmark --benchmark <id> --yes`.
 
 Disable seeding with:
 

--- a/apps/scoreboard/charts/scoreboard/values.yaml
+++ b/apps/scoreboard/charts/scoreboard/values.yaml
@@ -125,21 +125,16 @@ seedBenchmarks:
   #
   # Left empty, the job seeds only the entries listed below.
   engineUrl: ""
-  # Retained legacy demo entries (OME-775 D2). They predate the Engine benchmark catalogue and
-  # have no Engine definition, so their text has nowhere else to live.
-  benchmarks:
-    - id: livetruth-latest
-      display_name: News Livetruth Latest
-      description: OpenMined Livetruth latest demo dataset
-      dataset_url: https://scoreboard.screamingface.ai/livetruth-latest.jsonl
-    - id: hle
-      display_name: News Hallucinations
-      description: OpenMined HLE benchmark
-      dataset_url: https://github.com/openmined/HLE.jsonl
-    - id: livetruth
-      display_name: News Livetruth
-      description: OpenMined Livetruth benchmark
-      dataset_url: https://scoreboard.screamingface.ai/livetruth-masking.dataset.jsonl
+  # OME-986: the legacy news demo entries (hle, livetruth, livetruth-latest) were removed here.
+  # They were leftovers from the previous SF project, carried no Engine revision, and were still
+  # advertised on the public catalogue.
+  #
+  # AIDEV-NOTE: emptying this list only stops them being RE-CREATED. Seeding registers and
+  # updates; it never deletes, so any row already in a database stays and is still served by
+  # GET /v1/benchmarks. Removing an existing benchmark is a separate, deliberate step:
+  #   python -m scoreboard.retire_benchmark --benchmark <id> --yes
+  # which refuses while any score or baseline references it.
+  benchmarks: []
 networkPolicy:
   enabled: false
   ingressCIDRs: []

--- a/apps/scoreboard/src/scoreboard/retire_benchmark.py
+++ b/apps/scoreboard/src/scoreboard/retire_benchmark.py
@@ -25,6 +25,8 @@ import asyncio
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+from tortoise.exceptions import IntegrityError
+
 from .config import Settings
 from .db import close_db, init_db
 from .scores.models import Baseline, Benchmark, Score
@@ -67,7 +69,9 @@ async def collect_blockers(benchmark_id: str) -> Blockers:
     )
 
 
-async def retire_benchmark(benchmark_id: str, *, confirmed: bool = False) -> str:
+async def retire_benchmark(
+    benchmark_id: str, *, confirmed: bool = False, include_engine_owned: bool = False
+) -> str:
     """Delete ``benchmark_id`` when ``confirmed``, or explain why it was not deleted.
 
     Returns a line describing what happened, for the operator running it.
@@ -87,10 +91,40 @@ async def retire_benchmark(benchmark_id: str, *, confirmed: bool = False) -> str
     if blockers:
         raise RetirementRefused(blockers.describe(benchmark_id))
 
+    benchmark = await Benchmark.get(id=benchmark_id)
+    if benchmark.revision is not None and not include_engine_owned:
+        # WHY refuse rather than delete: an Engine-published benchmark is re-seeded from the
+        # Engine catalogue on the next deploy, so deleting it here does not achieve what the
+        # operator asked for — it comes straight back. Demonstrated in review of PR #726.
+        # Silently performing a deletion that undoes itself is worse than refusing.
+        #
+        # WHY an override rather than an absolute block: if the Engine STOPS publishing a
+        # benchmark, seeding will not recreate it — but seeding never deletes either, so the row
+        # is stranded and this module is the only way to remove it. A blanket refusal on a
+        # non-null revision would make that legitimate case unreachable.
+        raise RetirementRefused(
+            f"refusing to retire {benchmark_id!r}: it carries Engine revision "
+            f"{benchmark.revision!r}, so the next seed will recreate it. If the Engine no "
+            "longer publishes it, pass --include-engine-owned."
+        )
+
     if not confirmed:
         return f"would retire {benchmark_id!r}: nothing references it. Re-run with --yes."
 
-    await Benchmark.filter(id=benchmark_id).delete()
+    try:
+        await Benchmark.filter(id=benchmark_id).delete()
+    except IntegrityError as exc:
+        # INVARIANT: a score or baseline inserted between the check above and this DELETE must
+        # surface as the same readable refusal, not as the traceback this module exists to
+        # replace. The RESTRICT foreign key is what raises; re-read the counts so the message
+        # names what actually landed (found in review of PR #726).
+        raced = await collect_blockers(benchmark_id)
+        raise RetirementRefused(
+            raced.describe(benchmark_id)
+            if raced
+            else f"refusing to retire {benchmark_id!r}: something began referencing it "
+            "while this ran."
+        ) from exc
     return f"retired {benchmark_id!r}"
 
 
@@ -104,16 +138,26 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Actually delete. Without it, report what would happen and change nothing.",
     )
+    parser.add_argument(
+        "--include-engine-owned",
+        action="store_true",
+        help=(
+            "Allow retiring a benchmark that carries an Engine revision. Only correct when the "
+            "Engine no longer publishes it; otherwise the next seed recreates it."
+        ),
+    )
     return parser
 
 
-async def _run(benchmark_id: str, *, confirmed: bool) -> str:
+async def _run(benchmark_id: str, *, confirmed: bool, include_engine_owned: bool) -> str:
     # Database lifecycle only. The decision lives in retire_benchmark so it is testable without
     # standing up a connection, and so there is ONE copy of it.
     settings = Settings()
     await init_db(settings.database_url)
     try:
-        return await retire_benchmark(benchmark_id, confirmed=confirmed)
+        return await retire_benchmark(
+            benchmark_id, confirmed=confirmed, include_engine_owned=include_engine_owned
+        )
     finally:
         await close_db()
 
@@ -122,7 +166,13 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser = _build_parser()
     args = parser.parse_args(argv)
     try:
-        outcome = asyncio.run(_run(args.benchmark, confirmed=args.yes))
+        outcome = asyncio.run(
+            _run(
+                args.benchmark,
+                confirmed=args.yes,
+                include_engine_owned=args.include_engine_owned,
+            )
+        )
     except (LookupError, RetirementRefused) as exc:
         parser.error(str(exc))
     else:

--- a/apps/scoreboard/src/scoreboard/retire_benchmark.py
+++ b/apps/scoreboard/src/scoreboard/retire_benchmark.py
@@ -1,0 +1,133 @@
+"""Permanently delete a benchmark that nothing references.
+
+FEATURE: OME-986 — `hle`, `livetruth` and `livetruth-latest` are leftovers from the previous SF
+project and still advertised on the public catalogue. Seeding only registers and updates, so
+removing them from the chart's seed list stops them being recreated and changes nothing a reader
+of the board sees. This is the missing half.
+
+INVARIANT: this is an irreversible DELETE, not a status change. "Retire" is the word the request
+used and the name follows it, but nothing here is reversible and no row is kept — read that before
+running it. Deletion is opt-in behind `--yes` for the same reason: every other operator module in
+this app is additive (`seed`, `import_baselines`) or read-only (`export_private_submissions`), so a
+correct-looking command must not destroy anything by default.
+
+INVARIANT: a benchmark that any score or baseline references is REFUSED, and survives. Both
+foreign keys are `on_delete=RESTRICT`, so the database would refuse regardless; the value added
+here is naming which rows stand in the way instead of surfacing an IntegrityError at an operator.
+`Score` and `Baseline` are the only two models that reference `Benchmark` — `IdempotencyKey` links
+to `Score` — so counting those two is a complete check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from .config import Settings
+from .db import close_db, init_db
+from .scores.models import Baseline, Benchmark, Score
+
+
+class RetirementRefused(RuntimeError):
+    """Something references the benchmark, so it was not deleted."""
+
+
+@dataclass(frozen=True)
+class Blockers:
+    """What references a benchmark and therefore stands in the way of deleting it."""
+
+    scores: int
+    baselines: int
+
+    def __bool__(self) -> bool:
+        return bool(self.scores or self.baselines)
+
+    def describe(self, benchmark_id: str) -> str:
+        # WHY both counts in one message: an operator who clears only the blocker they were told
+        # about hits the identical refusal again. Say everything in the way the first time.
+        parts = []
+        if self.scores:
+            parts.append(f"{self.scores} score{'s' if self.scores != 1 else ''}")
+        if self.baselines:
+            parts.append(f"{self.baselines} baseline{'s' if self.baselines != 1 else ''}")
+        return (
+            f"refusing to retire {benchmark_id!r}: it still holds "
+            + " and ".join(parts)
+            + ". Retiring it would destroy submitted data."
+        )
+
+
+async def collect_blockers(benchmark_id: str) -> Blockers:
+    """Count the rows that reference ``benchmark_id``."""
+    return Blockers(
+        scores=await Score.filter(benchmark_id=benchmark_id).count(),
+        baselines=await Baseline.filter(benchmark_id=benchmark_id).count(),
+    )
+
+
+async def retire_benchmark(benchmark_id: str, *, confirmed: bool = False) -> str:
+    """Delete ``benchmark_id`` when ``confirmed``, or explain why it was not deleted.
+
+    Returns a line describing what happened, for the operator running it.
+
+    Raises ``LookupError`` for an unregistered benchmark rather than returning quietly: "already
+    gone" and "you typed it wrong" must not look identical to someone cleaning up a live board.
+
+    Raises ``RetirementRefused`` when anything references it. The benchmark survives.
+
+    INVARIANT: with ``confirmed`` false NOTHING is written. The default outcome of a
+    correct-looking call is a report, because this is the one operator module here that destroys.
+    """
+    if not await Benchmark.exists(id=benchmark_id):
+        raise LookupError(f"unknown benchmark_id: {benchmark_id!r}")
+
+    blockers = await collect_blockers(benchmark_id)
+    if blockers:
+        raise RetirementRefused(blockers.describe(benchmark_id))
+
+    if not confirmed:
+        return f"would retire {benchmark_id!r}: nothing references it. Re-run with --yes."
+
+    await Benchmark.filter(id=benchmark_id).delete()
+    return f"retired {benchmark_id!r}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Permanently delete a benchmark that holds no scores and no baselines.",
+    )
+    parser.add_argument("--benchmark", required=True, help="Benchmark id to delete.")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Actually delete. Without it, report what would happen and change nothing.",
+    )
+    return parser
+
+
+async def _run(benchmark_id: str, *, confirmed: bool) -> str:
+    # Database lifecycle only. The decision lives in retire_benchmark so it is testable without
+    # standing up a connection, and so there is ONE copy of it.
+    settings = Settings()
+    await init_db(settings.database_url)
+    try:
+        return await retire_benchmark(benchmark_id, confirmed=confirmed)
+    finally:
+        await close_db()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        outcome = asyncio.run(_run(args.benchmark, confirmed=args.yes))
+    except (LookupError, RetirementRefused) as exc:
+        parser.error(str(exc))
+    else:
+        print(outcome)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/scoreboard/src/scoreboard/retire_benchmark.py
+++ b/apps/scoreboard/src/scoreboard/retire_benchmark.py
@@ -69,6 +69,43 @@ async def collect_blockers(benchmark_id: str) -> Blockers:
     )
 
 
+async def _delete_exactly_one(benchmark_id: str, *, include_engine_owned: bool) -> None:
+    """Delete the benchmark, or raise ``RetirementRefused`` explaining why it did not happen.
+
+    INVARIANT: the Engine-ownership guard is repeated in the DELETE predicate, not merely read
+    beforehand. A benchmark that gains a revision between the read and the write must not be
+    removed by a call that refused to touch Engine-owned rows, and a predicate is the only way to
+    make that atomic (raised in review of PR #726).
+
+    INVARIANT: `QuerySet.delete()` returns a row count, and ignoring it reports success for
+    something that did not happen. Anything but exactly one row is a refusal.
+    """
+    predicate: dict[str, object] = {"id": benchmark_id}
+    if not include_engine_owned:
+        predicate["revision"] = None
+
+    try:
+        deleted = await Benchmark.filter(**predicate).delete()
+    except IntegrityError as exc:
+        # A score or baseline inserted between the blockers check and this DELETE must surface as
+        # the same readable refusal, not the traceback this module exists to replace. The RESTRICT
+        # foreign key is what raises; re-read the counts so the message names what actually landed.
+        raced = await collect_blockers(benchmark_id)
+        raise RetirementRefused(
+            raced.describe(benchmark_id)
+            if raced
+            else f"refusing to retire {benchmark_id!r}: something began referencing it "
+            "while this ran."
+        ) from exc
+
+    if deleted != 1:
+        raise RetirementRefused(
+            f"refusing to report {benchmark_id!r} retired: the delete matched {deleted} rows. "
+            "It disappeared or became Engine-owned while this ran; re-run to see its current "
+            "state."
+        )
+
+
 async def retire_benchmark(
     benchmark_id: str, *, confirmed: bool = False, include_engine_owned: bool = False
 ) -> str:
@@ -91,7 +128,13 @@ async def retire_benchmark(
     if blockers:
         raise RetirementRefused(blockers.describe(benchmark_id))
 
-    benchmark = await Benchmark.get(id=benchmark_id)
+    benchmark = await Benchmark.get_or_none(id=benchmark_id)
+    if benchmark is None:
+        # It was there for the existence check and gone by now. get() would raise DoesNotExist,
+        # which main() does not catch — the traceback this module exists to replace.
+        raise RetirementRefused(
+            f"refusing to retire {benchmark_id!r}: it disappeared while this ran."
+        )
     if benchmark.revision is not None and not include_engine_owned:
         # WHY refuse rather than delete: an Engine-published benchmark is re-seeded from the
         # Engine catalogue on the next deploy, so deleting it here does not achieve what the
@@ -111,20 +154,7 @@ async def retire_benchmark(
     if not confirmed:
         return f"would retire {benchmark_id!r}: nothing references it. Re-run with --yes."
 
-    try:
-        await Benchmark.filter(id=benchmark_id).delete()
-    except IntegrityError as exc:
-        # INVARIANT: a score or baseline inserted between the check above and this DELETE must
-        # surface as the same readable refusal, not as the traceback this module exists to
-        # replace. The RESTRICT foreign key is what raises; re-read the counts so the message
-        # names what actually landed (found in review of PR #726).
-        raced = await collect_blockers(benchmark_id)
-        raise RetirementRefused(
-            raced.describe(benchmark_id)
-            if raced
-            else f"refusing to retire {benchmark_id!r}: something began referencing it "
-            "while this ran."
-        ) from exc
+    await _delete_exactly_one(benchmark_id, include_engine_owned=include_engine_owned)
     return f"retired {benchmark_id!r}"
 
 

--- a/apps/scoreboard/tests/unit/test_retire_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_retire_benchmark.py
@@ -1,0 +1,189 @@
+"""Retiring a benchmark is the first operator module here that DESTROYS something.
+
+Every other one is additive (`seed`, `import_baselines`) or read-only
+(`export_private_submissions`), so the tests are ordered around the risk: the refusal path is
+pinned before the deletion path exists at all.
+
+INVARIANT under every test below: a benchmark holding a score or a baseline SURVIVES. The
+`on_delete=RESTRICT` foreign keys would refuse anyway; the module's job is to say WHICH rows block
+it rather than hand an operator an IntegrityError traceback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scoreboard.retire_benchmark import (
+    RetirementRefused,
+    collect_blockers,
+    retire_benchmark,
+)
+from scoreboard.scores.baseline_store import BaselineStore
+from scoreboard.scores.models import Benchmark
+from scoreboard.scores.schemas import BaselineImportRow, ScoreSubmission
+from scoreboard.scores.store import ScoreStore
+
+pytestmark = pytest.mark.asyncio
+
+BENCHMARK = "hle"
+
+
+async def _register(store: ScoreStore, benchmark_id: str = BENCHMARK) -> None:
+    await store.register_benchmark(benchmark_id=benchmark_id, display_name="News Hallucinations")
+
+
+def _submission(benchmark_id: str = BENCHMARK) -> ScoreSubmission:
+    return ScoreSubmission(
+        benchmark_id=benchmark_id,
+        spec_id="spec-1",
+        url4_expression="url4://benchmark/spec-1",
+        submitted_by="tester@example.test",
+        score=0.5,
+        total_questions=100,
+        correct_questions=50,
+        ran_with_providers=["openai"],
+    )
+
+
+async def test_a_benchmark_holding_a_score_is_refused_and_survives(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await _register(store)
+    await store.submit(_submission())
+
+    with pytest.raises(RetirementRefused) as refusal:
+        await retire_benchmark(BENCHMARK)
+
+    assert "1 score" in str(refusal.value)
+    assert await Benchmark.exists(id=BENCHMARK)
+
+
+async def test_a_benchmark_holding_a_baseline_is_refused_and_survives(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await _register(store)
+    await BaselineStore().import_many(
+        [
+            BaselineImportRow(
+                benchmark_id=BENCHMARK,
+                model_name="gpt-4",
+                source="lmarena",
+                score=0.7,
+            )
+        ]
+    )
+
+    with pytest.raises(RetirementRefused) as refusal:
+        await retire_benchmark(BENCHMARK)
+
+    assert "1 baseline" in str(refusal.value)
+    assert await Benchmark.exists(id=BENCHMARK)
+
+
+async def test_the_refusal_names_both_blockers_when_both_exist(tortoise_db: None) -> None:
+    # WHY both in one message: an operator who clears only the blocker they were told about hits
+    # the same refusal again. Say everything that stands in the way the first time.
+    store = ScoreStore()
+    await _register(store)
+    await store.submit(_submission())
+    await BaselineStore().import_many(
+        [
+            BaselineImportRow(
+                benchmark_id=BENCHMARK,
+                model_name="gpt-4",
+                source="lmarena",
+                score=0.7,
+            )
+        ]
+    )
+
+    with pytest.raises(RetirementRefused) as refusal:
+        await retire_benchmark(BENCHMARK)
+
+    message = str(refusal.value)
+    assert "1 score" in message
+    assert "1 baseline" in message
+
+
+async def test_collect_blockers_counts_what_references_the_benchmark(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await _register(store)
+    await store.submit(_submission())
+
+    blockers = await collect_blockers(BENCHMARK)
+
+    assert blockers.scores == 1
+    assert blockers.baselines == 0
+    assert bool(blockers) is True
+
+
+async def test_an_unreferenced_benchmark_has_no_blockers(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await _register(store)
+
+    blockers = await collect_blockers(BENCHMARK)
+
+    assert bool(blockers) is False
+
+
+async def test_an_unknown_benchmark_is_refused(tortoise_db: None) -> None:
+    # "Already gone" and "you typed it wrong" must not look identical to someone cleaning up a
+    # live board, so this is a refusal rather than a quiet success.
+    with pytest.raises(LookupError):
+        await retire_benchmark("no-such-benchmark")
+
+
+async def test_without_confirmation_nothing_is_deleted(tortoise_db: None) -> None:
+    # INVARIANT (D6): the default outcome of a correct-looking call is a REPORT. This is the one
+    # operator module here that destroys, so deletion is opt-in rather than the thing that
+    # happens when you get the command right.
+    store = ScoreStore()
+    await _register(store)
+
+    outcome = await retire_benchmark(BENCHMARK)
+
+    assert "would retire" in outcome
+    assert await Benchmark.exists(id=BENCHMARK)
+
+
+async def test_with_confirmation_an_unreferenced_benchmark_is_deleted(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await _register(store)
+
+    outcome = await retire_benchmark(BENCHMARK, confirmed=True)
+
+    assert "retired" in outcome
+    assert not await Benchmark.exists(id=BENCHMARK)
+    assert await store.list_benchmarks() == []
+
+
+async def test_retiring_twice_reports_the_second_as_unknown(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await _register(store)
+    await retire_benchmark(BENCHMARK, confirmed=True)
+
+    with pytest.raises(LookupError):
+        await retire_benchmark(BENCHMARK, confirmed=True)
+
+
+async def test_only_the_named_benchmark_is_deleted(tortoise_db: None) -> None:
+    # INVARIANT: exact id only. No globbing, and no "delete everything without a revision"
+    # shortcut — the neighbours on this board are Engine-published and must not be at risk.
+    store = ScoreStore()
+    await _register(store, "hle")
+    await _register(store, "livetruth")
+
+    await retire_benchmark("hle", confirmed=True)
+
+    assert [row.id for row in await store.list_benchmarks()] == ["livetruth"]
+
+
+async def test_confirmation_does_not_override_a_refusal(tortoise_db: None) -> None:
+    # --yes confirms intent to delete an UNREFERENCED benchmark. It is not a force flag, and must
+    # never become the way someone discards submitted data.
+    store = ScoreStore()
+    await _register(store)
+    await store.submit(_submission())
+
+    with pytest.raises(RetirementRefused):
+        await retire_benchmark(BENCHMARK, confirmed=True)
+
+    assert await Benchmark.exists(id=BENCHMARK)

--- a/apps/scoreboard/tests/unit/test_retire_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_retire_benchmark.py
@@ -269,3 +269,73 @@ async def test_a_reference_added_after_the_check_is_a_refusal_not_a_traceback(
 
     assert "1 score" in str(refusal.value)
     assert await Benchmark.exists(id=BENCHMARK)
+
+
+# --- review round 2: the delete must confirm it actually deleted ------------------------------
+# Same family as the check/delete race already fixed: reporting success for something that did
+# not happen. Raised by @HupBaHa on PR #726.
+
+
+async def test_a_benchmark_vanishing_before_the_revision_read_is_a_refusal(
+    tortoise_db: None,
+) -> None:
+    # `Benchmark.get()` raises DoesNotExist if the row went while we were deciding — a third
+    # unhandled path alongside the two already covered, and main() catches neither.
+    store = ScoreStore()
+    await _register(store)
+    real_collect = retire_benchmark.__globals__["collect_blockers"]
+
+    async def _delete_it(benchmark_id: str):
+        await Benchmark.filter(id=benchmark_id).delete()
+        return Blockers(scores=0, baselines=0)
+
+    retire_benchmark.__globals__["collect_blockers"] = _delete_it
+    try:
+        with pytest.raises(RetirementRefused):
+            await retire_benchmark(BENCHMARK, confirmed=True)
+    finally:
+        retire_benchmark.__globals__["collect_blockers"] = real_collect
+
+
+async def test_a_delete_matching_no_rows_is_not_reported_as_retired(
+    tortoise_db: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # INVARIANT: `QuerySet.delete()` returns a row count. Ignoring it means a benchmark that
+    # disappeared concurrently still prints "retired" — success reported for a no-op.
+    store = ScoreStore()
+    await _register(store)
+    stale = await Benchmark.get(id=BENCHMARK)
+
+    async def _stale_read(**kwargs: object):
+        # The guard read succeeds, then the row goes before the DELETE runs.
+        await Benchmark.filter(id=BENCHMARK).delete()
+        return stale
+
+    monkeypatch.setattr(Benchmark, "get_or_none", _stale_read)
+
+    with pytest.raises(RetirementRefused) as refusal:
+        await retire_benchmark(BENCHMARK, confirmed=True)
+
+    assert "matched 0 rows" in str(refusal.value)
+
+
+async def test_a_revision_appearing_after_the_guard_is_not_deleted(
+    tortoise_db: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # INVARIANT: the Engine-ownership guard must hold at the DELETE, not only at the read. A
+    # benchmark that gains a revision in between must not be removed by a call that refused to
+    # touch Engine-owned rows.
+    store = ScoreStore()
+    await _register(store)
+    stale = await Benchmark.get(id=BENCHMARK)  # revision is None here
+
+    async def _stale_read(**kwargs: object):
+        await Benchmark.filter(id=BENCHMARK).update(revision="rev-appeared")
+        return stale
+
+    monkeypatch.setattr(Benchmark, "get_or_none", _stale_read)
+
+    with pytest.raises(RetirementRefused):
+        await retire_benchmark(BENCHMARK, confirmed=True)
+
+    assert await Benchmark.exists(id=BENCHMARK)

--- a/apps/scoreboard/tests/unit/test_retire_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_retire_benchmark.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pytest
 
 from scoreboard.retire_benchmark import (
+    Blockers,
     RetirementRefused,
     collect_blockers,
     retire_benchmark,
@@ -186,4 +187,85 @@ async def test_confirmation_does_not_override_a_refusal(tortoise_db: None) -> No
     with pytest.raises(RetirementRefused):
         await retire_benchmark(BENCHMARK, confirmed=True)
 
+    assert await Benchmark.exists(id=BENCHMARK)
+
+
+# --- review round: Engine-owned benchmarks and the check/delete race -------------------------
+
+
+async def test_an_engine_owned_benchmark_is_refused_by_default(tortoise_db: None) -> None:
+    # WHY refuse: deleting an Engine-published benchmark does not achieve what the operator
+    # asked for — the next seed reads the Engine catalogue and recreates it. Demonstrated in
+    # review. Silently performing a deletion that undoes itself is worse than refusing.
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="draco", display_name="DRACO", revision="rev-1")
+
+    with pytest.raises(RetirementRefused) as refusal:
+        await retire_benchmark("draco", confirmed=True)
+
+    assert "Engine" in str(refusal.value)
+    assert await Benchmark.exists(id="draco")
+
+
+async def test_an_engine_owned_benchmark_can_be_retired_with_the_override(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: the override exists for the one legitimate case — the Engine STOPPED publishing
+    # it, so seeding will not recreate it, but seeding also never deletes, so the row would
+    # otherwise be stranded forever. A blanket refusal would make that unreachable.
+    store = ScoreStore()
+    await store.register_benchmark(
+        benchmark_id="draco-3pass", display_name="DRACO 3-Pass", revision="rev-1"
+    )
+
+    outcome = await retire_benchmark("draco-3pass", confirmed=True, include_engine_owned=True)
+
+    assert "retired" in outcome
+    assert not await Benchmark.exists(id="draco-3pass")
+
+
+async def test_the_override_does_not_bypass_the_reference_refusal(tortoise_db: None) -> None:
+    # INVARIANT: no flag on this module is a route to destroying submitted data.
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="draco", display_name="DRACO", revision="rev-1")
+    await store.submit(_submission("draco"))
+
+    with pytest.raises(RetirementRefused) as refusal:
+        await retire_benchmark("draco", confirmed=True, include_engine_owned=True)
+
+    assert "1 score" in str(refusal.value)
+    assert await Benchmark.exists(id="draco")
+
+
+async def test_a_reference_added_after_the_check_is_a_refusal_not_a_traceback(
+    tortoise_db: None,
+) -> None:
+    # The module exists to replace an IntegrityError traceback with a readable refusal. A score
+    # inserted between collect_blockers() and the DELETE would otherwise defeat that: the
+    # RESTRICT foreign key raises, and main() catches only LookupError and RetirementRefused.
+    store = ScoreStore()
+    await _register(store)
+
+    real_collect = retire_benchmark.__globals__["collect_blockers"]
+
+    calls = {"n": 0}
+
+    async def _stale_blockers(benchmark_id: str):
+        # First call reports "nothing references it" and races a submission in before the
+        # DELETE. Later calls tell the truth, so the re-check can name what actually landed —
+        # which is how a real race behaves.
+        calls["n"] += 1
+        if calls["n"] == 1:
+            await store.submit(_submission())
+            return Blockers(scores=0, baselines=0)
+        return await real_collect(benchmark_id)
+
+    retire_benchmark.__globals__["collect_blockers"] = _stale_blockers
+    try:
+        with pytest.raises(RetirementRefused) as refusal:
+            await retire_benchmark(BENCHMARK, confirmed=True)
+    finally:
+        retire_benchmark.__globals__["collect_blockers"] = real_collect
+
+    assert "1 score" in str(refusal.value)
     assert await Benchmark.exists(id=BENCHMARK)

--- a/apps/scoreboard/tests/unit/test_retire_benchmark_cli.py
+++ b/apps/scoreboard/tests/unit/test_retire_benchmark_cli.py
@@ -1,0 +1,149 @@
+"""The `python -m scoreboard.retire_benchmark` boundary.
+
+WHY a separate file with a real on-disk database instead of the `tortoise_db` fixture: `main()`
+goes through `Settings()`, `init_db()` and `close_db()`, and those are exactly what these tests
+exist to exercise. Running them against a real SQLite file proves the CLI opens and closes its own
+connection on both the success and the refusal path — which a fixture-provided connection would
+hide (raised by @HupBaHa on PR #726).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from tortoise import Tortoise
+
+from scoreboard.db import close_db, init_db
+from scoreboard.retire_benchmark import main
+from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.store import ScoreStore
+
+
+@pytest.fixture
+def seeded_database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    url = f"sqlite://{tmp_path / 'scoreboard.sqlite3'}"
+    monkeypatch.setenv("SCOREBOARD_DATABASE_URL", url)
+
+    async def _seed() -> None:
+        await init_db(url)
+        await Tortoise.generate_schemas(safe=True)
+        store = ScoreStore()
+        await store.register_benchmark(benchmark_id="legacy", display_name="Legacy")
+        await store.register_benchmark(
+            benchmark_id="engine-owned", display_name="Engine", revision="rev-1"
+        )
+        await store.register_benchmark(benchmark_id="referenced", display_name="Referenced")
+        await store.submit(
+            ScoreSubmission(
+                benchmark_id="referenced",
+                spec_id="spec-1",
+                url4_expression="url4://benchmark/spec-1",
+                submitted_by="tester@example.test",
+                score=0.5,
+                total_questions=100,
+                correct_questions=50,
+                ran_with_providers=["openai"],
+            )
+        )
+        await close_db()
+
+    asyncio.run(_seed())
+    yield
+
+
+async def _survivors() -> list[str]:
+    return [row.id for row in await ScoreStore().list_benchmarks()]
+
+
+def _read_back() -> list[str]:
+    import os
+
+    async def _go() -> list[str]:
+        await init_db(os.environ["SCOREBOARD_DATABASE_URL"])
+        try:
+            return await _survivors()
+        finally:
+            await close_db()
+
+    return asyncio.run(_go())
+
+
+def test_the_default_is_a_dry_run_that_deletes_nothing(
+    seeded_database: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    main(["--benchmark", "legacy"])
+
+    assert "would retire" in capsys.readouterr().out
+    assert "legacy" in _read_back()
+
+
+def test_yes_deletes_and_reports_it(
+    seeded_database: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    main(["--benchmark", "legacy", "--yes"])
+
+    assert "retired 'legacy'" in capsys.readouterr().out
+    assert "legacy" not in _read_back()
+
+
+def test_an_unknown_benchmark_exits_two_without_a_traceback(
+    seeded_database: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["--benchmark", "ghost", "--yes"])
+
+    assert exit_info.value.code == 2
+    assert "unknown benchmark_id" in capsys.readouterr().err
+
+
+def test_a_referenced_benchmark_exits_two_without_a_traceback(
+    seeded_database: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["--benchmark", "referenced", "--yes"])
+
+    assert exit_info.value.code == 2
+    assert "1 score" in capsys.readouterr().err
+    # INVARIANT: the refusal path must still close its connection, or the next call in the same
+    # process hangs. Reading back proves the database is usable afterwards.
+    assert "referenced" in _read_back()
+
+
+def test_an_engine_owned_benchmark_exits_two_and_names_the_override(
+    seeded_database: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["--benchmark", "engine-owned", "--yes"])
+
+    assert exit_info.value.code == 2
+    assert "--include-engine-owned" in capsys.readouterr().err
+    assert "engine-owned" in _read_back()
+
+
+def test_the_override_flag_is_wired_through(
+    seeded_database: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    main(["--benchmark", "engine-owned", "--yes", "--include-engine-owned"])
+
+    assert "retired 'engine-owned'" in capsys.readouterr().out
+    assert "engine-owned" not in _read_back()
+
+
+def test_the_override_alone_does_not_delete_without_yes(
+    seeded_database: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # --include-engine-owned relaxes WHICH benchmarks are eligible. It is not a confirmation.
+    main(["--benchmark", "engine-owned", "--include-engine-owned"])
+
+    assert "would retire" in capsys.readouterr().out
+    assert "engine-owned" in _read_back()
+
+
+def test_benchmark_is_required(seeded_database: None) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main([])
+
+    assert exit_info.value.code == 2

--- a/docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,0 +1,96 @@
+# OME-986 — Implementation plan
+
+**Spec:** `docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md`
+· **Ledger:** `docs/work/2026-08-25-OME-986-retire-news-benchmarks.md`
+· **Branch:** `OME-986-retire-news-benchmarks` · **Stack:** scoreboard
+
+Gates after every step:
+`uv run .claude/scripts/run_gates.py scoreboard --base origin/main`
+
+`tortoise-dev` applies (queryset + delete semantics), though no model or migration changes here.
+
+## Ordering principle
+
+The refusal path is built and tested **before** the deletion path. This module's only real risk is
+destroying submissions, so the guard exists before the thing it guards.
+
+---
+
+### Step 1 — refuse to retire a benchmark that is referenced
+
+**RED:** `retire_benchmark` raises a typed refusal when the benchmark has a score; likewise for a
+baseline; the message names which of the two blocks it and how many rows; **the benchmark still
+exists afterwards**.
+
+**GREEN:** `scoreboard/retire_benchmark.py` with `collect_blockers(benchmark_id)` returning the
+counts, and a refusal raised from them. Nothing deletes yet.
+
+**Why first:** `on_delete=RESTRICT` means the database refuses anyway (spec F4). The value added
+here is telling an operator *what* blocks it instead of surfacing an `IntegrityError` traceback.
+
+---
+
+### Step 2 — refuse an unknown benchmark
+
+**RED:** an unregistered id raises rather than reporting success.
+
+**GREEN:** existence check, mirroring `export_private_submissions.collect_submissions`.
+
+**Why:** "nothing to remove" and "you typed the id wrong" must not look identical to an operator
+cleaning up a live board.
+
+---
+
+### Step 3 — delete an unreferenced benchmark
+
+**RED:** a benchmark with no scores and no baselines is deleted and disappears from
+`list_benchmarks()`; a second run reports it unknown rather than crashing.
+
+**GREEN:** the delete, reachable only past Steps 1 and 2.
+
+---
+
+### Step 4 — the CLI wrapper
+
+**RED:** `main(["--benchmark", "hle"])` exits non-zero on a refusal and zero on success; it prints
+what it did.
+
+**GREEN:** `_build_parser` / `main(argv)`, shaped like `seed.py` and
+`export_private_submissions.py`. `parser.error` for refusals, so the exit code is non-zero without
+a traceback.
+
+---
+
+### Step 5 — chart seed list
+
+Remove `hle`, `livetruth` and `livetruth-latest` from
+`apps/scoreboard/charts/scoreboard/values.yaml`. Without this the next deploy recreates them
+(spec F2). Existing seed tests must stay green — this changes deployment data, not behaviour.
+
+---
+
+### Step 6 — close out
+
+Ledger Outcome · conventional commits with `Refs: OME-986` · PR · green CI · squash-merge · close
+comment per the card's `close_template` · close the `docs/tasks/` mirror.
+
+## Verification
+
+1. Gates green.
+2. Against a scratch database: seed a benchmark **with** a score, run the module, confirm it
+   refuses and the benchmark survives. Then an empty one, confirm it goes and
+   `GET /v1/benchmarks` stops advertising it.
+3. `git grep -n 'livetruth\|"hle"' apps/scoreboard/charts` returns nothing.
+
+## Risks
+
+| Risk | Handling |
+|---|---|
+| Destroying real submissions | Step 1 lands before Step 3; RESTRICT is a second line of defence, not the first |
+| Deleting the wrong benchmark | Exact id only, no globbing, no "delete everything without a revision" shortcut |
+| Config change landing nowhere | Not a code risk — spec §5, needs Stephen to confirm which values file is deployed |
+
+## Out of scope
+
+The five Engine-published benchmarks · any seed-job pruning behaviour (spec §4) · `OME-894` ·
+anything touching the Engine catalogue.

--- a/docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -41,12 +41,18 @@ cleaning up a live board.
 
 ---
 
-### Step 3 — delete an unreferenced benchmark
+### Step 3 — delete an unreferenced benchmark, and confirm it happened
 
 **RED:** a benchmark with no scores and no baselines is deleted and disappears from
 `list_benchmarks()`; a second run reports it unknown rather than crashing.
 
 **GREEN:** the delete, reachable only past Steps 1 and 2.
+
+**Revised after review (spec D9).** The delete must also *confirm* it deleted: `QuerySet.delete()`
+returns a row count, and discarding it reported `retired` for a benchmark that had vanished
+concurrently. The count is required to be exactly one, the revision read uses `get_or_none()`
+because the row can disappear before it, and the Engine-ownership guard is repeated in the DELETE
+predicate so it holds at the write rather than only at the read.
 
 ---
 
@@ -97,5 +103,11 @@ comment per the card's `close_template` · close the `docs/tasks/` mirror.
 
 ## Out of scope
 
-The five Engine-published benchmarks · any seed-job pruning behaviour (spec §4) · `OME-894` ·
-anything touching the Engine catalogue.
+Any seed-job pruning behaviour (spec §4) · `OME-894` · anything touching the Engine catalogue ·
+retiring an Engine benchmark **on the Engine side**.
+
+**Revised after review (spec D8).** This previously said "the five Engine-published benchmarks".
+That was the scope of the *ticket*, not of the tool: `retire_benchmark` is a general operator
+command for any unreferenced benchmark, and `--include-engine-owned` exists precisely for an
+Engine-owned row the Engine has stopped publishing. What stays out is changing what the Engine
+itself publishes.

--- a/docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -55,9 +55,14 @@ cleaning up a live board.
 **RED:** `main(["--benchmark", "hle"])` exits non-zero on a refusal and zero on success; it prints
 what it did.
 
+**RED, additionally:** without `--yes` it reports what it *would* delete and the benchmark still
+exists afterwards; with `--yes` it deletes.
+
 **GREEN:** `_build_parser` / `main(argv)`, shaped like `seed.py` and
 `export_private_submissions.py`. `parser.error` for refusals, so the exit code is non-zero without
-a traceback.
+a traceback. `--yes` gates the delete (spec D6): this is the first operator module here that
+destroys anything, so the destructive step is opt-in rather than the default outcome of a
+correct-looking command.
 
 ---
 

--- a/docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,0 +1,68 @@
+# OME-986 — Retire the legacy news demo benchmarks
+
+**Ticket:** [OME-986](https://linear.app/openmined/issue/OME-986/retire-the-legacy-news-demo-benchmarks-from-the-scoreboard-catalogue)
+· **Ledger:** `docs/work/2026-08-25-OME-986-retire-news-benchmarks.md`
+· **Stack:** scoreboard · **Date:** 2026-08-25
+
+## 1. Problem
+
+`hle`, `livetruth` and `livetruth-latest` are leftovers from the previous SF project. They are
+still advertised on the public catalogue, on the board being handed to internal testers this week.
+
+> *"still need to remove the old news benchmark as they are just old leftovers from the previous
+> SF project"* — Irina, `#scream-dev`, 2026-08-25 07:18
+
+## 2. Established facts
+
+Verified against `origin/main` and the live dev board; none assumed.
+
+| # | Finding | Evidence |
+|---|---|---|
+| F1 | **Seeding never deletes.** `seed_benchmarks` only registers and updates, and no delete path exists anywhere in the codebase | `seed.py`; `register_benchmark` is `update_or_create` |
+| F2 | So removing the three from `seedBenchmarks.benchmarks` stops them being re-created and changes nothing a reader sees — the rows persist and are still served | F1 + `routes/leaderboard.py::list_benchmarks` |
+| F3 | All three are empty on the live board: 0 entries, 0 baselines | `GET /v1/leaderboard/{id}` for each |
+| F4 | `Score.benchmark` and `Baseline.benchmark` are both `on_delete=RESTRICT`, so deletion is refused while anything references them | `models/score.py:107`, `models/baseline.py:35` |
+| F5 | Absent `revision` is the clean discriminator — the other five benchmarks on the board all carry Engine revisions | live `GET /v1/benchmarks` |
+| F6 | The deployed values are **not** this repo's chart defaults: the chart lists all three and sets `engineUrl: ""`, yet the live board serves five Engine-published benchmarks | `charts/scoreboard/values.yaml` vs live API |
+
+F3 + F4 together are why this is cheap **today** and not later: nothing blocks deletion right now,
+and that stops being true the moment a tester submits against one of them.
+
+## 3. Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | A **read-only-by-default operator module**, not a migration and not raw SQL | Owner call. Matches the `seed.py` / `import_baselines.py` / `export_private_submissions.py` precedent: `main(argv)`, no HTTP surface, run where database credentials already are. Reviewable and repeatable. |
+| D2 | It **refuses** when any score or baseline references the benchmark | F4 makes the database refuse anyway; the point is to report *which* rows block it, rather than surface an `IntegrityError` traceback at an operator. Never destroys submissions. |
+| D3 | Scope is exactly the three revision-less ids | Owner call. Precisely what Irina named, and precisely the set F5 identifies. The five Engine-published benchmarks are a different conversation, and retiring one of those would need Engine-side work too. |
+| D4 | Also remove the three from the chart seed list | Otherwise the next deploy recreates what the module just removed. Necessary but, per F2, not sufficient on its own. |
+
+## 4. Explicitly rejected
+
+**Teaching the seed job to prune any benchmark absent from its list.** During an Engine catalogue
+outage `published_rows` is empty, so the prune would delete every Engine-published benchmark. That
+is the exact failure shape review caught in `OME-894` — a transient outage silently changing board
+state — and it would be strictly worse here, because the loss is not recoverable by re-running.
+
+**A data migration.** It re-runs against every fresh database including local dev, is hard to
+reverse, and bakes a one-off cleanup into schema history.
+
+**Raw SQL by hand.** Fastest today, but unreviewable, unrepeatable, and it has to be redone on any
+fresh environment.
+
+## 5. Owner action, not code
+
+Per F6 the config half of this may land nowhere. **Confirm with Stephen which values file actually
+feeds the deployed seed job** — the same conversation as the `authMode` question on `OME-894`.
+
+The module itself is unaffected: it reads the database directly, so it works whichever file is
+deployed.
+
+## 6. Acceptance
+
+- The module deletes a benchmark that has no scores and no baselines.
+- It refuses, naming the blocker, when either exists — and the benchmark survives.
+- An unknown benchmark id is refused rather than reported as success.
+- The three ids are gone from the chart seed list.
+- `GET /v1/benchmarks` no longer advertises them once the module has run.
+- Full gates green.

--- a/docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -35,6 +35,9 @@ and that stops being true the moment a tester submits against one of them.
 | D1 | A **read-only-by-default operator module**, not a migration and not raw SQL | Owner call. Matches the `seed.py` / `import_baselines.py` / `export_private_submissions.py` precedent: `main(argv)`, no HTTP surface, run where database credentials already are. Reviewable and repeatable. |
 | D2 | It **refuses** when any score or baseline references the benchmark | F4 makes the database refuse anyway; the point is to report *which* rows block it, rather than surface an `IntegrityError` traceback at an operator. Never destroys submissions. |
 | D3 | Scope is exactly the three revision-less ids | Owner call. Precisely what Irina named, and precisely the set F5 identifies. The five Engine-published benchmarks are a different conversation, and retiring one of those would need Engine-side work too. |
+| D5 | The module is named `retire_benchmark`, and its docstring states plainly that it performs an irreversible DELETE | Owner call, 2026-08-25. Keeps the language the ticket and Irina used. The naming risk — "retire" reading as a reversible state the row does not get — is answered in the docstring rather than the filename. |
+| D6 | Deletion requires an explicit `--yes` | Owner call. Every other operator module here is additive or read-only; this is the first that destroys, so the destructive step is opt-in rather than the default outcome of a correct-looking command. |
+| D7 | An unknown benchmark id is refused with a non-zero exit | Owner call. "Already gone" and "you typed it wrong" must not look identical to someone cleaning up a live board. Matches `export_private_submissions`, which exits 2. |
 | D4 | Also remove the three from the chart seed list | Otherwise the next deploy recreates what the module just removed. Necessary but, per F2, not sufficient on its own. |
 
 ## 4. Explicitly rejected
@@ -60,7 +63,8 @@ deployed.
 
 ## 6. Acceptance
 
-- The module deletes a benchmark that has no scores and no baselines.
+- The module deletes a benchmark that has no scores and no baselines, **only** when `--yes` is given.
+- Without `--yes` it reports what it would do and deletes nothing.
 - It refuses, naming the blocker, when either exists — and the benchmark survives.
 - An unknown benchmark id is refused rather than reported as success.
 - The three ids are gone from the chart seed list.

--- a/docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -34,7 +34,7 @@ and that stops being true the moment a tester submits against one of them.
 |---|---|---|
 | D1 | A **read-only-by-default operator module**, not a migration and not raw SQL | Owner call. Matches the `seed.py` / `import_baselines.py` / `export_private_submissions.py` precedent: `main(argv)`, no HTTP surface, run where database credentials already are. Reviewable and repeatable. |
 | D2 | It **refuses** when any score or baseline references the benchmark | F4 makes the database refuse anyway; the point is to report *which* rows block it, rather than surface an `IntegrityError` traceback at an operator. Never destroys submissions. |
-| D3 | Scope is exactly the three revision-less ids | Owner call. Precisely what Irina named, and precisely the set F5 identifies. The five Engine-published benchmarks are a different conversation, and retiring one of those would need Engine-side work too. |
+| D3 | ~~Scope is exactly the three revision-less ids~~ — **superseded by D8** | Owner call. Precisely what Irina named, and precisely the set F5 identifies. The five Engine-published benchmarks are a different conversation, and retiring one of those would need Engine-side work too. |
 | D5 | The module is named `retire_benchmark`, and its docstring states plainly that it performs an irreversible DELETE | Owner call, 2026-08-25. Keeps the language the ticket and Irina used. The naming risk — "retire" reading as a reversible state the row does not get — is answered in the docstring rather than the filename. |
 | D6 | Deletion requires an explicit `--yes` | Owner call. Every other operator module here is additive or read-only; this is the first that destroys, so the destructive step is opt-in rather than the default outcome of a correct-looking command. |
 | D7 | An unknown benchmark id is refused with a non-zero exit | Owner call. "Already gone" and "you typed it wrong" must not look identical to someone cleaning up a live board. Matches `export_private_submissions`, which exits 2. |
@@ -70,3 +70,44 @@ deployed.
 - The three ids are gone from the chart seed list.
 - `GET /v1/benchmarks` no longer advertises them once the module has run.
 - Full gates green.
+
+
+## 7. Review round — 2026-08-25
+
+Three items from @HupBaHa on PR #726. He signed off explicitly on the FK protection, the dry-run
+default, the reference refusal and the check/delete race handling; these are the corrections.
+
+### D8 — `retire_benchmark` is a general operator command (supersedes D3)
+
+**Owner decision.** It retires any unreferenced benchmark, not only the three OME-986 legacy ids.
+D3 scoped the *ticket*; the tool built for it is reusable and the recorded intent now says so.
+
+Unchanged by this: the reference guard stays **unconditional**, `--include-engine-owned` stays for
+the stranded case where the Engine no longer publishes a benchmark, and the documentation keeps
+warning that an actively published Engine benchmark will simply be recreated by the next seed.
+
+### D9 — the delete must confirm it deleted
+
+`QuerySet.delete()` returns a row count and the first implementation discarded it, so a benchmark
+that vanished concurrently still printed `retired` — success reported for a no-op, the same family
+as the check/delete race already fixed and missed while fixing it.
+
+Three changes, all with tests that fail without them:
+
+* the row count is required to be exactly `1`, and anything else is a refusal;
+* `Benchmark.get()` became `get_or_none()` — the row disappearing between the existence check and
+  the revision read raised `DoesNotExist`, a third unhandled path `main()` does not catch;
+* **the Engine-ownership guard is repeated in the DELETE predicate**, not merely read beforehand.
+  A benchmark that gains a revision between the read and the write must not be removed by a call
+  that refused to touch Engine-owned rows, and a predicate is the only way to make that atomic.
+
+### D10 — the CLI boundary is tested
+
+`_build_parser`, `_run()` and `main()` had no coverage: the decision function was tested well and
+the boundary not at all. `tests/unit/test_retire_benchmark_cli.py` covers the dry-run default,
+`--yes`, exit code 2 without a traceback for both the unknown and the referenced case,
+`--include-engine-owned` wiring, and that the override alone does not delete without `--yes`.
+
+It runs against a real on-disk SQLite database rather than the `tortoise_db` fixture, deliberately:
+`main()` goes through `Settings()`, `init_db()` and `close_db()`, and a fixture-provided connection
+would hide whether the CLI opens and closes its own on both the success and the refusal path.

--- a/docs/tasks/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/tasks/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,0 +1,22 @@
+---
+id: OME-986
+linear_url: https://linear.app/openmined/issue/OME-986/retire-the-legacy-news-demo-benchmarks-from-the-scoreboard-catalogue
+status: planned
+type: task
+priority: P1
+labels: [scoreboard, agentic, autonomous, task]
+created: 2026-08-25
+closed:
+---
+
+`hle`, `livetruth` and `livetruth-latest` are leftovers from the previous SF project and still
+appear on the public catalogue. Requested by Irina in `#scream-dev` on 2026-08-25, the same
+morning the internal testing notebook went out.
+
+Removing them from the chart's seed list is necessary but not sufficient: seeding only registers
+and updates, so the rows persist and `GET /v1/benchmarks` keeps serving them. A deletion path has
+to exist first.
+
+Spec: `docs/spec/2026-08-25-OME-986-retire-news-benchmarks.md`
+Plan: `docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md`
+Ledger: `docs/work/2026-08-25-OME-986-retire-news-benchmarks.md`

--- a/docs/tasks/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/tasks/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,7 +1,7 @@
 ---
 id: OME-986
 linear_url: https://linear.app/openmined/issue/OME-986/retire-the-legacy-news-demo-benchmarks-from-the-scoreboard-catalogue
-status: planned
+status: in_review
 type: task
 priority: P1
 labels: [scoreboard, agentic, autonomous, task]

--- a/docs/tasks/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/tasks/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,12 +1,12 @@
 ---
 id: OME-986
 linear_url: https://linear.app/openmined/issue/OME-986/retire-the-legacy-news-demo-benchmarks-from-the-scoreboard-catalogue
-status: in_review
+status: done
 type: task
 priority: P1
 labels: [scoreboard, agentic, autonomous, task]
 created: 2026-08-25
-closed:
+closed: 2026-08-26
 ---
 
 `hle`, `livetruth` and `livetruth-latest` are leftovers from the previous SF project and still

--- a/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -113,6 +113,27 @@ public artifact files. Those are the portal's `PUBLIC_ARTIFACTS` allowlist, stil
 and still served — a separate concern from benchmark registration. Retiring the benchmark does not
 retire the artifact, and widening this unit to cover it would be scope creep.
 
+## Review round — 2026-08-25 (@HupBaHa, PR #726)
+
+Changes requested on three items; the safety core was signed off explicitly. Reasoning in spec §7
+(D8–D10).
+
+- **D8 — scope widened by owner decision.** `retire_benchmark` is a general operator command for
+  any unreferenced benchmark, not only the three legacy ids. The reference guard stays
+  unconditional and `--include-engine-owned` stays for the stranded case.
+- **D9 — the delete now confirms it deleted.** The row count was discarded, so a concurrently
+  vanished benchmark printed `retired`. Also fixed a third unhandled path (`get()` →
+  `get_or_none()`, which raised `DoesNotExist`), and moved the Engine-ownership guard into the
+  DELETE predicate so it holds at the write rather than only at the read.
+- **D10 — the CLI boundary is tested**, against a real on-disk database so the init/close paths are
+  genuinely exercised.
+
+Both new guards are mutation-proven: dropping the `--include-engine-owned` wiring fails two CLI
+tests, and ignoring the delete row count fails two decision tests.
+
+This is the second review round where the finding was **adjacent to something I had just fixed** —
+the row count sits directly beside the race I had hardened. Same pattern as OME-894's rounds.
+
 ## Owner-verify
 
 - **The config half may land nowhere.** The chart's seed list is now `[]`, but the deployed values

--- a/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-986
 stack: scoreboard
-status: planned
+status: in_review
 started: 2026-08-25
 finished:
 ---
@@ -18,10 +18,11 @@ Removing them from the chart's seed list is necessary but not sufficient: seedin
 and updates, so the rows persist and keep being served. A deletion path has to exist first, and
 this unit builds it as an operator module rather than a migration or hand-written SQL.
 
-## Status
+## Verified before starting
 
-**Prepared, not started.** Owner asked for the groundwork only — ticket, spec, plan, ledger — with
-no implementation yet. Nothing under `apps/` or `charts/` has been touched.
+Exactly **two** foreign keys point at `Benchmark` — `Score` and `Baseline`. `IdempotencyKey` links
+to `Score`, not `Benchmark`. So a blockers check covering scores and baselines is complete, and no
+third table can produce an `IntegrityError` the guard failed to predict.
 
 ## Facts established before design
 
@@ -37,6 +38,9 @@ Full table in the spec (§2). The two that shape the unit:
 - Operator module plus the config removal, rather than a migration or raw SQL.
 - Scope is exactly the three revision-less ids; the five Engine-published benchmarks are a
   different conversation.
+- Named `retire_benchmark`, with the docstring stating plainly that it is an irreversible DELETE.
+- Deletion requires an explicit `--yes`; without it the module reports and changes nothing.
+- An unknown id is refused with a non-zero exit, so a typo cannot read as success.
 
 ## Planned changes
 
@@ -54,9 +58,41 @@ stops being advertised.
 
 See spec §6.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files:** as planned — `src/scoreboard/retire_benchmark.py`,
+  `tests/unit/test_retire_benchmark.py`, `charts/scoreboard/values.yaml`.
+- **Gates:** `run_gates.py scoreboard --base origin/main` green — append-only ✓, ruff check ✓,
+  ruff format ✓, pyright ✓, pytest --cov ✓, node --test portal ✓. No prior test modified.
+- **Guards are mutation-proven**, not merely passing:
+  - removing the `--yes` gate → `test_without_confirmation_nothing_is_deleted` fails;
+  - removing the refusal → 4 tests fail, one of them with `IntegrityError: FOREIGN KEY constraint
+    failed`, which also demonstrates `RESTRICT` working as the second line of defence rather than
+    the first.
+- **End-to-end against a real database:** dry run changed nothing; the three legacy ids retired;
+  `draco`, holding one score, was refused **even with `--yes`** and survived. Exit codes verified
+  separately after an initial check misread `tail`'s status instead of the module's — refusal `2`,
+  unknown id `2`, dry run `0`, confirmed delete `0`.
+- **Deviations:** one, below.
+
+## Deviations
+
+1. **The module was written in one pass, then refactored, rather than grown strictly step by
+   step.** The first draft duplicated the existence check and the blockers check between
+   `retire_benchmark` and `_run`. It was collapsed to a single decision function with `_run`
+   reduced to database lifecycle, which also made the `--yes` gate testable without standing up a
+   connection. The refusal tests were written first and did drive the guard; the deletion and
+   confirmation tests followed the code, which is why both were mutation-checked before being
+   trusted.
+
+## Owner-verify
+
+- **The config half may land nowhere.** The chart's seed list is now `[]`, but the deployed values
+  are not this repo's defaults (spec F6) — confirm with @Stephen which file feeds the deployed seed
+  job. Same conversation as the `authMode` question on `OME-894`.
+- **Emptying the list does not remove anything that already exists.** The three rows on the live
+  board are still there until someone runs
+  `python -m scoreboard.retire_benchmark --benchmark <id> --yes` against that database. Order
+  matters: run the module *after* the config change is deployed, or the next deploy recreates them.
+- The five Engine-published benchmarks (`draco`, `draco-3pass`, `healthbench-professional`,
+  `healthbench-worst30`, `ifeval`) are untouched and were never in the chart list.

--- a/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,0 +1,62 @@
+---
+ticket: OME-986
+stack: scoreboard
+status: planned
+started: 2026-08-25
+finished:
+---
+
+# OME-986 — Retire the legacy news demo benchmarks
+
+## Intent
+
+`hle`, `livetruth` and `livetruth-latest` are leftovers from the previous SF project, still
+advertised on the catalogue of the board being handed to internal testers this week. Irina asked
+for their removal in `#scream-dev` on 2026-08-25.
+
+Removing them from the chart's seed list is necessary but not sufficient: seeding only registers
+and updates, so the rows persist and keep being served. A deletion path has to exist first, and
+this unit builds it as an operator module rather than a migration or hand-written SQL.
+
+## Status
+
+**Prepared, not started.** Owner asked for the groundwork only — ticket, spec, plan, ledger — with
+no implementation yet. Nothing under `apps/` or `charts/` has been touched.
+
+## Facts established before design
+
+Full table in the spec (§2). The two that shape the unit:
+
+- **F1/F2** — seeding never deletes, so the config change alone changes nothing a reader sees.
+- **F3/F4** — all three are empty today (0 entries, 0 baselines) and both foreign keys are
+  `RESTRICT`, so nothing blocks deletion right now. That stops being true the moment a tester
+  submits against one, which is why this is cheaper now than later.
+
+## Owner decisions (2026-08-25)
+
+- Operator module plus the config removal, rather than a migration or raw SQL.
+- Scope is exactly the three revision-less ids; the five Engine-published benchmarks are a
+  different conversation.
+
+## Planned changes
+
+Per `docs/plan/2026-08-25-OME-986-retire-news-benchmarks.md`: refusal path → unknown-id guard →
+deletion → CLI wrapper → chart seed list → close-out. The refusal path is built and tested before
+the deletion path, because destroying submissions is this module's only real risk.
+
+## Test plan
+
+Per the plan, RED-first. Contracts pinned: a referenced benchmark is refused **and survives**; an
+unknown id is refused rather than reported as success; an unreferenced benchmark is deleted and
+stops being advertised.
+
+## Acceptance
+
+See spec §6.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-986
 stack: scoreboard
-status: in_review
+status: done
 started: 2026-08-25
-finished:
+finished: 2026-08-26
 ---
 
 # OME-986 — Retire the legacy news demo benchmarks

--- a/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
+++ b/docs/work/2026-08-25-OME-986-retire-news-benchmarks.md
@@ -85,6 +85,34 @@ See spec §6.
    confirmation tests followed the code, which is why both were mutation-checked before being
    trusted.
 
+## Review round — 2026-08-25
+
+Three P2 findings, all reproduced before being acted on, all valid.
+
+- **Engine-owned benchmarks had no guard.** Reproduced something stronger than the report: the
+  deletion is not merely out of scope, it is **futile** — `retire draco` → `[]` → next seed →
+  `['draco']`. An Engine-published benchmark is re-seeded from the catalogue, so deleting it here
+  silently does not achieve what the operator asked. It is now refused, naming the revision.
+  **Not** an absolute block: if the Engine STOPS publishing a benchmark, seeding will not recreate
+  it but also never deletes it, so the row is stranded and this module is the only way out.
+  `--include-engine-owned` exists for exactly that case, and does not bypass the reference refusal.
+- **The check/delete race escaped as a traceback.** Reproduced with
+  `IntegrityError: FOREIGN KEY constraint failed` — `main()` catches only `LookupError` and
+  `RetirementRefused`, so a score landing between `collect_blockers()` and the `DELETE` handed the
+  operator the exact traceback this module exists to replace. The `IntegrityError` is now caught,
+  the counts re-read, and a readable refusal raised naming what actually landed.
+- **The docs went stale on my own change.** `DEPLOYMENT.md` claimed the default seed registers
+  HLE/Livetruth and its smoke check POSTed to `hle`, which now 404s on a fresh install;
+  `charts/README.md` said the list carries the legacy demos. Both rewritten: the default seeds
+  nothing, a real deployment points `engineUrl` at the Engine, and the smoke example uses a
+  `smoke` entry the reader is told to seed. Both now also state that seeding never deletes and
+  name the retire command.
+
+Checked and deliberately **not** changed: `DEPLOYMENT.md` still documents the three `livetruth-*`
+public artifact files. Those are the portal's `PUBLIC_ARTIFACTS` allowlist, still present on disk
+and still served — a separate concern from benchmark registration. Retiring the benchmark does not
+retire the artifact, and widening this unit to cover it would be scope creep.
+
 ## Owner-verify
 
 - **The config half may land nowhere.** The chart's seed list is now `[]`, but the deployed values


### PR DESCRIPTION
Closes OME-986.

`hle`, `livetruth` and `livetruth-latest` are leftovers from the previous SF project and were still advertised on the public catalogue — on the board being handed to internal testers this week. Requested by @Irina in `#scream-dev`.

## The part that isn't obvious

**Removing them from the chart's seed list does not remove them.** `seed_benchmarks` only registers and updates; there was no deletion path anywhere in the codebase. Emptying the list stops them being *recreated* and changes nothing a reader of the board sees — the rows persist and `GET /v1/benchmarks` keeps serving them.

So this adds the missing half, and the config change alone is deliberately not the deliverable.

## Why now

All three are empty today — 0 entries, 0 baselines. Both `Score.benchmark` and `Baseline.benchmark` are `on_delete=RESTRICT`, so deletion is refused the moment anything references them. One tester submitting against `hle` turns a clean delete into a data conversation.

## Design

This is the **first operator module here that destroys anything** — every other one is additive (`seed`, `import_baselines`) or read-only (`export_private_submissions`). So:

- Deletion is opt-in behind `--yes`. The default outcome of a correct-looking command is a report.
- A benchmark that any score or baseline references is **refused and survives**, and `--yes` does not override that. It confirms intent to delete something unreferenced; it is not a force flag.
- An unknown id is refused with a non-zero exit, because "already gone" and "you typed it wrong" must not look identical to someone cleaning up a live board.

`RESTRICT` means the database would refuse regardless. The module's job is naming *which* rows stand in the way rather than surfacing an `IntegrityError` traceback at an operator. `Score` and `Baseline` are the only two models referencing `Benchmark` (`IdempotencyKey` links to `Score`), so counting those two is a complete check.

**Rejected:** teaching the seed job to prune anything absent from its list. During an Engine catalogue outage `published_rows` is empty, so it would delete every Engine-published benchmark — the same failure shape review caught in OME-894, and worse here because re-running would not recover it. Also rejected: a data migration, which would re-run against every fresh database including local dev.

## Test plan

The refusal path was built and tested **before** the deletion path existed, since destroying submissions is this module's only real risk.

Both guards are **mutation-proven**, not merely passing:
- remove the `--yes` gate → `test_without_confirmation_nothing_is_deleted` fails
- remove the refusal → 4 tests fail, one with `IntegrityError: FOREIGN KEY constraint failed`, which also shows `RESTRICT` working as the second line of defence rather than the first

End-to-end against a real database: dry run changed nothing; the three legacy ids retired; `draco`, holding one score, was refused **even with `--yes`** and survived. Exit codes verified: refusal `2`, unknown id `2`, dry run `0`, confirmed delete `0`.

## Before this has any effect on the live board

**Two things, in this order.**

1. **Confirm with @Stephen which values file feeds the deployed seed job.** The chart here lists all three and sets `engineUrl: ""`, yet the live board serves five Engine-published benchmarks — so the deployed values are not this repo's defaults (OME-730). Without that, the config half lands nowhere.
2. **Then run the module against the deployed database.** Emptying the list does not touch rows that already exist:
   ```
   python -m scoreboard.retire_benchmark --benchmark hle --yes
   ```
   Order matters — run it *after* the config change is deployed, or the next deploy recreates them.

The five Engine-published benchmarks are untouched and were never in the chart list.