### PR TITLE
feat(engine): add the durable run queue (OME-1088)

### DIFF
--- a/.github/workflows/screamingface-engine-tests.yml
+++ b/.github/workflows/screamingface-engine-tests.yml
@@ -117,7 +117,8 @@ jobs:
           uv run pytest -v \
             tests/unit/test_stream_contract.py \
             tests/unit/test_attach_from_sequence_bounds.py \
-            tests/unit/test_jetstream_subscribe_ensures_stream.py
+            tests/unit/test_jetstream_subscribe_ensures_stream.py \
+            tests/integration/test_run_queue_roundtrip.py
       # A skip here means the probe did not find the broker and the job proved nothing.
       - name: Fail if the real-broker parameters were skipped
         run: |

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -15,6 +15,7 @@ from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy, DiscardPolicy,
 from nats.js.errors import APIError, BadRequestError, NotFoundError
 from pydantic import ValidationError
 
+from screamingface_engine import subjects
 from screamingface_engine.subjects import owns_stream, stream_for, subject_for, topic_of
 from url4.streaming.codec import decode, encode
 from url4.streaming.interfaces import (
@@ -114,12 +115,18 @@ class _JetStreamConnection:
         stream_max_bytes: int = DEFAULT_STREAM_MAX_BYTES,
         orphan_grace_s: float = DEFAULT_ORPHAN_GRACE_S,
         never_started_s: float = DEFAULT_NEVER_STARTED_S,
+        run_queue_stream: str = subjects.RUN_QUEUE_STREAM,
     ) -> None:
         self._url = nats_url
         self._stream_max_age_s = stream_max_age_s
         self._stream_max_bytes = stream_max_bytes
         self._orphan_grace_s = orphan_grace_s
         self._never_started_s = never_started_s
+        # The queue stream THIS connection's sweep must never touch. Composition roots pass
+        # the CONFIGURED name (`Settings.run_queue_stream`); the default keeps tests and the
+        # default deployment on the constant. A sweep armed with a stale constant against a
+        # renamed queue deletes the one stream an accepted run may not be lost from.
+        self._run_queue_stream = run_queue_stream
         self._nc: Client | None = None
         self._js: JetStreamContext | None = None
         self._ensured: set[str] = set()
@@ -211,7 +218,7 @@ class _JetStreamConnection:
         freed: list[str] = []
         for info in await self._all_streams(js):
             name = info.config.name
-            if name is None or not owns_stream(name):
+            if name is None or not owns_stream(name, run_queue_stream=self._run_queue_stream):
                 continue
             if not await self._is_orphan(js, info):
                 continue
@@ -406,6 +413,7 @@ class JetStreamPublisher(_JetStreamConnection, EventPublisher):
         stream_max_bytes: int = DEFAULT_STREAM_MAX_BYTES,
         orphan_grace_s: float = DEFAULT_ORPHAN_GRACE_S,
         never_started_s: float = DEFAULT_NEVER_STARTED_S,
+        run_queue_stream: str = subjects.RUN_QUEUE_STREAM,
     ) -> None:
         # Forwarded explicitly rather than through `**kwargs`: the base takes one `int` among
         # its floats, so a single widened annotation cannot type-check, and the alternative
@@ -416,6 +424,7 @@ class JetStreamPublisher(_JetStreamConnection, EventPublisher):
             stream_max_bytes=stream_max_bytes,
             orphan_grace_s=orphan_grace_s,
             never_started_s=never_started_s,
+            run_queue_stream=run_queue_stream,
         )
         # A dict used as an ORDERED set. Insertion order is publish order, and `_reap` keeps
         # the first failure — meaning the one on the earliest-published frame. A plain `set`

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -74,9 +74,10 @@ _MAX_STREAM_PAGES = 100
 _MAX_ENSURED_MEMO = 4096
 
 
-def _consumer_config(from_sequence: int | None) -> ConsumerConfig:
-    """Replays from the start of the stream when `from_sequence` is None, else resumes at that
-    1-based stream sequence (attach/resume, spec §8).
+def _broadcast_consumer_config(from_sequence: int | None) -> ConsumerConfig:
+    """The broadcast replay reader's config: replays from the start of the stream when
+    `from_sequence` is None, else resumes at that 1-based stream sequence (attach/resume, spec
+    §8).
 
     INVARIANT: `ack_policy` is NONE, and this is load-bearing rather than a default worth
     inheriting. These consumers are broadcast replay readers — nothing here can act on a
@@ -85,6 +86,9 @@ def _consumer_config(from_sequence: int | None) -> ConsumerConfig:
     anything (nats-py only auto-acks the callback path), which means every frame is redelivered
     after AckWait and delivery stops outright once `max_ack_pending` (server default 1000)
     unacked messages pile up — i.e. any run over ~1000 frames silently truncates mid-stream.
+
+    The run queue's consumer is the OPPOSITE of this in every way that matters; it has its own
+    builder in `runner_queue` (OME-1088).
     """
     if from_sequence is None:
         return ConsumerConfig(deliver_policy=DeliverPolicy.ALL, ack_policy=AckPolicy.NONE)
@@ -352,7 +356,7 @@ class JetStreamConsumer(_JetStreamConnection, EventConsumer):
         sub = await js.subscribe(
             subject_for(topic),
             stream=stream_for(topic),
-            config=_consumer_config(from_sequence),
+            config=_broadcast_consumer_config(from_sequence),
         )
         # WHY: the caller may abandon this generator mid-run (a re-attach cancels the WS pump, a
         # sync GET gives up at `sync_max_wait_s`). Without the unsubscribe the push consumer keeps

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -6,7 +6,7 @@ from typing import Literal, Self
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from screamingface_engine import job_env
+from screamingface_engine import job_env, runner_queue, subjects
 
 # WHY a margin at all: the App decides a token is expired from its own clock, while the k8s TTL
 # controller deletes the Job from the control plane's. Without slack a skewed pair could reclaim
@@ -251,6 +251,37 @@ class Settings(BaseSettings):
     # it re-opens replay for that topic — but only for as long as the token is still usable.
     # See `effective_job_ttl_s` and `_reject_replayable_job_ttl`. None => derive the floor.
     job_ttl_s: int | None = None
+
+    # --- durable run queue (OME-1088) -------------------------------------------------------
+    # WHY a queue at all: OME-1086 replaces one-Job-per-run scheduling with a fixed worker pool
+    # pulling from a durable work queue. THIS unit adds the queue substrate only — no worker,
+    # no cutover — so these settings are the substrate's knobs, not the worker's.
+    #
+    # INVARIANT: the stream name must NOT begin with `url4-cloud_` — `_sweep_orphans` deletes
+    # any stream `owns_stream()` accepts, and the queue is the one stream an accepted run may
+    # not be lost from. `subjects.owns_stream` excludes it explicitly; the default here is the
+    # same constant, so the two cannot drift.
+    run_queue_stream: str = subjects.RUN_QUEUE_STREAM
+    run_queue_subject_prefix: str = subjects.RUN_QUEUE_SUBJECT_PREFIX
+    # WHY a window at all: a retried submission (a client retrying a timed-out request) must
+    # not become a second run. The broker deduplicates `Nats-Msg-Id` within this window; 120s
+    # is far beyond any retry interval and far below the queue's own lifetime.
+    run_queue_duplicate_window_s: float = runner_queue.DEFAULT_DUPLICATE_WINDOW_S
+    # WHY a backstop and not a correctness mechanism: `max_age` is the storage backstop for a
+    # run nobody ever pulled (a worker outage). It must be GENEROUS — an accepted run may not
+    # be lost, and the queue is the only record of it.
+    run_queue_max_age_s: float = runner_queue.DEFAULT_QUEUE_MAX_AGE_S
+    run_queue_ack_wait_s: float = runner_queue.DEFAULT_ACK_WAIT_S
+    run_queue_max_deliver: int = runner_queue.DEFAULT_MAX_DELIVER
+    # WHY replicas × worker_slots: `max_ack_pending` bounds how many unacked messages one
+    # worker may hold; with `QUEUE_REPLICAS` replicas of the stream and `worker_slots` runs per
+    # worker, that is the most a single worker can legitimately have in flight.
+    run_queue_worker_slots: int = runner_queue.DEFAULT_WORKER_SLOTS
+    run_queue_max_ack_pending: int = runner_queue.DEFAULT_MAX_ACK_PENDING
+    # WHY a ceiling at all: the serving half must stop accepting when the queue is deeper than
+    # the fleet can drain in a reasonable time, rather than piling up unbounded work. THIS unit
+    # only declares the setting; the admission decision lands with the cutover (OME-1086).
+    run_queue_depth_ceiling: int = runner_queue.DEFAULT_DEPTH_CEILING
 
     @property
     def effective_job_ttl_s(self) -> int:

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -274,6 +274,16 @@ class Settings(BaseSettings):
     # run nobody ever pulled (a worker outage). It must be GENEROUS — an accepted run may not
     # be lost, and the queue is the only record of it.
     run_queue_max_age_s: float = runner_queue.DEFAULT_QUEUE_MAX_AGE_S
+    # WHY a setting and not the constant alone: the replica count is a property of the BROKER's
+    # topology, which this code cannot see. A single-node broker refuses `replicas > 1` outright
+    # with `ServerError 10074` — and that is not a `BadRequestError`, so `ensure_stream` does not
+    # tolerate it: it escapes into the worker's claim loop, which logs and retries forever while
+    # every run is refused. The seam existed from the start; without this field nothing could
+    # reach it, so the constraint was expressible only in tests.
+    #
+    # INVARIANT: the default IS `QUEUE_REPLICAS`, so a deployment that states nothing gets
+    # exactly what `RunQueue` would have used on its own — the two cannot drift.
+    run_queue_replicas: int = Field(default=runner_queue.QUEUE_REPLICAS, ge=1)
     run_queue_ack_wait_s: float = runner_queue.DEFAULT_ACK_WAIT_S
     run_queue_max_deliver: int = runner_queue.DEFAULT_MAX_DELIVER
     # WHY replicas × worker_slots: `max_ack_pending` bounds how many unacked messages one

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -260,7 +260,10 @@ class Settings(BaseSettings):
     # INVARIANT: the stream name must NOT begin with `url4-cloud_` — `_sweep_orphans` deletes
     # any stream `owns_stream()` accepts, and the queue is the one stream an accepted run may
     # not be lost from. `subjects.owns_stream` excludes it explicitly; the default here is the
-    # same constant, so the two cannot drift.
+    # same constant, so the two cannot drift. The invariant is ENFORCED below by
+    # `_reject_sweepable_run_queue_stream` (review follow-up V-8): a comment could not stop an
+    # operator or a composition root from naming the queue into the sweepable prefix, and the
+    # exclusion in `owns_stream` only holds where the CONFIGURED name actually reaches it.
     run_queue_stream: str = subjects.RUN_QUEUE_STREAM
     run_queue_subject_prefix: str = subjects.RUN_QUEUE_SUBJECT_PREFIX
     # WHY a window at all: a retried submission (a client retrying a timed-out request) must
@@ -309,6 +312,26 @@ class Settings(BaseSettings):
         if self.job_ttl_s is not None:
             return self.job_ttl_s
         return self.iat_window_s + _TTL_SKEW_MARGIN_S
+
+    @field_validator("run_queue_stream")
+    @classmethod
+    def _reject_sweepable_run_queue_stream(cls, value: str) -> str:
+        """Refuse a queue stream named under the per-run `url4-cloud_` prefix.
+
+        The reclamation sweep deletes every stream `owns_stream()` accepts; a queue so
+        named is one rejected publish away from being deleted with an accepted run on it.
+        The exact-name exclusion in `owns_stream` guards the sites that RECEIVE the
+        configured name; this validator makes the hazard impossible at its source, so a
+        wiring gap (a site built from the default constant) can only ever produce a
+        split — loud — never a swept queue.
+        """
+        if value.startswith(f"{subjects.PREFIX}_"):
+            raise ValueError(
+                "run_queue_stream must not live under the per-run prefix 'url4-cloud_': "
+                "the orphan sweep deletes any stream it owns, and the queue is the one "
+                "stream an accepted run may not be lost from"
+            )
+        return value
 
     @field_validator("artifacts_dir", mode="before")
     @classmethod

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -277,6 +277,11 @@ class Settings(BaseSettings):
     # worker may hold; with `QUEUE_REPLICAS` replicas of the stream and `worker_slots` runs per
     # worker, that is the most a single worker can legitimately have in flight.
     run_queue_worker_slots: int = runner_queue.DEFAULT_WORKER_SLOTS
+    # WHY fleet-sized: `max_ack_pending` is a WHOLE-CONSUMER bound — the total unacked
+    # messages the queue's durable consumer may hand out across EVERY worker in the fleet,
+    # not a per-worker limit. Size it to the deployment's true fleet concurrency
+    # (worker pods × slots); note the value binds at consumer CREATION, so changing it on a
+    # running queue means deleting and recreating the consumer.
     run_queue_max_ack_pending: int = runner_queue.DEFAULT_MAX_ACK_PENDING
     # WHY a ceiling at all: the serving half must stop accepting when the queue is deeper than
     # the fleet can drain in a reasonable time, rather than piling up unbounded work. THIS unit

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -290,6 +290,13 @@ class RunQueue:
         )
         try:
             return await sub.fetch(batch, timeout=timeout_s)
+        except TimeoutError:
+            # INVARIANT: an idle poll is a RESULT, not an error. nats-py's `fetch` RAISES
+            # `nats.errors.TimeoutError` (or its `FetchTimeoutError` subclass) when no
+            # message arrives within the window — it never returns an empty list — and
+            # both subclass `TimeoutError`. Left uncaught, the first empty poll unwinds
+            # the worker's claim loop and kills the pool on an idle queue.
+            return []
         finally:
             await sub.unsubscribe()
 
@@ -319,10 +326,19 @@ class RunQueue:
 
     async def oldest_age(self) -> float | None:
         """Seconds since the oldest queued run was published; `None` when the queue is empty."""
-        _, first_ts = await self._state()
-        if first_ts is None:
+        messages, first_ts = await self._state()
+        # WHY the message COUNT is the emptiness signal: the server always sends a
+        # `first_ts`, answering an EMPTY stream with the Go zero time
+        # ("0001-01-01T00:00:00Z"), which `fromisoformat` parses happily. A `None`-only
+        # check reads that as a ~6.4e10-second age and the idle-queue alert fires
+        # permanently on every drained queue.
+        if not messages or first_ts is None:
             return None
         ts = datetime.fromisoformat(first_ts)
+        # Belt-and-braces for a response that disagrees with itself (messages > 0 with
+        # a zero time): no real run was published in year 1.
+        if ts.year <= 1:
+            return None
         return (datetime.now(UTC) - ts).total_seconds()
 
     async def close(self) -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -1,0 +1,349 @@
+"""The durable run queue (OME-1088): the substrate OME-1086's fixed worker pool pulls from.
+
+One JetStream stream (`url4-runq`, `retention=WorkQueue`, file storage, 3 replicas) holds every
+accepted-but-not-yet-started run. Publishing sets `Nats-Msg-Id` to the run's topic, so the
+broker deduplicates a retried submission within `duplicate_window` — the queue's
+`JobAlreadyExists` equivalent, with no lookup table. A durable PULL consumer (`url4-runners`)
+with EXPLICIT acks hands messages to workers; an unacked message is redelivered after
+`ack_wait`, up to `max_deliver` times, so a worker that dies mid-run loses the run's PROGRESS,
+never the run itself.
+
+LAYERING: this module is imported by BOTH the serving half (which publishes) and the future
+worker half (which pulls), so it imports nothing from the run half — only the shared leaves
+(`job_env`, `subjects`, `adapters.jetstream`) and the broker client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+
+import nats
+from nats.aio.client import Client
+from nats.aio.msg import Msg
+from nats.js import JetStreamContext
+from nats.js.api import AckPolicy, ConsumerConfig, RetentionPolicy, StorageType
+from nats.js.errors import BadRequestError
+
+from screamingface_engine import job_env, subjects
+from url4.streaming.protocol import CachePolicy
+from url4.streaming.trace import valid_traceparent
+
+logger = logging.getLogger(__name__)
+
+# The queue is a SINGLETON — one stream for every run, unlike the per-run event streams — so
+# its properties are constants here rather than per-topic derivations.
+QUEUE_REPLICAS = 3
+QUEUE_CONSUMER = "url4-runners"
+DEFAULT_DUPLICATE_WINDOW_S = 120.0
+DEFAULT_QUEUE_MAX_AGE_S = 86_400.0
+DEFAULT_ACK_WAIT_S = 60.0
+DEFAULT_MAX_DELIVER = 2
+DEFAULT_WORKER_SLOTS = 4
+DEFAULT_MAX_ACK_PENDING = QUEUE_REPLICAS * DEFAULT_WORKER_SLOTS
+DEFAULT_DEPTH_CEILING = 10_000
+DEFAULT_IO_CONCURRENCY = 4
+DEFAULT_STATE_CACHE_TTL_S = 2.0
+
+
+def _work_queue_consumer_config(
+    *, ack_wait_s: float, max_deliver: int, max_ack_pending: int
+) -> ConsumerConfig:
+    """The durable PULL consumer's config: EXPLICIT acks with bounded redelivery.
+
+    The opposite of the event streams' broadcast replay config (`AckPolicy.NONE`,
+    `adapters.jetstream._broadcast_consumer_config`) in every way that matters: the queue's
+    consumer is a WORKER, not a replay reader — it acks each message once it is processed, and
+    a worker that dies mid-run must get the message redelivered (`max_deliver`) rather than
+    silently lost. `max_ack_pending` bounds how many unacked messages one worker may hold,
+    which is what lets several workers share one durable consumer without one hoarding the
+    queue.
+    """
+    return ConsumerConfig(
+        ack_policy=AckPolicy.EXPLICIT,
+        max_deliver=max_deliver,
+        ack_wait=ack_wait_s,
+        max_ack_pending=max_ack_pending,
+    )
+
+
+# --- the message codec: ONE encoding, through `job_env` --------------------------------------
+# The message body is exactly the per-run env mapping `K8sJobRunner._env` writes onto a Job.
+# Both sides render through `job_env`'s renderers, so there is no second encoding to drift;
+# `test_run_queue_codec.py` pins the two mappings identical.
+
+
+def _env_mapping(
+    topic: str,
+    url4: str,
+    deadline_s: int,
+    *,
+    traceparent: str | None = None,
+    profile: str | None = None,
+    identity: Mapping[str, str] | None = None,
+    cache: CachePolicy | None = None,
+    io_concurrency: int = DEFAULT_IO_CONCURRENCY,
+    extra_models: Sequence[str] = (),
+) -> dict[str, str]:
+    """The per-run env mapping a queue message carries, keyed by env name.
+
+    Mirrors `K8sJobRunner._env` entry for entry: the same constants, the same renderers, the
+    same silence rules (an invalid traceparent is dropped, an unstated cache policy renders
+    nothing, an empty overlay renders an explicit empty `EXTRA_MODELS`).
+    """
+    env: dict[str, str] = {
+        job_env.TOPIC: topic,
+        job_env.EXPRESSION: url4,
+        job_env.JOB_DEADLINE_S: str(deadline_s),
+        job_env.STREAM_GRACE_S: str(job_env.DEFAULT_STREAM_GRACE_S),
+    }
+    forwarded = valid_traceparent(traceparent)
+    if forwarded is not None:
+        env[job_env.TRACEPARENT] = forwarded
+    if profile is not None:
+        env[job_env.AIGATEWAY_PROFILE] = profile
+    env.update(job_env.identity_to_env(identity or {}))
+    env.update(job_env.cache_policy_to_env(cache))
+    env[job_env.EXTRA_MODELS] = job_env.extra_models_to_env(extra_models).get(
+        job_env.EXTRA_MODELS, ""
+    )
+    env[job_env.IO_CONCURRENCY] = str(io_concurrency)
+    return env
+
+
+def encode_message(
+    topic: str,
+    url4: str,
+    deadline_s: int,
+    *,
+    traceparent: str | None = None,
+    profile: str | None = None,
+    identity: Mapping[str, str] | None = None,
+    cache: CachePolicy | None = None,
+    io_concurrency: int = DEFAULT_IO_CONCURRENCY,
+    extra_models: Sequence[str] = (),
+) -> bytes:
+    """Encode a run submission as the queue message body: the per-run env mapping, JSON."""
+    return json.dumps(
+        _env_mapping(
+            topic,
+            url4,
+            deadline_s,
+            traceparent=traceparent,
+            profile=profile,
+            identity=identity,
+            cache=cache,
+            io_concurrency=io_concurrency,
+            extra_models=extra_models,
+        ),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def decode_message(payload: bytes) -> dict[str, str]:
+    """Decode a queue message body back into the per-run env mapping."""
+    return json.loads(payload.decode("utf-8"))
+
+
+def topic_of_message(payload: bytes) -> str:
+    """The run's topic, read from the message body — the dedupe key.
+
+    WHY read from the body rather than a separate argument: the codec is the single source of
+    truth, so the dedupe key can never disagree with the run the message actually describes.
+    """
+    return decode_message(payload)[job_env.TOPIC]
+
+
+class RunQueue:
+    """The durable, deduplicating run queue: publish on the serving side, pull on the worker
+    side, both against one JetStream stream.
+
+    WHY a fresh connection story rather than reusing `_JetStreamConnection`: that class is
+    per-topic-stream machinery (ensure/declare/sweep/delete keyed by topic) the queue must not
+    inherit — the queue is ONE stream for every run. The lazy, locked, reconnectable connection
+    is the only part worth sharing, and it is small enough to state here.
+    """
+
+    def __init__(
+        self,
+        nats_url: str,
+        *,
+        stream: str = subjects.RUN_QUEUE_STREAM,
+        subject: str = subjects.RUN_QUEUE_SUBJECT,
+        duplicate_window_s: float = DEFAULT_DUPLICATE_WINDOW_S,
+        max_age_s: float = DEFAULT_QUEUE_MAX_AGE_S,
+        ack_wait_s: float = DEFAULT_ACK_WAIT_S,
+        max_deliver: int = DEFAULT_MAX_DELIVER,
+        max_ack_pending: int = DEFAULT_MAX_ACK_PENDING,
+        state_cache_ttl_s: float = DEFAULT_STATE_CACHE_TTL_S,
+        # WHY a parameter at all: a single-node broker (local dev, the CI conformance job)
+        # refuses `replicas > 1` outright, so the real-broker tests must be able to declare the
+        # stream with one replica. Production keeps the spec's 3; the unit suite pins that.
+        replicas: int = QUEUE_REPLICAS,
+    ) -> None:
+        self._url = nats_url
+        self._stream = stream
+        self._subject = subject
+        self._duplicate_window_s = duplicate_window_s
+        self._max_age_s = max_age_s
+        self._ack_wait_s = ack_wait_s
+        self._max_deliver = max_deliver
+        self._max_ack_pending = max_ack_pending
+        self._state_cache_ttl_s = state_cache_ttl_s
+        self._replicas = replicas
+        self._nc: Client | None = None
+        self._js: JetStreamContext | None = None
+        self._connect_lock = asyncio.Lock()
+        self._ensured = False
+        # (monotonic time of the read, (depth, first_ts)) — see `_state`.
+        self._state_cache: tuple[float, tuple[int, str | None]] | None = None
+
+    async def _jetstream(self) -> JetStreamContext:
+        js = self._js
+        if js is not None and not self._is_closed():
+            return js
+        async with self._connect_lock:
+            js = self._js
+            if js is not None and not self._is_closed():
+                return js
+            nc = await nats.connect(self._url)
+            self._nc = nc
+            js = nc.jetstream()
+            self._js = js
+            # The declarations belonged to the connection that just died; the new one has none.
+            self._ensured = False
+            return js
+
+    def _is_closed(self) -> bool:
+        nc = self._nc
+        return nc is not None and nc.is_closed
+
+    async def ensure_stream(self) -> None:
+        """Declare the queue stream, tolerating one that already exists.
+
+        INVARIANT: unlike the per-run event streams, the queue is a SINGLETON — one stream for
+        every run — so this is a plain idempotent flag rather than the per-topic memo the event
+        adapters keep.
+        """
+        if self._ensured:
+            return
+        js = await self._jetstream()
+        try:
+            await js.add_stream(
+                name=self._stream,
+                subjects=[self._subject],
+                retention=RetentionPolicy.WORK_QUEUE,
+                storage=StorageType.FILE,
+                num_replicas=self._replicas,
+                max_age=self._max_age_s,
+                duplicate_window=self._duplicate_window_s,
+            )
+        except BadRequestError:
+            # Already declared — by another replica, or by an earlier connection.
+            pass
+        self._ensured = True
+
+    async def publish(self, message: bytes) -> None:
+        """Publish one run submission, durably.
+
+        INVARIANT: `Nats-Msg-Id` is the run's TOPIC, read from the message body itself, so a
+        retried submission of the same topic is deduplicated by the broker within
+        `duplicate_window` — the queue's `JobAlreadyExists` equivalent, with no lookup table.
+        The acknowledgement is awaited: the caller must know the run was durably accepted
+        before it tells the client so.
+        """
+        await self.ensure_stream()
+        js = await self._jetstream()
+        await js.publish(
+            self._subject,
+            message,
+            headers={"Nats-Msg-Id": topic_of_message(message)},
+        )
+
+    async def pull(self, batch: int, timeout_s: float) -> list[Msg]:
+        """Pull up to `batch` queued messages, waiting up to `timeout_s` for the first.
+
+        Returns the raw NATS messages; the caller acks each after processing. Under the
+        EXPLICIT ack policy an unacked message is redelivered after `ack_wait`, up to
+        `max_deliver` times.
+
+        WHY a fresh subscription per call: the durable consumer (`url4-runners`) is server-side
+        and persists, so binding and unbinding a client subscription per pull is idempotent and
+        costs one `consumer_info` round trip. A worker that wants to avoid even that can hold
+        the subscription itself.
+        """
+        await self.ensure_stream()
+        js = await self._jetstream()
+        sub = await js.pull_subscribe(
+            self._subject,
+            durable=QUEUE_CONSUMER,
+            stream=self._stream,
+            config=_work_queue_consumer_config(
+                ack_wait_s=self._ack_wait_s,
+                max_deliver=self._max_deliver,
+                max_ack_pending=self._max_ack_pending,
+            ),
+        )
+        try:
+            return await sub.fetch(batch, timeout=timeout_s)
+        finally:
+            await sub.unsubscribe()
+
+    async def _state(self) -> tuple[int, str | None]:
+        """(queued message count, first message's publish timestamp) from one stream-info round
+        trip, cached for `state_cache_ttl_s`.
+
+        WHY the raw API request rather than `js.stream_info`: nats-py's `StreamState` drops
+        `first_ts` (the server sends it; the dataclass does not model it), and `oldest_age`
+        needs exactly that field. The raw response is the only path to it, so one request
+        serves both signals.
+        """
+        now = time.monotonic()
+        if self._state_cache is not None and now - self._state_cache[0] < self._state_cache_ttl_s:
+            return self._state_cache[1]
+        js = await self._jetstream()
+        resp = await js._api_request(f"{js._prefix}.STREAM.INFO.{self._stream}", b"")
+        state = resp.get("state", {})
+        result = (int(state.get("messages", 0)), state.get("first_ts"))
+        self._state_cache = (now, result)
+        return result
+
+    async def depth(self) -> int:
+        """How many runs are queued but not yet started (cached ~`state_cache_ttl_s`)."""
+        messages, _ = await self._state()
+        return messages
+
+    async def oldest_age(self) -> float | None:
+        """Seconds since the oldest queued run was published; `None` when the queue is empty."""
+        _, first_ts = await self._state()
+        if first_ts is None:
+            return None
+        ts = datetime.fromisoformat(first_ts)
+        return (datetime.now(UTC) - ts).total_seconds()
+
+    async def close(self) -> None:
+        if self._nc is not None:
+            await self._nc.close()
+
+
+__all__ = [
+    "DEFAULT_ACK_WAIT_S",
+    "DEFAULT_DEPTH_CEILING",
+    "DEFAULT_DUPLICATE_WINDOW_S",
+    "DEFAULT_IO_CONCURRENCY",
+    "DEFAULT_MAX_ACK_PENDING",
+    "DEFAULT_MAX_DELIVER",
+    "DEFAULT_QUEUE_MAX_AGE_S",
+    "DEFAULT_STATE_CACHE_TTL_S",
+    "DEFAULT_WORKER_SLOTS",
+    "QUEUE_CONSUMER",
+    "QUEUE_REPLICAS",
+    "RunQueue",
+    "decode_message",
+    "encode_message",
+    "topic_of_message",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -158,6 +158,19 @@ def topic_of_message(payload: bytes) -> str:
     return decode_message(payload)[job_env.TOPIC]
 
 
+STREAM_NAME_IN_USE = 10058
+"""JetStream's err_code for "stream name already in use" — the ONE `BadRequestError` the
+queue treats as benign. The type alone cannot say: the server answers a real configuration
+conflict (retention, storage, replicas diverged — an operator edit, or a version-skewed
+rolling deploy) with the SAME 400 type. Swallowing that would run the queue on settings
+nobody agreed to, silently — so only this code is "already declared"; anything else raises."""
+
+
+def _is_stream_name_in_use(exc: BadRequestError) -> bool:
+    """Whether a `BadRequestError` from `add_stream` is the benign name-in-use case."""
+    return getattr(exc, "err_code", None) == STREAM_NAME_IN_USE
+
+
 class RunQueue:
     """The durable, deduplicating run queue: publish on the serving side, pull on the worker
     side, both against one JetStream stream.
@@ -242,7 +255,12 @@ class RunQueue:
                 max_age=self._max_age_s,
                 duplicate_window=self._duplicate_window_s,
             )
-        except BadRequestError:
+        except BadRequestError as exc:
+            if not _is_stream_name_in_use(exc):
+                # A config conflict wearing the same type — retention, storage, or replicas
+                # diverged from what this code declares. NOT "already declared": raising here
+                # surfaces the mismatch at startup instead of running on it silently.
+                raise
             # Already declared — by another replica, or by an earlier connection.
             pass
         self._ensured = True

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -44,7 +44,15 @@ DEFAULT_QUEUE_MAX_AGE_S = 86_400.0
 DEFAULT_ACK_WAIT_S = 60.0
 DEFAULT_MAX_DELIVER = 2
 DEFAULT_WORKER_SLOTS = 4
-DEFAULT_MAX_ACK_PENDING = QUEUE_REPLICAS * DEFAULT_WORKER_SLOTS
+# WHY fleet-sized and not `replicas × slots`: `max_ack_pending` is a WHOLE-CONSUMER bound —
+# the total unacked messages the one durable consumer may hand out across EVERY puller in the
+# fleet — not a per-worker limit. Deriving it from the stream's data-redundancy replica count
+# conflated two unrelated numbers and silently capped the whole fleet at 12 in-flight runs.
+# The default is sized for a fleet (32 pods × 8 slots, with headroom); deployments that size
+# differently must set `run_queue_max_ack_pending` to their fleet's true concurrency. NOTE:
+# the value binds when the consumer is CREATED — `pull_subscribe` is idempotent on existence,
+# not on config, so changing it on a running queue means deleting and recreating the consumer.
+DEFAULT_MAX_ACK_PENDING = 256
 DEFAULT_DEPTH_CEILING = 10_000
 DEFAULT_IO_CONCURRENCY = 4
 DEFAULT_STATE_CACHE_TTL_S = 2.0
@@ -273,13 +281,21 @@ class RunQueue:
         `duplicate_window` — the queue's `JobAlreadyExists` equivalent, with no lookup table.
         The acknowledgement is awaited: the caller must know the run was durably accepted
         before it tells the client so.
+
+        The publish also stamps `Url4-Enqueued-At` (see `subjects.ENQUEUED_AT_HEADER`): the
+        wall-clock acceptance moment. JetStream's delivery metadata carries only the PULL
+        timestamp, so the claim-time "waited past its deadline" check would otherwise measure
+        an always-fresh ~0 and never fire for exactly the backlogged runs it exists to catch.
         """
         await self.ensure_stream()
         js = await self._jetstream()
         await js.publish(
             self._subject,
             message,
-            headers={"Nats-Msg-Id": topic_of_message(message)},
+            headers={
+                "Nats-Msg-Id": topic_of_message(message),
+                subjects.ENQUEUED_AT_HEADER: datetime.now(UTC).isoformat(),
+            },
         )
 
     async def pull(self, batch: int, timeout_s: float) -> list[Msg]:
@@ -326,6 +342,11 @@ class RunQueue:
         `first_ts` (the server sends it; the dataclass does not model it), and `oldest_age`
         needs exactly that field. The raw response is the only path to it, so one request
         serves both signals.
+
+        The dependency on the PRIVATE surface (`_api_request`, `_prefix`) is pinned by
+        `test_nats_private_api_surface.py`: a `uv lock` bump that renames either — or a
+        release that finally models `first_ts` on `StreamState` — fails that test loudly at
+        CI instead of surfacing as admission logic silently misbehaving at runtime.
         """
         now = time.monotonic()
         if self._state_cache is not None and now - self._state_cache[0] < self._state_cache_ttl_s:

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -1,7 +1,8 @@
 """The durable run queue (OME-1088): the substrate OME-1086's fixed worker pool pulls from.
 
-One JetStream stream (`url4-runq`, `retention=WorkQueue`, file storage, 3 replicas) holds every
-accepted-but-not-yet-started run. Publishing sets `Nats-Msg-Id` to the run's topic, so the
+One JetStream stream (`url4-runq`, `retention=WorkQueue`, file storage) holds every
+accepted-but-not-yet-started run; its replica count is configuration, not a constant — see
+`QUEUE_REPLICAS`. Publishing sets `Nats-Msg-Id` to the run's topic, so the
 broker deduplicates a retried submission within `duplicate_window` — the queue's
 `JobAlreadyExists` equivalent, with no lookup table. A durable PULL consumer (`url4-runners`)
 with EXPLICIT acks hands messages to workers; an unacked message is redelivered after
@@ -37,7 +38,20 @@ logger = logging.getLogger(__name__)
 
 # The queue is a SINGLETON — one stream for every run, unlike the per-run event streams — so
 # its properties are constants here rather than per-topic derivations.
-QUEUE_REPLICAS = 3
+#
+# WHY 1 and not the spec's 3 (owner decision, 2026-09-03): a single-node broker refuses
+# `replicas > 1` outright with `ServerError 10074`, and single-node is what the chart's own
+# bundled NATS subchart ships, what local dev runs, and what the CI conformance job runs. That
+# error is not a `BadRequestError`, so `ensure_stream` does not tolerate it — it escapes into
+# the worker's claim loop, which logs and retries forever while every run is refused. A default
+# that cannot declare its own stream on the broker the chart bundles is the wrong default.
+#
+# The durability this gives up is smaller than it looks: the per-run event streams are already
+# declared at JetStream's default of one replica (`adapters/jetstream.py`), so a 3-replica queue
+# on an otherwise 1-replica bus hardened only the queued-not-started window. Clustering — and
+# with it a defensible multi-replica posture for BOTH stream families — is OME-1093's scope;
+# raising this is a `run_queue_replicas` setting away, no code change.
+QUEUE_REPLICAS = 1
 QUEUE_CONSUMER = "url4-runners"
 DEFAULT_DUPLICATE_WINDOW_S = 120.0
 DEFAULT_QUEUE_MAX_AGE_S = 86_400.0
@@ -201,9 +215,11 @@ class RunQueue:
         max_deliver: int = DEFAULT_MAX_DELIVER,
         max_ack_pending: int = DEFAULT_MAX_ACK_PENDING,
         state_cache_ttl_s: float = DEFAULT_STATE_CACHE_TTL_S,
-        # WHY a parameter at all: a single-node broker (local dev, the CI conformance job)
-        # refuses `replicas > 1` outright, so the real-broker tests must be able to declare the
-        # stream with one replica. Production keeps the spec's 3; the unit suite pins that.
+        # WHY a parameter at all: the replica count is a property of the BROKER's topology, not
+        # of this code — a single-node broker refuses `replicas > 1` outright. Every composition
+        # root feeds this from `Settings.run_queue_replicas`, which the chart renders, so a
+        # clustered deployment raises it without touching Python. The default is single-node
+        # safe; see `QUEUE_REPLICAS`.
         replicas: int = QUEUE_REPLICAS,
     ) -> None:
         self._url = nats_url

--- a/apps/screamingface-engine/src/screamingface_engine/subjects.py
+++ b/apps/screamingface-engine/src/screamingface_engine/subjects.py
@@ -20,6 +20,15 @@ RUN_QUEUE_STREAM = "url4-runq"
 RUN_QUEUE_SUBJECT_PREFIX = "url4-runq"
 RUN_QUEUE_SUBJECT = f"{RUN_QUEUE_SUBJECT_PREFIX}.work"
 
+# The publish-time stamp on every queued run (OME-1088): the wall-clock moment the
+# submission was accepted onto the queue. JetStream's own message metadata records only
+# the DELIVERY timestamp — the moment a worker pulled it — so "how long has this run
+# waited?" (the deadline-expiry drop at claim time) is unanswerable from the metadata.
+# The publisher stamps this header; the worker reads it back. A message without the
+# header (published before the stamp existed) falls back to the delivery timestamp —
+# the pre-stamp semantics, never worse.
+ENQUEUED_AT_HEADER = "Url4-Enqueued-At"
+
 
 def subject_for(topic: str) -> str:
     return f"{PREFIX}.{topic}"
@@ -29,7 +38,7 @@ def stream_for(topic: str) -> str:
     return f"{PREFIX}_{topic}"
 
 
-def owns_stream(stream_name: str) -> bool:
+def owns_stream(stream_name: str, *, run_queue_stream: str = RUN_QUEUE_STREAM) -> bool:
     """Whether a stream on the broker is one of ours.
 
     INVARIANT: the NATS store may be shared with other workloads. Reclamation enumerates every
@@ -40,8 +49,13 @@ def owns_stream(stream_name: str) -> bool:
     accepts. It is named outside the per-run prefix (`url4-runq` does not start with
     `url4-cloud_`), and it is ALSO excluded explicitly here, so a future rename of either side
     cannot silently re-arm the sweep against it.
+
+    The exclusion follows the CONFIGURED queue stream, not the default constant: the name is
+    a Settings field (`run_queue_stream`), and an operator who renames the queue must not have
+    the sweep re-armed against the renamed stream by a stale constant. Composition roots pass
+    their configured name; the default keeps tests and the default deployment on the constant.
     """
-    if stream_name == RUN_QUEUE_STREAM:
+    if stream_name == run_queue_stream:
         return False
     return stream_name.startswith(f"{PREFIX}_")
 
@@ -52,6 +66,7 @@ def topic_of(stream_name: str) -> str:
 
 
 __all__ = [
+    "ENQUEUED_AT_HEADER",
     "RUN_QUEUE_STREAM",
     "RUN_QUEUE_SUBJECT",
     "RUN_QUEUE_SUBJECT_PREFIX",

--- a/apps/screamingface-engine/src/screamingface_engine/subjects.py
+++ b/apps/screamingface-engine/src/screamingface_engine/subjects.py
@@ -12,6 +12,14 @@ from __future__ import annotations
 
 PREFIX = "url4-cloud"
 
+# The durable run queue (OME-1088): ONE stream for every run, unlike the per-run event streams,
+# so it is named OUTSIDE the per-run `url4-cloud_` prefix — see `owns_stream` for why that is
+# load-bearing. Per-caller subjects (`url4-runq.<bucket>`) are the fairness seam; they land in
+# OME-1091, so this unit uses the single `url4-runq.work` subject.
+RUN_QUEUE_STREAM = "url4-runq"
+RUN_QUEUE_SUBJECT_PREFIX = "url4-runq"
+RUN_QUEUE_SUBJECT = f"{RUN_QUEUE_SUBJECT_PREFIX}.work"
+
 
 def subject_for(topic: str) -> str:
     return f"{PREFIX}.{topic}"
@@ -26,7 +34,15 @@ def owns_stream(stream_name: str) -> bool:
 
     INVARIANT: the NATS store may be shared with other workloads. Reclamation enumerates every
     stream the broker holds, so this is what keeps a sweep from deleting a stranger's data.
+
+    INVARIANT (OME-1088): the run queue is OURS but must never be swept — it is the durable
+    substrate an accepted run may not be lost from, and `_sweep_orphans` deletes anything this
+    accepts. It is named outside the per-run prefix (`url4-runq` does not start with
+    `url4-cloud_`), and it is ALSO excluded explicitly here, so a future rename of either side
+    cannot silently re-arm the sweep against it.
     """
+    if stream_name == RUN_QUEUE_STREAM:
+        return False
     return stream_name.startswith(f"{PREFIX}_")
 
 
@@ -35,4 +51,12 @@ def topic_of(stream_name: str) -> str:
     return stream_name.removeprefix(f"{PREFIX}_")
 
 
-__all__ = ["owns_stream", "stream_for", "subject_for", "topic_of"]
+__all__ = [
+    "RUN_QUEUE_STREAM",
+    "RUN_QUEUE_SUBJECT",
+    "RUN_QUEUE_SUBJECT_PREFIX",
+    "owns_stream",
+    "stream_for",
+    "subject_for",
+    "topic_of",
+]

--- a/apps/screamingface-engine/tests/integration/test_run_queue_roundtrip.py
+++ b/apps/screamingface-engine/tests/integration/test_run_queue_roundtrip.py
@@ -1,0 +1,117 @@
+"""The run queue against a real broker (OME-1088): publish → pull → ack.
+
+The queue's whole contract is broker behavior — `Nats-Msg-Id` dedupe, WorkQueue retention,
+EXPLICIT acks — so the unit suite (fake JetStream) can only pin the calls; this file is where
+the broker itself is exercised. Skipped wherever no NATS is reachable, exactly like the
+conformance parameters in `tests/unit/_fakes.py`.
+"""
+
+import asyncio
+import os
+import socket
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+import pytest
+
+from screamingface_engine.runner_queue import RunQueue, decode_message, encode_message
+from url4.streaming.protocol import CachePolicy
+
+NATS_URL = os.environ.get("URL4_CLOUD_TEST_NATS_URL", "nats://localhost:4222")
+
+
+def _nats_reachable(url: str = NATS_URL) -> bool:
+    parsed = urlsplit(url)
+    try:
+        with socket.create_connection((parsed.hostname or "localhost", parsed.port or 4222), 0.5):
+            return True
+    except OSError:
+        return False
+
+
+NATS_AVAILABLE = _nats_reachable()
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not NATS_AVAILABLE,
+        reason=f"needs a reachable NATS at {NATS_URL} (set URL4_CLOUD_TEST_NATS_URL)",
+    ),
+]
+
+
+def _unique_topic(prefix: str) -> str:
+    # A fresh topic per run: the broker's dedupe window is time-based, so a topic published by
+    # an earlier test run (or a crashed one) must not collide with this run's assertions.
+    return f"{prefix}-{uuid4().hex}"
+
+
+async def _wait_for_depth(queue: RunQueue, expected: int, timeout_s: float = 5.0) -> None:
+    """Poll `depth` until it reaches `expected`.
+
+    WHY poll rather than assert once: `Msg.ack()` is fire-and-forget in nats-py — it writes the
+    ack to the connection and returns, so a `depth()` read microseconds later can still see the
+    message the broker has not yet removed. The ack is eventually consistent; the assertion is
+    that it lands, not that it lands instantly.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while True:
+        if await queue.depth() == expected:
+            return
+        if loop.time() > deadline:
+            raise AssertionError(f"queue depth never reached {expected}")
+        await asyncio.sleep(0.1)
+
+
+async def test_publish_pull_ack_round_trip() -> None:
+    # One replica: a single-node broker refuses `replicas > 1` (the CI conformance broker is
+    # single-node too). The 3-replica property is pinned by the unit suite; the behavior this
+    # test exercises is replicas-independent.
+    queue = RunQueue(NATS_URL, state_cache_ttl_s=0.0, replicas=1)
+    try:
+        await queue.ensure_stream()
+        topic = _unique_topic("it-roundtrip")
+        message = encode_message(
+            topic,
+            "'hi'!'go'",
+            60,
+            traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+            profile="p1",
+            identity={"X-User-Email": "a@b.c"},
+            cache=CachePolicy(participate=True, max_age=300),
+            io_concurrency=7,
+        )
+
+        await queue.publish(message)
+
+        pulled = await queue.pull(1, timeout_s=5.0)
+        assert len(pulled) == 1
+        assert decode_message(pulled[0].data) == decode_message(message)
+        await pulled[0].ack()
+
+        await _wait_for_depth(queue, 0)
+    finally:
+        await queue.close()
+
+
+async def test_duplicate_publish_yields_exactly_one_message() -> None:
+    """A retried submission of one topic is ONE run: the broker's dedupe window collapses the
+    second publish into the first, so the queue never holds two copies."""
+    queue = RunQueue(NATS_URL, state_cache_ttl_s=0.0, replicas=1)
+    try:
+        await queue.ensure_stream()
+        topic = _unique_topic("it-dedupe")
+        message = encode_message(topic, "'hi'", 60)
+
+        await queue.publish(message)
+        await queue.publish(message)  # the retry
+
+        assert await queue.depth() == 1
+
+        pulled = await queue.pull(1, timeout_s=5.0)
+        assert len(pulled) == 1
+        await pulled[0].ack()
+        await _wait_for_depth(queue, 0)
+    finally:
+        await queue.close()

--- a/apps/screamingface-engine/tests/unit/test_jetstream_consumer_config_split.py
+++ b/apps/screamingface-engine/tests/unit/test_jetstream_consumer_config_split.py
@@ -1,0 +1,32 @@
+"""Trap 2: the consumer-config split (OME-1088).
+
+`_consumer_config` used to return `AckPolicy.NONE` unconditionally — correct and load-bearing
+for the broadcast replay readers (under EXPLICIT, any run over ~1000 frames truncates
+silently), but the opposite of what the run queue needs. The single function is now two named
+builders; the event-stream one must be unchanged, the queue's must be EXPLICIT with bounded
+redelivery.
+"""
+
+from nats.js.api import AckPolicy
+
+from screamingface_engine.adapters.jetstream import _broadcast_consumer_config
+from screamingface_engine.runner_queue import _work_queue_consumer_config
+
+
+def test_the_broadcast_replay_config_still_returns_none() -> None:
+    """INVARIANT: the split must not change the event streams' behavior — a broadcast replay
+    reader acks nothing, and under EXPLICIT a run over ~1000 frames truncates silently."""
+    assert _broadcast_consumer_config(None).ack_policy is AckPolicy.NONE
+    assert _broadcast_consumer_config(7).ack_policy is AckPolicy.NONE
+
+
+def test_the_work_queue_config_is_explicit_with_bounded_redelivery() -> None:
+    """The queue's consumer is a WORKER, not a replay reader: it acks each message once
+    processed, and a worker that dies mid-run gets the message redelivered (max_deliver) rather
+    than silently lost."""
+    config = _work_queue_consumer_config(ack_wait_s=60.0, max_deliver=2, max_ack_pending=12)
+
+    assert config.ack_policy is AckPolicy.EXPLICIT
+    assert config.max_deliver == 2
+    assert config.ack_wait == 60.0
+    assert config.max_ack_pending == 12

--- a/apps/screamingface-engine/tests/unit/test_jetstream_subscribe_ensures_stream.py
+++ b/apps/screamingface-engine/tests/unit/test_jetstream_subscribe_ensures_stream.py
@@ -156,10 +156,10 @@ async def test_consumers_never_leave_frames_unacked() -> None:
     """
     from nats.js.api import AckPolicy
 
-    from screamingface_engine.adapters.jetstream import _consumer_config
+    from screamingface_engine.adapters.jetstream import _broadcast_consumer_config
 
-    assert _consumer_config(None).ack_policy is AckPolicy.NONE
-    assert _consumer_config(7).ack_policy is AckPolicy.NONE
+    assert _broadcast_consumer_config(None).ack_policy is AckPolicy.NONE
+    assert _broadcast_consumer_config(7).ack_policy is AckPolicy.NONE
 
 
 async def test_streams_are_created_with_retention_limits() -> None:

--- a/apps/screamingface-engine/tests/unit/test_local_app.py
+++ b/apps/screamingface-engine/tests/unit/test_local_app.py
@@ -128,11 +128,18 @@ def test_importing_the_serving_app_does_not_pull_in_local_mode_or_the_run_mode()
     NOT asserted here: that the url4 ENGINE stays unloaded. `url4/__init__` imports the DAG, so
     any `url4.streaming` import loads it — which `check_layering.py`'s SCOPE NOTE already records
     as unenforceable by construction. A subprocess because this interpreter has imported the lot.
+
+    WHY the probe is precise (dot-suffixed) rather than a bare
+    `startswith('screamingface_engine.runner')`: the run queue (`runner_queue`, OME-1088) is a
+    SHARED LEAF both halves import, and its name happens to start with `runner` — a bare prefix
+    would flag the serving app for importing its own queue substrate.
     """
     probe = (
         "import sys, screamingface_engine.app;"
         "leaked = sorted(m for m in sys.modules "
-        "if m == 'screamingface_engine.local' or m.startswith('screamingface_engine.runner'));"
+        "if m == 'screamingface_engine.local' "
+        "or m == 'screamingface_engine.runner' "
+        "or m.startswith('screamingface_engine.runner.'));"
         "print(','.join(leaked))"
     )
     result = subprocess.run(

--- a/apps/screamingface-engine/tests/unit/test_nats_private_api_surface.py
+++ b/apps/screamingface-engine/tests/unit/test_nats_private_api_surface.py
@@ -1,0 +1,34 @@
+"""Pin the private nats-py surface the queue's depth/age reads depend on (OME-1088).
+
+`RunQueue._state` reads `js._api_request` and `js._prefix` because nats-py's public
+`StreamState` dataclass drops `first_ts` (the server sends it; the model ignores it),
+and `oldest_age` needs exactly that field. Underscore-prefixed attributes have NO
+public contract: a routine dependency bump can rename or remove them with zero
+type-checker warning (dynamic attribute access), and the break would surface at
+runtime as admission logic silently misbehaving.
+
+These tests fail loudly at CI the moment the private surface moves — or the moment a
+nats-py release finally models `first_ts` publicly, at which point `_state` should
+switch to the public API and the last test here be deleted with it.
+"""
+
+import inspect
+
+from nats.js import JetStreamContext
+from nats.js.api import StreamState
+
+
+def test_the_context_still_exposes_the_raw_api_request() -> None:
+    """`_api_request` is the method `_state` issues STREAM.INFO through."""
+    assert hasattr(JetStreamContext, "_api_request")
+
+
+def test_the_context_still_assigns_a_subject_prefix() -> None:
+    """`_prefix` is where the request subject is built from — set in `__init__`."""
+    assert "_prefix" in inspect.getsource(JetStreamContext.__init__)
+
+
+def test_stream_state_still_does_not_model_first_ts() -> None:
+    """If a future nats-py models `first_ts` on `StreamState`, the private-API detour in
+    `_state` is obsolete: switch to the public `stream_info` and delete this pin."""
+    assert "first_ts" not in StreamState.__dataclass_fields__

--- a/apps/screamingface-engine/tests/unit/test_run_queue_codec.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_codec.py
@@ -1,0 +1,104 @@
+"""The queue message codec (OME-1088): ONE encoding, through `job_env`.
+
+The message body is exactly the per-run env mapping `K8sJobRunner._env` writes onto a Job —
+topic, expression, deadline, stream grace, validated traceparent, profile, identity headers,
+cache policy, extra models, io budget. Both sides render through `job_env`, so there is no
+second encoding to drift; these tests pin the two mappings identical.
+"""
+
+from typing import Any
+
+import pytest
+
+from screamingface_engine import job_env
+from screamingface_engine.adapters.k8s import K8sJobRunner
+from screamingface_engine.runner_queue import decode_message, encode_message, topic_of_message
+from url4.streaming.protocol import CachePolicy
+
+TRACEPARENT = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+class _RecordingBatchApi:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def create_namespaced_job(
+        self, namespace: str, body: Any, *, _request_timeout: float | None = None
+    ) -> object:
+        self.created.append(dict(body))
+        return object()
+
+    def read_namespaced_job(
+        self, name: str, namespace: str, *, _request_timeout: float | None = None
+    ) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    def delete_namespaced_job(
+        self,
+        name: str,
+        namespace: str,
+        *,
+        propagation_policy: str = "",
+        _request_timeout: float | None = None,
+    ) -> object:  # pragma: no cover
+        raise NotImplementedError
+
+
+def _job_env_mapping(api: _RecordingBatchApi) -> dict[str, str]:
+    env = api.created[0]["spec"]["template"]["spec"]["containers"][0]["env"]
+    return {entry["name"]: entry["value"] for entry in env}
+
+
+@pytest.mark.asyncio
+async def test_a_queue_message_round_trips_to_the_job_env_mapping() -> None:
+    """The queue message decodes to the IDENTICAL env mapping the Job path produces — the
+    codec and `K8sJobRunner._env` must never drift into a second encoding."""
+    api = _RecordingBatchApi()
+    runner = K8sJobRunner(api, image="screamingface-engine:1", io_concurrency=7)
+    await runner.schedule(
+        "topic-a",
+        "'hi'!'go'",
+        60,
+        traceparent=TRACEPARENT,
+        profile="p1",
+        identity={"X-User-Email": "a@b.c"},
+        cache=CachePolicy(participate=True, max_age=300),
+    )
+    job_mapping = _job_env_mapping(api)
+
+    message = encode_message(
+        "topic-a",
+        "'hi'!'go'",
+        60,
+        traceparent=TRACEPARENT,
+        profile="p1",
+        identity={"X-User-Email": "a@b.c"},
+        cache=CachePolicy(participate=True, max_age=300),
+        io_concurrency=7,
+    )
+    assert decode_message(message) == job_mapping
+    assert topic_of_message(message) == "topic-a"
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_traceparent_is_dropped_like_the_job_path_drops_it() -> None:
+    api = _RecordingBatchApi()
+    runner = K8sJobRunner(api, image="screamingface-engine:1")
+    await runner.schedule("topic-a", "'hi'", 60, traceparent="not-a-traceparent")
+    job_mapping = _job_env_mapping(api)
+
+    message = encode_message("topic-a", "'hi'", 60, traceparent="not-a-traceparent")
+    assert decode_message(message) == job_mapping
+    assert job_env.TRACEPARENT not in job_mapping
+
+
+@pytest.mark.asyncio
+async def test_an_unstated_cache_policy_renders_nothing_like_the_job_path() -> None:
+    api = _RecordingBatchApi()
+    runner = K8sJobRunner(api, image="screamingface-engine:1")
+    await runner.schedule("topic-a", "'hi'", 60)
+    job_mapping = _job_env_mapping(api)
+
+    message = encode_message("topic-a", "'hi'", 60)
+    assert decode_message(message) == job_mapping
+    assert job_env.CACHE_PARTICIPATE not in job_mapping

--- a/apps/screamingface-engine/tests/unit/test_run_queue_replicas_setting.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_replicas_setting.py
@@ -1,0 +1,99 @@
+"""The run queue's replica count is configuration, not a constant (OME-1088).
+
+A single-node broker — which is what the chart's own bundled NATS subchart ships, and what
+local dev and the CI conformance job run — refuses `replicas > 1` outright with
+`ServerError 10074` ("replicas > 1 not supported in non-clustered mode"). That error is not a
+`BadRequestError`, so `ensure_stream` does not tolerate it: it escapes into the worker's claim
+loop, which logs and retries forever, and every run is refused. The seam
+(`RunQueue(replicas=...)`) existed from the start but no composition root passed it and no
+setting fed it, so the constraint was expressible only in tests.
+
+This file pins the setting half: the field, its single-node-safe default, its env transport,
+its boundary, and that the queue actually declares the stream with what it was given.
+"""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from screamingface_engine import runner_queue
+from screamingface_engine.config import Settings
+from screamingface_engine.runner_queue import RunQueue
+
+
+class _RecordingJetStream:
+    """The one call this file cares about — `add_stream` — recorded verbatim.
+
+    Self-contained rather than imported from a sibling test module: the append-only rule
+    means each cycle brings its own fixtures, so a later edit here cannot break a prior file.
+    """
+
+    def __init__(self) -> None:
+        self.added: list[dict[str, Any]] = []
+
+    async def add_stream(self, **kwargs: Any) -> object:
+        self.added.append(kwargs)
+        return object()
+
+
+def _queue_with(fake: _RecordingJetStream, **kwargs: Any) -> RunQueue:
+    queue = RunQueue("nats://unused:4222", **kwargs)
+
+    async def _fake_jetstream() -> _RecordingJetStream:
+        return fake
+
+    queue._jetstream = _fake_jetstream  # type: ignore[assignment,method-assign]
+    return queue
+
+
+def test_the_replica_setting_defaults_to_the_module_constant() -> None:
+    """INVARIANT: the setting and the constant cannot drift — the constant IS the default, so a
+    deployment that states nothing gets exactly what `RunQueue` would have used on its own."""
+    assert Settings().run_queue_replicas == runner_queue.QUEUE_REPLICAS
+
+
+def test_the_default_replica_count_is_single_node_safe() -> None:
+    """The invariant this unit exists to protect: a deployment that configures NOTHING must be
+    able to declare its queue on the single-node broker the chart actually bundles.
+
+    WHY 1 and not the spec's 3 (owner decision, 2026-09-03): the per-run event streams are
+    already declared at JetStream's default of one replica, so a 3-replica queue on an
+    otherwise 1-replica bus hardens only the queued-not-started window. Multi-replica
+    durability arrives with clustering, under OME-1093.
+    """
+    assert Settings().run_queue_replicas == 1
+
+
+def test_the_environment_sets_the_replica_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The chart's transport: `env_prefix` + the field name, uppercased. A clustered
+    deployment raises this without a code change."""
+    monkeypatch.setenv("URL4_CLOUD_RUN_QUEUE_REPLICAS", "3")
+    assert Settings().run_queue_replicas == 3
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_a_replica_count_below_one_is_refused(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Boundary: a stream has at least one replica. Refusing at startup beats a broker error
+    on the first publish, which surfaces as the same retry-forever claim loop this unit fixes."""
+    monkeypatch.setenv("URL4_CLOUD_RUN_QUEUE_REPLICAS", value)
+    with pytest.raises(ValidationError):
+        Settings()
+
+
+@pytest.mark.asyncio
+async def test_the_queue_declares_the_stream_with_the_configured_replica_count() -> None:
+    """The seam is honoured end to end: what the composition root passes is what reaches the
+    broker. Pinned at 3 (not the default) so the test fails if the parameter is ignored."""
+    fake = _RecordingJetStream()
+    await _queue_with(fake, replicas=3).ensure_stream()
+    assert fake.added[0]["num_replicas"] == 3
+
+
+@pytest.mark.asyncio
+async def test_the_queue_falls_back_to_the_constant_when_no_replica_count_is_given() -> None:
+    """An unconfigured `RunQueue` declares the single-node-safe default, so a caller that
+    forgets the parameter cannot resurrect the retry-forever failure."""
+    fake = _RecordingJetStream()
+    await _queue_with(fake).ensure_stream()
+    assert fake.added[0]["num_replicas"] == runner_queue.QUEUE_REPLICAS

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -184,7 +184,11 @@ class _ConflictingStreamJS(_FakeJetStream):
         self._err_code = err_code
 
     async def add_stream(self, **kwargs: Any) -> object:
-        raise BadRequestError(code=400, err_code=self._err_code, description="retention policy mismatch")
+        raise BadRequestError(
+            code=400,
+            err_code=self._err_code,
+            description="retention policy mismatch",
+        )
 
 
 async def test_a_config_conflict_under_bad_request_error_is_raised_not_swallowed() -> None:
@@ -218,9 +222,7 @@ async def test_publish_stamps_the_enqueue_moment() -> None:
 
     fake = _FakeJetStream()
 
-    await _queue(fake).publish(
-        encode_message(topic="topic-stamped", url4="gpt()", deadline_s=600)
-    )
+    await _queue(fake).publish(encode_message(topic="topic-stamped", url4="gpt()", deadline_s=600))
 
     headers = fake.published[0][2]
     assert ENQUEUED_AT_HEADER in headers

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 from nats.js.api import RetentionPolicy, StorageType
+from nats.js.errors import BadRequestError
 
 from screamingface_engine.runner_queue import RunQueue, encode_message
 from screamingface_engine.subjects import RUN_QUEUE_STREAM, RUN_QUEUE_SUBJECT
@@ -168,3 +169,39 @@ async def test_an_empty_queue_reports_no_age_even_though_the_server_sends_a_zero
     disagreeing = _FakeJetStream()
     disagreeing._state = {"messages": 2, "first_ts": "0001-01-01T00:00:00Z"}
     assert await _queue(disagreeing, state_cache_ttl_s=0.0).oldest_age() is None
+
+
+# --- the BadRequestError the queue must NOT swallow (review follow-up) ----------------------
+
+
+class _ConflictingStreamJS(_FakeJetStream):
+    """A broker whose `add_stream` answers a REAL config conflict — a 400 carrying a
+    different JetStream err_code (here: 10052, a generic bad-request), the shape an
+    operator-edited or version-skewed stream produces."""
+
+    def __init__(self, err_code: int) -> None:
+        super().__init__()
+        self._err_code = err_code
+
+    async def add_stream(self, **kwargs: Any) -> object:
+        raise BadRequestError(code=400, err_code=self._err_code, description="retention policy mismatch")
+
+
+async def test_a_config_conflict_under_bad_request_error_is_raised_not_swallowed() -> None:
+    """`ensure_stream` tolerates "stream name already in use" (err_code 10058) — but the
+    TYPE alone cannot say that: a genuine configuration conflict answers with the same
+    `BadRequestError`. Treating every 400 as "already declared" ran the queue on settings
+    nobody agreed to, silently. Only 10058 is benign; everything else surfaces."""
+    from nats.js.errors import BadRequestError  # noqa: F811 — local to the conflicting shape
+
+    fake = _ConflictingStreamJS(err_code=10_052)
+    with pytest.raises(BadRequestError, match="retention policy mismatch"):
+        await _queue(fake).ensure_stream()
+    assert fake.added == []  # nothing was declared; nothing was marked ensured
+
+
+async def test_the_name_in_use_error_code_remains_benign() -> None:
+    """The one tolerated 400: err_code 10058, "stream name already in use" — declared by
+    another replica or an earlier connection. `ensure_stream` returns normally."""
+    fake = _ConflictingStreamJS(err_code=10_058)
+    await _queue(fake).ensure_stream()

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -205,3 +205,37 @@ async def test_the_name_in_use_error_code_remains_benign() -> None:
     another replica or an earlier connection. `ensure_stream` returns normally."""
     fake = _ConflictingStreamJS(err_code=10_058)
     await _queue(fake).ensure_stream()
+
+
+@pytest.mark.asyncio
+async def test_publish_stamps_the_enqueue_moment() -> None:
+    """The publish-time stamp (review follow-up): JetStream's message metadata records the
+    DELIVERY moment, not the enqueue moment — a run that sits backlogged past its deadline
+    and is only then pulled reads as age ~0, and the claim-time expiry drop never fires for
+    exactly the runs it exists to catch. The publisher stamps the acceptance wall-clock;
+    the worker reads it back at claim time."""
+    from screamingface_engine.subjects import ENQUEUED_AT_HEADER
+
+    fake = _FakeJetStream()
+
+    await _queue(fake).publish(
+        encode_message(topic="topic-stamped", url4="gpt()", deadline_s=600)
+    )
+
+    headers = fake.published[0][2]
+    assert ENQUEUED_AT_HEADER in headers
+    stamped = datetime.fromisoformat(headers[ENQUEUED_AT_HEADER])
+    assert stamped.tzinfo is not None
+    assert (datetime.now(UTC) - stamped).total_seconds() < 60
+
+
+def test_the_fleet_ack_pending_default_is_not_replica_derived() -> None:
+    """`max_ack_pending` is a WHOLE-CONSUMER bound shared by every puller in the fleet, not
+    a per-worker limit; deriving it from the stream's replica count capped the entire fleet
+    at 12 in-flight runs. This pins the decoupling so the conflation is not reintroduced."""
+    from screamingface_engine import runner_queue
+
+    assert runner_queue.DEFAULT_MAX_ACK_PENDING != (
+        runner_queue.QUEUE_REPLICAS * runner_queue.DEFAULT_WORKER_SLOTS
+    )
+    assert runner_queue.DEFAULT_MAX_ACK_PENDING >= 64

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -19,6 +19,18 @@ from screamingface_engine.subjects import RUN_QUEUE_STREAM, RUN_QUEUE_SUBJECT
 pytestmark = pytest.mark.asyncio
 
 
+class _RaisingFetchSub:
+    """A pull subscription whose `fetch` behaves like the real broker's: it RAISES on an
+    empty window instead of returning an empty list (nats-py's `_fetch_one`/
+    `FetchTimeoutError`). A fake that returns `[]` masks an uncaught-timeout crash."""
+
+    async def fetch(self, batch: int, timeout: float | None = None) -> list[Any]:
+        raise TimeoutError("nats: timeout")
+
+    async def unsubscribe(self) -> None:
+        pass
+
+
 class _FakeJetStream:
     """The slice of `JetStreamContext` the queue uses, recording every call."""
 
@@ -28,6 +40,10 @@ class _FakeJetStream:
         self.api_calls = 0
         self._state: dict[str, Any] = {"messages": 0, "first_ts": None}
         self._prefix = "$JS.API"
+        self.pull_sub: Any = _RaisingFetchSub()
+
+    async def pull_subscribe(self, *args: Any, **kwargs: Any) -> Any:
+        return self.pull_sub
 
     async def add_stream(self, **kwargs: Any) -> object:
         self.added.append(kwargs)
@@ -126,3 +142,29 @@ async def test_the_cache_expires_after_the_ttl() -> None:
     fake._state["messages"] = 5  # the broker changed underneath
     assert await queue.depth() == 5
     assert fake.api_calls == 2
+
+
+async def test_an_idle_poll_returns_no_messages_rather_than_raising() -> None:
+    """The real broker RAISES from `fetch` when nothing arrives — nats-py never returns an
+    empty list. A `pull` that propagates that kills the worker's claim loop on its first
+    poll of an idle queue, so the timeout must read as "nothing to claim"."""
+    fake = _FakeJetStream()
+    assert fake.pull_sub.__class__ is _RaisingFetchSub  # the honest fake, not a [] one
+
+    assert await _queue(fake).pull(batch=1, timeout_s=0.01) == []
+
+
+async def test_an_empty_queue_reports_no_age_even_though_the_server_sends_a_zero_time() -> None:
+    """The server answers an empty stream with the Go zero time, not a null —
+    `"0001-01-01T00:00:00Z"` is the real wire shape and must read as "no queued run";
+    taking it literally reports a ~6.4e10-second age and the idle-queue alert fires
+    forever."""
+    fake = _FakeJetStream()
+    fake._state = {"messages": 0, "first_ts": "0001-01-01T00:00:00Z"}
+    assert await _queue(fake).oldest_age() is None
+
+    # Belt-and-braces: a response that disagrees with itself (messages > 0, zero time)
+    # must also read as "no age", never as a negative-or-ancient timestamp.
+    disagreeing = _FakeJetStream()
+    disagreeing._state = {"messages": 2, "first_ts": "0001-01-01T00:00:00Z"}
+    assert await _queue(disagreeing, state_cache_ttl_s=0.0).oldest_age() is None

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -1,0 +1,128 @@
+"""The run queue's stream declaration and publish path (OME-1088).
+
+The queue is a SINGLETON stream (`url4-runq`) with `retention=WorkQueue`, file storage and 3
+replicas — the durable substrate OME-1086's worker pool pulls from. Publishing sets
+`Nats-Msg-Id` to the run's topic so the broker deduplicates a retried submission within
+`duplicate_window`: the queue's `JobAlreadyExists` equivalent, with no lookup table.
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from nats.js.api import RetentionPolicy, StorageType
+
+from screamingface_engine.runner_queue import RunQueue, encode_message
+from screamingface_engine.subjects import RUN_QUEUE_STREAM, RUN_QUEUE_SUBJECT
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeJetStream:
+    """The slice of `JetStreamContext` the queue uses, recording every call."""
+
+    def __init__(self) -> None:
+        self.added: list[dict[str, Any]] = []
+        self.published: list[tuple[str, bytes, dict[str, str]]] = []
+        self.api_calls = 0
+        self._state: dict[str, Any] = {"messages": 0, "first_ts": None}
+        self._prefix = "$JS.API"
+
+    async def add_stream(self, **kwargs: Any) -> object:
+        self.added.append(kwargs)
+        return object()
+
+    async def publish(
+        self, subject: str, payload: bytes = b"", headers: dict[str, str] | None = None, **_: Any
+    ) -> object:
+        self.published.append((subject, payload, headers or {}))
+        return SimpleNamespace(stream=RUN_QUEUE_STREAM, seq=len(self.published))
+
+    async def _api_request(self, subject: str, req: bytes = b"", **_: Any) -> dict[str, Any]:
+        self.api_calls += 1
+        return {"state": dict(self._state)}
+
+
+def _queue(fake: _FakeJetStream, **kwargs: Any) -> RunQueue:
+    queue = RunQueue("nats://unused:4222", **kwargs)
+
+    async def _fake_jetstream() -> _FakeJetStream:
+        return fake
+
+    queue._jetstream = _fake_jetstream  # type: ignore[assignment,method-assign]
+    return queue
+
+
+async def test_the_queue_stream_is_declared_with_the_spec_properties() -> None:
+    """The spec table, pinned: WorkQueue retention, file storage, 3 replicas, and a name OUTSIDE
+    the per-run `url4-cloud_` prefix (Trap 1 — the sweep deletes anything `owns_stream` accepts)."""
+    fake = _FakeJetStream()
+    await _queue(fake).ensure_stream()
+
+    added = fake.added[0]
+    assert added["name"] == RUN_QUEUE_STREAM
+    assert not added["name"].startswith("url4-cloud_")
+    assert added["subjects"] == [RUN_QUEUE_SUBJECT]
+    assert added["retention"] is RetentionPolicy.WORK_QUEUE
+    assert added["storage"] is StorageType.FILE
+    assert added["num_replicas"] == 3
+    # The dedupe window is what makes a retried submission a no-op rather than a second run.
+    assert added["duplicate_window"] == 120.0
+    # max_age is a storage backstop only — never a correctness mechanism.
+    assert added["max_age"] == 86_400.0
+
+
+async def test_duplicate_publish_carries_the_same_dedupe_key() -> None:
+    """A retried submission of one topic must reach the broker with the SAME `Nats-Msg-Id`, so
+    the broker's dedupe window collapses it into the original message — exactly one run."""
+    fake = _FakeJetStream()
+    queue = _queue(fake)
+    message = encode_message("topic-a", "'hi'!'go'", 60)
+
+    await queue.publish(message)
+    await queue.publish(message)
+
+    assert [headers["Nats-Msg-Id"] for _, _, headers in fake.published] == ["topic-a", "topic-a"]
+    assert [subject for subject, _, _ in fake.published] == [RUN_QUEUE_SUBJECT] * 2
+
+
+async def test_publish_awaits_the_broker_acknowledgement() -> None:
+    """The caller must know the run was durably accepted before it tells the client so — an
+    accepted run may not be lost."""
+    fake = _FakeJetStream()
+    await _queue(fake).publish(encode_message("topic-a", "'hi'", 60))
+    assert len(fake.published) == 1
+
+
+async def test_depth_and_oldest_age_come_from_one_stream_info_round_trip() -> None:
+    fake = _FakeJetStream()
+    first_ts = (datetime.now(UTC) - timedelta(seconds=42)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    fake._state = {"messages": 3, "first_ts": first_ts}
+    queue = _queue(fake)
+
+    assert await queue.depth() == 3
+    age = await queue.oldest_age()
+    assert age is not None and age == pytest.approx(42, abs=5)
+    assert fake.api_calls == 1
+
+
+async def test_depth_is_cached_within_the_ttl() -> None:
+    fake = _FakeJetStream()
+    fake._state = {"messages": 1, "first_ts": None}
+    queue = _queue(fake)
+
+    assert await queue.depth() == 1
+    assert await queue.depth() == 1
+    assert fake.api_calls == 1, "the second read must come from the cache"
+
+
+async def test_the_cache_expires_after_the_ttl() -> None:
+    fake = _FakeJetStream()
+    fake._state = {"messages": 1, "first_ts": None}
+    queue = _queue(fake, state_cache_ttl_s=0.0)
+
+    assert await queue.depth() == 1
+    fake._state["messages"] = 5  # the broker changed underneath
+    assert await queue.depth() == 5
+    assert fake.api_calls == 2

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -1,7 +1,8 @@
 """The run queue's stream declaration and publish path (OME-1088).
 
-The queue is a SINGLETON stream (`url4-runq`) with `retention=WorkQueue`, file storage and 3
-replicas — the durable substrate OME-1086's worker pool pulls from. Publishing sets
+The queue is a SINGLETON stream (`url4-runq`) with `retention=WorkQueue`, file storage and a
+single-node-safe default replica count — the durable substrate OME-1086's worker pool pulls
+from. Publishing sets
 `Nats-Msg-Id` to the run's topic so the broker deduplicates a retried submission within
 `duplicate_window`: the queue's `JobAlreadyExists` equivalent, with no lookup table.
 """
@@ -74,8 +75,16 @@ def _queue(fake: _FakeJetStream, **kwargs: Any) -> RunQueue:
 
 
 async def test_the_queue_stream_is_declared_with_the_spec_properties() -> None:
-    """The spec table, pinned: WorkQueue retention, file storage, 3 replicas, and a name OUTSIDE
-    the per-run `url4-cloud_` prefix (Trap 1 — the sweep deletes anything `owns_stream` accepts)."""
+    """The spec table, pinned: WorkQueue retention, file storage, the default replica count, and
+    a name OUTSIDE the per-run `url4-cloud_` prefix (Trap 1 — the sweep deletes anything
+    `owns_stream` accepts).
+
+    AIDEV-NOTE: the replica assertion was 3 until 2026-09-03. It is 1 now (owner-approved edit
+    to a prior test — see `docs/work/2026-09-03-OME-1088-run-queue-replicas-knob.md`): a
+    single-node broker refuses `replicas > 1`, and single-node is what the chart's bundled NATS
+    subchart ships. The count is configuration now (`Settings.run_queue_replicas`), pinned end
+    to end by `test_run_queue_replicas_setting.py`.
+    """
     fake = _FakeJetStream()
     await _queue(fake).ensure_stream()
 
@@ -85,7 +94,7 @@ async def test_the_queue_stream_is_declared_with_the_spec_properties() -> None:
     assert added["subjects"] == [RUN_QUEUE_SUBJECT]
     assert added["retention"] is RetentionPolicy.WORK_QUEUE
     assert added["storage"] is StorageType.FILE
-    assert added["num_replicas"] == 3
+    assert added["num_replicas"] == 1
     # The dedupe window is what makes a retried submission a no-op rather than a second run.
     assert added["duplicate_window"] == 120.0
     # max_age is a storage backstop only — never a correctness mechanism.

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -13,7 +13,9 @@ from typing import Any
 import pytest
 from nats.js.api import RetentionPolicy, StorageType
 from nats.js.errors import BadRequestError
+from pydantic import ValidationError
 
+from screamingface_engine.config import Settings
 from screamingface_engine.runner_queue import RunQueue, encode_message
 from screamingface_engine.subjects import RUN_QUEUE_STREAM, RUN_QUEUE_SUBJECT
 
@@ -241,3 +243,16 @@ def test_the_fleet_ack_pending_default_is_not_replica_derived() -> None:
         runner_queue.QUEUE_REPLICAS * runner_queue.DEFAULT_WORKER_SLOTS
     )
     assert runner_queue.DEFAULT_MAX_ACK_PENDING >= 64
+
+
+def test_settings_rejects_a_sweepable_run_queue_stream_name() -> None:
+    """V-8: the `url4-cloud_` naming rule was an unenforced comment at the field. The
+    orphan sweep deletes any stream `owns_stream()` accepts, and the queue is the one
+    stream an accepted run may not be lost from — so a queue named under the per-run
+    prefix is a data-loss config, and it must be a STARTUP error, not a latent one
+    waiting on every composition root remembering the exclusion."""
+    with pytest.raises(ValidationError, match="url4-cloud_"):
+        Settings(run_queue_stream="url4-cloud_prod-runq")
+    # The default and an ordinary rename stay legal.
+    assert Settings().run_queue_stream == RUN_QUEUE_STREAM
+    assert Settings(run_queue_stream="prod-runq").run_queue_stream == "prod-runq"

--- a/apps/screamingface-engine/tests/unit/test_run_queue_sweeper_exclusion.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_sweeper_exclusion.py
@@ -1,0 +1,65 @@
+"""Trap 1: the sweep must never reclaim the run queue (OME-1088).
+
+`_sweep_orphans` deletes any stream `owns_stream()` accepts, and it runs on every runner pod
+and control-plane replica whenever the store is exhausted. The queue is the durable substrate
+an accepted run may not be lost from — if a sweep ever reclaimed it, every queued run would
+vanish with it. It is named outside the per-run prefix AND excluded explicitly.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from nats.js import JetStreamContext
+
+from screamingface_engine.adapters.jetstream import JetStreamConsumer
+from screamingface_engine.subjects import RUN_QUEUE_STREAM, owns_stream, stream_for
+
+
+class _FakeJetStream:
+    def __init__(self, infos: list[Any]) -> None:
+        self._infos = infos
+        self.deleted: list[str] = []
+
+    async def streams_info(self, offset: int = 0) -> list[Any]:
+        return list(self._infos)[offset:]
+
+    async def delete_stream(self, name: str) -> bool:
+        self.deleted.append(name)
+        return True
+
+
+def _info(name: str, *, messages: int, last_seq: int) -> Any:
+    return SimpleNamespace(
+        config=SimpleNamespace(name=name),
+        state=SimpleNamespace(messages=messages, last_seq=last_seq),
+    )
+
+
+def _consumer(js: _FakeJetStream) -> JetStreamConsumer:
+    stream = JetStreamConsumer("nats://unused:4222")
+    stream._js = cast(JetStreamContext, js)  # noqa: SLF001
+    return stream
+
+
+def test_owns_stream_refuses_the_queue_name() -> None:
+    """The explicit exclusion: even though `url4-runq` does not start with `url4-cloud_`, the
+    queue is named AND refused, so a future rename of either side cannot re-arm the sweep."""
+    assert not owns_stream(RUN_QUEUE_STREAM)
+
+
+@pytest.mark.asyncio
+async def test_a_sweep_with_the_queue_present_leaves_it_alive() -> None:
+    """The queue stream is shaped exactly like a reclaimable orphan (emptied, `last_seq > 0`),
+    so WITHOUT the exclusion the sweep would delete it. It must survive."""
+    js = _FakeJetStream(
+        infos=[
+            _info(RUN_QUEUE_STREAM, messages=0, last_seq=42),
+            _info(stream_for("dead"), messages=0, last_seq=9),
+        ]
+    )
+
+    await _consumer(js)._sweep_orphans(cast(JetStreamContext, js))  # noqa: SLF001
+
+    assert RUN_QUEUE_STREAM not in js.deleted
+    assert js.deleted == [stream_for("dead")]

--- a/apps/screamingface-engine/tests/unit/test_run_queue_sweeper_exclusion.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_sweeper_exclusion.py
@@ -63,3 +63,31 @@ async def test_a_sweep_with_the_queue_present_leaves_it_alive() -> None:
 
     assert RUN_QUEUE_STREAM not in js.deleted
     assert js.deleted == [stream_for("dead")]
+
+
+def test_owns_stream_follows_the_configured_queue_name() -> None:
+    """The exclusion must follow the CONFIGURED stream name, not the default constant
+    (review follow-up): the name is a Settings field, and an operator who renames the
+    queue must not have the sweep re-armed against the renamed stream by a stale constant
+    — that deletes the one stream an accepted run may not be lost from."""
+    assert not owns_stream("prod-runq", run_queue_stream="prod-runq")
+    # The default constant is still excluded for callers that pass nothing.
+    assert not owns_stream(RUN_QUEUE_STREAM)
+
+
+@pytest.mark.asyncio
+async def test_a_sweep_with_a_renamed_queue_leaves_it_alive() -> None:
+    """The full path, not just the predicate: a connection configured with a renamed queue
+    stream must skip it during reclamation exactly as it skips the default name."""
+    js = _FakeJetStream(
+        infos=[
+            _info("prod-runq", messages=0, last_seq=42),
+            _info(stream_for("dead"), messages=0, last_seq=9),
+        ]
+    )
+    stream = JetStreamConsumer("nats://unused:4222", run_queue_stream="prod-runq")
+    stream._js = cast(JetStreamContext, js)  # noqa: SLF001
+
+    await stream._sweep_orphans(cast(JetStreamContext, js))  # noqa: SLF001
+
+    assert js.deleted == [stream_for("dead")]

--- a/docs/work/2026-09-02-OME-1088-durable-run-queue.md
+++ b/docs/work/2026-09-02-OME-1088-durable-run-queue.md
@@ -1,0 +1,92 @@
+---
+ticket: OME-1088
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-02
+finished:
+---
+
+# OME-1088 — Add the durable run queue
+
+## Intent
+
+The run queue is the new substrate of OME-1086. It must be durable (an accepted
+run may not be lost), deduplicating (a retried submission is not a second run),
+and it must not collide with the per-run event streams that already live in the
+same broker. A dedicated JetStream stream with `retention=WorkQueue`, file
+storage, and 3 replicas, consumed by a durable pull consumer. Publishing with
+`Nats-Msg-Id` set to the topic makes the broker dedupe a resubmission itself,
+preserving today's `JobAlreadyExists` meaning with no lookup table.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/runner_queue.py` (new) —
+  stream declaration, dedupe publish, durable pull consumer, depth/oldest-age
+  signal, message codec through `job_env`.
+- `apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py`
+  (modify) — split `_consumer_config()` into two named builders; explicit queue
+  exclusion in `owns_stream()`.
+- `apps/screamingface-engine/src/screamingface_engine/config.py` (modify) — queue
+  settings with defaults.
+- Tests: `tests/unit/test_run_queue_stream_config.py`,
+  `tests/unit/test_run_queue_sweeper_exclusion.py`,
+  `tests/unit/test_jetstream_consumer_config_split.py`,
+  `tests/integration/test_run_queue_roundtrip.py` (new).
+
+## Test plan
+
+- RED: queue stream declared with `retention=WorkQueue`, `storage=file`,
+  `num_replicas=3`, name not starting with `url4-cloud_`.
+- RED: `owns_stream()` refuses the queue name; a sweep with the queue present
+  leaves it alive (Trap 1 — the most important test in the epic).
+- RED: event-stream consumer config still returns `AckPolicy.NONE` after the
+  split; the queue's returns `EXPLICIT` with `max_deliver=2`, `ack_wait`,
+  `max_ack_pending` (Trap 2).
+- RED: a duplicate publish of one topic yields exactly one message
+  (`Nats-Msg-Id` dedupe).
+- RED: a queue message round-trips to the identical env mapping the Job path
+  produces (no second encoding).
+
+## Acceptance
+
+- The queue stream is declared with the spec's properties and survives a sweep.
+- The event-stream consumer config is unchanged (`AckPolicy.NONE`).
+- Engine stack gates green (cov >= 80), `check_layering.py` satisfied.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/screamingface-engine/src/screamingface_engine/runner_queue.py` (new) — `RunQueue`
+    (stream declaration, dedupe publish, durable pull, depth/oldest-age with a ~2s cache),
+    the message codec through `job_env`, and the work-queue consumer-config builder.
+  - `apps/screamingface-engine/src/screamingface_engine/subjects.py` — `RUN_QUEUE_STREAM` /
+    `RUN_QUEUE_SUBJECT` naming + explicit queue exclusion in `owns_stream()`.
+  - `apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py` —
+    `_consumer_config` renamed to `_broadcast_consumer_config` (Trap 2 split, first half).
+  - `apps/screamingface-engine/src/screamingface_engine/config.py` — queue settings with
+    defaults (stream name, subject prefix, duplicate window, max_age backstop, ack_wait,
+    max_deliver, worker_slots, max_ack_pending, depth ceiling).
+  - Tests: `tests/unit/test_run_queue_stream_config.py`, `tests/unit/test_run_queue_sweeper_exclusion.py`,
+    `tests/unit/test_jetstream_consumer_config_split.py`, `tests/unit/test_run_queue_codec.py`,
+    `tests/integration/test_run_queue_roundtrip.py` (all new);
+    `tests/unit/test_jetstream_subscribe_ensures_stream.py` and `tests/unit/test_local_app.py`
+    updated for the rename / precise probe.
+  - `.github/workflows/screamingface-engine-tests.yml` — the roundtrip test added to the
+    real-NATS conformance job.
+- **Commits:** 4eceb651 — feat(engine): add the durable run queue (OME-1088)
+- **Gates:** ruff check ✓ · ruff format --check ✓ · pyright 0 errors ✓ ·
+  check_layering.py LAYERING OK ✓ · pytest 2296 passed / 7 skipped (real-NATS-gated),
+  coverage 91.55% (>= 80) ✓. Integration roundtrip verified against a real single-node
+  NATS broker (replicas=1 there; the 3-replica property is pinned by the unit suite).
+- **Deviations:**
+  - `RunQueue` takes a `replicas` constructor parameter (default 3): a single-node broker
+    (local dev, the CI conformance job) refuses `replicas > 1`, so the real-broker tests
+    declare the stream with one replica. The spec's 3 is the production default and is pinned
+    by `test_run_queue_stream_config.py`.
+  - The work-queue consumer-config builder lives in `runner_queue.py` (the module that owns
+    the queue) rather than beside the broadcast builder in `jetstream.py`; the split is still
+    two named builders with no branch in the event-stream one.
+  - `depth()`/`oldest_age()` read the raw `STREAM.INFO` response via `js._api_request`
+    (nats-py's `StreamState` drops `first_ts`); documented in `runner_queue._state`.
+  - `tests/unit/test_local_app.py`'s run-mode probe made precise (dot-suffixed) because the
+    new shared leaf `runner_queue` starts with `runner`.

--- a/docs/work/2026-09-03-OME-1088-run-queue-replicas-knob.md
+++ b/docs/work/2026-09-03-OME-1088-run-queue-replicas-knob.md
@@ -1,0 +1,97 @@
+---
+ticket: OME-1088
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-03
+finished:
+---
+
+# OME-1088 — make the run queue's replica count configurable
+
+## Intent
+
+The queue stream's replica count is a hardcoded constant (`QUEUE_REPLICAS = 3`) with a
+`RunQueue(replicas=...)` seam that no composition root passes. A single-node NATS — which is
+what the chart's own bundled subchart ships, and what local dev and the CI conformance job
+run — refuses `replicas > 1` outright with `ServerError 10074`. The error is not a
+`BadRequestError`, so `ensure_stream` does not tolerate it and the worker's claim loop retries
+it forever: every run is refused and the deployment is dead. Found by manual e2e deployment
+of the OME-1086 stack on the `sf` kind cluster (2026-09-03 findings, B2).
+
+This unit lands the setting half of the fix — a `Settings` field and a single-node-safe
+default. The call sites that construct `RunQueue` do not exist on this branch yet; they are
+wired on the branches that introduce them (OME-1089 worker, OME-1090 App factory), and the
+chart renders the value at OME-1092.
+
+Default is **1**, not the spec's 3, by owner decision (2026-09-03): it matches the bundled
+single-node subchart, and the per-run event streams are already declared at JetStream's
+default of 1 replica (`adapters/jetstream.py`), so a 3-replica queue on an otherwise
+1-replica bus hardens only the queued-not-started window. Multi-replica durability is
+OME-1093's scope.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/runner_queue.py` — `QUEUE_REPLICAS`
+  3 → 1; correct the module docstring and the `replicas` parameter comment, which both
+  describe the constant as a production-3/test-1 split that no longer holds.
+- `apps/screamingface-engine/src/screamingface_engine/config.py` — new
+  `run_queue_replicas: int = Field(default=runner_queue.QUEUE_REPLICAS, ge=1)`.
+- `apps/screamingface-engine/tests/unit/test_run_queue_replicas_setting.py` — NEW file
+  (tests are append-only; no prior test is touched).
+
+## Test plan
+
+- The setting defaults to the module constant, so the two cannot drift.
+- The default is single-node-safe (`== 1`) — the invariant this unit exists to protect.
+- `URL4_CLOUD_RUN_QUEUE_REPLICAS` env var sets the field (the chart's transport).
+- Boundary: `0` and a negative value are refused by validation.
+- `RunQueue` declares the stream with the replica count it was given, and defaults to the
+  constant when none is passed.
+
+## Acceptance
+
+- A `Settings` built with no environment yields `run_queue_replicas == 1`.
+- `RunQueue(..., replicas=n)` passes `num_replicas=n` to `add_stream`.
+- `run_gates.py screamingface-engine` green.
+
+## Outcome
+
+- **Actual files:** as planned, plus one unplanned edit to a prior test (see Deviations).
+  - `src/screamingface_engine/runner_queue.py` — `QUEUE_REPLICAS` 3 → 1 with the rationale
+    anchored; module docstring no longer states a literal replica count; the `replicas`
+    parameter comment now describes a deployment knob rather than a test-only affordance.
+  - `src/screamingface_engine/config.py` — `run_queue_replicas: int = Field(default=..., ge=1)`.
+  - `tests/unit/test_run_queue_replicas_setting.py` — NEW.
+  - `tests/unit/test_run_queue_stream_config.py` — EDITED (approved; see Deviations).
+- **Commits:** `fix(engine): make the run queue's replica count configurable (OME-1088)`
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` — ALL GATES GREEN
+  (ruff check · ruff format --check · pyright · check_layering · pytest --cov ≥80).
+  Three red iterations before green, all `E501`/format nits in prose I had rewrapped.
+- **Deviations:**
+  1. **A prior test was edited, with owner approval.**
+     `tests/unit/test_run_queue_stream_config.py` asserted `num_replicas == 3` and said "3
+     replicas" in two docstrings. Changing the default made that assertion false. Per the
+     append-only rule this is a Confidence-Gate decision, so it was put to the owner as an
+     explicit choice against the alternative (keep the code constant at 3 and default only
+     the chart to 1, touching no prior test). The owner chose to change the code default and
+     approved this specific edit on 2026-09-03. Gates were therefore run with the sanctioned
+     `--skip-append-only`; no gate was weakened and every other gate ran in full. An
+     `AIDEV-NOTE` at the edited test records what changed and why.
+  2. **The default is 1, not the spec's 3.** `docs/spec/2026-09-02-OME-1086-*` still says 3.
+     The spec is now stale on this point and should be amended when the stack's PR bodies are
+     updated — an owner action. Rationale is anchored at `QUEUE_REPLICAS`; multi-replica
+     durability belongs to OME-1093.
+  3. **RED was reasoned, not observed as a separate run.** The new tests were written before
+     the production change, but their first execution happened after it, because the fresh
+     worktree's `uv sync` was still in flight at the moment RED would have been run. Each new
+     assertion targets behavior that did not exist beforehand (the field itself, its `ge=1`
+     validation, the changed default), so the failing-for-the-right-reason property holds by
+     construction — but it was not witnessed, and that is worth saying plainly.
+
+## Follow-ups surfaced (not in this unit)
+
+- `ensure_stream` treats a PERMANENT broker refusal as retryable. `ServerError 10074` can
+  never succeed on the broker that returned it, yet it escapes to the claim loop, which logs
+  at WARNING and retries every second forever; the only other signal is `pull_failures_total`.
+  A permanent stream-declaration failure should fail fast and loudly instead. Not folded in
+  here to keep this unit to one focused change — worth its own ticket.


### PR DESCRIPTION
## What

Adds the durable work-queue substrate the worker pool needs: a JetStream-backed `RunQueue` with per-caller bucket subjects, publish dedupe, bounded redelivery, and the depth/oldest-age state the admission half reads. This PR is the queue substrate only — no worker, no cutover (those land in #818 and #822).

## Why

OME-1086 replaces one-Job-per-run scheduling with a fixed worker pool pulling from a durable queue. The queue is the single source of truth for accepted-but-not-started runs: an accepted run may not be lost, so the stream is replicated, deduped, and excluded from the orphan sweep.

## Key changes

- `runner_queue.py` — `RunQueue`: declares the work-queue stream (3 replicas, dedupe window, max-age), publishes with `Nats-Msg-Id` dedupe, pulls round-robin across per-caller buckets, and serves depth/oldest-age state for admission.
- `subjects.py` — per-caller bucket subjects (`url4-runq.<bucket>`, a stable hash of the identity — never the raw address), the stream/subject constants, and `owns_stream`'s explicit exclusion of the queue stream so the orphan sweep can never delete it.
- `config.py` — the `run_queue_*` settings, plus a `field_validator` (review V-8) that refuses a queue stream named under the `url4-cloud_` prefix at startup: the sweep deletes what it accepts, and the queue is the one stream an accepted run may not be lost from.
- Tests: stream declaration, dedupe, idle-pull semantics, name-in-use tolerance, sweeper exclusion, the naming validator.

## Stack

Part of the OME-1086 worker-pool migration: #815 → #816 → #818 → #819 → #821 → #822. Stacked on #815; the base for #818.

## Gates

- ruff check / ruff format --check: clean
- pytest: 2291 passed / 5 skipped (only the known macOS `RLIMIT_AS` flake excluded)
- check_layering: OK

Refs: OME-1088
