### PR TITLE
docs(tasks): close the OME-936 mirror and ledger

### DIFF
--- a/docs/tasks/2026-08-22-OME-936-observability-review-spec.md
+++ b/docs/tasks/2026-08-22-OME-936-observability-review-spec.md
@@ -1,12 +1,12 @@
 ---
 id: OME-936
 linear_url: https://linear.app/openmined/issue/OME-936/write-the-observability-and-traceability-review-spec
-status: in_progress
+status: done
 type: task
 priority: 2
 labels: [repo, agentic, autonomous, task]
 created: 2026-08-22
-closed:
+closed: 2026-09-01
 ---
 
 # Write the observability & traceability review spec

--- a/docs/work/2026-08-22-OME-936-observability-review-spec.md
+++ b/docs/work/2026-08-22-OME-936-observability-review-spec.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-936
 stack: repo
-status: in_progress
+status: done
 started: 2026-08-22
-finished:
+finished: 2026-09-01
 ---
 
 # OME-936 — Write the observability & traceability review spec
@@ -45,11 +45,11 @@ audit evidence and the locked decisions.
 - All 12 `docs/tasks/` mirrors exist with correct frontmatter.
 - Lands via PR; `OME-936` closed with the close template after merge.
 
-## Review status
+## Review status — CLOSED
 
-PR #688 is a **draft** and stays that way until the owner confirms readiness (2026-08-24).
-The spec is under review; iterations land on this branch. Do not mark ready, do not merge,
-and do not close `OME-936` until that confirmation is given in plain words.
+PR #688 stayed a draft until the owner confirmed readiness in plain words on 2026-09-01, as
+this section required. Undrafted, squash-merged as `59950eb5`, and `OME-936` closed in Linear
+with the close template.
 
 ## Maintenance pass — 2026-09-01 (branch kept mergeable)
 


### PR DESCRIPTION
Close discipline for `OME-936`, whose PR #688 merged as `59950eb5`.

The card makes Linear the status authority and requires the repo-side record to match at finish. Two files:

- `docs/tasks/2026-08-22-OME-936-observability-review-spec.md` — `status: in_progress` → `done`, `closed: 2026-09-01`.
- `docs/work/2026-08-22-OME-936-observability-review-spec.md` — status/finished, and the **Review status** section rewritten. It previously said "PR #688 is a draft and stays that way until the owner confirms readiness... do not merge, do not close OME-936 until that confirmation is given in plain words." That confirmation was given on 2026-09-01, so the section now records what happened rather than a standing instruction that has been overtaken.

Docs-only; no stack gates apply.

Refs: OME-936