### PR TITLE
feat(py-screamingface): decode the Engine's retained per-operation accounting

### DIFF
--- a/docs/tasks/2026-08-28-OME-1032-decode-operation-accounting.md
+++ b/docs/tasks/2026-08-28-OME-1032-decode-operation-accounting.md
@@ -1,0 +1,28 @@
+---
+id: OME-1032
+linear_url: https://linear.app/openmined/issue/OME-1032/keep-each-operations-cost-and-token-facts-when-a-report-is-read-back
+status: in_progress
+type: feature
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-28
+closed:
+---
+
+# Keep each operation's cost and token facts when a report is read back
+
+Parent: `OME-1031` (which keeps the computed views, `MemberResult.usage`, and the
+completed-Report table). Grandparent: `OME-901`.
+
+The Engine (`OME-1030`, PR #762) retains `accounting` on Candidate `CaseOperation`
+and grading `Evidence`, emitted unconditionally and `null` when empty. The Client's
+strict decoder rejected the unknown field, so every evaluation against that Engine
+failed and #762's golden-replay lane was red. This slice decodes the retained value
+and round-trips it through the public API and Report JSON — nothing more.
+
+**Lands atomically with the Engine.** The field is required-nullable and the decoder
+has no compatibility fallback, so either side alone turns CI red in the mirror-image
+way. This branch is cut from `OME-901-runtime-accounting-lineage` and its PR targets
+that branch, not `main`.
+
+Ledger: `docs/work/2026-08-28-OME-1032-decode-operation-accounting.md`.

--- a/docs/tasks/2026-08-28-OME-1032-decode-operation-accounting.md
+++ b/docs/tasks/2026-08-28-OME-1032-decode-operation-accounting.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1032
 linear_url: https://linear.app/openmined/issue/OME-1032/keep-each-operations-cost-and-token-facts-when-a-report-is-read-back
-status: in_progress
+status: in_review
 type: feature
 priority: 2
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/work/2026-08-28-OME-1032-decode-operation-accounting.md
+++ b/docs/work/2026-08-28-OME-1032-decode-operation-accounting.md
@@ -1,0 +1,104 @@
+---
+ticket: OME-1032
+stack: screamingface
+status: in_progress   # planned | in_progress | done | blocked
+started: 2026-08-28
+finished:
+---
+
+# OME-1032 — Decode retained per-operation accounting in the Client
+
+## Intent
+
+The Engine (OME-1030, PR #762) now emits `accounting` on Candidate `CaseOperation`
+and grading `Evidence` — unconditionally, `null` when empty. The Client's strict
+decoder rejects the unknown field, so every evaluation against that Engine fails
+and PR #762's golden-replay lane is red. This unit teaches the Client to decode
+the retained value and round-trip it through the public API and Report JSON —
+nothing more. Computed views, `MemberResult.usage` and the completed-Report table
+stay in the parent OME-1031.
+
+Landing shape: branch is cut from `OME-901-runtime-accounting-lineage`; its PR
+targets that branch, NOT `main`. Engine and Client must land atomically — each
+side alone turns CI red in the mirror-image way (unsupported field vs missing
+field), and the e2e harness boots the Engine from the same checkout so there is
+no version skew.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/case_result.py`
+  - new `OperationCache` value (hits/misses/bypasses/unknown; ≥1 response).
+  - new `OperationAccounting` value (provider, request_model, response_model,
+    usage, provider_latency_ms, cache) reusing the SDK's existing
+    `_report_primitives.Usage` — the six fields match the Engine's
+    `OperationUsage` exactly, so no second usage type is introduced.
+  - `CaseOperation` gains `accounting: OperationAccounting | None`; `to_dict`
+    emits it unconditionally (required-nullable, mirroring the Engine).
+  - `Evidence` gains the same field + `to_dict` emission.
+- `packages/screamingface/src/screamingface/_evaluation/results.py`
+  - `_case_operation` / `_evidence`: `accounting` becomes a REQUIRED key; new
+    `_operation_accounting` decoder (strict: unknown fields refuse, negative
+    values refuse, blank identity refuses, cost must be fixed-point text).
+- `packages/screamingface/src/screamingface/__init__.py` — export the two new
+  public values.
+- Tests: new `packages/screamingface/tests/test_operation_accounting_decode.py`.
+
+## Test plan
+
+RED first:
+- a Case Operation / Evidence carrying full accounting decodes into the typed
+  value, cost as `Decimal`, and `to_dict` round-trips byte-equal.
+- `accounting: null` decodes to `None` (the common case — deterministic
+  evidence, unattributable operations).
+- a MISSING `accounting` key refuses loudly (`is missing 'accounting'`) — the
+  required-nullable contract, and the reason this must land with the Engine.
+- strictness: unknown sub-field, negative tokens, negative `provider_latency_ms`,
+  blank provider text, malformed `cost_usd`, and an all-zero `cache` each refuse
+  with a named error rather than a silent null or a false zero.
+- the invariant the parent spec names: absence stays absence — a null accounting
+  never becomes a zeroed value.
+
+## Acceptance
+
+- New tests green; every prior Client test green and unmodified.
+- Gates: `run_gates.py screamingface` all green.
+- Combined with the Engine branch, both goldens (`draco-3pass`,
+  `healthbench-worst30`) replay green with NO re-blessing — #762 touches no
+  revision-pinning file, so the expression must not have moved.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus two not foreseen:
+  - `src/screamingface/case_result.py` — `OperationCache` + `OperationAccounting`
+    values; `accounting` on `CaseOperation` and `Evidence` (+ `to_dict`);
+    `_validated_evidence_parts` extracted so `Evidence.__init__` stays under the
+    complexity gate (rules unchanged, only relocated).
+  - `src/screamingface/_evaluation/results.py` — `_operation_accounting`
+    decoder, `_positive_or_zero_integer`, `accounting` required on both owners.
+  - `src/screamingface/report.py`, `src/screamingface/__init__.py` — exports.
+  - `tests/test_operation_accounting_decode.py` (new, 21 tests).
+  - NOT planned: `tests/public_surface_snapshot.json` regenerated deliberately
+    (`UPDATE_SURFACE_SNAPSHOT=1`) for the two new public values.
+  - NOT planned: prior-test payload fixtures updated (see Deviations).
+- **Commits:** see git log on `OME-1032-decode-operation-accounting`.
+- **Gates:** `run_gates.py screamingface --skip-append-only` → ALL GATES GREEN.
+  Client suite 1229 passed / 17 skipped. Docker e2e lane on the COMBINED tree
+  (engine branch + this): **64 passed, 4 skipped, 0 failures** — the
+  `draco-3pass` golden replay that is red on PR #762 is green here, with no
+  re-blessing, confirming the expression did not move.
+- **Deviations:**
+  1. **26 prior tests hand-authored the old wire shape** and failed once
+     `accounting` became required. Their payload dicts gained
+     `"accounting": None`; three `to_dict()` expectations gained the same key
+     because the serialized shape now always carries it. No assertion's meaning
+     was changed or weakened — this is the sanctioned consequence of the
+     owner-approved contract evolution ("pre-release v1 evolves directly, no
+     compatibility fallback", spec §0). Two rows of
+     `test_a_malformed_operation_entry_fails_closed` needed the key added so
+     they still exercise the defect they name rather than tripping on the new
+     one first.
+  2. Append-only gate run with `--skip-append-only` for the same reason.
+  3. `Evidence.__init__` exceeded the complexity gate after one added branch;
+     validation extracted to a module-level helper rather than weakening the gate.
+  4. The e2e lane needs `SCREAMINGFACE_E2E_ASSETS` and a regenerated
+     `synthetic.manifest.json` (gitignored, per worktree) — environment, not code.

--- a/docs/work/2026-08-28-OME-1032-decode-operation-accounting.md
+++ b/docs/work/2026-08-28-OME-1032-decode-operation-accounting.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1032
 stack: screamingface
-status: in_progress   # planned | in_progress | done | blocked
+status: done   # planned | in_progress | done | blocked
 started: 2026-08-28
-finished:
+finished: 2026-08-28
 ---
 
 # OME-1032 — Decode retained per-operation accounting in the Client
@@ -25,6 +25,12 @@ field), and the e2e harness boots the Engine from the same checkout so there is
 no version skew.
 
 ## Planned changes
+
+- Review follow-up: make the wire decoder enforce the Engine's canonical
+  fixed-point `cost_usd` grammar and replace every production `type: ignore`
+  with typed boundary validation. Extract the accounting decoder/value seam so
+  this feature does not materially deepen the Client's already-large result
+  modules.
 
 - `packages/screamingface/src/screamingface/case_result.py`
   - new `OperationCache` value (hits/misses/bypasses/unknown; ≥1 response).
@@ -53,7 +59,8 @@ RED first:
 - a MISSING `accounting` key refuses loudly (`is missing 'accounting'`) — the
   required-nullable contract, and the reason this must land with the Engine.
 - strictness: unknown sub-field, negative tokens, negative `provider_latency_ms`,
-  blank provider text, malformed `cost_usd`, and an all-zero `cache` each refuse
+  blank provider text, exponent/leading-zero/non-string `cost_usd`, and an
+  all-zero `cache` each refuse
   with a named error rather than a silent null or a false zero.
 - the invariant the parent spec names: absence stays absence — a null accounting
   never becomes a zeroed value.
@@ -69,20 +76,28 @@ RED first:
 ## Outcome (fill at the end — required before COMMIT)
 
 - **Actual files:** as planned, plus two not foreseen:
-  - `src/screamingface/case_result.py` — `OperationCache` + `OperationAccounting`
-    values; `accounting` on `CaseOperation` and `Evidence` (+ `to_dict`);
+  - `src/screamingface/operation_accounting.py` — focused `OperationCache` +
+    `OperationAccounting` public values, extracted during review so the feature
+    does not materially grow the already-large Case Result module.
+  - `src/screamingface/case_result.py` — `accounting` on `CaseOperation` and
+    `Evidence` (+ `to_dict`);
     `_validated_evidence_parts` extracted so `Evidence.__init__` stays under the
     complexity gate (rules unchanged, only relocated).
-  - `src/screamingface/_evaluation/results.py` — `_operation_accounting`
-    decoder, `_positive_or_zero_integer`, `accounting` required on both owners.
+  - `src/screamingface/_evaluation/operation_accounting.py` — focused strict
+    wire decoder; canonical fixed-point cost and typed integer/cache boundaries.
+  - `src/screamingface/_evaluation/results.py` — `accounting` required on both
+    owners and delegated to the focused decoder.
   - `src/screamingface/report.py`, `src/screamingface/__init__.py` — exports.
-  - `tests/test_operation_accounting_decode.py` (new, 21 tests).
+  - `tests/test_operation_accounting_decode.py` (new, 29 tests after review
+    hardening, including exponent/leading-zero/leading-plus/Decimal cost refusal).
   - NOT planned: `tests/public_surface_snapshot.json` regenerated deliberately
     (`UPDATE_SURFACE_SNAPSHOT=1`) for the two new public values.
   - NOT planned: prior-test payload fixtures updated (see Deviations).
 - **Commits:** see git log on `OME-1032-decode-operation-accounting`.
 - **Gates:** `run_gates.py screamingface --skip-append-only` → ALL GATES GREEN.
-  Client suite 1229 passed / 17 skipped. Docker e2e lane on the COMBINED tree
+  Ruff check, Ruff format, Pyright, full Client suite with coverage ≥95%,
+  deterministic notebook check, wheel build, and distribution check all passed.
+  Docker e2e lane on the COMBINED tree
   (engine branch + this): **64 passed, 4 skipped, 0 failures** — the
   `draco-3pass` golden replay that is red on PR #762 is green here, with no
   re-blessing, confirming the expression did not move.
@@ -102,3 +117,9 @@ RED first:
      validation extracted to a module-level helper rather than weakening the gate.
   4. The e2e lane needs `SCREAMINGFACE_E2E_ASSETS` and a regenerated
      `synthetic.manifest.json` (gitignored, per worktree) — environment, not code.
+  5. The touched `case_result.py` and `_evaluation/results.py` remain above the
+     current 450-line target because they already exceeded it before this unit
+     (585 and 547 lines respectively). Review extraction removed this feature's
+     material growth: accounting now lives in focused 97- and 129-line modules;
+     the remaining pre-existing split is deliberately not bundled into this wire
+     contract fix.

--- a/packages/screamingface/src/screamingface/__init__.py
+++ b/packages/screamingface/src/screamingface/__init__.py
@@ -46,6 +46,8 @@ from screamingface.report import (
     EvidenceProducer,
     Failure,
     MemberResult,
+    OperationAccounting,
+    OperationCache,
     Report,
     Usage,
 )
@@ -102,6 +104,8 @@ __all__ = [
     "Report",
     "ScreamingFaceError",
     "SelfCorrective",
+    "OperationAccounting",
+    "OperationCache",
     "Usage",
     "Url4",
     "benchmarks",

--- a/packages/screamingface/src/screamingface/_evaluation/operation_accounting.py
+++ b/packages/screamingface/src/screamingface/_evaluation/operation_accounting.py
@@ -1,0 +1,129 @@
+"""Strict decoder for retained per-operation accounting."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from screamingface._report_primitives import Usage
+from screamingface.errors import ExecutionError
+from screamingface.operation_accounting import OperationAccounting, OperationCache
+
+_FIXED_POINT_COST = re.compile(r"^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$")
+_ACCOUNTING_KEYS = {
+    "provider",
+    "request_model",
+    "response_model",
+    "usage",
+    "provider_latency_ms",
+    "provider_attempts",
+    "cache",
+}
+_USAGE_KEYS = {
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+    "reasoning_tokens",
+    "cost_usd",
+}
+_CACHE_KEYS = {"hits", "misses", "bypasses", "unknown"}
+
+
+def decode_operation_accounting(value: object, label: str) -> OperationAccounting | None:
+    """Decode a complete accounting value, or preserve its explicit absence.
+
+    INVARIANT: a partial or noncanonical wire value refuses instead of becoming
+    a plausible subtotal. This is deliberately stricter than constructing
+    ``sf.Usage`` directly because the Engine's versioned JSON contract has one
+    canonical fixed-point representation for money.
+    """
+
+    if value is None:
+        return None
+    raw = _mapping(value, label)
+    _exact_keys(raw, _ACCOUNTING_KEYS, label)
+    usage_raw = _mapping(raw.get("usage"), f"{label} usage")
+    _exact_keys(usage_raw, _USAGE_KEYS, f"{label} usage")
+    cache_raw = _mapping(raw.get("cache"), f"{label} cache")
+    _exact_keys(cache_raw, _CACHE_KEYS, f"{label} cache")
+
+    try:
+        return OperationAccounting(
+            provider=_optional_text(raw.get("provider"), f"{label} provider"),
+            request_model=_optional_text(raw.get("request_model"), f"{label} request_model"),
+            response_model=_optional_text(raw.get("response_model"), f"{label} response_model"),
+            usage=Usage(
+                input_tokens=_optional_nonnegative_integer(
+                    usage_raw.get("input_tokens"), f"{label} usage input_tokens"
+                ),
+                output_tokens=_optional_nonnegative_integer(
+                    usage_raw.get("output_tokens"), f"{label} usage output_tokens"
+                ),
+                cache_read_tokens=_optional_nonnegative_integer(
+                    usage_raw.get("cache_read_tokens"), f"{label} usage cache_read_tokens"
+                ),
+                cache_creation_tokens=_optional_nonnegative_integer(
+                    usage_raw.get("cache_creation_tokens"),
+                    f"{label} usage cache_creation_tokens",
+                ),
+                reasoning_tokens=_optional_nonnegative_integer(
+                    usage_raw.get("reasoning_tokens"), f"{label} usage reasoning_tokens"
+                ),
+                cost_usd=_optional_fixed_point_cost(
+                    usage_raw.get("cost_usd"), f"{label} usage cost_usd"
+                ),
+            ),
+            provider_latency_ms=_optional_nonnegative_integer(
+                raw.get("provider_latency_ms"), f"{label} provider_latency_ms"
+            ),
+            provider_attempts=_optional_nonnegative_integer(
+                raw.get("provider_attempts"), f"{label} provider_attempts"
+            ),
+            cache=OperationCache(
+                hits=_nonnegative_integer(cache_raw.get("hits"), f"{label} cache hits"),
+                misses=_nonnegative_integer(cache_raw.get("misses"), f"{label} cache misses"),
+                bypasses=_nonnegative_integer(cache_raw.get("bypasses"), f"{label} cache bypasses"),
+                unknown=_nonnegative_integer(cache_raw.get("unknown"), f"{label} cache unknown"),
+            ),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"{label} is invalid: {exc}") from exc
+
+
+def _mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or not all(isinstance(key, str) for key in value):
+        raise ExecutionError(f"{label} must be an object with text keys")
+    return value
+
+
+def _exact_keys(value: Mapping[str, object], required: set[str], label: str) -> None:
+    present = set(value)
+    if missing := sorted(required - present):
+        raise ExecutionError(f"{label} is missing {missing[0]!r}")
+    if unknown := sorted(present - required):
+        raise ExecutionError(f"{label} contains unsupported field {unknown[0]!r}")
+
+
+def _optional_text(value: object, label: str) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    raise ExecutionError(f"{label} must be text or null")
+
+
+def _nonnegative_integer(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ExecutionError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _optional_nonnegative_integer(value: object, label: str) -> int | None:
+    return None if value is None else _nonnegative_integer(value, label)
+
+
+def _optional_fixed_point_cost(value: object, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or _FIXED_POINT_COST.fullmatch(value) is None:
+        raise ExecutionError(f"{label} must be fixed-point decimal text or null")
+    return value

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -8,13 +8,12 @@ from typing import Literal, cast
 
 from screamingface._core.ports import _RunOutcome
 from screamingface._evaluation.model import Candidate, _compiled_evaluation, _Evaluation
+from screamingface._evaluation.operation_accounting import decode_operation_accounting
 from screamingface._report_primitives import CaseId
 from screamingface._report_primitives import _case_id as _validate_case_id
 from screamingface.case_result import (
     CaseOperation,
     CaseStatus,
-    OperationAccounting,
-    OperationCache,
     StopReason,
 )
 from screamingface.discovery import BenchmarkInfo
@@ -289,82 +288,6 @@ def _case_operations(value: object) -> tuple[CaseOperation, ...]:
     return tuple(_case_operation(item) for item in _sequence(value, "Case Result operations"))
 
 
-def _operation_accounting(value: object, label: str) -> OperationAccounting | None:
-    """Decode one retained ``OperationAccounting``, or ``None`` — never in between.
-
-    INVARIANT: absence stays absence. The Engine already applied the exact-only
-    rule (a partial join publishes null rather than a subtotal), so the Client's
-    only job is to refuse anything it cannot decode faithfully. Every branch here
-    raises instead of substituting a plausible value, because a zero or a dropped
-    field would be read downstream as an observed fact.
-    """
-    if value is None:
-        return None
-    raw = _mapping(value, label)
-    _keys(
-        raw,
-        required={
-            "provider",
-            "request_model",
-            "response_model",
-            "usage",
-            "provider_latency_ms",
-            "provider_attempts",
-            "cache",
-        },
-        label=label,
-    )
-    usage_raw = _mapping(raw.get("usage"), f"{label} usage")
-    _keys(
-        usage_raw,
-        required={
-            "input_tokens",
-            "output_tokens",
-            "cache_read_tokens",
-            "cache_creation_tokens",
-            "reasoning_tokens",
-            "cost_usd",
-        },
-        label=f"{label} usage",
-    )
-    cache_raw = _mapping(raw.get("cache"), f"{label} cache")
-    _keys(cache_raw, required={"hits", "misses", "bypasses", "unknown"}, label=f"{label} cache")
-    latency = raw.get("provider_latency_ms")
-    attempts = raw.get("provider_attempts")
-    try:
-        return OperationAccounting(
-            provider=_optional_string(raw.get("provider"), f"{label} provider"),
-            request_model=_optional_string(raw.get("request_model"), f"{label} request_model"),
-            response_model=_optional_string(raw.get("response_model"), f"{label} response_model"),
-            usage=Usage(
-                input_tokens=usage_raw.get("input_tokens"),  # type: ignore[arg-type]
-                output_tokens=usage_raw.get("output_tokens"),  # type: ignore[arg-type]
-                cache_read_tokens=usage_raw.get("cache_read_tokens"),  # type: ignore[arg-type]
-                cache_creation_tokens=usage_raw.get("cache_creation_tokens"),  # type: ignore[arg-type]
-                reasoning_tokens=usage_raw.get("reasoning_tokens"),  # type: ignore[arg-type]
-                cost_usd=usage_raw.get("cost_usd"),  # type: ignore[arg-type]
-            ),
-            provider_latency_ms=(
-                None
-                if latency is None
-                else _positive_or_zero_integer(latency, f"{label} provider_latency_ms")
-            ),
-            provider_attempts=(
-                None
-                if attempts is None
-                else _positive_or_zero_integer(attempts, f"{label} provider_attempts")
-            ),
-            cache=OperationCache(
-                hits=cache_raw.get("hits"),  # type: ignore[arg-type]
-                misses=cache_raw.get("misses"),  # type: ignore[arg-type]
-                bypasses=cache_raw.get("bypasses"),  # type: ignore[arg-type]
-                unknown=cache_raw.get("unknown"),  # type: ignore[arg-type]
-            ),
-        )
-    except (TypeError, ValueError) as exc:
-        raise ExecutionError(f"{label} is invalid: {exc}") from exc
-
-
 def _case_operation(value: object) -> CaseOperation:
     raw = _mapping(value, "Case Operation")
     _keys(
@@ -382,7 +305,9 @@ def _case_operation(value: object) -> CaseOperation:
                 if finish_reason_value is None
                 else _text(finish_reason_value, "Case Operation finish_reason")
             ),
-            accounting=_operation_accounting(raw.get("accounting"), "Case Operation accounting"),
+            accounting=decode_operation_accounting(
+                raw.get("accounting"), "Case Operation accounting"
+            ),
         )
     except (TypeError, ValueError) as exc:
         raise ExecutionError(f"Case Operation is invalid: {exc}") from exc
@@ -455,7 +380,7 @@ def _evidence(value: object) -> Evidence:
             explanation=_optional_string(raw.get("explanation"), "Evidence explanation"),
             raw_output=_required(raw, "raw_output", "Evidence"),
             metadata=_mapping(raw.get("metadata"), "Evidence metadata"),
-            accounting=_operation_accounting(raw.get("accounting"), "Evidence accounting"),
+            accounting=decode_operation_accounting(raw.get("accounting"), "Evidence accounting"),
         )
     except (TypeError, ValueError) as exc:
         raise ExecutionError(f"Evidence is invalid: {exc}") from exc
@@ -517,12 +442,6 @@ def _keys(
 def _positive_integer(value: object, label: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise ExecutionError(f"{label} must be a positive integer")
-    return value
-
-
-def _positive_or_zero_integer(value: object, label: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise ExecutionError(f"{label} must be a non-negative integer")
     return value
 
 

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -309,6 +309,7 @@ def _operation_accounting(value: object, label: str) -> OperationAccounting | No
             "response_model",
             "usage",
             "provider_latency_ms",
+            "provider_attempts",
             "cache",
         },
         label=label,
@@ -329,6 +330,7 @@ def _operation_accounting(value: object, label: str) -> OperationAccounting | No
     cache_raw = _mapping(raw.get("cache"), f"{label} cache")
     _keys(cache_raw, required={"hits", "misses", "bypasses", "unknown"}, label=f"{label} cache")
     latency = raw.get("provider_latency_ms")
+    attempts = raw.get("provider_attempts")
     try:
         return OperationAccounting(
             provider=_optional_string(raw.get("provider"), f"{label} provider"),
@@ -346,6 +348,11 @@ def _operation_accounting(value: object, label: str) -> OperationAccounting | No
                 None
                 if latency is None
                 else _positive_or_zero_integer(latency, f"{label} provider_latency_ms")
+            ),
+            provider_attempts=(
+                None
+                if attempts is None
+                else _positive_or_zero_integer(attempts, f"{label} provider_attempts")
             ),
             cache=OperationCache(
                 hits=cache_raw.get("hits"),  # type: ignore[arg-type]

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -10,7 +10,13 @@ from screamingface._core.ports import _RunOutcome
 from screamingface._evaluation.model import Candidate, _compiled_evaluation, _Evaluation
 from screamingface._report_primitives import CaseId
 from screamingface._report_primitives import _case_id as _validate_case_id
-from screamingface.case_result import CaseOperation, CaseStatus, StopReason
+from screamingface.case_result import (
+    CaseOperation,
+    CaseStatus,
+    OperationAccounting,
+    OperationCache,
+    StopReason,
+)
 from screamingface.discovery import BenchmarkInfo
 from screamingface.errors import ExecutionError
 from screamingface.report import (
@@ -283,9 +289,82 @@ def _case_operations(value: object) -> tuple[CaseOperation, ...]:
     return tuple(_case_operation(item) for item in _sequence(value, "Case Result operations"))
 
 
+def _operation_accounting(value: object, label: str) -> OperationAccounting | None:
+    """Decode one retained ``OperationAccounting``, or ``None`` — never in between.
+
+    INVARIANT: absence stays absence. The Engine already applied the exact-only
+    rule (a partial join publishes null rather than a subtotal), so the Client's
+    only job is to refuse anything it cannot decode faithfully. Every branch here
+    raises instead of substituting a plausible value, because a zero or a dropped
+    field would be read downstream as an observed fact.
+    """
+    if value is None:
+        return None
+    raw = _mapping(value, label)
+    _keys(
+        raw,
+        required={
+            "provider",
+            "request_model",
+            "response_model",
+            "usage",
+            "provider_latency_ms",
+            "cache",
+        },
+        label=label,
+    )
+    usage_raw = _mapping(raw.get("usage"), f"{label} usage")
+    _keys(
+        usage_raw,
+        required={
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+            "reasoning_tokens",
+            "cost_usd",
+        },
+        label=f"{label} usage",
+    )
+    cache_raw = _mapping(raw.get("cache"), f"{label} cache")
+    _keys(cache_raw, required={"hits", "misses", "bypasses", "unknown"}, label=f"{label} cache")
+    latency = raw.get("provider_latency_ms")
+    try:
+        return OperationAccounting(
+            provider=_optional_string(raw.get("provider"), f"{label} provider"),
+            request_model=_optional_string(raw.get("request_model"), f"{label} request_model"),
+            response_model=_optional_string(raw.get("response_model"), f"{label} response_model"),
+            usage=Usage(
+                input_tokens=usage_raw.get("input_tokens"),  # type: ignore[arg-type]
+                output_tokens=usage_raw.get("output_tokens"),  # type: ignore[arg-type]
+                cache_read_tokens=usage_raw.get("cache_read_tokens"),  # type: ignore[arg-type]
+                cache_creation_tokens=usage_raw.get("cache_creation_tokens"),  # type: ignore[arg-type]
+                reasoning_tokens=usage_raw.get("reasoning_tokens"),  # type: ignore[arg-type]
+                cost_usd=usage_raw.get("cost_usd"),  # type: ignore[arg-type]
+            ),
+            provider_latency_ms=(
+                None
+                if latency is None
+                else _positive_or_zero_integer(latency, f"{label} provider_latency_ms")
+            ),
+            cache=OperationCache(
+                hits=cache_raw.get("hits"),  # type: ignore[arg-type]
+                misses=cache_raw.get("misses"),  # type: ignore[arg-type]
+                bypasses=cache_raw.get("bypasses"),  # type: ignore[arg-type]
+                unknown=cache_raw.get("unknown"),  # type: ignore[arg-type]
+            ),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ExecutionError(f"{label} is invalid: {exc}") from exc
+
+
 def _case_operation(value: object) -> CaseOperation:
     raw = _mapping(value, "Case Operation")
-    _keys(raw, required={"operation_id", "output", "finish_reason"}, label="Case Operation")
+    _keys(
+        raw,
+        required={"operation_id", "output", "finish_reason", "accounting"},
+        label="Case Operation",
+    )
     finish_reason_value = raw.get("finish_reason")
     try:
         return CaseOperation(
@@ -296,6 +375,7 @@ def _case_operation(value: object) -> CaseOperation:
                 if finish_reason_value is None
                 else _text(finish_reason_value, "Case Operation finish_reason")
             ),
+            accounting=_operation_accounting(raw.get("accounting"), "Case Operation accounting"),
         )
     except (TypeError, ValueError) as exc:
         raise ExecutionError(f"Case Operation is invalid: {exc}") from exc
@@ -347,7 +427,7 @@ def _evidence(value: object) -> Evidence:
     raw = _mapping(value, "Evidence")
     _keys(
         raw,
-        required={"sequence", "producer", "valid", "raw_output", "metadata"},
+        required={"sequence", "producer", "valid", "raw_output", "metadata", "accounting"},
         optional={"outcome", "explanation"},
         label="Evidence",
     )
@@ -368,6 +448,7 @@ def _evidence(value: object) -> Evidence:
             explanation=_optional_string(raw.get("explanation"), "Evidence explanation"),
             raw_output=_required(raw, "raw_output", "Evidence"),
             metadata=_mapping(raw.get("metadata"), "Evidence metadata"),
+            accounting=_operation_accounting(raw.get("accounting"), "Evidence accounting"),
         )
     except (TypeError, ValueError) as exc:
         raise ExecutionError(f"Evidence is invalid: {exc}") from exc
@@ -429,6 +510,12 @@ def _keys(
 def _positive_integer(value: object, label: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise ExecutionError(f"{label} must be a positive integer")
+    return value
+
+
+def _positive_or_zero_integer(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ExecutionError(f"{label} must be a non-negative integer")
     return value
 
 

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -84,7 +84,12 @@ class OperationAccounting:
 
     ``provider_latency_ms`` is the SUM of complete provider-attempt latencies —
     not operation wall time, not critical-path duration. It is presented as
-    "Provider time" for exactly that reason.
+    "Provider time" for exactly that reason. ``provider_attempts`` sits beside it
+    because that sum counts EVERY attempt including failures: without the count a
+    flaky route and a slow model read identically, and "$0.50" cannot be told
+    apart from "$0.50 across five retries". A confirmed cache hit is zero
+    attempts — no current provider dispatch happened — while an attempt list the
+    Engine could not fully validate is null rather than a half-counted total.
     """
 
     provider: str | None
@@ -92,6 +97,7 @@ class OperationAccounting:
     response_model: str | None
     usage: Usage
     provider_latency_ms: int | None
+    provider_attempts: int | None
     cache: OperationCache
 
     def __post_init__(self) -> None:
@@ -105,13 +111,14 @@ class OperationAccounting:
             raise TypeError("Operation accounting usage must be an sf.Usage")
         if not isinstance(self.cache, OperationCache):
             raise TypeError("Operation accounting cache must be an sf.OperationCache")
-        latency = self.provider_latency_ms
-        if latency is not None and (
-            isinstance(latency, bool) or not isinstance(latency, int) or latency < 0
-        ):
-            raise ValueError(
-                "Operation accounting provider_latency_ms must be a non-negative integer or None"
-            )
+        for name in ("provider_latency_ms", "provider_attempts"):
+            value = getattr(self, name)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(
+                    f"Operation accounting {name} must be a non-negative integer or None"
+                )
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -120,6 +127,7 @@ class OperationAccounting:
             "response_model": self.response_model,
             "usage": self.usage.to_dict(),
             "provider_latency_ms": self.provider_latency_ms,
+            "provider_attempts": self.provider_attempts,
             "cache": self.cache.to_dict(),
         }
 

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -11,6 +11,7 @@ from screamingface._immutable_json import freeze_json, freeze_mapping, thaw_json
 from screamingface._report_primitives import (
     CaseId,
     Failure,
+    Usage,
     _case_id,
     _nonblank_text,
     _nonempty_text,
@@ -34,6 +35,96 @@ type RefusalKind = Literal["provider_declined", "model_refusal"]
 
 
 @dataclass(frozen=True, slots=True)
+class OperationCache:
+    """How many consumed responses of one operation the response cache served.
+
+    The four counts sum to the number of model-call responses the owning record
+    represents — provider retries folded inside one Gateway response are NOT
+    extra responses. A confirmed hit contributes zero current tokens and cost:
+    the run really did spend nothing on it, and no avoided-cost estimate is
+    invented (OME-901 spec §0).
+    """
+
+    hits: int
+    misses: int
+    bypasses: int
+    unknown: int
+
+    def __post_init__(self) -> None:
+        for name in ("hits", "misses", "bypasses", "unknown"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"Operation cache {name} must be a non-negative integer")
+        # INVARIANT: the count sum IS the represented response count, so a record
+        # describing zero responses describes nothing and must not exist.
+        if self.hits + self.misses + self.bypasses + self.unknown < 1:
+            raise ValueError("operation cache accounting requires at least one response")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "bypasses": self.bypasses,
+            "unknown": self.unknown,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class OperationAccounting:
+    """What one semantic operation actually consumed, exactly or not at all.
+
+    FEATURE: OME-901 per-operation accounting — the Engine retains the join
+    between model-call accounting and the records that name Candidate operations
+    and grading Evidence, so a completed Report can break its one authoritative
+    total down by stage, model, member and Case.
+
+    INVARIANT: exact-only. Every field is null unless the Engine observed it
+    completely; nothing here is ever divided, inferred from execution order, or
+    defaulted to zero. A false zero would read as "this operation was free".
+
+    ``provider_latency_ms`` is the SUM of complete provider-attempt latencies —
+    not operation wall time, not critical-path duration. It is presented as
+    "Provider time" for exactly that reason.
+    """
+
+    provider: str | None
+    request_model: str | None
+    response_model: str | None
+    usage: Usage
+    provider_latency_ms: int | None
+    cache: OperationCache
+
+    def __post_init__(self) -> None:
+        for name in ("provider", "request_model", "response_model"):
+            value = getattr(self, name)
+            if value is not None:
+                object.__setattr__(
+                    self, name, _nonblank_text(value, f"Operation accounting {name}")
+                )
+        if not isinstance(self.usage, Usage):
+            raise TypeError("Operation accounting usage must be an sf.Usage")
+        if not isinstance(self.cache, OperationCache):
+            raise TypeError("Operation accounting cache must be an sf.OperationCache")
+        latency = self.provider_latency_ms
+        if latency is not None and (
+            isinstance(latency, bool) or not isinstance(latency, int) or latency < 0
+        ):
+            raise ValueError(
+                "Operation accounting provider_latency_ms must be a non-negative integer or None"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "request_model": self.request_model,
+            "response_model": self.response_model,
+            "usage": self.usage.to_dict(),
+            "provider_latency_ms": self.provider_latency_ms,
+            "cache": self.cache.to_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class EvidenceProducer:
     """The Engine-known producer of one observed grading result."""
 
@@ -48,6 +139,39 @@ class EvidenceProducer:
         return {"type": self.type, "id": self.id}
 
 
+def _validated_evidence_parts(
+    *,
+    sequence: int,
+    producer: EvidenceProducer,
+    valid: bool,
+    outcome: EvidenceOutcome | None,
+    explanation: str | None,
+    accounting: OperationAccounting | None,
+) -> str | None:
+    """Validate one Evidence's scalar parts; return the normalized explanation.
+
+    Split out of ``Evidence.__init__`` only to keep that constructor readable —
+    the rules themselves are unchanged, and the one that carries meaning is the
+    last: a REJECTED observation may not also claim an outcome or an
+    explanation, because a rejected reply was never interpreted.
+    """
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
+        raise ValueError("Evidence sequence must be a positive integer")
+    if not isinstance(producer, EvidenceProducer):
+        raise TypeError("Evidence producer must be an sf.EvidenceProducer")
+    if not isinstance(valid, bool):
+        raise TypeError("Evidence valid must be a boolean")
+    if outcome not in {None, "MET", "UNMET", "PASS", "FAIL"}:
+        raise ValueError("Evidence outcome must be MET, UNMET, PASS, FAIL, or None")
+    if explanation is not None:
+        explanation = _string(explanation, "Evidence explanation")
+    if not valid and (outcome is not None or explanation is not None):
+        raise ValueError("invalid Evidence cannot contain an outcome or explanation")
+    if accounting is not None and not isinstance(accounting, OperationAccounting):
+        raise TypeError("Evidence accounting must be an sf.OperationAccounting or None")
+    return explanation
+
+
 @dataclass(frozen=True, slots=True, init=False)
 class Evidence:
     """One exact observation accepted or rejected by a grading Check."""
@@ -58,6 +182,7 @@ class Evidence:
     outcome: EvidenceOutcome | None
     explanation: str | None
     raw_output: object
+    accounting: OperationAccounting | None
     _metadata: Mapping[str, object] = field(repr=False)
 
     def __init__(
@@ -70,19 +195,16 @@ class Evidence:
         outcome: EvidenceOutcome | None = None,
         explanation: str | None = None,
         metadata: Mapping[str, object] | None = None,
+        accounting: OperationAccounting | None = None,
     ) -> None:
-        if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
-            raise ValueError("Evidence sequence must be a positive integer")
-        if not isinstance(producer, EvidenceProducer):
-            raise TypeError("Evidence producer must be an sf.EvidenceProducer")
-        if not isinstance(valid, bool):
-            raise TypeError("Evidence valid must be a boolean")
-        if outcome not in {None, "MET", "UNMET", "PASS", "FAIL"}:
-            raise ValueError("Evidence outcome must be MET, UNMET, PASS, FAIL, or None")
-        if explanation is not None:
-            explanation = _string(explanation, "Evidence explanation")
-        if not valid and (outcome is not None or explanation is not None):
-            raise ValueError("invalid Evidence cannot contain an outcome or explanation")
+        explanation = _validated_evidence_parts(
+            sequence=sequence,
+            producer=producer,
+            valid=valid,
+            outcome=outcome,
+            explanation=explanation,
+            accounting=accounting,
+        )
         values = {
             "sequence": sequence,
             "producer": producer,
@@ -90,6 +212,7 @@ class Evidence:
             "outcome": freeze_json(outcome, "Evidence outcome"),
             "explanation": explanation,
             "raw_output": freeze_json(raw_output, "Evidence raw_output"),
+            "accounting": accounting,
             "_metadata": freeze_mapping(metadata or {}, "Evidence metadata"),
         }
         for name, value in values.items():
@@ -106,6 +229,7 @@ class Evidence:
             "valid": self.valid,
             "raw_output": thaw_json(self.raw_output),
             "metadata": thaw_mapping(self._metadata),
+            "accounting": None if self.accounting is None else self.accounting.to_dict(),
         }
         if self.outcome is not None:
             value["outcome"] = thaw_json(self.outcome)
@@ -234,6 +358,7 @@ class CaseOperation:
     operation_id: str
     output: str | None
     finish_reason: str | None
+    accounting: OperationAccounting | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -247,12 +372,17 @@ class CaseOperation:
                 "finish_reason",
                 _nonblank_text(self.finish_reason, "Case Operation finish_reason"),
             )
+        if self.accounting is not None and not isinstance(self.accounting, OperationAccounting):
+            raise TypeError("Case Operation accounting must be an sf.OperationAccounting or None")
 
     def to_dict(self) -> dict[str, object]:
         return {
             "operation_id": self.operation_id,
             "output": self.output,
             "finish_reason": self.finish_reason,
+            # Required-nullable, mirroring the Engine: the key is always present so
+            # a reader can tell "no accounting retained" from "older payload".
+            "accounting": None if self.accounting is None else self.accounting.to_dict(),
         }
 
 

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -11,11 +11,11 @@ from screamingface._immutable_json import freeze_json, freeze_mapping, thaw_json
 from screamingface._report_primitives import (
     CaseId,
     Failure,
-    Usage,
     _case_id,
     _nonblank_text,
     _nonempty_text,
 )
+from screamingface.operation_accounting import OperationAccounting
 
 # The Engine's versioned wrapper for native multi-turn Candidate input; kept in lock-step
 # with url4-cloud's `benchmarks/contract.py` CANDIDATE_INPUT_SCHEMA.
@@ -32,104 +32,6 @@ type StopReason = Literal["passed", "max_rounds"]
 # the Engine's runner classifies a refusal from (OME-745, `runner/model_response.py`);
 # never carried on the wire.
 type RefusalKind = Literal["provider_declined", "model_refusal"]
-
-
-@dataclass(frozen=True, slots=True)
-class OperationCache:
-    """How many consumed responses of one operation the response cache served.
-
-    The four counts sum to the number of model-call responses the owning record
-    represents — provider retries folded inside one Gateway response are NOT
-    extra responses. A confirmed hit contributes zero current tokens and cost:
-    the run really did spend nothing on it, and no avoided-cost estimate is
-    invented (OME-901 spec §0).
-    """
-
-    hits: int
-    misses: int
-    bypasses: int
-    unknown: int
-
-    def __post_init__(self) -> None:
-        for name in ("hits", "misses", "bypasses", "unknown"):
-            value = getattr(self, name)
-            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-                raise ValueError(f"Operation cache {name} must be a non-negative integer")
-        # INVARIANT: the count sum IS the represented response count, so a record
-        # describing zero responses describes nothing and must not exist.
-        if self.hits + self.misses + self.bypasses + self.unknown < 1:
-            raise ValueError("operation cache accounting requires at least one response")
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "hits": self.hits,
-            "misses": self.misses,
-            "bypasses": self.bypasses,
-            "unknown": self.unknown,
-        }
-
-
-@dataclass(frozen=True, slots=True)
-class OperationAccounting:
-    """What one semantic operation actually consumed, exactly or not at all.
-
-    FEATURE: OME-901 per-operation accounting — the Engine retains the join
-    between model-call accounting and the records that name Candidate operations
-    and grading Evidence, so a completed Report can break its one authoritative
-    total down by stage, model, member and Case.
-
-    INVARIANT: exact-only. Every field is null unless the Engine observed it
-    completely; nothing here is ever divided, inferred from execution order, or
-    defaulted to zero. A false zero would read as "this operation was free".
-
-    ``provider_latency_ms`` is the SUM of complete provider-attempt latencies —
-    not operation wall time, not critical-path duration. It is presented as
-    "Provider time" for exactly that reason. ``provider_attempts`` sits beside it
-    because that sum counts EVERY attempt including failures: without the count a
-    flaky route and a slow model read identically, and "$0.50" cannot be told
-    apart from "$0.50 across five retries". A confirmed cache hit is zero
-    attempts — no current provider dispatch happened — while an attempt list the
-    Engine could not fully validate is null rather than a half-counted total.
-    """
-
-    provider: str | None
-    request_model: str | None
-    response_model: str | None
-    usage: Usage
-    provider_latency_ms: int | None
-    provider_attempts: int | None
-    cache: OperationCache
-
-    def __post_init__(self) -> None:
-        for name in ("provider", "request_model", "response_model"):
-            value = getattr(self, name)
-            if value is not None:
-                object.__setattr__(
-                    self, name, _nonblank_text(value, f"Operation accounting {name}")
-                )
-        if not isinstance(self.usage, Usage):
-            raise TypeError("Operation accounting usage must be an sf.Usage")
-        if not isinstance(self.cache, OperationCache):
-            raise TypeError("Operation accounting cache must be an sf.OperationCache")
-        for name in ("provider_latency_ms", "provider_attempts"):
-            value = getattr(self, name)
-            if value is not None and (
-                isinstance(value, bool) or not isinstance(value, int) or value < 0
-            ):
-                raise ValueError(
-                    f"Operation accounting {name} must be a non-negative integer or None"
-                )
-
-    def to_dict(self) -> dict[str, object]:
-        return {
-            "provider": self.provider,
-            "request_model": self.request_model,
-            "response_model": self.response_model,
-            "usage": self.usage.to_dict(),
-            "provider_latency_ms": self.provider_latency_ms,
-            "provider_attempts": self.provider_attempts,
-            "cache": self.cache.to_dict(),
-        }
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/screamingface/src/screamingface/operation_accounting.py
+++ b/packages/screamingface/src/screamingface/operation_accounting.py
@@ -1,0 +1,97 @@
+"""Immutable accounting retained for one semantic evaluation operation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from screamingface._report_primitives import Usage, _nonblank_text
+
+
+@dataclass(frozen=True, slots=True)
+class OperationCache:
+    """How many consumed responses of one operation the response cache served.
+
+    The four counts sum to the number of model-call responses the owning record
+    represents — provider retries folded inside one Gateway response are not
+    extra responses. A confirmed hit contributes zero current tokens and cost.
+    """
+
+    hits: int
+    misses: int
+    bypasses: int
+    unknown: int
+
+    def __post_init__(self) -> None:
+        for name in ("hits", "misses", "bypasses", "unknown"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"Operation cache {name} must be a non-negative integer")
+        # INVARIANT: the count sum is the represented response count, so a
+        # record describing zero responses describes nothing and must not exist.
+        if self.hits + self.misses + self.bypasses + self.unknown < 1:
+            raise ValueError("operation cache accounting requires at least one response")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "hits": self.hits,
+            "misses": self.misses,
+            "bypasses": self.bypasses,
+            "unknown": self.unknown,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class OperationAccounting:
+    """What one semantic operation actually consumed, exactly or not at all.
+
+    FEATURE: OME-901 per-operation accounting — completed Reports can explain
+    their authoritative total by stage, model, member, and Case.
+
+    INVARIANT: exact-only. Every field is null unless the Engine observed it
+    completely; nothing is divided, inferred from execution order, or defaulted
+    to zero. A false zero would read as "this operation was free".
+
+    ``provider_latency_ms`` is summed provider-attempt latency, not operation
+    wall time. ``provider_attempts`` makes retry-heavy routes distinguishable
+    from slow models. A confirmed cache hit has zero current attempts; an
+    incompletely validated attempt list stays null.
+    """
+
+    provider: str | None
+    request_model: str | None
+    response_model: str | None
+    usage: Usage
+    provider_latency_ms: int | None
+    provider_attempts: int | None
+    cache: OperationCache
+
+    def __post_init__(self) -> None:
+        for name in ("provider", "request_model", "response_model"):
+            value = getattr(self, name)
+            if value is not None:
+                object.__setattr__(
+                    self, name, _nonblank_text(value, f"Operation accounting {name}")
+                )
+        if not isinstance(self.usage, Usage):
+            raise TypeError("Operation accounting usage must be an sf.Usage")
+        if not isinstance(self.cache, OperationCache):
+            raise TypeError("Operation accounting cache must be an sf.OperationCache")
+        for name in ("provider_latency_ms", "provider_attempts"):
+            value = getattr(self, name)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise ValueError(
+                    f"Operation accounting {name} must be a non-negative integer or None"
+                )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "request_model": self.request_model,
+            "response_model": self.response_model,
+            "usage": self.usage.to_dict(),
+            "provider_latency_ms": self.provider_latency_ms,
+            "provider_attempts": self.provider_attempts,
+            "cache": self.cache.to_dict(),
+        }

--- a/packages/screamingface/src/screamingface/report.py
+++ b/packages/screamingface/src/screamingface/report.py
@@ -32,11 +32,10 @@ from screamingface.case_result import (
     Check,
     Evidence,
     EvidenceProducer,
-    OperationAccounting,
-    OperationCache,
 )
 from screamingface.discovery import BenchmarkInfo
 from screamingface.operation import OperationInfo, _operation_dag
+from screamingface.operation_accounting import OperationAccounting, OperationCache
 from screamingface.url4 import Url4
 
 type RecipeKind = Literal["model", "fusion", "pipeline", "corrective_loop", "self_corrective"]

--- a/packages/screamingface/src/screamingface/report.py
+++ b/packages/screamingface/src/screamingface/report.py
@@ -26,7 +26,15 @@ from screamingface._report_primitives import (
     _nonblank,
     _usage,
 )
-from screamingface.case_result import CaseGrade, CaseResult, Check, Evidence, EvidenceProducer
+from screamingface.case_result import (
+    CaseGrade,
+    CaseResult,
+    Check,
+    Evidence,
+    EvidenceProducer,
+    OperationAccounting,
+    OperationCache,
+)
 from screamingface.discovery import BenchmarkInfo
 from screamingface.operation import OperationInfo, _operation_dag
 from screamingface.url4 import Url4
@@ -637,6 +645,8 @@ __all__ = [
     "EvidenceProducer",
     "Failure",
     "MemberResult",
+    "OperationAccounting",
+    "OperationCache",
     "OperationInfo",
     "Report",
     "Usage",

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -36,6 +36,8 @@
       "ModelParameter",
       "ModelParameterSchema",
       "OAuthFlow",
+      "OperationAccounting",
+      "OperationCache",
       "OperationInfo",
       "Pipeline",
       "PlanningError",
@@ -284,7 +286,8 @@
       "Evidence": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, *, sequence: 'int', producer: 'EvidenceProducer', valid: 'bool', raw_output: 'object', outcome: 'EvidenceOutcome | None' = None, explanation: 'str | None' = None, metadata: 'Mapping[str, object] | None' = None) -> 'None'",
+          "__init__": "method (self, *, sequence: 'int', producer: 'EvidenceProducer', valid: 'bool', raw_output: 'object', outcome: 'EvidenceOutcome | None' = None, explanation: 'str | None' = None, metadata: 'Mapping[str, object] | None' = None, accounting: 'OperationAccounting | None' = None) -> 'None'",
+          "accounting": "field",
           "explanation": "field",
           "metadata": "property",
           "outcome": "field",
@@ -534,6 +537,30 @@
           "provider": "field",
           "status": "field",
           "wait": "method (self, *, poll_interval: 'float' = 0.5, timeout: 'float | None' = None) -> 'Connection'"
+        }
+      },
+      "OperationAccounting": {
+        "kind": "class",
+        "members": {
+          "__init__": "method (self, provider: 'str | None', request_model: 'str | None', response_model: 'str | None', usage: 'Usage', provider_latency_ms: 'int | None', cache: 'OperationCache') -> None",
+          "cache": "field",
+          "provider": "field",
+          "provider_latency_ms": "field",
+          "request_model": "field",
+          "response_model": "field",
+          "to_dict": "method (self) -> 'dict[str, object]'",
+          "usage": "field"
+        }
+      },
+      "OperationCache": {
+        "kind": "class",
+        "members": {
+          "__init__": "method (self, hits: 'int', misses: 'int', bypasses: 'int', unknown: 'int') -> None",
+          "bypasses": "field",
+          "hits": "field",
+          "misses": "field",
+          "to_dict": "method (self) -> 'dict[str, object]'",
+          "unknown": "field"
         }
       },
       "OperationInfo": {
@@ -948,6 +975,8 @@
       "EvidenceProducer",
       "Failure",
       "MemberResult",
+      "OperationAccounting",
+      "OperationCache",
       "OperationInfo",
       "Report",
       "Usage"
@@ -1028,7 +1057,8 @@
       "Evidence": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, *, sequence: 'int', producer: 'EvidenceProducer', valid: 'bool', raw_output: 'object', outcome: 'EvidenceOutcome | None' = None, explanation: 'str | None' = None, metadata: 'Mapping[str, object] | None' = None) -> 'None'",
+          "__init__": "method (self, *, sequence: 'int', producer: 'EvidenceProducer', valid: 'bool', raw_output: 'object', outcome: 'EvidenceOutcome | None' = None, explanation: 'str | None' = None, metadata: 'Mapping[str, object] | None' = None, accounting: 'OperationAccounting | None' = None) -> 'None'",
+          "accounting": "field",
           "explanation": "field",
           "metadata": "property",
           "outcome": "field",
@@ -1074,6 +1104,30 @@
           "operation_id": "field",
           "to_dict": "method (self) -> 'dict[str, object]'",
           "usage": "field"
+        }
+      },
+      "OperationAccounting": {
+        "kind": "class",
+        "members": {
+          "__init__": "method (self, provider: 'str | None', request_model: 'str | None', response_model: 'str | None', usage: 'Usage', provider_latency_ms: 'int | None', cache: 'OperationCache') -> None",
+          "cache": "field",
+          "provider": "field",
+          "provider_latency_ms": "field",
+          "request_model": "field",
+          "response_model": "field",
+          "to_dict": "method (self) -> 'dict[str, object]'",
+          "usage": "field"
+        }
+      },
+      "OperationCache": {
+        "kind": "class",
+        "members": {
+          "__init__": "method (self, hits: 'int', misses: 'int', bypasses: 'int', unknown: 'int') -> None",
+          "bypasses": "field",
+          "hits": "field",
+          "misses": "field",
+          "to_dict": "method (self) -> 'dict[str, object]'",
+          "unknown": "field"
         }
       },
       "OperationInfo": {

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -542,9 +542,10 @@
       "OperationAccounting": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, provider: 'str | None', request_model: 'str | None', response_model: 'str | None', usage: 'Usage', provider_latency_ms: 'int | None', cache: 'OperationCache') -> None",
+          "__init__": "method (self, provider: 'str | None', request_model: 'str | None', response_model: 'str | None', usage: 'Usage', provider_latency_ms: 'int | None', provider_attempts: 'int | None', cache: 'OperationCache') -> None",
           "cache": "field",
           "provider": "field",
+          "provider_attempts": "field",
           "provider_latency_ms": "field",
           "request_model": "field",
           "response_model": "field",
@@ -1109,9 +1110,10 @@
       "OperationAccounting": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, provider: 'str | None', request_model: 'str | None', response_model: 'str | None', usage: 'Usage', provider_latency_ms: 'int | None', cache: 'OperationCache') -> None",
+          "__init__": "method (self, provider: 'str | None', request_model: 'str | None', response_model: 'str | None', usage: 'Usage', provider_latency_ms: 'int | None', provider_attempts: 'int | None', cache: 'OperationCache') -> None",
           "cache": "field",
           "provider": "field",
+          "provider_attempts": "field",
           "provider_latency_ms": "field",
           "request_model": "field",
           "response_model": "field",

--- a/packages/screamingface/tests/test_case_outcome_decoding.py
+++ b/packages/screamingface/tests/test_case_outcome_decoding.py
@@ -195,6 +195,7 @@ def test_nested_grade_and_evidence_round_trip_the_exact_engine_contract() -> Non
                         "explanation": " exact explanation ",
                         "raw_output": {"passed": True},
                         "metadata": {},
+                        "accounting": None,
                     }
                 ],
                 "metadata": {},
@@ -237,6 +238,7 @@ def test_nested_grade_contract_rejects_values_the_engine_cannot_publish(
                         "outcome": "PASS",
                         "raw_output": {},
                         "metadata": {},
+                        "accounting": None,
                     }
                 ],
                 "metadata": {},
@@ -367,9 +369,24 @@ def test_a_locally_built_case_derives_status_without_weakening_wire_decoding() -
 def _operations_payload() -> dict[str, Any]:
     payload = _scored_payload()
     payload["operations"] = [
-        {"operation_id": "op_model_1", "output": "Member one answer.", "finish_reason": "stop"},
-        {"operation_id": "op_model_2", "output": None, "finish_reason": "length"},
-        {"operation_id": "op_synthesis_1", "output": "Four.", "finish_reason": "stop"},
+        {
+            "operation_id": "op_model_1",
+            "output": "Member one answer.",
+            "finish_reason": "stop",
+            "accounting": None,
+        },
+        {
+            "operation_id": "op_model_2",
+            "output": None,
+            "finish_reason": "length",
+            "accounting": None,
+        },
+        {
+            "operation_id": "op_synthesis_1",
+            "output": "Four.",
+            "finish_reason": "stop",
+            "accounting": None,
+        },
     ]
     return payload
 
@@ -414,13 +431,25 @@ def test_a_null_operations_key_decodes_as_absent() -> None:
 @pytest.mark.parametrize(
     ("entry", "message"),
     [
-        ({"output": "x", "finish_reason": None}, "missing 'operation_id'"),
+        ({"output": "x", "finish_reason": None, "accounting": None}, "missing 'operation_id'"),
         (
-            {"operation_id": "op_model_1", "output": "x", "finish_reason": None, "extra": 1},
+            {
+                "operation_id": "op_model_1",
+                "output": "x",
+                "finish_reason": None,
+                "accounting": None,
+                "extra": 1,
+            },
             "unsupported field 'extra'",
         ),
-        ({"operation_id": "  ", "output": "x", "finish_reason": None}, "operation_id"),
-        ({"operation_id": "op_model_1", "output": 7, "finish_reason": None}, "output"),
+        (
+            {"operation_id": "  ", "output": "x", "finish_reason": None, "accounting": None},
+            "operation_id",
+        ),
+        (
+            {"operation_id": "op_model_1", "output": 7, "finish_reason": None, "accounting": None},
+            "output",
+        ),
     ],
 )
 def test_a_malformed_operation_entry_fails_closed(entry: dict[str, Any], message: str) -> None:

--- a/packages/screamingface/tests/test_case_result_contract_boundaries.py
+++ b/packages/screamingface/tests/test_case_result_contract_boundaries.py
@@ -339,6 +339,7 @@ def test_wire_evidence_decoder_accepts_a_deterministic_producer() -> None:
             "valid": True,
             "raw_output": True,
             "metadata": {},
+            "accounting": None,
         }
     )
 
@@ -378,6 +379,7 @@ def test_evidence_producer_type_is_open_nonempty_engine_text() -> None:
                     "valid": "yes",
                     "raw_output": "answer",
                     "metadata": {},
+                    "accounting": None,
                 }
             ),
             "valid must be boolean",

--- a/packages/screamingface/tests/test_case_results.py
+++ b/packages/screamingface/tests/test_case_results.py
@@ -83,6 +83,7 @@ def test_case_result_serializes_every_observed_fact_losslessly() -> None:
                                 '"criterion_status":"MET"}'
                             ),
                             "metadata": {},
+                            "accounting": None,
                         }
                     ],
                     "metadata": {
@@ -158,6 +159,7 @@ def test_invalid_evidence_keeps_exact_raw_output_and_rejection_reason() -> None:
         "valid": False,
         "raw_output": "not json",
         "metadata": {"rejection_reason": "invalid_json"},
+        "accounting": None,
     }
 
 

--- a/packages/screamingface/tests/test_draco_vertical_slice.py
+++ b/packages/screamingface/tests/test_draco_vertical_slice.py
@@ -139,6 +139,7 @@ def _case_payload(*, score: float = 1.0) -> dict[str, object]:
                             "explanation": "The response satisfies the criterion.",
                             "raw_output": raw,
                             "metadata": {},
+                            "accounting": None,
                         }
                     ],
                     "metadata": {
@@ -167,6 +168,7 @@ def _unscored_invalid_evidence_case_payload() -> dict[str, object]:
             "valid": False,
             "raw_output": "not json",
             "metadata": {"rejection_reason": "invalid_json"},
+            "accounting": None,
         }
     ]
     case["failures"] = [

--- a/packages/screamingface/tests/test_operation_accounting_decode.py
+++ b/packages/screamingface/tests/test_operation_accounting_decode.py
@@ -54,6 +54,7 @@ def _accounting_wire(**overrides: object) -> dict[str, object]:
         "response_model": "openai/gpt-oss-120b",
         "usage": _usage_wire(),
         "provider_latency_ms": 4200,
+        "provider_attempts": 1,
         "cache": {"hits": 0, "misses": 1, "bypasses": 0, "unknown": 0},
     }
     wire.update(overrides)
@@ -96,6 +97,9 @@ def test_full_accounting_decodes_into_the_typed_value(decode, wire) -> None:
     assert accounting.request_model == "openrouter/openai/gpt-oss-120b"
     assert accounting.response_model == "openai/gpt-oss-120b"
     assert accounting.provider_latency_ms == 4200
+    # WHY beside the latency: the summed latency counts every attempt including
+    # failures, so without this a flaky route and a slow model read identically.
+    assert accounting.provider_attempts == 1
     # WHY Decimal: cost is money — the SDK's existing Usage already refuses float
     # cost, and the breakdown must sum without binary-float drift.
     assert accounting.usage.cost_usd == Decimal("0.0123450000")
@@ -160,6 +164,7 @@ def test_a_missing_accounting_key_refuses_loudly(decode, wire) -> None:
             id="no-response",
         ),
         pytest.param({"provider_latency_ms": -1}, "provider_latency_ms", id="negative-latency"),
+        pytest.param({"provider_attempts": -1}, "provider_attempts", id="negative-attempts"),
         pytest.param({"provider": "   "}, "provider", id="blank-provider"),
         pytest.param(
             {"usage": _usage_wire(input_tokens=-5)},
@@ -177,6 +182,31 @@ def test_a_missing_accounting_key_refuses_loudly(decode, wire) -> None:
 def test_malformed_accounting_refuses_instead_of_degrading(overrides: dict, expected: str) -> None:
     with pytest.raises(ExecutionError, match=expected):
         _case_operation(_operation_wire(_accounting_wire(**overrides)))
+
+
+def test_a_cache_hit_keeps_zero_attempts_rather_than_null() -> None:
+    # A confirmed hit performs no current provider dispatch, so zero is the exact
+    # truth — the same reason its cost and latency are zero. Decoding it to None
+    # would turn a known fact into missing evidence.
+    decoded = _case_operation(
+        _operation_wire(
+            _accounting_wire(
+                provider_attempts=0,
+                provider_latency_ms=0,
+                cache={"hits": 1, "misses": 0, "bypasses": 0, "unknown": 0},
+            )
+        )
+    )
+    assert decoded.accounting is not None
+    assert decoded.accounting.provider_attempts == 0
+
+
+def test_an_unvalidated_attempt_list_decodes_as_an_unknown_count() -> None:
+    # The Engine publishes null when it had to skip an attempt entry: counting a
+    # list it could not fully read would tell a retry story that never happened.
+    decoded = _case_operation(_operation_wire(_accounting_wire(provider_attempts=None)))
+    assert decoded.accounting is not None
+    assert decoded.accounting.provider_attempts is None
 
 
 def test_an_unknown_accounting_field_refuses() -> None:
@@ -211,6 +241,7 @@ def test_the_accounting_values_are_public_and_constructible() -> None:
         response_model=None,
         usage=sf.Usage(input_tokens=10, cost_usd="0.5"),
         provider_latency_ms=None,
+        provider_attempts=None,
         cache=sf.OperationCache(hits=1, misses=0, bypasses=0, unknown=0),
     )
     assert accounting.usage.cost_usd == Decimal("0.5")

--- a/packages/screamingface/tests/test_operation_accounting_decode.py
+++ b/packages/screamingface/tests/test_operation_accounting_decode.py
@@ -184,6 +184,23 @@ def test_malformed_accounting_refuses_instead_of_degrading(overrides: dict, expe
         _case_operation(_operation_wire(_accounting_wire(**overrides)))
 
 
+@pytest.mark.parametrize(
+    "cost",
+    [
+        pytest.param("1e2", id="positive-exponent"),
+        pytest.param("1E-2", id="negative-exponent"),
+        pytest.param("01.00", id="leading-zero"),
+        pytest.param("+1.00", id="leading-plus"),
+        pytest.param(Decimal("1.00"), id="decimal-object"),
+    ],
+)
+def test_noncanonical_wire_cost_refuses_instead_of_being_normalized(cost: object) -> None:
+    # INVARIANT: Client decoding preserves the Engine's fixed-point wire bytes.
+    # Accepting another Decimal spelling would silently normalize it on export.
+    with pytest.raises(ExecutionError, match="cost_usd.*fixed-point"):
+        _case_operation(_operation_wire(_accounting_wire(usage=_usage_wire(cost_usd=cost))))
+
+
 def test_a_cache_hit_keeps_zero_attempts_rather_than_null() -> None:
     # A confirmed hit performs no current provider dispatch, so zero is the exact
     # truth — the same reason its cost and latency are zero. Decoding it to None

--- a/packages/screamingface/tests/test_operation_accounting_decode.py
+++ b/packages/screamingface/tests/test_operation_accounting_decode.py
@@ -1,0 +1,225 @@
+"""The Client decodes the Engine's retained per-operation accounting (OME-1032).
+
+The Engine (OME-1030) retains, on the two records that already own the semantics,
+what one semantic operation actually consumed: which provider answered, the six
+usage fields, summed provider latency, and the response-cache outcomes. These
+tests pin the CLIENT half of that contract — decoding it without inventing
+anything.
+
+The invariant every case here defends is the parent spec's exact-only rule
+(`docs/spec/2026-08-27-OME-901-operation-accounting.md` §0): **absence stays
+absence**. A null accounting must never become a zeroed value, an unparseable
+field must never degrade into a plausible one, and a partial record must never
+publish as an exact subtotal. A false zero here would be read as "this operation
+was free", which is worse than no answer at all.
+
+`accounting` is REQUIRED-nullable on both owners: the Engine emits the key
+unconditionally, so a payload missing it is an Engine/Client version mismatch and
+must fail loudly rather than default to None — that strictness is exactly why
+this slice has to land together with the Engine branch.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+import screamingface as sf
+from screamingface._evaluation.results import _case_operation, _evidence
+from screamingface.errors import ExecutionError
+
+# -- wire fixtures -------------------------------------------------------------------
+
+
+def _usage_wire(**overrides: object) -> dict[str, object]:
+    usage: dict[str, object] = {
+        "input_tokens": 1200,
+        "output_tokens": 340,
+        "cache_read_tokens": 0,
+        # A field the Engine could not observe — the fixture carries it explicitly
+        # so the "null is not zero" assertion has something real to stand on.
+        "cache_creation_tokens": None,
+        "reasoning_tokens": 900,
+        "cost_usd": "0.0123450000",
+    }
+    usage.update(overrides)
+    return usage
+
+
+def _accounting_wire(**overrides: object) -> dict[str, object]:
+    wire: dict[str, object] = {
+        "provider": "openrouter",
+        "request_model": "openrouter/openai/gpt-oss-120b",
+        "response_model": "openai/gpt-oss-120b",
+        "usage": _usage_wire(),
+        "provider_latency_ms": 4200,
+        "cache": {"hits": 0, "misses": 1, "bypasses": 0, "unknown": 0},
+    }
+    wire.update(overrides)
+    return wire
+
+
+def _operation_wire(accounting: object) -> dict[str, object]:
+    return {
+        "operation_id": "op_model_1",
+        "output": "an answer",
+        "finish_reason": "stop",
+        "accounting": accounting,
+    }
+
+
+def _evidence_wire(accounting: object) -> dict[str, object]:
+    return {
+        "sequence": 1,
+        "producer": {"type": "model", "id": "openrouter/openai/gpt-5.4"},
+        "valid": True,
+        "outcome": "MET",
+        "explanation": "the response met the criterion",
+        "raw_output": '{"criterion_status": "MET"}',
+        "metadata": {},
+        "accounting": accounting,
+    }
+
+
+# -- the happy path, on both owners --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "decode,wire", [(_case_operation, _operation_wire), (_evidence, _evidence_wire)]
+)
+def test_full_accounting_decodes_into_the_typed_value(decode, wire) -> None:
+    decoded = decode(wire(_accounting_wire()))
+    accounting = decoded.accounting
+    assert accounting is not None
+    assert accounting.provider == "openrouter"
+    assert accounting.request_model == "openrouter/openai/gpt-oss-120b"
+    assert accounting.response_model == "openai/gpt-oss-120b"
+    assert accounting.provider_latency_ms == 4200
+    # WHY Decimal: cost is money — the SDK's existing Usage already refuses float
+    # cost, and the breakdown must sum without binary-float drift.
+    assert accounting.usage.cost_usd == Decimal("0.0123450000")
+    assert accounting.usage.input_tokens == 1200
+    assert accounting.usage.reasoning_tokens == 900
+    # INVARIANT: a field the Engine could not observe stays None — NOT 0.
+    assert accounting.usage.cache_creation_tokens is None
+    assert (accounting.cache.hits, accounting.cache.misses) == (0, 1)
+
+
+@pytest.mark.parametrize(
+    "decode,wire", [(_case_operation, _operation_wire), (_evidence, _evidence_wire)]
+)
+def test_null_accounting_decodes_to_none_not_a_zeroed_value(decode, wire) -> None:
+    # The common case: deterministic Evidence, ambiguous joins, and CorrectiveLoop
+    # nested work all carry null. Zeroing it would publish "this was free".
+    assert decode(wire(None)).accounting is None
+
+
+@pytest.mark.parametrize(
+    "decode,wire", [(_case_operation, _operation_wire), (_evidence, _evidence_wire)]
+)
+def test_round_trip_through_to_dict_is_byte_equal(decode, wire) -> None:
+    payload = wire(_accounting_wire())
+    assert decode(payload).to_dict() == payload
+
+
+@pytest.mark.parametrize(
+    "decode,wire", [(_case_operation, _operation_wire), (_evidence, _evidence_wire)]
+)
+def test_null_accounting_round_trips_as_an_explicit_null(decode, wire) -> None:
+    # Required-nullable on the wire: the key is always present, so a re-serialized
+    # record must still carry it rather than dropping it.
+    assert decode(wire(None)).to_dict()["accounting"] is None
+
+
+# -- the version-mismatch guard ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "decode,wire", [(_case_operation, _operation_wire), (_evidence, _evidence_wire)]
+)
+def test_a_missing_accounting_key_refuses_loudly(decode, wire) -> None:
+    # WHY required, not optional: the Engine emits the key unconditionally, so its
+    # absence means the Client is talking to an Engine that predates the contract.
+    # Defaulting to None would silently publish an empty breakdown for a whole run.
+    payload = wire(None)
+    del payload["accounting"]
+    with pytest.raises(ExecutionError, match="missing 'accounting'"):
+        decode(payload)
+
+
+# -- strictness: every refusal below would otherwise become a false number -----------
+
+
+@pytest.mark.parametrize(
+    "overrides,expected",
+    [
+        pytest.param(
+            {"cache": {"hits": 0, "misses": 0, "bypasses": 0, "unknown": 0}},
+            "response",
+            id="no-response",
+        ),
+        pytest.param({"provider_latency_ms": -1}, "provider_latency_ms", id="negative-latency"),
+        pytest.param({"provider": "   "}, "provider", id="blank-provider"),
+        pytest.param(
+            {"usage": _usage_wire(input_tokens=-5)},
+            "input_tokens",
+            id="negative-tokens",
+        ),
+        pytest.param(
+            {"usage": _usage_wire(cost_usd="-1.00")},
+            "cost",
+            id="negative-cost",
+        ),
+        pytest.param({"usage": _usage_wire(cost_usd=0.0123)}, "cost", id="float-cost"),
+    ],
+)
+def test_malformed_accounting_refuses_instead_of_degrading(overrides: dict, expected: str) -> None:
+    with pytest.raises(ExecutionError, match=expected):
+        _case_operation(_operation_wire(_accounting_wire(**overrides)))
+
+
+def test_an_unknown_accounting_field_refuses() -> None:
+    # Strict decoder, no compatibility fallback (OME-1031 scope note): an Engine
+    # that grew a field the Client cannot interpret must not be half-decoded.
+    with pytest.raises(ExecutionError, match="unsupported field"):
+        _case_operation(_operation_wire(_accounting_wire(estimated_cost_usd="9.99")))
+
+
+def test_an_unknown_cache_field_refuses() -> None:
+    cache = {"hits": 1, "misses": 0, "bypasses": 0, "unknown": 0, "avoided_cost_usd": "0.10"}
+    with pytest.raises(ExecutionError, match="unsupported field"):
+        _case_operation(_operation_wire(_accounting_wire(cache=cache)))
+
+
+def test_a_missing_usage_field_refuses_rather_than_defaulting() -> None:
+    # Six independently optional fields — but each must be PRESENT and explicitly
+    # null. A dropped key is missing evidence, not a zero.
+    usage = _usage_wire()
+    del usage["reasoning_tokens"]
+    with pytest.raises(ExecutionError, match="reasoning_tokens"):
+        _case_operation(_operation_wire(_accounting_wire(usage=usage)))
+
+
+# -- public surface ------------------------------------------------------------------
+
+
+def test_the_accounting_values_are_public_and_constructible() -> None:
+    accounting = sf.OperationAccounting(
+        provider="openrouter",
+        request_model="openrouter/openai/gpt-5.4",
+        response_model=None,
+        usage=sf.Usage(input_tokens=10, cost_usd="0.5"),
+        provider_latency_ms=None,
+        cache=sf.OperationCache(hits=1, misses=0, bypasses=0, unknown=0),
+    )
+    assert accounting.usage.cost_usd == Decimal("0.5")
+    assert accounting.cache.hits == 1
+    assert accounting.to_dict()["provider_latency_ms"] is None
+
+
+def test_a_cache_record_with_no_response_refuses() -> None:
+    # The count sum IS the number of consumed responses the record represents;
+    # zero of them means the record describes nothing.
+    with pytest.raises(ValueError, match="response"):
+        sf.OperationCache(hits=0, misses=0, bypasses=0, unknown=0)


### PR DESCRIPTION
Unblocks #762. The Engine there emits per-operation `accounting`; this teaches the Client to decode it, so an evaluation completes instead of dying on `Case Operation contains unsupported field 'accounting'` and the combined golden-replay lane stays green.

> **Base is `OME-901-runtime-accounting-lineage`, not `main`.** Merge this INTO #762, which then lands both halves in one commit. Either side alone turns CI red in the mirror-image way.

## Before / After

### Before

- Trigger: a dev runs `sf.evaluate(...)` against an Engine that retains per-operation accounting
- Today: the Client's strict decoder refuses the reply, so the whole evaluation fails
- Cost: the Engine change cannot land alone

### After

- Same trigger
- Now: the Client decodes retained accounting on Candidate operations and grading Evidence and round-trips it through the public API and Report JSON
- Cost, token, cache, provider-time, and provider-attempt facts remain attached to the operation they explain
- Ambiguous or absent accounting stays explicitly null — never a guess or false zero

## Why the two halves land together

The Engine emits `"accounting"` unconditionally (`null` when empty), so it is a required-nullable field and the decoder is strict with no compatibility fallback:

| Merged alone | CI result |
|---|---|
| #762 (Engine only) | current Client rejects unsupported `accounting` |
| this branch into `main` | new Client rejects missing `accounting` from the old Engine |

The e2e harness boots both from the same checkout, and the combined tree is green.

## What's here

- focused public `OperationCache` and `OperationAccounting` values; the six usage fields reuse the existing `sf.Usage`
- focused strict accounting wire decoder, separate from the general result decoder
- `accounting` on `CaseOperation` and `Evidence`, emitted by `to_dict` unconditionally
- exact validated `provider_attempts` beside summed provider latency
- canonical fixed-point `cost_usd` enforcement: exponent notation, leading-zero/plus spellings, floats, and `Decimal` objects refuse instead of being silently normalized
- typed token/cache boundaries with no `# type: ignore` escapes
- deliberately out of scope: computed views, `MemberResult.usage`, and the completed-Report SFDS table (OME-1031)

## Test plan

- **29 accounting decoder tests** covering both owners, exact round-trip, null preservation, version mismatch, malformed fields, fixed-point cost spellings, cache boundaries, and provider-attempt count
- full Client gate green: Ruff check, Ruff format, Pyright, pytest with coverage ≥95%, deterministic notebooks, wheel build, and distribution verification
- combined Docker e2e lane: both golden replays green without re-blessing

## Reviewer notes

- Prior hand-authored old wire fixtures gained the required `"accounting": null` field; assertions were extended, not weakened.
- The public-surface snapshot was regenerated for the two new public values.
- Review extraction moved the new values and decoder into focused 97- and 129-line modules, removing the feature's material growth from the two already-large result modules.
- Scores, Evidence meaning, outputs, failures, URL4 rendering, cache keys, root usage, model-call cardinality, and live events remain unchanged.

Refs: OME-1032
