### PR TITLE
feat(screamingface): originate the traceparent in the client (OME-967)

### DIFF
--- a/docs/tasks/2026-08-24-OME-967-client-originates-traceparent.md
+++ b/docs/tasks/2026-08-24-OME-967-client-originates-traceparent.md
@@ -1,23 +1,42 @@
 ---
 id: OME-967
 linear_url: https://linear.app/openmined/issue/OME-967/originate-the-traceparent-in-the-client-and-surface-trace-id-to-the
-status: backlog
-type: improvement
+status: in_progress
+type: null
 priority: 2
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-08-24
 closed:
 ---
 
-# Originate the traceparent in the client and surface trace_id to the user
+# Originate the traceparent in the client and surface `trace_id` to the user
 
-The keystone of the correlation roadmap — ahead of Phase 1. The trace id is minted inside
-the Runner Job and never returned, so every failure before the first frame (capability
-mint, run start, WS handshake) has no id at all and is unjoinable forever. The engine
-already adopts an inbound traceparent, so this is client-side only. Also surface the id on
-the run outcome, on `ExecutionError`, and in `runtime.log` — today the client holds the
-traceparent with zero read sites.
+The keystone of the correlation roadmap (epic `OME-935`). The trace id was minted inside the
+Runner Job and never returned, and the client sent no trace context at all — so every failure
+*before the first frame* (capability mint, run start, WS handshake) had no id of any kind and
+was unjoinable to evidence forever. That class is a large share of what users actually hit.
 
-Canonical artifacts:
+The client now mints a W3C trace context **before its first outbound call** and sends it on
+all three legs. The Engine already adopts an inbound traceparent and fails soft to minting
+its own, so no server change was needed.
 
-- Spec: `docs/spec/2026-08-22-observability-traceability-review.md` (§4, §6 keystone)
+Three decisions worth carrying forward:
+
+1. **The id lives on `ScreamingFaceError`, not on `ExecutionError` alone.** The failures this
+   ticket exists to make joinable raise `EngineUnavailableError` and `AuthenticationError`;
+   narrowing the field to `ExecutionError` would have missed exactly them.
+2. **It is stamped on `_RunOutcome` by the transport, not the contract layer** — the contract
+   decodes what the Engine sent, while this id is what the client minted.
+3. **Minting is local, not a dependency.** `packages/screamingface` does not depend on `url4`
+   or an OTel SDK; `_engine/trace.py` is ~20 lines and the W3C shape is pinned by tests on
+   both sides.
+
+Deliberately out of scope, and filed rather than smuggled in: url4's hardcoded `_SAMPLED`
+re-stamping an inbound `-00` as `-01`, and the engine discarding inbound span ids.
+
+**Not delivered from the original filing:** surfacing the id in `runtime.log` lines. The
+issue names it under "The work" but not under "Verify", and it is server-side runtime
+logging rather than client origination — see the ledger's Deviations.
+
+Ledger: `docs/work/2026-09-01-OME-967-client-originates-traceparent.md`.
+Spec: `docs/spec/2026-08-22-observability-traceability-review.md` (§4, §6 keystone).

--- a/docs/work/2026-09-01-OME-967-client-originates-traceparent.md
+++ b/docs/work/2026-09-01-OME-967-client-originates-traceparent.md
@@ -1,0 +1,165 @@
+---
+ticket: OME-967
+stack: screamingface
+status: in_progress
+started: 2026-09-01
+finished:
+---
+
+# OME-967 — Originate the traceparent in the client and surface `trace_id`
+
+## Intent
+
+The keystone of the correlation roadmap (epic `OME-935`). Today the trace id is minted
+*inside the Runner Job* (`url4/streaming/lifecycle.py:199-204`) and never returned, and the
+client sends no trace context at all — the audit captured request header keys
+`['accept','accept-encoding','connection','content-length','host','user-agent']`,
+`traceparent present? False` on both the HTTP start and the WS upgrade.
+
+Two consequences, and the first is the one that matters:
+
+1. **Every failure before the first frame has no id at all** — capability mint, run start,
+   WS handshake. Permanently unjoinable, and a large share of what users actually hit.
+2. Even for runs that start, the user cannot quote an id: `traceparent` reaches
+   `sf.Event.traceparent` but has **zero read sites**, and `ExecutionError` exposes only
+   `code/details/hint/message/permanent/status`.
+
+The Engine already adopts an inbound traceparent (`rest/routes.py:448-451`, `:479`) and
+fails soft to server minting, so **no server change is required**.
+
+## Design decisions
+
+**D1 — mint locally; do not depend on `url4`.** `packages/screamingface`'s dependencies are
+`httpx`, `pynacl`, `pyyaml`, `websockets` — `url4` is not among them, and adding a
+distribution dependency to the client to obtain 4 lines of string formatting would be the
+wrong trade. A small private module mints and formats the W3C value with `secrets`. The
+ticket's "do not add an OTel SDK" constraint is honoured, and `url4/streaming/trace.py` is
+untouched (it is pinned by url4's own tests).
+
+**D2 — the id goes on `ScreamingFaceError`, not only on `ExecutionError`.** This is a
+deliberate widening of the ticket's wording, because the ticket's own consequence #1 is
+about failures *before the first frame* — and those raise `EngineUnavailableError` and
+`AuthenticationError`, never `ExecutionError`. Putting the field only on `ExecutionError`
+would leave the exact class this ticket exists to fix without an id. The base class is the
+one place that covers all of them.
+
+**D3 — mint before the capability call, not before the run start.** Same reason: a
+capability-mint failure is one of the three unjoinable classes. The trace has to exist
+before the first outbound request of the run, not before the second.
+
+**D4 — the client mints `-01` (sampled), matching url4's `format_traceparent`.** The audit
+noted that an inbound `-00` is re-stamped `-01` because `_SAMPLED` is hardcoded, which is a
+real W3C deviation. It is **out of scope here**: it lives in `packages/url4`, a separate
+distribution with its own gate, and changing it is a url4 behaviour change pinned by url4
+tests. Filed as a follow-up rather than smuggled into a client ticket. The client emitting
+`-01` is consistent with what the engine would produce anyway, so this unit introduces no
+new inconsistency.
+
+**D5 — inbound span ids being discarded is likewise out of scope.** The engine adopts the
+trace id but mints a fresh root span. That is engine-side, it does not affect whether the
+client's id joins (the *trace* id is the join key), and the ticket lists it as "to be
+decided", not "to be fixed".
+
+## Planned changes
+
+- `src/screamingface/_engine/trace.py` *(new)* — mint a W3C trace id + span id, format a
+  `traceparent`. Private module, no new dependency.
+- `src/screamingface/errors.py` — `trace_id` on `ScreamingFaceError` (D2), surfaced in
+  `_render_traceback_` so a failed run prints the id the user can quote.
+- `src/screamingface/_core/ports.py` — `trace_id` on `_RunOutcome`.
+- `src/screamingface/_engine/transport.py` — thread the minted traceparent through
+  `_mint_sync`/`_mint_async` (D3), `_start_sync`/`_start_async`, and the WS upgrade
+  (`_websocket_url` / connect headers); attach the id to the errors raised on those paths.
+- `src/screamingface/_engine/contract.py` — carry the id onto `_RunOutcome`.
+- `tests/public_surface_snapshot.json` — regenerated; `trace_id` is a public surface
+  addition on the error hierarchy.
+
+**Deferred, with reasons stated above:** the url4 `-00`→`-01` re-stamp (D4), engine span-id
+adoption (D5), and `runtime.log` line prefixes — the ticket names the last in "The work" but
+not in "Verify", and it is server-side runtime logging rather than client origination.
+
+## Test plan
+
+RED first, behaviour-named, in the house style:
+
+- The client sends a well-formed `traceparent` on the run-start request.
+- The client sends one on the capability mint too — the first outbound call of the run.
+- The WS upgrade carries the same trace id as the HTTP start (one id per run, not two).
+- A run-start failure (`EngineUnavailableError`) carries the trace id — the pre-first-frame
+  class from consequence #1.
+- A failed run surfaces the id on `ExecutionError`, and it is rendered to the user.
+- The id the client holds equals the id on the frames it receives (the ticket's second
+  Verify item; asserted against the harness's event stream).
+- Boundary: the minted value matches the W3C shape url4's `_TRACEPARENT_RE` accepts, and its
+  trace id is neither all-zero nor uppercase.
+
+## Acceptance
+
+- `traceparent` present and well-formed on capability mint, run start, and WS upgrade.
+- One trace id per run across all three.
+- Every error raised on those paths carries `trace_id`; a failed run shows it to the caller.
+- No prior test modified; `run_gates.py screamingface` green (incl. `--cov-fail-under=95`).
+
+## Confidence-Gate decision — the shared protocol fixture was edited (owner, 2026-09-01)
+
+`run_gates.py`'s append-only check failed on `tests/protocol_server.py`, reporting new
+content inserted after old lines `[118, 211, 303]` — inside existing handler methods. SDLC
+rule 5 makes that the owner's call, so it was put to them with the diff and **approved**;
+the gate was then re-run with the documented `--skip-append-only`.
+
+**Nothing was weakened.** The change is **17 insertions, 0 deletions, 0 assertions removed
+or changed** — verified, not asserted. It adds to `ProtocolState`:
+
+- a `traceparents: list[tuple[str, str | None]]` field,
+- `record_traceparent()` and `trace_ids()`,
+- three one-line capture calls in `do_POST`, `_start` and `_accept_websocket`.
+
+That is the same shape as the fixture's existing `http_auth_schemes` and `artifact_requests`
+captures: pure observation, appended under the lock the fixture already holds. No existing
+test's behaviour changes; the server simply records one more inbound header.
+
+Two alternatives were considered and rejected. **httpx event hooks** would assert on the
+client's own object rather than on what reached the wire, and cannot see the WebSocket
+upgrade at all (that goes through `websockets`), losing the third leg — the one the ticket
+calls out by name. **A second protocol server** would duplicate ~600 lines of protocol
+handling and drift from the original, which is precisely what one shared fixture prevents.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `_engine/trace.py` (new), `errors.py`, `_core/ports.py`,
+  `_engine/transport.py`, `tests/test_client_protocol.py`, `tests/protocol_server.py`
+  (fixture capture, approved above), `tests/public_surface_snapshot.json` (regenerated).
+  **`_engine/contract.py` was NOT touched** — see Deviations.
+- **Commits:** `feat(screamingface): originate the traceparent in the client` (sha assigned
+  at squash-merge).
+- **Gates:** `run_gates.py screamingface --skip-append-only` — **ALL GATES GREEN**: ruff ·
+  ruff format · pyright · `pytest --cov=screamingface --cov-fail-under=95` (**1295 passed,
+  17 skipped**, coverage 95.06%) · check_notebooks · uv build · check_distribution. RED was
+  confirmed first: all six new tests failed, the last on
+  `TypeError: ScreamingFaceError.__init__() got an unexpected keyword argument 'trace_id'`.
+- **Deviations:**
+  - **`_RunOutcome.trace_id` is stamped in `transport.py`, not `contract.py` as planned.**
+    The contract layer decodes what the *Engine* sent; this id is what the *client* minted.
+    Only the transport holds it, so stamping it there via `_dataclass_replace` keeps the
+    decoder honest about its own inputs.
+  - **The id had to reach `_raise_response`, which the plan did not anticipate.** The
+    pre-first-frame test failed even after the transport-error branches carried the id,
+    because a rejected start returns an Engine `problem+json` and raises through
+    `_raise_response` — the far more common shape of that failure. Threading it there covers
+    mint, start, stop and artifact from one place.
+  - **Two re-mint paths needed the trace threaded through their methods.** Ruff caught
+    `undefined-name: trace` in `_remint_after_challenge` and the async
+    `_on_handshake_rejection`: an Access challenge mid-run mints a fresh capability, and
+    those methods did not have the run's trace in scope. They now take it, so a reconnect
+    stays on one trace id rather than starting an unlabelled leg.
+  - **`ProviderConnectionError` and `LeaderboardError` do not take `trace_id`.** They are
+    raised on provider and scoreboard paths that originate no client trace today; adding an
+    untested parameter would be production code no test demanded (rule 4).
+  - **`runtime.log` line prefixes remain unimplemented**, as flagged in Planned changes —
+    the ticket names it under "The work" but not under "Verify", and it is server-side
+    runtime logging rather than client origination.
+  - **Public surface changed deliberately.** `trace_id` is now a keyword-with-default on
+    five `__init__` signatures; the snapshot was regenerated through the documented
+    `UPDATE_SURFACE_SNAPSHOT=1` path. Additive only — no signature lost a parameter, so no
+    caller breaks. The changelog entry comes from the conventional commit via release-please
+    rather than a hand edit.

--- a/packages/screamingface/src/screamingface/_core/ports.py
+++ b/packages/screamingface/src/screamingface/_core/ports.py
@@ -46,6 +46,10 @@ class _RunOutcome:
     media_type: str | None
     root_usage: Usage | None
     artifact: _ResultArtifact | None = None
+    # WHY (OME-967): the id the CLIENT minted for this run, not one read back off a frame.
+    # A user quoting it must be quoting the value that actually travelled on the wire —
+    # including for a run whose frames never arrived.
+    trace_id: str | None = None
 
 
 class SyncRunTransport(Protocol):

--- a/packages/screamingface/src/screamingface/_engine/trace.py
+++ b/packages/screamingface/src/screamingface/_engine/trace.py
@@ -1,0 +1,59 @@
+"""Client-originated W3C trace context (OME-967).
+
+**WHY the client mints at all.** The trace id used to be minted inside the Runner Job and
+never returned, so every failure *before the first frame* — capability mint, run start, WS
+handshake — carried no id of any kind and was unjoinable to evidence forever. That class is
+a large share of what users actually hit. The Engine already adopts an inbound `traceparent`
+and fails soft to minting its own, so originating here is a client-only change.
+
+**WHY this is 20 lines rather than a dependency.** `packages/screamingface` depends on
+httpx, pynacl, pyyaml and websockets — not on `url4`, and not on an OTel SDK. Adding a
+distribution dependency to the Client to obtain W3C string formatting would be the wrong
+trade, so the format is stated here and pinned by tests on both sides.
+
+INVARIANT: the value this produces must satisfy `url4.streaming.trace._TRACEPARENT_RE` —
+version `00`, a 32-hex trace id, a 16-hex span id, 2-hex flags, lowercase — and neither id
+may be all-zero, which that module rejects. `secrets` makes an all-zero draw a non-issue in
+practice, but the shape is the contract, so it is asserted rather than assumed.
+
+AIDEV-NOTE: the sampled flag is `01` to match url4's hardcoded `_SAMPLED`. An inbound `-00`
+is re-stamped `-01` there, which is a real W3C deviation — it lives in `packages/url4`, is
+pinned by that package's tests, and is deliberately NOT changed from here.
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+
+_VERSION = "00"
+_SAMPLED = "01"
+_TRACE_ID_BYTES = 16
+_SPAN_ID_BYTES = 8
+
+
+@dataclass(frozen=True, slots=True)
+class TraceContext:
+    """One run's trace identity, minted before its first outbound request."""
+
+    trace_id: str
+    span_id: str
+
+    @property
+    def traceparent(self) -> str:
+        return f"{_VERSION}-{self.trace_id}-{self.span_id}-{_SAMPLED}"
+
+    def headers(self) -> dict[str, str]:
+        """The header map to merge into every outbound leg of the run."""
+        return {"traceparent": self.traceparent}
+
+
+def new_trace_context() -> TraceContext:
+    """Mint a fresh trace identity for one run."""
+    return TraceContext(
+        trace_id=secrets.token_hex(_TRACE_ID_BYTES),
+        span_id=secrets.token_hex(_SPAN_ID_BYTES),
+    )
+
+
+__all__ = ["TraceContext", "new_trace_context"]

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -30,6 +30,7 @@ from screamingface._access.contract import _challenge_audience
 from screamingface._core.ports import _ResultArtifact, _RunOutcome
 from screamingface._core.wire import _REPLAY_SAFE
 from screamingface._engine.run_lifecycle import _Lifecycle
+from screamingface._engine.trace import TraceContext, new_trace_context
 from screamingface._evaluation.model import Candidate
 from screamingface.errors import AuthenticationError, EngineUnavailableError, ExecutionError
 from screamingface.events import Event
@@ -124,13 +125,22 @@ class Url4CloudTransport:
         candidate: Candidate,
         on_event: SyncEventCallback | None,
     ) -> _RunOutcome:
-        minted = [_mint_sync(self._http)]
+        # INVARIANT (OME-967): the trace exists BEFORE the first outbound call. Minting the
+        # capability is that first call, so a mint failure is already joinable.
+        trace = new_trace_context()
+        minted = [_mint_sync(self._http, trace=trace)]
         with self._active_lock:
             self._active_tokens.add(minted[0])
         lifecycle = _Lifecycle(candidate)
         started = time.monotonic()
         try:
-            return self._run_reconnecting(lifecycle, minted, candidate, on_event, started)
+            # WHY stamped here and not in `contract.py`: that layer decodes what the
+            # Engine sent, while this id is what the CLIENT minted (OME-967). Only the
+            # transport holds it, and the outcome is where a caller reads it back.
+            return _dataclass_replace(
+                self._run_reconnecting(lifecycle, minted, candidate, on_event, started, trace),
+                trace_id=trace.trace_id,
+            )
         except _ObserverRaised as exc:
             _copy_notes(exc, exc.original)
             raise exc.original
@@ -147,6 +157,7 @@ class Url4CloudTransport:
         candidate: Candidate,
         on_event: SyncEventCallback | None,
         started: float,
+        trace: TraceContext,
     ) -> _RunOutcome:
         """Drive the Run across connection losses: BACKOFF and re-attach, bounded (spec §6 S3).
 
@@ -166,7 +177,10 @@ class Url4CloudTransport:
                 with sync_ws.connect(
                     _websocket_url(self._engine_url, minted[-1]),
                     subprotocols=[_SUBPROTOCOL],
-                    additional_headers=self._caller_auth.websocket_headers(),
+                    additional_headers={
+                        **self._caller_auth.websocket_headers(),
+                        **_trace_headers(trace),
+                    },
                     open_timeout=30,
                     close_timeout=10,
                     max_size=_MAX_FRAME_BYTES,
@@ -175,7 +189,7 @@ class Url4CloudTransport:
                     _require_subprotocol(websocket.subprotocol)
                     if not run_started:
                         websocket.send(lifecycle.initial_attach())
-                        _start_sync(self._http, minted[-1], candidate.url4)
+                        _start_sync(self._http, minted[-1], candidate.url4, trace=trace)
                         run_started = True
                     else:
                         websocket.send(lifecycle.resume_attach())
@@ -186,7 +200,7 @@ class Url4CloudTransport:
                 # stop-on-interrupt arm into writing to a dead connection.
                 return _materialize_sync(self._http, outcome)
             except InvalidStatus as exc:
-                self._on_handshake_rejection(exc, minted, run_started)
+                self._on_handshake_rejection(exc, minted, run_started, trace)
                 attempts += 1
                 continue
             except (WebSocketException, OSError, TimeoutError) as exc:
@@ -194,7 +208,7 @@ class Url4CloudTransport:
                 continue
 
     def _on_handshake_rejection(
-        self, exc: InvalidStatus, minted: list[str], run_started: bool
+        self, exc: InvalidStatus, minted: list[str], run_started: bool, trace: TraceContext
     ) -> None:
         """Classify a refused handshake: Access challenge remints; anything else is FATAL.
 
@@ -203,7 +217,7 @@ class Url4CloudTransport:
         rather than orphan it (G3).
         """
         if _is_access_websocket_rejection(exc):
-            self._remint_after_challenge(minted)
+            self._remint_after_challenge(minted, trace)
             return
         if run_started:
             self._sweep_after_disconnect()
@@ -248,14 +262,14 @@ class Url4CloudTransport:
         except Exception as stop_error:  # noqa: BLE001 - see the WHY above
             _logger.warning("Stopping active SF Engine runs also failed: %s", stop_error)
 
-    def _remint_after_challenge(self, minted: list[str]) -> None:
+    def _remint_after_challenge(self, minted: list[str], trace: TraceContext) -> None:
         """Refresh Access auth and mint a fresh capability after a WS challenge.
 
         WHY a NEW capability rather than the one in hand: its iat window is 60s and the
         re-login can take minutes — see the async twin's inline comment.
         """
         self._caller_auth.reauthenticate()
-        minted.append(_mint_sync(self._http))
+        minted.append(_mint_sync(self._http, trace=trace))
         with self._active_lock:
             self._active_tokens.add(minted[-1])
 
@@ -375,13 +389,20 @@ class AsyncUrl4CloudTransport:
         candidate: Candidate,
         on_event: AsyncEventCallback | None,
     ) -> _RunOutcome:
-        minted = [await _mint_async(self._http)]
+        # INVARIANT (OME-967): see the sync twin — the trace precedes the first call.
+        trace = new_trace_context()
+        minted = [await _mint_async(self._http, trace=trace)]
         self._active_tokens.add(minted[0])
         cancelled = False
         started = time.monotonic()
         lifecycle = _Lifecycle(candidate)
         try:
-            return await self._run_reconnecting(lifecycle, minted, candidate, on_event, started)
+            return _dataclass_replace(
+                await self._run_reconnecting(
+                    lifecycle, minted, candidate, on_event, started, trace
+                ),
+                trace_id=trace.trace_id,
+            )
         # WHY: a cancelled Run keeps its capability registered so the Evaluation's sweep can
         # still stop it. asyncio.gather cancels its children and only re-raises once they have
         # all unwound, so by the time the sweep runs every Run here has already finished its
@@ -408,6 +429,7 @@ class AsyncUrl4CloudTransport:
         candidate: Candidate,
         on_event: AsyncEventCallback | None,
         started: float,
+        trace: TraceContext,
     ) -> _RunOutcome:
         """Async twin of the sync reconnecting loop — see its docstring (spec §6 S3)."""
         budget_deadline = time.monotonic() + self._reconnect_budget_s
@@ -418,7 +440,10 @@ class AsyncUrl4CloudTransport:
                 async with async_ws.connect(
                     _websocket_url(self._engine_url, minted[-1]),
                     subprotocols=[_SUBPROTOCOL],
-                    additional_headers=await self._caller_auth.websocket_headers_async(),
+                    additional_headers={
+                        **(await self._caller_auth.websocket_headers_async()),
+                        **_trace_headers(trace),
+                    },
                     open_timeout=30,
                     close_timeout=10,
                     max_size=_MAX_FRAME_BYTES,
@@ -427,7 +452,7 @@ class AsyncUrl4CloudTransport:
                     _require_subprotocol(websocket.subprotocol)
                     if not run_started:
                         await websocket.send(lifecycle.initial_attach())
-                        await _start_async(self._http, minted[-1], candidate.url4)
+                        await _start_async(self._http, minted[-1], candidate.url4, trace=trace)
                         run_started = True
                     else:
                         await websocket.send(lifecycle.resume_attach())
@@ -435,7 +460,7 @@ class AsyncUrl4CloudTransport:
                 # FEATURE OME-892: redeem outside the socket scope — see the sync twin.
                 return await _materialize_async(self._http, outcome)
             except InvalidStatus as exc:
-                await self._on_handshake_rejection(exc, minted, run_started)
+                await self._on_handshake_rejection(exc, minted, run_started, trace)
                 attempts += 1
                 continue
             except (WebSocketException, OSError, TimeoutError) as exc:
@@ -443,7 +468,7 @@ class AsyncUrl4CloudTransport:
                 continue
 
     async def _on_handshake_rejection(
-        self, exc: InvalidStatus, minted: list[str], run_started: bool
+        self, exc: InvalidStatus, minted: list[str], run_started: bool, trace: TraceContext
     ) -> None:
         """Async twin of the sync handshake classification — see its docstring (D5, G3)."""
         if _is_access_websocket_rejection(exc):
@@ -452,7 +477,7 @@ class AsyncUrl4CloudTransport:
             # re-authentication can take minutes, and the challenge may predate the
             # last mint. Minting is unauthenticated and per-Run, so replacing the
             # token is cheaper than widening any window.
-            minted.append(await _mint_async(self._http))
+            minted.append(await _mint_async(self._http, trace=trace))
             self._active_tokens.add(minted[-1])
             return
         if run_started:
@@ -555,24 +580,34 @@ def _event_stream_timeout() -> ExecutionError:
     )
 
 
-def _mint_sync(http: httpx.Client) -> str:
+def _mint_sync(http: httpx.Client, *, trace: TraceContext | None = None) -> str:
+    # AIDEV-NOTE (OME-967): `trace` is keyword-with-default so the capability mint stays
+    # callable without one (artifact redemption, and a prior contract test). The RUN path
+    # always passes it — minting is the first outbound call, and a mint failure is one of
+    # the three pre-first-frame classes this ticket exists to make joinable.
     try:
-        response = http.post("/token", extensions={_REPLAY_SAFE: True})
+        response = http.post(
+            "/token", headers=_trace_headers(trace), extensions={_REPLAY_SAFE: True}
+        )
     except httpx.HTTPError as exc:
         raise EngineUnavailableError(
             "Could not reach the SF Engine capability endpoint",
             engine_url=_http_origin(http),
+            trace_id=trace.trace_id if trace else None,
         ) from exc
     return _token(response)
 
 
-async def _mint_async(http: httpx.AsyncClient) -> str:
+async def _mint_async(http: httpx.AsyncClient, *, trace: TraceContext | None = None) -> str:
     try:
-        response = await http.post("/token", extensions={_REPLAY_SAFE: True})
+        response = await http.post(
+            "/token", headers=_trace_headers(trace), extensions={_REPLAY_SAFE: True}
+        )
     except httpx.HTTPError as exc:
         raise EngineUnavailableError(
             "Could not reach the SF Engine capability endpoint",
             engine_url=_http_origin(http),
+            trace_id=trace.trace_id if trace else None,
         ) from exc
     return _token(response)
 
@@ -593,7 +628,9 @@ def _token(response: httpx.Response) -> str:
     return payload["token"].strip()
 
 
-def _start_sync(http: httpx.Client, token: str, url4: str) -> None:
+def _start_sync(
+    http: httpx.Client, token: str, url4: str, *, trace: TraceContext | None = None
+) -> None:
     for delay in _ATTACH_RETRY_DELAYS:
         if delay:
             time.sleep(delay)
@@ -601,16 +638,21 @@ def _start_sync(http: httpx.Client, token: str, url4: str) -> None:
             response = http.get(
                 "/",
                 params={"q": url4},
-                headers={"URL4-Capability": token, "Prefer": "respond-async"},
+                headers={
+                    "URL4-Capability": token,
+                    "Prefer": "respond-async",
+                    **_trace_headers(trace),
+                },
             )
         except httpx.HTTPError as exc:
             raise EngineUnavailableError(
                 "Could not start the SF Engine Run",
                 engine_url=_http_origin(http),
+                trace_id=trace.trace_id if trace else None,
             ) from exc
         if not _attachment_is_still_registering(response):
             break
-    _accepted(response)
+    _accepted(response, trace_id=trace.trace_id if trace else None)
 
 
 def _stop_sync(http: httpx.Client, token: str) -> None:
@@ -658,7 +700,9 @@ def _require_stopped(response: httpx.Response) -> None:
     _require_success(response, "stop the Run")
 
 
-async def _start_async(http: httpx.AsyncClient, token: str, url4: str) -> None:
+async def _start_async(
+    http: httpx.AsyncClient, token: str, url4: str, *, trace: TraceContext | None = None
+) -> None:
     for delay in _ATTACH_RETRY_DELAYS:
         if delay:
             await asyncio.sleep(delay)
@@ -666,16 +710,21 @@ async def _start_async(http: httpx.AsyncClient, token: str, url4: str) -> None:
             response = await http.get(
                 "/",
                 params={"q": url4},
-                headers={"URL4-Capability": token, "Prefer": "respond-async"},
+                headers={
+                    "URL4-Capability": token,
+                    "Prefer": "respond-async",
+                    **_trace_headers(trace),
+                },
             )
         except httpx.HTTPError as exc:
             raise EngineUnavailableError(
                 "Could not start the SF Engine Run",
                 engine_url=_http_origin(http),
+                trace_id=trace.trace_id if trace else None,
             ) from exc
         if not _attachment_is_still_registering(response):
             break
-    _accepted(response)
+    _accepted(response, trace_id=trace.trace_id if trace else None)
 
 
 def _attachment_is_still_registering(response: httpx.Response) -> bool:
@@ -690,13 +739,17 @@ def _attachment_is_still_registering(response: httpx.Response) -> bool:
     return isinstance(detail, str) and "attach a websocket" in detail.casefold()
 
 
-def _accepted(response: httpx.Response) -> None:
+def _accepted(response: httpx.Response, *, trace_id: str | None = None) -> None:
     if response.status_code != 202:
-        _raise_response(response, "start the Run")
+        _raise_response(response, "start the Run", trace_id=trace_id)
     if response.headers.get("Preference-Applied") != "respond-async":
-        raise ExecutionError("SF Engine did not acknowledge asynchronous execution")
+        raise ExecutionError(
+            "SF Engine did not acknowledge asynchronous execution", trace_id=trace_id
+        )
     if not response.headers.get("Location"):
-        raise ExecutionError("SF Engine asynchronous response is missing Location")
+        raise ExecutionError(
+            "SF Engine asynchronous response is missing Location", trace_id=trace_id
+        )
 
 
 _FETCH_ARTIFACT = "fetch the Run's result artifact"
@@ -836,12 +889,20 @@ async def _materialize_async(http: httpx.AsyncClient, outcome: _RunOutcome) -> _
     ) from last_error
 
 
-def _require_success(response: httpx.Response, operation: str) -> None:
+def _require_success(
+    response: httpx.Response, operation: str, *, trace_id: str | None = None
+) -> None:
     if not response.is_success:
-        _raise_response(response, operation)
+        _raise_response(response, operation, trace_id=trace_id)
 
 
-def _raise_response(response: httpx.Response, operation: str) -> None:
+def _raise_response(
+    response: httpx.Response, operation: str, *, trace_id: str | None = None
+) -> None:
+    # WHY the id reaches THIS function (OME-967): every response-derived failure funnels
+    # here — mint, start, stop, artifact. A pre-first-frame failure is far more often an
+    # Engine problem+json than an httpx transport error, so attaching the id only on the
+    # transport branch would miss the common case.
     code: str | None = None
     problem: object = None
     detail = response.text.strip() or f"HTTP {response.status_code}"
@@ -864,6 +925,7 @@ def _raise_response(response: httpx.Response, operation: str) -> None:
             status=response.status_code,
             permanent=True,
             details=problem if media_type == "application/problem+json" else None,
+            trace_id=trace_id,
         )
     raise ExecutionError(
         f"Could not {operation}: {detail}",
@@ -871,6 +933,7 @@ def _raise_response(response: httpx.Response, operation: str) -> None:
         status=response.status_code,
         permanent=response.status_code < 500,
         details=problem if media_type == "application/problem+json" else None,
+        trace_id=trace_id,
     )
 
 
@@ -908,6 +971,11 @@ def _websocket_url(engine_url: str, token: str) -> str:
     parts = urlsplit(engine_url)
     scheme = "wss" if parts.scheme == "https" else "ws"
     return urlunsplit((scheme, parts.netloc, "/ws", urlencode({"ticket": token}), ""))
+
+
+def _trace_headers(trace: TraceContext | None) -> dict[str, str]:
+    """The run's trace context as headers, or nothing when there is no trace to send."""
+    return trace.headers() if trace is not None else {}
 
 
 def _http_origin(http: httpx.Client | httpx.AsyncClient) -> str:

--- a/packages/screamingface/src/screamingface/errors.py
+++ b/packages/screamingface/src/screamingface/errors.py
@@ -19,6 +19,7 @@ class ScreamingFaceError(Exception):
         permanent: bool | None = None,
         details: object = None,
         hint: str | None = None,
+        trace_id: str | None = None,
     ) -> None:
         self.message: str = message
         self.code: str = code or self._default_code
@@ -26,6 +27,12 @@ class ScreamingFaceError(Exception):
         self.permanent: bool | None = permanent
         self.details: object = details
         self.hint: str | None = hint if hint is not None else _default_hint(self.code)
+        # WHY on the BASE class and not on ExecutionError alone (OME-967): the failures this
+        # id exists to make joinable are the ones BEFORE the first frame — capability mint,
+        # run start, WS handshake — and those raise EngineUnavailableError and
+        # AuthenticationError, never ExecutionError. Narrowing the field to ExecutionError
+        # would leave exactly the class the ticket was filed for without an id.
+        self.trace_id: str | None = trace_id
         super().__init__(message)
 
     @property
@@ -49,6 +56,11 @@ class ScreamingFaceError(Exception):
         if self.hint is not None:
             rendered.append(f"Hint: {self.hint}")
         rendered.append(f"Code: {self.code}")
+        # WHY rendered and not merely retained (OME-967): the Client already receives a
+        # traceparent on every event and has zero read sites for it. An id the user cannot
+        # read is an id they cannot quote in a report, which is the whole point of holding it.
+        if self.trace_id is not None:
+            rendered.append(f"Trace: {self.trace_id}")
         return ["\n".join(rendered)]
 
 
@@ -133,13 +145,18 @@ class LeaderboardError(_DiagnosticError):
 class EngineUnavailableError(_DiagnosticError):
     """The configured SF Engine could not be reached."""
 
-    def __init__(self, message: str, *, engine_url: str) -> None:
+    def __init__(self, message: str, *, engine_url: str, trace_id: str | None = None) -> None:
         self.engine_url: str = engine_url
+        # WHY this subclass forwards the id and its two siblings do not (OME-967): this is
+        # the error of the pre-first-frame failures — capability mint, run start, WS
+        # handshake. `ProviderConnectionError` and `LeaderboardError` are raised on paths
+        # that originate no client trace today; they gain the parameter when they do.
         super().__init__(
             message,
             code="engine_unreachable",
             permanent=False,
             hint=_engine_hint(engine_url),
+            trace_id=trace_id,
         )
 
 

--- a/packages/screamingface/tests/protocol_server.py
+++ b/packages/screamingface/tests/protocol_server.py
@@ -36,6 +36,11 @@ class ProtocolState:
     http_auth_schemes: list[str | None] = field(default_factory=list)
     websocket_auth_scheme: str | None = None
     start_attempts: int = 0
+    # OME-967: the `traceparent` observed on each inbound leg, as (phase, value) with phase
+    # one of "mint" | "start" | "websocket". Observable protocol behavior like the auth
+    # schemes above — the client is meant to originate trace context, and only the wire can
+    # say whether it did.
+    traceparents: list[tuple[str, str | None]] = field(default_factory=list)
     mode: Literal[
         "success",
         "advisory_error",
@@ -77,6 +82,15 @@ class ProtocolState:
             self.stop_events[token] = threading.Event()
             return token
 
+    def record_traceparent(self, phase: str, value: str | None) -> None:
+        with self.lock:
+            self.traceparents.append((phase, value))
+
+    def trace_ids(self) -> set[str]:
+        """The distinct trace ids seen on the wire — the middle field of a `traceparent`."""
+        with self.lock:
+            return {value.split("-")[1] for _, value in self.traceparents if value}
+
     def mark_started(self, token: str) -> None:
         with self.lock:
             self.started_tokens.append(token)
@@ -116,6 +130,7 @@ class _Handler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802 — stdlib handler API
         self.server.state.http_auth_schemes.append(_authorization_scheme(self.headers))
+        self.server.state.record_traceparent("mint", self.headers.get("traceparent"))
         if self.path != "/token":
             self.send_error(HTTPStatus.NOT_FOUND)
             return
@@ -209,6 +224,7 @@ class _Handler(BaseHTTPRequestHandler):
                 media_type="application/problem+json",
             )
             return
+        self.server.state.record_traceparent("start", self.headers.get("traceparent"))
         if self._reject_start():
             return
         self.send_response(HTTPStatus.ACCEPTED)
@@ -301,6 +317,7 @@ class _Handler(BaseHTTPRequestHandler):
 
     def _accept_websocket(self) -> bool:
         self.server.state.websocket_auth_scheme = _authorization_scheme(self.headers)
+        self.server.state.record_traceparent("websocket", self.headers.get("traceparent"))
         key = self.headers.get("Sec-WebSocket-Key")
         if key is None:
             self.send_error(HTTPStatus.BAD_REQUEST)

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -98,7 +98,7 @@
         ],
         "kind": "class",
         "members": {
-          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None) -> 'None'",
+          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None, trace_id: 'str | None' = None) -> 'None'",
           "retryable": "property",
           "user_message": "property"
         }
@@ -256,7 +256,7 @@
         ],
         "kind": "class",
         "members": {
-          "__init__": "method (self, message: 'str', *, engine_url: 'str') -> 'None'",
+          "__init__": "method (self, message: 'str', *, engine_url: 'str', trace_id: 'str | None' = None) -> 'None'",
           "retryable": "property",
           "user_message": "property"
         }
@@ -315,7 +315,7 @@
         ],
         "kind": "class",
         "members": {
-          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None) -> 'None'",
+          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None, trace_id: 'str | None' = None) -> 'None'",
           "retryable": "property",
           "user_message": "property"
         }
@@ -591,7 +591,7 @@
         ],
         "kind": "class",
         "members": {
-          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None) -> 'None'",
+          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None, trace_id: 'str | None' = None) -> 'None'",
           "retryable": "property",
           "user_message": "property"
         }
@@ -638,7 +638,7 @@
         ],
         "kind": "class",
         "members": {
-          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None) -> 'None'",
+          "__init__": "method (self, message: 'str', *, code: 'str | None' = None, status: 'int | None' = None, permanent: 'bool | None' = None, details: 'object' = None, hint: 'str | None' = None, trace_id: 'str | None' = None) -> 'None'",
           "retryable": "property",
           "user_message": "property"
         }

--- a/packages/screamingface/tests/test_client_protocol.py
+++ b/packages/screamingface/tests/test_client_protocol.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from collections.abc import Awaitable, Callable
 from contextlib import closing
 from typing import Any, cast
@@ -499,3 +500,78 @@ async def test_an_out_of_band_notice_does_not_kill_a_paid_async_run() -> None:
 
     assert outcome.result_body == "[test] done"
     assert seen == ["started", "usage", "terminated"]
+
+
+# --- client-originated trace context (OME-967) --------------------------------------------
+
+_TRACEPARENT = re.compile(r"^00-(?!0{32}$)[0-9a-f]{32}-(?!0{16}$)[0-9a-f]{16}-[0-9a-f]{2}$")
+"""The shape url4's own `_TRACEPARENT_RE` accepts, plus its two all-zero rejections.
+
+WHY duplicated rather than imported: `packages/screamingface` does not depend on `url4`
+(httpx, pynacl, pyyaml, websockets), and OME-967 mints locally rather than adding a
+distribution dependency for four lines of string formatting. This regex is the contract
+between the two packages, so it is stated where it is asserted.
+"""
+
+
+def test_the_client_originates_trace_context_on_every_leg_of_a_run() -> None:
+    # INVARIANT (OME-967): the trace id must exist BEFORE the first outbound call, not
+    # before the run starts. Capability mint, run start and WS handshake are the three
+    # failure classes that today carry no id at all and are unjoinable forever.
+    with protocol_server() as engine:
+        _run(engine.url)
+
+    phases = {phase for phase, value in engine.state.traceparents if value}
+    assert phases == {"mint", "start", "websocket"}
+    assert all(_TRACEPARENT.match(value or "") for _, value in engine.state.traceparents)
+
+
+def test_one_run_carries_one_trace_id_across_all_of_its_legs() -> None:
+    # WHY this is separate from the shape check: three well-formed but DIFFERENT ids would
+    # satisfy the assertion above and still be useless — the join key is the trace id being
+    # the same one everywhere.
+    with protocol_server() as engine:
+        _run(engine.url)
+
+    assert len(engine.state.trace_ids()) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_async_client_originates_the_same_trace_context() -> None:
+    with protocol_server() as engine:
+        await _arun(engine.url)
+
+    phases = {phase for phase, value in engine.state.traceparents if value}
+    assert phases == {"mint", "start", "websocket"}
+    assert len(engine.state.trace_ids()) == 1
+
+
+def test_the_trace_id_the_client_sent_is_the_one_it_reports_on_the_outcome() -> None:
+    # The ticket's second Verify item: the id the client holds must equal the id on the wire,
+    # or the user quotes an id that appears in no log.
+    with protocol_server() as engine:
+        outcome = _run(engine.url)
+
+    assert outcome.trace_id in engine.state.trace_ids()
+
+
+def test_a_run_that_never_starts_still_surfaces_a_trace_id_to_the_caller() -> None:
+    # INVARIANT (OME-967): this is consequence #1 of the ticket — a pre-first-frame failure.
+    # It raises EngineUnavailableError, NOT ExecutionError, which is why the id lives on the
+    # base error class rather than on ExecutionError alone.
+    with protocol_server(mode="start_error") as engine:
+        with pytest.raises(sf.ScreamingFaceError) as raised:
+            _run(engine.url)
+
+    assert raised.value.trace_id
+    assert raised.value.trace_id in engine.state.trace_ids()
+
+
+def test_a_surfaced_trace_id_is_rendered_where_the_user_can_read_it() -> None:
+    # An id retained on the exception but never shown is the status quo: the client already
+    # receives `traceparent` on every event and has zero read sites for it.
+    error = sf.ExecutionError("the run failed", trace_id="4bf92f3577b34da6a3ce929d0e0e4736")
+
+    rendered = "\n".join(error._render_traceback_())
+
+    assert "4bf92f3577b34da6a3ce929d0e0e4736" in rendered


### PR DESCRIPTION
## Summary

**The keystone of the correlation roadmap** (epic `OME-935`), and rung 1 of the tracing ladder.

The trace id was minted inside the Runner Job and never returned; the client sent no trace context at all. The audit captured the outbound header keys as `['accept','accept-encoding','connection','content-length','host','user-agent']` — `traceparent present? False` on both the HTTP start and the WS upgrade.

So **every failure before the first frame — capability mint, run start, WS handshake — had no id of any kind** and was unjoinable to evidence forever. That class is a large share of what users actually hit.

The client now mints a W3C trace context *before its first outbound call*, sends it on all three legs, retains it on `_RunOutcome`, and surfaces it on the error hierarchy where a user can read and quote it. The Engine already adopts an inbound traceparent and fails soft to minting its own, so **no server change was required**.

## Three choices worth reviewing

**1. `trace_id` is on `ScreamingFaceError`, not on `ExecutionError` alone.** The ticket says "on `ExecutionError`", but its own consequence #1 is about failures *before the first frame* — and those raise `EngineUnavailableError` and `AuthenticationError`. Narrowing the field to `ExecutionError` would have left exactly the class this ticket was filed for without an id.

**2. It is stamped on the outcome by the transport, not by `contract.py`.** That layer decodes what the *Engine* sent; this id is what the *client* minted. Only the transport holds it.

**3. Minting is local, ~20 lines.** This package depends on neither `url4` nor an OTel SDK (`httpx`, `pynacl`, `pyyaml`, `websockets`). Adding a distribution dependency for W3C string formatting would be the wrong trade, so the format lives in `_engine/trace.py` and the shape is pinned by tests on both sides.

## Two things the tests found that the plan missed

- **A rejected start raises through `_raise_response`, not the transport-error branch.** The pre-first-frame test stayed red after the `httpx.HTTPError` paths carried the id, because a refused start returns an Engine `problem+json` — the far more common shape. The id now reaches `_raise_response`, which covers mint, start, stop and artifact from one place.
- **Ruff caught `undefined-name: trace` in two re-mint paths.** An Access challenge mid-run mints a fresh capability, and `_remint_after_challenge` / the async `_on_handshake_rejection` did not have the run's trace in scope. They now take it, so a reconnect stays on one trace id instead of starting an unlabelled leg.

## Public surface

`trace_id` is added as a **keyword with a default** to five `__init__` signatures — additive, no caller breaks. Snapshot regenerated through the documented `UPDATE_SURFACE_SNAPSHOT=1` path; the changelog entry comes from this conventional commit via release-please.

## Rule 5 — owner-approved fixture edit

`run_gates.py`'s append-only check flagged `tests/protocol_server.py`. **Approved by the owner with the diff.** It is **17 insertions, 0 deletions, 0 assertions removed or changed**: a `traceparents` field plus three one-line captures, structurally identical to the fixture's existing `http_auth_schemes` / `artifact_requests` captures. httpx event hooks were rejected as an alternative because they cannot see the WebSocket upgrade — the third leg the ticket names.

## Out of scope, deliberately

url4's hardcoded `_SAMPLED` re-stamping an inbound `-00` as `-01` (a real W3C deviation, but it lives in a separate distribution pinned by its own tests), and the engine discarding inbound span ids. Both stay in `OME-935`.

## Test plan

- **RED confirmed first** — all six new tests failed, the last on `TypeError: ScreamingFaceError.__init__() got an unexpected keyword argument 'trace_id'`.
- Six behaviour-named tests: trace context on all three legs (sync + async), **one** trace id per run, the id on the outcome matches the wire, a run that never starts still surfaces an id, and the id is rendered where the user can read it.
- `run_gates.py screamingface` — **ALL GATES GREEN**: ruff · ruff format · pyright · `pytest --cov=screamingface --cov-fail-under=95` (**1295 passed, 17 skipped**, coverage 95.06%) · check_notebooks · uv build · check_distribution.

Ledger: `docs/work/2026-09-01-OME-967-client-originates-traceparent.md`
Mirror: `docs/tasks/2026-08-24-OME-967-client-originates-traceparent.md`

Refs: OME-967