### PR TITLE
Sign and notarize the Studio runtime sidecar

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -81,7 +81,7 @@ jobs:
           TAURI_BUNDLER_DMG_IGNORE_CI: "true"
         with:
           projectPath: apps/screamingface-studio
-          tagName: desktop-v__VERSION__
+          tagName: studio-v__VERSION__
           releaseName: ScreamingFace Desktop v__VERSION__
           releaseBody: See the assets below to download and install this version.
           releaseDraft: true

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           projectPath: apps/screamingface-studio
           tagName: studio-v__VERSION__
-          releaseName: ScreamingFace Desktop v__VERSION__
+          releaseName: ScreamingFace Studio v__VERSION__
           releaseBody: See the assets below to download and install this version.
           releaseDraft: true
           prerelease: false

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -9,17 +9,27 @@ permissions:
 jobs:
   build-and-release:
     name: Build ${{ matrix.target }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - aarch64-apple-darwin
-          - x86_64-apple-darwin
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-26
+          - target: x86_64-apple-darwin
+            runner: macos-26-intel
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -48,6 +48,16 @@ jobs:
           p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
           p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
 
+      - name: Select Apple signing identity
+        shell: bash
+        run: |
+          identity="$(security find-identity -v -p codesigning | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
+          if [[ -z "$identity" ]]; then
+            echo "No Developer ID Application identity was imported" >&2
+            exit 1
+          fi
+          echo "APPLE_SIGNING_IDENTITY=$identity" >> "$GITHUB_ENV"
+
       - name: Build and create draft release
         uses: tauri-apps/tauri-action@v1
         env:
@@ -55,6 +65,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           TAURI_BUNDLER_DMG_IGNORE_CI: "true"

--- a/apps/screamingface-studio/runtime/README.md
+++ b/apps/screamingface-studio/runtime/README.md
@@ -22,6 +22,7 @@ All services bind to loopback and store writable state below the data directory 
 - `screamingface-runtime.spec` collects lazy imports, package data, metadata, and native libraries
   that PyInstaller cannot discover statically.
 - `build-sidecar.sh` builds the frozen `onedir` artifact.
+- `sign-sidecar.sh` signs nested Mach-O files and then the sidecar executable for macOS.
 - `verify-sidecar.sh` checks frozen startup, the three health endpoints, Engine model discovery,
   graceful shutdown, and port release.
 
@@ -85,12 +86,17 @@ specific executable.
 
 For application builds, `src-tauri/before_build.sh` builds the sidecar and copies the complete
 `onedir` directory into `src-tauri/resources/screamingface-runtime`. Tauri then includes that
-directory as an application resource.
+directory as an application resource. On macOS, the script signs every nested Mach-O artifact
+before signing the main sidecar executable. Local builds use an ad-hoc identity; release builds use
+`APPLE_SIGNING_IDENTITY` from the imported Developer ID Application certificate.
+
+The desktop release workflow passes the same identity to Tauri. Tauri signs the containing app and
+uses the configured Apple ID credentials to notarize the final macOS artifacts. Signing proceeds
+from the innermost PyInstaller libraries outward so later bundle steps do not invalidate signatures.
 
 ## Current limitations
 
 - Only the macOS arm64 frozen artifact has been verified.
 - Studio currently uses the default runtime ports.
 - Provider credentials and downloaded benchmark assets remain user data and are never bundled.
-- Release code signing, notarization, target-triple naming, and other platform builds are separate
-  release-pipeline work.
+- Target-triple naming and additional platform validation remain release-pipeline work.

--- a/apps/screamingface-studio/runtime/README.md
+++ b/apps/screamingface-studio/runtime/README.md
@@ -90,6 +90,10 @@ directory as an application resource. On macOS, the script signs every nested Ma
 before signing the main sidecar executable. Local builds use an ad-hoc identity; release builds use
 `APPLE_SIGNING_IDENTITY` from the imported Developer ID Application certificate.
 
+The copied `Python.framework` is removed before signing. PyInstaller includes equivalent standalone
+Python binaries in `_internal`, while dereferencing the framework's symlinks during resource copying
+produces an ambiguous bundle that Apple signing and notarization reject.
+
 The desktop release workflow passes the same identity to Tauri. Tauri signs the containing app and
 uses the configured Apple ID credentials to notarize the final macOS artifacts. Signing proceeds
 from the innermost PyInstaller libraries outward so later bundle steps do not invalidate signatures.

--- a/apps/screamingface-studio/runtime/sign-sidecar.sh
+++ b/apps/screamingface-studio/runtime/sign-sidecar.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: $0 <sidecar-directory> <entitlements.plist>" >&2
+  exit 2
+fi
+
+sidecar_dir="$1"
+entitlements="$2"
+executable="$sidecar_dir/screamingface-runtime"
+signing_identity="${APPLE_SIGNING_IDENTITY:--}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Skipping sidecar signing: codesign is only available on macOS"
+  exit 0
+fi
+if [[ ! -x "$executable" ]]; then
+  echo "Sidecar executable not found at $executable" >&2
+  exit 1
+fi
+if [[ ! -f "$entitlements" ]]; then
+  echo "Entitlements file not found at $entitlements" >&2
+  exit 1
+fi
+
+echo "Signing PyInstaller sidecar with identity: $signing_identity"
+while IFS= read -r -d '' candidate; do
+  if [[ "$candidate" != "$executable" ]] && file "$candidate" | grep -q "Mach-O"; then
+    codesign --force --options runtime --entitlements "$entitlements" \
+      --sign "$signing_identity" "$candidate"
+  fi
+done < <(find "$sidecar_dir" -type f -print0)
+
+# Sign the outer executable last so its signature covers the finalized onedir contents.
+codesign --force --options runtime --entitlements "$entitlements" \
+  --sign "$signing_identity" "$executable"
+codesign --verify --strict --verbose=2 "$executable"
+echo "Sidecar signing complete"

--- a/apps/screamingface-studio/src-tauri/before_build.sh
+++ b/apps/screamingface-studio/src-tauri/before_build.sh
@@ -14,6 +14,10 @@ chmod +x "$tauri_runtime/screamingface-runtime"
 
 target_triple="${TAURI_ENV_TARGET_TRIPLE:-$(rustc -vV | awk '/^host:/ { print $2 }')}"
 if [[ "$target_triple" == *-apple-* ]]; then
+  # PyInstaller also includes standalone Python binaries. The copied Python.framework is
+  # redundant, and cp -RL dereferences its internal symlinks into an ambiguous bundle that
+  # codesign and Apple's notarization service reject.
+  rm -rf "$tauri_runtime/_internal/Python.framework"
   "$studio_root/runtime/sign-sidecar.sh" \
     "$tauri_runtime" "$studio_root/src-tauri/entitlements.plist"
 fi

--- a/apps/screamingface-studio/src-tauri/before_build.sh
+++ b/apps/screamingface-studio/src-tauri/before_build.sh
@@ -12,4 +12,10 @@ rm -rf "$tauri_runtime/_internal" "$tauri_runtime/screamingface-runtime"
 cp -RL "$runtime_dist/"* "$tauri_runtime/"
 chmod +x "$tauri_runtime/screamingface-runtime"
 
+target_triple="${TAURI_ENV_TARGET_TRIPLE:-$(rustc -vV | awk '/^host:/ { print $2 }')}"
+if [[ "$target_triple" == *-apple-* ]]; then
+  "$studio_root/runtime/sign-sidecar.sh" \
+    "$tauri_runtime" "$studio_root/src-tauri/entitlements.plist"
+fi
+
 npm run --prefix "$studio_root/frontend" build

--- a/apps/screamingface-studio/src-tauri/tauri.conf.json
+++ b/apps/screamingface-studio/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ScreamingFace Studio",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "org.openmined.screamingface",
   "build": {
     "frontendDist": "../frontend/out",


### PR DESCRIPTION
## What this adds

Signs the PyInstaller runtime sidecar before it is embedded in the macOS app, then passes the same Developer ID Application identity to Tauri for outer app signing and notarization.

Sets the ScreamingFace Studio release version to `0.1.1`.

## How it works

1. `sign-sidecar.sh` walks the copied PyInstaller `onedir` bundle.
2. The pre-build copy removes the redundant `Python.framework` whose dereferenced symlinks form an invalid signing bundle; PyInstaller's standalone Python binaries remain.
3. It signs every nested Mach-O library with hardened runtime and Studio's entitlements.
4. It signs and verifies the main `screamingface-runtime` executable last.
5. Local builds default to an ad-hoc identity.
6. Release CI builds ARM64 on `macos-26` and x86_64 on `macos-26-intel` so PyInstaller runs natively for each target.
7. Release CI installs Python 3.12 and `uv`, then selects the imported Developer ID Application identity and exposes it as `APPLE_SIGNING_IDENTITY`.
8. Tauri inherits that identity and the existing Apple credentials to sign and notarize the containing macOS artifacts.

## Suggested review order

1. `.github/workflows/release-desktop.yml` — selects and exports the imported Developer ID identity.
2. `apps/screamingface-studio/runtime/sign-sidecar.sh` — nested Mach-O and executable signing.
3. `apps/screamingface-studio/src-tauri/before_build.sh` — invokes signing after resource copying on Apple targets.
4. `apps/screamingface-studio/runtime/README.md` — documents the release contract.
5. `apps/screamingface-studio/src-tauri/tauri.conf.json` — sets the packaged app version.

## Verification

- signed every nested Mach-O artifact in the arm64 PyInstaller bundle
- main executable passed `codesign --verify --strict`
- signed sidecar started Gateway, Scoreboard, and Engine successfully
- Engine model discovery returned 112 models
- graceful shutdown and port release passed after signing
- workflow YAML passed repository pre-commit validation
- release runners and Python architectures match both Tauri target triples

## Release requirements

Actual Developer ID notarization requires the repository's existing Apple certificate, Apple ID, app-specific password, and team secrets, so the final notarization submission runs in the release workflow rather than locally.
