### PR TITLE
WIP: Expose provider metadata for the Models UI

### DIFF
--- a/apps/aigateway/src/aigateway/core/plugin_base/_provider.py
+++ b/apps/aigateway/src/aigateway/core/plugin_base/_provider.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 from ..api_key_validation import ApiKeyValidator
 from ..cache_ports import PROJECTION_BYPASS_REASON, CacheBypass
@@ -52,6 +52,12 @@ class ProviderPluginCore[TSettings: PluginSettings](ABC):
 
     custom_llm_provider: str
     provider_display_name: str
+    provider_kind: Literal["local", "session", "api", "hub"] = "api"
+    provider_group: Literal["local_and_sessions", "providers", "hubs"] = "providers"
+    provider_group_display_name: str = "Providers"
+    provider_description: str = ""
+    provider_color: str = "#64748b"
+    provider_sort_order: int = 1000
     settings_cls: ClassVar[type[PluginSettings]] = PluginSettings
 
     def __init__(self, settings: TSettings | None = None) -> None:

--- a/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/anthropic_provider/plugin.py
@@ -72,6 +72,9 @@ def _api_key_headers(api_key: str) -> dict[str, str]:
 class AnthropicProviderPlugin(ProviderPluginBase[AnthropicPluginSettings]):
     custom_llm_provider = "anthropic"
     provider_display_name = "Anthropic"
+    provider_description = "Claude models direct from Anthropic"
+    provider_color = "#ca492c"
+    provider_sort_order = 100
     settings_cls = AnthropicPluginSettings
 
     def register_models(self) -> list[ModelEntry]:

--- a/apps/aigateway/src/aigateway/plugins/antigravity_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/antigravity_provider/plugin.py
@@ -78,6 +78,12 @@ def _detail_for_error(exc: CustomLLMError) -> dict[str, str]:
 class AntigravityProviderPlugin(ProviderPluginBase[AntigravityPluginSettings]):
     custom_llm_provider = "antigravity"
     provider_display_name = "Antigravity"
+    provider_kind = "session"
+    provider_group = "local_and_sessions"
+    provider_group_display_name = "Local & Sessions"
+    provider_description = "Models available through your Google Antigravity account"
+    provider_color = "#6976ae"
+    provider_sort_order = 40
     settings_cls = AntigravityPluginSettings
 
     def credential_service_provider(self) -> str:

--- a/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/codex_provider/plugin.py
@@ -50,6 +50,12 @@ class CodexProviderPlugin(ProviderPluginBase):
     # platform API instead is a possible follow-up.
     custom_llm_provider = "codex"
     provider_display_name = "Codex"
+    provider_kind = "session"
+    provider_group = "local_and_sessions"
+    provider_group_display_name = "Local & Sessions"
+    provider_description = "Models available through your Codex account"
+    provider_color = "#256b24"
+    provider_sort_order = 20
 
     def register_models(self) -> list[ModelEntry]:
         return list(MODELS)

--- a/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/gemini_provider/plugin.py
@@ -99,6 +99,12 @@ def _detail_for_error(exc: CustomLLMError) -> dict[str, str]:
 class GeminiProviderPlugin(ProviderPluginBase[GeminiPluginSettings]):
     custom_llm_provider = "gemini-cli"
     provider_display_name = "Gemini CLI"
+    provider_kind = "session"
+    provider_group = "local_and_sessions"
+    provider_group_display_name = "Local & Sessions"
+    provider_description = "Gemini models through your Google account or API key"
+    provider_color = "#4392c5"
+    provider_sort_order = 30
     settings_cls = GeminiPluginSettings
 
     def credential_service_provider(self) -> str:

--- a/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/huggingface_provider/plugin.py
@@ -79,6 +79,12 @@ def _credential_service_for(profile_name: str) -> str:
 class HuggingFaceProviderPlugin(ProviderPluginBase[HuggingFacePluginSettings]):
     custom_llm_provider = "huggingface"
     provider_display_name = "Hugging Face"
+    provider_kind = "hub"
+    provider_group = "hubs"
+    provider_group_display_name = "Hubs"
+    provider_description = "Hosted open-source models from Hugging Face"
+    provider_color = "#f79763"
+    provider_sort_order = 210
     settings_cls = HuggingFacePluginSettings
 
     def register_models(self) -> list[ModelEntry]:

--- a/apps/aigateway/src/aigateway/plugins/ollama_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/ollama_provider/plugin.py
@@ -25,6 +25,12 @@ _CLIENT_AUTH_HEADER_NAMES = {"authorization", "x-api-key", "proxy-authorization"
 class OllamaProviderPlugin(ProviderPluginBase):
     custom_llm_provider = "ollama"
     provider_display_name = "Ollama"
+    provider_kind = "local"
+    provider_group = "local_and_sessions"
+    provider_group_display_name = "Local & Sessions"
+    provider_description = "Local models on your machine — no API key required"
+    provider_color = "#52aec5"
+    provider_sort_order = 10
 
     def register_models(self) -> list[ModelEntry]:
         host = resolve_ollama_host()

--- a/apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openai_provider/plugin.py
@@ -80,6 +80,9 @@ def _unsafe_environment_error() -> HTTPException:
 class OpenAIProviderPlugin(ProviderPluginBase[OpenAIPluginSettings]):
     custom_llm_provider = "openai"
     provider_display_name = "OpenAI"
+    provider_description = "GPT and reasoning models direct from OpenAI"
+    provider_color = "#53bea9"
+    provider_sort_order = 110
     settings_cls = OpenAIPluginSettings
 
     def register_models(self) -> list[ModelEntry]:

--- a/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
+++ b/apps/aigateway/src/aigateway/plugins/openrouter_provider/plugin.py
@@ -185,6 +185,12 @@ _STRIPPED_CALLER_HEADERS = frozenset(
 class OpenRouterProviderPlugin(ProviderPluginBase[OpenRouterPluginSettings]):
     custom_llm_provider = "openrouter"
     provider_display_name = "OpenRouter"
+    provider_kind = "hub"
+    provider_group = "hubs"
+    provider_group_display_name = "Hubs"
+    provider_description = "A broad model catalog behind one connection"
+    provider_color = "#937098"
+    provider_sort_order = 200
     settings_cls = OpenRouterPluginSettings
 
     def register_models(self) -> list[ModelEntry]:

--- a/apps/aigateway/src/aigateway/routes/providers.py
+++ b/apps/aigateway/src/aigateway/routes/providers.py
@@ -30,4 +30,30 @@ async def list_providers(request: Request, _current: CurrentAccount) -> dict[str
     return {"object": "list", "data": rows}
 
 
+@router.get("/v1/provider-catalog")
+async def provider_catalog(request: Request, _current: CurrentAccount) -> dict[str, object]:
+    """List every loaded provider with provider-owned UI metadata."""
+
+    rows = [
+        {
+            "object": "provider",
+            "id": plugin.custom_llm_provider,
+            "display_name": plugin.provider_display_name,
+            "description": plugin.provider_description,
+            "kind": plugin.provider_kind,
+            "group": plugin.provider_group,
+            "group_display_name": plugin.provider_group_display_name,
+            "color": plugin.provider_color,
+            "sort_order": plugin.provider_sort_order,
+            "connection_required": plugin.available_auth_modes() != ("none",),
+            "auth_methods": [
+                method for method in plugin.available_auth_modes() if method != "none"
+            ],
+        }
+        for plugin in request.app.state.providers.all()
+    ]
+    rows.sort(key=lambda row: (row["sort_order"], row["id"]))
+    return {"object": "list", "data": rows}
+
+
 __all__ = ["router"]

--- a/apps/aigateway/tests/unit/test_provider_catalog_route.py
+++ b/apps/aigateway/tests/unit/test_provider_catalog_route.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+
+def test_provider_catalog_includes_keyless_and_disabled_catalogs(authenticated_client) -> None:
+    response = authenticated_client.get("/v1/provider-catalog")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["object"] == "list"
+    providers = {row["id"]: row for row in body["data"]}
+    assert providers["anthropic"] == {
+        "object": "provider",
+        "id": "anthropic",
+        "display_name": "Anthropic",
+        "description": "Claude models direct from Anthropic",
+        "kind": "api",
+        "group": "providers",
+        "group_display_name": "Providers",
+        "color": "#ca492c",
+        "sort_order": 100,
+        "connection_required": True,
+        "auth_methods": ["api_key", "oauth"],
+    }
+    assert providers["ollama"]["connection_required"] is False
+    assert providers["ollama"]["auth_methods"] == []
+    assert providers["ollama"]["kind"] == "local"
+    assert providers["openrouter"]["kind"] == "hub"
+
+
+def test_provider_catalog_requires_auth(client) -> None:
+    response = client.get("/v1/provider-catalog")
+
+    assert response.status_code == 401

--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 
 from fastapi import APIRouter, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from screamingface_engine import job_env
@@ -32,7 +33,7 @@ from screamingface_engine.catalog.cache import CatalogService
 from screamingface_engine.catalog.port import ModelParameterSource
 from screamingface_engine.config import INSECURE_DEFAULT_JWT_SECRET, Settings
 from screamingface_engine.connections import build_connections
-from screamingface_engine.connections.port import Connections
+from screamingface_engine.connections.port import Connections, ProviderCatalog
 from screamingface_engine.metrics import (
     MetricsMiddleware,
     build_metrics,
@@ -87,6 +88,7 @@ def create_app(
     catalog: CatalogService | None = None,
     model_parameters: ModelParameterSource | None = None,
     connections: Connections | None = None,
+    provider_catalog: ProviderCatalog | None = None,
     benchmarks: BenchmarkRegistry = EMPTY_BENCHMARKS,
 ) -> FastAPI:
     """Build the App instance.
@@ -102,6 +104,7 @@ def create_app(
     app.state.catalog = catalog
     app.state.model_parameters = model_parameters
     app.state.connections = connections
+    app.state.provider_catalog = provider_catalog if provider_catalog is not None else connections
     app.state.benchmarks = benchmarks
     app.state.metrics = build_metrics()
     # FEATURE: deliver large results in full (OME-892) — the serve side of the spill store.
@@ -121,8 +124,7 @@ def create_app(
     _install_artifact_sweeper(app, artifact_store, settings)
     # WHY: pass a getter, not `catalog` directly — the collector re-reads app.state.catalog on
     # every /metrics scrape rather than capturing the value built here.
-    register_catalog_metrics(app.state.metrics, lambda: app.state.catalog)
-    app.add_middleware(MetricsMiddleware)
+    _install_http_middleware(app)
     registry = ConnectionRegistry()
     app.state.registry = registry
     app.state.interest = interest if interest is not None else registry
@@ -136,6 +138,20 @@ def create_app(
     app.mount("/diagrams", StaticFiles(directory=_DIAGRAMS_DIR), name="diagrams")
     customize_openapi(app)
     return app
+
+
+def _install_http_middleware(app: FastAPI) -> None:
+    # Re-read app.state.catalog on every scrape rather than capturing the value built at startup.
+    register_catalog_metrics(app.state.metrics, lambda: app.state.catalog)
+    # Tauri pages have an application origin even though the Engine is loopback. Allow only
+    # Tauri's platform origins so the desktop UI can call the public Engine API directly.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["tauri://localhost", "http://tauri.localhost", "https://tauri.localhost"],
+        allow_methods=["GET", "PUT", "POST", "DELETE", "OPTIONS"],
+        allow_headers=["Authorization", "Content-Type", "X-User-Email", "X-User-Id"],
+    )
+    app.add_middleware(MetricsMiddleware)
 
 
 # RFC 7518 §3.2: an HMAC key must be at least as long as the hash output — 32 bytes for SHA-256.

--- a/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
@@ -24,6 +24,9 @@ from screamingface_engine.connections.port import (
     ConnectionTimeout,
     ConnectionUnavailable,
     OAuthAuthorization,
+    Provider,
+    ProviderGroup,
+    ProviderKind,
 )
 from screamingface_engine.connections.profile_availability import decode_profile_statuses
 from screamingface_engine.connections.provider_id import is_provider_id
@@ -32,6 +35,7 @@ from screamingface_engine.connections.upstream_errors import raise_for_status
 logger = logging.getLogger(__name__)
 
 _PROVIDERS_PATH = "/v1/providers"
+_PROVIDER_CATALOG_PATH = "/v1/provider-catalog"
 _CONNECTIONS_PATH = "/v1/oauth/connections"
 _PROFILES_PATH = "/v1/auth/profiles"
 _API_KEY_PATH = f"{_CONNECTIONS_PATH}/api-key"
@@ -43,7 +47,7 @@ ListingSource = Literal["connections", "profiles"]
 
 
 @dataclass(frozen=True, slots=True)
-class _Provider:
+class _ConnectionProvider:
     id: str
     display_name: str
     auth_methods: tuple[AuthMethod, ...]
@@ -75,7 +79,7 @@ class AigatewayConnections:
         self._listing_source = listing_source
 
     async def list(self, caller: Caller) -> tuple[Connection, ...]:
-        providers = await self._providers(caller)
+        providers = await self._connection_providers(caller)
         if self._listing_source == "profiles":
             statuses = await self._profile_statuses(caller)
             return tuple(
@@ -92,7 +96,7 @@ class AigatewayConnections:
 
     async def connect(self, caller: Caller, provider: str, api_key: str) -> Connection:
         self._require_mutable()
-        selected_provider = _provider(await self._providers(caller), provider)
+        selected_provider = _provider(await self._connection_providers(caller), provider)
         if "api_key" not in selected_provider.auth_methods:
             raise ConnectionMethodUnsupported()
         rows = await self._rows(caller, provider=provider)
@@ -127,7 +131,7 @@ class AigatewayConnections:
 
     async def start_oauth(self, caller: Caller, provider: str) -> OAuthAuthorization:
         self._require_mutable()
-        selected_provider = _provider(await self._providers(caller), provider)
+        selected_provider = _provider(await self._connection_providers(caller), provider)
         if "oauth" not in selected_provider.auth_methods:
             raise ConnectionMethodUnsupported()
         rows = await self._rows(caller, provider=provider)
@@ -144,7 +148,7 @@ class AigatewayConnections:
 
     async def disconnect(self, caller: Caller, provider: str) -> Connection:
         self._require_mutable()
-        selected_provider = _provider(await self._providers(caller), provider)
+        selected_provider = _provider(await self._connection_providers(caller), provider)
         rows = await self._rows(caller, provider=provider)
         selected = _select(rows, provider)
         if selected is None:
@@ -172,14 +176,27 @@ class AigatewayConnections:
         if self._listing_source == "profiles":
             raise ConnectionMethodUnsupported()
 
-    async def _providers(self, caller: Caller) -> tuple[_Provider, ...]:
+    async def providers(self, caller: Caller) -> tuple[Provider, ...]:
+        response = await self._request("GET", _PROVIDER_CATALOG_PATH, caller)
+        if response.status_code != 200:
+            raise ConnectionBadResponse()
+        body = _decode_object(response)
+        if body.get("object") != "list" or not isinstance(body.get("data"), list):
+            raise ConnectionBadResponse()
+        providers = tuple(_validate_catalog_provider(row) for row in body["data"])
+        ids = tuple(provider.id for provider in providers)
+        if len(ids) != len(set(ids)):
+            raise ConnectionBadResponse()
+        return providers
+
+    async def _connection_providers(self, caller: Caller) -> tuple[_ConnectionProvider, ...]:
         response = await self._request("GET", _PROVIDERS_PATH, caller)
         if response.status_code != 200:
             raise ConnectionBadResponse()
         body = _decode_object(response)
         if body.get("object") != "list" or not isinstance(body.get("data"), list):
             raise ConnectionBadResponse()
-        providers = tuple(_validate_provider(row) for row in body["data"])
+        providers = tuple(_validate_connection_provider(row) for row in body["data"])
         ids = tuple(provider.id for provider in providers)
         if len(ids) != len(set(ids)):
             raise ConnectionBadResponse()
@@ -240,7 +257,7 @@ class AigatewayConnections:
         return response
 
 
-def _provider(providers: tuple[_Provider, ...], provider: str) -> _Provider:
+def _provider(providers: tuple[_ConnectionProvider, ...], provider: str) -> _ConnectionProvider:
     selected = next((item for item in providers if item.id == provider), None)
     if selected is None:
         raise ConnectionNotFound()
@@ -256,7 +273,7 @@ def _select(rows: list[_ConnectionRow], provider: str) -> _ConnectionRow | None:
     return None
 
 
-def _disconnected(provider: _Provider) -> Connection:
+def _disconnected(provider: _ConnectionProvider) -> Connection:
     return Connection(
         provider=provider.id,
         display_name=provider.display_name,
@@ -266,7 +283,7 @@ def _disconnected(provider: _Provider) -> Connection:
 
 
 def _profile_connection(
-    provider: _Provider,
+    provider: _ConnectionProvider,
     status: ConnectionStatus,
 ) -> Connection:
     return Connection(
@@ -277,7 +294,7 @@ def _profile_connection(
     )
 
 
-def _public(row: _ConnectionRow, provider: _Provider) -> Connection:
+def _public(row: _ConnectionRow, provider: _ConnectionProvider) -> Connection:
     if row.provider != provider.id:
         raise ConnectionBadResponse()
     status = {
@@ -302,7 +319,7 @@ def _public(row: _ConnectionRow, provider: _Provider) -> Connection:
     )
 
 
-def _validate_provider(value: object) -> _Provider:
+def _validate_connection_provider(value: object) -> _ConnectionProvider:
     if not isinstance(value, dict) or set(value) != {
         "object",
         "id",
@@ -325,9 +342,76 @@ def _validate_provider(value: object) -> _Provider:
         set(methods)
     ):
         raise ConnectionBadResponse()
-    return _Provider(
+    return _ConnectionProvider(
         id=value["id"],
         display_name=value["display_name"],
+        auth_methods=cast(tuple[AuthMethod, ...], tuple(methods)),
+    )
+
+
+def _validate_catalog_provider(value: object) -> Provider:
+    if not isinstance(value, dict) or set(value) != {
+        "object",
+        "id",
+        "display_name",
+        "description",
+        "kind",
+        "group",
+        "group_display_name",
+        "color",
+        "sort_order",
+        "connection_required",
+        "auth_methods",
+    }:
+        raise ConnectionBadResponse()
+    methods = value.get("auth_methods")
+    if (
+        value.get("object") != "provider"
+        or not is_provider_id(value.get("id"))
+        or not isinstance(value.get("display_name"), str)
+        or not value["display_name"].strip()
+        or not isinstance(methods, list)
+        or any(not isinstance(method, str) for method in methods)
+    ):
+        raise ConnectionBadResponse()
+    if any(method not in {"api_key", "oauth"} for method in methods) or len(methods) != len(
+        set(methods)
+    ):
+        raise ConnectionBadResponse()
+    kind = value.get("kind")
+    group = value.get("group")
+    description = value.get("description")
+    group_display_name = value.get("group_display_name")
+    color = value.get("color")
+    sort_order = value.get("sort_order")
+    connection_required = value.get("connection_required")
+    if (
+        kind not in {"local", "session", "api", "hub"}
+        or group not in {"local_and_sessions", "providers", "hubs"}
+        or not isinstance(description, str)
+        or not isinstance(group_display_name, str)
+        or not group_display_name.strip()
+        or not isinstance(color, str)
+        or len(color) != 7
+        or not color.startswith("#")
+        or any(character not in "0123456789abcdefABCDEF" for character in color[1:])
+        or isinstance(sort_order, bool)
+        or not isinstance(sort_order, int)
+        or sort_order < 0
+        or not isinstance(connection_required, bool)
+        or connection_required != bool(methods)
+    ):
+        raise ConnectionBadResponse()
+    return Provider(
+        id=value["id"],
+        display_name=value["display_name"],
+        description=description,
+        kind=cast(ProviderKind, kind),
+        group=cast(ProviderGroup, group),
+        group_display_name=group_display_name,
+        color=color,
+        sort_order=sort_order,
+        connection_required=connection_required,
         auth_methods=cast(tuple[AuthMethod, ...], tuple(methods)),
     )
 

--- a/apps/screamingface-engine/src/screamingface_engine/connections/port.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/port.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, field
 from typing import Literal, Protocol, runtime_checkable
 
 AuthMethod = Literal["api_key", "oauth"]
+ProviderKind = Literal["local", "session", "api", "hub"]
+ProviderGroup = Literal["local_and_sessions", "providers", "hubs"]
 ConnectionStatus = Literal[
     "not_connected",
     "pending",
@@ -26,6 +28,22 @@ class Caller:
     """Verified identity headers associated with one Engine request."""
 
     identity: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class Provider:
+    """Provider catalog metadata owned by the Gateway plugin."""
+
+    id: str
+    display_name: str
+    description: str
+    kind: ProviderKind
+    group: ProviderGroup
+    group_display_name: str
+    color: str
+    sort_order: int
+    connection_required: bool
+    auth_methods: tuple[AuthMethod, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,6 +154,13 @@ class ConnectionTimeout(ConnectionError):
 
 
 @runtime_checkable
+class ProviderCatalog(Protocol):
+    """Provider discovery required by the Engine REST surface."""
+
+    async def providers(self, caller: Caller) -> tuple[Provider, ...]: ...
+
+
+@runtime_checkable
 class Connections(Protocol):
     """Provider-connection operations required by the Engine REST surface."""
 
@@ -167,4 +192,8 @@ __all__ = [
     "ConnectionUnavailable",
     "Connections",
     "OAuthAuthorization",
+    "Provider",
+    "ProviderCatalog",
+    "ProviderGroup",
+    "ProviderKind",
 ]

--- a/apps/screamingface-engine/src/screamingface_engine/rest/connections.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/connections.py
@@ -21,6 +21,10 @@ from screamingface_engine.connections.port import (
     Connections,
     ConnectionStatus,
     OAuthAuthorization,
+    Provider,
+    ProviderCatalog,
+    ProviderGroup,
+    ProviderKind,
 )
 
 logger = logging.getLogger(__name__)
@@ -82,6 +86,33 @@ class ConnectionListResponse(BaseModel):
     data: tuple[ConnectionResponse, ...]
 
 
+class ProviderResponse(BaseModel):
+    """Presentation and connection capabilities for one model provider."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    object: Literal["provider"] = "provider"
+    id: str
+    display_name: str
+    description: str
+    kind: ProviderKind
+    group: ProviderGroup
+    group_display_name: str
+    color: str
+    sort_order: int
+    connection_required: bool
+    auth_methods: tuple[AuthMethod, ...]
+
+
+class ProviderListResponse(BaseModel):
+    """The complete provider catalog exposed by this Engine."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    object: Literal["list"] = "list"
+    data: tuple[ProviderResponse, ...]
+
+
 class OAuthAuthorizationResponse(BaseModel):
     """The public browser authorization fields returned to the Client."""
 
@@ -127,6 +158,21 @@ def _serialize(connection: Connection) -> ConnectionResponse:
     )
 
 
+def _serialize_provider(provider: Provider) -> ProviderResponse:
+    return ProviderResponse(
+        id=provider.id,
+        display_name=provider.display_name,
+        description=provider.description,
+        kind=provider.kind,
+        group=provider.group,
+        group_display_name=provider.group_display_name,
+        color=provider.color,
+        sort_order=provider.sort_order,
+        connection_required=provider.connection_required,
+        auth_methods=provider.auth_methods,
+    )
+
+
 def _serialize_oauth(authorization: OAuthAuthorization) -> OAuthAuthorizationResponse:
     return OAuthAuthorizationResponse(
         provider=authorization.provider,
@@ -150,6 +196,17 @@ def _service(request: Request) -> Connections:
     return service
 
 
+def _provider_service(request: Request) -> ProviderCatalog:
+    service = getattr(request.app.state, "provider_catalog", None)
+    if service is None:
+        raise ProblemException(
+            status=503,
+            title="Service Unavailable",
+            detail="the provider catalog is not configured on this Engine",
+        )
+    return service
+
+
 def _problem(exc: ConnectionError) -> ProblemException:
     logger.info("provider connection request failed: %s", type(exc).__name__)
     return ProblemException(status=exc.status, title=exc.title, detail=exc.detail)
@@ -158,6 +215,22 @@ def _problem(exc: ConnectionError) -> ProblemException:
 def _mark_private(response: Response) -> None:
     response.headers["Cache-Control"] = "private, no-store"
     response.headers["Vary"] = "X-User-Email"
+
+
+@router.get(
+    "/v1/providers",
+    summary="List model providers",
+    description="Return provider-owned metadata and connection capabilities.",
+    response_model=ProviderListResponse,
+    responses=_error_responses(),
+)
+async def list_providers(request: Request, response: Response) -> ProviderListResponse:
+    try:
+        rows = await _provider_service(request).providers(_caller(request))
+    except ConnectionError as exc:
+        raise _problem(exc) from exc
+    _mark_private(response)
+    return ProviderListResponse(data=tuple(_serialize_provider(row) for row in rows))
 
 
 @router.get(

--- a/apps/screamingface-engine/tests/unit/test_provider_catalog_aigateway.py
+++ b/apps/screamingface-engine/tests/unit/test_provider_catalog_aigateway.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from screamingface_engine.connections.aigateway import AigatewayConnections
+from screamingface_engine.connections.port import Caller
+
+pytestmark = pytest.mark.asyncio
+
+
+def _row(
+    provider: str,
+    display_name: str,
+    *,
+    connection_required: bool,
+) -> dict[str, object]:
+    local = provider == "ollama"
+    return {
+        "object": "provider",
+        "id": provider,
+        "display_name": display_name,
+        "description": f"{display_name} models",
+        "kind": "local" if local else "hub",
+        "group": "local_and_sessions" if local else "hubs",
+        "group_display_name": "Local & Sessions" if local else "Hubs",
+        "color": "#52aec5" if local else "#937098",
+        "sort_order": 10 if local else 200,
+        "connection_required": connection_required,
+        "auth_methods": ["api_key"] if connection_required else [],
+    }
+
+
+async def test_catalog_adapter_includes_keyless_providers() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    _row("ollama", "Ollama", connection_required=False),
+                    _row("openrouter", "OpenRouter", connection_required=True),
+                ],
+            },
+        )
+
+    adapter = AigatewayConnections(
+        httpx.AsyncClient(
+            base_url="http://aigateway.test",
+            transport=httpx.MockTransport(handler),
+        )
+    )
+
+    providers = await adapter.providers(Caller({"X-User-Email": "alice@example.com"}))
+
+    assert [(provider.id, provider.connection_required) for provider in providers] == [
+        ("ollama", False),
+        ("openrouter", True),
+    ]
+    assert [request.url.path for request in seen] == ["/v1/provider-catalog"]
+    await adapter.aclose()

--- a/apps/screamingface-engine/tests/unit/test_rest_provider_catalog.py
+++ b/apps/screamingface-engine/tests/unit/test_rest_provider_catalog.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from screamingface_engine.app import create_app
+from screamingface_engine.config import Settings
+from screamingface_engine.connections.port import Caller, Provider
+from screamingface_engine.testing import InMemoryEventStream
+
+pytestmark = pytest.mark.asyncio
+
+
+class ProviderCatalog:
+    async def providers(self, caller: Caller) -> tuple[Provider, ...]:
+        assert caller.identity == {"X-User-Email": "researcher@example.com"}
+        return (
+            Provider(
+                id="ollama",
+                display_name="Ollama",
+                description="Local models on your machine — no API key required",
+                kind="local",
+                group="local_and_sessions",
+                group_display_name="Local & Sessions",
+                color="#52aec5",
+                sort_order=10,
+                connection_required=False,
+                auth_methods=(),
+            ),
+        )
+
+
+def _client(app) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_engine_exposes_complete_provider_catalog() -> None:
+    app = create_app(
+        Settings(jwt_secret="route-secret"),
+        stream=InMemoryEventStream(),
+        provider_catalog=ProviderCatalog(),
+    )
+    async with _client(app) as client:
+        response = await client.get(
+            "/v1/providers",
+            headers={"X-User-Email": "researcher@example.com"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == [
+        {
+            "object": "provider",
+            "id": "ollama",
+            "display_name": "Ollama",
+            "description": "Local models on your machine — no API key required",
+            "kind": "local",
+            "group": "local_and_sessions",
+            "group_display_name": "Local & Sessions",
+            "color": "#52aec5",
+            "sort_order": 10,
+            "connection_required": False,
+            "auth_methods": [],
+        }
+    ]
+    assert response.headers["cache-control"] == "private, no-store"
+
+
+async def test_tauri_origin_can_preflight_engine_api() -> None:
+    app = create_app(Settings(jwt_secret="route-secret"), stream=InMemoryEventStream())
+    async with _client(app) as client:
+        response = await client.options(
+            "/v1/providers",
+            headers={
+                "Origin": "tauri://localhost",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "tauri://localhost"


### PR DESCRIPTION
## What this enables

The desktop Models page can now build its provider list entirely from backend data. It no longer needs to know provider IDs in order to choose grouping, labels, descriptions, colors, ordering, or available connection methods.

## API shape

The Engine now exposes `GET /v1/providers`. Each provider includes:

- stable ID and display name
- description and accent color
- generic kind (`local`, `session`, `api`, or `hub`)
- group ID, group label, and sort order
- whether a connection is required
- supported auth methods

This is intentionally separate from the other two Models-page inputs:

- `GET /v1/connections` remains caller-specific connection state
- `GET /v1/models` remains the live model inventory and already identifies each model owner

The UI can join all three responses by provider ID.

## Backend changes

- Adds provider-owned presentation metadata to the AI Gateway plugin contract.
- Adds `GET /v1/provider-catalog` to AI Gateway, including keyless providers such as Ollama even when no models are currently discovered.
- Preserves the existing AI Gateway `GET /v1/providers` credential-management contract for compatibility.
- Proxies and validates the complete catalog through the Engine at `GET /v1/providers`.
- Allows the known Tauri application origins to call Engine HTTP endpoints directly.

## How to review

1. Start with `apps/aigateway/src/aigateway/core/plugin_base/_provider.py` to see the generic metadata contract.
2. Check the provider plugins to verify their classifications and copy.
3. Review `apps/aigateway/src/aigateway/routes/providers.py` for the backward-compatible catalog endpoint.
4. Review the Engine adapter and REST route for strict validation and secret-free serialization.
5. Run the focused tests:

```bash
cd apps/aigateway
uv run --frozen pytest tests/unit/test_providers_route.py tests/unit/test_provider_catalog_route.py -q

cd ../screamingface-engine
uv run --frozen pytest tests/unit/test_connections_aigateway.py tests/unit/test_connections_profile_availability.py tests/unit/test_rest_connections.py tests/unit/test_provider_catalog_aigateway.py tests/unit/test_rest_provider_catalog.py -q
```

## Verification

The repository push gates passed for both AI Gateway and ScreamingFace Engine, including Ruff, formatting, Pyright, layering checks, append-only test checks, and the full coverage test suites.