### PR TITLE
fix(aigateway): configurable componentLabel; refuse podLabels collision

### DIFF
--- a/.github/scripts/verify_chart_wiring.py
+++ b/.github/scripts/verify_chart_wiring.py
@@ -404,6 +404,61 @@ check(
     gw_service["spec"]["selector"].get("app.kubernetes.io/component") == "gateway",
     "the Service routes ONLY to gateway Pods, not merely saved by the named targetPort",
 )
+
+# WHY these four (regression, 2026-09-01): the checks above render DEFAULT values, where the
+# component label can only come from the chart itself — so they all passed while the deployed
+# gateway had no Endpoints for 40 minutes. The platform sets `podLabels`, which rendered AFTER the
+# Pod template's own labels, so its `component: server` won on the Pod by YAML duplicate-key
+# precedence while this Service selector still demanded `gateway`. Zero Endpoints, Pod Running,
+# Argo Synced, nothing in any log. A default-only render cannot see that class of break, so the
+# gate now renders the OVERRIDE path too: the Pod label and every selector must move together,
+# and the spelling that caused the outage must be refused outright.
+gw_component = render(
+    GATEWAY_CHART, GATEWAY_RELEASE, "--set", "componentLabel=server", "--set", "snapshot.enabled=true"
+)
+gwc_deployment = find_named(gw_component, "Deployment", f"{GATEWAY_RELEASE}-aigateway")
+gwc_service = find_named(gw_component, "Service", f"{GATEWAY_RELEASE}-aigateway")
+gwc_policy = find_named(gw_component, "NetworkPolicy", f"{GATEWAY_RELEASE}-aigateway")
+gwc_garage_policy = find_named(
+    gw_component, "NetworkPolicy", f"{GATEWAY_RELEASE}-aigateway-garage"
+)
+
+check(
+    gwc_deployment["spec"]["template"]["metadata"]["labels"].get(
+        "app.kubernetes.io/component"
+    )
+    == "server"
+    and gwc_service["spec"]["selector"].get("app.kubernetes.io/component") == "server",
+    "componentLabel moves the Pod label and the Service selector together — the Service keeps "
+    "selecting the Pod it fronts under a platform's own component convention",
+)
+check(
+    gwc_policy["spec"]["podSelector"]["matchLabels"].get("app.kubernetes.io/component")
+    == "server",
+    "componentLabel moves the gateway NetworkPolicy podSelector too",
+)
+check(
+    any(
+        peer.get("podSelector", {}).get("matchLabels", {}).get(
+            "app.kubernetes.io/component"
+        )
+        == "server"
+        for rule in gwc_garage_policy["spec"]["ingress"]
+        for peer in rule.get("from", [])
+    ),
+    "componentLabel moves Garage's :3900 ingress peer too — the snapshot PUTs keep working",
+)
+_pod_label_clash = render_fails(
+    GATEWAY_CHART,
+    GATEWAY_RELEASE,
+    "--set-string",
+    "podLabels.app\\.kubernetes\\.io/component=server",
+)
+check(
+    _pod_label_clash is not None and "componentLabel" in _pod_label_clash,
+    "podLabels cannot set app.kubernetes.io/component — the render is refused and names "
+    "componentLabel, instead of silently emptying the Service",
+)
 check(
     garage_sts["spec"]["template"]["metadata"]["labels"].get("app.kubernetes.io/component")
     == "garage",

--- a/apps/aigateway/charts/aigateway/templates/_helpers.tpl
+++ b/apps/aigateway/charts/aigateway/templates/_helpers.tpl
@@ -64,6 +64,40 @@ app.kubernetes.io/name: {{ include "aigateway.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{/*
+The gateway Pod's `app.kubernetes.io/component` value — the ONE place this chart decides it.
+
+INVARIANT: the Pod template AND every selector that must name the gateway (the Service, the
+NetworkPolicy, Garage's :3900 ingress) derive from this helper, so they cannot drift apart.
+
+WHY configurable: `selectorLabels` (name+instance) match EVERY workload this chart renders — the
+migrate Job and the bundled Garage included — so a selector that must name the gateway needs a
+component label. But a platform that owns the network boundary may already have its own name for
+this Pod (`component: server` across sf-aigw / sf-report-intake / sf-scoreboard). Hardcoding
+`gateway` forced such a platform to restate it through `podLabels`, which rendered AFTER the Pod
+template's own labels: the duplicate key won on the Pod, the Service selector kept demanding
+`gateway`, and the Service matched ZERO Pods — Pod Running, Argo Synced, no Endpoints, nothing in
+any log. Set `componentLabel` to adopt an existing convention and every selector moves with it.
+*/}}
+{{- define "aigateway.componentLabel" -}}
+{{- .Values.componentLabel | default "gateway" -}}
+{{- end -}}
+
+{{/*
+Refuse the `podLabels` spelling that silently empties this chart's Service.
+
+`podLabels` cannot express a label this chart's selectors depend on: YAML duplicate-key
+precedence decides the winner with no Helm error and no API-server rejection, so the override
+detaches every caller from the gateway while everything still reports healthy. `componentLabel`
+is the supported spelling because it moves the Pod label and the selectors together.
+*/}}
+{{- define "aigateway.validatePodLabels" -}}
+{{- $reserved := "app.kubernetes.io/component" -}}
+{{- if hasKey (.Values.podLabels | default dict) $reserved -}}
+{{- fail (printf "podLabels sets %s=%q, which this chart's Service and NetworkPolicy select on. podLabels renders after the Pod template's own labels, so the override wins on the Pod and leaves the Service matching zero Pods (Pod Running, Argo Synced, no Endpoints). Set componentLabel=%q instead — it moves the Pod label and every selector together." $reserved (get .Values.podLabels $reserved) (get .Values.podLabels $reserved)) -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "aigateway.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "aigateway.fullname" .) .Values.serviceAccount.name -}}

--- a/apps/aigateway/charts/aigateway/templates/configmap.yaml
+++ b/apps/aigateway/charts/aigateway/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- include "aigateway.validateAuth" . -}}
+{{- include "aigateway.validatePodLabels" . -}}
 {{- include "aigateway.validateSnapshot" . -}}
 apiVersion: v1
 kind: ConfigMap

--- a/apps/aigateway/charts/aigateway/templates/deployment.yaml
+++ b/apps/aigateway/charts/aigateway/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         # chart renders, so any selector that must name the gateway — the Service, the
         # NetworkPolicy — needs this label to stay scoped now that Garage Pods carry the same
         # name/instance pair. Template labels only: see the selector note above.
-        app.kubernetes.io/component: gateway
+        app.kubernetes.io/component: {{ include "aigateway.componentLabel" . }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/apps/aigateway/charts/aigateway/templates/garage.yaml
+++ b/apps/aigateway/charts/aigateway/templates/garage.yaml
@@ -187,6 +187,6 @@ spec:
         - podSelector:
             matchLabels:
               {{- include "aigateway.selectorLabels" . | nindent 14 }}
-              app.kubernetes.io/component: gateway
+              app.kubernetes.io/component: {{ include "aigateway.componentLabel" . }}
 {{- end }}
 {{- end }}

--- a/apps/aigateway/charts/aigateway/templates/networkpolicy.yaml
+++ b/apps/aigateway/charts/aigateway/templates/networkpolicy.yaml
@@ -47,7 +47,7 @@ spec:
       # Job Pods; applying this 9105-only rule to them is what denied the gateway's snapshot
       # PUTs to Garage:3900 under the default networkPolicy.enabled=true — the bundled
       # Garage gets its own scoped policy (templates/garage.yaml) instead.
-      app.kubernetes.io/component: gateway
+      app.kubernetes.io/component: {{ include "aigateway.componentLabel" . }}
   policyTypes:
     - Ingress
     - Egress

--- a/apps/aigateway/charts/aigateway/templates/service.yaml
+++ b/apps/aigateway/charts/aigateway/templates/service.yaml
@@ -15,4 +15,4 @@ spec:
     # The gateway ONLY: the bare selectorLabels would also match the bundled Garage Pods once
     # they exist — saved today by the named targetPort (`http`), which Garage's ports (`s3`,
     # `rpc`) do not carry, but that is an accident of port naming, not a design.
-    app.kubernetes.io/component: gateway
+    app.kubernetes.io/component: {{ include "aigateway.componentLabel" . }}

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -15,7 +15,17 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+# Extra Pod labels. MUST NOT contain `app.kubernetes.io/component` — the Service and the
+# NetworkPolicy select on it, and podLabels renders last, so an entry here would win on the Pod
+# and leave the Service with no Endpoints. The render fails if you try; use `componentLabel`.
 podLabels: {}
+
+# The gateway Pod's `app.kubernetes.io/component`, applied to the Pod template and to every
+# selector that names the gateway (Service, NetworkPolicy, Garage's :3900 ingress) at once.
+# Override it to adopt a platform convention that already names this Pod something else, e.g.
+# `server`. It must stay distinct from the migrate Job (`migrate`) and the bundled Garage
+# (`garage`), which share this release's name+instance labels.
+componentLabel: gateway
 
 podSecurityContext: {}
 


### PR DESCRIPTION
## Incident (2026-09-01, dev / aks-dev)

`sf.models.list()` and every url4-cloud catalog fetch failed with `HTTP 504 engine_contract_error` from ~13:25 UTC. Root cause chain:

- **#752** hardcoded `app.kubernetes.io/component: gateway` into the pod template **and** the Service selector / NetworkPolicy podSelector (needed to disambiguate from bundled Garage pods).
- The platform (`OpenMined/infrastructure`, `kubernetes/apps/sf-aigw/values/dev.yaml`) already stamps this pod `component: server` via `podLabels` — org-wide convention; the platform's `allow-aigateway-egress-providers` netpol keys on it.
- `podLabels` renders **after** the pod template's own labels → the duplicate key won on the pod; the Service selector kept demanding `gateway` → **zero Endpoints, Pod Running, Argo Synced, nothing in any log.** Kargo pinned `main-64e522…` at 13:07 UTC; broken pod born 13:08:32.

## Fix

| Defect | Fix |
|---|---|
| Selector-critical label hardcoded | New `componentLabel` value (default `gateway`) — single source of truth; pod template, Service selector, gateway NetworkPolicy podSelector, and Garage's `:3900` ingress peer all derive from it |
| Collision silent (YAML duplicate-key precedence) | Render now **fails** when `podLabels` sets `app.kubernetes.io/component`, naming `componentLabel` as the supported spelling |
| CI blind spot (`verify_chart_wiring.py` rendered defaults only) | Gate now renders the override path (`componentLabel=server` + `snapshot.enabled=true`) and asserts pod label + every selector move together; also asserts the outage's spelling is refused |

## Verification

- default render: `component: gateway` at all sites; `migrate`/`garage` untouched
- override render: all four gateway sites move to `server` together
- collision render: refused with an actionable message
- `verify_chart_wiring.py`: **110/110** (fixed the new check itself to use `find_named` — with Garage rendering, `find(kind)` returns Garage's Service, the exact trap `find_named`'s docstring warns about)
- `helm lint` default + override: clean
- rendered with the platform's real dev values (post-infra-change): Service selector `{name: aigateway, instance: aigw, component: server}` ⊆ pod labels → Endpoints populate; `allow-aigateway-egress-providers` still matches
- no cross-chart coupling: aigateway-ui selects gateway pods by `app.kubernetes.io/name` only

## Deployment order — read before merging

Companion PR in `OpenMined/infrastructure` switches dev.yaml from `podLabels` to `componentLabel: server`.

1. **Merge this PR first.** The next Kargo promotion of dev will render-fail loudly (`podLabels sets app.kubernetes.io/component…Set componentLabel="server" instead`) — that is the fail-fast working as designed; dev stays exactly as broken as it is now, no worse.
2. **Then merge the infrastructure PR.** Argo sync goes green, the pod rolls with matching labels, Endpoints populate, `sf.models.list()` recovers.

Do **not** merge the infrastructure PR first: against the currently-pinned chart, `componentLabel` is an unknown (silently ignored) value, the pod would render as `gateway`, and `allow-aigateway-egress-providers` would strip provider egress — a worse outage than the current one.

Refs: OME-1021 fallout (introduced by #752)