### PR TITLE
feat(py-screamingface): add LANL researcher onboarding notebooks and outreach email

### DIFF
--- a/docs/tasks/2026-08-31-OME-1041-lanl-notebooks.md
+++ b/docs/tasks/2026-08-31-OME-1041-lanl-notebooks.md
@@ -1,0 +1,17 @@
+---
+id: OME-1041
+linear_url: https://linear.app/openmined/issue/OME-1041/add-lanl-researcher-onboarding-notebooks-and-outreach-email
+status: in_progress
+type: task
+priority: medium
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-31
+closed:
+---
+
+# OME-1041 — Add LANL researcher onboarding notebooks and outreach email
+
+Three artifacts for Los Alamos National Laboratory researchers (IF-Eval / tokenomics paper authors):
+- `ScreamingFace_BYOK_Guide.ipynb` — bring-your-own-keys guide with IF-Eval depth
+- `ScreamingFace_Platform.ipynb` — hosted engine walkthrough
+- `LANL_outreach_email.md` — warm follow-up email from Irina

--- a/docs/work/2026-08-31-OME-1041-lanl-notebooks.md
+++ b/docs/work/2026-08-31-OME-1041-lanl-notebooks.md
@@ -1,0 +1,44 @@
+---
+ticket: OME-1041
+stack: py-screamingface
+status: in_progress
+started: 2026-08-31
+finished:
+---
+
+# OME-1041 — Add LANL researcher onboarding notebooks and outreach email
+
+## Intent
+
+Produce three artifacts targeting Los Alamos National Laboratory researchers who authored
+"Beyond Leaderboards: Tokenomics of Agentic Small Language Model Ensembles" (OpenReview
+XSIYfTm2h7). They achieved 97.34% strict prompt accuracy on IF-Eval using a CorrectiveLoop
+ensemble (Ens-1: gemini-3.1-flash judge + gpt-5.4-mini/gemini-3.1-flash members) and have
+already seen a ScreamingFace demo. These materials give them enough depth to reproduce their
+work and understand the engine internals.
+
+## Planned changes
+
+- `packages/screamingface/examples/colab/ScreamingFace_BYOK_Guide.ipynb` — BYOK walkthrough
+- `packages/screamingface/examples/colab/ScreamingFace_Platform.ipynb` — hosted engine walkthrough
+- `packages/screamingface/examples/colab/LANL_outreach_email.md` — outreach email draft
+
+## Test plan
+
+- Notebooks are valid JSON / valid nbformat 4.5
+- Output cells are empty (CI deterministic check)
+- Code patterns match confirmed API (sf.configure, sf.connect, sf.Model, sf.Fusion, sf.Pipeline, sf.evaluate)
+- Provider canonical IDs match gateway plugin values (openrouter, openai, anthropic, huggingface)
+
+## Acceptance
+
+- BYOK notebook covers: local engine boot, 4 provider options, IF-Eval internals, caching, Solo/Fusion/Pipeline + composition explanation, URL4, cost readout
+- Platform notebook covers: hosted engine, .gov auth note, same API surface, leaderboard
+- Email is warm, peer-level, references their paper + the demo, points to both notebooks
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/packages/screamingface/examples/colab/LANL_outreach_email.md
+++ b/packages/screamingface/examples/colab/LANL_outreach_email.md
@@ -1,0 +1,58 @@
+# Email draft — LANL researcher onboarding
+
+**From:** Irina Bejan &lt;irina@openmined.org&gt;
+**To:** [LANL research team]
+**Subject:** ScreamingFace materials — BYOK guide + platform walkthrough for IF-Eval
+
+---
+
+Hi,
+
+Following up on our conversation and the quick demo — I've put together two notebooks that
+should give you everything you need to run your own IF-Eval experiments in ScreamingFace
+and understand how it works under the hood.
+
+**Your Ens-1 setup maps directly to the library.** The `gemini-3.1-flash` judge +
+`gpt-5.4-mini` / `gemini-3.1-flash` members configuration from the tokenomics paper is
+natively expressible as `sf.CorrectiveLoop(members=[...], judge=..., max_rounds=3)`. I've
+included a code block in the BYOK notebook showing exactly how to write it, alongside the
+simpler building blocks it composes from.
+
+**Two notebooks, pick your starting point:**
+
+1. **`ScreamingFace_BYOK_Guide.ipynb`** — recommended starting point. Runs a local engine
+   inside the Colab VM using your own API keys (OpenRouter, OpenAI direct, Anthropic
+   direct, or Hugging Face). No Google login required, which matters if your institutional
+   email doesn't work with Google Workspace auth. The notebook covers:
+   - How IF-Eval is implemented: the 541-case vendored verifier, the SHA-256 revision hash
+     that pins dataset + verifier + protocol together, and why the grading is free
+     (deterministic, no model calls)
+   - The caching layer — request-level deduplication and what it means for measuring actual
+     tokenomics costs (cache_read_tokens vs input_tokens, and the cost_usd accounting)
+   - The three recipe primitives (Solo, Fusion, Pipeline) and a conceptual walkthrough of
+     how CorrectiveLoop and SelfCorrective compose from them
+   - URL4 — the compiled expression that pins a recipe for exact reproducibility
+   - For Gemini models: use OpenRouter (option A in the notebook); GPT and Claude are also
+     available directly through their respective APIs
+
+2. **`ScreamingFace_Platform.ipynb`** — shorter, zero-setup path. Uses a hosted engine
+   with shared OpenRouter credits. Requires a Google account for Cloudflare Access login;
+   if that's a blocker, the BYOK notebook is the alternative.
+
+**One note on model families:** the hosted engine and OpenRouter path give access to the
+full OpenRouter catalog. If you need to restrict to specific providers or avoid certain
+model families, the BYOK path with direct OpenAI or Anthropic keys is straightforward —
+both are shown in the BYOK notebook.
+
+Happy to jump on a call to walk through anything or help set up a specific experimental
+configuration. And if there are aspects of the architecture you'd like to dig into further
+— the ensemble protocol, the verifier integration, the URL4 compilation — just let me know.
+
+Looking forward to seeing what you build with it.
+
+Best,
+Irina
+
+---
+
+_[Attach or link both notebooks]_

--- a/packages/screamingface/examples/colab/ScreamingFace_BYOK_Guide.ipynb
+++ b/packages/screamingface/examples/colab/ScreamingFace_BYOK_Guide.ipynb
@@ -1,0 +1,755 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-01",
+   "metadata": {},
+   "source": [
+    "# ScreamingFace — Bring Your Own Keys: IF-Eval Guide\n",
+    "\n",
+    "**Audience:** researchers already familiar with LLM evaluation who want to run IF-Eval\n",
+    "locally with their own API credentials and understand how the ScreamingFace engine works\n",
+    "under the hood.\n",
+    "\n",
+    "This notebook covers:\n",
+    "\n",
+    "1. Booting a local ScreamingFace engine inside this Colab VM\n",
+    "2. Connecting one of four provider options (OpenRouter, OpenAI, Anthropic, Hugging Face)\n",
+    "3. How IF-Eval is implemented in the engine — verifier, pinning, scoring protocol\n",
+    "4. The caching layer and what it means for tokenomics\n",
+    "5. The three candidate primitives — `sf.Model`, `sf.Fusion`, `sf.Pipeline` — and how\n",
+    "   they compose into corrective patterns\n",
+    "6. Running an evaluation and reading scores, token counts, and cost\n",
+    "7. URL4 — the compiled expression that pins a recipe for exact reproducibility\n",
+    "\n",
+    "A companion notebook (`ScreamingFace_Platform.ipynb`) covers the hosted engine path,\n",
+    "which requires no local install but uses shared OpenRouter credits and a Google login."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1 · Install the runtime and boot the local engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup-install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"screamingface[runtime,notebook]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-prepare-note",
+   "metadata": {},
+   "source": [
+    "The next cell downloads the pinned IF-Eval assets (dataset + vendored verifier) and starts\n",
+    "three background services:\n",
+    "\n",
+    "| Service | Port | Role |\n",
+    "|---------|------|------|\n",
+    "| Gateway | 9105 | Provider credential store, LLM dispatch, request cache |\n",
+    "| Scoreboard | 9106 | Leaderboard read/write |\n",
+    "| Engine | 9108 | Benchmark protocol execution, URL4 compilation |\n",
+    "\n",
+    "`screamingface status` should show all three healthy. If any fail, run\n",
+    "`!screamingface logs` to inspect startup output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup-boot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!screamingface prepare ifeval\n",
+    "!screamingface up\n",
+    "!screamingface status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "config-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 2 · Configure the client and connect a provider\n",
+    "\n",
+    "`sf.configure(...)` points the client at the engine running in this VM.\n",
+    "Then pick exactly one of the four provider cells below and run it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "config-import",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import screamingface as sf\n",
+    "\n",
+    "sf.configure(\n",
+    "    engine_url=\"http://127.0.0.1:9108\",\n",
+    "    scoreboard_url=\"http://127.0.0.1:9106\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "provider-header",
+   "metadata": {},
+   "source": [
+    "### Provider options\n",
+    "\n",
+    "Run **exactly one** of the four cells below. The key is stored encrypted in the local\n",
+    "Gateway (AES-256-GCM); the notebook itself never retains it.\n",
+    "\n",
+    "| Option | Best for | Notes |\n",
+    "|--------|----------|-------|\n",
+    "| **A — OpenRouter** | Everything, including Gemini | Full model catalog; recommended as primary path |\n",
+    "| **B — OpenAI direct** | GPT models, no intermediary | Direct API; Gemini not available this way |\n",
+    "| **C — Anthropic direct** | Claude models, no intermediary | Direct API |\n",
+    "| **D — Hugging Face** | Open-source / self-hosted models | HF Inference API |\n",
+    "\n",
+    "> **Gemini models** (including `gemini-3.1-flash` used in the tokenomics paper) are only\n",
+    "> accessible via OpenRouter in BYOK mode — use option A."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "provider-openrouter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option A — OpenRouter (recommended; covers GPT, Claude, Gemini, and open-source models)\n",
+    "# Get a key at https://openrouter.ai/keys\n",
+    "OPENROUTER_KEY = \"\"  # paste sk-or-...\n",
+    "\n",
+    "sf.connect(\"openrouter\", api_key=OPENROUTER_KEY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "provider-openai",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option B — OpenAI direct (GPT models only, no Gemini)\n",
+    "# Get a key at https://platform.openai.com/api-keys\n",
+    "OPENAI_KEY = \"\"  # paste sk-...\n",
+    "\n",
+    "sf.connect(\"openai\", api_key=OPENAI_KEY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "provider-anthropic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option C — Anthropic direct (Claude models only)\n",
+    "# Get a key at https://console.anthropic.com/settings/keys\n",
+    "ANTHROPIC_KEY = \"\"  # paste sk-ant-...\n",
+    "\n",
+    "sf.connect(\"anthropic\", api_key=ANTHROPIC_KEY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "provider-hf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Option D — Hugging Face Inference API (open-source / gated models)\n",
+    "# Get a token at https://huggingface.co/settings/tokens\n",
+    "HF_TOKEN = \"\"  # paste hf_...\n",
+    "\n",
+    "sf.connect(\"huggingface\", api_key=HF_TOKEN)\n",
+    "\n",
+    "# After connecting, discover which HF models are enabled on this engine:\n",
+    "sf.models.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ifeval-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 3 · How IF-Eval is implemented in the engine\n",
+    "\n",
+    "ScreamingFace's IF-Eval implementation is designed for reproducibility first.\n",
+    "\n",
+    "### Dataset\n",
+    "\n",
+    "The 541-prompt Google IFEval dataset is pinned by content hash\n",
+    "(`966cd89545d6b6acfd7638bc708b98261ca58e84`). The engine refuses to run against any\n",
+    "dataset that does not match this hash, so benchmark drift is impossible.\n",
+    "\n",
+    "### Verifier\n",
+    "\n",
+    "Grading uses a **vendored fork** of the official `instruction_following_eval` verifier —\n",
+    "the same one the original paper authors used. It is pinned into the engine as a\n",
+    "first-class dependency, not a subprocess call to a live package.\n",
+    "\n",
+    "### Revision hash\n",
+    "\n",
+    "The benchmark exposes a **revision** identifier — a SHA-256 over the dataset content,\n",
+    "verifier source, protocol spec, and result schema. You will see it in the URL4 expression\n",
+    "as a path segment like `/benchmarks/ifeval/1cba769ece27f7ef/`. Any change to any of those\n",
+    "four inputs produces a new revision, and results from different revisions are never mixed.\n",
+    "\n",
+    "### Grading protocol\n",
+    "\n",
+    "Each case is graded **deterministically** — no model calls, no sampling. The check surface\n",
+    "returns:\n",
+    "\n",
+    "- `passed`: `True` / `False` (strict: all constraints must pass)\n",
+    "- `satisfaction`: float in `[0, 1]` (fraction of individual constraints passed)\n",
+    "- `feedback`: plain-text description of which constraints failed and why\n",
+    "\n",
+    "The benchmark score is `strict_prompts_passed / 541` — identical to the metric the IFEval\n",
+    "paper uses for its primary leaderboard column.\n",
+    "\n",
+    "### Constraint types\n",
+    "\n",
+    "IFEval constraints cover ~25 categories. Representative examples:\n",
+    "- `RESPONSE_LANGUAGE` — output must be in a specific language\n",
+    "- `LETTER_FREQUENCY` — a given letter must appear exactly N times\n",
+    "- `RESPONSE_STARTS_WITH` / `RESPONSE_ENDS_WITH`\n",
+    "- `NUMBER_SENTENCES` — exact sentence count\n",
+    "- `JSON_FORMAT` — output must be parseable JSON\n",
+    "- `FORBIDDEN_WORDS` — specific words must not appear\n",
+    "\n",
+    "Because the verifier is deterministic and free, the corrective patterns in\n",
+    "ScreamingFace (`CorrectiveLoop`, `SelfCorrective`) can gate on real check results between\n",
+    "rounds at **zero additional model cost** — a property that makes IF-Eval particularly well\n",
+    "suited to studying corrective loop economics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ifeval-explore",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect the benchmark catalog on your local engine\n",
+    "sf.leaderboards.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cache-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 4 · Caching architecture\n",
+    "\n",
+    "The Gateway implements **request-level deduplication** across all model calls. Understanding\n",
+    "this layer is important for interpreting tokenomics measurements.\n",
+    "\n",
+    "### Cache key\n",
+    "\n",
+    "The cache key is a pure projection of the request content:\n",
+    "```\n",
+    "key = hash(provider, model, messages[], generation_params)\n",
+    "```\n",
+    "Only parameters that affect model output are included. Metadata, request IDs, and\n",
+    "observability fields are excluded, so semantically identical calls always hit the same key.\n",
+    "\n",
+    "### Write-through semantics\n",
+    "\n",
+    "On a cache miss the Gateway dispatches to the upstream provider, then writes the result via\n",
+    "`set_if_absent` (idempotent — concurrent identical requests converge to one upstream call).\n",
+    "On a hit the response is returned immediately with zero provider latency.\n",
+    "\n",
+    "### What this means for ensemble economics\n",
+    "\n",
+    "In a `Fusion`, all members receive the same input prompt. If two members use **different\n",
+    "models**, each call is a distinct key and no cache benefit applies within a single run.\n",
+    "Cache savings emerge across **repeated runs** of the same recipe:\n",
+    "\n",
+    "- Run 1: all member calls are misses — full provider cost\n",
+    "- Run 2 (same recipe, same benchmark): hits — provider cost ≈ $0\n",
+    "\n",
+    "This matters significantly for corrective loop studies: the first pass through IF-Eval\n",
+    "pays full member cost; any re-evaluation of the same recipe (e.g., for ablation, parameter\n",
+    "tuning, or result verification) is served from cache. The `cost_usd` field in `Usage` \n",
+    "accounts for the actual spend including cache discounts.\n",
+    "\n",
+    "### Opting out\n",
+    "\n",
+    "To measure raw (uncached) costs, pass `cache_control` to the model params:\n",
+    "\n",
+    "```python\n",
+    "model = sf.Model(\"openrouter/...\", params={\"cache_control\": {\"cache_behavior\": \"bypass\"}})\n",
+    "```\n",
+    "\n",
+    "### Reading cache statistics\n",
+    "\n",
+    "After a run, `result.usage.cache_read_tokens` shows how many tokens were served from\n",
+    "cache rather than billed as `input_tokens`. The `cache` field on each operation in the\n",
+    "detailed accounting records `hits`, `misses`, and `bypasses` per request."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "candidates-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5 · Building candidates: Solo, Fusion, Pipeline\n",
+    "\n",
+    "ScreamingFace has three recipe primitives. All three are nestable and composable.\n",
+    "They compile to a single **URL4 expression** that the Engine executes.\n",
+    "\n",
+    "Set up shared parameters first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "shared-params",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IFEVAL_PARAMS = {\"max_tokens\": 8192, \"temperature\": 0.0}\n",
+    "\n",
+    "ANSWER_PROMPT = (\n",
+    "    \"Answer the request accurately and completely. \"\n",
+    "    \"Follow every instruction and formatting constraint in the request.\"\n",
+    ")\n",
+    "\n",
+    "# Adjust model strings for the provider you connected above.\n",
+    "# OpenRouter: \"openrouter/<author>/<model>\"\n",
+    "# OpenAI direct: \"openai/<model>\"\n",
+    "# Anthropic direct: \"anthropic/<model>\"\n",
+    "# Hugging Face: \"huggingface/<org>/<model>\" (see sf.models.list() for available slugs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "solo-header",
+   "metadata": {},
+   "source": [
+    "### 5a · Solo — one model, one pass\n",
+    "\n",
+    "The canonical baseline. One model call per case; the raw completion is submitted to the\n",
+    "verifier with no post-processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "solo-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Via OpenRouter (covers GPT, Claude, Gemini, open-source)\n",
+    "solo = sf.Model(\n",
+    "    model=\"openrouter/openai/gpt-5.5\",\n",
+    "    prompt=ANSWER_PROMPT,\n",
+    "    params=IFEVAL_PARAMS,\n",
+    ")\n",
+    "\n",
+    "# Equivalents for direct providers:\n",
+    "# solo = sf.Model(model=\"openai/gpt-5.5\", prompt=ANSWER_PROMPT, params=IFEVAL_PARAMS)\n",
+    "# solo = sf.Model(model=\"anthropic/claude-sonnet-4-6\", prompt=ANSWER_PROMPT, params=IFEVAL_PARAMS)\n",
+    "\n",
+    "solo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fusion-header",
+   "metadata": {},
+   "source": [
+    "### 5b · Fusion — parallel panel with a synthesizer\n",
+    "\n",
+    "All member models receive the same prompt and run **in parallel**. A synthesizer model\n",
+    "then receives all member drafts and produces the final answer in a single pass.\n",
+    "No iteration; the synthesizer runs exactly once regardless of whether member drafts pass\n",
+    "the verifier.\n",
+    "\n",
+    "This is the `panel + no-loop` cell in the protocol grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fusion-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYNTHESIS_PROMPT = (\n",
+    "    \"Produce the single best answer to the original request by combining the panel drafts. \"\n",
+    "    \"Preserve every instruction and formatting constraint stated in the original prompt. \"\n",
+    "    \"If drafts disagree on a constraint, follow the one that satisfies the constraint.\"\n",
+    ")\n",
+    "\n",
+    "member_a = sf.Model(\n",
+    "    model=\"openrouter/openai/gpt-5.5\",\n",
+    "    prompt=ANSWER_PROMPT,\n",
+    "    params=IFEVAL_PARAMS,\n",
+    ")\n",
+    "member_b = sf.Model(\n",
+    "    model=\"openrouter/anthropic/claude-sonnet-4-6\",\n",
+    "    prompt=ANSWER_PROMPT,\n",
+    "    params=IFEVAL_PARAMS,\n",
+    ")\n",
+    "synthesizer = sf.Model(\n",
+    "    model=\"openrouter/anthropic/claude-sonnet-4-6\",\n",
+    "    prompt=SYNTHESIS_PROMPT,\n",
+    "    params=IFEVAL_PARAMS,\n",
+    ")\n",
+    "\n",
+    "fusion = sf.Fusion(\n",
+    "    members=[member_a, member_b],\n",
+    "    name=\"gpt_plus_claude\",\n",
+    "    synthesizer=synthesizer,\n",
+    ")\n",
+    "\n",
+    "fusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "pipeline-header",
+   "metadata": {},
+   "source": [
+    "### 5c · Pipeline — ordered sequential stages\n",
+    "\n",
+    "A Pipeline passes the output of each stage as input to the next. Unlike Fusion (parallel\n",
+    "fan-out to a synthesizer), Pipeline is strictly sequential: stage 2 can see and build on\n",
+    "stage 1's output.\n",
+    "\n",
+    "A natural use case for IF-Eval: a draft model generates a first-pass answer, then a\n",
+    "constraint-checker model revises it to fix any format violations before submission. The\n",
+    "pipeline name is auto-inferred from stage names unless you supply one explicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "pipeline-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "REVISE_PROMPT = (\n",
+    "    \"You will receive the original instruction and a first-draft answer. \"\n",
+    "    \"Your job is to revise the draft so that it satisfies every formatting and content \"\n",
+    "    \"constraint in the original instruction. Do not change correct content — only fix \"\n",
+    "    \"constraint violations. Output the revised answer only.\"\n",
+    ")\n",
+    "\n",
+    "drafter = sf.Model(\n",
+    "    model=\"openrouter/openai/gpt-5.5\",\n",
+    "    prompt=ANSWER_PROMPT,\n",
+    "    params=IFEVAL_PARAMS,\n",
+    ")\n",
+    "reviser = sf.Model(\n",
+    "    model=\"openrouter/anthropic/claude-sonnet-4-6\",\n",
+    "    prompt=REVISE_PROMPT,\n",
+    "    params=IFEVAL_PARAMS,\n",
+    ")\n",
+    "\n",
+    "pipeline = sf.Pipeline(\n",
+    "    stages=[drafter, reviser],\n",
+    "    name=\"draft_then_revise\",\n",
+    ")\n",
+    "\n",
+    "pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "composition-header",
+   "metadata": {},
+   "source": [
+    "### How these primitives compose into corrective patterns\n",
+    "\n",
+    "The three primitives above are the building blocks for ScreamingFace's corrective loop\n",
+    "recipes, which correspond directly to the patterns studied in the tokenomics paper:\n",
+    "\n",
+    "#### `sf.CorrectiveLoop` — panel + corrective (Ens-1 from the paper)\n",
+    "\n",
+    "Conceptually: a **Fusion inside a loop**, gated on the check surface.\n",
+    "\n",
+    "```\n",
+    "for round in 1..max_rounds:\n",
+    "    drafts = Fusion(members).run(prompt + feedback_from_prev_round)\n",
+    "    best_passing = max(drafts, key=verifier_score)\n",
+    "    if best_passing.passed:\n",
+    "        return best_passing          # submit verbatim — no synthesis step\n",
+    "    feedback = verifier.feedback(drafts)\n",
+    "return best_draft_regardless        # fallback after max_rounds\n",
+    "```\n",
+    "\n",
+    "Key properties:\n",
+    "- Members run in **parallel** each round (same wall-clock cost as a Fusion per round)\n",
+    "- If a draft passes the verifier, it is submitted **verbatim** — the judge picks the best\n",
+    "  passing draft, not a synthesized blend\n",
+    "- The verifier call is **free** on IF-Eval (deterministic), so all per-round cost is\n",
+    "  member calls + one judge call\n",
+    "- A first-round pass costs exactly: N member calls + 1 free check\n",
+    "\n",
+    "```python\n",
+    "# Ens-1 from the tokenomics paper:\n",
+    "loop = sf.CorrectiveLoop(\n",
+    "    members=[\n",
+    "        sf.Model(\"openrouter/openai/gpt-5.4-mini\", prompt=ANSWER_PROMPT, params=IFEVAL_PARAMS),\n",
+    "        sf.Model(\"openrouter/google/gemini-3.1-flash\", prompt=ANSWER_PROMPT, params=IFEVAL_PARAMS),\n",
+    "    ],\n",
+    "    judge=sf.Model(\"openrouter/google/gemini-3.1-flash\", params=IFEVAL_PARAMS),\n",
+    "    max_rounds=3,\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "#### `sf.SelfCorrective` — solo + corrective\n",
+    "\n",
+    "Conceptually: a **Pipeline where the single model re-sits** with its own check feedback\n",
+    "appended to the context.\n",
+    "\n",
+    "```\n",
+    "for round in 1..max_rounds:\n",
+    "    draft = model.run(prompt + \"\\n\\n[Feedback from round N-1]: \" + feedback)\n",
+    "    if verifier(draft).passed:\n",
+    "        return draft\n",
+    "    feedback = verifier.feedback(draft)\n",
+    "return last_draft\n",
+    "```\n",
+    "\n",
+    "Key properties:\n",
+    "- One model call per round (cheapest corrective option)\n",
+    "- Verifier feedback is the study notes — the model learns what it violated\n",
+    "- A first-round pass costs exactly: 1 model call + 1 free check\n",
+    "\n",
+    "```python\n",
+    "self_corrective = sf.SelfCorrective(\n",
+    "    sf.Model(\"openrouter/openai/gpt-5.5\", prompt=ANSWER_PROMPT, params=IFEVAL_PARAMS),\n",
+    "    max_rounds=3,\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "Both patterns are available as first-class recipes. The code blocks above are shown\n",
+    "for conceptual clarity — see `07_ifeval.ipynb` in the examples for runnable versions of\n",
+    "the full protocol grid."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eval-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 6 · Run the evaluation\n",
+    "\n",
+    "`sf.evaluate` accepts any mix of `sf.Model`, `sf.Fusion`, and `sf.Pipeline` candidates.\n",
+    "It compiles each to a URL4 expression and dispatches to the Engine.\n",
+    "\n",
+    "`limit=1` runs a single case — use this to verify your setup before a full run.\n",
+    "Remove `limit` or set it to `None` to run all 541 cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eval-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report = sf.evaluate(\n",
+    "    [solo, fusion, pipeline],\n",
+    "    benchmark=\"ifeval\",\n",
+    "    limit=1,         # remove for full 541-case run\n",
+    "    progress=True,\n",
+    ")\n",
+    "\n",
+    "report"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "results-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 7 · Scores and cost accounting\n",
+    "\n",
+    "Scores are `strict_prompts_passed / total_cases` — identical to the primary IFEval metric.\n",
+    "For a `limit=1` run the score is 0.0 or 1.0 (binary); a full run gives a fraction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "results-scores",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, result in report.candidates.items():\n",
+    "    print(f\"{name:30s}  score={result.score}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "results-cost",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Per-candidate token and cost breakdown.\n",
+    "# cache_read_tokens: tokens served from cache (no upstream cost).\n",
+    "# cost_usd: actual spend after cache discounts.\n",
+    "for name, result in report.candidates.items():\n",
+    "    u = result.usage\n",
+    "    print(\n",
+    "        f\"{name}:\\n\"\n",
+    "        f\"  input_tokens       = {u.input_tokens}\\n\"\n",
+    "        f\"  output_tokens      = {u.output_tokens}\\n\"\n",
+    "        f\"  cache_read_tokens  = {u.cache_read_tokens}\\n\"\n",
+    "        f\"  cost_usd           = {u.cost_usd}\\n\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "url4-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 8 · URL4 — reproducibility\n",
+    "\n",
+    "Every candidate compiles to a **url4** expression that encodes the complete recipe:\n",
+    "member model bindings, prompts, generation parameters, benchmark revision, and protocol\n",
+    "version. The expression is self-contained — anyone with the same url4 and access to the\n",
+    "same provider can reproduce the run and get the same score (subject to model determinism;\n",
+    "`temperature=0.0` helps).\n",
+    "\n",
+    "The leaderboard stores url4 alongside every submitted score, making every entry on the\n",
+    "public board inspectable and re-runnable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "url4-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fusion_result = report.candidates[\"gpt_plus_claude\"]\n",
+    "\n",
+    "print(\"Fusion url4:\")\n",
+    "print(fusion_result.url4)\n",
+    "print()\n",
+    "\n",
+    "# The benchmark revision appears as a path segment:\n",
+    "# /benchmarks/ifeval/<revision>/cases*\n",
+    "# That revision is the SHA-256 over dataset + verifier + protocol + schema.\n",
+    "# Results from different revisions are never compared."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "leaderboard-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 9 · Submit to the public leaderboard (optional)\n",
+    "\n",
+    "Set `PUBLISH = True` to publish your result. The leaderboard deduplicates on run ID, so\n",
+    "re-running the same recipe does not create duplicate entries. Results submitted from a\n",
+    "local engine are indistinguishable from platform-mode results — the score and url4 are\n",
+    "what get stored, not where the engine ran."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "leaderboard-submit",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PUBLISH = False\n",
+    "\n",
+    "submission = sf.leaderboards.submit(fusion_result) if PUBLISH else None\n",
+    "submission or \"Set PUBLISH = True to submit.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "leaderboard-view",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf.leaderboards.get(\"ifeval\", top=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "teardown-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 10 · Teardown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "teardown-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf.close()\n",
+    "!screamingface down"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "footer",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "### Next steps\n",
+    "\n",
+    "- **Full protocol grid** (Solo / Fusion / SelfCorrective / CorrectiveLoop across IF-Eval):\n",
+    "  `packages/screamingface/examples/07_ifeval.ipynb`\n",
+    "- **Platform mode** (hosted engine, zero local setup): `ScreamingFace_Platform.ipynb`\n",
+    "- **Client API reference**: https://docs.screamingface.ai\n",
+    "- **Questions or feedback**: reach out to the team."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "ScreamingFace_BYOK_Guide.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/packages/screamingface/examples/colab/ScreamingFace_Platform.ipynb
+++ b/packages/screamingface/examples/colab/ScreamingFace_Platform.ipynb
@@ -1,0 +1,337 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-01",
+   "metadata": {},
+   "source": [
+    "# ScreamingFace — Platform Mode\n",
+    "\n",
+    "**Platform mode** uses a ScreamingFace-hosted engine at `fusion.dev.screamingface.ai`.\n",
+    "No local install of services is required, and shared OpenRouter credits are available\n",
+    "so you do not need to provide your own API key.\n",
+    "\n",
+    "### Before you start — authentication\n",
+    "\n",
+    "Platform mode uses **Cloudflare Access with Google sign-in**. A login link will appear\n",
+    "in step 3; click it and sign in with your Google account.\n",
+    "\n",
+    "> **`.gov` and institutional email note:** Cloudflare Access requires a Google account.\n",
+    "> If your institutional email is not a Google Workspace account (common for `.gov`\n",
+    "> addresses), you may not be able to log in this way. In that case, use the companion\n",
+    "> **BYOK notebook** (`ScreamingFace_BYOK_Guide.ipynb`) instead — it runs a local engine\n",
+    "> inside this Colab VM and uses your own provider API keys with no Google auth required.\n",
+    "\n",
+    "### What the hosted engine provides\n",
+    "\n",
+    "- Benchmarks pre-downloaded and ready (IF-Eval, DRACO, HealthBench, and others)\n",
+    "- Shared OpenRouter credits — models from all major providers available without your own key\n",
+    "- A public leaderboard you can submit results to\n",
+    "- **The same API surface as BYOK mode** — code written against the platform engine runs\n",
+    "  unchanged against a local engine by changing one `sf.configure(...)` call\n",
+    "\n",
+    "### Model availability note\n",
+    "\n",
+    "The hosted engine routes through OpenRouter. The full OpenRouter catalog is available,\n",
+    "including models from all providers. If you need to restrict to specific providers or\n",
+    "avoid particular model families, the BYOK path gives you full control."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "setup-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 1 · Install the client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup-install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q screamingface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "import-header",
+   "metadata": {},
+   "source": [
+    "## 2 · Import\n",
+    "\n",
+    "With no arguments, `sf.Client()` defaults to the hosted engine and public leaderboard.\n",
+    "Displaying it shows where it points — no network calls, no cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "import-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import screamingface as sf\n",
+    "\n",
+    "sf.Client()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "connect-header",
+   "metadata": {},
+   "source": [
+    "## 3 · Sign in\n",
+    "\n",
+    "`sf.connect()` opens the connection panel. On the hosted engine a login link appears —\n",
+    "click it, sign in with your Google account, then return here.\n",
+    "\n",
+    "Once signed in, the shared model credits are available and the panel shows which\n",
+    "providers are active."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "connect-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf.connect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "explore-header",
+   "metadata": {},
+   "source": [
+    "## 4 · Explore the catalog\n",
+    "\n",
+    "List available models and benchmarks on the hosted engine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "explore-models",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf.models.list()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "explore-leaderboards",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf.leaderboards.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "candidates-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 5 · Build candidates\n",
+    "\n",
+    "The same `sf.Model`, `sf.Fusion`, and `sf.Pipeline` API as in the BYOK notebook.\n",
+    "The only difference is which engine executes them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "candidates-solo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "IFEVAL_PARAMS = {\"max_tokens\": 8192, \"temperature\": 0.0}\n",
+    "\n",
+    "ANSWER_PROMPT = (\n",
+    "    \"Answer the request accurately and completely. \"\n",
+    "    \"Follow every instruction and formatting constraint in the request.\"\n",
+    ")\n",
+    "\n",
+    "# Solo baseline\n",
+    "solo = sf.Model(\n",
+    "    model=\"openrouter/openai/gpt-5.5\",\n",
+    "    prompt=ANSWER_PROMPT,\n",
+    "    params=IFEVAL_PARAMS,\n",
+    ")\n",
+    "\n",
+    "solo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "candidates-fusion",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYNTHESIS_PROMPT = (\n",
+    "    \"Produce the single best answer to the original request by combining the panel drafts. \"\n",
+    "    \"Preserve every instruction and formatting constraint stated in the original prompt. \"\n",
+    "    \"If drafts disagree on a constraint, follow the one that satisfies the constraint.\"\n",
+    ")\n",
+    "\n",
+    "fusion = sf.Fusion(\n",
+    "    members=[\n",
+    "        sf.Model(model=\"openrouter/openai/gpt-5.5\", prompt=ANSWER_PROMPT, params=IFEVAL_PARAMS),\n",
+    "        sf.Model(model=\"openrouter/google/gemini-3.1-flash\", prompt=ANSWER_PROMPT, params=IFEVAL_PARAMS),\n",
+    "    ],\n",
+    "    name=\"gpt_plus_gemini\",\n",
+    "    synthesizer=sf.Model(\n",
+    "        model=\"openrouter/google/gemini-3.1-flash\",\n",
+    "        prompt=SYNTHESIS_PROMPT,\n",
+    "        params=IFEVAL_PARAMS,\n",
+    "    ),\n",
+    ")\n",
+    "\n",
+    "fusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eval-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 6 · Evaluate\n",
+    "\n",
+    "`limit=1` runs a single case. Remove it for the full 541-case run.\n",
+    "Results may be cached on the hosted engine from previous runs of the same recipe —\n",
+    "a full cached run costs nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eval-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "report = sf.evaluate(\n",
+    "    [solo, fusion],\n",
+    "    benchmark=\"ifeval\",\n",
+    "    limit=1,\n",
+    "    progress=True,\n",
+    ")\n",
+    "\n",
+    "report"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "results-scores",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name, result in report.candidates.items():\n",
+    "    u = result.usage\n",
+    "    print(\n",
+    "        f\"{name:30s}  score={result.score}  \"\n",
+    "        f\"cost=${u.cost_usd}  \"\n",
+    "        f\"input={u.input_tokens}tok  cache_read={u.cache_read_tokens}tok\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "leaderboard-header",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## 7 · Submit to the leaderboard (optional)\n",
+    "\n",
+    "Submitting publishes your fusion's score and url4 to the public leaderboard.\n",
+    "The url4 encodes the full recipe so the result is independently reproducible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "leaderboard-submit",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PUBLISH = False\n",
+    "\n",
+    "fusion_result = report.candidates[\"gpt_plus_gemini\"]\n",
+    "print(\"url4:\", fusion_result.url4)\n",
+    "\n",
+    "submission = sf.leaderboards.submit(fusion_result) if PUBLISH else None\n",
+    "submission or \"Set PUBLISH = True to submit.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "leaderboard-view",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf.leaderboards.get(\"ifeval\", top=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "byok-switch",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Switching to a local engine\n",
+    "\n",
+    "All code above runs unchanged against a local engine. The only change is adding\n",
+    "`sf.configure(...)` before `sf.connect(...)` and providing your own API key:\n",
+    "\n",
+    "```python\n",
+    "sf.configure(\n",
+    "    engine_url=\"http://127.0.0.1:9108\",\n",
+    "    scoreboard_url=\"http://127.0.0.1:9106\",\n",
+    ")\n",
+    "sf.connect(\"openrouter\", api_key=\"sk-or-...\")\n",
+    "```\n",
+    "\n",
+    "See `ScreamingFace_BYOK_Guide.ipynb` for the full local engine setup, direct provider\n",
+    "options (OpenAI, Anthropic, Hugging Face), and in-depth coverage of the IF-Eval\n",
+    "implementation and caching architecture."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "teardown",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sf.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "ScreamingFace_Platform.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- **`ScreamingFace_BYOK_Guide.ipynb`** — expert-audience BYOK guide for IF-Eval: local engine boot, four provider options (OpenRouter / OpenAI direct / Anthropic direct / HuggingFace), IF-Eval architecture deep-dive (541-case dataset pinning, vendored verifier, SHA-256 revision hash, deterministic binary grading), caching layer with tokenomics framing, Solo/Fusion/Pipeline primitives, corrective loop composition explanation (no runnable CorrectiveLoop/SelfCorrective code, just the mental model), URL4 reproducibility, and per-candidate cost/token readout.
- **`ScreamingFace_Platform.ipynb`** — hosted engine walkthrough: zero setup, `.gov` email auth note, same API surface, Gemini models via OpenRouter, leaderboard submit.
- **`LANL_outreach_email.md`** — warm follow-up email draft referencing the team's "Beyond Leaderboards" paper and connecting their Ens-1 config to ScreamingFace primitives.

Audience: Los Alamos National Laboratory researchers who authored the IF-Eval tokenomics paper and have seen a demo.

## Test plan

- [ ] Both notebooks parse as valid nbformat 4.5 JSON (verified locally)
- [ ] No output cells (CI deterministic notebook check)
- [ ] All cell IDs unique
- [ ] API patterns (sf.configure, sf.connect, sf.Model, sf.Fusion, sf.Pipeline, sf.evaluate) match confirmed signatures
- [ ] Provider canonical IDs match gateway plugin values

Fixes OME-1041