### PR TITLE
feat(screamingface): add local diagnostic receipts

### DIFF
--- a/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
@@ -43,10 +43,13 @@ Keep the public surface shallow and the implementation deep:
 ### 3 · Evaluation context and execution evidence
 
 - RED first: one context per top-level sync/async Evaluation, multiple candidate execution slots,
-  validated effective model configuration, bounded safe breadcrumbs, public run ids and optional
-  trace evidence.
+  validated effective model configuration, bounded safe breadcrumbs and optional trace evidence;
+  private stream topics never become public run ids.
 - GREEN: one observer-compatible context that can see lifecycle events without consuming or
   changing user/progress callbacks.
+- Before compilation, retain only caller candidate name/kind. After compilation, replace that
+  fallback with the compiler-produced models and operation topology instead of recursively
+  reconstructing every concrete Recipe subtype in diagnostics.
 - Do not mint traces here; retain only evidence made available by `OME-967` or existing events.
 
 ### 4 · workflow boundary and interruption
@@ -77,6 +80,16 @@ Keep the public surface shallow and the implementation deep:
   exception renderer rather than installing `set_custom_exc`.
 - Keep HTTP submission and browser fact collection in `OME-1014`.
 - Run the full `screamingface` gate lane and the mandatory wisdom/confidence review.
+
+### 7 · review hardening
+
+- RED first: successful and repeated per-exception rendering returns the native traceback lines
+  while displaying the local receipt toolbar once.
+- RED first: internal Event stream topics are absent while valid trace ids remain observable.
+- RED first: the receipt construction boundary is a typed evidence aggregate and rejects unsafe
+  top-level error fields rather than accepting arbitrary mappings assembled by tests or callers.
+- GREEN: preserve the native exception as the sole error presentation; keep the widget additive,
+  use SFDS danger styling for export failures, and remove diagnostics-owned Recipe recursion.
 
 ## Risks and controls
 

--- a/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
@@ -72,10 +72,12 @@ Keep the public surface shallow and the implementation deep:
 - RED first: retained typed and raw Evaluation failures attach one renderer to the original
   exception; unrelated exceptions and declined receipts remain untouched.
 - RED first: Jupyter/Colab leaves the native exception summary as the only failure presentation and
-  adds one accessible neutral SFDS receipt toolbar with explicit Preview/Export actions and `%tb`
-  guidance.
-- RED first: JSON is absent before Preview; no file exists before Export; export success/failure is
-  reported locally; missing or broken notebook dependencies fall back to the prior renderer.
+  adds one accessible, transparent SFDS receipt footer with explicit View details/Save JSON actions.
+- RED first: JSON, runtime-lifetime disclosure and `%tb` guidance are absent before View details;
+  no file exists before Save JSON; save success/failure is reported locally; missing or broken
+  notebook dependencies fall back to the prior renderer.
+- RED first: the nested root does not use Colab-collapsing shrink-wrap, hidden rows reserve no
+  vertical space, and a successful rich render does not repeat terminal-only export guidance.
 - GREEN: a private `_ui` adapter lazily imports notebook dependencies and composes the existing
   exception renderer rather than installing `set_custom_exc`.
 - Keep HTTP submission and browser fact collection in `OME-1014`.

--- a/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
@@ -15,8 +15,10 @@ Keep the public surface shallow and the implementation deep:
   context. It has no HTTP client and no report-intake dependency.
 - `_evaluation/runner.py` is the single integration boundary shared by default, explicit sync and
   async Clients. Public facades do not each grow their own exception wrapper.
-- Future `OME-1014` maps the receipt into presentation and intake adapters without changing
-  Evaluation execution.
+- `_ui/diagnostic_view.py` owns optional notebook presentation. Capture knows only that a retained
+  receipt can be attached to its original exception; the adapter owns IPython and ipywidgets.
+- Future `OME-1014` maps the receipt into the intake envelope and adds explicit send behavior
+  without changing Evaluation execution.
 
 ## Batches
 
@@ -56,8 +58,20 @@ Keep the public surface shallow and the implementation deep:
 ### 5 · minimal local handoff
 
 - RED first: terminal guidance names the reference/export API without replacing the exception.
-- GREEN: minimal Python representation only. Full SFDS notebook card and send actions stay in
-  `OME-1014`.
+- GREEN: minimal Python representation and exact local export guidance.
+- Run the full `screamingface` gate lane and the mandatory wisdom/confidence review.
+
+### 6 · per-exception notebook panel
+
+- RED first: retained typed and raw Evaluation failures attach one renderer to the original
+  exception; unrelated exceptions and declined receipts remain untouched.
+- RED first: Jupyter/Colab rendering shows one accessible SFDS app-register panel with concise
+  evidence, diagnostic identity, explicit Preview and Export actions, and `%tb` guidance.
+- RED first: JSON is absent before Preview; no file exists before Export; export success/failure is
+  reported locally; missing or broken notebook dependencies fall back to the prior renderer.
+- GREEN: a private `_ui` adapter lazily imports notebook dependencies and composes the existing
+  exception renderer rather than installing `set_custom_exc`.
+- Keep HTTP submission and browser fact collection in `OME-1014`.
 - Run the full `screamingface` gate lane and the mandatory wisdom/confidence review.
 
 ## Risks and controls
@@ -71,5 +85,7 @@ Keep the public surface shallow and the implementation deep:
 - **Service-contract churn:** no intake types or HTTP dependency; the local receipt is projected by
   a later adapter.
 - **Unbounded memory:** enforce count and encoded-byte budgets before insertion.
-- **UI scope creep:** only local values/export here; report-card interaction remains blocked behind
-  `OME-1014`.
+- **Notebook-global interception:** attach the IPython protocol only to exceptions with a retained
+  receipt; never register a process-wide handler.
+- **UI scope creep:** only local Preview/Export here; send, consent, intake authentication and
+  browser fact collection remain blocked behind `OME-1014`.

--- a/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
@@ -65,8 +65,9 @@ Keep the public surface shallow and the implementation deep:
 
 - RED first: retained typed and raw Evaluation failures attach one renderer to the original
   exception; unrelated exceptions and declined receipts remain untouched.
-- RED first: Jupyter/Colab rendering shows one accessible SFDS app-register panel with concise
-  evidence, diagnostic identity, explicit Preview and Export actions, and `%tb` guidance.
+- RED first: Jupyter/Colab leaves the native exception summary as the only failure presentation and
+  adds one accessible neutral SFDS receipt toolbar with explicit Preview/Export actions and `%tb`
+  guidance.
 - RED first: JSON is absent before Preview; no file exists before Export; export success/failure is
   reported locally; missing or broken notebook dependencies fall back to the prior renderer.
 - GREEN: a private `_ui` adapter lazily imports notebook dependencies and composes the existing

--- a/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
@@ -1,0 +1,75 @@
+# OME-1013 — Local Client diagnostic receipts (plan)
+
+Spec: `docs/spec/2026-08-26-OME-1013-client-diagnostics.md`
+
+Implementation starts only after explicit approval of the linked spec.
+
+## Design
+
+Keep the public surface shallow and the implementation deep:
+
+- `diagnostic.py` owns the immutable public `DiagnosticReceipt` value and deterministic
+  serialization/export convention.
+- `diagnostics.py` is the small public lookup facade behind `sf.diagnostics`.
+- `_diagnostics/` owns allow-listed capture, bounded storage and mutable in-flight Evaluation
+  context. It has no HTTP client and no report-intake dependency.
+- `_evaluation/runner.py` is the single integration boundary shared by default, explicit sync and
+  async Clients. Public facades do not each grow their own exception wrapper.
+- Future `OME-1014` maps the receipt into presentation and intake adapters without changing
+  Evaluation execution.
+
+## Batches
+
+### 1 · receipt and bounded local store
+
+- RED first: deterministic immutable value, schema validation and Report-shaped export behavior.
+- RED first: `last()` / `get()`, unique refs, deterministic count/byte eviction, oversize decline.
+- GREEN: public `diagnostic.py`, `diagnostics.py`, private store, and exports from `__init__.py`.
+
+### 2 · privacy-safe capture primitives
+
+- RED first: structured ScreamingFace and unknown-exception projection; sanitized exception-chain
+  frames; allow-listed environment and host-only Engine identity.
+- RED first: explicit negative assertions for tokens, URL4, prompt/response text, log bodies,
+  source lines, locals, absolute paths and environment dumps.
+- GREEN: private capture helpers returning immutable receipt inputs rather than serializing
+  exception objects.
+
+### 3 · Evaluation context and execution evidence
+
+- RED first: one context per top-level sync/async Evaluation, multiple candidate execution slots,
+  validated effective model configuration, bounded safe breadcrumbs, public run ids and optional
+  trace evidence.
+- GREEN: one observer-compatible context that can see lifecycle events without consuming or
+  changing user/progress callbacks.
+- Do not mint traces here; retain only evidence made available by `OME-967` or existing events.
+
+### 4 · workflow boundary and interruption
+
+- RED first: failures at validation, loading, preflight, transport and Report decoding each create
+  one receipt while preserving exception identity/cause.
+- RED first: interruption and async-cancellation capture/re-raise; `SystemExit`/`GeneratorExit`
+  bypass; partial Report success path creates nothing.
+- GREEN: one fail-open sync wrapper and one parity-equivalent async wrapper inside the Evaluation
+  runner.
+
+### 5 · minimal local handoff
+
+- RED first: terminal guidance names the reference/export API without replacing the exception.
+- GREEN: minimal Python representation only. Full SFDS notebook card and send actions stay in
+  `OME-1014`.
+- Run the full `screamingface` gate lane and the mandatory wisdom/confidence review.
+
+## Risks and controls
+
+- **Secret leakage through generic serialization:** no `vars(exc)`, exception pickling or
+  environment dump; only named projectors with negative tests.
+- **Changing exception semantics:** capture in a guarded side path and use a bare re-raise for the
+  operation error; test object identity and causes.
+- **Async/sync drift:** shared pure capture/store logic with thin parity wrappers and parametrized
+  behavior tests.
+- **Service-contract churn:** no intake types or HTTP dependency; the local receipt is projected by
+  a later adapter.
+- **Unbounded memory:** enforce count and encoded-byte budgets before insertion.
+- **UI scope creep:** only local values/export here; report-card interaction remains blocked behind
+  `OME-1014`.

--- a/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/plan/2026-08-26-OME-1013-client-diagnostics.md
@@ -13,8 +13,11 @@ Keep the public surface shallow and the implementation deep:
 - `diagnostics.py` is the small public lookup facade behind `sf.diagnostics`.
 - `_diagnostics/` owns allow-listed capture, bounded storage and mutable in-flight Evaluation
   context. It has no HTTP client and no report-intake dependency.
-- `_evaluation/runner.py` is the single integration boundary shared by default, explicit sync and
-  async Clients. Public facades do not each grow their own exception wrapper.
+- `_evaluation/runner.py` owns the single Recipe integration boundary shared by default, explicit
+  sync and async Clients; `_evaluation/url4.py` owns the equivalent boundary for direct URL4 replay,
+  which bypasses Recipe preparation. Public facades do not each grow their own exception wrapper.
+- `_evaluation/observers.py` owns the fail-open progress, callback and diagnostic event fan-out so
+  both private Evaluation modes reuse one observer contract and the runner remains focused.
 - `_ui/diagnostic_view.py` owns optional notebook presentation. Capture knows only that a retained
   receipt can be attached to its original exception; the adapter owns IPython and ipywidgets.
 - Future `OME-1014` maps the receipt into the intake envelope and adds explicit send behavior
@@ -52,8 +55,8 @@ Keep the public surface shallow and the implementation deep:
   one receipt while preserving exception identity/cause.
 - RED first: interruption and async-cancellation capture/re-raise; `SystemExit`/`GeneratorExit`
   bypass; partial Report success path creates nothing.
-- GREEN: one fail-open sync wrapper and one parity-equivalent async wrapper inside the Evaluation
-  runner.
+- GREEN: one fail-open sync wrapper and one parity-equivalent async wrapper for each private
+  Evaluation mode, with no wrappers at the public facades.
 
 ### 5 · minimal local handoff
 

--- a/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
@@ -1,7 +1,8 @@
 # OME-1013 — Local Client diagnostic receipts (spec)
 
 Status: approved by the owner on 2026-08-26 after the Client diagnostics design session; notebook
-presentation amendment approved on 2026-08-26.
+presentation amendment approved on 2026-08-26 and recovery-footer refinement approved on
+2026-09-03.
 
 Related: `OME-1003` (Client-side reporting epic), `OME-967` (Client trace creation and retention),
 `OME-1002` (report-intake service), `OME-1004` (settled intake wire contract), and `OME-1014`
@@ -69,10 +70,12 @@ receipt.export("screamingface-diagnostic.json")
 - `to_json()` is deterministic UTF-8 JSON with the same compact encoding as `Report.to_json()`.
 - `.export()` follows `Report.export()`: `.json` only, creates parent directories, replaces the
   selected file, and returns its `Path`.
-- Preview bytes and exported bytes are identical.
+- View-details JSON and exported bytes are identical.
 - Export is the immediate recovery action, not a secondary convenience. Because the ring dies with
   the process, terminal guidance names the exact export command on every retained receipt and the
-  notebook panel makes Export its primary local action.
+  notebook footer offers Save JSON. The UI wording is intentionally different from the stable
+  `.export()` API: a generic hosted notebook can promise a file in its runtime, not a browser
+  download to the user's computer.
 - No public count or byte-limit tuning is introduced in v1. The store's limits are private and
   test-pinned so capacity can be tuned without a compatibility promise.
 
@@ -205,18 +208,20 @@ exception. IPython terminals retain concise text. In an ipykernel, the renderer 
 private notebook adapter that:
 
 - leaves IPython's native exception summary as the sole local error evidence and adds only the
-  diagnostic id and accepted in-memory lifetime as a neutral receipt toolbar;
-- exposes Preview and Export as explicit actions;
-- keeps receipt JSON hidden until Preview is selected;
-- writes only after Export is selected;
-- tells the user `%tb` remains available for the original traceback;
+  diagnostic id and local recovery actions as a neutral, transparent receipt footer;
+- exposes View details and Save JSON as explicit actions;
+- keeps receipt JSON, accepted in-memory lifetime and `%tb` guidance hidden until View details is
+  selected;
+- writes only after Save JSON is selected;
+- omits the terminal-only textual export note when the rich footer is available;
 - renders with SFDS v2's app register in both light and dark hosts; and
 - returns to the pre-existing traceback renderer if imports, widget construction or display fail.
 
 The renderer is attached only after the store accepts the receipt. An oversized or otherwise
 declined receipt cannot advertise actions against an id that lookup will not resolve.
 
-In a terminal, the failure guidance may name the diagnostic reference and the exact export call:
+Outside notebooks, the failure guidance may name the diagnostic reference and the exact export
+call:
 
 ```python
 sf.diagnostics.get("diag_...").export("screamingface-diagnostic.json")

--- a/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
@@ -1,6 +1,7 @@
 # OME-1013 — Local Client diagnostic receipts (spec)
 
-Status: approved by the owner on 2026-08-26 after the Client diagnostics design session.
+Status: approved by the owner on 2026-08-26 after the Client diagnostics design session; notebook
+presentation amendment approved on 2026-08-26.
 
 Related: `OME-1003` (Client-side reporting epic), `OME-967` (Client trace creation and retention),
 `OME-1002` (report-intake service), `OME-1004` (settled intake wire contract), and `OME-1014`
@@ -69,8 +70,8 @@ receipt.export("screamingface-diagnostic.json")
   selected file, and returns its `Path`.
 - Preview bytes and exported bytes are identical.
 - Export is the immediate recovery action, not a secondary convenience. Because the ring dies with
-  the process, terminal guidance names the exact export command on every retained receipt; the
-  future notebook card makes Export its primary local action.
+  the process, terminal guidance names the exact export command on every retained receipt and the
+  notebook panel makes Export its primary local action.
 - No public count or byte-limit tuning is introduced in v1. The store's limits are private and
   test-pinned so capacity can be tuned without a compatibility promise.
 
@@ -186,8 +187,25 @@ self-asserted contact information, never authorization.
 
 ## Presentation boundary
 
-`OME-1013` supplies receipt values, lookup/export and minimal honest Python representation. Full
-SFDS notebook report-card actions and HTTP submission remain `OME-1014`.
+`OME-1013` supplies receipt values, lookup/export and a local SFDS notebook panel. HTTP submission,
+intake shaping and the final Report action remain `OME-1014`.
+
+After a receipt has been retained, the Evaluation boundary may attach IPython's per-exception
+`_render_traceback_` protocol to that exact exception object. It never registers
+`InteractiveShell.set_custom_exc`, never handles unrelated notebook failures and never replaces the
+exception. IPython terminals retain concise text. In an ipykernel, the renderer delegates to a
+private notebook adapter that:
+
+- shows concise local error evidence, the diagnostic id and the accepted in-memory lifetime;
+- exposes Preview and Export as explicit actions;
+- keeps receipt JSON hidden until Preview is selected;
+- writes only after Export is selected;
+- tells the user `%tb` remains available for the original traceback;
+- renders with SFDS v2's app register in both light and dark hosts; and
+- returns to the pre-existing traceback renderer if imports, widget construction or display fail.
+
+The renderer is attached only after the store accepts the receipt. An oversized or otherwise
+declined receipt cannot advertise actions against an id that lookup will not resolve.
 
 In a terminal, the failure guidance may name the diagnostic reference and the exact export call:
 
@@ -195,8 +213,9 @@ In a terminal, the failure guidance may name the diagnostic reference and the ex
 sf.diagnostics.get("diag_...").export("screamingface-diagnostic.json")
 ```
 
-The normal exception remains visible. A diagnostic is additive evidence, not a replacement error
-screen.
+The normal exception remains available through `%tb` in notebooks and remains the ordinary raised
+exception everywhere. A diagnostic panel is additive presentation, not a replacement error
+contract.
 
 ## Non-goals
 
@@ -226,3 +245,6 @@ screen.
 8. Tests prove every forbidden content/secret source is absent from a representative receipt.
 9. A capture/store failure cannot change the operation exception observed by the caller.
 10. No network request or automatic filesystem write is possible from this unit.
+11. A retained notebook failure renders one accessible SFDS panel without a global exception hook;
+    Preview and Export require explicit actions and renderer failure restores ordinary traceback
+    presentation.

--- a/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
@@ -196,7 +196,8 @@ After a receipt has been retained, the Evaluation boundary may attach IPython's 
 exception. IPython terminals retain concise text. In an ipykernel, the renderer delegates to a
 private notebook adapter that:
 
-- shows concise local error evidence, the diagnostic id and the accepted in-memory lifetime;
+- leaves IPython's native exception summary as the sole local error evidence and adds only the
+  diagnostic id and accepted in-memory lifetime as a neutral receipt toolbar;
 - exposes Preview and Export as explicit actions;
 - keeps receipt JSON hidden until Preview is selected;
 - writes only after Export is selected;

--- a/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
@@ -1,0 +1,228 @@
+# OME-1013 — Local Client diagnostic receipts (spec)
+
+Status: approved by the owner on 2026-08-26 after the Client diagnostics design session.
+
+Related: `OME-1003` (Client-side reporting epic), `OME-967` (Client trace creation and retention),
+`OME-1002` (report-intake service), `OME-1004` (settled intake wire contract), and `OME-1014`
+(report-card/send adapter).
+
+## Outcome
+
+When a public Client Evaluation raises or is interrupted by its user, ScreamingFace leaves the
+ordinary Python exception behavior intact and stages one bounded, privacy-safe diagnostic receipt
+in memory. A user can inspect or explicitly export that receipt without sending data or writing a
+file automatically.
+
+This is a local domain artifact, not the report-intake wire envelope. A later adapter may project a
+receipt into the service contract once the service decides whether one submission represents one
+top-level operation or one candidate failure.
+
+The settled intake envelope carries one `correlation` and one candidate context, while this local
+artifact intentionally retains every candidate execution in one failed top-level Evaluation.
+Choosing the relevant execution or producing multiple wire envelopes is therefore an `OME-1014`
+adapter decision; the Client does not discard evidence early to imitate the narrower wire shape.
+
+## Identity model
+
+The identities describe different scopes and are never substituted for one another:
+
+```text
+Client/kernel session                     session_id
+└─ one failed public operation            diagnostic_id
+   ├─ candidate URL4 execution            run_id + trace_id, when observable
+   │  └─ relevant failed Gateway request  gateway_call_id, when observable
+   └─ candidate URL4 execution            run_id + trace_id, when observable
+```
+
+- Every real failed or interrupted top-level operation receives a new `diagnostic_id`.
+- Receipts are not fingerprint-deduplicated. Two failures are two facts even when their shapes
+  match.
+- `session_id` groups receipts produced by one Client/kernel lifetime. It is not an OpenTelemetry
+  trace and grants no authority.
+- A `trace_id` represents one bounded URL4 execution tree. One notebook session is never one
+  long-lived trace.
+- One Evaluation may contain multiple candidate execution records. Each may have its own trace.
+- `run_id` is the existing public execution id carried by `Event`/`CandidateResult` and sourced
+  from the CloudEvent subject. Retain it when observed, but do not confuse it with a trace, a
+  notebook session, an authorization credential, or an idempotency key.
+- A `gateway_call_id` identifies only the relevant concrete Gateway request when that fact is
+  already observable. The diagnostic does not enumerate every Gateway call; the execution trace
+  is the retrieval key for the tree.
+- Until `OME-967` lands, missing trace evidence remains absent. `OME-1013` never fabricates it.
+
+## Public local API
+
+```python
+receipt = sf.diagnostics.last()
+receipt = sf.diagnostics.get("diag_...")
+
+receipt.to_dict()
+receipt.to_json()
+receipt.export("screamingface-diagnostic.json")
+```
+
+- Lookup returns an immutable `DiagnosticReceipt` or `None` when no matching in-memory receipt
+  exists.
+- `to_dict()` returns a fresh JSON-compatible tree; mutating it cannot alter the receipt.
+- `to_json()` is deterministic UTF-8 JSON with the same compact encoding as `Report.to_json()`.
+- `.export()` follows `Report.export()`: `.json` only, creates parent directories, replaces the
+  selected file, and returns its `Path`.
+- Preview bytes and exported bytes are identical.
+- Export is the immediate recovery action, not a secondary convenience. Because the ring dies with
+  the process, terminal guidance names the exact export command on every retained receipt; the
+  future notebook card makes Export its primary local action.
+- No public count or byte-limit tuning is introduced in v1. The store's limits are private and
+  test-pinned so capacity can be tuned without a compatibility promise.
+
+## Capture boundary
+
+Capture happens once at the complete Evaluation workflow boundary shared by `sf.evaluate()`,
+`Client.evaluate()`, and `AsyncClient.evaluate()`. It covers input validation, Benchmark loading,
+model discovery, preflight, compilation, execution, and final Report decoding without adding
+parallel wrappers at each public facade.
+
+The capture context gains facts monotonically as the workflow advances:
+
+1. public operation and caller-supplied Benchmark/candidate inputs;
+2. compiled candidate identity and recipe topology;
+3. validated effective model configuration after preflight;
+4. bounded lifecycle evidence and execution identities while events arrive;
+5. structured terminal error or interruption state.
+
+If the workflow returns a `Report`, including a partial Report with benchmark Case failures, no
+diagnostic error receipt is created. The Report and its existing failure presentation remain the
+authoritative result.
+
+## Allow-listed receipt content
+
+### Client and environment
+
+- ScreamingFace distribution version;
+- Python implementation and version;
+- OS family and machine architecture;
+- host kind detectable by the kernel: notebook or CLI;
+- Engine mode and host only, never path, query, fragment or credentials;
+- the installed versions of exactly `httpx`, `websockets`, `pydantic`, and `ipywidgets` when
+  present. Missing optional packages remain absent.
+
+Browser user agent and frontend name/version are absent until an explicit widget communication
+channel supplies them. Kernel-side guessing is forbidden.
+
+### Error
+
+- exception type and safe structured fields already exposed by `ScreamingFaceError`: code,
+  status, retryability/permanence, hint, and safe typed details;
+- structured WebSocket close information from the cause when already modeled;
+- a sanitized exception chain;
+- structured traceback frames containing package/module, function and line number only.
+
+No raw traceback string, source line, frame local, or absolute filesystem path enters the normal
+receipt. For an unknown exception, the type and sanitized frames are retained; arbitrary exception
+attributes and messages are not serialized automatically.
+
+`ScreamingFaceError.code` is best-effort in v1. Many existing raise sites use only their class
+default (`planning_failed`, `execution_failed`, and peers), so code is useful evidence but not a
+complete grouping vocabulary. OME-1013 does not invent a second code catalogue. Intake-side
+triage must combine it with error type, structured fields and correlation ids.
+
+Plain `TypeError`, `ValueError`, and other non-ScreamingFace exceptions still create a degraded
+receipt at the same public-operation boundary. Their receipt contains type, sanitized exception
+chain/frames and available operation context, but no fabricated code, hint, retryability or raw
+message.
+
+### Reproduction context
+
+- Benchmark id and revision when known;
+- candidate name/kind and recipe topology;
+- exact **validated effective** supported model parameters used for execution;
+- for a preflight rejection, rejected parameter name, model and reason, but not the unvalidated
+  value;
+- bounded safe lifecycle breadcrumbs such as stage transitions, event kind, relative operation
+  name and outcome.
+
+Breadcrumbs never include Event log bodies, payloads, URL4, prompts or responses.
+
+## Interruption
+
+- `KeyboardInterrupt` during an active Evaluation stages a receipt with outcome
+  `interrupted_by_user`, then re-raises the same interrupt.
+- `asyncio.CancelledError` during an active asynchronous Evaluation stages a receipt with outcome
+  `cancelled`, then re-raises the same cancellation. The Client does not claim whether the caller,
+  notebook, timeout or parent task initiated it.
+- The receipt states only observable facts: elapsed time, last safe lifecycle event, and known
+  candidate states. It never labels the operation as hung.
+- `SystemExit` and `GeneratorExit` bypass diagnostic capture and retain ordinary Python behavior.
+
+## Privacy and consent
+
+The normal receipt never contains:
+
+- prompts, model responses, rubric/check material, notebook cell source or file attachments;
+- canonical URL4, Event log bodies, arbitrary exception attributes, or raw server payloads;
+- environment variables wholesale, access tokens, API keys, secrets, credential files, or
+  `~/.screamingface/*`;
+- full Engine/Scoreboard URLs or query strings;
+- source lines, frame locals or absolute filesystem paths.
+
+An exact canonical URL4 may be offered later as a **separate**, explicit, content-bearing local
+reproduction attachment. It is neither part of this receipt nor accepted by the v1 intake service.
+It is requested only when a responder cannot diagnose from the safe receipt, and the user must
+preview and approve it separately; it is never a default attachment.
+
+No identity is inferred from a Cloudflare token. A future optional `reply_to` field is
+self-asserted contact information, never authorization.
+
+## Storage and failure behavior
+
+- Receipts live in a process-local ring bounded by both count and serialized bytes.
+- Kernel/process exit discards the ring. This is an accepted privacy trade-off: a user who restarts
+  before explicitly exporting cannot recover that receipt.
+- Eviction removes the oldest receipt first and is deterministic.
+- A receipt larger than the entire byte budget is declined without evicting every usable receipt.
+- Nothing is persisted or sent before explicit user action.
+- Diagnostic capture is fail-open. Any internal capture/store/presentation failure is logged with
+  no payload and the original operation exception remains the one raised.
+- The original exception object and its cause chain are never replaced, wrapped or suppressed.
+
+## Presentation boundary
+
+`OME-1013` supplies receipt values, lookup/export and minimal honest Python representation. Full
+SFDS notebook report-card actions and HTTP submission remain `OME-1014`.
+
+In a terminal, the failure guidance may name the diagnostic reference and the exact export call:
+
+```python
+sf.diagnostics.get("diag_...").export("screamingface-diagnostic.json")
+```
+
+The normal exception remains visible. A diagnostic is additive evidence, not a replacement error
+screen.
+
+## Non-goals
+
+- Sending a report, retrying a submission, or authenticating to report intake.
+- Persisted blanket consent. A future send requires an explicit click after previewing that exact
+  report, every time.
+- A manual "snapshot now" action for a suspicious but non-raising active operation. That requires
+  an active-operation registry and is a separate capability; completed suspicious results already
+  have `Report.export()`.
+- Freezing the `screamingface.error-report/v1` service envelope.
+- SigNoz/Linear persistence or trace retrieval.
+- A browser-global exception hook or collection outside ScreamingFace public operations.
+- Capturing successful Evaluations or partial Report failures as error diagnostics.
+- Inferring a hang, replaying an execution, or proving reproduction from metadata alone.
+
+## Acceptance
+
+1. Sync and async Evaluation failures stage one distinct receipt and re-raise the original object.
+2. A user-interrupted Evaluation stages an honest interruption receipt and re-raises
+   `KeyboardInterrupt`; asynchronous cancellation stages `cancelled` and re-raises
+   `asyncio.CancelledError`; `SystemExit` and `GeneratorExit` stage nothing.
+3. A returned partial `Report` stages nothing.
+4. Receipt serialization is deterministic, versioned and byte-identical to explicit export.
+5. The store evicts deterministically under both count and byte pressure.
+6. Candidate execution identities remain separate; missing traces stay absent.
+7. Validated execution configuration is present when preflight completed; rejected values are not.
+8. Tests prove every forbidden content/secret source is absent from a representative receipt.
+9. A capture/store failure cannot change the operation exception observed by the caller.
+10. No network request or automatic filesystem write is possible from this unit.

--- a/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
@@ -30,9 +30,9 @@ The identities describe different scopes and are never substituted for one anoth
 ```text
 Client/kernel session                     session_id
 └─ one failed public operation            diagnostic_id
-   ├─ candidate URL4 execution            run_id + trace_id, when observable
+   ├─ candidate URL4 execution            trace_id, when observable
    │  └─ relevant failed Gateway request  gateway_call_id, when observable
-   └─ candidate URL4 execution            run_id + trace_id, when observable
+   └─ candidate URL4 execution            trace_id, when observable
 ```
 
 - Every real failed or interrupted top-level operation receives a new `diagnostic_id`.
@@ -43,9 +43,10 @@ Client/kernel session                     session_id
 - A `trace_id` represents one bounded URL4 execution tree. One notebook session is never one
   long-lived trace.
 - One Evaluation may contain multiple candidate execution records. Each may have its own trace.
-- `run_id` is the existing public execution id carried by `Event`/`CandidateResult` and sourced
-  from the CloudEvent subject. Retain it when observed, but do not confuse it with a trace, a
-  notebook session, an authorization credential, or an idempotency key.
+- The `Event.run_id` seen by the Client transport is currently an internal stream topic. It is not
+  a stable public execution identity and is never copied into the receipt as `run_id`. A future
+  stable execution identity requires an explicit Engine/Client contract; diagnostics do not rename
+  or infer one from transport plumbing.
 - A `gateway_call_id` identifies only the relevant concrete Gateway request when that fact is
   already observable. The diagnostic does not enumerate every Gateway call; the execution trace
   is the retrieval key for the tree.
@@ -86,7 +87,7 @@ final Report decoding.
 
 The capture context gains facts monotonically as the workflow advances:
 
-1. public operation and caller-supplied Benchmark/candidate inputs;
+1. public operation and the caller-supplied Benchmark/candidate name and kind only;
 2. compiled candidate identity and recipe topology;
 3. validated effective model configuration after preflight;
 4. bounded lifecycle evidence and execution identities while events arrive;
@@ -144,6 +145,11 @@ message.
   name and outcome.
 
 Breadcrumbs never include Event log bodies, payloads, URL4, prompts or responses.
+
+Before compilation, the receipt may retain only a Recipe's public name and canonical kind. The
+compiler-produced `Candidate` is the sole authority for models and operation topology. This avoids
+a second diagnostics-owned traversal that must learn every concrete Recipe subtype and prevents
+unvalidated prompts or parameters from entering the receipt.
 
 ## Interruption
 
@@ -243,7 +249,8 @@ contract.
 3. A returned partial `Report` stages nothing.
 4. Receipt serialization is deterministic, versioned and byte-identical to explicit export.
 5. The store evicts deterministically under both count and byte pressure.
-6. Candidate execution identities remain separate; missing traces stay absent.
+6. Candidate executions remain separate; valid trace ids are retained, internal stream topics are
+   absent, and missing traces stay absent.
 7. Validated execution configuration is present when preflight completed; rejected values are not.
 8. Tests prove every forbidden content/secret source is absent from a representative receipt.
 9. A capture/store failure cannot change the operation exception observed by the caller.

--- a/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/spec/2026-08-26-OME-1013-client-diagnostics.md
@@ -77,10 +77,12 @@ receipt.export("screamingface-diagnostic.json")
 
 ## Capture boundary
 
-Capture happens once at the complete Evaluation workflow boundary shared by `sf.evaluate()`,
-`Client.evaluate()`, and `AsyncClient.evaluate()`. It covers input validation, Benchmark loading,
-model discovery, preflight, compilation, execution, and final Report decoding without adding
-parallel wrappers at each public facade.
+Capture happens once per private Evaluation mode. Recipe evaluation owns one boundary in the
+runner, shared by `sf.evaluate()`, `Client.evaluate()`, and `AsyncClient.evaluate()`. Direct URL4
+replay owns one equivalent boundary because it bypasses Recipe preparation and enters through a
+separate private workflow. Public facades never add parallel wrappers. Together the two boundaries
+cover input validation, Benchmark loading, model discovery, preflight, compilation, execution, and
+final Report decoding.
 
 The capture context gains facts monotonically as the workflow advances:
 

--- a/docs/tasks/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/tasks/2026-08-26-OME-1013-client-diagnostics.md
@@ -1,0 +1,19 @@
+---
+id: OME-1013
+linear_url: https://linear.app/openmined/issue/OME-1013/assemble-the-client-side-error-report
+status: in_progress
+type: feature
+priority: medium
+labels:
+  - py-screamingface
+  - agentic
+  - autonomous
+created: 2026-08-26
+closed:
+---
+
+# Assemble local Client diagnostic receipts
+
+Capture a bounded, privacy-safe diagnostic receipt when a public Client evaluation fails or is
+interrupted, and make it inspectable and explicitly exportable without sending or automatically
+persisting anything.

--- a/docs/work/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/work/2026-08-26-OME-1013-client-diagnostics.md
@@ -8,6 +8,9 @@ finished: 2026-08-26
 
 # OME-1013 — Assemble local Client diagnostic receipts
 
+> This `done` status records the completed receipt-capture iteration, not closure of the parent
+> Linear issue. The authoritative ticket mirror remains `in_progress` until the full PR lands.
+
 ## Intent
 
 Give early ScreamingFace users a concrete, privacy-safe artifact when an Evaluation raises or is
@@ -43,7 +46,8 @@ future report-intake mapping remains a separate adapter and is not designed into
 - `sf.diagnostics.last()` and `sf.diagnostics.get(ref)` return immutable local receipts.
 - Receipts support `to_dict()`, `to_json()`, and explicit `.export()` using the Report convention.
 - One top-level failed Evaluation produces one unique receipt containing separate observable
-  candidate executions; each retains the existing public Event `run_id` when observed.
+  candidate executions; valid trace ids are retained when observed, but private Event stream
+  topics are not published as `run_id`.
 - Normal receipts contain no prompts, responses, URL4, notebook source, raw logs, secrets,
   environment dumps, source lines, locals, or absolute paths.
 - Capture is bounded, local-only and fail-open; normal Python exception behavior is unchanged.

--- a/docs/work/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/work/2026-08-26-OME-1013-client-diagnostics.md
@@ -1,0 +1,83 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-08-26
+finished: 2026-08-26
+---
+
+# OME-1013 — Assemble local Client diagnostic receipts
+
+## Intent
+
+Give early ScreamingFace users a concrete, privacy-safe artifact when an Evaluation raises or is
+interrupted. The Client captures only facts it already holds, preserves the original Python
+exception, keeps receipts in bounded memory, and exports only after an explicit user action. The
+future report-intake mapping remains a separate adapter and is not designed into the Client core.
+
+## Planned changes
+
+- `docs/spec/2026-08-26-OME-1013-client-diagnostics.md`
+- `docs/plan/2026-08-26-OME-1013-client-diagnostics.md`
+- `packages/screamingface/src/screamingface/diagnostic.py`
+- `packages/screamingface/src/screamingface/diagnostics.py`
+- `packages/screamingface/src/screamingface/_diagnostics/`
+- `packages/screamingface/src/screamingface/_evaluation/runner.py`
+- `packages/screamingface/src/screamingface/__init__.py`
+- focused new tests under `packages/screamingface/tests/`
+
+## Test plan
+
+- RED: immutable receipt serialization/export, stable bytes, and strict schema boundaries.
+- RED: count-and-byte-bounded store, distinct failure identities, lookup and eviction.
+- RED: allow-listed exception/environment/config capture and explicit forbidden-data assertions.
+- RED: synchronous and asynchronous Evaluation failure capture with original exception identity and
+  cause chain preserved.
+- RED: `KeyboardInterrupt` receipt followed by the same interrupt; `SystemExit` and
+  `GeneratorExit` bypass; `asyncio.CancelledError` produces a distinct cancelled receipt.
+- RED: partial `Report` outcomes create no diagnostic receipt.
+- RED: diagnostic capture failures never replace the operation's original exception.
+
+## Acceptance
+
+- `sf.diagnostics.last()` and `sf.diagnostics.get(ref)` return immutable local receipts.
+- Receipts support `to_dict()`, `to_json()`, and explicit `.export()` using the Report convention.
+- One top-level failed Evaluation produces one unique receipt containing separate observable
+  candidate executions; each retains the existing public Event `run_id` when observed.
+- Normal receipts contain no prompts, responses, URL4, notebook source, raw logs, secrets,
+  environment dumps, source lines, locals, or absolute paths.
+- Capture is bounded, local-only and fail-open; normal Python exception behavior is unchanged.
+
+## Outcome
+
+- **Actual files:** the approved spec/plan/task/ledger; public immutable receipt and lookup API;
+  private allow-listed capture, bounded store, and Evaluation context modules; sync/async Recipe
+  and URL4-replay workflow integration; concise exception handoff; changelog and public-surface
+  snapshot; three new behavior suites plus a focused shared fixture module; the one approved
+  transport-fixture contract amendment below.
+- **Commits:** `feat(screamingface): add local diagnostic receipts` (this unit).
+- **Gates:** `run_gates.py screamingface --skip-append-only` ALL GATES GREEN — Ruff lint and
+  formatting, Pyright (0 errors), the complete pytest suite with ≥95% coverage, deterministic
+  notebook validation, wheel/sdist build, and distribution validation. Final focused diagnostic
+  suite: 29 passed.
+- **Deviations:** `--skip-append-only` was used only for the two owner-approved contract updates
+  documented below. Notebook extras were installed in this worktree's private `.venv` to run the
+  declared Pyright and notebook gates. No dependency or lockfile changed.
+- **Review:** the merged `OME-1004` wire contract remains an adapter concern: its singular
+  correlation/candidate shape does not narrow this receipt's multi-execution evidence. `OME-1014`
+  owns projection, Turnstile/widget communication, retry semantics, 64 KiB shaping, and disk
+  fallback. `OME-967` remains the source of complete trace correlation and is not a blocker.
+
+## Owner-approved prior-test amendments
+
+On 2026-08-26 the append-only gate correctly stopped on two intentional contract updates. The
+owner explicitly approved both before the gate was resumed with `--skip-append-only`:
+
+- `tests/public_surface_snapshot.json` records the new public `sf.diagnostics` module and
+  `DiagnosticReceipt` value. The accompanying changelog entry makes the API change explicit.
+- `tests/test_draco_vertical_slice.py` permits the transport's optional event observer even when
+  user progress/callbacks are off. Local diagnostics need that private observer to retain
+  observable `run_id`/`trace_id` evidence; the transport port already permits `None | callable`.
+
+No assertion was deleted or skipped, and the complete package suite remained green before the
+official gate run.

--- a/docs/work/2026-08-26-OME-1013-client-diagnostics.md
+++ b/docs/work/2026-08-26-OME-1013-client-diagnostics.md
@@ -52,32 +52,44 @@ future report-intake mapping remains a separate adapter and is not designed into
 
 - **Actual files:** the approved spec/plan/task/ledger; public immutable receipt and lookup API;
   private allow-listed capture, bounded store, and Evaluation context modules; sync/async Recipe
-  and URL4-replay workflow integration; concise exception handoff; changelog and public-surface
-  snapshot; three new behavior suites plus a focused shared fixture module; the one approved
-  transport-fixture contract amendment below.
-- **Commits:** `feat(screamingface): add local diagnostic receipts` (this unit).
+  and URL4-replay workflow integration; shared fail-open observer plumbing; safe early candidate
+  identity and relative-route breadcrumbs; concise exception handoff; changelog and public-surface
+  snapshot; behavior suites plus a focused shared fixture module; and the owner-approved prior-test
+  amendments below.
+- **Commits:** `edbe0f68 feat(screamingface): add local diagnostic receipts` plus the final
+  `fix(screamingface): complete diagnostic evidence contract` review pass.
 - **Gates:** `run_gates.py screamingface --skip-append-only` ALL GATES GREEN — Ruff lint and
   formatting, Pyright (0 errors), the complete pytest suite with ≥95% coverage, deterministic
-  notebook validation, wheel/sdist build, and distribution validation. Final focused diagnostic
-  suite: 29 passed.
-- **Deviations:** `--skip-append-only` was used only for the two owner-approved contract updates
+  notebook validation, wheel/sdist build, and distribution validation. Final focused diagnostic,
+  progress and capture suites: 94 passed.
+- **Deviations:** `--skip-append-only` was used only for the four owner-approved contract updates
   documented below. Notebook extras were installed in this worktree's private `.venv` to run the
   declared Pyright and notebook gates. No dependency or lockfile changed.
 - **Review:** the merged `OME-1004` wire contract remains an adapter concern: its singular
   correlation/candidate shape does not narrow this receipt's multi-execution evidence. `OME-1014`
   owns projection, Turnstile/widget communication, retry semantics, 64 KiB shaping, and disk
-  fallback. `OME-967` remains the source of complete trace correlation and is not a blocker.
+  fallback. `OME-967` remains the source of complete trace correlation and is not a blocker. The
+  final review removed arbitrary typed server messages, guarded diagnostic-note attachment,
+  retained safe caller identity before preparation, restricted operation breadcrumbs to bounded
+  relative URL4 routes, and extracted observer fan-out from the runner.
 
 ## Owner-approved prior-test amendments
 
-On 2026-08-26 the append-only gate correctly stopped on two intentional contract updates. The
-owner explicitly approved both before the gate was resumed with `--skip-append-only`:
+The append-only gate correctly stopped on four intentional contract updates. The owner explicitly
+approved the first two on 2026-08-26 and the final two on 2026-08-27 before the gate was resumed
+with `--skip-append-only`:
 
 - `tests/public_surface_snapshot.json` records the new public `sf.diagnostics` module and
   `DiagnosticReceipt` value. The accompanying changelog entry makes the API change explicit.
 - `tests/test_draco_vertical_slice.py` permits the transport's optional event observer even when
   user progress/callbacks are off. Local diagnostics need that private observer to retain
   observable `run_id`/`trace_id` evidence; the transport port already permits `None | callable`.
+- `tests/test_diagnostic_capture.py` replaces the earlier assertion that retained arbitrary
+  peer-supplied WebSocket close-reason text. Owner approval on 2026-08-27 removed that unsafe field
+  and retained only the numeric close code.
+- `tests/test_evaluation_diagnostics.py` uses one fixture-module alias instead of thirteen repeated
+  imports. Owner approval on 2026-08-27 covered this mechanical, assertion-preserving reduction from
+  478 to 442 lines so the file satisfies the stack's ≤450-line rule.
 
-No assertion was deleted or skipped, and the complete package suite remained green before the
-official gate run.
+No behavior assertion was deleted or skipped, and the complete package suite remained green after
+the approved contract correction.

--- a/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
+++ b/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
@@ -25,6 +25,8 @@ exception handler.
 - Update the ScreamingFace changelog for the notebook presentation behavior.
 - Remove unsupported tooltips from root `VBox` containers after a real JupyterLab frontend
   reproduction showed that its widget manager dereferences a nonexistent `description` field.
+- Compact the default panel so the error remains primary and the diagnostic receipt reads as
+  supporting evidence rather than a second full error screen.
 
 ## Test plan
 
@@ -37,6 +39,8 @@ exception handler.
 - Run the full `screamingface` gate lane after focused tests pass.
 - RED: root `VBox` containers do not publish a tooltip trait, while supported control/table
   tooltips and the panel's HTML accessibility name remain intact.
+- RED: the default panel has no diagnostic eyebrow or repeated lifetime/traceback prose; receipt
+  identity, `local only`, `%tb`, Preview and Export share one compact footer.
 
 ## Acceptance
 
@@ -53,9 +57,12 @@ exception handler.
   `_ui/diagnostic_view.py` notebook adapter; attached it at the existing Evaluation diagnostic
   boundary; added append-only notebook renderer, action, fallback, accessibility and SFDS tests;
   updated the package changelog; and removed unsupported root-`VBox` tooltips from both diagnostic
-  and Evaluation widgets after a live JupyterLab reproduction identified the shared frontend crash.
+  and Evaluation widgets after a live JupyterLab reproduction identified the shared frontend
+  crash. The final notebook presentation is one compact alert with an inline receipt/action footer;
+  repeated diagnostic labels and lifetime/traceback prose were removed.
 - **Commits:** `feat(screamingface): render notebook diagnostics`; and
-  `fix(screamingface): avoid notebook container tooltip crash` (this follow-up).
+  `fix(screamingface): avoid notebook container tooltip crash`; and
+  `fix(screamingface): compact notebook diagnostic panel` (final presentation pass).
 - **Gates:** Ruff lint and formatting, Pyright (0 errors), complete package pytest suite (1,237
   passed, 17 skipped, 95.04% coverage), focused widget suites (57 passed), wheel/sdist build and
   distribution validation all passed. The new adapter has 100% focused statement coverage.

--- a/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
+++ b/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
@@ -1,0 +1,65 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-08-26
+finished: 2026-08-26
+---
+
+# OME-1013 — Render local diagnostics in notebooks
+
+## Intent
+
+Present a retained local diagnostic receipt as an SFDS notebook panel when an exception escapes a
+ScreamingFace Evaluation. Preserve the exact Python exception and keep ordinary terminal behavior,
+while giving Jupyter and Colab users explicit Preview and Export actions without a notebook-global
+exception handler.
+
+## Planned changes
+
+- Amend the approved OME-1013 spec and plan with the owner-approved per-exception presentation seam.
+- Add one private notebook presentation adapter under `packages/screamingface/src/screamingface/_ui/`.
+- Attach that adapter only after a diagnostic receipt has been retained.
+- Add append-only behavior tests for typed and raw exceptions, fallback behavior, privacy-safe
+  preview, explicit export, accessibility, and SFDS light/dark styling.
+- Update the ScreamingFace changelog for the notebook presentation behavior.
+
+## Test plan
+
+- RED: an Evaluation failure attaches a renderer to the original exception without replacing it.
+- RED: rendering publishes one branded panel with concise error evidence and diagnostic identity.
+- RED: Preview reveals the byte-identical receipt JSON only after an explicit click.
+- RED: Export writes only after an explicit click and reports success or failure locally.
+- RED: missing/broken IPython or ipywidgets falls back to the pre-existing traceback renderer.
+- RED: unrelated exceptions and successful/partial Evaluations are unaffected.
+- Run the full `screamingface` gate lane after focused tests pass.
+
+## Acceptance
+
+- Jupyter and Colab render a square, accessible SFDS app-register diagnostic panel for retained
+  Evaluation failures.
+- The same original exception object is re-raised; `%tb` remains available for its full traceback.
+- No global IPython exception handler is installed.
+- Preview and Export are explicit local actions; no send or automatic filesystem write exists.
+- Plain Python and terminal behavior remain unchanged, and presentation failure is fail-open.
+
+## Outcome
+
+- **Actual files:** amended the approved OME-1013 spec and plan; added the private
+  `_ui/diagnostic_view.py` notebook adapter; attached it at the existing Evaluation diagnostic
+  boundary; added append-only notebook renderer, action, fallback, accessibility and SFDS tests;
+  and updated the package changelog.
+- **Commits:** `feat(screamingface): render notebook diagnostics` (this unit).
+- **Gates:** Ruff lint and formatting, Pyright (0 errors), complete package pytest suite (1,237
+  passed, 17 skipped, 95.03% coverage), focused diagnostic suite (38 passed), wheel/sdist build and
+  distribution validation all passed. The new adapter has 100% focused statement coverage.
+- **Deviations:** the official gate wrapper's Ruff phase also inspected an unrelated, owner-edited
+  `examples/00_quickstart.ipynb` and stopped on that notebook's pre-existing undefined
+  `leaderboard` name. The owner file was preserved and excluded from this commit; the equivalent
+  source/test/type/build/distribution gates were run directly. Browser-based visual verification
+  could not run because no Browser plugin session was available, so the owner notebook check
+  remains the visual confirmation step.
+- **Review:** the renderer is attached only to the retained exception instance, preserves the same
+  exception and traceback, never installs a global IPython hook, performs no network or automatic
+  filesystem action, and falls back to the previous traceback renderer if optional notebook
+  presentation fails. The intake contract, consent and Send action remain isolated to OME-1014.

--- a/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
+++ b/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
@@ -8,6 +8,9 @@ finished: 2026-08-27
 
 # OME-1013 — Render local diagnostics in notebooks
 
+> This `done` status records the completed notebook-panel iteration, not closure of the parent
+> Linear issue. The authoritative ticket mirror remains `in_progress` until the full PR lands.
+
 ## Intent
 
 Present a retained local diagnostic receipt as an SFDS notebook panel when an exception escapes a

--- a/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
+++ b/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
@@ -3,7 +3,7 @@ ticket: OME-1013
 stack: screamingface
 status: done
 started: 2026-08-26
-finished: 2026-08-26
+finished: 2026-08-27
 ---
 
 # OME-1013 — Render local diagnostics in notebooks
@@ -27,6 +27,10 @@ exception handler.
   reproduction showed that its widget manager dereferences a nonexistent `description` field.
 - Compact the default panel so the error remains primary and the diagnostic receipt reads as
   supporting evidence rather than a second full error screen.
+- Remove the duplicate error card entirely after owner visual review confirmed that IPython always
+  renders the native exception summary beneath it; retain only a neutral receipt toolbar.
+- Make the receipt toolbar content-hugging after owner visual review identified the remaining
+  full-width dead space; shorten only its displayed id while retaining the complete value.
 
 ## Test plan
 
@@ -41,6 +45,10 @@ exception handler.
   tooltips and the panel's HTML accessibility name remain intact.
 - RED: the default panel has no diagnostic eyebrow or repeated lifetime/traceback prose; receipt
   identity, `local only`, `%tb`, Preview and Export share one compact footer.
+- RED: no title, message, danger surface or filled primary action remains; the native exception is
+  the only failure presentation and the receipt toolbar uses neutral structure plus link actions.
+- RED: the toolbar hugs its content at 32–36px, keeps actions adjacent, and exposes the full
+  diagnostic id through accessible/title text when the visible id is shortened.
 
 ## Acceptance
 
@@ -58,13 +66,14 @@ exception handler.
   boundary; added append-only notebook renderer, action, fallback, accessibility and SFDS tests;
   updated the package changelog; and removed unsupported root-`VBox` tooltips from both diagnostic
   and Evaluation widgets after a live JupyterLab reproduction identified the shared frontend
-  crash. The final notebook presentation is one compact alert with an inline receipt/action footer;
-  repeated diagnostic labels and lifetime/traceback prose were removed.
+  crash. Owner visual review then reduced the presentation to a content-hugging, borderless receipt
+  toolbar beside IPython's native exception: the visible id is shortened, its complete value stays
+  available to assistive technology and hover, and Preview/Export remain explicit local actions.
 - **Commits:** `feat(screamingface): render notebook diagnostics`; and
   `fix(screamingface): avoid notebook container tooltip crash`; and
   `fix(screamingface): compact notebook diagnostic panel` (final presentation pass).
-- **Gates:** Ruff lint and formatting, Pyright (0 errors), complete package pytest suite (1,237
-  passed, 17 skipped, 95.04% coverage), focused widget suites (57 passed), wheel/sdist build and
+- **Gates:** Ruff lint and formatting, Pyright (0 errors), complete package pytest suite (1,239
+  passed, 17 skipped, 95.04% coverage), focused widget suites (59 passed), wheel/sdist build and
   distribution validation all passed. The new adapter has 100% focused statement coverage.
 - **Deviations:** the official gate wrapper's Ruff phase also inspected an unrelated, owner-edited
   `examples/00_quickstart.ipynb` and stopped on that notebook's pre-existing undefined

--- a/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
+++ b/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
@@ -23,6 +23,8 @@ exception handler.
 - Add append-only behavior tests for typed and raw exceptions, fallback behavior, privacy-safe
   preview, explicit export, accessibility, and SFDS light/dark styling.
 - Update the ScreamingFace changelog for the notebook presentation behavior.
+- Remove unsupported tooltips from root `VBox` containers after a real JupyterLab frontend
+  reproduction showed that its widget manager dereferences a nonexistent `description` field.
 
 ## Test plan
 
@@ -33,6 +35,8 @@ exception handler.
 - RED: missing/broken IPython or ipywidgets falls back to the pre-existing traceback renderer.
 - RED: unrelated exceptions and successful/partial Evaluations are unaffected.
 - Run the full `screamingface` gate lane after focused tests pass.
+- RED: root `VBox` containers do not publish a tooltip trait, while supported control/table
+  tooltips and the panel's HTML accessibility name remain intact.
 
 ## Acceptance
 
@@ -48,18 +52,22 @@ exception handler.
 - **Actual files:** amended the approved OME-1013 spec and plan; added the private
   `_ui/diagnostic_view.py` notebook adapter; attached it at the existing Evaluation diagnostic
   boundary; added append-only notebook renderer, action, fallback, accessibility and SFDS tests;
-  and updated the package changelog.
-- **Commits:** `feat(screamingface): render notebook diagnostics` (this unit).
+  updated the package changelog; and removed unsupported root-`VBox` tooltips from both diagnostic
+  and Evaluation widgets after a live JupyterLab reproduction identified the shared frontend crash.
+- **Commits:** `feat(screamingface): render notebook diagnostics`; and
+  `fix(screamingface): avoid notebook container tooltip crash` (this follow-up).
 - **Gates:** Ruff lint and formatting, Pyright (0 errors), complete package pytest suite (1,237
-  passed, 17 skipped, 95.03% coverage), focused diagnostic suite (38 passed), wheel/sdist build and
+  passed, 17 skipped, 95.04% coverage), focused widget suites (57 passed), wheel/sdist build and
   distribution validation all passed. The new adapter has 100% focused statement coverage.
 - **Deviations:** the official gate wrapper's Ruff phase also inspected an unrelated, owner-edited
   `examples/00_quickstart.ipynb` and stopped on that notebook's pre-existing undefined
   `leaderboard` name. The owner file was preserved and excluded from this commit; the equivalent
-  source/test/type/build/distribution gates were run directly. Browser-based visual verification
-  could not run because no Browser plugin session was available, so the owner notebook check
-  remains the visual confirmation step.
+  source/test/type/build/distribution gates were run directly. A headless Chrome reproduction
+  confirmed the original `VBoxView` creation failure; the owner notebook rerun after a kernel
+  restart remains the final visual confirmation of the corrected model.
 - **Review:** the renderer is attached only to the retained exception instance, preserves the same
   exception and traceback, never installs a global IPython hook, performs no network or automatic
   filesystem action, and falls back to the previous traceback renderer if optional notebook
-  presentation fails. The intake contract, consent and Send action remain isolated to OME-1014.
+  presentation fails. Removing the root tooltip is the minimum compatible fix: supported button
+  and table tooltips remain, while accessibility naming stays in the panel HTML and live regions.
+  The intake contract, consent and Send action remain isolated to OME-1014.

--- a/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
+++ b/docs/work/2026-08-26-OME-1013-notebook-diagnostic-panel.md
@@ -71,16 +71,19 @@ exception handler.
   available to assistive technology and hover, and Preview/Export remain explicit local actions.
 - **Commits:** `feat(screamingface): render notebook diagnostics`; and
   `fix(screamingface): avoid notebook container tooltip crash`; and
-  `fix(screamingface): compact notebook diagnostic panel` (final presentation pass).
-- **Gates:** Ruff lint and formatting, Pyright (0 errors), complete package pytest suite (1,239
-  passed, 17 skipped, 95.04% coverage), focused widget suites (59 passed), wheel/sdist build and
-  distribution validation all passed. The new adapter has 100% focused statement coverage.
+  `fix(screamingface): compact notebook diagnostic panel`; and
+  `fix(screamingface): reduce notebook diagnostics to receipt toolbar` (final presentation pass).
+- **Gates:** final `run_gates.py screamingface --skip-append-only` ALL GATES GREEN — Ruff lint and
+  formatting, Pyright (0 errors), complete package pytest suite with ≥95% coverage, deterministic
+  notebook validation, wheel/sdist build and distribution validation. The append-only override is
+  documented in the primary OME-1013 ledger and does not concern notebook presentation tests.
 - **Deviations:** the official gate wrapper's Ruff phase also inspected an unrelated, owner-edited
   `examples/00_quickstart.ipynb` and stopped on that notebook's pre-existing undefined
   `leaderboard` name. The owner file was preserved and excluded from this commit; the equivalent
   source/test/type/build/distribution gates were run directly. A headless Chrome reproduction
-  confirmed the original `VBoxView` creation failure; the owner notebook rerun after a kernel
-  restart remains the final visual confirmation of the corrected model.
+  confirmed the original `VBoxView` creation failure. The owner then visually confirmed the
+  corrected, content-hugging toolbar in Jupyter. The overlapping Evaluation-widget tooltip fix was
+  dropped during rebase because `OME-1022` landed the authoritative fix on main.
 - **Review:** the renderer is attached only to the retained exception instance, preserves the same
   exception and traceback, never installs a global IPython hook, performs no network or automatic
   filesystem action, and falls back to the previous traceback renderer if optional notebook

--- a/docs/work/2026-09-01-OME-1013-diagnostic-hardening.md
+++ b/docs/work/2026-09-01-OME-1013-diagnostic-hardening.md
@@ -3,7 +3,7 @@ ticket: OME-1013
 stack: screamingface
 status: done
 started: 2026-09-01
-finished: 2026-09-01
+finished: 2026-09-02
 ---
 
 # OME-1013 — Harden diagnostic evidence and notebook presentation
@@ -51,14 +51,15 @@ evidence, and use the SFDS danger role for failures.
   updated the diagnostic receipt/evaluation/notebook modules and their focused behavior suites; and
   clarified that the two earlier `done` ledgers describe completed iterations, not ticket closure.
 - **Commits:** this iteration's `fix(screamingface): harden client diagnostics` commit.
-- **Gates:** `run_gates.py screamingface --skip-append-only` ALL GATES GREEN — Ruff lint and
-  formatting, Pyright (0 errors), the complete pytest suite with ≥95% coverage, deterministic
-  notebook validation, wheel/sdist build, and distribution validation. Focused diagnostic,
-  capture and fail-open suites: 62 passed.
-- **Deviations:** append-only comparison skipped only for the owner-approved contract corrections
-  listed below. The pre-existing modified quickstart notebook and untracked exported diagnostic
-  were temporarily stashed for gates because that notebook currently has an unrelated undefined
-  `leaderboard` reference; both user-owned files were restored unchanged immediately afterward.
+- **Gates:** after rebasing onto `origin/main`, plain `run_gates.py screamingface` ALL GATES GREEN —
+  append-only check, Ruff lint and formatting, Pyright (0 errors), the complete pytest suite with
+  ≥95% coverage, deterministic notebook validation, wheel/sdist build, and distribution
+  validation. Focused diagnostic, capture and fail-open suites: 62 passed.
+- **Deviations:** the pre-commit gate used `--skip-append-only` only for the owner-approved contract
+  corrections listed below; the post-rebase ordinary gate passed the append-only check. The
+  pre-existing modified quickstart notebook and untracked exported diagnostic were temporarily
+  stashed for gates because that notebook currently has an unrelated undefined `leaderboard`
+  reference; both user-owned files were restored unchanged immediately afterward.
 
 ## Owner-approved prior-test amendments
 

--- a/docs/work/2026-09-01-OME-1013-diagnostic-hardening.md
+++ b/docs/work/2026-09-01-OME-1013-diagnostic-hardening.md
@@ -1,0 +1,76 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-09-01
+finished: 2026-09-01
+---
+
+# OME-1013 — Harden diagnostic evidence and notebook presentation
+
+## Intent
+
+Correct the review findings without redesigning the diagnostic feature: preserve IPython's native
+traceback while adding the local receipt toolbar, stop publishing the private stream topic as a
+public run id, simplify receipt construction and recipe projection around typed allow-listed
+evidence, and use the SFDS danger role for failures.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_ui/diagnostic_view.py`
+- `packages/screamingface/src/screamingface/_diagnostics/evaluation.py`
+- `packages/screamingface/src/screamingface/_diagnostics/model.py`
+- focused diagnostic tests under `packages/screamingface/tests/`
+- OME-1013 spec, plan, task/ledger bookkeeping when required by the corrected contract
+
+## Test plan
+
+- RED: an attached notebook renderer returns the native traceback lines on first and repeated
+  rendering while displaying the receipt toolbar only once; adapter failure retains the prior
+  renderer's lines.
+- RED: event stream topics never enter a receipt as public `run_id`, while observable `trace_id`
+  remains attached to the correct execution.
+- RED: recipe evidence remains sufficient for preflight failures without a diagnostic switch over
+  every concrete recipe subtype.
+- RED: receipt construction rejects non-allow-listed top-level sections and unsafe error fields.
+- RED: failure presentation uses the semantic SFDS danger token.
+- Run focused tests, the full package suite, and `run_gates.py screamingface`.
+
+## Acceptance
+
+- Native exception rendering and `%tb` remain intact; the widget is additive and local.
+- The internal stream topic is absent from the public receipt schema.
+- Safe structured error, validated configuration, topology and report/export capabilities remain;
+  prompts, responses, raw messages and other forbidden content remain absent.
+- Diagnostic capture does not require edits for each new concrete recipe subtype.
+- All ScreamingFace gates pass at or above 95% coverage.
+
+## Outcome
+
+- **Actual files:** corrected the spec/plan and original capture ledger; added this hardening ledger;
+  updated the diagnostic receipt/evaluation/notebook modules and their focused behavior suites; and
+  clarified that the two earlier `done` ledgers describe completed iterations, not ticket closure.
+- **Commits:** this iteration's `fix(screamingface): harden client diagnostics` commit.
+- **Gates:** `run_gates.py screamingface --skip-append-only` ALL GATES GREEN — Ruff lint and
+  formatting, Pyright (0 errors), the complete pytest suite with ≥95% coverage, deterministic
+  notebook validation, wheel/sdist build, and distribution validation. Focused diagnostic,
+  capture and fail-open suites: 62 passed.
+- **Deviations:** append-only comparison skipped only for the owner-approved contract corrections
+  listed below. The pre-existing modified quickstart notebook and untracked exported diagnostic
+  were temporarily stashed for gates because that notebook currently has an unrelated undefined
+  `leaderboard` reference; both user-owned files were restored unchanged immediately afterward.
+
+## Owner-approved prior-test amendments
+
+The append-only guard stopped on three tests that encoded the review findings the owner explicitly
+approved fixing on 2026-09-01:
+
+- `test_diagnostic_notebook_view.py` now requires native traceback lines on successful and repeated
+  rendering instead of requiring `[]`, and requires the semantic danger token.
+- `test_evaluation_diagnostics.py` removes the internal stream topic from expected public receipt
+  evidence and limits pre-compilation candidate evidence to name/kind.
+- `test_diagnostics.py` constructs the typed receipt evidence aggregate and replaces the unsafe
+  arbitrary `error.message` fixture with an allow-listed hint; a new test rejects `message`.
+
+The assertions are stronger and directly cover the corrected privacy and exception-preservation
+invariants. The final gate run may use `--skip-append-only` for only these approved amendments.

--- a/docs/work/2026-09-02-OME-1013-colab-widget-root.md
+++ b/docs/work/2026-09-02-OME-1013-colab-widget-root.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-09-02
+finished: 2026-09-03
+---
+
+# OME-1013 — Refine the Colab diagnostic footer
+
+## Intent
+
+Fix the retained diagnostic toolbar rendering as an invisible root `VBox` in Google Colab, then
+reduce it to a transparent recovery footer after the native traceback. Keep local persistence and
+inspection explicit without duplicating terminal guidance or implying that saving downloads a file
+from a hosted runtime.
+
+## Planned changes
+
+- `packages/screamingface/tests/test_diagnostic_notebook_view.py` — add a regression test for the
+  Colab root-container layout contract and update the owner-approved notebook interaction contract.
+- `packages/screamingface/tests/test_evaluation_diagnostics.py` — preserve terminal export guidance
+  while proving notebook presentation does not duplicate it.
+- `packages/screamingface/src/screamingface/_ui/diagnostic_view.py` — make the root visible and
+  transparent, present `View details` and `Save JSON`, hide empty rows, and move runtime/%tb guidance
+  into the expanded details.
+- `packages/screamingface/src/screamingface/_diagnostics/evaluation.py` — attach textual export
+  guidance only outside notebooks, where no rich recovery footer is available.
+- Approved OME-1013 spec/plan wording and this ledger — record the refined presentation contract.
+
+## Test plan
+
+- RED: prove the root widget does not opt into a frontend-dependent width/layout mode that causes
+  Colab to collapse it while its child widgets remain renderable.
+- RED: prove the default footer is transparent and concise, calls its actions `View details` and
+  `Save JSON`, and does not reserve space for hidden detail/status rows.
+- RED: prove details reveal the exact receipt plus runtime-lifetime and `%tb` guidance, saving reports
+  a local path, and notebook exceptions omit the duplicate terminal-only export note.
+- GREEN: run the focused notebook diagnostic tests, then the full `screamingface` quality gates.
+- Preserve the existing tests for native traceback fallback, explicit inspect/save behavior,
+  accessibility, privacy, and SFDS styling.
+
+## Acceptance
+
+- Displaying `_display_notebook_diagnostic(sf.diagnostics.last())` produces a visible diagnostic
+  toolbar in Colab once its widget manager is enabled.
+- The default footer reads `Diagnostic <id>`, `View details`, and `Save JSON` without a contrasting
+  card background, visible `local only`/`%tb` copy, or empty vertical rows.
+- Details contain the exact receipt JSON, kernel-lifetime disclosure, and `%tb` guidance.
+- Terminal exceptions retain exact export guidance; notebooks show it once through the rich footer.
+- The public `DiagnosticReceipt.export()` API remains unchanged.
+- Existing Jupyter/IPython traceback and notebook diagnostic tests remain green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** updated the approved spec and plan, the diagnostic staging boundary, notebook
+  footer adapter, focused notebook tests, and this ledger. The public receipt/export API is
+  unchanged.
+- **Commits:** this iteration's `fix(screamingface): refine notebook diagnostic footer` commit.
+- **Gates:** focused diagnostics 45 passed; complete package suite 1,353 passed and 17 skipped at
+  95.01% coverage; Ruff lint and format, Pyright (0 errors), wheel/sdist build, and distribution
+  validation green.
+- **Deviations:** the ordinary gate wrapper and generated-notebook check remain blocked by the
+  pre-existing user-modified `examples/00_quickstart.ipynb` (`leaderboard` is undefined and the
+  generated notebook is stale). The equivalent source/test/type/build/distribution gates passed;
+  that notebook and the untracked exported diagnostic JSON were preserved unchanged and excluded
+  from this iteration. The owner approved the prior-test wording changes on 2026-09-03; they replace
+  the superseded Preview/Export/local-only presentation contract with View details/Save JSON and
+  notebook-only rich guidance. Live Colab verification confirmed that removing root shrink-wrap
+  makes the widget visible; the refined copy and transparent styling remain for owner visual check
+  from the pushed branch.

--- a/docs/work/2026-09-02-OME-1013-colab-widget-root.md
+++ b/docs/work/2026-09-02-OME-1013-colab-widget-root.md
@@ -57,15 +57,17 @@ from a hosted runtime.
   footer adapter, focused notebook tests, and this ledger. The public receipt/export API is
   unchanged.
 - **Commits:** this iteration's `fix(screamingface): refine notebook diagnostic footer` commit.
-- **Gates:** focused diagnostics 45 passed; complete package suite 1,353 passed and 17 skipped at
-  95.01% coverage; Ruff lint and format, Pyright (0 errors), wheel/sdist build, and distribution
-  validation green.
+- **Gates:** after rebasing onto current `origin/main`, focused diagnostics plus protocol integration
+  91 passed; complete package suite 1,376 passed and 17 skipped at 95.02% coverage; Ruff lint and
+  format, Pyright (0 errors), deterministic generated-notebook validation, wheel/sdist build, and
+  distribution validation green.
 - **Deviations:** the ordinary gate wrapper and generated-notebook check remain blocked by the
   pre-existing user-modified `examples/00_quickstart.ipynb` (`leaderboard` is undefined and the
-  generated notebook is stale). The equivalent source/test/type/build/distribution gates passed;
-  that notebook and the untracked exported diagnostic JSON were preserved unchanged and excluded
-  from this iteration. The owner approved the prior-test wording changes on 2026-09-03; they replace
+  generated notebook is stale). The clean generated-notebook check passed while those user-owned
+  artifacts were safely stashed; both were restored unchanged and remain excluded from this
+  iteration. The owner approved the prior-test wording changes on 2026-09-03; they replace
   the superseded Preview/Export/local-only presentation contract with View details/Save JSON and
   notebook-only rich guidance. Live Colab verification confirmed that removing root shrink-wrap
-  makes the widget visible; the refined copy and transparent styling remain for owner visual check
-  from the pushed branch.
+  makes the widget visible. The rebase conflict retained both `OME-967` trace rendering and
+  terminal-only OME-1013 diagnostic notes; the refined copy and transparent styling remain for
+  owner visual check from the pushed branch.

--- a/docs/work/2026-09-03-OME-1013-final-review-corrections.md
+++ b/docs/work/2026-09-03-OME-1013-final-review-corrections.md
@@ -1,0 +1,58 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-09-03
+finished: 2026-09-03
+---
+
+# OME-1013 — Apply final diagnostic review corrections
+
+## Intent
+
+Correct local Engine classification in diagnostic receipts, remove redundant immutable-JSON
+machinery, and explicitly test that direct URL4 input validation participates in OME-1013's
+diagnostic boundary without changing the original exception contract.
+
+## Planned changes
+
+- Move the existing IP-aware Engine-origin classifier from the notebook UI package to a neutral
+  private Client module and use it from diagnostics and existing UI consumers.
+- Reuse `screamingface._immutable_json` for receipt freezing and thawing instead of maintaining a
+  second recursive implementation.
+- Add regression coverage for unspecified/loopback Engine addresses and public direct-URL4 option
+  validation producing a degraded receipt while preserving the original `TypeError`.
+
+## Test plan
+
+- RED: extend Engine capture tests with local address aliases that the current hardcoded set
+  misclassifies.
+- RED: add direct URL4 misuse coverage that requires the validation error to be retained as a
+  diagnostic receipt and re-raised unchanged.
+- GREEN: run focused diagnostic tests, then the complete `screamingface` quality gates.
+
+## Acceptance
+
+- Local and unspecified IP Engine addresses are consistently classified as local across Client
+  surfaces and diagnostic receipts.
+- Direct URL4 option misuse retains a local receipt while the same `TypeError` reaches the caller.
+- Diagnostic receipts use the shared immutable JSON implementation with unchanged public JSON.
+- All `screamingface` gates pass and the changes are committed but not merged.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** moved Engine-origin classification from `_ui/engine_origin.py` to the neutral
+  `_engine_origin.py` module and repointed diagnostics plus all existing UI consumers; replaced the
+  diagnostic-specific freeze/thaw recursion with `_immutable_json` helpers; added local-address and
+  direct-URL4 validation coverage; recorded this ledger.
+- **Commits:** this iteration's `fix(screamingface): apply diagnostic review corrections` commit.
+- **Gates:** RED confirmed 3 intended locality failures with 28 passes; focused diagnostics and
+  connection coverage passed (115 tests); `uv run .claude/scripts/run_gates.py screamingface`
+  completed with `ALL GATES GREEN` across append-only protection, Ruff lint/format, Pyright, full
+  pytest coverage at the 95% threshold, deterministic notebook validation, build, and distribution
+  validation.
+- **Deviations:** the new direct-URL4 tests passed during RED because the reviewed behavior was
+  already intentional; the locality cases supplied the failing production signal. The user's
+  modified quickstart notebook and exported diagnostic JSON were temporarily stashed for the full
+  gate, restored unchanged, and excluded from the commit. One initial focused command named a
+  nonexistent connection-view test file; it ran no tests and was immediately corrected.

--- a/docs/work/2026-09-03-OME-1013-notebook-fallback-recovery.md
+++ b/docs/work/2026-09-03-OME-1013-notebook-fallback-recovery.md
@@ -1,0 +1,64 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-09-03
+finished: 2026-09-04
+---
+
+# OME-1013 — Preserve notebook recovery when widgets fail
+
+## Intent
+
+Keep the privacy-safe local receipt as the default evidence contract while making the notebook
+fallback useful when optional widget rendering fails: preserve the native traceback, log the
+presentation failure without receipt content, and show the diagnostic id plus explicit export
+command exactly once per rendering attempt.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_ui/diagnostic_view.py`
+- `packages/screamingface/src/screamingface/_diagnostics/evaluation.py`
+- `packages/screamingface/src/screamingface/diagnostic.py`
+- `packages/screamingface/tests/test_diagnostic_notebook_view.py`
+
+## Test plan
+
+- RED: a failed widget display retains every native traceback line and adds the diagnostic id and
+  exact export command.
+- RED: repeated traceback rendering neither retries the broken widget nor duplicates recovery text.
+- RED: presentation failure logging contains no receipt JSON.
+- GREEN: successful widget rendering remains additive and unchanged.
+- QUALITY: run the complete ScreamingFace gate runner.
+
+## Acceptance
+
+- A notebook without working `ipywidgets` still tells the user how to retrieve and export the
+  already-retained diagnostic.
+- The original exception and traceback remain intact and `%tb` remains useful.
+- The fallback logs the presentation failure without logging diagnostic content.
+- Full tracebacks remain local and are never added to the diagnostic receipt or report payload.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** shared the private export-guidance formatter from
+  `packages/screamingface/src/screamingface/diagnostic.py`; made
+  `packages/screamingface/src/screamingface/_ui/diagnostic_view.py` retain the native traceback,
+  log a failed widget once without receipt content, avoid retrying it, and append recovery
+  guidance; repointed `packages/screamingface/src/screamingface/_diagnostics/evaluation.py`; added
+  regression coverage in `packages/screamingface/tests/test_diagnostic_notebook_view.py`; and
+  recorded this ledger.
+- **Commits:** this iteration's `fix(screamingface): preserve diagnostic fallback recovery`
+  commit.
+- **Gates:** RED confirmed the missing recovery text and repeated widget attempt; 22 notebook-view
+  tests passed; 80 focused diagnostic tests passed; Ruff and Pyright passed; the complete
+  `python3 .claude/scripts/run_gates.py screamingface --skip-append-only` suite was green in a
+  byte-for-byte-verified clean worktree (Ruff lint/format, Pyright, full pytest with at least 95%
+  coverage, notebook validation, build, and distribution validation).
+- **Deviations:** the owner-approved behavior necessarily amended one existing fallback test, so
+  the append-only check was skipped after it correctly identified that prior assertion change.
+  The feature worktree's first complete run then stopped on the user's uncommitted quickstart
+  notebook (`leaderboard` was undefined); clean-worktree validation preserved that notebook and
+  the exported diagnostic JSON untouched. Full exception tracebacks remain local by design:
+  authenticated internal reporting does not make absolute paths, source lines, exception
+  messages, prompts, or secrets safe to upload by default.

--- a/docs/work/2026-09-03-OME-1013-receipt-validation-traceback-tail.md
+++ b/docs/work/2026-09-03-OME-1013-receipt-validation-traceback-tail.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-09-03
+finished: 2026-09-03
+---
+
+# OME-1013 — Harden receipt validation and traceback retention
+
+## Intent
+
+Close the final privacy and diagnostic-quality findings on the local receipt implementation:
+reject unexpected evidence fields at the receipt construction boundary, structurally exclude the
+internal event `run_id`, and retain the innermost failure frames when a traceback exceeds its bound.
+
+## Planned changes
+
+- `packages/screamingface/tests/test_diagnostics.py`
+- `packages/screamingface/tests/test_diagnostic_capture.py`
+- `packages/screamingface/src/screamingface/_diagnostics/model.py`
+- `packages/screamingface/src/screamingface/_diagnostics/capture.py`
+
+## Test plan
+
+- RED: receipt construction rejects unexpected keys in client, context, execution, and breadcrumb
+  evidence rather than freezing them into the public document.
+- RED: receipt construction rejects `run_id` wherever nested evidence could carry it.
+- RED: a traceback deeper than 32 frames keeps the innermost failure frame and remains ordered.
+- GREEN: all existing diagnostic tests remain unchanged and pass.
+- QUALITY: run the complete ScreamingFace gate runner.
+
+## Acceptance
+
+- The construction boundary accepts the current allow-listed receipt shapes and rejects widened
+  field sets without silently sanitizing them.
+- The private event stream topic cannot enter a receipt under the `run_id` field.
+- Deep tracebacks retain at most 32 frames, including the frame where the exception originated.
+- All ScreamingFace quality gates pass before commit.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `packages/screamingface/src/screamingface/_diagnostics/model.py`,
+  `packages/screamingface/src/screamingface/_diagnostics/capture.py`,
+  `packages/screamingface/tests/test_diagnostics.py`,
+  `packages/screamingface/tests/test_diagnostic_capture.py`, and this ledger.
+- **Commits:** this commit — `fix(screamingface): close diagnostic privacy gaps`.
+- **Gates:** RED confirmed 8 intended failures; 79 focused diagnostic tests passed; complete
+  `python3 .claude/scripts/run_gates.py screamingface` green (append-only check, Ruff lint/format,
+  Pyright, full pytest with at least 95% coverage, notebook validation, build, and distribution
+  validation).
+- **Deviations:** the first full-gate attempt in the feature worktree stopped on the user's
+  uncommitted quickstart notebook (`leaderboard` was undefined). The exact source/test patch was
+  hash-verified and gated in a clean detached worktree so the notebook and exported JSON remained
+  untouched. Parameter values remain governed by their existing generation-policy and Engine
+  preflight validation rather than duplicating model schemas inside diagnostics.

--- a/docs/work/2026-09-04-OME-1013-final-contract-hardening.md
+++ b/docs/work/2026-09-04-OME-1013-final-contract-hardening.md
@@ -1,0 +1,65 @@
+---
+ticket: OME-1013
+stack: screamingface
+status: done
+started: 2026-09-04
+finished: 2026-09-04
+---
+
+# OME-1013 — Finish diagnostic contract hardening
+
+## Intent
+
+Close the final agreed correctness and public-contract gaps before merge: accept only the
+Client-supported lowercase W3C traceparent grammar, directly pin the public diagnostics lookup
+facade, and report the canonical source-tree Client version in diagnostic receipts.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_diagnostics/evaluation.py`
+- `packages/screamingface/src/screamingface/_diagnostics/capture.py`
+- `packages/screamingface/tests/test_evaluation_diagnostics.py`
+- `packages/screamingface/tests/test_diagnostic_capture.py`
+- `packages/screamingface/tests/test_public_surface.py`
+- `packages/screamingface/tests/public_surface_snapshot.json`
+
+## Test plan
+
+- RED: reject reserved uppercase `FF` and other non-supported traceparent spellings instead of
+  retaining their trace id.
+- RED: a source-tree Client receipt uses the canonical `0.0.0+source` version marker.
+- RED: directly snapshot `screamingface.diagnostics`, including `get()` and `last()` signatures.
+- GREEN: run focused diagnostic, version, and public-surface tests, followed by every ScreamingFace
+  quality gate.
+
+## Acceptance
+
+- Only lowercase version `00` traceparents with lowercase nonzero trace/span ids become receipt
+  correlation evidence.
+- Diagnostic Client version resolution agrees with `sf.__version__` in installed and source-tree
+  environments.
+- Breaking changes to the public diagnostics lookup facade fail the public-surface snapshot test.
+- No URL4 parameter capture, new architectural seam, or unrelated serialization refactor is added.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** replaced the permissive traceparent parser in
+  `packages/screamingface/src/screamingface/_diagnostics/evaluation.py` with the exact supported
+  lowercase version-00 grammar; reused the canonical resolver in
+  `packages/screamingface/src/screamingface/_diagnostics/capture.py`; added boundary coverage in
+  `packages/screamingface/tests/test_evaluation_diagnostics.py` and
+  `packages/screamingface/tests/test_diagnostic_capture.py`; directly pinned the public facade in
+  `packages/screamingface/tests/test_public_surface.py` and its snapshot; and recorded this ledger.
+- **Commits:** this iteration's `fix(screamingface): finish diagnostic contract hardening` commit.
+- **Gates:** RED confirmed four noncanonical traceparents, the divergent source-tree version, and
+  the missing public-surface snapshot entry; 50 focused tests passed; Ruff and Pyright passed; the
+  complete `python3 .claude/scripts/run_gates.py screamingface --skip-append-only` suite completed
+  with `ALL GATES GREEN` (Ruff lint/format, Pyright, full pytest with at least 95% coverage,
+  notebook validation, build, and distribution validation).
+- **Deviations:** the owner-approved public-surface hardening necessarily updated an existing
+  snapshot and its pinned-module tuple, so the preservation check was skipped after correctly
+  flagging those changes. The complete suite ran against a byte-for-byte-verified clean worktree
+  because the feature worktree contains the owner's modified quickstart notebook and exported
+  diagnostic JSON; both remain untouched. URL4 parameter capture, traceback-renderer lifecycle,
+  serialization/export cleanup, and a speculative diagnostics registry remained intentionally out
+  of scope.

--- a/packages/screamingface/CHANGELOG.md
+++ b/packages/screamingface/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 * **screamingface:** add bounded local diagnostic receipts for failed Evaluations
+* **screamingface:** render retained Evaluation diagnostics as local notebook panels
 
 ## 0.1.1 (2026-08-13)
 

--- a/packages/screamingface/CHANGELOG.md
+++ b/packages/screamingface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **screamingface:** add bounded local diagnostic receipts for failed Evaluations
+
 ## 0.1.1 (2026-08-13)
 
 Baseline-only release. `0.1.0` and `0.1.1` were both uploaded to PyPI by hand rather than by

--- a/packages/screamingface/src/screamingface/__init__.py
+++ b/packages/screamingface/src/screamingface/__init__.py
@@ -1,12 +1,13 @@
 """ScreamingFace — evaluate composable Candidate Recipes on research Benchmarks."""
 
-from screamingface import benchmarks, connections, events, leaderboards, models
+from screamingface import benchmarks, connections, diagnostics, events, leaderboards, models
 from screamingface._default_client import close, configure, connect, disconnect, evaluate
 from screamingface._ui.connections import ConnectionPanel
 from screamingface._version import resolve_version
 from screamingface.client import AsyncClient, Client
 from screamingface.connections import AsyncOAuthFlow, Connection, OAuthFlow
 from screamingface.corrective import CorrectiveLoop, SelfCorrective
+from screamingface.diagnostic import DiagnosticReceipt
 from screamingface.discovery import (
     Benchmark,
     BenchmarkInfo,
@@ -78,6 +79,8 @@ __all__ = [
     "connect",
     "connections",
     "disconnect",
+    "DiagnosticReceipt",
+    "diagnostics",
     "Evidence",
     "EvidenceProducer",
     "Event",

--- a/packages/screamingface/src/screamingface/_default_client.py
+++ b/packages/screamingface/src/screamingface/_default_client.py
@@ -125,14 +125,6 @@ def evaluate(
     """Evaluate Recipes or a complete URL4 through the lazy default Client."""
 
     client = default_client()
-    if isinstance(candidates, str):
-        return cast(Any, client).evaluate(
-            candidates,
-            benchmark=benchmark,
-            limit=limit,
-            on_event=on_event,
-            progress=progress,
-        )
     return cast(Any, client).evaluate(
         candidates,
         benchmark=benchmark,

--- a/packages/screamingface/src/screamingface/_default_client.py
+++ b/packages/screamingface/src/screamingface/_default_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from threading import Lock
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
 from screamingface.client import DEFAULT_ENGINE_URL, DEFAULT_SCOREBOARD_URL, Client
 
@@ -126,14 +126,14 @@ def evaluate(
 
     client = default_client()
     if isinstance(candidates, str):
-        if benchmark is not None:
-            raise TypeError("benchmark must not be passed when evaluating a complete URL4")
-        if limit is not None:
-            raise TypeError("limit must not be passed when evaluating a complete URL4")
-        return client.evaluate(candidates, on_event=on_event, progress=progress)
-    if benchmark is None:
-        raise TypeError("benchmark is required when evaluating Recipes")
-    return client.evaluate(
+        return cast(Any, client).evaluate(
+            candidates,
+            benchmark=benchmark,
+            limit=limit,
+            on_event=on_event,
+            progress=progress,
+        )
+    return cast(Any, client).evaluate(
         candidates,
         benchmark=benchmark,
         limit=limit,

--- a/packages/screamingface/src/screamingface/_diagnostics/__init__.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Private capture and storage behind the public diagnostics facade."""

--- a/packages/screamingface/src/screamingface/_diagnostics/capture.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/capture.py
@@ -13,6 +13,7 @@ from websockets.exceptions import ConnectionClosed
 
 from screamingface._engine_origin import _is_hosted_engine
 from screamingface._environment import running_in_notebook
+from screamingface._version import resolve_version
 from screamingface.errors import ScreamingFaceError
 
 _DEPENDENCIES = ("httpx", "websockets", "pydantic", "ipywidgets")
@@ -42,7 +43,7 @@ def _client_document() -> dict[str, object]:
     }
     return {
         "name": "screamingface-python",
-        "version": _package_version("screamingface") or "unknown",
+        "version": resolve_version(),
         "host": "notebook" if running_in_notebook() else "cli",
         "platform": sys.platform,
         "architecture": platform.machine() or "unknown",

--- a/packages/screamingface/src/screamingface/_diagnostics/capture.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/capture.py
@@ -67,7 +67,6 @@ def _error_document(error: BaseException) -> dict[str, object]:
         document.update(
             {
                 "code": error.code,
-                "message": error.message,
                 "status": error.status,
                 "permanent": error.permanent,
                 "retryable": error.retryable,
@@ -88,7 +87,6 @@ def _exception_chain(error: BaseException) -> list[dict[str, object]]:
         seen.add(id(current))
         item: dict[str, object] = {"type": type(current).__name__}
         if isinstance(current, ScreamingFaceError):
-            item["message"] = current.message
             item["code"] = current.code
         if websocket_close := _websocket_close(current):
             item["websocket_close"] = websocket_close

--- a/packages/screamingface/src/screamingface/_diagnostics/capture.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/capture.py
@@ -106,15 +106,8 @@ def _websocket_close(error: BaseException) -> dict[str, object]:
     for name, close in (("received", error.rcvd), ("sent", error.sent)):
         if close is None:
             continue
-        value: dict[str, object] = {"code": close.code}
-        if reason := _safe_wire_text(close.reason):
-            value["reason"] = reason
-        selected[name] = value
+        selected[name] = {"code": close.code}
     return selected
-
-
-def _safe_wire_text(value: str) -> str:
-    return "".join(character for character in value if character.isprintable())[:256].strip()
 
 
 def _frames(traceback: TracebackType | None) -> list[dict[str, object]]:

--- a/packages/screamingface/src/screamingface/_diagnostics/capture.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/capture.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import platform
 import sys
+from collections import deque
 from importlib.metadata import PackageNotFoundError, version
 from types import TracebackType
 from urllib.parse import urlsplit
@@ -112,9 +113,10 @@ def _websocket_close(error: BaseException) -> dict[str, object]:
 
 
 def _frames(traceback: TracebackType | None) -> list[dict[str, object]]:
-    values: list[dict[str, object]] = []
+    # INVARIANT: when bounded, retain the failure site rather than only its outer callers.
+    values: deque[dict[str, object]] = deque(maxlen=_MAX_FRAMES)
     current = traceback
-    while current is not None and len(values) < _MAX_FRAMES:
+    while current is not None:
         module = current.tb_frame.f_globals.get("__name__")
         selected_module = module if isinstance(module, str) and module else "unknown"
         values.append(
@@ -126,7 +128,7 @@ def _frames(traceback: TracebackType | None) -> list[dict[str, object]]:
             }
         )
         current = current.tb_next
-    return values
+    return list(values)
 
 
 def _safe_details(value: object, *, code: str) -> dict[str, object]:

--- a/packages/screamingface/src/screamingface/_diagnostics/capture.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/capture.py
@@ -1,0 +1,162 @@
+"""Allow-listed projections from local runtime state into diagnostic facts."""
+
+from __future__ import annotations
+
+import platform
+import sys
+from importlib.metadata import PackageNotFoundError, version
+from types import TracebackType
+from urllib.parse import urlsplit
+
+from websockets.exceptions import ConnectionClosed
+
+from screamingface._environment import running_in_notebook
+from screamingface.errors import ScreamingFaceError
+
+_DEPENDENCIES = ("httpx", "websockets", "pydantic", "ipywidgets")
+_SAFE_DETAIL_KEYS = frozenset(
+    {
+        "applicable_auth_modes",
+        "case_id",
+        "error_kind",
+        "model",
+        "parameter",
+        "provider",
+        "reason",
+        "row_index",
+        "stage",
+    }
+)
+_MAX_CHAIN = 8
+_MAX_FRAMES = 32
+_SAFE_REASON_CODES = frozenset({"unsupported_model_parameter"})
+
+
+def _client_document() -> dict[str, object]:
+    dependencies = {
+        package: selected
+        for package in _DEPENDENCIES
+        if (selected := _package_version(package)) is not None
+    }
+    return {
+        "name": "screamingface-python",
+        "version": _package_version("screamingface") or "unknown",
+        "host": "notebook" if running_in_notebook() else "cli",
+        "platform": sys.platform,
+        "architecture": platform.machine() or "unknown",
+        "runtime": {
+            "name": sys.implementation.name,
+            "version": platform.python_version(),
+        },
+        "dependencies": dependencies,
+    }
+
+
+def _engine_document(engine_url: str) -> dict[str, str]:
+    selected = urlsplit(engine_url)
+    host = selected.hostname
+    if host is None:
+        raise ValueError("Engine URL must contain a host")
+    mode = "local" if host in {"localhost", "127.0.0.1", "::1"} else "hosted"
+    return {"host": host, "mode": mode}
+
+
+def _error_document(error: BaseException) -> dict[str, object]:
+    document: dict[str, object] = {"type": type(error).__name__}
+    if isinstance(error, ScreamingFaceError):
+        document.update(
+            {
+                "code": error.code,
+                "message": error.message,
+                "status": error.status,
+                "permanent": error.permanent,
+                "retryable": error.retryable,
+                "hint": error.hint,
+            }
+        )
+        if details := _safe_details(error.details, code=error.code):
+            document["details"] = details
+    document["chain"] = _exception_chain(error)
+    return {key: value for key, value in document.items() if value is not None}
+
+
+def _exception_chain(error: BaseException) -> list[dict[str, object]]:
+    values: list[dict[str, object]] = []
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and len(values) < _MAX_CHAIN and id(current) not in seen:
+        seen.add(id(current))
+        item: dict[str, object] = {"type": type(current).__name__}
+        if isinstance(current, ScreamingFaceError):
+            item["message"] = current.message
+            item["code"] = current.code
+        if websocket_close := _websocket_close(current):
+            item["websocket_close"] = websocket_close
+        if frames := _frames(current.__traceback__):
+            item["frames"] = frames
+        values.append(item)
+        current = current.__cause__ or (
+            None if current.__suppress_context__ else current.__context__
+        )
+    return values
+
+
+def _websocket_close(error: BaseException) -> dict[str, object]:
+    if not isinstance(error, ConnectionClosed):
+        return {}
+    selected: dict[str, object] = {}
+    for name, close in (("received", error.rcvd), ("sent", error.sent)):
+        if close is None:
+            continue
+        value: dict[str, object] = {"code": close.code}
+        if reason := _safe_wire_text(close.reason):
+            value["reason"] = reason
+        selected[name] = value
+    return selected
+
+
+def _safe_wire_text(value: str) -> str:
+    return "".join(character for character in value if character.isprintable())[:256].strip()
+
+
+def _frames(traceback: TracebackType | None) -> list[dict[str, object]]:
+    values: list[dict[str, object]] = []
+    current = traceback
+    while current is not None and len(values) < _MAX_FRAMES:
+        module = current.tb_frame.f_globals.get("__name__")
+        selected_module = module if isinstance(module, str) and module else "unknown"
+        values.append(
+            {
+                "package": selected_module.partition(".")[0],
+                "module": selected_module,
+                "function": current.tb_frame.f_code.co_name,
+                "line": current.tb_lineno,
+            }
+        )
+        current = current.tb_next
+    return values
+
+
+def _safe_details(value: object, *, code: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    selected: dict[str, object] = {}
+    for key in sorted(_SAFE_DETAIL_KEYS & value.keys()):
+        if key == "reason" and code not in _SAFE_REASON_CODES:
+            continue
+        item = value[key]
+        if isinstance(item, (str, int, bool)) or item is None:
+            selected[key] = item
+        elif isinstance(item, (list, tuple)) and all(isinstance(member, str) for member in item):
+            selected[key] = list(item)
+    return selected
+
+
+def _package_version(package: str) -> str | None:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return None
+
+
+__all__ = ["_client_document", "_engine_document", "_error_document"]

--- a/packages/screamingface/src/screamingface/_diagnostics/capture.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/capture.py
@@ -10,6 +10,7 @@ from urllib.parse import urlsplit
 
 from websockets.exceptions import ConnectionClosed
 
+from screamingface._engine_origin import _is_hosted_engine
 from screamingface._environment import running_in_notebook
 from screamingface.errors import ScreamingFaceError
 
@@ -57,7 +58,7 @@ def _engine_document(engine_url: str) -> dict[str, str]:
     host = selected.hostname
     if host is None:
         raise ValueError("Engine URL must contain a host")
-    mode = "local" if host in {"localhost", "127.0.0.1", "::1"} else "hosted"
+    mode = "hosted" if _is_hosted_engine(engine_url) else "local"
     return {"host": host, "mode": mode}
 
 

--- a/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from threading import Lock
 from uuid import uuid4
@@ -16,11 +18,17 @@ from screamingface._diagnostics.capture import (
 from screamingface._diagnostics.model import _new_receipt
 from screamingface._diagnostics.store import _STORE
 from screamingface._evaluation.model import Candidate, _Evaluation
+from screamingface.corrective import CorrectiveLoop, SelfCorrective
 from screamingface.diagnostic import DiagnosticReceipt
-from screamingface.events import Event, Terminated
+from screamingface.events import Event, Span, Terminated
+from screamingface.fusion import Fusion
+from screamingface.model import Model
+from screamingface.pipeline import Pipeline
+from screamingface.recipe import Recipe, _recipe_kind
 
 _SESSION_ID = f"session_{uuid4().hex}"
 _MAX_BREADCRUMBS = 20
+_logger = logging.getLogger(__name__)
 
 
 class _EvaluationDiagnostic:
@@ -31,6 +39,7 @@ class _EvaluationDiagnostic:
         *,
         engine_url: str,
         benchmark: object,
+        candidates: object = None,
         mode: str | None = None,
     ) -> None:
         self._context: dict[str, object] = {"engine": _engine_document(engine_url)}
@@ -38,6 +47,8 @@ class _EvaluationDiagnostic:
             self._context["benchmark"] = {"id": benchmark}
         if mode is not None:
             self._context["mode"] = mode
+        if caller_candidates := _caller_candidate_documents(candidates):
+            self._context["candidates"] = list(caller_candidates)
         self._executions: dict[str, dict[str, object]] = {}
         self._breadcrumbs: list[dict[str, object]] = []
         self._lock = Lock()
@@ -105,6 +116,7 @@ class _EvaluationDiagnostic:
                 event.kind,
                 sequence=event.sequence,
                 outcome=event.status if isinstance(event, Terminated) else None,
+                operation=_relative_operation(event),
             )
 
     def receipt(self, error: BaseException) -> DiagnosticReceipt:
@@ -134,7 +146,14 @@ class _EvaluationDiagnostic:
 
     def stage(self, error: BaseException) -> DiagnosticReceipt | None:
         receipt = self.receipt(error)
-        return receipt if _STORE.add(receipt) else None
+        if not _STORE.add(receipt):
+            return None
+        try:
+            BaseException.add_note(error, _export_guidance(receipt))
+        except Exception:
+            _STORE.remove(receipt.diagnostic_id)
+            raise
+        return receipt
 
     def _append_breadcrumb(
         self,
@@ -144,6 +163,7 @@ class _EvaluationDiagnostic:
         *,
         sequence: int | None = None,
         outcome: str | None = None,
+        operation: str | None = None,
     ) -> None:
         breadcrumb: dict[str, object] = {
             "candidate": candidate,
@@ -154,6 +174,8 @@ class _EvaluationDiagnostic:
             breadcrumb["sequence"] = sequence
         if outcome is not None:
             breadcrumb["outcome"] = outcome
+        if operation is not None:
+            breadcrumb["operation"] = operation
         self._breadcrumbs.append(breadcrumb)
         if len(self._breadcrumbs) > _MAX_BREADCRUMBS:
             del self._breadcrumbs[0]
@@ -174,6 +196,67 @@ def _candidate_document(candidate: Candidate) -> dict[str, object]:
         ],
         "parameters": [],
     }
+
+
+def _caller_candidate_documents(value: object) -> tuple[dict[str, object], ...]:
+    try:
+        if isinstance(value, Recipe):
+            recipes = (value,)
+        elif isinstance(value, Sequence) and not isinstance(value, str | bytes):
+            recipes = tuple(item for item in value if isinstance(item, Recipe))
+        else:
+            return ()
+    except Exception:
+        _logger.exception("ScreamingFace caller diagnostic projection failed")
+        return ()
+
+    selected: list[dict[str, object]] = []
+    for recipe in recipes:
+        try:
+            selected.append(
+                {
+                    "name": recipe.name,
+                    "kind": _recipe_kind(recipe),
+                    "models": list(dict.fromkeys(_declared_models(recipe))),
+                }
+            )
+        except Exception:
+            _logger.exception("ScreamingFace candidate diagnostic projection failed")
+            continue
+    return tuple(selected)
+
+
+def _declared_models(recipe: Recipe) -> tuple[str, ...]:
+    if isinstance(recipe, Model):
+        return (recipe.model,)
+    if isinstance(recipe, Fusion):
+        nested = (*recipe.members, recipe.synthesizer)
+    elif isinstance(recipe, Pipeline):
+        nested = recipe.stages
+    elif isinstance(recipe, CorrectiveLoop):
+        nested = (*recipe.members, recipe.judge)
+    elif isinstance(recipe, SelfCorrective):
+        nested = (recipe.member,)
+    else:
+        return ()
+    return tuple(model for child in nested for model in _declared_models(child))
+
+
+def _relative_operation(event: Event) -> str | None:
+    if not isinstance(event, Span) or event.operation not in {"RelUrlNode", "RemoteFetchNode"}:
+        return None
+    name = event.name
+    if not name.startswith("/") or len(name) > 256 or any(mark in name for mark in ("?", "#")):
+        return None
+    return name
+
+
+def _export_guidance(receipt: DiagnosticReceipt) -> str:
+    return (
+        f"Diagnostic: {receipt.diagnostic_id}. Export with "
+        f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
+        '"screamingface-diagnostic.json")'
+    )
 
 
 def _trace_id(traceparent: str | None) -> str | None:

--- a/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
@@ -17,6 +17,7 @@ from screamingface._diagnostics.capture import (
 )
 from screamingface._diagnostics.model import _new_receipt, _ReceiptEvidence
 from screamingface._diagnostics.store import _STORE
+from screamingface._environment import running_in_notebook
 from screamingface._evaluation.model import Candidate, _Evaluation
 from screamingface.diagnostic import DiagnosticReceipt
 from screamingface.events import Event, Span, Terminated
@@ -145,6 +146,8 @@ class _EvaluationDiagnostic:
         receipt = self.receipt(error)
         if not _STORE.add(receipt):
             return None
+        if running_in_notebook():
+            return receipt
         try:
             BaseException.add_note(error, _export_guidance(receipt))
         except Exception:

--- a/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
@@ -1,0 +1,204 @@
+"""In-flight, privacy-safe context for one Client Evaluation."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from threading import Lock
+from uuid import uuid4
+
+from screamingface._diagnostics.capture import (
+    _client_document,
+    _engine_document,
+    _error_document,
+)
+from screamingface._diagnostics.model import _new_receipt
+from screamingface._diagnostics.store import _STORE
+from screamingface._evaluation.model import Candidate, _Evaluation
+from screamingface.diagnostic import DiagnosticReceipt
+from screamingface.events import Event, Terminated
+
+_SESSION_ID = f"session_{uuid4().hex}"
+_MAX_BREADCRUMBS = 20
+
+
+class _EvaluationDiagnostic:
+    """Accumulate only allow-listed evidence while one Evaluation advances."""
+
+    def __init__(
+        self,
+        *,
+        engine_url: str,
+        benchmark: object,
+        mode: str | None = None,
+    ) -> None:
+        self._context: dict[str, object] = {"engine": _engine_document(engine_url)}
+        if isinstance(benchmark, str):
+            self._context["benchmark"] = {"id": benchmark}
+        if mode is not None:
+            self._context["mode"] = mode
+        self._executions: dict[str, dict[str, object]] = {}
+        self._breadcrumbs: list[dict[str, object]] = []
+        self._lock = Lock()
+        self._started_at = time.monotonic()
+
+    def compiled(self, evaluation: _Evaluation) -> None:
+        candidates = [_candidate_document(candidate) for candidate in evaluation.candidates]
+        with self._lock:
+            self._context["benchmark"] = {
+                "id": evaluation.benchmark.id,
+                "revision": evaluation.benchmark.revision,
+                "case_count": evaluation.case_count,
+            }
+            self._context["candidates"] = candidates
+
+    def validated(self, evaluation: _Evaluation) -> None:
+        parameters = {
+            candidate.name: [
+                {
+                    "operation_id": assignment.operation_id,
+                    "model": assignment.model,
+                    "values": dict(assignment.params),
+                }
+                for assignment in candidate.parameter_assignments
+            ]
+            for candidate in evaluation.candidates
+        }
+        with self._lock:
+            candidates = self._context.get("candidates")
+            if not isinstance(candidates, list):
+                raise AssertionError("compiled candidates must precede validation")
+            for candidate in candidates:
+                if not isinstance(candidate, dict):
+                    raise AssertionError("diagnostic candidates must remain objects")
+                name = candidate.get("name")
+                if isinstance(name, str):
+                    candidate["parameters"] = parameters[name]
+
+    def compiled_candidate(self, candidate: Candidate) -> None:
+        with self._lock:
+            self._context["candidates"] = [_candidate_document(candidate)]
+
+    def begin(self, candidate: Candidate) -> None:
+        with self._lock:
+            self._executions.setdefault(
+                candidate.name,
+                {"candidate": candidate.name, "status": "running"},
+            )
+            self._append_breadcrumb(candidate.name, "execution", "started")
+
+    def observe(self, candidate: Candidate, event: Event) -> None:
+        with self._lock:
+            execution = self._executions.setdefault(
+                candidate.name,
+                {"candidate": candidate.name, "status": "running"},
+            )
+            execution["run_id"] = event.run_id
+            if trace_id := _trace_id(event.traceparent):
+                execution["trace_id"] = trace_id
+            if isinstance(event, Terminated):
+                execution["status"] = event.status
+            self._append_breadcrumb(
+                candidate.name,
+                "execution",
+                event.kind,
+                sequence=event.sequence,
+                outcome=event.status if isinstance(event, Terminated) else None,
+            )
+
+    def receipt(self, error: BaseException) -> DiagnosticReceipt:
+        if isinstance(error, KeyboardInterrupt):
+            outcome = "interrupted_by_user"
+        elif isinstance(error, asyncio.CancelledError):
+            outcome = "cancelled"
+        else:
+            outcome = "failed"
+        with self._lock:
+            context = dict(self._context)
+            executions = tuple(dict(value) for value in self._executions.values())
+            breadcrumbs = tuple(dict(value) for value in self._breadcrumbs)
+        return _new_receipt(
+            diagnostic_id=f"diag_{uuid4().hex}",
+            session_id=_SESSION_ID,
+            occurred_at=datetime.now(UTC),
+            elapsed_seconds=max(0.0, time.monotonic() - self._started_at),
+            operation="evaluate",
+            outcome=outcome,
+            client=_client_document(),
+            error=_error_document(error),
+            context=context,
+            executions=executions,
+            breadcrumbs=breadcrumbs,
+        )
+
+    def stage(self, error: BaseException) -> DiagnosticReceipt | None:
+        receipt = self.receipt(error)
+        return receipt if _STORE.add(receipt) else None
+
+    def _append_breadcrumb(
+        self,
+        candidate: str,
+        stage: str,
+        event: str,
+        *,
+        sequence: int | None = None,
+        outcome: str | None = None,
+    ) -> None:
+        breadcrumb: dict[str, object] = {
+            "candidate": candidate,
+            "stage": stage,
+            "event": event,
+        }
+        if sequence is not None:
+            breadcrumb["sequence"] = sequence
+        if outcome is not None:
+            breadcrumb["outcome"] = outcome
+        self._breadcrumbs.append(breadcrumb)
+        if len(self._breadcrumbs) > _MAX_BREADCRUMBS:
+            del self._breadcrumbs[0]
+
+
+def _candidate_document(candidate: Candidate) -> dict[str, object]:
+    return {
+        "name": candidate.name,
+        "kind": candidate.kind,
+        "models": list(candidate.models),
+        "operations": [
+            {
+                "id": operation.id,
+                "kind": operation.kind,
+                "depends_on": list(operation.depends_on),
+            }
+            for operation in candidate.operations
+        ],
+        "parameters": [],
+    }
+
+
+def _trace_id(traceparent: str | None) -> str | None:
+    if traceparent is None:
+        return None
+    parts = traceparent.split("-")
+    if len(parts) == 4:
+        version, trace_id, parent_id, flags = parts
+        if (
+            _hex(version, 2)
+            and version != "ff"
+            and _hex(trace_id, 32)
+            and trace_id != "0" * 32
+            and _hex(parent_id, 16)
+            and parent_id != "0" * 16
+            and _hex(flags, 2)
+        ):
+            return trace_id.lower()
+    return None
+
+
+def _hex(value: str, length: int) -> bool:
+    return len(value) == length and all(
+        character in "0123456789abcdefABCDEF" for character in value
+    )
+
+
+__all__ = ["_EvaluationDiagnostic"]

--- a/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from collections.abc import Sequence
 from datetime import UTC, datetime
@@ -25,6 +26,7 @@ from screamingface.recipe import Recipe, _recipe_kind
 
 _SESSION_ID = f"session_{uuid4().hex}"
 _MAX_BREADCRUMBS = 20
+_TRACEPARENT = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$")
 _logger = logging.getLogger(__name__)
 
 
@@ -237,26 +239,11 @@ def _relative_operation(event: Event) -> str | None:
 def _trace_id(traceparent: str | None) -> str | None:
     if traceparent is None:
         return None
-    parts = traceparent.split("-")
-    if len(parts) == 4:
-        version, trace_id, parent_id, flags = parts
-        if (
-            _hex(version, 2)
-            and version != "ff"
-            and _hex(trace_id, 32)
-            and trace_id != "0" * 32
-            and _hex(parent_id, 16)
-            and parent_id != "0" * 16
-            and _hex(flags, 2)
-        ):
-            return trace_id.lower()
-    return None
-
-
-def _hex(value: str, length: int) -> bool:
-    return len(value) == length and all(
-        character in "0123456789abcdefABCDEF" for character in value
-    )
+    match = _TRACEPARENT.fullmatch(traceparent)
+    if match is None or match.group(1) == "0" * 32 or match.group(2) == "0" * 16:
+        return None
+    # INVARIANT: this is the exact lowercase version-00 grammar emitted by the Client.
+    return match.group(1)
 
 
 __all__ = ["_EvaluationDiagnostic"]

--- a/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
@@ -19,7 +19,7 @@ from screamingface._diagnostics.model import _new_receipt, _ReceiptEvidence
 from screamingface._diagnostics.store import _STORE
 from screamingface._environment import running_in_notebook
 from screamingface._evaluation.model import Candidate, _Evaluation
-from screamingface.diagnostic import DiagnosticReceipt
+from screamingface.diagnostic import DiagnosticReceipt, _export_guidance
 from screamingface.events import Event, Span, Terminated
 from screamingface.recipe import Recipe, _recipe_kind
 
@@ -232,14 +232,6 @@ def _relative_operation(event: Event) -> str | None:
     if not name.startswith("/") or len(name) > 256 or any(mark in name for mark in ("?", "#")):
         return None
     return name
-
-
-def _export_guidance(receipt: DiagnosticReceipt) -> str:
-    return (
-        f"Diagnostic: {receipt.diagnostic_id}. Export with "
-        f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
-        '"screamingface-diagnostic.json")'
-    )
 
 
 def _trace_id(traceparent: str | None) -> str | None:

--- a/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/evaluation.py
@@ -15,15 +15,11 @@ from screamingface._diagnostics.capture import (
     _engine_document,
     _error_document,
 )
-from screamingface._diagnostics.model import _new_receipt
+from screamingface._diagnostics.model import _new_receipt, _ReceiptEvidence
 from screamingface._diagnostics.store import _STORE
 from screamingface._evaluation.model import Candidate, _Evaluation
-from screamingface.corrective import CorrectiveLoop, SelfCorrective
 from screamingface.diagnostic import DiagnosticReceipt
 from screamingface.events import Event, Span, Terminated
-from screamingface.fusion import Fusion
-from screamingface.model import Model
-from screamingface.pipeline import Pipeline
 from screamingface.recipe import Recipe, _recipe_kind
 
 _SESSION_ID = f"session_{uuid4().hex}"
@@ -105,7 +101,6 @@ class _EvaluationDiagnostic:
                 candidate.name,
                 {"candidate": candidate.name, "status": "running"},
             )
-            execution["run_id"] = event.run_id
             if trace_id := _trace_id(event.traceparent):
                 execution["trace_id"] = trace_id
             if isinstance(event, Terminated):
@@ -131,17 +126,19 @@ class _EvaluationDiagnostic:
             executions = tuple(dict(value) for value in self._executions.values())
             breadcrumbs = tuple(dict(value) for value in self._breadcrumbs)
         return _new_receipt(
-            diagnostic_id=f"diag_{uuid4().hex}",
-            session_id=_SESSION_ID,
-            occurred_at=datetime.now(UTC),
-            elapsed_seconds=max(0.0, time.monotonic() - self._started_at),
-            operation="evaluate",
-            outcome=outcome,
-            client=_client_document(),
-            error=_error_document(error),
-            context=context,
-            executions=executions,
-            breadcrumbs=breadcrumbs,
+            _ReceiptEvidence(
+                diagnostic_id=f"diag_{uuid4().hex}",
+                session_id=_SESSION_ID,
+                occurred_at=datetime.now(UTC),
+                elapsed_seconds=max(0.0, time.monotonic() - self._started_at),
+                operation="evaluate",
+                outcome=outcome,
+                client=_client_document(),
+                error=_error_document(error),
+                context=context,
+                executions=executions,
+                breadcrumbs=breadcrumbs,
+            )
         )
 
     def stage(self, error: BaseException) -> DiagnosticReceipt | None:
@@ -217,29 +214,12 @@ def _caller_candidate_documents(value: object) -> tuple[dict[str, object], ...]:
                 {
                     "name": recipe.name,
                     "kind": _recipe_kind(recipe),
-                    "models": list(dict.fromkeys(_declared_models(recipe))),
                 }
             )
         except Exception:
             _logger.exception("ScreamingFace candidate diagnostic projection failed")
             continue
     return tuple(selected)
-
-
-def _declared_models(recipe: Recipe) -> tuple[str, ...]:
-    if isinstance(recipe, Model):
-        return (recipe.model,)
-    if isinstance(recipe, Fusion):
-        nested = (*recipe.members, recipe.synthesizer)
-    elif isinstance(recipe, Pipeline):
-        nested = recipe.stages
-    elif isinstance(recipe, CorrectiveLoop):
-        nested = (*recipe.members, recipe.judge)
-    elif isinstance(recipe, SelfCorrective):
-        nested = (recipe.member,)
-    else:
-        return ()
-    return tuple(model for child in nested for model in _declared_models(child))
 
 
 def _relative_operation(event: Event) -> str | None:

--- a/packages/screamingface/src/screamingface/_diagnostics/model.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/model.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from types import MappingProxyType
 
+from screamingface._immutable_json import freeze_mapping
 from screamingface.diagnostic import DiagnosticReceipt
 
 _SAFE_ERROR_FIELDS = frozenset(
@@ -52,9 +51,7 @@ def _new_receipt(evidence: _ReceiptEvidence) -> DiagnosticReceipt:
         "executions": [dict(value) for value in evidence.executions],
         "breadcrumbs": [dict(value) for value in evidence.breadcrumbs],
     }
-    frozen = _freeze(document)
-    if not isinstance(frozen, Mapping):
-        raise AssertionError("a diagnostic document must remain a mapping")
+    frozen = freeze_mapping(document, "Diagnostic")
     return DiagnosticReceipt._from_frozen(frozen)
 
 
@@ -64,31 +61,6 @@ def _validate_error(value: Mapping[str, object]) -> None:
     if unsafe:
         raise ValueError(f"Diagnostic contains unsafe error fields: {', '.join(unsafe)}")
     _nonblank(value.get("type"), "Diagnostic error type")
-
-
-def _freeze(value: object) -> object:
-    if value is None or isinstance(value, (str, bool, int)):
-        frozen: object = value
-    elif isinstance(value, float):
-        if not math.isfinite(value):
-            raise ValueError("Diagnostic numbers must be finite")
-        frozen = value
-    elif isinstance(value, Mapping):
-        frozen = _freeze_mapping(value)
-    elif isinstance(value, (list, tuple)):
-        frozen = tuple(_freeze(item) for item in value)
-    else:
-        raise TypeError(f"Diagnostic values cannot contain {type(value).__name__}")
-    return frozen
-
-
-def _freeze_mapping(value: Mapping[object, object]) -> Mapping[str, object]:
-    frozen: dict[str, object] = {}
-    for key, item in value.items():
-        if not isinstance(key, str):
-            raise TypeError("Diagnostic object keys must be strings")
-        frozen[key] = _freeze(item)
-    return MappingProxyType(frozen)
 
 
 def _nonblank(value: object, label: str) -> str:

--- a/packages/screamingface/src/screamingface/_diagnostics/model.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/model.py
@@ -12,6 +12,21 @@ from screamingface.diagnostic import DiagnosticReceipt
 _SAFE_ERROR_FIELDS = frozenset(
     {"type", "code", "status", "permanent", "retryable", "hint", "details", "chain"}
 )
+_SAFE_CLIENT_FIELDS = frozenset(
+    {"name", "version", "host", "platform", "architecture", "runtime", "dependencies"}
+)
+_SAFE_RUNTIME_FIELDS = frozenset({"name", "version"})
+_SAFE_DEPENDENCY_FIELDS = frozenset({"httpx", "websockets", "pydantic", "ipywidgets"})
+_SAFE_CONTEXT_FIELDS = frozenset({"engine", "benchmark", "mode", "candidates"})
+_SAFE_ENGINE_FIELDS = frozenset({"host", "mode"})
+_SAFE_BENCHMARK_FIELDS = frozenset({"id", "revision", "case_count"})
+_SAFE_CANDIDATE_FIELDS = frozenset({"name", "kind", "models", "operations", "parameters"})
+_SAFE_OPERATION_FIELDS = frozenset({"id", "kind", "depends_on"})
+_SAFE_PARAMETER_FIELDS = frozenset({"operation_id", "model", "values"})
+_SAFE_EXECUTION_FIELDS = frozenset({"candidate", "status", "trace_id", "gateway_call_id"})
+_SAFE_BREADCRUMB_FIELDS = frozenset(
+    {"candidate", "stage", "event", "sequence", "outcome", "operation"}
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,7 +51,15 @@ def _new_receipt(evidence: _ReceiptEvidence) -> DiagnosticReceipt:
 
     if not isinstance(evidence.occurred_at, datetime) or evidence.occurred_at.tzinfo is None:
         raise ValueError("Diagnostic occurred_at must be timezone-aware")
+    # INVARIANT: evidence containers are closed; widening one requires an explicit privacy review.
+    # Parameter values remain open by design because preflight already validated that typed map.
+    _validate_client(evidence.client)
     _validate_error(evidence.error)
+    _validate_context(evidence.context)
+    _reject_forbidden_field(evidence.executions, "run_id")
+    _reject_forbidden_field(evidence.breadcrumbs, "run_id")
+    _validate_objects(evidence.executions, _SAFE_EXECUTION_FIELDS, "execution")
+    _validate_objects(evidence.breadcrumbs, _SAFE_BREADCRUMB_FIELDS, "breadcrumb")
     document: dict[str, object] = {
         "schema": "screamingface.diagnostic/v1",
         "diagnostic_id": _nonblank(evidence.diagnostic_id, "Diagnostic id"),
@@ -61,6 +84,77 @@ def _validate_error(value: Mapping[str, object]) -> None:
     if unsafe:
         raise ValueError(f"Diagnostic contains unsafe error fields: {', '.join(unsafe)}")
     _nonblank(value.get("type"), "Diagnostic error type")
+
+
+def _validate_client(value: Mapping[str, object]) -> None:
+    _validate_fields(value, _SAFE_CLIENT_FIELDS, "client")
+    _validate_nested_fields(value, "runtime", _SAFE_RUNTIME_FIELDS, "client runtime")
+    _validate_nested_fields(
+        value,
+        "dependencies",
+        _SAFE_DEPENDENCY_FIELDS,
+        "client dependency",
+    )
+
+
+def _validate_context(value: Mapping[str, object]) -> None:
+    _validate_fields(value, _SAFE_CONTEXT_FIELDS, "context")
+    _validate_nested_fields(value, "engine", _SAFE_ENGINE_FIELDS, "engine")
+    _validate_nested_fields(value, "benchmark", _SAFE_BENCHMARK_FIELDS, "benchmark")
+    candidates = value.get("candidates")
+    if candidates is None:
+        return
+    _validate_objects(candidates, _SAFE_CANDIDATE_FIELDS, "candidate")
+    assert isinstance(candidates, Sequence) and not isinstance(candidates, str | bytes)
+    for candidate in candidates:
+        assert isinstance(candidate, Mapping)
+        operations = candidate.get("operations")
+        if operations is not None:
+            _validate_objects(operations, _SAFE_OPERATION_FIELDS, "operation")
+        parameters = candidate.get("parameters")
+        if parameters is not None:
+            _validate_objects(parameters, _SAFE_PARAMETER_FIELDS, "parameter")
+
+
+def _validate_nested_fields(
+    parent: Mapping[str, object],
+    field: str,
+    allowed: frozenset[str],
+    label: str,
+) -> None:
+    value = parent.get(field)
+    if value is None:
+        return
+    if not isinstance(value, Mapping):
+        raise TypeError(f"Diagnostic {label} must be an object")
+    _validate_fields(value, allowed, label)
+
+
+def _validate_objects(value: object, allowed: frozenset[str], label: str) -> None:
+    if isinstance(value, str | bytes) or not isinstance(value, Sequence):
+        raise TypeError(f"Diagnostic {label} values must be an ordered sequence")
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise TypeError(f"Diagnostic {label} values must contain objects")
+        _validate_fields(item, allowed, label)
+
+
+def _validate_fields(value: Mapping[str, object], allowed: frozenset[str], label: str) -> None:
+    unsafe = sorted(set(value) - allowed)
+    if unsafe:
+        raise ValueError(f"Diagnostic contains unsafe {label} fields: {', '.join(unsafe)}")
+
+
+def _reject_forbidden_field(value: object, field: str) -> None:
+    # INVARIANT: Event.run_id is an internal stream topic, never a receipt identity at any depth.
+    if isinstance(value, Mapping):
+        if field in value:
+            raise ValueError(f"Diagnostic contains forbidden field: {field}")
+        for item in value.values():
+            _reject_forbidden_field(item, field)
+    elif isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        for item in value:
+            _reject_forbidden_field(item, field)
 
 
 def _nonblank(value: object, label: str) -> str:

--- a/packages/screamingface/src/screamingface/_diagnostics/model.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/model.py
@@ -1,0 +1,87 @@
+"""Construction boundary for immutable local diagnostic receipts."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from types import MappingProxyType
+
+from screamingface.diagnostic import DiagnosticReceipt
+
+
+def _new_receipt(
+    *,
+    diagnostic_id: str,
+    session_id: str,
+    occurred_at: datetime,
+    elapsed_seconds: float,
+    operation: str,
+    outcome: str,
+    client: Mapping[str, object],
+    error: Mapping[str, object],
+    context: Mapping[str, object],
+    executions: Sequence[Mapping[str, object]],
+    breadcrumbs: Sequence[Mapping[str, object]],
+) -> DiagnosticReceipt:
+    """Validate and freeze one receipt assembled by the private capture layer."""
+
+    if not isinstance(occurred_at, datetime) or occurred_at.tzinfo is None:
+        raise ValueError("Diagnostic occurred_at must be timezone-aware")
+    document: dict[str, object] = {
+        "schema": "screamingface.diagnostic/v1",
+        "diagnostic_id": _nonblank(diagnostic_id, "Diagnostic id"),
+        "session_id": _nonblank(session_id, "Diagnostic session id"),
+        "occurred_at": _timestamp_text(occurred_at),
+        "elapsed_seconds": elapsed_seconds,
+        "operation": _nonblank(operation, "Diagnostic operation"),
+        "outcome": _nonblank(outcome, "Diagnostic outcome"),
+        "client": dict(client),
+        "error": dict(error),
+        "context": dict(context),
+        "executions": [dict(value) for value in executions],
+        "breadcrumbs": [dict(value) for value in breadcrumbs],
+    }
+    frozen = _freeze(document)
+    if not isinstance(frozen, Mapping):
+        raise AssertionError("a diagnostic document must remain a mapping")
+    return DiagnosticReceipt._from_frozen(frozen)
+
+
+def _freeze(value: object) -> object:
+    if value is None or isinstance(value, (str, bool, int)):
+        frozen: object = value
+    elif isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("Diagnostic numbers must be finite")
+        frozen = value
+    elif isinstance(value, Mapping):
+        frozen = _freeze_mapping(value)
+    elif isinstance(value, (list, tuple)):
+        frozen = tuple(_freeze(item) for item in value)
+    else:
+        raise TypeError(f"Diagnostic values cannot contain {type(value).__name__}")
+    return frozen
+
+
+def _freeze_mapping(value: Mapping[object, object]) -> Mapping[str, object]:
+    frozen: dict[str, object] = {}
+    for key, item in value.items():
+        if not isinstance(key, str):
+            raise TypeError("Diagnostic object keys must be strings")
+        frozen[key] = _freeze(item)
+    return MappingProxyType(frozen)
+
+
+def _nonblank(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _timestamp_text(value: datetime) -> str:
+    rendered = value.astimezone(UTC).isoformat(timespec="milliseconds")
+    return rendered.replace("+00:00", "Z")
+
+
+__all__ = ["_new_receipt"]

--- a/packages/screamingface/src/screamingface/_diagnostics/model.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/model.py
@@ -4,48 +4,66 @@ from __future__ import annotations
 
 import math
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from types import MappingProxyType
 
 from screamingface.diagnostic import DiagnosticReceipt
 
+_SAFE_ERROR_FIELDS = frozenset(
+    {"type", "code", "status", "permanent", "retryable", "hint", "details", "chain"}
+)
 
-def _new_receipt(
-    *,
-    diagnostic_id: str,
-    session_id: str,
-    occurred_at: datetime,
-    elapsed_seconds: float,
-    operation: str,
-    outcome: str,
-    client: Mapping[str, object],
-    error: Mapping[str, object],
-    context: Mapping[str, object],
-    executions: Sequence[Mapping[str, object]],
-    breadcrumbs: Sequence[Mapping[str, object]],
-) -> DiagnosticReceipt:
+
+@dataclass(frozen=True, slots=True)
+class _ReceiptEvidence:
+    """Typed evidence assembled for one immutable diagnostic receipt."""
+
+    diagnostic_id: str
+    session_id: str
+    occurred_at: datetime
+    elapsed_seconds: float
+    operation: str
+    outcome: str
+    client: Mapping[str, object]
+    error: Mapping[str, object]
+    context: Mapping[str, object]
+    executions: Sequence[Mapping[str, object]] = ()
+    breadcrumbs: Sequence[Mapping[str, object]] = ()
+
+
+def _new_receipt(evidence: _ReceiptEvidence) -> DiagnosticReceipt:
     """Validate and freeze one receipt assembled by the private capture layer."""
 
-    if not isinstance(occurred_at, datetime) or occurred_at.tzinfo is None:
+    if not isinstance(evidence.occurred_at, datetime) or evidence.occurred_at.tzinfo is None:
         raise ValueError("Diagnostic occurred_at must be timezone-aware")
+    _validate_error(evidence.error)
     document: dict[str, object] = {
         "schema": "screamingface.diagnostic/v1",
-        "diagnostic_id": _nonblank(diagnostic_id, "Diagnostic id"),
-        "session_id": _nonblank(session_id, "Diagnostic session id"),
-        "occurred_at": _timestamp_text(occurred_at),
-        "elapsed_seconds": elapsed_seconds,
-        "operation": _nonblank(operation, "Diagnostic operation"),
-        "outcome": _nonblank(outcome, "Diagnostic outcome"),
-        "client": dict(client),
-        "error": dict(error),
-        "context": dict(context),
-        "executions": [dict(value) for value in executions],
-        "breadcrumbs": [dict(value) for value in breadcrumbs],
+        "diagnostic_id": _nonblank(evidence.diagnostic_id, "Diagnostic id"),
+        "session_id": _nonblank(evidence.session_id, "Diagnostic session id"),
+        "occurred_at": _timestamp_text(evidence.occurred_at),
+        "elapsed_seconds": evidence.elapsed_seconds,
+        "operation": _nonblank(evidence.operation, "Diagnostic operation"),
+        "outcome": _nonblank(evidence.outcome, "Diagnostic outcome"),
+        "client": dict(evidence.client),
+        "error": dict(evidence.error),
+        "context": dict(evidence.context),
+        "executions": [dict(value) for value in evidence.executions],
+        "breadcrumbs": [dict(value) for value in evidence.breadcrumbs],
     }
     frozen = _freeze(document)
     if not isinstance(frozen, Mapping):
         raise AssertionError("a diagnostic document must remain a mapping")
     return DiagnosticReceipt._from_frozen(frozen)
+
+
+def _validate_error(value: Mapping[str, object]) -> None:
+    # INVARIANT: generic receipt assembly may freeze safe evidence, never widen capture policy.
+    unsafe = sorted(set(value) - _SAFE_ERROR_FIELDS)
+    if unsafe:
+        raise ValueError(f"Diagnostic contains unsafe error fields: {', '.join(unsafe)}")
+    _nonblank(value.get("type"), "Diagnostic error type")
 
 
 def _freeze(value: object) -> object:
@@ -84,4 +102,4 @@ def _timestamp_text(value: datetime) -> str:
     return rendered.replace("+00:00", "Z")
 
 
-__all__ = ["_new_receipt"]
+__all__ = ["_new_receipt", "_ReceiptEvidence"]

--- a/packages/screamingface/src/screamingface/_diagnostics/store.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/store.py
@@ -49,6 +49,12 @@ class _DiagnosticStore:
                 return None
             return next(reversed(self._receipts.values()))[0]
 
+    def remove(self, diagnostic_id: str) -> None:
+        with self._lock:
+            stored = self._receipts.pop(diagnostic_id, None)
+            if stored is not None:
+                self._bytes -= stored[1]
+
     def clear(self) -> None:
         """Clear process-local state for lifecycle reset and isolated tests."""
 

--- a/packages/screamingface/src/screamingface/_diagnostics/store.py
+++ b/packages/screamingface/src/screamingface/_diagnostics/store.py
@@ -1,0 +1,63 @@
+"""Bounded process-local storage for diagnostic receipts."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from threading import RLock
+
+from screamingface.diagnostic import DiagnosticReceipt
+
+
+class _DiagnosticStore:
+    def __init__(self, *, max_count: int, max_bytes: int) -> None:
+        if isinstance(max_count, bool) or not isinstance(max_count, int) or max_count < 1:
+            raise ValueError("Diagnostic max_count must be a positive integer")
+        if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes < 1:
+            raise ValueError("Diagnostic max_bytes must be a positive integer")
+        self._max_count = max_count
+        self._max_bytes = max_bytes
+        self._receipts: OrderedDict[str, tuple[DiagnosticReceipt, int]] = OrderedDict()
+        self._bytes = 0
+        self._lock = RLock()
+
+    def add(self, receipt: DiagnosticReceipt) -> bool:
+        if not isinstance(receipt, DiagnosticReceipt):
+            raise TypeError("Diagnostic store accepts DiagnosticReceipt values")
+        size = len(receipt.to_json().encode("utf-8"))
+        with self._lock:
+            if receipt.diagnostic_id in self._receipts:
+                raise ValueError(f"Diagnostic {receipt.diagnostic_id!r} already exists")
+            if size > self._max_bytes:
+                return False
+            while self._receipts and (
+                len(self._receipts) >= self._max_count or self._bytes + size > self._max_bytes
+            ):
+                _, (_, removed_size) = self._receipts.popitem(last=False)
+                self._bytes -= removed_size
+            self._receipts[receipt.diagnostic_id] = (receipt, size)
+            self._bytes += size
+            return True
+
+    def get(self, diagnostic_id: str) -> DiagnosticReceipt | None:
+        with self._lock:
+            stored = self._receipts.get(diagnostic_id)
+            return None if stored is None else stored[0]
+
+    def last(self) -> DiagnosticReceipt | None:
+        with self._lock:
+            if not self._receipts:
+                return None
+            return next(reversed(self._receipts.values()))[0]
+
+    def clear(self) -> None:
+        """Clear process-local state for lifecycle reset and isolated tests."""
+
+        with self._lock:
+            self._receipts.clear()
+            self._bytes = 0
+
+
+_STORE = _DiagnosticStore(max_count=20, max_bytes=2 * 1024 * 1024)
+
+
+__all__ = ["_DiagnosticStore", "_STORE"]

--- a/packages/screamingface/src/screamingface/_engine_origin.py
+++ b/packages/screamingface/src/screamingface/_engine_origin.py
@@ -1,4 +1,4 @@
-"""Shared Engine-origin classification for notebook UI surfaces."""
+"""Shared Engine-origin classification for Client surfaces and evidence."""
 
 from __future__ import annotations
 

--- a/packages/screamingface/src/screamingface/_evaluation/observers.py
+++ b/packages/screamingface/src/screamingface/_evaluation/observers.py
@@ -1,0 +1,323 @@
+"""Fail-open progress, callback, and diagnostic observation for Evaluations."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from threading import Lock
+
+from screamingface._diagnostics.evaluation import _EvaluationDiagnostic
+from screamingface._evaluation.model import Candidate, _Evaluation
+from screamingface.events import Event
+from screamingface.report import Report
+
+_logger = logging.getLogger(__name__)
+
+
+def _evaluation_diagnostic(
+    *,
+    engine_url: str,
+    benchmark: object,
+    candidates: object = None,
+    mode: str | None = None,
+) -> _EvaluationDiagnostic | None:
+    try:
+        return _EvaluationDiagnostic(
+            engine_url=engine_url,
+            benchmark=benchmark,
+            candidates=candidates,
+            mode=mode,
+        )
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic setup failed")
+        return None
+
+
+def _sync_event_observer(
+    callback: Callable[[Event], None] | None,
+    progress: bool | None,
+    candidates: tuple[Candidate, ...] = (),
+    case_count: int | None = None,
+    benchmark: str | None = None,
+    check_disclosure: str | None = None,
+    diagnostic: _EvaluationDiagnostic | None = None,
+) -> _SyncEventObserver | None:
+    from screamingface._evaluation.progress import _progress_observer
+
+    builtin = _progress_observer(
+        progress,
+        candidates=candidates,
+        case_count=case_count,
+        benchmark=benchmark,
+        check_disclosure=check_disclosure,
+    )
+    if builtin is None and callback is None and diagnostic is None:
+        return None
+    return _SyncEventObserver(builtin, callback, diagnostic)
+
+
+def _async_event_observer(
+    callback: Callable[[Event], None | Awaitable[None]] | None,
+    progress: bool | None,
+    candidates: tuple[Candidate, ...] = (),
+    case_count: int | None = None,
+    benchmark: str | None = None,
+    check_disclosure: str | None = None,
+    diagnostic: _EvaluationDiagnostic | None = None,
+) -> _AsyncEventObserver | None:
+    from screamingface._evaluation.progress import _progress_observer
+
+    builtin = _progress_observer(
+        progress,
+        candidates=candidates,
+        case_count=case_count,
+        benchmark=benchmark,
+        check_disclosure=check_disclosure,
+    )
+    if builtin is None and callback is None and diagnostic is None:
+        return None
+    return _AsyncEventObserver(builtin, callback, diagnostic)
+
+
+class _SyncEventObserver:
+    def __init__(
+        self,
+        builtin: object | None,
+        callback: Callable[[Event], None] | None,
+        diagnostic: _EvaluationDiagnostic | None = None,
+    ) -> None:
+        self._builtin = builtin
+        self._callback = callback
+        self._diagnostic = diagnostic
+        self._lock = Lock()
+
+    def begin(self, candidate: Candidate) -> None:
+        with self._lock:
+            _begin_diagnostic(self._diagnostic, candidate)
+            if self._builtin is not None:
+                _begin_candidate_progress(self._builtin, candidate)
+
+    def bind(self, candidate: Candidate) -> Callable[[Event], None]:
+        def observe(event: Event) -> None:
+            with self._lock:
+                _observe_diagnostic(self._diagnostic, candidate, event)
+                if self._builtin is not None:
+                    _observe_candidate_progress(self._builtin, candidate, event)
+                if self._callback is not None:
+                    self._callback(event)
+
+        return observe
+
+    def reconcile(self, report: Report) -> None:
+        _reconcile_progress(self._builtin, report)
+
+    def abort(self, exc: BaseException) -> None:
+        _abort_progress(self._builtin, exc)
+
+    def close(self) -> None:
+        _close_progress(self._builtin)
+
+
+class _AsyncEventObserver:
+    def __init__(
+        self,
+        builtin: object | None,
+        callback: Callable[[Event], None | Awaitable[None]] | None,
+        diagnostic: _EvaluationDiagnostic | None = None,
+    ) -> None:
+        self._builtin = builtin
+        self._callback = callback
+        self._diagnostic = diagnostic
+        self._lock = asyncio.Lock()
+
+    async def begin(self, candidate: Candidate) -> None:
+        async with self._lock:
+            _begin_diagnostic(self._diagnostic, candidate)
+            if self._builtin is not None:
+                _begin_candidate_progress(self._builtin, candidate)
+
+    def bind(self, candidate: Candidate) -> Callable[[Event], Awaitable[None]]:
+        async def observe(event: Event) -> None:
+            async with self._lock:
+                _observe_diagnostic(self._diagnostic, candidate, event)
+                if self._builtin is not None:
+                    _observe_candidate_progress(self._builtin, candidate, event)
+                if self._callback is not None:
+                    returned = self._callback(event)
+                    if inspect.isawaitable(returned):
+                        await returned
+
+        return observe
+
+    def reconcile(self, report: Report) -> None:
+        _reconcile_progress(self._builtin, report)
+
+    def abort(self, exc: BaseException) -> None:
+        _abort_progress(self._builtin, exc)
+
+    def close(self) -> None:
+        _close_progress(self._builtin)
+
+
+def _close_event_observer(observer: object) -> None:
+    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
+        observer.close()
+
+
+def _reconcile_event_observer(observer: object, report: Report) -> None:
+    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
+        observer.reconcile(report)
+
+
+def _abort_event_observer(observer: object, exc: BaseException) -> None:
+    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
+        observer.abort(exc)
+
+
+def _record_compiled_evaluation(
+    context: _EvaluationDiagnostic | None,
+    evaluation: _Evaluation,
+) -> None:
+    if context is None:
+        return
+    try:
+        context.compiled(evaluation)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic enrichment failed")
+
+
+def _record_validated_evaluation(
+    context: _EvaluationDiagnostic | None,
+    evaluation: _Evaluation,
+) -> None:
+    if context is None:
+        return
+    try:
+        context.validated(evaluation)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic enrichment failed")
+
+
+def _record_compiled_candidate(
+    context: _EvaluationDiagnostic | None,
+    candidate: Candidate,
+) -> None:
+    if context is None:
+        return
+    try:
+        context.compiled_candidate(candidate)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic enrichment failed")
+
+
+def _stage_diagnostic(context: _EvaluationDiagnostic | None, exc: BaseException) -> None:
+    """Keep local diagnostics strictly subordinate to the operation's exception."""
+
+    if context is None:
+        return
+    try:
+        receipt = context.stage(exc)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic capture failed")
+        return
+    if receipt is None:
+        _logger.warning("ScreamingFace diagnostic exceeded the local storage budget")
+        return
+    try:
+        from screamingface._ui.diagnostic_view import _attach_notebook_renderer
+
+        _attach_notebook_renderer(exc, receipt)
+    except Exception:
+        # INVARIANT: notebook presentation is subordinate to the original operation exception.
+        _logger.debug("ScreamingFace diagnostic presentation unavailable", exc_info=True)
+
+
+def _begin_diagnostic(context: _EvaluationDiagnostic | None, candidate: Candidate) -> None:
+    if context is None:
+        return
+    try:
+        context.begin(candidate)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic observation failed")
+
+
+def _observe_diagnostic(
+    context: _EvaluationDiagnostic | None,
+    candidate: Candidate,
+    event: Event,
+) -> None:
+    if context is None:
+        return
+    try:
+        context.observe(candidate, event)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic observation failed")
+
+
+def _close_progress(observer: object) -> None:
+    close = getattr(observer, "close", None)
+    if not callable(close):
+        return
+    try:
+        close()
+    except Exception:
+        _logger.exception("ScreamingFace progress cleanup failed")
+
+
+def _observe_candidate_progress(observer: object, candidate: Candidate, event: Event) -> None:
+    selected = getattr(observer, "observe", None)
+    if not callable(selected):
+        _logger.error("ScreamingFace progress observer has no Candidate observation method")
+        return
+    _observe_progress(selected, candidate, event)
+
+
+def _begin_candidate_progress(observer: object, candidate: Candidate) -> None:
+    begin = getattr(observer, "begin", None)
+    if not callable(begin):
+        _logger.error("ScreamingFace progress observer has no Candidate begin method")
+        return
+    _observe_progress(begin, candidate)
+
+
+def _reconcile_progress(observer: object | None, report: Report) -> None:
+    if observer is None:
+        return
+    reconcile = getattr(observer, "reconcile", None)
+    if not callable(reconcile):
+        return
+    try:
+        reconcile(report)
+    except Exception:
+        _logger.exception("ScreamingFace progress reconciliation failed")
+        _close_progress(observer)
+
+
+def _abort_progress(observer: object | None, exc: BaseException) -> None:
+    if observer is None:
+        return
+    abort = getattr(observer, "abort", None)
+    if not callable(abort):
+        _close_progress(observer)
+        return
+    try:
+        abort(exc)
+    except Exception:
+        _logger.exception("ScreamingFace progress finalization failed")
+        _close_progress(observer)
+
+
+def _observe_progress(observer: Callable[..., object], *values: object) -> None:
+    """Keep decorative progress output outside the Evaluation failure boundary."""
+
+    try:
+        observer(*values)
+    except (OSError, ValueError):
+        return
+    except Exception:
+        _logger.exception("ScreamingFace progress rendering failed")
+
+
+__all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_evaluation/runner.py
+++ b/packages/screamingface/src/screamingface/_evaluation/runner.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-import logging
 from collections.abc import Awaitable, Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from threading import Lock
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
@@ -23,6 +20,18 @@ from screamingface._evaluation.model import (
     _validate_limit,
 )
 from screamingface._evaluation.model_parameters import preflight_async, preflight_sync
+from screamingface._evaluation.observers import (
+    _abort_event_observer,
+    _async_event_observer,
+    _AsyncEventObserver,
+    _evaluation_diagnostic,
+    _reconcile_event_observer,
+    _record_compiled_evaluation,
+    _record_validated_evaluation,
+    _stage_diagnostic,
+    _sync_event_observer,
+    _SyncEventObserver,
+)
 from screamingface.discovery import ModelDetails, ModelInfo
 from screamingface.events import Event
 from screamingface.recipe import Recipe
@@ -42,7 +51,6 @@ type _SyncBenchmarkLoading = Callable[[str, int | None], _BenchmarkResource]
 type _AsyncBenchmarkLoading = Callable[[str, int | None], Awaitable[_BenchmarkResource]]
 
 _MAX_CANDIDATES_IN_FLIGHT = 8
-_logger = logging.getLogger(__name__)
 
 
 def evaluate_sync(
@@ -62,7 +70,11 @@ def evaluate_sync(
 
     from screamingface._evaluation.results import report_from_outcomes
 
-    diagnostic = _EvaluationDiagnostic(engine_url=engine_url, benchmark=benchmark)
+    diagnostic = _evaluation_diagnostic(
+        engine_url=engine_url,
+        benchmark=benchmark,
+        candidates=candidates,
+    )
     observer: _SyncEventObserver | None = None
     try:
         evaluation, check_disclosure = _prepare_evaluation_sync(
@@ -115,7 +127,11 @@ async def evaluate_async(
 
     from screamingface._evaluation.results import report_from_outcomes
 
-    diagnostic = _EvaluationDiagnostic(engine_url=engine_url, benchmark=benchmark)
+    diagnostic = _evaluation_diagnostic(
+        engine_url=engine_url,
+        benchmark=benchmark,
+        candidates=candidates,
+    )
     observer: _AsyncEventObserver | None = None
     try:
         evaluation, check_disclosure = await _prepare_evaluation_async(
@@ -160,7 +176,7 @@ def _prepare_evaluation_sync(
     limit: int | None,
     on_event: object,
     progress: object,
-    diagnostic: _EvaluationDiagnostic,
+    diagnostic: _EvaluationDiagnostic | None,
 ) -> tuple[_Evaluation, str | None]:
     from screamingface._evaluation.compilation import compile_evaluation
 
@@ -170,11 +186,11 @@ def _prepare_evaluation_sync(
     resource = load_benchmark(selected_benchmark, limit)
     check_disclosure = _validate_check_surface(values, selected_benchmark, resource)
     evaluation = compile_evaluation(values, resource, limit)
-    diagnostic.compiled(evaluation)
+    _record_compiled_evaluation(diagnostic, evaluation)
     catalog = load_models()
     _probe_missing_models_sync(evaluation, catalog.models, load_model_details)
     preflight_sync(tuple(evaluation.candidates), load_model_details)
-    diagnostic.validated(evaluation)
+    _record_validated_evaluation(diagnostic, evaluation)
     return evaluation, check_disclosure
 
 
@@ -187,7 +203,7 @@ async def _prepare_evaluation_async(
     limit: int | None,
     on_event: object,
     progress: object,
-    diagnostic: _EvaluationDiagnostic,
+    diagnostic: _EvaluationDiagnostic | None,
 ) -> tuple[_Evaluation, str | None]:
     from screamingface._evaluation.compilation import compile_evaluation
 
@@ -197,11 +213,11 @@ async def _prepare_evaluation_async(
     resource = await load_benchmark(selected_benchmark, limit)
     check_disclosure = _validate_check_surface(values, selected_benchmark, resource)
     evaluation = compile_evaluation(values, resource, limit)
-    diagnostic.compiled(evaluation)
+    _record_compiled_evaluation(diagnostic, evaluation)
     catalog = await load_models()
     await _probe_missing_models_async(evaluation, catalog.models, load_model_details)
     await preflight_async(tuple(evaluation.candidates), load_model_details)
-    diagnostic.validated(evaluation)
+    _record_validated_evaluation(diagnostic, evaluation)
     return evaluation, check_disclosure
 
 
@@ -238,259 +254,6 @@ def _evaluation_options(on_event: object, progress: object) -> None:
         raise TypeError("on_event must be callable or None")
     if progress is not None and not isinstance(progress, bool):
         raise TypeError("progress must be True, False, or None")
-
-
-def _sync_event_observer(
-    callback: Callable[[Event], None] | None,
-    progress: bool | None,
-    candidates: tuple[Candidate, ...] = (),
-    case_count: int | None = None,
-    benchmark: str | None = None,
-    check_disclosure: str | None = None,
-    diagnostic: _EvaluationDiagnostic | None = None,
-) -> _SyncEventObserver | None:
-    from screamingface._evaluation.progress import _progress_observer
-
-    builtin = _progress_observer(
-        progress,
-        candidates=candidates,
-        case_count=case_count,
-        benchmark=benchmark,
-        check_disclosure=check_disclosure,
-    )
-    if builtin is None and callback is None and diagnostic is None:
-        return None
-    return _SyncEventObserver(builtin, callback, diagnostic)
-
-
-def _async_event_observer(
-    callback: Callable[[Event], None | Awaitable[None]] | None,
-    progress: bool | None,
-    candidates: tuple[Candidate, ...] = (),
-    case_count: int | None = None,
-    benchmark: str | None = None,
-    check_disclosure: str | None = None,
-    diagnostic: _EvaluationDiagnostic | None = None,
-) -> _AsyncEventObserver | None:
-    from screamingface._evaluation.progress import _progress_observer
-
-    builtin = _progress_observer(
-        progress,
-        candidates=candidates,
-        case_count=case_count,
-        benchmark=benchmark,
-        check_disclosure=check_disclosure,
-    )
-    if builtin is None and callback is None and diagnostic is None:
-        return None
-    return _AsyncEventObserver(builtin, callback, diagnostic)
-
-
-class _SyncEventObserver:
-    def __init__(
-        self,
-        builtin: object | None,
-        callback: Callable[[Event], None] | None,
-        diagnostic: _EvaluationDiagnostic | None = None,
-    ) -> None:
-        self._builtin = builtin
-        self._callback = callback
-        self._diagnostic = diagnostic
-        self._lock = Lock()
-
-    def begin(self, candidate: Candidate) -> None:
-        with self._lock:
-            _observe_diagnostic(self._diagnostic, "begin", candidate)
-            if self._builtin is not None:
-                _begin_candidate_progress(self._builtin, candidate)
-
-    def bind(self, candidate: Candidate) -> Callable[[Event], None]:
-        def observe(event: Event) -> None:
-            with self._lock:
-                _observe_diagnostic(self._diagnostic, "observe", candidate, event)
-                if self._builtin is not None:
-                    _observe_candidate_progress(self._builtin, candidate, event)
-                if self._callback is not None:
-                    self._callback(event)
-
-        return observe
-
-    def reconcile(self, report: Report) -> None:
-        _reconcile_progress(self._builtin, report)
-
-    def abort(self, exc: BaseException) -> None:
-        _abort_progress(self._builtin, exc)
-
-    def close(self) -> None:
-        _close_progress(self._builtin)
-
-
-class _AsyncEventObserver:
-    def __init__(
-        self,
-        builtin: object | None,
-        callback: Callable[[Event], None | Awaitable[None]] | None,
-        diagnostic: _EvaluationDiagnostic | None = None,
-    ) -> None:
-        self._builtin = builtin
-        self._callback = callback
-        self._diagnostic = diagnostic
-        self._lock = asyncio.Lock()
-
-    async def begin(self, candidate: Candidate) -> None:
-        async with self._lock:
-            _observe_diagnostic(self._diagnostic, "begin", candidate)
-            if self._builtin is not None:
-                _begin_candidate_progress(self._builtin, candidate)
-
-    def bind(self, candidate: Candidate) -> Callable[[Event], Awaitable[None]]:
-        async def observe(event: Event) -> None:
-            async with self._lock:
-                _observe_diagnostic(self._diagnostic, "observe", candidate, event)
-                if self._builtin is not None:
-                    _observe_candidate_progress(self._builtin, candidate, event)
-                if self._callback is not None:
-                    returned = self._callback(event)
-                    if inspect.isawaitable(returned):
-                        await returned
-
-        return observe
-
-    def reconcile(self, report: Report) -> None:
-        _reconcile_progress(self._builtin, report)
-
-    def abort(self, exc: BaseException) -> None:
-        _abort_progress(self._builtin, exc)
-
-    def close(self) -> None:
-        _close_progress(self._builtin)
-
-
-def _close_event_observer(observer: object) -> None:
-    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
-        observer.close()
-
-
-def _reconcile_event_observer(observer: object, report: Report) -> None:
-    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
-        observer.reconcile(report)
-
-
-def _abort_event_observer(observer: object, exc: BaseException) -> None:
-    if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
-        observer.abort(exc)
-
-
-def _stage_diagnostic(context: _EvaluationDiagnostic, exc: BaseException) -> None:
-    """Keep local diagnostics strictly subordinate to the operation's exception."""
-
-    try:
-        receipt = context.stage(exc)
-    except Exception:
-        _logger.exception("ScreamingFace diagnostic capture failed")
-        return
-    if receipt is None:
-        _logger.warning("ScreamingFace diagnostic exceeded the local storage budget")
-        return
-    try:
-        exc.add_note(
-            f"Diagnostic: {receipt.diagnostic_id}. Export with "
-            f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
-            '"screamingface-diagnostic.json")'
-        )
-    except Exception:
-        _logger.debug("ScreamingFace diagnostic note unavailable", exc_info=True)
-    try:
-        from screamingface._ui.diagnostic_view import _attach_notebook_renderer
-
-        _attach_notebook_renderer(exc, receipt)
-    except Exception:
-        # INVARIANT: notebook presentation is subordinate to the original operation exception.
-        _logger.debug("ScreamingFace diagnostic presentation unavailable", exc_info=True)
-
-
-def _observe_diagnostic(
-    context: _EvaluationDiagnostic | None,
-    method: str,
-    *values: object,
-) -> None:
-    if context is None:
-        return
-    selected = getattr(context, method, None)
-    if not callable(selected):
-        _logger.error("ScreamingFace diagnostic observer is incomplete")
-        return
-    try:
-        selected(*values)
-    except Exception:
-        _logger.exception("ScreamingFace diagnostic observation failed")
-
-
-def _close_progress(observer: object) -> None:
-    close = getattr(observer, "close", None)
-    if not callable(close):
-        return
-    try:
-        close()
-    except Exception:
-        _logger.exception("ScreamingFace progress cleanup failed")
-
-
-def _observe_candidate_progress(observer: object, candidate: Candidate, event: Event) -> None:
-    selected = getattr(observer, "observe", None)
-    if not callable(selected):
-        _logger.error("ScreamingFace progress observer has no Candidate observation method")
-        return
-    _observe_progress(selected, candidate, event)
-
-
-def _begin_candidate_progress(observer: object, candidate: Candidate) -> None:
-    begin = getattr(observer, "begin", None)
-    if not callable(begin):
-        _logger.error("ScreamingFace progress observer has no Candidate begin method")
-        return
-    _observe_progress(begin, candidate)
-
-
-def _reconcile_progress(observer: object | None, report: Report) -> None:
-    if observer is None:
-        return
-    reconcile = getattr(observer, "reconcile", None)
-    if not callable(reconcile):
-        return
-    try:
-        reconcile(report)
-    except Exception:
-        _logger.exception("ScreamingFace progress reconciliation failed")
-        _close_progress(observer)
-
-
-def _abort_progress(observer: object | None, exc: BaseException) -> None:
-    if observer is None:
-        return
-    abort = getattr(observer, "abort", None)
-    if not callable(abort):
-        _close_progress(observer)
-        return
-    try:
-        abort(exc)
-    except Exception:
-        _logger.exception("ScreamingFace progress finalization failed")
-        _close_progress(observer)
-
-
-def _observe_progress(observer: Callable[..., object], *values: object) -> None:
-    """Keep decorative progress output outside the Evaluation failure boundary."""
-
-    try:
-        observer(*values)
-    except (OSError, ValueError):
-        # Closed pipes and notebook streams must not cancel paid Engine work.
-        return
-    except Exception:
-        # Progress is decorative, so an unexpected renderer defect must not abort paid work.
-        # Log it rather than swallowing it: this path needs to remain diagnosable.
-        _logger.exception("ScreamingFace progress rendering failed")
 
 
 def _run_candidates_sync(

--- a/packages/screamingface/src/screamingface/_evaluation/runner.py
+++ b/packages/screamingface/src/screamingface/_evaluation/runner.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from screamingface.errors import PlanningError
 
 from screamingface._core.ports import AsyncRunTransport, SyncRunTransport, _RunOutcome
+from screamingface._diagnostics.evaluation import _EvaluationDiagnostic
 from screamingface._evaluation.benchmark import _BenchmarkResource
 from screamingface._evaluation.model import (
     Candidate,
@@ -50,45 +51,48 @@ def evaluate_sync(
     load_models: _SyncModelLoading,
     load_model_details: _SyncModelDetailsLoading,
     candidates: Recipe | Sequence[Recipe],
-    benchmark: str,
+    benchmark: str | None,
     limit: int | None,
     on_event: Callable[[Event], None] | None,
     progress: bool | None,
+    *,
+    engine_url: str,
 ) -> Report:
     """Run the complete synchronous Evaluation workflow behind the Client interface."""
 
-    from screamingface._evaluation.compilation import compile_evaluation
     from screamingface._evaluation.results import report_from_outcomes
-    from screamingface.errors import PlanningError
 
-    _evaluation_options(on_event, progress)
-    values = _evaluation_inputs(candidates, benchmark, limit)
-    resource = load_benchmark(benchmark, limit)
-    check_disclosure = _validate_check_surface(values, benchmark, resource)
-    evaluation = compile_evaluation(values, resource, limit)
-    catalog = load_models()
-    # The availability probe (OME-878): a details fetch for EVERY listing-missing
-    # Model — the Engine admits it (run proceeds), relays a refusal (decoded,
-    # pre-spend), or answers a plain 404 that reads as today's refusal.
-    for model in _missing_required_models(evaluation, catalog.models):
-        try:
-            load_model_details(model)
-        except PlanningError as exc:
-            _reraise_probe_miss(model, exc)
-    preflight_sync(tuple(evaluation.candidates), load_model_details)
-    observer = _sync_event_observer(
-        on_event,
-        progress,
-        tuple(evaluation.candidates),
-        evaluation.case_count,
-        benchmark,
-        check_disclosure=check_disclosure,
-    )
+    diagnostic = _EvaluationDiagnostic(engine_url=engine_url, benchmark=benchmark)
+    observer: _SyncEventObserver | None = None
     try:
+        evaluation, check_disclosure = _prepare_evaluation_sync(
+            load_benchmark,
+            load_models,
+            load_model_details,
+            candidates,
+            benchmark,
+            limit,
+            on_event,
+            progress,
+            diagnostic,
+        )
+        observer = _sync_event_observer(
+            on_event,
+            progress,
+            tuple(evaluation.candidates),
+            evaluation.case_count,
+            benchmark,
+            check_disclosure=check_disclosure,
+            diagnostic=diagnostic,
+        )
         outcomes = _run_candidates_sync(transport, tuple(evaluation.candidates), observer)
         report = report_from_outcomes(evaluation, outcomes)
+    except (SystemExit, GeneratorExit) as exc:
+        _abort_event_observer(observer, exc)
+        raise
     except BaseException as exc:
         _abort_event_observer(observer, exc)
+        _stage_diagnostic(diagnostic, exc)
         raise
     _reconcile_event_observer(observer, report)
     return report
@@ -100,48 +104,133 @@ async def evaluate_async(
     load_models: _AsyncModelLoading,
     load_model_details: _AsyncModelDetailsLoading,
     candidates: Recipe | Sequence[Recipe],
-    benchmark: str,
+    benchmark: str | None,
     limit: int | None,
     on_event: Callable[[Event], None | Awaitable[None]] | None,
     progress: bool | None,
+    *,
+    engine_url: str,
 ) -> Report:
     """Run the complete asynchronous Evaluation workflow behind the Client interface."""
 
-    from screamingface._evaluation.compilation import compile_evaluation
     from screamingface._evaluation.results import report_from_outcomes
-    from screamingface.errors import PlanningError
+
+    diagnostic = _EvaluationDiagnostic(engine_url=engine_url, benchmark=benchmark)
+    observer: _AsyncEventObserver | None = None
+    try:
+        evaluation, check_disclosure = await _prepare_evaluation_async(
+            load_benchmark,
+            load_models,
+            load_model_details,
+            candidates,
+            benchmark,
+            limit,
+            on_event,
+            progress,
+            diagnostic,
+        )
+        observer = _async_event_observer(
+            on_event,
+            progress,
+            tuple(evaluation.candidates),
+            evaluation.case_count,
+            benchmark,
+            check_disclosure=check_disclosure,
+            diagnostic=diagnostic,
+        )
+        outcomes = await _run_candidates_async(transport, tuple(evaluation.candidates), observer)
+        report = report_from_outcomes(evaluation, outcomes)
+    except (SystemExit, GeneratorExit) as exc:
+        _abort_event_observer(observer, exc)
+        raise
+    except BaseException as exc:
+        _abort_event_observer(observer, exc)
+        _stage_diagnostic(diagnostic, exc)
+        raise
+    _reconcile_event_observer(observer, report)
+    return report
+
+
+def _prepare_evaluation_sync(
+    load_benchmark: _SyncBenchmarkLoading,
+    load_models: _SyncModelLoading,
+    load_model_details: _SyncModelDetailsLoading,
+    candidates: Recipe | Sequence[Recipe],
+    benchmark: str | None,
+    limit: int | None,
+    on_event: object,
+    progress: object,
+    diagnostic: _EvaluationDiagnostic,
+) -> tuple[_Evaluation, str | None]:
+    from screamingface._evaluation.compilation import compile_evaluation
 
     _evaluation_options(on_event, progress)
-    values = _evaluation_inputs(candidates, benchmark, limit)
-    resource = await load_benchmark(benchmark, limit)
-    check_disclosure = _validate_check_surface(values, benchmark, resource)
+    selected_benchmark = _benchmark_id(benchmark)
+    values = _evaluation_inputs(candidates, selected_benchmark, limit)
+    resource = load_benchmark(selected_benchmark, limit)
+    check_disclosure = _validate_check_surface(values, selected_benchmark, resource)
     evaluation = compile_evaluation(values, resource, limit)
+    diagnostic.compiled(evaluation)
+    catalog = load_models()
+    _probe_missing_models_sync(evaluation, catalog.models, load_model_details)
+    preflight_sync(tuple(evaluation.candidates), load_model_details)
+    diagnostic.validated(evaluation)
+    return evaluation, check_disclosure
+
+
+async def _prepare_evaluation_async(
+    load_benchmark: _AsyncBenchmarkLoading,
+    load_models: _AsyncModelLoading,
+    load_model_details: _AsyncModelDetailsLoading,
+    candidates: Recipe | Sequence[Recipe],
+    benchmark: str | None,
+    limit: int | None,
+    on_event: object,
+    progress: object,
+    diagnostic: _EvaluationDiagnostic,
+) -> tuple[_Evaluation, str | None]:
+    from screamingface._evaluation.compilation import compile_evaluation
+
+    _evaluation_options(on_event, progress)
+    selected_benchmark = _benchmark_id(benchmark)
+    values = _evaluation_inputs(candidates, selected_benchmark, limit)
+    resource = await load_benchmark(selected_benchmark, limit)
+    check_disclosure = _validate_check_surface(values, selected_benchmark, resource)
+    evaluation = compile_evaluation(values, resource, limit)
+    diagnostic.compiled(evaluation)
     catalog = await load_models()
-    # The availability probe (OME-878): a details fetch for EVERY listing-missing
-    # Model — the Engine admits it (run proceeds), relays a refusal (decoded,
-    # pre-spend), or answers a plain 404 that reads as today's refusal.
-    for model in _missing_required_models(evaluation, catalog.models):
+    await _probe_missing_models_async(evaluation, catalog.models, load_model_details)
+    await preflight_async(tuple(evaluation.candidates), load_model_details)
+    diagnostic.validated(evaluation)
+    return evaluation, check_disclosure
+
+
+def _probe_missing_models_sync(
+    evaluation: _Evaluation,
+    models: Sequence[ModelInfo],
+    load_model_details: _SyncModelDetailsLoading,
+) -> None:
+    from screamingface.errors import PlanningError
+
+    for model in _missing_required_models(evaluation, models):
+        try:
+            load_model_details(model)
+        except PlanningError as exc:
+            _reraise_probe_miss(model, exc)
+
+
+async def _probe_missing_models_async(
+    evaluation: _Evaluation,
+    models: Sequence[ModelInfo],
+    load_model_details: _AsyncModelDetailsLoading,
+) -> None:
+    from screamingface.errors import PlanningError
+
+    for model in _missing_required_models(evaluation, models):
         try:
             await load_model_details(model)
         except PlanningError as exc:
             _reraise_probe_miss(model, exc)
-    await preflight_async(tuple(evaluation.candidates), load_model_details)
-    observer = _async_event_observer(
-        on_event,
-        progress,
-        tuple(evaluation.candidates),
-        evaluation.case_count,
-        benchmark,
-        check_disclosure=check_disclosure,
-    )
-    try:
-        outcomes = await _run_candidates_async(transport, tuple(evaluation.candidates), observer)
-        report = report_from_outcomes(evaluation, outcomes)
-    except BaseException as exc:
-        _abort_event_observer(observer, exc)
-        raise
-    _reconcile_event_observer(observer, report)
-    return report
 
 
 def _evaluation_options(on_event: object, progress: object) -> None:
@@ -158,6 +247,7 @@ def _sync_event_observer(
     case_count: int | None = None,
     benchmark: str | None = None,
     check_disclosure: str | None = None,
+    diagnostic: _EvaluationDiagnostic | None = None,
 ) -> _SyncEventObserver | None:
     from screamingface._evaluation.progress import _progress_observer
 
@@ -168,9 +258,9 @@ def _sync_event_observer(
         benchmark=benchmark,
         check_disclosure=check_disclosure,
     )
-    if builtin is None and callback is None:
+    if builtin is None and callback is None and diagnostic is None:
         return None
-    return _SyncEventObserver(builtin, callback)
+    return _SyncEventObserver(builtin, callback, diagnostic)
 
 
 def _async_event_observer(
@@ -180,6 +270,7 @@ def _async_event_observer(
     case_count: int | None = None,
     benchmark: str | None = None,
     check_disclosure: str | None = None,
+    diagnostic: _EvaluationDiagnostic | None = None,
 ) -> _AsyncEventObserver | None:
     from screamingface._evaluation.progress import _progress_observer
 
@@ -190,9 +281,9 @@ def _async_event_observer(
         benchmark=benchmark,
         check_disclosure=check_disclosure,
     )
-    if builtin is None and callback is None:
+    if builtin is None and callback is None and diagnostic is None:
         return None
-    return _AsyncEventObserver(builtin, callback)
+    return _AsyncEventObserver(builtin, callback, diagnostic)
 
 
 class _SyncEventObserver:
@@ -200,19 +291,23 @@ class _SyncEventObserver:
         self,
         builtin: object | None,
         callback: Callable[[Event], None] | None,
+        diagnostic: _EvaluationDiagnostic | None = None,
     ) -> None:
         self._builtin = builtin
         self._callback = callback
+        self._diagnostic = diagnostic
         self._lock = Lock()
 
     def begin(self, candidate: Candidate) -> None:
         with self._lock:
+            _observe_diagnostic(self._diagnostic, "begin", candidate)
             if self._builtin is not None:
                 _begin_candidate_progress(self._builtin, candidate)
 
     def bind(self, candidate: Candidate) -> Callable[[Event], None]:
         def observe(event: Event) -> None:
             with self._lock:
+                _observe_diagnostic(self._diagnostic, "observe", candidate, event)
                 if self._builtin is not None:
                     _observe_candidate_progress(self._builtin, candidate, event)
                 if self._callback is not None:
@@ -235,19 +330,23 @@ class _AsyncEventObserver:
         self,
         builtin: object | None,
         callback: Callable[[Event], None | Awaitable[None]] | None,
+        diagnostic: _EvaluationDiagnostic | None = None,
     ) -> None:
         self._builtin = builtin
         self._callback = callback
+        self._diagnostic = diagnostic
         self._lock = asyncio.Lock()
 
     async def begin(self, candidate: Candidate) -> None:
         async with self._lock:
+            _observe_diagnostic(self._diagnostic, "begin", candidate)
             if self._builtin is not None:
                 _begin_candidate_progress(self._builtin, candidate)
 
     def bind(self, candidate: Candidate) -> Callable[[Event], Awaitable[None]]:
         async def observe(event: Event) -> None:
             async with self._lock:
+                _observe_diagnostic(self._diagnostic, "observe", candidate, event)
                 if self._builtin is not None:
                     _observe_candidate_progress(self._builtin, candidate, event)
                 if self._callback is not None:
@@ -280,6 +379,41 @@ def _reconcile_event_observer(observer: object, report: Report) -> None:
 def _abort_event_observer(observer: object, exc: BaseException) -> None:
     if isinstance(observer, (_SyncEventObserver, _AsyncEventObserver)):
         observer.abort(exc)
+
+
+def _stage_diagnostic(context: _EvaluationDiagnostic, exc: BaseException) -> None:
+    """Keep local diagnostics strictly subordinate to the operation's exception."""
+
+    try:
+        receipt = context.stage(exc)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic capture failed")
+        return
+    if receipt is None:
+        _logger.warning("ScreamingFace diagnostic exceeded the local storage budget")
+        return
+    exc.add_note(
+        f"Diagnostic: {receipt.diagnostic_id}. Export with "
+        f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
+        '"screamingface-diagnostic.json")'
+    )
+
+
+def _observe_diagnostic(
+    context: _EvaluationDiagnostic | None,
+    method: str,
+    *values: object,
+) -> None:
+    if context is None:
+        return
+    selected = getattr(context, method, None)
+    if not callable(selected):
+        _logger.error("ScreamingFace diagnostic observer is incomplete")
+        return
+    try:
+        selected(*values)
+    except Exception:
+        _logger.exception("ScreamingFace diagnostic observation failed")
 
 
 def _close_progress(observer: object) -> None:
@@ -527,6 +661,16 @@ def _evaluation_inputs(
         raise ValueError("benchmark must name an explicit Benchmark, not 'default'")
     _validate_limit(limit)
     return values
+
+
+def _benchmark_id(value: object) -> str:
+    if value is None:
+        raise TypeError("benchmark is required when evaluating Recipes")
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("benchmark must be a non-empty string")
+    if value == "default":
+        raise ValueError("benchmark must name an explicit Benchmark, not 'default'")
+    return value
 
 
 __all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_evaluation/runner.py
+++ b/packages/screamingface/src/screamingface/_evaluation/runner.py
@@ -392,11 +392,14 @@ def _stage_diagnostic(context: _EvaluationDiagnostic, exc: BaseException) -> Non
     if receipt is None:
         _logger.warning("ScreamingFace diagnostic exceeded the local storage budget")
         return
-    exc.add_note(
-        f"Diagnostic: {receipt.diagnostic_id}. Export with "
-        f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
-        '"screamingface-diagnostic.json")'
-    )
+    try:
+        exc.add_note(
+            f"Diagnostic: {receipt.diagnostic_id}. Export with "
+            f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
+            '"screamingface-diagnostic.json")'
+        )
+    except Exception:
+        _logger.debug("ScreamingFace diagnostic note unavailable", exc_info=True)
     try:
         from screamingface._ui.diagnostic_view import _attach_notebook_renderer
 

--- a/packages/screamingface/src/screamingface/_evaluation/runner.py
+++ b/packages/screamingface/src/screamingface/_evaluation/runner.py
@@ -397,6 +397,13 @@ def _stage_diagnostic(context: _EvaluationDiagnostic, exc: BaseException) -> Non
         f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
         '"screamingface-diagnostic.json")'
     )
+    try:
+        from screamingface._ui.diagnostic_view import _attach_notebook_renderer
+
+        _attach_notebook_renderer(exc, receipt)
+    except Exception:
+        # INVARIANT: notebook presentation is subordinate to the original operation exception.
+        _logger.debug("ScreamingFace diagnostic presentation unavailable", exc_info=True)
 
 
 def _observe_diagnostic(

--- a/packages/screamingface/src/screamingface/_evaluation/url4.py
+++ b/packages/screamingface/src/screamingface/_evaluation/url4.py
@@ -39,16 +39,17 @@ def evaluate_url4_sync(
 ) -> Report:
     """Execute one already-linked evaluation expression unchanged."""
 
-    from screamingface._diagnostics.evaluation import _EvaluationDiagnostic
-    from screamingface._evaluation.runner import (
+    from screamingface._evaluation.observers import (
         _abort_event_observer,
-        _evaluation_options,
+        _evaluation_diagnostic,
         _reconcile_event_observer,
+        _record_compiled_candidate,
         _stage_diagnostic,
         _sync_event_observer,
     )
+    from screamingface._evaluation.runner import _evaluation_options
 
-    diagnostic = _EvaluationDiagnostic(
+    diagnostic = _evaluation_diagnostic(
         engine_url=engine_url,
         benchmark=None,
         mode="url4_replay",
@@ -58,7 +59,7 @@ def evaluate_url4_sync(
         _raw_url4_options(benchmark, limit)
         _evaluation_options(on_event, progress)
         candidate = _candidate_from_url4(url4)
-        diagnostic.compiled_candidate(candidate)
+        _record_compiled_candidate(diagnostic, candidate)
         observer = _sync_event_observer(
             on_event,
             progress,
@@ -67,6 +68,8 @@ def evaluate_url4_sync(
             "URL4 replay",
             diagnostic=diagnostic,
         )
+        if observer is not None:
+            observer.begin(candidate)
         bound = None if observer is None else observer.bind(candidate)
         outcome = transport.run(candidate, bound)
         report = report_from_url4_outcome(candidate, outcome)
@@ -93,16 +96,17 @@ async def evaluate_url4_async(
 ) -> Report:
     """Asynchronously execute one already-linked evaluation expression unchanged."""
 
-    from screamingface._diagnostics.evaluation import _EvaluationDiagnostic
-    from screamingface._evaluation.runner import (
+    from screamingface._evaluation.observers import (
         _abort_event_observer,
         _async_event_observer,
-        _evaluation_options,
+        _evaluation_diagnostic,
         _reconcile_event_observer,
+        _record_compiled_candidate,
         _stage_diagnostic,
     )
+    from screamingface._evaluation.runner import _evaluation_options
 
-    diagnostic = _EvaluationDiagnostic(
+    diagnostic = _evaluation_diagnostic(
         engine_url=engine_url,
         benchmark=None,
         mode="url4_replay",
@@ -112,7 +116,7 @@ async def evaluate_url4_async(
         _raw_url4_options(benchmark, limit)
         _evaluation_options(on_event, progress)
         candidate = _candidate_from_url4(url4)
-        diagnostic.compiled_candidate(candidate)
+        _record_compiled_candidate(diagnostic, candidate)
         observer = _async_event_observer(
             on_event,
             progress,
@@ -121,6 +125,8 @@ async def evaluate_url4_async(
             "URL4 replay",
             diagnostic=diagnostic,
         )
+        if observer is not None:
+            await observer.begin(candidate)
         bound = None if observer is None else observer.bind(candidate)
         outcome = await transport.run(candidate, bound)
         report = report_from_url4_outcome(candidate, outcome)

--- a/packages/screamingface/src/screamingface/_evaluation/url4.py
+++ b/packages/screamingface/src/screamingface/_evaluation/url4.py
@@ -30,33 +30,52 @@ from screamingface.url4 import _validate_topology
 def evaluate_url4_sync(
     transport: SyncRunTransport,
     url4: str,
+    benchmark: str | None,
+    limit: int | None,
     on_event: Callable[[Event], None] | None,
     progress: bool | None,
+    *,
+    engine_url: str,
 ) -> Report:
     """Execute one already-linked evaluation expression unchanged."""
 
+    from screamingface._diagnostics.evaluation import _EvaluationDiagnostic
     from screamingface._evaluation.runner import (
         _abort_event_observer,
         _evaluation_options,
         _reconcile_event_observer,
+        _stage_diagnostic,
         _sync_event_observer,
     )
 
-    _evaluation_options(on_event, progress)
-    candidate = _candidate_from_url4(url4)
-    observer = _sync_event_observer(
-        on_event,
-        progress,
-        (candidate,),
-        None,
-        "URL4 replay",
+    diagnostic = _EvaluationDiagnostic(
+        engine_url=engine_url,
+        benchmark=None,
+        mode="url4_replay",
     )
+    observer = None
     try:
+        _raw_url4_options(benchmark, limit)
+        _evaluation_options(on_event, progress)
+        candidate = _candidate_from_url4(url4)
+        diagnostic.compiled_candidate(candidate)
+        observer = _sync_event_observer(
+            on_event,
+            progress,
+            (candidate,),
+            None,
+            "URL4 replay",
+            diagnostic=diagnostic,
+        )
         bound = None if observer is None else observer.bind(candidate)
         outcome = transport.run(candidate, bound)
         report = report_from_url4_outcome(candidate, outcome)
+    except (SystemExit, GeneratorExit) as exc:
+        _abort_event_observer(observer, exc)
+        raise
     except BaseException as exc:
         _abort_event_observer(observer, exc)
+        _stage_diagnostic(diagnostic, exc)
         raise
     _reconcile_event_observer(observer, report)
     return report
@@ -65,36 +84,62 @@ def evaluate_url4_sync(
 async def evaluate_url4_async(
     transport: AsyncRunTransport,
     url4: str,
+    benchmark: str | None,
+    limit: int | None,
     on_event: Callable[[Event], None | Awaitable[None]] | None,
     progress: bool | None,
+    *,
+    engine_url: str,
 ) -> Report:
     """Asynchronously execute one already-linked evaluation expression unchanged."""
 
+    from screamingface._diagnostics.evaluation import _EvaluationDiagnostic
     from screamingface._evaluation.runner import (
         _abort_event_observer,
         _async_event_observer,
         _evaluation_options,
         _reconcile_event_observer,
+        _stage_diagnostic,
     )
 
-    _evaluation_options(on_event, progress)
-    candidate = _candidate_from_url4(url4)
-    observer = _async_event_observer(
-        on_event,
-        progress,
-        (candidate,),
-        None,
-        "URL4 replay",
+    diagnostic = _EvaluationDiagnostic(
+        engine_url=engine_url,
+        benchmark=None,
+        mode="url4_replay",
     )
+    observer = None
     try:
+        _raw_url4_options(benchmark, limit)
+        _evaluation_options(on_event, progress)
+        candidate = _candidate_from_url4(url4)
+        diagnostic.compiled_candidate(candidate)
+        observer = _async_event_observer(
+            on_event,
+            progress,
+            (candidate,),
+            None,
+            "URL4 replay",
+            diagnostic=diagnostic,
+        )
         bound = None if observer is None else observer.bind(candidate)
         outcome = await transport.run(candidate, bound)
         report = report_from_url4_outcome(candidate, outcome)
+    except (SystemExit, GeneratorExit) as exc:
+        _abort_event_observer(observer, exc)
+        raise
     except BaseException as exc:
         _abort_event_observer(observer, exc)
+        _stage_diagnostic(diagnostic, exc)
         raise
     _reconcile_event_observer(observer, report)
     return report
+
+
+def _raw_url4_options(benchmark: str | None, limit: int | None) -> None:
+    if benchmark is not None:
+        raise TypeError("benchmark must not be passed when evaluating a complete URL4")
+    if limit is not None:
+        raise TypeError("limit must not be passed when evaluating a complete URL4")
 
 
 def _candidate_from_url4(value: str) -> Candidate:

--- a/packages/screamingface/src/screamingface/_ui/cards.py
+++ b/packages/screamingface/src/screamingface/_ui/cards.py
@@ -6,8 +6,8 @@ from collections.abc import Mapping, Sequence
 from html import escape
 from typing import TYPE_CHECKING
 
+from screamingface._engine_origin import _is_hosted_engine
 from screamingface._ui.card_style import CARD_STYLE
-from screamingface._ui.engine_origin import _is_hosted_engine
 from screamingface.recipe import _recipe_kind
 
 if TYPE_CHECKING:

--- a/packages/screamingface/src/screamingface/_ui/connection_view.py
+++ b/packages/screamingface/src/screamingface/_ui/connection_view.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from html import escape
 from typing import TYPE_CHECKING, Any, Protocol, assert_never
 
+from screamingface._engine_origin import _is_screamingface_engine
 from screamingface._ui.connection_state import _ConnectionPanelState
-from screamingface._ui.engine_origin import _is_screamingface_engine
 from screamingface._ui.provider_icons import provider_icon_html
 from screamingface._ui.style import STYLE, _theme_rules
 

--- a/packages/screamingface/src/screamingface/_ui/connections.py
+++ b/packages/screamingface/src/screamingface/_ui/connections.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast, overload
 
+from screamingface._engine_origin import _is_hosted_engine
 from screamingface._ui.connection_state import (
     _ConnectionPanelState,
     _sync_access_probe,
@@ -16,7 +17,6 @@ from screamingface._ui.connection_view import (
     _provider_presentation,
     static_panel_html,
 )
-from screamingface._ui.engine_origin import _is_hosted_engine
 from screamingface.errors import ScreamingFaceError
 
 if TYPE_CHECKING:

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -41,7 +41,7 @@ _STYLE = (
   font:500 12px/1.45 var(--f-mono)}
 .sf-diagnostic__status:empty{display:none}
 .sf-diagnostic__status--ok{color:var(--sf-success)}
-.sf-diagnostic__status--bad{color:var(--sf-blind)}
+.sf-diagnostic__status--bad{color:var(--sf-danger-solid)}
 .sf-diagnostic__preview{margin-top:8px;border:1px solid var(--sf-line-2);
   background:var(--sf-surface)}
 .sf-diagnostic__preview-label{padding:8px 12px;border-bottom:1px solid var(--sf-line);
@@ -123,15 +123,15 @@ def _attach_notebook_renderer(error: BaseException, receipt: DiagnosticReceipt) 
 
     def render() -> list[str]:
         nonlocal shown
-        if shown:
-            return []
-        try:
-            _display_notebook_diagnostic(receipt)
-        except Exception:
-            # INVARIANT: optional presentation can never hide the operation's real traceback.
-            return fallback()
-        shown = True
-        return []
+        if not shown:
+            try:
+                _display_notebook_diagnostic(receipt)
+            except Exception:
+                # INVARIANT: optional presentation can never hide the operation's real traceback.
+                return fallback()
+            shown = True
+        # INVARIANT: the toolbar is additive; IPython uses these lines as the native traceback.
+        return fallback()
 
     # WHY: IPython asks the exception value for this protocol. An instance attachment also covers
     # raw TypeError/ValueError failures without wrapping them or intercepting unrelated cells.

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -25,31 +25,31 @@ _STYLE = (
   margin:0!important;padding:0!important;border:0!important;
   border-radius:0!important;background:transparent!important;color:var(--sf-ink)}
 .sf-diagnostic__receipt{flex:0 1 auto!important;width:auto!important;min-width:0!important}
-.sf-diagnostic__receipt>div>div{display:flex;flex-wrap:wrap;gap:6px;
-  font:500 12px/1.4 "IBM Plex Mono",ui-monospace,monospace;color:var(--sf-ink-2)}
+.sf-diagnostic__receipt>div>div{display:flex;flex-wrap:wrap;gap:4px;
+  font:500 12px/1.4 var(--f-mono);color:var(--sf-ink-2)}
 .sf-diagnostic__receipt code{font:inherit;color:var(--sf-ink)}
 .sf-diagnostic__controls.widget-hbox{display:flex!important;flex-flow:row wrap!important;
   gap:4px!important;margin:0!important}
 .sf-diagnostic-widget .widget-button{height:24px!important;width:auto!important;
-  padding:0 3px!important;border:0!important;border-radius:0!important;box-shadow:none!important;
+  padding:0 4px!important;border:0!important;border-radius:0!important;box-shadow:none!important;
   background:transparent!important;background-image:none!important;color:var(--sf-accent)!important;
   text-decoration:underline;text-underline-offset:2px;
-  font:600 12px/1 "IBM Plex Mono",ui-monospace,monospace!important;white-space:nowrap}
+  font:600 12px/1 var(--f-mono)!important;white-space:nowrap}
 .sf-diagnostic-widget .widget-button:hover{background:transparent!important;
   color:var(--sf-accent-hover)!important}
 .sf-diagnostic__status{margin-top:4px;color:var(--sf-ink-2);
-  font:500 12px/1.45 "IBM Plex Mono",ui-monospace,monospace}
+  font:500 12px/1.45 var(--f-mono)}
 .sf-diagnostic__status:empty{display:none}
 .sf-diagnostic__status--ok{color:var(--sf-success)}
 .sf-diagnostic__status--bad{color:var(--sf-blind)}
 .sf-diagnostic__preview{margin-top:8px;border:1px solid var(--sf-line-2);
   background:var(--sf-surface)}
-.sf-diagnostic__preview-label{padding:8px 10px;border-bottom:1px solid var(--sf-line);
-  font:600 11px/1.4 "IBM Plex Mono",ui-monospace,monospace;text-transform:uppercase;
+.sf-diagnostic__preview-label{padding:8px 12px;border-bottom:1px solid var(--sf-line);
+  font:600 11px/1.4 var(--f-mono);text-transform:uppercase;
   letter-spacing:.08em;color:var(--sf-ink-2)}
-.sf-diagnostic__preview pre{max-height:280px;margin:0;padding:10px;overflow:auto;
+.sf-diagnostic__preview pre{max-height:280px;margin:0;padding:12px;overflow:auto;
   background:var(--sf-surface-2);color:var(--sf-ink);white-space:pre-wrap;overflow-wrap:anywhere;
-  font:500 12px/1.5 "IBM Plex Mono",ui-monospace,monospace}
+  font:500 12px/1.5 var(--f-mono)}
 @media(max-width:560px){.sf-diagnostic__receipt{flex-basis:100%!important}}
 </style>"""
 )

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -1,0 +1,234 @@
+"""Optional IPython presentation for retained local diagnostic receipts."""
+
+from __future__ import annotations
+
+import traceback
+import unicodedata
+from collections.abc import Callable, Mapping
+from html import escape
+from typing import Any, cast
+
+from screamingface._environment import running_in_notebook
+from screamingface._ui.style import STYLE
+from screamingface.diagnostic import DiagnosticReceipt
+
+_EXPORT_PATH = "screamingface-diagnostic.json"
+
+_STYLE = (
+    STYLE
+    + """<style>
+.sf-diagnostic-widget.widget-vbox{width:100%!important;max-width:920px!important;
+  margin:0!important;border:0!important;box-shadow:none!important}
+.sf-diagnostic__panel{--sf-diagnostic-solid:var(--sf-danger-solid);
+  --sf-diagnostic-bg:var(--sf-blind-bg);--sf-diagnostic-text:var(--sf-blind);
+  display:grid;grid-template-columns:10px minmax(0,1fr);gap:12px;padding:14px 16px;
+  border:1px solid var(--sf-line-2);border-left:2px solid var(--sf-diagnostic-solid);
+  border-radius:0;background:var(--sf-diagnostic-bg);color:var(--sf-ink)}
+.sf-diagnostic__panel.sf-diagnostic--stopped{--sf-diagnostic-solid:var(--sf-warning-solid);
+  --sf-diagnostic-bg:var(--sf-warning-bg);--sf-diagnostic-text:var(--sf-warning)}
+.sf-diagnostic__mark{width:10px;height:10px;margin-top:5px;background:var(--sf-diagnostic-solid)}
+.sf-diagnostic__eyebrow{font:600 11px/1.4 "IBM Plex Mono",ui-monospace,monospace;
+  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-diagnostic-text)}
+.sf-diagnostic__title{margin-top:4px;font-size:20px;font-weight:600;line-height:1.25}
+.sf-diagnostic__message{margin-top:5px;font-size:14px;line-height:1.45;white-space:pre-wrap}
+.sf-diagnostic__receipt{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;
+  font:500 12px/1.45 "IBM Plex Mono",ui-monospace,monospace;color:var(--sf-ink-2)}
+.sf-diagnostic__receipt code,.sf-diagnostic__trace code{font:inherit;color:var(--sf-ink)}
+.sf-diagnostic__meta,.sf-diagnostic__trace{margin-top:5px;color:var(--sf-ink-2);
+  font-size:12px;line-height:1.45}
+.sf-diagnostic__controls.widget-hbox{display:flex!important;flex-flow:row wrap!important;
+  gap:6px!important;margin:10px 0 0!important}
+.sf-diagnostic-widget .widget-button{height:32px!important;width:auto!important;
+  padding:0 12px!important;
+  border:1px solid var(--sf-line-2)!important;border-radius:0!important;box-shadow:none!important;
+  background:transparent!important;background-image:none!important;color:var(--sf-ink-2)!important;
+  font:600 13px/1 "IBM Plex Mono",ui-monospace,monospace!important;white-space:nowrap}
+.sf-diagnostic-widget .widget-button:hover{background:var(--sf-surface)!important;
+  border-color:var(--sf-ink-2)!important;color:var(--sf-ink)!important}
+.sf-diagnostic-widget .sf-diagnostic__export{background:var(--sf-accent)!important;
+  border-color:var(--sf-accent)!important;color:var(--sf-accent-contrast)!important}
+.sf-diagnostic-widget .sf-diagnostic__export:hover{background:var(--sf-accent-hover)!important;
+  border-color:var(--sf-accent-hover)!important;color:var(--sf-accent-contrast)!important}
+.sf-diagnostic__status{min-height:18px;margin-top:6px;color:var(--sf-ink-2);
+  font:500 12px/1.45 "IBM Plex Mono",ui-monospace,monospace}
+.sf-diagnostic__status--ok{color:var(--sf-success)}
+.sf-diagnostic__status--bad{color:var(--sf-blind)}
+.sf-diagnostic__preview{margin-top:8px;border:1px solid var(--sf-line-2);
+  background:var(--sf-surface)}
+.sf-diagnostic__preview-label{padding:8px 10px;border-bottom:1px solid var(--sf-line);
+  font:600 11px/1.4 "IBM Plex Mono",ui-monospace,monospace;text-transform:uppercase;
+  letter-spacing:.08em;color:var(--sf-ink-2)}
+.sf-diagnostic__preview pre{max-height:280px;margin:0;padding:10px;overflow:auto;
+  background:var(--sf-surface-2);color:var(--sf-ink);white-space:pre-wrap;overflow-wrap:anywhere;
+  font:500 12px/1.5 "IBM Plex Mono",ui-monospace,monospace}
+@media(max-width:560px){.sf-diagnostic__panel{padding:12px}.sf-diagnostic__controls.widget-hbox{
+  flex-direction:column!important;align-items:stretch!important}
+  .sf-diagnostic-widget .widget-button{
+  width:100%!important}}
+</style>"""
+)
+
+
+class _NotebookDiagnosticView:
+    """One local diagnostic panel; actions never leave the kernel."""
+
+    def __init__(self, error: BaseException, receipt: DiagnosticReceipt) -> None:
+        import ipywidgets as widgets
+
+        self._receipt = receipt
+        self._preview_visible = False
+        self._summary: Any = widgets.HTML(value=f"{_STYLE}{_summary_html(error, receipt)}")
+        self._export: Any = widgets.Button(
+            description="Export diagnostic",
+            tooltip="Save this diagnostic as a local JSON file",
+        )
+        self._export.add_class("sf-diagnostic__export")
+        self._export.on_click(self._export_receipt)
+        self._preview_button: Any = widgets.Button(
+            description="Preview diagnostic",
+            tooltip="Show the exact diagnostic JSON held in this kernel",
+        )
+        self._preview_button.on_click(self._toggle_preview)
+        self._controls: Any = widgets.HBox(children=(self._export, self._preview_button))
+        self._controls.add_class("sf-diagnostic__controls")
+        self._status: Any = widgets.HTML(value=_status_html())
+        self._preview: Any = widgets.HTML(value="")
+        self.widget: Any = widgets.VBox(
+            children=(self._summary, self._controls, self._status, self._preview),
+            tooltip="ScreamingFace diagnostic",
+        )
+        self.widget.add_class("sf-ui")
+        self.widget.add_class("sf-diagnostic-widget")
+
+    def _toggle_preview(self, _: object) -> None:
+        self._preview_visible = not self._preview_visible
+        if self._preview_visible:
+            self._preview.value = _preview_html(self._receipt)
+            self._preview_button.description = "Hide diagnostic"
+            self._preview_button.tooltip = "Hide the diagnostic JSON preview"
+        else:
+            self._preview.value = ""
+            self._preview_button.description = "Preview diagnostic"
+            self._preview_button.tooltip = "Show the exact diagnostic JSON held in this kernel"
+
+    def _export_receipt(self, _: object) -> None:
+        try:
+            selected = self._receipt.export(_EXPORT_PATH)
+        except (OSError, ValueError):
+            self._status.value = _status_html(
+                "Could not export the diagnostic. Choose a writable working directory and retry.",
+                state="bad",
+            )
+            return
+        self._status.value = _status_html(f"Exported {selected.name}", state="ok")
+
+
+def _attach_notebook_renderer(error: BaseException, receipt: DiagnosticReceipt) -> None:
+    """Attach one IPython renderer without changing the exception contract."""
+
+    if not running_in_notebook():
+        return
+    if getattr(error, "_screamingface_diagnostic_id", None) is not None:
+        return
+    fallback = _fallback_renderer(error)
+    shown = False
+
+    def render() -> list[str]:
+        nonlocal shown
+        if shown:
+            return []
+        try:
+            _display_notebook_diagnostic(error, receipt)
+        except Exception:
+            # INVARIANT: optional presentation can never hide the operation's real traceback.
+            return fallback()
+        shown = True
+        return []
+
+    # WHY: IPython asks the exception value for this protocol. An instance attachment also covers
+    # raw TypeError/ValueError failures without wrapping them or intercepting unrelated cells.
+    setattr(error, "_screamingface_diagnostic_id", receipt.diagnostic_id)
+    setattr(error, "_render_traceback_", render)
+
+
+def _fallback_renderer(error: BaseException) -> Callable[[], list[str]]:
+    existing = getattr(error, "_render_traceback_", None)
+    if callable(existing):
+        return cast(Callable[[], list[str]], existing)
+
+    def render() -> list[str]:
+        return traceback.format_exception(type(error), error, error.__traceback__)
+
+    return render
+
+
+def _display_notebook_diagnostic(
+    error: BaseException,
+    receipt: DiagnosticReceipt,
+) -> None:
+    from IPython.display import display
+
+    display(_NotebookDiagnosticView(error, receipt).widget)
+
+
+def _summary_html(error: BaseException, receipt: DiagnosticReceipt) -> str:
+    stopped = receipt.outcome in {"interrupted_by_user", "cancelled"}
+    state_class = " sf-diagnostic--stopped" if stopped else ""
+    title = _outcome_title(receipt.outcome)
+    message = _local_message(error)
+    error_document = receipt.to_dict().get("error")
+    code = error_document.get("code") if isinstance(error_document, Mapping) else None
+    identity = (
+        type(error).__name__ if not isinstance(code, str) else f"{type(error).__name__} · {code}"
+    )
+    title_id = f"sf-diagnostic-title-{receipt.diagnostic_id}"
+    return (
+        f"<div class='sf-diagnostic__panel{state_class}' role='alert' "
+        f"aria-labelledby='{escape(title_id, quote=True)}'>"
+        "<span class='sf-diagnostic__mark' aria-hidden='true'></span><div>"
+        "<div class='sf-diagnostic__eyebrow'>Diagnostic</div>"
+        f"<div class='sf-diagnostic__title' id='{escape(title_id, quote=True)}'>"
+        f"{escape(title)}</div>"
+        f"<div class='sf-diagnostic__message'>{escape(message)}</div>"
+        f"<div class='sf-diagnostic__receipt'><span>{escape(identity)}</span>"
+        f"<span>·</span><code>{escape(receipt.diagnostic_id)}</code></div>"
+        "<div class='sf-diagnostic__meta'>Nothing has been sent. This receipt is held only in "
+        "this kernel; restarting discards it.</div>"
+        "<div class='sf-diagnostic__trace'>Run <code>%tb</code> to inspect the original "
+        "traceback.</div></div></div>"
+    )
+
+
+def _outcome_title(outcome: str) -> str:
+    if outcome == "interrupted_by_user":
+        return "Evaluation interrupted"
+    if outcome == "cancelled":
+        return "Evaluation cancelled"
+    return "Evaluation failed"
+
+
+def _local_message(error: BaseException) -> str:
+    value = str(error).strip() or type(error).__name__
+    inert = "".join(
+        " " if unicodedata.category(character).startswith("C") else character for character in value
+    )
+    return " ".join(inert.split())[:500]
+
+
+def _status_html(message: str = "", *, state: str | None = None) -> str:
+    state_class = "" if state is None else f" sf-diagnostic__status--{state}"
+    return (
+        f"<div class='sf-diagnostic__status{state_class}' role='status' "
+        f"aria-live='polite'>{escape(message)}</div>"
+    )
+
+
+def _preview_html(receipt: DiagnosticReceipt) -> str:
+    return (
+        "<div class='sf-diagnostic__preview'>"
+        "<div class='sf-diagnostic__preview-label'>Receipt JSON</div>"
+        f"<pre tabindex='0' aria-label='Diagnostic JSON'>{escape(receipt.to_json())}</pre></div>"
+    )
+
+
+__all__: list[str] = []

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import traceback
-import unicodedata
 from collections.abc import Callable
 from html import escape
 from typing import Any, cast
@@ -17,40 +16,28 @@ _EXPORT_PATH = "screamingface-diagnostic.json"
 _STYLE = (
     STYLE
     + """<style>
-.sf-diagnostic-widget.widget-vbox{width:100%!important;max-width:920px!important;
-  --sf-diagnostic-solid:var(--sf-danger-solid);
-  --sf-diagnostic-bg:var(--sf-blind-bg);--sf-diagnostic-text:var(--sf-blind);
-  gap:0!important;margin:0!important;padding:10px 12px!important;
-  border:1px solid var(--sf-line-2);border-left:2px solid var(--sf-diagnostic-solid);
-  border-radius:0!important;box-shadow:none!important;
-  background:var(--sf-diagnostic-bg);color:var(--sf-ink)}
-.sf-diagnostic-widget.sf-diagnostic--stopped{--sf-diagnostic-solid:var(--sf-warning-solid);
-  --sf-diagnostic-bg:var(--sf-warning-bg);--sf-diagnostic-text:var(--sf-warning)}
-.sf-diagnostic__summary{display:grid;grid-template-columns:10px minmax(0,1fr);gap:10px}
-.sf-diagnostic__mark{width:10px;height:10px;margin-top:4px;background:var(--sf-diagnostic-solid)}
-.sf-diagnostic__title{font-size:16px;font-weight:600;line-height:1.3}
-.sf-diagnostic__message{margin-top:2px;font-size:14px;line-height:1.4;white-space:pre-wrap}
-.sf-diagnostic__footer.widget-hbox{display:flex!important;flex-flow:row wrap!important;
-  align-items:center!important;justify-content:space-between!important;gap:6px 12px!important;
-  margin:7px 0 0 20px!important}
-.sf-diagnostic__footer-meta{flex:1 1 300px!important;min-width:0!important}
-.sf-diagnostic__footer-meta>div>div{display:flex;flex-wrap:wrap;gap:6px;
+.sf-diagnostic-widget{width:fit-content!important;max-width:100%!important;
+  align-items:flex-start!important;gap:0!important;margin:0!important;
+  border:0!important;box-shadow:none!important}
+.sf-diagnostic__toolbar.widget-hbox{display:inline-flex!important;width:fit-content!important;
+  max-width:100%!important;flex-flow:row wrap!important;
+  align-items:center!important;justify-content:flex-start!important;gap:4px 12px!important;
+  margin:0!important;padding:0!important;border:0!important;
+  border-radius:0!important;background:transparent!important;color:var(--sf-ink)}
+.sf-diagnostic__receipt{flex:0 1 auto!important;width:auto!important;min-width:0!important}
+.sf-diagnostic__receipt>div>div{display:flex;flex-wrap:wrap;gap:6px;
   font:500 12px/1.4 "IBM Plex Mono",ui-monospace,monospace;color:var(--sf-ink-2)}
-.sf-diagnostic__footer-meta code{font:inherit;color:var(--sf-ink)}
+.sf-diagnostic__receipt code{font:inherit;color:var(--sf-ink)}
 .sf-diagnostic__controls.widget-hbox{display:flex!important;flex-flow:row wrap!important;
   gap:4px!important;margin:0!important}
-.sf-diagnostic-widget .widget-button{height:28px!important;width:auto!important;
-  padding:0 9px!important;
-  border:1px solid var(--sf-line-2)!important;border-radius:0!important;box-shadow:none!important;
-  background:transparent!important;background-image:none!important;color:var(--sf-ink-2)!important;
+.sf-diagnostic-widget .widget-button{height:24px!important;width:auto!important;
+  padding:0 3px!important;border:0!important;border-radius:0!important;box-shadow:none!important;
+  background:transparent!important;background-image:none!important;color:var(--sf-accent)!important;
+  text-decoration:underline;text-underline-offset:2px;
   font:600 12px/1 "IBM Plex Mono",ui-monospace,monospace!important;white-space:nowrap}
-.sf-diagnostic-widget .widget-button:hover{background:var(--sf-surface)!important;
-  border-color:var(--sf-ink-2)!important;color:var(--sf-ink)!important}
-.sf-diagnostic-widget .sf-diagnostic__export{background:var(--sf-accent)!important;
-  border-color:var(--sf-accent)!important;color:var(--sf-accent-contrast)!important}
-.sf-diagnostic-widget .sf-diagnostic__export:hover{background:var(--sf-accent-hover)!important;
-  border-color:var(--sf-accent-hover)!important;color:var(--sf-accent-contrast)!important}
-.sf-diagnostic__status{margin:5px 0 0 20px;color:var(--sf-ink-2);
+.sf-diagnostic-widget .widget-button:hover{background:transparent!important;
+  color:var(--sf-accent-hover)!important}
+.sf-diagnostic__status{margin-top:4px;color:var(--sf-ink-2);
   font:500 12px/1.45 "IBM Plex Mono",ui-monospace,monospace}
 .sf-diagnostic__status:empty{display:none}
 .sf-diagnostic__status--ok{color:var(--sf-success)}
@@ -63,8 +50,7 @@ _STYLE = (
 .sf-diagnostic__preview pre{max-height:280px;margin:0;padding:10px;overflow:auto;
   background:var(--sf-surface-2);color:var(--sf-ink);white-space:pre-wrap;overflow-wrap:anywhere;
   font:500 12px/1.5 "IBM Plex Mono",ui-monospace,monospace}
-@media(max-width:560px){.sf-diagnostic__footer.widget-hbox{align-items:flex-start!important}
-  .sf-diagnostic__footer-meta{flex-basis:100%!important}}
+@media(max-width:560px){.sf-diagnostic__receipt{flex-basis:100%!important}}
 </style>"""
 )
 
@@ -72,17 +58,17 @@ _STYLE = (
 class _NotebookDiagnosticView:
     """One local diagnostic panel; actions never leave the kernel."""
 
-    def __init__(self, error: BaseException, receipt: DiagnosticReceipt) -> None:
+    def __init__(self, receipt: DiagnosticReceipt) -> None:
         import ipywidgets as widgets
 
         self._receipt = receipt
         self._preview_visible = False
-        self._summary: Any = widgets.HTML(value=f"{_STYLE}{_summary_html(error, receipt)}")
+        self._receipt_html: Any = widgets.HTML(value=f"{_STYLE}{_receipt_html(receipt)}")
+        self._receipt_html.add_class("sf-diagnostic__receipt")
         self._export: Any = widgets.Button(
             description="Export",
             tooltip="Save this diagnostic as a local JSON file",
         )
-        self._export.add_class("sf-diagnostic__export")
         self._export.on_click(self._export_receipt)
         self._preview_button: Any = widgets.Button(
             description="Preview",
@@ -91,20 +77,16 @@ class _NotebookDiagnosticView:
         self._preview_button.on_click(self._toggle_preview)
         self._controls: Any = widgets.HBox(children=(self._export, self._preview_button))
         self._controls.add_class("sf-diagnostic__controls")
-        self._footer_meta: Any = widgets.HTML(value=_footer_html(receipt))
-        self._footer_meta.add_class("sf-diagnostic__footer-meta")
-        self._footer: Any = widgets.HBox(children=(self._footer_meta, self._controls))
-        self._footer.add_class("sf-diagnostic__footer")
+        self._toolbar: Any = widgets.HBox(children=(self._receipt_html, self._controls))
+        self._toolbar.add_class("sf-diagnostic__toolbar")
         self._status: Any = widgets.HTML(value=_status_html())
         self._preview: Any = widgets.HTML(value="")
         # INVARIANT: VBox has no description; a truthy tooltip crashes JupyterLab's VBoxView.
         self.widget: Any = widgets.VBox(
-            children=(self._summary, self._footer, self._status, self._preview),
+            children=(self._toolbar, self._status, self._preview),
         )
         self.widget.add_class("sf-ui")
         self.widget.add_class("sf-diagnostic-widget")
-        if receipt.outcome in {"interrupted_by_user", "cancelled"}:
-            self.widget.add_class("sf-diagnostic--stopped")
 
     def _toggle_preview(self, _: object) -> None:
         self._preview_visible = not self._preview_visible
@@ -144,7 +126,7 @@ def _attach_notebook_renderer(error: BaseException, receipt: DiagnosticReceipt) 
         if shown:
             return []
         try:
-            _display_notebook_diagnostic(error, receipt)
+            _display_notebook_diagnostic(receipt)
         except Exception:
             # INVARIANT: optional presentation can never hide the operation's real traceback.
             return fallback()
@@ -169,33 +151,20 @@ def _fallback_renderer(error: BaseException) -> Callable[[], list[str]]:
 
 
 def _display_notebook_diagnostic(
-    error: BaseException,
     receipt: DiagnosticReceipt,
 ) -> None:
     from IPython.display import display
 
-    display(_NotebookDiagnosticView(error, receipt).widget)
+    display(_NotebookDiagnosticView(receipt).widget)
 
 
-def _summary_html(error: BaseException, receipt: DiagnosticReceipt) -> str:
-    title = _outcome_title(receipt.outcome)
-    message = _local_message(error)
-    title_id = f"sf-diagnostic-title-{receipt.diagnostic_id}"
+def _receipt_html(receipt: DiagnosticReceipt) -> str:
+    diagnostic_id = escape(receipt.diagnostic_id, quote=True)
+    visible_id = escape(_visible_diagnostic_id(receipt.diagnostic_id))
     return (
-        f"<div class='sf-diagnostic__summary' role='alert' "
-        f"aria-labelledby='{escape(title_id, quote=True)}'>"
-        "<span class='sf-diagnostic__mark' aria-hidden='true'></span><div>"
-        f"<div class='sf-diagnostic__title' id='{escape(title_id, quote=True)}'>"
-        f"{escape(title)}</div>"
-        f"<div class='sf-diagnostic__message'>{escape(message)}</div>"
-        "</div></div>"
-    )
-
-
-def _footer_html(receipt: DiagnosticReceipt) -> str:
-    return (
-        "<div>"
-        f"<code>{escape(receipt.diagnostic_id)}</code>"
+        "<div role='group' aria-label='ScreamingFace diagnostic receipt'>"
+        f"<code title='{diagnostic_id}' aria-label='Diagnostic ID {diagnostic_id}'>"
+        f"{visible_id}</code>"
         "<span>·</span><span aria-label='Local only; cleared when this kernel restarts'>"
         "local only</span><span>·</span>"
         "<code title='Inspect the original traceback'>%tb</code>"
@@ -203,20 +172,10 @@ def _footer_html(receipt: DiagnosticReceipt) -> str:
     )
 
 
-def _outcome_title(outcome: str) -> str:
-    if outcome == "interrupted_by_user":
-        return "Evaluation interrupted"
-    if outcome == "cancelled":
-        return "Evaluation cancelled"
-    return "Evaluation failed"
-
-
-def _local_message(error: BaseException) -> str:
-    value = str(error).strip() or type(error).__name__
-    inert = "".join(
-        " " if unicodedata.category(character).startswith("C") else character for character in value
-    )
-    return " ".join(inert.split())[:500]
+def _visible_diagnostic_id(diagnostic_id: str) -> str:
+    if len(diagnostic_id) <= 14:
+        return diagnostic_id
+    return f"{diagnostic_id[:9]}…{diagnostic_id[-4:]}"
 
 
 def _status_html(message: str = "", *, state: str | None = None) -> str:

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -93,9 +93,9 @@ class _NotebookDiagnosticView:
         self._controls.add_class("sf-diagnostic__controls")
         self._status: Any = widgets.HTML(value=_status_html())
         self._preview: Any = widgets.HTML(value="")
+        # INVARIANT: VBox has no description; a truthy tooltip crashes JupyterLab's VBoxView.
         self.widget: Any = widgets.VBox(
             children=(self._summary, self._controls, self._status, self._preview),
-            tooltip="ScreamingFace diagnostic",
         )
         self.widget.add_class("sf-ui")
         self.widget.add_class("sf-diagnostic-widget")

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import traceback
 from collections.abc import Callable
 from html import escape
@@ -9,9 +10,10 @@ from typing import Any, cast
 
 from screamingface._environment import running_in_notebook
 from screamingface._ui.style import STYLE
-from screamingface.diagnostic import DiagnosticReceipt
+from screamingface.diagnostic import DiagnosticReceipt, _export_guidance
 
 _EXPORT_PATH = "screamingface-diagnostic.json"
+_logger = logging.getLogger(__name__)
 
 _STYLE = (
     STYLE
@@ -132,19 +134,24 @@ def _attach_notebook_renderer(error: BaseException, receipt: DiagnosticReceipt) 
     if getattr(error, "_screamingface_diagnostic_id", None) is not None:
         return
     fallback = _fallback_renderer(error)
-    shown = False
+    attempted = False
+    presentation_failed = False
 
     def render() -> list[str]:
-        nonlocal shown
-        if not shown:
+        nonlocal attempted, presentation_failed
+        if not attempted:
+            attempted = True
             try:
                 _display_notebook_diagnostic(receipt)
             except Exception:
-                # INVARIANT: optional presentation can never hide the operation's real traceback.
-                return fallback()
-            shown = True
+                presentation_failed = True
+                # INVARIANT: log adapter failure, never the retained receipt or its contents.
+                _logger.exception("ScreamingFace diagnostic presentation failed")
         # INVARIANT: the toolbar is additive; IPython uses these lines as the native traceback.
-        return fallback()
+        rendered = fallback()
+        if presentation_failed:
+            return [*rendered, f"\n{_export_guidance(receipt)}\n"]
+        return rendered
 
     # WHY: IPython asks the exception value for this protocol. An instance attachment also covers
     # raw TypeError/ValueError failures without wrapping them or intercepting unrelated cells.

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import traceback
 import unicodedata
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from html import escape
 from typing import Any, cast
 
@@ -18,39 +18,41 @@ _STYLE = (
     STYLE
     + """<style>
 .sf-diagnostic-widget.widget-vbox{width:100%!important;max-width:920px!important;
-  margin:0!important;border:0!important;box-shadow:none!important}
-.sf-diagnostic__panel{--sf-diagnostic-solid:var(--sf-danger-solid);
+  --sf-diagnostic-solid:var(--sf-danger-solid);
   --sf-diagnostic-bg:var(--sf-blind-bg);--sf-diagnostic-text:var(--sf-blind);
-  display:grid;grid-template-columns:10px minmax(0,1fr);gap:12px;padding:14px 16px;
+  gap:0!important;margin:0!important;padding:10px 12px!important;
   border:1px solid var(--sf-line-2);border-left:2px solid var(--sf-diagnostic-solid);
-  border-radius:0;background:var(--sf-diagnostic-bg);color:var(--sf-ink)}
-.sf-diagnostic__panel.sf-diagnostic--stopped{--sf-diagnostic-solid:var(--sf-warning-solid);
+  border-radius:0!important;box-shadow:none!important;
+  background:var(--sf-diagnostic-bg);color:var(--sf-ink)}
+.sf-diagnostic-widget.sf-diagnostic--stopped{--sf-diagnostic-solid:var(--sf-warning-solid);
   --sf-diagnostic-bg:var(--sf-warning-bg);--sf-diagnostic-text:var(--sf-warning)}
-.sf-diagnostic__mark{width:10px;height:10px;margin-top:5px;background:var(--sf-diagnostic-solid)}
-.sf-diagnostic__eyebrow{font:600 11px/1.4 "IBM Plex Mono",ui-monospace,monospace;
-  text-transform:uppercase;letter-spacing:.08em;color:var(--sf-diagnostic-text)}
-.sf-diagnostic__title{margin-top:4px;font-size:20px;font-weight:600;line-height:1.25}
-.sf-diagnostic__message{margin-top:5px;font-size:14px;line-height:1.45;white-space:pre-wrap}
-.sf-diagnostic__receipt{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;
-  font:500 12px/1.45 "IBM Plex Mono",ui-monospace,monospace;color:var(--sf-ink-2)}
-.sf-diagnostic__receipt code,.sf-diagnostic__trace code{font:inherit;color:var(--sf-ink)}
-.sf-diagnostic__meta,.sf-diagnostic__trace{margin-top:5px;color:var(--sf-ink-2);
-  font-size:12px;line-height:1.45}
+.sf-diagnostic__summary{display:grid;grid-template-columns:10px minmax(0,1fr);gap:10px}
+.sf-diagnostic__mark{width:10px;height:10px;margin-top:4px;background:var(--sf-diagnostic-solid)}
+.sf-diagnostic__title{font-size:16px;font-weight:600;line-height:1.3}
+.sf-diagnostic__message{margin-top:2px;font-size:14px;line-height:1.4;white-space:pre-wrap}
+.sf-diagnostic__footer.widget-hbox{display:flex!important;flex-flow:row wrap!important;
+  align-items:center!important;justify-content:space-between!important;gap:6px 12px!important;
+  margin:7px 0 0 20px!important}
+.sf-diagnostic__footer-meta{flex:1 1 300px!important;min-width:0!important}
+.sf-diagnostic__footer-meta>div>div{display:flex;flex-wrap:wrap;gap:6px;
+  font:500 12px/1.4 "IBM Plex Mono",ui-monospace,monospace;color:var(--sf-ink-2)}
+.sf-diagnostic__footer-meta code{font:inherit;color:var(--sf-ink)}
 .sf-diagnostic__controls.widget-hbox{display:flex!important;flex-flow:row wrap!important;
-  gap:6px!important;margin:10px 0 0!important}
-.sf-diagnostic-widget .widget-button{height:32px!important;width:auto!important;
-  padding:0 12px!important;
+  gap:4px!important;margin:0!important}
+.sf-diagnostic-widget .widget-button{height:28px!important;width:auto!important;
+  padding:0 9px!important;
   border:1px solid var(--sf-line-2)!important;border-radius:0!important;box-shadow:none!important;
   background:transparent!important;background-image:none!important;color:var(--sf-ink-2)!important;
-  font:600 13px/1 "IBM Plex Mono",ui-monospace,monospace!important;white-space:nowrap}
+  font:600 12px/1 "IBM Plex Mono",ui-monospace,monospace!important;white-space:nowrap}
 .sf-diagnostic-widget .widget-button:hover{background:var(--sf-surface)!important;
   border-color:var(--sf-ink-2)!important;color:var(--sf-ink)!important}
 .sf-diagnostic-widget .sf-diagnostic__export{background:var(--sf-accent)!important;
   border-color:var(--sf-accent)!important;color:var(--sf-accent-contrast)!important}
 .sf-diagnostic-widget .sf-diagnostic__export:hover{background:var(--sf-accent-hover)!important;
   border-color:var(--sf-accent-hover)!important;color:var(--sf-accent-contrast)!important}
-.sf-diagnostic__status{min-height:18px;margin-top:6px;color:var(--sf-ink-2);
+.sf-diagnostic__status{margin:5px 0 0 20px;color:var(--sf-ink-2);
   font:500 12px/1.45 "IBM Plex Mono",ui-monospace,monospace}
+.sf-diagnostic__status:empty{display:none}
 .sf-diagnostic__status--ok{color:var(--sf-success)}
 .sf-diagnostic__status--bad{color:var(--sf-blind)}
 .sf-diagnostic__preview{margin-top:8px;border:1px solid var(--sf-line-2);
@@ -61,10 +63,8 @@ _STYLE = (
 .sf-diagnostic__preview pre{max-height:280px;margin:0;padding:10px;overflow:auto;
   background:var(--sf-surface-2);color:var(--sf-ink);white-space:pre-wrap;overflow-wrap:anywhere;
   font:500 12px/1.5 "IBM Plex Mono",ui-monospace,monospace}
-@media(max-width:560px){.sf-diagnostic__panel{padding:12px}.sf-diagnostic__controls.widget-hbox{
-  flex-direction:column!important;align-items:stretch!important}
-  .sf-diagnostic-widget .widget-button{
-  width:100%!important}}
+@media(max-width:560px){.sf-diagnostic__footer.widget-hbox{align-items:flex-start!important}
+  .sf-diagnostic__footer-meta{flex-basis:100%!important}}
 </style>"""
 )
 
@@ -79,36 +79,42 @@ class _NotebookDiagnosticView:
         self._preview_visible = False
         self._summary: Any = widgets.HTML(value=f"{_STYLE}{_summary_html(error, receipt)}")
         self._export: Any = widgets.Button(
-            description="Export diagnostic",
+            description="Export",
             tooltip="Save this diagnostic as a local JSON file",
         )
         self._export.add_class("sf-diagnostic__export")
         self._export.on_click(self._export_receipt)
         self._preview_button: Any = widgets.Button(
-            description="Preview diagnostic",
+            description="Preview",
             tooltip="Show the exact diagnostic JSON held in this kernel",
         )
         self._preview_button.on_click(self._toggle_preview)
         self._controls: Any = widgets.HBox(children=(self._export, self._preview_button))
         self._controls.add_class("sf-diagnostic__controls")
+        self._footer_meta: Any = widgets.HTML(value=_footer_html(receipt))
+        self._footer_meta.add_class("sf-diagnostic__footer-meta")
+        self._footer: Any = widgets.HBox(children=(self._footer_meta, self._controls))
+        self._footer.add_class("sf-diagnostic__footer")
         self._status: Any = widgets.HTML(value=_status_html())
         self._preview: Any = widgets.HTML(value="")
         # INVARIANT: VBox has no description; a truthy tooltip crashes JupyterLab's VBoxView.
         self.widget: Any = widgets.VBox(
-            children=(self._summary, self._controls, self._status, self._preview),
+            children=(self._summary, self._footer, self._status, self._preview),
         )
         self.widget.add_class("sf-ui")
         self.widget.add_class("sf-diagnostic-widget")
+        if receipt.outcome in {"interrupted_by_user", "cancelled"}:
+            self.widget.add_class("sf-diagnostic--stopped")
 
     def _toggle_preview(self, _: object) -> None:
         self._preview_visible = not self._preview_visible
         if self._preview_visible:
             self._preview.value = _preview_html(self._receipt)
-            self._preview_button.description = "Hide diagnostic"
+            self._preview_button.description = "Hide"
             self._preview_button.tooltip = "Hide the diagnostic JSON preview"
         else:
             self._preview.value = ""
-            self._preview_button.description = "Preview diagnostic"
+            self._preview_button.description = "Preview"
             self._preview_button.tooltip = "Show the exact diagnostic JSON held in this kernel"
 
     def _export_receipt(self, _: object) -> None:
@@ -172,30 +178,28 @@ def _display_notebook_diagnostic(
 
 
 def _summary_html(error: BaseException, receipt: DiagnosticReceipt) -> str:
-    stopped = receipt.outcome in {"interrupted_by_user", "cancelled"}
-    state_class = " sf-diagnostic--stopped" if stopped else ""
     title = _outcome_title(receipt.outcome)
     message = _local_message(error)
-    error_document = receipt.to_dict().get("error")
-    code = error_document.get("code") if isinstance(error_document, Mapping) else None
-    identity = (
-        type(error).__name__ if not isinstance(code, str) else f"{type(error).__name__} · {code}"
-    )
     title_id = f"sf-diagnostic-title-{receipt.diagnostic_id}"
     return (
-        f"<div class='sf-diagnostic__panel{state_class}' role='alert' "
+        f"<div class='sf-diagnostic__summary' role='alert' "
         f"aria-labelledby='{escape(title_id, quote=True)}'>"
         "<span class='sf-diagnostic__mark' aria-hidden='true'></span><div>"
-        "<div class='sf-diagnostic__eyebrow'>Diagnostic</div>"
         f"<div class='sf-diagnostic__title' id='{escape(title_id, quote=True)}'>"
         f"{escape(title)}</div>"
         f"<div class='sf-diagnostic__message'>{escape(message)}</div>"
-        f"<div class='sf-diagnostic__receipt'><span>{escape(identity)}</span>"
-        f"<span>·</span><code>{escape(receipt.diagnostic_id)}</code></div>"
-        "<div class='sf-diagnostic__meta'>Nothing has been sent. This receipt is held only in "
-        "this kernel; restarting discards it.</div>"
-        "<div class='sf-diagnostic__trace'>Run <code>%tb</code> to inspect the original "
-        "traceback.</div></div></div>"
+        "</div></div>"
+    )
+
+
+def _footer_html(receipt: DiagnosticReceipt) -> str:
+    return (
+        "<div>"
+        f"<code>{escape(receipt.diagnostic_id)}</code>"
+        "<span>·</span><span aria-label='Local only; cleared when this kernel restarts'>"
+        "local only</span><span>·</span>"
+        "<code title='Inspect the original traceback'>%tb</code>"
+        "</div>"
     )
 
 

--- a/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
+++ b/packages/screamingface/src/screamingface/_ui/diagnostic_view.py
@@ -16,9 +16,9 @@ _EXPORT_PATH = "screamingface-diagnostic.json"
 _STYLE = (
     STYLE
     + """<style>
-.sf-diagnostic-widget{width:fit-content!important;max-width:100%!important;
+.sf-diagnostic-widget{max-width:100%!important;
   align-items:flex-start!important;gap:0!important;margin:0!important;
-  border:0!important;box-shadow:none!important}
+  border:0!important;background:transparent!important;box-shadow:none!important}
 .sf-diagnostic__toolbar.widget-hbox{display:inline-flex!important;width:fit-content!important;
   max-width:100%!important;flex-flow:row wrap!important;
   align-items:center!important;justify-content:flex-start!important;gap:4px 12px!important;
@@ -47,6 +47,9 @@ _STYLE = (
 .sf-diagnostic__preview-label{padding:8px 12px;border-bottom:1px solid var(--sf-line);
   font:600 11px/1.4 var(--f-mono);text-transform:uppercase;
   letter-spacing:.08em;color:var(--sf-ink-2)}
+.sf-diagnostic__preview-guidance{padding:8px 12px;border-bottom:1px solid var(--sf-line);
+  color:var(--sf-ink-2);font:500 12px/1.45 var(--f-mono)}
+.sf-diagnostic__preview-guidance code{font:inherit;color:var(--sf-ink)}
 .sf-diagnostic__preview pre{max-height:280px;margin:0;padding:12px;overflow:auto;
   background:var(--sf-surface-2);color:var(--sf-ink);white-space:pre-wrap;overflow-wrap:anywhere;
   font:500 12px/1.5 var(--f-mono)}
@@ -66,21 +69,27 @@ class _NotebookDiagnosticView:
         self._receipt_html: Any = widgets.HTML(value=f"{_STYLE}{_receipt_html(receipt)}")
         self._receipt_html.add_class("sf-diagnostic__receipt")
         self._export: Any = widgets.Button(
-            description="Export",
+            description="Save JSON",
             tooltip="Save this diagnostic as a local JSON file",
         )
         self._export.on_click(self._export_receipt)
         self._preview_button: Any = widgets.Button(
-            description="Preview",
+            description="View details",
             tooltip="Show the exact diagnostic JSON held in this kernel",
         )
         self._preview_button.on_click(self._toggle_preview)
-        self._controls: Any = widgets.HBox(children=(self._export, self._preview_button))
+        self._controls: Any = widgets.HBox(children=(self._preview_button, self._export))
         self._controls.add_class("sf-diagnostic__controls")
         self._toolbar: Any = widgets.HBox(children=(self._receipt_html, self._controls))
         self._toolbar.add_class("sf-diagnostic__toolbar")
-        self._status: Any = widgets.HTML(value=_status_html())
-        self._preview: Any = widgets.HTML(value="")
+        self._status: Any = widgets.HTML(
+            value=_status_html(),
+            layout=widgets.Layout(display="none"),
+        )
+        self._preview: Any = widgets.HTML(
+            value="",
+            layout=widgets.Layout(display="none"),
+        )
         # INVARIANT: VBox has no description; a truthy tooltip crashes JupyterLab's VBoxView.
         self.widget: Any = widgets.VBox(
             children=(self._toolbar, self._status, self._preview),
@@ -92,11 +101,13 @@ class _NotebookDiagnosticView:
         self._preview_visible = not self._preview_visible
         if self._preview_visible:
             self._preview.value = _preview_html(self._receipt)
-            self._preview_button.description = "Hide"
+            self._preview.layout.display = "block"
+            self._preview_button.description = "Hide details"
             self._preview_button.tooltip = "Hide the diagnostic JSON preview"
         else:
             self._preview.value = ""
-            self._preview_button.description = "Preview"
+            self._preview.layout.display = "none"
+            self._preview_button.description = "View details"
             self._preview_button.tooltip = "Show the exact diagnostic JSON held in this kernel"
 
     def _export_receipt(self, _: object) -> None:
@@ -104,11 +115,13 @@ class _NotebookDiagnosticView:
             selected = self._receipt.export(_EXPORT_PATH)
         except (OSError, ValueError):
             self._status.value = _status_html(
-                "Could not export the diagnostic. Choose a writable working directory and retry.",
+                "Could not save the diagnostic. Choose a writable working directory and retry.",
                 state="bad",
             )
+            self._status.layout.display = "block"
             return
-        self._status.value = _status_html(f"Exported {selected.name}", state="ok")
+        self._status.value = _status_html(f"Saved to {selected}", state="ok")
+        self._status.layout.display = "block"
 
 
 def _attach_notebook_renderer(error: BaseException, receipt: DiagnosticReceipt) -> None:
@@ -163,12 +176,9 @@ def _receipt_html(receipt: DiagnosticReceipt) -> str:
     visible_id = escape(_visible_diagnostic_id(receipt.diagnostic_id))
     return (
         "<div role='group' aria-label='ScreamingFace diagnostic receipt'>"
+        "<span>Diagnostic</span>"
         f"<code title='{diagnostic_id}' aria-label='Diagnostic ID {diagnostic_id}'>"
-        f"{visible_id}</code>"
-        "<span>·</span><span aria-label='Local only; cleared when this kernel restarts'>"
-        "local only</span><span>·</span>"
-        "<code title='Inspect the original traceback'>%tb</code>"
-        "</div>"
+        f"{visible_id}</code></div>"
     )
 
 
@@ -190,6 +200,9 @@ def _preview_html(receipt: DiagnosticReceipt) -> str:
     return (
         "<div class='sf-diagnostic__preview'>"
         "<div class='sf-diagnostic__preview-label'>Receipt JSON</div>"
+        "<div class='sf-diagnostic__preview-guidance'>"
+        "Stored in this runtime until restart. "
+        "Run <code>%tb</code> in another cell for the full traceback.</div>"
         f"<pre tabindex='0' aria-label='Diagnostic JSON'>{escape(receipt.to_json())}</pre></div>"
     )
 

--- a/packages/screamingface/src/screamingface/_ui/style.py
+++ b/packages/screamingface/src/screamingface/_ui/style.py
@@ -89,8 +89,10 @@ def _theme_rules(selector: str, light: str, dark: str) -> str:
 STYLE = f"""<style>
 .sf-ui{{
   {_LIGHT};
+  --f-sans:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+  --f-mono:"IBM Plex Mono",ui-monospace,monospace;
   max-width:920px;color:var(--sf-ink);background:var(--sf-bg);
-  font-family:"IBM Plex Sans",system-ui,-apple-system,"Segoe UI",sans-serif;
+  font-family:var(--f-sans);
   font-size:13px;line-height:1.45;
 }}
 {_theme_rules(".sf-ui", _LIGHT, _DARK)}

--- a/packages/screamingface/src/screamingface/client.py
+++ b/packages/screamingface/src/screamingface/client.py
@@ -236,15 +236,15 @@ class Client:
 
         self._require_open()
         if isinstance(candidates, str):
-            _raw_url4_options(benchmark, limit)
             return evaluate_url4_sync(
                 self._transport,
                 candidates,
+                benchmark,
+                limit,
                 on_event,
                 progress,
+                engine_url=self._engine_url,
             )
-        if benchmark is None:
-            raise TypeError("benchmark is required when evaluating Recipes")
         return evaluate_sync(
             self._benchmark_resources.load,
             self._transport,
@@ -255,6 +255,7 @@ class Client:
             limit,
             on_event,
             progress,
+            engine_url=self._engine_url,
         )
 
     @overload
@@ -560,15 +561,15 @@ class AsyncClient:
 
         self._require_open()
         if isinstance(candidates, str):
-            _raw_url4_options(benchmark, limit)
             return await evaluate_url4_async(
                 self._transport,
                 candidates,
+                benchmark,
+                limit,
                 on_event,
                 progress,
+                engine_url=self._engine_url,
             )
-        if benchmark is None:
-            raise TypeError("benchmark is required when evaluating Recipes")
         return await evaluate_async(
             self._benchmark_resources.load,
             self._transport,
@@ -579,6 +580,7 @@ class AsyncClient:
             limit,
             on_event,
             progress,
+            engine_url=self._engine_url,
         )
 
     @overload
@@ -667,13 +669,6 @@ class AsyncClient:
             headers=headers,
             extensions={_REPLAY_SAFE: replay_safe},
         )
-
-
-def _raw_url4_options(benchmark: str | None, limit: int | None) -> None:
-    if benchmark is not None:
-        raise TypeError("benchmark must not be passed when evaluating a complete URL4")
-    if limit is not None:
-        raise TypeError("limit must not be passed when evaluating a complete URL4")
 
 
 def _engine_access_discovery_error(origin: str) -> BaseException:

--- a/packages/screamingface/src/screamingface/diagnostic.py
+++ b/packages/screamingface/src/screamingface/diagnostic.py
@@ -1,0 +1,77 @@
+"""Immutable public local diagnostic receipt."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from os import PathLike
+from pathlib import Path
+from typing import Any
+
+
+class DiagnosticReceipt:
+    """One privacy-safe local record of a failed ScreamingFace operation."""
+
+    __slots__ = ("_document",)
+
+    def __init__(self) -> None:
+        raise TypeError("DiagnosticReceipt values are created by ScreamingFace operations")
+
+    @classmethod
+    def _from_frozen(cls, document: Mapping[str, object]) -> DiagnosticReceipt:
+        value = object.__new__(cls)
+        object.__setattr__(value, "_document", document)
+        return value
+
+    def __setattr__(self, name: str, value: object) -> None:
+        del name, value
+        raise AttributeError("DiagnosticReceipt values are immutable")
+
+    @property
+    def diagnostic_id(self) -> str:
+        return _string_field(self._document, "diagnostic_id")
+
+    @property
+    def session_id(self) -> str:
+        return _string_field(self._document, "session_id")
+
+    @property
+    def outcome(self) -> str:
+        return _string_field(self._document, "outcome")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {key: _thaw(value) for key, value in self._document.items()}
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"))
+
+    def export(self, path: str | PathLike[str] = "diagnostic.json") -> Path:
+        """Write this receipt after an explicit caller action and return its path."""
+
+        selected = Path(path)
+        if selected.suffix.lower() != ".json":
+            raise ValueError("Diagnostic export path must be a .json file")
+        selected.parent.mkdir(parents=True, exist_ok=True)
+        selected.write_text(self.to_json(), encoding="utf-8")
+        return selected
+
+    def __repr__(self) -> str:
+        return f"DiagnosticReceipt({self.diagnostic_id!r}, outcome={self.outcome!r})"
+
+
+def _string_field(document: Mapping[str, object], name: str) -> str:
+    value = document[name]
+    if not isinstance(value, str):
+        raise AssertionError(f"Diagnostic {name} must remain a string")
+    return value
+
+
+def _thaw(value: object) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+__all__ = ["DiagnosticReceipt"]

--- a/packages/screamingface/src/screamingface/diagnostic.py
+++ b/packages/screamingface/src/screamingface/diagnostic.py
@@ -61,6 +61,14 @@ class DiagnosticReceipt:
         return f"DiagnosticReceipt({self.diagnostic_id!r}, outcome={self.outcome!r})"
 
 
+def _export_guidance(receipt: DiagnosticReceipt) -> str:
+    return (
+        f"Diagnostic: {receipt.diagnostic_id}. Export with "
+        f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
+        '"screamingface-diagnostic.json")'
+    )
+
+
 def _string_field(document: Mapping[str, object], name: str) -> str:
     value = document[name]
     if not isinstance(value, str):

--- a/packages/screamingface/src/screamingface/diagnostic.py
+++ b/packages/screamingface/src/screamingface/diagnostic.py
@@ -8,6 +8,8 @@ from os import PathLike
 from pathlib import Path
 from typing import Any
 
+from screamingface._immutable_json import thaw_mapping
+
 
 class DiagnosticReceipt:
     """One privacy-safe local record of a failed ScreamingFace operation."""
@@ -40,7 +42,7 @@ class DiagnosticReceipt:
         return _string_field(self._document, "outcome")
 
     def to_dict(self) -> dict[str, Any]:
-        return {key: _thaw(value) for key, value in self._document.items()}
+        return thaw_mapping(self._document)
 
     def to_json(self) -> str:
         return json.dumps(self.to_dict(), ensure_ascii=False, separators=(",", ":"))
@@ -63,14 +65,6 @@ def _string_field(document: Mapping[str, object], name: str) -> str:
     value = document[name]
     if not isinstance(value, str):
         raise AssertionError(f"Diagnostic {name} must remain a string")
-    return value
-
-
-def _thaw(value: object) -> Any:
-    if isinstance(value, Mapping):
-        return {key: _thaw(item) for key, item in value.items()}
-    if isinstance(value, tuple):
-        return [_thaw(item) for item in value]
     return value
 
 

--- a/packages/screamingface/src/screamingface/diagnostics.py
+++ b/packages/screamingface/src/screamingface/diagnostics.py
@@ -1,0 +1,23 @@
+"""Public lookup for process-local diagnostic receipts."""
+
+from __future__ import annotations
+
+from screamingface._diagnostics.store import _STORE
+from screamingface.diagnostic import DiagnosticReceipt
+
+
+def get(diagnostic_id: str) -> DiagnosticReceipt | None:
+    """Return one retained local diagnostic receipt, if it has not been evicted."""
+
+    if not isinstance(diagnostic_id, str) or not diagnostic_id.strip():
+        raise ValueError("diagnostic_id must be a non-empty string")
+    return _STORE.get(diagnostic_id.strip())
+
+
+def last() -> DiagnosticReceipt | None:
+    """Return the newest retained local diagnostic receipt, if any."""
+
+    return _STORE.last()
+
+
+__all__ = ["get", "last"]

--- a/packages/screamingface/src/screamingface/errors.py
+++ b/packages/screamingface/src/screamingface/errors.py
@@ -61,6 +61,7 @@ class ScreamingFaceError(Exception):
         # read is an id they cannot quote in a report, which is the whole point of holding it.
         if self.trace_id is not None:
             rendered.append(f"Trace: {self.trace_id}")
+        rendered.extend(getattr(self, "__notes__", ()))
         return ["\n".join(rendered)]
 
 

--- a/packages/screamingface/tests/_evaluation_diagnostic_fixtures.py
+++ b/packages/screamingface/tests/_evaluation_diagnostic_fixtures.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import inspect
+import json
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import NoReturn
+
+from _model_parameter_fixtures import details as _model_details
+from url4 import RelExpr, expr, render, src, text
+
+import screamingface as sf
+from screamingface._core.ports import _RunOutcome
+from screamingface._engine.model_parameters import _decode_model_details
+from screamingface._evaluation.benchmark import _BenchmarkResource
+from screamingface._evaluation.model import Candidate
+from screamingface.discovery import ModelInfo
+
+TRACE_ID = "0123456789abcdef0123456789abcdef"
+BENCHMARK_URL4 = render(
+    expr(
+        src(
+            RelExpr(path="/candidate", context="question", intent=text("$candidate")),
+            name="answer",
+            weight=0.0,
+        ),
+        src(
+            RelExpr(path="/provider/judge", context="$answer", intent=text("Grade.")),
+            name="grade",
+            weight=0.0,
+        ),
+        intent=text("$grade"),
+    )
+)
+RESOURCE = _BenchmarkResource(
+    info=sf.BenchmarkInfo(id="draco", revision="fixture-revision", case_count=1),
+    case_count=1,
+    url4=BENCHMARK_URL4,
+)
+
+
+class Catalog:
+    models = (
+        ModelInfo(
+            id="provider/opus",
+            provider="provider",
+            supported_parameters=("max_tokens",),
+        ),
+    )
+
+
+class FailingTransport:
+    def __init__(self, error: BaseException) -> None:
+        self.error = error
+
+    def run(self, candidate: Candidate, on_event: object) -> NoReturn:
+        if callable(on_event):
+            on_event(started(candidate))
+        raise self.error
+
+    def cancel_active(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class AsyncFailingTransport(FailingTransport):
+    async def run(self, candidate: Candidate, on_event: object) -> NoReturn:
+        if callable(on_event):
+            returned = on_event(started(candidate))
+            if inspect.isawaitable(returned):
+                await returned
+        raise self.error
+
+    async def cancel_active(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass
+
+
+class SuccessfulTransport:
+    def run(self, candidate: Candidate, on_event: object) -> _RunOutcome:
+        if callable(on_event):
+            on_event(started(candidate))
+        now = datetime.now(UTC)
+        return _RunOutcome(
+            run_id="internal-stream-topic",
+            started_at=now,
+            completed_at=now,
+            result_body=json.dumps(
+                {
+                    "schema": "screamingface.candidate-result.v1",
+                    "benchmark_id": "draco",
+                    "benchmark_revision": "fixture-revision",
+                    "case_count": 1,
+                    "score": 1.0,
+                    "coverage": 1.0,
+                    "metrics": {},
+                    "cases": [
+                        {
+                            "status": "scored",
+                            "case_id": 1,
+                            "input": "Fixture question",
+                            "output": "Fixture answer",
+                            "finish_reason": "stop",
+                            "refusal": None,
+                            "stop_reason": None,
+                            "rounds_executed": None,
+                            "grade": {
+                                "method": "fixture",
+                                "score": 1.0,
+                                "metrics": {},
+                                "checks": [],
+                            },
+                            "failures": [],
+                            "metadata": {},
+                        }
+                    ],
+                    "failures": [],
+                }
+            ),
+            media_type="application/json",
+            root_usage=None,
+        )
+
+    def cancel_active(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class PartialTransport(SuccessfulTransport):
+    def run(self, candidate: Candidate, on_event: object) -> _RunOutcome:
+        outcome = super().run(candidate, on_event)
+        assert outcome.result_body is not None
+        document = json.loads(outcome.result_body)
+        document["failures"] = [
+            {
+                "stage": "grading",
+                "code": "case_not_graded",
+                "message": "One case could not be graded.",
+                "retryable": None,
+                "case_id": None,
+                "metadata": {},
+            }
+        ]
+        return replace(outcome, result_body=json.dumps(document))
+
+
+def started(
+    candidate: Candidate,
+    *,
+    traceparent: str | None = f"00-{TRACE_ID}-0123456789abcdef-01",
+) -> sf.events.Started:
+    return sf.events.Started(
+        id="event-1",
+        run_id="internal-stream-topic",
+        sequence=1,
+        timestamp=datetime.now(UTC),
+        source="fixture",
+        traceparent=traceparent,
+        url4=candidate.url4,
+    )
+
+
+def load_benchmark(benchmark: str, limit: int | None) -> _BenchmarkResource:
+    assert (benchmark, limit) == ("draco", 1)
+    return RESOURCE
+
+
+async def load_benchmark_async(
+    benchmark: str,
+    limit: int | None,
+) -> _BenchmarkResource:
+    return load_benchmark(benchmark, limit)
+
+
+def load_catalog() -> Catalog:
+    return Catalog()
+
+
+async def load_catalog_async() -> Catalog:
+    return Catalog()
+
+
+def load_details(model: str) -> sf.ModelDetails:
+    return _decode_model_details(_model_details(model), expected_model=model)
+
+
+async def load_details_async(model: str) -> sf.ModelDetails:
+    return load_details(model)
+
+
+def candidate() -> sf.Model:
+    return sf.Model(
+        "provider/opus",
+        prompt="private answer instruction",
+        params={"max_tokens": 64},
+    )
+
+
+__all__ = [
+    "AsyncFailingTransport",
+    "BENCHMARK_URL4",
+    "candidate",
+    "FailingTransport",
+    "load_benchmark",
+    "load_benchmark_async",
+    "load_catalog",
+    "load_catalog_async",
+    "load_details",
+    "load_details_async",
+    "PartialTransport",
+    "RESOURCE",
+    "started",
+    "TRACE_ID",
+]

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -14,6 +14,7 @@
       "Connection",
       "ConnectionPanel",
       "CorrectiveLoop",
+      "DiagnosticReceipt",
       "EngineUnavailableError",
       "EvaluationWarning",
       "Event",
@@ -54,6 +55,7 @@
       "configure",
       "connect",
       "connections",
+      "diagnostics",
       "disconnect",
       "evaluate",
       "events",
@@ -247,6 +249,18 @@
           "members": "field",
           "name": "field",
           "then": "method (self, next_recipe: 'str | Recipe') -> 'Pipeline'"
+        }
+      },
+      "DiagnosticReceipt": {
+        "kind": "class",
+        "members": {
+          "__init__": "method (self) -> 'None'",
+          "diagnostic_id": "property",
+          "export": "method (self, path: 'str | PathLike[str]' = 'diagnostic.json') -> 'Path'",
+          "outcome": "property",
+          "session_id": "property",
+          "to_dict": "method (self) -> 'dict[str, Any]'",
+          "to_json": "method (self) -> 'str'"
         }
       },
       "EngineUnavailableError": {
@@ -695,6 +709,10 @@
       "connections": {
         "kind": "module",
         "module": "screamingface.connections"
+      },
+      "diagnostics": {
+        "kind": "module",
+        "module": "screamingface.diagnostics"
       },
       "disconnect": {
         "kind": "function",

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -814,6 +814,22 @@
       }
     }
   },
+  "screamingface.diagnostics": {
+    "__all__": [
+      "get",
+      "last"
+    ],
+    "exports": {
+      "get": {
+        "kind": "function",
+        "signature": "(diagnostic_id: 'str') -> 'DiagnosticReceipt | None'"
+      },
+      "last": {
+        "kind": "function",
+        "signature": "() -> 'DiagnosticReceipt | None'"
+      }
+    }
+  },
   "screamingface.events": {
     "__all__": [
       "Event",

--- a/packages/screamingface/tests/test_diagnostic_capture.py
+++ b/packages/screamingface/tests/test_diagnostic_capture.py
@@ -126,16 +126,16 @@ def test_default_screamingface_code_is_retained_as_best_effort_evidence() -> Non
     assert document["code"] == "execution_failed"
 
 
-def test_websocket_close_cause_retains_bounded_structured_wire_facts() -> None:
-    cause = ConnectionClosedError(Close(1011, "engine unavailable\n"), None, None)
+def test_websocket_close_cause_retains_only_the_code() -> None:
+    private_reason = "sk-private-must-never-leak"
+    cause = ConnectionClosedError(Close(1011, private_reason), None, None)
     error = ExecutionError("The Engine disconnected.", code="websocket_disconnected")
     error.__cause__ = cause
 
     chain = cast(list[dict[str, object]], _error_document(error)["chain"])
 
-    assert chain[1]["websocket_close"] == {
-        "received": {"code": 1011, "reason": "engine unavailable"}
-    }
+    assert chain[1]["websocket_close"] == {"received": {"code": 1011}}
+    assert private_reason not in json.dumps(chain)
 
 
 def test_engine_capture_retains_only_host_and_locality() -> None:

--- a/packages/screamingface/tests/test_diagnostic_capture.py
+++ b/packages/screamingface/tests/test_diagnostic_capture.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
+from importlib.metadata import PackageNotFoundError
 from typing import cast
 
 import pytest
@@ -13,6 +14,7 @@ from screamingface._diagnostics.capture import (
     _engine_document,
     _error_document,
 )
+from screamingface._version import SOURCE_TREE_VERSION
 from screamingface.errors import ExecutionError
 
 
@@ -182,6 +184,16 @@ def test_client_capture_is_an_allowlist_not_an_environment_dump(monkeypatch) -> 
         "dependencies",
     }
     assert "must-never-leak" not in encoded
+
+
+def test_client_capture_uses_the_canonical_source_tree_version(monkeypatch) -> None:
+    def missing_distribution(_: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr("screamingface._diagnostics.capture.version", missing_distribution)
+    monkeypatch.setattr("screamingface._version.distribution_version", missing_distribution)
+
+    assert _client_document()["version"] == SOURCE_TREE_VERSION
 
 
 def _raise_deep_failure(depth: int) -> None:

--- a/packages/screamingface/tests/test_diagnostic_capture.py
+++ b/packages/screamingface/tests/test_diagnostic_capture.py
@@ -182,3 +182,35 @@ def test_client_capture_is_an_allowlist_not_an_environment_dump(monkeypatch) -> 
         "dependencies",
     }
     assert "must-never-leak" not in encoded
+
+
+def _raise_deep_failure(depth: int) -> None:
+    if depth == 0:
+        raise RuntimeError("private deep failure")
+    _raise_deep_failure(depth - 1)
+
+
+def test_traceback_bound_retains_the_innermost_failure_frame() -> None:
+    try:
+        _raise_deep_failure(40)
+    except RuntimeError as error:
+        traceback = error.__traceback__
+        assert traceback is not None
+        outermost_line = traceback.tb_lineno
+        while traceback.tb_next is not None:
+            traceback = traceback.tb_next
+        innermost = {
+            "module": traceback.tb_frame.f_globals["__name__"],
+            "function": traceback.tb_frame.f_code.co_name,
+            "line": traceback.tb_lineno,
+        }
+        chain = cast(list[dict[str, object]], _error_document(error)["chain"])
+    else:
+        raise AssertionError("deep failure must raise")
+
+    frames = cast(list[dict[str, object]], chain[0]["frames"])
+    assert len(frames) == 32
+    assert frames[-1]["module"] == innermost["module"]
+    assert frames[-1]["function"] == innermost["function"]
+    assert frames[-1]["line"] == innermost["line"]
+    assert frames[0]["line"] != outermost_line

--- a/packages/screamingface/tests/test_diagnostic_capture.py
+++ b/packages/screamingface/tests/test_diagnostic_capture.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import cast
+
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
+
+from screamingface._diagnostics.capture import (
+    _client_document,
+    _engine_document,
+    _error_document,
+)
+from screamingface.errors import ExecutionError
+
+
+def _captured_execution_error() -> ExecutionError:
+    local_api_key = "sk-local-must-never-leak"
+    try:
+        raise RuntimeError("private provider response must never leak")
+    except RuntimeError as cause:
+        error = ExecutionError(
+            "The Engine disconnected.",
+            code="websocket_disconnected",
+            status=503,
+            permanent=False,
+            details={
+                "model": "openrouter/anthropic/claude",
+                "parameter": "max_tokens",
+                "reason": "provider_disabled",
+                "prompt": "private prompt must never leak",
+                "api_key": local_api_key,
+                "nested": {"response": "private response must never leak"},
+            },
+            hint="Retry the operation.",
+        )
+        error.__traceback__ = cause.__traceback__
+        error.__cause__ = cause
+        return error
+
+
+def test_error_capture_is_structured_and_excludes_unsafe_exception_state() -> None:
+    document = _error_document(_captured_execution_error())
+    encoded = json.dumps(document)
+    chain = cast(list[dict[str, object]], document["chain"])
+
+    assert document["type"] == "ExecutionError"
+    assert document["code"] == "websocket_disconnected"
+    assert document["message"] == "The Engine disconnected."
+    assert document["status"] == 503
+    assert document["permanent"] is False
+    assert document["retryable"] is True
+    assert document["hint"] == "Retry the operation."
+    assert document["details"] == {
+        "model": "openrouter/anthropic/claude",
+        "parameter": "max_tokens",
+    }
+    assert chain[0]["type"] == "ExecutionError"
+    assert chain[1]["type"] == "RuntimeError"
+    assert chain[1].get("message") is None
+    frames = cast(list[dict[str, object]], chain[0]["frames"])
+    frame = frames[0]
+    assert set(frame) == {"package", "module", "function", "line"}
+
+    assert "sk-local-must-never-leak" not in encoded
+    assert "private prompt" not in encoded
+    assert "private response" not in encoded
+    assert "private provider response" not in encoded
+    assert __file__ not in encoded
+    assert "raise RuntimeError" not in encoded
+
+
+def test_unknown_error_capture_omits_arbitrary_message_and_attributes() -> None:
+    error = RuntimeError("private arbitrary exception message")
+    error.__dict__["secret"] = "private arbitrary attribute"
+
+    document = _error_document(error)
+    encoded = json.dumps(document)
+
+    assert document["type"] == "RuntimeError"
+    assert "message" not in document
+    assert "private arbitrary" not in encoded
+
+
+def test_unsafe_free_text_in_structured_details_is_not_captured() -> None:
+    error = ExecutionError(
+        "Candidate compilation failed.",
+        code="invalid_candidate_parameter",
+        details={"reason": "private rejected value must never leak"},
+    )
+
+    assert "private rejected value" not in json.dumps(_error_document(error))
+
+
+def test_preflight_reason_code_is_retained_as_reproduction_evidence() -> None:
+    error = ExecutionError(
+        "Parameter is unavailable.",
+        code="unsupported_model_parameter",
+        details={"reason": "provider_disabled"},
+    )
+
+    assert _error_document(error)["details"] == {"reason": "provider_disabled"}
+
+
+def test_default_screamingface_code_is_retained_as_best_effort_evidence() -> None:
+    document = _error_document(ExecutionError("Execution failed."))
+
+    assert document["code"] == "execution_failed"
+
+
+def test_websocket_close_cause_retains_bounded_structured_wire_facts() -> None:
+    cause = ConnectionClosedError(Close(1011, "engine unavailable\n"), None, None)
+    error = ExecutionError("The Engine disconnected.", code="websocket_disconnected")
+    error.__cause__ = cause
+
+    chain = cast(list[dict[str, object]], _error_document(error)["chain"])
+
+    assert chain[1]["websocket_close"] == {
+        "received": {"code": 1011, "reason": "engine unavailable"}
+    }
+
+
+def test_engine_capture_retains_only_host_and_locality() -> None:
+    assert _engine_document(
+        "https://user:password@engine.screamingface.ai/private?token=secret#fragment"
+    ) == {"host": "engine.screamingface.ai", "mode": "hosted"}
+    assert _engine_document("http://127.0.0.1:9108/private") == {
+        "host": "127.0.0.1",
+        "mode": "local",
+    }
+
+
+def test_client_capture_is_an_allowlist_not_an_environment_dump(monkeypatch) -> None:
+    monkeypatch.setenv("SCREAMINGFACE_PRIVATE_TOKEN", "must-never-leak")
+
+    document = _client_document()
+    encoded = json.dumps(document)
+
+    assert document["name"] == "screamingface-python"
+    assert document["version"]
+    assert document["host"] in {"notebook", "cli"}
+    assert set(cast(Mapping[str, object], document["runtime"])) == {"name", "version"}
+    assert set(document) == {
+        "name",
+        "version",
+        "host",
+        "platform",
+        "architecture",
+        "runtime",
+        "dependencies",
+    }
+    assert "must-never-leak" not in encoded

--- a/packages/screamingface/tests/test_diagnostic_capture.py
+++ b/packages/screamingface/tests/test_diagnostic_capture.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Mapping
 from typing import cast
 
+import pytest
 from websockets.exceptions import ConnectionClosedError
 from websockets.frames import Close
 
@@ -146,6 +147,19 @@ def test_engine_capture_retains_only_host_and_locality() -> None:
         "host": "127.0.0.1",
         "mode": "local",
     }
+
+
+@pytest.mark.parametrize(
+    ("engine_url", "host"),
+    [
+        ("http://0.0.0.0:9108", "0.0.0.0"),
+        ("http://127.0.0.42:9108", "127.0.0.42"),
+        ("http://[::]:9108", "::"),
+    ],
+)
+def test_engine_capture_treats_local_ip_aliases_as_local(engine_url: str, host: str) -> None:
+    # INVARIANT: support receipts use the same IP-aware locality semantics as Client UI surfaces.
+    assert _engine_document(engine_url) == {"host": host, "mode": "local"}
 
 
 def test_client_capture_is_an_allowlist_not_an_environment_dump(monkeypatch) -> None:

--- a/packages/screamingface/tests/test_diagnostic_capture.py
+++ b/packages/screamingface/tests/test_diagnostic_capture.py
@@ -47,7 +47,7 @@ def test_error_capture_is_structured_and_excludes_unsafe_exception_state() -> No
 
     assert document["type"] == "ExecutionError"
     assert document["code"] == "websocket_disconnected"
-    assert document["message"] == "The Engine disconnected."
+    assert "message" not in document
     assert document["status"] == 503
     assert document["permanent"] is False
     assert document["retryable"] is True
@@ -57,6 +57,7 @@ def test_error_capture_is_structured_and_excludes_unsafe_exception_state() -> No
         "parameter": "max_tokens",
     }
     assert chain[0]["type"] == "ExecutionError"
+    assert "message" not in chain[0]
     assert chain[1]["type"] == "RuntimeError"
     assert chain[1].get("message") is None
     frames = cast(list[dict[str, object]], chain[0]["frames"])
@@ -81,6 +82,22 @@ def test_unknown_error_capture_omits_arbitrary_message_and_attributes() -> None:
     assert document["type"] == "RuntimeError"
     assert "message" not in document
     assert "private arbitrary" not in encoded
+
+
+def test_typed_error_capture_omits_untrusted_server_message() -> None:
+    private_detail = "Patient Alice Smith has condition X."
+
+    encoded = json.dumps(
+        _error_document(
+            ExecutionError(
+                private_detail,
+                code="engine_problem",
+                status=502,
+            )
+        )
+    )
+
+    assert private_detail not in encoded
 
 
 def test_unsafe_free_text_in_structured_details_is_not_captured() -> None:

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -26,7 +26,7 @@ from _evaluation_diagnostic_fixtures import (
 from IPython.core.interactiveshell import InteractiveShell
 
 import screamingface as sf
-from screamingface._diagnostics.model import _new_receipt
+from screamingface._diagnostics.model import _new_receipt, _ReceiptEvidence
 from screamingface._diagnostics.store import _STORE
 from screamingface._evaluation.runner import evaluate_sync
 from screamingface._ui.diagnostic_view import (
@@ -51,17 +51,19 @@ def _receipt(
     outcome: str = "failed",
 ) -> DiagnosticReceipt:
     return _new_receipt(
-        diagnostic_id=diagnostic_id,
-        session_id="session_example",
-        occurred_at=datetime(2026, 8, 26, 17, 38, tzinfo=UTC),
-        elapsed_seconds=1.25,
-        operation="evaluate",
-        outcome=outcome,
-        client={"name": "screamingface-python", "host": "notebook"},
-        error={"type": "TypeError"},
-        context={"engine": {"host": "engine.example", "mode": "hosted"}},
-        executions=[],
-        breadcrumbs=[],
+        _ReceiptEvidence(
+            diagnostic_id=diagnostic_id,
+            session_id="session_example",
+            occurred_at=datetime(2026, 8, 26, 17, 38, tzinfo=UTC),
+            elapsed_seconds=1.25,
+            operation="evaluate",
+            outcome=outcome,
+            client={"name": "screamingface-python", "host": "notebook"},
+            error={"type": "TypeError"},
+            context={"engine": {"host": "engine.example", "mode": "hosted"}},
+            executions=[],
+            breadcrumbs=[],
+        )
     )
 
 
@@ -112,8 +114,10 @@ def test_evaluation_attaches_one_renderer_to_the_original_raw_exception(
 
     assert caught.value is error
     renderer = getattr(error, "_render_traceback_")
-    assert renderer() == []
-    assert renderer() == []
+    first = renderer()
+    second = renderer()
+    assert "TypeError: benchmark is required" in "".join(first)
+    assert second == first
     receipt = sf.diagnostics.last()
     assert receipt is not None
     assert published == [receipt]
@@ -182,6 +186,29 @@ def test_notebook_renderer_falls_back_to_the_existing_renderer(
     _attach_notebook_renderer(error, _receipt())
 
     assert error._render_traceback_() == expected
+
+
+def test_notebook_renderer_preserves_existing_traceback_after_successful_display(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = sf.ExecutionError("The Engine disconnected.", code="websocket_disconnected")
+    expected = error._render_traceback_()
+    published: list[DiagnosticReceipt] = []
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
+        published.append,
+    )
+    receipt = _receipt()
+
+    _attach_notebook_renderer(error, receipt)
+
+    assert error._render_traceback_() == expected
+    assert error._render_traceback_() == expected
+    assert published == [receipt]
 
 
 def test_raw_exception_fallback_retains_its_python_traceback(
@@ -368,7 +395,8 @@ def test_export_failure_is_reported_inside_the_panel(
 
 def test_panel_uses_sfds_app_tokens_and_colab_theme_contract() -> None:
     assert "border-radius:0" in _STYLE
-    assert "var(--sf-danger-solid)" not in _STYLE
+    assert "var(--sf-danger-solid)" in _STYLE
+    assert "var(--sf-blind)" not in _STYLE.split("<style>")[-1]
     assert "var(--sf-accent)" in _STYLE
     assert "background:var(--sf-gain)" not in _STYLE
     assert ".sf-diagnostic__toolbar.widget-hbox" in _STYLE

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -94,6 +94,10 @@ def test_evaluation_attaches_one_renderer_to_the_original_raw_exception(
         lambda: True,
     )
     monkeypatch.setattr(
+        "screamingface._diagnostics.evaluation.running_in_notebook",
+        lambda: True,
+    )
+    monkeypatch.setattr(
         "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
         published.append,
     )
@@ -113,6 +117,7 @@ def test_evaluation_attaches_one_renderer_to_the_original_raw_exception(
         )
 
     assert caught.value is error
+    assert not getattr(error, "__notes__", ())
     renderer = getattr(error, "_render_traceback_")
     first = renderer()
     second = renderer()
@@ -290,10 +295,11 @@ def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
     html = _html_values(view.widget)
     assert "Evaluation failed" not in html
     assert "benchmark is required" not in html
+    assert "Diagnostic" in html
     assert "diag_example" in html
-    assert "local only" in html
-    assert "aria-label='Local only; cleared when this kernel restarts'" in html
-    assert "%tb" in html
+    assert "local only" not in html
+    assert "%tb" not in html
+    assert "Stored in this runtime" not in html
     assert "sf-diagnostic__eyebrow" not in html
     assert "Nothing has been sent" not in html
     assert "Run <code>%tb</code>" not in html
@@ -303,8 +309,14 @@ def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
     assert set(view.widget._dom_classes) >= {"sf-ui", "sf-diagnostic-widget"}
     # INVARIANT: container tooltips crash JupyterLab's VBoxView because VBox has no description.
     assert view.widget.tooltip is None
-    assert _button(view.widget, "Export").tooltip
-    assert _button(view.widget, "Preview").tooltip
+    assert _button(view.widget, "Save JSON").tooltip
+    assert _button(view.widget, "View details").tooltip
+    assert tuple(button.description for button in view._controls.children) == (
+        "View details",
+        "Save JSON",
+    )
+    assert view._status.layout.display == "none"
+    assert view._preview.layout.display == "none"
     assert any(
         "sf-diagnostic__toolbar" in getattr(item, "_dom_classes", ()) for item in _walk(view.widget)
     )
@@ -344,23 +356,28 @@ def test_toolbar_shortens_only_the_visible_diagnostic_id() -> None:
     assert f"aria-label='Diagnostic ID {diagnostic_id}'" in html
 
 
-def test_preview_reveals_the_exact_receipt_only_after_a_click() -> None:
+def test_view_details_reveals_the_exact_receipt_and_recovery_guidance() -> None:
     receipt = _receipt()
     view = _NotebookDiagnosticView(receipt)
 
-    preview = _button(view.widget, "Preview")
+    details = _button(view.widget, "View details")
     assert receipt.to_json() not in unescape(_html_values(view.widget))
 
-    preview.click()
+    details.click()
 
-    assert receipt.to_json() in unescape(_html_values(view.widget))
-    assert preview.description == "Hide"
-    preview.click()
+    html = unescape(_html_values(view.widget))
+    assert receipt.to_json() in html
+    assert "Stored in this runtime until restart" in html
+    assert "Run <code>%tb</code>" in html
+    assert details.description == "Hide details"
+    assert view._preview.layout.display == "block"
+    details.click()
     assert receipt.to_json() not in unescape(_html_values(view.widget))
-    assert preview.description == "Preview"
+    assert details.description == "View details"
+    assert view._preview.layout.display == "none"
 
 
-def test_export_writes_only_after_an_explicit_click(
+def test_save_json_writes_only_after_an_explicit_click(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -370,13 +387,15 @@ def test_export_writes_only_after_an_explicit_click(
     selected = tmp_path / "screamingface-diagnostic.json"
 
     assert not selected.exists()
-    _button(view.widget, "Export").click()
+    assert view._status.layout.display == "none"
+    _button(view.widget, "Save JSON").click()
 
     assert selected.read_text(encoding="utf-8") == receipt.to_json()
-    assert "Exported screamingface-diagnostic.json" in _html_values(view.widget)
+    assert "Saved to screamingface-diagnostic.json" in _html_values(view.widget)
+    assert view._status.layout.display == "block"
 
 
-def test_export_failure_is_reported_inside_the_panel(
+def test_save_json_failure_is_reported_inside_the_panel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def unavailable_export(self: DiagnosticReceipt, path: object) -> Any:
@@ -386,11 +405,12 @@ def test_export_failure_is_reported_inside_the_panel(
     monkeypatch.setattr(DiagnosticReceipt, "export", unavailable_export)
     view = _NotebookDiagnosticView(_receipt())
 
-    _button(view.widget, "Export").click()
+    _button(view.widget, "Save JSON").click()
 
     html = _html_values(view.widget)
-    assert "Could not export the diagnostic" in html
+    assert "Could not save the diagnostic" in html
     assert "read-only filesystem" not in html
+    assert view._status.layout.display == "block"
 
 
 def test_panel_uses_sfds_app_tokens_and_colab_theme_contract() -> None:
@@ -411,8 +431,10 @@ def test_panel_uses_sfds_app_tokens_and_colab_theme_contract() -> None:
 
 
 def test_receipt_toolbar_is_unboxed_supporting_evidence() -> None:
+    root_rule = _STYLE.split(".sf-diagnostic-widget", 1)[1].split("}", 1)[0]
     toolbar_rule = _STYLE.split(".sf-diagnostic__toolbar.widget-hbox", 1)[1].split("}", 1)[0]
 
+    assert "background:transparent!important" in root_rule
     assert "border:0!important" in toolbar_rule
     assert "background:transparent!important" in toolbar_rule
     assert "padding:0!important" in toolbar_rule
@@ -426,3 +448,13 @@ def test_diagnostic_style_uses_sfds_font_and_spacing_tokens() -> None:
     assert "gap:6px" not in diagnostic_rules
     assert "padding:0 3px" not in diagnostic_rules
     assert "padding:10px" not in diagnostic_rules
+
+
+def test_colab_root_does_not_shrink_wrap_the_content_hugging_toolbar() -> None:
+    root_rule = _STYLE.split(".sf-diagnostic-widget", 1)[1].split("}", 1)[0]
+    toolbar_rule = _STYLE.split(".sf-diagnostic__toolbar.widget-hbox", 1)[1].split("}", 1)[0]
+
+    # INVARIANT: Colab collapses nested fit-content flex containers even though their children
+    # render independently. Only the visible toolbar should hug its content.
+    assert "width:fit-content" not in root_rule
+    assert "width:fit-content" in toolbar_rule

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -179,6 +179,7 @@ def test_notebook_renderer_falls_back_to_the_existing_renderer(
 ) -> None:
     error = sf.ExecutionError("The Engine disconnected.", code="websocket_disconnected")
     expected = error._render_traceback_()
+    receipt = _receipt()
     monkeypatch.setattr(
         "screamingface._ui.diagnostic_view.running_in_notebook",
         lambda: True,
@@ -188,9 +189,58 @@ def test_notebook_renderer_falls_back_to_the_existing_renderer(
         lambda receipt: (_ for _ in ()).throw(RuntimeError("display unavailable")),
     )
 
-    _attach_notebook_renderer(error, _receipt())
+    _attach_notebook_renderer(error, receipt)
 
-    assert error._render_traceback_() == expected
+    rendered = error._render_traceback_()
+    assert rendered[: len(expected)] == expected
+    recovery = "".join(rendered[len(expected) :])
+    assert recovery.count(receipt.diagnostic_id) == 2
+    assert (
+        f'sf.diagnostics.get("{receipt.diagnostic_id}").export("screamingface-diagnostic.json")'
+    ) in recovery
+
+
+def test_failed_notebook_display_is_logged_without_receipt_and_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    error = TypeError("benchmark is required")
+    receipt = _receipt(diagnostic_id="diag_private_evidence")
+    attempts = 0
+
+    def fail_display(selected: DiagnosticReceipt) -> None:
+        nonlocal attempts
+        assert selected is receipt
+        attempts += 1
+        raise RuntimeError("display unavailable")
+
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
+        fail_display,
+    )
+
+    _attach_notebook_renderer(error, receipt)
+
+    first = getattr(error, "_render_traceback_")()
+    second = getattr(error, "_render_traceback_")()
+    assert second == first
+    assert attempts == 1
+    assert "".join(first).count("Diagnostic: ") == 1
+    assert (
+        len(
+            [
+                record
+                for record in caplog.records
+                if record.message == "ScreamingFace diagnostic presentation failed"
+            ]
+        )
+        == 1
+    )
+    assert receipt.to_json() not in caplog.text
 
 
 def test_notebook_renderer_preserves_existing_traceback_after_successful_display(

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -45,9 +45,13 @@ def _empty_diagnostics() -> Generator[None, None, None]:
     _STORE.clear()
 
 
-def _receipt(*, outcome: str = "failed") -> DiagnosticReceipt:
+def _receipt(
+    *,
+    diagnostic_id: str = "diag_example",
+    outcome: str = "failed",
+) -> DiagnosticReceipt:
     return _new_receipt(
-        diagnostic_id="diag_example",
+        diagnostic_id=diagnostic_id,
         session_id="session_example",
         occurred_at=datetime(2026, 8, 26, 17, 38, tzinfo=UTC),
         elapsed_seconds=1.25,
@@ -82,14 +86,14 @@ def test_evaluation_attaches_one_renderer_to_the_original_raw_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     error = TypeError("benchmark is required")
-    published: list[tuple[BaseException, DiagnosticReceipt]] = []
+    published: list[DiagnosticReceipt] = []
     monkeypatch.setattr(
         "screamingface._ui.diagnostic_view.running_in_notebook",
         lambda: True,
     )
     monkeypatch.setattr(
         "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
-        lambda raised, receipt: published.append((raised, receipt)),
+        published.append,
     )
 
     with pytest.raises(TypeError) as caught:
@@ -112,7 +116,7 @@ def test_evaluation_attaches_one_renderer_to_the_original_raw_exception(
     assert renderer() == []
     receipt = sf.diagnostics.last()
     assert receipt is not None
-    assert published == [(error, receipt)]
+    assert published == [receipt]
 
 
 def test_renderer_attachment_failure_never_replaces_the_operation_error(
@@ -172,7 +176,7 @@ def test_notebook_renderer_falls_back_to_the_existing_renderer(
     )
     monkeypatch.setattr(
         "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
-        lambda raised, receipt: (_ for _ in ()).throw(RuntimeError("display unavailable")),
+        lambda receipt: (_ for _ in ()).throw(RuntimeError("display unavailable")),
     )
 
     _attach_notebook_renderer(error, _receipt())
@@ -190,7 +194,7 @@ def test_raw_exception_fallback_retains_its_python_traceback(
     )
     monkeypatch.setattr(
         "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
-        lambda raised, receipt: (_ for _ in ()).throw(RuntimeError("display unavailable")),
+        lambda receipt: (_ for _ in ()).throw(RuntimeError("display unavailable")),
     )
 
     _attach_notebook_renderer(error, _receipt())
@@ -219,7 +223,7 @@ def test_display_publishes_the_widget(monkeypatch: pytest.MonkeyPatch) -> None:
     published: list[widgets.Widget] = []
     monkeypatch.setattr("IPython.display.display", published.append)
 
-    _display_notebook_diagnostic(TypeError("failed"), _receipt())
+    _display_notebook_diagnostic(_receipt())
 
     assert len(published) == 1
     assert set(getattr(published[0], "_dom_classes", ())) >= {
@@ -232,14 +236,14 @@ def test_ipython_invokes_the_attached_renderer_for_the_original_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     error = TypeError("failed")
-    published: list[tuple[BaseException, DiagnosticReceipt]] = []
+    published: list[DiagnosticReceipt] = []
     monkeypatch.setattr(
         "screamingface._ui.diagnostic_view.running_in_notebook",
         lambda: True,
     )
     monkeypatch.setattr(
         "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
-        lambda raised, receipt: published.append((raised, receipt)),
+        published.append,
     )
     receipt = _receipt()
     _attach_notebook_renderer(error, receipt)
@@ -249,16 +253,16 @@ def test_ipython_invokes_the_attached_renderer_for_the_original_exception(
     result = shell.run_cell("raise diagnostic_test_error")
 
     assert result.error_in_exec is error
-    assert published == [(error, receipt)]
+    assert published == [receipt]
 
 
 def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
     receipt = _receipt()
-    view = _NotebookDiagnosticView(TypeError("benchmark is required"), receipt)
+    view = _NotebookDiagnosticView(receipt)
 
     html = _html_values(view.widget)
-    assert "Evaluation failed" in html
-    assert "benchmark is required" in html
+    assert "Evaluation failed" not in html
+    assert "benchmark is required" not in html
     assert "diag_example" in html
     assert "local only" in html
     assert "aria-label='Local only; cleared when this kernel restarts'" in html
@@ -267,7 +271,7 @@ def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
     assert "Nothing has been sent" not in html
     assert "Run <code>%tb</code>" not in html
     assert receipt.to_json() not in unescape(html)
-    assert "role='alert'" in html
+    assert "role='alert'" not in html
     assert "aria-live='polite'" in html
     assert set(view.widget._dom_classes) >= {"sf-ui", "sf-diagnostic-widget"}
     # INVARIANT: container tooltips crash JupyterLab's VBoxView because VBox has no description.
@@ -275,7 +279,7 @@ def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
     assert _button(view.widget, "Export").tooltip
     assert _button(view.widget, "Preview").tooltip
     assert any(
-        "sf-diagnostic__footer" in getattr(item, "_dom_classes", ()) for item in _walk(view.widget)
+        "sf-diagnostic__toolbar" in getattr(item, "_dom_classes", ()) for item in _walk(view.widget)
     )
 
 
@@ -286,27 +290,36 @@ def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
         ("cancelled", "Evaluation cancelled"),
     ],
 )
-def test_panel_names_non_failure_terminal_outcomes(outcome: str, title: str) -> None:
-    view = _NotebookDiagnosticView(KeyboardInterrupt(), _receipt(outcome=outcome))
+def test_toolbar_does_not_restate_terminal_outcomes(outcome: str, title: str) -> None:
+    view = _NotebookDiagnosticView(_receipt(outcome=outcome))
 
     html = _html_values(view.widget)
-    assert title in html
-    assert "sf-diagnostic--stopped" in html
+    assert title not in html
+    assert "sf-diagnostic--stopped" not in html
 
 
-def test_panel_escapes_and_bounds_local_exception_text() -> None:
+def test_toolbar_does_not_duplicate_local_exception_text() -> None:
     private_markup = "<script>not markup</script>\n" + "x" * 600
-    view = _NotebookDiagnosticView(TypeError(private_markup), _receipt())
+    view = _NotebookDiagnosticView(_receipt())
 
     html = _html_values(view.widget)
-    assert "<script>not markup</script>" not in html
-    assert "&lt;script&gt;not markup&lt;/script&gt;" in html
-    assert "x" * 501 not in html
+    assert private_markup not in html
+    assert "&lt;script&gt;not markup&lt;/script&gt;" not in html
+
+
+def test_toolbar_shortens_only_the_visible_diagnostic_id() -> None:
+    diagnostic_id = "diag_1234567890abcdef"
+    view = _NotebookDiagnosticView(_receipt(diagnostic_id=diagnostic_id))
+
+    html = _html_values(view.widget)
+    assert "diag_1234…cdef" in html
+    assert f"title='{diagnostic_id}'" in html
+    assert f"aria-label='Diagnostic ID {diagnostic_id}'" in html
 
 
 def test_preview_reveals_the_exact_receipt_only_after_a_click() -> None:
     receipt = _receipt()
-    view = _NotebookDiagnosticView(TypeError("failed"), receipt)
+    view = _NotebookDiagnosticView(receipt)
 
     preview = _button(view.widget, "Preview")
     assert receipt.to_json() not in unescape(_html_values(view.widget))
@@ -326,7 +339,7 @@ def test_export_writes_only_after_an_explicit_click(
 ) -> None:
     monkeypatch.chdir(tmp_path)
     receipt = _receipt()
-    view = _NotebookDiagnosticView(TypeError("failed"), receipt)
+    view = _NotebookDiagnosticView(receipt)
     selected = tmp_path / "screamingface-diagnostic.json"
 
     assert not selected.exists()
@@ -344,7 +357,7 @@ def test_export_failure_is_reported_inside_the_panel(
         raise OSError("read-only filesystem")
 
     monkeypatch.setattr(DiagnosticReceipt, "export", unavailable_export)
-    view = _NotebookDiagnosticView(TypeError("failed"), _receipt())
+    view = _NotebookDiagnosticView(_receipt())
 
     _button(view.widget, "Export").click()
 
@@ -355,11 +368,23 @@ def test_export_failure_is_reported_inside_the_panel(
 
 def test_panel_uses_sfds_app_tokens_and_colab_theme_contract() -> None:
     assert "border-radius:0" in _STYLE
-    assert "var(--sf-danger-solid)" in _STYLE
+    assert "var(--sf-danger-solid)" not in _STYLE
     assert "var(--sf-accent)" in _STYLE
     assert "background:var(--sf-gain)" not in _STYLE
-    assert ".sf-diagnostic__footer.widget-hbox" in _STYLE
-    assert ".sf-diagnostic__footer-meta>div>div" in _STYLE
-    assert "height:28px!important" in _STYLE
+    assert ".sf-diagnostic__toolbar.widget-hbox" in _STYLE
+    assert ".sf-diagnostic__receipt>div>div" in _STYLE
+    assert "height:24px!important" in _STYLE
+    assert "text-decoration:underline" in _STYLE
+    assert "width:fit-content!important" in _STYLE
+    assert "justify-content:flex-start!important" in _STYLE
+    assert ".sf-diagnostic__receipt{flex:0 1 auto!important" in _STYLE
     assert ':where(html[theme="light"]) .sf-ui' in _STYLE
     assert ':where(html[theme="dark"]) .sf-ui' in _STYLE
+
+
+def test_receipt_toolbar_is_unboxed_supporting_evidence() -> None:
+    toolbar_rule = _STYLE.split(".sf-diagnostic__toolbar.widget-hbox", 1)[1].split("}", 1)[0]
+
+    assert "border:0!important" in toolbar_rule
+    assert "background:transparent!important" in toolbar_rule
+    assert "padding:0!important" in toolbar_rule

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from html import unescape
+from pathlib import Path
+from typing import Any
+
+import ipywidgets as widgets
+import pytest
+from _evaluation_diagnostic_fixtures import (
+    FailingTransport as _FailingTransport,
+)
+from _evaluation_diagnostic_fixtures import (
+    candidate as _candidate,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_benchmark as _load_benchmark,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_catalog as _load_catalog,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_details as _load_details,
+)
+from IPython.core.interactiveshell import InteractiveShell
+
+import screamingface as sf
+from screamingface._diagnostics.model import _new_receipt
+from screamingface._diagnostics.store import _STORE
+from screamingface._evaluation.runner import evaluate_sync
+from screamingface._ui.diagnostic_view import (
+    _STYLE,
+    _attach_notebook_renderer,
+    _display_notebook_diagnostic,
+    _NotebookDiagnosticView,
+)
+from screamingface.diagnostic import DiagnosticReceipt
+
+
+@pytest.fixture(autouse=True)
+def _empty_diagnostics() -> Generator[None, None, None]:
+    _STORE.clear()
+    yield
+    _STORE.clear()
+
+
+def _receipt(*, outcome: str = "failed") -> DiagnosticReceipt:
+    return _new_receipt(
+        diagnostic_id="diag_example",
+        session_id="session_example",
+        occurred_at=datetime(2026, 8, 26, 17, 38, tzinfo=UTC),
+        elapsed_seconds=1.25,
+        operation="evaluate",
+        outcome=outcome,
+        client={"name": "screamingface-python", "host": "notebook"},
+        error={"type": "TypeError"},
+        context={"engine": {"host": "engine.example", "mode": "hosted"}},
+        executions=[],
+        breadcrumbs=[],
+    )
+
+
+def _walk(widget: widgets.Widget) -> tuple[widgets.Widget, ...]:
+    children = getattr(widget, "children", ())
+    return (widget, *(item for child in children for item in _walk(child)))
+
+
+def _button(widget: widgets.Widget, description: str) -> widgets.Button:
+    return next(
+        item
+        for item in _walk(widget)
+        if isinstance(item, widgets.Button) and item.description == description
+    )
+
+
+def _html_values(widget: widgets.Widget) -> str:
+    return "\n".join(item.value for item in _walk(widget) if isinstance(item, widgets.HTML))
+
+
+def test_evaluation_attaches_one_renderer_to_the_original_raw_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = TypeError("benchmark is required")
+    published: list[tuple[BaseException, DiagnosticReceipt]] = []
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
+        lambda raised, receipt: published.append((raised, receipt)),
+    )
+
+    with pytest.raises(TypeError) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(error),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is error
+    renderer = getattr(error, "_render_traceback_")
+    assert renderer() == []
+    assert renderer() == []
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert published == [(error, receipt)]
+
+
+def test_renderer_attachment_failure_never_replaces_the_operation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = sf.ExecutionError("The Engine disconnected.")
+
+    def broken_attachment(raised: BaseException, receipt: DiagnosticReceipt) -> None:
+        del raised, receipt
+        raise RuntimeError("notebook adapter failed")
+
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view._attach_notebook_renderer",
+        broken_attachment,
+    )
+
+    with pytest.raises(sf.ExecutionError) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(error),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is error
+    assert sf.diagnostics.last() is not None
+
+
+def test_non_notebook_raw_exception_keeps_the_normal_traceback_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = TypeError("benchmark is required")
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: False,
+    )
+
+    _attach_notebook_renderer(error, _receipt())
+
+    assert not hasattr(error, "_render_traceback_")
+
+
+def test_notebook_renderer_falls_back_to_the_existing_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = sf.ExecutionError("The Engine disconnected.", code="websocket_disconnected")
+    expected = error._render_traceback_()
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
+        lambda raised, receipt: (_ for _ in ()).throw(RuntimeError("display unavailable")),
+    )
+
+    _attach_notebook_renderer(error, _receipt())
+
+    assert error._render_traceback_() == expected
+
+
+def test_raw_exception_fallback_retains_its_python_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = TypeError("benchmark is required")
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
+        lambda raised, receipt: (_ for _ in ()).throw(RuntimeError("display unavailable")),
+    )
+
+    _attach_notebook_renderer(error, _receipt())
+
+    rendered = "".join(getattr(error, "_render_traceback_")())
+    assert "TypeError: benchmark is required" in rendered
+
+
+def test_attaching_twice_keeps_the_first_renderer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = TypeError("failed")
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: True,
+    )
+
+    _attach_notebook_renderer(error, _receipt())
+    first = getattr(error, "_render_traceback_")
+    _attach_notebook_renderer(error, _receipt(outcome="cancelled"))
+
+    assert getattr(error, "_render_traceback_") is first
+
+
+def test_display_publishes_the_widget(monkeypatch: pytest.MonkeyPatch) -> None:
+    published: list[widgets.Widget] = []
+    monkeypatch.setattr("IPython.display.display", published.append)
+
+    _display_notebook_diagnostic(TypeError("failed"), _receipt())
+
+    assert len(published) == 1
+    assert set(getattr(published[0], "_dom_classes", ())) >= {
+        "sf-ui",
+        "sf-diagnostic-widget",
+    }
+
+
+def test_ipython_invokes_the_attached_renderer_for_the_original_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    error = TypeError("failed")
+    published: list[tuple[BaseException, DiagnosticReceipt]] = []
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view.running_in_notebook",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        "screamingface._ui.diagnostic_view._display_notebook_diagnostic",
+        lambda raised, receipt: published.append((raised, receipt)),
+    )
+    receipt = _receipt()
+    _attach_notebook_renderer(error, receipt)
+    shell = InteractiveShell()
+    shell.user_ns["diagnostic_test_error"] = error
+
+    result = shell.run_cell("raise diagnostic_test_error")
+
+    assert result.error_in_exec is error
+    assert published == [(error, receipt)]
+
+
+def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
+    receipt = _receipt()
+    view = _NotebookDiagnosticView(TypeError("benchmark is required"), receipt)
+
+    html = _html_values(view.widget)
+    assert "Evaluation failed" in html
+    assert "benchmark is required" in html
+    assert "diag_example" in html
+    assert "Nothing has been sent" in html
+    assert "%tb" in html
+    assert receipt.to_json() not in unescape(html)
+    assert "role='alert'" in html
+    assert "aria-live='polite'" in html
+    assert set(view.widget._dom_classes) >= {"sf-ui", "sf-diagnostic-widget"}
+    assert _button(view.widget, "Export diagnostic").tooltip
+    assert _button(view.widget, "Preview diagnostic").tooltip
+
+
+@pytest.mark.parametrize(
+    ("outcome", "title"),
+    [
+        ("interrupted_by_user", "Evaluation interrupted"),
+        ("cancelled", "Evaluation cancelled"),
+    ],
+)
+def test_panel_names_non_failure_terminal_outcomes(outcome: str, title: str) -> None:
+    view = _NotebookDiagnosticView(KeyboardInterrupt(), _receipt(outcome=outcome))
+
+    html = _html_values(view.widget)
+    assert title in html
+    assert "sf-diagnostic--stopped" in html
+
+
+def test_panel_escapes_and_bounds_local_exception_text() -> None:
+    private_markup = "<script>not markup</script>\n" + "x" * 600
+    view = _NotebookDiagnosticView(TypeError(private_markup), _receipt())
+
+    html = _html_values(view.widget)
+    assert "<script>not markup</script>" not in html
+    assert "&lt;script&gt;not markup&lt;/script&gt;" in html
+    assert "x" * 501 not in html
+
+
+def test_preview_reveals_the_exact_receipt_only_after_a_click() -> None:
+    receipt = _receipt()
+    view = _NotebookDiagnosticView(TypeError("failed"), receipt)
+
+    preview = _button(view.widget, "Preview diagnostic")
+    assert receipt.to_json() not in unescape(_html_values(view.widget))
+
+    preview.click()
+
+    assert receipt.to_json() in unescape(_html_values(view.widget))
+    assert preview.description == "Hide diagnostic"
+    preview.click()
+    assert receipt.to_json() not in unescape(_html_values(view.widget))
+    assert preview.description == "Preview diagnostic"
+
+
+def test_export_writes_only_after_an_explicit_click(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    receipt = _receipt()
+    view = _NotebookDiagnosticView(TypeError("failed"), receipt)
+    selected = tmp_path / "screamingface-diagnostic.json"
+
+    assert not selected.exists()
+    _button(view.widget, "Export diagnostic").click()
+
+    assert selected.read_text(encoding="utf-8") == receipt.to_json()
+    assert "Exported screamingface-diagnostic.json" in _html_values(view.widget)
+
+
+def test_export_failure_is_reported_inside_the_panel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unavailable_export(self: DiagnosticReceipt, path: object) -> Any:
+        del self, path
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(DiagnosticReceipt, "export", unavailable_export)
+    view = _NotebookDiagnosticView(TypeError("failed"), _receipt())
+
+    _button(view.widget, "Export diagnostic").click()
+
+    html = _html_values(view.widget)
+    assert "Could not export the diagnostic" in html
+    assert "read-only filesystem" not in html
+
+
+def test_panel_uses_sfds_app_tokens_and_colab_theme_contract() -> None:
+    assert "border-radius:0" in _STYLE
+    assert "var(--sf-danger-solid)" in _STYLE
+    assert "var(--sf-accent)" in _STYLE
+    assert "background:var(--sf-gain)" not in _STYLE
+    assert ':where(html[theme="light"]) .sf-ui' in _STYLE
+    assert ':where(html[theme="dark"]) .sf-ui' in _STYLE

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -266,6 +266,8 @@ def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
     assert "role='alert'" in html
     assert "aria-live='polite'" in html
     assert set(view.widget._dom_classes) >= {"sf-ui", "sf-diagnostic-widget"}
+    # INVARIANT: container tooltips crash JupyterLab's VBoxView because VBox has no description.
+    assert view.widget.tooltip is None
     assert _button(view.widget, "Export diagnostic").tooltip
     assert _button(view.widget, "Preview diagnostic").tooltip
 

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -388,3 +388,13 @@ def test_receipt_toolbar_is_unboxed_supporting_evidence() -> None:
     assert "border:0!important" in toolbar_rule
     assert "background:transparent!important" in toolbar_rule
     assert "padding:0!important" in toolbar_rule
+
+
+def test_diagnostic_style_uses_sfds_font_and_spacing_tokens() -> None:
+    diagnostic_rules = _STYLE.split("<style>")[-1]
+
+    assert "var(--f-mono)" in diagnostic_rules
+    assert '"IBM Plex Mono"' not in diagnostic_rules
+    assert "gap:6px" not in diagnostic_rules
+    assert "padding:0 3px" not in diagnostic_rules
+    assert "padding:10px" not in diagnostic_rules

--- a/packages/screamingface/tests/test_diagnostic_notebook_view.py
+++ b/packages/screamingface/tests/test_diagnostic_notebook_view.py
@@ -260,16 +260,23 @@ def test_panel_starts_concise_accessible_and_without_receipt_json() -> None:
     assert "Evaluation failed" in html
     assert "benchmark is required" in html
     assert "diag_example" in html
-    assert "Nothing has been sent" in html
+    assert "local only" in html
+    assert "aria-label='Local only; cleared when this kernel restarts'" in html
     assert "%tb" in html
+    assert "sf-diagnostic__eyebrow" not in html
+    assert "Nothing has been sent" not in html
+    assert "Run <code>%tb</code>" not in html
     assert receipt.to_json() not in unescape(html)
     assert "role='alert'" in html
     assert "aria-live='polite'" in html
     assert set(view.widget._dom_classes) >= {"sf-ui", "sf-diagnostic-widget"}
     # INVARIANT: container tooltips crash JupyterLab's VBoxView because VBox has no description.
     assert view.widget.tooltip is None
-    assert _button(view.widget, "Export diagnostic").tooltip
-    assert _button(view.widget, "Preview diagnostic").tooltip
+    assert _button(view.widget, "Export").tooltip
+    assert _button(view.widget, "Preview").tooltip
+    assert any(
+        "sf-diagnostic__footer" in getattr(item, "_dom_classes", ()) for item in _walk(view.widget)
+    )
 
 
 @pytest.mark.parametrize(
@@ -301,16 +308,16 @@ def test_preview_reveals_the_exact_receipt_only_after_a_click() -> None:
     receipt = _receipt()
     view = _NotebookDiagnosticView(TypeError("failed"), receipt)
 
-    preview = _button(view.widget, "Preview diagnostic")
+    preview = _button(view.widget, "Preview")
     assert receipt.to_json() not in unescape(_html_values(view.widget))
 
     preview.click()
 
     assert receipt.to_json() in unescape(_html_values(view.widget))
-    assert preview.description == "Hide diagnostic"
+    assert preview.description == "Hide"
     preview.click()
     assert receipt.to_json() not in unescape(_html_values(view.widget))
-    assert preview.description == "Preview diagnostic"
+    assert preview.description == "Preview"
 
 
 def test_export_writes_only_after_an_explicit_click(
@@ -323,7 +330,7 @@ def test_export_writes_only_after_an_explicit_click(
     selected = tmp_path / "screamingface-diagnostic.json"
 
     assert not selected.exists()
-    _button(view.widget, "Export diagnostic").click()
+    _button(view.widget, "Export").click()
 
     assert selected.read_text(encoding="utf-8") == receipt.to_json()
     assert "Exported screamingface-diagnostic.json" in _html_values(view.widget)
@@ -339,7 +346,7 @@ def test_export_failure_is_reported_inside_the_panel(
     monkeypatch.setattr(DiagnosticReceipt, "export", unavailable_export)
     view = _NotebookDiagnosticView(TypeError("failed"), _receipt())
 
-    _button(view.widget, "Export diagnostic").click()
+    _button(view.widget, "Export").click()
 
     html = _html_values(view.widget)
     assert "Could not export the diagnostic" in html
@@ -351,5 +358,8 @@ def test_panel_uses_sfds_app_tokens_and_colab_theme_contract() -> None:
     assert "var(--sf-danger-solid)" in _STYLE
     assert "var(--sf-accent)" in _STYLE
     assert "background:var(--sf-gain)" not in _STYLE
+    assert ".sf-diagnostic__footer.widget-hbox" in _STYLE
+    assert ".sf-diagnostic__footer-meta>div>div" in _STYLE
+    assert "height:28px!important" in _STYLE
     assert ':where(html[theme="light"]) .sf-ui' in _STYLE
     assert ':where(html[theme="dark"]) .sf-ui' in _STYLE

--- a/packages/screamingface/tests/test_diagnostics.py
+++ b/packages/screamingface/tests/test_diagnostics.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 import pytest
 
 import screamingface as sf
-from screamingface._diagnostics.model import _new_receipt
+from screamingface._diagnostics.model import _new_receipt, _ReceiptEvidence
 from screamingface._diagnostics.store import _DiagnosticStore
 
 
@@ -16,26 +16,28 @@ def _receipt(
     error_message: str = "The Engine disconnected.",
 ) -> sf.DiagnosticReceipt:
     return _new_receipt(
-        diagnostic_id=diagnostic_id,
-        session_id="session_test",
-        occurred_at=datetime(2026, 8, 26, 14, 3, 11, 204000, tzinfo=UTC),
-        elapsed_seconds=0.5,
-        operation="evaluate",
-        outcome="failed",
-        client={"name": "screamingface-python", "version": "0.1.1.post5"},
-        error={
-            "type": "ExecutionError",
-            "code": "websocket_disconnected",
-            "message": error_message,
-        },
-        context={"benchmark": {"id": "draco", "revision": "rev-1"}},
-        executions=(
-            {
-                "candidate": "candidate-a",
-                "trace_id": "0123456789abcdef0123456789abcdef",
+        _ReceiptEvidence(
+            diagnostic_id=diagnostic_id,
+            session_id="session_test",
+            occurred_at=datetime(2026, 8, 26, 14, 3, 11, 204000, tzinfo=UTC),
+            elapsed_seconds=0.5,
+            operation="evaluate",
+            outcome="failed",
+            client={"name": "screamingface-python", "version": "0.1.1.post5"},
+            error={
+                "type": "ExecutionError",
+                "code": "websocket_disconnected",
+                "hint": error_message,
             },
-        ),
-        breadcrumbs=({"sequence": 1, "stage": "execution", "event": "started"},),
+            context={"benchmark": {"id": "draco", "revision": "rev-1"}},
+            executions=(
+                {
+                    "candidate": "candidate-a",
+                    "trace_id": "0123456789abcdef0123456789abcdef",
+                },
+            ),
+            breadcrumbs=({"sequence": 1, "stage": "execution", "event": "started"},),
+        )
     )
 
 
@@ -57,7 +59,7 @@ def test_receipt_serialization_is_deterministic_and_versioned() -> None:
         "error": {
             "type": "ExecutionError",
             "code": "websocket_disconnected",
-            "message": "The Engine disconnected.",
+            "hint": "The Engine disconnected.",
         },
         "context": {"benchmark": {"id": "draco", "revision": "rev-1"}},
         "executions": [
@@ -71,6 +73,23 @@ def test_receipt_serialization_is_deterministic_and_versioned() -> None:
     assert json.loads(receipt.to_json()) == receipt.to_dict()
     assert '": ' not in receipt.to_json()
     assert '", ' not in receipt.to_json()
+
+
+def test_receipt_construction_rejects_unsafe_error_fields() -> None:
+    with pytest.raises(ValueError, match="unsafe error fields: message"):
+        _new_receipt(
+            _ReceiptEvidence(
+                diagnostic_id="diag_unsafe",
+                session_id="session_test",
+                occurred_at=datetime(2026, 8, 26, tzinfo=UTC),
+                elapsed_seconds=0.5,
+                operation="evaluate",
+                outcome="failed",
+                client={"name": "screamingface-python"},
+                error={"type": "ExecutionError", "message": "private server response"},
+                context={},
+            )
+        )
 
 
 def test_receipt_to_dict_returns_an_independent_tree() -> None:

--- a/packages/screamingface/tests/test_diagnostics.py
+++ b/packages/screamingface/tests/test_diagnostics.py
@@ -180,3 +180,122 @@ def test_store_rejects_duplicate_diagnostic_identity() -> None:
 
     with pytest.raises(ValueError, match="already exists"):
         store.add(_receipt("diag_same", error_message="another failure"))
+
+
+def _evidence_with(
+    *,
+    client: dict[str, object] | None = None,
+    context: dict[str, object] | None = None,
+    executions: tuple[dict[str, object], ...] = (),
+    breadcrumbs: tuple[dict[str, object], ...] = (),
+) -> _ReceiptEvidence:
+    return _ReceiptEvidence(
+        diagnostic_id="diag_validation",
+        session_id="session_test",
+        occurred_at=datetime(2026, 9, 3, tzinfo=UTC),
+        elapsed_seconds=0.5,
+        operation="evaluate",
+        outcome="failed",
+        client=client or {"name": "screamingface-python"},
+        error={"type": "ExecutionError"},
+        context=context or {},
+        executions=executions,
+        breadcrumbs=breadcrumbs,
+    )
+
+
+@pytest.mark.parametrize(
+    ("section", "evidence"),
+    [
+        (
+            "client",
+            _evidence_with(client={"name": "screamingface-python", "access_token": "private"}),
+        ),
+        (
+            "client runtime",
+            _evidence_with(
+                client={
+                    "name": "screamingface-python",
+                    "runtime": {"name": "cpython", "token": "private"},
+                }
+            ),
+        ),
+        ("context", _evidence_with(context={"prompt": "private"})),
+        (
+            "candidate",
+            _evidence_with(
+                context={"candidates": [{"name": "one", "kind": "model", "prompt": "private"}]}
+            ),
+        ),
+        (
+            "operation",
+            _evidence_with(
+                context={
+                    "candidates": [
+                        {
+                            "name": "one",
+                            "kind": "model",
+                            "operations": [
+                                {
+                                    "id": "op_1",
+                                    "kind": "model",
+                                    "depends_on": [],
+                                    "url4": "private",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+        ),
+        (
+            "parameter",
+            _evidence_with(
+                context={
+                    "candidates": [
+                        {
+                            "name": "one",
+                            "kind": "model",
+                            "parameters": [
+                                {
+                                    "operation_id": "op_1",
+                                    "model": "provider/model",
+                                    "values": {"max_tokens": 64},
+                                    "input": "private",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+        ),
+        (
+            "execution",
+            _evidence_with(executions=({"candidate": "one", "payload": "private"},)),
+        ),
+        (
+            "breadcrumb",
+            _evidence_with(breadcrumbs=({"event": "started", "body": "private"},)),
+        ),
+    ],
+)
+def test_receipt_construction_rejects_unexpected_evidence_fields(
+    section: str,
+    evidence: _ReceiptEvidence,
+) -> None:
+    with pytest.raises(ValueError, match=rf"unsafe {section} fields"):
+        _new_receipt(evidence)
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        _evidence_with(executions=({"candidate": "one", "run_id": "internal-topic"},)),
+        _evidence_with(breadcrumbs=({"event": "started", "run_id": "internal-topic"},)),
+    ],
+)
+def test_receipt_construction_structurally_rejects_internal_run_id(
+    evidence: _ReceiptEvidence,
+) -> None:
+    with pytest.raises(ValueError, match="forbidden field: run_id"):
+        _new_receipt(evidence)

--- a/packages/screamingface/tests/test_diagnostics.py
+++ b/packages/screamingface/tests/test_diagnostics.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+import screamingface as sf
+from screamingface._diagnostics.model import _new_receipt
+from screamingface._diagnostics.store import _DiagnosticStore
+
+
+def _receipt(
+    diagnostic_id: str = "diag_first",
+    *,
+    error_message: str = "The Engine disconnected.",
+) -> sf.DiagnosticReceipt:
+    return _new_receipt(
+        diagnostic_id=diagnostic_id,
+        session_id="session_test",
+        occurred_at=datetime(2026, 8, 26, 14, 3, 11, 204000, tzinfo=UTC),
+        elapsed_seconds=0.5,
+        operation="evaluate",
+        outcome="failed",
+        client={"name": "screamingface-python", "version": "0.1.1.post5"},
+        error={
+            "type": "ExecutionError",
+            "code": "websocket_disconnected",
+            "message": error_message,
+        },
+        context={"benchmark": {"id": "draco", "revision": "rev-1"}},
+        executions=(
+            {
+                "candidate": "candidate-a",
+                "trace_id": "0123456789abcdef0123456789abcdef",
+            },
+        ),
+        breadcrumbs=({"sequence": 1, "stage": "execution", "event": "started"},),
+    )
+
+
+def test_receipt_serialization_is_deterministic_and_versioned() -> None:
+    receipt = _receipt()
+
+    assert receipt.diagnostic_id == "diag_first"
+    assert receipt.session_id == "session_test"
+    assert receipt.outcome == "failed"
+    assert receipt.to_dict() == {
+        "schema": "screamingface.diagnostic/v1",
+        "diagnostic_id": "diag_first",
+        "session_id": "session_test",
+        "occurred_at": "2026-08-26T14:03:11.204Z",
+        "elapsed_seconds": 0.5,
+        "operation": "evaluate",
+        "outcome": "failed",
+        "client": {"name": "screamingface-python", "version": "0.1.1.post5"},
+        "error": {
+            "type": "ExecutionError",
+            "code": "websocket_disconnected",
+            "message": "The Engine disconnected.",
+        },
+        "context": {"benchmark": {"id": "draco", "revision": "rev-1"}},
+        "executions": [
+            {
+                "candidate": "candidate-a",
+                "trace_id": "0123456789abcdef0123456789abcdef",
+            }
+        ],
+        "breadcrumbs": [{"sequence": 1, "stage": "execution", "event": "started"}],
+    }
+    assert json.loads(receipt.to_json()) == receipt.to_dict()
+    assert '": ' not in receipt.to_json()
+    assert '", ' not in receipt.to_json()
+
+
+def test_receipt_to_dict_returns_an_independent_tree() -> None:
+    receipt = _receipt()
+
+    first = receipt.to_dict()
+    client = first["client"]
+    executions = first["executions"]
+    assert isinstance(client, dict)
+    assert isinstance(executions, list)
+    assert isinstance(executions[0], dict)
+    client["version"] = "changed"
+    executions[0]["candidate"] = "changed"
+
+    assert receipt.to_dict()["client"] == {
+        "name": "screamingface-python",
+        "version": "0.1.1.post5",
+    }
+    assert receipt.to_dict()["executions"] == [
+        {
+            "candidate": "candidate-a",
+            "trace_id": "0123456789abcdef0123456789abcdef",
+        }
+    ]
+
+
+def test_receipt_cannot_be_mutated_after_creation() -> None:
+    receipt = _receipt()
+
+    with pytest.raises(AttributeError):
+        setattr(receipt, "_document", {})
+
+
+def test_receipt_export_matches_to_json_bytes(tmp_path) -> None:
+    receipt = _receipt()
+    selected = tmp_path / "nested" / "diagnostic.json"
+
+    assert receipt.export(selected) == selected
+    assert selected.read_text(encoding="utf-8") == receipt.to_json()
+    with pytest.raises(ValueError, match="must be a .json file"):
+        receipt.export(tmp_path / "diagnostic.txt")
+
+
+def test_store_evicts_oldest_receipt_at_count_limit() -> None:
+    store = _DiagnosticStore(max_count=2, max_bytes=100_000)
+    first = _receipt("diag_first")
+    second = _receipt("diag_second")
+    third = _receipt("diag_third")
+
+    assert store.add(first) is True
+    assert store.add(second) is True
+    assert store.add(third) is True
+
+    assert store.get("diag_first") is None
+    assert store.get("diag_second") is second
+    assert store.last() is third
+
+
+def test_store_evicts_oldest_receipt_at_byte_limit() -> None:
+    first = _receipt("diag_first", error_message="a")
+    second = _receipt("diag_second", error_message="b")
+    budget = len(first.to_json().encode("utf-8")) + len(second.to_json().encode("utf-8")) - 1
+    store = _DiagnosticStore(max_count=10, max_bytes=budget)
+
+    assert store.add(first) is True
+    assert store.add(second) is True
+
+    assert store.get("diag_first") is None
+    assert store.get("diag_second") is second
+
+
+def test_store_declines_oversize_receipt_without_evicting_existing() -> None:
+    existing = _receipt("diag_existing", error_message="ok")
+    oversize = _receipt("diag_oversize", error_message="x" * 2_000)
+    budget = len(existing.to_json().encode("utf-8"))
+    store = _DiagnosticStore(max_count=10, max_bytes=budget)
+    assert store.add(existing) is True
+
+    assert store.add(oversize) is False
+
+    assert store.last() is existing
+    assert store.get("diag_oversize") is None
+
+
+def test_store_rejects_duplicate_diagnostic_identity() -> None:
+    store = _DiagnosticStore(max_count=10, max_bytes=100_000)
+    assert store.add(_receipt("diag_same")) is True
+
+    with pytest.raises(ValueError, match="already exists"):
+        store.add(_receipt("diag_same", error_message="another failure"))

--- a/packages/screamingface/tests/test_draco_vertical_slice.py
+++ b/packages/screamingface/tests/test_draco_vertical_slice.py
@@ -192,7 +192,7 @@ class _FakeTransport:
         self._result_payload = deepcopy(result_payload)
 
     def run(self, candidate: Candidate, on_event: object) -> _RunOutcome:
-        assert on_event is None
+        assert on_event is None or callable(on_event)
         self.calls.append(candidate.name)
         self.url4s.append(candidate.url4)
         return _RunOutcome(

--- a/packages/screamingface/tests/test_evaluation_diagnostic_fail_open.py
+++ b/packages/screamingface/tests/test_evaluation_diagnostic_fail_open.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from typing import Any, NoReturn, cast
+
+import pytest
+from _evaluation_diagnostic_fixtures import (
+    RESOURCE as _RESOURCE,
+)
+from _evaluation_diagnostic_fixtures import (
+    AsyncFailingTransport as _AsyncFailingTransport,
+)
+from _evaluation_diagnostic_fixtures import (
+    FailingTransport as _FailingTransport,
+)
+from _evaluation_diagnostic_fixtures import (
+    SuccessfulTransport as _SuccessfulTransport,
+)
+from _evaluation_diagnostic_fixtures import (
+    candidate as _candidate,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_benchmark as _load_benchmark,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_catalog as _load_catalog,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_details as _load_details,
+)
+
+import screamingface as sf
+from screamingface._diagnostics.evaluation import _EvaluationDiagnostic
+from screamingface._diagnostics.store import _STORE
+from screamingface._evaluation.compilation import compile_evaluation
+from screamingface._evaluation.model import Candidate
+from screamingface._evaluation.runner import evaluate_sync
+from screamingface._evaluation.url4 import evaluate_url4_async, evaluate_url4_sync
+from screamingface.errors import ExecutionError
+
+
+@pytest.fixture(autouse=True)
+def _empty_diagnostics() -> Generator[None, None, None]:
+    _STORE.clear()
+    yield
+    _STORE.clear()
+
+
+@pytest.mark.parametrize("method", ["compiled", "validated"])
+def test_diagnostic_enrichment_failure_does_not_abort_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+    method: str,
+) -> None:
+    operation_error = ExecutionError("Original operation failure.", code="original")
+
+    def fail_enrichment(*values: object) -> NoReturn:
+        del values
+        raise RuntimeError("diagnostic enrichment failed")
+
+    monkeypatch.setattr(_EvaluationDiagnostic, method, fail_enrichment)
+
+    with pytest.raises(ExecutionError) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(operation_error),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is operation_error
+
+
+def test_diagnostic_setup_failure_does_not_abort_recipe_evaluation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_setup(*values: object, **named: object) -> NoReturn:
+        del values, named
+        raise RuntimeError("diagnostic setup failed")
+
+    monkeypatch.setattr(_EvaluationDiagnostic, "__init__", fail_setup)
+
+    report = evaluate_sync(
+        _load_benchmark,
+        _SuccessfulTransport(),
+        _load_catalog,
+        _load_details,
+        _candidate(),
+        "draco",
+        1,
+        None,
+        False,
+        engine_url="https://engine.example",
+    )
+
+    assert report.candidates[0].score == 1.0
+    assert sf.diagnostics.last() is None
+
+
+def test_diagnostic_setup_failure_does_not_abort_url4_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    replay_url4 = compile_evaluation((_candidate(),), _RESOURCE, 1).candidates[0].url4
+
+    def fail_setup(*values: object, **named: object) -> NoReturn:
+        del values, named
+        raise RuntimeError("diagnostic setup failed")
+
+    monkeypatch.setattr(_EvaluationDiagnostic, "__init__", fail_setup)
+
+    report = evaluate_url4_sync(
+        _SuccessfulTransport(),
+        replay_url4,
+        None,
+        None,
+        None,
+        False,
+        engine_url="https://engine.example",
+    )
+
+    assert report.candidates[0].score == 1.0
+    assert sf.diagnostics.last() is None
+
+
+def test_unpresentable_terminal_guidance_is_not_retained() -> None:
+    operation_error = ExecutionError("Original operation failure.", code="original")
+    cast(Any, operation_error).__notes__ = ()
+
+    with pytest.raises(ExecutionError) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(operation_error),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is operation_error
+    assert sf.diagnostics.last() is None
+
+
+class _ImmediateFailureTransport(_FailingTransport):
+    def run(self, candidate: Candidate, on_event: object) -> NoReturn:
+        del candidate, on_event
+        raise self.error
+
+
+class _ImmediateAsyncFailureTransport(_AsyncFailingTransport):
+    async def run(self, candidate: Candidate, on_event: object) -> NoReturn:
+        del candidate, on_event
+        raise self.error
+
+
+def test_url4_interruption_retains_known_running_candidate() -> None:
+    interruption = KeyboardInterrupt()
+    replay_url4 = compile_evaluation((_candidate(),), _RESOURCE, 1).candidates[0].url4
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        evaluate_url4_sync(
+            _ImmediateFailureTransport(interruption),
+            replay_url4,
+            None,
+            None,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is interruption
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.to_dict()["executions"] == [{"candidate": "opus", "status": "running"}]
+
+
+@pytest.mark.asyncio
+async def test_async_url4_cancellation_retains_known_running_candidate() -> None:
+    cancellation = asyncio.CancelledError()
+    replay_url4 = compile_evaluation((_candidate(),), _RESOURCE, 1).candidates[0].url4
+
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await evaluate_url4_async(
+            _ImmediateAsyncFailureTransport(cancellation),
+            replay_url4,
+            None,
+            None,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is cancellation
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.to_dict()["executions"] == [{"candidate": "opus", "status": "running"}]

--- a/packages/screamingface/tests/test_evaluation_diagnostics.py
+++ b/packages/screamingface/tests/test_evaluation_diagnostics.py
@@ -9,6 +9,7 @@ import _evaluation_diagnostic_fixtures as _fixtures
 import pytest
 
 import screamingface as sf
+from screamingface._diagnostics.evaluation import _trace_id
 from screamingface._diagnostics.store import _STORE
 from screamingface._evaluation.model import Candidate
 from screamingface._evaluation.runner import evaluate_async, evaluate_sync
@@ -255,6 +256,20 @@ def test_malformed_trace_context_is_not_fabricated() -> None:
     receipt = sf.diagnostics.last()
     assert receipt is not None
     assert "trace_id" not in receipt.to_dict()["executions"][0]
+
+
+@pytest.mark.parametrize(
+    "traceparent",
+    [
+        f"FF-{_fixtures.TRACE_ID}-0123456789abcdef-01",
+        f"00-{_fixtures.TRACE_ID.upper()}-0123456789abcdef-01",
+        f"00-{_fixtures.TRACE_ID}-0123456789ABCDEF-01",
+        f"00-{_fixtures.TRACE_ID}-0123456789abcdef-0A",
+    ],
+)
+def test_trace_id_rejects_noncanonical_traceparent(traceparent: str) -> None:
+    # INVARIANT: receipts retain only the lowercase version-00 grammar the Client produces.
+    assert _trace_id(traceparent) is None
 
 
 def test_breadcrumb_retains_only_relative_route_span_names() -> None:

--- a/packages/screamingface/tests/test_evaluation_diagnostics.py
+++ b/packages/screamingface/tests/test_evaluation_diagnostics.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator
+from typing import Any, NoReturn, cast
+
+import pytest
+from _evaluation_diagnostic_fixtures import (
+    RESOURCE as _RESOURCE,
+)
+from _evaluation_diagnostic_fixtures import (
+    TRACE_ID as _TRACE_ID,
+)
+from _evaluation_diagnostic_fixtures import (
+    AsyncFailingTransport as _AsyncFailingTransport,
+)
+from _evaluation_diagnostic_fixtures import (
+    FailingTransport as _FailingTransport,
+)
+from _evaluation_diagnostic_fixtures import (
+    PartialTransport as _PartialTransport,
+)
+from _evaluation_diagnostic_fixtures import (
+    candidate as _candidate,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_benchmark as _load_benchmark,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_benchmark_async as _load_benchmark_async,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_catalog as _load_catalog,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_catalog_async as _load_catalog_async,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_details as _load_details,
+)
+from _evaluation_diagnostic_fixtures import (
+    load_details_async as _load_details_async,
+)
+from _evaluation_diagnostic_fixtures import (
+    started as _started,
+)
+
+import screamingface as sf
+from screamingface._diagnostics.store import _STORE
+from screamingface._evaluation.model import Candidate
+from screamingface._evaluation.runner import evaluate_async, evaluate_sync
+from screamingface._evaluation.url4 import evaluate_url4_sync
+from screamingface.errors import ExecutionError
+
+
+@pytest.fixture(autouse=True)
+def _empty_diagnostics() -> Generator[None, None, None]:
+    _STORE.clear()
+    yield
+    _STORE.clear()
+
+
+def test_sync_evaluation_failure_stages_one_receipt_and_preserves_exception() -> None:
+    error = ExecutionError(
+        "The Engine disconnected.",
+        code="websocket_disconnected",
+        permanent=False,
+    )
+
+    with pytest.raises(ExecutionError) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(error),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://user:secret@engine.example/private?token=secret",
+        )
+
+    assert caught.value is error
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert error.__notes__ == [
+        f"Diagnostic: {receipt.diagnostic_id}. Export with "
+        f'sf.diagnostics.get("{receipt.diagnostic_id}").export('
+        '"screamingface-diagnostic.json")'
+    ]
+    assert error.__notes__[0] in error._render_traceback_()[0]
+    document = receipt.to_dict()
+    assert document["operation"] == "evaluate"
+    assert document["outcome"] == "failed"
+    assert isinstance(document["elapsed_seconds"], float)
+    assert document["elapsed_seconds"] >= 0
+    assert document["context"]["engine"] == {"host": "engine.example", "mode": "hosted"}
+    assert document["context"]["benchmark"] == {
+        "id": "draco",
+        "revision": "fixture-revision",
+        "case_count": 1,
+    }
+    assert document["context"]["candidates"][0]["parameters"] == [
+        {
+            "operation_id": "op_model_1",
+            "model": "provider/opus",
+            "values": {"max_tokens": 64},
+        }
+    ]
+    assert document["executions"] == [
+        {
+            "candidate": "opus",
+            "status": "running",
+            "run_id": "internal-stream-topic",
+            "trace_id": _TRACE_ID,
+        }
+    ]
+    encoded = receipt.to_json()
+    assert "private answer instruction" not in encoded
+    assert "user:secret" not in encoded
+    assert "token=secret" not in encoded
+
+
+def test_plain_argument_error_stages_a_degraded_receipt() -> None:
+    with pytest.raises(TypeError) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(AssertionError("transport must not run")),
+            _load_catalog,
+            _load_details,
+            cast(Any, object()),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    error = receipt.to_dict()["error"]
+    assert error["type"] == "TypeError"
+    assert "code" not in error
+    assert "message" not in error
+    assert receipt.diagnostic_id in caught.value.__notes__[0]
+
+
+def test_public_client_input_validation_stages_a_degraded_receipt() -> None:
+    with sf.Client(
+        engine_url="https://engine.example",
+        run_transport=_FailingTransport(AssertionError("transport must not run")),
+    ) as client:
+        with pytest.raises(TypeError, match="benchmark is required"):
+            cast(Any, client).evaluate(_candidate())
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.to_dict()["error"]["type"] == "TypeError"
+
+
+def test_unvalidated_benchmark_object_is_not_captured() -> None:
+    class PrivateBenchmark:
+        def __repr__(self) -> str:
+            return "private-benchmark-value"
+
+    with sf.Client(
+        engine_url="https://engine.example",
+        run_transport=_FailingTransport(AssertionError("transport must not run")),
+    ) as client:
+        with pytest.raises(ValueError, match="benchmark"):
+            cast(Any, client).evaluate(_candidate(), benchmark=PrivateBenchmark())
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert "private-benchmark-value" not in receipt.to_json()
+
+
+@pytest.mark.asyncio
+async def test_async_evaluation_failure_uses_the_same_receipt_contract() -> None:
+    error = ExecutionError("Async failed.", code="async_failed", permanent=True)
+
+    with pytest.raises(ExecutionError) as caught:
+        await evaluate_async(
+            _load_benchmark_async,
+            _AsyncFailingTransport(error),
+            _load_catalog_async,
+            _load_details_async,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is error
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.to_dict()["executions"] == [
+        {
+            "candidate": "opus",
+            "status": "running",
+            "run_id": "internal-stream-topic",
+            "trace_id": _TRACE_ID,
+        }
+    ]
+
+
+def test_malformed_trace_context_is_not_fabricated() -> None:
+    class InvalidTraceTransport(_FailingTransport):
+        def run(self, candidate: Candidate, on_event: object) -> NoReturn:
+            if callable(on_event):
+                on_event(_started(candidate, traceparent="00-invalid-parent-01"))
+            raise self.error
+
+    with pytest.raises(ExecutionError):
+        evaluate_sync(
+            _load_benchmark,
+            InvalidTraceTransport(ExecutionError("Failed.")),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert "trace_id" not in receipt.to_dict()["executions"][0]
+
+
+def test_url4_replay_failure_uses_the_same_diagnostic_boundary() -> None:
+    from screamingface._evaluation.compilation import compile_evaluation
+
+    error = ExecutionError("Replay failed.", code="replay_failed")
+    replay_url4 = compile_evaluation((_candidate(),), _RESOURCE, 1).candidates[0].url4
+
+    with pytest.raises(ExecutionError) as caught:
+        evaluate_url4_sync(
+            _FailingTransport(error),
+            replay_url4,
+            None,
+            None,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is error
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    document = receipt.to_dict()
+    assert document["context"]["mode"] == "url4_replay"
+    assert replay_url4 not in receipt.to_json()
+
+
+def test_keyboard_interrupt_stages_observable_state_and_is_reraised() -> None:
+    interruption = KeyboardInterrupt()
+
+    with pytest.raises(KeyboardInterrupt) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(interruption),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is interruption
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.outcome == "interrupted_by_user"
+    assert receipt.to_dict()["executions"][0]["status"] == "running"
+    assert "hung" not in receipt.to_json().lower()
+
+
+@pytest.mark.asyncio
+async def test_async_cancellation_stages_cancelled_state_and_is_reraised() -> None:
+    cancellation = asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await evaluate_async(
+            _load_benchmark_async,
+            _AsyncFailingTransport(cancellation),
+            _load_catalog_async,
+            _load_details_async,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is cancellation
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.outcome == "cancelled"
+
+
+@pytest.mark.parametrize("signal", [SystemExit(2), GeneratorExit()])
+def test_process_control_exceptions_bypass_diagnostics(signal: BaseException) -> None:
+    with pytest.raises(type(signal)):
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(signal),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert sf.diagnostics.last() is None
+
+
+def test_partial_report_with_case_failures_stages_no_diagnostic() -> None:
+    report = evaluate_sync(
+        _load_benchmark,
+        _PartialTransport(),
+        _load_catalog,
+        _load_details,
+        _candidate(),
+        "draco",
+        1,
+        None,
+        False,
+        engine_url="https://engine.example",
+    )
+
+    assert report.failures[0].code == "case_not_graded"
+    assert sf.diagnostics.last() is None
+
+
+def test_capture_failure_never_replaces_the_operation_error(monkeypatch) -> None:
+    error = ExecutionError("Original failure.", code="original")
+
+    def broken_capture(context: object, raised: BaseException) -> NoReturn:
+        del context, raised
+        raise RuntimeError("diagnostic capture failed")
+
+    monkeypatch.setattr(
+        "screamingface._diagnostics.evaluation._EvaluationDiagnostic.stage",
+        broken_capture,
+    )
+
+    with pytest.raises(ExecutionError) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(error),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is error
+    assert sf.diagnostics.last() is None

--- a/packages/screamingface/tests/test_evaluation_diagnostics.py
+++ b/packages/screamingface/tests/test_evaluation_diagnostics.py
@@ -372,3 +372,29 @@ def test_capture_failure_never_replaces_the_operation_error(monkeypatch) -> None
 
     assert caught.value is error
     assert sf.diagnostics.last() is None
+
+
+def test_diagnostic_note_failure_never_replaces_the_operation_error() -> None:
+    class NoteFailure(ExecutionError):
+        def add_note(self, note: str) -> None:
+            del note
+            raise RuntimeError("note attachment failed")
+
+    error = NoteFailure("Original failure.", code="original")
+
+    with pytest.raises(NoteFailure) as caught:
+        evaluate_sync(
+            _load_benchmark,
+            _FailingTransport(error),
+            _load_catalog,
+            _load_details,
+            _candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    assert caught.value is error
+    assert sf.diagnostics.last() is not None

--- a/packages/screamingface/tests/test_evaluation_diagnostics.py
+++ b/packages/screamingface/tests/test_evaluation_diagnostics.py
@@ -75,11 +75,11 @@ def test_sync_evaluation_failure_stages_one_receipt_and_preserves_exception() ->
         {
             "candidate": "opus",
             "status": "running",
-            "run_id": "internal-stream-topic",
             "trace_id": _fixtures.TRACE_ID,
         }
     ]
     encoded = receipt.to_json()
+    assert "internal-stream-topic" not in encoded
     assert "private answer instruction" not in encoded
     assert "user:secret" not in encoded
     assert "token=secret" not in encoded
@@ -136,7 +136,6 @@ def test_preparation_failure_retains_safe_caller_candidate_identity() -> None:
         {
             "name": "opus",
             "kind": "model",
-            "models": ["provider/opus"],
         }
     ]
     assert "private answer instruction" not in receipt.to_json()
@@ -184,10 +183,27 @@ async def test_async_evaluation_failure_uses_the_same_receipt_contract() -> None
         {
             "candidate": "opus",
             "status": "running",
-            "run_id": "internal-stream-topic",
             "trace_id": _fixtures.TRACE_ID,
         }
     ]
+
+
+def test_preparation_failure_does_not_reconstruct_composite_recipe_models() -> None:
+    candidate = sf.Fusion(
+        ["provider/opus", "provider/gpt"],
+        synthesizer="provider/synth",
+        name="panel",
+    )
+    with sf.Client(
+        engine_url="https://engine.example",
+        run_transport=_fixtures.FailingTransport(AssertionError("transport must not run")),
+    ) as client:
+        with pytest.raises(TypeError, match="benchmark is required"):
+            cast(Any, client).evaluate(candidate)
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.to_dict()["context"]["candidates"] == [{"name": "panel", "kind": "fusion"}]
 
 
 def test_malformed_trace_context_is_not_fabricated() -> None:

--- a/packages/screamingface/tests/test_evaluation_diagnostics.py
+++ b/packages/screamingface/tests/test_evaluation_diagnostics.py
@@ -122,6 +122,31 @@ def test_public_client_input_validation_stages_a_degraded_receipt() -> None:
     assert receipt.to_dict()["error"]["type"] == "TypeError"
 
 
+@pytest.mark.parametrize(
+    ("option", "message"),
+    [
+        ({"benchmark": "draco"}, "benchmark must not be passed"),
+        ({"limit": 1}, "limit must not be passed"),
+    ],
+)
+def test_public_url4_option_validation_stages_a_degraded_receipt(
+    option: dict[str, object],
+    message: str,
+) -> None:
+    # INVARIANT: direct URL4 replay owns the same diagnostic boundary as Recipe evaluation.
+    with sf.Client(
+        engine_url="https://engine.example",
+        run_transport=_fixtures.FailingTransport(AssertionError("transport must not run")),
+    ) as client:
+        with pytest.raises(TypeError, match=message) as caught:
+            cast(Any, client).evaluate("(@)!'hello'", **option)
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.to_dict()["error"]["type"] == "TypeError"
+    assert receipt.diagnostic_id in caught.value.__notes__[0]
+
+
 def test_preparation_failure_retains_safe_caller_candidate_identity() -> None:
     with sf.Client(
         engine_url="https://engine.example",

--- a/packages/screamingface/tests/test_evaluation_diagnostics.py
+++ b/packages/screamingface/tests/test_evaluation_diagnostics.py
@@ -2,48 +2,11 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Generator
+from datetime import UTC, datetime
 from typing import Any, NoReturn, cast
 
+import _evaluation_diagnostic_fixtures as _fixtures
 import pytest
-from _evaluation_diagnostic_fixtures import (
-    RESOURCE as _RESOURCE,
-)
-from _evaluation_diagnostic_fixtures import (
-    TRACE_ID as _TRACE_ID,
-)
-from _evaluation_diagnostic_fixtures import (
-    AsyncFailingTransport as _AsyncFailingTransport,
-)
-from _evaluation_diagnostic_fixtures import (
-    FailingTransport as _FailingTransport,
-)
-from _evaluation_diagnostic_fixtures import (
-    PartialTransport as _PartialTransport,
-)
-from _evaluation_diagnostic_fixtures import (
-    candidate as _candidate,
-)
-from _evaluation_diagnostic_fixtures import (
-    load_benchmark as _load_benchmark,
-)
-from _evaluation_diagnostic_fixtures import (
-    load_benchmark_async as _load_benchmark_async,
-)
-from _evaluation_diagnostic_fixtures import (
-    load_catalog as _load_catalog,
-)
-from _evaluation_diagnostic_fixtures import (
-    load_catalog_async as _load_catalog_async,
-)
-from _evaluation_diagnostic_fixtures import (
-    load_details as _load_details,
-)
-from _evaluation_diagnostic_fixtures import (
-    load_details_async as _load_details_async,
-)
-from _evaluation_diagnostic_fixtures import (
-    started as _started,
-)
 
 import screamingface as sf
 from screamingface._diagnostics.store import _STORE
@@ -69,11 +32,11 @@ def test_sync_evaluation_failure_stages_one_receipt_and_preserves_exception() ->
 
     with pytest.raises(ExecutionError) as caught:
         evaluate_sync(
-            _load_benchmark,
-            _FailingTransport(error),
-            _load_catalog,
-            _load_details,
-            _candidate(),
+            _fixtures.load_benchmark,
+            _fixtures.FailingTransport(error),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
+            _fixtures.candidate(),
             "draco",
             1,
             None,
@@ -113,7 +76,7 @@ def test_sync_evaluation_failure_stages_one_receipt_and_preserves_exception() ->
             "candidate": "opus",
             "status": "running",
             "run_id": "internal-stream-topic",
-            "trace_id": _TRACE_ID,
+            "trace_id": _fixtures.TRACE_ID,
         }
     ]
     encoded = receipt.to_json()
@@ -125,10 +88,10 @@ def test_sync_evaluation_failure_stages_one_receipt_and_preserves_exception() ->
 def test_plain_argument_error_stages_a_degraded_receipt() -> None:
     with pytest.raises(TypeError) as caught:
         evaluate_sync(
-            _load_benchmark,
-            _FailingTransport(AssertionError("transport must not run")),
-            _load_catalog,
-            _load_details,
+            _fixtures.load_benchmark,
+            _fixtures.FailingTransport(AssertionError("transport must not run")),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
             cast(Any, object()),
             "draco",
             1,
@@ -149,14 +112,34 @@ def test_plain_argument_error_stages_a_degraded_receipt() -> None:
 def test_public_client_input_validation_stages_a_degraded_receipt() -> None:
     with sf.Client(
         engine_url="https://engine.example",
-        run_transport=_FailingTransport(AssertionError("transport must not run")),
+        run_transport=_fixtures.FailingTransport(AssertionError("transport must not run")),
     ) as client:
         with pytest.raises(TypeError, match="benchmark is required"):
-            cast(Any, client).evaluate(_candidate())
+            cast(Any, client).evaluate(_fixtures.candidate())
 
     receipt = sf.diagnostics.last()
     assert receipt is not None
     assert receipt.to_dict()["error"]["type"] == "TypeError"
+
+
+def test_preparation_failure_retains_safe_caller_candidate_identity() -> None:
+    with sf.Client(
+        engine_url="https://engine.example",
+        run_transport=_fixtures.FailingTransport(AssertionError("transport must not run")),
+    ) as client:
+        with pytest.raises(TypeError, match="benchmark is required"):
+            cast(Any, client).evaluate(_fixtures.candidate())
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    assert receipt.to_dict()["context"]["candidates"] == [
+        {
+            "name": "opus",
+            "kind": "model",
+            "models": ["provider/opus"],
+        }
+    ]
+    assert "private answer instruction" not in receipt.to_json()
 
 
 def test_unvalidated_benchmark_object_is_not_captured() -> None:
@@ -166,10 +149,10 @@ def test_unvalidated_benchmark_object_is_not_captured() -> None:
 
     with sf.Client(
         engine_url="https://engine.example",
-        run_transport=_FailingTransport(AssertionError("transport must not run")),
+        run_transport=_fixtures.FailingTransport(AssertionError("transport must not run")),
     ) as client:
         with pytest.raises(ValueError, match="benchmark"):
-            cast(Any, client).evaluate(_candidate(), benchmark=PrivateBenchmark())
+            cast(Any, client).evaluate(_fixtures.candidate(), benchmark=PrivateBenchmark())
 
     receipt = sf.diagnostics.last()
     assert receipt is not None
@@ -182,11 +165,11 @@ async def test_async_evaluation_failure_uses_the_same_receipt_contract() -> None
 
     with pytest.raises(ExecutionError) as caught:
         await evaluate_async(
-            _load_benchmark_async,
-            _AsyncFailingTransport(error),
-            _load_catalog_async,
-            _load_details_async,
-            _candidate(),
+            _fixtures.load_benchmark_async,
+            _fixtures.AsyncFailingTransport(error),
+            _fixtures.load_catalog_async,
+            _fixtures.load_details_async,
+            _fixtures.candidate(),
             "draco",
             1,
             None,
@@ -202,25 +185,25 @@ async def test_async_evaluation_failure_uses_the_same_receipt_contract() -> None
             "candidate": "opus",
             "status": "running",
             "run_id": "internal-stream-topic",
-            "trace_id": _TRACE_ID,
+            "trace_id": _fixtures.TRACE_ID,
         }
     ]
 
 
 def test_malformed_trace_context_is_not_fabricated() -> None:
-    class InvalidTraceTransport(_FailingTransport):
+    class InvalidTraceTransport(_fixtures.FailingTransport):
         def run(self, candidate: Candidate, on_event: object) -> NoReturn:
             if callable(on_event):
-                on_event(_started(candidate, traceparent="00-invalid-parent-01"))
+                on_event(_fixtures.started(candidate, traceparent="00-invalid-parent-01"))
             raise self.error
 
     with pytest.raises(ExecutionError):
         evaluate_sync(
-            _load_benchmark,
+            _fixtures.load_benchmark,
             InvalidTraceTransport(ExecutionError("Failed.")),
-            _load_catalog,
-            _load_details,
-            _candidate(),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
+            _fixtures.candidate(),
             "draco",
             1,
             None,
@@ -233,15 +216,74 @@ def test_malformed_trace_context_is_not_fabricated() -> None:
     assert "trace_id" not in receipt.to_dict()["executions"][0]
 
 
+def test_breadcrumb_retains_only_relative_route_span_names() -> None:
+    class SpanTransport(_fixtures.FailingTransport):
+        def run(self, candidate: Candidate, on_event: object) -> NoReturn:
+            assert callable(on_event)
+            on_event(_fixtures.started(candidate))
+            now = datetime.now(UTC)
+            on_event(
+                sf.events.Span(
+                    id="event-2",
+                    run_id="internal-stream-topic",
+                    sequence=2,
+                    timestamp=now,
+                    source="fixture",
+                    name="/benchmarks/case-execution",
+                    operation="RelUrlNode",
+                    start=now,
+                    end=now,
+                )
+            )
+            on_event(
+                sf.events.Span(
+                    id="event-3",
+                    run_id="internal-stream-topic",
+                    sequence=3,
+                    timestamp=now,
+                    source="fixture",
+                    name="private prompt text",
+                    operation="TextNode",
+                    start=now,
+                    end=now,
+                )
+            )
+            raise self.error
+
+    with pytest.raises(ExecutionError):
+        evaluate_sync(
+            _fixtures.load_benchmark,
+            SpanTransport(ExecutionError("Failed.")),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
+            _fixtures.candidate(),
+            "draco",
+            1,
+            None,
+            False,
+            engine_url="https://engine.example",
+        )
+
+    receipt = sf.diagnostics.last()
+    assert receipt is not None
+    breadcrumbs = receipt.to_dict()["breadcrumbs"]
+    assert [item["operation"] for item in breadcrumbs if "operation" in item] == [
+        "/benchmarks/case-execution"
+    ]
+    assert "private prompt text" not in receipt.to_json()
+
+
 def test_url4_replay_failure_uses_the_same_diagnostic_boundary() -> None:
     from screamingface._evaluation.compilation import compile_evaluation
 
     error = ExecutionError("Replay failed.", code="replay_failed")
-    replay_url4 = compile_evaluation((_candidate(),), _RESOURCE, 1).candidates[0].url4
+    replay_url4 = (
+        compile_evaluation((_fixtures.candidate(),), _fixtures.RESOURCE, 1).candidates[0].url4
+    )
 
     with pytest.raises(ExecutionError) as caught:
         evaluate_url4_sync(
-            _FailingTransport(error),
+            _fixtures.FailingTransport(error),
             replay_url4,
             None,
             None,
@@ -263,11 +305,11 @@ def test_keyboard_interrupt_stages_observable_state_and_is_reraised() -> None:
 
     with pytest.raises(KeyboardInterrupt) as caught:
         evaluate_sync(
-            _load_benchmark,
-            _FailingTransport(interruption),
-            _load_catalog,
-            _load_details,
-            _candidate(),
+            _fixtures.load_benchmark,
+            _fixtures.FailingTransport(interruption),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
+            _fixtures.candidate(),
             "draco",
             1,
             None,
@@ -289,11 +331,11 @@ async def test_async_cancellation_stages_cancelled_state_and_is_reraised() -> No
 
     with pytest.raises(asyncio.CancelledError) as caught:
         await evaluate_async(
-            _load_benchmark_async,
-            _AsyncFailingTransport(cancellation),
-            _load_catalog_async,
-            _load_details_async,
-            _candidate(),
+            _fixtures.load_benchmark_async,
+            _fixtures.AsyncFailingTransport(cancellation),
+            _fixtures.load_catalog_async,
+            _fixtures.load_details_async,
+            _fixtures.candidate(),
             "draco",
             1,
             None,
@@ -311,11 +353,11 @@ async def test_async_cancellation_stages_cancelled_state_and_is_reraised() -> No
 def test_process_control_exceptions_bypass_diagnostics(signal: BaseException) -> None:
     with pytest.raises(type(signal)):
         evaluate_sync(
-            _load_benchmark,
-            _FailingTransport(signal),
-            _load_catalog,
-            _load_details,
-            _candidate(),
+            _fixtures.load_benchmark,
+            _fixtures.FailingTransport(signal),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
+            _fixtures.candidate(),
             "draco",
             1,
             None,
@@ -328,11 +370,11 @@ def test_process_control_exceptions_bypass_diagnostics(signal: BaseException) ->
 
 def test_partial_report_with_case_failures_stages_no_diagnostic() -> None:
     report = evaluate_sync(
-        _load_benchmark,
-        _PartialTransport(),
-        _load_catalog,
-        _load_details,
-        _candidate(),
+        _fixtures.load_benchmark,
+        _fixtures.PartialTransport(),
+        _fixtures.load_catalog,
+        _fixtures.load_details,
+        _fixtures.candidate(),
         "draco",
         1,
         None,
@@ -358,11 +400,11 @@ def test_capture_failure_never_replaces_the_operation_error(monkeypatch) -> None
 
     with pytest.raises(ExecutionError) as caught:
         evaluate_sync(
-            _load_benchmark,
-            _FailingTransport(error),
-            _load_catalog,
-            _load_details,
-            _candidate(),
+            _fixtures.load_benchmark,
+            _fixtures.FailingTransport(error),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
+            _fixtures.candidate(),
             "draco",
             1,
             None,
@@ -384,11 +426,11 @@ def test_diagnostic_note_failure_never_replaces_the_operation_error() -> None:
 
     with pytest.raises(NoteFailure) as caught:
         evaluate_sync(
-            _load_benchmark,
-            _FailingTransport(error),
-            _load_catalog,
-            _load_details,
-            _candidate(),
+            _fixtures.load_benchmark,
+            _fixtures.FailingTransport(error),
+            _fixtures.load_catalog,
+            _fixtures.load_details,
+            _fixtures.candidate(),
             "draco",
             1,
             None,

--- a/packages/screamingface/tests/test_live_candidate_progress.py
+++ b/packages/screamingface/tests/test_live_candidate_progress.py
@@ -12,14 +12,13 @@ import pytest
 import screamingface as sf
 from screamingface._core.ports import _RunOutcome
 from screamingface._evaluation.model import Candidate, _compiled_candidate, _compiled_operation
-from screamingface._evaluation.runner import (
+from screamingface._evaluation.observers import (
     _abort_event_observer,
     _AsyncEventObserver,
     _reconcile_event_observer,
-    _run_candidates_async,
-    _run_candidates_sync,
     _SyncEventObserver,
 )
+from screamingface._evaluation.runner import _run_candidates_async, _run_candidates_sync
 from screamingface._ui.evaluation_state import _EvaluationProgress
 from screamingface._ui.evaluation_view import _evaluation_fragments
 from screamingface._ui.style import _DARK, _LIGHT, FUSION_GRADIENT, STYLE

--- a/packages/screamingface/tests/test_progress.py
+++ b/packages/screamingface/tests/test_progress.py
@@ -8,12 +8,12 @@ from typing import Any, cast
 import pytest
 
 import screamingface as sf
-from screamingface._evaluation.progress import _message, _progress_observer
-from screamingface._evaluation.runner import (
+from screamingface._evaluation.observers import (
     _async_event_observer,
     _close_event_observer,
     _sync_event_observer,
 )
+from screamingface._evaluation.progress import _message, _progress_observer
 
 
 def envelope() -> dict[str, Any]:

--- a/packages/screamingface/tests/test_public_surface.py
+++ b/packages/screamingface/tests/test_public_surface.py
@@ -62,6 +62,7 @@ PINNED_MODULES = (
     "screamingface",
     "screamingface.benchmarks",
     "screamingface.connections",
+    "screamingface.diagnostics",
     "screamingface.events",
     "screamingface.leaderboards",
     "screamingface.models",


### PR DESCRIPTION
## Summary

- retain bounded, privacy-safe local receipts for failed or interrupted evaluations
- preserve the original exception and native traceback while adding a one-time local notebook receipt toolbar
- expose `sf.diagnostics` lookup, preview, and explicit JSON export without network submission or automatic persistence
- capture safe candidate, compiled topology, validated configuration, lifecycle, and trace evidence through fail-open sync and async boundaries
- keep the internal Event stream topic private instead of publishing it as a receipt `run_id`
- use compiler-produced topology instead of a diagnostics-owned switch over every Recipe subtype
- validate receipt assembly through one typed evidence aggregate and reject unsafe error fields

## Test plan

- `uv run .claude/scripts/run_gates.py screamingface`
- append-only check, Ruff lint/format, Pyright, full pytest suite at ≥95% coverage, notebook validation, build, and distribution validation all green after rebasing onto `origin/main`
- 62 focused diagnostic, capture, and fail-open tests pass
- owner-approved prior-test contract corrections are recorded in `docs/work/2026-09-01-OME-1013-diagnostic-hardening.md`

## Review findings resolved

- notebook renderer now returns the original/native traceback lines on initial and repeated rendering; the toolbar displays once and `%tb` remains useful
- private stream-topic `Event.run_id` is absent from receipts while valid trace ids remain
- pre-compilation fallback captures only candidate name/kind; compilation remains authoritative for models and operation topology
- diagnostic export failures use the SFDS danger token
- earlier completed-iteration ledgers now explicitly distinguish their status from the still-open Linear issue

Owner visually verified the compact toolbar in Jupyter before this hardening pass; an updated screenshot can be attached before marking ready.

Refs: OME-1013
