### PR TITLE
docs(repo): spec and plan for Runner Job capacity admission (OME-1064)

### DIFF
--- a/docs/plan/2026-09-01-OME-1064-runner-capacity-admission.md
+++ b/docs/plan/2026-09-01-OME-1064-runner-capacity-admission.md
@@ -1,0 +1,196 @@
+# OME-1064 — Implementation plan: Runner Job capacity
+
+Spec: `docs/spec/2026-09-01-OME-1064-runner-capacity-admission.md`
+
+Six units. Each is one Linear issue, one branch, one PR. Units 1 and 2 are independent and
+can run in parallel; unit 4 must merge with or after unit 3; unit 6 is blocked on unit 3.
+
+---
+
+## Unit 1 — `OME-1059` · Surface un-startable Runner Jobs (engine)
+
+**Ship first.** No infrastructure dependency, and it alone removes the silence.
+
+### Files
+
+- `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py` — `_map_status`,
+  `_terminal_status`, `_read`
+- `packages/url4/src/url4/streaming/interfaces/jobs.py` — extend the `JobStatus` literal
+- `apps/screamingface-engine/src/screamingface_engine/ws/bridge.py` or the run supervisor —
+  producer-side watchdog
+- `apps/screamingface-engine/src/screamingface_engine/config.py` — `run_start_grace_s`
+- `apps/screamingface-engine/deploy/helm/` — expose the grace as a chart value
+
+### Approach
+
+1. Add an `unschedulable` member to `JobStatus`. Every `match`/branch over `JobStatus` must be
+   updated — pyright will list them; treat that list as the blast radius.
+2. `_read` currently reads only the Job. To distinguish the two shapes it must also see the
+   Pod (label selector `RUNNER_LABELS`) or the Job's events. Prefer the **Pod**: one list call,
+   no event-TTL dependency. A Pod in `Pending` with condition
+   `type=PodScheduled, status=False, reason=Unschedulable` → `unschedulable`. **No Pod at all**
+   past a short grace, with the Job still active, is the quota case → also `unschedulable`.
+3. Watchdog: per attached topic, if zero frames have been published after `run_start_grace_s`
+   (default 120s), call `status()`; on `unschedulable`, publish a typed `ai.url4.error`
+   (`run_unschedulable`, carrying the Kubernetes reason string) and terminate the run.
+
+### Tests (RED first)
+
+- `_map_status` returns `unschedulable` for a Pending+Unschedulable Pod.
+- `_map_status` returns `unschedulable` for an active Job with no Pod past the grace.
+- `_map_status` still returns `scheduled` for an active Job whose Pod exists and is Pending
+  **within** the grace — the N5 regression guard.
+- Watchdog publishes the typed error and terminates, via the existing fake
+  `BatchV1JobsClient` seam.
+- A run producing frames normally is never failed by the watchdog.
+
+### Risks
+
+Widening `JobStatus` touches the shared `packages/url4` port, so it fans out into every
+adapter (`inprocess`, mocks, test doubles). Land the port change and the adapter updates in
+one commit so no intermediate state fails typecheck.
+
+---
+
+## Unit 2 — `OME-1067` · Narrow the disconnect blast radius (SDK)
+
+Independent. Highest value per line changed.
+
+### Files
+
+- `packages/screamingface/src/screamingface/_engine/transport.py` — `cancel_active`,
+  `_sweep_after_disconnect` (sync `:240-281`, async `:350-371`, `:484-493`)
+- `packages/screamingface/src/screamingface/_evaluation/runner.py` — the failure branches at
+  `:382-389` and `:416-427`
+
+### Approach
+
+Split one method into two intents: `cancel_run(token)` for a single lost stream, and the
+existing sweep for client shutdown / explicit abort. `_sweep_after_disconnect` calls the
+former with only the affected token. Guard: never cancel a run already in a terminal state.
+
+### Tests (RED first)
+
+- One stream lost past its budget fails exactly one candidate; siblings complete.
+- A candidate already terminal is not cancelled by a sibling's disconnect.
+- Explicit abort still stops every owned run — pins the existing guarantee.
+- Report distinguishes "stream failed" from "aborted".
+
+---
+
+## Unit 3 — `OME-1065` · Quota-aware admission (engine)
+
+### Files
+
+- `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py` — `_schedule_blocking`
+- new `apps/screamingface-engine/src/screamingface_engine/adapters/quota.py` — the reader and
+  the fit calculation
+- `apps/screamingface-engine/src/screamingface_engine/adapters/factory.py` — wiring
+- `apps/screamingface-engine/deploy/helm/templates/` — Role gains `get`/`watch` on
+  `resourcequotas`
+
+### Approach
+
+1. `QuotaHeadroom` reads the namespace ResourceQuota (`status.used` / `status.hard`), cached
+   ~2s behind a monotonic clock. Injected as a port so tests need no cluster.
+2. The Pod's charge is computed from the **rendered manifest** plus LimitRange defaults —
+   derive it from `_manifest()` rather than restating the numbers, so the two cannot drift.
+   The runner sets no `limits.cpu`; the LimitRange supplies 500m. Omitting this makes the
+   arithmetic wrong by 500m per Pod.
+3. Reservation counter: increment on admit, decrement when the run reaches a terminal state or
+   is stopped. Compare `used + reserved + this_pod` against `hard`.
+4. Not fitting on **any** constrained dimension → raise `JobRunnerAtCapacity(active, limit)`.
+   The REST edge already maps it (`rest/routes.py:198-208`); no change there.
+5. Any failure to read the quota (absent, RBAC denied, API error) → log once and proceed as
+   today. Unit 1's detection is the backstop.
+
+### Tests (RED first)
+
+- At the ceiling → `JobRunnerAtCapacity`; REST returns 503 with `Retry-After`.
+- Below the ceiling → 202 and the Job is created byte-identically to today (N1).
+- A Pod spec omitting `limits.cpu` is charged the LimitRange default, not zero.
+- Each of the five dimensions binds independently.
+- Concurrent `schedule()` calls between refreshes cannot jointly overshoot.
+- Quota unreadable → schedule proceeds, no exception escapes.
+- Reservation is released on terminal status and on `stop()`.
+
+### Risks
+
+The reservation counter is the subtle part: a leaked reservation permanently reduces capacity.
+Tie release to the same lifecycle hook that already drives run teardown rather than adding a
+parallel path, and add a reconciliation against observed quota usage on each refresh.
+
+---
+
+## Unit 4 — `OME-1066` · Honour 503 backpressure (SDK)
+
+**Merges with or after Unit 3.** Alone it is untestable against a real Engine.
+
+### Files
+
+- `packages/screamingface/src/screamingface/_engine/transport.py` — submission path
+  (`:596-613` sync, `:661-678` async), `permanent` at `:872`, retry ladder at `:40`
+- `packages/screamingface/src/screamingface/_evaluation/runner.py` — queued-state progress
+- SDK settings — the wait budget
+
+### Approach
+
+1. Parse `Retry-After` (delta-seconds); absent or unparseable → existing full-jitter
+   `_reconnect_delay` (`:72-77`).
+2. Retry under a **total wait budget**, not an attempt count — a queued run may legitimately
+   wait minutes behind a large evaluation. Configurable; expiry raises an error naming cluster
+   capacity.
+3. Waiting for capacity must not trigger `cancel_active()` (depends on Unit 2's split).
+4. Emit a queued state so `progress=True` shows *queued*, not apparent hang. This is what
+   distinguishes the fix from the bug.
+
+### Tests (RED first)
+
+- 503 + `Retry-After: 5` → retries after ~5s.
+- 503 without the header → jittered backoff.
+- Budget expiry → error naming capacity, not a generic transport failure.
+- A waiting candidate does not cancel siblings.
+- Non-503 5xx keeps today's behaviour.
+- Progress surface shows queued.
+
+---
+
+## Unit 5 — `OME-1058` · Capacity (infra repo, owner decision)
+
+Lands in `OpenMined/infrastructure`, not this monorepo. Blocked on an owner decision between
+the three options in the issue. Recommendation on the issue: enable user-pool autoscaling
+**and** rely on Unit 3 for demand bounding; treat a second node as a later throughput decision
+taken on evidence.
+
+Also update the `docs/ledger.md` deferral trigger, which is stated in node **memory** terms
+while both real signals were **CPU**.
+
+---
+
+## Unit 6 — `OME-908` · Fair ordering (engine)
+
+Blocked on Unit 3. After admission exists, order the queue per identity (the Engine already
+receives `identity` on `schedule()`). Re-measure gateway per-provider contention at that point;
+it was not the constraint in this incident.
+
+---
+
+## Gates
+
+Per unit, in its own worktree and branch `OME-N-<desc>`:
+
+```
+uv run ruff check && uv run pyright && uv run pytest
+```
+
+Engine and SDK units run their own path-filtered CI lane
+(`screamingface-engine-tests.yml`, `screamingface-tests.yml`). Unit 1 also touches
+`packages/url4`, so `url4-tests.yml` gates it too. Unit 3 touches the Helm chart, so
+`charts.yml` gates it as well.
+
+## Verification of the whole epic
+
+Reproduce the incident shape: two concurrent evaluations against `sf-fusion` at its current
+ceiling. Expected after units 1–4: the second evaluation reports queued candidates and
+completes, or fails with a message naming capacity — never a silent stall, and never a
+sibling-induced failure of completed work.

--- a/docs/spec/2026-09-01-OME-1064-runner-capacity-admission.md
+++ b/docs/spec/2026-09-01-OME-1064-runner-capacity-admission.md
@@ -1,0 +1,271 @@
+# OME-1064 — Runner Job capacity: admission, detection, and backpressure
+
+Status: proposed · Date: 2026-09-01 · Epic: OME-1064
+
+## 1. The incident this specifies against
+
+On 2026-09-01 an `sf.evaluate(list(solos.values()), benchmark="draco-3pass", progress=True)`
+run of 9 candidates was submitted at 11:23:50 UTC. It reported 24% progress (220 of 900
+cases), then froze — no error, no warning, the model-call counter static. After ~23 minutes
+the SDK failed every candidate with `websocket_disconnected ... after 1369.6s`. Six of nine
+candidates completed **0 of 100 cases**. One candidate had completed **100 of 100** and was
+failed anyway.
+
+Nothing crashed. The Engine pod never restarted (`restart_count=0`, up since 2026-08-29).
+The AI Gateway served 4,000–5,800 req/min with zero errors throughout. The runs never got
+Pods.
+
+Only one Runner Pod started in the whole window. It had been submitted at 11:23:50 and sat
+Pending for ~19 minutes, then emitted 42,448 frames in ~207s — which is why progress arrived
+in bursts and then stopped.
+
+Cluster events in `sf-fusion`:
+
+```
+FailedScheduling  0/3 nodes are available: 1 Insufficient cpu, 2 node(s) had untolerated taint(s)
+NotTriggerScaleUp pod didn't trigger scale-up: 1 node(s) had untolerated taint(s)
+FailedCreate      Error creating: pods "url4-..." is forbidden: exceeded quota: ns-ceiling
+```
+
+## 2. Root cause
+
+### 2.1 Five capacity ceilings, none aware of each other
+
+| Layer | Ceiling | Source |
+|---|---|---|
+| SDK | `_MAX_CANDIDATES_IN_FLIGHT = 8` | `packages/screamingface/src/screamingface/_evaluation/runner.py:43` |
+| Engine (K8s mode) | **none** | `adapters/k8s.py:182-206` |
+| Engine (local mode) | `DEFAULT_MAX_CONCURRENT_RUNS = 32` | `adapters/inprocess.py:47` |
+| Namespace quota | `requests.cpu: 2` → 8 runners | infra `kubernetes/apps/sf-fusion/base/quota.yaml` |
+| Node | 1 × `D4as_v5`, not autoscaled | infra `terraform/stacks/azure/aks-platform/dev/main.tf` |
+| Gateway | `provider_max_concurrency = 4` | `apps/aigateway/src/aigateway/config.py:111` |
+
+The **client** decides the fan-out. Nothing below it can refuse. Each layer either absorbs
+the load or fails silently. This is the structural defect; every symptom below follows from
+it.
+
+### 2.2 The binding constraint is `requests.cpu`
+
+The `sf-fusion` LimitRange defaults resource-less containers to `{cpu: 500m, memory: 512Mi}`.
+The Runner Job declares `requests: {cpu: 200m, memory: 256Mi}` and `limits: {memory: 1Gi}`
+with **no CPU limit** (`apps/screamingface-engine/deploy/helm/values.yaml:365-370`), so the
+LimitRange supplies `limits.cpu: 500m`. Each Runner Pod charges the quota
+**requests 200m/256Mi, limits 500m/1Gi**.
+
+Against measured standing usage (310m/528Mi requests; 2.5 CPU/2.6Gi limits):
+
+| Dimension | Ceiling | Headroom | Runners that fit |
+|---|---|---|---|
+| `limits.cpu` | 8 | 5500m | 11 |
+| `limits.memory` | 12Gi | ~9.4Gi | 9 |
+| `requests.memory` | 3Gi | 2544Mi | 9 |
+| **`requests.cpu`** | **2** | **1690m** | **8** |
+
+`requests.cpu` binds at exactly 8 — precisely `_MAX_CANDIDATES_IN_FLIGHT`. One evaluation
+saturates the namespace exactly, leaving nothing for a concurrent evaluation or for the
+Engine's own rollout surge pod. Engine logs show unrelated `ifeval` runs scheduled at 11:29,
+11:30:58 and 11:42:38, overlapping this run.
+
+The 2026-08-25 quota resize raised the *limits* ceilings and deliberately left requests
+unchanged. The intent (keep scheduling pressure visible) was sound; the effect was to move
+the bottleneck onto `requests.cpu` at exactly the client's fan-out.
+
+### 2.3 The false invariant
+
+`packages/url4/src/url4/streaming/interfaces/jobs.py:24-34`:
+
+> `JobRunnerAtCapacity` — *"Only substrates that own a finite local resource raise it — an
+> in-process runner shares one event loop across every run it accepts, so admission is its own
+> job. **A cluster-backed runner lets the scheduler absorb the load and never raises.**"*
+
+`rest/routes.py:200-202` restates it. A namespace carrying a ResourceQuota **is** a substrate
+that owns a finite local resource. A quota does not absorb load; it refuses Pod creation.
+
+The consequence is that the entire backpressure path — `JobRunnerAtCapacity` → 503 +
+`Retry-After` (`rest/routes.py:198-208`) — exists, is wired, and is switched off for the one
+runner that needs it.
+
+### 2.4 Why the failure was silent
+
+Three independent gaps, each sufficient to hide the condition:
+
+1. **`schedule()` cannot see the refusal.** `create_namespaced_job` returns 201; the quota
+   rejection is raised later against the Job *controller*. `FailedCreate` from quota does not
+   count against `backoffLimit: 0`, so the Job retries creation indefinitely instead of
+   failing. Observed retries: 11:42:39, :40, :42, :46, :54, 11:43:10, :42, 11:44:42, 11:45:42,
+   11:46:42.
+2. **`_map_status` cannot represent it.** A Job whose Pod is Pending-unschedulable and a Job
+   whose Pod was refused both have `active = 0` and no terminal condition, so both map to
+   `"scheduled"` — identical to a healthy Job one second from starting
+   (`adapters/k8s.py:96-104`).
+3. **Nothing watches the producer.** The bridge heartbeats every 15s regardless
+   (`ws_heartbeat_s = 15.0`); the SDK's receive timeout is 120s and never fires; `RunReaper`
+   fires only on *audience* loss (`orphan_grace_s = 120`), never producer silence.
+
+Five streams carried zero frames for their entire life while heartbeating normally:
+
+```
+duration_s=1356.9  frames=0  heartbeats=90
+duration_s=1636.3  frames=0  heartbeats=109
+duration_s=2449.4  frames=0  heartbeats=163
+duration_s=2510.1  frames=0  heartbeats=167
+duration_s=2686.1  frames=0  heartbeats=179
+```
+
+### 2.5 Why one failure destroyed nine candidates
+
+`transport.py:240-249` (`_sweep_after_disconnect`) calls `cancel_active()` when the 90s
+reconnect budget expires. `cancel_active()` (`:262-281`) iterates `self._active_tokens` —
+*every* capability the client instance owns — and stops all of them. One lost socket therefore
+failed all nine candidates, including the one that had completed 100/100.
+
+### 2.6 Secondary hazard
+
+`activeDeadlineSeconds = job_deadline_s + 60 + 30 ≈ 16h` with the default
+`job_deadline_s = 57600`. A Pending Pod holds its quota reservation for up to 16 hours, so
+un-startable runs ratchet capacity away from healthy ones.
+
+## 3. Requirements
+
+### Functional
+
+- **F1** A run that cannot obtain a Pod must reach the client as a **typed, named error**
+  within a bounded time, never as silence and never as `websocket_disconnected`.
+- **F2** The Engine must refuse a run it cannot place, using the existing 503 + `Retry-After`
+  contract, rather than creating a Job that will never produce a Pod.
+- **F3** The SDK must treat that refusal as **backpressure** — wait and retry — not as a
+  candidate failure.
+- **F4** A stream failure must fail **only its own run**. Runs that are healthy, or already
+  terminal, must survive a sibling's disconnect.
+- **F5** The status port must be able to represent "will never start" distinctly from
+  "waiting to start".
+
+### Non-functional
+
+- **N1** No behaviour change for a run that fits: same 202, same Job, same latency.
+- **N2** Capacity must have exactly **one** source of truth. A second copy of the ceiling in
+  Engine configuration is a defect, not a feature.
+- **N3** Admission must degrade safely: if capacity cannot be determined, fall back to
+  today's behaviour plus F1 detection. Detection is the floor; admission is the optimisation.
+- **N4** Correct under >1 Engine replica. A process-local counter alone does not satisfy this.
+- **N5** A healthy run that is merely slow to schedule must not be failed early — every grace
+  is configurable and defaults above normal scheduling latency.
+
+### Explicitly out of scope
+
+- **Fairness between runs.** Ordering the queue is `OME-908`, which is not implementable
+  until F2 creates a queue. After this spec lands, admission order is FIFO.
+- **Cluster sizing.** `OME-1058`.
+- **Gateway per-provider concurrency.** Not the constraint in this incident; re-measure after
+  F2.
+
+## 4. Design
+
+### 4.1 Detection (F1, F5) — `OME-1059`
+
+Extend the status mapping so an un-startable Job is representable: a Pod in `Pending` whose
+condition carries `reason=Unschedulable`, or a Job carrying a `FailedCreate` event, is not
+`"scheduled"`. Add a distinct `JobStatus` member rather than collapsing the difference at the
+port.
+
+Add a **producer-side watchdog**: when a topic has been attached and has published zero
+frames after a configurable grace (proposal `URL4_CLOUD_RUN_START_GRACE_S`, default ~120s),
+query the runner status and publish a typed `ai.url4.error` naming the real cause
+(`run_unschedulable`, carrying the Kubernetes reason text), then terminate the run.
+
+This mirrors the `stream_reclaimed` treatment added in `OME-1019`: an indistinguishable
+silent state replaced by a typed error the SDK can surface.
+
+**Detection is the correctness floor and ships first.** It is independent of infrastructure,
+and it alone converts 23 minutes of silence into a named error in ~30s.
+
+### 4.2 Admission (F2, N2, N3, N4) — `OME-1065`
+
+`K8sJobRunner` becomes capacity-aware by reading the **namespace ResourceQuota**:
+
+1. Read `status.used` vs `status.hard`, cached ~2s.
+2. Before creating a Job, test whether one more Runner Pod fits on every constrained
+   dimension — `requests.cpu`, `requests.memory`, `limits.cpu`, `limits.memory`, `pods`. The
+   Pod's charge is its own spec **plus LimitRange defaults**; omitting the LimitRange makes
+   the arithmetic wrong by 500m per Pod (§2.2).
+3. If it does not fit, raise `JobRunnerAtCapacity`, which `rest/routes.py:198-208` already
+   maps to 503 + `Retry-After`.
+4. Maintain a local in-flight reservation counter over the cached reading, so several
+   `schedule()` calls between two refreshes cannot jointly overshoot.
+
+**Why the quota and not a configured number.** The quota is already the operator's declared
+capacity. Reading it satisfies N2 (one source of truth — a config value would be a second copy
+that drifts), gives self-tuning when infrastructure resizes the ceiling with no redeploy, and
+satisfies N4, because every replica reads the same authoritative object. The reservation
+counter is a race guard over a shared reading, not a private ceiling.
+
+Requires `get`/`watch` on `resourcequotas` in the Engine's Role — the deployed Role has none
+today.
+
+**Rejected alternative.** An Engine-local counter with a configured maximum is simpler, but
+duplicates the ceiling, drifts from the cluster silently, and is wrong with more than one
+replica. Rejected on N2 and N4.
+
+### 4.3 Backpressure at the client (F3) — `OME-1066`
+
+Today `transport.py:872` sets `permanent=response.status_code < 500`, so a 503 raises
+immediately; `Retry-After` is never parsed and the `_ATTACH_RETRY_DELAYS` ladder covers only
+428. Treat 503 as retryable, honour `Retry-After` (falling back to the existing full-jitter
+`_reconnect_delay`), bound the total wait, and surface *queued* state through `progress=True`.
+
+**`OME-1065` and `OME-1066` must ship together.** Admission alone converts a silent hang into
+a fast failure — more legible, but the user still cannot run 9 candidates. Together they
+convert it into a wait, which is the actual fix. After both, `_MAX_CANDIDATES_IN_FLIGHT = 8`
+stops being a capacity decision taken by the client.
+
+### 4.4 Blast radius (F4) — `OME-1067`
+
+Separate the two cases currently sharing `cancel_active()`:
+
+- one stream lost past its reconnect budget → cancel that run only;
+- client shutdown / explicit abort → keep today's sweep-everything semantics.
+
+A run already in a terminal state must never be cancelled retroactively.
+
+Independent of the capacity work; reduces the blast radius of *any* stream failure.
+
+### 4.5 Infrastructure (`OME-1058`)
+
+`requests.cpu` and node capacity must move **together**. Raising the quota alone converts
+`FailedCreate` into `FailedScheduling` — both were already present in this one incident, which
+is the evidence that the node is co-binding. The user pool is not autoscaled, so nothing can
+grow; enabling autoscaling is the prerequisite for either sizing option. Detail and options in
+`OME-1058`.
+
+## 5. Sequencing
+
+| # | Issue | Landing | Depends on |
+|---|---|---|---|
+| 1 | `OME-1059` detection | engine | — |
+| 2 | `OME-1067` blast radius | SDK | — |
+| 3 | `OME-1065` admission | engine | — |
+| 4 | `OME-1066` client backpressure | SDK | `OME-1065` |
+| 5 | `OME-1058` capacity | infra | owner decision |
+| 6 | `OME-908` fairness | engine | `OME-1065` |
+
+Steps 1–2 fix the reported experience and carry no infrastructure dependency. Steps 3–5 fix
+the outcome. Step 6 becomes tractable only after step 3.
+
+## 6. Acceptance for the epic
+
+- A run refused by quota surfaces a typed error naming capacity, within the start grace —
+  not `websocket_disconnected`, not silence.
+- With the namespace at its ceiling, submission returns 503 + `Retry-After`; the SDK waits and
+  the run subsequently completes.
+- A 9-candidate `draco-3pass` evaluation concurrent with another evaluation completes, or
+  reports precisely which candidates were queued and why.
+- One stream failure fails exactly one candidate.
+- No behaviour change when capacity is available.
+
+## 7. Long-term direction (not specified here)
+
+Job-per-run makes Pod count elastic against a fixed quota — that is the collision at the heart
+of this incident. A fixed worker pool consuming runs from NATS inverts it: constant Pod count,
+elastic queue. That removes the failure class rather than bounding it, and makes fairness a
+property of the queue rather than a scheduler to be written. Recorded as direction; not
+proposed for this epic.

--- a/docs/tasks/2026-08-26-OME-908-fair-run-scheduling.md
+++ b/docs/tasks/2026-08-26-OME-908-fair-run-scheduling.md
@@ -39,3 +39,21 @@ every Runner Job (`URL4_CLOUD_IO_CONCURRENCY`, default 4 — written uncondition
 work-conserving fewest-in-flight gate for local runs (`local_io_capacity`, default 32).
 Layer 2 remains the companion gateway ticket — text drafted in the work ledger, filing
 pending the owner (Linear writes are owner/MCP actions).
+
+## Update 2026-09-01 — Layer 0's measurement resolved, and it moves the locus
+
+The 2026-09-01 `draco-3pass` incident (`OME-1064`) supplied the Layer 0 measurement this spec
+asked for, and it points at the alternative locus the checklist named: **k8s Job
+co-scheduling**, not the gateway queue.
+
+Six of nine candidates completed 0 of 100 cases because their Runner Pods were never created
+(`exceeded quota: ns-ceiling`). The gateway served 4,000–5,800 req/min with zero errors
+throughout — a run that cannot get a Pod never reaches it, so no gateway-side fairness
+mechanism could have helped those candidates.
+
+Layer 1 (shipped, PR #750) is unaffected: it throttles concurrency *inside* one run. Layer 2
+is not wrong but is **not sufficient**, and is not the first constraint to relieve. `OME-1065`
+adds the admission queue that cross-run fairness needs to order, and is now set as a
+**blocked-by** on this issue.
+
+Detail: `docs/spec/2026-09-01-OME-1064-runner-capacity-admission.md` §2.1 and §4.2.

--- a/docs/tasks/2026-09-01-OME-1058-sf-fusion-capacity.md
+++ b/docs/tasks/2026-09-01-OME-1058-sf-fusion-capacity.md
@@ -1,0 +1,29 @@
+---
+id: OME-1058
+linear_url: https://linear.app/openmined/issue/OME-1058/size-sf-fusion-capacity-for-concurrent-evaluations-ns-ceiling-quota
+status: planned
+type: task
+priority: 2
+labels: [repo, human, deferred]
+created: 2026-09-01
+closed:
+---
+
+# Size sf-fusion capacity for concurrent evaluations
+
+Lands in `OpenMined/infrastructure`, not this monorepo. Parent: `OME-1064`.
+
+With the namespace LimitRange applied, each Runner Pod charges `requests 200m/256Mi`.
+Against 310m standing usage, `requests.cpu: 2` fits **exactly 8 runners** — precisely
+`_MAX_CANDIDATES_IN_FLIGHT`. The 2026-08-25 resize raised the `limits.*` ceilings and left
+requests alone, which moved the bottleneck onto `requests.cpu` at exactly the client's
+fan-out.
+
+Raising the quota alone is not a fix: `Insufficient cpu` and `exceeded quota` both appeared
+in the same incident, so the single non-autoscaled user node is co-binding. Recommendation
+on the issue is to enable user-pool autoscaling and bound demand via `OME-1065`, treating a
+second node as a later throughput decision.
+
+Blocked on an owner decision between the three options. Also needs the `docs/ledger.md`
+deferral trigger restated in CPU terms — it currently gates on node memory, while both real
+signals were CPU.

--- a/docs/tasks/2026-09-01-OME-1059-unschedulable-detection.md
+++ b/docs/tasks/2026-09-01-OME-1059-unschedulable-detection.md
@@ -1,0 +1,23 @@
+---
+id: OME-1059
+linear_url: https://linear.app/openmined/issue/OME-1059/surface-unschedulable-runner-jobs-as-a-typed-run-error-instead-of
+status: planned
+type: bug
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-01
+closed:
+---
+
+# Surface unschedulable Runner Jobs as a typed run error
+
+Parent: `OME-1064`. First unit to ship — no infrastructure dependency, and it alone removes
+the silence.
+
+`_map_status` maps both "Pending, starting soon" and "Pod refused by quota" to `"scheduled"`,
+and no watchdog watches the producer, so a run that will never start is indistinguishable
+from one about to start. Add an `unschedulable` `JobStatus` and a producer-side watchdog that
+publishes a typed `ai.url4.error` when a topic has produced zero frames past a configurable
+grace.
+
+Spec §4.1. Plan unit 1.

--- a/docs/tasks/2026-09-01-OME-1064-runner-capacity-epic.md
+++ b/docs/tasks/2026-09-01-OME-1064-runner-capacity-epic.md
@@ -1,0 +1,29 @@
+---
+id: OME-1064
+linear_url: https://linear.app/openmined/issue/OME-1064/make-runner-job-capacity-explicit-and-enforced-end-to-end
+status: in_progress
+type: epic
+priority: 2
+labels: [screamingface-engine, py-screamingface, agentic, autonomous]
+created: 2026-09-01
+closed:
+---
+
+# Make Runner Job capacity explicit and enforced end to end
+
+Cross-cutting epic from the 2026-09-01 `draco-3pass` incident: a 9-candidate evaluation
+froze for 23 minutes with no error, then failed every candidate, because Runner Job Pods
+were never created.
+
+Root cause is five capacity ceilings that do not know about each other — the SDK picks the
+fan-out (`_MAX_CANDIDATES_IN_FLIGHT = 8`), the Engine's K8s path has no admission control at
+all, and the `sf-fusion` `requests.cpu: 2` quota fits exactly 8 runners. One evaluation
+saturates the namespace; anything concurrent is refused, silently.
+
+Children: `OME-1059` (detection), `OME-1067` (blast radius), `OME-1065` (admission),
+`OME-1066` (client backpressure), `OME-1058` (infra capacity). Related: `OME-908` (fairness,
+blocked on `OME-1065`).
+
+Spec: `docs/spec/2026-09-01-OME-1064-runner-capacity-admission.md`.
+Plan: `docs/plan/2026-09-01-OME-1064-runner-capacity-admission.md`.
+Ledger: `docs/work/2026-09-01-OME-1064-runner-capacity-design.md`.

--- a/docs/tasks/2026-09-01-OME-1065-quota-aware-admission.md
+++ b/docs/tasks/2026-09-01-OME-1065-quota-aware-admission.md
@@ -1,0 +1,26 @@
+---
+id: OME-1065
+linear_url: https://linear.app/openmined/issue/OME-1065/refuse-a-run-when-the-namespace-resourcequota-has-no-headroom
+status: planned
+type: bug
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-01
+closed:
+---
+
+# Refuse a run when the namespace ResourceQuota has no headroom
+
+Parent: `OME-1064`. Blocks `OME-1066` and `OME-908`.
+
+`K8sJobRunner.schedule()` creates a Job unconditionally. The port documents this as
+deliberate — "a cluster-backed runner lets the scheduler absorb the load and never raises" —
+but a namespace with a ResourceQuota does not absorb load, it refuses Pod creation
+asynchronously after `create_namespaced_job` has returned 201.
+
+The 503 + `Retry-After` path already exists at `rest/routes.py:198-208`. Make the K8s adapter
+raise `JobRunnerAtCapacity` by reading the namespace ResourceQuota's `status.used` vs
+`status.hard`, accounting for LimitRange defaults, with a local reservation counter to close
+the read-modify-write race. Requires `get`/`watch` on `resourcequotas` in the Engine Role.
+
+Spec §4.2. Plan unit 3.

--- a/docs/tasks/2026-09-01-OME-1066-sdk-503-backpressure.md
+++ b/docs/tasks/2026-09-01-OME-1066-sdk-503-backpressure.md
@@ -1,0 +1,23 @@
+---
+id: OME-1066
+linear_url: https://linear.app/openmined/issue/OME-1066/retry-run-submission-on-503-retry-after-instead-of-failing-the
+status: planned
+type: bug
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-01
+closed:
+---
+
+# Retry run submission on 503 Retry-After
+
+Parent: `OME-1064`. Blocked by `OME-1065`; must merge with or after it.
+
+`transport.py:872` sets `permanent=response.status_code < 500`, so a 503 raises immediately
+and `Retry-After` is never parsed; the existing retry ladder covers only 428. Engine-side
+admission without this converts a silent hang into a fast failure rather than into a wait.
+
+Honour `Retry-After` under a bounded total wait budget, and surface queued state through
+`progress=True` so a waiting candidate reads as queued rather than hung.
+
+Spec §4.3. Plan unit 4.

--- a/docs/tasks/2026-09-01-OME-1067-disconnect-blast-radius.md
+++ b/docs/tasks/2026-09-01-OME-1067-disconnect-blast-radius.md
@@ -1,0 +1,24 @@
+---
+id: OME-1067
+linear_url: https://linear.app/openmined/issue/OME-1067/cancel-only-the-affected-run-when-a-stream-disconnects
+status: planned
+type: bug
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-01
+closed:
+---
+
+# Cancel only the affected run when a stream disconnects
+
+Parent: `OME-1064`. Independent of the capacity work.
+
+`_sweep_after_disconnect()` calls `cancel_active()`, which stops every capability in
+`self._active_tokens`. In the 2026-09-01 incident one lost socket failed all nine candidates,
+including one that had already completed 100 of 100 cases.
+
+Split the two intents: one stream lost past its reconnect budget cancels only that run;
+client shutdown or explicit abort keeps today's sweep-everything semantics. A run already
+terminal is never cancelled retroactively.
+
+Spec §4.4. Plan unit 2.

--- a/docs/work/2026-09-01-OME-1064-runner-capacity-design.md
+++ b/docs/work/2026-09-01-OME-1064-runner-capacity-design.md
@@ -1,0 +1,98 @@
+---
+ticket: OME-1064
+stack: repo
+status: done
+started: 2026-09-01
+finished: 2026-09-01
+---
+
+# OME-1064 — Runner Job capacity: incident diagnosis, spec, plan, and decomposition
+
+## Intent
+
+Diagnose the 2026-09-01 `draco-3pass` stall to root cause, then turn the diagnosis into SDLC
+artifacts and a filed decomposition. This unit produces **documents and work items only** — no
+production code. Implementation of each child unit is gated on owner approval.
+
+## What was done
+
+### Investigation
+
+1. Read the deployment architecture of `apps/screamingface-engine` + `apps/aigateway`.
+2. Queried SigNoz for the incident window (2026-09-01 11:23–12:10 UTC): Kubernetes events in
+   `sf-fusion`, Engine `ws.bridge` stream records, gateway request rates, pod restart counts.
+3. Cloned `OpenMined/infrastructure` (shallow) and read the real cluster configuration —
+   `kubernetes/apps/sf-fusion/base/quota.yaml`, `terraform/stacks/azure/aks-platform/dev/main.tf`,
+   `terraform/modules/azure/aks/main.tf`, `docs/ledger.md`.
+4. Recomputed the quota arithmetic with the namespace LimitRange applied.
+
+### Findings
+
+Root cause is **five capacity ceilings that do not know about each other**, with the client
+choosing the fan-out and nothing below it able to refuse. Full detail in the spec.
+
+The binding constraint is **`requests.cpu: 2`**, which fits exactly 8 Runner Pods — precisely
+`_MAX_CANDIDATES_IN_FLIGHT = 8`. One evaluation saturates the namespace; anything concurrent
+is refused, and the refusal is invisible because `create_namespaced_job` returns 201 while the
+quota rejection lands asynchronously on the Job controller.
+
+`packages/url4/src/url4/streaming/interfaces/jobs.py:24-34` documents the assumption that made
+this possible: *"a cluster-backed runner lets the scheduler absorb the load and never raises."*
+A namespace with a ResourceQuota does not absorb load. The 503 + `Retry-After` backpressure
+path already exists and is switched off for the only runner that needs it.
+
+## Corrections made during this unit
+
+Three of my own earlier conclusions were wrong and were retracted:
+
+1. **Caching / gateway provider-concurrency starvation.** Proposed first; rejected by the owner
+   from direct prior experience (fully-cached runs had completed end to end). Re-investigated
+   from SigNoz rather than argued.
+2. **"Add the missing toleration" to Runner Pods.** Wrong — the taints are deliberate isolation
+   boundaries (system addon pool; PR-preview isolation enforced by
+   `sf-preview/templates/admission.yaml`). Retracted in `OME-1058`.
+3. **"The `limits.*` ceilings bind."** Wrong — recomputing with the LimitRange shows
+   `requests.cpu` binds first, at exactly 8 runners. `OME-1058` was rewritten and retitled; its
+   recommendation changed materially, because raising the quota alone converts `FailedCreate`
+   into `FailedScheduling`.
+
+The third correction also invalidated the trigger recorded in the infrastructure ledger, which
+gates a second user node on >85% node **memory** while both real signals in this incident were
+**CPU**.
+
+## Artifacts produced
+
+- `docs/spec/2026-09-01-OME-1064-runner-capacity-admission.md`
+- `docs/plan/2026-09-01-OME-1064-runner-capacity-admission.md`
+- `docs/tasks/2026-09-01-OME-{1058,1059,1064,1065,1066,1067}-*.md`
+
+## Work items
+
+| Issue | Title | Landing |
+|---|---|---|
+| `OME-1064` | Make Runner Job capacity explicit and enforced end to end (epic) | engine + SDK |
+| `OME-1059` | Surface unschedulable Runner Jobs as a typed run error | engine |
+| `OME-1067` | Cancel only the affected run when a stream disconnects | SDK |
+| `OME-1065` | Refuse a run when the namespace ResourceQuota has no headroom | engine |
+| `OME-1066` | Retry run submission on 503 Retry-After | SDK |
+| `OME-1058` | Size sf-fusion capacity for concurrent evaluations | infra |
+
+Relations set: `OME-1066` blocked-by `OME-1065`; `OME-908` blocked-by `OME-1065`; `OME-1064`
+related to `OME-908`. `OME-1058` and `OME-1059` reparented under `OME-1064`.
+
+`OME-908` received a comment correcting its stated starvation locus: it names the gateway
+per-provider FIFO, but the gateway served 4,000–5,800 req/min with zero errors during the
+incident. A run that cannot get a Pod never reaches the gateway. That issue is also **not
+implementable today** — fair scheduling orders a queue, and nothing currently queues.
+
+## Outcome
+
+- **Actual files:** as listed above; no source files touched.
+- **Commits:** see PR.
+- **Gates:** none applicable — documentation-only unit, no code paths changed.
+- **Deviations:** the epic was filed as `OME-1064`; the spec and plan filenames were written
+  against that number after filing, so the placeholder `OME-1060` used while drafting does not
+  appear in any committed artifact.
+- **Owner-verify:** the capacity option in `OME-1058` is an owner decision (spend). The
+  recommendation there is autoscaling plus `OME-1065`, deferring a second node until there is
+  CPU-based evidence.


### PR DESCRIPTION
Documentation only. No source paths touched, so no app CI lane applies.

## Summary

Diagnoses the 2026-09-01 `draco-3pass` incident to root cause and decomposes it into six units.

A 9-candidate evaluation reported 24% progress, froze for 23 minutes with no error, then failed every candidate with `websocket_disconnected`. Six of nine completed 0 of 100 cases; one had completed 100/100 and was failed anyway. Nothing crashed — the Engine never restarted and the gateway served 4,000–5,800 req/min with zero errors. The runs never got Pods.

## Root cause

Five capacity ceilings that do not know about each other. The **client** picks the fan-out; nothing below it can refuse.

| Layer | Ceiling |
|---|---|
| SDK | `_MAX_CANDIDATES_IN_FLIGHT = 8` |
| Engine (K8s mode) | **none** |
| Namespace quota | `requests.cpu: 2` → 8 runners |
| Node | 1 × `D4as_v5`, not autoscaled |
| Gateway | `provider_max_concurrency = 4` |

With the `sf-fusion` LimitRange applied, each Runner Pod charges `requests 200m/256Mi`. Against 310m standing usage, `requests.cpu: 2` fits **exactly 8** — precisely the SDK's fan-out. One evaluation saturates the namespace; anything concurrent is refused.

The 2026-08-25 quota resize raised the `limits.*` ceilings and deliberately left requests alone. The intent was sound; the effect moved the bottleneck onto `requests.cpu` at exactly the client's fan-out.

## The backpressure path already exists

`JobRunnerAtCapacity` → 503 + `Retry-After` is wired at `rest/routes.py:198-208`. The port disables it for the one runner that needs it:

> *"A cluster-backed runner lets the scheduler absorb the load and never raises."*

A namespace with a ResourceQuota does not absorb load — it refuses Pod creation, asynchronously, after `create_namespaced_job` has returned 201.

## Decomposition

| # | Issue | Landing | Depends on |
|---|---|---|---|
| 1 | OME-1059 detection | engine | — |
| 2 | OME-1067 blast radius | SDK | — |
| 3 | OME-1065 admission | engine | — |
| 4 | OME-1066 client backpressure | SDK | OME-1065 |
| 5 | OME-1058 capacity | infra | owner decision |
| 6 | OME-908 fairness | engine | OME-1065 |

Steps 1–2 fix the reported experience with no infrastructure dependency. Steps 3–5 fix the outcome.

## Corrections recorded

Three earlier conclusions were wrong and are retracted in-place: caching/gateway starvation, "add the missing toleration" (the taints are deliberate isolation boundaries), and "the `limits.*` ceilings bind". OME-1058 was rewritten and retitled as a result — its recommendation changed materially, because raising the quota alone converts `FailedCreate` into `FailedScheduling`.

## Test plan

None applicable — documentation-only change, no code paths modified.