### PR TITLE
fix(screamingface): detect a missing [runtime] extra before the local stack boots

### DIFF
--- a/docs/plan/2026-08-28-OME-1036-runtime-extra-preflight.md
+++ b/docs/plan/2026-08-28-OME-1036-runtime-extra-preflight.md
@@ -1,0 +1,24 @@
+---
+title: Detect a missing [runtime] extra before the local stack boots
+ticket: OME-1036
+status: approved
+date: 2026-08-28
+spec: ../spec/2026-08-28-OME-1036-runtime-extra-preflight.md
+---
+
+# Detect a missing [runtime] extra before the local stack boots
+
+1. Add failing tests in `packages/screamingface/tests/test_runtime_cli.py`:
+   the missing-module probe (fake finder), the `require_runtime_extra` message (missing
+   list injected), the probe-list invariant (`tortoise`, `litellm`, `kubernetes` pinned),
+   the `_serve` install hint for `ImportError`, and the `_wait_ready` log tail.
+2. Implement the probe in `_runtime/server.py`: the module tuple, `_missing_runtime_modules`
+   with an injectable finder, and the friendly error before the vendored-app imports.
+3. Implement the `_serve` `ImportError` branch and the `_wait_ready` log tail in
+   `_runtime/cli.py`.
+4. Update the README "Install" section with both commands and add the troubleshooting
+   entry.
+5. Run the screamingface stack gates (ruff, format, pyright, pytest, notebook check,
+   build, distribution check).
+6. Review `origin/main...HEAD`, fill the ledger outcome, commit, and push the branch. Do
+   not open a PR until the owner requests it.

--- a/docs/spec/2026-08-28-OME-1036-runtime-extra-preflight.md
+++ b/docs/spec/2026-08-28-OME-1036-runtime-extra-preflight.md
@@ -1,0 +1,69 @@
+---
+title: Detect a missing [runtime] extra before the local stack boots
+ticket: OME-1036
+status: approved
+date: 2026-08-28
+---
+
+# Detect a missing [runtime] extra before the local stack boots
+
+## Outcome
+
+On a host without the `screamingface[runtime]` extra, `screamingface up` and
+`screamingface doctor` say what is missing and how to fix it. No raw
+`No module named 'tortoise'` line appears in a runtime log without the install command
+beside it. This holds on hosts that preinstall `uvicorn` and `fastapi` (Colab ships them
+through gradio), which is where the current guard passes by accident.
+
+## Why the current guard fails
+
+`require_runtime_extra()` imports `aigateway`, `scoreboard`, `screamingface_engine`,
+`url4`, and `uvicorn`. The build hook vendors the four app sources into the wheel, and
+their `__init__` files import nothing heavy, so four of the five imports succeed on a
+plain install. Only `uvicorn` probes the extra, and Colab preinstalls it. The first
+extra-only import the boot path reaches is `from tortoise import Tortoise` inside the
+`_serve` child (`_migrate`), which dies with a raw `ModuleNotFoundError`.
+
+## Preflight contract
+
+- `require_runtime_extra()` probes a fixed tuple of module names with
+  `importlib.util.find_spec`. It does NOT import them: the check must stay fast (no
+  `litellm` import at guard time) and must run in CI, which installs no runtime extra.
+- The tuple lists the modules that only the extra provides and that the local boot path
+  needs: `aiosqlite`, `bcrypt`, `cryptography`, `fastapi`, `kubernetes`, `litellm`,
+  `prometheus_client`, `pydantic_settings`, `tortoise`, `uvicorn`. The tuple lives beside
+  the `runtime` extra in `pyproject.toml` and both change together.
+- On any missing module, the error names every missing module and ends with
+  `Install "screamingface[runtime]"`.
+- The vendored-app imports and checkout verification (OME-1001) stay as they are, after
+  the probe.
+
+## Error translation contract
+
+`_serve` handles `ImportError` before the generic `Exception` branch and appends the
+install command to the `SCREAMINGFACE_RUNTIME_ERROR` line. Any future gap in the preflight
+list still produces an actionable log line.
+
+## Startup failure contract
+
+When `_wait_ready` observes a dead `_serve` child, the raised error includes the last
+runtime log lines (up to 15), not only the log path. The user sees the cause on screen.
+
+## Documentation contract
+
+The README "Install" section states both commands: `pip install screamingface` for the
+hosted client, and `pip install "screamingface[runtime,notebook]"` for the local stack. A
+troubleshooting entry maps `No module named 'X'` during `up` to the missing extra.
+
+## Consequences
+
+- `screamingface prepare` on a plain install now fails with the install command instead of
+  working by accident where `datasets` and `nltk` are preinstalled. This is intended:
+  every `prepare` dependency ships in the same extra.
+
+## Boundaries
+
+- No dependency, packaging, or public API change.
+- No app code changes; only the SDK runtime and README.
+- Tests must not require the runtime extra, and must not depend on which modules the host
+  happens to have installed.

--- a/docs/tasks/2026-08-28-OME-1036-runtime-extra-preflight.md
+++ b/docs/tasks/2026-08-28-OME-1036-runtime-extra-preflight.md
@@ -1,0 +1,36 @@
+---
+id: OME-1036
+linear_url: https://linear.app/openmined/issue/OME-1036/detect-a-missing-runtime-extra-before-the-local-stack-boots-colab-no
+status: in_progress
+type: bug
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-28
+closed:
+---
+
+# Detect a missing [runtime] extra before the local stack boots
+
+A user on fresh Colab installed plain `screamingface` (the line the README "Install"
+section shows). Part A on the hosted engine worked. `screamingface up` then died during
+startup with `SCREAMINGFACE_RUNTIME_ERROR No module named 'tortoise'`, and `status`
+showed all three services down.
+
+`require_runtime_extra()` probes five imports. Four come from the wheel itself (the build
+hook vendors the app sources, and their `__init__` files import nothing heavy). The fifth,
+`uvicorn`, is preinstalled on Colab because gradio needs it. So the guard passes without
+the `[runtime]` extra, and the first missing module dies inside the `_serve` child at
+`_migrate()`, with no hint to install the extra. `screamingface doctor` calls the same
+guard, so it reports the broken state as healthy.
+
+Fix, in layers:
+
+1. Probe the modules only the extra provides and the local boot path needs, with
+   `importlib.util.find_spec` (fast; no `litellm` import; runs in CI without the extra).
+   Name the missing modules and the install command.
+2. Translate an `ImportError` in the `_serve` child into the install hint.
+3. Include the last runtime log lines when `_wait_ready` reports a dead child.
+4. State both README install lines: plain (hosted client) and `[runtime,notebook]` (local).
+
+Ledger: `docs/work/2026-08-28-OME-1036-runtime-extra-preflight.md`.
+Spec: `docs/spec/2026-08-28-OME-1036-runtime-extra-preflight.md`.

--- a/docs/work/2026-08-28-OME-1036-runtime-extra-preflight.md
+++ b/docs/work/2026-08-28-OME-1036-runtime-extra-preflight.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-1036
+stack: screamingface
+status: done   # planned | in_progress | done | blocked
+started: 2026-08-28
+finished: 2026-08-28
+---
+
+# OME-1036 — Detect a missing [runtime] extra before the local stack boots
+
+## Intent
+
+`screamingface up` must refuse to start, with a message that names the missing modules and
+the install command, when the `[runtime]` extra is absent — even on hosts (Colab) that
+preinstall `uvicorn` and `fastapi`. Today the guard passes there, the `_serve` child dies
+at `from tortoise import Tortoise`, and the log shows a raw `No module named 'tortoise'`
+with no remediation. `doctor` shares the guard and reports the broken state as healthy.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_runtime/server.py` — probe the extra-only
+  modules with `importlib.util.find_spec`; raise the friendly error naming what is missing.
+- `packages/screamingface/src/screamingface/_runtime/cli.py` — `ImportError` in `_serve`
+  logs the install hint; `_wait_ready` includes the last runtime log lines when the child
+  dies during startup.
+- `packages/screamingface/README.md` — both install lines (hosted vs local stack) and a
+  troubleshooting entry.
+- `packages/screamingface/tests/test_runtime_cli.py` — new tests for the preflight, the
+  hint, and the log tail.
+
+## Test plan
+
+- `_missing_runtime_modules` reports each absent module (fake finder), and only those.
+- `require_runtime_extra` raises with the module names and `screamingface[runtime]` in the
+  message (missing list injected; CI installs no extra).
+- The probe list pins the extra differentiators (`tortoise`, `litellm`, …) — the Colab gap.
+- `_serve` prints the install hint for an `ImportError`.
+- `_wait_ready` includes the last log lines when the child has exited.
+
+## Acceptance
+
+- On a host with `uvicorn` preinstalled and `tortoise` absent, `up` fails in the parent
+  process with an actionable message; `doctor` reports the missing modules.
+- All stack gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `src/screamingface/_runtime/server.py`,
+  `src/screamingface/_runtime/cli.py`, `README.md`, `tests/test_runtime_cli.py` (all under
+  `packages/screamingface/`), plus the four SDLC docs. As planned.
+- **Commits:** see `git log origin/main..HEAD` on `OME-1036-runtime-extra-preflight`.
+- **Gates:** ruff check ✓ · ruff format ✓ · pyright 0 errors · pytest 1272 passed /
+  17 skipped, coverage 95.02% (floor 95) · check_notebooks ✓ · uv build ✓ ·
+  check_distribution ✓
+- **Deviations:** none. The preflight probe runs before `enable_local_providers` so a
+  refused boot leaves no environment mutation; spec already allowed this ordering.

--- a/docs/work/2026-08-28-OME-1036-runtime-extra-preflight.md
+++ b/docs/work/2026-08-28-OME-1036-runtime-extra-preflight.md
@@ -48,7 +48,7 @@ with no remediation. `doctor` shares the guard and reports the broken state as h
 - **Actual files:** `src/screamingface/_runtime/server.py`,
   `src/screamingface/_runtime/cli.py`, `README.md`, `tests/test_runtime_cli.py` (all under
   `packages/screamingface/`), plus the four SDLC docs. As planned.
-- **Commits:** see `git log origin/main..HEAD` on `OME-1036-runtime-extra-preflight`.
+- **Commits:** `7a55fe3b` — fix(screamingface): detect a missing [runtime] extra before the local stack boots
 - **Gates:** ruff check ✓ · ruff format ✓ · pyright 0 errors · pytest 1272 passed /
   17 skipped, coverage 95.02% (floor 95) · check_notebooks ✓ · uv build ✓ ·
   check_distribution ✓

--- a/packages/screamingface/README.md
+++ b/packages/screamingface/README.md
@@ -210,7 +210,19 @@ stateful protocols without a Client-interpreted workflow language.
 pip install screamingface
 ```
 
-Python 3.12 or newer is required.
+Python 3.12 or newer is required. This command installs the hosted client. The local stack
+(`screamingface up`) also needs the runtime services and notebook tools:
+
+```bash
+pip install "screamingface[runtime,notebook]"
+```
+
+### Troubleshooting
+
+`SCREAMINGFACE_RUNTIME_ERROR No module named 'X'` from `screamingface up` — common on
+Colab, which preinstalls some of the runtime dependencies: the `[runtime]` extra is not
+installed. Run `pip install "screamingface[runtime,notebook]"` and start again with
+`screamingface up`. `screamingface doctor` names the missing modules.
 
 ## Client configuration
 

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -25,6 +25,9 @@ from screamingface._runtime.config import RuntimeConfig, default_data_dir
 _STATE_VERSION = 1
 _PORT_DEFAULTS = {"gateway": 9105, "scoreboard": 9106, "engine": 9108}
 _BENCHMARKS = ("draco", "ifeval", "healthbench", "gdpval")
+# WHY 15: enough to carry the failing import plus its traceback into the `up` error;
+# short enough that the message stays readable where it lands (OME-1036).
+_STARTUP_LOG_TAIL_LINES = 15
 
 
 def _parser() -> argparse.ArgumentParser:  # noqa: PLR0915
@@ -264,6 +267,16 @@ def _serve(config: RuntimeConfig, token: str, *, foreground: bool) -> None:
     with capture_runtime_log(config.log_path, foreground=foreground):
         try:
             _serve_logged(config, token)
+        except ImportError as exc:
+            # WHY a branch of its own (OME-1036): a missing runtime dependency otherwise
+            # reaches the log as a bare module error with no remediation. Any import the
+            # preflight list missed still lands with the fix attached.
+            print(
+                f'SCREAMINGFACE_RUNTIME_ERROR {exc} — install "screamingface[runtime]"',
+                file=sys.stderr,
+                flush=True,
+            )
+            raise
         except Exception as exc:
             print(f"SCREAMINGFACE_RUNTIME_ERROR {exc}", file=sys.stderr, flush=True)
             raise
@@ -691,11 +704,31 @@ def _write_json_atomic(path: Path, value: dict[str, object]) -> None:
         temporary.unlink(missing_ok=True)
 
 
+def _runtime_log_tail(path: Path, *, limit: int = _STARTUP_LOG_TAIL_LINES) -> str:
+    """The last runtime log lines, for errors raised where the log is not on screen.
+
+    Returns "" when the log is unreadable or absent — the caller's message already
+    points at the log path, so a missing file must not mask the startup failure itself.
+    """
+    try:
+        with path.open(encoding="utf-8", errors="replace") as stream:
+            return "".join(deque(stream, maxlen=limit)).rstrip("\n")
+    except OSError:
+        return ""
+
+
 def _wait_ready(process: subprocess.Popen[bytes], config: RuntimeConfig, *, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
-            raise RuntimeError("runtime exited during startup; inspect the runtime log")
+            # WHY the tail (OME-1036): the child dies in the background with its cause in
+            # the log file; repeating the last lines here puts the cause where the user is
+            # already looking instead of sending them hunting for a file.
+            tail = _runtime_log_tail(config.log_path)
+            raise RuntimeError(
+                "runtime exited during startup"
+                + (f":\n{tail}" if tail else "; inspect the runtime log")
+            )
         state = _read_state(config)
         if all(_health(config.services).values()) and state is not None and _verify_owner(state):
             return

--- a/packages/screamingface/src/screamingface/_runtime/server.py
+++ b/packages/screamingface/src/screamingface/_runtime/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import importlib.util
 import json
 import os
 import signal
@@ -9,7 +10,7 @@ import socket
 import subprocess
 import sys
 import threading
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from functools import cache
 from types import FrameType
 from typing import Any, Protocol
@@ -34,12 +35,70 @@ class Server(Protocol):
     async def serve(self) -> None: ...
 
 
+# The modules ONLY the "runtime" extra provides AND the local boot path reaches before it
+# can serve: the gateway app (fastapi, litellm, pydantic_settings, tortoise, bcrypt,
+# cryptography), its sqlite database (aiosqlite), the Engine app (kubernetes — adapters.k8s
+# imports it at module level; prometheus_client for metrics), and the servers (uvicorn).
+#
+# WHY probed with find_spec and not imported: the check must stay fast (importing litellm
+# alone costs seconds) and must run in CI, which installs no runtime extra.
+#
+# WHY a fixed list and not "import the vendored apps": the vendored aigateway, scoreboard,
+# and screamingface_engine packages import nothing heavy, so importing them proves nothing
+# about the extra — the Colab gap (OME-1036). Fresh Colab preinstalls uvicorn and fastapi
+# (gradio needs them) but not tortoise, so the old five-import guard passed on a plain
+# install and the stack died inside the child with a raw ModuleNotFoundError. Keep this
+# tuple in step with the "runtime" extra in pyproject.toml.
+_RUNTIME_ONLY_MODULES: tuple[str, ...] = (
+    "aiosqlite",
+    "bcrypt",
+    "cryptography",
+    "fastapi",
+    "kubernetes",
+    "litellm",
+    "prometheus_client",
+    "pydantic_settings",
+    "tortoise",
+    "uvicorn",
+)
+
+
+def _missing_runtime_modules(
+    names: Sequence[str], find_spec: Callable[[str], Any] = importlib.util.find_spec
+) -> tuple[str, ...]:
+    """The probed names that are not importable, in probe order.
+
+    ``find_spec`` is a parameter so tests can simulate a host without the extra; the
+    default locates a module WITHOUT executing it.
+    """
+    missing: list[str] = []
+    for name in names:
+        try:
+            located = find_spec(name)
+        except (ImportError, ValueError):
+            # find_spec raises for a broken parent package or an invalid name; either way
+            # this module is not usable, which is the answer the caller needs.
+            located = None
+        if located is None:
+            missing.append(name)
+    return tuple(missing)
+
+
 def require_runtime_extra() -> RuntimeSource:
     # INVARIANT (OME-1001): the runtime source activates before ANY runtime app
     # import — in a checkout, the live apps/ code must shadow the stale build-time
     # copies a dev venv carries in site-packages.
     source = resolve_source(os.environ)
     activate(source)
+    # WHY before `enable_local_providers` (which mutates os.environ): a refused boot must
+    # leave no trace beyond the error, and find_spec imports nothing, so nothing about the
+    # provider defaults matters to the probe (OME-1036).
+    missing = _missing_runtime_modules(_RUNTIME_ONLY_MODULES)
+    if missing:
+        raise RuntimeError(
+            f"Local runtime dependencies are missing: {', '.join(missing)}. "
+            'Install "screamingface[runtime]".'
+        )
     # Configure provider discovery before importing URL4 Cloud: its compiled model world may load
     # AI Gateway plugins, whose module-level instances capture provider settings at import time.
     enable_local_providers(os.environ)

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -7,10 +7,11 @@ import sys
 import threading
 import types
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from screamingface._runtime import cli, runtime_logging
+from screamingface._runtime import cli, runtime_logging, server
 from screamingface._runtime.bootstrap import enable_local_providers, scoreboard_seed_json
 from screamingface._runtime.config import RuntimeConfig
 
@@ -584,3 +585,131 @@ def test_the_local_projection_omits_display_fields_a_benchmark_did_not_declare()
 
     assert "focus" not in projected
     assert "dataset_url" not in projected
+
+
+# --- the [runtime] extra preflight (OME-1036) ---------------------------------------------
+
+
+def test_missing_runtime_modules_reports_each_absent_module() -> None:
+    def find_spec(name: str) -> object:
+        return None if name in {"litellm", "tortoise"} else object()
+
+    missing = server._missing_runtime_modules(
+        ("fastapi", "litellm", "tortoise", "uvicorn"), find_spec
+    )
+
+    assert missing == ("litellm", "tortoise")
+
+
+def test_missing_runtime_modules_treats_a_raising_finder_as_absent() -> None:
+    def find_spec(name: str) -> object:
+        raise ModuleNotFoundError(f"No module named {name!r}")
+
+    assert server._missing_runtime_modules(("tortoise",), find_spec) == ("tortoise",)
+
+
+def test_require_runtime_extra_names_missing_modules_and_the_install_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "_missing_runtime_modules", lambda names: ("tortoise",))
+
+    with pytest.raises(RuntimeError) as raised:
+        server.require_runtime_extra()
+
+    message = str(raised.value)
+    assert "tortoise" in message
+    assert 'Install "screamingface[runtime]"' in message
+
+
+def test_the_probe_list_pins_the_colab_gap_differentiators() -> None:
+    # Fresh Colab preinstalls uvicorn and fastapi (gradio needs them) but none of the
+    # rest — exactly the host where the old five-import guard passed and the stack died
+    # inside the child on `from tortoise import Tortoise` (OME-1036).
+    assert {
+        "aiosqlite",
+        "bcrypt",
+        "cryptography",
+        "fastapi",
+        "kubernetes",
+        "litellm",
+        "prometheus_client",
+        "pydantic_settings",
+        "tortoise",
+        "uvicorn",
+    } == set(server._RUNTIME_ONLY_MODULES)
+
+
+def test_serve_logs_the_install_hint_for_an_import_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+
+    def fail(_config: object, _token: str) -> None:
+        raise ModuleNotFoundError("No module named 'tortoise'")
+
+    monkeypatch.setattr(cli, "_serve_logged", fail)
+
+    with pytest.raises(ModuleNotFoundError):
+        cli._serve(config, "token", foreground=True)
+
+    # WHY `.out`: capture_runtime_log routes every line through RuntimeLog, whose console
+    # stream is the process stdout — the stderr the print() targets is replaced by it.
+    rendered = capsys.readouterr().out
+    assert "SCREAMINGFACE_RUNTIME_ERROR No module named 'tortoise'" in rendered
+    assert 'install "screamingface[runtime]"' in rendered
+
+
+def test_serve_keeps_the_plain_runtime_error_for_other_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+
+    def fail(_config: object, _token: str) -> None:
+        raise RuntimeError("the port is taken")
+
+    monkeypatch.setattr(cli, "_serve_logged", fail)
+
+    with pytest.raises(RuntimeError):
+        cli._serve(config, "token", foreground=True)
+
+    rendered = capsys.readouterr().out
+    assert "SCREAMINGFACE_RUNTIME_ERROR the port is taken" in rendered
+    assert "screamingface[runtime]" not in rendered
+
+
+class _DeadProcess:
+    def __init__(self, exit_code: int) -> None:
+        self._exit_code = exit_code
+
+    def poll(self) -> int:
+        return self._exit_code
+
+
+def test_wait_ready_reports_the_log_tail_when_the_child_dies(tmp_path: Path) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    config.log_path.parent.mkdir(parents=True, exist_ok=True)
+    config.log_path.write_text(
+        "[engine] listening\nSCREAMINGFACE_RUNTIME_ERROR No module named 'tortoise'\n"
+    )
+    process = cast(subprocess.Popen[bytes], _DeadProcess(1))
+
+    with pytest.raises(RuntimeError) as raised:
+        cli._wait_ready(process, config, timeout=0.1)
+
+    message = str(raised.value)
+    assert "runtime exited during startup" in message
+    assert "No module named 'tortoise'" in message
+
+
+def test_wait_ready_still_points_at_the_log_when_it_cannot_be_read(tmp_path: Path) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    process = cast(subprocess.Popen[bytes], _DeadProcess(1))
+
+    with pytest.raises(RuntimeError) as raised:
+        cli._wait_ready(process, config, timeout=0.1)
+
+    assert "runtime exited during startup; inspect the runtime log" in str(raised.value)


### PR DESCRIPTION
## Summary

A user on fresh Colab with plain `pip install screamingface` ran `screamingface up` and got a dead stack plus a repeated `SCREAMINGFACE_RUNTIME_ERROR No module named 'tortoise'` in the log — no hint about the fix. Part A (hosted) and `prepare` worked, so the missing extra was invisible until boot.

**Root cause:** `require_runtime_extra()` probed five imports. Four are satisfied by the wheel itself (the build hook vendors the app sources; their `__init__`s import nothing heavy), and the only real probe of the `[runtime]` extra — `uvicorn` — is preinstalled on Colab (gradio ships it). The guard passed, and the first extra-only import died inside the `_serve` child at `_migrate()` (`from tortoise import Tortoise`). `screamingface doctor` shared the guard and reported the broken state as healthy.

## Changes

- **`_runtime/server.py`** — `require_runtime_extra()` probes the extra-only modules the local boot path needs (`tortoise`, `litellm`, `pydantic_settings`, `kubernetes`, `bcrypt`, `cryptography`, `aiosqlite`, `fastapi`, `prometheus_client`, `uvicorn`) with `importlib.util.find_spec` — located, never imported, so the check stays fast and runs in CI without the extra. The error names every missing module and the install command. The probe runs before `enable_local_providers`, so a refused boot mutates no environment. `doctor` inherits the fix.
- **`_runtime/cli.py`** — `_serve` translates an `ImportError` into the install hint (safety net for any future gap in the probe list); `_wait_ready` includes the last 15 runtime log lines when the child dies during startup, so `up` fails with the cause on screen.
- **`README.md`** — both install lines side by side (hosted client vs local stack) and a troubleshooting entry for the exact Colab symptom.
- **8 new unit tests** — none require the runtime extra or a specific host environment.

## Consequence (intended)

`screamingface prepare` on a plain install now fails with the install command instead of working by accident where `datasets`/`nltk` are preinstalled: every `prepare` dependency ships in the same extra.

## Gates (stack: screamingface)

ruff check ✓ · ruff format ✓ · pyright 0 errors · pytest 1272 passed / 17 skipped, coverage 95.02% (floor 95) · check_notebooks ✓ · uv build ✓ · check_distribution ✓

SDLC: spec/plan/tasks/work artifacts under `docs/` (2026-08-28-OME-1036-runtime-extra-preflight).

Refs: OME-1036
