### PR TITLE
fix(aigateway): recover BYOK connection auth type

### DIFF
--- a/apps/aigateway/src/aigateway/core/oauth/store.py
+++ b/apps/aigateway/src/aigateway/core/oauth/store.py
@@ -73,6 +73,7 @@ class OAuthConnectionStore:
             provider=provider,
             label=label,
             status="pending",
+            auth_type="oauth",
             credential_locator=credential_locator_for(
                 credential_provider or provider,
                 account_id,
@@ -98,7 +99,7 @@ class OAuthConnectionStore:
         "oauth"). The credential_locator points at the same blob slot the chat
         path reads via credential_key_for(account_id, connection_id)."""
         await _ensure_anonymous_account(account_id)
-        return await OAuthConnection.create(
+        connection = await OAuthConnection.create(
             id=connection_id,
             account_id=account_id,
             provider=provider,
@@ -111,6 +112,10 @@ class OAuthConnectionStore:
                 connection_id,
             ),
         )
+        repaired = await self.set_auth_type(connection, "api_key")
+        if repaired is None:  # pragma: no cover - the row was just inserted in this transaction.
+            raise RuntimeError("api-key connection disappeared during creation")
+        return repaired
 
     async def find_by_identity(
         self,
@@ -325,6 +330,21 @@ class OAuthConnectionStore:
         connection.status = "active"
         connection.error_message = None
         connection.last_refreshed_at = refreshed_at
+        return connection
+
+    async def set_auth_type(
+        self,
+        connection: OAuthConnection,
+        auth_type: AuthType,
+    ) -> OAuthConnection | None:
+        """Republish the persisted auth discriminator for an existing connection."""
+        updated = await OAuthConnection.filter(
+            id=connection.id,
+            account_id=connection.account_id,
+        ).update(auth_type=auth_type)
+        if updated != 1:
+            return None
+        connection.auth_type = auth_type
         return connection
 
     async def mark_revoked(

--- a/apps/aigateway/src/aigateway/routes/chat_credentials.py
+++ b/apps/aigateway/src/aigateway/routes/chat_credentials.py
@@ -79,7 +79,29 @@ def resolved_auth_mode(
             return profileless_mode
         if plugin.available_auth_modes() == ("none",):
             return "none"
-    return auth_mode_for_target(profile, connection)
+    auth_mode = auth_mode_for_target(profile, connection)
+    if auth_mode not in _available_auth_modes(plugin):
+        raise _unsupported_auth_mode_error(plugin, auth_mode)
+    return auth_mode
+
+
+def _available_auth_modes(plugin: Any) -> tuple[AuthMode, ...]:
+    modes = getattr(plugin, "available_auth_modes", None)
+    if not callable(modes):
+        return ("oauth",)
+    return cast("tuple[AuthMode, ...]", tuple(cast(Any, modes)()))
+
+
+def _unsupported_auth_mode_error(plugin: Any, auth_mode: str) -> HTTPException:
+    provider = getattr(plugin, "custom_llm_provider", "")
+    detail = {
+        "code": "api_key_not_supported"
+        if auth_mode == "api_key"
+        else "provider_does_not_use_oauth",
+    }
+    if isinstance(provider, str) and provider:
+        detail["provider"] = provider
+    return HTTPException(status_code=400, detail=detail)
 
 
 _BUCKET_A_FIELDS = (
@@ -118,6 +140,31 @@ def _oauth_connection_store(request: Request) -> OAuthConnectionStore:
     store = OAuthConnectionStore()
     request.app.state.oauth_connections = store
     return store
+
+
+async def _repair_api_key_only_connection_auth_type(
+    request: Request,
+    *,
+    plugin: Any,
+    connection: OAuthConnection,
+) -> OAuthConnection:
+    auth_type = auth_mode_for_target(None, connection)
+    modes = _available_auth_modes(plugin)
+    if auth_type != "oauth" or "oauth" in modes or "api_key" not in modes:
+        return connection
+    # INVARIANT: an api-key-only provider has no OAuth path. Retag the connection
+    # before parameter validation and credential reads so failures stay recoverable
+    # through the connection-native replace-key endpoint.
+    repaired = await _oauth_connection_store(request).set_auth_type(connection, "api_key")
+    if repaired is None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "connection_conflict",
+                "message": "Connection changed during auth-type repair",
+            },
+        )
+    return repaired
 
 
 async def _active_oauth_connection_for_profile(
@@ -183,6 +230,11 @@ async def _credential_target_for_chat(
             profile_name=profile_name,
         )
         if connection is not None:
+            connection = await _repair_api_key_only_connection_auth_type(
+                request,
+                plugin=plugin,
+                connection=connection,
+            )
             return None, connection, ProfileDefaults()
         if not _allows_chatless_profile(plugin):
             raise HTTPException(

--- a/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
+++ b/apps/aigateway/tests/unit/openrouter/test_openrouter_dispatch.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
+from uuid import UUID
 
 import pytest
 from fastapi import HTTPException
 
 from aigateway.core.api_key_strategy import ApiKeyStrategy
+from aigateway.core.oauth.store import OAuthConnectionStore, credential_key_for
 from aigateway.plugins.openrouter_provider import plugin as openrouter_plugin_module
 from aigateway.plugins.openrouter_provider.plugin import OpenRouterProviderPlugin
 from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSettings
@@ -22,6 +24,26 @@ from aigateway.plugins.openrouter_provider.settings import OpenRouterPluginSetti
 
 def _plugin(*, enabled: bool) -> OpenRouterProviderPlugin:
     return OpenRouterProviderPlugin(OpenRouterPluginSettings(enabled=enabled))
+
+
+def _account_id(client) -> str:
+    return client.get("/v1/auth/me").json()["id"]
+
+
+def _create_openrouter_connection(client) -> dict[str, Any]:
+    response = client.post(
+        "/v1/oauth/connections/api-key",
+        json={"provider": "openrouter", "label": "work-openrouter", "api_key": "sk-or-v1-test"},
+    )
+    assert response.status_code == 201, response.text
+    return cast("dict[str, Any]", response.json())
+
+
+async def _set_connection_auth_type(account_id: str, connection_id: str, auth_type: str) -> None:
+    connection = await OAuthConnectionStore().get(account_id, UUID(connection_id))
+    assert connection is not None
+    connection.auth_type = auth_type
+    await connection.save(update_fields=["auth_type"])
 
 
 # --- D1: normal auto-discovery, no loader/registry edits ---
@@ -195,6 +217,93 @@ def test_chat_openrouter_byok_end_to_end(
     assert resp.status_code == 200, resp.text
     assert captured["model"] == "openrouter/anthropic/claude-fable-5"
     assert captured["api_key"] == "sk-or-v1-test"
+
+
+def test_chat_repairs_openrouter_oauth_connection_with_api_key_blob(
+    enabled_openrouter,
+    authenticated_client,
+) -> None:
+    account_id = _account_id(authenticated_client)
+    created = _create_openrouter_connection(authenticated_client)
+    authenticated_client.portal.call(
+        _set_connection_auth_type,
+        account_id,
+        created["id"],
+        "oauth",
+    )
+    captured: dict[str, Any] = {}
+
+    async def fake_chat_completion(_self, body):
+        captured.update(body)
+        return SimpleNamespace(
+            model_dump=lambda: {"id": "or-1", "choices": [{"message": {"content": "ok"}}]}
+        )
+
+    with patch(
+        "aigateway.plugins.openrouter_provider.plugin.OpenRouterProviderPlugin.chat_completion",
+        fake_chat_completion,
+    ):
+        response = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openrouter/anthropic/claude-fable-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert captured["api_key"] == "sk-or-v1-test"
+    repaired = authenticated_client.portal.call(
+        OAuthConnectionStore().get,
+        account_id,
+        UUID(created["id"]),
+    )
+    assert repaired is not None
+    assert repaired.auth_type == "api_key"
+
+
+def test_chat_corrupted_openrouter_oauth_connection_without_key_does_not_dispatch(
+    enabled_openrouter,
+    credential_blobs,
+    authenticated_client,
+) -> None:
+    account_id = _account_id(authenticated_client)
+    created = _create_openrouter_connection(authenticated_client)
+    authenticated_client.portal.call(
+        _set_connection_auth_type,
+        account_id,
+        created["id"],
+        "oauth",
+    )
+    credential_blobs.delete(
+        f"aigateway:openrouter:{credential_key_for(account_id, created['id'])}",
+        "default",
+    )
+
+    with patch(
+        "aigateway.plugins.openrouter_provider.plugin.OpenRouterProviderPlugin.chat_completion",
+    ) as dispatched:
+        response = authenticated_client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "openrouter/anthropic/claude-fable-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+
+    assert response.status_code == 401
+    detail = response.json()["detail"]
+    assert detail["code"] == "auth_required"
+    assert detail["reauth_url"] == f"/v1/oauth/connections/{created['id']}/api-key"
+    dispatched.assert_not_called()
+    connection = authenticated_client.portal.call(
+        OAuthConnectionStore().get,
+        account_id,
+        UUID(created["id"]),
+    )
+    assert connection is not None
+    assert connection.auth_type == "api_key"
+    assert connection.status == "error"
 
 
 def test_chat_openrouter_stream_rejected_before_dispatch(

--- a/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
+++ b/apps/aigateway/tests/unit/test_oauth_connection_api_key_routes.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -51,6 +52,62 @@ def test_create_api_key_connection_is_active_and_typed(authenticated_client) -> 
     assert data["provider"] == "anthropic"
     # The raw key must never be echoed back.
     assert _KEY not in resp.text
+
+
+def test_create_api_key_connection_overrides_a_stale_insert_shape(
+    authenticated_client,
+    credential_blobs,
+) -> None:
+    from tortoise.backends.base.executor import EXECUTOR_CACHE
+
+    cache_key = ("default", None, "oauth_connections")
+    previous = EXECUTOR_CACHE.get(cache_key)
+    old_columns = [
+        "id",
+        "provider",
+        "label",
+        "status",
+        "identity_sub",
+        "identity_email",
+        "identity_name",
+        "identity_raw",
+        "credential_locator",
+        "created_at",
+        "last_used_at",
+        "last_refreshed_at",
+        "error_message",
+        "account_id",
+    ]
+    old_insert = (
+        'INSERT INTO "oauth_connections" '
+        '("id","provider","label","status","identity_sub","identity_email",'
+        '"identity_name","identity_raw","credential_locator","created_at",'
+        '"last_used_at","last_refreshed_at","error_message","account_id") '
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+    )
+    EXECUTOR_CACHE[cache_key] = (
+        old_columns,
+        old_insert,
+        old_columns,
+        old_insert,
+        'DELETE FROM "oauth_connections" WHERE "id"=?',
+        {},
+    )
+    try:
+        resp = _create(authenticated_client, label="stale-shape")
+    finally:
+        if previous is None:
+            EXECUTOR_CACHE.pop(cache_key, None)
+        else:
+            EXECUTOR_CACHE[cache_key] = previous
+
+    assert resp.status_code == 201, resp.text
+    with sqlite3.connect(credential_blobs.db_path) as conn:
+        row = conn.execute(
+            "select auth_type from oauth_connections where id = ?",
+            (resp.json()["id"],),
+        ).fetchone()
+    assert row == ("api_key",)
 
 
 def test_create_writes_key_to_chat_read_slot_encrypted(


### PR DESCRIPTION
## Description
Fixes BYOK connection auth-type recovery in AIGateway.

API-key connection creation now durably republishes the persisted `auth_type` discriminator after insert, so a stale insert shape cannot leave the database row as `oauth`. Chat resolution also validates stored auth mode against provider capabilities before dispatch. For API-key-only providers, a corrupted active connection stored as `oauth` is retagged to `api_key` before credential injection, preserving the normal recoverable replace-key path.

Refs: OME-1061

## Affected Dependencies
None.

## How has this been tested?
- `uv run pytest tests/unit/test_oauth_connection_api_key_routes.py::test_create_api_key_connection_overrides_a_stale_insert_shape tests/unit/openrouter/test_openrouter_dispatch.py::test_chat_repairs_openrouter_oauth_connection_with_api_key_blob tests/unit/openrouter/test_openrouter_dispatch.py::test_chat_corrupted_openrouter_oauth_connection_without_key_does_not_dispatch -q`
- `uv run pytest tests/unit/test_oauth_connection_api_key_routes.py tests/unit/openrouter/test_openrouter_dispatch.py tests/unit/test_chat_x_profile.py::test_chat_api_key_auth_type_without_strategy_returns_400 tests/unit/test_migration_populated_db.py::test_full_chain_applies_to_populated_database -q`
- `uv run .claude/scripts/run_gates.py aigateway`
- Push hook reran the AIGateway gate and passed.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
