### PR TITLE
docs(tasks): mirror the Dependabot backlog follow-ups

### DIFF
--- a/docs/tasks/2026-09-01-OME-1062-aigateway-minor-bump-red.md
+++ b/docs/tasks/2026-09-01-OME-1062-aigateway-minor-bump-red.md
@@ -1,0 +1,31 @@
+---
+id: OME-1062
+linear_url: https://linear.app/openmined/issue/OME-1062/diagnose-the-aigateway-python-minor-bump-that-breaks-the-test-suite
+status: backlog
+type: task
+priority: 3
+labels: [aigateway, agentic, autonomous, task]
+created: 2026-09-01
+closed:
+---
+
+# Diagnose the aigateway-python-minor bump that breaks the test suite (#774)
+
+Dependabot PR #774 (`build(deps): bump the aigateway-python-minor group across 1
+directory with 2 updates`) is `MERGEABLE/UNSTABLE`. It is the only Dependabot PR left
+open after the 2026-09-01 backlog clear-out, and it is red for a real reason.
+
+Failing checks — `test (3.12)` and `test (3.13)` (runs 33172319416 and 33172323365) plus
+`images` (run 33172323029). Both Python versions fail, so this is not a matrix-specific
+flake. The group carries two updates; the job is to find which one breaks the suite.
+
+Then either fix forward in `apps/aigateway`, or hold the offending dependency with a
+scoped `ignore:` entry in `.github/dependabot.yml` carrying a rationale comment in that
+file's existing style — every `ignore:` there names its blocking ticket and states the
+trigger that lifts it.
+
+Do not close #774 without a diagnosis. Dependabot re-raises the same red PR next cycle
+with nothing learned; the config header records #480 as exactly that failure.
+
+Related: OME-1063 (Dependabot volume), which is where the `ignore:` entry lands if the
+decision is to hold.

--- a/docs/tasks/2026-09-01-OME-1063-dependabot-volume.md
+++ b/docs/tasks/2026-09-01-OME-1063-dependabot-volume.md
@@ -1,0 +1,44 @@
+---
+id: OME-1063
+linear_url: https://linear.app/openmined/issue/OME-1063/cut-dependabot-pr-volume-without-weakening-the-securityminormajor
+status: backlog
+type: task
+priority: 3
+labels: [repo, agentic, autonomous, task]
+created: 2026-09-01
+closed:
+---
+
+# Cut Dependabot PR volume without weakening the security/minor/major split
+
+Dependabot raised eight PRs in under a week — roughly a quarter of the open-PR board.
+Seven were green and merged on 2026-09-01; this item slows the refill rate.
+
+`.github/dependabot.yml` is heavily and deliberately tuned (OME-733, -736, -737, -740,
+-747, -748) with the rationale in comments. It is not a file to rewrite from scratch.
+
+**Do not collapse the `-security` / `-minor` / `-major` groups.** The file documents why:
+with one group per ecosystem a single breaking major holds every security patch behind
+it, and a major can slip in under cover of them. OME-736 was exactly that — react and
+react-dom security bumps stuck behind an ESLint 10 crash, in a PR quietly carrying a
+TypeScript 5 to 7 compiler rewrite. The split is load-bearing.
+
+Three changes that reduce volume without touching it:
+
+1. `weekly` to `monthly` on every `schedule:` block. Safe because groups declaring
+   `applies-to: security-updates` are not governed by the version-update schedule and
+   still fire on discovery. Biggest single lever.
+2. One multi-directory `uv` entry in place of six per-directory entries, using the plural
+   `directories:` list. Live proof: #728 and #733 were the same `ruff 0.16.3 -> 0.16.4`
+   bump in two directories, with #729 and #775 in the same cycle. VERIFY the plural
+   `directories:` key against current Dependabot docs before writing it — it was not
+   confirmed at filing time and this change depends on it. If unsupported, ship 1 and 3.
+3. Fix the `screamingface-python` group: `/packages/screamingface` declares one group with
+   `patterns: ["*"]` and no `applies-to:`, which the file's own header explains defaults
+   to version updates. That is the OME-733 fault that made security fixes arrive as nine
+   ungrouped PRs. Every other ecosystem was fixed; this one was missed.
+
+Verify: the next Dependabot run produces one grouped uv PR rather than one per directory,
+and a security update still arrives grouped and on discovery.
+
+Related: OME-1062 (#774, the one Dependabot PR still open, red).

--- a/docs/work/2026-09-01-OME-1063-dependabot-backlog-clearout.md
+++ b/docs/work/2026-09-01-OME-1063-dependabot-backlog-clearout.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-1063
+stack: repo
+status: in_progress
+started: 2026-09-01
+finished:
+---
+
+# OME-1063 — clear the Dependabot backlog, then cut its refill rate
+
+## Intent
+
+The repo had 31 open PRs; 8 were Dependabot, roughly a quarter of the board. This unit
+clears the standing pile and files the follow-ups needed so it does not immediately
+refill. It carries the `docs/tasks/` mirrors for both filed items — deliberately one
+branch rather than two, since adding PRs to a PR-count problem is self-defeating.
+
+## Planned changes
+
+- `docs/tasks/2026-09-01-OME-1062-aigateway-minor-bump-red.md` (new)
+- `docs/tasks/2026-09-01-OME-1063-dependabot-volume.md` (new)
+- `docs/work/2026-09-01-OME-1063-dependabot-backlog-clearout.md` (this file)
+
+The `.github/dependabot.yml` edit itself is NOT in this branch — it is OME-1063's own
+implementation and needs its own RED/GREEN loop against a real Dependabot run.
+
+## Test plan
+
+Docs-only branch; no code under test. The verification is the board state itself:
+
+- `gh pr list --state open --json number --jq length` returns 24 (was 31).
+- No open Dependabot PR except #774.
+- Every merged PR reports `MERGED` with a `mergedAt`.
+
+## Acceptance
+
+- The seven green Dependabot PRs are merged, not closed.
+- The one red Dependabot PR is diagnosed under its own ticket, not closed blind.
+- Both filed items exist in Linear AND as `docs/tasks/` mirrors.
+
+## Findings that shaped the work
+
+Recorded because two of them contradicted the plan we started from:
+
+1. **Zero file overlap across the seven green PRs** — `apps/scoreboard/uv.lock`,
+   `packages/url4/uv.lock`, `apps/screamingface-engine/uv.lock`,
+   `public-docs/package-lock.json`, `apps/aigateway-ui/package-lock.json`,
+   `packages/screamingface/uv.lock`, one workflow file. Per-directory lockfiles are what
+   made merging them in any order safe, with no rebase between.
+2. **`mergeStateStatus` is lazily computed.** A bulk `gh pr list` returns `UNKNOWN` for
+   every PR; only a per-PR `gh pr view` (often a second call) resolves it. All seven were
+   `MERGEABLE/CLEAN`, which also proved branch protection was not requiring a review.
+3. **Closing release-please PRs does not cancel a release — it recreates them.** The
+   original intent for this session was to close all six. Repo history refutes it: #375
+   (aigateway) and #449 (scoreboard) were closed on 2026-08-05, and #512 and #511 were
+   created the same day. The two oldest PRs on the board are the product of that exact
+   action. Twenty-four release PRs have been merged, most recently 2026-08-27, so
+   "unmerged means unwanted" does not hold either — the four stale components simply have
+   no release owner. Only merging, or deregistering the component in
+   `release-please-config.json`, removes them for good. Left untouched by owner decision.
+4. **`.github/dependabot.yml` carries a live bug**: `/packages/screamingface` declares a
+   group with no `applies-to:`, the OME-733 fault every other ecosystem had fixed. Folded
+   into OME-1063's scope.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — two `docs/tasks/` mirrors plus this ledger.
+- **Commits:** <sha — message>
+- **Gates:** docs-only; repo lint/CI on the PR.
+- **Deviations:** the release-please half of the original request was dropped on evidence
+  (finding 3) and the owner's call; this branch does not touch `release-please-config.json`.


### PR DESCRIPTION
Clears the standing Dependabot pile and files what stops it refilling.

## What already landed

Seven green Dependabot PRs — #728 #729 #733 #771 #772 #775 #776 — were squash-merged.
**Board: 31 → 24 open PRs. Dependabot: 8 → 1.** They had zero file overlap (per-directory
lockfiles), so merge order did not matter.

## What this PR adds

Mirrors and ledger only — no config changes.

| File | For |
|---|---|
| `docs/tasks/2026-09-01-OME-1062-…md` | OME-1062 — diagnose #774 |
| `docs/tasks/2026-09-01-OME-1063-…md` | OME-1063 — cut Dependabot volume |
| `docs/work/2026-09-01-OME-1063-…md` | work ledger |

- **OME-1062** — #774 is the one Dependabot PR still open. It fails `test (3.12)`,
  `test (3.13)` and `images` on *both* Python versions, so it is real signal, not flake.
  Closing it blind re-raises the same red PR next cycle; the config header already records
  #480 as exactly that.
- **OME-1063** — reduce volume via schedule and multi-directory grouping, explicitly
  **without** collapsing the `-security`/`-minor`/`-major` split that OME-736 exists to
  protect. Also picks up a live bug found while reading the config: `/packages/screamingface`
  declares a group with no `applies-to:`, the OME-733 fault fixed everywhere else.

Both mirrors ride one branch on purpose — opening two PRs to fix a PR-count problem defeats
the point.

## Release-please PRs: deliberately untouched

The session started from "close all unmerged release PRs — nobody wanted the release".
The history refutes it. Closing a release-please PR does not cancel a release, it recreates
it: #375 (aigateway) and #449 (scoreboard) were closed on 2026-08-05 and #512 + #511 were
created **the same day** — which is why those two are now the oldest PRs on the board.
24 release PRs have been merged, most recently 2026-08-27, so releases clearly are wanted;
the four stale components just have no release owner. Only merging, or deregistering the
component in `release-please-config.json`, removes them for good.

Refs: OME-1063, OME-1062