### PR TITLE
docs(spec): report-intake service (OME-1004)

### DIFF
--- a/docs/spec/2026-08-26-OME-1004-report-intake-service.md
+++ b/docs/spec/2026-08-26-OME-1004-report-intake-service.md
@@ -48,8 +48,18 @@ one bad database into a restart loop; `/readyz` is the one that may fail closed.
 
 ### 2.1 Request
 
-`Content-Type: application/json`. No form encoding — the client posts kernel-side from
-Python, never from a browser.
+`Content-Type: application/json` only. **No form encoding, from any client.** In the
+notebook that decision is load-bearing: an HTML `<form>` would serialize the report body
+and any credential into the saved `.ipynb`, and JupyterLab's sanitizer strips `action` and
+`name` from untrusted output anyway, so the notebook client posts kernel-side. Browser
+clients — the portal and aigateway-ui — post the same JSON with `fetch`; they are
+first-class callers, not an exception.
+
+Because browser callers are first-class, the service is CORS-relevant: JSON bodies are not
+simple requests, so every browser submission is preceded by a preflight. Allow the origins
+the clients actually run on, allow `Content-Type` and `Idempotency-Key`, and **do not**
+allow credentials — the mesh supplies identity, so no cookie ever needs to cross. An origin
+allowlist is not an authorization control and is not counted as one.
 
 | Header | Meaning |
 |---|---|
@@ -63,13 +73,19 @@ Python, never from a browser.
   "occurred_at": "2026-08-26T14:03:11.204Z",   // required, RFC 3339
 
   "client": {                                   // required
-    "name": "screamingface",
+    "name": "screamingface-python",             // the SDK or app, NOT the language
     "version": "0.1.1.post5",
-    "platform": "darwin",
-    "python": "3.13.1",
     "host": "notebook",                         // notebook | cli | studio | web
-    "frontend": "jupyterlab/4.5.3",             // nullable; browser-side, via widget comm
-    "user_agent": "..."                         // nullable; browser-side
+    "platform": "darwin",                       // darwin | linux | windows | browser
+    "runtime": {                                // the language runtime
+      "name": "cpython",                        // cpython | node | browser | …
+      "version": "3.13.1"
+    },
+    "frontend": {                               // nullable; browser-side, via widget comm
+      "name": "jupyterlab",
+      "version": "4.5.3"
+    },
+    "user_agent": "..."                         // nullable; browser-side, opaque
   },
 
   "error": {                                    // required
@@ -102,6 +118,36 @@ Python, never from a browser.
   "reply_to": "someone@example.org"             // nullable, self-asserted, never identity
 }
 ```
+
+**`client` is language-neutral by construction.** Three of the four client surfaces are not
+Python — Studio (Electron), aigateway-ui (Next.js), and the portal (browser JS) — so no
+field may name a language. `name` identifies the SDK or app; `runtime` identifies whatever
+executes it. The same `{name, version}` pair is reused for `client`, `runtime`, and
+`frontend` so that "which versions are failing?" is a group-by rather than a string parse.
+
+| Surface | `name` | `host` | `platform` | `runtime.name` |
+|---|---|---|---|---|
+| Python SDK | `screamingface-python` | `notebook` / `cli` | `darwin` / `linux` / `windows` | `cpython` |
+| Studio (Electron) | `screamingface-studio` | `studio` | `darwin` / `linux` / `windows` | `node` |
+| aigateway-ui | `aigateway-ui` | `web` | `browser` | `browser` |
+| Portal | `scoreboard-portal` | `web` | `browser` | `browser` |
+
+Studio reports as `node`, not `browser`: Electron's renderer cannot make the external call
+(CORS), so the submission runs in the main process. Studio is a click-through prototype
+today, so its row is the contract it will satisfy, not behaviour that exists.
+
+**The vocabularies are documented, not enforced.** `host`, `platform`, and `runtime.name`
+carry the values listed above, but an unrecognised value is **stored, not rejected** — it is
+triage metadata and routes nothing in v1. A client shipping before the service learns its
+name must still be able to report a bug. Each is a bounded string (§2.4) and is escaped at
+ticket-render time; nothing is ever branched on. Only *structural* violations reject.
+
+**Unknown keys: forbidden at the top level, preserved inside `client` and `context`.** The
+top level is a small stable set, so an unknown key there is a typo worth a `422`. `client`
+and `context` are the extension points, and clients in four languages will not ship in
+lockstep — a `node` client adding `electron_version` must not be rejected by a service that
+predates it. Unknown keys inside those two objects are stored verbatim, counted against the
+depth and key-count caps, and never interpreted.
 
 **`error.message` is carried verbatim and must not be "cleaned up" into structured
 fields.** In the current client the WebSocket close code and elapsed seconds exist *only*
@@ -169,13 +215,17 @@ Concrete, because "bounded" is how `OME-969` happened.
 | `error.traceback` | 32 KiB | truncate **head and tail kept**, mark |
 | `error.details` | 8 KiB | truncate, mark |
 | `notes[]` | 16 items | drop excess, mark |
+| any `client` / `context` string | 256 B | truncate, mark |
+| `user_agent` | 1 KiB | truncate, mark |
 | JSON depth | 6 | `422` |
 | object keys per node | 64 | `422` |
 
 Oversized *individual strings* are truncated with an explicit marker rather than rejected —
 a truncated report is worth more than no report. Only the total body cap and structural
 violations reject. Truncation keeps the head **and** tail of a traceback, because the
-innermost frame is usually the informative one.
+innermost frame is usually the informative one — and runtimes disagree about which end that
+is. CPython renders it last, V8's `Error.stack` renders it first. Keeping both ends means
+the truncator does not need to know which runtime produced the string.
 
 Control characters other than tab and newline are stripped from every free-text field.
 

--- a/docs/spec/2026-08-26-OME-1004-report-intake-service.md
+++ b/docs/spec/2026-08-26-OME-1004-report-intake-service.md
@@ -9,9 +9,13 @@ date: 2026-08-26
 
 `apps/report-intake` accepts an error report from a ScreamingFace client, persists it, and
 files it into the **private** Linear workspace. Its reason to exist is that a reporter
-should need no account of their own — the service holds the credential, so a researcher in
-a notebook can send a diagnosable bug report without a GitHub login, a Linear seat, or an
-email we can verify.
+should need no account of their own: a researcher in a notebook can send a diagnosable bug
+report without a GitHub login, a Linear seat, or an email we can verify.
+
+In v1 the service itself holds no Linear credential either — `QueueSink` stores the report
+and an agent files it via MCP during triage (§9). The reporter-needs-no-account property
+comes from the service standing between the reporter and the tracker, not from the service
+holding a key.
 
 Epic: `OME-1002`. The decisions behind it are recorded in
 `docs/spec/2026-08-22-observability-traceability-review.md` §6 Phase 3 and in the
@@ -65,7 +69,7 @@ allowlist is not an authorization control and is not counted as one.
 |---|---|
 | `Idempotency-Key` | client-minted; recommended. Absent means the service cannot dedupe a retry. |
 | `X-User-Email` | **honoured only when injected by the mesh.** Any client-supplied copy is stripped at the edge. |
-| `Cf-Turnstile-Response` | present only if anonymous submission is admitted — see §7. |
+| `Cf-Turnstile-Response` | **required for anonymous callers**; ignored for mesh-verified ones — see §7. |
 
 ```jsonc
 {
@@ -195,13 +199,23 @@ RFC 9457 `application/problem+json`, matching the engine's existing convention i
 | Status | Cause |
 |---|---|
 | `400` | malformed JSON; unknown `schema` **major** |
+| `403` | bot gate not satisfied — anonymous caller, missing or invalid Turnstile token |
 | `413` | body over cap — `detail` **names the cap** |
 | `422` | schema violation (field pointers), or content rejected (§4) |
 | `429` | rate limited |
-| `503` | storage unavailable |
+| `503` | storage unavailable, **or** the bot gate could not be evaluated |
 
 A `503` is meaningful to the client: it means *nothing was stored*, so the client must fall
 back to writing the report to disk rather than assuming delivery.
+
+**`403` and `503` split the two ways a gate can stop a report, because the client must do
+different things.** A `403` says *your token was missing or rejected* — obtain a fresh one
+and retry; retrying the same token is pointless. A `503` says *we could not reach
+siteverify* — nothing was stored, so back off and retry unchanged, exactly as for storage.
+Collapsing both into one status would make one of those two behaviours wrong.
+
+A mesh-verified caller never sees `403`: identity satisfies the gate, so the Turnstile path
+is not reached (§7).
 
 ### 2.4 Caps
 
@@ -292,9 +306,13 @@ for idempotency, retry, and operational forensics.
 `TicketSink` is a port. Core defines it; core never imports an adapter; wiring happens in a
 registry.
 
-- **`LinearSink`** — creates the issue directly. Requires the `OME-976` amendment.
-- **`QueueSink`** — the fallback: mark the record ready and let an agent file it via MCP
-  during triage. Still private Linear, but asynchronous and with no ticket id returned.
+- **`QueueSink`** — **v1.** Mark the record ready and let an agent file it via MCP during
+  triage. Still private Linear, but asynchronous and with no ticket id returned.
+- **`LinearSink`** — **deferred**, gated on `OME-976`. Creates the issue directly. See §9.
+
+A sink receives already-rendered ticket content, never a report object. An adapter cannot
+leak a payload it was never handed, which is what keeps the §4 content rule enforceable at
+the port rather than by convention inside each adapter.
 
 **Ticket content:** the envelope, `trace_id`, `ref`, the reporter's note, `reply_to` when
 present, and the caller email when the mesh supplied one. **Never** prompt-bearing content
@@ -307,7 +325,15 @@ limits.
 
 ## 7. Identity and auth
 
-Settled regardless of the open fork:
+**Anonymous submission is admitted** (owner, 2026-08-26 — see §9). Two caller classes reach
+the same endpoint:
+
+- **Mesh-verified** — Envoy injected `X-User-Email` after re-verifying the Cloudflare Access
+  assertion. The bot gate is skipped; identity already answers the question the gate asks.
+- **Anonymous** — no mesh identity. A valid Cloudflare Turnstile token is required (`403`
+  without one) and an edge rate limit applies (`429`).
+
+Settled for both classes:
 
 - `X-User-Email` is trusted **only** when Envoy injects it after re-verifying the
   Cloudflare Access assertion, exactly as aigateway does. Client-supplied copies are
@@ -319,7 +345,16 @@ Settled regardless of the open fork:
 - **Nothing is ever authorized by `trace_id` or `run_id`.** An id in a report is a claim,
   not a credential (`OME-966`).
 
-The rest depends on the `OME-973` fork — see §9.
+Two consequences of admitting anonymous callers, both binding on implementation:
+
+- **The rate-limit key must not be attacker-controlled.** Trusting `CF-Connecting-IP`
+  whenever the peer is inside the trusted networks means trusting it always, since the mesh
+  proxy is always the peer. Key on the verified connection, strip inbound copies of
+  `CF-Connecting-IP` at the edge alongside `X-User-Email`, and make key-table overflow refuse
+  new keys as throttled rather than evicting old ones — filling the table must fail closed.
+- **The bot gate never gates liveness.** `/healthz` and `/readyz` answer regardless of caller
+  class or auth posture. A probe endpoint behind an auth check is how a pod ends up failing
+  its own kubelet probe.
 
 ## 8. Failure modes
 
@@ -332,34 +367,53 @@ The rest depends on the `OME-973` fork — see §9.
 | over body cap | `413` naming the cap | truncate and retry once, else disk |
 | content present | `422` | drop content, resend envelope |
 | rate limited | `429` | back off, offer disk fallback |
+| no/invalid bot token | `403`, nothing stored | fetch a fresh token, retry once, else disk |
+| siteverify unreachable | `503`, nothing stored | back off and retry unchanged, else disk |
 
 The client rule behind this table: **a report is never lost.** Every terminal failure path
 ends with the report on the user's disk and a path printed.
 
-## 9. Open decisions
+## 9. Decisions
 
-Both block implementation, not this spec.
+Both forks that blocked implementation were settled by the owner on 2026-08-26. Recorded
+here rather than only in a ticket, because an unwritten amendment is the thing that gets
+re-litigated in six months.
 
-**`OME-976` — rule 9.** As written, CLAUDE.md rule 9 forbids product code from calling
-Linear's API. Amending it selects `LinearSink`; declining selects `QueueSink` and the
-reporter stops getting a ticket id. The amendment must also state where the credential
-lives and who rotates it — a long-lived Linear API key in a deployed service is a new
-secret class for this repo.
+**Sink — `QueueSink` for v1; `LinearSink` deferred.** CLAUDE.md rule 9 forbids product code
+from calling Linear's API. Rather than amend the rule to unblock this service, v1 ships the
+`TicketSink` port with `QueueSink` only: the service marks a record ready and an agent files
+it via MCP during triage. Reports still reach private Linear; the reporter gets a `ref` but
+no ticket id, which the success shape already models as `delivery.state: "pending"`.
 
-**`OME-973` — anonymous or authenticated.** This decides whether the abuse surface exists
-at all.
+This keeps `OME-976` off the critical path and introduces no new secret class — no long-lived
+Linear API key in a deployed service. `LinearSink` remains a follow-up gated on `OME-976`
+landing *and* on a decision about where that credential lives and who rotates it. Because
+the port is the seam, adding it later is one adapter plus one registry entry.
 
-| | Authenticated | Anonymous |
+**Auth — anonymous submission is admitted**, with Turnstile and an edge rate limit;
+mesh-verified callers bypass the gate.
+
+| | Mesh-verified | Anonymous |
 |---|---|---|
-| gate | none | Turnstile + edge rate limit |
+| gate | none — identity suffices | Turnstile (`403`) + edge rate limit (`429`) |
 | `X-User-Email` | mesh-injected | absent |
-| `reply_to` | ignored | accepted, unverified |
+| `reply_to` | accepted, but identity is already known | accepted, unverified |
 | content | rejected | rejected |
 
-Admitting anonymous callers makes this the repo's first unauthenticated write that reaches
-human eyes, in a codebase with no rate limiting anywhere. The stakes rose when reports were
-routed to private Linear: spam lands in the workspace the team works in, rather than a
-public tracker that could be moderated at arm's length.
+This was chosen knowing it is the larger surface. The reason is that the client producing the
+richest reports is the one that cannot authenticate: the Python SDK holds a Cloudflare Access
+token but parses only `exp` from it, so it has no email and no way to present one.
+Authenticated-only would have made the best reports unsendable.
+
+The cost is real and is accepted: this becomes the repo's **first unauthenticated write that
+reaches human eyes**, in a codebase with no rate limiting anywhere today, and spam lands in
+the private workspace the team works in rather than a public tracker moderated at arm's
+length. Turnstile and the edge rate limit are therefore part of the work, not a follow-up —
+see the two binding constraints in §7.
+
+**Still open, and owned elsewhere:** `OME-967` (client-minted trace id) is a degradation, not
+a blocker. `correlation` is all-nullable by design, so a report without a trace id is weaker,
+not invalid — until it lands, reports join on *(endpoint, approximate timestamp)* only.
 
 ## 10. Verification
 
@@ -373,5 +427,12 @@ public tracker that could be moderated at arm's length.
 - The same `Idempotency-Key` twice produces one row and one ticket.
 - Storage down returns `503` and creates nothing.
 - A forged `X-User-Email` from outside the mesh is not honoured.
+- An anonymous request with no Turnstile token is `403` and creates nothing; with a valid
+  token it is accepted; a mesh-verified request is accepted with no token at all.
+- With siteverify unreachable, the response is `503` and not `403` — the client must be told
+  to retry unchanged rather than to fetch a new token.
+- Rotating the client-IP header does not reset the rate-limit budget, and filling the key
+  table throttles rather than releasing budgets.
+- `/healthz` answers 200 from a non-loopback caller in every auth posture.
 - `helm template` renders for default and prod values; `verify_chart_wiring.py` asserts
   something real about this chart; liveness and readiness point at **different** endpoints.

--- a/docs/spec/2026-08-26-OME-1004-report-intake-service.md
+++ b/docs/spec/2026-08-26-OME-1004-report-intake-service.md
@@ -1,0 +1,327 @@
+---
+title: Report-intake service
+ticket: OME-1004
+status: draft
+date: 2026-08-26
+---
+
+# Report-intake service
+
+`apps/report-intake` accepts an error report from a ScreamingFace client, persists it, and
+files it into the **private** Linear workspace. Its reason to exist is that a reporter
+should need no account of their own — the service holds the credential, so a researcher in
+a notebook can send a diagnosable bug report without a GitHub login, a Linear seat, or an
+email we can verify.
+
+Epic: `OME-1002`. The decisions behind it are recorded in
+`docs/spec/2026-08-22-observability-traceability-review.md` §6 Phase 3 and in the
+pre-decision `OME-973`.
+
+## 1. Non-goals
+
+These are settled and should not be re-litigated during implementation.
+
+- **No bundle or blob store.** Prompt-bearing content is rejected, not stored. This removes
+  content-addressing, TTL sweeps, a retention policy, and an Access-gated read surface from
+  the service entirely.
+- **No `GET /v1/reports/{ref}`.** It was inherited from a browser-form design that no
+  longer exists; with a kernel-side POST nothing consumes it. Support questions are
+  answered from our own storage.
+- **No query or search API, no triage logic, no human sessions, no UI.** Triage happens in
+  Linear.
+- **It is its own app.** It cannot be added to scoreboard (the submitter check is a plain
+  call rather than a `Depends`; production is Traefik-fronted rather than Access-meshed, so
+  `X-User-Email` is forgeable there; and flipping `authMode` CrashLoops on current chart
+  defaults) or to aigateway-ui (whose chart fails the render on `ingress.enabled=true` —
+  unreachability *is* its authentication boundary).
+
+## 2. API
+
+```
+POST /v1/reports              the only write
+GET  /healthz                 liveness, static
+GET  /readyz                  readiness, checks storage
+```
+
+`/healthz` must never touch storage. A liveness probe that depends on the database turns
+one bad database into a restart loop; `/readyz` is the one that may fail closed.
+
+### 2.1 Request
+
+`Content-Type: application/json`. No form encoding — the client posts kernel-side from
+Python, never from a browser.
+
+| Header | Meaning |
+|---|---|
+| `Idempotency-Key` | client-minted; recommended. Absent means the service cannot dedupe a retry. |
+| `X-User-Email` | **honoured only when injected by the mesh.** Any client-supplied copy is stripped at the edge. |
+| `Cf-Turnstile-Response` | present only if anonymous submission is admitted — see §7. |
+
+```jsonc
+{
+  "schema": "screamingface.error-report/v1",   // required
+  "occurred_at": "2026-08-26T14:03:11.204Z",   // required, RFC 3339
+
+  "client": {                                   // required
+    "name": "screamingface",
+    "version": "0.1.1.post5",
+    "platform": "darwin",
+    "python": "3.13.1",
+    "host": "notebook",                         // notebook | cli | studio | web
+    "frontend": "jupyterlab/4.5.3",             // nullable; browser-side, via widget comm
+    "user_agent": "..."                         // nullable; browser-side
+  },
+
+  "error": {                                    // required
+    "type": "ExecutionError",
+    "code": "websocket_disconnected",
+    "message": "...",                           // carried VERBATIM — see note below
+    "status": null,
+    "permanent": false,
+    "retryable": true,
+    "hint": "...",
+    "notes": ["..."],
+    "details": { },                             // nullable; unbounded server JSON — see caps
+    "cause": { "type": "...", "rcvd": { "code": 1011, "reason": "..." } },
+    "traceback": "..."                          // nullable
+  },
+
+  "correlation": {                              // all nullable
+    "trace_id": null,
+    "run_id": null,
+    "gateway_call_id": null
+  },
+
+  "context": {                                  // nullable throughout
+    "engine_host": "engine.screamingface.ai",   // HOST only, never a full URL or query
+    "benchmark": { "id": "...", "revision": "..." },
+    "candidate": { "name": "...", "kind": "fusion", "models": ["..."] }
+  },
+
+  "note": "...",                                // nullable, user free text
+  "reply_to": "someone@example.org"             // nullable, self-asserted, never identity
+}
+```
+
+**`error.message` is carried verbatim and must not be "cleaned up" into structured
+fields.** In the current client the WebSocket close code and elapsed seconds exist *only*
+inside that string — `ExecutionError` adds no attributes over its base. A future client may
+add structured fields; until then, discarding the message loses the two facts that most
+often explain a disconnect.
+
+**`context` is caller-supplied.** A generic `except` around an evaluation gets none of it,
+because the runner re-raises untouched and the transport attaches no candidate. The service
+must treat every `context` field as optional and must never infer it.
+
+### 2.2 Success
+
+One shape, for both new reports and replays.
+
+```jsonc
+{
+  "ref": "r_8f21c0",
+  "classification": "envelope",                 // the SERVER's verdict, not the client's
+  "delivery": {
+    "state": "delivered",                       // delivered | pending | failed
+    "ticket": { "id": "OME-1042", "url": "https://linear.app/..." }   // null unless delivered
+  }
+}
+```
+
+- `202 Accepted` — a new report was persisted.
+- `200 OK` — idempotent replay; the original record is returned unchanged.
+
+`202` rather than `201` is deliberate: it encodes that the report is durable while the
+ticket may not exist yet. Delivery is attempted inline with a **3 s** timeout, so `state`
+is usually `delivered` and the ticket id returns on the first call; a slow or failing sink
+degrades to `pending` instead of failing the reporter's request.
+
+### 2.3 Errors
+
+RFC 9457 `application/problem+json`, matching the engine's existing convention in
+`auth/problem.py`.
+
+```jsonc
+{ "type": "about:blank", "title": "Payload Too Large", "status": 413,
+  "detail": "report body is 91 kB; the limit is 64 kB" }
+```
+
+| Status | Cause |
+|---|---|
+| `400` | malformed JSON; unknown `schema` **major** |
+| `413` | body over cap — `detail` **names the cap** |
+| `422` | schema violation (field pointers), or content rejected (§4) |
+| `429` | rate limited |
+| `503` | storage unavailable |
+
+A `503` is meaningful to the client: it means *nothing was stored*, so the client must fall
+back to writing the report to disk rather than assuming delivery.
+
+### 2.4 Caps
+
+Concrete, because "bounded" is how `OME-969` happened.
+
+| Limit | Value | On breach |
+|---|---|---|
+| total body | 64 KiB | `413` |
+| `note` | 4 KiB | truncate, mark |
+| `error.message` | 8 KiB | truncate, mark |
+| `error.traceback` | 32 KiB | truncate **head and tail kept**, mark |
+| `error.details` | 8 KiB | truncate, mark |
+| `notes[]` | 16 items | drop excess, mark |
+| JSON depth | 6 | `422` |
+| object keys per node | 64 | `422` |
+
+Oversized *individual strings* are truncated with an explicit marker rather than rejected —
+a truncated report is worth more than no report. Only the total body cap and structural
+violations reject. Truncation keeps the head **and** tail of a traceback, because the
+innermost frame is usually the informative one.
+
+Control characters other than tab and newline are stripped from every free-text field.
+
+## 3. Pipeline
+
+```
+bound  ->  classify  ->  persist  ->  dedupe  ->  deliver  ->  respond
+```
+
+Bound before trusting. Classify without believing the client. **Persist before
+delivering.** Dedupe on the idempotency key. Deliver through a port.
+
+## 4. Classification
+
+The service decides the class. It does **not** trust `client`-declared intent.
+
+- Scan the payload for content-bearing material: prompt text, model responses, cell source,
+  log bodies, url4 expressions.
+- Content present → **reject with `422`**, with a `detail` explaining that prompt-bearing
+  content is not accepted by this service.
+- Fail safe: undeclared content is still content. Never fail open.
+- Echo the verdict as `classification` so a client can tell what was understood.
+
+**Why reject rather than store.** v1 has no bundle store, so there is nowhere safe to put
+it: Linear is third-party SaaS and the review spec permits prompt-bearing bodies only in
+the Cloudflare-Access-gated SigNoz sink. A responder who needs prompt text asks the
+reporter — which is why `reply_to` exists — or, once Phase 2 lands, pulls it from SigNoz by
+`trace_id`.
+
+**Do not attempt redact-and-accept.** Partial redaction of free text is unreliable and
+creates false confidence. Reject cleanly and say why.
+
+## 5. Storage and idempotency
+
+One table. The service has state, but it is a retry queue, not a document store.
+
+| Column | Notes |
+|---|---|
+| `ref` | primary key, minted server-side, never derived from client input |
+| `idempotency_key` | unique, nullable |
+| `payload` | the validated, truncated report |
+| `classification` | server verdict |
+| `caller_email` | from the mesh only; nullable |
+| `reply_to` | self-asserted; nullable |
+| `delivery_state` | `pending` / `delivered` / `failed` |
+| `attempts` | integer |
+| `ticket_id`, `ticket_url` | nullable until delivered |
+| `created_at`, `updated_at` | |
+
+**Persist before deliver.** The record is committed before the sink is called. A sink
+outage is then a retry rather than a lost bug report. Calling the sink first and storing on
+success is the single most common way services like this drop reports, and it is
+prohibited here.
+
+**Idempotency window: 24 h**, matching the scoreboard's existing `idempotency_keys` TTL.
+Within it, a replayed key returns `200` with the original record — one report, one ticket,
+regardless of double-clicks or client retries. After it, the same key is treated as new.
+
+**Row retention: 90 days**, then purged. The ticket is the durable artifact; the row exists
+for idempotency, retry, and operational forensics.
+
+## 6. Delivery
+
+`TicketSink` is a port. Core defines it; core never imports an adapter; wiring happens in a
+registry.
+
+- **`LinearSink`** — creates the issue directly. Requires the `OME-976` amendment.
+- **`QueueSink`** — the fallback: mark the record ready and let an agent file it via MCP
+  during triage. Still private Linear, but asynchronous and with no ticket id returned.
+
+**Ticket content:** the envelope, `trace_id`, `ref`, the reporter's note, `reply_to` when
+present, and the caller email when the mesh supplied one. **Never** prompt-bearing content
+— see §4.
+
+**Retry:** exponential backoff, 6 attempts over roughly 24 h, then terminal `failed`.
+`failed` must be visible to us through a metric or log line; a report we permanently failed
+to file is an operational event, not a shrug. Retries must not stampede the sink's rate
+limits.
+
+## 7. Identity and auth
+
+Settled regardless of the open fork:
+
+- `X-User-Email` is trusted **only** when Envoy injects it after re-verifying the
+  Cloudflare Access assertion, exactly as aigateway does. Client-supplied copies are
+  stripped at the edge.
+- `reply_to` is self-asserted and is never identity. It matters more here than it looks:
+  the Python client parses only `exp` from its Access token, so it has **no email of its
+  own** — without `reply_to`, an SDK report cannot be answered.
+- Content is rejected for every caller, authenticated or not.
+- **Nothing is ever authorized by `trace_id` or `run_id`.** An id in a report is a claim,
+  not a credential (`OME-966`).
+
+The rest depends on the `OME-973` fork — see §9.
+
+## 8. Failure modes
+
+| Condition | Service | Client |
+|---|---|---|
+| sink slow (>3 s) | persist, `delivery.state=pending`, retry | shows `ref`, no ticket id |
+| sink down | as above | as above |
+| sink permanently failing | `failed` after 6 attempts, alarm | already returned |
+| storage down | `503`, nothing stored | write report to disk, print path |
+| over body cap | `413` naming the cap | truncate and retry once, else disk |
+| content present | `422` | drop content, resend envelope |
+| rate limited | `429` | back off, offer disk fallback |
+
+The client rule behind this table: **a report is never lost.** Every terminal failure path
+ends with the report on the user's disk and a path printed.
+
+## 9. Open decisions
+
+Both block implementation, not this spec.
+
+**`OME-976` — rule 9.** As written, CLAUDE.md rule 9 forbids product code from calling
+Linear's API. Amending it selects `LinearSink`; declining selects `QueueSink` and the
+reporter stops getting a ticket id. The amendment must also state where the credential
+lives and who rotates it — a long-lived Linear API key in a deployed service is a new
+secret class for this repo.
+
+**`OME-973` — anonymous or authenticated.** This decides whether the abuse surface exists
+at all.
+
+| | Authenticated | Anonymous |
+|---|---|---|
+| gate | none | Turnstile + edge rate limit |
+| `X-User-Email` | mesh-injected | absent |
+| `reply_to` | ignored | accepted, unverified |
+| content | rejected | rejected |
+
+Admitting anonymous callers makes this the repo's first unauthenticated write that reaches
+human eyes, in a codebase with no rate limiting anywhere. The stakes rose when reports were
+routed to private Linear: spam lands in the workspace the team works in, rather than a
+public tracker that could be moderated at arm's length.
+
+## 10. Verification
+
+- Behavior-named tests per cap: an over-cap body is rejected *and names the cap*; a
+  deep-nested payload is rejected; an ordinary report is untouched; an oversized traceback
+  is truncated head-and-tail with a marker.
+- A report containing an undeclared prompt string is rejected; an envelope-only report
+  passes; the rejection says why.
+- A report survives a sink failure: the record exists, `state=pending`, and the response is
+  still `202`.
+- The same `Idempotency-Key` twice produces one row and one ticket.
+- Storage down returns `503` and creates nothing.
+- A forged `X-User-Email` from outside the mesh is not honoured.
+- `helm template` renders for default and prod values; `verify_chart_wiring.py` asserts
+  something real about this chart; liveness and readiness point at **different** endpoints.

--- a/docs/work/2026-08-26-OME-1004-report-intake-spec.md
+++ b/docs/work/2026-08-26-OME-1004-report-intake-spec.md
@@ -49,6 +49,17 @@ Docs-only unit — no code, no tests. Verification is owner review against the t
   status codes used all appear in the error catalogue, and one real inconsistency was
   caught and fixed (`error.details` was bounded in the caps table but missing from the
   request schema).
+- **Review round 1 (owner, 2026-08-26):** the `client` block was Python-shaped — a required
+  `python` field, and a §2.1 sentence generalising the notebook's kernel-side posting rule
+  into "never from a browser". Both were wrong for three of the four client surfaces
+  (Studio/Electron, aigateway-ui/Next.js, portal/browser JS), and the second contradicted §7,
+  which already treats aigateway-ui as the only client that knows its user's email. Fixed:
+  `python` → `runtime {name, version}`; a surface→values table; documented-not-enforced
+  vocabularies for `host`/`platform`/`runtime.name`; unknown-key policy split (forbid at top
+  level, preserve inside `client`/`context`); a CORS paragraph the browser clients now
+  require; caps rows for the new strings; head/tail truncation rationale made runtime-neutral
+  (CPython renders the innermost frame last, V8 first). `error.traceback` is left named as-is
+  and raised with the owner as the one remaining language-specific field name.
 - **Deviations:** branched from `origin/main` at `5cba291b`, so the observability review
   spec (`docs/spec/2026-08-22-observability-traceability-review.md`, PR #688, still draft)
   is not present on this branch. This spec references it by path; the link resolves once

--- a/docs/work/2026-08-26-OME-1004-report-intake-spec.md
+++ b/docs/work/2026-08-26-OME-1004-report-intake-spec.md
@@ -1,0 +1,55 @@
+---
+ticket: OME-1004
+stack: repo
+status: in_progress
+started: 2026-08-26
+finished:
+---
+
+# OME-1004 — Spec the report-intake service
+
+## Intent
+
+Write the design spec for `apps/report-intake` (epic `OME-1002`): a small FastAPI service
+that accepts an error report from a ScreamingFace client, persists it, and files it into
+the private Linear workspace so a reporter needs no account of their own. Spec before plan,
+plan before code — no other item in the epic starts until this lands.
+
+The API surface was narrowed during design review: two endpoints were proposed and both
+pruned (`GET /v1/reports/{ref}`, `GET /v1/bundles/{id}`), leaving one real endpoint plus
+two probes. That pruning is a load-bearing part of the spec, not trivia — dropping the
+bundle store removed the entire storage layer for content.
+
+## Planned changes
+
+- `docs/spec/2026-08-26-OME-1004-report-intake-service.md` — the spec.
+- This ledger.
+
+## Test plan
+
+Docs-only unit — no code, no tests. Verification is owner review against the ticket's
+"must pin down" list, and the absence of any surviving "TBD".
+
+## Acceptance
+
+- The spec fixes the `POST /v1/reports` contract, the single success shape, the RFC 9457
+  error catalogue, and **concrete numeric caps** (not "bounded").
+- Classification is specified as a server-side decision that disbelieves the client.
+- Persist-before-deliver, the data model, and idempotency semantics are unambiguous.
+- The two unresolved forks (`OME-976` sink, `OME-973` auth) are recorded as open decisions
+  with their consequences, rather than silently resolved by the author.
+- A non-goals section carries the epic's scope guards.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — the spec plus this ledger.
+- **Commits:** one docs-only commit on `OME-1004-report-intake-spec`; sha recorded in the
+  Linear close comment after squash-merge.
+- **Gates:** docs-only; no stack gates apply. Self-review run: no placeholders survive, the
+  status codes used all appear in the error catalogue, and one real inconsistency was
+  caught and fixed (`error.details` was bounded in the caps table but missing from the
+  request schema).
+- **Deviations:** branched from `origin/main` at `5cba291b`, so the observability review
+  spec (`docs/spec/2026-08-22-observability-traceability-review.md`, PR #688, still draft)
+  is not present on this branch. This spec references it by path; the link resolves once
+  #688 merges.

--- a/docs/work/2026-08-26-OME-1004-report-intake-spec.md
+++ b/docs/work/2026-08-26-OME-1004-report-intake-spec.md
@@ -60,6 +60,21 @@ Docs-only unit — no code, no tests. Verification is owner review against the t
   require; caps rows for the new strings; head/tail truncation rationale made runtime-neutral
   (CPython renders the innermost frame last, V8 first). `error.traceback` is left named as-is
   and raised with the owner as the one remaining language-specific field name.
+- **Review round 2 (owner, 2026-08-26):** the owner settled both forks the spec recorded as
+  open, so §9 and §7 were stating an undecided posture that no longer existed. Landed as one
+  amendment rather than a row: §2.3 gains `403` (bot gate not satisfied) and `503` extends to
+  cover an unevaluable gate — split deliberately, because `403` means *fetch a new token* and
+  `503` means *retry unchanged*, and collapsing them makes one client behaviour wrong. §7
+  rewritten around two caller classes with the two binding constraints (rate-limit key must
+  not be attacker-controlled; the gate never covers `/healthz`). §8 gains both gate rows. §9
+  became "Decisions", recording `QueueSink`-for-v1 with `LinearSink` deferred behind
+  `OME-976`, and anonymous-admitted with the cost stated plainly. §6 marks `QueueSink` as v1
+  and adds the port-level content argument. §10 gains five verification lines.
+  Self-review caught two stale spots a targeted edit would have missed: the
+  `Cf-Turnstile-Response` header row still read "present only if anonymous submission is
+  admitted", and the preamble still claimed "the service holds the credential" — false under
+  `QueueSink`, where the reporter-needs-no-account property comes from the service standing
+  between reporter and tracker, not from holding a key.
 - **Deviations:** branched from `origin/main` at `5cba291b`, so the observability review
   spec (`docs/spec/2026-08-22-observability-traceability-review.md`, PR #688, still draft)
   is not present on this branch. This spec references it by path; the link resolves once


### PR DESCRIPTION
## Summary

Design spec for `apps/report-intake` — the service that accepts an error report from a ScreamingFace client and files it into private Linear, so a reporter needs no account of their own.

First unit of epic OME-1002; nothing else in that epic starts until this lands.

**What it fixes:**
- `POST /v1/reports` contract, one success shape (`202` new / `200` replay), RFC 9457 error catalogue matching the engine's convention.
- **Concrete numeric caps** — body 64 KiB, note 4 KiB, traceback 32 KiB truncated head-and-tail, JSON depth 6. Numbers, not "bounded", because that is how OME-969 happened.
- Classification as a **server-side** decision that disbelieves the client's declaration and fails safe.
- Persist-before-deliver, the data model, a 24 h idempotency window and 90 d row retention.
- `TicketSink` port with `LinearSink` / `QueueSink` adapters.
- Failure-mode table, including the client rule that a report is never lost.

**Deliberately narrowed during review:** no bundle/blob store, no `GET /v1/reports/{ref}`, no query surface. Two endpoints were proposed and both pruned; dropping the bundle store removed the entire content storage layer.

**Two forks recorded as open rather than resolved by the author:** OME-976 (rule 9 — decides `LinearSink` vs `QueueSink`) and OME-973 (anonymous vs authenticated — decides whether the abuse surface exists).

## Test plan

Docs-only; no code paths touched, no stack gates apply. Pre-commit hooks green. Self-review found and fixed one inconsistency (`error.details` bounded in the caps table but absent from the request schema).

Note: branched from `origin/main`, so the observability review spec this references (PR #688, draft) is not on this branch; the link resolves once #688 merges.

Refs: OME-1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HieZHSC1R6GDobhFyb4d2E