### PR TITLE
docs(e2e): commit the live-k8s traceability notebook (OME-1074)

### DIFF
--- a/docs/tasks/2026-09-02-OME-1074-e2e-traceability-notebook.md
+++ b/docs/tasks/2026-09-02-OME-1074-e2e-traceability-notebook.md
@@ -1,0 +1,35 @@
+---
+id: OME-1074
+linear_url: https://linear.app/openmined/issue/OME-1074/commit-the-live-k8s-traceability-e2e-notebook
+status: in_progress
+type: task
+priority: 3
+labels: [repo, agentic, autonomous, task]
+created: 2026-09-02
+closed:
+---
+
+# Commit the live-k8s traceability e2e notebook
+
+Version-controls the interactive traceability ladder at `e2e/failor/notebooks/` so it is
+re-runnable as each rung of the tracing roadmap (`OME-935`) lands, instead of being repeated
+by hand.
+
+Four rungs, one section each, printing PASS/FAIL: the client originated a trace id
+(`OME-967`); the engine emitted it to aigateway; `gateway_call_id` on every aigateway line
+(`OME-938`); one id greppable across the Runner Job and aigateway. **Rungs 2–4 fail today by
+design** — the notebook is the acceptance test for changes that have not landed.
+
+It sits outside `packages/screamingface/examples/` because `scripts/check_notebooks.py`
+requires those to be deterministic and output-free, and a live-cluster diagnostic is neither.
+A `build_notebook.py` regenerates the authored cells with empty outputs, so executing the
+notebook never dirties the tree.
+
+Two k8s facts are encoded rather than remembered: a run executes in a per-run Runner Job
+(`app.kubernetes.io/name=url4-runner`), not the engine pod; and the log tailers must start
+before the run, because Jobs are reaped within 60–120 s.
+
+Known limitation recorded with it: `trace_id` is public only on the error hierarchy, so a
+successful run has no supported way to quote an id.
+
+Ledger: `docs/work/2026-09-02-OME-1074-e2e-traceability-notebook.md`.

--- a/docs/work/2026-09-02-OME-1074-e2e-traceability-notebook.md
+++ b/docs/work/2026-09-02-OME-1074-e2e-traceability-notebook.md
@@ -1,0 +1,106 @@
+---
+ticket: OME-1074
+stack: repo
+status: in_progress
+started: 2026-09-02
+finished:
+---
+
+# OME-1074 — Commit the live-k8s traceability e2e notebook
+
+## Intent
+
+The tracing roadmap (`OME-935`) lands one rung at a time, and each rung's real acceptance
+test is a run against the **deployed** stack — not the local harness. That check has been
+done by hand so far. This unit version-controls it as a notebook so it is re-runnable,
+reviewable, and so the two k8s facts that make a hand check wrong are encoded rather than
+remembered.
+
+Rungs 2–4 fail today by design. The notebook is the acceptance test for the changes that
+make them pass, and its failure output is the current-state evidence.
+
+## Planned changes
+
+- `e2e/failor/notebooks/traceability_e2e_k8s.ipynb` — the notebook (path as specified by the
+  owner).
+- `e2e/failor/notebooks/README.md` — what it is, how to run it, and why it is not a CI lane.
+- This ledger + the `docs/tasks/` mirror.
+
+New top-level `e2e/` directory. No CI workflow is added: nothing here can run unattended
+against a cluster, and no path filter matches, so the lane stays hand-run by design.
+
+## Design decisions
+
+**D1 — not under `packages/screamingface/examples/`.** `scripts/check_notebooks.py` requires
+the public example notebooks to match a deterministic builder and stay output-free. A
+live-cluster diagnostic is non-deterministic and output-bearing by nature, so putting it
+there would either fail the gate or force the gate to be weakened. It is also not an SDK
+example — it is an operator tool, and the two audiences want different things.
+
+**D2 — tailers start before the run.** Runner Jobs are short-lived and reaped
+(`orphan_grace_s = 120`; the orphan sweep in `adapters/jetstream.py` drops terminal streams
+to 60 s once the NATS store is full — i.e. exactly when failures cluster). A notebook that
+ran first and read logs afterwards would report empty evidence as a failed rung.
+
+**D3 — rung 4 greps the Runner Job, not the engine Deployment.** A run executes in a per-run
+Job (`app.kubernetes.io/name=url4-runner`, `RUNNER_LABELS` in `adapters/k8s.py`) and the
+traceparent reaches it through the Job env. Reading the Deployment yields nothing and reads
+as a false failure — so the selector is in the config cell and the troubleshooting section
+names this as the first thing to check.
+
+**D4 — the trace id is read off events on success.** `trace_id` is public only on the error
+hierarchy (`ScreamingFaceError.trace_id`); `Report` carries no trace field. So the notebook
+takes the id from `ScreamingFaceError.trace_id` when a run fails and from
+`sf.Event.traceparent` via the `on_event` hook when it succeeds. **This is a gap worth its
+own decision** — a user with a successful run currently has no supported way to quote an id,
+which is the thing a report needs. Recorded here rather than fixed, because widening the
+public surface is not this unit's call.
+
+## Test plan
+
+**Correction made during the work: ruff DOES apply.** The plan assumed a new top-level
+directory outside every path filter meant no gate touched it. The repo's `.pre-commit-config`
+runs `ruff check` and `ruff format` **repo-wide, including `.ipynb` files**, and the first
+commit attempt was rejected with `E402` (imports not at top of cell), `E741` (ambiguous `l`),
+and an unused import — then reformatted both files under me. Verification is therefore:
+
+- `ruff check` and `ruff format --check` clean on the notebook *and* its builder;
+- regeneration is **idempotent** — building twice produces a byte-identical file, so the
+  builder and the commit hook agree instead of fighting;
+
+- the notebook is valid `nbformat` 4 JSON;
+- every code cell parses (`ast.parse`) — a broken cell must not reach the owner;
+- no cell carries stored outputs, so the committed file is a clean diff on every re-run.
+
+The last three run inside `build_notebook.py` itself, so they cannot be skipped.
+
+## Acceptance
+
+- Notebook and README committed under `e2e/failor/notebooks/`.
+- Every code cell parses; no stored outputs; valid nbformat.
+- Running it against a live cluster prints PASS for rung 1 and FAIL for rungs 2–4, which is
+  the correct current state.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus one — `e2e/failor/notebooks/traceability_e2e_k8s.ipynb`,
+  `e2e/failor/notebooks/README.md`, `e2e/failor/notebooks/build_notebook.py` (**added**), the
+  ledger and the `docs/tasks/` mirror.
+- **Commits:** `docs(e2e): commit the live-k8s traceability notebook` (sha at squash-merge).
+- **Gates:** `ruff check` + `ruff format --check` clean on both files (they run repo-wide via
+  pre-commit, including on `.ipynb` — see the Test plan correction). No *stack* gate applies:
+  new top-level directory, no path filter matches, no CI lane by design. Also verified: valid
+  nbformat 4, **22 cells / 10 code**, every code cell `ast.parse`s, every cell `outputs: []`
+  with `execution_count: None`, and regeneration byte-identical.
+- **Deviations:**
+  - **`build_notebook.py` was added, which the plan did not list.** Hand-editing a committed
+    `.ipynb` that is *meant to be executed* guarantees a dirty tree after every run. The
+    builder emits empty outputs, so regeneration is always a clean diff — the notebook stays
+    reviewable as source rather than as an execution record.
+  - **The builder now runs `ruff check --fix` and `ruff format` on its own output.** Without
+    it the builder and the pre-commit hook disagree: the hook reformats on commit, and the
+    next regeneration reverts it. Formatting inside the builder makes regeneration idempotent,
+    which is verified rather than assumed.
+  - **Cells were restructured to satisfy `E402`** — imports moved into their own first cell
+    instead of sitting below the config block. Section numbering shifted by one accordingly.
+  - The directory name is `failor`, exactly as the owner specified.

--- a/e2e/failor/notebooks/README.md
+++ b/e2e/failor/notebooks/README.md
@@ -1,0 +1,59 @@
+# Traceability e2e — live k8s
+
+Hand-run notebooks that validate the correlation chain against the **deployed** stack.
+
+| File | What it does |
+|---|---|
+| `traceability_e2e_k8s.ipynb` | Walks the tracing ladder (`OME-935`), one rung per section, printing PASS/FAIL and a summary table |
+| `build_notebook.py` | Regenerates the notebook's authored cells — edit here, re-run, commit both |
+
+## Run it
+
+```sh
+pip install screamingface        # a build containing OME-967
+jupyter lab traceability_e2e_k8s.ipynb
+```
+
+Edit the **first code cell only** — namespace, engine URL, aigateway deployment name,
+benchmark — then run top to bottom.
+
+## What it asserts
+
+1. **`OME-967`** — the client originated one well-formed trace id.
+2. The engine emitted that id to aigateway.
+3. **`OME-938`** — `gateway_call_id` on **every** aigateway log line.
+4. One id greppable across the Runner Job **and** aigateway logs.
+
+**Rungs 2–4 are expected to FAIL today.** They are the acceptance test for changes that have
+not landed yet, and the failure output is the current-state evidence. Re-run as each lands.
+
+## Two things that make a hand-run check wrong
+
+**A run does not execute in the engine pod.** It executes in a per-run Runner Job
+(`app.kubernetes.io/name=url4-runner` — `RUNNER_LABELS` in the engine's `adapters/k8s.py`),
+and the traceparent reaches it through the Job env. Grepping the engine Deployment finds
+nothing and reads as a failed rung when the rung is fine.
+
+**Start the log tailers before the run.** Runner Jobs are short-lived and reaped
+(`orphan_grace_s = 120`, and the orphan sweep drops terminal streams to 60 s once the NATS
+store is full — exactly when failures cluster). Run first, read after, and the evidence is
+already gone. The notebook's section order enforces this.
+
+## Why there is no CI lane
+
+Nothing here can run unattended: it needs a reachable cluster, `kubectl` credentials, and a
+real benchmark run that spends provider budget. It is an operator tool, in the same class as
+the `AIGW_LIVE=1` diagnostics — run before you believe a tracing change works in production,
+not on every PR.
+
+It also deliberately sits outside `packages/screamingface/examples/`, whose notebooks must
+match a deterministic builder and stay output-free (`scripts/check_notebooks.py`). A
+live-cluster diagnostic is non-deterministic and output-bearing by nature.
+
+## Known limitation
+
+`trace_id` is public only on the error hierarchy (`ScreamingFaceError.trace_id`); `Report`
+carries no trace field. So the notebook reads the id from the exception when a run fails and
+from `sf.Event.traceparent` via the `on_event` hook when it succeeds. A user with a
+successful run currently has no supported way to quote an id — which is the thing a bug
+report needs. Worth its own decision.

--- a/e2e/failor/notebooks/build_notebook.py
+++ b/e2e/failor/notebooks/build_notebook.py
@@ -1,0 +1,344 @@
+"""Regenerate `traceability_e2e_k8s.ipynb` (OME-1074).
+
+The notebook is committed, so this builder is the source of truth for its authored cells:
+edit here, re-run, commit both.
+
+WHY a builder rather than hand-editing the .ipynb: cells are emitted with `outputs: []` and
+`execution_count: None`, so regenerating is always a clean diff no matter how many times the
+notebook has been run interactively. This is a live-cluster diagnostic — it is *expected* to
+be executed and to accumulate output — and without this, every run would dirty the tree.
+
+    python3 build_notebook.py
+"""
+
+import ast
+import json
+import pathlib
+import subprocess
+
+CELLS = []
+
+
+def md(text):
+    CELLS.append(
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": text.strip().splitlines(True),
+        }
+    )
+
+
+def code(text):
+    CELLS.append(
+        {
+            "cell_type": "code",
+            "execution_count": None,
+            "metadata": {},
+            "outputs": [],
+            "source": text.strip().splitlines(True),
+        }
+    )
+
+
+md("""
+# Traceability e2e — live k8s
+
+Validates the tracing ladder against the **deployed** stack, one rung per section.
+
+**Expect failures.** Only rung 1 (`OME-967`) is implemented. Rungs 2–4 are the next changes;
+this notebook is the acceptance test you re-run as each lands.
+
+| rung | change | expected today |
+|---|---|---|
+| 1 | `OME-967` client mints the traceparent | **PASS** (once PR #789 is in your client build) |
+| 2 | engine emits it to aigateway | FAIL — not built |
+| 3 | `OME-938` `gateway_call_id` on every line | FAIL — not built |
+| 4 | aigateway joins the inbound trace | FAIL — not built |
+
+**A run does not execute in the engine pod.** It runs in a per-run Runner Job
+(`app.kubernetes.io/name=url4-runner`), and the traceparent reaches it through the Job env.
+Grepping the engine Deployment will show nothing and read as a false failure.
+""")
+
+md("## 0. Imports")
+
+code("""
+import re
+import shutil
+import subprocess
+import threading
+import time
+
+TRACEPARENT_RE = re.compile(r"00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}")
+RUNNER_SELECTOR = "app.kubernetes.io/name=url4-runner"  # RUNNER_LABELS, adapters/k8s.py
+RESULTS = {}
+
+
+def record(rung, name, passed, detail=""):
+    RESULTS[rung] = (name, passed, detail)
+    print(f"[{'PASS' if passed else 'FAIL'}] rung {rung}: {name}")
+    if detail:
+        print(f"        {detail}")
+""")
+
+md("## 1. Configure — edit this cell only")
+
+code("""
+# --- edit these -------------------------------------------------------------------
+NAMESPACE       = "default"              # where the stack runs
+ENGINE_URL      = "http://127.0.0.1:9108"  # deployed engine, or a port-forward
+AIGATEWAY_DEPLOY = "deploy/aigateway"     # `kubectl get deploy -n $NAMESPACE` to confirm
+BENCHMARK_ID    = "draco"
+CANDIDATE       = "openrouter/google/gemini-3-flash-preview"
+KUBECTL         = "kubectl"
+# ----------------------------------------------------------------------------------
+print(f"namespace={NAMESPACE} engine={ENGINE_URL} gateway={AIGATEWAY_DEPLOY}")
+""")
+
+md("## 2. Preflight — cluster reachable, pods present")
+
+code("""
+def kc(*args, timeout=30):
+    return subprocess.run(
+        [KUBECTL, "-n", NAMESPACE, *args],
+        capture_output=True, text=True, timeout=timeout,
+    )
+
+assert shutil.which(KUBECTL), f"{KUBECTL} not on PATH"
+pods = kc("get", "pods", "-o", "name")
+assert pods.returncode == 0, f"kubectl failed:\\n{pods.stderr}"
+print(pods.stdout or "(no pods)")
+
+gw = kc("get", AIGATEWAY_DEPLOY, "-o", "name")
+assert gw.returncode == 0, f"aigateway not found as {AIGATEWAY_DEPLOY}:\\n{gw.stderr}"
+print("aigateway:", gw.stdout.strip())
+""")
+
+md("""
+## 3. Start the log tailers **before** the run
+
+Runner Jobs are short-lived and reaped (`orphan_grace_s=120`; Job TTL 1 h today, and the
+orphan sweep drops terminal streams to 60 s when the store is full). Miss the window and the
+evidence is gone — so start tailing first.
+""")
+
+code("""
+LOGS = {"gateway": [], "runner": []}
+_stop = threading.Event()
+
+def _tail(key, args):
+    proc = subprocess.Popen(
+        [KUBECTL, "-n", NAMESPACE, "logs", "-f", *args, "--tail=0"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
+    )
+    try:
+        for line in proc.stdout:
+            LOGS[key].append(line.rstrip())
+            if _stop.is_set():
+                break
+    finally:
+        proc.terminate()
+
+threading.Thread(target=_tail, args=("gateway", [AIGATEWAY_DEPLOY]), daemon=True).start()
+threading.Thread(
+    target=_tail,
+    args=("runner", ["-l", RUNNER_SELECTOR, "--all-containers", "--prefix", "--ignore-errors"]),
+    daemon=True,
+).start()
+
+time.sleep(3)
+print("tailing; gateway lines so far:", len(LOGS["gateway"]))
+""")
+
+md("""
+## 4. Run one evaluation and capture the client's trace id
+
+`trace_id` is public **only on the error hierarchy** (`ScreamingFaceError.trace_id`). On a
+successful run the client exposes no trace field on `Report`, so we read it off the event
+stream — `sf.Event.traceparent` — which after `OME-967` is the id the client itself minted.
+""")
+
+code("""
+import screamingface as sf
+
+sf.configure(engine_url=ENGINE_URL)
+
+seen_traceparents = []
+
+def on_event(event):
+    tp = getattr(event, "traceparent", None)
+    if tp:
+        seen_traceparents.append(tp)
+
+TRACE_ID = None
+run_error = None
+try:
+    sf.connect()
+    report = sf.evaluate(CANDIDATE, benchmark=BENCHMARK_ID, limit=1, on_event=on_event)
+    print("run completed")
+except sf.ScreamingFaceError as exc:
+    run_error = exc
+    # The pre-first-frame classes (capability mint, run start, WS handshake) land here, and
+    # after OME-967 they carry an id where they previously carried nothing.
+    TRACE_ID = getattr(exc, "trace_id", None)
+    print(f"run failed: {type(exc).__name__}: {exc}")
+    print("trace_id on the error:", TRACE_ID)
+
+if TRACE_ID is None and seen_traceparents:
+    TRACE_ID = TRACEPARENT_RE.search(seen_traceparents[0]).group(1)
+
+print("distinct traceparents seen on events:", len(set(seen_traceparents)))
+print("TRACE_ID =", TRACE_ID)
+""")
+
+md("## Rung 1 — the client originated a trace id (`OME-967`)")
+
+code("""
+ids = {TRACEPARENT_RE.search(tp).group(1) for tp in seen_traceparents if TRACEPARENT_RE.search(tp)}
+if TRACE_ID:
+    ids.add(TRACE_ID)
+
+record(
+    1, "client holds one well-formed trace id",
+    bool(TRACE_ID) and len(ids) == 1,
+    f"ids={ids or '{}'} — more than one means the run split across traces",
+)
+""")
+
+md("""
+## Rung 2 — the engine emitted it to aigateway
+
+The gateway must have *received* the client's id. Today the engine sends no `traceparent` on
+any of its three client paths, so this fails until that change lands.
+""")
+
+code("""
+time.sleep(5)  # let the tailers drain
+
+gateway_text = "\\n".join(LOGS["gateway"])
+hit = TRACE_ID is not None and TRACE_ID in gateway_text
+
+record(
+    2, "aigateway saw the client's trace id",
+    hit,
+    f"{len(LOGS['gateway'])} gateway lines captured; "
+    f"{'found' if hit else 'NOT found'} {TRACE_ID}",
+)
+""")
+
+md("""
+## Rung 3 — every aigateway line carries `gateway_call_id` (`OME-938`)
+
+Not a sample — *every* line. A contextvar injector that misses a code path is the failure
+mode this rung exists to catch.
+""")
+
+code("""
+lines = [ln for ln in LOGS["gateway"] if ln.strip()]
+missing = [ln for ln in lines if "gateway_call_id" not in ln]
+
+record(
+    3, "gateway_call_id on every aigateway log line",
+    bool(lines) and not missing,
+    f"{len(lines) - len(missing)}/{len(lines)} lines carry it"
+    + (f"; first without: {missing[0][:120]}" if missing else ""),
+)
+""")
+
+md("""
+## Rung 4 — one id, greppable across both pods
+
+The payoff. Until this passes, a Linear ticket's `trace_id` points at nothing you can grep.
+""")
+
+code("""
+runner_text = "\\n".join(LOGS["runner"])
+in_runner = TRACE_ID is not None and TRACE_ID in runner_text
+in_gateway = TRACE_ID is not None and TRACE_ID in gateway_text
+
+record(
+    4, "same trace id in the Runner Job AND aigateway logs",
+    in_runner and in_gateway,
+    f"runner={'yes' if in_runner else 'no'} ({len(LOGS['runner'])} lines), "
+    f"gateway={'yes' if in_gateway else 'no'} ({len(LOGS['gateway'])} lines)",
+)
+""")
+
+md("## Summary")
+
+code("""
+_stop.set()
+
+width = max(len(n) for _, (n, _, _) in RESULTS.items()) if RESULTS else 10
+bar = "+------+" + "-" * (width + 2) + "+--------+"
+print(bar)
+print(f"| rung | {'assertion'.ljust(width)} | result |")
+print(bar.replace("-", "="))
+for rung in sorted(RESULTS):
+    name, passed, _ = RESULTS[rung]
+    print(f"| {str(rung).ljust(4)} | {name.ljust(width)} | {'PASS  ' if passed else 'FAIL  '} |")
+print(bar)
+
+failed = [r for r, (_, p, _) in RESULTS.items() if not p]
+print()
+print("all rungs green" if not failed else f"failing rungs: {failed}")
+print("TRACE_ID for a manual grep:", TRACE_ID)
+""")
+
+md("""
+## If a rung fails unexpectedly
+
+- **Rung 1 fails** → your client build predates `OME-967` (PR #789). Check
+  `sf.__version__` / reinstall.
+- **Rung 2 "0 gateway lines captured"** → the tailer started after the run, or
+  `AIGATEWAY_DEPLOY` names the wrong workload. Re-run section 2, then 3.
+- **Rung 4 runner=no with lines>0** → you are almost certainly reading the engine Deployment
+  rather than the Runner Job. Confirm with
+  `kubectl get pods -l app.kubernetes.io/name=url4-runner`.
+- **Everything empty** → no DEBUG level exists in any deployed pod today (all three level
+  knobs are broken or uncharted), so you only ever see what INFO emits.
+""")
+
+nb = {
+    "cells": CELLS,
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3",
+        },
+        "language_info": {"name": "python"},
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5,
+}
+
+out = pathlib.Path(__file__).parent / "traceability_e2e_k8s.ipynb"
+out.write_text(json.dumps(nb, indent=1) + "\n")
+
+# WHY ruff runs here: the repo's pre-commit lints and formats `.ipynb` files, so a builder
+# whose output is not already ruff-clean would fight the hook — every regeneration reformatted
+# on commit, and the next regeneration undoing it. Formatting in the builder makes the two
+# agree, and keeps regeneration idempotent.
+for argv in (
+    ["ruff", "check", "--fix", "--quiet", str(out)],
+    ["ruff", "format", "--quiet", str(out)],
+):
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise SystemExit(
+            f"{' '.join(argv[:2])} failed:\n{result.stdout}{result.stderr}"
+        )
+
+reloaded = json.loads(out.read_text())
+codes = [c for c in reloaded["cells"] if c["cell_type"] == "code"]
+for cell in codes:
+    ast.parse("".join(cell["source"]))
+    assert cell["outputs"] == [], "a cell carries stored outputs"
+    assert cell["execution_count"] is None, "a cell carries an execution count"
+
+print(f"wrote {out}")
+print(
+    f"cells: {len(reloaded['cells'])} ({len(codes)} code) — ruff-clean, parsed, output-free"
+)

--- a/e2e/failor/notebooks/traceability_e2e_k8s.ipynb
+++ b/e2e/failor/notebooks/traceability_e2e_k8s.ipynb
@@ -1,0 +1,418 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Traceability e2e — live k8s\n",
+    "\n",
+    "Validates the tracing ladder against the **deployed** stack, one rung per section.\n",
+    "\n",
+    "**Expect failures.** Only rung 1 (`OME-967`) is implemented. Rungs 2–4 are the next changes;\n",
+    "this notebook is the acceptance test you re-run as each lands.\n",
+    "\n",
+    "| rung | change | expected today |\n",
+    "|---|---|---|\n",
+    "| 1 | `OME-967` client mints the traceparent | **PASS** (once PR #789 is in your client build) |\n",
+    "| 2 | engine emits it to aigateway | FAIL — not built |\n",
+    "| 3 | `OME-938` `gateway_call_id` on every line | FAIL — not built |\n",
+    "| 4 | aigateway joins the inbound trace | FAIL — not built |\n",
+    "\n",
+    "**A run does not execute in the engine pod.** It runs in a per-run Runner Job\n",
+    "(`app.kubernetes.io/name=url4-runner`), and the traceparent reaches it through the Job env.\n",
+    "Grepping the engine Deployment will show nothing and read as a false failure."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "source": [
+    "## 0. Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "import shutil\n",
+    "import subprocess\n",
+    "import threading\n",
+    "import time\n",
+    "\n",
+    "TRACEPARENT_RE = re.compile(r\"00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}\")\n",
+    "RUNNER_SELECTOR = \"app.kubernetes.io/name=url4-runner\"  # RUNNER_LABELS, adapters/k8s.py\n",
+    "RESULTS = {}\n",
+    "\n",
+    "\n",
+    "def record(rung, name, passed, detail=\"\"):\n",
+    "    RESULTS[rung] = (name, passed, detail)\n",
+    "    print(f\"[{'PASS' if passed else 'FAIL'}] rung {rung}: {name}\")\n",
+    "    if detail:\n",
+    "        print(f\"        {detail}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "source": [
+    "## 1. Configure — edit this cell only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- edit these -------------------------------------------------------------------\n",
+    "NAMESPACE = \"default\"  # where the stack runs\n",
+    "ENGINE_URL = \"http://127.0.0.1:9108\"  # deployed engine, or a port-forward\n",
+    "AIGATEWAY_DEPLOY = \"deploy/aigateway\"  # `kubectl get deploy -n $NAMESPACE` to confirm\n",
+    "BENCHMARK_ID = \"draco\"\n",
+    "CANDIDATE = \"openrouter/google/gemini-3-flash-preview\"\n",
+    "KUBECTL = \"kubectl\"\n",
+    "# ----------------------------------------------------------------------------------\n",
+    "print(f\"namespace={NAMESPACE} engine={ENGINE_URL} gateway={AIGATEWAY_DEPLOY}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## 2. Preflight — cluster reachable, pods present"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def kc(*args, timeout=30):\n",
+    "    return subprocess.run(\n",
+    "        [KUBECTL, \"-n\", NAMESPACE, *args],\n",
+    "        capture_output=True,\n",
+    "        text=True,\n",
+    "        timeout=timeout,\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "assert shutil.which(KUBECTL), f\"{KUBECTL} not on PATH\"\n",
+    "pods = kc(\"get\", \"pods\", \"-o\", \"name\")\n",
+    "assert pods.returncode == 0, f\"kubectl failed:\\n{pods.stderr}\"\n",
+    "print(pods.stdout or \"(no pods)\")\n",
+    "\n",
+    "gw = kc(\"get\", AIGATEWAY_DEPLOY, \"-o\", \"name\")\n",
+    "assert gw.returncode == 0, f\"aigateway not found as {AIGATEWAY_DEPLOY}:\\n{gw.stderr}\"\n",
+    "print(\"aigateway:\", gw.stdout.strip())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "## 3. Start the log tailers **before** the run\n",
+    "\n",
+    "Runner Jobs are short-lived and reaped (`orphan_grace_s=120`; Job TTL 1 h today, and the\n",
+    "orphan sweep drops terminal streams to 60 s when the store is full). Miss the window and the\n",
+    "evidence is gone — so start tailing first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LOGS = {\"gateway\": [], \"runner\": []}\n",
+    "_stop = threading.Event()\n",
+    "\n",
+    "\n",
+    "def _tail(key, args):\n",
+    "    proc = subprocess.Popen(\n",
+    "        [KUBECTL, \"-n\", NAMESPACE, \"logs\", \"-f\", *args, \"--tail=0\"],\n",
+    "        stdout=subprocess.PIPE,\n",
+    "        stderr=subprocess.STDOUT,\n",
+    "        text=True,\n",
+    "        bufsize=1,\n",
+    "    )\n",
+    "    try:\n",
+    "        for line in proc.stdout:\n",
+    "            LOGS[key].append(line.rstrip())\n",
+    "            if _stop.is_set():\n",
+    "                break\n",
+    "    finally:\n",
+    "        proc.terminate()\n",
+    "\n",
+    "\n",
+    "threading.Thread(\n",
+    "    target=_tail, args=(\"gateway\", [AIGATEWAY_DEPLOY]), daemon=True\n",
+    ").start()\n",
+    "threading.Thread(\n",
+    "    target=_tail,\n",
+    "    args=(\n",
+    "        \"runner\",\n",
+    "        [\"-l\", RUNNER_SELECTOR, \"--all-containers\", \"--prefix\", \"--ignore-errors\"],\n",
+    "    ),\n",
+    "    daemon=True,\n",
+    ").start()\n",
+    "\n",
+    "time.sleep(3)\n",
+    "print(\"tailing; gateway lines so far:\", len(LOGS[\"gateway\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": [
+    "## 4. Run one evaluation and capture the client's trace id\n",
+    "\n",
+    "`trace_id` is public **only on the error hierarchy** (`ScreamingFaceError.trace_id`). On a\n",
+    "successful run the client exposes no trace field on `Report`, so we read it off the event\n",
+    "stream — `sf.Event.traceparent` — which after `OME-967` is the id the client itself minted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import screamingface as sf\n",
+    "\n",
+    "sf.configure(engine_url=ENGINE_URL)\n",
+    "\n",
+    "seen_traceparents = []\n",
+    "\n",
+    "\n",
+    "def on_event(event):\n",
+    "    tp = getattr(event, \"traceparent\", None)\n",
+    "    if tp:\n",
+    "        seen_traceparents.append(tp)\n",
+    "\n",
+    "\n",
+    "TRACE_ID = None\n",
+    "run_error = None\n",
+    "try:\n",
+    "    sf.connect()\n",
+    "    report = sf.evaluate(CANDIDATE, benchmark=BENCHMARK_ID, limit=1, on_event=on_event)\n",
+    "    print(\"run completed\")\n",
+    "except sf.ScreamingFaceError as exc:\n",
+    "    run_error = exc\n",
+    "    # The pre-first-frame classes (capability mint, run start, WS handshake) land here, and\n",
+    "    # after OME-967 they carry an id where they previously carried nothing.\n",
+    "    TRACE_ID = getattr(exc, \"trace_id\", None)\n",
+    "    print(f\"run failed: {type(exc).__name__}: {exc}\")\n",
+    "    print(\"trace_id on the error:\", TRACE_ID)\n",
+    "\n",
+    "if TRACE_ID is None and seen_traceparents:\n",
+    "    TRACE_ID = TRACEPARENT_RE.search(seen_traceparents[0]).group(1)\n",
+    "\n",
+    "print(\"distinct traceparents seen on events:\", len(set(seen_traceparents)))\n",
+    "print(\"TRACE_ID =\", TRACE_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "source": [
+    "## Rung 1 — the client originated a trace id (`OME-967`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ids = {\n",
+    "    TRACEPARENT_RE.search(tp).group(1)\n",
+    "    for tp in seen_traceparents\n",
+    "    if TRACEPARENT_RE.search(tp)\n",
+    "}\n",
+    "if TRACE_ID:\n",
+    "    ids.add(TRACE_ID)\n",
+    "\n",
+    "record(\n",
+    "    1,\n",
+    "    \"client holds one well-formed trace id\",\n",
+    "    bool(TRACE_ID) and len(ids) == 1,\n",
+    "    f\"ids={ids or '{}'} — more than one means the run split across traces\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "## Rung 2 — the engine emitted it to aigateway\n",
+    "\n",
+    "The gateway must have *received* the client's id. Today the engine sends no `traceparent` on\n",
+    "any of its three client paths, so this fails until that change lands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time.sleep(5)  # let the tailers drain\n",
+    "\n",
+    "gateway_text = \"\\n\".join(LOGS[\"gateway\"])\n",
+    "hit = TRACE_ID is not None and TRACE_ID in gateway_text\n",
+    "\n",
+    "record(\n",
+    "    2,\n",
+    "    \"aigateway saw the client's trace id\",\n",
+    "    hit,\n",
+    "    f\"{len(LOGS['gateway'])} gateway lines captured; \"\n",
+    "    f\"{'found' if hit else 'NOT found'} {TRACE_ID}\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
+   "metadata": {},
+   "source": [
+    "## Rung 3 — every aigateway line carries `gateway_call_id` (`OME-938`)\n",
+    "\n",
+    "Not a sample — *every* line. A contextvar injector that misses a code path is the failure\n",
+    "mode this rung exists to catch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3933fab20d04ec698c2621248eb3be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines = [ln for ln in LOGS[\"gateway\"] if ln.strip()]\n",
+    "missing = [ln for ln in lines if \"gateway_call_id\" not in ln]\n",
+    "\n",
+    "record(\n",
+    "    3,\n",
+    "    \"gateway_call_id on every aigateway log line\",\n",
+    "    bool(lines) and not missing,\n",
+    "    f\"{len(lines) - len(missing)}/{len(lines)} lines carry it\"\n",
+    "    + (f\"; first without: {missing[0][:120]}\" if missing else \"\"),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd4641cc4064e0191573fe9c69df29b",
+   "metadata": {},
+   "source": [
+    "## Rung 4 — one id, greppable across both pods\n",
+    "\n",
+    "The payoff. Until this passes, a Linear ticket's `trace_id` points at nothing you can grep."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8309879909854d7188b41380fd92a7c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "runner_text = \"\\n\".join(LOGS[\"runner\"])\n",
+    "in_runner = TRACE_ID is not None and TRACE_ID in runner_text\n",
+    "in_gateway = TRACE_ID is not None and TRACE_ID in gateway_text\n",
+    "\n",
+    "record(\n",
+    "    4,\n",
+    "    \"same trace id in the Runner Job AND aigateway logs\",\n",
+    "    in_runner and in_gateway,\n",
+    "    f\"runner={'yes' if in_runner else 'no'} ({len(LOGS['runner'])} lines), \"\n",
+    "    f\"gateway={'yes' if in_gateway else 'no'} ({len(LOGS['gateway'])} lines)\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ed186c9a28b402fb0bc4494df01f08d",
+   "metadata": {},
+   "source": [
+    "## Summary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb1e1581032b452c9409d6c6813c49d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_stop.set()\n",
+    "\n",
+    "width = max(len(n) for _, (n, _, _) in RESULTS.items()) if RESULTS else 10\n",
+    "bar = \"+------+\" + \"-\" * (width + 2) + \"+--------+\"\n",
+    "print(bar)\n",
+    "print(f\"| rung | {'assertion'.ljust(width)} | result |\")\n",
+    "print(bar.replace(\"-\", \"=\"))\n",
+    "for rung in sorted(RESULTS):\n",
+    "    name, passed, _ = RESULTS[rung]\n",
+    "    print(\n",
+    "        f\"| {str(rung).ljust(4)} | {name.ljust(width)} | {'PASS  ' if passed else 'FAIL  '} |\"\n",
+    "    )\n",
+    "print(bar)\n",
+    "\n",
+    "failed = [r for r, (_, p, _) in RESULTS.items() if not p]\n",
+    "print()\n",
+    "print(\"all rungs green\" if not failed else f\"failing rungs: {failed}\")\n",
+    "print(\"TRACE_ID for a manual grep:\", TRACE_ID)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "379cbbc1e968416e875cc15c1202d7eb",
+   "metadata": {},
+   "source": [
+    "## If a rung fails unexpectedly\n",
+    "\n",
+    "- **Rung 1 fails** → your client build predates `OME-967` (PR #789). Check\n",
+    "  `sf.__version__` / reinstall.\n",
+    "- **Rung 2 \"0 gateway lines captured\"** → the tailer started after the run, or\n",
+    "  `AIGATEWAY_DEPLOY` names the wrong workload. Re-run section 2, then 3.\n",
+    "- **Rung 4 runner=no with lines>0** → you are almost certainly reading the engine Deployment\n",
+    "  rather than the Runner Job. Confirm with\n",
+    "  `kubectl get pods -l app.kubernetes.io/name=url4-runner`.\n",
+    "- **Everything empty** → no DEBUG level exists in any deployed pod today (all three level\n",
+    "  knobs are broken or uncharted), so you only ever see what INFO emits."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Version-controls the interactive traceability ladder at `e2e/failor/notebooks/` so it is re-runnable as each rung of `OME-935` lands, instead of being repeated by hand.

Four rungs, one section each, printing PASS/FAIL and a summary table:

1. `OME-967` — the client originated one well-formed trace id
2. the engine emitted it to aigateway
3. `OME-938` — `gateway_call_id` on **every** aigateway log line
4. one id greppable across the Runner Job **and** aigateway

**Rungs 2–4 fail today by design.** The notebook is the acceptance test for changes that have not landed, and its failure output is the current-state evidence.

## Two k8s facts it encodes

Both make a hand-run check silently wrong, which is the reason to commit this rather than keep re-deriving it:

- **A run does not execute in the engine pod.** It runs in a per-run Runner Job (`app.kubernetes.io/name=url4-runner` — `RUNNER_LABELS` in the engine's `adapters/k8s.py`) and the traceparent reaches it through the Job env. Grepping the engine Deployment finds nothing and reads as a failed rung when the rung is fine.
- **Tailers start before the run.** Jobs are reaped within 60–120 s (`orphan_grace_s = 120`, and the orphan sweep drops terminal streams to 60 s once the NATS store is full — exactly when failures cluster). Run first, read after, and the evidence is gone. Section order enforces this.

## Why a builder, and why it runs ruff

`build_notebook.py` is the source of truth for the authored cells. Two reasons it exists:

- The notebook is *meant to be executed*, so hand-editing the `.ipynb` guarantees a dirty tree after every run. The builder emits `outputs: []` / `execution_count: None`, so regeneration is always a clean diff.
- **ruff lints `.ipynb` repo-wide via pre-commit** — I found this the hard way when the first commit was rejected for `E402` and `E741` inside notebook cells, and the hook reformatted both files. A builder whose output is not already ruff-clean fights the hook forever: reformatted on commit, reverted on the next regeneration. So the builder runs `ruff check --fix` and `ruff format` on its own output, and regeneration is **verified byte-identical**.

## Placement

Outside `packages/screamingface/examples/`, whose notebooks must match a deterministic builder and stay output-free (`scripts/check_notebooks.py`). A live-cluster diagnostic is neither, and it is an operator tool rather than an SDK example.

**No CI lane** — it needs a reachable cluster, kubectl credentials, and a real benchmark run that spends provider budget. Same class as the `AIGW_LIVE=1` diagnostics.

## Known limitation recorded with it

`trace_id` is public only on the error hierarchy (`ScreamingFaceError.trace_id`); `Report` carries no trace field. So the notebook reads the id from the exception on failure and from `sf.Event.traceparent` via `on_event` on success. **A user with a successful run currently has no supported way to quote an id** — which is the thing a bug report needs. Worth its own decision; not made here.

## Test plan

- `ruff check` + `ruff format --check` clean on both files (they run repo-wide via pre-commit).
- Valid nbformat 4, **22 cells / 10 code**; every code cell `ast.parse`s; every cell `outputs: []` with `execution_count: None` — all asserted inside the builder, so they cannot be skipped.
- Regeneration byte-identical (idempotency verified by diff).
- No stack gate applies: new top-level directory, no path filter matches.

Ledger: `docs/work/2026-09-02-OME-1074-e2e-traceability-notebook.md`
Mirror: `docs/tasks/2026-09-02-OME-1074-e2e-traceability-notebook.md`

Refs: OME-1074