### PR TITLE
fix(screamingface-engine): preserve upstream grading errors instead of masking them (OME-924)

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py
@@ -239,6 +239,14 @@ def build_draco_protocol(routes: Routes, case_count: int, judge_passes: int) -> 
         ),
         body=(src(criterion_evaluation, name="evaluated", weight=0.0),),
         intent=Text("$evaluated"),
+        # WHY fail, not the collect default (OME-924): a judge branch that fails (e.g. an
+        # upstream 429) must surface as ITS OWN error at the case-execution boundary, not be
+        # collected into the criterion list — where the case-evaluation route would decode
+        # the error object as a typed grading record and mask the real failure with
+        # "invalid Criterion envelope". The shared preserve_candidate_outcome() boundary
+        # below still collects this error per Case, so one bad judge pass fails only that
+        # Case, with the Candidate answer intact.
+        on_error="fail",
     )
     case_evaluation = expr(
         src(criteria, name="criteria", weight=0.0),

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/exam.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/exam.py
@@ -223,6 +223,14 @@ def build_exam_protocol(routes: Routes, case_count: int, available_case_count: i
         ),
         body=(src(rubric_evaluation, name="evaluated", weight=0.0),),
         intent=Text("$evaluated"),
+        # WHY fail, not the collect default (OME-924): a failed rubric-item judge branch
+        # (e.g. an upstream 429, or judge_reply_invalid after its bounded retries) must
+        # surface as ITS OWN error at the case-execution boundary, not be collected into
+        # the rubric-row list — where the case-evaluation route would decode the error
+        # object as a typed grading record and mask the real failure. The shared
+        # preserve_candidate_outcome() boundary still collects this error per Case, so one
+        # bad rubric item fails only that Case, with the Candidate answer intact.
+        on_error="fail",
     )
     # Stage 4a — roll a Case's rubric rows up into one per-Case score.
     case_evaluation = expr(

--- a/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
@@ -109,7 +109,14 @@ async def test_protocol_preserves_selected_order_and_collects_a_case_failure() -
         "intent": "aggregate:2",
         "case_evaluations": [
             {"case_id": 11, "output": "first"},
-            {"error": {"kind": "ResolutionError", "message": "candidate failed"}},
+            {
+                "error": {
+                    "kind": "ResolutionError",
+                    "message": "candidate failed",
+                    "code": "candidate_failed",
+                    "retryable": False,
+                }
+            },
         ],
     }
 
@@ -217,7 +224,16 @@ async def test_case_execution_preserves_candidate_invocation_when_grading_fails(
         "schema": CASE_EXECUTION_SCHEMA,
         "case_id": "case-1",
         "candidate_invocation": encode_candidate_invocation("", "content_filter", "exact refusal"),
-        "grading": [{"error": {"kind": "ResolutionError", "message": "checker unavailable"}}],
+        "grading": [
+            {
+                "error": {
+                    "kind": "ResolutionError",
+                    "message": "checker unavailable",
+                    "code": "checker_failed",
+                    "retryable": False,
+                }
+            }
+        ],
     }
 
 
@@ -235,11 +251,11 @@ def test_protocol_rejects_an_impossible_case_selection() -> None:
 @pytest.mark.parametrize(
     ("benchmark", "expected_sha256"),
     (
-        (DRACO, "fe91990b18cf4672d9eccc412fca7bf533de1cb33de38bee589d37302c04d8dc"),
+        (DRACO, "7fdef3acb7f97ff14d91c1c7eb1937bc58681367555cfa4206d615cb4bb69f87"),
         (IFEVAL, "c272779623671772ad8c2629e320e283837f34e3b270c693643285174794e4f8"),
         (
             HEALTHBENCH_WORST30,
-            "963cbe2cbffed4ff4123adf6b667af4191ab5337f774bbd43e0ec547d3f6b3e9",
+            "bc4c584c826b5fa40ff0b563b4470cb89790712f08e92f0c0aeff151f3210102",
         ),
     ),
 )

--- a/apps/screamingface-engine/tests/unit/test_grading_error_integrity.py
+++ b/apps/screamingface-engine/tests/unit/test_grading_error_integrity.py
@@ -1,0 +1,333 @@
+"""Grading failures reach the Case Result as the ORIGINAL upstream error (OME-924).
+
+Before this fix, a failed judge branch inside a Benchmark's inner model-grading fan-out
+was collected (url4's default ``on_error="collect"``) into the criterion/rubric row list,
+where the case-evaluation route decoded the error object as a typed grading record and
+masked the real failure with "invalid Criterion envelope". These tests pin the two halves
+of the repair:
+
+- the inner fan-outs (DRACO criteria, HealthBench rubric items) now fail fast, so the
+  original error propagates to the shared ``preserve_candidate_outcome()`` boundary
+  instead of being collected as a malformed grading record;
+- url4's collect payload carries the exception's own ``code`` and ``retryable`` beside
+  kind/message, so ``public_error`` renders the upstream failure instead of the default.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from screamingface_engine.benchmarks.candidate_adapter import install_candidate_invocation
+from screamingface_engine.benchmarks.case_execution import case_execution_payload
+from screamingface_engine.benchmarks.contract import (
+    CandidateResult,
+    encode_candidate_invocation,
+)
+from screamingface_engine.benchmarks.definition import link_candidate
+from screamingface_engine.benchmarks.draco import aggregate as draco_agg
+from screamingface_engine.benchmarks.draco import prepare
+from screamingface_engine.benchmarks.draco.definition import DRACO
+from screamingface_engine.benchmarks.draco.exam import (
+    JUDGE_MODEL,
+    build_draco_protocol,
+)
+from screamingface_engine.benchmarks.draco.exam import (
+    Routes as DracoRoutes,
+)
+from screamingface_engine.benchmarks.healthbench import aggregate as healthbench_agg
+from screamingface_engine.benchmarks.healthbench.exam import (
+    Routes as HealthRoutes,
+)
+from screamingface_engine.benchmarks.healthbench.exam import (
+    build_exam_protocol,
+)
+from screamingface_engine.benchmarks.registry import BenchmarkRegistry
+from screamingface_engine.runner.connector import (
+    AigatewayConfig,
+    AigatewayWorld,
+    build_aigateway_world,
+)
+from screamingface_engine.world_config import ModelSpec
+from url4 import RelExpr, render, text
+
+pytestmark = pytest.mark.asyncio
+
+_RUBRIC = {
+    "sections": [
+        {"id": "Factual Accuracy", "criteria": [{"id": "a1", "weight": 2, "requirement": "x"}]}
+    ]
+}
+
+_CANDIDATE_MODEL = "openrouter/deepseek/deepseek-v4-pro"
+
+
+# --- the protocol fan-outs fail fast ---------------------------------------------------
+
+
+async def test_draco_inner_grading_fanout_fails_fast() -> None:
+    routes = DracoRoutes.for_exam("draco", "0123456789abcdef")
+    rendered = render(build_draco_protocol(routes, case_count=1, judge_passes=5))
+    # Exactly ONE explicit fail-fast policy: the inner criterion fan-out. The outer Case
+    # fan-out and the preserve_candidate_outcome boundary keep the collect default, which
+    # renders nothing (collect IS the default).
+    assert rendered.count(";iteration.on_error=fail") == 1
+
+
+async def test_healthbench_inner_grading_fanout_fails_fast() -> None:
+    routes = HealthRoutes.for_exam("healthbench-worst30", "0123456789abcdef")
+    rendered = render(build_exam_protocol(routes, case_count=1, available_case_count=1))
+    assert rendered.count(";iteration.on_error=fail") == 1
+
+
+# --- the aggregate renders the original error, not an envelope failure ------------------
+
+
+def _execution(case_id: int, answer: str, grading: object) -> dict[str, object]:
+    return case_execution_payload(
+        case_id,
+        encode_candidate_invocation(answer, "stop", None),
+        [grading],
+    )
+
+
+def _error_row(
+    *,
+    kind: str = "ResolutionError",
+    code: str | None = None,
+    message: str = "upstream judge rate limited",
+    retryable: bool | None = None,
+    permanent: bool | None = None,
+) -> dict[str, object]:
+    error: dict[str, object] = {"kind": kind, "message": message}
+    if code is not None:
+        error["code"] = code
+    if retryable is not None:
+        error["retryable"] = retryable
+    if permanent is not None:
+        error["permanent"] = permanent
+    return {"error": error}
+
+
+async def test_draco_grading_error_preserves_code_and_retryable() -> None:
+    rows = json.dumps(
+        [
+            _execution(
+                1,
+                "the candidate answer",
+                _error_row(code="rate_limited", retryable=True),
+            )
+        ]
+    )
+    result = draco_agg.aggregate(
+        rows,
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=[{"id": 1, "input": "Question 1"}],
+        judge_passes=5,
+    )
+
+    (case,) = result["cases"]
+    assert case["status"] == "failed"
+    assert case["output"] == "the candidate answer"
+    assert case["grade"]["score"] is None
+    (failure,) = case["failures"]
+    assert failure == {
+        "stage": "grading",
+        "code": "rate_limited",
+        "message": "upstream judge rate limited",
+        "retryable": True,
+        "case_id": 1,
+        "metadata": {"error_kind": "ResolutionError"},
+    }
+    assert "Criterion envelope" not in failure["message"]
+
+
+async def test_draco_grading_failure_keeps_a_permanent_classification() -> None:
+    result = draco_agg.aggregate(
+        json.dumps(
+            [
+                _execution(
+                    1,
+                    "the candidate answer",
+                    _error_row(code="aigateway_bad_response", permanent=True),
+                )
+            ]
+        ),
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=[{"id": 1, "input": "Question 1"}],
+        judge_passes=5,
+    )
+
+    (case,) = result["cases"]
+    (failure,) = case["failures"]
+    assert failure["code"] == "aigateway_bad_response"
+    assert failure["retryable"] is False
+
+
+async def test_draco_grading_failure_without_code_falls_back_to_the_default() -> None:
+    # A legacy collect payload (kind + message only) still renders, with the benchmark's
+    # declared default code — backward compatible with pre-OME-924 error rows.
+    result = draco_agg.aggregate(
+        json.dumps([_execution(1, "the candidate answer", _error_row())]),
+        {1: _RUBRIC},
+        "draco",
+        selected_cases=[{"id": 1, "input": "Question 1"}],
+        judge_passes=5,
+    )
+
+    (case,) = result["cases"]
+    (failure,) = case["failures"]
+    assert failure["stage"] == "grading"
+    assert failure["code"] == "draco_grading_failed"
+    assert failure["retryable"] is None
+    assert failure["message"] == "upstream judge rate limited"
+
+
+def _write_healthbench_case(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "cases.json").write_text(json.dumps([{"id": 1, "input": "input-1"}]), encoding="utf-8")
+
+
+async def test_healthbench_grading_error_preserves_code_and_retryable(tmp_path: Path) -> None:
+    _write_healthbench_case(tmp_path)
+    rows = json.dumps(
+        [
+            _execution(
+                1,
+                "the candidate answer",
+                _error_row(code="rate_limited", retryable=True),
+            )
+        ]
+    )
+    result = healthbench_agg.aggregate(
+        rows,
+        tmp_path,
+        benchmark_id="healthbench-test",
+        benchmark_revision="revision",
+        case_ids=(1,),
+        mean=sum,
+    )
+
+    (case,) = result["cases"]
+    assert case["status"] == "failed"
+    assert case["output"] == "the candidate answer"
+    assert case["grade"]["score"] is None
+    (failure,) = case["failures"]
+    assert failure["stage"] == "grading"
+    assert failure["code"] == "rate_limited"
+    assert failure["retryable"] is True
+    assert failure["metadata"] == {"error_kind": "ResolutionError"}
+
+
+# --- end to end: a real judge 429 through the full DRACO protocol -----------------------
+
+
+def _draco_assets(root: Path) -> Path:
+    bundle = root / "draco"
+    prepare.build(
+        [
+            {"problem": f"Question {index}", "answer": json.dumps(_RUBRIC), "domain": "finance"}
+            for index in range(1, 101)
+        ],
+        bundle,
+    )
+    return root
+
+
+def _tavily(_request: httpx.Request) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"results": [{"title": "s", "url": "https://allowed.test/x", "content": "public"}]},
+    )
+
+
+async def _judge_429_world(
+    tmp_path: Path,
+) -> tuple[
+    httpx.AsyncClient,
+    httpx.AsyncClient,
+    AigatewayWorld,
+    list[dict[str, object]],
+]:
+    """A full DRACO world whose judge route answers 429 and candidates answer fine."""
+    requests: list[dict[str, object]] = []
+
+    def gateway(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        requests.append(body)
+        if body.get("model") == JUDGE_MODEL:
+            return httpx.Response(
+                429,
+                json={
+                    "detail": {
+                        "code": "rate_limited",
+                        "message": "upstream judge rate limited",
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "A fine answer."}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+            },
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(gateway),
+        base_url="http://aigateway.test",
+    )
+    tavily = httpx.AsyncClient(
+        transport=httpx.MockTransport(_tavily),
+        base_url="https://api.tavily.com",
+    )
+    world = await build_aigateway_world(
+        AigatewayConfig(
+            default_model=_CANDIDATE_MODEL,
+            models=(ModelSpec(id=_CANDIDATE_MODEL), ModelSpec(id=JUDGE_MODEL)),
+        ),
+        client=client,
+        tavily_api_key="tvly-test",
+        tavily_client=tavily,
+    )
+    install_candidate_invocation(world.node)
+    BenchmarkRegistry((DRACO,)).install(world.node, assets_root=_draco_assets(tmp_path))
+    return client, tavily, world, requests
+
+
+async def test_a_judge_429_lands_as_the_original_grading_error(tmp_path: Path) -> None:
+    """Judge calls 429, the candidate answers fine — the case failure carries the upstream
+    code/message/retryability, never an envelope mask."""
+    client, tavily, world, requests = await _judge_429_world(tmp_path)
+    candidate_expression = RelExpr(
+        path=f"/{_CANDIDATE_MODEL}",
+        context="$input",
+        intent=text("Answer the question."),
+    )
+    linked = link_candidate(candidate_expression, DRACO.build(1))
+    try:
+        result = await world.node.evaluate(linked)
+    finally:
+        await world.aclose()
+        await client.aclose()
+        await tavily.aclose()
+
+    candidate = CandidateResult.model_validate(json.loads(result.text))
+    (case,) = candidate.cases
+    assert case.output == "A fine answer."
+    assert case.grade is not None
+    assert case.grade.score is None
+    (failure,) = case.failures
+    assert failure.stage == "grading"
+    assert failure.code == "rate_limited"
+    assert failure.retryable is True
+    assert "upstream judge rate limited" in failure.message
+    assert "Criterion envelope" not in failure.message
+    # Every judge pass was paid as a real 429 — no masking swallowed them.
+    judge_calls = [body for body in requests if body.get("model") == JUDGE_MODEL]
+    assert judge_calls, "the judge must actually have been called"

--- a/docs/tasks/2026-08-26-OME-924-preserve-grading-errors.md
+++ b/docs/tasks/2026-08-26-OME-924-preserve-grading-errors.md
@@ -1,0 +1,39 @@
+---
+id: OME-924
+linear_url: https://linear.app/openmined/issue/OME-924/preserve-upstream-grading-errors-in-model-graded-benchmarks
+status: in_progress
+type: fix
+priority: high
+labels: [screamingface-engine, url4, agentic]
+created: 2026-08-20
+closed:
+---
+
+# Preserve upstream grading errors in model-graded benchmarks
+
+Fix for GitHub #740 / OME-993: a judge failure inside a model-graded benchmark was masked
+as "invalid Criterion envelope" (`draco_grading_failed`) because url4's default
+`on_error="collect"` turned the failed judge branch into an error-shaped item in the
+criterion/rubric fan-out, which the case-evaluation route then decoded as a typed grading
+record. The original upstream error (e.g. OpenRouter 429 → `rate_limited`) never reached
+the report.
+
+## Fix
+
+- Inner fan-outs now fail fast: DRACO criteria iteration and HealthBench rubric-item
+  iteration declare `on_error="fail"`, so the original error propagates to the shared
+  `preserve_candidate_outcome()` boundary (which still collects per Case).
+- url4 `_error_payload` keeps the exception's `code` and `retryable` (from `permanent`)
+  beside `kind`/`message`, so `public_error` renders the upstream failure instead of the
+  benchmark default.
+
+## Acceptance
+
+- Simulated judge 429 in DRACO reports `rate_limited`, original message, `retryable=true`,
+  never "invalid Criterion envelope".
+- HealthBench equivalent; candidate answer retained; affected case unscored.
+- Permanent judge failures keep `retryable=false`.
+- Successful grading unchanged (protocol hashes updated deliberately; DRACO revision
+  fingerprint untouched).
+
+Ledger: `docs/work/2026-08-26-OME-924-preserve-grading-errors.md`

--- a/docs/work/2026-08-26-OME-924-preserve-grading-errors.md
+++ b/docs/work/2026-08-26-OME-924-preserve-grading-errors.md
@@ -1,0 +1,75 @@
+---
+ticket: OME-924
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-26
+finished:
+---
+
+# OME-924 — Preserve upstream grading errors in model-graded benchmarks
+
+## Intent
+
+A judge failure inside a model-graded benchmark (DRACO, HealthBench) was collected by
+url4's default `on_error="collect"` into the inner criterion/rubric fan-out, then decoded
+by the case-evaluation route as a typed grading record — surfacing as
+`draco_grading_failed: "DRACO Case evaluation contains an invalid Criterion envelope"` and
+swallowing the real upstream failure (e.g. OpenRouter 429). Live incident: GitHub
+ScreamingFace/screamingface#740 (Linear OME-993). This unit makes the original error reach
+the shared `preserve_candidate_outcome()` boundary and render with its own code/message/
+retryability, so a billed run ends in scores or an honest, actionable grading error.
+
+## Planned changes
+
+- `packages/url4/src/url4/dag/nodes.py` — `_error_payload` keeps the exception's `code`
+  and `permanent` (rendered as `retryable`) beside kind/message.
+- `apps/screamingface-engine/.../benchmarks/draco/exam.py` — inner criteria fan-out
+  `on_error="fail"`.
+- `apps/screamingface-engine/.../benchmarks/healthbench/exam.py` — inner rubric-item
+  fan-out `on_error="fail"`.
+- Tests: url4 collect-payload fidelity; engine aggregate/protocol/e2e judge-429
+  regression; update pinned draco/healthbench protocol hashes and OME-962 e2e assertions.
+
+## Test plan
+
+- url4 unit: a collected `ResolutionError(code, permanent)` row carries code + retryable;
+  a plain exception keeps the legacy kind/message payload.
+- Engine: DRACO and HealthBench aggregates render a grading error's code/retryable/
+  message; a permanent error keeps `retryable=False`; a legacy payload falls back to the
+  benchmark default code.
+- Engine protocol: rendered DRACO and HealthBench protocols carry exactly one
+  `;iteration.on_error=fail` (the inner fan-out).
+- Engine e2e: full DRACO board with a scripted gateway that 429s the judge → the case
+  failure is `stage=grading`, `code=rate_limited`, `retryable=True`, original message,
+  candidate output preserved, and never "invalid Criterion envelope".
+- Regression: `pytest tests/unit` (engine), `tests/unit` (url4), SDK
+  `test_benchmark_compilation.py` + `test_draco_vertical_slice.py`; ruff + pyright clean.
+
+## Acceptance
+
+- Simulated judge 429 in DRACO reports `rate_limited`, preserves the original message and
+  `retryable=true`, and does not report an invalid Criterion envelope.
+- HealthBench has equivalent behavior for a failed rubric-item judge call.
+- The candidate answer is retained and the affected case remains unscored.
+- Permanent judge failures retain their original classification (`retryable=false`).
+- Successful grading behavior is unchanged (pinned protocol hashes updated deliberately;
+  DRACO revision hash `66a463248586b277` is untouched — the revision input tuple is
+  unchanged).
+- Behavior is independent of the outer case-iteration concurrency.
+- Cross-benchmark regression tests cover DRACO and HealthBench.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `packages/url4/src/url4/dag/nodes.py` — `_error_payload` preserves `code` + `retryable`
+  - `packages/url4/tests/unit/test_iteration.py` — collect-payload fidelity tests
+  - `apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/exam.py` — `on_error="fail"` on the criteria fan-out
+  - `apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/exam.py` — `on_error="fail"` on the rubric-item fan-out
+  - `apps/screamingface-engine/tests/unit/test_grading_error_integrity.py` — new cross-benchmark regression suite (aggregate, protocol render, full DRACO e2e judge-429)
+  - `apps/screamingface-engine/tests/unit/test_benchmark_protocol.py` — updated pinned hashes + payload-shape assertions
+  - `packages/screamingface/tests/e2e/test_failures.py` — updated OME-962 assertions/docstring to the preserved code/retryable behavior
+  - `docs/work/2026-08-26-OME-924-preserve-grading-errors.md`, `docs/tasks/2026-08-26-OME-924-preserve-grading-errors.md`
+- **Commits:**
+  - `e102c9a0` — fix(url4): preserve code and retryable in collected error payloads
+  - `cea8d529` — fix(screamingface-engine): fail fast benchmark grading fan-outs so upstream errors survive
+- **Verification:** engine `tests/unit` 2026 passed / 5 skipped; url4 `tests/unit` 752 passed; SDK `test_benchmark_compilation.py` + `test_draco_vertical_slice.py` 33 passed; ruff + pyright clean on all changed files.

--- a/packages/screamingface/tests/e2e/test_failures.py
+++ b/packages/screamingface/tests/e2e/test_failures.py
@@ -18,11 +18,12 @@ The declared policy chain, with the code that declares it:
   (``runner/model_response.py::raise_if_unusable``).
 - a failed CANDIDATE call errors the whole Case row; the board's cases fan out with
   ``on_error="collect"`` (``benchmarks/protocol.py``), so the row becomes
-  ``{"error": {"kind", "message"}}`` (url4 ``dag/nodes.py::_error_payload``) and DRACO's
+  ``{"error": {"kind", "message", "code", "retryable"}}`` (url4
+  ``dag/nodes.py::_error_payload``) and DRACO's
   aggregate maps it to a ``stage="candidate"`` Failure via ``public_error``
-  (``benchmarks/draco/aggregate.py::_row_failure``). The wire row carries no code, so
-  the Failure code is the declared default ``case_execution_failed`` and the
-  gateway-authored MESSAGE is what names the provider failure.
+  (``benchmarks/draco/aggregate.py::_row_failure``). The wire row carries the connector's
+  own code/retryable (OME-924), so the Failure code and retryability are the upstream
+  ones and the gateway-authored MESSAGE names the provider failure.
 - a judge that answers but is cut off (truncated verdict JSON) never errors the row:
   every verdict is bound invalid (``benchmarks/draco/verdict.py::bind``) and the case
   lands as a ``stage="grading"`` Failure, code ``no_valid_judge_verdict``
@@ -399,9 +400,10 @@ def test_a_provider_429_lands_as_a_candidate_provider_failure_never_malformed(
     assert failure.stage == "candidate"
     assert "rate limiting" in failure.message
     assert "malformed" not in failure.message.lower()
-    # Declared today: the collect row strips the connector's code/permanent, so the
-    # Failure code is DRACO's default for an errored case row (public_error fallback).
-    assert failure.code == "case_execution_failed"
+    # OME-924: the collect row keeps the connector's code/retryable, so the Failure
+    # carries the upstream rate-limit code instead of the DRACO default.
+    assert failure.code == "rate_limited"
+    assert failure.retryable is True
 
 
 @pytest.mark.e2e

--- a/packages/url4/src/url4/dag/nodes.py
+++ b/packages/url4/src/url4/dag/nodes.py
@@ -177,7 +177,26 @@ def _media_type_of(payload: Payload) -> str | None:
 
 
 def _error_payload(exc: BaseException) -> dict:
-    return {"error": {"kind": type(exc).__name__, "message": str(exc) or repr(exc)}}
+    """One collected row's wire error object (spec §5.3.6 ``collect``).
+
+    Preserves the exception's URL4 diagnostics — ``code`` and ``permanent`` — beside the
+    kind/message pair, so a ``collect``-boundary consumer (a benchmark's outcome envelope,
+    the SDK report) can render the ORIGINAL upstream failure instead of falling back to a
+    default code. ``permanent`` travels as ``retryable`` (its inverse): permanent errors
+    must not be retried, and every reader of this payload already keys on retryability
+    (``screamingface_engine.benchmarks.aggregation.public_error``).
+    """
+    payload: dict[str, object] = {
+        "kind": type(exc).__name__,
+        "message": str(exc) or repr(exc),
+    }
+    code = getattr(exc, "code", None)
+    if isinstance(code, str) and code:
+        payload["code"] = code
+    permanent = getattr(exc, "permanent", None)
+    if isinstance(permanent, bool):
+        payload["retryable"] = not permanent
+    return {"error": payload}
 
 
 def _wire_params(params: Params) -> list[tuple[str, str]]:

--- a/packages/url4/tests/unit/test_iteration.py
+++ b/packages/url4/tests/unit/test_iteration.py
@@ -223,6 +223,55 @@ async def test_iteration_on_error_collect_captures_failures() -> None:
 
 
 @pytest.mark.asyncio
+async def test_iteration_collect_preserves_code_and_retryable() -> None:
+    # OME-924: a collected row must keep the exception's own diagnostics (code +
+    # retryable), so a collect-boundary consumer can render the ORIGINAL upstream
+    # failure instead of falling back to a default code. ``permanent`` travels as
+    # ``retryable`` (its inverse) — permanent errors must not be retried.
+    from url4.core.errors import ResolutionError
+
+    def rate_limited(_context: str, _intent: str) -> str:
+        raise ResolutionError("rate limit reached", code="rate_limited", permanent=False)
+
+    rows = json.dumps([{"q": "x"}])
+    resolver = StaticIOLayer(
+        fetch_map={"https://data": rows},
+        routes={"/solve": rate_limited},
+    )
+    ctx = ExecutionContext(resolver, strict_fields=True)
+    node = Iteration(collection=Url("https://data"), body="/solve($q)!go")
+    result = await run(node, ctx=ctx)
+    (row,) = json.loads(result)
+    assert row == {
+        "error": {
+            "kind": "ResolutionError",
+            "code": "rate_limited",
+            "message": "rate limit reached",
+            "retryable": True,
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_iteration_collect_leaves_retryable_unset_without_permanent() -> None:
+    # A non-URL4 exception carries no ``code``/``permanent``: the payload keeps the
+    # legacy kind/message pair so older readers stay byte-compatible.
+    def broken(_context: str, _intent: str) -> str:
+        raise RuntimeError("boom")
+
+    rows = json.dumps([{"q": "x"}])
+    resolver = StaticIOLayer(
+        fetch_map={"https://data": rows},
+        routes={"/solve": broken},
+    )
+    ctx = ExecutionContext(resolver, strict_fields=True)
+    node = Iteration(collection=Url("https://data"), body="/solve($q)!go")
+    result = await run(node, ctx=ctx)
+    (row,) = json.loads(result)
+    assert row == {"error": {"kind": "RuntimeError", "message": "boom"}}
+
+
+@pytest.mark.asyncio
 async def test_empty_collection_resolves_to_empty_array() -> None:
     # Spec §5.3.9 — zero elements is a SUCCESS with an empty result collection.
     resolver = StaticIOLayer(fetch_map={"https://data": "[]"})


### PR DESCRIPTION
## Summary

A judge failure inside a model-graded benchmark was masked as `draco_grading_failed: "invalid Criterion envelope"` — the real upstream failure (e.g. OpenRouter 429) never reached the report, so a billed run ended with no score and no actionable error (GitHub #740 / OME-993). This PR makes the original error survive to the shared `preserve_candidate_outcome()` boundary and render with its own code/message/retryability.

Two loss points fixed:

1. **Masking** — the inner model-grading fan-outs (DRACO criteria, HealthBench rubric items) used url4's default `on_error="collect"`, so a failed judge branch became an error-shaped object *inside* the row list, which the case-evaluation route decoded as a typed grading record. Both fan-outs now declare `on_error="fail"`: the first failing judge branch aborts the fan-out and propagates its own `ResolutionError` to the shared boundary, which still collects per Case with the candidate answer intact.
2. **Fidelity** — url4's `_error_payload` kept only `{kind, message}`, dropping the exception's `code`/`permanent`. It now carries `code` and `retryable` (from `permanent`) beside kind/message; legacy kind/message-only payloads stay byte-compatible.

**Refs:** OME-924

## Components touched

- `packages/url4` — `_error_payload` fidelity
- `apps/screamingface-engine` — DRACO + HealthBench fan-out policy, new regression suite, updated pinned protocol hashes
- `packages/screamingface` — OME-962 e2e assertions updated to the preserved code/retryable behavior (e2e-gated)

## Test plan

- [x] Engine `tests/unit`: 2026 passed, 5 skipped
- [x] url4 `tests/unit`: 752 passed
- [x] SDK `test_benchmark_compilation.py` + `test_draco_vertical_slice.py`: 33 passed
- [x] `uv run ruff check` + `uv run ruff format --check` + `uv run pyright` clean on all changed files
- [x] New `test_grading_error_integrity.py`: aggregate code/retryable/message preservation (DRACO + HealthBench), permanent classification, legacy fallback, protocol-render pins, and a full DRACO run against a scripted gateway that 429s the judge → `stage=grading, code=rate_limited, retryable=true`, candidate output preserved, never "invalid Criterion envelope"

## Cross-service notes

- DRACO revision fingerprint `66a463248586b277` is untouched (the revision input tuple is unchanged); only the rendered protocol text changed, so the deliberately pinned hashes in `test_benchmark_protocol.py` were updated.
- Related: OME-993 (incident mirror of GitHub #740) linked to OME-924 in Linear.
