### PR TITLE
fix(screamingface): stop logging prompts and make the runtime log private (OME-990)

### DIFF
--- a/docs/tasks/2026-08-25-OME-990-runtime-log-prompts.md
+++ b/docs/tasks/2026-08-25-OME-990-runtime-log-prompts.md
@@ -1,0 +1,40 @@
+---
+id: OME-990
+linear_url: https://linear.app/openmined/issue/OME-990/runtimelog-records-user-prompts-in-cleartext
+status: in_progress
+type: null
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-25
+closed:
+---
+
+# runtime.log records user prompts in cleartext
+
+A local run starts as `GET /?q=<url4 expression>`, and a url4 expression is prompt-bearing by
+construction. The local runtime served via uvicorn with `access_log` at its default `True`, so
+uvicorn's access line wrote the full query string — the user's prompt — into
+`~/.screamingface/runtime.log`, retained across 5 × 10 MiB rotations and tailed by
+`screamingface logs`. `runtime.log` was also written `0644` while `runtime.json` beside it is
+deliberately `0600`.
+
+Fix, in two parts:
+
+1. `access_log=False` in `_server()`, the shared factory for the gateway and the Engine. The
+   test asserts the **whole sweep** rather than one server: uvicorn clears the
+   `uvicorn.access` handlers only for the Config being constructed at that moment, and each
+   later Config re-runs `dictConfig` and re-creates them.
+2. `_open_private()` in `runtime_logging.py`, used by both the initial open and `_rotate`, so
+   the log is created `0600` and an existing world-readable log is tightened on reopen.
+
+**Necessary, not sufficient.** An adversarial review established that `runtime.log` is the
+process's entire stdout+stderr sink, that `uvicorn.error` still logs the WS path including
+`?ticket=<capability JWT>`, that rotated backups keep their old mode and contents, and that
+`LITELLM_LOG=DEBUG` turns the file into a full prompt transcript. Those are recorded as
+follow-ups in the ledger, not fixed here.
+
+First rung of the observability programme (epic `OME-935`), sequenced ahead of every
+tracing-wiring change because Phase 3 ends in "attach your logs to a report".
+
+Ledger: `docs/work/2026-08-31-OME-990-runtime-access-log-off.md`.
+PR: #780.

--- a/docs/work/2026-08-31-OME-990-runtime-access-log-off.md
+++ b/docs/work/2026-08-31-OME-990-runtime-access-log-off.md
@@ -30,8 +30,14 @@ One has a one-line fix and should land before anything else."
 - `packages/screamingface/src/screamingface/_runtime/server.py` — `_server()`, the shared
   factory booting the **gateway** and the **engine**: pass `access_log=False` to
   `uvicorn.Config`.
-- `packages/screamingface/tests/test_runtime_cli.py` — new test asserting *every* uvicorn
-  configuration the runtime builds disables access logging, without booting a server.
+- `packages/screamingface/src/screamingface/_runtime/runtime_logging.py` — `_open_private()`,
+  used by both `RuntimeLog.__init__` and `_rotate`, so the log is created `0600` **and** an
+  existing world-readable log is tightened on reopen. The Linear issue names this in its own
+  Verify line ("check the file mode while there") and calls the `0644`/`0600` split with
+  `runtime.json` an aggravating detail.
+- `packages/screamingface/tests/test_runtime_cli.py` — a test asserting *every* uvicorn
+  configuration the runtime builds disables access logging (without booting a server), plus
+  three file-mode tests (create, remediate-on-reopen, survive-rotation).
 
 **Not in this unit** — `run_scoreboard()` (`server.py:258`) also omits `access_log`, but it
 runs in a separate interpreter and its query strings are leaderboard filters (`?top=<int>`),
@@ -55,6 +61,8 @@ silently re-armed request logging for the whole process.
 
 - Every uvicorn server the client runtime starts in-process has access logging disabled.
 - A local run no longer writes `GET /?q=<expression>` access lines into `runtime.log`.
+- `runtime.log` is `0600` on creation, on reopen of an existing wider-moded file, and after
+  rotation.
 - No prior test modified; `run_gates.py screamingface` green (incl. `--cov-fail-under=95`).
 
 **Deliberately NOT claimed:** that `runtime.log` is free of prompt text. The adversarial
@@ -89,21 +97,29 @@ because litellm is imported *inside* the capture, so `LITELLM_LOG=DEBUG` turns t
 full prompt/completion transcript; and prompt text is embedded in url4/litellm exception
 *messages*, kept out today only by first-party discipline with no sink-level control.
 
-**Follow-ups to file** (none block this PR): chmod `runtime.log` `0600` + remediate existing
-backups; suppress the `uvicorn.error` WS ticket line; pin
-`litellm.redact_messages_in_exceptions` and neutralise `LITELLM_LOG` in the runtime env;
-install a redacting `setLogRecordFactory` for the capture's lifetime (aigateway already ships
-that pattern at `core/auth/log_filter.py:71-85`); `access_log=False` in `run_scoreboard()`.
+Finding 4 is **addressed in this unit** — `_open_private` creates the log `0600` and
+tightens an existing world-readable one on reopen — because the Linear issue asks for it
+directly. Its second half is not: **rotated backups** (`runtime.log.1` … `.5`) written by an
+earlier version keep their old mode until they rotate through, and no pass removes the
+prompts already inside them.
+
+**Follow-ups to file** (none block this PR): remediate existing rotated backups; suppress the
+`uvicorn.error` WS ticket line; pin `litellm.redact_messages_in_exceptions` and neutralise
+`LITELLM_LOG` in the runtime env; install a redacting `setLogRecordFactory` for the capture's
+lifetime (aigateway already ships that pattern at `core/auth/log_filter.py:71-85`);
+`access_log=False` in `run_scoreboard()`.
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:** as planned — `_runtime/server.py` (one `uvicorn.Config` call) and
-  `tests/test_runtime_cli.py` (one test + one helper, appended).
+- **Actual files:** `_runtime/server.py` (one `uvicorn.Config` call);
+  `_runtime/runtime_logging.py` (`_open_private` + both open sites);
+  `tests/test_runtime_cli.py` (4 tests + 1 helper, appended);
+  `docs/tasks/2026-08-25-OME-990-runtime-log-prompts.md` (mirror).
 - **Commits:** `fix(screamingface): stop logging prompt-bearing query strings` (sha assigned
   at squash-merge).
 - **Gates:** `run_gates.py screamingface` — **ALL GATES GREEN**: append-only test check (vs
   HEAD) · ruff check · ruff format --check · pyright · `pytest --cov=screamingface
-  --cov-fail-under=95` (**1278 passed, 17 skipped**) · check_notebooks · uv build ·
+  --cov-fail-under=95` (**1281 passed, 17 skipped**) · check_notebooks · uv build ·
   check_distribution. RED was confirmed first: the new test failed on
   `options.get("access_log") is False` with both configs constructed and every other
   assertion passing.

--- a/docs/work/2026-08-31-OME-990-runtime-access-log-off.md
+++ b/docs/work/2026-08-31-OME-990-runtime-access-log-off.md
@@ -1,0 +1,112 @@
+---
+ticket: OME-990
+stack: screamingface
+status: in_progress
+started: 2026-08-31
+finished:
+---
+
+# OME-990 — Stop writing prompt-bearing query strings into `runtime.log`
+
+## Intent
+
+A local run starts as `GET /?q=<url4 expression>`, and a url4 expression is prompt-bearing by
+construction — it carries the user's prompt text structurally. uvicorn's access logger is left
+at its default (on), so every local run writes the user's prompt into
+`<data_dir>/runtime.log`, a file created with mode `0644`.
+
+This is the first rung of the observability programme (epic `OME-935`, spec
+`docs/spec/2026-08-22-observability-traceability-review.md` — still on PR #688 at the time of
+writing) and it is deliberately sequenced ahead of every tracing-wiring change. That
+programme ends in "attach your logs to a report" (Phase 3); shipping that while prompts sit
+in cleartext in a world-readable file converts a local exposure into an exfiltration path.
+The one-line fix must land first.
+
+Source: `docs/observability-state-of-play.md` — "Two security defects turned up along the way.
+One has a one-line fix and should land before anything else."
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_runtime/server.py` — `_server()`, the shared
+  factory booting the **gateway** and the **engine**: pass `access_log=False` to
+  `uvicorn.Config`.
+- `packages/screamingface/tests/test_runtime_cli.py` — new test asserting *every* uvicorn
+  configuration the runtime builds disables access logging, without booting a server.
+
+**Not in this unit** — `run_scoreboard()` (`server.py:258`) also omits `access_log`, but it
+runs in a separate interpreter and its query strings are leaderboard filters (`?top=<int>`),
+never prompts. Testing it means stubbing five runtime-extra imports for no prompt-leak value;
+it goes to the follow-up below rather than inflating this unit.
+
+## Test plan
+
+RED first, behaviour-named, matching the house style in `tests/test_runtime_cli.py`:
+
+- Every uvicorn configuration the local stack constructs disables the access log — asserted
+  over the **whole sweep** (gateway *and* engine), not a single call.
+
+The sweep is the point, not pedantry. uvicorn's `access_log=False` clears the
+`uvicorn.access` handlers only for the Config being constructed at that moment, while every
+later Config re-runs `dictConfig` and re-creates them, and the HTTP protocol re-reads
+`hasHandlers()` per connection. A test asserting one server would pass while a second server
+silently re-armed request logging for the whole process.
+
+## Acceptance
+
+- Every uvicorn server the client runtime starts in-process has access logging disabled.
+- A local run no longer writes `GET /?q=<expression>` access lines into `runtime.log`.
+- No prior test modified; `run_gates.py screamingface` green (incl. `--cov-fail-under=95`).
+
+**Deliberately NOT claimed:** that `runtime.log` is free of prompt text. The adversarial
+review (below) proved that is a stronger statement than this change can support.
+
+## Adversarial review — `access_log=False` is necessary but NOT sufficient
+
+A three-agent investigation workflow swept the start sites, the test conventions, and the
+sufficiency of the fix. The sufficiency verdict was **not sufficient**, with each finding
+empirically reproduced rather than reasoned. Recorded here so the follow-ups are not lost
+and so nobody reads this ticket as "prompts are out of the log now".
+
+1. **`runtime.log` is the process's entire stdout+stderr**, not an access log.
+   `capture_runtime_log` (`runtime_logging.py:89-92`) swaps both streams wholesale, so any
+   library print, `warnings.warn`, traceback, or WARNING+ record from an unconfigured logger
+   (via `logging.lastResort`, which resolves `sys.stderr` at emit time) lands in the file.
+   `access_log=False` removes exactly one producer from that set.
+2. **The flag is a process-global logger mutation, not a server property.**
+   `uvicorn/config.py:421-423` clears `uvicorn.access`'s handlers, but every later
+   `uvicorn.Config` re-runs `dictConfig(LOGGING_CONFIG)` and re-creates them;
+   `h11_impl.py:57` re-reads `hasHandlers()` per connection. This is why the test asserts
+   the whole sweep — a single-server assertion would ship this regression green.
+3. **`uvicorn.error` logs the full path with query string on the WS path**
+   (`websockets_impl.py:280/297/307`), which this flag does not touch — and the engine's WS
+   URL is `/ws?ticket=<capability JWT>`, so a live token sits in the same file.
+4. **Nothing remediates what is already on disk.** `runtime.log` is opened without a chmod
+   (`runtime_logging.py:35,84`) — contrast `cli.py:702`, which chmods `runtime.json` to
+   `0600` — and `LOG_BACKUPS = 5` keeps up to six historical files of already-leaked prompts.
+
+Lower-severity, same file: litellm's module-level `StreamHandler` binds to the RuntimeLog
+because litellm is imported *inside* the capture, so `LITELLM_LOG=DEBUG` turns the log into a
+full prompt/completion transcript; and prompt text is embedded in url4/litellm exception
+*messages*, kept out today only by first-party discipline with no sink-level control.
+
+**Follow-ups to file** (none block this PR): chmod `runtime.log` `0600` + remediate existing
+backups; suppress the `uvicorn.error` WS ticket line; pin
+`litellm.redact_messages_in_exceptions` and neutralise `LITELLM_LOG` in the runtime env;
+install a redacting `setLogRecordFactory` for the capture's lifetime (aigateway already ships
+that pattern at `core/auth/log_filter.py:71-85`); `access_log=False` in `run_scoreboard()`.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `_runtime/server.py` (one `uvicorn.Config` call) and
+  `tests/test_runtime_cli.py` (one test + one helper, appended).
+- **Commits:** `fix(screamingface): stop logging prompt-bearing query strings` (sha assigned
+  at squash-merge).
+- **Gates:** `run_gates.py screamingface` — **ALL GATES GREEN**: append-only test check (vs
+  HEAD) · ruff check · ruff format --check · pyright · `pytest --cov=screamingface
+  --cov-fail-under=95` (**1278 passed, 17 skipped**) · check_notebooks · uv build ·
+  check_distribution. RED was confirmed first: the new test failed on
+  `options.get("access_log") is False` with both configs constructed and every other
+  assertion passing.
+- **Deviations:** `run_scoreboard()` deliberately left unchanged (rationale above) — the
+  ledger's original acceptance criterion ("a local run leaves no `?q=` in `runtime.log`") was
+  narrowed after the adversarial review showed it overstated what this change achieves.

--- a/packages/screamingface/src/screamingface/_runtime/runtime_logging.py
+++ b/packages/screamingface/src/screamingface/_runtime/runtime_logging.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import io
+import os
 import sys
 import threading
 from collections.abc import Iterator
@@ -14,6 +15,23 @@ MAX_LOG_BYTES = 10 * 1024 * 1024
 LOG_BACKUPS = 5
 
 _service = contextvars.ContextVar("screamingface_runtime_log_service", default="supervisor")
+
+
+def _open_private(path: Path) -> TextIO:
+    """Open the runtime log for append, readable only by its owner.
+
+    INVARIANT (OME-990): this file carries the same class of secret as the ``runtime.json``
+    beside it — prompt-bearing output and the Engine's WS capability ticket — and that file
+    has been ``0600`` since it started holding the owner token.
+    """
+    # WHY both the mode argument AND the chmod: the mode is applied only when the file is
+    # CREATED, so opening privately protects a new log but leaves a `runtime.log` written
+    # 0644 by an earlier version at its old mode forever. The chmod is what remediates the
+    # logs already on disk, on the reopen every `screamingface up` performs.
+    descriptor = os.open(path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+    stream = os.fdopen(descriptor, "a", encoding="utf-8")
+    path.chmod(0o600)
+    return stream
 
 
 @contextlib.contextmanager
@@ -32,7 +50,7 @@ class RuntimeLog(io.TextIOBase):
         self._lock = threading.Lock()
         self._buffer = ""
         path.parent.mkdir(parents=True, exist_ok=True)
-        self._stream = path.open("a", encoding="utf-8")
+        self._stream = _open_private(path)
 
     def write(self, value: str) -> int:
         with self._lock:
@@ -81,7 +99,7 @@ class RuntimeLog(io.TextIOBase):
                 source.replace(self._path.with_name(f"{self._path.name}.{index + 1}"))
         if self._path.exists():
             self._path.replace(self._path.with_name(f"{self._path.name}.1"))
-        self._stream = self._path.open("a", encoding="utf-8")
+        self._stream = _open_private(self._path)
 
 
 @contextlib.contextmanager

--- a/packages/screamingface/src/screamingface/_runtime/server.py
+++ b/packages/screamingface/src/screamingface/_runtime/server.py
@@ -267,8 +267,25 @@ def _server(app: Any, port: int, name: str) -> Server:
     # rejected it against uvicorn.Config's ASGIApplication parameter.
     import uvicorn  # pyright: ignore[reportMissingImports]
 
+    # WHY access_log=False (OME-990): a run starts as `GET /?q=<url4 expression>`, and a url4
+    # expression carries the user's prompt verbatim as its intent text. uvicorn's access line
+    # records the full request line including the query string, and this process's stdout is
+    # the RuntimeLog — so every prompt would be written to `<data_dir>/runtime.log`, which is
+    # world-readable and is tailed back into the notebook by `_runtime_log_tail` when the
+    # stack fails to start. The stdlib control server at `cli._control_server` already takes
+    # this posture by overriding `log_message`.
+    # INVARIANT: EVERY uvicorn Config built in this process must pass it. uvicorn clears the
+    # `uvicorn.access` handlers only for the Config being constructed at that moment, while
+    # each new Config re-runs dictConfig and re-creates them.
     return _embedded_server_type()(
-        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="info", lifespan="on"),
+        uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=port,
+            log_level="info",
+            lifespan="on",
+            access_log=False,
+        ),
         name=name,
     )
 

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -713,3 +713,53 @@ def test_wait_ready_still_points_at_the_log_when_it_cannot_be_read(tmp_path: Pat
         cli._wait_ready(process, config, timeout=0.1)
 
     assert "runtime exited during startup; inspect the runtime log" in str(raised.value)
+
+
+# --- embedded server configuration (OME-990) ----------------------------------------------
+
+
+def _recording_uvicorn(configs: list[dict[str, object]]) -> types.ModuleType:
+    # WHY a stub and not the real package: the SDK test job installs only the notebook extra
+    # (screamingface-tests.yml), so uvicorn is absent here exactly as it is after a plain
+    # `pip install screamingface` — the same reason `_stub_runtime_extra` exists above.
+    class Config:
+        def __init__(self, app: object, **options: object) -> None:
+            configs.append(options)
+
+    module = types.ModuleType("uvicorn")
+    module.Config = Config  # type: ignore[attr-defined]
+    return module
+
+
+def test_every_embedded_server_is_configured_without_an_access_log(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # INVARIANT (OME-990): a run starts as `GET /?q=<url4 expression>` and the expression
+    # carries the user's prompt verbatim, so uvicorn's access line writes that prompt into
+    # runtime.log — which `_runtime_log_tail` also echoes back into the notebook when the
+    # stack fails to start.
+    #
+    # WHY every construction and not merely one: uvicorn clears the `uvicorn.access`
+    # handlers for the Config being built AT THAT MOMENT, but each later Config re-runs
+    # dictConfig and re-creates them, and the HTTP protocol re-reads `hasHandlers()` per
+    # connection. One server passing the flag does not protect a process that afterwards
+    # builds another Config without it — so the assertion is over the whole sweep.
+    configs: list[dict[str, object]] = []
+
+    class Recorder:
+        def __init__(self, config: object, *, name: str) -> None:
+            self.config, self.name = config, name
+
+    monkeypatch.setitem(sys.modules, "uvicorn", _recording_uvicorn(configs))
+    # WHY patch the factory itself: `_embedded_server_type` is @cache'd and subclasses
+    # uvicorn.Server, so a stub installed through it would outlive this test.
+    monkeypatch.setattr(server, "_embedded_server_type", lambda: Recorder)
+
+    server._server(object(), 9105, "AI Gateway")
+    server._server(object(), 9106, "Engine")
+
+    assert len(configs) == 2, "both the gateway and the Engine must be configured"
+    assert all(options.get("access_log") is False for options in configs)
+    # The rest of the boot contract is unchanged by this ticket.
+    assert all(options["host"] == "127.0.0.1" for options in configs)
+    assert all(options["lifespan"] == "on" for options in configs)

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -763,3 +763,51 @@ def test_every_embedded_server_is_configured_without_an_access_log(
     # The rest of the boot contract is unchanged by this ticket.
     assert all(options["host"] == "127.0.0.1" for options in configs)
     assert all(options["lifespan"] == "on" for options in configs)
+
+
+# --- runtime log file mode (OME-990) ------------------------------------------------------
+
+
+def test_the_runtime_log_is_created_with_private_permissions(tmp_path: Path) -> None:
+    # INVARIANT (OME-990): runtime.log holds the same class of secret as runtime.json beside
+    # it — prompt-bearing output, and the Engine's WS capability ticket. runtime.json is
+    # deliberately 0600 (`_write_state`); this file must not be the 0644 exception.
+    path = tmp_path / "runtime.log"
+
+    runtime_logging.RuntimeLog(path).close()
+
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_a_world_readable_runtime_log_is_tightened_when_it_is_reopened(tmp_path: Path) -> None:
+    # WHY reopening matters: creating the file privately does nothing for the logs already on
+    # disk from before this change. Every `screamingface up` reopens the same path, so the
+    # reopen is the remediation path for an existing world-readable log.
+    path = tmp_path / "runtime.log"
+    path.write_text("leaked ?q=an+earlier+prompt\n")
+    path.chmod(0o644)
+
+    runtime_logging.RuntimeLog(path).close()
+
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_rotation_keeps_the_replacement_log_private(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # WHY: `_rotate` reopens the path, so a mode applied only in __init__ would be silently
+    # dropped the first time a busy runtime rolled its log over.
+    path = tmp_path / "runtime.log"
+    monkeypatch.setattr(runtime_logging, "MAX_LOG_BYTES", 100)
+    monkeypatch.setattr(runtime_logging, "LOG_BACKUPS", 2)
+    log = runtime_logging.RuntimeLog(path)
+
+    log.write("x" * 100 + "\n")
+    log.write("after the roll\n")
+    log.close()
+
+    assert path.with_name("runtime.log.1").exists()
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Summary

Closes both halves of `OME-990`.

A local run starts as `GET /?q=<url4 expression>`, and a url4 expression carries the user's prompt **verbatim** as its intent text. uvicorn's access logger was left at its default (on), so every run wrote the user's prompt into `<data_dir>/runtime.log` — a **`0644`** file that `_runtime_log_tail` also echoes back into the notebook when the stack fails to start.

1. **`access_log=False`** in `_server()`, the shared factory for both the gateway and the Engine.
2. **`_open_private()`** in `runtime_logging.py`, used by both the initial open and `_rotate`, so the log is created `0600` and an existing world-readable log is tightened on reopen.

Part 2 is the ticket's own Verify line ("check the file mode while there") — it flags `runtime.log` at `0644` beside a deliberately-`0600` `runtime.json` as an aggravating detail.

This is **rung 0 of the observability programme** (epic `OME-935`), sequenced ahead of every tracing-wiring change: that programme ends in "attach your logs to a report" (Phase 3), and shipping that while prompts sit in cleartext converts a local exposure into an exfiltration path.

## Why the access-log test asserts the whole sweep

uvicorn's `access_log=False` clears the `uvicorn.access` handlers **only for the Config being constructed at that moment**. Every later `uvicorn.Config` re-runs `dictConfig(LOGGING_CONFIG)` and re-creates them, and `h11_impl.py:57` re-reads `hasHandlers()` per connection.

`server.py` builds two Configs in one process. A test asserting a single server would pass while a second server silently re-armed request logging for the whole process — so the assertion covers gateway **and** Engine together.

## Why the mode needs a chmod and not just `os.open`

The mode argument applies only when the file is **created**. Opening privately protects a new log but leaves a `runtime.log` written `0644` by an earlier version at its old mode forever. The chmod is what remediates the logs already on disk, on the reopen every `screamingface up` performs.

## Necessary, not sufficient

An adversarial review (empirically reproduced, not reasoned) established that this closes the largest and most reliable producer but does **not** make `runtime.log` free of prompt text:

- `capture_runtime_log` swaps `sys.stdout` **and** `sys.stderr` wholesale, so the log is the process's entire stderr sink — access logging is one producer among many.
- `uvicorn.error` still logs the full path with query string on the WS path, which this flag does not touch — and the Engine's WS URL is `/ws?ticket=<capability JWT>`.
- **Rotated backups are not remediated** — `runtime.log.1` … `.5` keep their old mode until they roll off, and nothing removes the prompts already inside them.
- `LITELLM_LOG=DEBUG` turns the log into a full prompt/completion transcript, because litellm's module-level handler binds to the RuntimeLog.

Follow-ups are recorded in the ledger; **none block this PR**. `run_scoreboard()` is deliberately untouched — separate interpreter, and its query strings are leaderboard filters (`?top=<int>`), never prompts.

## Test plan

- **RED confirmed first** for both halves: the access-log test failed on `options.get("access_log") is False` with both configs constructed; the three mode tests failed `0o644 != 0o600`.
- `run_gates.py screamingface` — **ALL GATES GREEN**: append-only test check · ruff check · ruff format · pyright · `pytest --cov=screamingface --cov-fail-under=95` (**1281 passed, 17 skipped**) · check_notebooks · uv build · check_distribution.
- No prior test modified (independently confirmed by the append-only gate).
- Mode assertions follow the existing `if os.name != "nt":` precedent from `test_state_is_written_atomically_with_private_permissions`.

Ledger: `docs/work/2026-08-31-OME-990-runtime-access-log-off.md`
Mirror: `docs/tasks/2026-08-25-OME-990-runtime-log-prompts.md`

Refs: OME-990