### PR TITLE
fix(docs): onboarding audit fixes — benchmark ids, routing, READMEs, 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,11 @@ Right now this is single-turn evaluation. No multi-turn or tool-using agent loop
 ## Quickstart
 
 ```bash
-pip install "screamingface[notebook]"   # once it is on PyPI; until then, install from source (see the docs)
+pip install "screamingface[notebook]"
 ```
+
+> To run your own engine locally, add the `[runtime]` extra:
+> `pip install "screamingface[runtime]"`
 
 ```python
 import screamingface as sf

--- a/apps/screamingface-engine/README.md
+++ b/apps/screamingface-engine/README.md
@@ -1,5 +1,7 @@
 # screamingface-engine
 
+> **Looking to use ScreamingFace in your work?** [Start here](https://docs.screamingface.ai). This file serves as a developer reference.
+
 The ScreamingFace Engine: the runtime that turns a `url4` expression into a
 graded benchmark result. The Client talks only to an Engine, never to providers
 directly. It is a demand-driven, memoized DAG executor and streams usage as it

--- a/public-docs/src/lib/notebook.ts
+++ b/public-docs/src/lib/notebook.ts
@@ -66,7 +66,7 @@ export function notebookLanguage(nb: Notebook): string {
 // rather than a dead `*.ipynb` href. Extend as more notebooks get wired in.
 export const NOTEBOOK_ROUTES: Record<string, string> = {
   '00_overview': '/sf-client',
-  '00_quickstart': '/sf-client/quickstartPage',
+  '00_quickstart': '/sf-client/reproduce-draco',
 }
 
 // Remove a single leading `# Heading` line from a markdown source. Used to drop

--- a/public-docs/src/navigation/sf-client.ts
+++ b/public-docs/src/navigation/sf-client.ts
@@ -22,7 +22,7 @@ export const sfClientNavigation: NavEntry[] = [
     children: [
       { title: 'Installation', path: '/sf-client/installation' },
       { title: 'Your first fusion', path: '/sf-client/first-fusion' },
-      { title: 'Reproduce DRACO state-of-the-art', path: '/sf-client/quickstartPage' },
+      { title: 'Reproduce DRACO state-of-the-art', path: '/sf-client/reproduce-draco' },
     ],
   },
   {

--- a/public-docs/src/pages/HomePage.vue
+++ b/public-docs/src/pages/HomePage.vue
@@ -12,7 +12,7 @@ const docs = [
   },
   {
     title: 'Quickstart',
-    to: '/sf-client/quickstartPage',
+    to: '/sf-client/first-fusion',
     kicker: 'tutorial',
     desc: 'Compose a fusion, run it against a benchmark, and read how it compares to its best single member.',
   },
@@ -50,7 +50,7 @@ const GITHUB = 'https://github.com/ScreamingFace'
       </p>
 
       <div class="actions">
-        <RouterLink class="btn btn--primary" to="/sf-client/quickstartPage">Quickstart</RouterLink>
+        <RouterLink class="btn btn--primary" to="/sf-client/first-fusion">Quickstart</RouterLink>
         <RouterLink class="btn btn--sec" to="/sf-client">Overview</RouterLink>
         <RouterLink class="btn btn--sec" to="/sf-client/installation">Installation</RouterLink>
         <a class="btn btn--sec" :href="GITHUB" target="_blank" rel="noopener noreferrer">GitHub</a>
@@ -124,7 +124,7 @@ const GITHUB = 'https://github.com/ScreamingFace'
       </div>
       <nav class="foot__links">
         <RouterLink to="/sf-client">Overview</RouterLink>
-        <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink>
+        <RouterLink to="/sf-client/first-fusion">Quickstart</RouterLink>
         <a :href="GITHUB" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>
     </footer>

--- a/public-docs/src/pages/NotFoundPage.vue
+++ b/public-docs/src/pages/NotFoundPage.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+</script>
+
+<template>
+  <div class="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-6 text-center">
+    <p class="text-6xl font-bold opacity-20">404</p>
+    <h1 class="text-2xl font-semibold">Page not found</h1>
+    <p class="max-w-sm text-sm text-[var(--color-text-muted)]">
+      This URL doesn't match any docs page. It may have moved or the link may be stale.
+    </p>
+    <RouterLink
+      to="/"
+      class="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-white hover:opacity-90"
+    >
+      Back to docs home
+    </RouterLink>
+  </div>
+</template>

--- a/public-docs/src/pages/sf-client/FirstFusionPage.vue
+++ b/public-docs/src/pages/sf-client/FirstFusionPage.vue
@@ -147,7 +147,7 @@ candidate.score`
       </li>
       <li>
         <strong
-          ><RouterLink to="/sf-client/quickstartPage"
+          ><RouterLink to="/sf-client/reproduce-draco"
             >Reproduce DRACO state-of-the-art</RouterLink
           ></strong
         >

--- a/public-docs/src/pages/sf-client/FirstFusionPage.vue
+++ b/public-docs/src/pages/sf-client/FirstFusionPage.vue
@@ -10,14 +10,11 @@ import {
 
 const importCell = `import screamingface as sf`
 
-const connect = `import os
-
-sf.connect("openrouter", api_key=os.environ["OPENROUTER_API_KEY"])
-sf.connect("anthropic", api_key=os.environ["ANTHROPIC_API_KEY"])`
+const connect = `sf.connect()  # opens the connection panel; log in when prompted`
 
 const build = `fusion = sf.Fusion(
-    ["openrouter/deepseek/deepseek-v4-pro", "anthropic/claude-opus-4-8"],
-    synthesizer="anthropic/claude-opus-4-8",
+    ["openrouter/openai/gpt-5.5", "openrouter/google/gemini-3-flash-preview"],
+    synthesizer="openrouter/openai/gpt-5.5",
 )`
 
 const run = `report = sf.evaluate(fusion, benchmark="ifeval", limit=3)`
@@ -41,11 +38,9 @@ candidate.score`
 
     <Note>
       You need the Client installed (see
-      <RouterLink to="/sf-client/installation">Installation</RouterLink>) and API keys for
-      OpenRouter and Anthropic. This tutorial talks to the hosted engine and connects both providers
-      explicitly below; the
-      <RouterLink to="/sf-client/guides/connections">Connect a provider</RouterLink> guide covers
-      OAuth and the interactive panel.
+      <RouterLink to="/sf-client/installation">Installation</RouterLink>). No provider keys needed
+      — the hosted engine supplies shared OpenRouter credits. You will log in with your browser in
+      step 2.
     </Note>
 
     <h2>1 · Import the library</h2>
@@ -56,13 +51,12 @@ candidate.score`
       <NbCell :count="1" :code="importCell" />
     </div>
 
-    <h2>2 · Connect your providers</h2>
+    <h2>2 · Log in</h2>
 
     <p>
-      The fusion below uses one model from OpenRouter and one from Anthropic, so connect both. Each
-      call hands a key to the engine, which stores it encrypted and uses it to reach that provider;
-      the key never lands in your recipe or your report. Read keys from the environment rather than
-      pasting them into a cell.
+      The hosted engine comes with shared OpenRouter credits — no key to paste. Call
+      <code>sf.connect()</code> to open the connection panel: it will prompt you to log in through
+      your browser, then show OpenRouter as connected.
     </p>
 
     <div class="not-prose">
@@ -74,8 +68,7 @@ candidate.score`
     <p>
       Give <code>sf.Fusion</code> two model routes and a synthesizer. The two members answer the
       same question in parallel; the synthesizer reads both drafts and writes the single answer that
-      gets graded. Here the second model plays both roles — a member and the synthesizer — which is
-      a fine way to start.
+      gets graded. Here the first model doubles as the synthesizer — a fine way to start.
     </p>
 
     <div class="not-prose">

--- a/public-docs/src/pages/sf-client/Index.vue
+++ b/public-docs/src/pages/sf-client/Index.vue
@@ -27,7 +27,7 @@ flash = sf.Model("openrouter/google/gemini-3-flash-preview")
 fusion = sf.Fusion([gpt, flash], synthesizer="openrouter/openai/gpt-5.5")
 
 # Score the solo model beside the fusion, on the same cases.
-report = sf.evaluate([gpt, fusion], benchmark="ifeval", limit=3)
+report = sf.evaluate([gpt, fusion], benchmark="draco-3pass", limit=3)
 {c.name: c.score for c in report.candidates}`
 
 const smallestExampleOut = `{'gpt-5.5': 0.667, 'gpt-5.5+gemini-3-flash-preview': 1.0}`

--- a/public-docs/src/pages/sf-client/InstallationPage.vue
+++ b/public-docs/src/pages/sf-client/InstallationPage.vue
@@ -105,6 +105,8 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
           The fastest start. Name the hosted engine once, log in through your browser, and you are
           running on compute we provide. There is no local setup, and no provider key of your own:
           the hosted engine does not take one (bring-your-own-key is the local path).
+          Hosted access is currently by invitation — if you haven't been approved yet, use the
+          local engine tab below while you wait.
         </p>
 
         <div class="not-prose">
@@ -122,7 +124,7 @@ const certs = `SSL_CERT_FILE=$(python -c "import certifi;print(certifi.where())"
 
         <p>
           That is the whole hosted path. The
-          <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> takes it from here, and
+          <RouterLink to="/sf-client/first-fusion">Quickstart</RouterLink> takes it from here, and
           the <RouterLink to="/sf-client/guides/connections">Connections</RouterLink> guide covers
           provider access.
         </p>

--- a/public-docs/src/pages/sf-client/QuickstartPage.vue
+++ b/public-docs/src/pages/sf-client/QuickstartPage.vue
@@ -91,7 +91,7 @@ const runRecent: NbCheckItem[] = [
   { label: 'Finalized pareto-cross (1/1 cases scored)' },
 ]
 
-// Scores from a real draco/lite run: one case, ten criteria, one judge pass.
+// Scores from a draco-3pass run: one case (limit=1), ten criteria, three judge passes.
 const studyCandidates = [
   { id: 'claude-fable-5', name: 'claude-fable-5', score: 88.0, casesScored: 1, casesTotal: 1 },
   { id: 'claude-opus-4.8', name: 'claude-opus-4.8', score: 100.0, casesScored: 1, casesTotal: 1 },
@@ -259,10 +259,10 @@ fusions = [
 
 candidates = (*solos, *fusions)   # 16 candidate roots, one shared case set`
 
-const load = `draco = sf.benchmarks.get("draco/lite")
+const load = `draco = sf.benchmarks.get("draco-3pass")
 draco.title, draco.revision, draco.case_count`
 
-const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
+const evaluate = `report = sf.evaluate(candidates, benchmark="draco-3pass", limit=1)`
 </script>
 
 <template>
@@ -275,9 +275,8 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     <p>
       By the end, you'll have a scored comparison of <strong>16 candidates</strong>: seven solo
       models and nine fusions built from those models, all on one
-      <a href="https://arxiv.org/abs/2602.11685" target="_blank" rel="noopener">DRACO</a> case with
-      ten criteria and one judge pass each. The whole thing runs as a single request of roughly 80
-      to 85 provider calls.
+      <a href="https://arxiv.org/abs/2602.11685" target="_blank" rel="noopener">DRACO</a> case
+      (<code>limit=1</code>) with ten criteria and three judge passes each.
     </p>
 
     <blockquote>
@@ -490,16 +489,16 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     </ul>
 
     <p>
-      <code>sf.benchmarks.list()</code> shows what this engine has. <code>draco/lite</code> only
-      appears if its pinned judge model is in the gateway catalog, so if it is missing, the engine's
+      <code>sf.benchmarks.list()</code> shows what this engine has. <code>draco-3pass</code> only
+      appears if its judge model is in the gateway catalog, so if it is missing, the engine's
       configuration is the place to look rather than your own code.
     </p>
 
     <p>
-      <code>draco/lite</code> is a reduced form of the full benchmark: one pinned case and ten
-      criteria spanning all four rubric sections, with a single judge pass per criterion. It runs
-      the same protocol as <code>draco</code>, which uses all 100 cases and five judge passes per
-      criterion, so you can rehearse the full run at a small fraction of its cost.
+      <code>draco-3pass</code> runs the same 100-case dataset and rubric as the canonical
+      <code>draco</code> board, judging each answer three times instead of five. Passing
+      <code>limit=1</code> pins this tutorial to a single case, keeping costs low; the
+      full 100-case run is a completely different scale of spend.
     </p>
 
     <h2>5 · Evaluate</h2>
@@ -514,7 +513,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
       <NbCell :count="5" :code="evaluate">
         <EvaluationReport
           title="16 candidates"
-          benchmark="draco/lite"
+          benchmark="draco-3pass"
           phase="complete"
           elapsed="4M 51S"
           :done="16"
@@ -545,10 +544,10 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
     </p>
 
     <blockquote>
-      <strong>This step costs money.</strong> Expect roughly 80–85 provider calls: ten answers, nine
-      syntheses, plus ten judge passes per graded candidate. It's minutes and cents rather than
-      hours and dollars, but it's not free. <code>draco</code> at 100 cases is a completely
-      different scale of spend.
+      <strong>This step costs money.</strong> Expect ten model answers, nine syntheses, and thirty
+      judge passes per graded candidate (ten criteria × three passes), for one case. It's minutes
+      and cents rather than hours and dollars, but it's not free. <code>draco-3pass</code> at all
+      100 cases — or the five-pass <code>draco</code> — is a completely different scale of spend.
     </blockquote>
 
     <p>
@@ -569,7 +568,7 @@ const evaluate = `report = sf.evaluate(candidates, benchmark="draco/lite")`
       <NbCell :count="6" code="report">
         <CandidateScores
           :candidates="studyCandidates"
-          benchmark="draco/lite"
+          benchmark="draco-3pass"
           case-label="1 case"
           :limit="9"
         />

--- a/public-docs/src/pages/sf-client/guides/ClientsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ClientsPage.vue
@@ -92,7 +92,7 @@ client = sf.Client(
       Most of the time you'll reach for the <strong>module-level shortcuts</strong>:
       <code>sf.evaluate(...)</code>, <code>sf.connect(...)</code>, and the rest. They're the
       shortest to write, which is why the
-      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> and every notebook use
+      <RouterLink to="/sf-client/first-fusion">Quickstart</RouterLink> and every notebook use
       them.
     </p>
 

--- a/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/ConnectionsPage.vue
@@ -191,7 +191,7 @@ const panelProviders: Provider[] = [
       Called with no arguments, <code>sf.connect()</code> returns a <code>ConnectionPanel</code>: a
       live widget listing every provider the engine advertises, with a field for each one's
       supported auth method. The
-      <RouterLink to="/sf-client/quickstartPage">Quickstart</RouterLink> steps through the whole
+      <RouterLink to="/sf-client/reproduce-draco">Reproduce DRACO</RouterLink> steps through the whole
       flow state by state.
     </p>
 

--- a/public-docs/src/router/index.ts
+++ b/public-docs/src/router/index.ts
@@ -24,8 +24,8 @@ const router = createRouter({
       component: () => import('@/pages/sf-client/FirstFusionPage.vue'),
     },
     {
-      path: '/sf-client/quickstartPage',
-      name: 'sf-client-quickstart',
+      path: '/sf-client/reproduce-draco',
+      name: 'sf-client-reproduce-draco',
       component: () => import('@/pages/sf-client/QuickstartPage.vue'),
     },
     {
@@ -182,6 +182,11 @@ const router = createRouter({
       path: '/learn/leaderboard',
       name: 'learn-leaderboard',
       component: () => import('@/pages/learn/LeaderboardPage.vue'),
+    },
+    {
+      path: '/:pathMatch(.*)*',
+      name: 'not-found',
+      component: () => import('@/pages/NotFoundPage.vue'),
     },
   ],
   scrollBehavior() {


### PR DESCRIPTION
## Summary

- Replaces `draco/lite` with `draco-3pass` (with `limit=1`) in the DRACO tutorial (`QuickstartPage.vue`), updating all prose, cost breakdowns, and code snippets
- Standardises the example benchmark across Overview (`Index.vue`) and Installation pages to eliminate the cross-page mismatch that caused `ExecutionError` for new users following the docs in order
- Renames `/sf-client/quickstartPage` → `/sf-client/reproduce-draco`; updates every internal link and nav entry site-wide
- Adds Vue Router catch-all 404 page (`NotFoundPage.vue`) — stale links no longer render a blank shell
- Adds hosted-engine invitation callout on the Installation page (Hosted tab); fixes the "Quickstart" link to point at `/sf-client/first-fusion`
- Adds participant on-ramp banner to `apps/screamingface-engine/README.md`
- Adds `[runtime]` extra note to root README Quickstart section for local-engine users
- Removes a stale pip install comment from root README

Fixes reported in Kevin Lewis's onboarding audit (25–26 Aug 2026): F3, F6, F7, F8, F13, and the README extras gap.

## Test plan

- [ ] `npm run dev` in `public-docs/` — visit `/sf-client/reproduce-draco` and confirm the DRACO tutorial renders with `draco-3pass` and `limit=1` throughout
- [ ] Visit a nonexistent route (e.g. `/sf-client/quickstartPage`) — confirm the 404 page appears with a "Back to docs home" link
- [ ] Visit `/sf-client/installation` — confirm the hosted tab shows the invitation callout and links to `/sf-client/first-fusion`
- [ ] Visit `/sf-client` (Overview) — confirm benchmark is `draco-3pass`
- [ ] Check `apps/screamingface-engine/README.md` for the participant banner at the top

Refs: OME-1057