### PR TITLE
fix(repo): remove Preview labels from fork pull requests

### DIFF
--- a/.github/scripts/preview_contract.py
+++ b/.github/scripts/preview_contract.py
@@ -161,6 +161,16 @@ def preview_tag(number: int, sha: str) -> str:
     return f"pr-{number}-{sha[:7]}"
 
 
+def is_fork(pull: dict, repository: str) -> bool:
+    """Return True when the pull request head is outside the repository.
+
+    A deleted fork reports no head repository. That case counts as a fork,
+    so the safe branch of every caller handles it.
+    """
+    head_repository = (pull.get("head") or {}).get("repo") or {}
+    return head_repository.get("full_name") != repository
+
+
 def plan_admission(
     pulls: Sequence[PullState],
     now: datetime,
@@ -320,6 +330,20 @@ def preview_comment(
     return "\n".join(lines) + "\n"
 
 
+def fork_comment() -> str:
+    """Explain why a fork pull request lost its Preview labels."""
+    lines = [
+        COMMENT_MARKER,
+        "## Preview: unavailable",
+        "",
+        "Fork pull requests cannot receive a Preview.",
+        "The Preview labels were removed.",
+        "To preview this change, a maintainer pushes it to a repository",
+        "branch and opens a pull request from that branch.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def _parse_time(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
@@ -386,9 +410,24 @@ def _pull_selection(pull: dict) -> tuple[tuple[str, ...], tuple[str, ...]]:
     return components, images
 
 
+def _disable_fork(github: GitHub, pull: dict) -> None:
+    """Remove every managed Preview label from a fork pull request."""
+    number = pull["number"]
+    labels = {item["name"] for item in pull["labels"]}
+    if not labels & MANAGED_LABELS:
+        print(f"Fork pull request {number} carries no Preview label")
+        return
+    print(f"Remove the Preview labels from fork pull request {number}")
+    github.set_managed_labels(number, set())
+    github.upsert_comment(number, fork_comment())
+
+
 def _update(number: int, sha: str, status: str, selection: Selection) -> None:
     github = GitHub()
     pull = github.pull(number)
+    if is_fork(pull, github.repo):
+        _disable_fork(github, pull)
+        return
     if pull["head"]["sha"] != sha:
         print(f"Ignore stale revision {sha}; current revision is {pull['head']['sha']}")
         return
@@ -406,6 +445,9 @@ def reconcile() -> None:
     raw_pulls = github.pulls()
     pulls: list[PullState] = []
     for pull in raw_pulls:
+        if is_fork(pull, github.repo):
+            _disable_fork(github, pull)
+            continue
         labels = frozenset(item["name"] for item in pull["labels"])
         events = github.events(pull["number"])
         added = {
@@ -465,6 +507,8 @@ def main() -> None:
         command.add_argument("--components", default="[]")
         command.add_argument("--images", default="[]")
     subparsers.add_parser("reconcile")
+    guard = subparsers.add_parser("guard")
+    guard.add_argument("--number", type=int, required=True)
     args = parser.parse_args()
     if args.command == "classify":
         selection = classify_paths(args.paths.read_text().splitlines())
@@ -482,6 +526,13 @@ def main() -> None:
                 output.write(f"{name}={value}\n")
     elif args.command == "reconcile":
         reconcile()
+    elif args.command == "guard":
+        github = GitHub()
+        pull = github.pull(args.number)
+        if is_fork(pull, github.repo):
+            _disable_fork(github, pull)
+        else:
+            print(f"Pull request {args.number} is not from a fork; no change")
     else:
         selection = _selection(args)
         status = {

--- a/.github/scripts/test_preview_contract.py
+++ b/.github/scripts/test_preview_contract.py
@@ -207,6 +207,87 @@ def test_active_comment_uses_the_selected_deployment(
     assert f"--selector app.kubernetes.io/name={pod_label}" in comment
 
 
+def test_fork_detection_requires_the_exact_repository() -> None:
+    contract = load_contract()
+    repository = "ScreamingFace/screamingface"
+
+    same = {"head": {"repo": {"full_name": repository}}}
+    fork = {"head": {"repo": {"full_name": "outside/screamingface"}}}
+    deleted = {"head": {"repo": None}}
+
+    assert not contract.is_fork(same, repository)
+    assert contract.is_fork(fork, repository)
+    assert contract.is_fork(deleted, repository)
+
+
+def test_fork_comment_explains_the_removal() -> None:
+    contract = load_contract()
+
+    comment = contract.fork_comment()
+
+    assert comment.startswith(contract.COMMENT_MARKER)
+    assert "## Preview: unavailable" in comment
+    assert "Fork pull requests cannot receive a Preview." in comment
+    assert "The Preview labels were removed." in comment
+
+
+def test_reconcile_strips_a_queued_fork_instead_of_promoting_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = load_contract()
+    instances: list = []
+
+    class FakeGitHub:
+        repo = "ScreamingFace/screamingface"
+
+        def __init__(self) -> None:
+            self.stripped: list[int] = []
+            self.commented: list[int] = []
+            instances.append(self)
+
+        def pulls(self) -> list[dict]:
+            return [
+                {
+                    "number": 7,
+                    "labels": [{"name": "preview-queued"}],
+                    "head": {"repo": {"full_name": "outside/screamingface"}},
+                    "created_at": "2026-08-24T00:00:00Z",
+                    "draft": False,
+                }
+            ]
+
+        def set_managed_labels(self, number: int, wanted: set[str]) -> None:
+            assert wanted == set()
+            self.stripped.append(number)
+
+        def upsert_comment(self, number: int, body: str) -> None:
+            assert "## Preview: unavailable" in body
+            self.commented.append(number)
+
+        def events(self, number: int) -> list[dict]:
+            raise AssertionError("fork pull requests must not reach admission")
+
+    monkeypatch.setattr(contract, "GitHub", FakeGitHub)
+
+    contract.reconcile()
+
+    assert instances[0].stripped == [7]
+    assert instances[0].commented == [7]
+
+
+def test_fork_guard_runs_trusted_code_on_the_label_event() -> None:
+    guard = (ROOT / ".github/workflows/preview-fork-guard.yml").read_text()
+
+    assert "pull_request_target:" in guard
+    assert "types: [labeled]" in guard
+    assert "head.repo.full_name != github.repository" in guard
+    assert "startsWith(github.event.label.name, 'preview')" in guard
+    assert "persist-credentials: false" in guard
+    assert "ref:" not in guard
+    assert "preview_contract.py guard" in guard
+    assert "id-token" not in guard
+
+
 def test_workflows_keep_oidc_away_from_forks_and_serialize_admission() -> None:
     images = (ROOT / ".github/workflows/preview-images.yml").read_text()
     admission = (ROOT / ".github/workflows/preview-admission.yml").read_text()

--- a/.github/workflows/preview-fork-guard.yml
+++ b/.github/workflows/preview-fork-guard.yml
@@ -1,0 +1,40 @@
+name: Preview fork guard
+
+# SECURITY: `pull_request_target` grants a write token, so this workflow never
+# checks out or executes pull-request code. The checkout reads the trusted base
+# revision only, and every `run:` below is a static command — no event payload
+# is interpolated into a shell context.
+#
+# WHY this exists: the `preview` label authorizes a platform deployment, and
+# the Argo CD pull-request generator cannot see fork origin. The admission
+# reconciler also strips Preview labels from forks, but only every five
+# minutes. This guard reacts to the labeling event itself, inside the
+# generator's polling interval.
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: screamingface-preview-fork-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  strip:
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      startsWith(github.event.label.name, 'preview')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Remove the Preview labels from the fork pull request
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python3 .github/scripts/preview_contract.py guard --number "$PR_NUMBER"


### PR DESCRIPTION
## Summary

- deny every managed Preview label to fork pull requests
- strip labels structurally in the reconciler: a queued fork can never promote
- strip labels in every status update as defense in depth
- add a fork guard workflow that reacts to the labeling event itself, inside the Argo CD generator polling interval
- explain each removal in the maintained Preview comment
- treat a deleted fork repository as a fork

Before this change, nothing removed a hand-added Preview label from a fork. Both `preview-images` jobs skip forks, and the reconciler promoted any `preview-queued` pull request without a fork check. The `preview` label authorizes a platform deployment, and the Argo CD pull-request generator cannot see fork origin.

The guard uses `pull_request_target` with a write token. It never checks out or executes pull-request code, runs static commands only, and receives no cloud credential.

## Test plan

- `uv run --project apps/screamingface-engine pytest .github/scripts/test_preview_contract.py -q`
- result: 19 passed
- Ruff check and format: passed
- Actionlint 1.7.12 on the guard workflow: passed
- Python compilation and YAML parsing: passed



## Update 2026-09-09: the timing this guard depends on, confirmed

The summary says the guard reacts "inside the Argo CD generator polling interval". That interval is now confirmed from the consuming side: the platform's pull-request generator polls with `requeueAfterSeconds: 180`.

That makes the guard the part that matters. The reconciler alone runs on a five-minute schedule, so a Preview label added by hand to a fork could be seen by the generator roughly two minutes before the reconciler stripped it. The labeling-event guard closes that window.

For the same reason the platform does not treat this as its security boundary. The consuming ApplicationSet documents the boundary as "maintainers must never add this label to a fork", because the Argo CD pull-request generator exposes no fork-origin field. This workflow is defence in depth on top of that rule, which is the right place for it.

Ticket reference: the earlier `Refs: OME-965` line was wrong. OME-965 is "Apply Engine scheduling settings to Kubernetes Runner Jobs", a different piece of work, and one that is now moot since Runner Jobs were retired in the worker-pool cutover. This change has no ticket of its own.
