### PR TITLE
feat(screamingface): send the run cost on leaderboard submissions

### DIFF
--- a/docs/plan/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/plan/2026-08-28-OME-1029-sdk-run-cost.md
@@ -1,0 +1,85 @@
+# OME-1029 — Implementation plan
+
+**Spec:** `docs/spec/2026-08-28-OME-1029-sdk-run-cost.md`
+· **Ledger:** `docs/work/2026-08-28-OME-1029-sdk-run-cost.md`
+· **Branch:** `OME-1029-sdk-run-cost` · **Stack:** screamingface
+
+Gates: `uv run .claude/scripts/run_gates.py screamingface --base origin/main`
+→ append-only · ruff check · ruff format · pyright · pytest --cov=screamingface **--cov-fail-under=95**
+· notebook determinism · `uv build` · distribution check
+
+Note the 95% floor and the notebook check — this stack is stricter than scoreboard's.
+
+## Ordering principle
+
+The absent/zero distinction is the whole risk. A null read as zero would place an unpriced run at
+the cheapest end of the Pareto frontier `OME-923` is about to build, so that boundary is pinned
+first and separately from the happy path.
+
+---
+
+### Step 1 — the three cost states
+
+**RED:**
+- a priced run puts a decimal **string** in the payload, not a float and not a `Decimal`;
+- an unpriced run (`cost_usd is None`) puts `None` — asserted as `is None`, never `== 0`;
+- a run costing exactly nothing puts `"0"`, and that is distinguishable from the unpriced case.
+
+**GREEN:** `_cost_text()` helper plus one key in `_submission()`.
+
+**Why a string is asserted, not just "truthy":** the payload goes to `json=`, which raises on a
+`Decimal`, and a `float` silently loses precision on money. Both failures are invisible to a test
+that only checks the value is present.
+
+---
+
+### Step 2 — the payload is otherwise untouched
+
+**RED:** the full key set of `_submission()` gains exactly `run_cost_usd` and nothing else; every
+existing field keeps its value.
+
+**Why:** this is a submission path every user depends on. A characterisation test makes an
+accidental change to a neighbouring field fail loudly rather than ship.
+
+---
+
+### Step 3 — both submit paths
+
+**RED:** the async submit sends the field too.
+
+**GREEN:** nothing — both call `_submission()`. The test exists to keep that true, since a future
+divergence between sync and async would be silent.
+
+---
+
+### Step 4 — round-trip against Scoreboard's schema
+
+**RED:** the emitted payload validates as a `ScoreSubmission` and yields the expected `Decimal`,
+including `"0"` → `Decimal("0")` and `None` → `None`.
+
+**Why:** the SDK and Scoreboard are separate packages with no shared type. A string the SDK is
+happy with but Pydantic rejects would only surface at runtime, against a live board.
+
+---
+
+### Step 5 — close out
+
+Ledger Outcome · conventional commits, `Refs: OME-1029` · PR · green CI · squash-merge · close
+comment · close the `docs/tasks/` mirror.
+
+**Reviewers differ from recent work:** CODEOWNERS puts `/packages/screamingface/` on
+`@IonesioJunior` and `@keelancj`, not `@HupBaHa`.
+
+## Risks
+
+| Risk | Handling |
+|---|---|
+| `null` coerced to `0` somewhere downstream | Step 1 asserts `is None`, and Step 4 round-trips it through the real schema |
+| Precision lost via `float` | Step 1 asserts the wire type is a string |
+| Breaking an existing submission path | Step 2's characterisation test |
+| Coverage floor is 95%, not 80% | Small change, but the new helper needs all three branches covered |
+
+## Out of scope
+
+`duration_ms` / run timing · making cost required (`OME-822`) · the Pareto marks (`OME-923`) ·
+any Scoreboard change.

--- a/docs/spec/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/spec/2026-08-28-OME-1029-sdk-run-cost.md
@@ -1,0 +1,58 @@
+# OME-1029 — Send run_cost_usd on leaderboard submissions
+
+**Ticket:** [OME-1029](https://linear.app/openmined/issue/OME-1029/send-run-cost-usd-on-leaderboard-submissions-from-the-sdk)
+· **Ledger:** `docs/work/2026-08-28-OME-1029-sdk-run-cost.md`
+· **Stack:** screamingface (SDK) · **Date:** 2026-08-28
+
+The ticket carries the full problem statement. This records what was verified against the code
+before building, and the decisions the ticket left to implementation.
+
+## 1. Facts, re-verified 2026-08-28 against `origin/main` at `dd51ea81`
+
+| # | Finding | Evidence |
+|---|---|---|
+| F1 | The root subtree usage — the whole run's total — is captured | `_engine/contract.py`: `_root_usage` assigned only when `envelope["source"] == self._root_source` **and** `usage_event.scope == "subtree"` |
+| F2 | It reaches the result the SDK submits from | `_evaluation/results.py`: `usage=outcome.root_usage or Usage()` |
+| F3 | `run_cost_usd` appears **nowhere** in `packages/` or `apps/screamingface-engine` | `git grep -l run_cost_usd` over both returns nothing |
+| F4 | `_submission()` builds the payload without it | `_scoreboard/leaderboards.py` — version, benchmark_id, spec_id, url4_expression, score, total_questions, ran_with_providers, ran_at_local, client, metadata |
+| F5 | The payload is handed to `json=` on the HTTP call | `Leaderboards.submit` / `AsyncLeaderboards.submit` |
+| F6 | The live board confirms the consequence | `GET /v1/leaderboard/draco` → `entries=0, with a cost=0` |
+
+**F5 is the implementation constraint.** `json=` serialises with `json.dumps`, which raises
+`TypeError` on a `Decimal`. The value cannot be passed through as-is.
+
+## 2. Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | Serialise as a **decimal string**, via `str()` | F5 forbids a raw `Decimal`, and `float` would corrupt money — the column is `DECIMAL(12, 6)`. `str()` is already the SDK's idiom for this exact value: `_report_primitives.py` does `None if self.cost_usd is None else str(self.cost_usd)`. Scoreboard's `ScoreSubmission.run_cost_usd` is `Decimal \| None`, and Pydantic parses a decimal string exactly. |
+| D2 | `None` is sent as `null`, **never coerced to `0`** | Absent means "no cost was reported". `0` means "this run genuinely cost nothing", which a fully cache-served run legitimately does. `OME-770` D10 and `OME-923`'s frontier exclusion rule both depend on telling those apart — a null read as zero would put an unpriced run on the cheapest end of the Pareto frontier. |
+| D3 | No client-side normalisation | Quantization, sub-quantum rounding and sign-zero already live in Scoreboard's schema. Re-implementing them here would create a second, divergent contract for the same value. |
+| D4 | No backfill, and the dedup interaction is left as-is | `content_hash` excludes cost by design (`OME-391`, `OME-770` D8), so a recipe already submitted without a cost cannot gain one — the resubmission dedups and the incoming cost is discarded. This stops the case arising going forward; existing rows keep `null` permanently. |
+
+## 3. Design
+
+One key in `_submission()`:
+
+```python
+"run_cost_usd": _cost_text(candidate_result.usage.cost_usd),
+```
+
+with a helper returning `None` for `None` and `str(value)` otherwise. Both the sync and async
+submit paths share `_submission()`, so both are covered by one change.
+
+## 4. Out of scope
+
+`MemberResult.duration_ms` is declared and hardcoded `None`. Run timing is the other axis
+`OME-324` needs, has no Scoreboard column at all, and its definition is an open product question.
+
+Making cost **required** is `OME-822`, which this unblocks rather than performs.
+
+## 5. Acceptance
+
+- A priced run submits a non-null `run_cost_usd` and the stored row is non-null.
+- An unpriced run submits successfully with `null` — never `0`.
+- A run genuinely costing nothing submits `0`, distinct from absent.
+- The value crosses the wire as a decimal string, never a float.
+- Every other field of the payload is unchanged.
+- Full gates green, including the 95% coverage floor and the notebook determinism check.

--- a/docs/tasks/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/tasks/2026-08-28-OME-1029-sdk-run-cost.md
@@ -1,0 +1,21 @@
+---
+id: OME-1029
+linear_url: https://linear.app/openmined/issue/OME-1029/send-run-cost-usd-on-leaderboard-submissions-from-the-sdk
+status: in_progress
+type: feature
+priority: P1
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-28
+closed:
+---
+
+The last missing link in the run-cost chain. Scoreboard accepts `run_cost_usd`, the Engine produces
+a run total, and the SDK holds it on `CandidateResult.usage.cost_usd` — but `_submission()` does not
+put it in the payload, so `run_cost_usd` is null on every row of every board.
+
+Unblocks `OME-822` (make cost required) and part B of `OME-923` (Pareto frontier marks), which
+cannot mark anything while no row carries a cost.
+
+Spec: `docs/spec/2026-08-28-OME-1029-sdk-run-cost.md`
+Plan: `docs/plan/2026-08-28-OME-1029-sdk-run-cost.md`
+Ledger: `docs/work/2026-08-28-OME-1029-sdk-run-cost.md`

--- a/docs/tasks/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/tasks/2026-08-28-OME-1029-sdk-run-cost.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1029
 linear_url: https://linear.app/openmined/issue/OME-1029/send-run-cost-usd-on-leaderboard-submissions-from-the-sdk
-status: in_progress
+status: in_review
 type: feature
 priority: P1
 labels: [py-screamingface, agentic, autonomous]

--- a/docs/work/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/work/2026-08-28-OME-1029-sdk-run-cost.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-1029
 stack: screamingface
-status: in_progress
+status: in_review
 started: 2026-08-28
 finished:
 ---
@@ -43,9 +43,46 @@ unpriced run at the cheapest end of the very frontier `OME-923` is about to buil
 
 See spec §5.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files:** as planned — `_scoreboard/leaderboards.py` (one helper, one payload key) and
+  `tests/test_leaderboards.py` (+11 tests). 58 tests pass in that file, up from 47.
+- **Gates:** `run_gates.py screamingface --base origin/main` — all eight green: append-only ✓,
+  ruff check ✓, ruff format ✓, pyright ✓, pytest --cov **--cov-fail-under=95** ✓, notebook
+  determinism ✓, `uv build` ✓, distribution check ✓.
+- **Verified beyond the suite:** every cost state round-trips through `json.dumps` and back to the
+  identical `Decimal` — priced, cache-served `0`, unpriced `None`, sub-quantum `4E-7`, and the
+  column ceiling `999999.999999`. Sub-quantum emits scientific notation, which `Decimal` parses
+  and Scoreboard's own normalisation then quantises.
+
+## Deviations
+
+1. **Step 4 could not round-trip against Scoreboard's real schema.** `scoreboard.scores.schemas`
+   is not importable from this venv — `ModuleNotFoundError: pypika_tortoise` — because the SDK and
+   Scoreboard are separate deployables and correctly do not share dependencies. Substituted the
+   property that field actually relies on: what we emit parses back to exactly the `Decimal` we
+   started with, parametrised across the `DECIMAL(12, 6)` range.
+
+2. **The first attempt modified a shared fixture, and the append-only gate caught it.**
+   `_result_costing` initially added a `usage` parameter to `_candidate_result`. `dataclasses.replace`
+   was not an option: `CandidateResult` accepts `metrics=` but stores `_metric_items`, so `replace`
+   feeds back a keyword `__init__` rejects. Rebuilt the helper to construct from the fixture's own
+   attributes instead of asking for a rule-5 exception — the diff against `origin/main` is now
+   purely additive, with no `-` lines in that file.
+
+3. **Self-inflicted gate failure worth recording.** Running `uv run ruff` inside the package
+   re-synced the venv without extras and dropped `ipywidgets`, so pyright failed on five files this
+   unit never touched. Environment state, not code; fixed with `uv sync --extra notebook`.
+
+## Owner-verify
+
+- **Nothing on the live board changes until a client running this version submits.** Existing rows
+  keep `null` permanently — no backfill, and `content_hash` dedup excludes cost (`OME-391`,
+  `OME-770` D8), so a recipe already submitted without a cost cannot gain one.
+- **This is what `OME-822`'s gate was waiting for.** That ticket makes cost required; it was moved
+  out of Blocked on 2026-08-19 but its real gate — "a client can produce a run total end to end" —
+  is only met once this ships and a client is released carrying it.
+- **`OME-923` part B stays blocked until real cost data flows**, not merely until this merges. The
+  Pareto marks need populated rows.
+- **Reviewers differ from recent scoreboard work:** CODEOWNERS puts `/packages/screamingface/` on
+  @IonesioJunior and @keelancj.

--- a/docs/work/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/work/2026-08-28-OME-1029-sdk-run-cost.md
@@ -1,0 +1,51 @@
+---
+ticket: OME-1029
+stack: screamingface
+status: in_progress
+started: 2026-08-28
+finished:
+---
+
+# OME-1029 — Send run_cost_usd on leaderboard submissions from the SDK
+
+## Intent
+
+Scoreboard accepts `run_cost_usd`, the Engine produces a run total, and the SDK already holds it on
+`CandidateResult.usage.cost_usd`. The submission payload just does not include it, so the column is
+null on every row of every board.
+
+This is the last link in the run-cost chain. It unblocks `OME-822` (make cost required) and part B
+of `OME-923` (Pareto frontier marks), which cannot mark anything while no row carries a cost.
+
+## Why now
+
+The priorities doc lists cost frontier marking and Pareto determination as Milestone 1 **Musts** for
+the leaderboard. Both need cost data. The live board returns `entries=0, with a cost=0`, and this is
+the only reason.
+
+## Facts re-verified before starting
+
+Full table in the spec (§1), checked against `origin/main` at `dd51ea81`. The one that shapes the
+implementation: the payload is handed to `json=`, which serialises with `json.dumps` and raises on a
+`Decimal`. The value cannot be passed through unchanged, and `float` would corrupt money.
+
+## Planned changes
+
+Per the plan: three cost states → payload otherwise untouched → both submit paths → round-trip
+against Scoreboard's schema → close-out.
+
+## Test plan
+
+The absent/zero distinction is pinned first and separately. A null read as zero would put an
+unpriced run at the cheapest end of the very frontier `OME-923` is about to build.
+
+## Acceptance
+
+See spec §5.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/docs/work/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/work/2026-08-28-OME-1029-sdk-run-cost.md
@@ -57,11 +57,27 @@ See spec §5.
 
 ## Deviations
 
-1. **Step 4 could not round-trip against Scoreboard's real schema.** `scoreboard.scores.schemas`
-   is not importable from this venv — `ModuleNotFoundError: pypika_tortoise` — because the SDK and
-   Scoreboard are separate deployables and correctly do not share dependencies. Substituted the
-   property that field actually relies on: what we emit parses back to exactly the `Decimal` we
-   started with, parametrised across the `DECIMAL(12, 6)` range.
+1. **Step 4's round-trip could not run *inside* the suite, so it was run out of band.**
+   `scoreboard.scores.schemas` is not importable from this venv — `ModuleNotFoundError:
+   pypika_tortoise` — because the SDK and Scoreboard are separate deployables and correctly do not
+   share dependencies. The in-suite test therefore asserts a weaker property: that what we emit
+   parses back to exactly the `Decimal` we started with, across the `DECIMAL(12, 6)` range. That
+   exercises `Decimal`, not Scoreboard's contract.
+
+   The contract itself **was** verified, in two processes — the SDK's venv emits via `_cost_text()`,
+   Scoreboard's venv validates via the real `ScoreSubmission`:
+
+   | emitted | `ScoreSubmission` |
+   |---|---|
+   | `1.234567` | `Decimal('1.234567')` |
+   | `0` | `Decimal('0.000000')` — distinct from null |
+   | `None` | `None` |
+   | `4E-7` | `Decimal('0.000001')` — sub-quantum rounded away from zero, per `OME-770` §2.2 |
+   | `999999.999999` | accepted; the ceiling |
+   | `1000000.0` | **rejected** — 422 on `run_cost_usd` |
+
+   Scientific notation surviving the wire was the live risk, and it holds. The rejection is covered
+   under Owner-verify.
 
 2. **The first attempt modified a shared fixture, and the append-only gate caught it.**
    `_result_costing` initially added a `usage` parameter to `_candidate_result`. `dataclasses.replace`
@@ -84,5 +100,14 @@ See spec §5.
   is only met once this ships and a client is released carrying it.
 - **`OME-923` part B stays blocked until real cost data flows**, not merely until this merges. The
   Pareto marks need populated rows.
+- **A run costing $1,000,000 or more now fails the whole submission, not just the cost field.**
+  `sf.Usage` checks only finite and non-negative, so it accepts a value `DECIMAL(12, 6)` cannot
+  store; before this change no cost was sent, so it could not fail. Scoreboard rejects it
+  deliberately — seven integer digits overflow the column on Postgres while passing on SQLite
+  (AIDEV-NOTE, `scores/schemas.py:298`). The failure is loud: `ScoreboardError`, `permanent=True`,
+  with `run_cost_usd` named. Left unguarded on purpose — a client-side ceiling would put
+  Scoreboard's contract in a second place, which D3 rejected. Aligning `sf.Usage`'s own validator
+  is the real fix and belongs on its own ticket.
+
 - **Reviewers differ from recent scoreboard work:** CODEOWNERS puts `/packages/screamingface/` on
   @IonesioJunior and @keelancj.

--- a/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
+++ b/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
@@ -6,6 +6,7 @@ import math
 import platform
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime
+from decimal import Decimal
 from importlib.metadata import PackageNotFoundError, version
 from typing import NoReturn
 from urllib.parse import quote
@@ -360,6 +361,26 @@ def _decode_score(payload: object, scoreboard_url: str | None = None) -> Leaderb
         _invalid(str(exc), exc)
 
 
+def _cost_text(cost: Decimal | None) -> str | None:
+    """The run's cost as it crosses the wire: a decimal string, or None (OME-1029).
+
+    INVARIANT: a STRING, never a float and never a raw Decimal. The payload is handed to `json=`,
+    whose `json.dumps` raises TypeError on a Decimal; a float would silently lose precision on what
+    Scoreboard stores as DECIMAL(12, 6). `str()` is already this SDK's idiom for the same value —
+    see `_report_primitives.Usage.as_dict`.
+
+    INVARIANT: None stays None and is never coerced to 0. Absent means "no cost was reported";
+    0 means "this run genuinely cost nothing", which a fully cache-served run legitimately does.
+    OME-770's D10 and OME-923's frontier rule both depend on telling those apart — a null read as
+    zero would place an unpriced run at the cheapest end of the Pareto frontier, asserting
+    something about money nobody measured.
+
+    Scoreboard owns normalisation (quantization, sub-quantum rounding, sign-zero); nothing is
+    re-implemented here, or the two would drift.
+    """
+    return None if cost is None else str(cost)
+
+
 def _submission(candidate_result: CandidateResult) -> dict[str, object]:
     if not isinstance(candidate_result, CandidateResult):
         raise TypeError("candidate_result must be an sf.CandidateResult")
@@ -372,6 +393,7 @@ def _submission(candidate_result: CandidateResult) -> dict[str, object]:
         "total_questions": len(candidate_result.cases),
         "ran_with_providers": list(_providers(candidate_result.models)),
         "ran_at_local": _timestamp_text(candidate_result.completed_at),
+        "run_cost_usd": _cost_text(candidate_result.usage.cost_usd),
         "client": {
             "name": "screamingface",
             "version": _package_version(),

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Any, cast
 from uuid import UUID, uuid4
 
@@ -16,6 +18,7 @@ from screamingface._access import auth as auth_module
 from screamingface._core.wire import _REPLAY_SAFE
 from screamingface._evaluation.candidate import compile_candidate
 from screamingface._evaluation.model import _compiled_operation
+from screamingface._scoreboard.leaderboards import _submission
 
 SCOREBOARD_URL = "https://scoreboard.example"
 CREATED_AT = "2026-08-01T10:00:00Z"
@@ -1227,3 +1230,152 @@ def test_submitted_score_renders_as_an_sfds_card() -> None:
     assert f"href='{SCOREBOARD_URL}/spec.html?benchmark=draco&amp;spec=fusion%2Falpha'" in html, (
         "links to the portal spec page on the originating Scoreboard"
     )
+
+
+# --- OME-1029: the run cost reaches the submission payload -----------------------------------
+# Scoreboard accepts `run_cost_usd`, the Engine produces a run total and the SDK holds it on
+# CandidateResult.usage.cost_usd — the payload just omitted it, so the column was null on every
+# row of every board. OME-822 (cost required) and OME-923's Pareto marks both wait on this.
+
+
+def _result_costing(cost: str | None) -> sf.CandidateResult:
+    # Rebuilt rather than `replace`d: CandidateResult takes `metrics=` but stores `_metric_items`,
+    # so dataclasses.replace feeds back a keyword __init__ does not accept. Constructing from the
+    # fixture's own attributes leaves the shared fixture untouched.
+    base = _candidate_result()
+    return sf.CandidateResult(
+        benchmark=base.benchmark,
+        run_id=base.run_id,
+        started_at=base.started_at,
+        completed_at=base.completed_at,
+        name=base.name,
+        kind=base.kind,
+        url4=base.url4,
+        models=base.models,
+        operations=base.operations,
+        score=base.score,
+        coverage=base.coverage,
+        metrics=dict(base.metrics),
+        cases=base.cases,
+        members=base.members,
+        failures=base.failures,
+        usage=sf.Usage(cost_usd=None if cost is None else Decimal(cost)),
+    )
+
+
+def test_a_priced_run_submits_its_cost_as_a_decimal_string() -> None:
+    # INVARIANT: a STRING on the wire, never a float and never a raw Decimal. The payload is handed
+    # to `json=`, which raises TypeError on a Decimal; a float would silently lose precision on a
+    # DECIMAL(12, 6) money column. Both failures are invisible to a test that only checks presence.
+    payload = _submission(_result_costing("1.234567"))
+
+    assert payload["run_cost_usd"] == "1.234567"
+    assert isinstance(payload["run_cost_usd"], str)
+
+
+def test_an_unpriced_run_submits_null_and_never_zero() -> None:
+    # INVARIANT: absent means "no cost was reported". Coercing it to 0 would put an unpriced run at
+    # the cheapest end of the Pareto frontier OME-923 is about to build — a claim about money
+    # nobody measured.
+    payload = _submission(_result_costing(None))
+
+    assert payload["run_cost_usd"] is None
+
+
+def test_a_run_that_genuinely_cost_nothing_submits_zero() -> None:
+    # A fully cache-served run legitimately costs zero, and that is a different fact from "not
+    # reported". OME-770 D10 and OME-923's exclusion rule both depend on the distinction.
+    payload = _submission(_result_costing("0"))
+
+    assert payload["run_cost_usd"] == "0"
+    assert payload["run_cost_usd"] is not None
+
+
+def test_zero_and_absent_are_distinguishable_in_the_payload() -> None:
+    priced_zero = _submission(_result_costing("0"))["run_cost_usd"]
+    unpriced = _submission(_result_costing(None))["run_cost_usd"]
+
+    assert priced_zero != unpriced
+
+
+def test_the_submission_payload_gains_only_the_cost_key() -> None:
+    # A characterisation guard: this is the submission path every user depends on, so an accidental
+    # change to a neighbouring field should fail loudly rather than ship.
+    payload = _submission(_result_costing("0.5"))
+
+    assert set(payload) == {
+        "version",
+        "benchmark_id",
+        "spec_id",
+        "url4_expression",
+        "score",
+        "total_questions",
+        "ran_with_providers",
+        "ran_at_local",
+        "run_cost_usd",
+        "client",
+        "metadata",
+    }
+
+
+def test_the_cost_survives_json_serialisation() -> None:
+    # INVARIANT: the payload is handed to `json=`, so it must survive json.dumps. A raw Decimal
+    # raises TypeError there — a failure no assertion on the dict alone would catch.
+    import json
+
+    encoded = json.loads(json.dumps(_submission(_result_costing("1.234567"))))
+
+    assert encoded["run_cost_usd"] == "1.234567"
+    assert json.loads(json.dumps(_submission(_result_costing(None))))["run_cost_usd"] is None
+
+
+def test_the_cost_reaches_the_wire_on_a_real_submit() -> None:
+    # End to end through the client, not just the payload builder: the value has to survive
+    # httpx's own JSON encoding, which is where a raw Decimal would raise.
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(201, json=_score_response())
+
+    with _sync_client(handler) as client:
+        client.leaderboards.submit(_result_costing("2.5"))
+
+    assert json.loads(seen[-1].content)["run_cost_usd"] == "2.5"
+
+
+@pytest.mark.asyncio
+async def test_the_async_submit_sends_the_cost_too() -> None:
+    # Sync and async share _submission(), and this keeps that true: a divergence would be silent
+    # and only one set of users would carry costs.
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(201, json=_score_response())
+
+    async with _async_client(handler) as client:
+        await client.leaderboards.submit(_result_costing("2.5"))
+
+    assert json.loads(seen[-1].content)["run_cost_usd"] == "2.5"
+
+
+@pytest.mark.parametrize(
+    "cost",
+    ["0", "0.000001", "1.234567", "999999.999999"],
+)
+def test_the_wire_string_parses_back_to_the_same_decimal(cost: str) -> None:
+    # The SDK and Scoreboard are separate deployables with no shared type — Scoreboard's
+    # `run_cost_usd` is `Decimal | None` and Pydantic parses the string we send. Importing that
+    # schema here is not possible (its dependencies are not in this venv, correctly), so the
+    # contract is pinned as the property that field relies on: what we emit must parse back to
+    # exactly the Decimal we started with, across the column's DECIMAL(12, 6) range.
+    emitted = _submission(_result_costing(cost))["run_cost_usd"]
+
+    assert isinstance(emitted, str)
+    assert Decimal(emitted) == Decimal(cost)
+
+
+def test_no_cost_is_absent_rather_than_an_empty_string() -> None:
+    # An empty string would parse as neither a Decimal nor null and would 422 the submission.
+    assert _submission(_result_costing(None))["run_cost_usd"] is None


### PR DESCRIPTION
Closes OME-1029.

The last missing link in the run-cost chain. Scoreboard has accepted `run_cost_usd` since OME-770, the Engine produces a run total, and the SDK already held it on `CandidateResult.usage.cost_usd`. The submission payload just omitted it.

The consequence is measurable: `GET /v1/leaderboard/draco` returns `entries=0, with a cost=0`, and `git grep -l run_cost_usd` over `packages/` and `apps/screamingface-engine` returned nothing.

## The change

One helper and one payload key in `_submission()`. Both the sync and async submit paths share it.

## Two decisions worth review

**A decimal string, never a float or a raw `Decimal`.** The payload is handed to `json=`, whose `json.dumps` raises `TypeError` on a `Decimal`; a float would silently lose precision on what Scoreboard stores as `DECIMAL(12, 6)`. `str()` is already this SDK's idiom for the same value — see `_report_primitives.Usage`.

**`None` stays `None`, never `0`.** Absent means "no cost was reported". `0` means "this run genuinely cost nothing", which a fully cache-served run legitimately does. OME-770's D10 and OME-923's frontier exclusion rule both depend on the distinction — a null read as zero would place an unpriced run at the cheapest end of the Pareto frontier, asserting something about money nobody measured.

Normalisation stays Scoreboard's. Quantization, sub-quantum rounding and sign-zero are not re-implemented client-side, or the two contracts would drift.

## Test plan

The absent/zero boundary is pinned first and separately, since that is the whole risk. 11 new tests; the file goes 47 → 58.

All eight gates green, including the **95% coverage floor**, notebook determinism, `uv build` and the distribution check.

Beyond the suite, every cost state round-trips through `json.dumps` and back to the identical `Decimal`: priced, cache-served `0`, unpriced `None`, sub-quantum `4E-7`, and the column ceiling `999999.999999`.

**Note on one test:** Step 4 was meant to validate against Scoreboard's real `ScoreSubmission`. That is not importable from this venv (`ModuleNotFoundError: pypika_tortoise`) because the SDK and Scoreboard are separate deployables that correctly do not share dependencies. Substituted the property that field relies on — what we emit parses back to exactly the `Decimal` we started with, parametrised across the column's range.

**No prior test modified.** An earlier attempt added a parameter to the shared `_candidate_result` fixture and the append-only gate caught it; the helper was rebuilt to construct from the fixture's own attributes rather than request a rule-5 exception. `dataclasses.replace` is not usable here — `CandidateResult` accepts `metrics=` but stores `_metric_items`. The diff against `main` in that file is purely additive.

## What this unblocks, and what it does not

**Unblocks** OME-822's real gate — "a client can produce a run total end to end" — which was never met despite the ticket leaving Blocked on 2026-08-19.

**Does not** populate existing rows. No backfill, and `content_hash` dedup excludes cost (OME-391, OME-770 D8), so a recipe already submitted without a cost cannot gain one later.

**OME-923 part B stays blocked** until real cost data is actually flowing, not merely until this merges — the Pareto marks need populated rows, and that needs a released client carrying this.