### PR TITLE
feat(scoreboard): compute the Pareto frontier of score against cost (OME-923 part A)

### DIFF
--- a/apps/scoreboard/src/scoreboard/scores/pareto.py
+++ b/apps/scoreboard/src/scoreboard/scores/pareto.py
@@ -1,0 +1,78 @@
+"""Pareto frontier computation (OME-923 part A).
+
+Pure function, no I/O — takes already-fetched schemas so it's directly
+unit-testable without a DB, mirroring `frontier.py`.
+
+AIDEV-NOTE: deliberately NOT named `frontier` anything. `frontier.py`,
+`compute_frontier`, `FrontierPoint` and `FrontierResult` are OME-323's open/closed
+frontier — a different measure, on a different endpoint, that keeps its name and
+meaning. Qualifying this one keeps a grep for either honest (OME-923).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from decimal import Decimal
+
+from .schemas import LeaderboardEntry
+
+
+def compute_pareto_frontier(entries: Sequence[LeaderboardEntry]) -> frozenset[str]:
+    """The `spec_id`s whose score-for-cost no other entry beats.
+
+    FEATURE: OME-923 — "best score for the money" is a set, not a single row, so
+    several participants can hold a defensible claim on the same board.
+
+    INVARIANT: one row per `spec_id`. Callers pass the RANKED board
+    (`ScoreStore.leaderboard`), which collapses to best-per-spec. Do NOT pass
+    `ScoreStore.list_owned_entries` — it deliberately does not collapse, so a
+    repeated `spec_id` would mark rows that are not themselves on the frontier.
+
+    INVARIANT: an absent cost is excluded, never read as 0. Zero would dominate
+    every priced row and hand the board to an unknown (OME-770 D8). The exclusion
+    follows the missing VALUE, not the row: populate that cost later and the row
+    joins the frontier on its own, with no backfill.
+
+    AIDEV-NOTE: quadratic, and deliberately left so — the board is capped at
+    `top_n` (50), where this is a few thousand comparisons. A sort-based frontier
+    scan would be faster and harder to read for no reachable benefit.
+    """
+    # WHY the tuple: narrowing `run_cost_usd` once here keeps the comparison free of
+    # None-checks, and drops unpriced rows from BOTH sides of it — an unpriced row
+    # must neither qualify nor dominate. Excluding it from only the output would
+    # still let an unknown cost beat a real one.
+    priced: list[tuple[str, float, Decimal]] = []
+    for entry in entries:
+        cost = entry.run_cost_usd
+        if cost is not None:
+            priced.append((entry.spec_id, entry.score, cost))
+
+    return frozenset(
+        spec_id
+        for spec_id, score, cost in priced
+        if not any(
+            _dominates(other_score, other_cost, score, cost)
+            for _, other_score, other_cost in priced
+        )
+    )
+
+
+def _dominates(
+    other_score: float,
+    other_cost: Decimal,
+    score: float,
+    cost: Decimal,
+) -> bool:
+    """Standard Pareto dominance: at least as good on both axes, strictly better on one.
+
+    WHY not the ticket's literal "no other has BOTH a higher score AND a lower cost":
+    read strictly, that keeps a row scoring the same at nine times the price, because
+    nobody outscored it — indefensible on a board claiming best value (owner decision,
+    2026-08-29).
+
+    INVARIANT: nothing dominates itself — equal on both axes fails the strictly-better
+    clause — so an exact tie leaves both rows on the frontier.
+    """
+    return (
+        other_score >= score and other_cost <= cost and (other_score > score or other_cost < cost)
+    )

--- a/apps/scoreboard/src/scoreboard/scores/pareto.py
+++ b/apps/scoreboard/src/scoreboard/scores/pareto.py
@@ -16,39 +16,59 @@ from decimal import Decimal
 
 from .schemas import LeaderboardEntry
 
+# A frontier member: the spec, qualified by the revision it was measured against.
+# INVARIANT: the revision is part of the KEY, never dropped. `spec_id` alone is not unique
+# on a board whose benchmark has no registered revision, and collapsing the two let a row
+# beaten on BOTH axes inherit the mark its own spec earned on a different revision (found
+# in review of PR #778).
+ParetoKey = tuple[str, str | None]
 
-def compute_pareto_frontier(entries: Sequence[LeaderboardEntry]) -> frozenset[str]:
-    """The `spec_id`s whose score-for-cost no other entry beats.
 
-    FEATURE: OME-923 — "best score for the money" is a set, not a single row, so
-    several participants can hold a defensible claim on the same board.
+def compute_pareto_frontier(entries: Sequence[LeaderboardEntry]) -> frozenset[ParetoKey]:
+    """The `(spec_id, benchmark_revision)` pairs whose score-for-cost no comparable entry beats.
 
-    INVARIANT: one row per `spec_id`. Callers pass the RANKED board
-    (`ScoreStore.leaderboard`), which collapses to best-per-spec. Do NOT pass
-    `ScoreStore.list_owned_entries` — it deliberately does not collapse, so a
-    repeated `spec_id` would mark rows that are not themselves on the frontier.
+    FEATURE: OME-923 — "best score for the money" is a set, not a single row, so several
+    participants can hold a defensible claim on the same board.
 
-    INVARIANT: an absent cost is excluded, never read as 0. Zero would dominate
-    every priced row and hand the board to an unknown (OME-770 D8). The exclusion
-    follows the missing VALUE, not the row: populate that cost later and the row
-    joins the frontier on its own, with no backfill.
+    INVARIANT: rows are compared **only within one `benchmark_revision`**. A board whose
+    benchmark has no registered revision filters nothing and ranks one row per
+    `(spec_id, benchmark_revision)`, so it can carry several mutually incomparable cohorts
+    at once — and OME-775 exists precisely because numbers measured against different
+    revisions are not comparable. Each cohort therefore gets its own frontier. Where the
+    benchmark DOES declare a revision the query filters to it, leaving exactly one cohort,
+    so this is identical to comparing the whole board.
 
-    AIDEV-NOTE: quadratic, and deliberately left so — the board is capped at
-    `top_n` (50), where this is a few thousand comparisons. A sort-based frontier
-    scan would be faster and harder to read for no reachable benefit.
+    INVARIANT: an absent cost is excluded, never read as 0. Zero would dominate every priced
+    row and hand the board to an unknown (OME-770 D8). The exclusion follows the missing
+    VALUE, not the row: populate that cost later and the row joins the frontier on its own,
+    with no backfill.
+
+    AIDEV-NOTE: pass the **whole ranked set**, never a truncated page.
+    `ScoreStore.leaderboard` orders by score alone and then applies `top_n`, so a row just
+    past the cutoff can tie the boundary score at a lower cost and dominate a visible row it
+    was never compared against. The frontier would then change with `top`, which is not a
+    property a claim about money may have. The ticket says "no other submission on the same
+    board", and the board is not the visible page (found in review of PR #778).
+
+    AIDEV-NOTE: quadratic within a cohort, and deliberately so — a cohort is bounded by the
+    board's distinct spec count, where this is a few thousand comparisons. A sort-based
+    frontier scan would be faster and harder to read for no reachable benefit.
     """
-    # WHY the tuple: narrowing `run_cost_usd` once here keeps the comparison free of
-    # None-checks, and drops unpriced rows from BOTH sides of it — an unpriced row
-    # must neither qualify nor dominate. Excluding it from only the output would
-    # still let an unknown cost beat a real one.
-    priced: list[tuple[str, float, Decimal]] = []
+    # WHY grouped first: one pass does the revision partitioning and the None-narrowing, and
+    # drops unpriced rows from BOTH sides of the comparison — an unpriced row must neither
+    # qualify nor dominate. Excluding it from only the output would still let an unknown cost
+    # beat a real one.
+    cohorts: dict[str | None, list[tuple[str, float, Decimal]]] = {}
     for entry in entries:
         cost = entry.run_cost_usd
         if cost is not None:
-            priced.append((entry.spec_id, entry.score, cost))
+            cohorts.setdefault(entry.benchmark_revision, []).append(
+                (entry.spec_id, entry.score, cost)
+            )
 
     return frozenset(
-        spec_id
+        (spec_id, revision)
+        for revision, priced in cohorts.items()
         for spec_id, score, cost in priced
         if not any(
             _dominates(other_score, other_cost, score, cost)

--- a/apps/scoreboard/tests/unit/scores/test_pareto.py
+++ b/apps/scoreboard/tests/unit/scores/test_pareto.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from decimal import Decimal
+from decimal import Decimal as D
 
 from scoreboard.scores.pareto import compute_pareto_frontier
 from scoreboard.scores.schemas import LeaderboardEntry
@@ -19,12 +20,12 @@ def _entry(
     spec_id: str,
     score: float,
     run_cost_usd: Decimal | None,
+    benchmark_revision: str | None = None,
 ) -> LeaderboardEntry:
-    """Only score, cost and spec_id matter here; everything else is inert filler."""
+    """Only score, cost, spec_id and revision matter here; the rest is inert filler."""
     return LeaderboardEntry(
         spec_id=spec_id,
-        # None is honest: the frontier does not depend on which revision produced the row.
-        benchmark_revision=None,
+        benchmark_revision=benchmark_revision,
         score=score,
         total_questions=10,
         ran_with_providers=["huggingface"],
@@ -42,7 +43,7 @@ def test_no_entries_yields_an_empty_frontier() -> None:
 
 def test_a_lone_priced_entry_is_on_the_frontier() -> None:
     entries = [_entry(spec_id="solo", score=0.5, run_cost_usd=Decimal("1.00"))]
-    assert compute_pareto_frontier(entries) == {"solo"}
+    assert compute_pareto_frontier(entries) == {("solo", None)}
 
 
 def test_a_strictly_dominated_entry_is_excluded() -> None:
@@ -51,7 +52,7 @@ def test_a_strictly_dominated_entry_is_excluded() -> None:
         _entry(spec_id="better", score=0.90, run_cost_usd=Decimal("1.00")),
         _entry(spec_id="worse", score=0.50, run_cost_usd=Decimal("9.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"better"}
+    assert compute_pareto_frontier(entries) == {("better", None)}
 
 
 def test_a_genuine_tradeoff_puts_both_on_the_frontier() -> None:
@@ -60,7 +61,7 @@ def test_a_genuine_tradeoff_puts_both_on_the_frontier() -> None:
         _entry(spec_id="cheap", score=0.50, run_cost_usd=Decimal("1.00")),
         _entry(spec_id="accurate", score=0.90, run_cost_usd=Decimal("9.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"cheap", "accurate"}
+    assert compute_pareto_frontier(entries) == {("cheap", None), ("accurate", None)}
 
 
 def test_equal_score_the_cheaper_entry_wins() -> None:
@@ -71,7 +72,7 @@ def test_equal_score_the_cheaper_entry_wins() -> None:
         _entry(spec_id="alice", score=0.90, run_cost_usd=Decimal("1.00")),
         _entry(spec_id="bob", score=0.90, run_cost_usd=Decimal("9.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"alice"}
+    assert compute_pareto_frontier(entries) == {("alice", None)}
 
 
 def test_equal_cost_the_higher_scoring_entry_wins() -> None:
@@ -79,7 +80,7 @@ def test_equal_cost_the_higher_scoring_entry_wins() -> None:
         _entry(spec_id="higher", score=0.90, run_cost_usd=Decimal("1.00")),
         _entry(spec_id="lower", score=0.50, run_cost_usd=Decimal("1.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"higher"}
+    assert compute_pareto_frontier(entries) == {("higher", None)}
 
 
 def test_an_exact_tie_on_both_axes_qualifies_both() -> None:
@@ -89,7 +90,7 @@ def test_an_exact_tie_on_both_axes_qualifies_both() -> None:
         _entry(spec_id="twin-a", score=0.90, run_cost_usd=Decimal("1.00")),
         _entry(spec_id="twin-b", score=0.90, run_cost_usd=Decimal("1.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"twin-a", "twin-b"}
+    assert compute_pareto_frontier(entries) == {("twin-a", None), ("twin-b", None)}
 
 
 def test_an_unpriced_entry_is_excluded_even_with_the_top_score() -> None:
@@ -99,7 +100,7 @@ def test_an_unpriced_entry_is_excluded_even_with_the_top_score() -> None:
         _entry(spec_id="unpriced", score=0.99, run_cost_usd=None),
         _entry(spec_id="priced", score=0.50, run_cost_usd=Decimal("1.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"priced"}
+    assert compute_pareto_frontier(entries) == {("priced", None)}
 
 
 def test_an_unpriced_entry_never_excludes_a_priced_one() -> None:
@@ -110,7 +111,7 @@ def test_an_unpriced_entry_never_excludes_a_priced_one() -> None:
         _entry(spec_id="dear", score=0.60, run_cost_usd=Decimal("9.00")),
         _entry(spec_id="cheap", score=0.50, run_cost_usd=Decimal("1.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"dear", "cheap"}
+    assert compute_pareto_frontier(entries) == {("dear", None), ("cheap", None)}
 
 
 def test_a_board_with_no_cost_data_yields_an_empty_frontier() -> None:
@@ -130,4 +131,78 @@ def test_a_zero_cost_is_a_real_value_and_can_win() -> None:
         _entry(spec_id="free", score=0.50, run_cost_usd=Decimal("0")),
         _entry(spec_id="paid", score=0.50, run_cost_usd=Decimal("1.00")),
     ]
-    assert compute_pareto_frontier(entries) == {"free"}
+    assert compute_pareto_frontier(entries) == {("free", None)}
+
+
+# ---- revision cohorts (found in review of PR #778) ---------------------------------
+
+
+def test_one_spec_on_two_revisions_is_judged_only_against_its_own_revision() -> None:
+    """The regression from review. A benchmark with no REGISTERED revision filters nothing
+    and ranks one row per (spec_id, benchmark_revision), so a spec appears twice. Keyed on
+    spec_id alone, the rev-2 row inherited the mark its own spec earned on rev-1 — even
+    though a rev-2 peer beats it on BOTH axes."""
+    entries = [
+        _entry(spec_id="fusion-a", benchmark_revision="rev-1", score=0.90, run_cost_usd=D("1.00")),
+        _entry(spec_id="fusion-a", benchmark_revision="rev-2", score=0.50, run_cost_usd=D("9.00")),
+        _entry(spec_id="rival", benchmark_revision="rev-2", score=0.80, run_cost_usd=D("2.00")),
+    ]
+    frontier = compute_pareto_frontier(entries)
+    assert ("fusion-a", "rev-1") in frontier
+    assert ("rival", "rev-2") in frontier
+    assert ("fusion-a", "rev-2") not in frontier
+
+
+def test_rows_never_dominate_across_revisions() -> None:
+    """INVARIANT: revisions are not comparable (OME-775), so a cheap high scorer on one
+    revision must not knock out a dear low scorer on another."""
+    entries = [
+        _entry(spec_id="on-old", benchmark_revision="rev-1", score=0.95, run_cost_usd=D("0.10")),
+        _entry(spec_id="on-new", benchmark_revision="rev-2", score=0.20, run_cost_usd=D("9.99")),
+    ]
+    assert compute_pareto_frontier(entries) == {("on-old", "rev-1"), ("on-new", "rev-2")}
+
+
+def test_a_lone_priced_row_on_a_revision_is_that_revisions_frontier() -> None:
+    """AIDEV-NOTE: a deliberate consequence of per-cohort comparison, pinned so it is a
+    decision and not a surprise. With one priced row on a revision, that row IS the best
+    value available on it, so it carries a mark — even while another revision holds a run
+    that is both better and cheaper. The two were never comparable (OME-775), which is the
+    whole reason the cohorts exist. A reader needs `benchmark_revision`, which the board
+    already exposes, to tell the two rows apart."""
+    entries = [
+        _entry(spec_id="alone", benchmark_revision="rev-2", score=0.10, run_cost_usd=D("99.00")),
+        _entry(spec_id="better", benchmark_revision="rev-1", score=0.99, run_cost_usd=D("0.01")),
+    ]
+    assert compute_pareto_frontier(entries) == {("alone", "rev-2"), ("better", "rev-1")}
+
+
+def test_each_revision_computes_its_own_frontier() -> None:
+    """Domination still applies fully *inside* a cohort."""
+    entries = [
+        _entry(spec_id="best-old", benchmark_revision="rev-1", score=0.90, run_cost_usd=D("1.00")),
+        _entry(spec_id="poor-old", benchmark_revision="rev-1", score=0.40, run_cost_usd=D("5.00")),
+        _entry(spec_id="best-new", benchmark_revision="rev-2", score=0.70, run_cost_usd=D("2.00")),
+        _entry(spec_id="poor-new", benchmark_revision="rev-2", score=0.30, run_cost_usd=D("8.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {("best-old", "rev-1"), ("best-new", "rev-2")}
+
+
+def test_a_registered_revision_board_is_one_cohort() -> None:
+    """The common case: the benchmark declares a revision, so the query filters to it and
+    every row shares it. Behaviour must be identical to comparing the whole board."""
+    entries = [
+        _entry(spec_id="winner", benchmark_revision="rev-9", score=0.90, run_cost_usd=D("1.00")),
+        _entry(spec_id="loser", benchmark_revision="rev-9", score=0.50, run_cost_usd=D("9.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {("winner", "rev-9")}
+
+
+def test_a_null_revision_is_its_own_cohort_not_a_wildcard() -> None:
+    """Legacy rows predating the column carry NULL. NULL is a cohort like any other — it
+    must not merge with, or compare against, rows that name a revision."""
+    entries = [
+        _entry(spec_id="legacy", benchmark_revision=None, score=0.30, run_cost_usd=D("9.00")),
+        _entry(spec_id="modern", benchmark_revision="rev-1", score=0.95, run_cost_usd=D("0.10")),
+    ]
+    assert compute_pareto_frontier(entries) == {("legacy", None), ("modern", "rev-1")}

--- a/apps/scoreboard/tests/unit/scores/test_pareto.py
+++ b/apps/scoreboard/tests/unit/scores/test_pareto.py
@@ -1,0 +1,133 @@
+"""Unit tests for compute_pareto_frontier (OME-923 part A).
+
+Pure function, no DB — entries are constructed directly.
+
+FEATURE: OME-923 — mark the submissions with the best score for the money.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from scoreboard.scores.pareto import compute_pareto_frontier
+from scoreboard.scores.schemas import LeaderboardEntry
+
+
+def _entry(
+    *,
+    spec_id: str,
+    score: float,
+    run_cost_usd: Decimal | None,
+) -> LeaderboardEntry:
+    """Only score, cost and spec_id matter here; everything else is inert filler."""
+    return LeaderboardEntry(
+        spec_id=spec_id,
+        # None is honest: the frontier does not depend on which revision produced the row.
+        benchmark_revision=None,
+        score=score,
+        total_questions=10,
+        ran_with_providers=["huggingface"],
+        submitted_at=datetime(2026, 8, 29, tzinfo=UTC),
+        submitted_by="tester@example.com",
+        verified_by_screamingface=False,
+        url4_expression=f"url4://benchmark/{spec_id}",
+        run_cost_usd=run_cost_usd,
+    )
+
+
+def test_no_entries_yields_an_empty_frontier() -> None:
+    assert compute_pareto_frontier([]) == frozenset()
+
+
+def test_a_lone_priced_entry_is_on_the_frontier() -> None:
+    entries = [_entry(spec_id="solo", score=0.5, run_cost_usd=Decimal("1.00"))]
+    assert compute_pareto_frontier(entries) == {"solo"}
+
+
+def test_a_strictly_dominated_entry_is_excluded() -> None:
+    """Worse score AND higher cost — beaten on both axes, so it cannot be best value."""
+    entries = [
+        _entry(spec_id="better", score=0.90, run_cost_usd=Decimal("1.00")),
+        _entry(spec_id="worse", score=0.50, run_cost_usd=Decimal("9.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"better"}
+
+
+def test_a_genuine_tradeoff_puts_both_on_the_frontier() -> None:
+    """Cheaper-but-worse and dearer-but-better: neither dominates, both are defensible."""
+    entries = [
+        _entry(spec_id="cheap", score=0.50, run_cost_usd=Decimal("1.00")),
+        _entry(spec_id="accurate", score=0.90, run_cost_usd=Decimal("9.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"cheap", "accurate"}
+
+
+def test_equal_score_the_cheaper_entry_wins() -> None:
+    """INVARIANT (D7): standard Pareto dominance. Paying 9x for the same score is
+    strictly worse value, so it is NOT a best-score-for-the-money winner — even
+    though nobody outscored it."""
+    entries = [
+        _entry(spec_id="alice", score=0.90, run_cost_usd=Decimal("1.00")),
+        _entry(spec_id="bob", score=0.90, run_cost_usd=Decimal("9.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"alice"}
+
+
+def test_equal_cost_the_higher_scoring_entry_wins() -> None:
+    entries = [
+        _entry(spec_id="higher", score=0.90, run_cost_usd=Decimal("1.00")),
+        _entry(spec_id="lower", score=0.50, run_cost_usd=Decimal("1.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"higher"}
+
+
+def test_an_exact_tie_on_both_axes_qualifies_both() -> None:
+    """The ticket's "ties both qualify": identical on both axes, so neither
+    dominates the other and both hold the claim."""
+    entries = [
+        _entry(spec_id="twin-a", score=0.90, run_cost_usd=Decimal("1.00")),
+        _entry(spec_id="twin-b", score=0.90, run_cost_usd=Decimal("1.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"twin-a", "twin-b"}
+
+
+def test_an_unpriced_entry_is_excluded_even_with_the_top_score() -> None:
+    """INVARIANT (D6): a null cost means "not reported", never zero. Read as zero it
+    would dominate every priced row and win the board outright on an unknown."""
+    entries = [
+        _entry(spec_id="unpriced", score=0.99, run_cost_usd=None),
+        _entry(spec_id="priced", score=0.50, run_cost_usd=Decimal("1.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"priced"}
+
+
+def test_an_unpriced_entry_never_excludes_a_priced_one() -> None:
+    """The unpriced row must not participate as a dominator either — excluding it
+    from the OUTPUT while still letting it beat others would be the same bug."""
+    entries = [
+        _entry(spec_id="unpriced-cheap-looking", score=0.99, run_cost_usd=None),
+        _entry(spec_id="dear", score=0.60, run_cost_usd=Decimal("9.00")),
+        _entry(spec_id="cheap", score=0.50, run_cost_usd=Decimal("1.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"dear", "cheap"}
+
+
+def test_a_board_with_no_cost_data_yields_an_empty_frontier() -> None:
+    """Today's real board: every row null. Must return empty, not raise — the
+    ticket's "a board with no cost data renders without error and marks nothing"."""
+    entries = [
+        _entry(spec_id="a", score=0.90, run_cost_usd=None),
+        _entry(spec_id="b", score=0.50, run_cost_usd=None),
+    ]
+    assert compute_pareto_frontier(entries) == frozenset()
+
+
+def test_a_zero_cost_is_a_real_value_and_can_win() -> None:
+    """INVARIANT: 0 is "this run genuinely cost nothing" (a fully cache-served run),
+    which is distinct from null and is the strongest possible cost."""
+    entries = [
+        _entry(spec_id="free", score=0.50, run_cost_usd=Decimal("0")),
+        _entry(spec_id="paid", score=0.50, run_cost_usd=Decimal("1.00")),
+    ]
+    assert compute_pareto_frontier(entries) == {"free"}

--- a/docs/tasks/2026-08-20-OME-923-pareto-frontier.md
+++ b/docs/tasks/2026-08-20-OME-923-pareto-frontier.md
@@ -1,0 +1,65 @@
+---
+id: OME-923
+linear_url: https://linear.app/openmined/issue/OME-923/add-a-pareto-frontier-to-the-leaderboard-mark-the-best-score-for-cost
+status: in_progress
+type: feature
+priority: 2
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-20
+closed:
+---
+
+# Add a Pareto frontier to the leaderboard: mark the best score-for-cost submissions
+
+Mark the submissions where no other submission on the same board is both better and cheaper.
+Multiple winners are expected and wanted — the frontier is a set, so more than one participant
+can hold a defensible "best score for the money" claim on one board.
+
+## Parts
+
+| Part | What | State |
+|---|---|---|
+| A | Compute the frontier — a pure function, unit-testable without a DB | **Done**, PR #778 |
+| B | Mark qualifying rows, distinct from the gold highest-score mark | gated |
+| C | Accuracy-vs-cost chart with the frontier drawn | gated |
+
+A → B → C. A gates the other two. B carries most of the value at a fraction of C's cost.
+
+## The gate on B and C
+
+`run_cost_usd` is null on every row today. B and C must not merge until real cost data flows:
+OME-1029 (PR #770) merged, a client release carrying it, then a submission reporting a cost. An
+empty frontier rendering cleanly is acceptable; a cost claim computed over nulls is not. Part A
+merges alone safely because nothing imports it.
+
+## Decisions
+
+Irina answered the four open questions on 2026-08-24:
+
+1. **Cost is the whole benchmark run**, not per case.
+2. **"Pareto-frontier SOTA"** for this mark; absolute SOTA remains the highest score, a separate
+   and visually distinct mark.
+3. **Imported baselines are excluded** — they have no run cost and were never run by us.
+4. **3D charts are out of scope here.** OME-923 covers accuracy vs cost only; OME-324 keeps 3D.
+
+Two further decisions were escalated during part A (2026-08-29):
+
+5. **Standard Pareto dominance**, not the ticket's literal *"no other has both a higher score and
+   a lower cost"*. Read strictly, that keeps a row scoring the same at nine times the price
+   because nobody outscored it. Exact ties on both axes still both qualify.
+6. **Part A returns `frozenset[str]` of `spec_id`** — robust to the ranking route's re-sorting.
+   Valid only for the collapsed board; `list_owned_entries()` does not collapse and is not a
+   valid input.
+
+## Don't regress
+
+- OME-323's open/closed frontier keeps its name, endpoint and meaning. It owns `frontier.py`,
+  `compute_frontier`, `FrontierPoint`, `FrontierResult`. The new code is `pareto.py` /
+  `compute_pareto_frontier` so a grep for either stays honest.
+- A null cost never reads as zero and never wins a comparison.
+- The highest-score mark keeps its current meaning and wording.
+- Neither mark relies on colour alone.
+
+## Ledger
+
+`docs/work/2026-08-29-OME-923-pareto-frontier-compute.md` (part A)

--- a/docs/tasks/2026-08-20-OME-923-pareto-frontier.md
+++ b/docs/tasks/2026-08-20-OME-923-pareto-frontier.md
@@ -47,9 +47,22 @@ Two further decisions were escalated during part A (2026-08-29):
 5. **Standard Pareto dominance**, not the ticket's literal *"no other has both a higher score and
    a lower cost"*. Read strictly, that keeps a row scoring the same at nine times the price
    because nobody outscored it. Exact ties on both axes still both qualify.
-6. **Part A returns `frozenset[str]` of `spec_id`** — robust to the ranking route's re-sorting.
-   Valid only for the collapsed board; `list_owned_entries()` does not collapse and is not a
-   valid input.
+6. **Part A returns `frozenset[tuple[str, str | None]]`, keyed on
+   `(spec_id, benchmark_revision)`.** Rows are compared only within one revision; a spec can
+   hold rows on several non-comparable revisions and each is judged inside its own cohort.
+   Keys survive the ranking route's re-sorting.
+
+   An earlier revision of this decision returned `frozenset[str]` of `spec_id` alone. Review of
+   PR #778 showed that is wrong on any benchmark with no registered revision: the board filters
+   nothing there, one spec appears once per revision, and the bare key let a row beaten on BOTH
+   axes inherit the mark its own spec earned elsewhere. Recorded rather than silently replaced,
+   because dropping the revision again is the exact regression to avoid.
+
+7. **The frontier is computed over the whole ranked board, never a `top_n` page.** `leaderboard()`
+   orders by score alone before truncating, so a row past the cutoff can tie the boundary score at
+   a lower cost and dominate a visible row. The caller passes `top_n=None` and serves the page as a
+   prefix of the same result — which also keeps marks and rows on one snapshot, and keeps the
+   `turned_private` guard the last read before a public response.
 
 ## Don't regress
 

--- a/docs/work/2026-08-29-OME-923-pareto-frontier-compute.md
+++ b/docs/work/2026-08-29-OME-923-pareto-frontier-compute.md
@@ -1,0 +1,99 @@
+---
+ticket: OME-923
+stack: scoreboard
+status: done
+started: 2026-08-29
+finished: 2026-08-29
+---
+
+# OME-923 — Compute the Pareto frontier (part A)
+
+## Intent
+
+Mark the submissions where no other submission on the same board is **both** higher-scoring and
+cheaper. This unit is **part A only**: the pure computation that decides what the board will
+claim. Parts B (marking rows) and C (the accuracy-vs-cost chart) follow and are explicitly
+gated — the ticket allows A against fixtures now, but forbids B/C from merging until real cost
+data flows.
+
+## Why now
+
+`OME-303` (per-call cost, Done 2026-08-14) and `OME-304` (cumulative run cost, Done
+2026-08-19) closed the producer chain. `OME-1029` (PR #770) makes the SDK send the run total.
+`OME-923` itself has an empty `blockedBy`, and Irina answered all four design questions on
+2026-08-24, so the semantics are settled rather than assumed.
+
+## Decisions
+
+| # | Decision | Source |
+|---|---|---|
+| D1 | Cost is the **whole benchmark run**, not per case | Irina, 2026-08-24 |
+| D2 | The frontier mark is "Pareto-frontier SOTA"; absolute SOTA stays the highest score, a separate mark | Irina, 2026-08-24 |
+| D3 | Imported baselines are **excluded** | Irina, 2026-08-24 |
+| D4 | 3D charts are **out of scope** here — `OME-923` covers accuracy vs cost only; `OME-324` keeps 3D | Irina, 2026-08-24 |
+| D5 | New identifiers must **qualify** — `frontier.py`, `compute_frontier`, `FrontierPoint`, `FrontierResult` are `OME-323`'s and keep their meaning | ticket |
+| D7 | **Standard Pareto dominance**, not the ticket's literal wording. A row is dominated when another is at-least-as-good on both axes and strictly better on one. The ticket says "no other has **both** a higher score **and** a lower cost", which read strictly would keep a row scoring the same at 9x the cost — indefensible on a "best score for the money" board. Exact ties on both axes still both qualify, which is what the ticket's "ties both qualify" line means. | owner, 2026-08-29 |
+| D8 | Returns `frozenset[str]` of `spec_id`. Robust to the re-sorting the ranking route does; safe because `leaderboard()` collapses to best-per-spec. **INVARIANT: not for `list_owned_entries()`**, which deliberately does not collapse. | owner, 2026-08-29 |
+| D6 | A null cost is **excluded, never zero**; exclusion follows the missing value, so a row joins automatically if cost is populated later | ticket + `OME-770` |
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/pareto.py` — new, the pure function
+- `apps/scoreboard/tests/test_pareto.py` — new, the tests that carry this unit
+
+No schema change, no migration, no route change, no store change in part A. `tortoise-dev`'s
+`when` condition (models/querysets/migrations/transactions/signals/lifespan) does **not** match
+this unit — it is a pure function over already-fetched schemas.
+
+## Test plan
+
+RED first. The invariant under test is D6: **a null cost never reads as zero and never wins.**
+
+- Empty input → empty frontier.
+- Single priced row → that row.
+- Strictly dominated row (lower score AND higher cost) → excluded.
+- Cheaper-but-worse and dearer-but-better → **both** on the frontier.
+- Equal score, different cost → the cheaper one only.
+- Equal cost, different score → the higher-scoring one only.
+- Exact tie on both score and cost → **both** qualify (D6 ties).
+- Null cost alongside priced rows → excluded, and never treated as 0 even when it holds the
+  top score.
+- **All** rows null cost → empty frontier, no error (the board-with-no-cost-data case).
+- A zero cost is a real value, distinct from null, and can win.
+
+## Acceptance
+
+- The frontier is correct for ties, domination, and excluded null-cost rows, unit-tested with
+  no database.
+- `OME-323`'s open/closed frontier keeps its name, endpoint and meaning — untouched.
+- Full `scoreboard` gates green.
+
+## Outcome
+
+- **Actual files:** exactly as planned — `scores/pareto.py` and `tests/unit/scores/test_pareto.py`
+  added, nothing modified. No schema, migration, route or store change, so `tortoise-dev`'s
+  `when` never matched and stack rule S1 is satisfied vacuously.
+- **Gates:** ALL GREEN — append-only check, ruff check, ruff format, pyright (no `type: ignore`),
+  pytest `--cov-fail-under=80`, and the Node portal test. Suite 518 → **529 passed**, 3 skipped.
+- **Mutation-checked, both guards, re-verified after the formatter rewrote `_dominates`:**
+  reading a null cost as `0` fails 3 tests; the ticket's literal strict-both dominance fails 3
+  tests. Source restored byte-for-byte after each.
+- **Blast radius: zero.** Nothing imports `pareto.py` yet — part B wires it. `frontier.py`,
+  `compute_frontier`, `FrontierPoint` and `FrontierResult` are untouched, so `OME-323` keeps its
+  name, endpoint and meaning.
+- **Deviations:**
+  1. **No `docs/spec/` or `docs/plan/` artifact.** The ticket body carries the spec and Irina's
+     2026-08-24 comment locks every open decision, so a separate spec would have duplicated the
+     issue — which `task-management` explicitly forbids ("they cross-reference, never duplicate").
+     The ledger carries the plan. Matches the `OME-1029` precedent, a comparable single-function
+     unit that shipped ledger-only; specs/plans here are reserved for design-heavy units
+     (`OME-901`, `OME-1004`, `OME-986`). Flagged rather than skipped silently.
+  2. **D7 contradicts the ticket's literal wording** and was escalated rather than assumed. See
+     the decision table.
+
+## Still gated — do NOT merge parts B or C on this branch
+
+Part B (marking rows) and part C (the accuracy-vs-cost chart) must wait for real cost data:
+`OME-1029` (PR #770) merged, a client release carrying it, and a submission that reports a cost.
+Every `run_cost_usd` on the live board is null today, so B would render a frontier of nothing and
+C would chart an empty axis. Part A is safe to merge alone precisely because nothing calls it.

--- a/docs/work/2026-08-29-OME-923-pareto-frontier-compute.md
+++ b/docs/work/2026-08-29-OME-923-pareto-frontier-compute.md
@@ -33,7 +33,9 @@ data flows.
 | D4 | 3D charts are **out of scope** here — `OME-923` covers accuracy vs cost only; `OME-324` keeps 3D | Irina, 2026-08-24 |
 | D5 | New identifiers must **qualify** — `frontier.py`, `compute_frontier`, `FrontierPoint`, `FrontierResult` are `OME-323`'s and keep their meaning | ticket |
 | D7 | **Standard Pareto dominance**, not the ticket's literal wording. A row is dominated when another is at-least-as-good on both axes and strictly better on one. The ticket says "no other has **both** a higher score **and** a lower cost", which read strictly would keep a row scoring the same at 9x the cost — indefensible on a "best score for the money" board. Exact ties on both axes still both qualify, which is what the ticket's "ties both qualify" line means. | owner, 2026-08-29 |
-| D8 | Returns `frozenset[str]` of `spec_id`. Robust to the re-sorting the ranking route does; safe because `leaderboard()` collapses to best-per-spec. **INVARIANT: not for `list_owned_entries()`**, which deliberately does not collapse. | owner, 2026-08-29 |
+| D12 | **Rows are compared only within one `benchmark_revision`**, and the key is `(spec_id, benchmark_revision)`. Supersedes D8. Raised in review of PR #778. | owner, 2026-08-29 |
+| D13 | The caller must pass the **whole ranked set**, never a truncated page. Documented as an `AIDEV-NOTE`; enforced by the only caller, part B. Raised in review of PR #778. | owner, 2026-08-29 |
+| D8 | ~~Returns `frozenset[str]` of `spec_id`~~ — **superseded by D12**. Original text: Robust to the re-sorting the ranking route does; safe because `leaderboard()` collapses to best-per-spec. **INVARIANT: not for `list_owned_entries()`**, which deliberately does not collapse. | owner, 2026-08-29 |
 | D6 | A null cost is **excluded, never zero**; exclusion follows the missing value, so a row joins automatically if cost is populated later | ticket + `OME-770` |
 
 ## Planned changes
@@ -97,3 +99,49 @@ Part B (marking rows) and part C (the accuracy-vs-cost chart) must wait for real
 `OME-1029` (PR #770) merged, a client release carrying it, and a submission that reports a cost.
 Every `run_cost_usd` on the live board is null today, so B would render a frontier of nothing and
 C would chart an empty axis. Part A is safe to merge alone precisely because nothing calls it.
+
+
+## Review response — PR #778 (2026-08-29)
+
+Two P2 findings, both verified against the query before acting on them. Both were correct.
+
+### 1. The revision must be preserved and partitioned on — CONFIRMED, reproduced
+
+`_build_leaderboard_query` partitions its window by `(spec_id, benchmark_revision)` and applies
+the revision filter **only** when the benchmark has a registered revision:
+
+```python
+if registered_revision is not None:
+    ranked = ranked.where(scores.benchmark_revision == registered_revision)
+```
+
+I had checked that `leaderboard()` collapses best-per-spec, but only on the registered-revision
+path. On the other branch — the legacy boards the code's own AIDEV-NOTE names — nothing is
+filtered, so a spec appears once per revision and D8's `INVARIANT: one row per spec_id` was
+false. Reproduced before fixing: a row beaten on **both** axes was marked, because it inherited
+the mark its own spec earned on a different revision.
+
+Fixed per D12. Note the deliberate consequence, pinned by
+`test_a_lone_priced_row_on_a_revision_is_that_revisions_frontier`: a revision with a single
+priced row marks that row, since it is trivially the best value available on that revision. The
+two rows were never comparable, which is why the cohorts exist.
+
+### 2. Boundary score ties at the `top_n` cutoff — CONFIRMED, documented here, enforced in part B
+
+`leaderboard()` ends `.orderby(ranked.score, order=Order.desc).limit(top_n)` — cost never enters
+the ordering. A row just past the cutoff can tie the boundary score at a lower cost and dominate
+a visible row it was never compared against, so the frontier would change with `top`.
+
+One refinement to the report: this bites **only** on an exact score tie. Rows past the cutoff
+have score ≤ the boundary and dominance requires score ≥, so a strictly-lower-scoring omission is
+harmless. The reviewer's 51-equal-scores example is the reachable case.
+
+A pure function cannot defend against what it was not given, so part A carries the contract as an
+`AIDEV-NOTE` (D13) and **part B, the only caller, fetches the full ranked set**. Not reachable on
+today's data — real boards hold ~6 rows against a cutoff of 50 — but wrong by the ticket's own
+wording ("no other submission on the same board"), independent of row counts.
+
+### Gates after the fix
+
+ALL GREEN, append-only included. 17 unit tests on this module (11 → 17). Mutation-checked:
+collapsing every revision into one cohort fails; dropping the revision from the key fails.


### PR DESCRIPTION
Part **A only** of [OME-923](https://linear.app/openmined/issue/OME-923) — the pure function
deciding which submissions hold the "best score for the money" claim.

**This does not close OME-923.** Parts B (mark rows) and C (accuracy-vs-cost chart) remain, and
are gated: every `run_cost_usd` on the live board is null today, so B would render a frontier of
nothing. The ticket's own gate allows A against fixtures now. Part A is safe to merge alone
because nothing imports it yet.

## Two decisions that differ from a literal reading of the ticket

Both were escalated to the owner rather than assumed.

1. **Standard Pareto dominance**, not the ticket's *"no other has **both** a higher score **and**
   a lower cost"*. Read strictly, that keeps a row scoring the same at nine times the price,
   because nobody outscored it — indefensible on a board claiming best value. Exact ties on both
   axes still both qualify, which is what the ticket's "ties both qualify" line means.
2. **Returns `frozenset[tuple[str, str | None]]`, keyed on `(spec_id, benchmark_revision)`**,
   which survives the re-sorting the ranking route does. Rows are compared only within one
   revision — a benchmark with no registered revision filters nothing and ranks one row per
   `(spec_id, revision)`, and `OME-775` exists because those numbers are not comparable.

Irina's 2026-08-24 comment on the ticket settled the other four open questions: cost is the whole
run, baselines are excluded, the frontier mark is "Pareto-frontier SOTA" distinct from absolute
SOTA, and 3D charts stay in OME-324.

## Naming

`pareto.py` / `compute_pareto_frontier`, deliberately not `frontier` anything — OME-323's
open/closed frontier owns `frontier.py`, `compute_frontier`, `FrontierPoint` and `FrontierResult`
and keeps its name, endpoint and meaning. That file is untouched.

## Test plan

11 new tests, no DB. Empty input · lone entry · strict domination · genuine tradeoff (both
qualify) · equal score (cheaper wins) · equal cost (higher score wins) · exact tie (both) ·
unpriced excluded at top score · unpriced never dominates a priced row · all-null board yields
empty without error · zero cost is real and can win.

**Mutation-checked**, re-verified after the formatter rewrote `_dominates`:

| Reverted guard | Result |
|---|---|
| null cost read as `0` | 3 tests fail |
| ticket's literal strict-both dominance | 3 tests fail |

Gates all green: append-only, ruff, ruff format, pyright (no `type: ignore`), pytest
`--cov-fail-under=80`, Node portal test. Suite 518 → **529 passed**, 3 skipped.

Ledger: `docs/work/2026-08-29-OME-923-pareto-frontier-compute.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MJnetigGbLfyz6hLiGkij



---

## Updated after review (2026-08-31)

Two P2 findings were raised and both were confirmed against `_build_leaderboard_query` before
acting, then fixed in `61dcd464`:

- **Revision keying.** The bare `spec_id` key was wrong on any benchmark with no registered
  revision: the board filters nothing there, so one spec appears once per revision and a row
  beaten on BOTH axes inherited the mark its own spec earned elsewhere. Reproduced first. Now
  keyed on `(spec_id, benchmark_revision)`, with comparisons partitioned by revision.
- **`top_n` truncation.** `leaderboard()` orders by score alone before truncating, so a row past
  the cutoff can tie the boundary score at a lower cost and dominate a visible row. This module
  carries the contract as an `AIDEV-NOTE`; part B honours it by reading the board whole.

Thanks for catching the stale wording — the task mirror and the section above now match the
implementation. Both said `frozenset[str]`, which is exactly the regression not to reintroduce.

Tests 11 → 17. Mutation-checked: collapsing every revision into one cohort fails; dropping the
revision from the key fails.