### PR TITLE
feat(screamingface-engine): runner traceability and logging layer (OME-1069)

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/logs.py
+++ b/apps/screamingface-engine/src/screamingface_engine/logs.py
@@ -14,10 +14,22 @@ and a dropped Run stream is otherwise indistinguishable from every other dropped
 
 Stdlib only, deliberately: the run mode (a Job) needs this as much as the serving mode, and
 the layering rule keeps the two import graphs disjoint.
+
+FEATURE (OME-1069): the run-context machinery below is the runner's traceability layer. A
+Job's process logs are the operator's only view of a run that is not the CloudEvents stream,
+and before this they carried no topic and no trace id — a line could not be attributed to a
+run, and a failed Job could not be correlated with the stream that holds its real outcome.
+The mechanism is a ContextVar the run mode binds around one run, plus a Filter that renders
+it onto every record emitted inside that scope. The control plane never binds the context,
+so its lines are byte-identical to before.
 """
 
+import contextvars
 import logging
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import TextIO
 
 APP_LOGGER = "screamingface_engine"
@@ -25,7 +37,68 @@ LEVEL_ENV = "URL4_CLOUD_LOG_LEVEL"
 DEFAULT_LEVEL = "INFO"
 
 # Matches uvicorn's own column so a deployment's logs read as one stream rather than two.
-_FORMAT = "%(levelname)s:     %(name)s %(message)s"
+# `%(run_context)s` is set by `RunContextFilter`; `defaults=` keeps a record that somehow
+# reaches the handler without passing the filter (a foreign handler's record, say) from
+# raising KeyError in the formatter.
+_FORMAT = "%(levelname)s:     %(name)s %(run_context)s%(message)s"
+
+
+@dataclass(frozen=True, slots=True)
+class RunContext:
+    """The one run a process log line belongs to, when it belongs to one."""
+
+    topic: str
+    trace_id: str | None = None
+
+
+_run_context: contextvars.ContextVar[RunContext | None] = contextvars.ContextVar(
+    "screamingface_engine_run_context", default=None
+)
+
+
+@contextmanager
+def run_scope(topic: str, trace_id: str | None = None) -> Iterator[None]:
+    """Bind one run's identity for the duration of a scope; restore on exit.
+
+    The run mode wraps its whole run in this, so every `screamingface_engine` record emitted
+    inside — including the executor's own warnings, which never see the topic — carries the
+    run's `topic` and, when known, its W3C `trace_id`. ContextVars propagate across awaits
+    within a task and into child tasks, so the executor's `_drive` task inherits the binding.
+    """
+
+    token = _run_context.set(RunContext(topic=topic, trace_id=trace_id))
+    try:
+        yield
+    finally:
+        _run_context.reset(token)
+
+
+def current_run_context() -> RunContext | None:
+    """The bound run identity, or None outside any run scope."""
+
+    return _run_context.get()
+
+
+class RunContextFilter(logging.Filter):
+    """Render the bound run's identity onto every record that passes through.
+
+    A Filter rather than a per-call argument so the executor's existing warnings and any
+    future log call inside a run are attributed without threading the topic through every
+    signature. Unbound (the control plane, tests, boot) it is a no-op: `run_context` is
+    empty and the line renders exactly as before.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        context = _run_context.get()
+        if context is None:
+            record.run_context = ""
+            return True
+        parts = [f"topic={context.topic}"]
+        if context.trace_id is not None:
+            parts.append(f"trace_id={context.trace_id}")
+        record.run_context = " ".join(parts) + " "
+        return True
+
 
 _INSTALLED = "_screamingface_engine_log_handler"
 """Marks the handler THIS module installed.
@@ -49,10 +122,20 @@ def configure(stream: TextIO | None = None) -> None:
     logger.setLevel(os.getenv(LEVEL_ENV, DEFAULT_LEVEL).upper())
     if not any(getattr(handler, _INSTALLED, False) for handler in logger.handlers):
         handler = logging.StreamHandler(stream)
-        handler.setFormatter(logging.Formatter(_FORMAT))
+        handler.setFormatter(logging.Formatter(_FORMAT, defaults={"run_context": ""}))
+        handler.addFilter(RunContextFilter())
         setattr(handler, _INSTALLED, True)
         logger.addHandler(handler)
     logger.propagate = False
 
 
-__all__ = ["APP_LOGGER", "DEFAULT_LEVEL", "LEVEL_ENV", "configure"]
+__all__ = [
+    "APP_LOGGER",
+    "DEFAULT_LEVEL",
+    "LEVEL_ENV",
+    "RunContext",
+    "RunContextFilter",
+    "configure",
+    "current_run_context",
+    "run_scope",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import time
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
@@ -24,6 +25,7 @@ from screamingface_engine import job_env
 from screamingface_engine.artifacts import ArtifactWriter
 from screamingface_engine.runner.accounting import PRICING_VERSION, UNPRICED, accumulate
 from screamingface_engine.runner.cache_counters import RunCacheCounters
+from screamingface_engine.runner.summary import RunOutcome, RunSummary
 from url4.core.errors import ResolutionError
 from url4.dag import run as url4_run
 from url4.io.layer import IOLayer
@@ -736,6 +738,10 @@ class Url4Executor(Executor):
         self._io_wrap = io_wrap
         self._io_concurrency = io_concurrency
         self._io_wrapped = False
+        # FEATURE (OME-1069): the most recent run's process-level summary, recorded in
+        # `execute` and read back by the composition root for its terminal/summary log lines.
+        # `None` until a run has executed (or when the caller closed the generator early).
+        self._last_summary: RunSummary | None = None
         # Derived ONCE, at construction, from the injected policy: which `concurrency` (if
         # any) the `url4_run` call states. See the policy comment above for why gate-mode
         # must say `None` explicitly while an unconfigured run says nothing at all.
@@ -750,13 +756,11 @@ class Url4Executor(Executor):
     ) -> AsyncIterator[ExecStep]:
         """Run `url4` to completion, yielding `ExecStep` frames as observation events arrive.
 
-        Runs the engine in a separate task (`_drive`) while draining its events through the
-        `_Bridge` on this task, so a slow consumer never blocks the engine's synchronous
-        observer callback. On exit — including early return by the caller not exhausting the
-        iterator — any still-running driving task is cancelled and awaited, and an already
-        finished task's exception (if not itself a cancellation) is retrieved so it isn't
-        reported as "never retrieved". The world is always closed via `_aclose_world`, even
-        when the run failed or was cancelled.
+        The engine runs in a separate task while this generator drains its events through the
+        `_Bridge`, so a slow consumer never blocks the engine's synchronous observer callback
+        (see `_run_steps`). On exit — including early return by the caller not exhausting the
+        iterator — the world is always closed via `_aclose_world`, even when the run failed
+        or was cancelled.
         """
         # INVARIANT: the world is resolved HERE, not in the composition root. Anything raised
         # before `lifecycle.run` publishes its first frame is invisible — no NATS connection,
@@ -766,6 +770,43 @@ class Url4Executor(Executor):
         await self._resolve_world()
         bridge = _Bridge(self._queue_cap, memory_budget=self._memory_budget)
         state = _RunState()
+        started = time.monotonic()
+        try:
+            async for step in self._run_steps(url4, trace, bridge, state, started):
+                yield step
+        except asyncio.CancelledError:
+            # The run was stopped (deadline, an external stop, the caller's cancellation).
+            # `lifecycle.run` publishes Terminated(stopped) and re-raises; the summary
+            # records the outcome so the composition root can log it.
+            self._record_summary("stopped", trace, started, bridge, state)
+            raise
+        except Exception as exc:
+            # A failed run states no cost and no cache counts: neither is exact, and a
+            # partial figure would read as a complete one. The error code/type follow the
+            # stream's own `_error_info` vocabulary (code, or None when the exception
+            # carries none).
+            self._record_summary("failed", trace, started, bridge, state, error=exc)
+            raise
+        finally:
+            await self._aclose_world()
+
+    async def _run_steps(
+        self,
+        url4: str,
+        trace: TraceContext | None,
+        bridge: _Bridge,
+        state: _RunState,
+        started: float,
+    ) -> AsyncIterator[ExecStep]:
+        """Drive the engine task and yield its wire frames, ending with `Completed`.
+
+        The engine runs in a separate task (`_drive`) while this generator drains its events
+        through the `_Bridge`, so a slow consumer never blocks the engine's synchronous
+        observer callback. On exit — including early return by the caller not exhausting the
+        iterator — any still-running driving task is cancelled and awaited, and an already
+        finished task's exception (if not itself a cancellation) is retrieved so it isn't
+        reported as "never retrieved".
+        """
 
         async def _drive() -> str:
             try:
@@ -800,7 +841,14 @@ class Url4Executor(Executor):
                 hard_cap=self._hard_cap,
                 store=self._artifact_store,
             )
-            yield Completed(result=result, subtree_cost=state.build_subtree())
+            subtree = state.build_subtree()
+            # FEATURE (OME-1069): recorded BEFORE the Completed yield, because
+            # `lifecycle.run` breaks out of its `async for` on Completed and never resumes
+            # this generator — code after the yield would never run. The summary is the
+            # operator's one-stop answer in a Job's logs; exact-only, like the stream's
+            # own cost frames.
+            self._record_summary("succeeded", trace, started, bridge, state, subtree=subtree)
+            yield Completed(result=result, subtree_cost=subtree)
         finally:
             if not task.done():
                 task.cancel()
@@ -808,7 +856,50 @@ class Url4Executor(Executor):
                     await task
             elif not task.cancelled():
                 task.exception()
-            await self._aclose_world()
+
+    def _record_summary(
+        self,
+        outcome: RunOutcome,
+        trace: TraceContext | None,
+        started: float,
+        bridge: _Bridge,
+        state: _RunState,
+        *,
+        subtree: CostUsageData | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        """Record the run's process-level summary (OME-1069).
+
+        Exact-only, like the rest of the run's accounting: cost and cache counters are
+        stated only for a completed run — a failed run's figures are partial and must not
+        read as exact. The error code/type follow the stream's own `_error_info`
+        vocabulary.
+        """
+
+        code = getattr(error, "code", None) if error is not None else None
+        self._last_summary = RunSummary(
+            outcome=outcome,
+            trace_id=trace.trace_id if trace is not None else None,
+            error_code=code if isinstance(code, str) else None,
+            error_type=type(error).__name__ if error is not None else None,
+            duration_s=time.monotonic() - started,
+            cost_usd=subtree.cost.total_usd if subtree is not None else None,
+            pricing_version=subtree.pricing_version if subtree is not None else None,
+            cache_attributes=state.cache_counters.attributes() if subtree is not None else None,
+            dropped_logs=bridge.dropped,
+            high_water=bridge.high_water,
+        )
+
+    def last_summary(self) -> RunSummary | None:
+        """The most recent run's process-level summary, or None if no run executed.
+
+        FEATURE (OME-1069): read by the composition root after `lifecycle.run` returns to
+        log the run's terminal outcome and summary. `None` covers both "never executed"
+        and "the caller closed the generator before it completed" — the two shapes a
+        caller cannot tell apart, and neither has a summary to state.
+        """
+
+        return self._last_summary
 
     async def _resolve_world(self) -> None:
         """Build the world on first execute. Idempotent; a failure leaves nothing to close.

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -10,11 +10,13 @@ layering note in :mod:`screamingface_engine.runner`.
 import asyncio
 import logging
 import os
+import time
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -26,15 +28,28 @@ from screamingface_engine.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry,
 from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.candidate_adapter import install_candidate_invocation
 from screamingface_engine.benchmarks.ensemble import install_corrective_runtime
+from screamingface_engine.logs import run_scope
 from screamingface_engine.runner.connector import AigatewayConfig, build_aigateway_world
 from screamingface_engine.runner.executor import Url4Executor, World, deny_by_default_world
 from screamingface_engine.runner.fair_share import FairShareGate, FairShareIOLayer
 from screamingface_engine.runner.operation_capture import OperationCapturingExecutor
+from screamingface_engine.runner.summary import RunSummary
 from screamingface_engine.world_config import WorldConfig, WorldConfigError, load_config
-from url4.streaming.interfaces import Executor
 from url4.streaming.lifecycle import run
+from url4.streaming.protocol import CachePolicy
+from url4.streaming.trace import parse_traceparent
 
 logger = logging.getLogger(__name__)
+
+
+class _SummarizingExecutor(Protocol):
+    """The executor surface the runner's terminal logging needs beyond the port.
+
+    A Protocol rather than the concrete wrapper so `_log_terminal` is testable with a fake
+    that records a summary and nothing else — the function needs exactly this accessor.
+    """
+
+    def last_summary(self) -> RunSummary | None: ...
 
 
 class RunnerConfigError(ValueError):
@@ -212,7 +227,7 @@ def build_executor(
     benchmarks: BenchmarkRegistry = EMPTY_BENCHMARKS,
     benchmark_assets_root: Path | None = None,
     io_gate: FairShareGate | None = None,
-) -> Executor:
+) -> OperationCapturingExecutor:
     """Wire an executor over the DECLARED world — without building it yet.
 
     The world is resolved on first ``execute`` (see ``Url4Executor._resolve_world``), so a bad
@@ -228,6 +243,10 @@ def build_executor(
     ``build_aigateway_world`` as ``tavily_api_key``; when it is unset, the built world disables
     the web-search/web-fetch tool loop entirely (deny-by-default — see
     ``web_tools.build_client``), rather than leaving it half-configured.
+
+    The concrete return type (not the ``Executor`` port) is deliberate: the composition root
+    reads the run's process-level summary back off the wrapper after the run (OME-1069), and
+    the wrapper is the only executor this function ever builds.
     """
 
     async def _world() -> World:
@@ -249,6 +268,7 @@ def build_executor(
         # demand. Identity is forwarded when present and simply absent locally, where every caller
         # is anonymous. The old unconditional token requirement made every deployed run fail
         # before it issued a single request, because a deployed caller has no way to obtain one.
+        cache = job_env.cache_policy_from_env(env)
         world = await build_aigateway_world(
             AigatewayConfig(
                 base_url=section.base_url,
@@ -265,7 +285,7 @@ def build_executor(
             # process serves. `cache_policy_from_env` is total, so an env that states nothing
             # yields a policy that states nothing, which the connector sends as no `cache` field
             # at all — participation, without this half re-deciding what silence means.
-            cache=job_env.cache_policy_from_env(env),
+            cache=cache,
             client=client,
             tavily_api_key=env.get(job_env.TAVILY_API_KEY),
             tavily_client=tavily_client,
@@ -289,6 +309,20 @@ def build_executor(
                     ),
                 )
                 cleanup.pop_all()
+        # FEATURE (OME-1069): the world's resolved shape, logged once per run. The topic comes
+        # from the run's own env (`run_key`); the trace id is appended by the run-context
+        # filter, which is bound by the time the world is built. Model ids are public catalog
+        # names; `web_tools` is derived from the PRESENCE of the Tavily key, never the key
+        # itself; `cache` states whether the run declared a policy, not the policy's content.
+        logger.info(
+            "runner world topic=%s models=%d default_model=%s web_tools=%s cache=%s outbound=%s",
+            run_key,
+            len(section.models),
+            section.default_model,
+            "enabled" if world.web_tools_enabled else "disabled",
+            _cache_stated(cache),
+            "allowed" if section.allow_outbound else "denied",
+        )
         return world.node, world.aclose
 
     inline_cap, hard_cap, artifact_store = result_delivery_from_env(env)
@@ -317,25 +351,137 @@ def build_executor(
     )
 
 
+def _cache_stated(policy: CachePolicy) -> str:
+    """Whether a run's cache policy stated anything — 'stated' or 'not-stated'.
+
+    Its own token rather than the rendered policy: "did not declare" and "declared an
+    all-unset policy" are different statements, and the world log only needs the first.
+    """
+
+    if policy.participate is not None or policy.max_age is not None:
+        return "stated"
+    return "not-stated"
+
+
+def _nats_host(url: str) -> str:
+    """The NATS host for a log line — never the userinfo, which may carry credentials."""
+
+    if "://" in url:
+        return urlsplit(url).hostname or url
+    return url.rsplit("@", 1)[-1]
+
+
+def _log_boot(params: RunnerParams, traceparent: str | None) -> None:
+    """The Job's first line: what this run is, sanitized.
+
+    The expression itself is never logged — it is the caller's and may carry prompts; its
+    LENGTH is enough to tell a large Evaluation from a smoke run (the control plane's own
+    precedent). The NATS URL is reduced to its host for the same reason.
+    """
+
+    logger.info(
+        "runner boot topic=%s url4_chars=%d deadline_s=%s nats_host=%s traceparent=%s",
+        params.topic,
+        len(params.url4),
+        params.deadline_s,
+        _nats_host(params.nats_url),
+        "present" if traceparent else "absent",
+    )
+
+
+def _log_terminal(executor: _SummarizingExecutor, topic: str, started: float) -> None:
+    """The run's process-level outcome and summary — the operator's one-stop answer.
+
+    Exact-only, like the stream's own cost frames: a failed run states no cost and no cache
+    counts, because neither is exact. The summary's `trace_id` is the one the executor
+    received from `lifecycle.run` — exactly the id on the stream frames.
+    """
+
+    summary = executor.last_summary()
+    duration_s = time.monotonic() - started
+    if summary is None:
+        logger.warning(
+            "run ended without an executor summary topic=%s duration_s=%.1f",
+            topic,
+            duration_s,
+        )
+        return
+    code = f" code={summary.error_code}" if summary.error_code is not None else ""
+    error_type = f" type={summary.error_type}" if summary.error_type is not None else ""
+    logger.info(
+        "run finished topic=%s outcome=%s%s%s duration_s=%.1f",
+        topic,
+        summary.outcome,
+        code,
+        error_type,
+        duration_s,
+    )
+    if summary.outcome != "succeeded":
+        return
+    cost = (
+        "unpriced"
+        if summary.pricing_version == "unpriced"
+        else (f"{summary.cost_usd}" if summary.cost_usd is not None else "unknown")
+    )
+    fields = [
+        f"topic={topic}",
+        f"trace_id={summary.trace_id or 'none'}",
+        f"outcome={summary.outcome}",
+        f"duration_s={duration_s:.1f}",
+        f"cost_usd={cost}",
+        f"pricing={summary.pricing_version or 'unknown'}",
+    ]
+    fields.extend(f"{key}={value}" for key, value in (summary.cache_attributes or {}).items())
+    fields.append(f"dropped_logs={summary.dropped_logs}")
+    fields.append(f"high_water={summary.high_water}")
+    logger.info("run summary %s", " ".join(fields))
+
+
+async def _run_and_log(
+    executor: OperationCapturingExecutor,
+    publisher: JetStreamPublisher,
+    params: RunnerParams,
+    traceparent: str | None,
+) -> None:
+    """Drive one run, then log its terminal outcome and summary from the executor's record.
+
+    `lifecycle.run` publishes the terminal frame and returns normally on failure, so the
+    outcome is read back from the executor rather than inferred from an exception.
+    """
+
+    started = time.monotonic()
+    try:
+        await run(
+            publisher,
+            executor,
+            params.topic,
+            params.url4,
+            traceparent=traceparent,
+            deadline_s=params.deadline_s,
+        )
+    finally:
+        _log_terminal(executor, params.topic, started)
+
+
 def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)
     async def _main() -> None:
         params = params_from_env(os.environ)
         executor = build_executor(os.environ, benchmarks=BUILTIN_BENCHMARKS)
         traceparent = os.environ.get(job_env.TRACEPARENT)
         publisher = JetStreamPublisher(params.nats_url)
-        await run_and_reclaim(
-            publisher,
-            params.topic,
-            lambda: run(
+        _log_boot(params, traceparent)
+        # The trace id the run's own frames will carry: parsed from the App-forwarded
+        # traceparent, or None when the caller sent none (the stream then mints one, which
+        # the executor records and the summary line reports). Bound for the whole run so
+        # every process log line inside it carries topic and trace id.
+        trace_id = parse_traceparent(traceparent)
+        with run_scope(params.topic, trace_id):
+            await run_and_reclaim(
                 publisher,
-                executor,
                 params.topic,
-                params.url4,
-                traceparent=traceparent,
-                deadline_s=params.deadline_s,
-            ),
-            grace_s=stream_grace_s(os.environ),
-        )
+                lambda: _run_and_log(executor, publisher, params, traceparent),
+                grace_s=stream_grace_s(os.environ),
+            )
 
     asyncio.run(_main())
 

--- a/apps/screamingface-engine/src/screamingface_engine/runner/operation_capture.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/operation_capture.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from typing import cast
 
 from screamingface_engine.grading_accounting import capture_grading_requests
 from screamingface_engine.operation_calls import (
     RequestAccountingRecorder,
     capture_request_accounting,
 )
+from screamingface_engine.runner.summary import RunSummary
 from url4.streaming.interfaces import ExecStep, Executor, TraceContext
 
 
@@ -44,6 +46,19 @@ class OperationCapturingExecutor(Executor):
                 with capture_request_accounting(requests):
                     with capture_grading_requests(registry):
                         await close()
+
+    def last_summary(self) -> RunSummary | None:
+        """Delegate the inner executor's process-level run summary (OME-1069).
+
+        The inner `Url4Executor` records the summary in its own `execute`; the composition
+        root holds THIS wrapper, so the accessor must travel through it. An inner executor
+        that does not record a summary (a test double, say) answers None.
+        """
+
+        accessor = getattr(self._inner, "last_summary", None)
+        if not callable(accessor):
+            return None
+        return cast(RunSummary | None, accessor())
 
 
 __all__ = ["OperationCapturingExecutor"]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/summary.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/summary.py
@@ -1,0 +1,42 @@
+"""The process-level summary one run leaves behind (OME-1069).
+
+The run's telemetry lives in the CloudEvents stream; this is the small, exact
+record the run mode logs to its own process output so an operator reading a Job's
+logs gets the one-stop answer — outcome, duration, cost, cache, overflow — without
+correlating the stream by hand. Exact-only, like the rest of the run's accounting:
+``cost_usd`` is the subtree total or ``None`` (unpriced/unknown), never a false
+zero, and cache counters are present only when the run completed, because a failed
+run's counters are partial and must not read as exact.
+
+Deliberately a leaf with no engine imports: both ``runner.executor`` (which
+computes the data) and ``runner.operation_capture`` (which delegates the accessor)
+import it without dragging the url4 engine into the latter's import graph.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Literal
+
+RunOutcome = Literal["succeeded", "failed", "stopped"]
+
+
+@dataclass(frozen=True, slots=True)
+class RunSummary:
+    """What one run's process-level telemetry can state, exactly or not at all."""
+
+    outcome: RunOutcome
+    trace_id: str | None
+    error_code: str | None = None
+    error_type: str | None = None
+    duration_s: float | None = None
+    cost_usd: Decimal | None = None
+    pricing_version: str | None = None
+    cache_attributes: Mapping[str, str | int | float | bool | None] | None = None
+    dropped_logs: int | None = None
+    high_water: int | None = None
+
+
+__all__ = ["RunOutcome", "RunSummary"]

--- a/apps/screamingface-engine/tests/unit/test_logs_configuration.py
+++ b/apps/screamingface-engine/tests/unit/test_logs_configuration.py
@@ -14,7 +14,7 @@ from collections.abc import Iterator
 
 import pytest
 
-from screamingface_engine.logs import APP_LOGGER, LEVEL_ENV, configure
+from screamingface_engine.logs import APP_LOGGER, LEVEL_ENV, configure, run_scope
 
 
 @pytest.fixture(autouse=True)
@@ -93,3 +93,47 @@ def test_a_foreign_handler_does_not_suppress_our_own() -> None:
     logging.getLogger("screamingface_engine.ws.bridge").info("still recorded")
 
     assert "still recorded" in stream.getvalue()
+
+
+def test_a_record_inside_a_run_scope_carries_topic_and_trace_id() -> None:
+    # FEATURE (OME-1069): a Job's process logs are the operator's only view of a run that is
+    # not the CloudEvents stream, and every line inside a run must be attributable to it.
+    stream = io.StringIO()
+    configure(stream)
+
+    with run_scope("cap-topic", "ab" * 16):
+        logging.getLogger("screamingface_engine.ws.bridge").info("run started")
+
+    rendered = stream.getvalue()
+    assert "topic=cap-topic trace_id=" in rendered
+    assert "run started" in rendered
+
+
+def test_a_record_outside_a_run_scope_renders_unchanged() -> None:
+    # The control plane never binds a run scope, so its lines must be byte-identical to
+    # before the feature existed — an empty run-context field, not a placeholder.
+    stream = io.StringIO()
+    configure(stream)
+
+    logging.getLogger("screamingface_engine.ws.bridge").info("ws stream ended")
+
+    rendered = stream.getvalue()
+    assert "ws stream ended" in rendered
+    assert "topic=" not in rendered
+
+
+def test_run_scope_restores_the_previous_context_on_exit() -> None:
+    # Nested scopes (a run wrapping a benchmark's own scope) must restore the outer run's
+    # identity rather than leaving the inner one bound for the rest of the process.
+    stream = io.StringIO()
+    configure(stream)
+    logger = logging.getLogger("screamingface_engine.ws.bridge")
+
+    with run_scope("outer-topic"):
+        with run_scope("inner-topic"):
+            logger.info("inner")
+        logger.info("outer")
+
+    rendered = stream.getvalue()
+    assert "topic=inner-topic" in rendered
+    assert "topic=outer-topic" in rendered

--- a/apps/screamingface-engine/tests/unit/test_runner_summary.py
+++ b/apps/screamingface-engine/tests/unit/test_runner_summary.py
@@ -1,0 +1,244 @@
+"""The runner's process-level summary and its log rendering (OME-1069).
+
+The run's telemetry lives in the CloudEvents stream; the summary is the small, exact record
+the run mode logs to its own process output so an operator reading a Job's logs gets the
+one-stop answer. Exact-only, like the rest of the run's accounting: a failed run states no
+cost and no cache counts, because neither is exact.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from decimal import Decimal
+
+import pytest
+from _fakes import MockExecutor
+
+from screamingface_engine.runner.executor import Url4Executor
+from screamingface_engine.runner.main import (
+    RunnerParams,
+    _log_boot,
+    _log_terminal,
+    _nats_host,
+)
+from screamingface_engine.runner.operation_capture import OperationCapturingExecutor
+from screamingface_engine.runner.summary import RunSummary
+from url4.core.errors import ParseError
+from url4.io.static import StaticIOLayer
+from url4.streaming.interfaces import TraceContext
+
+TRACE = TraceContext(trace_id="ab" * 16, root_span_id="cd" * 8)
+_MAIN_LOGGER = "screamingface_engine.runner.main"
+
+
+class _SummarizingExecutor:
+    """A fake executor that records a summary, for `_log_terminal` tests."""
+
+    def __init__(self, summary: RunSummary | None) -> None:
+        self._summary = summary
+
+    def last_summary(self) -> RunSummary | None:
+        return self._summary
+
+
+# --- Url4Executor.last_summary -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_summary_is_none_before_any_execute() -> None:
+    executor = Url4Executor(StaticIOLayer())
+
+    assert executor.last_summary() is None
+
+
+@pytest.mark.asyncio
+async def test_a_completed_run_records_an_exact_summary() -> None:
+    io = StaticIOLayer(fetch_map={"https://a": "A"})
+    executor = Url4Executor(io)
+
+    async for _ in executor.execute("https://a!go", trace=TRACE):
+        pass
+
+    summary = executor.last_summary()
+    assert summary is not None
+    assert summary.outcome == "succeeded"
+    # The trace id the stream frames carry — recorded from the TraceContext the executor
+    # received, never re-derived.
+    assert summary.trace_id == TRACE.trace_id
+    # A static run makes no model call: the subtree is unpriced, never a false zero.
+    assert summary.pricing_version == "unpriced"
+    assert summary.cost_usd == Decimal("0")
+    assert summary.cache_attributes == {
+        "cache.hits": 0,
+        "cache.misses": 0,
+        "cache.bypasses": 0,
+    }
+    assert summary.error_code is None
+    assert summary.error_type is None
+    assert summary.duration_s is not None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_run_records_failed_without_cost_or_cache() -> None:
+    executor = Url4Executor(StaticIOLayer())
+
+    with pytest.raises(ParseError):
+        async for _ in executor.execute("((("):
+            pass
+
+    summary = executor.last_summary()
+    assert summary is not None
+    assert summary.outcome == "failed"
+    assert summary.error_code == "malformed_source"
+    assert summary.error_type == "ParseError"
+    # Exact-only: a failed run's cost and cache figures are partial and must not read as exact.
+    assert summary.cost_usd is None
+    assert summary.pricing_version is None
+    assert summary.cache_attributes is None
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_run_records_stopped() -> None:
+    gate = asyncio.Event()
+
+    async def gated(_context: str, _intent: str) -> str:
+        await gate.wait()
+        return "GATED"
+
+    io = StaticIOLayer(fetch_map={"https://fast": "FAST"}, routes={"/gated": gated})
+    executor = Url4Executor(io)
+    gen = executor.execute("(f=https://fast, g=/gated()!go)!'$f $g'", trace=TRACE)
+
+    # The run starts and blocks on the gate; the first frame is already out.
+    await asyncio.wait_for(gen.__anext__(), timeout=2.0)
+    pending = asyncio.ensure_future(gen.__anext__())
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+
+    summary = executor.last_summary()
+    assert summary is not None
+    assert summary.outcome == "stopped"
+    assert summary.trace_id == TRACE.trace_id
+    assert summary.cost_usd is None
+
+
+# --- OperationCapturingExecutor.last_summary ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_wrapper_delegates_last_summary_to_the_inner_executor() -> None:
+    io = StaticIOLayer(fetch_map={"https://a": "A"})
+    wrapper = OperationCapturingExecutor(Url4Executor(io))
+
+    async for _ in wrapper.execute("https://a!go", trace=TRACE):
+        pass
+
+    summary = wrapper.last_summary()
+    assert summary is not None
+    assert summary.outcome == "succeeded"
+    assert summary.trace_id == TRACE.trace_id
+
+
+def test_the_wrapper_answers_none_for_an_inner_executor_without_a_summary() -> None:
+    # A test double that does not record a summary must not crash the accessor.
+    wrapper = OperationCapturingExecutor(MockExecutor())
+
+    assert wrapper.last_summary() is None
+
+
+# --- _log_terminal / _log_boot rendering ----------------------------------------------------
+
+
+def test_log_terminal_renders_the_finished_and_summary_lines(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    summary = RunSummary(
+        outcome="succeeded",
+        trace_id="ab" * 16,
+        duration_s=1.5,
+        cost_usd=Decimal("0.0042"),
+        pricing_version="2026-07-01",
+        cache_attributes={"cache.hits": 3, "cache.misses": 1, "cache.bypasses": 0},
+        dropped_logs=0,
+        high_water=5,
+    )
+    with caplog.at_level(logging.INFO, logger=_MAIN_LOGGER):
+        _log_terminal(_SummarizingExecutor(summary), "cap-topic", time.monotonic() - 1.5)
+
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "run finished topic=cap-topic outcome=succeeded duration_s=" in message
+        for message in messages
+    )
+    assert any(
+        "run summary topic=cap-topic trace_id=" in message
+        and "cost_usd=0.0042" in message
+        and "cache.hits=3" in message
+        and "dropped_logs=0" in message
+        and "high_water=5" in message
+        for message in messages
+    )
+
+
+def test_log_terminal_omits_cost_and_cache_for_a_failed_run(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    summary = RunSummary(
+        outcome="failed",
+        trace_id=None,
+        error_code="provider_refusal",
+        error_type="RunnerRequestError",
+        duration_s=2.0,
+    )
+    with caplog.at_level(logging.INFO, logger=_MAIN_LOGGER):
+        _log_terminal(_SummarizingExecutor(summary), "cap-topic", time.monotonic() - 2.0)
+
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "run finished topic=cap-topic outcome=failed code=provider_refusal "
+        "type=RunnerRequestError" in message
+        for message in messages
+    )
+    assert not any("run summary" in message for message in messages)
+
+
+def test_log_terminal_warns_when_no_summary_exists(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger=_MAIN_LOGGER):
+        _log_terminal(_SummarizingExecutor(None), "cap-topic", time.monotonic())
+
+    assert any(
+        "run ended without an executor summary topic=cap-topic" in record.message
+        for record in caplog.records
+    )
+
+
+def test_log_boot_sanitizes_the_nats_url_and_never_logs_the_expression(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    params = RunnerParams(
+        topic="cap-topic",
+        url4="(secret prompt here)!'$x'",
+        nats_url="nats://user:pass@nats.example.com:4222",
+        deadline_s=3600.0,
+    )
+    with caplog.at_level(logging.INFO, logger=_MAIN_LOGGER):
+        _log_boot(params, "00-" + "ab" * 16 + "-" + "cd" * 8 + "-01")
+
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "runner boot topic=cap-topic url4_chars=25 deadline_s=3600.0 "
+        "nats_host=nats.example.com traceparent=present" in message
+        for message in messages
+    )
+    # The expression may carry prompts; the NATS URL may carry credentials. Neither is logged.
+    assert not any("secret prompt" in message for message in messages)
+    assert not any("user:pass" in message for message in messages)
+
+
+def test_nats_host_strips_userinfo() -> None:
+    assert _nats_host("nats://user:pass@nats.example.com:4222") == "nats.example.com"
+    assert _nats_host("nats://localhost:4222") == "localhost"
+    assert _nats_host("nats.example.com:4222") == "nats.example.com:4222"

--- a/docs/tasks/2026-09-01-OME-1069-runner-traceability.md
+++ b/docs/tasks/2026-09-01-OME-1069-runner-traceability.md
@@ -1,0 +1,27 @@
+---
+id: OME-1069
+linear_url: https://linear.app/openmined/issue/OME-1069/runner-traceability-logging-layer
+status: in_progress
+type: task
+priority: medium
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+  - task
+created: 2026-09-01
+closed:
+---
+
+# Runner traceability and logging layer (k8s mode)
+
+Give the run-mode Job process a structured, correlated logging layer: every process log line
+carries the run's `topic` and W3C `trace_id`, the runner logs its lifecycle (boot, world
+resolution, start, terminal outcome, summary), and the final summary line is the operator's
+one-stop answer for a Job's logs. The CloudEvents stream remains the source of truth; the
+process logs point at it.
+
+NOTE: the Linear issue must be filed by the owner (Linear MCP is not available in this
+session — MCP-uncovered operations are owner actions in the Linear UI). Labels per
+`.claude/task-board.local.md`: landing `screamingface-engine`, `actor=agentic`,
+`who-acts=autonomous`, `type=task`.

--- a/docs/work/2026-09-01-OME-1069-runner-traceability.md
+++ b/docs/work/2026-09-01-OME-1069-runner-traceability.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-1069
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-01
+finished:
+---
+
+# OME-1069 — Runner traceability and logging layer (k8s mode)
+
+## Intent
+
+The run-mode Job process (`screamingface-engine run`) is nearly silent in its own logs: five
+warning-only `_logger` calls, no lifecycle, no outcome, no correlation. An operator reading
+`kubectl logs <runner-pod>` cannot tell what run a line belongs to, whether it succeeded, or
+how it maps to the CloudEvents stream. This unit gives the runner a structured, correlated
+logging layer: every process log line carries `topic` + W3C `trace_id`, the runner logs its
+lifecycle (boot, world resolution, start, terminal outcome, summary), and the final summary
+line is the operator's one-stop answer. The CloudEvents stream remains the source of truth;
+the process logs point at it.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/logs.py` — `run_context` ContextVar,
+  `RunContextFilter`, `%(run_context)s` in the format string (renders empty when unbound).
+- `apps/screamingface-engine/src/screamingface_engine/runner/summary.py` (new) — the
+  `RunSummary` dataclass (exact-only: cost is the subtree total or `None`, never a false zero).
+- `apps/screamingface-engine/src/screamingface_engine/runner/executor.py` — record the run's
+  summary in `execute()` (outcome, trace_id, cost, cache counters, bridge overflow stats);
+  expose `last_summary()`.
+- `apps/screamingface-engine/src/screamingface_engine/runner/operation_capture.py` — delegate
+  `last_summary()` to the inner executor.
+- `apps/screamingface-engine/src/screamingface_engine/runner/main.py` — boot log (sanitized),
+  bind `run_scope(topic, trace_id)`, world-resolution log, terminal + summary logs.
+- Tests: run-context filter/format, executor summary (success/failure/unexecuted), wrapper
+  delegation, `_log_terminal` rendering.
+
+## Test plan
+
+- The run-context filter appends `topic=`/`trace_id=` only inside a bound scope; unbound
+  records render unchanged (existing `test_logs_configuration.py` must stay green).
+- `Url4Executor.last_summary()`: `None` before any execute; `succeeded` with exact cost and
+  cache counters after a completed run; `failed` with error code/type after a raising run;
+  `stopped` on cancellation.
+- `OperationCapturingExecutor.last_summary()` delegates to the inner executor.
+- `_log_terminal`: renders the finished line and the summary line on success; omits cost/cache
+  on failure; warns when no summary exists.
+
+## Acceptance
+
+- Every runner process log line inside a run carries `topic=` and (when known) `trace_id=`.
+- The runner logs boot, world, start, terminal outcome, and a final summary line.
+- The summary line's `trace_id` is exactly the one on the stream frames (recorded from the
+  `TraceContext` the executor receives).
+- No url4 expression, NATS credential, identity, or provider content is ever logged.
+- All existing gates pass (ruff, pyright, layering, pytest).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `logs.py` (run-context machinery), `runner/summary.py` (new), `runner/executor.py`
+  (summary recording + `last_summary()`), `runner/operation_capture.py` (delegation),
+  `runner/main.py` (boot/world/terminal/summary logs), `tests/unit/test_logs_configuration.py`
+  (run-context tests), `tests/unit/test_runner_summary.py` (new), plus this unit's task and
+  work records.
+- **Commits:** `feat(screamingface-engine): runner traceability and logging layer (OME-1069)`
+- **Gates:** ruff check + format clean; pyright 0 errors; `check_layering.py` OK; full engine
+  suite 2274 passed, 5 skipped, 91.62% coverage (gate 80%).
+- **Deviations:** the planned `trace` param on `url4.streaming.lifecycle.run` was NOT needed —
+  the executor already receives the `TraceContext` from `lifecycle.run`, so the summary records
+  the exact stream trace id with zero cross-package change. The Linear issue must be filed by
+  the owner (Linear MCP unavailable this session).


### PR DESCRIPTION
## What

Give the run-mode Job process (`screamingface-engine run`) a structured, correlated logging layer. Before this, a runner pod's logs were nearly silent: five warning-only calls, no lifecycle, no outcome, no correlation. An operator reading `kubectl logs <runner-pod>` could not tell what run a line belonged to, whether it succeeded, or how it maps to the CloudEvents stream.

## Changes

- **`logs.py`** — run-context `ContextVar` + `RunContextFilter` + `%(run_context)s` format field. The control plane never binds the context, so its lines are byte-identical to before.
- **`runner/summary.py`** (new) — exact-only `RunSummary`: cost is the subtree total or `None` (unpriced), never a false zero; cache counters only on success.
- **`runner/executor.py`** — records the summary in `execute()` *before* the `Completed` yield (`lifecycle.run` breaks there and never resumes the generator), with the exact `TraceContext` the executor received; `last_summary()` accessor. Extracted `_run_steps` to keep `execute` under the complexity gate.
- **`runner/operation_capture.py`** — delegates `last_summary()` to the inner executor.
- **`runner/main.py`** — boot log (sanitized: url4 length, NATS host only), world-resolution log, `run_scope` binding, terminal + summary logs.

## What an operator now sees

```
INFO:     screamingface_engine.runner.main topic=cap-topic url4_chars=1234 deadline_s=3600 nats_host=nats.example.com traceparent=present
INFO:     screamingface_engine.runner.main topic=cap-topic trace_id=abab… runner world models=3 default_model=claude-haiku-4-5 web_tools=disabled cache=not-stated outbound=allowed
INFO:     screamingface_engine.runner.main topic=cap-topic trace_id=abab… run finished topic=cap-topic outcome=succeeded duration_s=12.3
INFO:     screamingface_engine.runner.main topic=cap-topic trace_id=abab… run summary topic=cap-topic trace_id=abab… outcome=succeeded duration_s=12.3 cost_usd=0.0042 pricing=2026-07-01 cache.hits=3 cache.misses=1 cache.bypasses=0 dropped_logs=0 high_water=5
```

The summary's `trace_id` is exactly the one on the stream frames (recorded from the `TraceContext` the executor receives — no re-derivation). Sanitization follows the system's discipline: never the url4 expression (may carry prompts — length only), never NATS credentials, never identity/provider content. Exact-only: a failed run states no cost and no cache counts.

## Notes

- The CloudEvents stream remains the source of truth; the process logs point at it.
- The planned `trace` param on `url4.streaming.lifecycle.run` was **not** needed — the executor already receives the `TraceContext`, so the summary records the exact stream trace id with zero cross-package change.
- The Linear issue (OME-1069) must be filed by the owner — Linear MCP is not available in this session.

## Gates

- ruff check + format: clean
- pyright: 0 errors
- `check_layering.py`: OK
- Full engine suite: 2274 passed, 5 skipped, 91.62% coverage (gate 80%)

Refs: OME-1069