### PR TITLE
fix(screamingface-engine): retry aigateway transport failures in grading

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/runner/connector.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/connector.py
@@ -6,7 +6,9 @@ resolves and runs an expression against.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import random
 from collections.abc import Mapping
 from dataclasses import dataclass
 from decimal import Decimal
@@ -59,6 +61,16 @@ from url4.streaming.protocol import CachePolicy
 
 _COMPLETIONS_PATH = "/v1/chat/completions"
 _truncate_tool_result = truncate_tool_result
+
+# Transport-retry policy for the aigateway hop (OME-1016). A transport failure
+# (connection reset, read error, timeout) is transient by nature, so the connector
+# retries it with exponential backoff + jitter before surfacing a retryable
+# ResolutionError. Module-level so tests can zero them; the benchmark's own ``retry=``
+# (url4) remains a second layer for HTTP-status failures and for a sustained outage.
+_TRANSPORT_RETRIES = 1  # one retry → two attempts; url4's retry= adds more if needed
+_TRANSPORT_BACKOFF_BASE_S = 0.5
+_TRANSPORT_BACKOFF_MAX_S = 8.0
+_TRANSPORT_BACKOFF_JITTER_S = 0.25
 
 
 @dataclass(frozen=True)
@@ -408,6 +420,63 @@ def _report_usage(
     )
 
 
+async def _post_completion(
+    http_client: httpx.AsyncClient,
+    *,
+    headers: dict[str, str],
+    body: dict,
+) -> httpx.Response:
+    """One chat-completions POST: retry transport failures, then translate to a retryable error.
+
+    WHY (OME-1016): a transport failure (connection reset, read error, timeout) is
+    transient by nature — aigateway may be restarting or a pooled keep-alive connection
+    went stale. Left raw, an ``httpx.ReadError`` bypasses the benchmark's declared
+    ``retry=`` policy (url4 retries only ``Url4Error``) and carries no error ``code``,
+    so the report falls back to the opaque benchmark default (``draco_grading_failed``)
+    with a useless ``ReadError('')`` message. This retries the transport failure with
+    exponential backoff + jitter (so concurrent judge calls that fail together do not
+    retry in lockstep), then raises a retryable ``ResolutionError`` that names the real
+    cause. ``HTTPStatusError`` is deliberately NOT caught — ``_raise_for_status``
+    handles non-2xx after the post returns.
+    """
+    last: httpx.TransportError | None = None
+    for attempt in range(_TRANSPORT_RETRIES + 1):
+        try:
+            return await http_client.post(_COMPLETIONS_PATH, headers=headers, json=body)
+        except httpx.TransportError as exc:
+            last = exc
+            if attempt < _TRANSPORT_RETRIES:
+                await asyncio.sleep(_transport_backoff(attempt))
+    assert last is not None  # the loop always runs at least once
+    raise ResolutionError(
+        f"aigateway request failed at the transport layer: {_transport_detail(last)}",
+        code="aigateway_transport_error",
+        permanent=False,
+    ) from last
+
+
+def _transport_backoff(attempt: int) -> float:
+    """Exponential backoff plus jitter for the next transport retry.
+
+    ``attempt`` is the zero-based index of the attempt that just failed, so the first
+    retry waits ``base``, the second ``2*base``, capped at ``backoff_max_s``; jitter
+    de-synchronises concurrent siblings that failed together.
+    """
+    delay = min(_TRANSPORT_BACKOFF_BASE_S * 2**attempt, _TRANSPORT_BACKOFF_MAX_S)
+    return delay + random.uniform(0.0, _TRANSPORT_BACKOFF_JITTER_S)
+
+
+def _transport_detail(exc: httpx.TransportError) -> str:
+    """A stable one-line description of a transport failure, even when ``str()`` is empty.
+
+    ``httpx.ReadError('')`` stringifies to an empty string; the class name alone is
+    still actionable, and a non-empty message keeps ``_error_payload`` from falling
+    back to ``repr(exc)``.
+    """
+    detail = str(exc).strip()
+    return f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__
+
+
 async def _fetch_completion(
     http_client: httpx.AsyncClient,
     *,
@@ -432,14 +501,14 @@ async def _fetch_completion(
         The response to consume, and the cache outcome of the round trip that produced IT — not
         of the one that was discarded, whose only remaining trace is that it happened.
     """
-    resp = await http_client.post(
-        _COMPLETIONS_PATH,
+    resp = await _post_completion(
+        http_client,
         headers=headers,
         # `policy_to_body_field` yields an EMPTY dict for a run that participates, so an ordinary
         # run's body is byte-identical to the one this connector has always sent — which is also
         # the smallest surface exposed to the gateway's closed cache grammar, where one
         # unrecognised key silently costs every hit (spec §1.0).
-        json={**body, **policy_to_body_field(cache)},
+        body={**body, **policy_to_body_field(cache)},
     )
     _raise_for_status(resp)
     outcome = read_cache_outcome(resp.headers)
@@ -448,10 +517,10 @@ async def _fetch_completion(
     # An explicit opt-out, built here rather than derived from `cache`: the run's own policy
     # PARTICIPATES (a bound is not a refusal), and the re-issue must state the one thing the
     # closed grammar understands — `use-cache: false` — and nothing else.
-    resp = await http_client.post(
-        _COMPLETIONS_PATH,
+    resp = await _post_completion(
+        http_client,
         headers=headers,
-        json={**body, **policy_to_body_field(CachePolicy(participate=False))},
+        body={**body, **policy_to_body_field(CachePolicy(participate=False))},
     )
     _raise_for_status(resp)
     return resp, read_cache_outcome(resp.headers)

--- a/apps/screamingface-engine/tests/unit/test_aigateway_connector.py
+++ b/apps/screamingface-engine/tests/unit/test_aigateway_connector.py
@@ -397,6 +397,86 @@ async def test_aigateway_http_errors_map_to_resolution_error(
     assert exc_info.value.permanent is expected_permanent
 
 
+async def test_aigateway_transport_errors_map_to_retryable_resolution_error() -> None:
+    """A transport failure (connection reset / read error) is retryable and named.
+
+    WHY (OME-1016): a raw ``httpx.ReadError`` bypasses the benchmark's declared ``retry=``
+    policy (url4 retries only ``Url4Error``) and carries no error ``code``, so the report
+    would fall back to the opaque benchmark default (``draco_grading_failed``) with a
+    useless ``ReadError('')`` message. The connector must translate it into a retryable
+    ``ResolutionError`` with a non-empty message.
+    """
+
+    def _drop_connection(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError("")
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_drop_connection),
+        base_url="http://aigateway.test",
+    ) as client:
+        cfg = AigatewayConfig(
+            models=(ModelSpec(id="anthropic/claude-haiku-4-5"),),
+            default_model="anthropic/claude-haiku-4-5",
+        )
+        world = await build_aigateway_world(cfg, client=client)
+
+        with (
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_BASE_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_MAX_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_JITTER_S", 0.0),
+        ):
+            with pytest.raises(ResolutionError) as exc_info:
+                await url4_run("/anthropic/claude-haiku-4-5(ctx)!go", io=world.node)
+
+    assert exc_info.value.code == "aigateway_transport_error"
+    assert exc_info.value.permanent is False
+    assert "ReadError" in str(exc_info.value)
+    assert str(exc_info.value).strip()
+
+
+async def test_aigateway_transport_error_is_retried_then_succeeds() -> None:
+    """A transient transport failure is retried once (backoff) and the call succeeds.
+
+    WHY (OME-1016): the connector retries ``httpx.TransportError`` with backoff before
+    surfacing a retryable error, so a stale keep-alive connection or a brief aigateway
+    blip costs one extra attempt instead of a failed Case.
+    """
+    posts = 0
+
+    def _flaky(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        posts += 1
+        if posts == 1:
+            raise httpx.ReadError("")
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "hello there"}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+            },
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(_flaky),
+        base_url="http://aigateway.test",
+    ) as client:
+        cfg = AigatewayConfig(
+            models=(ModelSpec(id="anthropic/claude-haiku-4-5"),),
+            default_model="anthropic/claude-haiku-4-5",
+        )
+        world = await build_aigateway_world(cfg, client=client)
+
+        with (
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_BASE_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_MAX_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_JITTER_S", 0.0),
+        ):
+            result = await url4_run("/anthropic/claude-haiku-4-5(ctx)!go", io=world.node)
+
+    assert result == "hello there"
+    assert posts == 2
+
+
 async def test_default_model_must_be_one_of_the_declared_models() -> None:
     gw = _MockAigateway(("openrouter/gpt-4o",))
     cfg = AigatewayConfig(

--- a/apps/screamingface-engine/tests/unit/test_grading_error_integrity.py
+++ b/apps/screamingface-engine/tests/unit/test_grading_error_integrity.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest import mock
 
 import httpx
 import pytest
@@ -329,5 +330,160 @@ async def test_a_judge_429_lands_as_the_original_grading_error(tmp_path: Path) -
     assert "upstream judge rate limited" in failure.message
     assert "Criterion envelope" not in failure.message
     # Every judge pass was paid as a real 429 — no masking swallowed them.
+    judge_calls = [body for body in requests if body.get("model") == JUDGE_MODEL]
+    assert judge_calls, "the judge must actually have been called"
+
+
+async def _judge_transport_world(
+    tmp_path: Path,
+    *,
+    fail_first_judge_posts: int | None = None,
+) -> tuple[
+    httpx.AsyncClient,
+    httpx.AsyncClient,
+    AigatewayWorld,
+    list[dict[str, object]],
+]:
+    """A full DRACO world whose judge route raises httpx.ReadError and candidates answer fine.
+
+    ``fail_first_judge_posts``: raise ReadError for the first N judge POSTs, then answer
+    with a valid verdict. None → always raise for judge POSTs.
+    """
+    requests: list[dict[str, object]] = []
+    judge_posts = 0
+
+    def gateway(request: httpx.Request) -> httpx.Response:
+        nonlocal judge_posts
+        body = json.loads(request.content)
+        requests.append(body)
+        if body.get("model") == JUDGE_MODEL:
+            if fail_first_judge_posts is None or judge_posts < fail_first_judge_posts:
+                judge_posts += 1
+                raise httpx.ReadError("")
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps(
+                                    {"explanation": "evidence", "criterion_status": "MET"}
+                                )
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+                },
+            )
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "A fine answer."}, "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+            },
+        )
+
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(gateway),
+        base_url="http://aigateway.test",
+    )
+    tavily = httpx.AsyncClient(
+        transport=httpx.MockTransport(_tavily),
+        base_url="https://api.tavily.com",
+    )
+    world = await build_aigateway_world(
+        AigatewayConfig(
+            default_model=_CANDIDATE_MODEL,
+            models=(ModelSpec(id=_CANDIDATE_MODEL), ModelSpec(id=JUDGE_MODEL)),
+        ),
+        client=client,
+        tavily_api_key="tvly-test",
+        tavily_client=tavily,
+    )
+    install_candidate_invocation(world.node)
+    BenchmarkRegistry((DRACO,)).install(world.node, assets_root=_draco_assets(tmp_path))
+    return client, tavily, world, requests
+
+
+async def test_a_judge_transport_error_is_retried_and_the_case_is_graded(
+    tmp_path: Path,
+) -> None:
+    """A transient judge transport failure is retried (connector backoff) and the case is graded.
+
+    WHY (OME-1016): the connector retries ``httpx.TransportError`` with backoff, so a
+    stale keep-alive connection or a brief aigateway blip costs one extra attempt instead
+    of a failed Case.
+    """
+    client, tavily, world, requests = await _judge_transport_world(
+        tmp_path, fail_first_judge_posts=1
+    )
+    candidate_expression = RelExpr(
+        path=f"/{_CANDIDATE_MODEL}",
+        context="$input",
+        intent=text("Answer the question."),
+    )
+    linked = link_candidate(candidate_expression, DRACO.build(1))
+    try:
+        with (
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_BASE_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_MAX_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_JITTER_S", 0.0),
+        ):
+            result = await world.node.evaluate(linked)
+    finally:
+        await world.aclose()
+        await client.aclose()
+        await tavily.aclose()
+
+    candidate = CandidateResult.model_validate(json.loads(result.text))
+    (case,) = candidate.cases
+    assert case.failures == []
+    assert case.grade is not None
+    assert case.grade.score is not None
+    # The first judge call consumed the single transport failure across its retry.
+    judge_calls = [body for body in requests if body.get("model") == JUDGE_MODEL]
+    assert len(judge_calls) >= 2
+
+
+async def test_a_judge_transport_error_exhaustion_lands_as_aigateway_transport_error(
+    tmp_path: Path,
+) -> None:
+    """Judge transport failures exhaust retries — the case failure names the real cause.
+
+    WHY (OME-1016): after the connector's bounded retries, the failure must render as
+    ``aigateway_transport_error`` with ``retryable=true`` and a non-empty message —
+    never the opaque ``draco_grading_failed`` fallback.
+    """
+    client, tavily, world, requests = await _judge_transport_world(tmp_path)
+    candidate_expression = RelExpr(
+        path=f"/{_CANDIDATE_MODEL}",
+        context="$input",
+        intent=text("Answer the question."),
+    )
+    linked = link_candidate(candidate_expression, DRACO.build(1))
+    try:
+        with (
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_BASE_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_MAX_S", 0.0),
+            mock.patch("screamingface_engine.runner.connector._TRANSPORT_BACKOFF_JITTER_S", 0.0),
+        ):
+            result = await world.node.evaluate(linked)
+    finally:
+        await world.aclose()
+        await client.aclose()
+        await tavily.aclose()
+
+    candidate = CandidateResult.model_validate(json.loads(result.text))
+    (case,) = candidate.cases
+    assert case.output == "A fine answer."
+    assert case.grade is not None
+    assert case.grade.score is None
+    (failure,) = case.failures
+    assert failure.stage == "grading"
+    assert failure.code == "aigateway_transport_error"
+    assert failure.retryable is True
+    assert "ReadError" in failure.message
+    assert "Criterion envelope" not in failure.message
     judge_calls = [body for body in requests if body.get("model") == JUDGE_MODEL]
     assert judge_calls, "the judge must actually have been called"

--- a/docs/plan/2026-08-26-OME-1016-aigateway-transport-retry.md
+++ b/docs/plan/2026-08-26-OME-1016-aigateway-transport-retry.md
@@ -1,0 +1,64 @@
+# OME-1016 — Plan: retry aigateway transport failures in benchmark grading
+
+## Constraint
+
+`packages/url4` is untouchable (agnosticism). All changes live in
+`apps/screamingface-engine`.
+
+## Steps
+
+1. **Connector transport retry + translation.** In
+   `apps/screamingface-engine/src/screamingface_engine/runner/connector.py`:
+   - Add `import asyncio` and `import random`.
+   - Add module constants `_TRANSPORT_RETRIES = 1`,
+     `_TRANSPORT_BACKOFF_BASE_S = 0.5`, `_TRANSPORT_BACKOFF_MAX_S = 8.0`,
+     `_TRANSPORT_BACKOFF_JITTER_S = 0.25`.
+   - `_post_completion` retries `httpx.TransportError` up to
+     `_TRANSPORT_RETRIES` times with `_transport_backoff(attempt)` sleep, then
+     raises `ResolutionError(code="aigateway_transport_error",
+     permanent=False)` with a non-empty message.
+   - Add `_transport_backoff(attempt)` (exponential + jitter) and
+     `_transport_detail(exc)` (class name when `str()` is empty) helpers.
+   - Replace both `http_client.post` calls in `_fetch_completion` with
+     `_post_completion`.
+
+2. **Connector tests.** In
+   `apps/screamingface-engine/tests/unit/test_aigateway_connector.py`:
+   - `test_aigateway_transport_errors_map_to_retryable_resolution_error`:
+     always-raise `httpx.ReadError("")` → `ResolutionError` with
+     `code="aigateway_transport_error"`, `permanent=False`, non-empty message.
+   - `test_aigateway_transport_error_is_retried_then_succeeds`: fail once,
+     then succeed → result returned, 2 POSTs observed.
+   - Zero the backoff constants via `mock.patch` for speed.
+
+3. **Grading-integrity tests.** In
+   `apps/screamingface-engine/tests/unit/test_grading_error_integrity.py`:
+   - `_judge_transport_world` helper: judge route raises `httpx.ReadError`
+     (configurable: first N posts, or always), then answers a valid verdict
+     `{"explanation": "evidence", "criterion_status": "MET"}`.
+   - `test_a_judge_transport_error_is_retried_and_the_case_is_graded`: fail
+     the first judge post → connector retry fires → case graded (score set,
+     no failures).
+   - `test_a_judge_transport_error_exhaustion_lands_as_aigateway_transport_error`:
+     always raise → failure is `stage=grading`,
+     `code=aigateway_transport_error`, `retryable=True`, candidate output
+     preserved, never "Criterion envelope".
+   - Zero the backoff constants via `mock.patch` for speed.
+
+4. **Gates.** `uv run run_gates.py screamingface-engine` green.
+
+## Files
+
+- `apps/screamingface-engine/src/screamingface_engine/runner/connector.py`
+- `apps/screamingface-engine/tests/unit/test_aigateway_connector.py`
+- `apps/screamingface-engine/tests/unit/test_grading_error_integrity.py`
+- docs: work ledger, task mirror, spec, plan (this file)
+
+## Risks
+
+- Double-retry with the benchmark's `retry=` in a sustained outage (2 × 3 = 6
+  POSTs per judge call) — accepted: bounded, rare, backoff-spaced, and the
+  judge call is idempotent-ish via aigateway's global cache.
+- Connector translation changes the error surface for ALL aigateway calls
+  (judge + candidate + tool-loop round trips) — strictly an improvement
+  (retryable + meaningful code), covered by the connector unit tests.

--- a/docs/spec/2026-08-26-OME-1016-aigateway-transport-retry.md
+++ b/docs/spec/2026-08-26-OME-1016-aigateway-transport-retry.md
@@ -1,0 +1,95 @@
+# OME-1016 — Spec: retry aigateway transport failures in benchmark grading
+
+## Problem
+
+A transient `httpx.ReadError` on the runner→aigateway hop during a judge call
+renders as `grading · draco_grading_failed · cases N, M — ReadError('')`.
+
+Three defects combine:
+
+1. **Retry never fires for transport errors.** The connector's
+   `_fetch_completion` (`apps/screamingface-engine/src/screamingface_engine/
+   runner/connector.py`) has no try/except around `http_client.post`, so an
+   `httpx.ReadError` escapes raw. The benchmark's declared `retry=2` (OME-993)
+   retries only `Url4Error` — a raw transport error bypasses it.
+2. **No error code.** `httpx.ReadError` has no `code` attribute, so
+   `_error_payload` produces `{"error": {"kind": "ReadError", "message":
+   "ReadError('')"}}` with no code, and `public_error` falls back to the
+   benchmark default `draco_grading_failed`.
+3. **Useless message.** `str(ReadError(''))` is empty, so `_error_payload`
+   falls back to `repr(exc)` → `ReadError('')`.
+4. **No backoff.** Concurrent judge calls that fail together on a gateway blip
+   retry in lockstep — a retry storm against a recovering aigateway
+   (api-expert: "Never retry in parallel"; aigateway's own
+   `with_overload_retry` already uses backoff + jitter).
+
+## Constraint
+
+**`packages/url4` is untouchable and must stay agnostic to the
+screamingface/aigateway use cases.** The retry/backoff must live entirely in
+the screamingface-engine connector. The benchmark's `retry=` (url4) stays as
+the second layer for HTTP-status failures and for a sustained outage.
+
+## Design
+
+### The connector owns the transport retry (`runner/connector.py`)
+
+`_fetch_completion`'s two `http_client.post` calls move behind a
+`_post_completion` helper that:
+
+1. Retries `httpx.TransportError` (the narrow network-layer tuple:
+   `ReadError`, `ConnectError`, `ReadTimeout`, `WriteError`, `PoolTimeout` —
+   all transient) with exponential backoff + jitter, bounded by
+   `_TRANSPORT_RETRIES = 1` (two attempts).
+2. After exhaustion, raises:
+
+```python
+ResolutionError(
+    f"aigateway request failed at the transport layer: {_transport_detail(exc)}",
+    code="aigateway_transport_error",
+    permanent=False,
+)
+```
+
+- `permanent=False` → `retryable=True` in the report.
+- `_transport_detail` yields `ReadError` (class name) when `str(exc)` is
+  empty, else `ReadError: <detail>`.
+- Chained `from exc` so the original cause survives.
+- `HTTPStatusError` is deliberately NOT caught — `_raise_for_status` handles
+  non-2xx after the post returns.
+- Backoff constants are module-level (`_TRANSPORT_BACKOFF_BASE_S = 0.5`,
+  `_TRANSPORT_BACKOFF_MAX_S = 8.0`, `_TRANSPORT_BACKOFF_JITTER_S = 0.25`,
+  matching aigateway's `RetryPolicy`) so tests can zero them.
+
+### Interaction with the benchmark's `retry=` (url4)
+
+The connector's retry is the transport retry; the benchmark's `retry=2`
+remains the HTTP-status retry. In the common transient case the connector's
+single retry succeeds and the url4 retry never fires. In a sustained outage
+both layers fire — bounded at 2 connector attempts × 3 url4 attempts = 6
+POSTs per judge call, backoff-spaced. This is accepted: bounded, rare, and
+the judge call is idempotent-ish (aigateway's global cache replays an
+identical retried request).
+
+## Non-goals (Chesterton's Fence)
+
+- Do NOT touch `packages/url4` (agnosticism constraint).
+- Do NOT change `retry=2` / `retry=JUDGE_RETRIES` counts (would bump the
+  protocol revision and invalidate seeded cache keys).
+- Do NOT change `on_error="fail"` fan-outs (OME-924) or the
+  `preserve_candidate_outcome` collect boundary.
+- Do NOT retry on `Exception` — only `httpx.TransportError`.
+- Do NOT add httpx transport `retries=` — httpx only retries connect errors,
+  never `ReadError`.
+
+## Tests
+
+- Connector: `httpx.MockTransport` raising `httpx.ReadError("")` →
+  `ResolutionError` with `code="aigateway_transport_error"`,
+  `permanent=False`, non-empty message; a flaky transport (fail once, then
+  succeed) → the connector retries and the call succeeds (2 POSTs).
+- Grading integrity: judge world whose gateway raises `ReadError` once then
+  answers a valid verdict → case graded (retry fired); always-raises world →
+  failure is `stage=grading`, `code=aigateway_transport_error`,
+  `retryable=True`, candidate output preserved.
+- Backoff constants zeroed via `mock.patch` in tests for speed.

--- a/docs/tasks/2026-08-26-OME-1016-aigateway-transport-retry.md
+++ b/docs/tasks/2026-08-26-OME-1016-aigateway-transport-retry.md
@@ -1,0 +1,46 @@
+---
+ticket: OME-1016
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-26
+labels: [screamingface-engine]
+actor: agentic
+who-acts: agent
+---
+
+# OME-1016 — Retry aigateway transport failures in benchmark grading
+
+## Context
+
+Follow-up to OME-993 (grading-error propagation). A transient `httpx.ReadError`
+on the runner→aigateway hop during a judge call bypasses the declared `retry=`
+policy (only `Url4Error` is retried), carries no error `code`, and renders as
+the opaque `draco_grading_failed` fallback with the useless message
+`ReadError('')`. Concurrent judge calls that fail together retry in lockstep.
+
+**Constraint: `packages/url4` is untouchable (agnosticism).** All changes live
+in the screamingface-engine connector.
+
+## Scope
+
+- **Connector:** retry `httpx.TransportError` with exponential backoff + jitter
+  (bounded, module constants), then raise
+  `ResolutionError(code="aigateway_transport_error", permanent=False)` with a
+  non-empty message, so the report names the real cause and `retryable=true`.
+- **Tests:** connector translation + retry-then-succeed; grading-integrity
+  retry/exhaustion.
+
+## Out of scope
+
+- `packages/url4` (agnosticism constraint).
+- Changing `retry=2` / `retry=JUDGE_RETRIES` counts (would bump the protocol
+  revision and invalidate seeded cache keys).
+- Changing `on_error="fail"` fan-outs (OME-924) or the collect boundary.
+- aigateway-side or SDK-side changes.
+
+## Definition of done
+
+- Judge transport failure is retried (connector backoff); exhaustion renders
+  `aigateway_transport_error` + `retryable=true` + non-empty message.
+- `packages/url4` untouched; protocol text unchanged.
+- `screamingface-engine` gates green.

--- a/docs/work/2026-08-26-OME-1016-aigateway-transport-retry.md
+++ b/docs/work/2026-08-26-OME-1016-aigateway-transport-retry.md
@@ -1,0 +1,81 @@
+---
+ticket: OME-1016
+stack: screamingface-engine
+status: in_progress
+started: 2026-08-26
+finished:
+---
+
+# OME-1016 — Retry aigateway transport failures in benchmark grading
+
+## Intent
+
+A transient `httpx.ReadError` on the runner→aigateway hop during a judge call
+surfaces as `grading · draco_grading_failed · cases N, M — ReadError('')` in the
+report. Two defects combine: (1) the connector lets `httpx.TransportError`
+escape raw, so the benchmark's declared `retry=` policy (OME-993) never fires
+for transport errors — only `Url4Error` is retried; (2) the error carries no
+`code`, so `public_error` falls back to the opaque benchmark default
+`draco_grading_failed`, and the message is `ReadError('')` because `str(exc)`
+is empty. Concurrent judge calls that fail together on a gateway blip also
+retry in lockstep — a retry storm against a recovering aigateway.
+
+**Constraint: `packages/url4` is untouchable and must stay agnostic to the
+screamingface/aigateway use cases.** This unit therefore retries and translates
+transport errors entirely in the screamingface-engine connector: a bounded
+backoff retry for `httpx.TransportError`, then a retryable
+`ResolutionError(code="aigateway_transport_error")` with a non-empty message.
+The benchmark's `retry=` (url4) stays as the second layer for HTTP-status
+failures and for a sustained outage.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/runner/connector.py` —
+  `_fetch_completion` posts go through a `_post_completion` helper that retries
+  `httpx.TransportError` with exponential backoff + jitter (module constants,
+  `_TRANSPORT_RETRIES = 1`) and then raises
+  `ResolutionError(code="aigateway_transport_error", permanent=False)` with a
+  non-empty message (`_transport_detail`).
+- Tests: `apps/screamingface-engine/tests/unit/test_aigateway_connector.py`
+  (transport-error translation + retry-then-succeed),
+  `apps/screamingface-engine/tests/unit/test_grading_error_integrity.py`
+  (judge ReadError → retry fires → graded; exhausted →
+  `aigateway_transport_error` + `retryable=True`).
+
+## Test plan
+
+- Connector unit: a `httpx.MockTransport` raising `httpx.ReadError("")` →
+  `ResolutionError` with `code="aigateway_transport_error"`, `permanent=False`,
+  non-empty message; a flaky transport (fail once, then succeed) → the call
+  succeeds after one retry (2 POSTs).
+- Engine grading-integrity: a judge world whose gateway raises `ReadError` on
+  the first judge post then answers a valid verdict → the case is graded
+  (retry fired); a world that always raises → the case failure is
+  `stage=grading`, `code=aigateway_transport_error`, `retryable=True`,
+  candidate output preserved.
+
+## Acceptance
+
+- A judge transport failure is retried (connector backoff) and, if still
+  failing, renders as `aigateway_transport_error` with `retryable=true` and a
+  non-empty message — never the opaque `draco_grading_failed` fallback.
+- `packages/url4` is untouched; the benchmark protocol text is unchanged (no
+  revision bump, no cache-key invalidation).
+- All gates green for `screamingface-engine`.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `runner/connector.py` (transport retry +
+  translation), `test_aigateway_connector.py` (2 tests),
+  `test_grading_error_integrity.py` (2 tests + `_judge_transport_world`
+  helper), plus the four docs. `packages/url4` untouched.
+- **Commits:** `3faaedfc` — fix(screamingface-engine): retry aigateway
+  transport failures in grading
+- **Gates:** `uv run .claude/scripts/run_gates.py screamingface-engine` —
+  ALL GATES GREEN (ruff check, ruff format, pyright, check_layering, pytest
+  --cov-fail-under=80). Full unit suite: 2036 passed, 5 skipped.
+- **Deviations:** Level 2 (url4 `GuardNode` backoff) was dropped after the
+  constraint that `packages/url4` is untouchable; the backoff retry moved
+  into the connector (`_post_completion`), with the benchmark's `retry=`
+  remaining a second layer for HTTP-status failures and sustained outages
+  (bounded at 2×3 = 6 POSTs per judge call).


### PR DESCRIPTION
## What

A transient `httpx.ReadError` on the runner→aigateway hop during a judge call
surfaced as `grading · draco_grading_failed · cases N, M — ReadError('')` in
the report. Two defects combined:

1. The connector let `httpx.TransportError` escape raw, so the benchmark's
   declared `retry=` policy (OME-993) never fired for transport errors — url4
   retries only `Url4Error`.
2. The error carried no `code`, so `public_error` fell back to the opaque
   benchmark default `draco_grading_failed`, and the message was
   `ReadError('')` because `str(exc)` is empty.

## Fix

`_fetch_completion`'s posts now go through `_post_completion`, which retries
`httpx.TransportError` with exponential backoff + jitter (bounded, module
constants) and then raises a retryable
`ResolutionError(code="aigateway_transport_error", permanent=False)` with a
non-empty message. The declared retry now fires and the report names the real
cause.

**Constraint honored: `packages/url4` is untouched** (agnosticism). The
backoff retry lives entirely in the engine connector; the benchmark's `retry=`
remains the second layer for HTTP-status failures and sustained outages
(bounded at 2×3 = 6 POSTs per judge call).

## Tests

- Connector: transport error → `aigateway_transport_error` + `permanent=False`
  + non-empty message; flaky transport (fail once) → retried, call succeeds.
- Grading integrity: judge `ReadError` once → case graded (retry fired);
  always raise → `stage=grading`, `code=aigateway_transport_error`,
  `retryable=True`, candidate output preserved.
- `uv run .claude/scripts/run_gates.py screamingface-engine` — ALL GATES GREEN.

Refs: OME-1016