### PR TITLE
docs(repo): close the OME-964 task mirror

### DIFF
--- a/docs/tasks/2026-08-24-OME-964-golden-scores.md
+++ b/docs/tasks/2026-08-24-OME-964-golden-scores.md
@@ -1,12 +1,12 @@
 ---
 id: OME-964
 linear_url: https://linear.app/openmined/issue/OME-964/fail-ci-when-a-change-shifts-a-published-benchmark-score
-status: in_progress
+status: done
 type: feature
 priority: 3
 labels: [py-screamingface, agentic, deferred]
 created: 2026-08-24
-closed:
+closed: 2026-08-26
 ---
 
 # Turn one real benchmark run into a free CI replay that fails when the published score drifts

--- a/packages/screamingface/tests/e2e/README.md
+++ b/packages/screamingface/tests/e2e/README.md
@@ -3,7 +3,7 @@
 One paid run becomes a permanent free regression test: CI replays the whole benchmark
 from committed fixtures and goes red when the published number drifts.
 
-<img src="../../../../docs/diagrams/e2e-board-onboarding.png" width="900">
+<img src="../../../../docs/diagrams/e2e-board-onboarding.png" width="1300">
 
 ## The five steps
 
@@ -23,7 +23,7 @@ SCREAMINGFACE_TEST_E2E=1 uv run pytest tests/e2e -rs        # opt-in, needs dock
 
 ## How the bless run moves the data
 
-<img src="../../../../docs/diagrams/e2e-replay-data-flow.png" width="900">
+<img src="../../../../docs/diagrams/e2e-replay-data-flow.png" width="1200">
 
 Everything below the recordings runs in throwaway Docker containers with **no API
 keys** — a cache miss is a loud failure, never a live call. Full mechanics: the


### PR DESCRIPTION
Housekeeping after #722 merged: flips the OME-964 docs/tasks mirror to done (close status lives in both Linear and the mirror), and carries the owner's post-merge diagram-width tweak to the e2e README.

Refs: OME-964

🤖 Generated with [Claude Code](https://claude.com/claude-code)