### PR TITLE
feat(aigateway): discover OpenRouter models live

### DIFF
--- a/apps/aigateway/DEPLOYMENT.md
+++ b/apps/aigateway/DEPLOYMENT.md
@@ -354,6 +354,55 @@ This feature writes no accounting or attribution fields, and a hit performs no p
 so a hit currently produces no provider-side usage record of its own. Do not read cache-hit volume
 out of provider billing.
 
+## Live OpenRouter Model Discovery (OME-972)
+
+`GET /v1/models` lists the models OpenRouter actually serves now, refreshed from its public
+catalog (`https://openrouter.ai/api/v1/models`, no credential attached) through one
+deployment-wide cached snapshot. Default **on**.
+
+- `AIGW_OPENROUTER_LIVE_MODELS=false` restores the static compiled-seed listing with **zero**
+  catalog egress. `AIGW_DISCOVERY_ENABLED=false` (the discovery kill switch) silences the
+  catalog together with all other discovery traffic.
+- **Snapshot-or-fallback:** with a healthy snapshot the listing is the discovered plain
+  `vendor/model` ids plus anything explicitly configured in `AIGW_OPENROUTER_DEFAULT_MODELS`
+  plus admitted models — compiled defaults absent from the snapshot are not listed, so retired
+  models disappear within one TTL. When the catalog is cold or degraded, the listing falls back
+  to the compiled/operator seeds, identical to today's static behavior.
+- **Degrade ladder:** fresh snapshot (≤5 min) → served from cache; refresh failure → last good
+  snapshot serves for up to 1 h (stale window); beyond that → seed fallback. Failed refreshes
+  are damped to at most one upstream attempt per 30 s. A failure never evicts the last good
+  snapshot, and a partial/malformed/oversized/off-policy catalog read is never cached.
+- **Explicit config vs. fallback:** setting `AIGW_OPENROUTER_DEFAULT_MODELS` makes those models
+  operator intent — they are listed first and survive every healthy snapshot. Leaving it unset
+  means the compiled seeds are only the fallback.
+- **Variants are never discovered automatically.** Colon variants (`:free`, `:batch`) and tilde
+  aliases (`~`) are excluded from auto-publication; a variant reaches the listing only through
+  explicit `AIGW_OPENROUTER_DEFAULT_MODELS` configuration — **not** through
+  `POST /v1/models/admit`, which refuses the same shapes. Variants stay dispatchable directly
+  whether or not they are listed.
+- **`:online` is refused at startup.** Chat dispatch rejects the `:online` suffix
+  (`unsupported_model_variant`) because web search is a provider-neutral Gateway parameter, so
+  configuring one would publish a model whose every request fails. The settings validator now
+  rejects it outright — use the Gateway's own web-search parameter instead.
+- **Fail-closed catalog parsing.** A catalog page must carry `data`, `links.next` (string or
+  null) and a non-negative integer `total_count`, and every row must carry a string `id`; the
+  per-page `total_count` must agree across pages and with the number of rows collected. Any
+  deviation — one malformed row included — fails the **whole** refresh. Nothing partial or
+  salvaged is ever cached as fresh, so an upstream schema drift degrades to the last good
+  snapshot (then to seeds) instead of silently publishing a shrunken listing.
+- **Refresh latency is paid inline** by whichever request finds the snapshot cold or expired:
+  typically 1–2 s (one to two catalog pages), hard-bounded by a 10 s aggregate deadline across
+  the whole pagination chain. Concurrent callers share that one refresh (single-flight) and all
+  receive the same answer; failures are damped to one attempt per 30 s, so an outage costs at
+  most one slow request per damping window.
+- **Each replica caches independently.** The snapshot is process-local (no shared store), so
+  every worker and every replica performs its own refresh and may briefly serve a different
+  tier than its peers during an upstream incident. Sizing note: N replicas ⇒ up to N catalog
+  fetches per TTL.
+- Listing only: discovery never changes what is dispatchable — admission and chat dispatch are
+  untouched. Log lines carry counts, reason codes, the HTTP status class, and the served tier
+  (`tier=fresh|stale|seeds`, logged on change) — never catalog content.
+
 ## Operations Notes
 
 - The container listens on `0.0.0.0:9105` and exposes `/healthz`.

--- a/apps/aigateway/DEPLOYMENT.md
+++ b/apps/aigateway/DEPLOYMENT.md
@@ -357,8 +357,8 @@ out of provider billing.
 ## Live OpenRouter Model Discovery (OME-972)
 
 `GET /v1/models` lists the models OpenRouter actually serves now, refreshed from its public
-catalog (`https://openrouter.ai/api/v1/models`, no credential attached) through one
-deployment-wide cached snapshot. Default **on**.
+catalog (`https://openrouter.ai/api/v1/models`, no credential attached) through a cached
+catalog snapshot, held per process (see the replica note below). Default **on**.
 
 - `AIGW_OPENROUTER_LIVE_MODELS=false` restores the static compiled-seed listing with **zero**
   catalog egress. `AIGW_DISCOVERY_ENABLED=false` (the discovery kill switch) silences the
@@ -376,14 +376,18 @@ deployment-wide cached snapshot. Default **on**.
   operator intent — they are listed first and survive every healthy snapshot. Leaving it unset
   means the compiled seeds are only the fallback.
 - **Variants are never discovered automatically.** Colon variants (`:free`, `:batch`) and tilde
-  aliases (`~`) are excluded from auto-publication; a variant reaches the listing only through
-  explicit `AIGW_OPENROUTER_DEFAULT_MODELS` configuration — **not** through
-  `POST /v1/models/admit`, which refuses the same shapes. Variants stay dispatchable directly
-  whether or not they are listed.
+  aliases (`~`) are excluded from auto-publication; a variant reaches the listing only by
+  being configured in `AIGW_OPENROUTER_DEFAULT_MODELS` or by sitting in the compiled seed
+  list that the fallback serves (some seeds are `:batch` slugs) — never from the catalog and
+  **not** through `POST /v1/models/admit`, which refuses the same shapes. Variants stay
+  dispatchable directly whether or not they are listed.
 - **`:online` is refused at startup.** Chat dispatch rejects the `:online` suffix
   (`unsupported_model_variant`) because web search is a provider-neutral Gateway parameter, so
   configuring one would publish a model whose every request fails. The settings validator now
   rejects it outright — use the Gateway's own web-search parameter instead.
+  **Breaking on upgrade:** a deployment that currently lists a `:online` slug in
+  `AIGW_OPENROUTER_DEFAULT_MODELS` fails to start after this change. Scrub the variant from
+  the env var before rolling out.
 - **Fail-closed catalog parsing.** A catalog page must carry `data`, `links.next` (string or
   null) and a non-negative integer `total_count`, and every row must carry a string `id`; the
   per-page `total_count` must agree across pages and with the number of rows collected. Any
@@ -391,8 +395,8 @@ deployment-wide cached snapshot. Default **on**.
   salvaged is ever cached as fresh, so an upstream schema drift degrades to the last good
   snapshot (then to seeds) instead of silently publishing a shrunken listing.
 - **Refresh latency is paid inline** by whichever request finds the snapshot cold or expired:
-  typically 1–2 s (one to two catalog pages), hard-bounded by a 10 s aggregate deadline across
-  the whole pagination chain. Concurrent callers share that one refresh (single-flight) and all
+  one fetch per catalog page (two pages at the current ~420-model catalog size), hard-bounded
+  by a 10 s aggregate deadline across the whole pagination chain. Concurrent callers share that one refresh (single-flight) and all
   receive the same answer; failures are damped to one attempt per 30 s, so an outage costs at
   most one slow request per damping window.
 - **Each replica caches independently.** The snapshot is process-local (no shared store), so
@@ -400,8 +404,14 @@ deployment-wide cached snapshot. Default **on**.
   tier than its peers during an upstream incident. Sizing note: N replicas ⇒ up to N catalog
   fetches per TTL.
 - Listing only: discovery never changes what is dispatchable — admission and chat dispatch are
-  untouched. Log lines carry counts, reason codes, the HTTP status class, and the served tier
+  untouched. Log lines carry counts, reason codes, the upstream HTTP status code, and the
+  served tier
   (`tier=fresh|stale|seeds`, logged on change) — never catalog content.
+- **A shifting census fails the refresh, by design.** `total_count` must agree across pages,
+  and upstream's count does move between page fetches (measured 418 → 419 seconds apart on
+  2026-08-25). Such a refresh is rejected as `model_catalog_truncated`, the previous snapshot
+  keeps serving, and the next attempt (after 30 s damping) normally succeeds. Fail-safe and
+  self-healing, but expect occasional truncation reasons in the logs that are drift, not loss.
 
 ## Operations Notes
 

--- a/apps/aigateway/src/aigateway/core/discovery_runtime.py
+++ b/apps/aigateway/src/aigateway/core/discovery_runtime.py
@@ -10,9 +10,10 @@ INVARIANT (evidence, never authorization): a snapshot returned here NEVER enable
 a parameter — only a provider-local rule does. Callers overlay this evidence onto
 rules; on its own it authorizes nothing.
 
-INVARIANT (off the critical path): only the detailed-contract route consumes this.
-Chat dispatch holds no reference to it, so no chat request can ever wait on a
-network fetch.
+INVARIANT (off the critical path): only listing/contract surfaces consume this —
+the detailed-contract route's per-model observations, model admission (OME-879),
+and the live model catalog (OME-972) via the shared client/limits. Chat dispatch
+holds no reference to it, so no chat request can ever wait on a network fetch.
 
 INVARIANT (no secrets, no caller URLs): ``observe`` takes a model id and nothing
 else. The URL comes from the provider's own fixed allowlisted constants, and no

--- a/apps/aigateway/src/aigateway/core/model_catalog.py
+++ b/apps/aigateway/src/aigateway/core/model_catalog.py
@@ -1,4 +1,4 @@
-"""OME-972 — the deployment-wide live model-listing catalog.
+"""OME-972 — the app-lifetime, process-local live model-listing catalog.
 
 FEATURE: live model discovery — ``GET /v1/models`` consults this catalog per
 provider and lists the cached live snapshot when one is healthy, falling back
@@ -44,7 +44,7 @@ class ModelListingProvider(Protocol):
 
     # WHY a Protocol and not ``ProviderPluginBase``: the catalog needs exactly
     # these three members — depending on the full plugin contract would couple
-    # the deployment-wide cache to every unrelated provider hook and force test
+    # the app-lifetime cache to every unrelated provider hook and force test
     # doubles to carry the whole base class.
     """
 

--- a/apps/aigateway/src/aigateway/core/model_catalog.py
+++ b/apps/aigateway/src/aigateway/core/model_catalog.py
@@ -1,0 +1,218 @@
+"""OME-972 — the deployment-wide live model-listing catalog.
+
+FEATURE: live model discovery — ``GET /v1/models`` consults this catalog per
+provider and lists the cached live snapshot when one is healthy, falling back
+to the provider's compiled ``register_models()`` seeds when the catalog is
+cold or degraded (snapshot-or-fallback).
+
+INVARIANT (hexagonal): core consults only the ``model_discovery_source`` /
+``discover_live_models`` port pair — it never learns provider URLs, parsers,
+or which entries were seeds. The provider returns FINISHED rows.
+
+INVARIANT: live data changes what is LISTED, never what is dispatchable —
+nothing here touches admission, dispatch, or credentials, and the catalog is
+consulted off the chat critical path only.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Protocol, cast
+
+from .model_capabilities import canonical_model_id
+from .parameter_discovery import DiscoveryError
+from .parameter_discovery_cache import (
+    CacheLimits,
+    MonotonicClock,
+    ObservationCache,
+    SystemMonotonicClock,
+)
+
+if TYPE_CHECKING:
+    from .parameter_discovery import DiscoveryHttpClient, DiscoveryLimits
+    from .plugin_base import ModelDiscoverySource, ModelEntry
+
+logger = logging.getLogger(__name__)
+
+# WHY 4: each provider cache holds ONE listing key; the headroom exists only so
+# a source-revision bump does not evict the key it replaces mid-transition.
+_CACHE_MAX_ENTRIES = 4
+
+
+class ModelListingProvider(Protocol):
+    """The minimal provider surface the catalog consumes (hexagonal port).
+
+    # WHY a Protocol and not ``ProviderPluginBase``: the catalog needs exactly
+    # these three members — depending on the full plugin contract would couple
+    # the deployment-wide cache to every unrelated provider hook and force test
+    # doubles to carry the whole base class.
+    """
+
+    custom_llm_provider: str
+
+    def model_discovery_source(self) -> ModelDiscoverySource | None: ...
+
+    async def discover_live_models(
+        self,
+        *,
+        client: DiscoveryHttpClient,
+        limits: DiscoveryLimits | None = None,
+    ) -> tuple[ModelEntry, ...] | None: ...
+
+
+class ModelCatalog:
+    """Per-provider cached live listings behind single-flight refresh.
+
+    # AIDEV-NOTE: the catalog owns NO transport — callers pass the discovery
+    # runtime's client/limits per call (the admission-route precedent), so the
+    # test suite's transport seams govern every dial this class can cause.
+    """
+
+    def __init__(self, *, clock: MonotonicClock | None = None) -> None:
+        self._clock = clock if clock is not None else SystemMonotonicClock()
+        self._caches: dict[str, ObservationCache] = {}
+        # OME-972: the tier each provider was last SERVED at, so a change is
+        # logged once instead of every request. Per-attempt warnings cannot
+        # answer "are users still seeing live models?" — they look identical
+        # while a stale snapshot still serves and after it collapses to seeds.
+        self._served_tier: dict[str, str] = {}
+
+    async def entries_for(
+        self,
+        plugin: ModelListingProvider,
+        *,
+        client: DiscoveryHttpClient,
+        limits: DiscoveryLimits | None,
+    ) -> tuple[ModelEntry, ...] | None:
+        """The provider's live listing, or ``None`` meaning "fall back to seeds".
+
+        ``None`` covers: no declared source, a cold failure, and a snapshot
+        older than the stale window. A stale-but-trusted snapshot is returned
+        as entries — the caller cannot (and must not) tell it from fresh.
+        """
+        source = plugin.model_discovery_source()
+        if source is None:
+            return None
+        provider = plugin.custom_llm_provider
+        cache = self._cache_for(provider, source)
+
+        async def _refresh() -> tuple[ModelEntry, ...]:
+            try:
+                entries = await plugin.discover_live_models(client=client, limits=limits)
+            except AssertionError:
+                # INVARIANT: the test suite's no-egress tripwire raises
+                # AssertionError — absorbing it would turn a forbidden real
+                # dial into a quiet degraded outcome. Stay loud.
+                raise
+            except DiscoveryError as error:
+                self._log_failure(provider, error)
+                raise
+            except Exception as error:
+                # Sanitized: the TYPE names the bug class for operators; the
+                # message may carry upstream content and is dropped, and the
+                # cause chain is cut so it cannot resurface downstream.
+                logger.warning(
+                    "live model listing refresh failed provider=%s reason=internal_error type=%s",
+                    provider,
+                    type(error).__name__,
+                )
+                raise DiscoveryError("internal_error") from None
+            if entries is None:
+                # AIDEV-NOTE: a None under a DECLARED source would be stored as
+                # a successful fresh value and evict the last good listing —
+                # convert the inconsistency to a failed attempt instead (the
+                # same rule DiscoveryRuntime.observe enforces as no_snapshot).
+                error = DiscoveryError("no_snapshot")
+                self._log_failure(provider, error)
+                raise error
+            logger.info(
+                "live model listing refreshed provider=%s models=%d", provider, len(entries)
+            )
+            return entries
+
+        outcome = await cache.get_or_refresh(source.key, revision=source.revision, refresh=_refresh)
+        if outcome.value is None:
+            self._log_tier(provider, "seeds")
+            return None
+        self._log_tier(provider, outcome.freshness)
+        return cast("tuple[ModelEntry, ...]", outcome.value)
+
+    async def ids_for(
+        self,
+        plugin: ModelListingProvider,
+        *,
+        client: DiscoveryHttpClient,
+        limits: DiscoveryLimits | None,
+    ) -> frozenset[str]:
+        """The gateway model ids of the live listing; empty when degraded/absent."""
+        entries = await self.entries_for(plugin, client=client, limits=limits)
+        if entries is None:
+            return frozenset()
+        # INVARIANT: canonical ids, matching exactly what ``/v1/models`` publishes
+        # (``model_row`` canonicalizes too). A provider using the established
+        # unprefixed ``model_name`` convention would otherwise publish an id this
+        # set never matches — and the detail route would 404 its own listing.
+        return frozenset(
+            canonical_model_id(
+                custom_llm_provider=plugin.custom_llm_provider, model_name=entry.model_name
+            )
+            for entry in entries
+        )
+
+    def _cache_for(self, provider: str, source: ModelDiscoverySource) -> ObservationCache:
+        # WHY per provider: the cache policy (TTL/stale/damping) rides on each
+        # provider's declared source — one shared cache would force one policy
+        # on catalogs with very different upstream freshness guarantees.
+        cache = self._caches.get(provider)
+        if cache is None:
+            cache = ObservationCache(
+                clock=self._clock,
+                limits=CacheLimits(
+                    ttl_s=source.ttl_s,
+                    stale_ttl_s=source.stale_ttl_s,
+                    max_entries=_CACHE_MAX_ENTRIES,
+                    failure_ttl_s=source.failure_ttl_s,
+                ),
+            )
+            self._caches[provider] = cache
+        return cache
+
+    def _log_tier(self, provider: str, tier: str) -> None:
+        """Log the SERVED tier once per change (fresh / stale / seeds)."""
+        if self._served_tier.get(provider) == tier:
+            return
+        self._served_tier[provider] = tier
+        if tier == "fresh":
+            logger.info("live model listing serving provider=%s tier=fresh", provider)
+        else:
+            logger.warning("live model listing degraded provider=%s tier=%s", provider, tier)
+
+    @staticmethod
+    def _log_failure(provider: str, error: DiscoveryError) -> None:
+        # WHY the status rides along: reason stays the closed vocabulary, but
+        # 401 (auth onset) and 5xx (outage) need different operator responses.
+        if error.status is not None:
+            logger.warning(
+                "live model listing refresh failed provider=%s reason=%s status=%d",
+                provider,
+                error.reason,
+                error.status,
+            )
+        else:
+            logger.warning(
+                "live model listing refresh failed provider=%s reason=%s",
+                provider,
+                error.reason,
+            )
+
+
+def build_model_catalog(*, enabled: bool) -> ModelCatalog | None:
+    """The app-lifetime catalog, or ``None`` under the discovery kill switch.
+
+    INVARIANT: ``AIGW_DISCOVERY_ENABLED=false`` silences ALL discovery egress —
+    the listing catalog obeys the same switch as the parameter-discovery
+    runtime, so one flag audits to zero catalog traffic.
+    """
+    if not enabled:
+        return None
+    return ModelCatalog()

--- a/apps/aigateway/src/aigateway/core/parameter_discovery.py
+++ b/apps/aigateway/src/aigateway/core/parameter_discovery.py
@@ -32,9 +32,13 @@ class DiscoveryError(Exception):
     # body or raw exception text is attached, so it is safe to surface.
     """
 
-    def __init__(self, reason: str) -> None:
+    def __init__(self, reason: str, *, status: int | None = None) -> None:
         super().__init__(reason)
         self.reason = reason
+        # OME-972: the upstream HTTP status for ``bad_status`` failures ONLY — an
+        # integer class marker (401 auth onset vs 429 vs 5xx outage) that log
+        # lines may render. Never a body, never text; None for every other reason.
+        self.status = status
 
 
 @dataclass(frozen=True)
@@ -134,7 +138,7 @@ async def fetch_discovery_json(
 
     # A redirect (3xx) is never followed: any non-200 is a failure, not a hop.
     if response.status != 200:
-        raise DiscoveryError("bad_status")
+        raise DiscoveryError("bad_status", status=response.status)
     if response.content_type.split(";")[0].strip().lower() != "application/json":
         raise DiscoveryError("bad_content_type")
     if len(response.body.encode("utf-8")) > limits.max_bytes:

--- a/apps/aigateway/src/aigateway/core/plugin_base/__init__.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base/__init__.py
@@ -18,7 +18,7 @@ single ``plugin_base`` module. Import from here, never from a half.
 """
 
 from ..cache_ports import PROJECTION_BYPASS_REASON, CacheBypass, GlobalCacheProjection
-from ._contract import ProviderPluginBase
+from ._contract import ModelDiscoverySource, ProviderPluginBase
 from ._ports import (
     CredentialStrategy,
     ModelAdmission,
@@ -47,6 +47,7 @@ __all__ = [
     "CredentialStrategy",
     "GlobalCacheProjection",
     "ModelAdmission",
+    "ModelDiscoverySource",
     "ModelEntry",
     "OAuthCodeExchangeRequest",
     "OAuthConfig",

--- a/apps/aigateway/src/aigateway/core/plugin_base/_contract.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base/_contract.py
@@ -51,8 +51,9 @@ class ModelDiscoverySource:
     """Identity + cache policy of a provider's live MODEL-LIST source (OME-972).
 
     # WHY a separate type from ``DiscoverySourceRef``: the model list is one
-    # deployment-wide document per provider, so its cache policy (how fresh the
-    # LISTING must be) is provider knowledge and rides on the declaration —
+    # process-local cached document per provider, shared across accounts, so
+    # its policy (how fresh the LISTING must be) is provider knowledge and rides
+    # on the declaration —
     # parameter evidence keys per model and takes its policy from app settings.
     # INVARIANT: declared BEFORE any fetch, like every discovery source ref —
     # the cache judges a stored snapshot by this ``revision`` without dialing.
@@ -274,9 +275,9 @@ class ProviderPluginBase[TSettings: PluginSettings](ProviderPluginCore[TSettings
     def model_discovery_source(self) -> ModelDiscoverySource | None:
         """Identity + cache policy of this provider's live model-LIST source (OME-972).
 
-        The listing sibling of ``chat_discovery_source``: one deployment-wide
-        document per provider, declared before any fetch so the model catalog can
-        trust or expire a stored snapshot without dialing.
+        The listing sibling of ``chat_discovery_source``: one process-local cached
+        document per provider, shared across accounts and declared before any
+        fetch so the catalog can trust or expire a stored snapshot without dialing.
 
         INVARIANT: returning a source commits the provider to answering
         ``discover_live_models`` with entries or a sanitized ``DiscoveryError`` —

--- a/apps/aigateway/src/aigateway/core/plugin_base/_contract.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base/_contract.py
@@ -19,6 +19,7 @@ contract half is the subclass rather than a mixin.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 # Runtime (not TYPE_CHECKING) import: the default transport capability and both
@@ -30,7 +31,7 @@ from ..chat_parameters import (
     overlay_tool_capabilities,
     stream_transport_capability,
 )
-from ._ports import PluginSettings
+from ._ports import ModelEntry, PluginSettings
 from ._provider import ProviderPluginCore
 
 if TYPE_CHECKING:
@@ -43,6 +44,25 @@ if TYPE_CHECKING:
     )
     from ..parameter_discovery import DiscoveryHttpClient, DiscoveryLimits, DiscoverySourceRef
     from ..profile_models import AuthMode
+
+
+@dataclass(frozen=True)
+class ModelDiscoverySource:
+    """Identity + cache policy of a provider's live MODEL-LIST source (OME-972).
+
+    # WHY a separate type from ``DiscoverySourceRef``: the model list is one
+    # deployment-wide document per provider, so its cache policy (how fresh the
+    # LISTING must be) is provider knowledge and rides on the declaration —
+    # parameter evidence keys per model and takes its policy from app settings.
+    # INVARIANT: declared BEFORE any fetch, like every discovery source ref —
+    # the cache judges a stored snapshot by this ``revision`` without dialing.
+    """
+
+    key: str
+    revision: str
+    ttl_s: float
+    stale_ttl_s: float
+    failure_ttl_s: float
 
 
 class ProviderPluginBase[TSettings: PluginSettings](ProviderPluginCore[TSettings]):
@@ -248,6 +268,50 @@ class ProviderPluginBase[TSettings: PluginSettings](ProviderPluginCore[TSettings
 
         Default: None — no dynamic source; the caller relies on labelled-local
         observations alone.
+        """
+        return None
+
+    def model_discovery_source(self) -> ModelDiscoverySource | None:
+        """Identity + cache policy of this provider's live model-LIST source (OME-972).
+
+        The listing sibling of ``chat_discovery_source``: one deployment-wide
+        document per provider, declared before any fetch so the model catalog can
+        trust or expire a stored snapshot without dialing.
+
+        INVARIANT: returning a source commits the provider to answering
+        ``discover_live_models`` with entries or a sanitized ``DiscoveryError`` —
+        a ``None`` there is an inconsistency the catalog fails the attempt on
+        rather than caching (the same rule ``DiscoveryRuntime.observe`` enforces).
+
+        Default: None — no live model-list discovery; ``register_models()`` seeds
+        are the provider's whole listing.
+        """
+        return None
+
+    async def discover_live_models(
+        self,
+        *,
+        client: DiscoveryHttpClient,
+        limits: DiscoveryLimits | None = None,
+    ) -> tuple[ModelEntry, ...] | None:
+        """This provider's complete live LISTING from its fixed public catalog (OME-972).
+
+        Returns ready ``ModelEntry`` rows (the provider owns its own merge of
+        explicitly configured operator models with discovered ids), fetched
+        through the INJECTED bounded transport — never a raw client, never a
+        caller-supplied URL, never a credential. Never runs on the chat dispatch
+        path, and never changes what is dispatchable — only what is listed.
+
+        INVARIANT (three outcomes, same contract as
+        ``discover_chat_parameter_snapshot``): entries = the source was reached;
+        raises sanitized ``DiscoveryError`` = attempted and FAILED (the catalog
+        maps this to stale/fallback); ``None`` = NOT attempted, no connection.
+
+        AIDEV-NOTE: ``None`` must not be widened to cover failure — the cache
+        stores every normal return as a successful refresh, so a ``None``
+        returned for a failure would be stored labelled fresh and evict the last
+        good listing. ``ModelCatalog`` converts an inconsistent None into a
+        failed attempt for exactly this reason.
         """
         return None
 

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -29,6 +29,7 @@ from .core.auth.middleware import ANONYMOUS_ACCOUNT_ID
 from .core.credential_blob.store import CredentialBlobMutationConflict, ORMStore
 from .core.discovery_runtime import DiscoveryRuntime
 from .core.loader import load_plugins
+from .core.model_catalog import build_model_catalog
 from .core.parameter_discovery import DiscoveryLimits, HttpxDiscoveryClient
 from .core.parameter_discovery_cache import (
     CacheLimits,
@@ -379,6 +380,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.pending_auth = PendingAuthTable(ttl_seconds=600)
     app.state.discovery_runtime = _build_discovery_runtime(settings)
+    # OME-972: the deployment-wide live model-listing catalog. Same kill switch
+    # as the runtime above — AIGW_DISCOVERY_ENABLED=false audits to zero
+    # discovery egress of ANY kind. The catalog owns no transport; the models
+    # route passes the runtime's client/limits per call.
+    app.state.model_catalog = build_model_catalog(enabled=settings.discovery_enabled)
     # OME-952: the admin cache-snapshot upload runner. app-state-only by the same reasoning
     # as `admitted_models` above: job REPORTS are deployment-lifetime, the loaded data and
     # the audit log are the durable truth.

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -380,7 +380,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     app.state.pending_auth = PendingAuthTable(ttl_seconds=600)
     app.state.discovery_runtime = _build_discovery_runtime(settings)
-    # OME-972: the deployment-wide live model-listing catalog. Same kill switch
+    # OME-972: the app-lifetime, process-local live model-listing catalog. Same kill switch
     # as the runtime above — AIGW_DISCOVERY_ENABLED=false audits to zero
     # discovery egress of ANY kind. The catalog owns no transport; the models
     # route passes the runtime's client/limits per call.

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/live_models.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/live_models.py
@@ -1,0 +1,252 @@
+"""OME-972 — live discovery of the OpenRouter public model catalog.
+
+FEATURE: automatic model discovery — ``GET /v1/models`` lists what OpenRouter
+actually serves now (plain ids only), refreshed through a deployment-wide
+cached snapshot instead of compiled seeds frozen at deploy time.
+
+INVARIANT (fail-closed, all-or-nothing): a catalog read that is incomplete,
+malformed, empty, over a cap, or paginated off-policy raises a sanitized
+``DiscoveryError`` and is NEVER partially returned — the cache keeps serving
+the last good snapshot instead. Live data changes what is LISTED, never what
+is dispatchable: dispatch admission (``admission.py``) is untouched.
+
+INVARIANT (auto-publish shape): only plain ``vendor/model`` ids pass — the
+same ``_admissible_upstream_id`` predicate the admission route enforces.
+Colon variants and tilde aliases stay reachable via explicit operator config
+(``AIGW_OPENROUTER_DEFAULT_MODELS``) or direct dispatch, never via listing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from typing import Any
+from urllib.parse import parse_qs, urljoin, urlsplit
+
+from aigateway.core.parameter_discovery import (
+    DiscoveryError,
+    DiscoveryHttpClient,
+    DiscoveryLimits,
+    fetch_discovery_json,
+)
+from aigateway.core.plugin_base import ModelDiscoverySource, ModelEntry
+
+from .admission import _admissible_upstream_id
+from .discovery import _MAX_CATALOG_MODELS, ALLOWED_ORIGINS, MODELS_URL
+from .settings import GATEWAY_MODEL_PREFIX, OpenRouterPluginSettings
+
+# WHY 250 (not the API maximum): each page must clear the §5.2 envelope's
+# 1 MB byte cap and 50k node cap with >2x headroom — a fatter page that
+# drifts over either cap would fail EVERY refresh at once, deployment-wide.
+_PAGE_LIMIT = 250
+# WHY: 40 pages x 250 = the same 10_000-model bound the admission catalog
+# already enforces on the single-page read; more pages means a runaway or
+# looping chain, not a bigger catalog.
+_MAX_PAGES = _MAX_CATALOG_MODELS // _PAGE_LIMIT
+_MAX_PUBLISHED_MODELS = 5_000
+_MAX_ID_LENGTH = 256
+# INVARIANT: single-flight dedupes the DIAL, not the wait — every concurrent
+# lister queues on one refresh, so the WHOLE pagination chain gets one
+# aggregate wall-clock deadline on top of the per-page timeout.
+_AGGREGATE_TIMEOUT_S = 10.0
+
+_ORIGIN = "https://openrouter.ai"
+_MODELS_PATH = "/api/v1/models"
+# INVARIANT: the pinned query policy. output_modalities=text keeps the
+# catalog to chat-servable models; every followed ``links.next`` must carry
+# EXACTLY these params plus the one expected offset — nothing else.
+_PINNED_QUERY = {"output_modalities": "text", "limit": str(_PAGE_LIMIT)}
+LIVE_MODELS_URL = f"{MODELS_URL}?output_modalities=text&limit={_PAGE_LIMIT}"
+
+# INVARIANT: identity + cache policy declared BEFORE any fetch (§5.3) — the
+# deployment-wide catalog judges a stored snapshot by this revision without
+# dialing. Bumping the revision (e.g. on a parser change) invalidates every
+# stored snapshot at once.
+LIVE_MODELS_DISCOVERY_SOURCE = ModelDiscoverySource(
+    key="openrouter:models:list",
+    revision="openrouter:models:list-v1",
+    ttl_s=300.0,
+    stale_ttl_s=3600.0,
+    failure_ttl_s=30.0,
+)
+
+
+def parse_catalog_page(payload: Any) -> tuple[tuple[str, ...], str | None, int]:
+    """One page of the catalog -> (ids in page order, next link, total_count).
+
+    STRICT by construction: the envelope must be a dict carrying a ``data``
+    list, a ``links`` mapping with an explicit ``next`` (string or null), and a
+    non-negative integer ``total_count``; every row must be an object with a
+    string ``id``. Anything else raises ``malformed_json``.
+
+    INVARIANT: nothing is skipped and salvaged. A page whose rows or
+    completeness metadata cannot be parsed is not a trustworthy census of what
+    upstream serves, so it can never be cached as a fresh, complete catalog —
+    tolerating a bad row would publish a listing that silently omits models,
+    which is indistinguishable from upstream having retired them.
+
+    # WHY the metadata is REQUIRED rather than advisory: without ``links.next``
+    # and ``total_count`` a page cannot be told apart from a truncated read, and
+    # the live envelope always carries both (probed 2026-08-24 — the final page
+    # says ``links.next = null``, it does not omit the key).
+    """
+    if not isinstance(payload, dict):
+        raise DiscoveryError("malformed_json")
+    data = payload.get("data")
+    if not isinstance(data, list):
+        raise DiscoveryError("malformed_json")
+    ids: list[str] = []
+    for row in data:
+        if not isinstance(row, dict):
+            raise DiscoveryError("malformed_json")
+        model_id = row.get("id")
+        if not isinstance(model_id, str):
+            raise DiscoveryError("malformed_json")
+        ids.append(model_id)
+    links = payload.get("links")
+    if not isinstance(links, dict) or "next" not in links:
+        raise DiscoveryError("malformed_json")
+    next_url = links["next"]
+    if next_url is not None and not isinstance(next_url, str):
+        raise DiscoveryError("malformed_json")
+    total_count = payload.get("total_count")
+    # bool is an int subclass in Python: ``total_count: true`` must not read as 1.
+    if not isinstance(total_count, int) or isinstance(total_count, bool) or total_count < 0:
+        raise DiscoveryError("malformed_json")
+    return tuple(ids), next_url, total_count
+
+
+def validate_next_url(next_url: str, *, expected_offset: int) -> str:
+    """Resolve + strictly validate a ``links.next`` BEFORE it is ever dialed.
+
+    INVARIANT: exact https origin, exact ``/api/v1/models`` path, exactly the
+    pinned query plus the one expected numeric offset, no fragment, no
+    duplicates, no extras. Any deviation is ``model_catalog_truncated`` — the
+    whole refresh fails and nothing partial is returned or cached.
+    """
+    absolute = urljoin(_ORIGIN, next_url)
+    parts = urlsplit(absolute)
+    origin = f"{parts.scheme}://{parts.netloc}"
+    if parts.scheme != "https" or origin not in ALLOWED_ORIGINS or parts.path != _MODELS_PATH:
+        raise DiscoveryError("model_catalog_truncated")
+    if parts.fragment:
+        raise DiscoveryError("model_catalog_truncated")
+    # WHY exact-dict comparison of parse_qs output: it refuses unexpected and
+    # duplicated parameters in the same check — a duplicated offset parses to a
+    # two-element list and no longer equals the expected one-element value.
+    expected = {key: [value] for key, value in _PINNED_QUERY.items()}
+    expected["offset"] = [str(expected_offset)]
+    if parse_qs(parts.query, keep_blank_values=True) != expected:
+        raise DiscoveryError("model_catalog_truncated")
+    return absolute
+
+
+def publishable_upstream_ids(ids: Iterable[str]) -> tuple[str, ...]:
+    """The deduplicated, sorted, auto-publishable subset of raw catalog ids.
+
+    INVARIANT: zero survivors fail closed (an empty catalog is
+    indistinguishable from a broken read and must not evict the last good
+    snapshot); over the publish cap fails closed (never truncate-and-cache).
+    """
+    unique = {
+        upstream
+        for upstream in ids
+        if len(upstream) <= _MAX_ID_LENGTH and _admissible_upstream_id(upstream)
+    }
+    if not unique:
+        raise DiscoveryError("model_catalog_empty")
+    if len(unique) > _MAX_PUBLISHED_MODELS:
+        raise DiscoveryError("model_catalog_too_large")
+    return tuple(sorted(unique))
+
+
+def explicit_operator_entries(settings: OpenRouterPluginSettings) -> tuple[ModelEntry, ...]:
+    """Operator-configured model entries, or none when config is compiled defaults.
+
+    WHY ``model_fields_set``: pydantic records a field there only when a value
+    arrived from the constructor or the environment — a ``default_factory``
+    fill does not register. That is the exact line between "the operator asked
+    for these models" (survive every healthy snapshot, colon variants included)
+    and "compiled fallback seeds" (replaced entirely by a healthy snapshot).
+    """
+    if "default_models" not in settings.model_fields_set:
+        return ()
+    return tuple(
+        ModelEntry(model_name=slug, litellm_params={"model": slug})
+        for slug in settings.default_models
+    )
+
+
+def live_listing_entries(
+    settings: OpenRouterPluginSettings, upstream_ids: tuple[str, ...]
+) -> tuple[ModelEntry, ...]:
+    """The finished healthy-snapshot listing: operator entries first, then discovered.
+
+    INVARIANT: the provider owns this merge — core receives finished rows and
+    never learns which entries were seeds, so seed provenance cannot leak into
+    route logic. Operator entries keep configured order; discovered ids arrive
+    sorted from ``publishable_upstream_ids`` and dedupe against operator rows.
+    """
+    operator = explicit_operator_entries(settings)
+    seen = {entry.model_name for entry in operator}
+    discovered = tuple(
+        ModelEntry(model_name=gateway_id, litellm_params={"model": gateway_id})
+        for upstream in upstream_ids
+        if (gateway_id := f"{GATEWAY_MODEL_PREFIX}{upstream}") not in seen
+    )
+    return operator + discovered
+
+
+async def fetch_live_model_ids(
+    *, client: DiscoveryHttpClient, limits: DiscoveryLimits | None = None
+) -> tuple[str, ...]:
+    """Every raw model id in the catalog, or a sanitized ``DiscoveryError``.
+
+    Walks the pinned first page plus every strictly validated ``links.next``
+    under ONE aggregate wall-clock deadline (on top of the per-page envelope
+    timeout). All-or-nothing: a failure on any page discards everything —
+    pages already collected are never returned, so the caller's cache can
+    never store a partial catalog as fresh.
+    """
+    bounds = limits if limits is not None else DiscoveryLimits()
+    collected: list[str] = []
+    total_count: int | None = None
+    try:
+        async with asyncio.timeout(_AGGREGATE_TIMEOUT_S):
+            url = LIVE_MODELS_URL
+            pages = 0
+            while True:
+                # INVARIANT: the page cap refuses BEFORE dialing page N+1 — a
+                # looping or runaway next-chain costs at most _MAX_PAGES dials.
+                if pages >= _MAX_PAGES:
+                    raise DiscoveryError("model_catalog_truncated")
+                pages += 1
+                payload = await fetch_discovery_json(
+                    url, allowed_origins=ALLOWED_ORIGINS, client=client, limits=bounds
+                )
+                ids, next_url, page_total = parse_catalog_page(payload)
+                # INVARIANT: the census must hold STILL for the whole walk. A
+                # total that moves between pages means the catalog changed under
+                # us (or a page answers a different query), so the rows we hold
+                # are not one coherent snapshot.
+                if total_count is None:
+                    total_count = page_total
+                elif page_total != total_count:
+                    raise DiscoveryError("model_catalog_truncated")
+                collected.extend(ids)
+                if len(collected) > _MAX_CATALOG_MODELS:
+                    raise DiscoveryError("model_catalog_too_large")
+                if next_url is None:
+                    break
+                url = validate_next_url(next_url, expected_offset=pages * _PAGE_LIMIT)
+    except TimeoutError:
+        # sanitized: the aggregate deadline expiry, same token the per-page
+        # envelope uses — callers need one vocabulary, not two.
+        raise DiscoveryError("timeout") from None
+    # WHY reconciliation LAST: a claimed count differing from what the finished
+    # chain delivered means a page went missing silently, which is truncation
+    # even though every dial succeeded. ``total_count`` is never None here —
+    # the strict parser required it on every page, including the first.
+    if total_count != len(collected):
+        raise DiscoveryError("model_catalog_truncated")
+    return tuple(collected)

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/live_models.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/live_models.py
@@ -1,8 +1,8 @@
 """OME-972 — live discovery of the OpenRouter public model catalog.
 
 FEATURE: automatic model discovery — ``GET /v1/models`` lists what OpenRouter
-actually serves now (plain ids only), refreshed through a deployment-wide
-cached snapshot instead of compiled seeds frozen at deploy time.
+actually serves now (plain ids only), refreshed through a per-process cached
+snapshot instead of compiled seeds frozen at deploy time.
 
 INVARIANT (fail-closed, all-or-nothing): a catalog read that is incomplete,
 malformed, empty, over a cap, or paginated off-policy raises a sanitized
@@ -13,7 +13,9 @@ is dispatchable: dispatch admission (``admission.py``) is untouched.
 INVARIANT (auto-publish shape): only plain ``vendor/model`` ids pass — the
 same ``_admissible_upstream_id`` predicate the admission route enforces.
 Colon variants and tilde aliases stay reachable via explicit operator config
-(``AIGW_OPENROUTER_DEFAULT_MODELS``) or direct dispatch, never via listing.
+(``AIGW_OPENROUTER_DEFAULT_MODELS``) or direct dispatch, never via listing --
+except ``:online``, which ``settings.py`` now refuses to configure at all
+because dispatch refuses it (OME-972 correction pass).
 """
 
 from __future__ import annotations
@@ -37,7 +39,7 @@ from .settings import GATEWAY_MODEL_PREFIX, OpenRouterPluginSettings
 
 # WHY 250 (not the API maximum): each page must clear the §5.2 envelope's
 # 1 MB byte cap and 50k node cap with >2x headroom — a fatter page that
-# drifts over either cap would fail EVERY refresh at once, deployment-wide.
+# drifts over either cap would fail every refresh in the process.
 _PAGE_LIMIT = 250
 # WHY: 40 pages x 250 = the same 10_000-model bound the admission catalog
 # already enforces on the single-page read; more pages means a runaway or
@@ -59,7 +61,7 @@ _PINNED_QUERY = {"output_modalities": "text", "limit": str(_PAGE_LIMIT)}
 LIVE_MODELS_URL = f"{MODELS_URL}?output_modalities=text&limit={_PAGE_LIMIT}"
 
 # INVARIANT: identity + cache policy declared BEFORE any fetch (§5.3) — the
-# deployment-wide catalog judges a stored snapshot by this revision without
+# process-local catalog judges a stored snapshot by this revision without
 # dialing. Bumping the revision (e.g. on a parser change) invalidates every
 # stored snapshot at once.
 LIVE_MODELS_DISCOVERY_SOURCE = ModelDiscoverySource(

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -36,6 +36,7 @@ from aigateway.core.parameter_projection import IncompatibleParametersError
 from aigateway.core.plugin_base import (
     CredentialStrategy,
     ModelAdmission,
+    ModelDiscoverySource,
     ModelEntry,
     ProviderPluginBase,
 )
@@ -76,6 +77,12 @@ from .global_cache import project_global_cache_request
 from .litellm_controls import (
     _has_unsafe_litellm_global_state,
     _strip_openrouter_litellm_controls,
+)
+from .live_models import (
+    LIVE_MODELS_DISCOVERY_SOURCE,
+    fetch_live_model_ids,
+    live_listing_entries,
+    publishable_upstream_ids,
 )
 from .observations import ROUTING_POLICY_OBSERVATIONS
 from .parameters import openrouter_chat_parameter_rules, openrouter_chat_parameter_tools
@@ -188,6 +195,31 @@ class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
             ModelEntry(model_name=slug, litellm_params={"model": slug})
             for slug in self.settings.default_models
         ]
+
+    def model_discovery_source(self) -> ModelDiscoverySource | None:
+        # INVARIANT (OME-972): gated on BOTH flags — a disabled provider or
+        # live_models=false declares no source, so the catalog never opens a
+        # cache slot or dials for it (zero egress when off).
+        if not (self.settings.enabled and self.settings.live_models):
+            return None
+        return LIVE_MODELS_DISCOVERY_SOURCE
+
+    async def discover_live_models(
+        self,
+        *,
+        client: DiscoveryHttpClient,
+        limits: DiscoveryLimits | None = None,
+    ) -> tuple[ModelEntry, ...] | None:
+        """The finished live listing: operator-explicit entries, then discovered.
+
+        Three-outcome contract (see the base hook): entries = reached; raises
+        sanitized ``DiscoveryError`` = attempted and failed; None = gated off,
+        not attempted, no connection.
+        """
+        if not (self.settings.enabled and self.settings.live_models):
+            return None
+        raw_ids = await fetch_live_model_ids(client=client, limits=limits)
+        return live_listing_entries(self.settings, publishable_upstream_ids(raw_ids))
 
     async def admit_model(
         self,

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -186,6 +186,17 @@ def _validate_gateway_slug(slug: str) -> str:
             f"malformed OpenRouter model {slug!r}: expected "
             "'openrouter/<author>/<model>' with an optional single ':variant'"
         )
+    # OME-972: refuse at CONFIG time what dispatch will always refuse. Every
+    # listing path publishes explicitly configured slugs (they survive a healthy
+    # live snapshot by design), while ``prepare_chat_body`` rejects ``:online``
+    # with ``unsupported_model_variant`` — web search is a provider-neutral
+    # Gateway parameter and this suffix is a second route around it. Configuring
+    # one would publish a model whose every chat request fails.
+    if is_online_variant(slug):
+        raise ValueError(
+            f"OpenRouter ':online' model {slug!r} cannot be configured: chat dispatch refuses "
+            "the variant (use the provider-neutral web-search parameter instead)"
+        )
     return slug
 
 
@@ -206,6 +217,10 @@ class OpenRouterPluginSettings(PluginSettings):
     # OpenRouter catalog). Default ON — prod can pin a closed world by setting
     # AIGW_OPENROUTER_DYNAMIC=false without a breaking change.
     dynamic: bool = True
+    # OME-972: gates LIVE catalog discovery for the /v1/models LISTING (never
+    # dispatch). Default ON — AIGW_OPENROUTER_LIVE_MODELS=false restores the
+    # static compiled-seed listing with zero catalog egress.
+    live_models: bool = True
     default_models: list[str] = Field(default_factory=_default_model_slugs)
     validation_model: str = "openrouter/openrouter/free"
 

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/settings.py
@@ -57,9 +57,10 @@ ONLINE_VARIANT_SUFFIX = ":online"
 def is_online_variant(model: str) -> bool:
     """True for OpenRouter's implicit web-search model variant.
 
-    ONE predicate for two call sites that must never disagree: ``prepare_chat_body``
+    ONE predicate for three call sites that must never disagree: ``prepare_chat_body``
     REFUSES such a model (search is a provider-neutral Gateway parameter, and this suffix
-    is a second route around it), and the global-cache projection BYPASSES it. Both are
+    is a second route around it), the global-cache projection BYPASSES it, and
+    ``_validate_gateway_slug`` refuses to CONFIGURE one (OME-972). The first two are
     required, because the cache is consulted before dispatch — a guard only on the
     dispatch path would still let a stored entry answer 200 for a refused request.
 

--- a/apps/aigateway/src/aigateway/routes/model_parameters.py
+++ b/apps/aigateway/src/aigateway/routes/model_parameters.py
@@ -29,6 +29,7 @@ from .chat_credentials import _credential_target_for_chat, resolved_auth_mode
 
 if TYPE_CHECKING:
     from ..core.oauth.models import OAuthConnection
+    from ..core.plugin_base import ProviderPluginBase
     from ..core.profile_models import AuthMode, Profile
 
 router = APIRouter()
@@ -43,10 +44,12 @@ async def _discovery_outcome(
 ) -> DiscoveryOutcome:
     """Observe this provider's public evidence for ``model``, or report static-only.
 
-    # INVARIANT: this is the ONLY route that reaches the discovery runtime. The
-    # model reaching it has already been validated against the canonical
-    # inventory, so a caller cannot steer discovery at an arbitrary target — and
-    # no credential is in scope: the runtime reads PUBLIC catalogs only.
+    # INVARIANT: the runtime's transport also serves model admission (OME-879)
+    # and the live model catalog (OME-972), but this helper remains the only
+    # per-model OBSERVATION path. The model reaching it has already been
+    # validated against the canonical inventory, so a caller cannot steer
+    # discovery at an arbitrary target — and no credential is in scope: the
+    # runtime reads PUBLIC catalogs only.
     # OME-632: the RESOLVED auth mode is bound here, never caller-declared. A
     # provider whose modes reach different upstreams may publish a source for one
     # and none for the other; binding at this boundary keeps that decision with the
@@ -109,6 +112,8 @@ async def _contract_document(request: Request, *, account_id: str, model: str) -
 
     # Canonical-id lookup BEFORE any profile work: reject unknown/cross-provider
     # ids (an id owned by another plugin is simply not in this plugin's set).
+    # Seeded and admitted ids resolve OFFLINE; the live catalog is consulted
+    # lazily, only to rescue a would-be 404 (OME-972).
     known = {
         canonical_model_id(custom_llm_provider=provider, model_name=entry.model_name)
         for entry in plugin.register_models()
@@ -116,10 +121,15 @@ async def _contract_document(request: Request, *, account_id: str, model: str) -
     # OME-879: dynamically admitted ids resolve like seeded ones — a model the
     # gateway agreed to serve must not 404 on its own contract endpoint.
     if model not in known and model not in request.app.state.admitted_models:
-        raise HTTPException(
-            status_code=404,
-            detail={"code": "model_not_found", "provider": provider, "model": model},
-        )
+        # OME-972: an id published from a healthy live snapshot must resolve on
+        # its own contract endpoint. Lazy by construction — a known-set hit
+        # above never pays for a listing read — and served from the same
+        # deployment-wide cache the /v1/models route fills.
+        if model not in await _live_catalog_ids(request, plugin):
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "model_not_found", "provider": provider, "model": model},
+            )
 
     profile_name = (request.headers.get("X-Profile") or "default").strip() or "default"
     # Reuse the chat resolution verbatim (raises the same 404/409 on a missing/
@@ -134,7 +144,8 @@ async def _contract_document(request: Request, *, account_id: str, model: str) -
     auth_mode = resolved_auth_mode(profile, connection, plugin=plugin)
 
     # Observed LAST: a request that fails profile resolution must not have spent a
-    # fetch on a contract it will never serve.
+    # fetch on a contract it will never serve. (The lazy catalog consult above is
+    # the one earlier read, and only a would-be 404 pays for it.)
     discovered = await _discovery_outcome(request, plugin, model=model, auth_mode=auth_mode)
 
     # OME-629: the observed snapshot reaches the EVIDENCE argument and nothing else.
@@ -172,6 +183,19 @@ async def _contract_document(request: Request, *, account_id: str, model: str) -
         # contract_id is not silently handed evidence with a different provenance.
         source_revision=discovered.snapshot.source_revision if discovered.snapshot else None,
     )
+
+
+async def _live_catalog_ids(request: Request, plugin: ProviderPluginBase[Any]) -> frozenset[str]:
+    """Gateway ids in the provider's live listing snapshot; empty when absent.
+
+    # WHY empty over raising: a degraded catalog must leave the 404 verdict to
+    # the offline inventory — this helper widens the known set, never gates it.
+    """
+    catalog = request.app.state.model_catalog
+    runtime: DiscoveryRuntime | None = request.app.state.discovery_runtime
+    if catalog is None or runtime is None:
+        return frozenset()
+    return await catalog.ids_for(plugin, client=runtime.client, limits=runtime.limits)
 
 
 @router.get("/v1/model-parameters")

--- a/apps/aigateway/src/aigateway/routes/model_parameters.py
+++ b/apps/aigateway/src/aigateway/routes/model_parameters.py
@@ -124,7 +124,7 @@ async def _contract_document(request: Request, *, account_id: str, model: str) -
         # OME-972: an id published from a healthy live snapshot must resolve on
         # its own contract endpoint. Lazy by construction — a known-set hit
         # above never pays for a listing read — and served from the same
-        # deployment-wide cache the /v1/models route fills.
+        # process-local cache the /v1/models route fills.
         if model not in await _live_catalog_ids(request, plugin):
             raise HTTPException(
                 status_code=404,

--- a/apps/aigateway/src/aigateway/routes/models.py
+++ b/apps/aigateway/src/aigateway/routes/models.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 
 from ..core.auth.middleware import CurrentAccount
 from ..core.model_capabilities import model_row
+from ..core.parameter_discovery import DiscoveryError
 
 router = APIRouter()
 
@@ -16,16 +17,46 @@ async def list_models(request: Request, _current: CurrentAccount) -> dict:
     ``id`` + effective ``supported_parameters``/``supported_tools`` + literal
     ``reject`` + a same-origin detail URL), composed from each plugin's own
     provider-local rule set.
+
+    OME-972 (snapshot-or-fallback): a provider with a healthy live-catalog
+    snapshot lists that snapshot's rows verbatim — the provider owns the merge
+    of operator-explicit and discovered entries, so core never learns seed
+    provenance. A cold or degraded catalog falls back to the provider's
+    compiled ``register_models()`` seeds, byte-identical to static behavior.
     """
     registry = request.app.state.providers
-    data = [
-        model_row(plugin, entry) for plugin in registry.all() for entry in plugin.register_models()
-    ]
+    catalog = request.app.state.model_catalog
+    runtime = request.app.state.discovery_runtime
+    data: list[dict] = []
+    seen: set[str] = set()
+    for plugin in registry.all():
+        entries = None
+        if catalog is not None and runtime is not None:
+            try:
+                entries = await catalog.entries_for(
+                    plugin, client=runtime.client, limits=runtime.limits
+                )
+            except DiscoveryError:
+                # Defense in depth only: the catalog maps refresh failures to
+                # None itself. Anything else (AssertionError included) must
+                # propagate — a swallowed programming error here would silently
+                # pin the listing to seeds forever.
+                entries = None
+        if entries is None:
+            entries = plugin.register_models()
+        for entry in entries:
+            row = model_row(plugin, entry)
+            if row["id"] in seen:
+                continue
+            seen.add(row["id"])
+            data.append(row)
     # OME-879: dynamically admitted models (deployment-lifetime, app.state only)
-    # join the listing after the seeded catalog. The admit route never stores a
-    # seeded id here, so no row can appear twice.
+    # join the listing after the catalog/seed rows. An admitted id can now ALSO
+    # arrive from a live snapshot (OME-972), so the join deduplicates on the
+    # canonical id instead of assuming disjoint sources.
     for model_id, entry in request.app.state.admitted_models.items():
         plugin = registry.get(model_id.split("/", 1)[0])
-        if plugin is not None:
+        if plugin is not None and model_id not in seen:
+            seen.add(model_id)
             data.append(model_row(plugin, entry))
     return {"object": "list", "data": data}

--- a/apps/aigateway/tests/unit/core/test_model_catalog.py
+++ b/apps/aigateway/tests/unit/core/test_model_catalog.py
@@ -1,4 +1,4 @@
-"""OME-972 U4 — the deployment-wide live model catalog over the observation cache.
+"""OME-972 U4 — the app-lifetime, process-local live model catalog.
 
 INVARIANT: the catalog never fabricates a listing. Healthy refreshes are cached
 fresh for one TTL; a failed refresh serves the last-good snapshot within the

--- a/apps/aigateway/tests/unit/core/test_model_catalog.py
+++ b/apps/aigateway/tests/unit/core/test_model_catalog.py
@@ -1,0 +1,390 @@
+"""OME-972 U4 — the deployment-wide live model catalog over the observation cache.
+
+INVARIANT: the catalog never fabricates a listing. Healthy refreshes are cached
+fresh for one TTL; a failed refresh serves the last-good snapshot within the
+stale window and degrades to ``None`` (seed fallback) beyond it; a port that
+answers ``None`` under a declared source is an inconsistency treated as a
+FAILED attempt — never cached fresh, never evicting last-good state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import cast
+
+import pytest
+
+from aigateway.core.model_catalog import ModelCatalog, build_model_catalog
+from aigateway.core.parameter_discovery import (
+    DiscoveryError,
+    DiscoveryHttpClient,
+    DiscoveryLimits,
+    RawResponse,
+)
+from aigateway.core.plugin_base import ModelDiscoverySource, ModelEntry
+
+_SOURCE = ModelDiscoverySource(
+    key="stub:models:list",
+    revision="stub:models:list-v1",
+    ttl_s=60.0,
+    stale_ttl_s=120.0,
+    failure_ttl_s=30.0,
+)
+
+_ENTRIES = (ModelEntry(model_name="stubprov/a/x", litellm_params={"model": "stubprov/a/x"}),)
+_ENTRIES_2 = (ModelEntry(model_name="stubprov/b/y", litellm_params={"model": "stubprov/b/y"}),)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.value = 1_000.0
+
+    def now(self) -> float:
+        return self.value
+
+
+class _StubPlugin:
+    """Duck-typed provider double: scripted port outcomes, call counting."""
+
+    def __init__(
+        self,
+        *,
+        provider: str = "stubprov",
+        source: ModelDiscoverySource | None = _SOURCE,
+        outcomes: list[object] | None = None,
+    ) -> None:
+        self.custom_llm_provider = provider
+        self._source = source
+        self._outcomes = list(outcomes or [])
+        self.calls = 0
+
+    def model_discovery_source(self) -> ModelDiscoverySource | None:
+        return self._source
+
+    async def discover_live_models(
+        self, *, client: DiscoveryHttpClient, limits: DiscoveryLimits | None = None
+    ) -> tuple[ModelEntry, ...] | None:
+        self.calls += 1
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return cast("tuple[ModelEntry, ...] | None", outcome)
+
+
+class _NullClient:
+    """Protocol-shaped sentinel: the catalog forwards it opaquely to the port."""
+
+    async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+        raise AssertionError("stub port outcomes never dial the client")
+
+
+_CLIENT = _NullClient()
+
+
+async def _entries(catalog: ModelCatalog, plugin: _StubPlugin) -> tuple[ModelEntry, ...] | None:
+    return await catalog.entries_for(plugin, client=_CLIENT, limits=None)
+
+
+# ------------------------------------------------------------------ gating
+
+
+@pytest.mark.asyncio
+async def test_no_declared_source_returns_none_without_calling_the_port() -> None:
+    plugin = _StubPlugin(source=None, outcomes=[_ENTRIES])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await _entries(catalog, plugin) is None
+    assert plugin.calls == 0
+
+
+def test_build_model_catalog_follows_the_discovery_switch() -> None:
+    # WHY: AIGW_DISCOVERY_ENABLED=false is the deployment-wide kill switch for
+    # ALL discovery egress — the listing catalog obeys the same switch the
+    # parameter-discovery runtime does.
+    assert build_model_catalog(enabled=False) is None
+    assert isinstance(build_model_catalog(enabled=True), ModelCatalog)
+
+
+# ------------------------------------------------------------------ caching
+
+
+@pytest.mark.asyncio
+async def test_healthy_snapshot_is_cached_for_one_ttl() -> None:
+    plugin = _StubPlugin(outcomes=[_ENTRIES, _ENTRIES_2])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await _entries(catalog, plugin) == _ENTRIES
+    assert await _entries(catalog, plugin) == _ENTRIES
+    assert plugin.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_triggers_one_refresh() -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[_ENTRIES, _ENTRIES_2])
+    catalog = ModelCatalog(clock=clock)
+    assert await _entries(catalog, plugin) == _ENTRIES
+    clock.value += _SOURCE.ttl_s + 1.0
+    assert await _entries(catalog, plugin) == _ENTRIES_2
+    assert plugin.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_serves_the_stale_last_good_snapshot() -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[_ENTRIES, DiscoveryError("bad_status", status=500)])
+    catalog = ModelCatalog(clock=clock)
+    assert await _entries(catalog, plugin) == _ENTRIES
+    clock.value += _SOURCE.ttl_s + 1.0
+    # INVARIANT: an upstream outage never evicts the last good listing.
+    assert await _entries(catalog, plugin) == _ENTRIES
+
+
+@pytest.mark.asyncio
+async def test_cold_failure_returns_none_for_seed_fallback() -> None:
+    plugin = _StubPlugin(outcomes=[DiscoveryError("unreachable")])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await _entries(catalog, plugin) is None
+
+
+@pytest.mark.asyncio
+async def test_stale_window_expiry_degrades_to_none() -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[_ENTRIES, DiscoveryError("timeout"), DiscoveryError("timeout")])
+    catalog = ModelCatalog(clock=clock)
+    assert await _entries(catalog, plugin) == _ENTRIES
+    clock.value += _SOURCE.ttl_s + _SOURCE.stale_ttl_s + 1.0
+    # WHY: beyond ttl+stale the snapshot is too old to trust — honest absence
+    # (seed fallback) beats a listing that may be hours wrong.
+    assert await _entries(catalog, plugin) is None
+
+
+@pytest.mark.asyncio
+async def test_failure_damping_suppresses_immediate_retries() -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[DiscoveryError("unreachable"), _ENTRIES])
+    catalog = ModelCatalog(clock=clock)
+    assert await _entries(catalog, plugin) is None
+    clock.value += _SOURCE.failure_ttl_s / 2
+    # INVARIANT: within failure_ttl the failed attempt is NOT retried — a dead
+    # upstream costs one dial per damping window, not one per request.
+    assert await _entries(catalog, plugin) is None
+    assert plugin.calls == 1
+    clock.value += _SOURCE.failure_ttl_s
+    assert await _entries(catalog, plugin) == _ENTRIES
+    assert plugin.calls == 2
+
+
+# ------------------------------------------------------- port contract guards
+
+
+@pytest.mark.asyncio
+async def test_port_none_under_a_declared_source_is_a_failed_attempt() -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[_ENTRIES, None])
+    catalog = ModelCatalog(clock=clock)
+    assert await _entries(catalog, plugin) == _ENTRIES
+    clock.value += _SOURCE.ttl_s + 1.0
+    # INVARIANT: an inconsistent None is converted to a failed refresh — were it
+    # stored as a successful value it would be cached FRESH and evict last-good.
+    assert await _entries(catalog, plugin) == _ENTRIES
+
+
+@pytest.mark.asyncio
+async def test_cold_port_none_returns_none() -> None:
+    plugin = _StubPlugin(outcomes=[None])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await _entries(catalog, plugin) is None
+
+
+@pytest.mark.asyncio
+async def test_foreign_exception_is_wrapped_and_sanitized(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    plugin = _StubPlugin(outcomes=[ValueError("secret-token-xyz")])
+    catalog = ModelCatalog(clock=_Clock())
+    with caplog.at_level(logging.WARNING, logger="aigateway.core.model_catalog"):
+        assert await _entries(catalog, plugin) is None
+    text = caplog.text
+    # INVARIANT (sanitized): the exception TYPE is observable, its message —
+    # which can carry upstream content — never reaches a log line.
+    assert "ValueError" in text
+    assert "secret-token-xyz" not in text
+
+
+@pytest.mark.asyncio
+async def test_assertion_error_propagates_loudly() -> None:
+    # INVARIANT: the test-suite no-egress tripwire raises AssertionError — the
+    # catalog must NEVER absorb it into a quiet degraded outcome.
+    plugin = _StubPlugin(outcomes=[AssertionError("test attempted real discovery egress")])
+    catalog = ModelCatalog(clock=_Clock())
+    with pytest.raises(AssertionError):
+        await _entries(catalog, plugin)
+
+
+# ------------------------------------------------------------- concurrency
+
+
+@pytest.mark.asyncio
+async def test_concurrent_callers_share_one_refresh() -> None:
+    class _SlowPlugin(_StubPlugin):
+        async def discover_live_models(
+            self, *, client: DiscoveryHttpClient, limits: DiscoveryLimits | None = None
+        ) -> tuple[ModelEntry, ...] | None:
+            self.calls += 1
+            await asyncio.sleep(0.02)
+            return _ENTRIES
+
+    plugin = _SlowPlugin()
+    catalog = ModelCatalog(clock=_Clock())
+    results = await asyncio.gather(*(_entries(catalog, plugin) for _ in range(5)))
+    assert all(result == _ENTRIES for result in results)
+    assert plugin.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_providers_are_cached_independently() -> None:
+    source_b = ModelDiscoverySource(
+        key="otherprov:models:list",
+        revision="otherprov:models:list-v1",
+        ttl_s=60.0,
+        stale_ttl_s=120.0,
+        failure_ttl_s=30.0,
+    )
+    plugin_a = _StubPlugin(outcomes=[_ENTRIES])
+    plugin_b = _StubPlugin(provider="otherprov", source=source_b, outcomes=[_ENTRIES_2])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await _entries(catalog, plugin_a) == _ENTRIES
+    assert await _entries(catalog, plugin_b) == _ENTRIES_2
+    assert plugin_a.calls == 1
+    assert plugin_b.calls == 1
+
+
+# ------------------------------------------------------------------- logging
+
+
+@pytest.mark.asyncio
+async def test_successful_refresh_logs_the_row_count_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    plugin = _StubPlugin(outcomes=[_ENTRIES])
+    catalog = ModelCatalog(clock=_Clock())
+    with caplog.at_level(logging.INFO, logger="aigateway.core.model_catalog"):
+        await _entries(catalog, plugin)
+    assert "stubprov" in caplog.text
+    assert "models=1" in caplog.text
+    # INVARIANT: counts, never content — no model id appears in log output.
+    assert "stubprov/a/x" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_logs_reason_and_status_class(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    plugin = _StubPlugin(outcomes=[DiscoveryError("bad_status", status=401)])
+    catalog = ModelCatalog(clock=_Clock())
+    with caplog.at_level(logging.WARNING, logger="aigateway.core.model_catalog"):
+        await _entries(catalog, plugin)
+    assert "bad_status" in caplog.text
+    assert "401" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_damped_window_produces_no_new_log_lines(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[DiscoveryError("unreachable")])
+    catalog = ModelCatalog(clock=clock)
+    with caplog.at_level(logging.INFO, logger="aigateway.core.model_catalog"):
+        await _entries(catalog, plugin)
+        first_batch = len(caplog.records)
+        clock.value += _SOURCE.failure_ttl_s / 2
+        await _entries(catalog, plugin)
+    # WHY: the damped path never re-runs the refresh thunk, so a dead upstream
+    # cannot flood the log — at most one line per damping window.
+    assert len(caplog.records) == first_batch
+
+
+# --------------------------------------------------------------------- ids_for
+
+
+@pytest.mark.asyncio
+async def test_ids_for_projects_model_names() -> None:
+    plugin = _StubPlugin(outcomes=[_ENTRIES])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await catalog.ids_for(plugin, client=_CLIENT, limits=None) == frozenset({"stubprov/a/x"})
+
+
+@pytest.mark.asyncio
+async def test_ids_for_is_empty_when_no_source_or_degraded() -> None:
+    catalog = ModelCatalog(clock=_Clock())
+    no_source = _StubPlugin(source=None)
+    assert await catalog.ids_for(no_source, client=_CLIENT, limits=None) == frozenset()
+    failing = _StubPlugin(provider="coldprov", outcomes=[DiscoveryError("unreachable")])
+    # WHY reusing a fresh key: per-provider caches — a cold failure yields no ids.
+    source = ModelDiscoverySource(
+        key="coldprov:models:list", revision="v1", ttl_s=60.0, stale_ttl_s=120.0, failure_ttl_s=0.0
+    )
+    failing._source = source
+    assert await catalog.ids_for(failing, client=_CLIENT, limits=None) == frozenset()
+
+
+# --- OME-972 correction pass ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ids_for_canonicalizes_unprefixed_entries() -> None:
+    # INVARIANT: the rescue set and the published listing must live in ONE
+    # identity space. /v1/models publishes canonical (provider-prefixed) ids, so
+    # a provider following the established unprefixed-``model_name`` convention
+    # would otherwise publish an id that 404s on its own detail endpoint.
+    bare = (ModelEntry(model_name="a/x", litellm_params={"model": "a/x"}),)
+    plugin = _StubPlugin(outcomes=[bare])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await catalog.ids_for(plugin, client=_CLIENT, limits=None) == frozenset({"stubprov/a/x"})
+
+
+@pytest.mark.asyncio
+async def test_already_canonical_entries_are_not_double_prefixed() -> None:
+    plugin = _StubPlugin(outcomes=[_ENTRIES])
+    catalog = ModelCatalog(clock=_Clock())
+    assert await catalog.ids_for(plugin, client=_CLIENT, limits=None) == frozenset({"stubprov/a/x"})
+
+
+@pytest.mark.asyncio
+async def test_served_tier_transitions_are_logged_once_per_change(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[_ENTRIES, DiscoveryError("timeout"), DiscoveryError("timeout")])
+    catalog = ModelCatalog(clock=clock)
+    with caplog.at_level(logging.INFO, logger="aigateway.core.model_catalog"):
+        assert await _entries(catalog, plugin) == _ENTRIES
+        assert await _entries(catalog, plugin) == _ENTRIES  # cached: same tier, no new line
+        fresh_lines = [r for r in caplog.records if "tier=fresh" in r.getMessage()]
+        clock.value += _SOURCE.ttl_s + 1.0
+        assert await _entries(catalog, plugin) == _ENTRIES  # failed refresh -> stale last-good
+        clock.value += _SOURCE.stale_ttl_s + 1.0
+        assert await _entries(catalog, plugin) is None  # past the window -> compiled seeds
+    text = caplog.text
+    # WHY: during an outage the per-attempt warnings look identical at minute 30
+    # (users still see the full stale listing) and at hour 2 (users see only
+    # seeds). The tier line is what tells those two states apart.
+    assert len(fresh_lines) == 1, "an unchanged tier must not re-log"
+    assert "tier=stale" in text
+    assert "tier=seeds" in text
+    assert "stubprov/a/x" not in text  # counts and tiers only, never content
+
+
+@pytest.mark.asyncio
+async def test_recovery_back_to_fresh_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    clock = _Clock()
+    plugin = _StubPlugin(outcomes=[DiscoveryError("unreachable"), _ENTRIES])
+    catalog = ModelCatalog(clock=clock)
+    with caplog.at_level(logging.INFO, logger="aigateway.core.model_catalog"):
+        assert await _entries(catalog, plugin) is None
+        clock.value += _SOURCE.failure_ttl_s + 1.0
+        assert await _entries(catalog, plugin) == _ENTRIES
+    messages = [r.getMessage() for r in caplog.records if "tier=" in r.getMessage()]
+    assert any("tier=seeds" in m for m in messages)
+    assert any("tier=fresh" in m for m in messages)

--- a/apps/aigateway/tests/unit/core/test_models_route_live_catalog.py
+++ b/apps/aigateway/tests/unit/core/test_models_route_live_catalog.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import cast
 
@@ -19,8 +18,13 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from aigateway.core.discovery_runtime import DiscoveryRuntime
-from aigateway.core.model_catalog import ModelCatalog
-from aigateway.core.parameter_discovery import DiscoveryError, DiscoveryLimits, RawResponse
+from aigateway.core.model_catalog import ModelCatalog, ModelListingProvider
+from aigateway.core.parameter_discovery import (
+    DiscoveryError,
+    DiscoveryHttpClient,
+    DiscoveryLimits,
+    RawResponse,
+)
 from aigateway.core.parameter_discovery_cache import CacheLimits, ObservationCache
 from aigateway.core.plugin_base import ModelEntry
 from aigateway.plugins.openrouter_provider import plugin as plugin_module
@@ -82,7 +86,7 @@ def _openrouter_ids(client: TestClient) -> list[str]:
 
 
 def test_app_wiring_installs_the_model_catalog(authenticated_client: TestClient) -> None:
-    # WHY: the catalog must be app-lifetime state (deployment-wide cache), not
+    # WHY: the catalog must be app-lifetime, process-local state, not
     # per-request — this pins the main.py wiring next to discovery_runtime.
     app = cast(FastAPI, authenticated_client.app)
     assert isinstance(app.state.model_catalog, ModelCatalog)
@@ -252,9 +256,27 @@ def test_a_malformed_refresh_never_replaces_the_last_good_snapshot(
 ) -> None:
     _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
     clock = _MutableClock()
-    # Second dial answers 200 with a page missing its completeness metadata —
-    # the shape that silently looked like a complete catalog before this pass.
-    http = _ScriptedClient([_strict_body(["openai/gpt-5"]), json.dumps({"data": []})])
+    # WHY this exact second body: it is the shape a row-skipping parser would
+    # have SALVAGED — one unusable row plus one good id, and no completeness
+    # metadata at all. Lenient parsing publishes ``gpt-4.1-mini`` as a complete
+    # catalog and REPLACES the snapshot; strict parsing must reject the page.
+    # A body that fails both readings (e.g. ``{"data": []}``) would let this
+    # test pass without the fix, so it would not guard anything.
+    http = _ScriptedClient(
+        [
+            _strict_body(["openai/gpt-5"]),
+            json.dumps(
+                {
+                    "data": [{"name": "drifted-row-without-an-id"}, {"id": "openai/gpt-4.1-mini"}],
+                    "links": {"next": None},
+                    # Consistent with the SALVAGEABLE row count, so the
+                    # completeness reconciliation cannot catch this page —
+                    # only the all-or-nothing row rule can.
+                    "total_count": 1,
+                }
+            ),
+        ]
+    )
     app = cast(FastAPI, authenticated_client.app)
     app.state.discovery_runtime = DiscoveryRuntime(
         client=http,
@@ -273,9 +295,10 @@ def test_a_malformed_refresh_never_replaces_the_last_good_snapshot(
     clock.value += LIVE_MODELS_DISCOVERY_SOURCE.ttl_s + 1.0
     after = _openrouter_ids(authenticated_client)
 
-    # INVARIANT: a malformed catalog is a FAILED attempt, never a fresh empty
-    # one — the last good snapshot keeps serving inside the stale window.
+    # INVARIANT: a malformed catalog is a FAILED attempt, never a new snapshot —
+    # the last good one keeps serving inside the stale window.
     assert after == healthy
+    assert "openrouter/openai/gpt-4.1-mini" not in after
     assert len(http.dialed) == 2
 
 
@@ -326,24 +349,44 @@ def test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200(
     )
     app.state.model_catalog = ModelCatalog(clock=_Clock())
 
-    def _timed_get(_n: int) -> tuple[int, float, float]:
-        started = time.monotonic()
-        response = authenticated_client.get("/v1/models")
-        return response.status_code, started, time.monotonic()
+    # WHY instrument the catalog instead of timing the client: every caller
+    # enters ``entries_for`` and all but the winner park on the single-flight,
+    # so its peak depth IS the concurrency. Client-side start stamps prove
+    # nothing — the pool launches all six threads at once, so they are all ~t0
+    # even if the server answered them strictly one after another.
+    depth = {"now": 0, "peak": 0}
+    unwrapped = ModelCatalog.entries_for
+
+    async def _counting_entries_for(
+        self: ModelCatalog,
+        plugin: ModelListingProvider,
+        *,
+        client: DiscoveryHttpClient,
+        limits: DiscoveryLimits | None,
+    ) -> tuple[ModelEntry, ...] | None:
+        depth["now"] += 1
+        depth["peak"] = max(depth["peak"], depth["now"])
+        try:
+            return await unwrapped(self, plugin, client=client, limits=limits)
+        finally:
+            depth["now"] -= 1
+
+    monkeypatch.setattr(ModelCatalog, "entries_for", _counting_entries_for)
+
+    def _get(_n: int) -> int:
+        return authenticated_client.get("/v1/models").status_code
 
     callers = 6
     with ThreadPoolExecutor(max_workers=callers) as pool:
-        results = list(pool.map(_timed_get, range(callers)))
+        statuses = list(pool.map(_get, range(callers)))
 
-    assert [status for status, _s, _e in results] == [200] * callers
+    assert statuses == [200] * callers
     # INVARIANT: single-flight — one refresh serves every contemporaneous caller,
     # so a burst of listings costs ONE upstream fetch chain, not N.
     assert http.dialed == [LIVE_MODELS_URL]
-    # ...and they really were contemporaneous: the last request to start did so
-    # before the first one finished (otherwise this would only prove caching).
-    latest_start = max(start for _s, start, _e in results)
-    earliest_end = min(end for _s, _st, end in results)
-    assert latest_start < earliest_end, "requests did not overlap; concurrency unproven"
+    # ...and all six really were in flight together, so the single dial is
+    # single-flight and not just a cache hit behind a serialized server.
+    assert depth["peak"] == callers
 
 
 def test_a_raising_discovery_source_stays_loud_on_the_listing_route(

--- a/apps/aigateway/tests/unit/core/test_models_route_live_catalog.py
+++ b/apps/aigateway/tests/unit/core/test_models_route_live_catalog.py
@@ -1,0 +1,381 @@
+"""OME-972 U5 — /v1/models snapshot-or-fallback merge through the live catalog.
+
+INVARIANT (snapshot-or-fallback): a healthy snapshot IS the provider's listing
+(operator-explicit entries first, discovered next; compiled defaults absent
+from it are NOT listed); a cold or degraded catalog lists the compiled seeds
+byte-identically to today's behavior. Admitted models always join, deduplicated.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aigateway.core.discovery_runtime import DiscoveryRuntime
+from aigateway.core.model_catalog import ModelCatalog
+from aigateway.core.parameter_discovery import DiscoveryError, DiscoveryLimits, RawResponse
+from aigateway.core.parameter_discovery_cache import CacheLimits, ObservationCache
+from aigateway.core.plugin_base import ModelEntry
+from aigateway.plugins.openrouter_provider import plugin as plugin_module
+from aigateway.plugins.openrouter_provider.live_models import (
+    LIVE_MODELS_DISCOVERY_SOURCE,
+    LIVE_MODELS_URL,
+)
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+# A compiled default seed (factory list) that the canned live catalog below
+# deliberately omits — retired upstream, so a healthy snapshot must drop it.
+_COMPILED_SEED = "openrouter/anthropic/claude-fable-5"
+
+
+class _Clock:
+    def now(self) -> float:
+        return 1_000.0
+
+
+class _CatalogClient:
+    """Canned live catalog; records dials; optionally fails every dial."""
+
+    def __init__(self, ids: list[str] | None = None, *, fail: bool = False) -> None:
+        rows = list(ids or [])
+        # Strict envelope: the live parser requires links.next + total_count.
+        self._body = json.dumps(
+            {"data": [{"id": i} for i in rows], "links": {"next": None}, "total_count": len(rows)}
+        )
+        self._fail = fail
+        self.dialed: list[str] = []
+
+    async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+        self.dialed.append(url)
+        if self._fail:
+            raise DiscoveryError("unreachable")
+        return RawResponse(status=200, content_type="application/json", body=self._body)
+
+
+def _enable_openrouter(monkeypatch: pytest.MonkeyPatch, settings: OpenRouterPluginSettings) -> None:
+    monkeypatch.setattr(plugin_module.PLUGIN, "settings", settings)
+
+
+def _install(client: TestClient, http: _CatalogClient) -> None:
+    app = cast(FastAPI, client.app)
+    app.state.discovery_runtime = DiscoveryRuntime(
+        client=http,
+        cache=ObservationCache(
+            clock=_Clock(), limits=CacheLimits(ttl_s=60.0, stale_ttl_s=120.0, max_entries=8)
+        ),
+        limits=DiscoveryLimits(),
+    )
+    app.state.model_catalog = ModelCatalog(clock=_Clock())
+
+
+def _openrouter_ids(client: TestClient) -> list[str]:
+    response = client.get("/v1/models")
+    assert response.status_code == 200
+    return [row["id"] for row in response.json()["data"] if row["owned_by"] == "openrouter"]
+
+
+def test_app_wiring_installs_the_model_catalog(authenticated_client: TestClient) -> None:
+    # WHY: the catalog must be app-lifetime state (deployment-wide cache), not
+    # per-request — this pins the main.py wiring next to discovery_runtime.
+    app = cast(FastAPI, authenticated_client.app)
+    assert isinstance(app.state.model_catalog, ModelCatalog)
+
+
+def test_healthy_snapshot_replaces_compiled_seeds(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    http = _CatalogClient(["qwen/qwen3-coder", "openai/gpt-5", "zed/zeta:free"])
+    _install(authenticated_client, http)
+    ids = _openrouter_ids(authenticated_client)
+    # INVARIANT: discovered plain ids only, sorted; the colon variant is never
+    # auto-published; a compiled default absent from the healthy snapshot is
+    # NOT listed (retired models disappear).
+    assert ids == ["openrouter/openai/gpt-5", "openrouter/qwen/qwen3-coder"]
+    assert _COMPILED_SEED not in ids
+    assert http.dialed == [LIVE_MODELS_URL]
+
+
+def test_other_providers_are_untouched_by_the_live_catalog(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    _install(authenticated_client, _CatalogClient(["openai/gpt-5"]))
+    response = authenticated_client.get("/v1/models")
+    rows = response.json()["data"]
+    anthropic = [row["id"] for row in rows if row["owned_by"] == "anthropic"]
+    assert "anthropic/claude-opus-4-8" in anthropic
+
+
+def test_explicit_operator_models_survive_a_healthy_snapshot_first(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(
+        monkeypatch,
+        OpenRouterPluginSettings(
+            enabled=True,
+            default_models=["openrouter/deepseek/deepseek-chat-v3.1:free"],
+        ),
+    )
+    _install(authenticated_client, _CatalogClient(["openai/gpt-5"]))
+    # INVARIANT: operator-explicit config (colon variant included) is listed
+    # FIRST and survives every healthy snapshot.
+    assert _openrouter_ids(authenticated_client) == [
+        "openrouter/deepseek/deepseek-chat-v3.1:free",
+        "openrouter/openai/gpt-5",
+    ]
+
+
+def test_cold_failure_falls_back_to_compiled_seeds_byte_identically(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = OpenRouterPluginSettings(enabled=True)
+    _enable_openrouter(monkeypatch, settings)
+    _install(authenticated_client, _CatalogClient(fail=True))
+    # INVARIANT: cold/degraded == today's static behavior, exactly.
+    assert _openrouter_ids(authenticated_client) == list(settings.default_models)
+
+
+def test_live_models_disabled_means_seeds_and_zero_egress(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = OpenRouterPluginSettings(enabled=True, live_models=False)
+    _enable_openrouter(monkeypatch, settings)
+    http = _CatalogClient(["openai/gpt-5"])
+    _install(authenticated_client, http)
+    assert _openrouter_ids(authenticated_client) == list(settings.default_models)
+    # INVARIANT (owner decision): the opt-out restores static behavior with
+    # ZERO catalog egress — not one dial.
+    assert http.dialed == []
+
+
+def test_missing_catalog_state_falls_back_to_seeds(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = OpenRouterPluginSettings(enabled=True)
+    _enable_openrouter(monkeypatch, settings)
+    http = _CatalogClient(["openai/gpt-5"])
+    _install(authenticated_client, http)
+    app = cast(FastAPI, authenticated_client.app)
+    app.state.model_catalog = None  # AIGW_DISCOVERY_ENABLED=false shape
+    assert _openrouter_ids(authenticated_client) == list(settings.default_models)
+    assert http.dialed == []
+
+
+def test_admitted_models_join_once_even_when_also_discovered(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    _install(authenticated_client, _CatalogClient(["openai/gpt-5"]))
+    app = cast(FastAPI, authenticated_client.app)
+    app.state.admitted_models["openrouter/openai/gpt-5"] = ModelEntry(
+        model_name="openrouter/openai/gpt-5",
+        litellm_params={"model": "openrouter/openai/gpt-5"},
+    )
+    app.state.admitted_models["openrouter/moon/kimi-k2:free"] = ModelEntry(
+        model_name="openrouter/moon/kimi-k2:free",
+        litellm_params={"model": "openrouter/moon/kimi-k2:free"},
+    )
+    ids = _openrouter_ids(authenticated_client)
+    # WHY once: an id can now arrive from BOTH the snapshot and admission —
+    # the row set stays deduplicated on the canonical id.
+    assert ids.count("openrouter/openai/gpt-5") == 1
+    assert ids.count("openrouter/moon/kimi-k2:free") == 1
+
+
+def test_repeat_requests_reuse_one_fetch_chain_and_stay_deterministic(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    http = _CatalogClient(["b/y", "a/x"])
+    _install(authenticated_client, http)
+    first = authenticated_client.get("/v1/models").json()
+    second = authenticated_client.get("/v1/models").json()
+    # INVARIANT: one upstream fetch chain per TTL window regardless of request
+    # volume, and a byte-stable listing between refreshes.
+    assert first == second
+    assert http.dialed == [LIVE_MODELS_URL]
+
+
+def test_the_no_egress_tripwire_stays_loud_through_the_whole_stack(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    # No runtime/catalog installed: the app's DEFAULT wiring (real discovery
+    # client, no transport) is what a forgetful future test would hit.
+    with pytest.raises(AssertionError, match="discovery egress"):
+        authenticated_client.get("/v1/models")
+    # INVARIANT: the conftest tripwire's AssertionError must surface as a test
+    # failure — a catalog or route that absorbed it would convert forbidden
+    # real egress into a silent seed fallback and the suite would stay green.
+
+
+# --- OME-972 correction pass: acceptance completion --------------------------
+
+
+class _MutableClock:
+    def __init__(self) -> None:
+        self.value = 1_000.0
+
+    def now(self) -> float:
+        return self.value
+
+
+class _ScriptedClient:
+    """Serves a different canned body per dial, in order."""
+
+    def __init__(self, bodies: list[str]) -> None:
+        self._bodies = list(bodies)
+        self.dialed: list[str] = []
+
+    async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+        self.dialed.append(url)
+        body = self._bodies.pop(0) if len(self._bodies) > 1 else self._bodies[0]
+        return RawResponse(status=200, content_type="application/json", body=body)
+
+
+def _strict_body(ids: list[str]) -> str:
+    return json.dumps(
+        {"data": [{"id": i} for i in ids], "links": {"next": None}, "total_count": len(ids)}
+    )
+
+
+def test_a_malformed_refresh_never_replaces_the_last_good_snapshot(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    clock = _MutableClock()
+    # Second dial answers 200 with a page missing its completeness metadata —
+    # the shape that silently looked like a complete catalog before this pass.
+    http = _ScriptedClient([_strict_body(["openai/gpt-5"]), json.dumps({"data": []})])
+    app = cast(FastAPI, authenticated_client.app)
+    app.state.discovery_runtime = DiscoveryRuntime(
+        client=http,
+        cache=ObservationCache(
+            clock=clock, limits=CacheLimits(ttl_s=60.0, stale_ttl_s=120.0, max_entries=8)
+        ),
+        limits=DiscoveryLimits(),
+    )
+    app.state.model_catalog = ModelCatalog(clock=clock)
+
+    healthy = _openrouter_ids(authenticated_client)
+    assert healthy == ["openrouter/openai/gpt-5"]
+
+    # Past the LIVE-SOURCE ttl (300 s, declared by the provider — not the
+    # runtime cache's own limits): the next request refreshes and gets junk.
+    clock.value += LIVE_MODELS_DISCOVERY_SOURCE.ttl_s + 1.0
+    after = _openrouter_ids(authenticated_client)
+
+    # INVARIANT: a malformed catalog is a FAILED attempt, never a fresh empty
+    # one — the last good snapshot keeps serving inside the stale window.
+    assert after == healthy
+    assert len(http.dialed) == 2
+
+
+def test_a_page_without_completeness_metadata_falls_back_to_seeds_when_cold(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings = OpenRouterPluginSettings(enabled=True)
+    _enable_openrouter(monkeypatch, settings)
+    http = _ScriptedClient([json.dumps({"data": [{"id": "openai/gpt-5"}]})])
+    app = cast(FastAPI, authenticated_client.app)
+    app.state.discovery_runtime = DiscoveryRuntime(
+        client=http,
+        cache=ObservationCache(
+            clock=_Clock(), limits=CacheLimits(ttl_s=60.0, stale_ttl_s=120.0, max_entries=8)
+        ),
+        limits=DiscoveryLimits(),
+    )
+    app.state.model_catalog = ModelCatalog(clock=_Clock())
+    # With no last-good snapshot to fall back to, the honest answer is the
+    # compiled seed listing — never the salvaged rows of an unverifiable page.
+    assert _openrouter_ids(authenticated_client) == list(settings.default_models)
+
+
+def test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+
+    class _SlowClient:
+        def __init__(self) -> None:
+            self.dialed: list[str] = []
+
+        async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+            self.dialed.append(url)
+            await asyncio.sleep(0.2)
+            return RawResponse(
+                status=200, content_type="application/json", body=_strict_body(["openai/gpt-5"])
+            )
+
+    http = _SlowClient()
+    app = cast(FastAPI, authenticated_client.app)
+    app.state.discovery_runtime = DiscoveryRuntime(
+        client=http,
+        cache=ObservationCache(
+            clock=_Clock(), limits=CacheLimits(ttl_s=60.0, stale_ttl_s=120.0, max_entries=8)
+        ),
+        limits=DiscoveryLimits(),
+    )
+    app.state.model_catalog = ModelCatalog(clock=_Clock())
+
+    def _timed_get(_n: int) -> tuple[int, float, float]:
+        started = time.monotonic()
+        response = authenticated_client.get("/v1/models")
+        return response.status_code, started, time.monotonic()
+
+    callers = 6
+    with ThreadPoolExecutor(max_workers=callers) as pool:
+        results = list(pool.map(_timed_get, range(callers)))
+
+    assert [status for status, _s, _e in results] == [200] * callers
+    # INVARIANT: single-flight — one refresh serves every contemporaneous caller,
+    # so a burst of listings costs ONE upstream fetch chain, not N.
+    assert http.dialed == [LIVE_MODELS_URL]
+    # ...and they really were contemporaneous: the last request to start did so
+    # before the first one finished (otherwise this would only prove caching).
+    latest_start = max(start for _s, start, _e in results)
+    earliest_end = min(end for _s, _st, end in results)
+    assert latest_start < earliest_end, "requests did not overlap; concurrency unproven"
+
+
+def test_a_raising_discovery_source_stays_loud_on_the_listing_route(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    _install(authenticated_client, _CatalogClient(["openai/gpt-5"]))
+
+    def _boom() -> None:
+        raise ValueError("provider bug in the source declaration")
+
+    monkeypatch.setattr(plugin_module.PLUGIN, "model_discovery_source", _boom)
+    # INVARIANT (plan D21): a PROGRAMMING error in the cheap synchronous hook is
+    # not an upstream failure and must never be laundered into a quiet seed
+    # fallback — that would hide a permanently broken provider behind a listing
+    # that looks merely degraded.
+    with pytest.raises(ValueError, match="provider bug"):
+        authenticated_client.get("/v1/models")
+
+
+def test_a_raising_discovery_source_stays_loud_on_the_detail_route(
+    authenticated_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
+    _install(authenticated_client, _CatalogClient(["openai/gpt-5"]))
+
+    def _boom() -> None:
+        raise ValueError("provider bug in the source declaration")
+
+    monkeypatch.setattr(plugin_module.PLUGIN, "model_discovery_source", _boom)
+    # The lazy 404-rescue reaches the same hook; the same rule applies there.
+    with pytest.raises(ValueError, match="provider bug"):
+        authenticated_client.get(
+            "/v1/model-parameters", params={"model": "openrouter/nope/not-here"}
+        )

--- a/apps/aigateway/tests/unit/openrouter/_openapi_document.py
+++ b/apps/aigateway/tests/unit/openrouter/_openapi_document.py
@@ -122,6 +122,13 @@ class _RoutingClient(DiscoveryHttpClient):
         self.seen.append((url, timeout_s, max_bytes))
         if self._fail == url:
             raise DiscoveryError("unreachable")
+        if url not in self._bodies:
+            # OME-972: LOUD on an unrouted URL. A KeyError here is caught by the
+            # model catalog's foreign-exception guard and converted into a quiet
+            # seed fallback, so a suite that accidentally starts dialing a new
+            # document (e.g. the live model catalog) would keep passing for the
+            # wrong reason. AssertionError propagates through every guard.
+            raise AssertionError(f"canned client has no body for {url!r} — unexpected dial")
         return RawResponse(
             status=200, content_type="application/json", body=json.dumps(self._bodies[url])
         )

--- a/apps/aigateway/tests/unit/openrouter/test_live_models_fetch.py
+++ b/apps/aigateway/tests/unit/openrouter/test_live_models_fetch.py
@@ -1,0 +1,270 @@
+"""OME-972 U2 — the paginated catalog fetch and its complete failure surface.
+
+INVARIANT (all-or-nothing): ``fetch_live_model_ids`` either walks the WHOLE
+``links.next`` chain under one aggregate deadline and returns every raw id, or
+raises a sanitized ``DiscoveryError`` — a mid-chain failure never yields the
+pages already collected, and an off-policy next link is refused BEFORE it is
+ever dialed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aigateway.core.parameter_discovery import DiscoveryError, RawResponse
+from aigateway.plugins.openrouter_provider import live_models
+from aigateway.plugins.openrouter_provider.live_models import (
+    LIVE_MODELS_URL,
+    fetch_live_model_ids,
+)
+
+_BASE = "https://openrouter.ai/api/v1/models?output_modalities=text&limit=250"
+
+
+def _paged_url(offset: int) -> str:
+    return f"{_BASE}&offset={offset}"
+
+
+def _next_link(offset: int) -> str:
+    return f"/api/v1/models?output_modalities=text&limit=250&offset={offset}"
+
+
+def _page(ids: list[str], *, next_url: str | None = None, total: int | None = None) -> RawResponse:
+    """A STRICT well-formed page: both completeness fields always present.
+
+    Mirrors the live envelope (probed 2026-08-24): ``{data, links, total_count}``
+    on every page, with ``links.next = null`` marking the last one.
+    """
+    payload: dict[str, object] = {
+        "data": [{"id": i} for i in ids],
+        "links": {"next": next_url},
+        "total_count": len(ids) if total is None else total,
+    }
+    return RawResponse(status=200, content_type="application/json", body=json.dumps(payload))
+
+
+def _raw_page(payload: object) -> RawResponse:
+    return RawResponse(status=200, content_type="application/json", body=json.dumps(payload))
+
+
+class _RoutingClient:
+    """Canned catalog server: one response per exact URL, every dial recorded."""
+
+    def __init__(self, responses: dict[str, RawResponse]) -> None:
+        self._responses = responses
+        self.dialed: list[str] = []
+
+    async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+        self.dialed.append(url)
+        response = self._responses.get(url)
+        if response is None:  # pragma: no cover - test authoring error, not behavior
+            raise AssertionError(f"unexpected dial: {url}")
+        return response
+
+
+# ------------------------------------------------------------------ happy paths
+
+
+@pytest.mark.asyncio
+async def test_single_page_returns_raw_ids_and_dials_the_pinned_url_once() -> None:
+    client = _RoutingClient({LIVE_MODELS_URL: _page(["b/y", "a/x", "a/x:free"])})
+    ids = await fetch_live_model_ids(client=client)
+    # WHY raw: publishability (colon filter, dedupe, sort, caps) is applied by
+    # the CALLER — the fetch owns completeness of the chain, nothing else.
+    assert ids == ("b/y", "a/x", "a/x:free")
+    assert client.dialed == [LIVE_MODELS_URL]
+
+
+@pytest.mark.asyncio
+async def test_multi_page_chain_concatenates_in_order_with_validated_offsets() -> None:
+    client = _RoutingClient(
+        {
+            LIVE_MODELS_URL: _page(["a/1"], next_url=_next_link(250), total=3),
+            _paged_url(250): _page(["b/2"], next_url=_next_link(500), total=3),
+            _paged_url(500): _page(["c/3"], total=3),
+        }
+    )
+    ids = await fetch_live_model_ids(client=client)
+    assert ids == ("a/1", "b/2", "c/3")
+    assert client.dialed == [LIVE_MODELS_URL, _paged_url(250), _paged_url(500)]
+
+
+@pytest.mark.asyncio
+async def test_matching_total_count_reconciles_clean() -> None:
+    client = _RoutingClient({LIVE_MODELS_URL: _page(["a/1", "b/2"], total=2)})
+    assert await fetch_live_model_ids(client=client) == ("a/1", "b/2")
+
+
+# ------------------------------------------------------------- failure surface
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [401, 429, 500])
+async def test_upstream_error_status_propagates_with_the_status_class(status: int) -> None:
+    client = _RoutingClient(
+        {LIVE_MODELS_URL: RawResponse(status=status, content_type="application/json", body="{}")}
+    )
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    # INVARIANT: reason stays the closed vocabulary token; the integer status
+    # rides along so operators can tell auth onset (401) from outage (5xx)
+    # in logs without any body content leaking.
+    assert exc.value.reason == "bad_status"
+    assert exc.value.status == status
+
+
+@pytest.mark.asyncio
+async def test_mid_chain_failure_discards_pages_already_collected() -> None:
+    client = _RoutingClient(
+        {
+            LIVE_MODELS_URL: _page(["a/1"], next_url=_next_link(250)),
+            _paged_url(250): RawResponse(status=500, content_type="application/json", body=""),
+        }
+    )
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "bad_status"
+
+
+@pytest.mark.asyncio
+async def test_off_policy_next_fails_before_the_foreign_url_is_dialed() -> None:
+    foreign = "https://evil.example/api/v1/models?output_modalities=text&limit=250&offset=250"
+    client = _RoutingClient({LIVE_MODELS_URL: _page(["a/1"], next_url=foreign)})
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "model_catalog_truncated"
+    # INVARIANT: validation happens BEFORE the dial — the foreign origin never
+    # sees a connection attempt.
+    assert client.dialed == [LIVE_MODELS_URL]
+
+
+@pytest.mark.asyncio
+async def test_unexpected_offset_in_next_fails_the_refresh() -> None:
+    client = _RoutingClient({LIVE_MODELS_URL: _page(["a/1"], next_url=_next_link(500))})
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "model_catalog_truncated"
+    assert client.dialed == [LIVE_MODELS_URL]
+
+
+@pytest.mark.asyncio
+async def test_total_count_mismatch_after_final_page_is_truncation() -> None:
+    # WHY: next == null with fewer rows than the catalog claims means a page
+    # silently went missing — treat exactly like a broken chain.
+    client = _RoutingClient({LIVE_MODELS_URL: _page(["a/1", "b/2"], total=412)})
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "model_catalog_truncated"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"data": "nope", "links": {"next": None}, "total_count": 0},
+        # Missing completeness metadata: indistinguishable from a truncated read.
+        {"data": [{"id": "a/1"}]},
+        {"data": [{"id": "a/1"}], "total_count": 1},
+        {"data": [{"id": "a/1"}], "links": {"next": None}},
+        # One malformed row poisons the page — never salvage the rest.
+        {"data": [{"id": "a/1"}, {"name": "drifted"}], "links": {"next": None}, "total_count": 2},
+    ],
+    ids=["data-not-a-list", "no-metadata", "no-links", "no-total-count", "one-malformed-row"],
+)
+async def test_malformed_or_incomplete_page_fails_the_whole_refresh(payload: object) -> None:
+    client = _RoutingClient({LIVE_MODELS_URL: _raw_page(payload)})
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "malformed_json"
+
+
+@pytest.mark.asyncio
+async def test_one_malformed_row_on_a_later_page_discards_the_whole_chain() -> None:
+    # INVARIANT: all-or-nothing across the CHAIN too — page 1's good rows are
+    # never returned because page 2 drifted.
+    client = _RoutingClient(
+        {
+            LIVE_MODELS_URL: _page(["a/1"], next_url=_next_link(250), total=2),
+            _paged_url(250): _raw_page(
+                {"data": [{"id": 7}], "links": {"next": None}, "total_count": 2}
+            ),
+        }
+    )
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "malformed_json"
+
+
+@pytest.mark.asyncio
+async def test_total_count_disagreeing_between_pages_is_truncation() -> None:
+    # WHY: the census must be stable for the whole walk. A shifting total means
+    # the catalog changed under us (or a page answers a different query) —
+    # either way the collected rows are not a complete snapshot.
+    client = _RoutingClient(
+        {
+            LIVE_MODELS_URL: _page(["a/1"], next_url=_next_link(250), total=2),
+            _paged_url(250): _page(["b/2"], total=9),
+        }
+    )
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "model_catalog_truncated"
+
+
+@pytest.mark.asyncio
+async def test_oversized_page_body_fails_the_refresh() -> None:
+    huge = json.dumps({"data": [{"id": "a/" + "x" * 2_000_000}]})
+    client = _RoutingClient(
+        {LIVE_MODELS_URL: RawResponse(status=200, content_type="application/json", body=huge)}
+    )
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "oversized"
+
+
+@pytest.mark.asyncio
+async def test_chain_longer_than_max_pages_is_truncation_not_a_bigger_read() -> None:
+    responses = {LIVE_MODELS_URL: _page(["v/m-0"], next_url=_next_link(250))}
+    for page in range(1, live_models._MAX_PAGES + 1):
+        responses[_paged_url(page * 250)] = _page(
+            [f"v/m-{page}"], next_url=_next_link((page + 1) * 250)
+        )
+    client = _RoutingClient(responses)
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "model_catalog_truncated"
+    # WHY: the cap refuses BEFORE dialing page _MAX_PAGES+1.
+    assert len(client.dialed) == live_models._MAX_PAGES
+
+
+@pytest.mark.asyncio
+async def test_raw_ids_over_the_catalog_bound_fail_as_too_large() -> None:
+    # A single page that lies about its limit and floods rows past the
+    # 10_000-model catalog bound is refused as soon as the bound is crossed.
+    flood = [f"v/m-{i}" for i in range(10_001)]
+    client = _RoutingClient({LIVE_MODELS_URL: _page(flood)})
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=client)
+    assert exc.value.reason == "model_catalog_too_large"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_deadline_bounds_the_whole_chain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    class _StallingClient:
+        async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+            await asyncio.sleep(0.5)
+            return _page(["a/1"])
+
+    # INVARIANT: one wall-clock deadline covers the WHOLE pagination chain —
+    # concurrent listers queue on this single flight, so a dribbling upstream
+    # must not hold every caller for pages x per-page-timeout.
+    monkeypatch.setattr(live_models, "_AGGREGATE_TIMEOUT_S", 0.05)
+    with pytest.raises(DiscoveryError) as exc:
+        await fetch_live_model_ids(client=_StallingClient())
+    assert exc.value.reason == "timeout"

--- a/apps/aigateway/tests/unit/openrouter/test_live_models_parse.py
+++ b/apps/aigateway/tests/unit/openrouter/test_live_models_parse.py
@@ -28,7 +28,7 @@ from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSetti
 
 def test_discovery_source_pins_identity_and_cache_policy() -> None:
     # INVARIANT: the source identity/policy is declared BEFORE any fetch and is
-    # what the deployment-wide cache scopes TTLs to — changing it invalidates
+    # what the process-local cache scopes TTLs to — changing it invalidates
     # every stored snapshot, so the exact values are pinned here.
     assert LIVE_MODELS_DISCOVERY_SOURCE.key == "openrouter:models:list"
     assert LIVE_MODELS_DISCOVERY_SOURCE.revision == "openrouter:models:list-v1"
@@ -300,3 +300,32 @@ def test_listing_without_explicit_config_is_discovered_only() -> None:
         "openrouter/qwen/qwen3-coder",
     ]
     assert all(e.litellm_params == {"model": e.model_name} for e in entries)
+
+
+def test_the_real_envelope_shape_parses_with_all_its_extra_keys() -> None:
+    """STRICT must not mean BRITTLE: unknown keys are upstream's business.
+
+    WHY pinned: a live page (probed 2026-08-25) carries ~14 keys per row —
+    ``architecture``, ``pricing``, ``context_length``, ``canonical_slug`` and
+    more — and the envelope may grow siblings of ``total_count``. Requiring an
+    exact key set would turn any upstream addition into a total listing outage,
+    so the parser reads only what it needs and ignores the rest.
+    """
+    ids, next_url, total = parse_catalog_page(
+        {
+            "data": [
+                {
+                    "id": "openai/gpt-5",
+                    "canonical_slug": "openai/gpt-5",
+                    "name": "GPT-5",
+                    "context_length": 400_000,
+                    "architecture": {"modality": "text+image->text"},
+                    "pricing": {"prompt": "0.00000125"},
+                },
+            ],
+            "links": {"next": None, "prev": None},
+            "total_count": 1,
+            "some_future_field": {"unread": True},
+        }
+    )
+    assert (ids, next_url, total) == (("openai/gpt-5",), None, 1)

--- a/apps/aigateway/tests/unit/openrouter/test_live_models_parse.py
+++ b/apps/aigateway/tests/unit/openrouter/test_live_models_parse.py
@@ -1,0 +1,302 @@
+"""OME-972 U1 — parsing, publishability, and merge halves of live model discovery.
+
+FEATURE: live OpenRouter model discovery — ``/v1/models`` lists what OpenRouter
+actually serves now instead of compiled seeds frozen at deploy time.
+
+INVARIANT (fail-closed): a catalog that is malformed, empty, over the publish
+cap, or paginated off-policy NEVER yields a partial listing — every such case
+raises a sanitized ``DiscoveryError`` so the cache keeps the last good snapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aigateway.core.parameter_discovery import DiscoveryError
+from aigateway.plugins.openrouter_provider.live_models import (
+    LIVE_MODELS_DISCOVERY_SOURCE,
+    explicit_operator_entries,
+    live_listing_entries,
+    parse_catalog_page,
+    publishable_upstream_ids,
+    validate_next_url,
+)
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+# ---------------------------------------------------------------- source policy
+
+
+def test_discovery_source_pins_identity_and_cache_policy() -> None:
+    # INVARIANT: the source identity/policy is declared BEFORE any fetch and is
+    # what the deployment-wide cache scopes TTLs to — changing it invalidates
+    # every stored snapshot, so the exact values are pinned here.
+    assert LIVE_MODELS_DISCOVERY_SOURCE.key == "openrouter:models:list"
+    assert LIVE_MODELS_DISCOVERY_SOURCE.revision == "openrouter:models:list-v1"
+    assert LIVE_MODELS_DISCOVERY_SOURCE.ttl_s == 300.0
+    assert LIVE_MODELS_DISCOVERY_SOURCE.stale_ttl_s == 3600.0
+    assert LIVE_MODELS_DISCOVERY_SOURCE.failure_ttl_s == 30.0
+
+
+# ---------------------------------------------------------------- parse_catalog_page
+
+
+def test_parse_catalog_page_extracts_ids_next_and_total() -> None:
+    payload = {
+        "data": [
+            {"id": "openai/gpt-5", "name": "GPT-5"},
+            {"id": "qwen/qwen3-coder"},
+        ],
+        "links": {"next": "/api/v1/models?output_modalities=text&limit=250&offset=250"},
+        "total_count": 412,
+    }
+    ids, next_url, total = parse_catalog_page(payload)
+    assert ids == ("openai/gpt-5", "qwen/qwen3-coder")
+    assert next_url == "/api/v1/models?output_modalities=text&limit=250&offset=250"
+    assert total == 412
+
+
+def test_parse_catalog_page_last_page_carries_an_explicit_null_next() -> None:
+    # The live envelope always carries both completeness fields; the FINAL page
+    # says so with ``links.next = null``, never by omitting the key.
+    ids, next_url, total = parse_catalog_page(
+        {"data": [{"id": "a/b"}], "links": {"next": None}, "total_count": 1}
+    )
+    assert ids == ("a/b",)
+    assert next_url is None
+    assert total == 1
+
+
+def test_parse_catalog_page_empty_data_is_a_well_formed_page() -> None:
+    # WHY not a failure here: an empty PAGE is structurally valid; an empty
+    # CATALOG is refused later by ``publishable_upstream_ids``, which is the one
+    # place that can distinguish the two.
+    ids, next_url, total = parse_catalog_page(
+        {"data": [], "links": {"next": None}, "total_count": 0}
+    )
+    assert ids == ()
+    assert next_url is None
+    assert total == 0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        ["not", "a", "dict"],
+        {"data": "not-a-list", "links": {"next": None}, "total_count": 0},
+        {"data": {"id": "a/b"}, "links": {"next": None}, "total_count": 1},
+        {},
+        {"links": {"next": None}, "total_count": 0},
+        {"data": [{"id": "a/b"}], "links": {"next": 42}, "total_count": 1},
+        # Completeness metadata is REQUIRED, not advisory: without it a page
+        # cannot be told apart from a silently truncated one.
+        {"data": [{"id": "a/b"}], "total_count": 1},
+        {"data": [{"id": "a/b"}], "links": {}, "total_count": 1},
+        {"data": [{"id": "a/b"}], "links": "next", "total_count": 1},
+        {"data": [{"id": "a/b"}], "links": {"next": None}},
+        {"data": [{"id": "a/b"}], "links": {"next": None}, "total_count": "1"},
+        {"data": [{"id": "a/b"}], "links": {"next": None}, "total_count": True},
+        {"data": [{"id": "a/b"}], "links": {"next": None}, "total_count": 1.0},
+        {"data": [{"id": "a/b"}], "links": {"next": None}, "total_count": -1},
+        # A malformed ROW is malformed DATA: the page is no longer a trustworthy
+        # census of what upstream serves, so the whole refresh fails.
+        {"data": [{"id": "a/b"}, {"name": "no-id"}], "links": {"next": None}, "total_count": 2},
+        {"data": [{"id": "a/b"}, "bare-string"], "links": {"next": None}, "total_count": 2},
+        {"data": [{"id": "a/b"}, {"id": 7}], "links": {"next": None}, "total_count": 2},
+        {"data": [{"id": "a/b"}, {"id": None}], "links": {"next": None}, "total_count": 2},
+    ],
+    ids=[
+        "list-envelope",
+        "data-string",
+        "data-dict",
+        "empty-envelope",
+        "no-data",
+        "non-string-next",
+        "no-links",
+        "links-without-next",
+        "links-not-a-dict",
+        "no-total-count",
+        "total-count-string",
+        "total-count-bool",
+        "total-count-float",
+        "total-count-negative",
+        "row-without-id",
+        "row-not-an-object",
+        "row-id-not-a-string",
+        "row-id-null",
+    ],
+)
+def test_parse_catalog_page_malformed_envelope_or_row_fails_closed(payload: object) -> None:
+    # INVARIANT (owner correction, 2026-08-25): NOTHING is skipped and salvaged.
+    # A page that cannot be fully parsed can never be cached as a fresh, complete
+    # catalog — the last good snapshot must survive instead.
+    with pytest.raises(DiscoveryError) as exc:
+        parse_catalog_page(payload)
+    assert exc.value.reason == "malformed_json"
+
+
+# ---------------------------------------------------------------- validate_next_url
+
+
+def test_validate_next_url_accepts_exact_on_policy_relative_next() -> None:
+    absolute = validate_next_url(
+        "/api/v1/models?output_modalities=text&limit=250&offset=250", expected_offset=250
+    )
+    assert (
+        absolute
+        == "https://openrouter.ai/api/v1/models?output_modalities=text&limit=250&offset=250"
+    )
+
+
+def test_validate_next_url_accepts_exact_on_policy_absolute_next() -> None:
+    url = "https://openrouter.ai/api/v1/models?output_modalities=text&limit=250&offset=500"
+    assert validate_next_url(url, expected_offset=500) == url
+
+
+@pytest.mark.parametrize(
+    ("next_url", "expected_offset"),
+    [
+        # INVARIANT: a next link is validated BEFORE it is dialed — any deviation
+        # from the pinned origin/path/query fails the WHOLE refresh, so a partial
+        # or policy-violating chain can never be cached as fresh.
+        ("https://evil.example/api/v1/models?output_modalities=text&limit=250&offset=250", 250),
+        ("http://openrouter.ai/api/v1/models?output_modalities=text&limit=250&offset=250", 250),
+        ("https://openrouter.ai/api/v2/models?output_modalities=text&limit=250&offset=250", 250),
+        ("/api/v1/models?output_modalities=text&limit=250&offset=500", 250),
+        ("/api/v1/models?limit=250&offset=250", 250),
+        ("/api/v1/models?output_modalities=text&limit=500&offset=250", 250),
+        ("/api/v1/models?output_modalities=text&limit=250&offset=250&extra=1", 250),
+        ("/api/v1/models?output_modalities=text&limit=250&offset=250&offset=250", 250),
+        ("/api/v1/models?output_modalities=text&limit=250&offset=250#frag", 250),
+        ("/api/v1/models?output_modalities=image&limit=250&offset=250", 250),
+    ],
+    ids=[
+        "foreign-origin",
+        "insecure-scheme",
+        "wrong-path",
+        "wrong-offset",
+        "missing-modality",
+        "wrong-limit",
+        "extra-param",
+        "duplicate-offset",
+        "fragment",
+        "wrong-modality",
+    ],
+)
+def test_validate_next_url_refuses_any_off_policy_next(next_url: str, expected_offset: int) -> None:
+    with pytest.raises(DiscoveryError) as exc:
+        validate_next_url(next_url, expected_offset=expected_offset)
+    assert exc.value.reason == "model_catalog_truncated"
+
+
+# ---------------------------------------------------------------- publishable_upstream_ids
+
+
+def test_publishable_keeps_plain_ids_and_drops_variants_and_junk() -> None:
+    # INVARIANT: auto-publish admits ONLY plain upstream ids — the same shape
+    # predicate the admission route enforces. Colon variants and tilde aliases
+    # stay reachable via explicit operator config or direct dispatch, never
+    # via automatic listing.
+    ids = publishable_upstream_ids(
+        [
+            "qwen/qwen3-coder",
+            "openai/gpt-5",
+            "openai/gpt-5",  # duplicate collapses
+            "deepseek/deepseek-chat:free",  # colon variant — dropped
+            "meta/llama~4",  # tilde alias — dropped
+            "not-a-slug",  # no vendor/model shape — dropped
+            "vendor/" + "a" * 300,  # over-length — dropped
+        ]
+    )
+    assert ids == ("openai/gpt-5", "qwen/qwen3-coder")
+
+
+@pytest.mark.parametrize(
+    "raw_ids",
+    [[], ["deepseek/deepseek-chat:free", "meta/llama~4", "not-a-slug"]],
+    ids=["no-rows", "all-filtered"],
+)
+def test_publishable_empty_result_fails_closed(raw_ids: list[str]) -> None:
+    # WHY: an empty catalog is indistinguishable from a broken upstream read —
+    # caching it as fresh would evict the entire last-good listing.
+    with pytest.raises(DiscoveryError) as exc:
+        publishable_upstream_ids(raw_ids)
+    assert exc.value.reason == "model_catalog_empty"
+
+
+def test_publishable_over_publish_cap_fails_never_truncates() -> None:
+    too_many = [f"vendor/model-{i}" for i in range(5_001)]
+    with pytest.raises(DiscoveryError) as exc:
+        publishable_upstream_ids(too_many)
+    assert exc.value.reason == "model_catalog_too_large"
+
+
+def test_publishable_exactly_at_cap_is_allowed() -> None:
+    at_cap = [f"vendor/model-{i}" for i in range(5_000)]
+    assert len(publishable_upstream_ids(at_cap)) == 5_000
+
+
+# ---------------------------------------------------------------- operator explicitness
+
+
+def test_default_constructed_settings_yield_no_operator_entries() -> None:
+    # INVARIANT (snapshot-or-fallback): compiled default seeds are the FALLBACK,
+    # not operator intent — a healthy snapshot replaces them entirely, so a
+    # default-constructed settings object contributes no operator entries.
+    assert explicit_operator_entries(OpenRouterPluginSettings(enabled=True)) == ()
+
+
+def test_constructor_configured_models_are_operator_entries_in_order() -> None:
+    settings = OpenRouterPluginSettings(
+        enabled=True,
+        default_models=[
+            "openrouter/deepseek/deepseek-chat-v3.1:free",  # colon variant survives explicitly
+            "openrouter/qwen/qwen3-coder",
+        ],
+    )
+    entries = explicit_operator_entries(settings)
+    assert [e.model_name for e in entries] == [
+        "openrouter/deepseek/deepseek-chat-v3.1:free",
+        "openrouter/qwen/qwen3-coder",
+    ]
+    assert all(e.litellm_params == {"model": e.model_name} for e in entries)
+
+
+def test_env_configured_models_count_as_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    # WHY: operators configure via AIGW_OPENROUTER_DEFAULT_MODELS in deployment —
+    # env-sourced values land in ``model_fields_set`` exactly like constructor
+    # arguments, which is the mechanism that makes explicit config survive a
+    # healthy snapshot.
+    monkeypatch.setenv("AIGW_OPENROUTER_DEFAULT_MODELS", '["openrouter/qwen/qwen3-coder"]')
+    settings = OpenRouterPluginSettings(enabled=True)
+    entries = explicit_operator_entries(settings)
+    assert [e.model_name for e in entries] == ["openrouter/qwen/qwen3-coder"]
+
+
+# ---------------------------------------------------------------- live_listing_entries
+
+
+def test_listing_is_operator_first_then_discovered_without_duplicates() -> None:
+    settings = OpenRouterPluginSettings(
+        enabled=True,
+        default_models=[
+            "openrouter/deepseek/deepseek-chat-v3.1:free",
+            "openrouter/qwen/qwen3-coder",  # also discovered — listed once, operator-first
+        ],
+    )
+    entries = live_listing_entries(settings, ("openai/gpt-5", "qwen/qwen3-coder"))
+    assert [e.model_name for e in entries] == [
+        "openrouter/deepseek/deepseek-chat-v3.1:free",
+        "openrouter/qwen/qwen3-coder",
+        "openrouter/openai/gpt-5",
+    ]
+
+
+def test_listing_without_explicit_config_is_discovered_only() -> None:
+    entries = live_listing_entries(
+        OpenRouterPluginSettings(enabled=True), ("openai/gpt-5", "qwen/qwen3-coder")
+    )
+    assert [e.model_name for e in entries] == [
+        "openrouter/openai/gpt-5",
+        "openrouter/qwen/qwen3-coder",
+    ]
+    assert all(e.litellm_params == {"model": e.model_name} for e in entries)

--- a/apps/aigateway/tests/unit/openrouter/test_live_models_port.py
+++ b/apps/aigateway/tests/unit/openrouter/test_live_models_port.py
@@ -1,0 +1,149 @@
+"""OME-972 U3 — the provider port pair and its gating flags.
+
+INVARIANT (zero egress when off): ``enabled=False`` or ``live_models=False``
+answers ``None`` from BOTH port hooks without a single transport dial —
+``AIGW_OPENROUTER_LIVE_MODELS=false`` restores exactly today's static listing
+behavior with no catalog traffic at all.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aigateway.core.parameter_discovery import RawResponse
+from aigateway.core.plugin_base import ModelEntry, PluginSettings, ProviderPluginBase
+from aigateway.plugins.openrouter_provider.live_models import (
+    LIVE_MODELS_DISCOVERY_SOURCE,
+    LIVE_MODELS_URL,
+)
+from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+
+class _CountingClient:
+    """Records every dial; serves one canned catalog page."""
+
+    def __init__(self, ids: list[str]) -> None:
+        # Strict envelope: the live parser requires links.next + total_count.
+        self._body = json.dumps(
+            {
+                "data": [{"id": i} for i in ids],
+                "links": {"next": None},
+                "total_count": len(ids),
+            }
+        )
+        self.dialed: list[str] = []
+
+    async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+        self.dialed.append(url)
+        return RawResponse(status=200, content_type="application/json", body=self._body)
+
+
+# ------------------------------------------------------------------- settings
+
+
+def test_live_models_defaults_on() -> None:
+    # INVARIANT (owner decision): live discovery is the DEFAULT — deployments
+    # opt OUT via AIGW_OPENROUTER_LIVE_MODELS=false, not in.
+    assert OpenRouterPluginSettings().live_models is True
+
+
+def test_live_models_env_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIGW_OPENROUTER_LIVE_MODELS", "false")
+    assert OpenRouterPluginSettings().live_models is False
+
+
+# ------------------------------------------------------------------- base port
+
+
+def test_base_port_pair_is_inert() -> None:
+    # WHY: providers without live discovery inherit "no source, no fetch" —
+    # core consults the port on EVERY provider, so the default must be a
+    # clean None/None, never an abstract method.
+    class _BarePlugin(ProviderPluginBase[PluginSettings]):
+        custom_llm_provider = "bareprov"
+        provider_display_name = "Bare"
+
+        def register_models(self) -> list[ModelEntry]:
+            return []
+
+    plugin = _BarePlugin(PluginSettings())
+    assert plugin.model_discovery_source() is None
+
+
+@pytest.mark.asyncio
+async def test_base_discover_live_models_returns_none() -> None:
+    class _BarePlugin(ProviderPluginBase[PluginSettings]):
+        custom_llm_provider = "bareprov"
+        provider_display_name = "Bare"
+
+        def register_models(self) -> list[ModelEntry]:
+            return []
+
+    client = _CountingClient(["a/b"])
+    assert await _BarePlugin(PluginSettings()).discover_live_models(client=client) is None
+    assert client.dialed == []
+
+
+# -------------------------------------------------------------------- gating
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        OpenRouterPluginSettings(enabled=False, live_models=True),
+        OpenRouterPluginSettings(enabled=True, live_models=False),
+        OpenRouterPluginSettings(enabled=False, live_models=False),
+    ],
+    ids=["provider-disabled", "live-disabled", "both-disabled"],
+)
+@pytest.mark.asyncio
+async def test_gated_off_means_none_and_zero_dials(settings: OpenRouterPluginSettings) -> None:
+    plugin = OpenRouterProviderPlugin(settings)
+    client = _CountingClient(["openai/gpt-5"])
+    assert plugin.model_discovery_source() is None
+    assert await plugin.discover_live_models(client=client) is None
+    assert client.dialed == []
+
+
+# ------------------------------------------------------------------ live path
+
+
+def test_enabled_plugin_declares_the_pinned_source() -> None:
+    plugin = OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=True))
+    assert plugin.model_discovery_source() is LIVE_MODELS_DISCOVERY_SOURCE
+
+
+@pytest.mark.asyncio
+async def test_discover_live_models_returns_the_finished_merged_listing() -> None:
+    # INVARIANT: the provider owns the merge — operator-explicit entries first
+    # (colon variant included), then discovered publishable ids sorted; colon
+    # variants from the CATALOG are never auto-published.
+    plugin = OpenRouterProviderPlugin(
+        OpenRouterPluginSettings(
+            enabled=True,
+            default_models=["openrouter/deepseek/deepseek-chat-v3.1:free"],
+        )
+    )
+    client = _CountingClient(["qwen/qwen3-coder", "openai/gpt-5", "openai/gpt-5:free"])
+    entries = await plugin.discover_live_models(client=client)
+    assert entries is not None
+    assert [e.model_name for e in entries] == [
+        "openrouter/deepseek/deepseek-chat-v3.1:free",
+        "openrouter/openai/gpt-5",
+        "openrouter/qwen/qwen3-coder",
+    ]
+    assert client.dialed == [LIVE_MODELS_URL]
+
+
+@pytest.mark.asyncio
+async def test_default_seeds_do_not_survive_a_healthy_snapshot() -> None:
+    # INVARIANT (snapshot-or-fallback): compiled default seeds are the
+    # FALLBACK — with factory-default settings a healthy snapshot IS the
+    # listing, so a retired compiled default disappears when upstream is healthy.
+    plugin = OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=True))
+    entries = await plugin.discover_live_models(client=_CountingClient(["openai/gpt-5"]))
+    assert entries is not None
+    assert [e.model_name for e in entries] == ["openrouter/openai/gpt-5"]

--- a/apps/aigateway/tests/unit/openrouter/test_live_models_resolvability.py
+++ b/apps/aigateway/tests/unit/openrouter/test_live_models_resolvability.py
@@ -1,0 +1,221 @@
+"""OME-972 U6 — every published id resolves; seeded reads stay catalog-free.
+
+INVARIANT (lazy known-set): the detail route consults the live catalog ONLY on
+a would-be 404 — a seeded or admitted id resolves with zero live-catalog work,
+and an id published from a healthy snapshot resolves on its own contract
+endpoint instead of 404ing. Chat dispatch stays membership-free: listing
+changes never change what is dispatchable.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aigateway.core.discovery_runtime import DiscoveryRuntime
+from aigateway.core.model_catalog import ModelCatalog
+from aigateway.core.parameter_discovery import DiscoveryLimits, RawResponse
+from aigateway.core.parameter_discovery_cache import CacheLimits, ObservationCache
+from aigateway.core.profile_index import ProfileIndexStore
+from aigateway.core.profile_models import Profile, ProfileState, profile_id_for
+from aigateway.plugins.openrouter_provider import plugin as plugin_module
+from aigateway.plugins.openrouter_provider.discovery import MODELS_URL, OPENAPI_URL
+from aigateway.plugins.openrouter_provider.live_models import LIVE_MODELS_URL
+from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
+
+_DISCOVERED_UPSTREAM = "newvendor/newmodel"
+_DISCOVERED = f"openrouter/{_DISCOVERED_UPSTREAM}"
+# First compiled default seed — present without any explicit configuration.
+_SEEDED = "openrouter/anthropic/claude-fable-5"
+_SEEDED_UPSTREAM = _SEEDED.removeprefix("openrouter/")
+
+
+@pytest.fixture
+def openrouter_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True))
+
+
+class _ServingClient:
+    """All three OpenRouter public documents, in process, dials recorded."""
+
+    def __init__(self) -> None:
+        self.dialed: list[str] = []
+        self._bodies: dict[str, Any] = {
+            LIVE_MODELS_URL: {
+                "data": [{"id": _DISCOVERED_UPSTREAM}],
+                "links": {"next": None},
+                "total_count": 1,
+            },
+            MODELS_URL: {
+                "data": [
+                    {"id": _DISCOVERED_UPSTREAM, "supported_parameters": ["temperature"]},
+                    {"id": _SEEDED_UPSTREAM, "supported_parameters": ["temperature"]},
+                ]
+            },
+            OPENAPI_URL: {
+                "components": {"schemas": {"ChatRequest": {"properties": {"temperature": {}}}}}
+            },
+        }
+
+    async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
+        self.dialed.append(url)
+        return RawResponse(
+            status=200, content_type="application/json", body=json.dumps(self._bodies[url])
+        )
+
+
+class _Clock:
+    def now(self) -> float:
+        return 1_000.0
+
+
+def _install(client: TestClient) -> _ServingClient:
+    http = _ServingClient()
+    app = cast(FastAPI, client.app)
+    app.state.discovery_runtime = DiscoveryRuntime(
+        client=http,
+        cache=ObservationCache(
+            clock=_Clock(), limits=CacheLimits(ttl_s=60.0, stale_ttl_s=120.0, max_entries=8)
+        ),
+        limits=DiscoveryLimits(),
+    )
+    app.state.model_catalog = ModelCatalog(clock=_Clock())
+    return http
+
+
+async def _upsert_profile(client: TestClient, credential_blobs: Any) -> None:
+    account_id = client.get("/v1/auth/me").json()["id"]
+    await ProfileIndexStore(credential_store=credential_blobs.store).upsert(
+        Profile(
+            id=profile_id_for(account_id, "openrouter", "default"),
+            account_id=account_id,
+            provider="openrouter",
+            name="default",
+            state=ProfileState.AUTHENTICATED,
+            auth_type="api_key",
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_discovered_id_resolves_on_its_own_contract_endpoint(
+    openrouter_enabled, authenticated_client: TestClient, credential_blobs: Any
+) -> None:
+    _install(authenticated_client)
+    await _upsert_profile(authenticated_client, credential_blobs)
+    response = authenticated_client.get("/v1/model-parameters", params={"model": _DISCOVERED})
+    # INVARIANT: what /v1/models publishes, /v1/model-parameters resolves — a
+    # listed id that 404s on its own detail URL is a broken published contract.
+    assert response.status_code == 200, response.text
+    assert response.json()["model"]["id"] == _DISCOVERED
+
+
+@pytest.mark.asyncio
+async def test_an_id_absent_from_snapshot_and_seeds_still_404s(
+    openrouter_enabled, authenticated_client: TestClient, credential_blobs: Any
+) -> None:
+    _install(authenticated_client)
+    await _upsert_profile(authenticated_client, credential_blobs)
+    response = authenticated_client.get(
+        "/v1/model-parameters", params={"model": "openrouter/nope/not-here"}
+    )
+    assert response.status_code == 404
+    assert response.json()["detail"]["code"] == "model_not_found"
+
+
+@pytest.mark.asyncio
+async def test_a_seeded_id_never_pays_for_a_live_catalog_read(
+    openrouter_enabled, authenticated_client: TestClient, credential_blobs: Any
+) -> None:
+    http = _install(authenticated_client)
+    await _upsert_profile(authenticated_client, credential_blobs)
+    response = authenticated_client.get("/v1/model-parameters", params={"model": _SEEDED})
+    assert response.status_code == 200, response.text
+    # INVARIANT (lazy): the known-set hit short-circuits BEFORE the catalog —
+    # the parameter-snapshot documents may be dialed, the listing never is.
+    assert LIVE_MODELS_URL not in http.dialed
+
+
+def test_chat_dispatch_is_membership_free_for_discovered_and_seeded_alike(
+    openrouter_enabled, authenticated_client: TestClient
+) -> None:
+    _install(authenticated_client)
+    body = {"messages": [{"role": "user", "content": "hi"}]}
+    seeded = authenticated_client.post("/v1/chat/completions", json={"model": _SEEDED, **body})
+    discovered = authenticated_client.post(
+        "/v1/chat/completions", json={"model": _DISCOVERED, **body}
+    )
+    # WHY equality of ``detail``: with no credential profile, BOTH fail at the
+    # same later stage with the same semantic error — proving the listing never
+    # gates dispatch (a membership check would 404 the discovered id earlier,
+    # with a different code). The ``_aigw`` envelope carries per-request
+    # accounting metadata and is deliberately excluded.
+    assert seeded.status_code == discovered.status_code
+    assert seeded.json()["detail"] == discovered.json()["detail"]
+
+
+def test_a_discovered_only_model_reaches_the_dispatch_boundary_with_a_credential(
+    openrouter_enabled,
+    authenticated_client: TestClient,
+    credential_blobs: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The end of the acceptance chain: listed -> resolvable -> actually dispatched.
+
+    The parity test above proves dispatch is membership-free by comparing
+    refusals; this proves the positive case all the way to the provider
+    boundary, so "every published id resolves via chat" rests on a request that
+    really arrives at ``litellm.acompletion`` carrying the discovered id.
+    """
+    _install(authenticated_client)
+    # Explicit test double: key READINESS is not what this test exercises —
+    # dispatch reachability of a discovered-only id is.
+    from aigateway.core.api_key_validation import (
+        ApiKeyValidationResult,
+        ApiKeyValidationStage,
+        ApiKeyValidationState,
+    )
+    from aigateway.core.api_key_validation_service import ApiKeyValidationService
+
+    async def _valid(_self: Any, _plugin: Any, _provider: Any, _api_key: Any):
+        return ApiKeyValidationResult(
+            state=ApiKeyValidationState.VALID, stage=ApiKeyValidationStage.READINESS
+        )
+
+    monkeypatch.setattr(ApiKeyValidationService, "validate", _valid)
+    created = authenticated_client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "live-discovery", "api_key": "sk-or-v1-live"},
+    )
+    assert created.status_code == 201, created.text
+
+    # The model is published ONLY by the live snapshot — it is in no seed list.
+    assert _DISCOVERED not in OpenRouterPluginSettings(enabled=True).default_models
+    listed = [row["id"] for row in authenticated_client.get("/v1/models").json()["data"]]
+    assert _DISCOVERED in listed
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_acompletion(**kwargs: Any) -> SimpleNamespace:
+        captured.update(kwargs)
+        return SimpleNamespace(
+            model_dump=lambda: {
+                "id": "gen-live",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            }
+        )
+
+    with patch("litellm.acompletion", _fake_acompletion):
+        response = authenticated_client.post(
+            "/v1/chat/completions",
+            json={"model": _DISCOVERED, "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    assert response.status_code == 200, response.text
+    assert captured["model"] == _DISCOVERED

--- a/apps/aigateway/tests/unit/openrouter/test_live_models_resolvability.py
+++ b/apps/aigateway/tests/unit/openrouter/test_live_models_resolvability.py
@@ -65,6 +65,12 @@ class _ServingClient:
 
     async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
         self.dialed.append(url)
+        # AIDEV-NOTE: loud, not KeyError. ``ModelCatalog`` converts a stray
+        # exception into DiscoveryError("internal_error") -> seed fallback, so a
+        # KeyError here would let an unexpected dial pass as a green test that
+        # silently stopped exercising the live listing.
+        if url not in self._bodies:
+            raise AssertionError(f"canned client has no body for {url!r} — unexpected dial")
         return RawResponse(
             status=200, content_type="application/json", body=json.dumps(self._bodies[url])
         )

--- a/apps/aigateway/tests/unit/openrouter/test_model_admission_route.py
+++ b/apps/aigateway/tests/unit/openrouter/test_model_admission_route.py
@@ -53,7 +53,11 @@ def openrouter_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         plugin_module.PLUGIN,
         "settings",
-        OpenRouterPluginSettings(enabled=True, default_models=[_SEED]),
+        # OME-972 setup-only amendment: this suite exercises ADMISSION and its
+        # canned two-document client; live listing discovery is not under test,
+        # and leaving it on made /v1/models dial an unrouted catalog URL whose
+        # KeyError was silently absorbed into a seed fallback. Assertions untouched.
+        OpenRouterPluginSettings(enabled=True, live_models=False, default_models=[_SEED]),
     )
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_catalog_route.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_catalog_route.py
@@ -96,7 +96,9 @@ def openrouter_enabled(monkeypatch) -> None:
     monkeypatch.setattr(
         plugin_module.PLUGIN,
         "settings",
-        OpenRouterPluginSettings(enabled=True, default_models=[_FLASH, _FABLE]),
+        # OME-972 setup-only amendment: this suite pins the SEEDED catalog route —
+        # live_models=False keeps its listing reads static. Assertions untouched.
+        OpenRouterPluginSettings(enabled=True, live_models=False, default_models=[_FLASH, _FABLE]),
     )
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_openapi_endpoint_route.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_openapi_endpoint_route.py
@@ -54,7 +54,9 @@ def openrouter_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         plugin_module.PLUGIN,
         "settings",
-        OpenRouterPluginSettings(enabled=True, default_models=[_MODEL]),
+        # OME-972 setup-only amendment: this suite pins the OpenAPI-source
+        # decision surface, not live listing discovery. Assertions untouched.
+        OpenRouterPluginSettings(enabled=True, live_models=False, default_models=[_MODEL]),
     )
 
 

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_settings.py
@@ -200,3 +200,29 @@ def test_valid_upstream_model_ids(upstream: str) -> None:
 )
 def test_invalid_upstream_model_ids(upstream: object) -> None:
     assert is_valid_upstream_model_id(upstream) is False
+
+
+# OME-972 correction pass: `:online` is refused at CONFIG time, not just dispatch.
+
+
+def test_online_variant_is_rejected_at_configuration() -> None:
+    # INVARIANT: what the gateway lists, it must be able to dispatch. A
+    # `:online` slug is published by every listing path (explicit operator
+    # config survives every healthy snapshot) while `prepare_chat_body` refuses
+    # it with `unsupported_model_variant` — so configuring one creates a model
+    # that can only ever fail. Fail fast at startup instead.
+    with pytest.raises(ValidationError):
+        OpenRouterPluginSettings(default_models=["openrouter/openai/gpt-5:online"])
+
+
+def test_online_variant_is_rejected_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AIGW_OPENROUTER_DEFAULT_MODELS", '["openrouter/openai/gpt-5:online"]')
+    with pytest.raises(ValidationError):
+        OpenRouterPluginSettings()
+
+
+@pytest.mark.parametrize("slug", ["openrouter/openai/gpt-5:free", "openrouter/a/b:batch"])
+def test_other_colon_variants_remain_configurable(slug: str) -> None:
+    # Scope guard: only `:online` is refused. Every other variant dispatch
+    # already accepts stays explicitly configurable (and listable).
+    assert OpenRouterPluginSettings(default_models=[slug]).default_models == [slug]

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_top_p_promotion.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_top_p_promotion.py
@@ -61,7 +61,12 @@ def _api_key_validation_ok(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture()
 def enabled_openrouter(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
-        openrouter_plugin_module.PLUGIN, "settings", OpenRouterPluginSettings(enabled=True)
+        openrouter_plugin_module.PLUGIN,
+        "settings",
+        # OME-972 setup-only amendment: this suite exercises the STATIC top_p
+        # promotion, not live discovery — live_models=False keeps its listing
+        # reads off the (transport-less) live catalog. Assertions untouched.
+        OpenRouterPluginSettings(enabled=True, live_models=False),
     )
 
 

--- a/docs/tasks/2026-08-25-OME-972-live-openrouter-model-discovery.md
+++ b/docs/tasks/2026-08-25-OME-972-live-openrouter-model-discovery.md
@@ -1,0 +1,21 @@
+---
+id: OME-972
+linear_url: https://linear.app/openmined/issue/OME-972/aigateway-automatically-discover-models-offered-by-openrouter
+status: In Progress
+type: feature
+priority: 2
+labels: [aigateway]
+created: 2026-08-24
+closed:
+---
+
+# AIGateway: automatically discover models offered by OpenRouter
+
+Live model discovery for the OpenRouter provider: bounded async fetch of the public catalog,
+cached deployment-wide snapshot (TTL 300 s, stale 3600 s, single-flight), published through
+`GET /v1/models` with snapshot-or-fallback semantics — discovered plain IDs + explicitly
+configured operator models + admitted models when healthy; compiled/operator seeds + admitted
+when cold or degraded. Default-on behind `AIGW_OPENROUTER_LIVE_MODELS`.
+
+- Ledger: `docs/work/2026-08-25-OME-972-live-openrouter-model-discovery.md`
+- Standalone task; NOT a child of OME-308. Related: OME-492, OME-878, OME-879.

--- a/docs/tasks/2026-08-25-OME-972-live-openrouter-model-discovery.md
+++ b/docs/tasks/2026-08-25-OME-972-live-openrouter-model-discovery.md
@@ -12,10 +12,26 @@ closed:
 # AIGateway: automatically discover models offered by OpenRouter
 
 Live model discovery for the OpenRouter provider: bounded async fetch of the public catalog,
-cached deployment-wide snapshot (TTL 300 s, stale 3600 s, single-flight), published through
+cached in a process-local snapshot shared across accounts (TTL 300 s, stale 3600 s,
+single-flight), published through
 `GET /v1/models` with snapshot-or-fallback semantics — discovered plain IDs + explicitly
 configured operator models + admitted models when healthy; compiled/operator seeds + admitted
 when cold or degraded. Default-on behind `AIGW_OPENROUTER_LIVE_MODELS`.
 
 - Ledger: `docs/work/2026-08-25-OME-972-live-openrouter-model-discovery.md`
 - Standalone task; NOT a child of OME-308. Related: OME-492, OME-878, OME-879.
+
+## Follow-ups
+
+1. **`plugins/openrouter_provider/plugin.py` exceeds the 450-line split discipline** — 558 lines
+   (526 before this unit; +32 for the discovery/live-listing port pair). Proposed fix: extract
+   the discovery/live-listing hooks into a cohesive module.
+2. **`is_online_variant` is case-sensitive**, so `openrouter/<a>/<m>:Online` is still
+   configurable and unpoliced at dispatch. The predicate is shared with OME-712's dispatch
+   refusal and the global-cache bypass, so the fix belongs in one place, in its own unit.
+3. **Colon variants are not auto-published** (deferred by design); tilde aliases should later
+   fold to canonical ids via `alias_target` rather than being published raw.
+4. **Census drift vs truncation share one reason token.** `total_count` legitimately moves
+   between page fetches upstream (measured 418 → 419 seconds apart), so a drifting refresh is
+   reported as `model_catalog_truncated`. A distinct reason would let operators separate benign
+   drift from real page loss.

--- a/docs/work/2026-08-25-OME-972-live-openrouter-model-discovery.md
+++ b/docs/work/2026-08-25-OME-972-live-openrouter-model-discovery.md
@@ -12,7 +12,7 @@ finished: 2026-08-25
 
 `GET /v1/models` currently lists compiled OpenRouter seeds frozen at deploy time. This unit adds
 provider-owned, bounded, async live discovery of OpenRouter's public model catalog behind a
-cached deployment-wide snapshot, so the gateway lists what OpenRouter actually serves now —
+process-local snapshot shared across accounts, so the gateway lists what OpenRouter actually serves now —
 default-on (`AIGW_OPENROUTER_LIVE_MODELS=true`), fail-closed, credential-free, with compiled
 seeds as the cold-failure fallback and explicitly configured operator models always preserved.
 Standalone task — not a child of OME-308.
@@ -218,3 +218,93 @@ a cohesive module. New files added by this unit are within limit (`live_models.p
   cap, `ModelListingProvider` vs the plugin-base port having no static conformance check, the
   three DRY items, and the boundary tests at exactly `_MAX_PAGES` / `_MAX_ID_LENGTH`.
 - `plugin.py` size violation above.
+
+
+## Verification round 2 — 2026-08-25
+
+The second verification pass found two acceptance tests that did not prove their stated
+invariants. Both tests were strengthened against the corresponding pre-fix behavior, and live
+catalog evidence was checked across both pagination pages.
+
+### C1 strictness validated against both live pages
+
+C1 made `links.next` and `total_count` mandatory on EVERY page, justified by a probe that had
+only ever seen a **single-page** response. With `limit=250` against ~420 text models, production
+dials a continuation page on every refresh — so if a continuation page omitted either field,
+every refresh would fail and the listing would be pinned to seeds forever, with the whole suite
+green. Probed both real pages on 2026-08-25:
+
+| Probe | keys | rows | `total_count` | `links.next` |
+|---|---|---|---|---|
+| `?output_modalities=text&limit=250` | `data, links, total_count` | 250 | 419 | `/api/v1/models?output_modalities=text&offset=250&limit=250` |
+| `…&limit=250&offset=250` | `data, links, total_count` | 168 | 418 | `null` |
+
+Conclusions: (1) continuation pages carry both completeness fields and an explicit `next: null`,
+so C1's strictness matches the live contract; (2) `links.next` echoes the pinned
+`output_modalities` filter required by `validate_next_url`; (3) `total_count` moved 418 → 419
+between two probes seconds apart, so cross-page equality can reject a refresh on benign census
+drift. The strict behavior fails safe, self-heals after the 30 s damping window, and is documented
+in DEPLOYMENT.md. A distinct reason token for drift remains a follow-up.
+
+### Fixed in this round
+
+- **The "never replaces the last good snapshot" test did not guard the fix.** Its
+  malformed body (`{"data": []}`) fails under the OLD lenient parser too, so it was green
+  either way. Replaced with a body the row-skipping parser would have SALVAGED into a
+  *different fresh snapshot* (one unusable row + one good id, with `links`/`total_count`
+  consistent with the salvageable count, so the completeness reconciliation cannot catch it and
+  only the all-or-nothing row rule can). Verified by injecting the pre-pass parser: the test now
+  FAILS without the fix and passes with it.
+- **The concurrency test's overlap assertion could not fail.** Client-side start stamps are all
+  ≈t0 because the pool launches all six threads at once, so `latest_start < earliest_end` held
+  even for a strictly serialized server — leaving `dialed == 1`, which plain caching satisfies.
+  Replaced with a server-side measurement: peak concurrent depth inside `ModelCatalog.entries_for`
+  must equal the caller count. Confirmed a real measurement (reports `6`, not a tautology) and
+  stable over 8 consecutive runs.
+- **A sibling canned client still laundered a stray dial into a silent seed fallback** —
+  `_ServingClient` in `test_live_models_resolvability.py` raised `KeyError`, the exact path C3
+  closed in `_openapi_document.py`; now raises `AssertionError`.
+- **DEPLOYMENT.md, six corrections**: the cache-scope sentence contradicted the per-replica
+  behavior; the variant bullet was still wrong (the
+  compiled seed FALLBACK also lists variants — several seeds are `:batch` slugs); logs carry the
+  exact upstream status code, not a "status class"; the `1–2 s` figure was an unmeasured estimate
+  and is now expressed as one fetch per page at the measured catalog size; added a **breaking
+  upgrade** note (a deployment with a `:online` slug in `AIGW_OPENROUTER_DEFAULT_MODELS` will not
+  boot after C2); added the census-drift note above.
+- **Two stale docstrings** the pass itself invalidated: `live_models.py` misstated cache scope
+  and still listed `:online` as reachable via operator config;
+  `is_online_variant` still claimed two call sites after C2 added a third.
+- **One test added**: the real envelope (14+ keys per row, extra top-level keys) must still
+  parse — strict must not mean brittle. Evidence-backed by the probe above; without it, a future
+  exact-key-set tightening would take the listing down. Parse suite 44 → 45 collected.
+
+### Remaining limitations and follow-ups
+
+- **Append-only against the merge base.** `run_gates.py aigateway --base origin/main` flags
+  **5** files: `_openapi_document.py`, `test_model_admission_route.py`,
+  `test_openrouter_openapi_endpoint_route.py`, `test_openrouter_catalog_route.py`, and
+  `test_openrouter_top_p_promotion.py`. All five changes are `live_models=False` setup amendments
+  or the loud-client change, with assertions untouched. **The PR needs an explicit waiver naming
+  these 5 files.**
+- `:online` rejection is **case-sensitive** (`:Online` still configures and is unpoliced at
+  dispatch). The fix belongs in the shared OME-712 `is_online_variant` predicate, which also
+  governs dispatch and the global-cache bypass — out of scope for a correction pass. Follow-up.
+- `LIVE_MODELS_DISCOVERY_SOURCE.revision` NOT bumped despite the parser contract change, against
+  the module's own stated policy. No live effect (the cache is process-local and dies with the
+  process, so a deploy already invalidates every snapshot); bumping would edit a same-unit test
+  assertion for zero runtime benefit. Bump if the cache ever becomes durable or shared.
+- `publishable_upstream_ids` still skips over-long ids rather than failing the refresh. It is a
+  publication FILTER (its job is to drop non-publishable shapes), not the census, so the
+  no-partial-catalog invariant is not weakened by it.
+- No `tier=` line when a provider declares no discovery source: for those providers a seed
+  listing is normal, not degraded, so logging it would be pure noise.
+
+### Round-2 gates (actually run)
+
+- `run_gates.py aigateway --skip-append-only`: ruff check ✓, ruff format --check ✓, pyright ✓
+  (0 errors), `check_no_enterprise.py` ✓, `pytest --cov=aigateway --cov-fail-under=80 -q` ✓ →
+  ALL GATES GREEN.
+- `run_gates.py aigateway --base origin/main`: append-only RED on the 5 files enumerated above
+  (waiver required, each justified).
+- Branch-only full non-live suite: **4102 collected, 4047 passed, 55 skipped, 0 failed**.
+- Focused OME-972 set (9 modules): 192 passed, then 193 with the added parse case.

--- a/docs/work/2026-08-25-OME-972-live-openrouter-model-discovery.md
+++ b/docs/work/2026-08-25-OME-972-live-openrouter-model-discovery.md
@@ -1,0 +1,220 @@
+---
+ticket: OME-972
+stack: aigateway
+status: done
+started: 2026-08-25
+finished: 2026-08-25
+---
+
+# OME-972 — Live OpenRouter model discovery for /v1/models
+
+## Intent
+
+`GET /v1/models` currently lists compiled OpenRouter seeds frozen at deploy time. This unit adds
+provider-owned, bounded, async live discovery of OpenRouter's public model catalog behind a
+cached deployment-wide snapshot, so the gateway lists what OpenRouter actually serves now —
+default-on (`AIGW_OPENROUTER_LIVE_MODELS=true`), fail-closed, credential-free, with compiled
+seeds as the cold-failure fallback and explicitly configured operator models always preserved.
+Standalone task — not a child of OME-308.
+
+## Planned changes
+
+- NEW `src/aigateway/plugins/openrouter_provider/live_models.py` — pinned-query fetch, strict
+  pagination validation, publishability (admission shape predicate), operator/discovered merge
+  (`model_fields_set`), cache policy constants.
+- NEW `src/aigateway/core/model_catalog.py` — `ModelCatalog` (per-provider ObservationCaches,
+  refresh-thunk guards, transition logging) + `build_model_catalog`.
+- `src/aigateway/core/plugin_base/_contract.py` — frozen `ModelDiscoverySource` + inert port
+  pair `model_discovery_source` / `discover_live_models`.
+- `src/aigateway/plugins/openrouter_provider/settings.py` — `live_models: bool = True`.
+- `src/aigateway/plugins/openrouter_provider/plugin.py` — implement the port pair.
+- `src/aigateway/main.py` — `app.state.model_catalog`.
+- `src/aigateway/routes/models.py` — snapshot-or-fallback merge + admitted dedupe.
+- `src/aigateway/routes/model_parameters.py` — lazy known-set extension + comment amendments.
+- `src/aigateway/core/parameter_discovery.py` — additive `DiscoveryError.status`.
+- `src/aigateway/core/discovery_runtime.py` — docstring-only correction (two consumers now).
+- Existing-test setup amendments (`live_models=False`, assertions untouched):
+  `tests/unit/openrouter/test_model_admission_route.py` (openrouter_enabled fixture),
+  `test_openrouter_catalog_route.py`, `test_openrouter_top_p_promotion.py`,
+  `test_openrouter_openapi_endpoint_route.py`.
+- `DEPLOYMENT.md` — flag, degrade ladder, fallback-vs-operator semantics.
+- NEW tests: `tests/unit/openrouter/test_live_models_parse.py`, `test_live_models_fetch.py`,
+  `test_live_models_port.py`, `tests/unit/core/test_model_catalog.py`,
+  `tests/unit/core/test_models_route_live_catalog.py`,
+  `tests/unit/openrouter/test_live_models_resolvability.py`.
+
+## Test plan
+
+Coverage includes parse/publishability/next-URL validation (incl. cap ⇒ failure,
+empty ⇒ failure); pagination failure surface (401/500/timeout/oversized/mid-chain/aggregate
+deadline/off-policy next never dialed); port gating (default true; enabled=False and
+live_models=False ⇒ None + zero dials); ModelCatalog cache semantics (single-flight, TTL, stale,
+stale-expiry, no_snapshot/internal_error guards, AssertionError propagates, per-provider policy,
+transition logging with negative content assertions); route merge (snapshot-or-fallback,
+compiled defaults absent from healthy snapshot are unlisted, explicit operator + colon seed
+survive, admitted dedupe, byte-identical fallback, determinism, route-level single-flight);
+resolvability (discovered id on /v1/model-parameters, seeded id ⇒ zero dials, chat dispatch
+parity). Invariant protected: live data changes what is LISTED, never what is dispatchable, and
+never evicts last-good state on failure.
+
+## Acceptance
+
+Acceptance criteria: default-on discovery; `false` ⇒ today's
+behavior + zero egress; TTL-window freshness; retired compiled defaults disappear when healthy;
+operator + admitted survive; colon/tilde not auto-published; cold ⇒ seeds, failure ⇒ stale;
+nothing partial/malformed/oversized/policy-violating cached as fresh; one upstream fetch chain
+under concurrency; published ids resolve via model details + chat; admission unchanged; full
+AIGateway gates green.
+
+## Outcome
+
+- **Actual files:**
+  - NEW `src/aigateway/plugins/openrouter_provider/live_models.py` — pinned-query paginated
+    fetch (strict `links.next` validation, aggregate 10 s deadline, page/raw caps, total_count
+    reconciliation), publishability (admission shape predicate, ≤256 chars, dedupe/sort,
+    empty/cap fail-closed), operator explicitness (`model_fields_set`), listing merge.
+  - NEW `src/aigateway/core/model_catalog.py` — `ModelCatalog` over per-provider
+    `ObservationCache`s (single-flight, TTL 300 s / stale 3600 s / failure damping 30 s),
+    refresh-thunk guards (AssertionError re-raised; foreign exceptions wrapped sanitized as
+    `internal_error`; port `None` under a declared source → `no_snapshot` failed attempt),
+    attempt-scoped logging (counts/reason/status only), `ModelListingProvider` Protocol,
+    `build_model_catalog(enabled=...)`.
+  - `core/plugin_base/_contract.py` — frozen `ModelDiscoverySource` + inert port pair
+    `model_discovery_source` / `discover_live_models`; `_ports` untouched; exports via
+    `plugin_base/__init__.py`.
+  - `core/parameter_discovery.py` — additive `DiscoveryError.status` (set only at the
+    `bad_status` raise site).
+  - `core/discovery_runtime.py` — docstring-only consumer-list correction.
+  - `plugins/openrouter_provider/settings.py` — `live_models: bool = True`.
+  - `plugins/openrouter_provider/plugin.py` — port pair gated on
+    `enabled and live_models`; provider-owned merge.
+  - `routes/models.py` — snapshot-or-fallback per provider + canonical-id dedupe incl.
+    admitted rows.
+  - `routes/model_parameters.py` — lazy live-catalog rescue of a would-be 404
+    (`_live_catalog_ids`); comment/docstring amendments.
+  - `main.py` — `app.state.model_catalog = build_model_catalog(enabled=settings.discovery_enabled)`.
+  - `DEPLOYMENT.md` — "Live OpenRouter Model Discovery" operator section (flag, degrade
+    ladder, explicit-config vs fallback semantics).
+  - NEW tests (90): `tests/unit/openrouter/test_live_models_parse.py` (32),
+    `test_live_models_fetch.py` (13), `test_live_models_port.py` (10),
+    `test_live_models_resolvability.py` (4), `tests/unit/core/test_model_catalog.py` (19),
+    `tests/unit/core/test_models_route_live_catalog.py` (10, incl. the no-egress tripwire
+    meta-test + default wiring pin); counts do not sum to 90 verbatim due to parametrize
+    expansion — 90 is the collected total of the six files.
+  - Setup-only amendments (`live_models=False`, assertions unchanged) isolate four existing
+    suites from live listing discovery: `test_model_admission_route.py`,
+    `test_openrouter_catalog_route.py`, `test_openrouter_openapi_endpoint_route.py`, and
+    `test_openrouter_top_p_promotion.py`.
+- **Commit:** `feat(aigateway): discover openrouter models live for /v1/models`
+  (`Refs: OME-972`).
+- **Checks:** ruff check ✓, ruff format --check ✓, pyright ✓ (0 errors),
+  check_no_enterprise ✓, pytest --cov ≥80 ✓. Standalone full suite: 4069 collected,
+  4014 passed, 55 skipped (pre-existing opt-in live markers), 0 failed.
+- **Deviations:**
+  - D25 transition-state logging simplified to attempt-scoped logging (warning per real
+    failed attempt with reason+status, info per successful refresh with row count); the
+    cache's failure damping bounds log volume, so the ok↔failed state dict was dead weight.
+  - `ModelCatalog` typed against a narrow `ModelListingProvider` Protocol instead of
+    `ProviderPluginBase` (pyright-driven; strictly better hexagonal coupling).
+  - `build_model_catalog` takes `enabled: bool` rather than the `Settings` object — keeps
+    core free of the config module; `main.py` passes `settings.discovery_enabled`.
+  - Chat parity pinned as behavioral equality of the credential-stage error `detail` for
+    seeded vs discovered ids (membership-free dispatch), not a stubbed dispatch round-trip.
+
+---
+
+## Correction pass — 2026-08-25
+
+The correction pass closes catalog-completeness, test-isolation, resolvability, documentation,
+and observability gaps. Product scope is unchanged: only plain `vendor/model` ids are
+auto-published; colon variants and tilde aliases stay out of automatic publication (tilde
+folding via `alias_target` is a later unit).
+
+### C1 — partial catalogs can no longer be cached as fresh
+
+`parse_catalog_page` is now STRICT: `data` must be a list, `links` must carry an explicit
+`next` (string or null), `total_count` must be a non-negative int, and **every** row must be an
+object with a string `id`. A malformed row is no longer skipped — it fails the whole refresh.
+`fetch_live_model_ids` additionally requires `total_count` to agree ACROSS pages and with the
+final collected count. The live envelope always carries both completeness fields (probed
+2026-08-24), so strictness matches upstream.
+Coverage: `test_live_models_parse.py` 32 → 44 collected cases (18-case malformed matrix),
+`test_live_models_fetch.py` + mid-chain bad row / cross-page census / missing-metadata cases,
+plus two route-level tests proving a malformed refresh serves the STALE last-good snapshot
+(never replaces it) and that a cold malformed read falls back to compiled seeds.
+
+### C2 — `:online` refused at configuration
+
+`_validate_gateway_slug` now rejects `:online` slugs: dispatch refuses them with
+`unsupported_model_variant`, so configuring one published a model whose every request failed.
+Other colon variants remain configurable (regression-pinned). 3 new tests.
+
+### C3 — the two accidentally-passing legacy suites
+
+`live_models=False` added to the `openrouter_enabled` fixtures of `test_model_admission_route.py`
+and `test_openrouter_openapi_endpoint_route.py` (setup only; test and assertion counts identical
+vs HEAD: 20/62 and 6/15). The shared canned client (`tests/unit/openrouter/_openapi_document.py`
+`_RoutingClient`) now raises **AssertionError** for an unrouted URL instead of `KeyError`, so no
+guard can launder a future accidental catalog dial into a silent fallback — the change immediately
+exposed 5 failing tests across those two suites, which the fixture amendment then fixed.
+
+### C4 — acceptance completion
+
+- Concurrent route-level `/v1/models`: 6 threads, all 200, exactly ONE upstream fetch chain,
+  with an interval-overlap assertion so the test cannot pass by mere caching.
+- Credentialed discovered-only dispatch: a snapshot-only id (absent from every seed list) is
+  listed, then reaches the patched `litellm.acompletion` carrying that id, response 200.
+- `model_discovery_source()` raising a non-`DiscoveryError` stays LOUD on **both**
+  `/v1/models` and `/v1/model-parameters`: programming errors are never laundered into a
+  degraded listing. Pinned by two tests; behavior deliberately unchanged.
+
+### C5 — canonical catalog ids
+
+`ModelCatalog.ids_for` now returns `canonical_model_id(...)` per entry, so a future provider
+using the established unprefixed `model_name` convention cannot publish an id that 404s on its
+own detail endpoint. 2 new tests (unprefixed + already-prefixed).
+
+### C6 — operator documentation
+
+`DEPLOYMENT.md` corrected and extended: variants are listable through explicit configuration
+ONLY (admission refuses the same shapes — the previous text was wrong); `:online` is rejected
+and why; colon/tilde are never auto-discovered; fail-closed parsing described; inline refresh
+latency (typical 1–2 s, hard-bounded by the 10 s aggregate deadline, single-flight, 30 s
+damping); each replica caches independently (N replicas ⇒ up to N fetches per TTL); the new
+`tier=` log field. Task mirror renamed to
+`docs/tasks/2026-08-25-OME-972-live-openrouter-model-discovery.md` (id-keyed like its siblings).
+
+### C7 — observability
+
+`ModelCatalog` now logs the SERVED tier on change only —
+`tier=fresh` (info) / `tier=stale` / `tier=seeds` (warning) — so an operator can tell "users
+still see live models" from "the listing has collapsed to seeds" during an outage, which the
+per-attempt warnings could not. 2 new tests, including "an unchanged tier must not re-log".
+
+**Open follow-up:** `plugins/openrouter_provider/plugin.py` is **558 lines**, over the repo's
+450-line split discipline. Pre-existing at 526 lines before OME-972; this unit added 32 (the port
+pair). NOT refactored here. Recommended follow-up: extract the discovery/live-listing hooks into
+a cohesive module. New files added by this unit are within limit (`live_models.py` 252,
+`model_catalog.py` 218).
+
+### Correction-pass gates (actually run)
+
+- Test/assertion counts vs HEAD confirmed non-decreasing everywhere except
+  `test_live_models_parse.py`, where three lenient tests were consolidated into the strict
+  parametrized matrix (functions 18 → 17, collected cases 32 → 44). No prior-unit assertion
+  was weakened; the two legacy suites' counts are byte-identical.
+- Ruff check ✓, ruff format --check ✓, pyright ✓ (0 errors),
+  `check_no_enterprise.py` ✓, `pytest --cov=aigateway --cov-fail-under=80 -q` ✓ → ALL GATES GREEN.
+- Standalone full non-live suite: **4102 collected, 4047 passed, 55 skipped** (pre-existing
+  opt-in live markers), 0 failed (was 4069/4014 before this pass).
+
+### Remaining known deviations after this pass
+
+- Inline (request-path) refresh retained by design with a 10 s aggregate deadline; latency is
+  documented.
+- Per-process cache retained (no shared store); documented as a replica-count sizing note.
+- Remaining improvements: HTTP connection reuse across pages, aggregate-deadline configurability,
+  `/v1/models` row-render cost at the 5000-model
+  cap, `ModelListingProvider` vs the plugin-base port having no static conformance check, the
+  three DRY items, and the boundary tests at exactly `_MAX_PAGES` / `_MAX_ID_LENGTH`.
+- `plugin.py` size violation above.


### PR DESCRIPTION
## Description

Adds live OpenRouter model discovery to the OpenAI-compatible `/v1/models` endpoint so clients receive the models OpenRouter currently serves instead of relying only on compiled defaults.

The provider fetches the public catalog through a bounded, credential-free pagination contract. A complete healthy snapshot contains operator-explicit models first, followed by sorted plain discovered IDs without duplicates. Discovered models are also resolvable through `/v1/model-parameters` and credentialed chat dispatch.

Snapshots are cached per process with single-flight refresh, a 5-minute fresh TTL, a 1-hour stale window, and a 30-second retry damping interval. Malformed, partial, oversized, cross-origin, or inconsistent catalogs are rejected without replacing the last-good snapshot. Cold or expired degraded state falls back to configured or compiled seeds.

`AIGW_DISCOVERY_ENABLED` remains the global discovery-egress kill switch. `AIGW_OPENROUTER_LIVE_MODELS` controls this listing specifically; both default to enabled. Only plain IDs are auto-published. Explicit `AIGW_OPENROUTER_DEFAULT_MODELS` entries retain their configured order and win exact-ID deduplication.

### Append-only waiver

The merge-base append-only check flags these five existing fixtures:

- `apps/aigateway/tests/unit/openrouter/_openapi_document.py`
- `apps/aigateway/tests/unit/openrouter/test_model_admission_route.py`
- `apps/aigateway/tests/unit/openrouter/test_openrouter_openapi_endpoint_route.py`
- `apps/aigateway/tests/unit/openrouter/test_openrouter_catalog_route.py`
- `apps/aigateway/tests/unit/openrouter/test_openrouter_top_p_promotion.py`

The changes disable live catalog egress in legacy isolated fixtures or make unexpected client calls fail loudly. Existing assertions are unchanged.

Refs: OME-972

## Affected Dependencies

None. No dependency or lockfile changes are required.

## How has this been tested?

- Full non-live AIGateway suite: 4047 passed, 55 skipped.
- Focused live-listing, strict parsing, concurrency, and resolvability suites: 65 passed.
- Formatting, lint, static typing, coverage, and the Enterprise import guard pass.
- The live two-page OpenRouter response shape, continuation URL, and completeness fields were validated.
- Malformed rows, incomplete pagination, hostile continuation URLs, page and model caps, stale preservation, cold fallback, concurrent callers, detail resolution, and credentialed dispatch have regression coverage.

Run the project checks from `apps/aigateway`:

```bash
uv run ruff check .
uv run ruff format --check
uv run pyright
uv run python scripts/check_no_enterprise.py
uv run pytest -m "not live"
```

## Checklist

- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests