### PR TITLE
fix(ci): use the repository token for release-please releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,10 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          # Releases are created by the repository token, not a PAT: GITHUB_TOKEN with the
+          # workflow's `permissions` (contents: write, pull-requests: write) can create
+          # releases, tags, and release PRs, and cannot expire or lose scopes like a PAT.
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # release-please bumps `version` in pyproject.toml and stops there, but every uv.lock
       # records that same version — so the release PR it just opened already fails

--- a/docs/tasks/2026-08-27-OME-1028-release-please-token.md
+++ b/docs/tasks/2026-08-27-OME-1028-release-please-token.md
@@ -1,0 +1,46 @@
+---
+ticket: OME-1028
+linear_url: https://linear.app/openmined/issue/OME-1028/fix-release-please-token-so-releases-are-created-by-the-repository
+stack: repo
+status: in_progress
+started: 2026-08-27
+labels: [repo]
+actor: agentic
+who-acts: autonomous
+type: task
+priority: P2
+---
+
+# OME-1028 — Fix release-please token so releases are created by the repository
+
+## Context
+
+The `Release Please` workflow (`.github/workflows/release-please.yml`) has failed on
+every push to `main` since 2026-08-23, blocking the releases for `url4 1.5.0` (#628)
+and `screamingface-engine 1.4.0` (#644).
+
+Error: `release-please failed: Resource not accessible by personal access token -
+create-a-release`. The action step passes `token: ${{ secrets.RELEASE_PAT ||
+secrets.GITHUB_TOKEN }}`; since `RELEASE_PAT` is set, the action always uses that
+PAT, which has lost the permission to create GitHub releases (403). It worked through
+2026-08-13 (last release created) and degraded by 2026-08-19 (first `Error adding to
+tree` — a swallowed 403 on git-tree creation, per googleapis/release-please-action#938).
+
+## Scope
+
+- `.github/workflows/release-please.yml`: use `token: ${{ secrets.GITHUB_TOKEN }}`
+  for the release-please action. The workflow already declares
+  `permissions: contents: write, pull-requests: write`, sufficient for creating
+  releases, tags, and release PRs; GITHUB_TOKEN cannot expire or lose scopes.
+- Keep `RELEASE_PAT` on the lockfile-sync checkout step (a GITHUB_TOKEN push raises
+  no workflow events, so the release PR would keep the red check it was opened with).
+
+## Out of scope
+
+- Rotating/regenerating `RELEASE_PAT` (owner action; the checkout step still needs it).
+- Any application code.
+
+## Definition of done
+
+- Release-please action uses the repository token.
+- Next push to `main` creates the pending releases (url4 1.5.0, screamingface-engine 1.4.0).

--- a/docs/work/2026-08-27-OME-1028-release-please-token.md
+++ b/docs/work/2026-08-27-OME-1028-release-please-token.md
@@ -1,0 +1,42 @@
+---
+ticket: OME-1028
+stack: repo
+status: in_progress
+started: 2026-08-27
+finished:
+---
+
+# OME-1028 — Fix release-please token so releases are created by the repository
+
+## Intent
+
+The release-please CI/CD pipeline has failed on every push to `main` since 2026-08-23:
+the action uses `RELEASE_PAT` (which has lost release-creation permission) instead of
+the repository token, so the pending releases for `url4 1.5.0` and
+`screamingface-engine 1.4.0` cannot be created. This unit switches the release-please
+action to `GITHUB_TOKEN` so releases are created by the repository.
+
+## Planned changes
+
+- `.github/workflows/release-please.yml` — release-please action `token:` →
+  `${{ secrets.GITHUB_TOKEN }}` (+ comment). Checkout step keeps `RELEASE_PAT`.
+- `docs/tasks/2026-08-27-OME-1028-release-please-token.md` — mirror (this unit).
+- `docs/work/2026-08-27-OME-1028-release-please-token.md` — ledger (this unit).
+
+## Test plan
+
+- No test suite applies (workflow YAML change). Verification is the next
+  `Release Please` run on `main` creating the pending releases.
+
+## Acceptance
+
+- Release-please action uses the repository token; `RELEASE_PAT` remains only on the
+  lockfile-sync checkout step.
+- Next push to `main` creates the pending releases (url4 1.5.0, screamingface-engine 1.4.0).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `.github/workflows/release-please.yml` (token → GITHUB_TOKEN + comment); `docs/tasks/2026-08-27-OME-1028-release-please-token.md`; `docs/work/2026-08-27-OME-1028-release-please-token.md`
+- **Commits:** 6f923601 — fix(ci): use the repository token for release-please releases
+- **Gates:** n/a (workflow YAML change; no test suite applies)
+- **Deviations:** none


### PR DESCRIPTION
## Summary

The `Release Please` workflow has failed on **every push to `main` since 2026-08-23**, blocking the pending releases for `url4 1.5.0` (#628) and `screamingface-engine 1.4.0` (#644).

**Error:** `release-please failed: Resource not accessible by personal access token - create-a-release`

**Root cause:** the action step passed `token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}`. Since `RELEASE_PAT` is set, the action always used that PAT — the `GITHUB_TOKEN` fallback never engaged. The PAT has lost the permission to create GitHub releases (403). It worked through 2026-08-13 (last release created) and degraded by 2026-08-19 (first `Error adding to tree` — a swallowed 403 on git-tree creation, per googleapis/release-please-action#938).

**Fix:** the release-please action now uses `token: ${{ secrets.GITHUB_TOKEN }}` — releases are created by the repository. The workflow's `permissions: contents: write, pull-requests: write` is sufficient for creating releases, tags, and release PRs, and the repository token cannot expire or lose scopes like a PAT.

The lockfile-sync checkout step **keeps** `RELEASE_PAT`: a GITHUB_TOKEN push raises no workflow events, so the release PR would keep the red check it was opened with (documented in the workflow).

## Test plan

- No test suite applies (workflow YAML change).
- Verify: next push to `main` runs `Release Please` green and creates the pending releases (`url4-v1.5.0`, `screamingface-engine-v1.4.0`).

Fixes OME-1028
