### PR TITLE
fix(scoreboard): keep partial runs out of the ranked leaderboard

### DIFF
--- a/apps/scoreboard/src/scoreboard/scores/migrations/0011_benchmark_case_count.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0011_benchmark_case_count.py
@@ -1,0 +1,39 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("models", "0010_idempotency_key_scheme"),
+    ]
+
+    initial = False
+
+    # FEATURE: OME-1056 — the number of cases a benchmark defines, so a partial run stops
+    # ranking against a complete one. Fewer cases makes a perfect score easier, so before this
+    # a one-case run did not merely rank, it WON.
+    #
+    # WHY nullable with NO backfill: NULL is meaningful here and is not a gap to be filled. It
+    # means "this board declares no canonical scope", and such a board filters nothing — the
+    # same rule `revision` already follows for the retained legacy entries. Inventing a count
+    # for a board the Engine does not publish would assert a scope nobody verified.
+    #
+    # The value is filled by the seed job from the Engine catalogue, which already carries
+    # `case_count` and was discarding it. So no data migration is needed: the next seed after
+    # this deploy populates every Engine-published board.
+    #
+    # AIDEV-NOTE: no `scores` change and no backfill of existing submissions. Ranking is
+    # computed at READ time from `total_questions`, which is already stored on every row, so
+    # partial rows already in the table drop out of the ranking on the next request and stay
+    # readable through history. Nothing is deleted.
+    #
+    # AIDEV-NOTE: SAFE for a rolling multi-replica rollout — old pods ignore a column they do
+    # not know. See "Breaking migrations and multi-replica rollouts" in DEPLOYMENT.md.
+
+    operations = [
+        ops.AddField(
+            model_name="Benchmark",
+            name="case_count",
+            field=fields.IntField(null=True),
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/benchmark.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/benchmark.py
@@ -26,6 +26,16 @@ class BaseBenchmark(BaseScoreboardModel):
     # WHY nullable: the retained legacy demo entries (hle/livetruth/livetruth-latest) have no
     # Engine revision, so this column is added without a backfill.
     revision = fields.CharField(max_length=64, null=True)
+    # INVARIANT (OME-1056): how many cases the Engine benchmark defines. A submission reporting
+    # FEWER than this measured a subset, so it is not comparable with a complete run — and it is
+    # ADVANTAGED, not merely different, because fewer cases makes a perfect score easier. A
+    # one-case IFEval run scoring 1.0 held rank 1 over a 541-case run scoring 0.85.
+    # WHY nullable, and why that is not a hole: a benchmark with no registered count filters
+    # nothing, exactly as one with no registered revision filters nothing. Legacy and non-Engine
+    # boards keep ranking as they did. The value is Engine-owned — it arrives in the catalogue
+    # the seed job already fetches and is deliberately NOT accepted from deployment
+    # configuration, so a hand-written entry cannot declare a smaller canonical scope.
+    case_count = fields.IntField(null=True)
     # INVARIANT (OME-894): privacy is a property of the BENCHMARK, enforced in the API on every
     # read path — not a portal concern. The portal is static JS against a public API, so hiding
     # rows in the page would leave `curl /v1/leaderboard/{id}` serving the whole board.

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -373,6 +373,10 @@ class BenchmarkSchema(BaseModel):
     # WHY exposed: a client comparing its run against the board needs to know which revision
     # the board is registered at, so it can tell a real score gap from an incomparable one.
     revision: str | None
+    # WHY exposed (OME-1056): a client that ran a subset needs to see the canonical size to
+    # understand why its score is absent from the ranking. None means the board declares no
+    # canonical scope and therefore ranks everything.
+    case_count: int | None
     visibility: Visibility
     created_at: datetime
 

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -55,6 +55,7 @@ def benchmark_to_schema(model: Benchmark) -> BenchmarkSchema:
         focus=model.focus,
         dataset_url=model.dataset_url,
         revision=model.revision,
+        case_count=model.case_count,
         # A pre-migration row can carry NULL; it was world-readable before the column existed,
         # so it reads as public. The column stays nullable so 0008 need not rebuild the table.
         visibility=cast(Visibility, model.visibility or "public"),
@@ -367,7 +368,10 @@ class SubmitOutcome(NamedTuple):
 
 
 def _build_leaderboard_query(
-    benchmark_id: str, top_n: int, registered_revision: str | None
+    benchmark_id: str,
+    top_n: int,
+    registered_revision: str | None,
+    registered_case_count: int | None = None,
 ) -> QueryBuilder:
     scores = Score.get_table()
     # INVARIANT: every entry the board ranks was measured against the revision the benchmark is
@@ -410,6 +414,24 @@ def _build_leaderboard_query(
     )
     if registered_revision is not None:
         ranked = ranked.where(scores.benchmark_revision == registered_revision)
+    # INVARIANT (OME-1056): a run covering fewer cases than the benchmark defines is not
+    # comparable with a complete one, and is ADVANTAGED rather than merely different — fewer
+    # cases makes a perfect score easier, so a one-case run scoring 1.0 outranked a 541-case run
+    # scoring 0.85. A board declaring no count filters nothing, mirroring the revision rule
+    # directly above, so legacy and non-Engine boards are untouched.
+    #
+    # WHY `>=` and not `==`: the predicate asks "did this cover the canonical set", so a run
+    # reporting more cases than registered is anomalous but not a SUBSET, and excluding it would
+    # hide a complete run because the board's count went stale.
+    #
+    # AIDEV-NOTE: this belongs in the INNER query, beside the revision filter and NOT after the
+    # window. SQL evaluates WHERE before window functions, so an excluded row never receives a
+    # row_number — which is the point. Applied outside, a spec whose PARTIAL run scored higher
+    # than its own full run would give the partial row `rn = 1`, and the outer `rn = 1` filter
+    # would then drop that spec's complete run entirely: the invisible-submission failure this
+    # change exists to prevent, reintroduced one level up.
+    if registered_case_count is not None:
+        ranked = ranked.where(scores.total_questions >= registered_case_count)
     ranked = ranked.as_("ranked")
 
     return (
@@ -442,6 +464,7 @@ class ScoreStore:
         revision: str | None = None,
         focus: str | None = None,
         visibility: Visibility | None = None,
+        case_count: int | None = None,
     ) -> BenchmarkSchema:
         defaults: dict[str, object] = {
             "display_name": display_name,
@@ -449,6 +472,7 @@ class ScoreStore:
             "dataset_url": dataset_url,
             "revision": revision,
             "focus": focus,
+            "case_count": case_count,
         }
         if visibility is not None:
             # WHY conditional (OME-894): seeding runs on every deploy, and an omitted visibility
@@ -906,7 +930,10 @@ class ScoreStore:
         benchmark = await Benchmark.get_or_none(id=benchmark_id)
         result = await execute_pypika(
             _build_leaderboard_query(
-                benchmark_id, top_n, benchmark.revision if benchmark else None
+                benchmark_id,
+                top_n,
+                benchmark.revision if benchmark else None,
+                benchmark.case_count if benchmark else None,
             ),
             using_db=conn,
         )

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -63,6 +63,13 @@ class SeedBenchmark(BaseModel):
     # Short editorial line for the portal catalogue's "Focus" column (OME-874). Optional: it is
     # copy someone writes, not a value the Engine derives.
     focus: str | None = Field(default=None, max_length=120)
+    # OME-1056: how many cases the Engine benchmark defines, used to keep partial runs out of the
+    # ranking.
+    # INVARIANT: Engine-owned, exactly like `revision`. A row that DECLARES it in deployment
+    # configuration is refused by `_classify_configured`, because a hand-written entry claiming
+    # `case_count: 1` would re-open the hole from the other side — every one-case run would then
+    # rank as complete. It reaches this model only via `_CatalogEntry.as_seed`.
+    case_count: int | None = Field(default=None, ge=1)
 
 
 class _CatalogEntry(BaseModel):
@@ -102,6 +109,11 @@ class _CatalogEntry(BaseModel):
     revision: str = Field(min_length=1, max_length=64)
     focus: str | None = Field(default=None, max_length=120)
     dataset_url: str | None = None
+    # OME-1056: the Engine has always published this and the board discarded it via
+    # `extra="ignore"`, which is why a one-case run could rank as though it were complete.
+    # Optional for the same reason `description` is: a catalogue that omits it costs the board
+    # its ranking filter, not the benchmark its row.
+    case_count: int | None = Field(default=None, ge=1)
 
     @field_validator("description", "focus", mode="after")
     @classmethod
@@ -119,6 +131,7 @@ class _CatalogEntry(BaseModel):
             dataset_url=self.dataset_url,
             revision=self.revision,
             focus=self.focus,
+            case_count=self.case_count,
         )
 
 
@@ -354,7 +367,7 @@ def _classify_configured(
     for row in configured:
         if row.id in published:
             report.shadowed.append(row.id)
-        elif row.revision is not None or row.id in engine_owned:
+        elif row.revision is not None or row.case_count is not None or row.id in engine_owned:
             report.refused.append(row.id)
         elif row.visibility is not None and row.id not in existing_ids:
             # INVARIANT: a row declaring `visibility` OVERRIDES; it never brings a board into
@@ -509,6 +522,7 @@ async def seed_benchmarks(benchmarks: Sequence[SeedBenchmark]) -> list[Benchmark
                 revision=benchmark.revision,
                 focus=benchmark.focus,
                 visibility=benchmark.visibility,
+                case_count=benchmark.case_count,
             )
         )
     return seeded

--- a/apps/scoreboard/tests/unit/scores/test_leaderboard_coverage.py
+++ b/apps/scoreboard/tests/unit/scores/test_leaderboard_coverage.py
@@ -1,0 +1,114 @@
+"""A partial run must not rank against a complete one (OME-1056).
+
+FEATURE: OME-1056 / OME-867. A run covering fewer cases than the benchmark defines is a valid
+Report but not a comparable one, and it is ADVANTAGED rather than merely admitted: fewer cases
+makes a perfect score easier. Before this, a one-case IFEval run scoring 1.0 held rank 1 over a
+541-case run scoring 0.85.
+
+INVARIANT: only the RANKING changes. A partial run stays accepted, stored, and readable through
+history, score id and the submission response — a participant running `limit=1` to prove the
+submission path works is a supported workflow, and the client already warns them (OME-922).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.store import ScoreStore
+
+pytestmark = pytest.mark.asyncio
+
+REV = "0b88a52b5f10a6d9"
+FULL = 541
+
+
+def _submission(spec_id: str, score: float, total_questions: int) -> ScoreSubmission:
+    return ScoreSubmission(
+        benchmark_id="ifeval",
+        benchmark_revision=REV,
+        spec_id=spec_id,
+        url4_expression=f"url4://{spec_id}",
+        submitted_by="participant@example.test",
+        score=score,
+        total_questions=total_questions,
+        ran_with_providers=["openrouter"],
+    )
+
+
+async def _board(case_count: int | None) -> ScoreStore:
+    store = ScoreStore()
+    await store.register_benchmark(
+        benchmark_id="ifeval",
+        display_name="IFEval",
+        revision=REV,
+        case_count=case_count,
+    )
+    return store
+
+
+async def test_a_partial_run_does_not_rank_against_a_complete_one(tortoise_db: None) -> None:
+    # The reproduction this ticket was opened from, verbatim.
+    store = await _board(FULL)
+    await store.submit(_submission("honest-full-run", 0.85, FULL))
+    await store.submit(_submission("one-case-run", 1.00, 1))
+
+    ranked = [entry.spec_id for entry in await store.leaderboard("ifeval", top_n=50)]
+
+    assert ranked == ["honest-full-run"]
+
+
+async def test_a_run_matching_the_registered_count_ranks(tortoise_db: None) -> None:
+    store = await _board(FULL)
+    await store.submit(_submission("complete", 0.5, FULL))
+
+    assert [e.spec_id for e in await store.leaderboard("ifeval", top_n=50)] == ["complete"]
+
+
+async def test_one_case_short_does_not_rank(tortoise_db: None) -> None:
+    # BOUNDARY: the predicate is "fewer than registered", not "suspiciously few".
+    store = await _board(FULL)
+    await store.submit(_submission("almost", 0.99, FULL - 1))
+
+    assert await store.leaderboard("ifeval", top_n=50) == []
+
+
+async def test_a_board_with_no_registered_count_ranks_everything(tortoise_db: None) -> None:
+    # INVARIANT: mirrors the existing revision rule — a benchmark that declares no count
+    # filters nothing, so legacy and non-Engine boards are untouched by this change.
+    store = await _board(None)
+    await store.submit(_submission("one-case-run", 1.00, 1))
+
+    assert [e.spec_id for e in await store.leaderboard("ifeval", top_n=50)] == ["one-case-run"]
+
+
+async def test_a_partial_run_is_still_readable(tortoise_db: None) -> None:
+    # INVARIANT: this is the half that keeps `limit=1` testing viable. Excluding a row from the
+    # RANKING must not hide it from the person who submitted it, or the warning in OME-922
+    # ("your submission is partial") would be describing a submission that vanished.
+    store = await _board(FULL)
+    outcome = await store.submit(_submission("one-case-run", 1.00, 1))
+
+    assert outcome.score.total_questions == 1
+    history = await store.list_for_spec(benchmark_id="ifeval", spec_id="one-case-run")
+    assert [row.spec_id for row in history] == ["one-case-run"]
+
+
+async def test_a_specs_complete_run_survives_its_own_higher_scoring_partial(
+    tortoise_db: None,
+) -> None:
+    # INVARIANT: the coverage filter runs INSIDE the window, beside the revision filter.
+    #
+    # The ranking assigns row_number() per (spec_id, revision) ordered by score, then keeps
+    # rn == 1. Filter partial rows AFTER that window and this spec's partial run — which scored
+    # HIGHER — takes rn == 1, so the outer filter drops the whole spec and its complete run
+    # disappears from the board. The participant did the full run and vanishes because they also
+    # smoke-tested. SQL evaluates WHERE before window functions, so the excluded row never gets a
+    # row_number at all; this test is what proves the filter stayed on that side.
+    store = await _board(FULL)
+    await store.submit(_submission("same-spec", 0.60, FULL))
+    await store.submit(_submission("same-spec", 1.00, 1))
+
+    ranked = await store.leaderboard("ifeval", top_n=50)
+
+    assert [(e.spec_id, e.score) for e in ranked] == [("same-spec", 0.60)]

--- a/apps/scoreboard/tests/unit/test_seed_case_count.py
+++ b/apps/scoreboard/tests/unit/test_seed_case_count.py
@@ -1,0 +1,65 @@
+"""`case_count` reaches the board from the Engine, and never from deployment config (OME-1056).
+
+The Engine has always published `case_count` in its catalogue and the board discarded it via
+`extra="ignore"`. That is why a one-case run could rank as though it were complete. These tests
+pin both halves: the value now arrives, and configuration cannot forge it.
+
+AIDEV-NOTE: `test_catalog_fields_the_board_does_not_display_are_ignored` in
+test_seed_engine_catalog.py names `case_count` in its comment as an example of a field the board
+ignores. That parenthetical predates this change and is now stale; its ASSERTION is unaffected
+(unknown fields still do not break a deploy) and was deliberately left untouched.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from scoreboard.scores.models import Benchmark
+from scoreboard.seed import fetch_engine_benchmarks, load_benchmarks_json, seed_from_sources
+from tests.unit.test_seed_engine_catalog import ENGINE_URL, _refusing, _serving
+
+pytestmark = pytest.mark.asyncio
+
+
+def _catalog(entry: dict[str, object]) -> dict[str, object]:
+    return {"object": "list", "data": [{"id": "ifeval", "title": "IFEval", **entry}]}
+
+
+async def test_the_catalogue_case_count_reaches_the_seed_row() -> None:
+    payload = _catalog({"revision": "rev-ifeval", "case_count": 541})
+
+    with _serving(payload) as client:
+        row = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0).rows[0]
+
+    assert row.case_count == 541
+
+
+async def test_a_catalogue_without_a_case_count_seeds_none() -> None:
+    # WHY tolerated rather than required: a catalogue that omits it costs the board its ranking
+    # filter, not the benchmark its row — the same trade `description` already makes. A board
+    # with no count ranks everything, exactly as it did before this change.
+    payload = _catalog({"revision": "rev-ifeval"})
+
+    with _serving(payload) as client:
+        row = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0).rows[0]
+
+    assert row.case_count is None
+
+
+async def test_configuration_may_never_declare_a_case_count(tortoise_db: None) -> None:
+    # INVARIANT: `case_count` is the Engine's claim about its own benchmark, exactly like
+    # `revision`. Deployment configuration asserting one would re-open this ticket's hole from
+    # the other side: a hand-written `case_count: 1` makes every one-case run rank as complete.
+    # So the row is refused and named, not written.
+    configured = load_benchmarks_json(
+        '[{"id":"ifeval","display_name":"Stale IFEval","case_count":1}]'
+    )
+
+    with _refusing(httpx.ConnectError("down")) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=configured, client=client, retry_delay=0
+        )
+
+    assert report.refused == ["ifeval"]
+    assert await Benchmark.filter(id="ifeval").count() == 0

--- a/docs/work/2026-09-01-OME-1056-partial-runs-not-ranked.md
+++ b/docs/work/2026-09-01-OME-1056-partial-runs-not-ranked.md
@@ -1,0 +1,94 @@
+---
+ticket: OME-1056
+stack: scoreboard
+status: done
+started: 2026-09-01
+finished: 2026-09-01
+---
+
+# OME-1056 — Keep partial runs out of the ranked leaderboard
+
+## Intent
+
+A run covering fewer cases than the benchmark defines currently ranks alongside a complete
+run, and beats it: fewer cases makes a perfect score easier. Reproduced before any code was
+written — a one-case IFEval run scoring 1.0 takes rank 1 over a 541-case run scoring 0.85.
+
+The Scoreboard cannot presently tell the two apart. `total_questions` is validated only for
+`> 0`, `Benchmark` stores no expected count, and the ranking query filters on `benchmark_id`
+and `benchmark_revision` alone. The Engine already publishes `case_count` in the catalogue the
+seed job fetches on every deploy; `_CatalogEntry` sets `extra="ignore"` and discards it.
+
+Partial runs stay accepted and readable. A participant running `limit=1` to prove the
+submission path works is a supported workflow, and the client already warns the run is partial
+(OME-922). Only the RANKING changes.
+
+## Planned changes
+
+- `src/scoreboard/scores/models/benchmark.py` — `case_count`, nullable int
+- `src/scoreboard/scores/migrations/00NN_benchmark_case_count.py` — new
+- `src/scoreboard/scores/schemas.py` — `case_count` on `BenchmarkSchema` and `_CatalogEntry`;
+  NOT on `SeedBenchmark` (deployment config must not claim canonical scope)
+- `src/scoreboard/scores/store.py` — `benchmark_to_schema`, `register_benchmark`, and the
+  `_build_leaderboard_query` predicate
+- `src/scoreboard/seed.py` — carry `case_count` from the catalogue
+- tests as below
+
+## Test plan
+
+RED first, from the reproduction:
+
+1. **The bug itself** — a 1-case row and a full row on a benchmark with a registered
+   `case_count`; only the full row ranks. Fails today.
+2. **Boundary** — `total_questions == case_count` ranks; `case_count - 1` does not.
+3. **No registered count filters nothing** — mirrors the existing revision rule, so legacy and
+   non-Engine boards are unaffected.
+4. **Still readable** — the excluded row is returned by `list_for_spec`, by score id, and in
+   the submission response. This is the half that keeps `limit=1` testing viable.
+5. **Deployment config cannot supply `case_count`** — same refusal the `revision` rule gives.
+6. **Regression** — a public board with no partial rows is byte-identical to today.
+
+## Acceptance
+
+- A run below the registered `case_count` is absent from `entries` and present everywhere else.
+- A benchmark with no `case_count` ranks exactly as today.
+- `tortoise makemigrations` reports no further drift.
+- Full gates green.
+
+## Outcome
+
+- **Actual files:** as planned. `models/benchmark.py`, `migrations/0011_benchmark_case_count.py`,
+  `schemas.py`, `store.py`, `seed.py`, plus `tests/unit/scores/test_leaderboard_coverage.py` and
+  `tests/unit/test_seed_case_count.py`.
+- **Gates:** ALL GATES GREEN. 544 passed, 3 skipped, 3 deselected. `makemigrations` reports
+  "No changes detected". The append-only check passes unaided — no prior test was modified.
+- **Deviations:** none from the plan. Two things learned while building it, both recorded below.
+
+## What the mutation checks proved
+
+**The coverage filter must live inside the window.** Moved outside — onto the outer query beside
+`rn == 1` — only `test_a_specs_complete_run_survives_its_own_higher_scoring_partial` fails, and it
+fails with `[] == [('same-spec', 0.6)]`: the spec's COMPLETE run disappears entirely. The partial
+row takes `rn = 1` within its partition, the outer filter then drops the row that would have
+ranked, and the participant vanishes from the board for having smoke-tested. SQL evaluates WHERE
+before window functions, which is why the filter sits beside the revision filter and not after it.
+The other five tests still pass under that mutation, so the test is specific rather than redundant.
+
+**Configuration cannot forge a scope.** Removing `row.case_count is not None` from
+`_classify_configured` makes `test_configuration_may_never_declare_a_case_count` fail. Without it,
+a chart entry declaring `case_count: 1` would make every one-case run rank as complete — the same
+hole this unit closes, re-opened from the other side.
+
+## Two notes for whoever picks up OME-867
+
+**A prior test's comment is now stale, and was deliberately left alone.**
+`test_catalog_fields_the_board_does_not_display_are_ignored` names `case_count` in its comment as
+an example of a catalogue field the board ignores. Its ASSERTION is unaffected — unknown fields
+still do not break a deploy — so under the append-only rule it was not touched. The staleness is
+recorded in the new seed test's module docstring so the next reader finds it.
+
+**Dedup already separates coverage levels, so nothing collides.** `total_questions` participates in
+`_content_hash`, and the SDK sends `Idempotency-Key: run_id`, unique per run. So a `limit=1` run and
+a full run of the same recipe are two rows on both paths. The partial one exists and does not rank;
+the full one ranks. Neither displaces the other, and no participant loses a submission by having
+tested first — which is the whole reason partial runs stay accepted.


### PR DESCRIPTION
Closes OME-1056. Parent: OME-867.

A run covering fewer cases than the benchmark defines ranked alongside a complete one — and beat it. Fewer cases makes a perfect score easier, so partial runs were not merely admitted, they were **advantaged**.

Reproduced before any code was written:

```
rank  spec_id              score   total_questions
1     one-case-run         1.0     1
2     honest-full-run      0.85    541
```

541 is IFEval's real `CASE_COUNT`. That is the first test in this PR, and it failed on `main`.

## Why the board could not tell

`total_questions` is validated only for `> 0`. `Benchmark` stored no expected count. The ranking filtered on `benchmark_id` and `benchmark_revision` alone.

Meanwhile the Engine has **always** published `case_count` in the catalogue the seed job fetches on every deploy, and `_CatalogEntry` set `extra="ignore"` and threw it away. So the number needed to spot a partial run was arriving all along.

## What changed

- `Benchmark.case_count`, nullable, migration `0011`, no backfill.
- The seed carries it from the Engine catalogue.
- The ranking excludes rows below it.

**A board declaring no count filters nothing**, mirroring the revision rule immediately above it, so legacy and non-Engine boards rank exactly as before.

**Deployment configuration may not declare a count**, exactly as it may not declare a revision. A hand-written `case_count: 1` would re-open this hole from the other side, so such a row is refused and named.

## The subtle part

The filter sits **inside** the window, beside the revision filter, not after it.

The ranking assigns `row_number()` per `(spec_id, revision)` ordered by score, then keeps `rn == 1`. Filter partial rows *after* that, and a spec whose partial run outscored its own complete run gives the partial row `rn = 1` — so the outer filter drops the spec entirely and the participant's full run vanishes for having smoke-tested first. SQL evaluates `WHERE` before window functions, which is what makes the inner placement correct.

Mutation-checked: moved outside, exactly one test fails, with `[] == [('same-spec', 0.6)]`. The other five still pass, so the test is specific rather than redundant.

## What deliberately did not change

Partial runs stay **accepted, stored and readable** — through history, `GET /v1/scores/{id}`, and the submission response, none of which filter on revision or rank. Running `limit=1` to prove the submission path works end to end is a supported workflow, and the client already warns the run is partial (OME-922). Rejecting at write time was considered and rejected: it discards real work, contradicts that warning, and does nothing about rows already ranked.

Dedup already keeps the two apart. `total_questions` participates in `_content_hash`, and the SDK sends `Idempotency-Key: run_id`, unique per run — so a `limit=1` run and a full run of the same recipe are two rows on both paths. Neither displaces the other.

## Existing rows fix themselves

Ranking is computed at read time and `total_questions` is already stored on every row, so partial entries already in the table drop out of the ranking on the next request. The `scores` table is untouched and nothing is deleted.

## Scope

This is the common first step of every option still open on OME-867 — the main board stops ranking partials under all of them — so it does not pre-empt that design. A separate ranking for partial runs, grouped by matched coverage, can be built on the column this adds.

Pairs with OME-909: a submitter whose score does not rank should be told why.

## One thing left alone on purpose

`test_catalog_fields_the_board_does_not_display_are_ignored` names `case_count` in its comment as an example of a field the board ignores. That parenthetical is now stale, but its assertion is unaffected, so under the append-only rule I did not touch it. The staleness is recorded in the new seed test's module docstring.

## Gates

ALL GATES GREEN. 544 passed, 3 skipped. `makemigrations` reports no drift. The append-only check passes unaided.