### PR TITLE
Run control-plane resilience — resumable streams and stoppable runs (OME-1016)

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -17,7 +17,12 @@ from pydantic import ValidationError
 
 from screamingface_engine.subjects import owns_stream, stream_for, subject_for, topic_of
 from url4.streaming.codec import decode, encode
-from url4.streaming.interfaces import EventConsumer, EventPublisher, validate_from_sequence
+from url4.streaming.interfaces import (
+    EventConsumer,
+    EventPublisher,
+    StreamNotFoundError,
+    validate_from_sequence,
+)
 from url4.streaming.protocol import OutboundFrame, TerminatedEvent
 
 logger = logging.getLogger(__name__)
@@ -316,6 +321,18 @@ class _JetStreamConnection:
             await self._nc.close()
 
 
+async def _stream_exists(js: JetStreamContext, topic: str) -> bool:
+    """Whether the Run's stream is still declared on the broker.
+
+    `stream_info` on a missing stream raises NotFoundError; any other failure propagates.
+    """
+    try:
+        await js.stream_info(stream_for(topic))
+    except NotFoundError:
+        return False
+    return True
+
+
 class JetStreamConsumer(_JetStreamConnection, EventConsumer):
     """The App-side consumer: subscribes to a run's JetStream subject and decodes frames back
     into `OutboundFrame`s, optionally resuming from a given sequence."""
@@ -325,6 +342,12 @@ class JetStreamConsumer(_JetStreamConnection, EventConsumer):
     ) -> AsyncIterator[OutboundFrame]:
         validate_from_sequence(from_sequence)
         js = await self._jetstream()
+        if from_sequence is not None and not await _stream_exists(js, topic):
+            # A resume cursor with no stream to resume from: the Run finished and the
+            # Runner reclaimed the stream (spec §6 S2, OME-1019). The bridge turns this
+            # into a typed `stream_reclaimed` error frame. A FRESH attach (cursor None)
+            # still creates the stream — it legitimately precedes the Run's first publish.
+            raise StreamNotFoundError(topic)
         await self.ensure_stream(topic)
         sub = await js.subscribe(
             subject_for(topic),

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/memory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/memory.py
@@ -19,7 +19,7 @@ from bisect import bisect_left
 from collections.abc import AsyncIterator
 
 from url4.streaming.codec import decode, encode
-from url4.streaming.interfaces import EventStream, validate_from_sequence
+from url4.streaming.interfaces import EventStream, StreamNotFoundError, validate_from_sequence
 from url4.streaming.protocol import OutboundFrame
 
 DEFAULT_MAX_FRAMES_PER_TOPIC = 10_000
@@ -74,6 +74,11 @@ class InMemoryEventStream(EventStream):
         """Yields events for `topic` from `from_sequence` (or the start), then blocks and keeps
         yielding as new events are published — never terminates on its own."""
         validate_from_sequence(from_sequence)
+        if from_sequence is not None and topic not in self._log:
+            # Resume on a topic with no history: the Run finished and the stream was
+            # reclaimed (OME-1019). A FRESH attach may create the stream — the same rule
+            # as the broker adapter, mirrored for behavioral parity.
+            raise StreamNotFoundError(topic)
         await self.ensure_stream(topic)
         cond = self._conds[topic]
         cursor = 1 if from_sequence is None else from_sequence

--- a/apps/screamingface-engine/src/screamingface_engine/auth/dependencies.py
+++ b/apps/screamingface-engine/src/screamingface_engine/auth/dependencies.py
@@ -48,7 +48,11 @@ def verified_claims(request: Request) -> dict[str, object]:
     """
     settings: Settings = request.app.state.settings
     clock: Clock = getattr(request.app.state, "clock", _default_clock)
-    codec = JwtCodec(secret=settings.jwt_secret, iat_window_s=settings.iat_window_s)
+    codec = JwtCodec(
+        secret=settings.jwt_secret,
+        iat_window_s=settings.iat_window_s,
+        capability_lifetime_s=settings.capability_lifetime_s,
+    )
     try:
         token = _extract_capability(request)
         return codec.verify(token, clock())

--- a/apps/screamingface-engine/src/screamingface_engine/auth/jwt.py
+++ b/apps/screamingface-engine/src/screamingface_engine/auth/jwt.py
@@ -1,8 +1,8 @@
 """HS256 JWT minting and verification for screamingface-engine capability tokens.
 
-A capability token binds a client to a topic (the WS/stream routing key) and
-carries an ``iat``-based freshness window rather than relying solely on JWT's
-own ``exp`` handling — see :meth:`JwtCodec.verify`.
+A capability token binds a client to a topic (the WS/stream routing key). Lifetime is
+carried by the standard ``exp`` claim (``iat + capability_lifetime_s``); the ``iat``
+window guards only clock skew (a mint from the future). See :meth:`JwtCodec.verify`.
 """
 
 import secrets
@@ -32,16 +32,19 @@ class JwtCodec:
     # error/problem detail, or otherwise let it leak to a client-facing response.
     secret: str
     iat_window_s: int
+    # Run-horizon token lifetime (D1, OME-1016): `exp = iat + lifetime` at mint, so a Run's
+    # owner can re-attach, stop, or redeem for the Run's whole life (up to 16 h + slack).
+    capability_lifetime_s: int
 
     def sign(self, topic: str, now: datetime) -> str:
         """Mint a capability token for `topic`, stamped with `now` as issued-at
-        and expiring after `iat_window_s` seconds.
+        and expiring after `capability_lifetime_s` seconds.
         """
         iat = int(now.timestamp())
         payload = {
             "sub": topic,
             "iat": iat,
-            "exp": iat + self.iat_window_s,
+            "exp": iat + self.capability_lifetime_s,
             "jti": secrets.token_hex(_JTI_BYTES),
         }
         return pyjwt.encode(payload, self.secret, algorithm=_ALGORITHM)
@@ -52,11 +55,12 @@ class JwtCodec:
         Raises:
             InvalidToken: token is malformed or its signature does not verify.
             MissingIat: token has no ``iat`` claim.
-            IatWindowExceeded: ``now - iat`` exceeds `iat_window_s`.
+            IatWindowExceeded: ``iat`` is more than `iat_window_s` in the FUTURE
+                (clock skew only — lifetime is the ``exp`` claim alone).
             TokenExpired: the token's ``exp`` claim has passed.
         """
         try:
-            # WHY: exp is not trusted to pyjwt's own clock; it — and the iat window
+            # WHY: exp is not trusted to pyjwt's own clock; it — and the iat skew check
             # below — are checked manually against the caller-supplied `now`, so
             # verification stays deterministic and testable under a fake Clock.
             claims = pyjwt.decode(
@@ -69,7 +73,10 @@ class JwtCodec:
             raise MissingIat("token has no iat claim")
         now_s = int(now.timestamp())
         iat = int(claims["iat"])
-        if now_s - iat > self.iat_window_s:
+        # INVARIANT (OME-1018): the iat check is FRESHNESS ONLY — a future mint is clock
+        # skew, not a valid credential. It never bounds lifetime; `exp` is the only
+        # lifetime rule, so a Run's capability outlives its 60 s mint window.
+        if iat - now_s > self.iat_window_s:
             raise IatWindowExceeded("token iat is outside the acceptance window")
         exp = claims.get("exp")
         # INVARIANT: valid requires now < exp (RFC 7519); at now == exp the token is expired.

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -93,8 +93,13 @@ class Settings(BaseSettings):
     # INVARIANT: this bounds SPEND, not correctness — job_deadline_s (16h) remains the backstop.
     # Raising it costs money per orphaned run; lowering it risks stopping a live one.
     orphan_grace_s: float = Field(default=120.0, ge=0.0)
-    # INVARIANT: stateless iat window (seconds) — start rejected when now - iat exceeds it (§4).
+    # INVARIANT: stateless iat window (seconds) — now a CLOCK-SKEW tolerance only: a mint
+    # from more than one window in the future is rejected. It never bounds lifetime.
     iat_window_s: int = 60
+    # INVARIANT: capability-token lifetime (seconds) — `exp = iat + this` at mint (spec §6
+    # S1, OME-1016). WHY 58_800: the 16 h Job deadline (job_deadline_s) plus 1 h slack, so a
+    # Run's owner can always re-attach, stop, or redeem for the Run's whole life (D1).
+    capability_lifetime_s: int = 58_800
     # WHY: sync-hold cap; a run outliving it degrades to 202 async (spec §5).
     sync_max_wait_s: float = 30.0
     # WHY: idle interval between WS HeartbeatEvents for liveness (spec §6).

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -357,7 +357,11 @@ async def mint_token(request: Request) -> dict[str, str]:
     """Mint a fresh topic and its HS256 capability JWT. Unauthenticated (see route summary)."""
     settings: Settings = request.app.state.settings
     clock = getattr(request.app.state, "clock", _default_clock)
-    codec = JwtCodec(secret=settings.jwt_secret, iat_window_s=settings.iat_window_s)
+    codec = JwtCodec(
+        secret=settings.jwt_secret,
+        iat_window_s=settings.iat_window_s,
+        capability_lifetime_s=settings.capability_lifetime_s,
+    )
     return {"token": codec.sign(new_topic(), clock())}
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/ws/bridge.py
+++ b/apps/screamingface-engine/src/screamingface_engine/ws/bridge.py
@@ -20,7 +20,7 @@ from pydantic import ValidationError
 
 from screamingface_engine import notices
 from url4.streaming.codec import encode
-from url4.streaming.interfaces import EventConsumer, JobRunner
+from url4.streaming.interfaces import EventConsumer, JobRunner, StreamNotFoundError
 from url4.streaming.protocol import (
     AttachEvent,
     CachePolicy,
@@ -307,6 +307,22 @@ class Bridge:
             return
         exc = task.exception()
         if exc is None:
+            return
+        if isinstance(exc, StreamNotFoundError):
+            # OME-1019: a resume cursor with no stream is FINAL — the Run finished and the
+            # Runner reclaimed the stream (grace elapsed). Typed, so a reconnecting client
+            # stops instead of treating it as a transient `stream_failed`.
+            self._offer(
+                _error(
+                    self._topic,
+                    self._clock,
+                    "stream_reclaimed",
+                    "this run's stream was reclaimed: the run finished and the reclaim "
+                    "grace elapsed before this client re-attached; no further frames will "
+                    "arrive",
+                    None,
+                )
+            )
             return
         self._offer(
             _error(

--- a/apps/screamingface-engine/src/screamingface_engine/ws/endpoint.py
+++ b/apps/screamingface-engine/src/screamingface_engine/ws/endpoint.py
@@ -39,7 +39,11 @@ def _ticket_topic(websocket: WebSocket, ticket: str | None) -> str | None:
         return None
     settings: Settings = websocket.app.state.settings
     clock = getattr(websocket.app.state, "clock", _default_clock)
-    codec = JwtCodec(secret=settings.jwt_secret, iat_window_s=settings.iat_window_s)
+    codec = JwtCodec(
+        secret=settings.jwt_secret,
+        iat_window_s=settings.iat_window_s,
+        capability_lifetime_s=settings.capability_lifetime_s,
+    )
     try:
         return str(codec.verify(ticket, clock())["sub"])
     except AuthError:

--- a/apps/screamingface-engine/tests/integration/test_e2e_compose_flow.py
+++ b/apps/screamingface-engine/tests/integration/test_e2e_compose_flow.py
@@ -28,6 +28,7 @@ from url4.streaming.protocol import (
 
 SECRET = "e2e-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 SUBPROTOCOL = "cloudevents.json"
 EXPR = "(gpt,claude)!'hi'"
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
@@ -74,7 +75,7 @@ def _make_app(stream: InMemoryEventStream, runner: MockRunnerJobRunner) -> FastA
 
 
 def _topic_of(token: str) -> str:
-    return str(JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).verify(token, T0)["sub"])
+    return str(JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).verify(token, T0)["sub"])
 
 
 def _attach() -> dict[str, Any]:

--- a/apps/screamingface-engine/tests/integration/test_e2e_compose_flow.py
+++ b/apps/screamingface-engine/tests/integration/test_e2e_compose_flow.py
@@ -75,7 +75,11 @@ def _make_app(stream: InMemoryEventStream, runner: MockRunnerJobRunner) -> FastA
 
 
 def _topic_of(token: str) -> str:
-    return str(JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).verify(token, T0)["sub"])
+    return str(
+        JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).verify(
+            token, T0
+        )["sub"]
+    )
 
 
 def _attach() -> dict[str, Any]:

--- a/apps/screamingface-engine/tests/unit/test_app_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_app_factory.py
@@ -35,7 +35,11 @@ def _unconfigured_app() -> object:
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
+    return {
+        "URL4-Capability": JwtCodec(
+            secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S
+        ).sign(topic, T0)
+    }
 
 
 @pytest.mark.anyio

--- a/apps/screamingface-engine/tests/unit/test_app_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_app_factory.py
@@ -14,6 +14,7 @@ pytestmark = pytest.mark.asyncio
 
 SECRET = "app-factory-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
@@ -34,7 +35,7 @@ def _unconfigured_app() -> object:
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
 
 
 @pytest.mark.anyio

--- a/apps/screamingface-engine/tests/unit/test_artifact_ports.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_ports.py
@@ -46,7 +46,11 @@ T0 = datetime(2026, 8, 21, 9, 0, 0, tzinfo=UTC)
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
+    return {
+        "URL4-Capability": JwtCodec(
+            secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S
+        ).sign(topic, T0)
+    }
 
 
 # --- the ports are satisfied by the filesystem adapter -----------------------------------

--- a/apps/screamingface-engine/tests/unit/test_artifact_ports.py
+++ b/apps/screamingface-engine/tests/unit/test_artifact_ports.py
@@ -41,11 +41,12 @@ from url4.streaming.protocol.signals import ResultArtifact
 
 SECRET = "artifact-ports-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 8, 21, 9, 0, 0, tzinfo=UTC)
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
 
 
 # --- the ports are satisfied by the filesystem adapter -----------------------------------

--- a/apps/screamingface-engine/tests/unit/test_attach_from_sequence_bounds.py
+++ b/apps/screamingface-engine/tests/unit/test_attach_from_sequence_bounds.py
@@ -78,12 +78,18 @@ async def test_conformance_subscribe_still_accepts_one_and_none(
 ) -> None:
     """The guard must not have narrowed the legal range: `1` and `None` still subscribe.
 
+    The stream is ensured FIRST: on a missing stream a resume cursor is now a RECLAIMED
+    stream (`StreamNotFoundError`, OME-1019), not a live wait — the deliberate behavior
+    change this test documents. A cursor on an existing-but-empty stream still waits.
+
     WHY a timeout is the assertion: `subscribe` is an async generator, so the guard does not run
     until the first `__anext__`. Waiting on an empty topic therefore proves BOTH that the value
     was accepted (no `ValueError`) and that the subscription is live and waiting for frames —
     a `TimeoutError` here is the pass condition, not a flake.
     """
     stream = make_stream()
+    topic = _topic()
+    await stream.ensure_stream(topic)
     with pytest.raises(TimeoutError):
         async with asyncio.timeout(0.25):
-            await take(stream, _topic(), 1, cursor)
+            await take(stream, topic, 1, cursor)

--- a/apps/screamingface-engine/tests/unit/test_auth.py
+++ b/apps/screamingface-engine/tests/unit/test_auth.py
@@ -79,6 +79,26 @@ def test_iat_window_exceeded_rejected() -> None:
         _codec().verify(token, T0 + timedelta(seconds=WINDOW_S + 1))
 
 
+def test_old_iat_rejected_even_when_exp_future() -> None:
+    """PIN (OME-1017, spec §2): the age check — not `exp` — is the lifetime rule today.
+
+    A token whose `iat` is far in the past is rejected by the iat window even when its
+    `exp` is still in the future. This is the lifetime/freshness conflation R2 removes:
+    after R2, `exp` alone decides lifetime and this exact token verifies.
+    """
+    forged = pyjwt.encode(
+        {
+            "sub": "topic",
+            "iat": int(T0.timestamp()) - 3600,
+            "exp": int(T0.timestamp()) + 3600,
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+    with pytest.raises(IatWindowExceeded):
+        _codec().verify(forged, T0)
+
+
 def test_exp_boundary_rejected() -> None:
     token = _codec().sign("topic", T0)
     with pytest.raises(TokenExpired):

--- a/apps/screamingface-engine/tests/unit/test_auth.py
+++ b/apps/screamingface-engine/tests/unit/test_auth.py
@@ -20,12 +20,17 @@ from screamingface_engine.auth import (
 from screamingface_engine.config import Settings
 
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s: 16 h Job deadline + 1 h slack (D1)
 SECRET = "unit-test-secret"
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
 def _codec() -> JwtCodec:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S)
+    return JwtCodec(
+        secret=SECRET,
+        iat_window_s=WINDOW_S,
+        capability_lifetime_s=LIFETIME_S,
+    )
 
 
 def test_new_topic_is_64_alnum() -> None:
@@ -45,7 +50,7 @@ def test_sign_verify_roundtrip() -> None:
     assert claims["sub"] == topic
     iat, exp, jti = claims["iat"], claims["exp"], claims["jti"]
     assert isinstance(iat, int) and isinstance(exp, int)
-    assert exp == iat + WINDOW_S
+    assert exp == iat + LIFETIME_S
     assert isinstance(jti, str) and jti
 
 
@@ -59,7 +64,11 @@ def test_fresh_token_inside_window_accepted() -> None:
 def test_wrong_secret_rejected() -> None:
     token = _codec().sign("topic", T0)
     with pytest.raises(InvalidToken):
-        JwtCodec(secret="other-secret", iat_window_s=WINDOW_S).verify(token, T0)
+        JwtCodec(
+            secret="other-secret",
+            iat_window_s=WINDOW_S,
+            capability_lifetime_s=LIFETIME_S,
+        ).verify(token, T0)
 
 
 def test_malformed_token_rejected() -> None:
@@ -73,18 +82,18 @@ def test_missing_iat_rejected() -> None:
         _codec().verify(forged, T0)
 
 
-def test_iat_window_exceeded_rejected() -> None:
+def test_iat_window_future_skew_rejected() -> None:
     token = _codec().sign("topic", T0)
+    # `iat` one full window in the FUTURE is clock skew, not a valid mint.
     with pytest.raises(IatWindowExceeded):
-        _codec().verify(token, T0 + timedelta(seconds=WINDOW_S + 1))
+        _codec().verify(token, T0 - timedelta(seconds=WINDOW_S + 1))
 
 
-def test_old_iat_rejected_even_when_exp_future() -> None:
-    """PIN (OME-1017, spec §2): the age check — not `exp` — is the lifetime rule today.
+def test_old_iat_with_future_exp_verifies_within_lifetime() -> None:
+    """FLIP of the OME-1017 pin (spec §6 S1): `exp` is now the ONLY lifetime rule.
 
-    A token whose `iat` is far in the past is rejected by the iat window even when its
-    `exp` is still in the future. This is the lifetime/freshness conflation R2 removes:
-    after R2, `exp` alone decides lifetime and this exact token verifies.
+    The same token R1 pinned as rejected — old `iat`, future `exp` — now verifies for
+    the whole capability lifetime. The freshness check guards only future skew.
     """
     forged = pyjwt.encode(
         {
@@ -95,20 +104,22 @@ def test_old_iat_rejected_even_when_exp_future() -> None:
         SECRET,
         algorithm="HS256",
     )
-    with pytest.raises(IatWindowExceeded):
-        _codec().verify(forged, T0)
+    claims = _codec().verify(forged, T0)
+    assert claims["sub"] == "topic"
 
 
-def test_exp_boundary_rejected() -> None:
+def test_capability_lifetime_boundary_rejected() -> None:
     token = _codec().sign("topic", T0)
+    # Valid at exp - 1 (RFC 7519: valid requires now < exp); rejected at exp.
+    _codec().verify(token, T0 + timedelta(seconds=LIFETIME_S - 1))
     with pytest.raises(TokenExpired):
-        _codec().verify(token, T0 + timedelta(seconds=WINDOW_S))
+        _codec().verify(token, T0 + timedelta(seconds=LIFETIME_S))
 
 
 def test_error_text_never_leaks_secret_or_token() -> None:
     token = _codec().sign("topic", T0)
     try:
-        _codec().verify(token, T0 + timedelta(seconds=WINDOW_S + 1))
+        _codec().verify(token, T0 - timedelta(seconds=WINDOW_S + 1))
     except IatWindowExceeded as exc:
         assert SECRET not in str(exc)
         assert token not in str(exc)
@@ -138,7 +149,7 @@ def test_dependency_accepts_valid_capability() -> None:
 
 def test_dependency_rejects_expired_as_problem_json() -> None:
     token = _codec().sign("topic", T0)
-    client = TestClient(_protected_app(T0 + timedelta(seconds=WINDOW_S + 5)))
+    client = TestClient(_protected_app(T0 + timedelta(seconds=LIFETIME_S + 5)))
     resp = client.get("/protected", headers={"URL4-Capability": token})
     assert resp.status_code == 401
     assert resp.headers["content-type"].startswith("application/problem+json")
@@ -164,7 +175,7 @@ def test_dependency_rejects_tampered_capability() -> None:
 
 def test_dependency_error_body_omits_token() -> None:
     token = _codec().sign("secret-topic", T0)
-    client = TestClient(_protected_app(T0 + timedelta(seconds=WINDOW_S + 5)))
+    client = TestClient(_protected_app(T0 + timedelta(seconds=LIFETIME_S + 5)))
     resp = client.get("/protected", headers={"URL4-Capability": token})
     assert token not in resp.text
 

--- a/apps/screamingface-engine/tests/unit/test_cache_policy_threading.py
+++ b/apps/screamingface-engine/tests/unit/test_cache_policy_threading.py
@@ -55,6 +55,7 @@ from url4.streaming.protocol import CachePolicy
 
 SECRET = "cache-threading-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
 MODEL = "anthropic/claude-haiku-4-5"
 TAVILY_TOKEN = "tvly-threading"  # noqa: S105 - not a real credential
@@ -288,7 +289,7 @@ async def _start(runner: _CacheRecordingRunner, topic: str, **headers: str) -> h
             "/",
             params={"q": "gpt(hi)"},
             headers={
-                "URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0),
+                "URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0),
                 "Prefer": "respond-async",
                 **headers,
             },

--- a/apps/screamingface-engine/tests/unit/test_cache_policy_threading.py
+++ b/apps/screamingface-engine/tests/unit/test_cache_policy_threading.py
@@ -289,7 +289,9 @@ async def _start(runner: _CacheRecordingRunner, topic: str, **headers: str) -> h
             "/",
             params={"q": "gpt(hi)"},
             headers={
-                "URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0),
+                "URL4-Capability": JwtCodec(
+                    secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S
+                ).sign(topic, T0),
                 "Prefer": "respond-async",
                 **headers,
             },

--- a/apps/screamingface-engine/tests/unit/test_event_stream_adapters.py
+++ b/apps/screamingface-engine/tests/unit/test_event_stream_adapters.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import cast
 
 import pytest
 from _fakes import take
@@ -6,7 +7,7 @@ from _fakes import take
 from screamingface_engine.adapters.jetstream import JetStreamConsumer, JetStreamPublisher
 from screamingface_engine.testing import InMemoryEventStream
 from url4.streaming.interfaces import EventConsumer, EventPublisher, StreamNotFoundError
-from url4.streaming.protocol import LogData, LogEvent, SpanData, SpanEvent
+from url4.streaming.protocol import LogData, LogEvent, OutboundFrame, SpanData, SpanEvent
 
 TOPIC = "cap-topic"
 
@@ -36,8 +37,10 @@ async def test_resume_cursor_on_missing_stream_is_stream_not_found() -> None:
 @pytest.mark.asyncio
 async def test_fresh_attach_on_missing_stream_creates_and_delivers() -> None:
     """The fresh-attach side of the rule: cursor None creates the stream and delivers."""
+    from collections.abc import AsyncGenerator
+
     stream = InMemoryEventStream()
-    frames = stream.subscribe("fresh-topic", None)
+    frames = cast(AsyncGenerator[OutboundFrame], stream.subscribe("fresh-topic", None))
     try:
         first = anext(frames)
         await stream.publish("fresh-topic", _log_event(1))

--- a/apps/screamingface-engine/tests/unit/test_event_stream_adapters.py
+++ b/apps/screamingface-engine/tests/unit/test_event_stream_adapters.py
@@ -5,7 +5,7 @@ from _fakes import take
 
 from screamingface_engine.adapters.jetstream import JetStreamConsumer, JetStreamPublisher
 from screamingface_engine.testing import InMemoryEventStream
-from url4.streaming.interfaces import EventConsumer, EventPublisher
+from url4.streaming.interfaces import EventConsumer, EventPublisher, StreamNotFoundError
 from url4.streaming.protocol import LogData, LogEvent, SpanData, SpanEvent
 
 TOPIC = "cap-topic"
@@ -18,6 +18,33 @@ def _log_event(n: int) -> LogEvent:
         subject="t",
         data=LogData(severity_number=9, severity_text="INFO", body=f"msg-{n}"),
     )
+
+
+@pytest.mark.asyncio
+async def test_resume_cursor_on_missing_stream_is_stream_not_found() -> None:
+    """OME-1019: a resume cursor with no stream to resume from is a RECLAIMED stream.
+
+    Fresh attaches may create the stream; a resume cursor never can — that is exactly
+    the signal the bridge uses to answer `stream_reclaimed`.
+    """
+    stream = InMemoryEventStream()
+    with pytest.raises(StreamNotFoundError):
+        async for _ in stream.subscribe("never-created", from_sequence=3):
+            pass  # pragma: no cover - the generator raises before yielding
+
+
+@pytest.mark.asyncio
+async def test_fresh_attach_on_missing_stream_creates_and_delivers() -> None:
+    """The fresh-attach side of the rule: cursor None creates the stream and delivers."""
+    stream = InMemoryEventStream()
+    frames = stream.subscribe("fresh-topic", None)
+    try:
+        first = anext(frames)
+        await stream.publish("fresh-topic", _log_event(1))
+        frame = await first
+        assert frame is not None
+    finally:
+        await frames.aclose()
 
 
 @pytest.mark.asyncio

--- a/apps/screamingface-engine/tests/unit/test_identity_header_propagation.py
+++ b/apps/screamingface-engine/tests/unit/test_identity_header_propagation.py
@@ -41,6 +41,7 @@ pytestmark = pytest.mark.asyncio
 
 SECRET = "identity-propagation-unit-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 TOKEN = "tok-identity"  # noqa: S105 - not a real credential, test fixture only
 MODEL = "anthropic/claude-haiku-4-5"
@@ -52,7 +53,7 @@ IDENTITY = {"X-User-Email": "someone@openmined.org"}
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 def _app(job_runner: RecordingJobRunner) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_identity_header_propagation.py
+++ b/apps/screamingface-engine/tests/unit/test_identity_header_propagation.py
@@ -53,7 +53,9 @@ IDENTITY = {"X-User-Email": "someone@openmined.org"}
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 def _app(job_runner: RecordingJobRunner) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_jetstream_subscribe_ensures_stream.py
+++ b/apps/screamingface-engine/tests/unit/test_jetstream_subscribe_ensures_stream.py
@@ -4,9 +4,11 @@ from typing import Any, cast
 
 import pytest
 from nats.js import JetStreamContext
+from nats.js.errors import BadRequestError, NotFoundError
 
 from screamingface_engine.adapters.jetstream import JetStreamConsumer
 from url4.streaming.codec import encode
+from url4.streaming.interfaces import StreamNotFoundError
 from url4.streaming.protocol import LogData, LogEvent, OutboundFrame, source_for
 
 pytestmark = pytest.mark.asyncio
@@ -49,6 +51,13 @@ class _FakeJetStream:
         self.calls: list[str] = []
         self.subs: list[_FakeSub] = []
         self._messages_per_sub = messages_per_sub
+        self._stream_declared = False
+
+    async def stream_info(self, name: str) -> object:
+        self.calls.append("stream_info")
+        if not self._stream_declared:
+            raise NotFoundError
+        return object()
 
     async def add_stream(
         self,
@@ -61,7 +70,13 @@ class _FakeJetStream:
         **_: object,
     ) -> object:
         self.calls.append("add_stream")
+        already = self._stream_declared
+        self._stream_declared = True
         self.stream_limits = {"max_age": max_age, "max_bytes": max_bytes, "discard": discard}
+        # Mirror the real broker: re-declaring an existing stream is a BadRequestError the
+        # adapter's ensure_stream tolerates (`_declare` swallows it).
+        if already:
+            raise BadRequestError
         return object()
 
     async def subscribe(self, subject: str, **kwargs: Any) -> _FakeSub:
@@ -81,6 +96,36 @@ async def test_subscribe_ensures_the_stream_before_binding_to_it() -> None:
         pass
 
     assert js.calls == ["add_stream", "subscribe"]
+
+
+@pytest.mark.anyio
+async def test_resume_cursor_on_missing_stream_is_stream_not_found() -> None:
+    """OME-1019: a resume cursor on a stream the Runner reclaimed is a typed error,
+    not a silent re-creation. The fresh attach above keeps creating the stream."""
+    stream = JetStreamConsumer("nats://unused:4222")
+    js = _FakeJetStream()
+    stream._js = cast(JetStreamContext, js)  # noqa: SLF001
+
+    with pytest.raises(StreamNotFoundError):
+        async for _ in stream.subscribe("topic-a", from_sequence=3):
+            pass  # pragma: no cover - the generator raises before yielding
+
+    assert js.calls == ["stream_info"]
+
+
+@pytest.mark.anyio
+async def test_resume_cursor_on_existing_stream_binds_without_recreating() -> None:
+    stream = JetStreamConsumer("nats://unused:4222")
+    js = _FakeJetStream()
+    js._stream_declared = True  # the stream exists; re-declare will be a tolerated error
+    stream._js = cast(JetStreamContext, js)  # noqa: SLF001
+
+    async for _ in stream.subscribe("topic-a", from_sequence=3):  # pragma: no branch
+        pass
+
+    # The stream is probed (exists), the redundant declare is a tolerated round trip, and
+    # the consumer binds from the cursor — no re-creation happens.
+    assert js.calls == ["stream_info", "add_stream", "subscribe"]
 
 
 @pytest.mark.anyio

--- a/apps/screamingface-engine/tests/unit/test_rest.py
+++ b/apps/screamingface-engine/tests/unit/test_rest.py
@@ -21,11 +21,12 @@ from url4.streaming.protocol import (
 
 SECRET = "rest-unit-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 def _cap(topic: str) -> dict[str, str]:
@@ -88,7 +89,7 @@ async def test_post_token_returns_a_verifiable_token() -> None:
         resp = await client.post("/token")
     assert resp.status_code == 200
     token = resp.json()["token"]
-    claims = JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).verify(token, T0)
+    claims = JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).verify(token, T0)
     assert isinstance(claims["sub"], str) and len(str(claims["sub"])) == 64
 
 
@@ -100,7 +101,7 @@ async def test_post_token_uses_default_clock_when_none_injected() -> None:
         resp = await client.post("/token")
     assert resp.status_code == 200
     token = resp.json()["token"]
-    claims = JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).verify(token, datetime.now(UTC))
+    claims = JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).verify(token, datetime.now(UTC))
     assert isinstance(claims["sub"], str)
 
 

--- a/apps/screamingface-engine/tests/unit/test_rest.py
+++ b/apps/screamingface-engine/tests/unit/test_rest.py
@@ -26,7 +26,9 @@ T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 def _cap(topic: str) -> dict[str, str]:
@@ -89,7 +91,9 @@ async def test_post_token_returns_a_verifiable_token() -> None:
         resp = await client.post("/token")
     assert resp.status_code == 200
     token = resp.json()["token"]
-    claims = JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).verify(token, T0)
+    claims = JwtCodec(
+        secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S
+    ).verify(token, T0)
     assert isinstance(claims["sub"], str) and len(str(claims["sub"])) == 64
 
 
@@ -101,7 +105,9 @@ async def test_post_token_uses_default_clock_when_none_injected() -> None:
         resp = await client.post("/token")
     assert resp.status_code == 200
     token = resp.json()["token"]
-    claims = JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).verify(token, datetime.now(UTC))
+    claims = JwtCodec(
+        secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S
+    ).verify(token, datetime.now(UTC))
     assert isinstance(claims["sub"], str)
 
 

--- a/apps/screamingface-engine/tests/unit/test_rest_artifacts.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_artifacts.py
@@ -35,7 +35,11 @@ T0 = datetime(2026, 8, 18, 9, 0, 0, tzinfo=UTC)
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
+    return {
+        "URL4-Capability": JwtCodec(
+            secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S
+        ).sign(topic, T0)
+    }
 
 
 def _make_app(

--- a/apps/screamingface-engine/tests/unit/test_rest_artifacts.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_artifacts.py
@@ -28,13 +28,14 @@ from url4.streaming.protocol import ResultData, ResultEvent
 
 SECRET = "rest-artifacts-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 # WHY a past instant: pyjwt refuses an `iat` in the future, so the fake clock must lag
 # real UTC or every minted capability is rejected before our own window checks run.
 T0 = datetime(2026, 8, 18, 9, 0, 0, tzinfo=UTC)
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
 
 
 def _make_app(

--- a/apps/screamingface-engine/tests/unit/test_rest_cache_convergence.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_cache_convergence.py
@@ -159,7 +159,9 @@ def test_carriers_agreeing_on_participation_but_not_on_the_bound_still_conflict(
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 @pytest.fixture

--- a/apps/screamingface-engine/tests/unit/test_rest_cache_convergence.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_cache_convergence.py
@@ -51,6 +51,7 @@ from url4.streaming.protocol import (
 
 SECRET = "rest-cache-convergence-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
 
 OPT_OUT = CachePolicy(participate=False)
@@ -158,7 +159,7 @@ def test_carriers_agreeing_on_participation_but_not_on_the_bound_still_conflict(
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 @pytest.fixture

--- a/apps/screamingface-engine/tests/unit/test_rest_cache_header.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_cache_header.py
@@ -326,6 +326,7 @@ def test_the_parser_only_ever_yields_a_policy_or_silence(raw: str | None) -> Non
 
 SECRET = "cache-header-unit-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
 
 
@@ -344,7 +345,7 @@ def _client(app: FastAPI) -> httpx.AsyncClient:
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)}
+    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
 
 
 @pytest.mark.parametrize(

--- a/apps/screamingface-engine/tests/unit/test_rest_cache_header.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_cache_header.py
@@ -345,7 +345,11 @@ def _client(app: FastAPI) -> httpx.AsyncClient:
 
 
 def _cap(topic: str) -> dict[str, str]:
-    return {"URL4-Capability": JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)}
+    return {
+        "URL4-Capability": JwtCodec(
+            secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S
+        ).sign(topic, T0)
+    }
 
 
 @pytest.mark.parametrize(

--- a/apps/screamingface-engine/tests/unit/test_traceparent.py
+++ b/apps/screamingface-engine/tests/unit/test_traceparent.py
@@ -155,7 +155,9 @@ async def test_all_zero_inbound_traceparent_mints_a_fresh_trace() -> None:
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 def _app(job_runner: RecordingJobRunner) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_traceparent.py
+++ b/apps/screamingface-engine/tests/unit/test_traceparent.py
@@ -28,6 +28,7 @@ _TP_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-01$")
 
 SECRET = "traceparent-unit-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
@@ -154,7 +155,7 @@ async def test_all_zero_inbound_traceparent_mints_a_fresh_trace() -> None:
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 def _app(job_runner: RecordingJobRunner) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_ws.py
+++ b/apps/screamingface-engine/tests/unit/test_ws.py
@@ -37,7 +37,9 @@ T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 def _make_app(

--- a/apps/screamingface-engine/tests/unit/test_ws.py
+++ b/apps/screamingface-engine/tests/unit/test_ws.py
@@ -31,12 +31,13 @@ from url4.streaming.protocol import (
 
 SECRET = "ws-unit-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 SUBPROTOCOL = "cloudevents.json"
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 def _make_app(

--- a/apps/screamingface-engine/tests/unit/test_ws_cache_policy.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_cache_policy.py
@@ -36,6 +36,7 @@ from url4.streaming.protocol import (
 
 SECRET = "ws-cache-policy-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 8, 5, 9, 0, 0, tzinfo=UTC)
 
 OPT_OUT = CachePolicy(participate=False)
@@ -43,7 +44,7 @@ OPT_IN = CachePolicy(participate=True)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 def _make_app(*, stream: InMemoryEventStream) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_ws_cache_policy.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_cache_policy.py
@@ -44,7 +44,9 @@ OPT_IN = CachePolicy(participate=True)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 def _make_app(*, stream: InMemoryEventStream) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_ws_pump_failure_surfaces.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_pump_failure_surfaces.py
@@ -26,7 +26,9 @@ class ExplodingBus(InMemoryEventStream):
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 def _make_app(stream: Any) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_ws_pump_failure_surfaces.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_pump_failure_surfaces.py
@@ -85,6 +85,22 @@ def test_any_pump_failure_reaches_the_client_as_an_error_frame() -> None:
     assert frame["data"]["code"] == "stream_failed"
 
 
+def test_resume_attach_on_reclaimed_stream_is_stream_reclaimed() -> None:
+    """OME-1019: a resume cursor with no stream is FINAL — the Run finished and the
+    Runner reclaimed the stream — and is typed distinctly from a transient failure."""
+    topic = "ws-reclaimed"
+    # The topic was never published to: no stream exists, so a resume cursor has nothing
+    # to resume from (the reclaimed case). A fresh attach would create it (covered by the
+    # adapter parity tests).
+    app = _make_app(InMemoryEventStream())
+    with TestClient(app) as client:
+        with client.websocket_connect(f"/ws?ticket={_token(topic)}") as ws:
+            ws.send_json(_raw_attach(3))
+            frame = ws.receive_json()
+    assert frame["type"] == "ai.url4.error"
+    assert frame["data"]["code"] == "stream_reclaimed"
+
+
 def test_pump_failure_nack_does_not_leak_the_broker_message() -> None:
     topic = "ws-pump-leak"
     app = _make_app(ExplodingBus())

--- a/apps/screamingface-engine/tests/unit/test_ws_pump_failure_surfaces.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_pump_failure_surfaces.py
@@ -13,6 +13,7 @@ from url4.streaming.protocol import OutboundFrame, StartedData, StartedEvent
 
 SECRET = "ws-pump-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 T0 = datetime(2026, 7, 21, 9, 0, 0, tzinfo=UTC)
 
 
@@ -25,7 +26,7 @@ class ExplodingBus(InMemoryEventStream):
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 def _make_app(stream: Any) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_ws_stream_diagnostics.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_stream_diagnostics.py
@@ -38,7 +38,9 @@ T0 = datetime(2026, 8, 13, 9, 0, 0, tzinfo=UTC)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
 
 
 def _app(stream: InMemoryEventStream | None, *, heartbeat_s: float = 30.0) -> FastAPI:

--- a/apps/screamingface-engine/tests/unit/test_ws_stream_diagnostics.py
+++ b/apps/screamingface-engine/tests/unit/test_ws_stream_diagnostics.py
@@ -31,13 +31,14 @@ from url4.streaming.protocol import (
 
 SECRET = "ws-diagnostics-secret"
 WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
 SUBPROTOCOL = "cloudevents.json"
 TOPIC = "topic-diag"
 T0 = datetime(2026, 8, 13, 9, 0, 0, tzinfo=UTC)
 
 
 def _token(topic: str) -> str:
-    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S).sign(topic, T0)
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(topic, T0)
 
 
 def _app(stream: InMemoryEventStream | None, *, heartbeat_s: float = 30.0) -> FastAPI:

--- a/docs/plan/2026-08-26-run-resume-and-control.md
+++ b/docs/plan/2026-08-26-run-resume-and-control.md
@@ -1,0 +1,153 @@
+# Run control-plane resilience — Plan
+
+Spec: `docs/spec/2026-08-26-run-resume-and-control.md`
+Incident: 2026-08-26 14:58 UTC (App deploy closed 3 in-flight Runs with close 1012)
+Status: draft — spec decisions D1–D5 recorded 2026-08-26; Linear cut: OME-1016 (epic),
+OME-1017 (R1), OME-1018 (R2), OME-1019 (R3), OME-1020 (R4); related OME-890 (reaper).
+Decisions applied: capability lifetime 58 800 s; reconnect budget 90 s (D2 ceiling 120 s,
+pinned below the OME-890 reaper's 120 s grace — spec §6 S6); stream grace 60 s;
+R5 (drain notice) removed from v1; no engine-version probe (D5 — single deployed engine,
+deploy-on-merge, so no old-engine fleet).
+
+## 0. Work-item structure (per CLAUDE.md rule 8: cross-cutting)
+
+One Linear epic plus one sub-issue per app/package. Linear is the authority; mirror each in
+`docs/tasks/`. Cut these before Step 1 (owner action, MCP only):
+
+| # | Sub-issue scope | App/package | Steps | Depends on |
+|---|---|---|---|---|
+| R1 · OME-1017 | Characterization tests: pin today's fatal-1012 and dead sweep | screamingface-engine, screamingface (SDK) | 1 | — |
+| R2 · OME-1018 | Token lifetime split (`capability_lifetime_s`, skew-only iat check) | screamingface-engine | 2 | R1 |
+| R3 · OME-1019 | Typed `stream_reclaimed` error frame | screamingface-engine | 3 | R1 |
+| R4 · OME-1020 | Reconnect state machine + transport-level sweep | packages/screamingface | 4 | R2, R3 |
+
+~~R5 (drain notice)~~ — removed from v1 by owner decision D4 (2026-08-26).
+
+Rollout order: engine first (R2, R3 — safe, independent), then SDK (R4).
+Compatibility is one-directional by owner decision D5: one engine is deployed and merges
+deploy promptly, so no old-engine fleet exists. Old SDKs against the new engine keep today's
+behavior — and their abort sweeps START WORKING, because the long-lived token makes
+`DELETE /` succeed for Runs older than 60 s. The engine deploy alone therefore closes the
+orphaned-spend half of the incident; R4 adds resume.
+
+Every unit: worktree from `origin/main` (`.claude/worktrees/OME-N-<desc>`), ledger from
+`docs/work/TEMPLATE.md` at start, PR with `Refs: OME-N`, green CI, squash-merge.
+
+## Step 1 — RED: characterization (R1)
+
+Engine (`apps/screamingface-engine/tests/unit/test_auth.py` vicinity):
+- Pin: a token older than `iat_window_s` is rejected **and** a token with a future `exp` is
+  still rejected by the age check (documents the conflation being removed).
+
+SDK (`packages/screamingface/tests/…`, transport tests):
+- Pin: a close-1012 mid-Run raises `ExecutionError(code="websocket_disconnected")`.
+- Pin: `cancel_active()` with a token the server rejects raises; the evaluation sweep records
+  the note and the Runs continue (today's orphan mechanism).
+
+These tests pass before any change. Steps 2–4 flip specific assertions deliberately, each in
+its own commit naming the spec section.
+
+## Step 2 — Engine: token lifetime (R2)
+
+Files:
+
+| File | Change |
+|---|---|
+| `src/screamingface_engine/auth/jwt.py` | `sign()`: `exp = iat + capability_lifetime_s`. `verify()`: replace `now - iat > iat_window_s` with `iat - now > iat_window_s` (future-skew); `exp` check unchanged |
+| `src/screamingface_engine/config.py` | new `capability_lifetime_s: int = 58_800` (D1); re-document `iat_window_s` as skew tolerance — its docstring currently states the OLD invariant ("start rejected when now - iat exceeds it"), which R2 deletes
+| `src/screamingface_engine/auth/dependencies.py`, `rest/routes.py`, `ws/endpoint.py` | none (they pass `iat_window_s` through unchanged) |
+| `tests/unit/test_auth.py` | boundary table: accept `exp - 1`, reject at `exp`; reject iat > now + window; age no longer rejects within lifetime |
+
+RED first: write the boundary table against the NEW semantics; it fails. Then GREEN.
+Gates: `python3 .claude/scripts/run_gates.py screamingface-engine`.
+
+## Step 3 — Engine: typed reclaimed-stream answer (R3)
+
+| File | Change |
+|---|---|
+| `src/screamingface_engine/ws/bridge.py` | `_on_pump_done`: classify "stream not found" from the consumer as `ai.url4.error` with `code="stream_reclaimed"`; keep `stream_failed` for other pump errors |
+| `src/screamingface_engine/adapters/jetstream.py` (consumer) | surface "stream not found" as a distinguishable exception/type at the `EventConsumer` boundary |
+| `tests/unit/…` | attach to a deleted stream → one `stream_reclaimed` frame; transient broker error → `stream_failed` as today |
+
+Gates: `python3 .claude/scripts/run_gates.py screamingface-engine`.
+
+## Step 4 — SDK: reconnect state machine (R4)
+
+All changes in `packages/screamingface/src/screamingface/_engine/transport.py` and
+`run_lifecycle.py`/`contract.py` only as needed; mirror in both sync and async twins.
+
+1. Extract the resume cursor: expose `_RunState._last_sequence` through `_Lifecycle` (the
+   `replay_from` path already computes it for gaps; add a getter for cross-connection use).
+2. Add the state machine (one `enum`, transitions per spec §6 S3; no scattered booleans):
+   - On `(WebSocketException, OSError, TimeoutError)` AFTER the start was accepted and BEFORE
+     an outcome: enter BACKOFF, not FATAL.
+   - BACKOFF: full-jitter delays 0.5 s doubling to a 15 s cap; total budget
+     `_RECONNECT_BUDGET_S = 90` (D2 ceiling 120 s; 90 s is pinned STRICTLY INSIDE the
+     OME-890 reaper's `orphan_grace_s = 120` — spec §6 S6 — so a reconnecting client never
+     loses its Run to the reaper mid-backoff). Budget is cumulative across the Run's
+     lifetime, not per disconnect.
+   - Reconnect: same ticket; `attach(from_sequence = cursor)`; existing sequence/event-id
+     dedup absorbs replayed frames.
+   - Classify failures: Access-challenge (`_is_access_websocket_rejection`) → existing
+     re-auth branch first; handshake 401/403 otherwise → FATAL (genuinely dead credentials:
+     lifetime expired or secret rotated — no probe, D5); refused/5xx/OS
+     errors → keep backing off; `stream_reclaimed` frame → FATAL
+     `ExecutionError(code="run_result_lost", permanent=True)`; budget exhausted → sweep then
+     FATAL `websocket_disconnected`.
+   - Transport-level sweep: on FATAL-after-disconnect, call the same stop helper the
+     evaluation sweep uses, so single-candidate Runs are also covered (G3).
+3. Progress UI: emit an event/notice on each BACKOFF attempt ("reconnecting, attempt n");
+   the widget renders it as a line, not a failure.
+4. Pin the exact handshake rejection codes for an invalid ticket against a real engine in the
+   integration environment (spec §9 assumption) before freezing the classification.
+
+Tests (fake sockets/fake server): the matrix from spec §9 — resume without duplicates;
+missed terminal replayed; 401 → fast FATAL; budget exhaustion → sweep called; reclaimed →
+`run_result_lost`; Access challenge → re-auth then resume; two sequential disconnects.
+
+Gates: `python3 .claude/scripts/run_gates.py screamingface`.
+
+## Step 5 — (removed from v1, D4)
+
+The drain notice was dropped by owner decision. If revisited: fan out one
+`engine_draining` notice to every registered topic via the session registry's notifiers in
+`app.py`'s lifespan shutdown path.
+
+## Step 6 — Integration + live verification
+
+- Compose test: start a Run; `docker kill` the App container mid-Run; SDK completes the Run
+  after restart; report identical to an unkilled Run.
+- Compose test: `DELETE /` a Run older than 60 s → 204 (was 401).
+- Live: trigger a deploy during a 9-candidate evaluation; expect 0 failed candidates, and
+  SigNoz shows `ws stream ended … 1012` followed by successful re-attaches on the new pod.
+
+## Files (indicative, all units)
+
+| File | Unit | Change |
+|---|---|---|
+| `apps/screamingface-engine/src/screamingface_engine/auth/jwt.py` | R2 | lifetime/skew split |
+| `apps/screamingface-engine/src/screamingface_engine/config.py` | R2 | `capability_lifetime_s` |
+| `apps/screamingface-engine/src/screamingface_engine/ws/bridge.py` | R3 | typed reclaimed frame |
+| `apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py` | R3 | distinguishable not-found error |
+| `apps/screamingface-engine/src/screamingface_engine/app.py` | — | no change in v1 (R5 dropped, D4) |
+| `packages/screamingface/src/screamingface/_engine/transport.py` | R4 | reconnect state machine, both twins |
+| `packages/screamingface/src/screamingface/_engine/run_lifecycle.py` | R4 | cursor getter |
+| `packages/screamingface/src/screamingface/_engine/contract.py` | R4 | (only if the cursor needs exposing) |
+| `packages/screamingface/src/screamingface/_ui/…` | R4 | reconnecting line |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Bearer token valid for the run horizon | spec §8: exposure is one Run's own stream/stop; tokens never logged; accepted |
+| Reconnect storm on many clients after a deploy | full jitter + 15 s cap; budget bounded; heartbeats not required during BACKOFF |
+| `stream_reclaimed` misclassification (transient broker error read as reclaim) | Step 3 types the error at the consumer boundary; unit tests pin both branches |
+| Reclaim race (terminal during outage > grace) | documented (spec §6 S4); honest `run_result_lost`; grace dial is D3 |
+| Sync/async twin divergence | the state machine is one pure function over events; twins provide I/O only |
+
+## Definition of done
+
+- Killing the App mid-Run in compose and in the dev cluster loses no candidate.
+- A Run older than 60 s is stoppable by its caller (204, not 401).
+- The orphan note from the incident ("stop also failed") no longer occurs on deploys.
+- Spec §10 D1–D5 answered and recorded; ledgers closed; Linear closed in both places.

--- a/docs/spec/2026-08-26-run-resume-and-control.md
+++ b/docs/spec/2026-08-26-run-resume-and-control.md
@@ -1,0 +1,279 @@
+---
+title: Run control-plane resilience — resumable streams and stoppable runs
+status: approved-design, pending-implementation — owner decisions D1–D5 recorded 2026-08-26 (§10)
+created: 2026-08-26
+ticket: OME-1016 (epic) — sub-issues OME-1017 (R1), OME-1018 (R2), OME-1019 (R3), OME-1020 (R4); related OME-890 (subscriber-loss reaper, Done)
+source: incident of 2026-08-26 14:58 UTC (App deployment closed 3 in-flight Runs with close 1012);
+        related GitHub issue #737 (separate spec: fusion member failure resilience)
+---
+
+# Run control-plane resilience
+
+## Outcome
+
+A Run survives an Engine App restart. The SDK reconnects, replays the missed frames, and
+returns the normal Report. Every Run stays stoppable by its owner for its whole life. No Run
+continues to spend after its caller is gone.
+
+```text
+                       deploy: App pod replaced
+                                │
+client ── ws ──► old pod  ──X (close 1012)
+client ◄───────────────────────┘  disconnected
+client ── ws ──► new pod  ──► attach(from_sequence = last seen + 1)
+client ◄── replay of missed frames from the JetStream log ── Result, Terminated
+```
+
+## 1. Incident (verified, 2026-08-26)
+
+| Time (UTC) | Event | Evidence |
+|---|---|---|
+| 14:31:08 | Evaluation schedules 8 Runs (9 candidates, cap 8) | App log `run scheduled` ×8 |
+| 14:33:37 | PR #751 merges to main | GitHub |
+| 14:44:24 | New pod created (image rollout) | k8s pod start time |
+| 14:39–14:56 | 6 Runs complete normally | `ws stream ended … close 1000` |
+| 14:58:03 | Old pod SIGTERM; uvicorn closes live sockets with **1012** | `INFO: Shutting down` |
+| 14:58:03 | 3 Runs die mid-flight; SDK raises `websocket_disconnected` | `close 1012`, durations 1615.2 s, 1615.2 s, 1081.6 s |
+
+The Runner Jobs are separate pods. They kept running and publishing to their NATS streams
+until completion, then reclaimed the streams after the 60 s grace. The token spend had no
+consumer. The client could not re-attach, and could not stop the Runs.
+
+## 2. Root cause — one claim carries three different concerns
+
+The capability token is an HS256 JWT with `sub = topic` (unguessable, 64 chars). Its lifetime
+is the mint freshness window:
+
+- `auth/jwt.py:36-47` — `sign()` sets `exp = iat + iat_window_s`.
+- `auth/jwt.py:72-77` — `verify()` rejects `now - iat > iat_window_s` **and** `now >= exp`.
+
+`iat_window_s` is 60 s. So the token answers three questions with one 60-second answer:
+
+1. *Freshness of the mint* (an anti-replay concern) — legitimately 60 s.
+2. *May the holder attach to the topic's stream?* — needed for the whole Run, up to 16 h.
+3. *May the holder stop the Run or redeem its result?* — needed for the whole Run.
+
+Three features of the codebase exist **because** of this conflation, each a work-around:
+
+- The Runner reclaims its own stream (`run_and_reclaim`, `runner/main.py:113`): the comment
+  records that tokens "expire 60 s after minting and cannot be re-issued for an existing
+  topic, so any run longer than a minute could never tear its own stream down".
+- Artifact redemption mints a **fresh** token (`transport.py::_materialize_*`): "Capability
+  tokens live ~60 s while an evaluation can run for hours... reusing one 401s".
+- The abort sweep is defeated in practice: `_evaluation/runner.py:382-389` calls
+  `transport.cancel_active()` on every abort, but each `DELETE /` presents a token older than
+  60 s → 401 → `AuthenticationError` → the sweep swallows it as a note. This is the exact
+  mechanism that orphaned the 3 Runs in the incident.
+
+## 3. What already exists (and must be reused, not rebuilt)
+
+- **Durable sequenced log per Run.** The Runner publishes every frame to a per-topic NATS
+  JetStream stream. It survives the App pod. Frames carry a broker-stamped `sequence`.
+- **Client cursor and gap replay.** The SDK's `_RunState` tracks `_last_sequence`, detects
+  gaps, and answers with `replay_from` — the transport then sends `attach(from_sequence=N)`
+  on the *same* socket (`run_lifecycle.py::accept`). Deduplication is by sequence and event
+  id. Reconnect is the same mechanism on a *new* socket.
+- **Bridge re-attach.** `ws/bridge.py` accepts attach with `from_sequence` at any time, from
+  any pod; it cancels the old subscription and replays from the cursor. Multiple sockets per
+  topic are permitted.
+- **Stop path.** `DELETE /` stops the Job and deletes the stream; it needs a verified token
+  for that topic.
+- **Subscriber-loss reaper (OME-890, shipped).** When a topic's last subscriber disconnects,
+  the App arms `orphan_grace_s = 120` and stops the Run through `JobRunner.stop` if nobody
+  re-attaches inside the window. This covers a client that vanishes while the App lives. It
+  does NOT cover the App itself dying (the registry is in-memory) — the incident's case —
+  which is what S1+S3 close. Its grace window also bounds S3's reconnect budget (§6 S6).
+
+The missing piece is one: a session credential that survives the Run.
+
+## 4. Goals
+
+- **G1** A Run whose stream connection dies (deploy, network, pod loss) completes normally on
+  the client after reconnect and replay.
+- **G2** A Run is stoppable by its caller at any age.
+- **G3** No Run outlives a caller that abandoned it (disconnect, abort, crash) without a stop
+  attempt that can actually succeed. Same-pod disconnects are already covered by the OME-890
+  reaper (`orphan_grace_s = 120`); this spec adds the cross-pod case (the App itself died —
+  the reaper's registry is in-memory and dies with it), via the long-lived token making the
+  sweep's `DELETE /` succeed (S1) plus the transport-level sweep (S3).
+- **G4** Deploys need no coordination with in-flight Runs.
+- **G5** Old SDKs against the new Engine keep today's behavior — with their abort sweeps
+  starting to work (long-lived tokens make `DELETE /` succeed at any Run age). A mixed
+  old-engine fleet is out of scope per D5: one engine is deployed, merges deploy promptly.
+
+## 5. Non-goals
+
+- No identity-bound Run registry (account-scoped resume). Local mode is anonymous by design;
+  identity binding does not exist there.
+- No change to Runner execution, benchmarks, or billing.
+- No multi-App failover orchestration beyond what the rolling update already gives.
+
+## 6. Design
+
+### S1 — Split token lifetime from mint freshness (Engine, `auth/jwt.py`)
+
+- `sign()`: `exp = iat + capability_lifetime_s` (new `Settings.capability_lifetime_s`,
+  proposed default `58_800` s = 16 h Job deadline + 1 h slack; §10 D1).
+- `verify()`: replace the age check `now - iat > iat_window_s` (lifetime semantics) with a
+  future-iat check `iat - now > iat_window_s` (clock-skew tolerance; keep the 60 s default and
+  the field name, re-documented). The `exp` check is unchanged and becomes the only lifetime
+  rule.
+- Boundary semantics pinned by tests: accept at `exp - 1`, reject at `exp`; reject an `iat`
+  more than one window in the future; accept normal skew.
+
+What a holder gains: attach (read their own Run's telemetry), stop (destroy their own Run),
+start (already single-shot: 409 on replay), artifacts (unchanged — the artifact route is not
+topic-scoped today; it admits any valid token against an unguessable content address, so the
+lifetime change adds nothing there).
+
+### S2 — Make "stream reclaimed" an explicit, typed answer (Engine, `ws/`)
+
+Today an attach to a topic whose stream was deleted surfaces as a `stream_failed` error frame
+(pump exception), which a reconnecting client cannot distinguish from a transient failure.
+
+- The bridge maps "stream not found" from the consumer to a typed terminal error frame,
+  `ai.url4.error` with `code = stream_reclaimed`, instead of the generic `stream_failed`.
+- The SDK treats `stream_reclaimed` as final: the Run finished while the client was away and
+  the Runner reclaimed the stream (grace elapsed). Raise `run_result_lost`, not
+  `websocket_disconnected`.
+
+### S3 — Reconnect state machine (SDK, `_engine/transport.py`, both sync and async twins)
+
+State machine (explicit; one enum, no scattered booleans):
+
+```text
+CONNECTING ──► ATTACHED ──► stream loop ──► OUTCOME
+     ▲             │ ws error / close 1012|1001|1006 / OSError
+     └── BACKOFF ──┘        (any cause; budget not spent)
+BACKOFF ── handshake 401/403 (not Access) ──► FATAL websocket_disconnected   (dead credentials)
+BACKOFF ── connect refused / 5xx / timeout ──► BACKOFF (full jitter, cap 15 s)
+ATTACHED (resumed) ── attach(from_sequence = last) ──► dedup by sequence/id (existing)
+ATTACHED ── stream_reclaimed frame ──► FATAL run_result_lost
+BACKOFF budget exhausted (90 s total per Run, D2 ceiling 120 s — §6 S6) ──► SWEEP ──► FATAL
+```
+
+- Reconnect reuses the SAME token (S1 makes it valid). `attach(from_sequence =
+  _RunState._last_sequence)` — identical to today's in-connection gap replay.
+- BACKOFF pacing: full-jitter delays 0.5 s doubling to a 15 s cap; total budget
+  `_RECONNECT_BUDGET_S = 90`, cumulative across the Run's lifetime, not per disconnect —
+  pinned BELOW D2's 120 s ceiling by the reaper race (§6 S6).
+- The existing Access-challenge branch (`InvalidStatus` with a challenge audience) stays first:
+  re-authenticate, then re-attach. With long-lived tokens there is no re-mint on this path.
+- On FATAL after a disconnect, run `cancel_active()` before raising (G3). The sweep is already
+  wired at the evaluation level; the transport-level sweep covers single-candidate Runs.
+- The 120 s inter-frame watchdog and the engine's ~30 s heartbeats are unchanged; heartbeats
+  from the new pod satisfy the watchdog.
+- Cache-policy "first attach wins" is pod-local registry state; a re-attach on the new pod
+  re-declares the same policy the SDK already holds. No divergence path exists (one Run, one
+  client, one policy).
+- Progress UI: while in BACKOFF, render "SF Engine connection lost — reconnecting (attempt
+  n)". The Run itself is unaffected.
+
+### S4 — The reclaim race, stated honestly
+
+If the Run TERMINATES while the client is disconnected and the Runner's grace
+(`STREAM_GRACE_S`, default 60 s) elapses before re-attach, the stream is deleted and the
+result is unrecoverable (inline result gone; spilled artifact's id rode the deleted stream).
+The client fails with `run_result_lost` (S2) — an honest outcome, not a hang.
+
+Options were keep 60 s or raise it. Disk math from the incident: one Run produced ~112 k
+frames; at ~300 B/frame that is ~34 MB held per finished Run for each extra grace minute.
+DECIDED (D3, 2026-08-26): keep 60 s; revisit with data. Interaction with D2: a Run that
+terminates while the client is disconnected for 60–120 s lands in `stream_reclaimed`
+(`run_result_lost`) rather than resume — the honest outcome.
+
+### S5 — Drain notice before close (Engine) — OUT OF SCOPE FOR v1 (D4)
+
+Deferred by owner decision D4 (2026-08-26). Recorded for a future iteration: on shutdown,
+before uvicorn closes sockets, push one notice frame to every attached topic
+(`engine_draining`, with a retry hint) — the GOAWAY pattern, one `sessions.notify` fan-out in
+the lifespan shutdown path. Purely advisory; S3 reconnects correctly with or without it.
+
+### S6 — Interaction with the OME-890 reaper
+
+The reaper stops a Run whose last subscriber has been gone for `orphan_grace_s = 120` s. A
+reconnecting client is EXACTLY such a subscriber gap — so the reconnect budget must land
+strictly inside the reaper's grace, or a client still backing off at t≈120 s loses its Run
+to the reaper one attempt before giving up. Hence `_RECONNECT_BUDGET_S = 90` (within D2's
+ceiling, with margin for the reaper's sweep latency — reap fires at grace to grace +
+grace/8).
+
+If the reaper wins anyway (budget raised, grace lowered), the outcome stays honest: the
+re-attach replays the `Terminated(stopped)` frame the reaper's stop produced, and the SDK
+reports the stopped outcome — no hang, no silent loss. The race costs work, not
+correctness.
+
+## 7. Contract changes
+
+| Contract | Change | Compatibility |
+|---|---|---|
+| Capability JWT | `exp` = mint + `capability_lifetime_s`; `iat` check = future-skew only | Old SDKs keep today's behavior and their stops IMPROVE (see below). Mixed old-engine fleet: out of scope per D5 — one engine is deployed, merges deploy promptly. No version field needed. |
+| WS error frames | new typed `stream_reclaimed` code | additive; unknown codes already surface as generic errors on old SDKs |
+| Notice frames | none in v1 (drain notice dropped, D4) | — |
+| REST | none (all routes unchanged) | — |
+
+## 8. Security review
+
+- No new endpoints; mint stays unauthenticated (unchanged surface).
+- Bearer exposure grows from 60 s to the Run horizon for: read-own-stream, stop-own-run,
+  start (single-shot, 409 on replay), artifacts (route is already token-agnostic; the id is an
+  unguessable content address). The stream may carry the Run's answer text — a stolen token
+  leaks one Run's output. Tokens live in SDK process memory only and are never logged
+  (pinned by existing auth error invariants). Accepted: the exposure is one Run, owned by the
+  caller.
+- DoS: minting tokens creates topics but schedules nothing without an attach and a start;
+  unchanged.
+- The 401 responses remain uniform (no oracle about which check failed) — `dependencies.py`
+  is untouched.
+
+## 9. Test strategy
+
+Characterization first (pin today's behavior):
+
+1. 1012 mid-Run → `websocket_disconnected` is fatal (today).
+2. Abort sweep on a Run older than 60 s → stop fails with 401, note attached (today).
+
+New — engine unit: codec boundary table (accept `exp-1`, reject `exp`; future-iat skew;
+old-style age rejection is gone); bridge `stream_reclaimed` mapping.
+
+New — SDK unit (fake sockets): disconnect at frame N → resume from N+1, no duplicates
+(sequence dedup); missed Result+Terminated replayed after reconnect; handshake 401 → FATAL
+fast (invalid or rotated token); budget exhaustion → `cancel_active` called, then FATAL;
+`stream_reclaimed` → `run_result_lost`; Access-challenge during reconnect re-authenticates.
+
+Integration (compose): kill the App container mid-Run → SDK completes the Run from the new
+container; stop a Run older than 60 s via `DELETE /` (401 before, 204 after).
+
+Live verification: deploy during a 9-candidate evaluation; expect zero failed candidates.
+
+Gaps and assumptions: exact WS rejection codes for an invalid ticket during handshake are to
+be pinned in implementation (S3 classification step); multi-node App deployments rely on the
+ingress routing re-attach to any pod — assumed supported (stateless App, topic in ticket).
+
+## 10. Owner decisions
+
+- **D1 — DECIDED 2026-08-26:** `capability_lifetime_s = 58_800` (16 h Job deadline + 1 h).
+- **D2 — DECIDED 2026-08-26:** reconnect budget ceiling 120 s total per Run (backoff 0.5 s
+  doubling, 15 s cap, full jitter; cumulative across the Run, not per disconnect).
+  IMPLEMENTATION NOTE (post-decision discovery): OME-890's reaper `orphan_grace_s` is 120 s,
+  so the budget lands at **90 s** — strictly inside the grace (§6 S6); still within the
+  decided ceiling.
+- **D3 — DECIDED 2026-08-26:** `STREAM_GRACE_S` stays 60 s; revisit with data.
+- **D4 — DECIDED 2026-08-26:** S5 drain notice is out of scope for v1.
+- **D5 — DECIDED 2026-08-26:** Option A — no probe, no capability field. A handshake 401/403
+  (after ruling out the Access challenge) is terminal: stop retrying, sweep, fail. The
+  mixed-version fleet that motivated the question is out of scope by owner statement: one
+  engine is deployed, and merges are deployed promptly, so no "old engine" exists.
+
+All decisions (D1–D5) are answered. Implementation starts on explicit approval in plain
+words; work items: `docs/plan/2026-08-26-run-resume-and-control.md`.
+
+### 10.1 D5 — why the 401 rule needs no engine version probe
+
+(Background for the record; the decision above closes it.) Even with a single engine, a
+reconnect handshake can still be rejected 401 for genuinely dead credentials (lifetime
+expired, signing secret rotated) — and "fail fast on 401" is the correct answer for that
+case too, so the rule needs no way to distinguish causes. The tempting alternative — mint a
+fresh token and retry — is wrong by construction: a fresh mint binds a NEW random topic and
+attaches to a different, empty stream. Rejected option B (a `capabilities` field on
+`POST /token`) would only have improved an error message for a fleet that no longer exists.

--- a/docs/work/2026-08-26-OME-1017-characterization-—-pin-todays-fatal-10.md
+++ b/docs/work/2026-08-26-OME-1017-characterization-—-pin-todays-fatal-10.md
@@ -1,0 +1,44 @@
+---
+ticket: OME-1017
+stack: repo
+status: done
+started: 2026-08-26
+finished: 2026-08-26
+---
+
+# OME-1017 — Characterization: pin today's fatal 1012 and the dead abort sweep
+
+## Intent
+
+Pin the incident behavior this epic removes, before any fix, so R2/R4 flip
+assertions deliberately. A close-1012 mid-Run is fatal today; the abort sweep's
+`DELETE /` 401s on a capability older than 60 s and the engine keeps spending.
+
+## Planned changes
+
+- `apps/screamingface-engine/tests/unit/test_auth.py` — add the iat/exp conflation pin
+- `packages/screamingface/tests/test_run_resume_reconnect.py` — new self-contained stub;
+  pins fatal 1012, rejected `cancel_active`, sweep note
+
+## Test plan
+
+- Engine: a forged token with old `iat` and future `exp` is rejected by the age check
+  (passes today; R2 flips it to accept)
+- SDK: close 1012 → `ExecutionError(websocket_disconnected)`, exactly one handshake
+- SDK: `cancel_active()` with a 401-rejecting server raises `ExceptionGroup`
+  containing `AuthenticationError`
+- SDK: `_run_candidates_sync` abort path attaches the sweep failure as a note and
+  re-raises the original error
+
+## Acceptance
+
+All four characterizations green on unchanged code; each names the spec section that
+later flips it.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned (2 files).
+- **Commits:** (added by commit step)
+- **Gates:** unit-level only; full stack gates run at epic end
+- **Deviations:** none — HTTP/1.0 default on the stub handler needed an explicit
+  `protocol_version` (websockets refuses HTTP/1.0 handshakes), a harness detail, not a plan deviation.

--- a/docs/work/2026-08-26-OME-1017-characterization-—-pin-todays-fatal-10.md
+++ b/docs/work/2026-08-26-OME-1017-characterization-—-pin-todays-fatal-10.md
@@ -38,7 +38,7 @@ later flips it.
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** as planned (2 files).
-- **Commits:** (added by commit step)
+- **Commits:** `f2a0e9e3` — test: characterize today's fatal 1012 and dead abort sweep
 - **Gates:** unit-level only; full stack gates run at epic end
 - **Deviations:** none — HTTP/1.0 default on the stub handler needed an explicit
   `protocol_version` (websockets refuses HTTP/1.0 handshakes), a harness detail, not a plan deviation.

--- a/docs/work/2026-08-26-OME-1018-capability-token-lifetime-split-(16h+1h).md
+++ b/docs/work/2026-08-26-OME-1018-capability-token-lifetime-split-(16h+1h).md
@@ -1,0 +1,45 @@
+---
+ticket: OME-1018
+stack: repo
+status: done
+started: 2026-08-26
+finished: 2026-08-26
+---
+
+# OME-1018 — Capability-token lifetime split (16h+1h)
+
+## Intent
+
+Split the capability token's lifetime from its mint-freshness window so a Run's
+owner can re-attach, stop, or redeem for the Run's whole life. Today `exp = iat +
+iat_window_s` (60 s), so every control path dies 60 s after mint — the root cause of
+the 2026-08-26 orphaned-Run incident (spec §2).
+
+## Planned changes
+
+- `auth/jwt.py` — `JwtCodec` gains `capability_lifetime_s`; `sign()` sets
+  `exp = iat + capability_lifetime_s`; `verify()` iat check becomes future-skew only
+- `config.py` — new `capability_lifetime_s: int = 58_800`; re-document `iat_window_s`
+- construction sites: `auth/dependencies.py`, `rest/routes.py`, `ws/endpoint.py`
+- `tests/unit/test_auth.py` — boundary table (exp-1/exp, future-iat skew) + deliberate
+  flips; 13 other test files get the mechanical `LIFETIME_S` param (no semantic change)
+
+## Test plan
+
+- RED: boundary table against new semantics fails on old codec
+- GREEN: accept `exp - 1`, reject at `exp`; reject future iat beyond window; the
+  OME-1017 conflation pin flips to verify
+
+## Acceptance
+
+Full engine unit suite green; the 60 s age rejection no longer exists anywhere.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned (jwt.py, config.py, 3 call sites, test_auth.py + 14
+  mechanical test patches).
+- **Commits:** (added by commit step)
+- **Gates:** engine unit suite 2037 passed / 5 skipped; full stack gates at epic end
+- **Deviations:** none — the 14 other construction sites in tests were patched
+  mechanically (uniform `LIFETIME_S` constant); no semantic flips outside test_auth.py
+  were needed, confirmed by the full green run.

--- a/docs/work/2026-08-26-OME-1018-capability-token-lifetime-split-(16h+1h).md
+++ b/docs/work/2026-08-26-OME-1018-capability-token-lifetime-split-(16h+1h).md
@@ -38,7 +38,7 @@ Full engine unit suite green; the 60 s age rejection no longer exists anywhere.
 
 - **Actual files:** as planned (jwt.py, config.py, 3 call sites, test_auth.py + 14
   mechanical test patches).
-- **Commits:** (added by commit step)
+- **Commits:** `8b0b2d81` — feat(screamingface-engine): split capability-token lifetime from mint freshness
 - **Gates:** engine unit suite 2037 passed / 5 skipped; full stack gates at epic end
 - **Deviations:** none — the 14 other construction sites in tests were patched
   mechanically (uniform `LIFETIME_S` constant); no semantic flips outside test_auth.py

--- a/docs/work/2026-08-26-OME-1019-typed-stream_reclaimed-error-frame.md
+++ b/docs/work/2026-08-26-OME-1019-typed-stream_reclaimed-error-frame.md
@@ -1,0 +1,50 @@
+---
+ticket: OME-1019
+stack: repo
+status: done
+started: 2026-08-26
+finished: 2026-08-26
+---
+
+# OME-1019 — Typed stream_reclaimed error frame
+
+## Intent
+
+Give a reconnecting client a typed answer when the Run's stream is gone. Today an attach
+to a reclaimed stream is silently RECREATED empty and the client heartbeats forever —
+indistinguishable from a transient failure. R4's reconnect loop needs "reclaimed" to be
+final and distinct from "retry".
+
+## Planned changes
+
+- `packages/url4/src/url4/streaming/interfaces/stream.py` (+`__init__.py`) — new
+  `StreamNotFoundError` on the port
+- `adapters/jetstream.py` — resume cursor (from_sequence != None) on a missing stream
+  raises `StreamNotFoundError` (`stream_info` probe); fresh attach still creates
+- `adapters/memory.py` — same rule, parity with the broker adapter
+- `ws/bridge.py` — `_on_pump_done` maps `StreamNotFoundError` → `ai.url4.error`
+  `code="stream_reclaimed"`; other pump errors stay `stream_failed`
+
+## Test plan
+
+- RED: adapter parity tests (cursor-on-missing raises; fresh attach creates), fake-js
+  consumer tests (stream_info probe; bind-without-recreate), bridge test
+  (resume attach → one `stream_reclaimed` frame)
+- The `test_attach_from_sequence_bounds` conformance contract is updated: cursors are
+  legal on an EXISTING stream (ensured first); missing stream + cursor is the new
+  reclaimed error
+
+## Acceptance
+
+Full engine + url4 suites green; a resume attach on a reclaimed topic answers
+`stream_reclaimed` instead of hanging.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned (1 port file + exports, 2 adapters, bridge, 3 test files).
+- **Commits:** (added by commit step)
+- **Gates:** engine 2059 passed / 5 skipped; url4 1164 passed; full stack gates at epic end
+- **Deviations:** the pre-existing `test_attach_from_sequence_bounds` conformance test
+  needed its documented precondition updated (ensure the stream before subscribing) —
+  the cursor-on-missing behavior is the deliberate change of this issue, and the test now
+  documents it.

--- a/docs/work/2026-08-26-OME-1019-typed-stream_reclaimed-error-frame.md
+++ b/docs/work/2026-08-26-OME-1019-typed-stream_reclaimed-error-frame.md
@@ -42,7 +42,7 @@ Full engine + url4 suites green; a resume attach on a reclaimed topic answers
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** as planned (1 port file + exports, 2 adapters, bridge, 3 test files).
-- **Commits:** (added by commit step)
+- **Commits:** `a38f06c2` — feat(screamingface-engine): typed stream_reclaimed answer for reclaimed streams
 - **Gates:** engine 2059 passed / 5 skipped; url4 1164 passed; full stack gates at epic end
 - **Deviations:** the pre-existing `test_attach_from_sequence_bounds` conformance test
   needed its documented precondition updated (ensure the stream before subscribing) —

--- a/docs/work/2026-08-26-OME-1020-sdk-reconnect-state-machine-—-resume-r.md
+++ b/docs/work/2026-08-26-OME-1020-sdk-reconnect-state-machine-—-resume-r.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-1020
+stack: repo
+status: done
+started: 2026-08-26
+finished: 2026-08-26
+---
+
+# OME-1020 — SDK reconnect state machine — resume runs from the stream cursor
+
+## Intent
+
+A Run survives an Engine restart: the SDK backs off (full jitter, 90 s budget), re-attaches
+on a new socket with `attach(from_sequence = last accepted + 1)`, replays missed frames,
+and returns the normal Report. The 60-second-forever `websocket_disconnected` of the
+2026-08-26 incident becomes recoverable; only budget exhaustion or a typed
+`stream_reclaimed` ends the Run.
+
+## Planned changes
+
+- `_engine/contract.py` — `stream_reclaimed` error frame raises
+  `ExecutionError(code="run_result_lost", permanent=True)`; `last_sequence` property
+- `_engine/run_lifecycle.py` — `resume_attach()`: cursor attach for a new socket
+- `_engine/transport.py` (both twins) — `_run_reconnecting` loop: first connection attaches
+  fresh + starts; reconnects resume, never re-start (topic single-shot); full-jitter
+  backoff 0.5 s doubling to 15 s cap, 90 s cumulative budget (inside the reaper's 120 s
+  grace); handshake 401/403 non-Access → FATAL (no probe, D5); budget exhausted →
+  `cancel_active()` sweep then `websocket_disconnected`; `cancel_active` sets an abort
+  flag so owner-aborted Runs stop reconnecting immediately
+- test-only seams: `reconnect_budget_s`, `reconnect_base_delay_s` constructor params
+
+## Test plan
+
+- restart → resume from cursor 3 → completes (sync + async twins)
+- reclaim-after-restart → `run_result_lost`, permanent
+- persistent 1012 → reconnects (≥2 handshakes), sweeps on budget exhaustion
+- OME-1017's fatal-1012 pin flipped deliberately
+- existing interrupt test stays green (abort flag: workers exit the loop once swept)
+
+## Acceptance
+
+Full SDK suite green (1198 passed / 17 skipped); no test may spend the default 90 s
+budget (disconnect-diagnosis tests use the 0.2 s seam).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned (3 SDK source files + tests; disconnect-diagnosis tests
+  got the 0.2 s budget seam so they keep testing DIAGNOSIS, not pacing).
+- **Commits:** (added by commit step)
+- **Gates:** SDK 1198 passed / 17 skipped; engine + url4 suites re-run at epic end
+- **Deviations:** (1) the reconnect notice is a log line, not a widget event — the Event
+  set is closed and versioned; a widget line would be a public API addition (out of
+  scope, noted for a follow-up). (2) The abort-flag (`_aborted`) was added beyond the
+  plan: without it, a SIGINT abort left worker threads reconnecting for the whole 90 s
+  budget after the sweep had already stopped their Runs (found via
+  `test_concurrent_interrupt_deletes_every_active_engine_capability`).

--- a/docs/work/2026-08-26-OME-1020-sdk-reconnect-state-machine-—-resume-r.md
+++ b/docs/work/2026-08-26-OME-1020-sdk-reconnect-state-machine-—-resume-r.md
@@ -46,7 +46,7 @@ budget (disconnect-diagnosis tests use the 0.2 s seam).
 
 - **Actual files:** as planned (3 SDK source files + tests; disconnect-diagnosis tests
   got the 0.2 s budget seam so they keep testing DIAGNOSIS, not pacing).
-- **Commits:** (added by commit step)
+- **Commits:** `4e2df695` — feat(screamingface): reconnect state machine — resume runs from the stream cursor
 - **Gates:** SDK 1198 passed / 17 skipped; engine + url4 suites re-run at epic end
 - **Deviations:** (1) the reconnect notice is a log line, not a widget event — the Event
   set is closed and versioned; a widget line would be a public API addition (out of

--- a/packages/screamingface/src/screamingface/_engine/contract.py
+++ b/packages/screamingface/src/screamingface/_engine/contract.py
@@ -58,6 +58,11 @@ class _RunState:
         self._consecutive_replay_requests = 0
         self._stream_reattach_requests = 0
 
+    @property
+    def last_sequence(self) -> int:
+        """The highest broker-sequenced frame accepted so far — the resume cursor."""
+        return self._last_sequence
+
     def accept(self, raw: str | bytes) -> _Accepted:
         payload = _payload(raw)
         event_type = _text(payload, "type")
@@ -100,6 +105,16 @@ class _RunState:
         self._observe_run(_common_envelope(payload)["run_id"])
         if event_type == "ai.url4.error":
             code, message = _advisory_error(data)
+            if code == "stream_reclaimed":
+                # OME-1019/1020: FINAL — the Run finished and the Runner reclaimed its
+                # stream (grace elapsed) while this client was away. The result is
+                # unrecoverable; reconnecting cannot change that.
+                raise ExecutionError(
+                    message or "this run's stream was reclaimed",
+                    code="run_result_lost",
+                    permanent=True,
+                    details=data,
+                )
             if code == "stream_failed":
                 self._stream_reattach_requests += 1
                 if self._stream_reattach_requests > _MAX_STREAM_REATTACH_REQUESTS:

--- a/packages/screamingface/src/screamingface/_engine/run_lifecycle.py
+++ b/packages/screamingface/src/screamingface/_engine/run_lifecycle.py
@@ -30,6 +30,16 @@ class _Lifecycle:
     def initial_attach() -> str:
         return _attach(None)
 
+    def resume_attach(self) -> str:
+        """The attach frame for a NEW socket resuming a started Run.
+
+        Replays from the first frame this Run has not yet accepted (`last_sequence + 1`,
+        the same inclusive-from convention the in-connection gap replay uses). A Run with
+        no accepted frames resumes from the start.
+        """
+        last = self._state.last_sequence
+        return _attach(None if last < 1 else last + 1)
+
     @staticmethod
     def stop() -> str:
         return _stop("client stopped consuming events")

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import inspect
+import logging
+import random
 import ssl
 import time
 from collections.abc import Awaitable, Callable
@@ -56,6 +58,22 @@ _ALREADY_STOPPED_STATUSES = frozenset({404, 409, 410})
 # URL4_CLOUD_RESULT_INLINE_CAP_BYTES past 4 MiB must account for this client-side bound too.
 _MAX_FRAME_BYTES = 8 * 1024 * 1024
 
+# OME-1020 (spec §6 S3/S6): reconnect pacing. The budget is 90 s — STRICTLY inside the
+# engine's subscriber-loss reaper grace (`orphan_grace_s = 120`, OME-890): a reconnecting
+# client IS exactly the "no subscriber" the reaper waits on, so a budget at or above the
+# grace lets the reaper kill the Run one attempt before the client gets back.
+_RECONNECT_BUDGET_S = 90.0
+_RECONNECT_BASE_DELAY_S = 0.5
+_RECONNECT_MAX_DELAY_S = 15.0
+
+_logger = logging.getLogger(__name__)
+
+
+def _reconnect_delay(attempt: int, base_s: float, *, max_s: float = _RECONNECT_MAX_DELAY_S) -> float:
+    """Full-jitter backoff (AWS): uniform in [0, min(cap, base * 2^attempt)]."""
+    cap = min(max_s, base_s * (2**attempt))
+    return random.random() * cap
+
 
 class _SyncSender(Protocol):
     def send(self, message: str) -> None: ...
@@ -75,7 +93,14 @@ class _ObserverRaised(Exception):
 class Url4CloudTransport:
     """Synchronous adapter for the confirmed url4-cloud lifecycle."""
 
-    def __init__(self, engine_url: str, caller_auth: _TransportAuth | None = None) -> None:
+    def __init__(
+        self,
+        engine_url: str,
+        caller_auth: _TransportAuth | None = None,
+        *,
+        reconnect_budget_s: float = _RECONNECT_BUDGET_S,
+        reconnect_base_delay_s: float = _RECONNECT_BASE_DELAY_S,
+    ) -> None:
         self._engine_url = engine_url
         self._owns_auth = caller_auth is None
         self._caller_auth = caller_auth or _default_caller_auth(engine_url)
@@ -83,6 +108,12 @@ class Url4CloudTransport:
         # INVARIANT: built from the same source as the client above, so the two halves of
         # this transport can never verify against different roots.
         self._ssl = _websocket_ssl_context(engine_url)
+        # Test-only seams; production callers leave the defaults (spec §6 S3).
+        self._reconnect_budget_s = reconnect_budget_s
+        self._reconnect_base_delay_s = reconnect_base_delay_s
+        # Set by `cancel_active`: once the OWNER has aborted, reconnecting is pointless —
+        # the sweep already stopped every Run this client owns. Plain bool, GIL-atomic.
+        self._aborted = False
         self._active_lock = Lock()
         self._active_tokens: set[str] = set()
 
@@ -97,34 +128,7 @@ class Url4CloudTransport:
         lifecycle = _Lifecycle(candidate)
         started = time.monotonic()
         try:
-            for attempt in range(2):
-                try:
-                    with sync_ws.connect(
-                        _websocket_url(self._engine_url, minted[-1]),
-                        subprotocols=[_SUBPROTOCOL],
-                        additional_headers=self._caller_auth.websocket_headers(),
-                        open_timeout=30,
-                        close_timeout=10,
-                        max_size=_MAX_FRAME_BYTES,
-                        ssl=self._ssl,
-                    ) as websocket:
-                        outcome = self._run_connected(
-                            websocket,
-                            lifecycle,
-                            minted[-1],
-                            candidate,
-                            on_event,
-                        )
-                    # FEATURE OME-892: redeem the claim ticket OUTSIDE the socket scope.
-                    # By now the run is over and the WS is closed — a fetch failure here
-                    # must surface as its own error, never trip the socket-scoped
-                    # stop-on-interrupt arm into writing to a dead connection.
-                    return _materialize_sync(self._http, outcome)
-                except InvalidStatus as exc:
-                    if attempt != 0 or not _is_access_websocket_rejection(exc):
-                        raise
-                    self._remint_after_challenge(minted)
-            raise AssertionError("WebSocket authentication retry loop exhausted")
+            return self._run_reconnecting(lifecycle, minted, candidate, on_event, started)
         except _ObserverRaised as exc:
             _copy_notes(exc, exc.original)
             raise exc.original
@@ -133,6 +137,91 @@ class Url4CloudTransport:
         finally:
             with self._active_lock:
                 self._active_tokens.difference_update(minted)
+
+    def _run_reconnecting(
+        self,
+        lifecycle: _Lifecycle,
+        minted: list[str],
+        candidate: Candidate,
+        on_event: SyncEventCallback | None,
+        started: float,
+    ) -> _RunOutcome:
+        """Drive the Run across connection losses: BACKOFF and re-attach, bounded (spec §6 S3).
+
+        The FIRST connection attaches fresh and starts the Run; every later connection
+        resumes from the last accepted stream sequence with the SAME capability (valid for
+        the Run's whole life after OME-1018). A handshake 401/403 that is not an Access
+        challenge is FATAL — dead credentials, no probe on a single-engine fleet (D5). A
+        connect/OS/timeout failure backs off with full jitter; when the cumulative budget
+        is spent, everything this client owns is stopped and the Run surfaces as
+        `websocket_disconnected`.
+        """
+        budget_deadline = time.monotonic() + self._reconnect_budget_s
+        attempts = 0
+        run_started = False
+        while True:
+            try:
+                with sync_ws.connect(
+                    _websocket_url(self._engine_url, minted[-1]),
+                    subprotocols=[_SUBPROTOCOL],
+                    additional_headers=self._caller_auth.websocket_headers(),
+                    open_timeout=30,
+                    close_timeout=10,
+                    max_size=_MAX_FRAME_BYTES,
+                    ssl=self._ssl,
+                ) as websocket:
+                    _require_subprotocol(websocket.subprotocol)
+                    if not run_started:
+                        websocket.send(lifecycle.initial_attach())
+                        _start_sync(self._http, minted[-1], candidate.url4)
+                        run_started = True
+                    else:
+                        websocket.send(lifecycle.resume_attach())
+                    outcome = self._run_connected(websocket, lifecycle, on_event)
+                # FEATURE OME-892: redeem the claim ticket OUTSIDE the socket scope.
+                # By now the run is over and the WS is closed — a fetch failure here
+                # must surface as its own error, never trip the socket-scoped
+                # stop-on-interrupt arm into writing to a dead connection.
+                return _materialize_sync(self._http, outcome)
+            except InvalidStatus as exc:
+                if _is_access_websocket_rejection(exc):
+                    self._remint_after_challenge(minted)
+                    attempts += 1
+                    continue
+                if run_started:
+                    # The Run is live server-side but this client can never get back to
+                    # it: dead credentials. Stop it rather than orphan it (G3).
+                    self._sweep_after_disconnect()
+                raise
+            except (WebSocketException, OSError, TimeoutError) as exc:
+                # WHY the abort check first: the owner's sweep (`cancel_active`) has
+                # already stopped every Run this client owns — reconnecting now is
+                # pointless and only delays the abort the user already chose (the
+                # SIGINT lands on the main thread; worker threads learn of it here).
+                if self._aborted or time.monotonic() >= budget_deadline:
+                    if not self._aborted:
+                        _logger.warning("SF Engine reconnect budget exhausted; stopping Runs")
+                        self._sweep_after_disconnect()
+                    raise _disconnected(exc, time.monotonic() - started) from exc
+                delay = _reconnect_delay(attempts, self._reconnect_base_delay_s)
+                _logger.warning(
+                    "SF Engine connection lost; reconnecting in %.1fs (attempt %d)",
+                    delay,
+                    attempts + 1,
+                )
+                attempts += 1
+                time.sleep(delay)
+
+    def _sweep_after_disconnect(self) -> None:
+        """Stop every Run this client owns after a reconnect gives up (G3, OME-1020).
+
+        Best-effort: a failed sweep must not mask the disconnect itself — the sweep's own
+        failure is logged, not raised.
+        """
+        try:
+            self.cancel_active()
+        except Exception as stop_error:  # noqa: BLE001 - see the WHY above
+            _logger.warning("Stopping active SF Engine runs also failed: %s", stop_error)
 
     def _remint_after_challenge(self, minted: list[str]) -> None:
         """Refresh Access auth and mint a fresh capability after a WS challenge.
@@ -148,6 +237,7 @@ class Url4CloudTransport:
     def cancel_active(self) -> None:
         """Stop every run currently owned by this synchronous Client."""
 
+        self._aborted = True
         with self._active_lock:
             tokens = tuple(self._active_tokens)
         if not tokens:
@@ -169,14 +259,9 @@ class Url4CloudTransport:
         self,
         websocket: SyncConnection,
         lifecycle: _Lifecycle,
-        token: str,
-        candidate: Candidate,
         on_event: SyncEventCallback | None,
     ) -> _RunOutcome:
-        _require_subprotocol(websocket.subprotocol)
-        websocket.send(lifecycle.initial_attach())
         try:
-            _start_sync(self._http, token, candidate.url4)
             while True:
                 try:
                     frame = websocket.recv(timeout=_EVENT_RECEIVE_TIMEOUT_SECONDS)
@@ -214,18 +299,33 @@ class AsyncUrl4CloudTransport:
     That one is genuinely required, because a thread pool drives it.
     """
 
-    def __init__(self, engine_url: str, caller_auth: _TransportAuth | None = None) -> None:
+    def __init__(
+        self,
+        engine_url: str,
+        caller_auth: _TransportAuth | None = None,
+        *,
+        reconnect_budget_s: float = _RECONNECT_BUDGET_S,
+        reconnect_base_delay_s: float = _RECONNECT_BASE_DELAY_S,
+    ) -> None:
         self._engine_url = engine_url
         self._owns_auth = caller_auth is None
         self._caller_auth = caller_auth or _default_caller_auth(engine_url)
         self._http = httpx.AsyncClient(base_url=engine_url, timeout=30.0, auth=self._caller_auth)
         # INVARIANT: see the synchronous twin — one trust store for HTTP and WebSocket.
         self._ssl = _websocket_ssl_context(engine_url)
+        # Test-only seams; production callers leave the defaults (spec §6 S3).
+        self._reconnect_budget_s = reconnect_budget_s
+        self._reconnect_base_delay_s = reconnect_base_delay_s
+        # Set by `cancel_active`: once the OWNER has aborted, reconnecting is pointless —
+        # the sweep already stopped every Run this client owns. One loop per instance;
+        # plain bool, no lock (see the class INVARIANT above).
+        self._aborted = False
         self._active_tokens: set[str] = set()
 
     async def cancel_active(self) -> None:
         """Stop every Run currently owned by this asynchronous Client."""
 
+        self._aborted = True
         tokens = tuple(self._active_tokens)
         if not tokens:
             return
@@ -255,7 +355,9 @@ class AsyncUrl4CloudTransport:
         cancelled = False
         started = time.monotonic()
         try:
-            return await self._connected_run(minted, candidate, on_event)
+            return await self._run_reconnecting(
+                lifecycle := _Lifecycle(candidate), minted, candidate, on_event, started
+            )
         # WHY: a cancelled Run keeps its capability registered so the Evaluation's sweep can
         # still stop it. asyncio.gather cancels its children and only re-raises once they have
         # all unwound, so by the time the sweep runs every Run here has already finished its
@@ -275,14 +377,19 @@ class AsyncUrl4CloudTransport:
             if not cancelled:
                 self._active_tokens.difference_update(minted)
 
-    async def _connected_run(
+    async def _run_reconnecting(
         self,
+        lifecycle: _Lifecycle,
         minted: list[str],
         candidate: Candidate,
         on_event: AsyncEventCallback | None,
+        started: float,
     ) -> _RunOutcome:
-        lifecycle = _Lifecycle(candidate)
-        for attempt in range(2):
+        """Async twin of the sync reconnecting loop — see its docstring (spec §6 S3)."""
+        budget_deadline = time.monotonic() + self._reconnect_budget_s
+        attempts = 0
+        run_started = False
+        while True:
             try:
                 async with async_ws.connect(
                     _websocket_url(self._engine_url, minted[-1]),
@@ -293,41 +400,68 @@ class AsyncUrl4CloudTransport:
                     max_size=_MAX_FRAME_BYTES,
                     ssl=self._ssl,
                 ) as websocket:
-                    outcome = await self._run_connected(
-                        websocket,
-                        lifecycle,
-                        minted[-1],
-                        candidate,
-                        on_event,
-                    )
+                    _require_subprotocol(websocket.subprotocol)
+                    if not run_started:
+                        await websocket.send(lifecycle.initial_attach())
+                        await _start_async(self._http, minted[-1], candidate.url4)
+                        run_started = True
+                    else:
+                        await websocket.send(lifecycle.resume_attach())
+                    outcome = await self._run_connected(websocket, lifecycle, on_event)
                 # FEATURE OME-892: redeem outside the socket scope — see the sync twin.
                 return await _materialize_async(self._http, outcome)
             except InvalidStatus as exc:
-                if attempt != 0 or not _is_access_websocket_rejection(exc):
-                    raise
-                await self._caller_auth.reauthenticate_async()
-                # WHY a NEW capability rather than the one already in hand: its iat window is
-                # 60s, and `reauthenticate` runs a Cloudflare Access browser login worth up to
-                # 300s. Retrying with the pre-challenge token therefore presents an expired
-                # capability, the Engine refuses the handshake with 1008, and the Run dies as
-                # `websocket_disconnected`. Minting is unauthenticated and per-Run, so
-                # replacing the token is cheaper than widening the window that protects it.
-                minted.append(await _mint_async(self._http))
-                self._active_tokens.add(minted[-1])
-        raise AssertionError("WebSocket authentication retry loop exhausted")
+                if _is_access_websocket_rejection(exc):
+                    await self._caller_auth.reauthenticate_async()
+                    # WHY a NEW capability rather than the one already in hand: a
+                    # re-authentication can take minutes, and the challenge may predate the
+                    # last mint. Minting is unauthenticated and per-Run, so replacing the
+                    # token is cheaper than widening any window.
+                    minted.append(await _mint_async(self._http))
+                    self._active_tokens.add(minted[-1])
+                    attempts += 1
+                    continue
+                if run_started:
+                    # The Run is live server-side but this client can never get back to
+                    # it: dead credentials. Stop it rather than orphan it (G3).
+                    self._sweep_after_disconnect()
+                raise
+            except (WebSocketException, OSError, TimeoutError) as exc:
+                # WHY the abort check first: the owner's sweep (`cancel_active`) has
+                # already stopped every Run this client owns — reconnecting now is
+                # pointless and only delays the abort the caller already chose.
+                if self._aborted or time.monotonic() >= budget_deadline:
+                    if not self._aborted:
+                        _logger.warning("SF Engine reconnect budget exhausted; stopping Runs")
+                        self._sweep_after_disconnect()
+                    raise _disconnected(exc, time.monotonic() - started) from exc
+                delay = _reconnect_delay(attempts, self._reconnect_base_delay_s)
+                _logger.warning(
+                    "SF Engine connection lost; reconnecting in %.1fs (attempt %d)",
+                    delay,
+                    attempts + 1,
+                )
+                attempts += 1
+                await asyncio.sleep(delay)
+
+    async def _sweep_after_disconnect(self) -> None:
+        """Stop every Run this client owns after a reconnect gives up (G3, OME-1020).
+
+        Best-effort: a failed sweep must not mask the disconnect itself — the sweep's own
+        failure is logged, not raised.
+        """
+        try:
+            await self.cancel_active()
+        except Exception as stop_error:  # noqa: BLE001 - see the WHY above
+            _logger.warning("Stopping active SF Engine runs also failed: %s", stop_error)
 
     async def _run_connected(
         self,
         websocket: AsyncClientConnection,
         lifecycle: _Lifecycle,
-        token: str,
-        candidate: Candidate,
         on_event: AsyncEventCallback | None,
     ) -> _RunOutcome:
-        _require_subprotocol(websocket.subprotocol)
-        await websocket.send(lifecycle.initial_attach())
         try:
-            await _start_async(self._http, token, candidate.url4)
             while True:
                 try:
                     frame = await asyncio.wait_for(

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -69,7 +69,9 @@ _RECONNECT_MAX_DELAY_S = 15.0
 _logger = logging.getLogger(__name__)
 
 
-def _reconnect_delay(attempt: int, base_s: float, *, max_s: float = _RECONNECT_MAX_DELAY_S) -> float:
+def _reconnect_delay(
+    attempt: int, base_s: float, *, max_s: float = _RECONNECT_MAX_DELAY_S
+) -> float:
     """Full-jitter backoff (AWS): uniform in [0, min(cap, base * 2^attempt)]."""
     cap = min(max_s, base_s * (2**attempt))
     return random.random() * cap
@@ -184,33 +186,56 @@ class Url4CloudTransport:
                 # stop-on-interrupt arm into writing to a dead connection.
                 return _materialize_sync(self._http, outcome)
             except InvalidStatus as exc:
-                if _is_access_websocket_rejection(exc):
-                    self._remint_after_challenge(minted)
-                    attempts += 1
-                    continue
-                if run_started:
-                    # The Run is live server-side but this client can never get back to
-                    # it: dead credentials. Stop it rather than orphan it (G3).
-                    self._sweep_after_disconnect()
-                raise
-            except (WebSocketException, OSError, TimeoutError) as exc:
-                # WHY the abort check first: the owner's sweep (`cancel_active`) has
-                # already stopped every Run this client owns — reconnecting now is
-                # pointless and only delays the abort the user already chose (the
-                # SIGINT lands on the main thread; worker threads learn of it here).
-                if self._aborted or time.monotonic() >= budget_deadline:
-                    if not self._aborted:
-                        _logger.warning("SF Engine reconnect budget exhausted; stopping Runs")
-                        self._sweep_after_disconnect()
-                    raise _disconnected(exc, time.monotonic() - started) from exc
-                delay = _reconnect_delay(attempts, self._reconnect_base_delay_s)
-                _logger.warning(
-                    "SF Engine connection lost; reconnecting in %.1fs (attempt %d)",
-                    delay,
-                    attempts + 1,
-                )
+                self._on_handshake_rejection(exc, minted, run_started)
                 attempts += 1
-                time.sleep(delay)
+                continue
+            except (WebSocketException, OSError, TimeoutError) as exc:
+                attempts = self._on_stream_failure(exc, attempts, budget_deadline, started)
+                continue
+
+    def _on_handshake_rejection(
+        self, exc: InvalidStatus, minted: list[str], run_started: bool
+    ) -> None:
+        """Classify a refused handshake: Access challenge remints; anything else is FATAL.
+
+        A non-Access 401/403 means dead credentials — retrying cannot help and no probe
+        is needed on a single-engine fleet (D5). If the Run already started, stop it
+        rather than orphan it (G3).
+        """
+        if _is_access_websocket_rejection(exc):
+            self._remint_after_challenge(minted)
+            return
+        if run_started:
+            self._sweep_after_disconnect()
+        raise exc
+
+    def _on_stream_failure(
+        self,
+        exc: WebSocketException | OSError | TimeoutError,
+        attempts: int,
+        budget_deadline: float,
+        started: float,
+    ) -> int:
+        """Sleep the backoff delay, or raise the terminal disconnect error.
+
+        WHY the abort check first: the owner's sweep (`cancel_active`) has already
+        stopped every Run this client owns — reconnecting now is pointless and only
+        delays the abort the user already chose (the SIGINT lands on the main thread;
+        worker threads learn of it here).
+        """
+        if self._aborted or time.monotonic() >= budget_deadline:
+            if not self._aborted:
+                _logger.warning("SF Engine reconnect budget exhausted; stopping Runs")
+                self._sweep_after_disconnect()
+            raise _disconnected(exc, time.monotonic() - started) from exc
+        delay = _reconnect_delay(attempts, self._reconnect_base_delay_s)
+        _logger.warning(
+            "SF Engine connection lost; reconnecting in %.1fs (attempt %d)",
+            delay,
+            attempts + 1,
+        )
+        time.sleep(delay)
+        return attempts + 1
 
     def _sweep_after_disconnect(self) -> None:
         """Stop every Run this client owns after a reconnect gives up (G3, OME-1020).
@@ -354,10 +379,9 @@ class AsyncUrl4CloudTransport:
         self._active_tokens.add(minted[0])
         cancelled = False
         started = time.monotonic()
+        lifecycle = _Lifecycle(candidate)
         try:
-            return await self._run_reconnecting(
-                lifecycle := _Lifecycle(candidate), minted, candidate, on_event, started
-            )
+            return await self._run_reconnecting(lifecycle, minted, candidate, on_event, started)
         # WHY: a cancelled Run keeps its capability registered so the Evaluation's sweep can
         # still stop it. asyncio.gather cancels its children and only re-raises once they have
         # all unwound, so by the time the sweep runs every Run here has already finished its
@@ -411,38 +435,51 @@ class AsyncUrl4CloudTransport:
                 # FEATURE OME-892: redeem outside the socket scope — see the sync twin.
                 return await _materialize_async(self._http, outcome)
             except InvalidStatus as exc:
-                if _is_access_websocket_rejection(exc):
-                    await self._caller_auth.reauthenticate_async()
-                    # WHY a NEW capability rather than the one already in hand: a
-                    # re-authentication can take minutes, and the challenge may predate the
-                    # last mint. Minting is unauthenticated and per-Run, so replacing the
-                    # token is cheaper than widening any window.
-                    minted.append(await _mint_async(self._http))
-                    self._active_tokens.add(minted[-1])
-                    attempts += 1
-                    continue
-                if run_started:
-                    # The Run is live server-side but this client can never get back to
-                    # it: dead credentials. Stop it rather than orphan it (G3).
-                    self._sweep_after_disconnect()
-                raise
-            except (WebSocketException, OSError, TimeoutError) as exc:
-                # WHY the abort check first: the owner's sweep (`cancel_active`) has
-                # already stopped every Run this client owns — reconnecting now is
-                # pointless and only delays the abort the caller already chose.
-                if self._aborted or time.monotonic() >= budget_deadline:
-                    if not self._aborted:
-                        _logger.warning("SF Engine reconnect budget exhausted; stopping Runs")
-                        self._sweep_after_disconnect()
-                    raise _disconnected(exc, time.monotonic() - started) from exc
-                delay = _reconnect_delay(attempts, self._reconnect_base_delay_s)
-                _logger.warning(
-                    "SF Engine connection lost; reconnecting in %.1fs (attempt %d)",
-                    delay,
-                    attempts + 1,
-                )
+                await self._on_handshake_rejection(exc, minted, run_started)
                 attempts += 1
-                await asyncio.sleep(delay)
+                continue
+            except (WebSocketException, OSError, TimeoutError) as exc:
+                attempts = await self._on_stream_failure(exc, attempts, budget_deadline, started)
+                continue
+
+    async def _on_handshake_rejection(
+        self, exc: InvalidStatus, minted: list[str], run_started: bool
+    ) -> None:
+        """Async twin of the sync handshake classification — see its docstring (D5, G3)."""
+        if _is_access_websocket_rejection(exc):
+            await self._caller_auth.reauthenticate_async()
+            # WHY a NEW capability rather than the one already in hand: a
+            # re-authentication can take minutes, and the challenge may predate the
+            # last mint. Minting is unauthenticated and per-Run, so replacing the
+            # token is cheaper than widening any window.
+            minted.append(await _mint_async(self._http))
+            self._active_tokens.add(minted[-1])
+            return
+        if run_started:
+            await self._sweep_after_disconnect()
+        raise exc
+
+    async def _on_stream_failure(
+        self,
+        exc: WebSocketException | OSError | TimeoutError,
+        attempts: int,
+        budget_deadline: float,
+        started: float,
+    ) -> int:
+        """Async twin of the sync backoff/terminal decision — see its docstring."""
+        if self._aborted or time.monotonic() >= budget_deadline:
+            if not self._aborted:
+                _logger.warning("SF Engine reconnect budget exhausted; stopping Runs")
+                await self._sweep_after_disconnect()
+            raise _disconnected(exc, time.monotonic() - started) from exc
+        delay = _reconnect_delay(attempts, self._reconnect_base_delay_s)
+        _logger.warning(
+            "SF Engine connection lost; reconnecting in %.1fs (attempt %d)",
+            delay,
+            attempts + 1,
+        )
+        await asyncio.sleep(delay)
+        return attempts + 1
 
     async def _sweep_after_disconnect(self) -> None:
         """Stop every Run this client owns after a reconnect gives up (G3, OME-1020).

--- a/packages/screamingface/tests/test_run_resume_reconnect.py
+++ b/packages/screamingface/tests/test_run_resume_reconnect.py
@@ -1,0 +1,289 @@
+"""Characterization (OME-1017): today's run-control failures, pinned before R2–R4.
+
+These tests record the INCIDENT behavior this epic removes:
+
+1. An Engine that closes the run stream with WS close 1012 (Service Restart — exactly
+   what a deployment rollout sends) kills the Run on the client: fatal
+   `websocket_disconnected`, one connection attempt, no resume.
+2. `cancel_active()` cannot stop a Run whose capability token the server rejects — the
+   abort sweep's `DELETE /` 401s and the engine keeps spending (the orphan mechanism of
+   the 2026-08-26 incident).
+3. The evaluation-level abort path records that sweep failure as a note on the original
+   error and the server-side Run continues.
+
+R4 flips the first; R2 flips the second and third (the token then lives for the whole
+Run, so the sweep's `DELETE /` succeeds).
+
+Self-contained by design (sdlc rule 5): this stub serves only the scenarios above.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import struct
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+
+from screamingface._evaluation.model import (
+    Candidate,
+    _compiled_candidate,
+    _compiled_operation,
+)
+from screamingface._evaluation.runner import _run_candidates_sync
+from screamingface._engine.transport import Url4CloudTransport
+from screamingface.errors import AuthenticationError, ExecutionError
+
+_WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+_CANDIDATE_URL4 = "(@)!'hello'"
+
+
+@dataclass
+class EngineState:
+    close_code: int | None
+    delete_rejected: bool = False
+    attached: threading.Event = field(default_factory=threading.Event)
+    started: threading.Event = field(default_factory=threading.Event)
+    handshakes: int = 0
+    minted_tokens: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Engine:
+    url: str
+    state: EngineState
+
+
+class _Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # websockets refuses an HTTP/1.0 handshake
+
+    def log_message(self, *_args: object) -> None:  # noqa: ARG002 - stdlib handler API
+        pass
+
+    def do_POST(self) -> None:  # noqa: N802 — stdlib handler API
+        if urlsplit(self.path).path != "/token":
+            self.send_error(HTTPStatus.NOT_FOUND)
+            return
+        state = self.server.state
+        token = "tok_" + str(len(state.minted_tokens))
+        state.minted_tokens.append(token)
+        self._json(HTTPStatus.OK, {"token": token})
+
+    def do_DELETE(self) -> None:  # noqa: N802 — stdlib handler API
+        if self.server.state.delete_rejected:
+            self._json(
+                HTTPStatus.UNAUTHORIZED,
+                {
+                    "type": "run_control",
+                    "title": "Unauthorized",
+                    "status": 401,
+                    "detail": "missing, invalid, or expired capability token",
+                },
+                media_type="application/problem+json",
+            )
+            return
+        self._no_content(HTTPStatus.NO_CONTENT)
+
+    def do_GET(self) -> None:  # noqa: N802 — stdlib handler API
+        if self.headers.get("Upgrade", "").casefold() == "websocket":
+            self._websocket()
+        else:
+            self._start()
+
+    def _start(self) -> None:
+        self.send_response(HTTPStatus.ACCEPTED)
+        self.send_header("Preference-Applied", "respond-async")
+        self.send_header("Location", "/?topic=run_resume")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+        self.server.state.started.set()
+
+    def _websocket(self) -> None:
+        if not self._accept_websocket():
+            return
+        if not self._read_attach():
+            return
+        self.server.state.attached.set()
+        if self.server.state.started.wait(timeout=5):
+            self._send_close(self.server.state.close_code)
+
+    def _accept_websocket(self) -> bool:
+        self.server.state.handshakes += 1
+        key = self.headers.get("Sec-WebSocket-Key")
+        if key is None:
+            self.send_error(HTTPStatus.BAD_REQUEST)
+            return False
+        accept = base64.b64encode(
+            hashlib.sha1(f"{key}{_WEBSOCKET_GUID}".encode()).digest()
+        ).decode()
+        self.send_response(HTTPStatus.SWITCHING_PROTOCOLS)
+        self.send_header("Upgrade", "websocket")
+        self.send_header("Connection", "Upgrade")
+        self.send_header("Sec-WebSocket-Accept", accept)
+        self.send_header("Sec-WebSocket-Protocol", "cloudevents.json")
+        self.end_headers()
+        self.close_connection = True
+        return True
+
+    def _read_attach(self) -> bool:
+        try:
+            event = json.loads(_read_client_text_frame(self.rfile))
+        except (AssertionError, IndexError, json.JSONDecodeError):
+            return False
+        return isinstance(event, dict) and event.get("type") == "ai.url4.attach"
+
+    def _send_close(self, code: int) -> None:
+        _send_server_close(self.wfile, code)
+
+    def _json(
+        self, status: HTTPStatus, value: object, *, media_type: str = "application/json"
+    ) -> None:
+        body = json.dumps(value).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", media_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _no_content(self, status: HTTPStatus, headers: dict[str, str] | None = None) -> None:
+        self.send_response(status)
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+class _Server(ThreadingHTTPServer):
+    def __init__(self, address: tuple[str, int], state: EngineState) -> None:
+        super().__init__(address, _Handler)
+        self.state = state
+
+
+def _read_client_text_frame(stream: Any) -> str:
+    header = stream.read(2)
+    length = header[1] & 0x7F
+    if length == 126:
+        length = struct.unpack("!H", stream.read(2))[0]
+    elif length == 127:
+        length = struct.unpack("!Q", stream.read(8))[0]
+    mask = stream.read(4) if header[1] & 0x80 else b""
+    payload = stream.read(length)
+    if mask:
+        payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    return payload.decode()
+
+
+def _send_server_close(stream: Any, code: int) -> None:
+    # RFC 6455 close frame: FIN + opcode 8, two-byte status. Server frames are unmasked.
+    payload = struct.pack("!H", code)
+    stream.write(bytes((0x88, len(payload))) + payload)
+    stream.flush()
+
+
+@contextmanager
+def _engine(*, close_code: int | None, delete_rejected: bool = False) -> Iterator[Engine]:
+    state = EngineState(close_code=close_code, delete_rejected=delete_rejected)
+    server = _Server(("127.0.0.1", 0), state)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host = str(server.server_address[0])
+        port = int(server.server_address[1])
+        yield Engine(url=f"http://{host}:{port}", state=state)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _candidate() -> Candidate:
+    return _compiled_candidate(
+        name="opus",
+        kind="model",
+        models=("provider/opus",),
+        url4=_CANDIDATE_URL4,
+        operations=(
+            _compiled_operation(id="op_opus", kind="model", label="opus answer", depends_on=()),
+        ),
+    )
+
+
+def test_close_1012_mid_run_is_fatal_today() -> None:
+    """PIN: an engine Service Restart (close 1012) kills the Run today.
+
+    The client makes ONE connection attempt, surfaces `websocket_disconnected`, and never
+    re-attaches. R4 flips this: the Run resumes from the JetStream cursor on a new socket.
+    """
+    with _engine(close_code=1012) as eng:
+        transport = Url4CloudTransport(eng.url)
+        try:
+            with pytest.raises(ExecutionError) as caught:
+                transport.run(_candidate(), None)
+        finally:
+            transport.close()
+    assert caught.value.code == "websocket_disconnected"
+    assert "1012" in str(caught.value)
+    # One connection attempt, no resume: the fatal behavior R4 replaces.
+    assert eng.state.handshakes == 1
+
+
+def test_cancel_active_raises_when_delete_is_rejected() -> None:
+    """PIN: the abort sweep cannot stop a Run whose capability the server rejects.
+
+    `DELETE /` 401s — the capability is older than its 60 s window for a real long run —
+    so `cancel_active()` raises and the engine keeps spending. R2 (long-lived capability)
+    makes this `DELETE /` succeed for the whole Run life.
+    """
+    with _engine(close_code=1012, delete_rejected=True) as eng:
+        transport = Url4CloudTransport(eng.url)
+        try:
+            # R4 changes this surface; today the sweep stops whatever is registered.
+            transport._active_tokens.add("stale-capability")  # noqa: SLF001
+            with pytest.raises(ExceptionGroup) as caught:
+                transport.cancel_active()
+        finally:
+            transport.close()
+    group = caught.value
+    assert any(isinstance(error, AuthenticationError) for error in group.exceptions)
+
+
+def test_abort_sweep_records_note_when_stop_rejected() -> None:
+    """PIN: the evaluation abort path swallows a failed sweep as a note.
+
+    Today's orphan mechanism: `_run_candidates_sync` catches any Run failure, calls
+    `cancel_active()`, and — because the sweep itself raised (server rejected the stale
+    capability) — records it as a note and re-raises the original error. The engine-side
+    Run continues spending with no consumer.
+    """
+
+    class _FakeTransport:
+        def __init__(self) -> None:
+            self.cancel_calls = 0
+
+        def run(self, candidate: Candidate, on_event: object = None) -> object:
+            raise ExecutionError("Run stream lost", code="websocket_disconnected")
+
+        def cancel_active(self) -> None:
+            self.cancel_calls += 1
+            raise RuntimeError("DELETE / failed with 401")
+
+    fake = _FakeTransport()
+    with pytest.raises(ExecutionError) as caught:
+        _run_candidates_sync(fake, (_candidate(), _candidate()), None)  # type: ignore[arg-type]
+    assert caught.value.code == "websocket_disconnected"
+    assert any(
+        "Stopping active SF Engine runs also failed" in note
+        for note in getattr(caught.value, "__notes__", ())
+    )
+    assert fake.cancel_calls == 1

--- a/packages/screamingface/tests/test_run_resume_reconnect.py
+++ b/packages/screamingface/tests/test_run_resume_reconnect.py
@@ -1,20 +1,17 @@
-"""Characterization (OME-1017): today's run-control failures, pinned before R2–R4.
+"""Run-resume behavior: characterization (OME-1017) flipped by the OME-1020 reconnect loop.
 
-These tests record the INCIDENT behavior this epic removes:
+History of this file:
 
-1. An Engine that closes the run stream with WS close 1012 (Service Restart — exactly
-   what a deployment rollout sends) kills the Run on the client: fatal
-   `websocket_disconnected`, one connection attempt, no resume.
-2. `cancel_active()` cannot stop a Run whose capability token the server rejects — the
-   abort sweep's `DELETE /` 401s and the engine keeps spending (the orphan mechanism of
-   the 2026-08-26 incident).
-3. The evaluation-level abort path records that sweep failure as a note on the original
-   error and the server-side Run continues.
+- OME-1017 pinned the INCIDENT behavior: close 1012 mid-Run was fatal
+  (`websocket_disconnected`, one connection attempt) and the abort sweep's `DELETE /`
+  401'd on a capability older than 60 s, orphaning paid Runs.
+- OME-1018 made the capability live for the whole Run (16 h + 1 h).
+- OME-1020 (spec §6 S3) added the reconnect state machine. The 1012 pin FLIPS here: a
+  Service Restart is now a recoverable disconnect — the client backs off (full jitter,
+  bounded budget) and resumes from the stream cursor; only budget exhaustion or a typed
+  `stream_reclaimed` ends the Run.
 
-R4 flips the first; R2 flips the second and third (the token then lives for the whole
-Run, so the sweep's `DELETE /` succeeds).
-
-Self-contained by design (sdlc rule 5): this stub serves only the scenarios above.
+Self-contained by design (sdlc rule 5): the stub serves exactly these scenarios.
 """
 
 from __future__ import annotations
@@ -30,10 +27,9 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import parse_qs, urlsplit
 
-import httpx
 import pytest
 
 from screamingface._evaluation.model import (
@@ -42,21 +38,25 @@ from screamingface._evaluation.model import (
     _compiled_operation,
 )
 from screamingface._evaluation.runner import _run_candidates_sync
-from screamingface._engine.transport import Url4CloudTransport
+from screamingface._engine.transport import AsyncUrl4CloudTransport, Url4CloudTransport
 from screamingface.errors import AuthenticationError, ExecutionError
 
 _WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 _CANDIDATE_URL4 = "(@)!'hello'"
 
+Mode = Literal["restart", "reclaim_after_restart", "always_1012"]
+
 
 @dataclass
 class EngineState:
-    close_code: int | None
+    mode: Mode
     delete_rejected: bool = False
     attached: threading.Event = field(default_factory=threading.Event)
     started: threading.Event = field(default_factory=threading.Event)
     handshakes: int = 0
+    deletes: int = 0
     minted_tokens: list[str] = field(default_factory=list)
+    resume_from: int | None = None
 
 
 @dataclass
@@ -81,6 +81,7 @@ class _Handler(BaseHTTPRequestHandler):
         self._json(HTTPStatus.OK, {"token": token})
 
     def do_DELETE(self) -> None:  # noqa: N802 — stdlib handler API
+        self.server.state.deletes += 1
         if self.server.state.delete_rejected:
             self._json(
                 HTTPStatus.UNAUTHORIZED,
@@ -110,16 +111,53 @@ class _Handler(BaseHTTPRequestHandler):
         self.server.state.started.set()
 
     def _websocket(self) -> None:
+        state = self.server.state
+        state.handshakes += 1
         if not self._accept_websocket():
             return
-        if not self._read_attach():
+        attach = self._read_attach()
+        if attach is None:
             return
-        self.server.state.attached.set()
-        if self.server.state.started.wait(timeout=5):
-            self._send_close(self.server.state.close_code)
+        from_sequence = attach.get("from_sequence")
+        if not state.started.wait(timeout=5):
+            return
+        if state.handshakes == 1:
+            # First connection: deliver frames 1..2, then the deploy-style restart (1012).
+            _send_server_text_frame(
+                self.wfile, json.dumps(_frame("ai.url4.started", {"url4": _CANDIDATE_URL4}, 1))
+            )
+            _send_server_text_frame(
+                self.wfile, json.dumps(_frame("ai.url4.log", {"severity_text": "INFO", "severity_number": 9, "body": "working"}, 2))
+            )
+            _send_server_close(self.wfile, 1012)
+            return
+        # Reconnect: record the resume cursor the client asked for.
+        state.resume_from = from_sequence
+        if state.mode == "reclaim_after_restart":
+            _send_server_text_frame(
+                self.wfile,
+                json.dumps(_error_frame("stream_reclaimed", "the run's stream was reclaimed")),
+            )
+            return
+        if state.mode == "always_1012":
+            _send_server_text_frame(
+                self.wfile, json.dumps(_frame("ai.url4.log", {"severity_text": "INFO", "severity_number": 9, "body": "still going"}, 3))
+            )
+            _send_server_close(self.wfile, 1012)
+            return
+        # restart: complete the run from the resume point.
+        _send_server_text_frame(
+            self.wfile,
+            json.dumps(
+                _frame("ai.url4.result", {"body": "restart-result", "media_type": "application/json"}, 3)
+            ),
+        )
+        _send_server_text_frame(
+            self.wfile,
+            json.dumps(_frame("ai.url4.terminated", {"status": "succeeded", "error": None}, 4)),
+        )
 
     def _accept_websocket(self) -> bool:
-        self.server.state.handshakes += 1
         key = self.headers.get("Sec-WebSocket-Key")
         if key is None:
             self.send_error(HTTPStatus.BAD_REQUEST)
@@ -136,15 +174,20 @@ class _Handler(BaseHTTPRequestHandler):
         self.close_connection = True
         return True
 
-    def _read_attach(self) -> bool:
+    def _read_attach(self) -> dict[str, object] | None:
+        """Parse the client's attach frame; None ONLY on an unparseable frame.
+
+        A FRESH attach (`from_sequence` absent/None) is a valid attach — returning it as a
+        dict is what distinguishes it from a parse failure.
+        """
         try:
             event = json.loads(_read_client_text_frame(self.rfile))
         except (AssertionError, IndexError, json.JSONDecodeError):
-            return False
-        return isinstance(event, dict) and event.get("type") == "ai.url4.attach"
-
-    def _send_close(self, code: int) -> None:
-        _send_server_close(self.wfile, code)
+            return None
+        if not isinstance(event, dict) or event.get("type") != "ai.url4.attach":
+            return None
+        data = event.get("data")
+        return data if isinstance(data, dict) else {}
 
     def _json(
         self, status: HTTPStatus, value: object, *, media_type: str = "application/json"
@@ -170,6 +213,35 @@ class _Server(ThreadingHTTPServer):
         self.state = state
 
 
+def _frame(kind: str, data: dict[str, object], sequence: int) -> dict[str, object]:
+    return {
+        "specversion": "1.0",
+        "id": f"event_{sequence}",
+        "source": "/trace/run_resume/node/root",
+        "subject": "run_resume",
+        "time": datetime.now(UTC).isoformat(),
+        "type": kind,
+        "datacontenttype": "application/json",
+        "sequence": str(sequence),
+        "sequencetype": "Integer",
+        "data": data,
+    }
+
+
+def _error_frame(code: str, message: str) -> dict[str, object]:
+    # Advisory frames carry no broker sequence (spec §6 S2, OME-1019).
+    return {
+        "specversion": "1.0",
+        "id": "err_reclaimed",
+        "source": "/trace/run_resume/node/root",
+        "subject": "run_resume",
+        "time": datetime.now(UTC).isoformat(),
+        "type": "ai.url4.error",
+        "datacontenttype": "application/json",
+        "data": {"code": code, "message": message},
+    }
+
+
 def _read_client_text_frame(stream: Any) -> str:
     header = stream.read(2)
     length = header[1] & 0x7F
@@ -184,6 +256,18 @@ def _read_client_text_frame(stream: Any) -> str:
     return payload.decode()
 
 
+def _send_server_text_frame(stream: Any, value: str) -> None:
+    payload = value.encode()
+    if len(payload) < 126:
+        header = bytes((0x81, len(payload)))
+    elif len(payload) < 65536:
+        header = bytes((0x81, 126)) + struct.pack("!H", len(payload))
+    else:
+        header = bytes((0x81, 127)) + struct.pack("!Q", len(payload))
+    stream.write(header + payload)
+    stream.flush()
+
+
 def _send_server_close(stream: Any, code: int) -> None:
     # RFC 6455 close frame: FIN + opcode 8, two-byte status. Server frames are unmasked.
     payload = struct.pack("!H", code)
@@ -192,8 +276,10 @@ def _send_server_close(stream: Any, code: int) -> None:
 
 
 @contextmanager
-def _engine(*, close_code: int | None, delete_rejected: bool = False) -> Iterator[Engine]:
-    state = EngineState(close_code=close_code, delete_rejected=delete_rejected)
+def _engine(
+    *, mode: Mode, delete_rejected: bool = False
+) -> Iterator[Engine]:
+    state = EngineState(mode=mode, delete_rejected=delete_rejected)
     server = _Server(("127.0.0.1", 0), state)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -219,36 +305,87 @@ def _candidate() -> Candidate:
     )
 
 
-def test_close_1012_mid_run_is_fatal_today() -> None:
-    """PIN: an engine Service Restart (close 1012) kills the Run today.
+def test_restart_resumes_from_cursor_and_completes() -> None:
+    """OME-1020 (spec §6 S3): a deploy-style restart is RECOVERABLE.
 
-    The client makes ONE connection attempt, surfaces `websocket_disconnected`, and never
-    re-attaches. R4 flips this: the Run resumes from the JetStream cursor on a new socket.
+    First connection receives frames 1..2, then the server closes 1012 (Service Restart).
+    The client re-attaches with `from_sequence = 3` (last accepted 2 + 1) on a NEW socket,
+    replays the missed frames, and returns the normal Report.
     """
-    with _engine(close_code=1012) as eng:
+    with _engine(mode="restart") as eng:
+        transport = Url4CloudTransport(eng.url)
+        try:
+            outcome = transport.run(_candidate(), None)
+        finally:
+            transport.close()
+    assert outcome.result_body == "restart-result"
+    assert eng.state.handshakes == 2
+    assert eng.state.resume_from == 3
+
+
+def test_reclaimed_stream_after_restart_is_run_result_lost() -> None:
+    """OME-1019+1020: a stream reclaimed while we were away is FINAL.
+
+    The Run finished and the Runner deleted the stream (grace elapsed). The engine answers
+    the resume attach with `stream_reclaimed`; the client raises `run_result_lost`,
+    permanent — reconnecting cannot change that.
+    """
+    with _engine(mode="reclaim_after_restart") as eng:
         transport = Url4CloudTransport(eng.url)
         try:
             with pytest.raises(ExecutionError) as caught:
                 transport.run(_candidate(), None)
         finally:
             transport.close()
+    assert caught.value.code == "run_result_lost"
+    assert caught.value.permanent is True
+    assert eng.state.resume_from == 3
+
+
+def test_reconnect_budget_exhaustion_sweeps_then_fails() -> None:
+    """FLIP of the OME-1017 pin: a persistently-restarting engine is not fatal at once.
+
+    The client backs off and retries within its budget, then — with the budget spent —
+    stops every Run it owns (the `DELETE /` sweep, which the long-lived token makes
+    succeed) and surfaces `websocket_disconnected`.
+    """
+    with _engine(mode="always_1012") as eng:
+        transport = Url4CloudTransport(
+            eng.url, reconnect_budget_s=0.3, reconnect_base_delay_s=0.01
+        )
+        try:
+            with pytest.raises(ExecutionError) as caught:
+                transport.run(_candidate(), None)
+        finally:
+            transport.close()
     assert caught.value.code == "websocket_disconnected"
-    assert "1012" in str(caught.value)
-    # One connection attempt, no resume: the fatal behavior R4 replaces.
-    assert eng.state.handshakes == 1
+    assert eng.state.handshakes >= 2  # it tried to reconnect, not one-shot fatal
+    assert eng.state.deletes >= 1  # the sweep's DELETE reached the engine
+
+
+@pytest.mark.asyncio
+async def test_async_restart_resumes_from_cursor_and_completes() -> None:
+    """The async twin resumes identically from the stream cursor."""
+    with _engine(mode="restart") as eng:
+        transport = AsyncUrl4CloudTransport(eng.url)
+        try:
+            outcome = await transport.run(_candidate(), None)
+        finally:
+            await transport.close()
+    assert outcome.result_body == "restart-result"
+    assert eng.state.resume_from == 3
 
 
 def test_cancel_active_raises_when_delete_is_rejected() -> None:
-    """PIN: the abort sweep cannot stop a Run whose capability the server rejects.
+    """PIN (OME-1017, still true): the sweep raises when the server rejects the DELETE.
 
-    `DELETE /` 401s — the capability is older than its 60 s window for a real long run —
-    so `cancel_active()` raises and the engine keeps spending. R2 (long-lived capability)
-    makes this `DELETE /` succeed for the whole Run life.
+    R2 makes this impossible for real long runs (the token now lives for the whole Run),
+    so this pins the RESULT the sweep must not produce: an un-stoppable Run surfaces as
+    an error, not as silent continued spend.
     """
-    with _engine(close_code=1012, delete_rejected=True) as eng:
+    with _engine(mode="always_1012", delete_rejected=True) as eng:
         transport = Url4CloudTransport(eng.url)
         try:
-            # R4 changes this surface; today the sweep stops whatever is registered.
             transport._active_tokens.add("stale-capability")  # noqa: SLF001
             with pytest.raises(ExceptionGroup) as caught:
                 transport.cancel_active()
@@ -259,13 +396,8 @@ def test_cancel_active_raises_when_delete_is_rejected() -> None:
 
 
 def test_abort_sweep_records_note_when_stop_rejected() -> None:
-    """PIN: the evaluation abort path swallows a failed sweep as a note.
-
-    Today's orphan mechanism: `_run_candidates_sync` catches any Run failure, calls
-    `cancel_active()`, and — because the sweep itself raised (server rejected the stale
-    capability) — records it as a note and re-raises the original error. The engine-side
-    Run continues spending with no consumer.
-    """
+    """PIN (OME-1017, still honored): the evaluation abort path records a failed sweep
+    as a note on the original error."""
 
     class _FakeTransport:
         def __init__(self) -> None:

--- a/packages/screamingface/tests/test_run_resume_reconnect.py
+++ b/packages/screamingface/tests/test_run_resume_reconnect.py
@@ -28,17 +28,17 @@ from datetime import UTC, datetime
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Literal
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import urlsplit
 
 import pytest
 
+from screamingface._engine.transport import AsyncUrl4CloudTransport, Url4CloudTransport
 from screamingface._evaluation.model import (
     Candidate,
     _compiled_candidate,
     _compiled_operation,
 )
 from screamingface._evaluation.runner import _run_candidates_sync
-from screamingface._engine.transport import AsyncUrl4CloudTransport, Url4CloudTransport
 from screamingface.errors import AuthenticationError, ExecutionError
 
 _WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
@@ -66,6 +66,7 @@ class Engine:
 
 
 class _Handler(BaseHTTPRequestHandler):
+    server: _Server
     protocol_version = "HTTP/1.1"  # websockets refuses an HTTP/1.0 handshake
 
     def log_message(self, *_args: object) -> None:  # noqa: ARG002 - stdlib handler API
@@ -116,32 +117,34 @@ class _Handler(BaseHTTPRequestHandler):
         if not self._accept_websocket():
             return
         attach = self._read_attach()
-        if attach is None:
-            return
-        from_sequence = attach.get("from_sequence")
-        if not state.started.wait(timeout=5):
+        if attach is None or not state.started.wait(timeout=5):
             return
         if state.handshakes == 1:
-            # First connection: deliver frames 1..2, then the deploy-style restart (1012).
-            _send_server_text_frame(
-                self.wfile, json.dumps(_frame("ai.url4.started", {"url4": _CANDIDATE_URL4}, 1))
-            )
-            _send_server_text_frame(
-                self.wfile, json.dumps(_frame("ai.url4.log", {"severity_text": "INFO", "severity_number": 9, "body": "working"}, 2))
-            )
-            _send_server_close(self.wfile, 1012)
-            return
-        # Reconnect: record the resume cursor the client asked for.
+            self._stream_first_connection()
+        else:
+            cursor = attach.get("from_sequence")
+            resume = cursor if cursor is None or isinstance(cursor, int) else None
+            self._stream_reconnect(state, resume)
+
+    def _stream_first_connection(self) -> None:
+        # Deliver frames 1..2, then the deploy-style restart (close 1012).
+        _send_server_text_frame(
+            self.wfile, json.dumps(_frame("ai.url4.started", {"url4": _CANDIDATE_URL4}, 1))
+        )
+        _send_server_text_frame(
+            self.wfile, json.dumps(_frame("ai.url4.log", LOG_FRAME("working"), 2))
+        )
+        _send_server_close(self.wfile, 1012)
+
+    def _stream_reconnect(self, state: EngineState, from_sequence: int | None) -> None:
+        # Record the resume cursor the client asked for.
         state.resume_from = from_sequence
         if state.mode == "reclaim_after_restart":
-            _send_server_text_frame(
-                self.wfile,
-                json.dumps(_error_frame("stream_reclaimed", "the run's stream was reclaimed")),
-            )
+            _send_server_text_frame(self.wfile, json.dumps(_error_frame("stream_reclaimed")))
             return
         if state.mode == "always_1012":
             _send_server_text_frame(
-                self.wfile, json.dumps(_frame("ai.url4.log", {"severity_text": "INFO", "severity_number": 9, "body": "still going"}, 3))
+                self.wfile, json.dumps(_frame("ai.url4.log", LOG_FRAME("still going"), 3))
             )
             _send_server_close(self.wfile, 1012)
             return
@@ -149,7 +152,11 @@ class _Handler(BaseHTTPRequestHandler):
         _send_server_text_frame(
             self.wfile,
             json.dumps(
-                _frame("ai.url4.result", {"body": "restart-result", "media_type": "application/json"}, 3)
+                _frame(
+                    "ai.url4.result",
+                    {"body": "restart-result", "media_type": "application/json"},
+                    3,
+                )
             ),
         )
         _send_server_text_frame(
@@ -213,6 +220,10 @@ class _Server(ThreadingHTTPServer):
         self.state = state
 
 
+def LOG_FRAME(body: str) -> dict[str, object]:
+    return {"severity_text": "INFO", "severity_number": 9, "body": body}
+
+
 def _frame(kind: str, data: dict[str, object], sequence: int) -> dict[str, object]:
     return {
         "specversion": "1.0",
@@ -228,7 +239,7 @@ def _frame(kind: str, data: dict[str, object], sequence: int) -> dict[str, objec
     }
 
 
-def _error_frame(code: str, message: str) -> dict[str, object]:
+def _error_frame(code: str) -> dict[str, object]:
     # Advisory frames carry no broker sequence (spec §6 S2, OME-1019).
     return {
         "specversion": "1.0",
@@ -238,7 +249,7 @@ def _error_frame(code: str, message: str) -> dict[str, object]:
         "time": datetime.now(UTC).isoformat(),
         "type": "ai.url4.error",
         "datacontenttype": "application/json",
-        "data": {"code": code, "message": message},
+        "data": {"code": code, "message": f"advisory {code}"},
     }
 
 
@@ -276,9 +287,7 @@ def _send_server_close(stream: Any, code: int) -> None:
 
 
 @contextmanager
-def _engine(
-    *, mode: Mode, delete_rejected: bool = False
-) -> Iterator[Engine]:
+def _engine(*, mode: Mode, delete_rejected: bool = False) -> Iterator[Engine]:
     state = EngineState(mode=mode, delete_rejected=delete_rejected)
     server = _Server(("127.0.0.1", 0), state)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -350,9 +359,7 @@ def test_reconnect_budget_exhaustion_sweeps_then_fails() -> None:
     succeed) and surfaces `websocket_disconnected`.
     """
     with _engine(mode="always_1012") as eng:
-        transport = Url4CloudTransport(
-            eng.url, reconnect_budget_s=0.3, reconnect_base_delay_s=0.01
-        )
+        transport = Url4CloudTransport(eng.url, reconnect_budget_s=0.3, reconnect_base_delay_s=0.01)
         try:
             with pytest.raises(ExecutionError) as caught:
                 transport.run(_candidate(), None)

--- a/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
+++ b/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
@@ -51,6 +51,12 @@ the cap can therefore never receive a capped result.
 Mode = Literal["oversize_result", "access_challenge", "abrupt_disconnect"]
 
 
+# OME-1020: these tests pin disconnect DIAGNOSIS, not reconnect pacing — a fast budget
+# keeps them quick while the transport retries inside the (default 90 s) reconnect loop.
+_RECONNECT_FAST_BUDGET_S = 0.2
+_RECONNECT_FAST_BASE_DELAY_S = 0.01
+
+
 @dataclass
 class EngineState:
     mode: Mode
@@ -327,7 +333,13 @@ def test_a_result_at_the_engine_cap_reaches_the_researcher() -> None:
     # the envelope around a capped body always overflowed it: the Client refused the frame
     # with close 1009 and every large Evaluation died as `websocket_disconnected`.
     with engine(mode="oversize_result") as stub:
-        with closing(Url4CloudTransport(stub.url, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)) as transport:
+        with closing(
+            Url4CloudTransport(
+                stub.url,
+                reconnect_budget_s=_RECONNECT_FAST_BUDGET_S,
+                reconnect_base_delay_s=_RECONNECT_FAST_BASE_DELAY_S,
+            )
+        ) as transport:
             outcome = transport.run(_candidate(), None)
 
     assert outcome.result_body is not None
@@ -337,7 +349,11 @@ def test_a_result_at_the_engine_cap_reaches_the_researcher() -> None:
 @pytest.mark.asyncio
 async def test_a_result_at_the_engine_cap_reaches_an_async_researcher() -> None:
     with engine(mode="oversize_result") as stub:
-        transport = AsyncUrl4CloudTransport(stub.url, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)
+        transport = AsyncUrl4CloudTransport(
+            stub.url,
+            reconnect_budget_s=_RECONNECT_FAST_BUDGET_S,
+            reconnect_base_delay_s=_RECONNECT_FAST_BASE_DELAY_S,
+        )
         try:
             outcome = await transport.run(_candidate(), None)
         finally:
@@ -354,7 +370,14 @@ def test_an_access_challenge_retries_with_a_freshly_minted_capability() -> None:
     # handshake and the whole Evaluation failed on a successful login.
     auth = _StubAccessAuth()
     with engine(mode="access_challenge") as stub:
-        with closing(Url4CloudTransport(stub.url, auth, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)) as transport:
+        with closing(
+            Url4CloudTransport(
+                stub.url,
+                auth,
+                reconnect_budget_s=_RECONNECT_FAST_BUDGET_S,
+                reconnect_base_delay_s=_RECONNECT_FAST_BASE_DELAY_S,
+            )
+        ) as transport:
             outcome = transport.run(_candidate(), None)
 
     assert auth.reauthentications == 1
@@ -366,7 +389,12 @@ def test_an_access_challenge_retries_with_a_freshly_minted_capability() -> None:
 async def test_an_access_challenge_retries_with_a_fresh_capability_when_async() -> None:
     auth = _StubAccessAuth()
     with engine(mode="access_challenge") as stub:
-        transport = AsyncUrl4CloudTransport(stub.url, auth, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)
+        transport = AsyncUrl4CloudTransport(
+            stub.url,
+            auth,
+            reconnect_budget_s=_RECONNECT_FAST_BUDGET_S,
+            reconnect_base_delay_s=_RECONNECT_FAST_BASE_DELAY_S,
+        )
         try:
             outcome = await transport.run(_candidate(), None)
         finally:
@@ -383,7 +411,13 @@ def test_a_dropped_stream_reports_its_close_code_and_elapsed_time() -> None:
     # all read identically otherwise, which is what made these causes indistinguishable in
     # production for weeks.
     with engine(mode="abrupt_disconnect") as stub:
-        with closing(Url4CloudTransport(stub.url, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)) as transport:
+        with closing(
+            Url4CloudTransport(
+                stub.url,
+                reconnect_budget_s=_RECONNECT_FAST_BUDGET_S,
+                reconnect_base_delay_s=_RECONNECT_FAST_BASE_DELAY_S,
+            )
+        ) as transport:
             with pytest.raises(sf.ExecutionError) as caught:
                 transport.run(_candidate(), None)
 

--- a/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
+++ b/packages/screamingface/tests/test_transport_disconnect_diagnosis.py
@@ -327,7 +327,7 @@ def test_a_result_at_the_engine_cap_reaches_the_researcher() -> None:
     # the envelope around a capped body always overflowed it: the Client refused the frame
     # with close 1009 and every large Evaluation died as `websocket_disconnected`.
     with engine(mode="oversize_result") as stub:
-        with closing(Url4CloudTransport(stub.url)) as transport:
+        with closing(Url4CloudTransport(stub.url, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)) as transport:
             outcome = transport.run(_candidate(), None)
 
     assert outcome.result_body is not None
@@ -337,7 +337,7 @@ def test_a_result_at_the_engine_cap_reaches_the_researcher() -> None:
 @pytest.mark.asyncio
 async def test_a_result_at_the_engine_cap_reaches_an_async_researcher() -> None:
     with engine(mode="oversize_result") as stub:
-        transport = AsyncUrl4CloudTransport(stub.url)
+        transport = AsyncUrl4CloudTransport(stub.url, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)
         try:
             outcome = await transport.run(_candidate(), None)
         finally:
@@ -354,7 +354,7 @@ def test_an_access_challenge_retries_with_a_freshly_minted_capability() -> None:
     # handshake and the whole Evaluation failed on a successful login.
     auth = _StubAccessAuth()
     with engine(mode="access_challenge") as stub:
-        with closing(Url4CloudTransport(stub.url, auth)) as transport:
+        with closing(Url4CloudTransport(stub.url, auth, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)) as transport:
             outcome = transport.run(_candidate(), None)
 
     assert auth.reauthentications == 1
@@ -366,7 +366,7 @@ def test_an_access_challenge_retries_with_a_freshly_minted_capability() -> None:
 async def test_an_access_challenge_retries_with_a_fresh_capability_when_async() -> None:
     auth = _StubAccessAuth()
     with engine(mode="access_challenge") as stub:
-        transport = AsyncUrl4CloudTransport(stub.url, auth)
+        transport = AsyncUrl4CloudTransport(stub.url, auth, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)
         try:
             outcome = await transport.run(_candidate(), None)
         finally:
@@ -383,7 +383,7 @@ def test_a_dropped_stream_reports_its_close_code_and_elapsed_time() -> None:
     # all read identically otherwise, which is what made these causes indistinguishable in
     # production for weeks.
     with engine(mode="abrupt_disconnect") as stub:
-        with closing(Url4CloudTransport(stub.url)) as transport:
+        with closing(Url4CloudTransport(stub.url, reconnect_budget_s=0.2, reconnect_base_delay_s=0.01)) as transport:
             with pytest.raises(sf.ExecutionError) as caught:
                 transport.run(_candidate(), None)
 

--- a/packages/url4/src/url4/streaming/interfaces/__init__.py
+++ b/packages/url4/src/url4/streaming/interfaces/__init__.py
@@ -41,6 +41,7 @@ from url4.streaming.interfaces.stream import (
     EventConsumer,
     EventPublisher,
     EventStream,
+    StreamNotFoundError,
     validate_from_sequence,
 )
 
@@ -56,6 +57,7 @@ __all__ = [
     "JobRunnerAtCapacity",
     "JobStatus",
     "SpanRef",
+    "StreamNotFoundError",
     "Telemetry",
     "TraceContext",
     "Traced",

--- a/packages/url4/src/url4/streaming/interfaces/stream.py
+++ b/packages/url4/src/url4/streaming/interfaces/stream.py
@@ -4,6 +4,16 @@ from collections.abc import AsyncIterator
 from url4.streaming.protocol import OutboundFrame
 
 
+class StreamNotFoundError(LookupError):
+    """The topic's stream does not exist — the Run finished and its stream was reclaimed.
+
+    Raised by a consumer's :meth:`EventConsumer.subscribe` ONLY on a resume attach
+    (``from_sequence`` set): a fresh attach legitimately precedes the Run's first publish,
+    so it may create the stream. A resume cursor with no stream to resume from means the
+    Run ended and the reclaim grace elapsed — the client can stop reconnecting (OME-1019).
+    """
+
+
 class EventPublisher(ABC):
     @abstractmethod
     async def ensure_stream(self, topic: str) -> None:
@@ -89,4 +99,4 @@ def validate_from_sequence(from_sequence: int | None) -> None:
         )
 
 
-__all__ = ["EventConsumer", "EventPublisher", "EventStream", "validate_from_sequence"]
+__all__ = ["EventConsumer", "EventPublisher", "EventStream", "StreamNotFoundError", "validate_from_sequence"]

--- a/packages/url4/src/url4/streaming/interfaces/stream.py
+++ b/packages/url4/src/url4/streaming/interfaces/stream.py
@@ -99,4 +99,10 @@ def validate_from_sequence(from_sequence: int | None) -> None:
         )
 
 
-__all__ = ["EventConsumer", "EventPublisher", "EventStream", "StreamNotFoundError", "validate_from_sequence"]
+__all__ = [
+    "EventConsumer",
+    "EventPublisher",
+    "EventStream",
+    "StreamNotFoundError",
+    "validate_from_sequence",
+]


### PR DESCRIPTION
## Summary

Implements the run control-plane resilience epic (OME-1016): a Run now survives an Engine App restart, and is stoppable by its caller for its whole life. Fixes the incident of 2026-08-26 14:58 UTC (deployment rollout closed 3 in-flight Runs with WS close 1012; the SDK failed them as `websocket_disconnected` and the Runner Jobs kept spending with no consumer).

Commits (R1 → R4 + gate compliance):

1. **OME-1017** `test: characterize today's fatal 1012 and dead abort sweep` — pins pre-fix behavior (fatal disconnect, 401-ing stop sweep).
2. **OME-1018** `feat(screamingface-engine): split capability-token lifetime from mint freshness` — `exp = iat + capability_lifetime_s` (58 800 s = 16 h deadline + 1 h slack, D1); the iat check is now future-skew tolerance only. Makes every control path (re-attach, stop, redeem) work for the Run's whole life.
3. **OME-1019** `feat(screamingface-engine): typed stream_reclaimed answer for reclaimed streams` — a resume cursor on a missing stream is `StreamNotFoundError` on the port (both adapters), surfaced as `ai.url4.error` code=`stream_reclaimed` by the bridge; previously a reclaimed stream was silently re-created and the client heartbeated forever.
4. **OME-1020** `feat(screamingface): reconnect state machine — resume runs from the stream cursor` — on mid-run socket loss the SDK backs off (full jitter, 0.5 s doubling to 15 s cap) within a 90 s budget (strictly inside the OME-890 reaper's 120 s grace), re-attaches with `from_sequence = last accepted + 1`, replays via the existing dedup. Classification per spec §6 S3/D5: Access challenge → re-auth; non-Access 401/403 → fatal; `stream_reclaimed` → `run_result_lost` (permanent); budget exhausted → `cancel_active()` sweep then `websocket_disconnected`. `cancel_active` also sets an abort flag so owner-aborted runs stop reconnecting immediately.
5. `e23a3da3` gate compliance (ruff/pyright/format).

## Owner decisions (spec §10, all recorded 2026-08-26)

D1 token lifetime 58 800 s · D2 reconnect budget 90 s (ceiling 120 s, pinned below the reaper's grace) · D3 stream grace stays 60 s · D4 drain notice out of scope · D5 no engine-version probe (single deployed engine).

## Prior-test modification (Confidence Gate)

The repo's append-only test check flags ~15 files modified in this PR. Owner approved (`approved, modify the prior tests`). The changes are three deliberate shapes: (1) mechanical `JwtCodec` constructor updates required by the new `capability_lifetime_s` field (no assertion changed), (2) the OME-1018 boundary flips in `test_auth.py` (token lifetime 60 s → 16 h+1 h), (3) the OME-1020 pacing seams + flipped fatal-1012 pin in the SDK transport tests.

## Docs

- Spec: `docs/spec/2026-08-26-run-resume-and-control.md` (approved-design, pending-implementation → implemented)
- Plan: `docs/plan/2026-08-26-run-resume-and-control.md`
- Ledgers: `docs/work/2026-08-26-OME-101{7,8,9}-*`, `2026-08-26-OME-1020-*`
- Related: Linear OME-1016 (epic) with sub-issues OME-1017–1020; related OME-890 (subscriber-loss reaper, shipped)

Refs: OME-1016
