### PR TITLE
test(aigateway): make the /v1/models single-flight test deterministic

### DIFF
--- a/apps/aigateway/tests/unit/core/test_models_route_live_catalog.py
+++ b/apps/aigateway/tests/unit/core/test_models_route_live_catalog.py
@@ -38,6 +38,9 @@ from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSetti
 # deliberately omits — retired upstream, so a healthy snapshot must drop it.
 _COMPILED_SEED = "openrouter/anthropic/claude-fable-5"
 
+# A deadlock bound, not a timing assumption — the happy path releases in milliseconds.
+_RENDEZVOUS_TIMEOUT_S = 10.0
+
 
 class _Clock:
     def now(self) -> float:
@@ -327,18 +330,35 @@ def test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200(
 ) -> None:
     _enable_openrouter(monkeypatch, OpenRouterPluginSettings(enabled=True))
 
-    class _SlowClient:
+    callers = 6
+    # WHY a rendezvous, not a slow fetch: the peak-depth assertion needs every caller in
+    # the catalog AT ONCE. A fixed sleep only HOPES so — on a loaded runner late threads
+    # are served by the refresh that already finished and never overlap (CI: `assert
+    # 4 == 6` on 3.12, gateway behaving perfectly, OME-1055). Waiting for the last
+    # caller makes the overlap structural.
+    all_callers_in = asyncio.Event()
+    # AIDEV-NOTE: a dict like `depth` below — written on the loop, read after the join.
+    rendezvous = {"timed_out": False}
+
+    class _RendezvousClient:
+        """Upstream stub that answers only once every caller is parked behind it."""
+
         def __init__(self) -> None:
             self.dialed: list[str] = []
 
         async def get(self, url: str, *, timeout_s: float, max_bytes: int) -> RawResponse:
             self.dialed.append(url)
-            await asyncio.sleep(0.2)
+            # INVARIANT: the fetch never outruns the burst it exists to serve. The timeout
+            # keeps a real failure-to-assemble loud and bounded instead of hanging.
+            try:
+                await asyncio.wait_for(all_callers_in.wait(), timeout=_RENDEZVOUS_TIMEOUT_S)
+            except TimeoutError:
+                rendezvous["timed_out"] = True
             return RawResponse(
                 status=200, content_type="application/json", body=_strict_body(["openai/gpt-5"])
             )
 
-    http = _SlowClient()
+    http = _RendezvousClient()
     app = cast(FastAPI, authenticated_client.app)
     app.state.discovery_runtime = DiscoveryRuntime(
         client=http,
@@ -366,6 +386,8 @@ def test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200(
     ) -> tuple[ModelEntry, ...] | None:
         depth["now"] += 1
         depth["peak"] = max(depth["peak"], depth["now"])
+        if depth["now"] == callers:
+            all_callers_in.set()
         try:
             return await unwrapped(self, plugin, client=client, limits=limits)
         finally:
@@ -376,11 +398,14 @@ def test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200(
     def _get(_n: int) -> int:
         return authenticated_client.get("/v1/models").status_code
 
-    callers = 6
     with ThreadPoolExecutor(max_workers=callers) as pool:
         statuses = list(pool.map(_get, range(callers)))
 
     assert statuses == [200] * callers
+    # A timed-out rendezvous means the burst never assembled, so the assertions below
+    # would measure a serialized run. Name that cause instead of a bare depth mismatch.
+    msg = f"rendezvous timed out — peak overlap {depth['peak']} of {callers} callers"
+    assert not rendezvous["timed_out"], msg
     # INVARIANT: single-flight — one refresh serves every contemporaneous caller,
     # so a burst of listings costs ONE upstream fetch chain, not N.
     assert http.dialed == [LIVE_MODELS_URL]

--- a/docs/tasks/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
+++ b/docs/tasks/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
@@ -1,0 +1,38 @@
+---
+id: OME-1055
+linear_url: https://linear.app/openmined/issue/OME-1055/make-the-v1models-single-flight-concurrency-test-deterministic
+status: in_progress
+type: task
+priority: 2
+labels: [aigateway, agentic, autonomous, task]
+created: 2026-08-31
+closed:
+---
+
+# Make the /v1/models single-flight concurrency test deterministic
+
+`test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200` fails
+intermittently in CI on Python 3.12 with `assert 4 == 6`, blocking unrelated aigateway PRs.
+First observed on PR #782 (OME-1044), whose diff touches none of the code under test — the
+same tree passed once and failed twice.
+
+The test proves single-flight on `/v1/models`: six concurrent callers must cost one upstream
+fetch. Two claims sit in it. The product invariant,
+`assert http.dialed == [LIVE_MODELS_URL]`, passes on every observed run. The failing line is
+the test's own self-check, `assert depth["peak"] == callers`, which exists for a good reason
+— without it, "one dial" could be satisfied by a serialized server hitting a warm cache, and
+single-flight would be unproven.
+
+The flaw is only in how the overlap is arranged: a fixed `await asyncio.sleep(0.2)` races six
+thread startups. On a loaded runner two threads arrive after the refresh completed, are served
+from the warm cache, and never overlap — peak reads 4.
+
+Fix: replace the timed window with an explicit rendezvous. The counting wrapper sets an
+`asyncio.Event` when the last caller enters; the fake upstream client awaits it under a
+timeout instead of sleeping. The overlap becomes structural, and a genuine failure to overlap
+reports itself with a diagnostic instead of a bare `4 == 6`. Both original assertions stay.
+No production code changes.
+
+Introduced by `cc9deb4a` / PR #739 (OME-972), merged 2026-08-27; latent through ~16 runs.
+
+Ledger: `docs/work/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md`.

--- a/docs/tasks/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
+++ b/docs/tasks/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1055
 linear_url: https://linear.app/openmined/issue/OME-1055/make-the-v1models-single-flight-concurrency-test-deterministic
-status: in_progress
+status: done
 type: task
 priority: 2
 labels: [aigateway, agentic, autonomous, task]
 created: 2026-08-31
-closed:
+closed: 2026-08-31
 ---
 
 # Make the /v1/models single-flight concurrency test deterministic

--- a/docs/work/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
+++ b/docs/work/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-1055
+stack: aigateway
+status: in_progress   # planned | in_progress | done | blocked
+started: 2026-08-31
+finished:
+---
+
+# OME-1055 — Make the /v1/models single-flight concurrency test deterministic
+
+## Intent
+
+`test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200` fails
+intermittently in CI on Python 3.12 with `assert 4 == 6`, which intermittently blocks every
+aigateway PR (first observed on PR #782 / OME-1044, whose diff touches none of the code
+under test). The failing assertion is the test's own self-check that six callers overlapped,
+not the product invariant — `assert http.dialed == [LIVE_MODELS_URL]` passes on every run.
+The overlap is currently arranged by a fixed `await asyncio.sleep(0.2)` racing six thread
+startups; on a loaded runner two threads land late, get served by the completed refresh, and
+never overlap. This unit replaces the timed window with an explicit rendezvous so the overlap
+is a fact rather than a race, keeping both existing assertions intact.
+
+Introduced by `cc9deb4a` / PR #739 (OME-972), merged 2026-08-27; latent through ~16 runs.
+
+## Planned changes
+
+- `apps/aigateway/tests/unit/core/test_models_route_live_catalog.py` — MODIFY
+  `test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200` only:
+  - add a module-level `_RENDEZVOUS_TIMEOUT_S` constant
+  - add an `asyncio.Event` the counting wrapper sets once `depth["now"]` reaches `callers`
+  - `_SlowClient.get` awaits that event under `asyncio.wait_for` instead of
+    `asyncio.sleep(0.2)`; a timeout records a flag rather than raising inside the app stack
+  - add an assertion on that flag, ahead of the peak assertion, so a genuine failure to
+    overlap reports itself instead of surfacing as `4 == 6`
+  - `WHY:` anchor recording why a rendezvous replaces a timed fetch
+
+No production code changes. No other test touched.
+
+## Test plan
+
+This unit's deliverable IS a test change, so the RED/GREEN evidence is behavioural rather
+than a new test file:
+
+- **RED (reproduce the defect's mechanism):** force the failure deterministically by making
+  the rendezvous unreachable — set the barrier target above the caller count — and confirm
+  the new timeout assertion fires with its diagnostic message rather than `assert N == 6`.
+  This proves the new guard detects a real overlap failure instead of masking it.
+- **GREEN:** the test passes with the rendezvous in place.
+- **Determinism:** run the target test in a loop (>=25 iterations) and the whole test file,
+  with coverage on, and additionally under CPU restriction (`taskset -c 0,1`) — the
+  condition the fixed sleep was sensitive to.
+- **No weakening:** both original assertions (`http.dialed == [LIVE_MODELS_URL]` and
+  `depth["peak"] == callers`) remain present and unmodified in meaning.
+- **Full suite:** the whole aigateway suite stays green (the test shares the app fixture with
+  4107 other tests).
+
+## Acceptance
+
+- The fake upstream fetch completes only after all `callers` callers have entered the catalog.
+- Both original assertions still asserted; neither relaxed.
+- A failure to rendezvous fails loudly with a diagnostic, bounded by a timeout — never hangs.
+- Target test green repeatedly (>=25 consecutive runs) under coverage, including pinned CPUs.
+- `uv run .claude/scripts/run_gates.py aigateway --skip-append-only` all green.
+- CI green on both 3.12 and 3.13.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/docs/work/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
+++ b/docs/work/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1055
 stack: aigateway
-status: in_progress   # planned | in_progress | done | blocked
+status: done   # planned | in_progress | done | blocked
 started: 2026-08-31
-finished:
+finished: 2026-08-31
 ---
 
 # OME-1055 — Make the /v1/models single-flight concurrency test deterministic
@@ -63,9 +63,57 @@ than a new test file:
 - `uv run .claude/scripts/run_gates.py aigateway --skip-append-only` all green.
 - CI green on both 3.12 and 3.13.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files:** as planned — only
+  `apps/aigateway/tests/unit/core/test_models_route_live_catalog.py` (+29 / -4), plus this
+  ledger and the `docs/tasks/` mirror. No production code touched.
+
+- **Commits:**
+  - `9f2a2d4d` — test(aigateway): make the /v1/models single-flight test deterministic
+
+- **Gates:** `uv run .claude/scripts/run_gates.py aigateway --skip-append-only` — ALL GREEN.
+  ruff check / ruff format --check / pyright / check_no_enterprise.py /
+  `pytest --cov=aigateway --cov-fail-under=80` (4108 passed). File 449 lines, under the 450 rule.
+
+- **Verification evidence:**
+
+  | Probe | Design | Result |
+  |---|---|---|
+  | RED-1 — upstream fetch made instant | original | `assert 1 == 6` — reproduces the CI signature |
+  | RED-2 — rendezvous made unreachable | fixed | new guard fires with its diagnostic, bounded by the timeout |
+  | Stagger — callers arrive 0.15s apart | original | `assert 2 == 6` |
+  | Stagger — callers arrive 0.15s apart | **fixed** | **pass** |
+  | 30x loop, coverage on, every 2nd run pinned to 2 CPUs | fixed | 30/30 pass |
+
+  RED-1 also justifies keeping the assertion the fix repairs: with ZERO overlap,
+  `http.dialed == [LIVE_MODELS_URL]` still passed. The peak-depth assertion is the only
+  thing separating "single-flight works" from "a serialized server hit a warm cache".
+
+- **Deviations:**
+  1. **Append-only gate bypassed (rule 5).** The unit's deliverable IS a change to a prior
+     test, so the gate necessarily fires; adding a new file would have left the flake in
+     place. Owner approved the specific edit; ran with `--skip-append-only`. Verified the
+     gate does flag it when the flag is omitted:
+     `M tests/unit/core/test_models_route_live_catalog.py (removed/changed old line(s)
+     [330, 336, 341, 379] …)`. No other gate was skipped or weakened.
+  2. **RED/GREEN inverted in form, not in substance.** With no production code to drive,
+     RED was executed as a deterministic reproduction of the defect (RED-1) plus a
+     verification that the new guard catches a real overlap failure (RED-2), rather than as
+     a new failing test file. Declared in the Test plan up front.
+  3. **Diagnostic message reworded after RED-2.** The first version read "only 6 of 6 callers
+     ever overlapped" under the probe — self-contradictory, because the probe timed out while
+     the overlap genuinely happened. Changed to "rendezvous timed out — peak overlap N of M",
+     which is accurate in every case. RED-2 earned its keep here.
+  4. **Comments trimmed twice to satisfy the 450-line rule** (459 -> 453 -> 449). One comment
+     was deleted outright under rule 12 for restating the code beneath it.
+
+- **Residual uncertainty:** the original failure was never reproduced under true CI
+  conditions — 27 isolated local runs of the old test passed, and CI runs it inside the full
+  4107-test suite. The mechanism is inferred from the assertion signature and the structure
+  of the test, both of which the probes reproduce exactly. CI on both 3.12 and 3.13 is the
+  real verdict.
+
+- **Follow-up noted, not actioned:** the CI logs also show six `RuntimeError: Event loop is
+  closed` lines at teardown of this test. Pre-existing, unrelated to the peak assertion, and
+  out of scope here.


### PR DESCRIPTION
## Summary

`test_concurrent_callers_share_one_upstream_fetch_chain_and_all_get_200` fails intermittently
in CI on Python 3.12 with `assert 4 == 6`, blocking unrelated aigateway PRs. This makes it
deterministic. **Test-only — no production code changes.**

The test proves single-flight on `/v1/models`: six concurrent callers must cost one upstream
fetch. It carries two claims:

- **The product invariant** — `assert http.dialed == [LIVE_MODELS_URL]`. Passes on every
  observed run, including every failing one.
- **The test's own self-check** — `assert depth["peak"] == callers`. This is the line that
  fails.

The self-check exists for a good reason, and this PR keeps it. Without it, "one dial" could be
satisfied by a serialized server hitting a warm cache, and single-flight would be unproven.

The flaw is only in *how* the overlap was arranged: a fixed `await asyncio.sleep(0.2)` racing
six thread startups. On a loaded runner the late threads are served by the refresh that already
completed, never overlap, and the peak reads low. So the red signal meant "the test could not
create the conditions it wanted to measure", not "the gateway is broken".

**Fix:** the counting wrapper sets an `asyncio.Event` once the last caller has entered the
catalog; the upstream stub awaits that event under a timeout instead of sleeping. The overlap
becomes structural rather than raced. A genuine failure to assemble now reports itself
(`rendezvous timed out — peak overlap N of M`) instead of surfacing as a bare `4 == 6`, so this
**strengthens** the assertion rather than relaxing it.

## Evidence

Observed on #782, whose diff touches none of the code under test. Same tree throughout — the
branch was current with `main`, so the PR merge ref and head commit have identical trees:

| Run | Event | 3.12 | 3.13 |
|---|---|---|---|
| 33402724993 | push | pass | pass |
| 33402739017 | pull_request | **fail** `assert 4 == 6` | cancelled (fail-fast) |
| 33402739017 rerun | pull_request | **fail** `assert 4 == 6` | pass |

Introduced by `cc9deb4a` (#739, OME-972, merged 2026-08-27). Latent through ~16 runs before it
first fired.

## Test plan

| Probe | Design | Result |
|---|---|---|
| RED-1 — upstream fetch made instant | original | `assert 1 == 6` — reproduces the CI signature |
| RED-2 — rendezvous made unreachable | fixed | new guard fires with its diagnostic, bounded by the timeout |
| Stagger — callers arrive 0.15s apart | original | `assert 2 == 6` |
| Stagger — callers arrive 0.15s apart | **fixed** | **pass** |
| 30x loop, coverage on, every 2nd run pinned to 2 CPUs | fixed | 30/30 pass |

RED-1 is also the argument for keeping the assertion: with **zero** overlap,
`http.dialed == [LIVE_MODELS_URL]` still passed.

Gates: `run_gates.py aigateway --skip-append-only` — ALL GREEN (ruff, ruff format, pyright,
check_no_enterprise, pytest --cov-fail-under=80, 4108 passed).

## Deviations

1. **Append-only gate bypassed (sdlc rule 5).** The deliverable IS a change to a prior test, so
   the gate necessarily fires; a new file would have left the flake in place. Owner approved
   the specific edit. Confirmed the gate does flag it when the flag is omitted; no other gate
   was skipped or weakened.
2. **RED/GREEN inverted in form.** With no production code to drive, RED ran as a deterministic
   reproduction of the defect plus a check that the new guard catches a real overlap failure.
3. **Diagnostic message reworded after RED-2** — the first wording was self-contradictory under
   the probe.

## Residual uncertainty

The original failure was never reproduced under true CI conditions: 27 isolated local runs of
the old test passed, and CI runs it inside the full 4107-test suite. The mechanism is inferred
from the assertion signature and the test's structure, both of which the probes reproduce
exactly. CI on 3.12 and 3.13 is the real verdict here.

Unrelated and out of scope: the CI logs also show six `RuntimeError: Event loop is closed` lines
at this test's teardown. Pre-existing; noted in the ledger, not addressed.

Ledger: `docs/work/2026-08-31-OME-1055-models-single-flight-test-rendezvous.md`

Refs: OME-1055
