### PR TITLE
fix(screamingface-engine): stop requiring every board's assets to run one benchmark

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/runtime.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/runtime.py
@@ -8,6 +8,7 @@ addresses and the evidence cardinality differ.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -39,9 +40,16 @@ from url4.peer.server import Request, Url4Node
 
 
 def install(node: Url4Node, root: Path, exam: DracoExam) -> None:
-    """Register the routes referenced by one DRACO board."""
-    cases_json, selected_cases, rubrics = _protocol_assets(root)
-    node.data(exam.routes.cases, cases_json, media_type="application/json")
+    """Register the routes referenced by one DRACO board.
+
+    INVARIANT (OME-999): install registers LAZY providers and reads no asset. A Runner world
+    carries every registered board, so an eager read here would make every other board's run
+    require DRACO's assets — the shared lazy-install contract HealthBench's install documents.
+    Assets load on the first resolution of one of THIS board's routes; only successes are
+    memoized, so a missing asset fails identically — and loudly — on every resolution.
+    """
+    assets = _lazy_protocol_assets(root)
+    node.data(exam.routes.cases, _cases(assets), media_type="application/json")
     node.endpoint(exam.routes.tasks)(_task_rows(root))
     # The mid-run check surface the corrective loop consumes. It closes over `node` so the
     # judge route resolves per request — installation must still work in a world that holds
@@ -65,20 +73,49 @@ def install(node: Url4Node, root: Path, exam: DracoExam) -> None:
     node.endpoint(exam.routes.aggregate)(
         aggregate_endpoint(
             label="DRACO",
-            available_case_count=len(selected_cases),
+            # WHY the constant: the lazy load validates len(cases) == CASE_COUNT on first
+            # resolution, so the eager `len(selected_cases)` this replaced was always equal.
+            available_case_count=CASE_COUNT,
             aggregate=_aggregate(
-                selected_cases,
-                rubrics,
+                assets,
                 exam,
             ),
         )
     )
 
 
+ProtocolAssets = tuple[str, list[dict[str, object]], dict[int, dict[str, Any]]]
+
+
+def _lazy_protocol_assets(root: Path) -> Callable[[], ProtocolAssets]:
+    """A memoized accessor for the board's shared assets — loaded on first use, never at install.
+
+    Baked assets are immutable for the process lifetime, so one successful load serves every
+    later resolution. A FAILED load is never cached: the next resolution re-reads and re-fails
+    with the same named error, keeping missing-asset failures loud rather than one-shot.
+    """
+
+    memo: dict[str, ProtocolAssets] = {}
+
+    def load() -> ProtocolAssets:
+        if "assets" not in memo:
+            memo["assets"] = _protocol_assets(root)
+        return memo["assets"]
+
+    return load
+
+
+def _cases(assets: Callable[[], ProtocolAssets]):
+    def cases() -> str:
+        return assets()[0]
+
+    return cases
+
+
 def _protocol_assets(
     root: Path,
-) -> tuple[str, list[dict[str, object]], dict[int, dict[str, Any]]]:
-    """Load and validate DRACO's shared assets before registering any route."""
+) -> ProtocolAssets:
+    """Load and validate DRACO's shared assets before serving any route."""
 
     raw = _read(root / "cases.json", "DRACO cases")
     selected = _parse_cases(raw)
@@ -205,11 +242,11 @@ def _criterion_evaluation(judge_passes: int):
 
 
 def _aggregate(
-    selected_cases: list[dict[str, object]],
-    rubrics: dict[int, dict[str, Any]],
+    assets: Callable[[], ProtocolAssets],
     exam: DracoExam,
 ):
     def aggregate(case_evaluations: str, selected_case_count: int) -> dict[str, Any]:
+        _cases_json, selected_cases, rubrics = assets()
         return scoring.aggregate(
             case_evaluations,
             rubrics,

--- a/apps/screamingface-engine/tests/unit/test_benchmark_asset_isolation.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_asset_isolation.py
@@ -1,0 +1,87 @@
+"""Board asset isolation — running one benchmark must not require any other board's assets.
+
+INVARIANT under test (OME-999): a Runner world carries EVERY registered board, so a board
+whose ``install()`` touches its assets eagerly makes every other board's run require them —
+a dev who prepared only GDPval could not evaluate it because DRACO's cases.json was missing.
+Install registers lazy providers; a board's assets are read on the first resolution of one
+of ITS routes, and a missing asset fails there, named by the board that owns it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from screamingface_engine.benchmarks.builtins import BUILTIN_DEPLOYMENT
+from screamingface_engine.benchmarks.draco.definition import CANONICAL_EXAM, CASES_ROUTE
+from screamingface_engine.benchmarks.draco.runtime import install as install_draco
+from url4 import RelUrl, Text, expr, render, src
+from url4.core.errors import ResolutionError
+from url4.peer.server import Url4Node
+
+
+async def _resolve_data(node: Url4Node, path: str) -> str:
+    expression = expr(
+        src(RelUrl(path), name="result", weight=0.0),
+        intent=Text("$result"),
+    )
+    return (await node.evaluate(render(expression))).text
+
+
+def test_every_builtin_board_installs_into_a_world_without_any_assets(tmp_path: Path) -> None:
+    # The registry-wide pin: install must never read an asset, for ANY registered board —
+    # this is the exact call the Runner makes when creating a world, over an empty root.
+    node = Url4Node("test")
+    BUILTIN_DEPLOYMENT.benchmarks.install(node, assets_root=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_an_unprepared_board_fails_at_its_own_route_with_its_own_name(
+    tmp_path: Path,
+) -> None:
+    # WHY: laziness must not soften the failure — DRACO without assets still fails loudly,
+    # at DRACO's route, named as DRACO, exactly as the eager path failed.
+    node = Url4Node("test")
+    install_draco(node, tmp_path, CANONICAL_EXAM)
+    with pytest.raises(ResolutionError, match="DRACO cases"):
+        await _resolve_data(node, CASES_ROUTE)
+
+
+@pytest.mark.asyncio
+async def test_a_board_reads_its_assets_once_across_resolutions(tmp_path: Path) -> None:
+    # Baked assets are immutable for the process lifetime; the memo must serve every later
+    # resolution without re-reading, and both resolutions must serve identical bytes.
+    (tmp_path / "criteria").mkdir(parents=True)
+    (tmp_path / "rubrics").mkdir()
+    cases = [{"id": case_id, "input": f"Question {case_id}"} for case_id in range(1, 101)]
+    (tmp_path / "cases.json").write_text(json.dumps(cases), encoding="utf-8")
+    for case_id in range(1, 101):
+        (tmp_path / "criteria" / f"{case_id}.json").write_text(
+            '[{"id":"c1","requirement":"Be correct","criterion_type":"positive"}]',
+            encoding="utf-8",
+        )
+        (tmp_path / "rubrics" / f"{case_id}.json").write_text(
+            '{"sections":[{"id":"accuracy","criteria":[{"id":"c1","weight":1}]}]}',
+            encoding="utf-8",
+        )
+    node = Url4Node("test")
+    install_draco(node, tmp_path, CANONICAL_EXAM)
+
+    reads: list[Path] = []
+    original = Path.read_text
+
+    def counting(self: Path, encoding: str | None = None, errors: str | None = None) -> str:
+        reads.append(Path(self))
+        return original(self, encoding=encoding, errors=errors)
+
+    try:
+        Path.read_text = counting  # type: ignore[method-assign]
+        first = await _resolve_data(node, CASES_ROUTE)
+        second = await _resolve_data(node, CASES_ROUTE)
+    finally:
+        Path.read_text = original  # type: ignore[method-assign]
+
+    assert first == second
+    assert reads.count(tmp_path / "cases.json") == 1

--- a/apps/screamingface-engine/tests/unit/test_draco_case_evaluation_route.py
+++ b/apps/screamingface-engine/tests/unit/test_draco_case_evaluation_route.py
@@ -22,7 +22,7 @@ from screamingface_engine.benchmarks.draco.definition import (
 from screamingface_engine.benchmarks.draco.records import CASE_SCHEMA, CHECK_SCHEMA
 from screamingface_engine.benchmarks.draco.runtime import install
 from screamingface_engine.benchmarks.draco.verdict import SCHEMA as VERDICT_SCHEMA
-from url4 import RelExpr, Text, expr, render, src
+from url4 import RelExpr, RelUrl, Text, expr, render, src
 from url4.core.errors import ResolutionError
 from url4.peer.server import Url4Node
 
@@ -172,23 +172,43 @@ def test_case_record_requires_explicit_execution_provenance() -> None:
         bind_criterion_evaluation(1, case, check, [evidence])
 
 
-def test_install_fails_atomically_when_assets_are_missing(tmp_path: Path) -> None:
+# WHY these two tests were REWRITTEN (OME-999, owner-approved): install used to validate
+# assets ATOMICALLY, refusing to register routes over a broken asset set. That eager read
+# meant a Runner world — which installs EVERY registered board — required DRACO's assets to
+# run any other board. Install is now lazy (the shared contract HealthBench's install
+# documents); the protection moves to resolution: a DRACO run's first touch is its cases
+# route, so a broken asset still fails before any model spend, with the same named error —
+# on EVERY resolution, since failures are never memoized.
+
+
+async def _fetch_cases(node: Url4Node) -> str:
+    expression = expr(
+        src(RelUrl(CASES_ROUTE), name="result", weight=0.0),
+        intent=Text("$result"),
+    )
+    return (await node.evaluate(render(expression))).text
+
+
+@pytest.mark.asyncio
+async def test_missing_assets_fail_every_cases_resolution_by_name(tmp_path: Path) -> None:
     node = Url4Node("test")
+    install(node, tmp_path, CANONICAL_EXAM)
 
-    with pytest.raises(ResolutionError, match="could not read DRACO cases"):
-        install(node, tmp_path, CANONICAL_EXAM)
+    for _attempt in range(2):  # never memoized: the second resolution fails identically
+        with pytest.raises(ResolutionError, match="could not read DRACO cases"):
+            await _fetch_cases(node)
 
-    assert CASES_ROUTE not in node.processor_routes()
 
-
-def test_canonical_install_rejects_a_truncated_case_set_atomically(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_a_truncated_case_set_fails_resolution_with_the_expected_count(
+    tmp_path: Path,
+) -> None:
     _one_case_assets(tmp_path)
     node = Url4Node("test")
+    install(node, tmp_path, CANONICAL_EXAM)
 
     with pytest.raises(ResolutionError, match="expected 100 DRACO cases"):
-        install(node, tmp_path, CANONICAL_EXAM)
-
-    assert CASES_ROUTE not in node.processor_routes()
+        await _fetch_cases(node)
 
 
 def test_asset_validation_rejects_duplicate_case_ids(tmp_path: Path) -> None:

--- a/docs/tasks/2026-08-26-OME-999-per-board-asset-isolation.md
+++ b/docs/tasks/2026-08-26-OME-999-per-board-asset-isolation.md
@@ -1,0 +1,21 @@
+---
+id: OME-999
+linear_url: https://linear.app/openmined/issue/OME-999/running-one-benchmark-no-longer-requires-every-other-benchmarks-assets
+status: in_progress
+type: null
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-26
+closed: null
+---
+
+# Running one benchmark no longer requires every other benchmark's assets
+
+`prepare gdpval` then `evaluate(benchmark="gdpval-text")` dies on DRACO's missing assets:
+world creation installs every registered board, and DRACO's `install()` reads its assets
+eagerly — the one violator of the lazy-install invariant HealthBench's docstring documents
+and IFEval/HealthBench/GDPval honor.
+
+Fix: lazy providers in DRACO's install + a registry-level regression test pinning the
+invariant (full builtin install over an empty assets root succeeds; only a board's own
+route resolution requires its assets). Details in the Linear issue.

--- a/docs/work/2026-08-26-OME-999-per-board-asset-isolation.md
+++ b/docs/work/2026-08-26-OME-999-per-board-asset-isolation.md
@@ -1,0 +1,63 @@
+---
+ticket: OME-999
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-26
+finished:
+---
+
+# OME-999 — Running one benchmark no longer requires every other benchmark's assets
+
+## Intent
+
+A dev who prepared only GDPval's assets cannot evaluate `gdpval-text`: world creation
+installs every registered board, and DRACO's `install()` reads its assets EAGERLY
+(`_protocol_assets(root)` at `draco/runtime.py:43`), so any run for any board demands
+DRACO's `cases.json`. The lazy-install invariant is already documented in HealthBench's
+install docstring and honored by IFEval, HealthBench, and GDPval — DRACO is the one
+violator. Make DRACO lazy and pin the invariant registry-wide so no future board can
+regress it.
+
+## Planned changes
+
+- `src/screamingface_engine/benchmarks/draco/runtime.py` — `install()` registers lazy
+  providers: a memoized `_lazy_protocol_assets(root)` accessor shared by the cases data
+  route and the aggregate handler; `available_case_count` becomes the static `CASE_COUNT`
+  (the eager load validated equality anyway). Failures never cached.
+- `tests/unit/test_benchmark_asset_isolation.py` — NEW: (1) installing every builtin board
+  (`BUILTIN_DEPLOYMENT.benchmarks.install`) into a world over an EMPTY assets root
+  succeeds; (2) resolving DRACO's cases route without its assets fails with DRACO's own
+  named error; (3) DRACO reads its assets once per board across repeated resolutions.
+
+## Test plan
+
+- RED: registry-wide empty-root install currently raises via DRACO → test 1 fails.
+- RED: with install fixed, route resolution must fail lazily with the same
+  `benchmark_unavailable` message the eager path produced → test 2.
+- Memo behavior: repeated cases-route resolutions read `cases.json` once → test 3.
+- All existing DRACO tests stay green and unmodified — they write fixtures BEFORE
+  resolving routes, so laziness is invisible to them.
+
+## Acceptance
+
+- `prepare gdpval` alone suffices to evaluate `gdpval-text` locally (no DRACO assets).
+- Running DRACO without assets fails at DRACO's own route with its existing message.
+- Both gate suites green; no prior test altered.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `benchmarks/draco/runtime.py` (lazy `_lazy_protocol_assets`
+  accessor + `_cases` provider, `available_case_count=CASE_COUNT`, `_aggregate` takes the
+  accessor), new `tests/unit/test_benchmark_asset_isolation.py` (3 tests), PLUS one deviation:
+  two prior tests in `tests/unit/test_draco_case_evaluation_route.py` rewrote from
+  install-time-atomic to resolution-time-named failures.
+- **Commits:** one commit on `OME-999-per-board-assets` (sha in git log).
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` — ruff, format, pyright,
+  layering, pytest 2,047 passing w/ coverage — ALL GREEN. The skip flag covers exactly the
+  owner-approved rewrite of the two atomic-install tests; a WHY comment above them records
+  the approval and the reasoning.
+- **Deviations:** the two prior DRACO tests pinned the eager contract and were mutually
+  exclusive with the lazy invariant — surfaced, owner approved the rewrite in plain words
+  ("this is a good design … rewrite those tests"). Failure protection moved, not removed:
+  a DRACO run's first touch is its cases route, so broken assets still fail before model
+  spend, with the same named errors, on every resolution.


### PR DESCRIPTION
Running one benchmark no longer requires every other benchmark's assets.

**Asana:** _n/a — technical work; tracked in Linear as [OME-999](https://linear.app/openmined/issue/OME-999/running-one-benchmark-no-longer-requires-every-other-benchmarks-assets)_

## Before / After

### Before
- Trigger: a dev prepares ONE benchmark's assets (`screamingface prepare gdpval`) and evaluates that board locally
- Today: the run dies with `ExecutionError: could not read DRACO cases … benchmark_unavailable` — a board they never asked for. World creation installs every registered board, and DRACO's `install()` reads its assets eagerly
- Cost: every local tester must `prepare --all` (every board's dataset) to run any single board; each new benchmark raises the setup cost of all the others; the error names the wrong board

### After
- Same trigger
- Now: the run works with only that board's assets prepared — a board's assets are read on the first resolution of one of ITS routes
- Win: `prepare gdpval` → evaluate `gdpval-text` — done. Board setup costs are independent

### Don't regress
- DRACO's missing/truncated-asset failures stay loud and named — they fire on EVERY resolution of a DRACO route (never memoized), and a DRACO run's first touch is its cases route, so still before any model spend
- Registry install-time validation (protocol rendering, endpoint-coverage) is untouched — it needs no assets
- Both DRACO boards still share one lazily-loaded asset read per board

## Root cause + fix

The lazy-install contract is already documented in HealthBench's `runtime.install` docstring and honored by IFEval, HealthBench, and GDPval — their installs register closures. DRACO was the one violator: `draco/runtime.py::install` called `_protocol_assets(root)` eagerly and registered the result as a static data value.

The fix gives DRACO a memoized lazy accessor shared by the cases route and the aggregate handler (successes cached, failures never), and `available_case_count` becomes the static `CASE_COUNT` the eager load validated equality against anyway.

## Components touched

- `apps/screamingface-engine` only — `benchmarks/draco/runtime.py` + tests

## Test plan

- [x] New `test_benchmark_asset_isolation.py`: (1) every builtin board installs into a world over an EMPTY assets root — the registry-wide pin that stops any future board reintroducing the coupling; (2) an unprepared DRACO fails at its own route with its own name; (3) assets are read once across resolutions
- [x] **Owner-approved rewrite of two prior tests** (`test_draco_case_evaluation_route.py`): the atomic-install contract they pinned is mutually exclusive with the lazy invariant; failure protection moved to resolution time with the same named messages. A WHY comment above them records the approval and reasoning; gates ran with `--skip-append-only` for exactly this change
- [x] `run_gates.py screamingface-engine` — ruff, format, pyright, layering, pytest (2,047 passing w/ coverage) ALL GREEN
- [ ] Gateway request/refresh change → n/a
- [ ] Screenshots / recording → n/a

## Cross-service notes

None — single-app change. Surfaced while testing PR #714's GDPval notebook: `prepare gdpval` alone, then `evaluate(benchmark="gdpval-text")` → DRACO error. After merge, that flow works with only GDPval's assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)