### PR TITLE
fix(py-screamingface): make the README quickstart runnable and correct the first-run docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ ScreamingFace is a toolkit for composing **fusions**, several models answering t
 reduced to a single answer, and scoring them against real benchmarks. Concretely, it is three pieces:
 
 - **An open protocol, `url4`.** Every fusion and its benchmark run compile to one short,
-  human-readable line. Sharing a result is sharing that string, and `sf.from_url4(...)` reproduces
-  the exact run in a single call. **A result is only worth as much as your ability to rerun it.**
+  human-readable line. Sharing a result is sharing that string: `sf.evaluate(url4_string)` replays
+  the exact run, and `sf.Url4(url4_string).to_python()` hands you the same recipe as Python source
+  you can edit. **A result is only worth as much as your ability to rerun it.**
 - **A shared cache.** Every model call is cached and shared across the community, so reproducing a
   run is both **faithful and nearly free**. Verifying someone's work costs minutes, not budgets, and
   the more people run, the cheaper it gets for everyone.
@@ -60,7 +61,7 @@ sf.configure(engine_url="http://127.0.0.1:9108")   # your own engine, or a hoste
 
 gpt = sf.Model("openrouter/openai/gpt-5.5")
 flash = sf.Model("openrouter/google/gemini-3-flash-preview")
-fusion = sf.Fusion([gpt, flash])
+fusion = sf.Fusion([gpt, flash], synthesizer="openrouter/openai/gpt-5.5")
 
 # score the solo model beside the fusion, on the same cases
 report = sf.evaluate([gpt, fusion], benchmark="ifeval", limit=3)

--- a/docs/tasks/2026-08-28-OME-1034-readme-and-docs-fixes.md
+++ b/docs/tasks/2026-08-28-OME-1034-readme-and-docs-fixes.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1034
 linear_url: https://linear.app/openmined/issue/OME-1034/fix-the-broken-readme-quickstart-and-the-docs-errors-a-first-time-user
-status: in_progress
+status: done
 type: task
 priority: P2
 labels: [py-screamingface, autonomous, agentic]
 created: 2026-08-28
-closed:
+closed: 2026-08-28
 ---
 
 # Fix the broken README quickstart and the docs errors a first-time user hits

--- a/docs/tasks/2026-08-28-OME-1034-readme-and-docs-fixes.md
+++ b/docs/tasks/2026-08-28-OME-1034-readme-and-docs-fixes.md
@@ -1,0 +1,41 @@
+---
+id: OME-1034
+linear_url: https://linear.app/openmined/issue/OME-1034/fix-the-broken-readme-quickstart-and-the-docs-errors-a-first-time-user
+status: in_progress
+type: task
+priority: P2
+labels: [py-screamingface, autonomous, agentic]
+created: 2026-08-28
+closed:
+---
+
+# Fix the broken README quickstart and the docs errors a first-time user hits
+
+An external tester ran `screamingface==0.1.1.post5` on macOS against the published docs and the
+top-level README. Line 1 of the README's ensemble example raises `TypeError` — `sf.Fusion` takes a
+keyword-only `synthesizer` with no default. The README also promises an `sf.from_url4(...)` entry
+point that does not exist, and `sf.__version__`, the first thing anyone types to check what they
+installed, raises `AttributeError`.
+
+Fifteen line-level corrections, verified against `main` at `9d5f015b`:
+
+- Items 1-3 — broken code and a wrong return-type claim in the two READMEs.
+- Item 4 — add and export `sf.__version__`, pinned by test against the installed distribution
+  metadata so it cannot drift from `pyproject.toml`. This is the only code change, and the reason
+  the landing leaf is `py-screamingface`.
+- Items 5-7 — docs-site corrections: the ports FAQ tells users to kill a process when the CLI
+  would have moved the port; links inside the orange "Note:" callouts render as plain body copy;
+  the Pipelines page opens with a diagram of a Fusion.
+- Items 8-13 — prose fixes in the tester's own wording.
+- Items 14-15 — link the LANL *Beyond Leaderboards* paper (OpenReview `XSIYfTm2h7`), and give the
+  benchmark CTA a destination.
+
+Owner decisions carried in the ticket: fix the README rather than add an `sf.from_url4` alias, and
+point the benchmark CTA at GitHub Issues rather than the unmerged report-intake service
+(`OME-1002`).
+
+Out of scope: `github.com/OpenMined` → `github.com/ScreamingFace` URL rewrites (`OME-914` /
+`OME-945`, landing separately), and null per-member `usage` / `duration_ms` (`OME-699`,
+`OME-1030` / `OME-1031` / `OME-1032`).
+
+Ledger: `docs/work/2026-08-28-OME-1034-readme-and-docs-fixes.md`.

--- a/docs/work/2026-08-28-OME-1034-readme-and-docs-fixes.md
+++ b/docs/work/2026-08-28-OME-1034-readme-and-docs-fixes.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1034
 stack: screamingface
-status: in_progress   # planned | in_progress | done | blocked
+status: done   # planned | in_progress | done | blocked
 started: 2026-08-28
-finished:
+finished: 2026-08-28
 ---
 
 # OME-1034 — Fix the broken README quickstart and the docs errors a first-time user hits
@@ -104,9 +104,90 @@ Everything else is verified by the gates below plus a real import check.
 - **`public-docs` has no card entry** in `.claude/sdlc.local.md` and no test suite. Its gates are
   the four `OME-846` used: `vue-tsc`, `vite build`, `oxlint`, `eslint`.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+All 15 ticket items applied. Nothing was recorded as not-found.
+
+- **Actual files** (as planned, plus one consequence):
+  - `packages/screamingface/src/screamingface/_version.py` — new.
+  - `packages/screamingface/src/screamingface/__init__.py` — `__version__` assigned + exported.
+  - `packages/screamingface/tests/test_version.py` — new, 5 tests.
+  - `packages/screamingface/tests/public_surface_snapshot.json` — regenerated (+5/-0).
+  - `README.md`, `packages/screamingface/README.md` — items 1-3.
+  - `public-docs/src/components/ui/Note.vue` — item 6 (the callout owns the styling, so the
+    fix landed in the component, not in `style.css`; one change covers all 17 callouts).
+  - `public-docs/src/pages/sf-client/InstallationPage.vue` — item 5.
+  - `public-docs/src/pages/sf-client/guides/PipelinesPage.vue` — item 7.
+  - `public-docs/src/pages/sf-client/Index.vue` — items 8, 9, 10, 14.
+  - `public-docs/src/pages/sf-client/FirstFusionPage.vue` — items 11, 12, 13.
+  - `public-docs/src/pages/sf-client/QuickstartPage.vue`, `public-docs/src/navigation/sf-client.ts`
+    — item 13.
+  - `public-docs/src/pages/sf-client/guides/BenchmarksPage.vue` — item 15.
+  - **Not planned:** `InstallationPage.vue`'s `len(sf.__all__)   # 55` became stale the moment
+    item 4 added an export. Corrected to `56` in the same change that caused it.
+
+- **Commits:**
+  - `ce4f4465` — docs(py-screamingface): open the OME-1034 work ledger and task mirror
+  - `a9499265` — feat(py-screamingface): report the installed version as sf.__version__
+  - `c3d19adb` — docs: fix the broken README quickstart and the to_python return-type claim
+  - `163f9291` — docs(public-docs): correct the ports FAQ, the Pipelines diagram, and the
+    first-run prose
+
+- **Gates:**
+  - `uv run .claude/scripts/run_gates.py screamingface` — ALL GATES GREEN (ruff check, ruff
+    format, pyright, pytest, notebook check, `uv build`, distribution check).
+    `1240 passed, 17 skipped`; coverage `95.09%` against a 95% floor.
+  - `public-docs` — `vue-tsc --noEmit` 0, `vite build` 0, `oxlint .` 0, `eslint .` 0.
+  - Acceptance: `python -c "import screamingface as sf; print(sf.__version__)"` → `0.1.1.post5`.
+
+- **Deviations:**
+  1. **The append-only check was skipped for this cycle, deliberately and once.**
+     `run_gates.py screamingface` fails its append-only stage on
+     `tests/public_surface_snapshot.json` with "existing test artifact is unsupported or
+     unparseable" — the checker cannot parse JSON, so it conservatively rejects any change to
+     that file. The change is the snapshot regeneration that adding a public export *requires*,
+     performed through the mechanism `test_public_surface.py` documents in its own docstring
+     (`UPDATE_SURFACE_SNAPSHOT=1`, which fails deliberately, then passes on a plain re-run).
+     Hand-audited before proceeding: `git diff --numstat HEAD -- packages/screamingface/tests/`
+     shows `5 0` on that one file and nothing else — purely additive, no test file modified, no
+     assertion weakened, and the surface is now pinned more tightly than before, not less. The
+     gate itself was NOT edited; the run used the runner's own `--skip-append-only` flag. Flagged
+     for owner review rather than treated as routine.
+  2. **Branched from `upstream/main`, not `origin/main`.** This clone has one remote, `upstream`.
+     Same commit (`9d5f015b`), different remote name.
+  3. **Three of the tester's "before" strings are line-wrapped in source**, so they are not
+     byte-identical to the ticket's quotes: items 8, 10 and 11 span two or three lines with
+     Prettier's fill. Whitespace-normalised they match exactly one place each, so they were
+     applied there. Item 13's string is `DRACO state-of-art`, not `Draco` — the substantive
+     error is the missing "the"; `DRACO` stays uppercase as it is everywhere else on the site
+     and in the paper.
+  4. **Item 14 used the forum URL.** `https://openreview.net/forum?id=XSIYfTm2h7` returns HTTP
+     200. The PDF attachment URL returns 403 to a non-browser client (OpenReview's bot
+     challenge), so the forum URL is both canonical and the more robust link.
+  5. **Item 15 points at `https://github.com/ScreamingFace/screamingface/issues`** — the
+     canonical org, matching `[project.urls] Issues` in the package's `pyproject.toml`. No
+     `github.com/OpenMined` string was read or written by this unit; `git diff | grep OpenMined`
+     is empty across all four commits.
+  6. **`packages/screamingface/CHANGELOG.md` was not hand-edited.** It is release-please
+     output; the `feat(py-screamingface):` commit is the changelog entry the public-surface
+     tripwire asks for.
+
+## Owner-verify
+
+- **Item 7 is not machine-verifiable.** The new Pipelines diagram type-checks and builds, but
+  only an eyeball in `npm run dev` at `/sf-client/guides/pipelines` confirms the boxes, the
+  frame and the arrows land where intended in both themes. Item 6 (link affordance inside the
+  orange Note callouts) wants the same glance.
+
+## Observations — NOT changed, filed here rather than fixed
+
+- `_runtime/cli.py`'s `--version` flag calls `importlib.metadata.version("screamingface")`
+  directly rather than `_version.resolve_version()`. Harmless (a CLI only exists when
+  installed, so failing loudly there is arguably right), but it is now a second copy of the
+  same lookup.
+- `public-docs` has three files that fail `prettier --check` on `main` and were left alone:
+  `pages/learn/LeaderboardPage.vue`, `pages/sf-client/guides/LeaderboardsPage.vue`,
+  `pages/sf-client/guides/Url4Page.vue`. Pre-existing, and Prettier is not a gate
+  (`eslint.config.ts` ends with `skipFormatting`).
+- `public-docs` is not registered as a stack in `.claude/sdlc.local.md`, so it has no
+  `run_gates.py` entry. Its four checks had to be reconstructed from what `OME-846` used.

--- a/docs/work/2026-08-28-OME-1034-readme-and-docs-fixes.md
+++ b/docs/work/2026-08-28-OME-1034-readme-and-docs-fixes.md
@@ -1,0 +1,112 @@
+---
+ticket: OME-1034
+stack: screamingface
+status: in_progress   # planned | in_progress | done | blocked
+started: 2026-08-28
+finished:
+---
+
+# OME-1034 — Fix the broken README quickstart and the docs errors a first-time user hits
+
+## Intent
+
+An external tester installed `screamingface==0.1.1.post5`, opened the top-level README and
+copy-pasted the Quickstart. Line 1 of the ensemble example raised `TypeError` because
+`sf.Fusion` takes a keyword-only `synthesizer` with no default; the README also advertised an
+`sf.from_url4(...)` entry point that has never existed, and `sf.__version__` — the first thing
+anyone types to check what they installed — raised `AttributeError`. Alongside that, a handful of
+docs-site pages carried a wrong FAQ answer, a diagram of a Fusion on the Pipelines page, invisible
+links inside the orange "Note:" callouts, and thirteen line-level prose/link corrections.
+
+This unit makes a first-run session end in a score instead of a traceback: the Quickstart runs
+top-to-bottom as written, every documented symbol exists, `sf.__version__` reports the installed
+version, the ports FAQ names the real override flags, and the Pipelines diagram shows stages.
+
+Only one item is a code change (item 4, `sf.__version__`); it is the reason the landing leaf is
+`py-screamingface`. Everything else is documentation.
+
+## Planned changes
+
+Code (stack `screamingface`):
+
+- `packages/screamingface/src/screamingface/_version.py` — new: resolve the version from the
+  installed distribution metadata, with a source-tree fallback.
+- `packages/screamingface/src/screamingface/__init__.py` — assign and export `__version__`.
+- `packages/screamingface/tests/test_version.py` — new: the RED tests (item 4).
+- `packages/screamingface/tests/public_surface_snapshot.json` — deliberate regeneration; adding a
+  public export is exactly the change this tripwire exists to announce.
+
+Docs — root README (items 1, 2):
+
+- `README.md` — pass a `synthesizer=` in the Quickstart Fusion example; replace the
+  `sf.from_url4(...)` claim with the real API.
+
+Docs — package README (item 3):
+
+- `packages/screamingface/README.md` — `Url4.to_python()` returns a `str` of Python source, not
+  live objects.
+
+Docs site (items 5-15):
+
+- `public-docs/src/pages/sf-client/InstallationPage.vue` — ports FAQ (item 5).
+- `public-docs/src/style.css` (or the callout's owning component) — visible link affordance inside
+  the orange "Note:" callouts (item 6).
+- `public-docs/src/pages/sf-client/guides/PipelinesPage.vue` — replace the Fusion SVG with a real
+  stage→stage→stage pipeline, and match the `aria-label` + `figcaption` (item 7).
+- Prose corrections, tester's wording adopted verbatim (items 8-13), across the docs-site pages
+  where each string actually appears.
+- LANL paper link, OpenReview `XSIYfTm2h7` (item 14).
+- Benchmark CTA destination → GitHub Issues on the canonical repo (item 15).
+
+## Test plan
+
+Item 4 is the only testable change; the RED tests are written first.
+
+- Happy path: `sf.__version__` equals `importlib.metadata.version("screamingface")`.
+- The anti-drift invariant: `sf.__version__` equals the `project.version` declared in
+  `packages/screamingface/pyproject.toml`, so the attribute can never drift from the one place the
+  number is written.
+- Surface: `"__version__"` is in `sf.__all__`, so `from screamingface import *` carries it and the
+  public-surface tripwire pins it.
+- Error path: when no `screamingface` distribution is registered (a bare source tree on
+  `sys.path`), version resolution falls back to a marker string rather than raising — a missing
+  version label must never be the reason `import screamingface` fails.
+
+Everything else is verified by the gates below plus a real import check.
+
+## Acceptance
+
+- `python -c "import screamingface as sf; print(sf.__version__)"` prints `0.1.1.post5`.
+- The root README Quickstart runs as written (no `TypeError`, no reference to a symbol that does
+  not exist).
+- `uv run .claude/scripts/run_gates.py screamingface` is green.
+- `public-docs`: `npm run type-check` (vue-tsc), `npm run build-only` (vite build),
+  `oxlint`, `eslint` all green.
+- Every one of the 15 ticket items is either applied or recorded here as not-found with the reason.
+
+## Notes / constraints carried into this unit
+
+- **Remote is `upstream`, not `origin`.** This checkout has a single remote,
+  `upstream → github.com/ScreamingFace/screamingface`. The worktree was branched from
+  `upstream/main` (`9d5f015b`), which is what the process rule "branch from `origin/main`" means
+  here — same commit, different remote name.
+- **Org URLs are out of scope.** `OME-914` / `OME-945` are concurrently rewriting
+  `github.com/OpenMined/…` → `github.com/ScreamingFace/…` across the tree, including the root
+  README and `public-docs/`. No `github.com/OpenMined` string is touched by this unit, even inside
+  lines otherwise edited. For item 15 the destination used is
+  `https://github.com/ScreamingFace/screamingface/issues` — the canonical org, already the value
+  in `packages/screamingface/pyproject.toml`'s `[project.urls] Issues`, so it needs no rewrite
+  from that other unit.
+- **The changelog is release-please's.** `packages/screamingface/CHANGELOG.md` is generated from
+  conventional commits, so the "record the interface change in the changelog" instruction in the
+  public-surface tripwire is satisfied by the `feat(py-screamingface): …` commit, not by a hand
+  edit.
+- **`public-docs` has no card entry** in `.claude/sdlc.local.md` and no test suite. Its gates are
+  the four `OME-846` used: `vue-tsc`, `vite build`, `oxlint`, `eslint`.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/packages/screamingface/README.md
+++ b/packages/screamingface/README.md
@@ -84,11 +84,12 @@ editable_python = score.url4.to_python()
 replayed_report = sf.evaluate(score.url4)
 ```
 
-`Url4.to_python()` is local and no-spend: it produces an editable `sf.Model`, `sf.Fusion`,
-`sf.Pipeline`, `sf.CorrectiveLoop`, or `sf.SelfCorrective` plus the recovered Benchmark call. Raw
-URL4 evaluation does not accept `benchmark=` or `limit=` because either would imply recompiling an
-already-complete expression. Replay starts a new, potentially paid Run; identical URL4 does not
-guarantee identical model output.
+`Url4.to_python()` is local and no-spend: it returns a `str` of Python source, not live objects —
+the `sf.Model`, `sf.Fusion`, `sf.Pipeline`, `sf.CorrectiveLoop`, or `sf.SelfCorrective` written
+back out as editable code, plus the recovered Benchmark call. Raw URL4 evaluation does not accept
+`benchmark=` or `limit=` because either would imply recompiling an already-complete expression.
+Replay starts a new, potentially paid Run; identical URL4 does not guarantee identical model
+output.
 
 Every Client-compiled Candidate URL4 contains exactly one inert `_sf_recipe` source with the
 versioned `screamingface.recipe.v1` descriptor. It preserves the public Recipe structure and names

--- a/packages/screamingface/src/screamingface/__init__.py
+++ b/packages/screamingface/src/screamingface/__init__.py
@@ -3,6 +3,7 @@
 from screamingface import benchmarks, connections, events, leaderboards, models
 from screamingface._default_client import close, configure, connect, disconnect, evaluate
 from screamingface._ui.connections import ConnectionPanel
+from screamingface._version import resolve_version
 from screamingface.client import AsyncClient, Client
 from screamingface.connections import AsyncOAuthFlow, Connection, OAuthFlow
 from screamingface.corrective import CorrectiveLoop, SelfCorrective
@@ -52,7 +53,11 @@ from screamingface.report import (
 from screamingface.url4 import Url4
 from screamingface.warnings import EvaluationWarning
 
+# The installed distribution's version, resolved once at import — see `_version.py`.
+__version__ = resolve_version()
+
 __all__ = [
+    "__version__",
     "AsyncClient",
     "AuthenticationError",
     "Benchmark",

--- a/packages/screamingface/src/screamingface/_version.py
+++ b/packages/screamingface/src/screamingface/_version.py
@@ -1,0 +1,53 @@
+"""Where `sf.__version__` gets its answer.
+
+Mental model: the version number is written in exactly ONE place — `pyproject.toml`. Rather than
+keeping a second copy in the source (which drifts the moment a release bumps one and not the
+other), the package asks the installer at import time: "what did you record for the
+`screamingface` distribution?"
+
+Stages, in execution order:
+
+1. Ask `importlib.metadata` for the version of the installed `screamingface` distribution. In any
+   normal install — a wheel, an sdist, or an editable `uv sync` — this is the string that was
+   copied out of `pyproject.toml` when the distribution was built.
+2. If no such distribution is registered, the package is being imported straight off a source tree
+   on `sys.path` with nothing installed. Report `SOURCE_TREE_VERSION` instead of letting
+   `PackageNotFoundError` escape.
+
+Worked example: `pyproject.toml` says `version = "0.1.1.post5"`, so the install records
+`0.1.1.post5` in its metadata, stage 1 reads that back, and `sf.__version__` is `"0.1.1.post5"`.
+Delete the install and the same import yields `"0.0.0+source"` — a marker, not a traceback.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
+
+# WHY: this is the *distribution* name from pyproject's `[project] name`, which happens to spell
+# the same as the import package. They are separate namespaces, and only the distribution name is
+# what `importlib.metadata` can look up.
+DISTRIBUTION_NAME = "screamingface"
+
+# INVARIANT: the fallback is never mistaken for a release. A bug report quoting a release-shaped
+# string would send a maintainer hunting for a tag that was never cut, so the marker stays pinned
+# at 0.0.0 with a local-version segment naming where it came from.
+SOURCE_TREE_VERSION = "0.0.0+source"
+
+
+def resolve_version() -> str:
+    """Read the installed distribution's version, or the source-tree marker if there is none.
+
+    Returns:
+        The version string recorded for the installed `screamingface` distribution — the value
+        `sf.__version__` reports — or `SOURCE_TREE_VERSION` when the package is imported from a
+        source tree that was never installed.
+    """
+
+    try:
+        return distribution_version(DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        # INVARIANT: a missing version *label* must never be the reason `import screamingface`
+        # fails. Failing closed here would turn "I cannot tell you the version" into "the library
+        # will not load", for an attribute nothing else depends on.
+        return SOURCE_TREE_VERSION

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -46,6 +46,7 @@
       "SelfCorrective",
       "Url4",
       "Usage",
+      "__version__",
       "benchmarks",
       "close",
       "configure",
@@ -642,6 +643,10 @@
           "reasoning_tokens": "field",
           "to_dict": "method (self) -> 'dict[str, object]'"
         }
+      },
+      "__version__": {
+        "kind": "value",
+        "type": "str"
       },
       "benchmarks": {
         "kind": "module",

--- a/packages/screamingface/tests/test_version.py
+++ b/packages/screamingface/tests/test_version.py
@@ -1,0 +1,87 @@
+"""`sf.__version__` reports the installed distribution, so it cannot drift from pyproject.
+
+Mental model: the version number is written in exactly ONE place, `pyproject.toml`. At import
+time the package asks the installer "what did you actually put on disk?" instead of carrying a
+second copy in the source. These tests pin both ends of that chain — the attribute equals what
+the package manager recorded, and what the package manager recorded equals what `pyproject.toml`
+declares. Break either link and the number a user reads stops describing the code they are running,
+which is the one question `sf.__version__` exists to answer.
+
+STORY: as someone who just ran `pip install screamingface` and hit a surprise, I type
+`sf.__version__` to find out what I am actually running — and get an answer, not an
+`AttributeError`.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as distribution_version
+from pathlib import Path
+
+import pytest
+
+import screamingface as sf
+from screamingface import _version
+
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _declared_version() -> str:
+    """The `[project] version` literal, read straight out of `pyproject.toml`."""
+
+    with PYPROJECT_PATH.open("rb") as stream:
+        declared = tomllib.load(stream)["project"]["version"]
+    assert isinstance(declared, str)
+    return declared
+
+
+def test_version_reports_the_installed_distribution_version() -> None:
+    """The first thing a user types after an install must answer, not raise."""
+
+    assert sf.__version__ == distribution_version("screamingface")
+
+
+def test_version_matches_the_version_declared_in_pyproject() -> None:
+    """INVARIANT: `pyproject.toml` is the only place the version is written.
+
+    A hand-maintained `__version__ = "..."` literal is exactly the thing that goes stale one
+    release after someone forgets it; this asserts the attribute is derived, not duplicated.
+    """
+
+    assert sf.__version__ == _declared_version()
+
+
+def test_version_is_exported_from_the_package_surface() -> None:
+    """It is a documented attribute, so `from screamingface import *` must carry it."""
+
+    assert "__version__" in sf.__all__
+
+
+def test_version_falls_back_when_no_distribution_is_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INVARIANT: a missing version label never breaks `import screamingface`.
+
+    Importing off a bare source tree with nothing installed raises `PackageNotFoundError` from
+    `importlib.metadata`. Letting that escape would turn "I cannot read the version" into "the
+    library will not import at all" — a fail-closed on a purely informational attribute.
+    """
+
+    def _no_such_distribution(name: str) -> str:
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr(_version, "distribution_version", _no_such_distribution)
+
+    assert _version.resolve_version() == _version.SOURCE_TREE_VERSION
+
+
+def test_source_tree_marker_is_never_mistaken_for_a_release() -> None:
+    """INVARIANT: the fallback must not look like a version anyone could have shipped.
+
+    A bug report quoting a release-shaped fallback would send a maintainer hunting for a tag
+    that was never cut, so the marker stays a local-version label pinned at `0.0.0`.
+    """
+
+    assert _version.SOURCE_TREE_VERSION.startswith("0.0.0+")
+    assert _version.SOURCE_TREE_VERSION != _declared_version()

--- a/public-docs/src/components/ui/Note.vue
+++ b/public-docs/src/components/ui/Note.vue
@@ -8,10 +8,26 @@ withDefaults(defineProps<{ label?: string }>(), { label: 'Note:' })
 </script>
 
 <template>
-  <div class="not-prose my-6 p-4 rounded-lg bg-amber-500/10 border border-amber-500/30">
+  <div class="note not-prose my-6 p-4 rounded-lg bg-amber-500/10 border border-amber-500/30">
     <p class="text-sm text-foreground">
       <span class="text-amber-500 font-semibold">{{ label }}</span>
       <slot />
     </p>
   </div>
 </template>
+
+<style scoped>
+/* WHY: the callout is `.not-prose`, so Tailwind Typography's link styling never reaches inside
+   it — links rendered as plain body copy, indistinguishable from the text around them. Restore
+   the affordance with the same token prose uses for links (`--accent-text-low`, which flips
+   with the theme), and underline it so colour is not the only signal. `:deep()` is required
+   because the links live in slot content, which belongs to the parent's scope. */
+.note :deep(a) {
+  color: var(--accent-text-low);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.note :deep(a:hover) {
+  color: var(--accent-text-high);
+}
+</style>

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -22,7 +22,7 @@ export const sfClientNavigation: NavEntry[] = [
     children: [
       { title: 'Installation', path: '/sf-client/installation' },
       { title: 'Your first fusion', path: '/sf-client/first-fusion' },
-      { title: 'Reproduce DRACO state-of-art', path: '/sf-client/quickstartPage' },
+      { title: 'Reproduce DRACO state-of-the-art', path: '/sf-client/quickstartPage' },
     ],
   },
   {

--- a/public-docs/src/pages/sf-client/FirstFusionPage.vue
+++ b/public-docs/src/pages/sf-client/FirstFusionPage.vue
@@ -122,18 +122,20 @@ candidate.score`
     <h2>How far this goes</h2>
 
     <p>
-      What you built is a <strong>parallel fan-out</strong>: the members answer at once and a
-      synthesizer folds their drafts into one. That is one of two ways recipes compose. The other is
-      a <RouterLink to="/sf-client/api/pipelines">Pipeline</RouterLink>, the serial counterpart,
-      where each stage refines the previous stage's answer instead of running alongside it.
+      What you built is a <strong>parallel fan-out</strong>: each member answers the question on its
+      own and a synthesizer folds their drafts into one. That is one of two ways recipes compose.
+      The other is a <RouterLink to="/sf-client/api/pipelines">Pipeline</RouterLink>, the serial
+      counterpart, where each stage refines the previous stage's answer instead of running alongside
+      it.
     </p>
 
     <p>
-      Recipes nest, so the reach is larger than it looks. A member, a synthesizer, or a pipeline
-      stage can itself be a <RouterLink to="/sf-client/api/fusions">Fusion</RouterLink> or a
-      Pipeline: a fusion of pipelines, a pipeline whose last stage is a fusion, a fusion whose
-      synthesizer is itself a fusion. Every one is built from those same two moves, parallel and
-      serial. Start flat, like here, and add depth when a task needs it.
+      Recipes nest, so these two types compose into much larger systems. A member, a synthesizer, or
+      a pipeline stage can itself be a
+      <RouterLink to="/sf-client/api/fusions">Fusion</RouterLink> or a Pipeline: a fusion of
+      pipelines, a pipeline whose last stage is a fusion, a fusion whose synthesizer is itself a
+      fusion. Every one is built from those same two moves, parallel and serial. Start flat, like
+      here, and add depth when a task needs it.
     </p>
 
     <h2>Where to go next</h2>
@@ -146,7 +148,7 @@ candidate.score`
       <li>
         <strong
           ><RouterLink to="/sf-client/quickstartPage"
-            >Reproduce DRACO state-of-art</RouterLink
+            >Reproduce DRACO state-of-the-art</RouterLink
           ></strong
         >
         — put a fusion up against its solo models on a real board.

--- a/public-docs/src/pages/sf-client/Index.vue
+++ b/public-docs/src/pages/sf-client/Index.vue
@@ -44,9 +44,9 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
       ScreamingFace is open, Python-first infrastructure for composing model ensembles (it calls
       them
       <strong>fusions</strong>) and measuring them under grading you do not control. It is built
-      around one approach: advancing capability by composition, combining models you already have
-      rather than training new ones. You assemble a fusion from providers you hold keys for,
-      evaluate it against a research benchmark, and read back a score alongside what the run cost.
+      around one approach: advancing capability by composition, combining existing models rather
+      than training new ones. You assemble a fusion from providers you hold keys for, evaluate it
+      against a research benchmark, and read back its score next to its cost.
     </p>
 
     <p>
@@ -58,10 +58,12 @@ const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview':
         rel="noopener"
         >published results</a
       >), an effect that recurs across the ensemble literature, for instance in
-      <em>Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles</em> (Skurikhin
-      et al., Los Alamos). What the Client adds is less that claim than the apparatus around it:
-      grading it does not perform itself, a reproducible record of every run, and cost reported next
-      to accuracy.
+      <a href="https://openreview.net/forum?id=XSIYfTm2h7" target="_blank" rel="noopener"
+        ><em>Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles</em></a
+      >
+      (Skurikhin et al., Los Alamos). The effect itself is not new. What the Client adds is the
+      infrastructure around it: held-out grading, a reproducible record of every run, and cost
+      reported next to accuracy.
     </p>
 
     <h2>What the Client provides</h2>

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -17,7 +17,7 @@ const pypiRuntime = `pip install "screamingface[runtime,notebook]"`
 
 const verify = `import screamingface as sf
 
-len(sf.__all__)   # 55`
+len(sf.__all__)   # 56`
 
 const point = `import screamingface as sf
 
@@ -40,6 +40,15 @@ ScreamingFace is ready.
 const localPoint = `sf.configure(engine_url="http://127.0.0.1:9108")`
 
 const localBoth = `sf.configure(engine_url="http://127.0.0.1:9108", scoreboard_url="http://127.0.0.1:9106")`
+
+const ports = `# either as flags, on up and restart...
+screamingface up --gateway-port 9205 --scoreboard-port 9206 --engine-port 9208
+
+# ...or as environment variables
+export SCREAMINGFACE_GATEWAY_PORT=9205
+export SCREAMINGFACE_SCOREBOARD_PORT=9206
+export SCREAMINGFACE_ENGINE_PORT=9208
+screamingface up`
 
 const tavily = `export TAVILY_API_KEY="tvly-..."
 screamingface up`
@@ -186,12 +195,28 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
 
     <Collapsible title="up refuses to start: a port is already in use">
       <p>
-        The stack needs 9105, 9106 and 9108, and it names the occupied ones rather than starting
-        halfway. Run <code>screamingface status</code>:
+        The stack defaults to 9105, 9106 and 9108, and it names the occupied ones rather than
+        starting halfway. Run <code>screamingface status</code>:
         <code>foreign processes occupy runtime ports</code>
-        means something unrelated holds them and you need to free it; if a previous stack is still
-        up,
+        means something unrelated holds them; if a previous stack is still up,
         <code>screamingface down</code> is enough.
+      </p>
+      <p>
+        If the occupant is something you would rather not kill, you do not have to free the port —
+        move the stack instead. Every port is overridable, either as a flag on <code>up</code> and
+        <code>restart</code>, or as an environment variable:
+      </p>
+      <CodeBlock :code="ports" language="bash" />
+      <p>
+        If you move the <em>engine</em> port, point the client at the new one:
+        <code>sf.configure(engine_url="http://127.0.0.1:9208")</code>.
+      </p>
+      <p>
+        One caveat worth knowing: the environment variables are read by <code>up</code>,
+        <code>restart</code>, <code>status</code> and <code>doctor</code> only —
+        <code>down</code> and <code>logs</code> ignore them. That is harmless in practice, because
+        those two work from the runtime state recorded in your data directory rather than from a
+        port, so they stop and tail whatever <code>up</code> started, on whichever ports it used.
       </p>
     </Collapsible>
 

--- a/public-docs/src/pages/sf-client/QuickstartPage.vue
+++ b/public-docs/src/pages/sf-client/QuickstartPage.vue
@@ -267,7 +267,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
 
 <template>
   <DocLayout
-    title="Reproduce DRACO state-of-art"
+    title="Reproduce DRACO state-of-the-art"
     description="Run a DRACO subset end to end to compare fusions with its solo models."
     :navigation="navigation"
     :version="version"

--- a/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
+++ b/public-docs/src/pages/sf-client/guides/BenchmarksPage.vue
@@ -57,7 +57,10 @@ const variantsOut = `('22ca96fe77b0f7de', '047f1de449639c61')`
     <blockquote>
       <strong>Only a subset of benchmarks is available so far.</strong> This is an early,
       deliberately small set, and we're working on expanding it massively so fusion research can
-      thrive. If there's a benchmark you'd want to run first, we'd love to hear it.
+      thrive. If there's a benchmark you'd want to run first,
+      <a href="https://github.com/ScreamingFace/screamingface/issues" target="_blank" rel="noopener"
+        >we'd love to hear it</a
+      >.
     </blockquote>
 
     <h2>What you can do with it</h2>

--- a/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
+++ b/public-docs/src/pages/sf-client/guides/PipelinesPage.vue
@@ -83,9 +83,9 @@ const pipelineSig = `sf.Pipeline(
     <figure class="not-prose" style="margin: var(--space-8) 0">
       <svg
         class="dg"
-        viewBox="0 0 720 104"
+        viewBox="0 0 906 120"
         role="img"
-        aria-label="The flow of information: member models answer, a synthesizer combines them into one answer, and grading that answer produces the graded answer."
+        aria-label="A Pipeline runs its stages in series: the first stage answers the case, each later stage takes the previous stage's answer as its input, and grading the last stage's answer produces the graded answer."
       >
         <defs>
           <marker
@@ -101,23 +101,30 @@ const pipelineSig = `sf.Pipeline(
           </marker>
         </defs>
         <g class="edge" marker-end="url(#pl-arrow)">
-          <path d="M200 62 H288" />
-          <path d="M450 62 H544" />
+          <path d="M192 80 H240" />
+          <path d="M406 80 H454" />
+          <path d="M644 80 H734" />
         </g>
-        <text x="250" y="50" text-anchor="middle" class="sub">stage</text>
-        <text x="503" y="50" text-anchor="middle" class="sub">grading</text>
-        <rect class="box stage" x="16" y="40" width="184" height="44" />
-        <rect class="box synth" x="300" y="40" width="150" height="44" />
-        <rect class="box graded" x="556" y="40" width="150" height="44" />
+        <rect class="frame" x="16" y="34" width="628" height="80" />
+        <text x="24" y="50" class="sub">Pipeline</text>
+        <text x="216" y="66" text-anchor="middle" class="sub">stage</text>
+        <text x="430" y="66" text-anchor="middle" class="sub">stage</text>
+        <text x="689" y="66" text-anchor="middle" class="sub">grading</text>
+        <rect class="box stage" x="32" y="60" width="160" height="40" />
+        <rect class="box stage" x="246" y="60" width="160" height="40" />
+        <rect class="box synth" x="460" y="60" width="168" height="40" />
+        <rect class="box graded" x="744" y="60" width="150" height="40" />
         <g class="lbl" text-anchor="middle">
-          <text x="108" y="66">members / models</text>
-          <text x="375" y="66">synthesizer</text>
-          <text x="631" y="66">Graded answer</text>
+          <text x="112" y="84">first stage</text>
+          <text x="326" y="84">next stage</text>
+          <text x="544" y="84">last stage</text>
+          <text x="819" y="84">Graded answer</text>
         </g>
       </svg>
       <figcaption class="dgcap">
-        The flow of information: the member models answer, a synthesizer combines them into one
-        answer, and grading that answer produces the graded answer.
+        The flow of information: the first stage answers the case, each later stage takes the
+        previous stage's answer as its input, and grading the last stage's answer produces the
+        graded answer.
       </figcaption>
     </figure>
 


### PR DESCRIPTION
Closes the gap an external tester found on 2026-08-27: the top-level README's Quickstart does not run, and `sf.__version__` — the first thing anyone types to check what they installed — raises. Fifteen fixes across the client README and the docs site, all from one tester report, all verified against `main` before being written up.

Linear: [OME-1034](https://linear.app/openmined/issue/OME-1034/fix-the-broken-readme-quickstart-and-the-docs-errors-a-first-time-user)

## Before / After

### Before
- Trigger: someone installs `screamingface`, opens the README, and copy-pastes the Quickstart.
- Today: **line 1 of the ensemble example raises `TypeError: missing 1 required keyword-only argument: 'synthesizer'`.** The README also promises an `sf.from_url4(...)` entry point that does not exist, and `sf.__version__` raises `AttributeError`. On the docs site the installation FAQ tells them to go kill a process when the CLI would have moved the port for them, and the Pipelines page opens with a diagram of a Fusion.
- Cost: the first thing a stranger runs fails, and the one command that would tell them what they installed fails too — so they cannot tell a bad install from stale docs from a broken product.

### After
- Same trigger.
- Now: the Quickstart runs top-to-bottom as written, every documented symbol exists, `sf.__version__` reports the installed version, the ports FAQ names the override flags, and the Pipelines diagram shows stages.
- Win: a first-run session ends in a score instead of a traceback.

### Don't regress
- `packages/screamingface/README.md` examples were already correct and are untouched — the root README was the sole code outlier.
- No `github.com/OpenMined` link is touched here; that is OME-914 / OME-945 on a sibling branch.
- Scores, evaluation behaviour, and the live widget are unchanged.

## Root cause

Three independent kinds of drift, none of them caught by CI because none of them is executable:

1. **The README examples are not tested.** `Fusion.__init__` takes `synthesizer` as keyword-only with no default (`fusion.py:20-26`). Every docs-site page and the package README pass it. The root README never did, and nothing runs it.
2. **`sf.from_url4` was documented but never built.** The real replay path is `sf.evaluate(url4_string)`; the editable-copy path is `sf.Url4(v).to_python()`, which returns a `str` of source rather than an object — also mis-described in the package README.
3. **The docs site drifted from the CLI.** `--gateway-port` / `--scoreboard-port` / `--engine-port` and the `SCREAMINGFACE_*_PORT` env vars have worked since `_runtime/config.py:23-35`, but the FAQ still told users to free the port by hand. Separately, the Pipelines page's lead diagram was a copy of the Fusions one — boxes, `aria-label` and `figcaption` all described a synthesizer combining members.

## What's here

**Client (`packages/screamingface`)**
- New `_version.py` exporting `sf.__version__`, read from `importlib.metadata` so it cannot drift from `pyproject.toml`. A bare source tree resolves to `0.0.0+source` rather than raising. Five tests, written RED-first.
- README: the Fusion example passes `synthesizer=`; the `from_url4` claim replaced with the two real entry points; `to_python()` correctly described as returning source text.

**Docs site (`public-docs`)**
- Ports FAQ rewritten around the override flags and env vars, including the real caveat that `down` and `logs` ignore them.
- `Note.vue` callout links get a visible affordance (`--accent-text-low` + underline) instead of rendering as plain body text.
- The Pipelines lead diagram is now three stages in series inside a labelled Pipeline frame, with `aria-label` and `figcaption` rewritten to match.
- Six prose corrections adopted verbatim from the tester, the LANL paper (*Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles*) linked where it was cited bare, and the benchmark feedback CTA given a destination.

## Test plan

- `run_gates.py screamingface`: **ALL GATES GREEN** — 1240 passed, 17 skipped, coverage 95.09% against a 95% floor.
- `public-docs`: `vue-tsc`, `vite build`, `oxlint`, `eslint` all exit 0.
- Acceptance: `python -c "import screamingface as sf; print(sf.__version__)"` → `0.1.1.post5`.

## Reviewer notes

- **One gate was skipped and it needs a call.** Adding a public export necessarily moves `tests/public_surface_snapshot.json`, and the append-only stage cannot parse JSON, so it rejects any change to that file. Regeneration used the documented `UPDATE_SURFACE_SNAPSHOT=1` path and the run used the runner's own `--skip-append-only` flag; no gate config was edited. Hand-audited and independently re-checked: the snapshot diff is **+5/−0**, all five lines being `__version__`, and no pre-existing test file or assertion was modified.
- **Two items need eyes, not CI.** The Pipelines diagram and the Note-callout link styling type-check and build but are not machine-verifiable: `npm run dev` → `/sf-client/guides/pipelines`, both themes.
- Item 13's source read `DRACO state-of-art` (uppercase), not `Draco`; the missing "the" was added and the existing casing left alone.
- Item 14 links the OpenReview **forum** URL (HTTP 200 verified); the PDF attachment URL 403s to non-browser clients.
- Unplanned but necessary: `InstallationPage.vue` asserted `len(sf.__all__)  # 55`, which went stale the moment the new export landed. Corrected to 56.

## Not fixed here

The tester also reported per-member `usage` and `duration_ms` always reading `None`. That is correct-as-designed on this branch — hard-coded null at `_evaluation/results.py:137-147` — and belongs to OME-699 and the OME-1030/1031/1032 stack. Worth knowing: OME-1031 keeps `duration_ms` null deliberately, because Gateway provider time is not wall duration, so that half of the report has no ticket that closes it.

## Follow-ups spotted, not actioned

- `_runtime/cli.py`'s `--version` still calls `importlib.metadata.version(...)` directly rather than the new `resolve_version()` — a second copy of the same lookup.
- Three `public-docs` files already fail `prettier --check` on `main` (`learn/LeaderboardPage.vue`, `sf-client/guides/LeaderboardsPage.vue`, `sf-client/guides/Url4Page.vue`). Pre-existing; Prettier is not a gate.

Refs: OME-1034
