### PR TITLE
fix(screamingface): ship python-multipart so a fresh [runtime] install boots

### DIFF
--- a/docs/tasks/2026-08-26-OME-994-client-extras-missing-deps.md
+++ b/docs/tasks/2026-08-26-OME-994-client-extras-missing-deps.md
@@ -1,0 +1,21 @@
+---
+id: OME-994
+linear_url: https://linear.app/openmined/issue/OME-994/ship-the-missing-dependencies-so-a-fresh-install-works-first-try
+status: backlog
+type: bug
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-26
+closed:
+---
+
+# Ship the missing dependencies so a fresh install works first try
+
+From community GitHub issue
+[#735](https://github.com/ScreamingFace/screamingface/issues/735): on a clean
+machine, `pip install "screamingface[runtime,notebook]"` (0.1.1.post5) leaves
+`screamingface up` crashing (missing `python-multipart` in `[runtime]`) and the
+`[notebook]` extra without `jupyterlab`, both promised by the Installation docs.
+
+Fix: declare both deps in the extras in `packages/screamingface`, add a test
+that each documented extra imports what it promises, cut a post release.

--- a/docs/work/2026-08-26-OME-994-runtime-multipart.md
+++ b/docs/work/2026-08-26-OME-994-runtime-multipart.md
@@ -1,0 +1,64 @@
+---
+ticket: OME-994
+stack: screamingface
+status: done
+started: 2026-08-26
+finished: 2026-08-26
+---
+
+# OME-994 — Ship the missing dependencies so a fresh install works first try
+
+## Intent
+
+Community GitHub issue #735: on a clean machine,
+`pip install "screamingface[runtime,notebook]"` then `screamingface up` dies with
+`Form data requires "python-multipart" to be installed`. The wheel bundles the
+gateway app, whose own pyproject declares `python-multipart`, but the client's
+`[runtime]` extra — the thing pip actually resolves — omits it. Second half of
+the report: the Installation docs claim the `[notebook]` extra pulls jupyterlab;
+the extra deliberately stays minimal (INVARIANT in pyproject), so the docs
+sentence is the bug, not the extra.
+
+## Planned changes
+
+- `packages/screamingface/pyproject.toml` — add `python-multipart>=0.0.20` to the
+  `[runtime]` extra (mirrors the gateway's own pin).
+- `packages/screamingface/tests/test_runtime_extra_parity.py` — NEW invariant
+  test: every direct dependency of the three bundled runtime apps is resolvable
+  from the client's base deps + `[runtime]` extra, with an explicit allowlist for
+  names satisfied transitively (pydantic, asyncpg) and vendored code (url4).
+- `public-docs/src/pages/sf-client/InstallationPage.vue` — stop promising
+  jupyterlab in the `[notebook]` extra sentence.
+- `docs/tasks/2026-08-26-OME-994-client-extras-missing-deps.md` — mirror
+  committed with the work.
+
+## Test plan
+
+- RED: parity test fails on today's pyproject naming exactly `python-multipart`
+  as missing from the runtime extra.
+- GREEN: adding the dep turns it green; full screamingface suite stays green.
+- Invariant protected: a bundled app can never again grow a direct dependency
+  that the installable extra silently drops (#735 bug class).
+
+## Acceptance
+
+- `screamingface[runtime]` resolves `python-multipart` (extra declares it).
+- Parity test red-flags any future drift between bundled apps' deps and the extra.
+- Installation docs no longer promise jupyterlab from `[notebook]`.
+- All screamingface stack gates green; PR opened referencing OME-994 / GH #735.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `packages/screamingface/pyproject.toml`,
+  `packages/screamingface/tests/test_runtime_extra_parity.py` (new),
+  `public-docs/src/pages/sf-client/InstallationPage.vue`, the docs/tasks mirror,
+  this ledger.
+- **Commits:** single commit on `OME-994-runtime-multipart` (squash-merged via PR;
+  sha recorded in the Linear close comment).
+- **Gates:** `run_gates.py screamingface` ALL GREEN (ruff, format, pyright,
+  pytest cov≥95, notebooks, uv build, distribution). public-docs lane: prettier
+  --check, oxlint, eslint, `npm run build` all clean (no test suite there).
+- **Deviations:** jupyterlab was NOT added to `[notebook]` — the extra carries an
+  INVARIANT keeping it panel-only; the docs sentence was the bug and was fixed
+  instead. RED confirmed before the fix: parity test named exactly
+  `python-multipart` missing.

--- a/packages/screamingface/pyproject.toml
+++ b/packages/screamingface/pyproject.toml
@@ -54,6 +54,9 @@ runtime = [
     "prometheus-client>=0.26.0",
     "pydantic-settings>=2.14.2",
     "pyjwt==2.13.0",
+    # WHY: the bundled gateway's FastAPI form endpoints need it at startup, but pip only
+    # resolves THIS extra, never the bundled apps' own pyprojects (GitHub #735).
+    "python-multipart>=0.0.20",
     "tortoise-orm[asyncpg]==1.1.8",
     "uvicorn[standard]>=0.52.3",
 ]

--- a/packages/screamingface/tests/test_runtime_extra_parity.py
+++ b/packages/screamingface/tests/test_runtime_extra_parity.py
@@ -1,0 +1,89 @@
+"""The [runtime] extra must declare what the bundled apps need.
+
+Mental model: the wheel smuggles three whole applications (gateway, scoreboard,
+engine) into `screamingface/_runtime`, but pip never reads THEIR pyprojects —
+it only resolves the client's `[runtime]` extra. So the extra is a hand-written
+mirror of the apps' direct dependencies, and any drift ships a broken install.
+
+Worked example (GitHub #735): the gateway declares `python-multipart>=0.0.20`
+for its FastAPI form endpoints. The extra didn't mirror it, so a fresh
+`pip install "screamingface[runtime]"` + `screamingface up` died at startup
+with `Form data requires "python-multipart" to be installed`. This test turns
+that bug class into a red gate at PR time.
+
+Stage 1 — read the client's pyproject: base deps + the [runtime] extra.
+Stage 2 — read each bundled app's pyproject: its direct `dependencies`.
+Stage 3 — every app dependency name must be covered by the client's names,
+unless it is on an explicit, commented allowlist (satisfied transitively, or
+vendored inside the wheel itself).
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+
+# WHY: mirrors scripts/runtime_build_hook.py — the same three apps it bundles
+# into the wheel are the ones whose dependencies the extra must cover.
+BUNDLED_APPS = ("aigateway", "scoreboard", "screamingface-engine")
+
+# INVARIANT: every name here must state HOW it is satisfied without being in
+# the extra — an entry without a reason is drift waiting to happen.
+SATISFIED_TRANSITIVELY = {
+    "pydantic",  # pulled by fastapi and pydantic-settings, both in the extra
+    "asyncpg",  # pulled by the extra's tortoise-orm[asyncpg]
+}
+VENDORED_IN_WHEEL = {
+    "url4",  # runtime_build_hook copies the url4 sources into the wheel itself
+}
+
+
+def _canonical(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _requirement_name(requirement: str) -> str:
+    # Dep strings here are simple ("name[extra]>=1.2"); cut at the first
+    # character that can't be part of a distribution name.
+    match = re.match(r"[A-Za-z0-9._-]+", requirement.strip())
+    assert match is not None, f"unparseable requirement: {requirement!r}"
+    return _canonical(match.group(0))
+
+
+def _project_dependencies(pyproject: Path) -> list[str]:
+    with pyproject.open("rb") as handle:
+        return tomllib.load(handle)["project"]["dependencies"]
+
+
+def test_runtime_extra_covers_every_bundled_app_dependency() -> None:
+    apps_dir = PACKAGE_ROOT.parents[1] / "apps"
+    if not apps_dir.is_dir():
+        # AIDEV-NOTE: sdists vendor only the apps' sources, not their
+        # pyprojects — this parity check is meaningful only in the checkout.
+        pytest.skip("bundled apps' pyprojects are only present in the monorepo checkout")
+
+    client = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text())
+    provided = {
+        _requirement_name(requirement)
+        for requirement in (
+            *client["project"]["dependencies"],
+            *client["project"]["optional-dependencies"]["runtime"],
+        )
+    }
+    allowed = provided | SATISFIED_TRANSITIVELY | VENDORED_IN_WHEEL
+
+    missing: dict[str, list[str]] = {}
+    for app in BUNDLED_APPS:
+        for requirement in _project_dependencies(apps_dir / app / "pyproject.toml"):
+            if _requirement_name(requirement) not in allowed:
+                missing.setdefault(app, []).append(requirement)
+
+    assert not missing, (
+        "bundled apps declare dependencies the [runtime] extra does not provide "
+        f"(a fresh `pip install screamingface[runtime]` will break): {missing}"
+    )

--- a/packages/screamingface/uv.lock
+++ b/packages/screamingface/uv.lock
@@ -2642,6 +2642,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "312"
 source = { registry = "https://pypi.org/simple" }
@@ -3081,6 +3090,7 @@ runtime = [
     { name = "prometheus-client" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "python-multipart" },
     { name = "tortoise-orm", extra = ["asyncpg"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -3119,6 +3129,7 @@ requires-dist = [
     { name = "pydantic-settings", marker = "extra == 'runtime'", specifier = ">=2.14.2" },
     { name = "pyjwt", marker = "extra == 'runtime'", specifier = "==2.13.0" },
     { name = "pynacl", specifier = ">=1.5" },
+    { name = "python-multipart", marker = "extra == 'runtime'", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "tortoise-orm", extras = ["asyncpg"], marker = "extra == 'runtime'", specifier = "==1.1.8" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'runtime'", specifier = ">=0.52.3" },

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -78,8 +78,8 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
     <CodeBlock :code="pypiTerminal" language="bash" />
 
     <p>
-      The <code>[notebook]</code> extra pulls in ipywidgets and jupyterlab, so
-      <code>sf.connect()</code> renders a live panel; drop it for scripts. Everything else,
+      The <code>[notebook]</code> extra pulls in ipywidgets, so <code>sf.connect()</code> renders a
+      live panel in whatever Jupyter frontend you already use; drop it for scripts. Everything else,
       including <RouterLink to="/learn/url4"><code>url4</code></RouterLink
       >, resolves automatically. A quick check that it worked:
     </p>


### PR DESCRIPTION
One-liner: a brand-new `pip install "screamingface[runtime]"` crashed at the very first command; this declares the missing dependency, adds a parity gate so the bug class can't return, and fixes the docs sentence that oversold the `[notebook]` extra.

## Before / After

### Before
- Trigger: a new user follows the Installation docs on a clean machine and runs `screamingface up`.
- Today: the runtime dies at startup — `Form data requires "python-multipart" to be installed` — because the wheel bundles the gateway but pip only resolves the client's `[runtime]` extra, which omitted the gateway's dependency. The docs also promise jupyterlab from `[notebook]`, which the wheel never shipped.
- Cost: onboarding dead at step 1 (GitHub #735, found on a fresh Windows laptop).

### After
- Same trigger.
- Now: `[runtime]` declares `python-multipart>=0.0.20` (the gateway's own pin) and the stack boots first try; the docs say what the `[notebook]` extra actually does.
- Win: fresh install → first command works; any future drift between a bundled app's deps and the extra is a red test, not a user bug report.

### Don't regress
- `[notebook]` deliberately stays panel-only (ipywidgets) per its pyproject INVARIANT — the docs sentence moved, not the extra.
- Base install gains no new dependencies.

## Root cause

The wheel smuggles three apps (gateway, scoreboard, engine) into `screamingface/_runtime`, but their pyprojects are invisible to pip — the `[runtime]` extra is a hand-written mirror. The gateway grew `python-multipart` for its FastAPI form endpoints; the mirror was never updated.

## Implementation

- `packages/screamingface/pyproject.toml` — add `python-multipart>=0.0.20` to `[runtime]` (+ lockfile).
- `packages/screamingface/tests/test_runtime_extra_parity.py` — NEW: every direct dependency of the three bundled apps must be covered by client base deps + `[runtime]`, with an explicit reasoned allowlist (transitively satisfied: pydantic, asyncpg; vendored: url4). RED before the fix named exactly `python-multipart`.
- `public-docs/.../InstallationPage.vue` — `[notebook]` sentence no longer claims jupyterlab.
- Ledger + docs/tasks mirror.

## Test plan

- `run_gates.py screamingface`: ALL GREEN (ruff, format, pyright, pytest cov≥95, notebook check, uv build, distribution check).
- public-docs: prettier --check, oxlint, eslint, `npm run build` clean.
- Before/after diagram + triage context: Linear OME-994.

Fixes #735
Refs: OME-994

🤖 Generated with [Claude Code](https://claude.com/claude-code)