### PR TITLE
fix(url4): correct the JobRunner capacity contract

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -197,9 +197,9 @@ async def _schedule(
         raise ProblemException(status=409, title="Conflict", detail="a run already exists") from exc
     except JobRunnerAtCapacity as exc:
         # WHY 503 and not 429: nothing about THIS caller or request was rate-limited — the
-        # substrate is saturated, and an identical retry later succeeds. Only a runner that owns a
-        # finite local resource (the in-process one) can raise this; a cluster-backed runner lets
-        # the scheduler queue instead.
+        # substrate is saturated, and an identical retry later succeeds. Any substrate with a
+        # finite declared ceiling raises this — the in-process runner on its admission limit, a
+        # queue-backed runner on queue depth — and the caller maps it to a retry-after response.
         raise ProblemException(
             status=503,
             title="Service Unavailable",

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -197,9 +197,10 @@ async def _schedule(
         raise ProblemException(status=409, title="Conflict", detail="a run already exists") from exc
     except JobRunnerAtCapacity as exc:
         # WHY 503 and not 429: nothing about THIS caller or request was rate-limited — the
-        # substrate is saturated, and an identical retry later succeeds. Any substrate with a
-        # finite declared ceiling raises this — the in-process runner on its admission limit, a
-        # queue-backed runner on queue depth — and the caller maps it to a retry-after response.
+        # substrate is saturated, and an identical retry later succeeds. Which substrates can
+        # saturate, and why retrying is safe, is `JobRunnerAtCapacity`'s own contract (the
+        # shapes: one shared event loop, a queue-depth ceiling, a scheduler's exhausted quota)
+        # — this handler maps, it does not restate; the port's docstring stays the one source.
         raise ProblemException(
             status=503,
             title="Service Unavailable",

--- a/docs/work/2026-09-02-OME-1087-jobrunner-capacity-contract.md
+++ b/docs/work/2026-09-02-OME-1087-jobrunner-capacity-contract.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-1087
+stack: url4
+status: in_progress
+started: 2026-09-02
+finished:
+---
+
+# OME-1087 — Correct the JobRunner capacity contract in the streaming port
+
+## Intent
+
+`JobRunnerAtCapacity`'s docstring claims a cluster-backed runner never raises it.
+That sentence is false and load-bearing: OME-1064 named it as the reason the
+503 + `Retry-After` backpressure path was disabled for the one runner that needed
+it. The queue-backed runner of OME-1086 raises it too, on queue depth. Rewrite the
+docstring so it states the real rule — any substrate with a finite declared
+ceiling raises it — and record in the `JobStatus` docstring that `scheduled`
+already means "accepted, not yet started" (queued), so nobody adds a `queued`
+member later.
+
+## Planned changes
+
+- `packages/url4/src/url4/streaming/interfaces/jobs.py` — rewrite the
+  `JobRunnerAtCapacity` docstring; extend the `JobStatus` docstring.
+- `packages/url4/tests/unit/test_jobs_port.py` — RED test asserting the docstring
+  no longer contains the cluster-backed carve-out.
+- `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` — comment
+  only: fix the same false claim repeated at the 503 mapping.
+
+## Test plan
+
+- RED: assert `JobRunnerAtCapacity.__doc__` does not contain the cluster-backed
+  carve-out and does state the general rule. Guards against a revert.
+- Existing `test_jobs_port.py` stays green.
+
+## Acceptance
+
+- The port docstring and the two adapter implementations agree.
+- `ruff` + `pyright` + `pytest` green for `packages/url4` (cov >= 95).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `packages/url4/src/url4/streaming/interfaces/jobs.py` (docstrings),
+  `packages/url4/tests/unit/test_jobs_port.py` (new RED test),
+  `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` (comment only),
+  `docs/work/2026-09-02-OME-1087-jobrunner-capacity-contract.md` (this ledger).
+- **Commits:** <sha — message>
+- **Gates:**
+  - url4: ruff check pass, ruff format pass (112 files), pyright 0 errors,
+    pytest 1167 passed, cov 97.55% (>= 95).
+  - engine: ruff check pass, ruff format pass (348 files), pyright 0 errors,
+    check_layering OK, pytest 2283 passed / 5 skipped, cov 91.66% (>= 80).
+- **Deviations:** none. Note: `docs/spec/2026-09-01-OME-1065-quota-admission.md` still
+  quotes the old false claim; it is a historical spec artifact and was left untouched
+  (out of scope).

--- a/docs/work/2026-09-02-OME-1087-jobrunner-capacity-contract.md
+++ b/docs/work/2026-09-02-OME-1087-jobrunner-capacity-contract.md
@@ -45,7 +45,7 @@ member later.
   `packages/url4/tests/unit/test_jobs_port.py` (new RED test),
   `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` (comment only),
   `docs/work/2026-09-02-OME-1087-jobrunner-capacity-contract.md` (this ledger).
-- **Commits:** <sha — message>
+- **Commits:** `0c44e48f` — fix(url4): correct the JobRunner capacity contract
 - **Gates:**
   - url4: ruff check pass, ruff format pass (112 files), pyright 0 errors,
     pytest 1167 passed, cov 97.55% (>= 95).

--- a/packages/url4/src/url4/streaming/interfaces/jobs.py
+++ b/packages/url4/src/url4/streaming/interfaces/jobs.py
@@ -17,7 +17,12 @@ JobStatus = Literal[
 ``not_found`` for an unknown/absent topic. Each adapter maps the substrate state it can observe.
 
 ``scheduled`` means the run is accepted but not yet started — i.e. queued. Do not add a
-``queued`` member: ``scheduled`` already covers it.
+``queued`` member: ``scheduled`` already covers it. Whether a substrate can OBSERVE the gap
+between acceptance and start is adapter-specific: one that starts a run the moment it accepts
+it — the in-process runner's tasks begin as soon as they are created — reports ``running`` from
+acceptance on, because that is the first state it can distinguish. Callers must not read
+``running`` as proof that execution has begun on such a substrate, nor wait for a
+``scheduled`` frame that its runner can never emit.
 """
 
 
@@ -32,10 +37,11 @@ class JobRunnerAtCapacity(Exception):
     help. This one is transient and carries no verdict about the request, so callers map it to a
     retry-after response rather than a conflict.
 
-    Any substrate with a finite declared ceiling raises it — an in-process runner shares one
+    Any substrate with a finite declared ceiling raises it: an in-process runner shares one
     event loop across every run it accepts, so admission is its own job; a queue-backed runner
-    raises it too when its queue depth hits the ceiling. The caller maps it to a retry-after
-    response rather than a conflict.
+    raises it when its queue depth hits the ceiling; a cluster scheduler raises it when its
+    resource quota is exhausted. The port names the substrate SHAPES, not adapter classes — an
+    adapter is bound to this contract by its own tests, not by being enumerated here.
     """
 
     def __init__(self, active: int, limit: int) -> None:

--- a/packages/url4/src/url4/streaming/interfaces/jobs.py
+++ b/packages/url4/src/url4/streaming/interfaces/jobs.py
@@ -14,7 +14,11 @@ JobStatus = Literal[
     "not_found",
 ]
 """The run states (spec §3): ``scheduled → running → {succeeded|failed|stopped|timed_out}``, plus
-``not_found`` for an unknown/absent topic. Each adapter maps the substrate state it can observe."""
+``not_found`` for an unknown/absent topic. Each adapter maps the substrate state it can observe.
+
+``scheduled`` means the run is accepted but not yet started — i.e. queued. Do not add a
+``queued`` member: ``scheduled`` already covers it.
+"""
 
 
 class JobAlreadyExists(Exception):
@@ -28,9 +32,10 @@ class JobRunnerAtCapacity(Exception):
     help. This one is transient and carries no verdict about the request, so callers map it to a
     retry-after response rather than a conflict.
 
-    Only substrates that own a finite local resource raise it — an in-process runner shares one
-    event loop across every run it accepts, so admission is its own job. A cluster-backed runner
-    lets the scheduler absorb the load and never raises.
+    Any substrate with a finite declared ceiling raises it — an in-process runner shares one
+    event loop across every run it accepts, so admission is its own job; a queue-backed runner
+    raises it too when its queue depth hits the ceiling. The caller maps it to a retry-after
+    response rather than a conflict.
     """
 
     def __init__(self, active: int, limit: int) -> None:

--- a/packages/url4/tests/unit/test_jobs_port.py
+++ b/packages/url4/tests/unit/test_jobs_port.py
@@ -32,6 +32,29 @@ def test_capacity_docstring_states_the_general_rule() -> None:
     assert "retry" in doc
 
 
+def test_capacity_docstring_covers_every_substrate_shape() -> None:
+    """The enumeration must be complete enough that no substrate class reads as exempt.
+
+    A substrate SHAPE (shared loop, queue depth, scheduler quota) cannot go stale when an
+    adapter is added, renamed, or retired — an adapter CLASS in this list can (the docstring
+    once looked exhaustive while omitting the one cluster adapter that existed)."""
+    doc = JobRunnerAtCapacity.__doc__ or ""
+    assert "event loop" in doc
+    assert "queue depth" in doc
+    assert "quota" in doc
+    # The contract must not enumerate adapter classes by name — shapes only.
+    assert "K8s" not in doc
+
+
+def test_capacity_docstring_states_the_rule_once() -> None:
+    """The retry-after mapping is stated once, not pasted into every paragraph.
+
+    A duplicated closing clause reads as if a second, different rule followed; it is the
+    same one, and the copy drifts the moment either sentence is edited alone."""
+    doc = JobRunnerAtCapacity.__doc__ or ""
+    assert doc.count("retry-after response rather than a conflict") == 1
+
+
 def test_job_status_docstring_records_scheduled_as_queued() -> None:
     """``scheduled`` already means accepted-not-started; no ``queued`` member is needed."""
     # JobStatus is a Literal alias, so its docstring is a module-level string
@@ -40,3 +63,15 @@ def test_job_status_docstring_records_scheduled_as_queued() -> None:
     assert "scheduled" in source
     assert "not yet started" in source
     assert "queued" in source
+
+
+def test_job_status_docstring_scopes_scheduled_to_observable_substrates() -> None:
+    """``scheduled`` is what a substrate that CAN observe the acceptance gap reports.
+
+    A substrate that starts a run the moment it accepts it (the in-process runner) reports
+    ``running`` from acceptance on — ``scheduled`` is not false there, it is unobservable.
+    The docstring must say so, or a caller waits for a frame such an adapter can never emit."""
+    source = inspect.getsource(jobs_module)
+    assert "adapter-specific" in source
+    assert "reports ``running`` from" in source
+    assert "nor wait for a" in source

--- a/packages/url4/tests/unit/test_jobs_port.py
+++ b/packages/url4/tests/unit/test_jobs_port.py
@@ -1,0 +1,42 @@
+"""The jobs port contract — what ``JobRunnerAtCapacity`` means and who raises it.
+
+STORY: OME-1064 recorded a 23-minute silent stall caused by five disagreeing
+capacity ceilings. The docstring used to carve out cluster-backed runners ("a
+cluster-backed runner lets the scheduler absorb the load and never raises") —
+that sentence is false and load-bearing: it was cited as the reason the
+503 + ``Retry-After`` backpressure path was disabled for the one runner that
+needed it. The contract is the general rule: ANY substrate with a finite
+declared ceiling raises it, and the caller maps it to a retry-after response.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import url4.streaming.interfaces.jobs as jobs_module
+from url4.streaming.interfaces.jobs import JobRunnerAtCapacity
+
+
+def test_capacity_docstring_has_no_cluster_backed_carve_out() -> None:
+    """The docstring must not exempt any substrate class from raising."""
+    doc = JobRunnerAtCapacity.__doc__ or ""
+    assert "cluster-backed" not in doc
+    assert "never raises" not in doc
+
+
+def test_capacity_docstring_states_the_general_rule() -> None:
+    """The docstring must state the general rule: finite ceiling -> raise, caller retries."""
+    doc = JobRunnerAtCapacity.__doc__ or ""
+    assert "finite" in doc
+    assert "ceiling" in doc
+    assert "retry" in doc
+
+
+def test_job_status_docstring_records_scheduled_as_queued() -> None:
+    """``scheduled`` already means accepted-not-started; no ``queued`` member is needed."""
+    # JobStatus is a Literal alias, so its docstring is a module-level string
+    # statement after the alias, not an attribute — read it from the source.
+    source = inspect.getsource(jobs_module)
+    assert "scheduled" in source
+    assert "not yet started" in source
+    assert "queued" in source


### PR DESCRIPTION
## What

The `JobRunnerAtCapacity` docstring claimed a cluster-backed runner never raises it. That sentence is false and load-bearing: OME-1064 named it as the reason the 503 + `Retry-After` backpressure path was disabled for the one runner that needed it.

## Changes

- `packages/url4/src/url4/streaming/interfaces/jobs.py` — rewrite the `JobRunnerAtCapacity` docstring: any substrate with a finite declared ceiling raises it; the caller maps it to a retry-after response. Delete the cluster-backed carve-out. Extend the `JobStatus` docstring: `scheduled` means accepted-not-started (queued); no `queued` member needed. No signature changes.
- `packages/url4/tests/unit/test_jobs_port.py` — new RED test guarding the docstring against a revert.
- `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` — comment only: fix the same false claim at the 503 mapping.

## Gates

- url4: ruff check/format pass, pyright 0 errors, pytest 1167 passed, cov 97.55% (>= 95)
- engine: ruff check/format pass, pyright 0 errors, check_layering OK, pytest 2283 passed / 5 skipped, cov 91.66% (>= 80)

Refs: OME-1087