### PR TITLE
docs(tasks): close the OME-1029 mirror

### DIFF
--- a/docs/tasks/2026-08-28-OME-1029-sdk-run-cost.md
+++ b/docs/tasks/2026-08-28-OME-1029-sdk-run-cost.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1029
 linear_url: https://linear.app/openmined/issue/OME-1029/send-run-cost-usd-on-leaderboard-submissions-from-the-sdk
-status: in_review
+status: done
 type: feature
 priority: P1
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-08-28
-closed:
+closed: 2026-08-31
 ---
 
 The last missing link in the run-cost chain. Scoreboard accepts `run_cost_usd`, the Engine produces


### PR DESCRIPTION
PR #770 merged as `ea4c866a` and `OME-1029` is Done in Linear with its close comment, but the repo mirror still read `status: in_review`.

Docs-only, one file, two frontmatter fields. The card treats a close as incomplete until both sides agree — a mirror left open is what makes a later status sweep re-open settled work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MJnetigGbLfyz6hLiGkij