### PR TITLE
feat(engine): refuse a run when the namespace quota has no headroom (OME-1065)

### DIFF
--- a/apps/screamingface-engine/deploy/helm/templates/role.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/role.yaml
@@ -36,4 +36,23 @@ rules:
       - pods/log
     verbs:
       - get
+  # FEATURE (OME-1065): quota-aware admission. The App reads the namespace ResourceQuota
+  # (status.used vs status.hard) and the LimitRanges (for the Pod's defaulted charge) before
+  # scheduling a Job, so a saturated namespace refuses a run with 503 + Retry-After instead of
+  # creating a Job whose Pod is silently refused.
+  - apiGroups:
+      - ""
+    resources:
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - limitranges
+    verbs:
+      - get
+      - list
 {{- end }}

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -9,7 +9,11 @@ import functools
 from collections.abc import Callable, Sequence
 from typing import Any, cast
 
-from screamingface_engine.adapters.k8s import BatchV1JobsClient, K8sJobRunner
+from screamingface_engine.adapters.k8s import (
+    BatchV1JobsClient,
+    CoreV1QuotaClient,
+    K8sJobRunner,
+)
 from screamingface_engine.config import Settings
 from url4.streaming.interfaces import JobRunner
 
@@ -49,10 +53,18 @@ def _in_cluster_batch_client() -> BatchV1JobsClient:  # pragma: no cover - live 
     return cast(BatchV1JobsClient, BatchV1Api(_in_cluster_api_client()))
 
 
+def _in_cluster_core_client() -> CoreV1QuotaClient:  # pragma: no cover - live cluster (INFRA)
+    """The quota/limitrange read surface, sharing the process's single cached ApiClient."""
+    from kubernetes.client import CoreV1Api
+
+    return cast(CoreV1QuotaClient, CoreV1Api(_in_cluster_api_client()))
+
+
 def build_job_runner(
     settings: Settings,
     *,
     k8s_client_factory: Callable[[], BatchV1JobsClient] = _in_cluster_batch_client,
+    core_client_factory: Callable[[], CoreV1QuotaClient] = _in_cluster_core_client,
     extra_models: Callable[[], Sequence[str]] | None = None,
 ) -> JobRunner | None:
     """Selects the `JobRunner` adapter for `settings.runner`.
@@ -68,6 +80,7 @@ def build_job_runner(
         # source of truth, and it is next to the Job spec that uses it.
         return K8sJobRunner(
             k8s_client_factory(),
+            core_client=core_client_factory(),
             request_timeout_s=_K8S_REQUEST_TIMEOUT_S,
             image=settings.runner_image,
             namespace=settings.namespace,

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py
@@ -9,14 +9,23 @@ would cost a per-run Secret plus the RBAC to write one.
 """
 
 import asyncio
+import threading
+import time
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from typing import Protocol
 
 from kubernetes.client import ApiException
+from kubernetes.utils.quantity import parse_quantity
 
 from screamingface_engine import job_env
 from screamingface_engine.ports import IdentityAwareJobRunner
-from url4.streaming.interfaces import JobAlreadyExists, JobStatus, job_name
+from url4.streaming.interfaces import (
+    JobAlreadyExists,
+    JobRunnerAtCapacity,
+    JobStatus,
+    job_name,
+)
 from url4.streaming.protocol import CachePolicy
 from url4.streaming.trace import valid_traceparent
 
@@ -24,6 +33,10 @@ _CONFLICT = 409
 _NOT_FOUND = 404
 # Slack on top of the run deadline and the drain grace, covering the delete round trip itself.
 _TEARDOWN_MARGIN_S = 30
+# How long a failed quota read disables admission before the next retry. A permanently denied
+# read (RBAC) must not hammer the API server every refresh; a transient error recovers on the
+# next retry. During the backoff, schedules proceed exactly as before this feature.
+_QUOTA_FAILURE_BACKOFF_S = 30
 
 RUNNER_LABELS = {
     "app.kubernetes.io/name": "url4-runner",
@@ -80,6 +93,60 @@ class BatchV1JobsClient(Protocol):
     ) -> object: ...
 
 
+# The quota/limitrange read surface, in the same narrow structural style as `BatchV1JobsClient`:
+# only the fields this adapter reads, so tests can supply fakes without importing the generated
+# client models. `_request_timeout` is spelled out for the same reason as on the jobs client —
+# these are blocking round trips running on `to_thread` workers.
+class _QuotaStatus(Protocol):
+    @property
+    def used(self) -> Mapping[str, str] | None: ...
+    @property
+    def hard(self) -> Mapping[str, str] | None: ...
+
+
+class _QuotaView(Protocol):
+    @property
+    def status(self) -> _QuotaStatus | None: ...
+
+
+class _QuotaList(Protocol):
+    @property
+    def items(self) -> Sequence[_QuotaView]: ...
+
+
+class _LimitRangeItem(Protocol):
+    @property
+    def type(self) -> str: ...
+    @property
+    def default(self) -> Mapping[str, str] | None: ...
+    @property
+    def defaultRequest(self) -> Mapping[str, str] | None: ...
+
+
+class _LimitRangeSpec(Protocol):
+    @property
+    def limits(self) -> Sequence[_LimitRangeItem] | None: ...
+
+
+class _LimitRangeView(Protocol):
+    @property
+    def spec(self) -> _LimitRangeSpec | None: ...
+
+
+class _LimitRangeList(Protocol):
+    @property
+    def items(self) -> Sequence[_LimitRangeView]: ...
+
+
+class CoreV1QuotaClient(Protocol):
+    def list_namespaced_resource_quota(
+        self, namespace: str, *, _request_timeout: float | None = None
+    ) -> _QuotaList: ...
+    def list_namespaced_limit_range(
+        self, namespace: str, *, _request_timeout: float | None = None
+    ) -> _LimitRangeList: ...
+
+
 def _terminal_status(conditions: Sequence[_JobCondition] | None) -> JobStatus | None:
     """Reads the Job's `Complete`/`Failed` condition, if either has fired; `None` while running."""
     for cond in conditions or ():
@@ -104,6 +171,137 @@ def _map_status(job: _JobView | None) -> JobStatus:
     return "running" if (view and view.active) else "scheduled"
 
 
+@dataclass(frozen=True, slots=True)
+class _QuotaSnapshot:
+    """One cached reading of the namespace's capacity, in exact integer units.
+
+    cpu is in millicores ("200m" → 200, "2" → 2000), memory in bytes, pods as a count.
+    Integer arithmetic keeps the ceiling comparison exact: a float comparison at the ceiling
+    (0.4 + 8*0.2 > 2.0) would refuse the run that exactly fills the quota.
+    """
+
+    used: dict[str, int]
+    hard: dict[str, int]
+    # The quota charge of ONE Runner Pod: its own `resources` spec plus LimitRange defaults.
+    charge: dict[str, int]
+
+
+def _quantity(dimension: str, value: str) -> int:
+    """Parse a k8s resource quantity into an exact integer in the dimension's natural unit.
+
+    cpu → millicores, everything else → its natural unit (bytes for memory, count for pods).
+    `parse_quantity` returns a float (0.2 for "200m"); scaling to the natural unit and
+    truncating keeps the admission arithmetic exact.
+    """
+
+    parsed = parse_quantity(value)
+    if "cpu" in dimension:
+        return int(parsed * 1000)
+    return int(parsed)
+
+
+def _max_quantity(target: dict[str, int], key: str, value: str) -> None:
+    parsed = _quantity(key, value)
+    if key not in target or parsed > target[key]:
+        target[key] = parsed
+
+
+def _limitrange_defaults(
+    limitranges: Sequence[_LimitRangeView],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """The namespace's effective LimitRange defaults: max per resource across LimitRanges.
+
+    Conservative: if two LimitRanges disagree on a default, the Pod would be rejected as
+    ambiguous anyway, and the larger charge is the honest estimate. `default` fills missing
+    LIMITS, `defaultRequest` fills missing REQUESTS.
+    """
+
+    default_limits: dict[str, int] = {}
+    default_requests: dict[str, int] = {}
+    for limitrange in limitranges:
+        spec = limitrange.spec
+        if spec is None:
+            continue
+        for item in spec.limits or ():
+            if item.type != "Container":
+                continue
+            for key, value in (item.default or {}).items():
+                _max_quantity(default_limits, key, value)
+            for key, value in (item.defaultRequest or {}).items():
+                _max_quantity(default_requests, key, value)
+    return default_limits, default_requests
+
+
+def _pod_charge(
+    resources: Mapping[str, Mapping[str, str]] | None,
+    limitranges: Sequence[_LimitRangeView],
+) -> dict[str, int]:
+    """The quota charge of one Runner Pod: its own spec plus LimitRange defaults.
+
+    The runner sets no `limits.cpu`, so the namespace LimitRange supplies it — the arithmetic
+    is wrong by 500m per Pod if that default is not accounted for (OME-1064).
+    """
+
+    requests = (resources or {}).get("requests", {})
+    limits = (resources or {}).get("limits", {})
+    default_limits, default_requests = _limitrange_defaults(limitranges)
+
+    def spec_or_default(
+        spec: Mapping[str, str], defaults: Mapping[str, int], key: str, dimension: str
+    ) -> int:
+        value = spec.get(key)
+        if value is not None:
+            return _quantity(dimension, value)
+        return defaults.get(key, 0)
+
+    return {
+        "pods": 1,
+        "requests.cpu": spec_or_default(requests, default_requests, "cpu", "requests.cpu"),
+        "requests.memory": spec_or_default(requests, default_requests, "memory", "requests.memory"),
+        "limits.cpu": spec_or_default(limits, default_limits, "cpu", "limits.cpu"),
+        "limits.memory": spec_or_default(limits, default_limits, "memory", "limits.memory"),
+    }
+
+
+def _merge_quota(
+    target_used: dict[str, int], target_hard: dict[str, int], quota: _QuotaView
+) -> None:
+    """Fold one quota into the running used/hard: max used, min hard per dimension."""
+    status = quota.status
+    if status is None:
+        return
+    for key, value in (status.used or {}).items():
+        parsed = _quantity(key, value)
+        if key not in target_used or parsed > target_used[key]:
+            target_used[key] = parsed
+    for key, value in (status.hard or {}).items():
+        parsed = _quantity(key, value)
+        if key not in target_hard or parsed < target_hard[key]:
+            target_hard[key] = parsed
+
+
+def _build_snapshot(
+    quotas: Sequence[_QuotaView],
+    limitranges: Sequence[_LimitRangeView],
+    resources: Mapping[str, Mapping[str, str]] | None,
+) -> _QuotaSnapshot | None:
+    """Merge the namespace's quotas into one snapshot; `None` when nothing constrains it.
+
+    Multiple quotas all apply, so the effective hard is the MIN per dimension and the effective
+    used the MAX (the used values should agree, modulo update timing).
+    """
+
+    if not quotas:
+        return None
+    used: dict[str, int] = {}
+    hard: dict[str, int] = {}
+    for quota in quotas:
+        _merge_quota(used, hard, quota)
+    if not hard:
+        return None
+    return _QuotaSnapshot(used=used, hard=hard, charge=_pod_charge(resources, limitranges))
+
+
 class K8sJobRunner(IdentityAwareJobRunner):
     """Implements `JobRunner` by scheduling one Kubernetes Batch v1 Job per run. The Job's name
     is derived deterministically from the topic (`job_name`), so `schedule`/`stop`/`status` all
@@ -113,6 +311,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
         self,
         client: BatchV1JobsClient,
         *,
+        core_client: CoreV1QuotaClient | None = None,
         image: str,
         namespace: str = "default",
         # WHY this default: the Job runs the App's OWN image in its run mode
@@ -134,8 +333,16 @@ class K8sJobRunner(IdentityAwareJobRunner):
         # Default matches the setting's default so a directly-constructed runner (tests) is
         # honest about what a scheduled run actually gets.
         io_concurrency: int = 4,
+        # FEATURE (OME-1065): how long a quota reading stays fresh before the next refresh.
+        # A `get` per schedule would add an API round-trip to the hot path; the reservation
+        # counter covers the window between refreshes.
+        quota_cache_ttl_s: float = 2.0,
     ) -> None:
         self._client = client
+        # WHY optional: admission is an optimisation over detection (OME-1059), never a
+        # replacement for it. `None` disables admission — the factory always wires the real
+        # client; direct constructions (tests) opt out by default.
+        self._core_client = core_client
         self._request_timeout_s = request_timeout_s
         self._image = image
         self._namespace = namespace
@@ -152,6 +359,17 @@ class K8sJobRunner(IdentityAwareJobRunner):
         # the app runs, and a model admitted a second ago must reach the very next Job.
         self._extra_models = extra_models
         self._io_concurrency = io_concurrency
+        # FEATURE (OME-1065): quota admission state. `_quota_snapshot` is the last successful
+        # reading; `_quota_cache_time` is when it was taken (or, on a failed read, when the
+        # backoff ends). `_reserved` counts runs admitted since the last refresh — it closes
+        # the read-modify-write race when several `schedule()` calls run between two refreshes.
+        # The lock makes refresh + check + reserve atomic; `_schedule_blocking` runs on
+        # `to_thread` workers, so it is a threading lock, not an asyncio one.
+        self._quota_cache_ttl_s = quota_cache_ttl_s
+        self._quota_snapshot: _QuotaSnapshot | None = None
+        self._quota_cache_time: float | None = None
+        self._reserved = 0
+        self._admission_lock = threading.Lock()
 
     async def schedule(
         self,
@@ -173,6 +391,8 @@ class K8sJobRunner(IdentityAwareJobRunner):
 
         Raises:
             JobAlreadyExists: a Job for this topic already exists (409 from the API server).
+            JobRunnerAtCapacity: the namespace ResourceQuota has no headroom for one more
+                Runner Pod (503 + `Retry-After` at the REST edge).
         """
         return await asyncio.to_thread(
             self._schedule_blocking,
@@ -197,6 +417,7 @@ class K8sJobRunner(IdentityAwareJobRunner):
         cache: CachePolicy | None = None,
     ) -> str:
         name = job_name(topic)
+        self._reserve_or_raise()
         try:
             self._client.create_namespaced_job(
                 self._namespace,
@@ -206,10 +427,93 @@ class K8sJobRunner(IdentityAwareJobRunner):
                 _request_timeout=self._request_timeout_s,
             )
         except ApiException as exc:
+            # The reservation was for a Job that does not exist — release it so the next
+            # schedule in this window is not refused for a run that never started.
+            self._release_reservation()
             if exc.status == _CONFLICT:
                 raise JobAlreadyExists(name) from exc
             raise
         return name
+
+    # --- quota admission (OME-1065) ---------------------------------------------------------
+
+    def _reserve_or_raise(self) -> None:
+        """Admission gate: refresh the quota, refuse if one more Pod does not fit, else reserve.
+
+        Raises:
+            JobRunnerAtCapacity: the namespace quota has no headroom for one more Runner Pod.
+        """
+        if self._core_client is None:
+            return
+        with self._admission_lock:
+            self._refresh_quota_if_stale()
+            if self._quota_snapshot is not None and not self._fits(
+                self._quota_snapshot, self._reserved
+            ):
+                raise JobRunnerAtCapacity(
+                    self._reserved, self._max_runs_that_fit(self._quota_snapshot)
+                )
+            self._reserved += 1
+
+    def _release_reservation(self) -> None:
+        if self._core_client is None:
+            return
+        with self._admission_lock:
+            self._reserved -= 1
+
+    def _refresh_quota_if_stale(self) -> None:
+        """Re-read the quota and LimitRanges when the cache is stale; degrade on failure.
+
+        A failed read (absent, RBAC denied, API error) falls back to today's behaviour: create
+        the Job and let OME-1059's detection catch an un-startable run. The backoff is longer
+        than the TTL so a permanently denied read does not hammer the API server.
+        """
+        now = time.monotonic()
+        if (
+            self._quota_cache_time is not None
+            and now - self._quota_cache_time < self._quota_cache_ttl_s
+        ):
+            return
+        core = self._core_client
+        if core is None:
+            return
+        try:
+            quotas = core.list_namespaced_resource_quota(
+                self._namespace, _request_timeout=self._request_timeout_s
+            )
+            limitranges = core.list_namespaced_limit_range(
+                self._namespace, _request_timeout=self._request_timeout_s
+            )
+        except ApiException:
+            self._quota_snapshot = None
+            self._quota_cache_time = now + _QUOTA_FAILURE_BACKOFF_S
+            return
+        self._quota_snapshot = _build_snapshot(quotas.items, limitranges.items, self._resources)
+        self._quota_cache_time = now
+        # The quota's `used` now reflects everything older than the window, so the window's
+        # reservations are reset — the counter only covers the gap between refreshes.
+        self._reserved = 0
+
+    def _fits(self, snapshot: _QuotaSnapshot, reserved: int) -> bool:
+        """Whether one more Pod fits on every charged dimension the quota constrains."""
+        for dimension, charge in snapshot.charge.items():
+            if charge <= 0 or dimension not in snapshot.hard:
+                continue
+            used = snapshot.used.get(dimension, 0)
+            if used + (reserved + 1) * charge > snapshot.hard[dimension]:
+                return False
+        return True
+
+    def _max_runs_that_fit(self, snapshot: _QuotaSnapshot) -> int:
+        """The number of additional Pods that fit, bounded by the tightest dimension."""
+        limit: int | None = None
+        for dimension, charge in snapshot.charge.items():
+            if charge <= 0 or dimension not in snapshot.hard:
+                continue
+            headroom = snapshot.hard[dimension] - snapshot.used.get(dimension, 0)
+            fits = headroom // charge
+            limit = fits if limit is None else min(limit, fits)
+        return limit if limit is not None else 0
 
     async def stop(self, topic: str) -> None:
         await asyncio.to_thread(self._stop_blocking, topic)

--- a/apps/screamingface-engine/tests/unit/_k8s_fakes.py
+++ b/apps/screamingface-engine/tests/unit/_k8s_fakes.py
@@ -13,3 +13,73 @@ class FakeCreatedJob:
 
 def fake_created_job(uid: str) -> FakeCreatedJob:
     return FakeCreatedJob(metadata=FakeObjectMeta(uid=uid))
+
+
+# --- quota/limitrange fakes for the admission tests (OME-1065) ------------------------------
+
+
+@dataclass
+class FakeQuotaStatus:
+    used: dict[str, str] | None = None
+    hard: dict[str, str] | None = None
+
+
+@dataclass
+class FakeQuota:
+    status: FakeQuotaStatus | None = None
+
+
+@dataclass
+class FakeQuotaList:
+    items: list[FakeQuota]
+
+
+@dataclass
+class FakeLimitRangeItem:
+    type: str
+    default: dict[str, str] | None = None
+    defaultRequest: dict[str, str] | None = None
+
+
+@dataclass
+class FakeLimitRangeSpec:
+    limits: list[FakeLimitRangeItem] | None = None
+
+
+@dataclass
+class FakeLimitRange:
+    spec: FakeLimitRangeSpec | None = None
+
+
+@dataclass
+class FakeLimitRangeList:
+    items: list[FakeLimitRange]
+
+
+class FakeCoreV1:
+    """The quota/limitrange read surface for the admission tests.
+
+    A subclass can raise ApiException from either read to exercise the degradation path.
+    """
+
+    def __init__(
+        self,
+        quotas: list[FakeQuota] | None = None,
+        limitranges: list[FakeLimitRange] | None = None,
+    ) -> None:
+        self.quotas = quotas or []
+        self.limitranges = limitranges or []
+        self.quota_reads = 0
+        self.limitrange_reads = 0
+
+    def list_namespaced_resource_quota(
+        self, namespace: str, *, _request_timeout: float | None = None
+    ) -> FakeQuotaList:
+        self.quota_reads += 1
+        return FakeQuotaList(self.quotas)
+
+    def list_namespaced_limit_range(
+        self, namespace: str, *, _request_timeout: float | None = None
+    ) -> FakeLimitRangeList:
+        self.limitrange_reads += 1
+        return FakeLimitRangeList(self.limitranges)

--- a/apps/screamingface-engine/tests/unit/test_aigateway_base_url_forwarding.py
+++ b/apps/screamingface-engine/tests/unit/test_aigateway_base_url_forwarding.py
@@ -9,7 +9,7 @@ of truth for one value, and the quiet one wins.
 from typing import Any
 
 import pytest
-from _k8s_fakes import FakeCreatedJob, fake_created_job
+from _k8s_fakes import FakeCoreV1, FakeCreatedJob, fake_created_job
 
 from screamingface_engine import job_env as runner_job_env
 from screamingface_engine.adapters.factory import build_job_runner
@@ -91,6 +91,7 @@ def test_the_factory_threads_the_configmap_name_from_settings() -> None:
     runner = build_job_runner(
         settings,
         k8s_client_factory=_RecordingBatchApi,
+        core_client_factory=FakeCoreV1,
     )
 
     assert isinstance(runner, K8sJobRunner)

--- a/apps/screamingface-engine/tests/unit/test_runner_job_lifecycle_settings.py
+++ b/apps/screamingface-engine/tests/unit/test_runner_job_lifecycle_settings.py
@@ -1,5 +1,5 @@
 import pytest
-from _k8s_fakes import FakeCreatedJob, fake_created_job
+from _k8s_fakes import FakeCoreV1, FakeCreatedJob, fake_created_job
 from kubernetes.client import ApiException
 
 from screamingface_engine.adapters.factory import build_job_runner
@@ -102,6 +102,7 @@ async def test_k8s_runner_job_carries_the_configured_resources_and_ttl() -> None
     runner = build_job_runner(
         settings,
         k8s_client_factory=lambda: client,
+        core_client_factory=FakeCoreV1,
     )
     assert runner is not None
     name = await runner.schedule(TOPIC, "chat(hi)", deadline_s=57600)
@@ -118,6 +119,7 @@ async def test_k8s_runner_job_without_configured_resources_still_gets_its_ttl() 
     runner = build_job_runner(
         _k8s_settings(),
         k8s_client_factory=lambda: client,
+        core_client_factory=FakeCoreV1,
     )
     assert runner is not None
     name = await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import pytest
-from _k8s_fakes import FakeCreatedJob
+from _k8s_fakes import FakeCoreV1, FakeCreatedJob
 
 from screamingface_engine.adapters.factory import build_job_runner
 from screamingface_engine.adapters.k8s import K8sJobRunner
@@ -31,18 +31,6 @@ class _FakeBatchApi:
         raise NotImplementedError
 
 
-class _FakeCoreV1Api:
-    def create_namespaced_secret(
-        self, namespace: str, body: Mapping[str, object], *, _request_timeout: float | None = None
-    ) -> object:  # pragma: no cover
-        raise NotImplementedError
-
-    def delete_namespaced_secret(
-        self, name: str, namespace: str, *, _request_timeout: float | None = None
-    ) -> object:  # pragma: no cover
-        raise NotImplementedError
-
-
 def test_runner_none_builds_no_job_runner() -> None:
     assert build_job_runner(Settings(runner="none")) is None
 
@@ -63,6 +51,7 @@ def test_k8s_runner_is_built_from_settings() -> None:
     runner = build_job_runner(
         settings,
         k8s_client_factory=lambda: (loaded.append(True), _FakeBatchApi())[1],
+        core_client_factory=FakeCoreV1,
     )
 
     assert isinstance(runner, K8sJobRunner)
@@ -92,7 +81,11 @@ def test_k8s_runner_receives_deployment_scheduling() -> None:
         ],
     )
 
-    runner = build_job_runner(settings, k8s_client_factory=_FakeBatchApi)
+    runner = build_job_runner(
+        settings,
+        k8s_client_factory=_FakeBatchApi,
+        core_client_factory=FakeCoreV1,
+    )
 
     assert isinstance(runner, K8sJobRunner)
     assert runner._node_selector == {"openmined.org/pool": "preview"}
@@ -110,7 +103,25 @@ def test_k8s_runner_receives_the_settings_io_concurrency() -> None:
     """OME-908: the per-run downstream budget reaches the runner that writes it onto Jobs."""
     settings = Settings(runner="k8s", runner_io_concurrency=9)
 
-    runner = build_job_runner(settings, k8s_client_factory=_FakeBatchApi)
+    runner = build_job_runner(
+        settings,
+        k8s_client_factory=_FakeBatchApi,
+        core_client_factory=FakeCoreV1,
+    )
 
     assert isinstance(runner, K8sJobRunner)
     assert runner._io_concurrency == 9
+
+
+def test_k8s_runner_receives_the_core_client() -> None:
+    """OME-1065: the quota/limitrange read surface is wired alongside the batch client."""
+    settings = Settings(runner="k8s", namespace="url4-prod")
+
+    runner = build_job_runner(
+        settings,
+        k8s_client_factory=_FakeBatchApi,
+        core_client_factory=FakeCoreV1,
+    )
+
+    assert isinstance(runner, K8sJobRunner)
+    assert isinstance(runner._core_client, FakeCoreV1)

--- a/apps/screamingface-engine/tests/unit/test_runners_k8s.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_k8s.py
@@ -1,12 +1,28 @@
+import asyncio
 from dataclasses import dataclass
 
 import pytest
-from _k8s_fakes import FakeCreatedJob, fake_created_job
+from _k8s_fakes import (
+    FakeCoreV1,
+    FakeCreatedJob,
+    FakeLimitRange,
+    FakeLimitRangeItem,
+    FakeLimitRangeSpec,
+    FakeQuota,
+    FakeQuotaList,
+    FakeQuotaStatus,
+    fake_created_job,
+)
 from kubernetes.client import ApiException
 
 from screamingface_engine import job_env
 from screamingface_engine.adapters.k8s import K8sJobRunner
-from url4.streaming.interfaces import JobAlreadyExists, JobRunner, job_name
+from url4.streaming.interfaces import (
+    JobAlreadyExists,
+    JobRunner,
+    JobRunnerAtCapacity,
+    job_name,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -469,3 +485,200 @@ async def test_an_overridden_io_concurrency_reaches_the_job() -> None:
 
     env = _container_env(client, job_name(TOPIC))
     assert env[job_env.IO_CONCURRENCY] == "9"
+
+
+# --- quota admission (OME-1065) -------------------------------------------------------------
+
+# The deployed Runner Pod's charge: requests 200m/256Mi, limits.memory 1Gi, and the
+# namespace LimitRange's defaulted limits.cpu 500m (the runner sets no limits.cpu).
+_ADMISSION_RESOURCES = {
+    "requests": {"cpu": "200m", "memory": "256Mi"},
+    "limits": {"memory": "1Gi"},
+}
+
+
+def _quota(used: dict[str, str], hard: dict[str, str]) -> FakeQuota:
+    return FakeQuota(status=FakeQuotaStatus(used=used, hard=hard))
+
+
+def _limitrange(
+    default: dict[str, str] | None = None,
+    default_request: dict[str, str] | None = None,
+) -> FakeLimitRange:
+    return FakeLimitRange(
+        spec=FakeLimitRangeSpec(
+            limits=[
+                FakeLimitRangeItem(
+                    type="Container", default=default, defaultRequest=default_request
+                )
+            ]
+        )
+    )
+
+
+def _admission_runner(client: FakeBatchV1, core: FakeCoreV1) -> K8sJobRunner:
+    return K8sJobRunner(
+        client,
+        core_client=core,
+        image="registry/screamingface-engine:1",
+        namespace="url4",
+        resources=_ADMISSION_RESOURCES,
+    )
+
+
+async def test_schedule_refuses_when_the_quota_has_no_headroom() -> None:
+    client = FakeBatchV1()
+    core = FakeCoreV1(
+        quotas=[
+            _quota(
+                used={
+                    "requests.cpu": "1900m",
+                    "requests.memory": "2Gi",
+                    "limits.cpu": "7",
+                    "limits.memory": "10Gi",
+                    "pods": "7",
+                },
+                hard={
+                    "requests.cpu": "2",
+                    "requests.memory": "3Gi",
+                    "limits.cpu": "8",
+                    "limits.memory": "12Gi",
+                    "pods": "8",
+                },
+            )
+        ],
+        limitranges=[_limitrange(default={"cpu": "500m", "memory": "512Mi"})],
+    )
+    runner = _admission_runner(client, core)
+
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+
+    assert client.jobs == {}
+
+
+async def test_schedule_creates_the_job_when_the_quota_has_headroom() -> None:
+    client = FakeBatchV1()
+    core = FakeCoreV1(
+        quotas=[
+            _quota(
+                used={
+                    "requests.cpu": "1000m",
+                    "requests.memory": "1Gi",
+                    "limits.cpu": "4",
+                    "limits.memory": "6Gi",
+                    "pods": "4",
+                },
+                hard={
+                    "requests.cpu": "2",
+                    "requests.memory": "3Gi",
+                    "limits.cpu": "8",
+                    "limits.memory": "12Gi",
+                    "pods": "8",
+                },
+            )
+        ],
+        limitranges=[_limitrange(default={"cpu": "500m", "memory": "512Mi"})],
+    )
+    runner = _admission_runner(client, core)
+
+    name = await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+
+    assert name == job_name(TOPIC)
+    assert job_name(TOPIC) in client.jobs
+
+
+async def test_quota_accounting_includes_limitrange_defaults() -> None:
+    """REGRESSION (OME-1064): the runner sets no `limits.cpu`, so the namespace LimitRange
+    supplies it — the arithmetic is wrong by 500m per Pod if that default is not accounted for.
+    """
+    client = FakeBatchV1()
+    core = FakeCoreV1(
+        quotas=[_quota(used={"limits.cpu": "600m"}, hard={"limits.cpu": "1"})],
+        limitranges=[_limitrange(default={"cpu": "500m", "memory": "512Mi"})],
+    )
+    runner = _admission_runner(client, core)
+
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+
+    assert client.jobs == {}
+
+
+async def test_concurrent_schedules_cannot_jointly_overshoot_the_ceiling() -> None:
+    """The reservation counter closes the read-modify-write race between quota refreshes:
+    ten concurrent schedules fit (0 + 10*200m = 2000m), the eleventh is refused.
+    """
+    client = FakeBatchV1()
+    core = FakeCoreV1(
+        quotas=[_quota(used={"requests.cpu": "0"}, hard={"requests.cpu": "2"})],
+        limitranges=[_limitrange(default={"cpu": "500m", "memory": "512Mi"})],
+    )
+    runner = _admission_runner(client, core)
+
+    results = await asyncio.gather(
+        *(runner.schedule(f"topic-{i}", "chat(hi)", deadline_s=60) for i in range(11)),
+        return_exceptions=True,
+    )
+
+    accepted = [r for r in results if isinstance(r, str)]
+    refused = [r for r in results if isinstance(r, JobRunnerAtCapacity)]
+    assert len(accepted) == 10
+    assert len(refused) == 1
+    assert len(client.jobs) == 10
+
+
+async def test_schedule_proceeds_when_the_quota_cannot_be_read() -> None:
+    class Boom(FakeCoreV1):
+        def list_namespaced_resource_quota(
+            self, namespace: str, *, _request_timeout: float | None = None
+        ) -> FakeQuotaList:
+            raise ApiException(status=403)
+
+    client = FakeBatchV1()
+    runner = _admission_runner(client, Boom())
+
+    name = await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+
+    assert name == job_name(TOPIC)
+    assert job_name(TOPIC) in client.jobs
+
+
+async def test_schedule_proceeds_when_the_namespace_has_no_quota() -> None:
+    client = FakeBatchV1()
+    runner = _admission_runner(client, FakeCoreV1())
+
+    name = await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+
+    assert name == job_name(TOPIC)
+    assert job_name(TOPIC) in client.jobs
+
+
+async def test_a_failed_create_releases_the_reservation() -> None:
+    class Flaky(FakeBatchV1):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fail_creates = 1
+
+        def create_namespaced_job(
+            self, namespace: str, body, *, _request_timeout: float | None = None
+        ) -> FakeCreatedJob:
+            if self.fail_creates > 0:
+                self.fail_creates -= 1
+                raise ApiException(status=500)
+            return super().create_namespaced_job(namespace, body, _request_timeout=_request_timeout)
+
+    client = Flaky()
+    core = FakeCoreV1(
+        quotas=[_quota(used={"requests.cpu": "1700m"}, hard={"requests.cpu": "2"})],
+        limitranges=[_limitrange(default={"cpu": "500m", "memory": "512Mi"})],
+    )
+    runner = _admission_runner(client, core)
+
+    with pytest.raises(ApiException):
+        await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+
+    # The reservation was released, so the retry still fits (1700 + 200 = 1900 <= 2000).
+    name = await runner.schedule(TOPIC, "chat(hi)", deadline_s=60)
+    assert name == job_name(TOPIC)
+    assert job_name(TOPIC) in client.jobs

--- a/apps/screamingface-engine/tests/unit/test_tavily_key_forwarding.py
+++ b/apps/screamingface-engine/tests/unit/test_tavily_key_forwarding.py
@@ -11,7 +11,7 @@ literal in the Job spec. A Job object is readable with `get jobs` RBAC alone.
 from typing import Any
 
 import pytest
-from _k8s_fakes import FakeCreatedJob, fake_created_job
+from _k8s_fakes import FakeCoreV1, FakeCreatedJob, fake_created_job
 
 from screamingface_engine import job_env as runner_job_env
 from screamingface_engine.adapters.factory import build_job_runner
@@ -129,6 +129,7 @@ def test_settings_build_a_runner_carrying_the_secret_name() -> None:
     runner = build_job_runner(
         settings,
         k8s_client_factory=_RecordingBatchApi,
+        core_client_factory=FakeCoreV1,
     )
 
     assert isinstance(runner, K8sJobRunner)
@@ -139,6 +140,7 @@ def test_settings_without_a_secret_name_attach_no_secret() -> None:
     runner = build_job_runner(
         Settings(runner="k8s"),
         k8s_client_factory=_RecordingBatchApi,
+        core_client_factory=FakeCoreV1,
     )
 
     assert isinstance(runner, K8sJobRunner)

--- a/docs/plan/2026-09-01-OME-1065-quota-admission.md
+++ b/docs/plan/2026-09-01-OME-1065-quota-admission.md
@@ -1,0 +1,61 @@
+# OME-1065 — Plan: quota-aware admission in K8sJobRunner
+
+## Steps
+
+1. **`adapters/k8s.py` — the client seam and snapshot types.**
+   Add `CoreV1QuotaClient` Protocol plus the structural Protocols for the
+   returned objects (`_QuotaView`, `_QuotaList`, `_LimitRangeView`,
+   `_LimitRangeList`, `_LimitRangeItem`, `_LimitRangeSpec`), in the same style as
+   the existing `_JobView` family. Add `_QuotaSnapshot` dataclass
+   (`used`/`hard`/`charge` as `dict[str, int]`).
+
+2. **`adapters/k8s.py` — quantity parsing and charge computation.**
+   `_quantity(dimension, value)` parses a k8s quantity to an exact int
+   (millicores for cpu, natural unit otherwise) via
+   `kubernetes.utils.quantity.parse_quantity`. `_limitrange_defaults` merges
+   LimitRange defaults (max per resource). `_pod_charge` computes the charge of
+   one Runner Pod from `self._resources` plus the defaults.
+
+3. **`adapters/k8s.py` — the admission gate.**
+   Constructor gains `core_client: CoreV1QuotaClient | None = None` and
+   `quota_cache_ttl_s: float = 2.0`. Add `_quota_snapshot`, `_quota_cache_time`,
+   `_reserved`, `_admission_lock`. `_schedule_blocking` calls `_reserve_or_raise`
+   before the create and `_release_reservation` on `ApiException`. Add
+   `_refresh_quota_if_stale`, `_fits`, `_max_runs_that_fit`. Import
+   `JobRunnerAtCapacity`.
+
+4. **`adapters/factory.py` — wire the core client.**
+   Add `_in_cluster_core_client()` (shares the cached `ApiClient`). Add
+   `core_client_factory` parameter to `build_job_runner`, pass
+   `core_client=core_client_factory()`.
+
+5. **`deploy/helm/templates/role.yaml` — RBAC.**
+   Add `resourcequotas` (get/list/watch) and `limitranges` (get/list) rules.
+
+6. **Tests.**
+   `_k8s_fakes.py`: add `FakeQuotaStatus`, `FakeQuota`, `FakeLimitRangeItem`,
+   `FakeLimitRangeSpec`, `FakeLimitRange`, `FakeQuotaList`, `FakeLimitRangeList`,
+   `FakeCoreV1`. `test_runners_k8s.py`: admission tests (ceiling, fits,
+   LimitRange default, concurrency, unreadable, no quota, create-failure
+   release). `test_runners_factory.py` + the 3 other factory callers: pass
+   `core_client_factory` returning the fake.
+
+## Files
+
+- `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py`
+- `apps/screamingface-engine/src/screamingface_engine/adapters/factory.py`
+- `apps/screamingface-engine/deploy/helm/templates/role.yaml`
+- `apps/screamingface-engine/tests/unit/_k8s_fakes.py`
+- `apps/screamingface-engine/tests/unit/test_runners_k8s.py`
+- `apps/screamingface-engine/tests/unit/test_runners_factory.py`
+- `apps/screamingface-engine/tests/unit/test_aigateway_base_url_forwarding.py`
+- `apps/screamingface-engine/tests/unit/test_runner_job_lifecycle_settings.py`
+- `apps/screamingface-engine/tests/unit/test_tavily_key_forwarding.py`
+
+## Gates
+
+- `uv run ruff check`
+- `uv run ruff format --check`
+- `uv run pyright`
+- `python3 ../../.claude/scripts/check_layering.py`
+- `uv run pytest --cov=screamingface_engine --cov=url4.streaming --cov-fail-under=80 -q`

--- a/docs/spec/2026-09-01-OME-1065-quota-admission.md
+++ b/docs/spec/2026-09-01-OME-1065-quota-admission.md
@@ -1,0 +1,123 @@
+# OME-1065 — Refuse a run when the namespace ResourceQuota has no headroom
+
+## Problem
+
+`K8sJobRunner.schedule()` creates a Job unconditionally. The `sf-fusion` namespace
+carries a `ResourceQuota` (`ns-ceiling`). A quota does not absorb load. It refuses
+Pod creation asynchronously, after `create_namespaced_job` has already returned
+201. On 2026-09-01 this produced 23 minutes of silent non-execution (OME-1064).
+
+The port documents this as deliberate:
+
+> "A cluster-backed runner lets the scheduler absorb the load and never raises."
+> — `packages/url4/src/url4/streaming/interfaces/jobs.py:31-34`
+
+That sentence is false in this deployment. A namespace with a ResourceQuota is a
+substrate that owns a finite local resource. The 503 + `Retry-After` backpressure
+path already exists and is fully wired (`rest/routes.py:198-208`). Only the K8s
+adapter never raises `JobRunnerAtCapacity`.
+
+## Decision
+
+`K8sJobRunner` gains capacity awareness sourced from the namespace ResourceQuota
+itself:
+
+1. Read the ResourceQuota's `status.used` vs `status.hard`, cached ~2 seconds.
+2. Before creating a Job, compute whether one more Runner Pod fits on every
+   constrained dimension: `requests.cpu`, `requests.memory`, `limits.cpu`,
+   `limits.memory`, `pods`.
+3. The Pod's charge is its own spec plus any LimitRange defaults. The runner sets
+   no `limits.cpu`, so the namespace LimitRange supplies it. The arithmetic is
+   wrong by 500m per Pod if this is not accounted for.
+4. If one more Pod does not fit, raise `JobRunnerAtCapacity`. The REST edge turns
+   this into 503 + `Retry-After`.
+5. Hold a local in-flight reservation counter alongside the cached quota reading.
+   This closes the read-modify-write race when several `schedule()` calls run
+   between two quota refreshes.
+
+### Why read the quota rather than configure a number
+
+The quota is already the operator's declared capacity. Reading it keeps one source
+of truth. A configured limit would be a second copy that silently drifts from the
+cluster. It self-tunes when infrastructure resizes the ceiling with no redeploy.
+It stays correct across multiple Engine replicas — a process-local counter would
+not.
+
+### Degradation
+
+If the quota or the LimitRange cannot be read (absent, RBAC denied, API error),
+fall back to today's behaviour: create the Job and let OME-1059's detection catch
+an un-startable run. Admission is an optimisation over detection, never a
+replacement for it. A failed read backs off 30 seconds so a permanently denied
+read does not hammer the API server.
+
+## Design
+
+### The quota snapshot
+
+`_QuotaSnapshot` holds `used`, `hard`, and `charge` as exact integers:
+
+- cpu in millicores (`"200m"` → 200, `"2"` → 2000)
+- memory in bytes (`"256Mi"` → 268435456)
+- pods as a count
+
+Integer arithmetic keeps the ceiling comparison exact. A float comparison at the
+ceiling (`0.4 + 8*0.2 > 2.0`) would refuse the run that exactly fills the quota.
+
+`used` and `hard` are merged across the namespace's quotas: max used, min hard per
+dimension. `charge` is the quota charge of one Runner Pod: its own `resources`
+spec plus LimitRange defaults, merged across LimitRanges (max per resource —
+conservative when two LimitRanges disagree).
+
+### The admission gate
+
+`_schedule_blocking` runs on a `to_thread` worker. A `threading.Lock` makes the
+refresh + check + reserve atomic:
+
+```
+with lock:
+    refresh quota if stale
+    if snapshot exists and not fits(snapshot, reserved):
+        raise JobRunnerAtCapacity(reserved, max_runs_that_fit(snapshot))
+    reserved += 1
+create the Job
+on ApiException:
+    with lock: reserved -= 1
+    map 409 to JobAlreadyExists, else re-raise
+```
+
+`fits` checks every charged dimension the quota constrains:
+
+```
+used + (reserved + 1) * charge <= hard
+```
+
+The reservation counter covers the window between refreshes. It resets to zero at
+each successful refresh, because the quota's `used` then reflects everything older
+than the window. A create failure releases the reservation immediately.
+
+### The client seam
+
+`CoreV1QuotaClient` is a narrow structural Protocol, in the same style as the
+existing `BatchV1JobsClient`:
+
+- `list_namespaced_resource_quota(namespace, *, _request_timeout=...)`
+- `list_namespaced_limit_range(namespace, *, _request_timeout=...)`
+
+`build_job_runner` wires a `CoreV1Api` alongside the `BatchV1Api`, sharing the
+process's single cached `ApiClient`. `core_client=None` disables admission
+(direct constructions in tests keep today's behaviour).
+
+### RBAC
+
+The Engine's Role gains `get`/`list`/`watch` on `resourcequotas` and
+`get`/`list` on `limitranges` (core API group). The chart change is part of this
+issue.
+
+## Out of scope
+
+- Fairness between runs (OME-908). This issue only decides whether there is room,
+  not whose run gets it.
+- Cluster capacity sizing (OME-1058).
+- Client-side retry on 503 (OME-1066, the sibling SDK issue, which must ship with
+  this one).

--- a/docs/tasks/2026-09-01-OME-1065-quota-admission.md
+++ b/docs/tasks/2026-09-01-OME-1065-quota-admission.md
@@ -1,0 +1,33 @@
+---
+id: OME-1065
+linear_url: https://linear.app/openmined/issue/OME-1065/refuse-a-run-when-the-namespace-resourcequota-has-no-headroom
+status: in_progress
+type: task
+priority: high
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+  - task
+created: 2026-09-01
+closed:
+---
+
+# Refuse a run when the namespace ResourceQuota has no headroom
+
+`K8sJobRunner.schedule()` creates a Job unconditionally. The `sf-fusion` namespace
+carries a `ResourceQuota` (`ns-ceiling`) that refuses Pod creation asynchronously,
+after `create_namespaced_job` has already returned 201. On 2026-09-01 this
+produced 23 minutes of silent non-execution (OME-1064).
+
+Make the K8s adapter raise the existing `JobRunnerAtCapacity` — which the REST
+edge already maps to 503 + `Retry-After` — when one more Runner Pod does not fit
+the namespace quota. Read the quota's `status.used` vs `status.hard` (cached
+~2s), account for LimitRange defaults in the Pod's charge, hold a local
+in-flight reservation counter to close the read-modify-write race, and degrade
+to today's behaviour when the quota cannot be read. The Engine's Role gains
+`get`/`watch` on `resourcequotas` (plus `limitranges` for the charge).
+
+Spec: `docs/spec/2026-09-01-OME-1065-quota-admission.md`
+Plan: `docs/plan/2026-09-01-OME-1065-quota-admission.md`
+Work: `docs/work/2026-09-01-OME-1065-quota-admission.md`

--- a/docs/work/2026-09-01-OME-1065-quota-admission.md
+++ b/docs/work/2026-09-01-OME-1065-quota-admission.md
@@ -1,0 +1,73 @@
+---
+ticket: OME-1065
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-01
+finished:
+---
+
+# OME-1065 — Refuse a run when the namespace ResourceQuota has no headroom
+
+## Intent
+
+`K8sJobRunner.schedule()` creates a Job unconditionally. The `sf-fusion` namespace
+carries a `ResourceQuota` (`ns-ceiling`) that refuses Pod creation asynchronously,
+after `create_namespaced_job` has already returned 201. On 2026-09-01 this produced
+23 minutes of silent non-execution (OME-1064). This unit makes the K8s adapter
+raise the existing `JobRunnerAtCapacity` — which the REST edge already maps to
+503 + `Retry-After` — when one more Runner Pod does not fit the namespace quota.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/adapters/k8s.py` — quota
+  admission in `K8sJobRunner`: `CoreV1QuotaClient` protocol, quota snapshot,
+  LimitRange-aware Pod charge, ~2s cached refresh, reservation counter, admission
+  gate in `_schedule_blocking`.
+- `apps/screamingface-engine/src/screamingface_engine/adapters/factory.py` —
+  `build_job_runner` wires a `CoreV1Api` client alongside the batch client.
+- `apps/screamingface-engine/deploy/helm/templates/role.yaml` — RBAC: `get`/`list`/
+  `watch` on `resourcequotas`, `get`/`list` on `limitranges`.
+- `apps/screamingface-engine/tests/unit/_k8s_fakes.py` — shared fake core client.
+- `apps/screamingface-engine/tests/unit/test_runners_k8s.py` — admission tests.
+- `apps/screamingface-engine/tests/unit/test_runners_factory.py` + 3 other factory
+  callers — pass the fake core client factory.
+
+## Test plan
+
+- Quota at ceiling → `JobRunnerAtCapacity`, no Job created.
+- A submission that fits → Job created exactly as today.
+- LimitRange default accounted: Pod spec omits `limits.cpu`, quota `limits.cpu`
+  binds → refused.
+- Concurrent `schedule()` calls cannot jointly overshoot the ceiling.
+- Quota unreadable → schedules proceed, no exception leaks.
+- No quota in namespace → schedules proceed.
+- Create failure releases the reservation.
+- Factory threads the core client.
+
+## Acceptance
+
+- With the namespace quota at its ceiling, a run submission returns 503 with
+  `Retry-After`, not 202.
+- A submission that fits still returns 202, and the Job is created exactly as today.
+- Quota accounting includes LimitRange-defaulted values, verified against a Pod
+  spec that omits `limits.cpu`.
+- Concurrent `schedule()` calls cannot jointly overshoot the ceiling.
+- Quota unreadable → schedules proceed, no exception leaks into the request path.
+- RBAC: the Engine's Role gains `get`/`watch` on `resourcequotas` (plus
+  `limitranges` for the charge computation).
+- Unit coverage via the existing fake `BatchV1JobsClient` seam.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `adapters/k8s.py`, `adapters/factory.py`,
+  `deploy/helm/templates/role.yaml`, `tests/unit/_k8s_fakes.py`,
+  `tests/unit/test_runners_k8s.py`, `tests/unit/test_runners_factory.py`,
+  `tests/unit/test_aigateway_base_url_forwarding.py`,
+  `tests/unit/test_runner_job_lifecycle_settings.py`,
+  `tests/unit/test_tavily_key_forwarding.py` + the four docs artifacts.
+- **Commits:** <sha> — feat(engine): refuse a run when the namespace quota has no headroom (OME-1065)
+- **Gates:** ruff check ✓ · ruff format ✓ · pyright 0 errors ✓ · layering OK ✓ ·
+  pytest 2282 passed, 5 skipped, 91.65% coverage (≥80) ✓
+- **Deviations:** the spec adds `limitranges` RBAC (get/list) beyond the ticket's
+  `resourcequotas` line — the LimitRange read is required for the defaulted-charge
+  accounting the acceptance criteria demand.


### PR DESCRIPTION
## What

`K8sJobRunner.schedule()` created a Job unconditionally. The `sf-fusion` namespace carries a `ResourceQuota` (`ns-ceiling`) that refuses Pod creation asynchronously, after `create_namespaced_job` has already returned 201 — on 2026-09-01 that produced 23 minutes of silent non-execution (OME-1064).

The runner now reads the namespace ResourceQuota (`status.used` vs `status.hard`, cached ~2s) and the LimitRanges (for the defaulted charge: the runner sets no `limits.cpu`, so the namespace LimitRange supplies it). Before creating a Job it checks whether one more Runner Pod fits on every constrained dimension (`requests.cpu`, `requests.memory`, `limits.cpu`, `limits.memory`, `pods`) in exact integer arithmetic, and raises the existing `JobRunnerAtCapacity` — which the REST edge already maps to **503 + `Retry-After`**. A local reservation counter under a `threading.Lock` closes the read-modify-write race between refreshes. If the quota cannot be read, schedules proceed exactly as before (admission is an optimisation over OME-1059's detection, never a replacement).

## Acceptance

- [x] Quota at ceiling → 503 + `Retry-After`, not 202
- [x] Fits → 202, Job created exactly as today
- [x] LimitRange-defaulted values accounted (Pod spec omits `limits.cpu`)
- [x] Concurrent `schedule()` calls cannot jointly overshoot the ceiling
- [x] Quota unreadable → schedules proceed, no exception leaks
- [x] RBAC: Role gains `get`/`list`/`watch` on `resourcequotas` + `get`/`list` on `limitranges`
- [x] Unit coverage via the existing fake `BatchV1JobsClient` seam

## Gates

ruff check ✓ · ruff format ✓ · pyright 0 errors ✓ · layering OK ✓ · pytest 2282 passed, 5 skipped, 91.65% coverage (≥80) ✓

## Docs

Spec: `docs/spec/2026-09-01-OME-1065-quota-admission.md` · Plan: `docs/plan/2026-09-01-OME-1065-quota-admission.md` · Work: `docs/work/2026-09-01-OME-1065-quota-admission.md`

Refs: OME-1065