### PR TITLE
feat(engine): add the runner worker (OME-1089)

### DIFF
--- a/.claude/scripts/check_layering.py
+++ b/.claude/scripts/check_layering.py
@@ -8,10 +8,17 @@ One image ships two modes, and the whole point of that shape is a rule about wha
         |          |
     control plane   run mode                    Every concrete implementation, in the half that
     (serve)         (run)                       runs it — and the two halves stay disjoint.
+        ^
+        |
+    worker (OME-1089)                           The third mode: claims runs from the queue and
+                                                forks the run as a child process. It may import
+                                                the serving half and `runner_queue`; it must
+                                                import NOTHING from the run half.
 
   Control plane: app · rest · ws · auth · catalog · connections · config · metrics · ops · reaper
                  schemas · adapters.k8s · adapters.factory  (FastAPI, uvicorn, the k8s client)
   Run mode:      runner.executor (the url4 engine) · runner.connector · runner.main
+  Worker:        worker (the claim loop, the supervisor, the exec wrapper)
 
   Shared leaves, importable by BOTH: job_env · subjects · adapters.jetstream · world_config
 
@@ -67,6 +74,7 @@ CONTROL_PLANE = {
     "adapters.factory",
 }
 RUN_MODE = {"runner"}
+WORKER_MODE = {"worker"}
 
 # (subtree under screamingface_engine/, forbidden screamingface_engine submodules, why)
 RULES: list[tuple[str, set[str], str]] = [
@@ -81,6 +89,13 @@ RULES: list[tuple[str, set[str], str]] = [
         RUN_MODE,
         "the control plane schedules runs and reads their log over NATS; it never evaluates an "
         "expression in-process, so it must not reach into the engine-bearing half",
+    ),
+    (
+        "worker",
+        RUN_MODE,
+        "the worker spawns the run as a child process; it never imports it — the run half stays "
+        "a separate crash domain, and the worker's import graph stays the serving half's plus "
+        "the queue",
     ),
 ]
 
@@ -171,13 +186,16 @@ def files_for(subtree: str) -> list[pathlib.Path]:
 
 
 def _half_of(path: pathlib.Path) -> str | None:
-    """Which half a module belongs to: "control-plane", "run-mode", or None for a shared leaf."""
+    """Which half a module belongs to: "control-plane", "run-mode", "worker-mode", or None for a
+    shared leaf."""
     parts = path.relative_to(SRC).with_suffix("").parts
     if not parts:
         return None
     top, two = parts[0], ".".join(parts[:2])
     if top in RUN_MODE:
         return "run-mode"
+    if top in WORKER_MODE:
+        return "worker-mode"
     if top in CONTROL_PLANE or two in CONTROL_PLANE:
         return "control-plane"
     return None
@@ -242,7 +260,8 @@ def main() -> int:
         )
         return 1
     print(
-        "LAYERING OK: screamingface_engine.runner and the control plane stay disjoint."
+        "LAYERING OK: screamingface_engine.runner, the worker, and the control plane stay "
+        "disjoint."
     )
     return 0
 

--- a/.claude/scripts/check_layering.py
+++ b/.claude/scripts/check_layering.py
@@ -91,6 +91,14 @@ RULES: list[tuple[str, set[str], str]] = [
         "expression in-process, so it must not reach into the engine-bearing half",
     ),
     (
+        "",  # every control-plane module, listed below
+        WORKER_MODE,
+        "the control plane never spawns runs itself — only the worker does, so it must not "
+        "reach into the worker's subprocess-spawning/RLIMIT_AS-bearing half; the dependency "
+        "arrow is one-way (worker → serving half), and this rule checks the direction the "
+        "other three forgot",
+    ),
+    (
         "worker",
         RUN_MODE,
         "the worker spawns the run as a child process; it never imports it — the run half stays "

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -335,7 +335,18 @@ class _JetStreamConnection:
         the stream's tail without subscribing. A missing stream, an empty stream, or an
         unreadable frame all read as None — the conservative direction for both checks.
         """
-        js = await self._jetstream()
+        try:
+            js = await self._jetstream()
+        except NatsError as exc:
+            # The connect/declare path sits OUTSIDE the fetch's try below, so a dropped
+            # broker — a failed reconnect raising a bare transport error — used to escape
+            # `last_frame` unwrapped, bypassing every `except QueueReadError` guard the
+            # callers rely on (review follow-up V-7 / pass-1 #11): unreadable is unreadable
+            # however it was reached, so it gets the same typed translation. A JetStream
+            # API verdict from the connect-time declare is translated the same way — it is
+            # a config failure, and the retry-and-log shape it produces is both visible
+            # and non-cascading.
+            raise QueueReadError(f"queue backend unreachable for {topic}: {exc!r}") from exc
         try:
             raw = await js.get_last_msg(stream_for(topic), subject_for(topic))
         except APIError:

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 
 import nats
 from nats.aio.client import Client
+from nats.errors import Error as NatsError
 from nats.js import JetStreamContext, api
 from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy, DiscardPolicy, StreamInfo
 from nats.js.errors import APIError, BadRequestError, NotFoundError
@@ -45,6 +46,18 @@ class DeferredPublishError(RuntimeError):
     error. Wrapped rather than re-raised bare so the message says WHERE it surfaced: the
     frame that caused it is long gone by then, and a naked APIError at a later sequence
     number reads as a failure of the wrong frame.
+    """
+
+
+class QueueReadError(RuntimeError):
+    """The stream tail could not be read — a TRANSIENT broker failure, not an answer.
+
+    Distinct from "no frame" (which `last_frame` returns as `None`): this says the read
+    itself failed — a `nats.errors.Error` that is not a JetStream `APIError` (a request
+    timeout, a closed connection, a reconnect in flight). Callers that must not mistake
+    "unreadable" for "empty" — the worker's claim-time dedupe gate — catch this and skip
+    the claim, leaving the message for redelivery, instead of either acting on a phantom
+    `None` or letting the error escape into a shared task group.
     """
 
 
@@ -326,7 +339,15 @@ class _JetStreamConnection:
         try:
             raw = await js.get_last_msg(stream_for(topic), subject_for(topic))
         except APIError:
+            # A missing stream or an empty one: a REAL answer — there is no last frame.
             return None
+        except NatsError as exc:
+            # Transport-level (not a JetStream API verdict): a request timeout, a closed
+            # connection, a reconnect in flight. That is NOT "no frame" — translating it to
+            # None would let the claim gate mistake an unreadable tail for "no terminal
+            # frame" and execute a finished run a second time. Raise the typed error; the
+            # callers that can safely wait catch it.
+            raise QueueReadError(f"stream tail unreadable for {topic}: {exc!r}") from exc
         try:
             return decode(raw.data or b"")
         except ValidationError:
@@ -509,4 +530,4 @@ class JetStreamPublisher(_JetStreamConnection, EventPublisher):
             ) from exc
 
 
-__all__ = ["DeferredPublishError", "JetStreamConsumer", "JetStreamPublisher"]
+__all__ = ["DeferredPublishError", "JetStreamConsumer", "JetStreamPublisher", "QueueReadError"]

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -313,6 +313,25 @@ class _JetStreamConnection:
         ended = frame.time if frame.time.tzinfo is not None else frame.time.replace(tzinfo=UTC)
         return (datetime.now(UTC) - ended).total_seconds() > self._orphan_grace_s
 
+    async def last_frame(self, topic: str) -> OutboundFrame | None:
+        """The run's last published frame, or None when the stream is missing or empty.
+
+        WHY this exists: the worker's dedupe check (a terminal frame already on the stream
+        means the run is over — redelivery, cancel-before-claim, or stale) and its
+        post-exit check (did the child publish its own terminal frame?) both need to read
+        the stream's tail without subscribing. A missing stream, an empty stream, or an
+        unreadable frame all read as None — the conservative direction for both checks.
+        """
+        js = await self._jetstream()
+        try:
+            raw = await js.get_last_msg(stream_for(topic), subject_for(topic))
+        except APIError:
+            return None
+        try:
+            return decode(raw.data or b"")
+        except ValidationError:
+            return None
+
     async def delete_stream(self, topic: str) -> None:
         """Drop a run's stream entirely, tolerating one that is already gone.
 

--- a/apps/screamingface-engine/src/screamingface_engine/cli.py
+++ b/apps/screamingface-engine/src/screamingface_engine/cli.py
@@ -1,14 +1,16 @@
-"""``screamingface-engine`` console entrypoint — one image, two modes.
+"""``screamingface-engine`` console entrypoint — one image, three modes.
 
-    screamingface-engine serve   # the control plane: mint tokens, bridge WS, schedule Runner Jobs
-    screamingface-engine run     # one url4 evaluation, streamed to NATS, then exit
+    screamingface-engine serve    # the control plane: mint tokens, bridge WS, schedule Runner Jobs
+    screamingface-engine run      # one url4 evaluation, streamed to NATS, then exit
+    screamingface-engine worker   # claim runs from the durable queue, supervise each as a child
 
 WHY one artifact with a mode argument rather than two images: the two halves already shared
 their whole wire vocabulary (`job_env`, `subjects`, the JetStream binding), and keeping them in
 separate distributions meant maintaining hand-synced duplicates of all three plus contract tests
 whose only job was to catch the copies drifting. The run mode's dependencies are a strict subset
 of the serving mode's, so merging cost no new dependency — only the serving-side packages now
-sitting unused on a Job's disk.
+sitting unused on a Job's disk. The worker mode (OME-1089) is the third mode: it imports the
+serving half and the queue, and spawns the run as a child process rather than importing it.
 
 INVARIANT: the mode is chosen by ARGV, never sniffed from the environment.
 `K8sJobRunner` schedules `["screamingface-engine", "run"]` explicitly, so a Job that
@@ -81,6 +83,15 @@ def _run() -> None:
     run_main()
 
 
+def _worker() -> None:
+    """Claim runs from the durable queue and supervise each as a child process."""
+    # WHY: lazy, like the other modes — the worker's import graph is the serving half's plus
+    # the queue, and a mode that is not running must not pay for it.
+    from screamingface_engine.worker.loop import run_worker
+
+    run_worker()
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         prog="screamingface-engine",
@@ -105,13 +116,22 @@ def main(argv: list[str] | None = None) -> None:
         ),
     )
     sub.add_parser("run", help="execute one url4 expression from the environment, then exit")
+    sub.add_parser(
+        "worker",
+        help=(
+            "claim runs from the durable run queue and supervise each as a child process "
+            "(the fixed worker pool of OME-1086)"
+        ),
+    )
     args = parser.parse_args(argv)
 
     # BEFORE dispatch, and for every mode: a Job's logs are as load-bearing as the control
     # plane's, and neither `uvicorn.run` nor `run_main` configures anything for this package.
     configure_logging()
 
-    if args.mode == "run":
+    if args.mode == "worker":
+        _worker()
+    elif args.mode == "run":
         _run()
     elif args.local:
         _serve_local()

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -409,3 +409,20 @@ class Settings(BaseSettings):
                 f"still valid re-opens replay"
             )
         return self
+
+    @model_validator(mode="after")
+    def _enforce_ack_wait_floor(self) -> Self:
+        """INVARIANT: the worker's heartbeat cadence is derived as ``ack_wait / 3`` (capped
+        at 20s), and it must never collapse below ~1s or the in-progress cadence hammers the
+        broker — and must always stay well under ``ack_wait``, or JetStream redelivers a
+        STILL-RUNNING run to a second worker and it executes twice. The derivation guarantees
+        the ratio for every legal value; this floor bounds the legal range so the derived
+        cadence stays sane. Refused at startup rather than as a mid-flight double execution.
+        """
+        if self.run_queue_ack_wait_s < 3.0:
+            raise ValueError(
+                f"run_queue_ack_wait_s={self.run_queue_ack_wait_s} is below the floor of 3s — "
+                f"the worker derives its heartbeat as ack_wait/3 and refuses to run one that "
+                f"would hammer the broker or fall behind the redelivery clock"
+            )
+        return self

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -22,6 +22,10 @@ ArtifactStoreBackend = Literal["filesystem", "s3"]
 and bridges NATS but schedules nothing.
 """
 
+# The worker's per-run address-space cap (OME-1089). 2 GiB — see the field's comment for why it
+# sits above the old 1 GiB k8s cgroup limit.
+DEFAULT_WORKER_MEMORY_BUDGET_BYTES = 2 * 1024**3
+
 # WHY a named module constant (not a bare literal) for the insecure default: the prod guard in
 # app.py (_require_prod_secret) compares against this same sentinel so the two never drift. If the
 # default changes and the guard isn't updated, a prod boot would silently proceed on the weak
@@ -300,6 +304,36 @@ class Settings(BaseSettings):
     # the fleet can drain in a reasonable time, rather than piling up unbounded work. THIS unit
     # only declares the setting; the admission decision lands with the cutover (OME-1086).
     run_queue_depth_ceiling: int = runner_queue.DEFAULT_DEPTH_CEILING
+
+    # --- worker (OME-1089) -----------------------------------------------------------------
+    # WHY a worker at all: OME-1086 replaces one-Job-per-run scheduling with a fixed pool of
+    # worker Pods pulling from the durable run queue. THIS unit adds the worker mode itself: a
+    # slot pool that claims runs from the queue and forks the run entrypoint as a supervised
+    # child process, so the crash domain stays one run.
+    #
+    # INVARIANT: the worker's slot count is `run_queue_worker_slots` (above) — the same value
+    # the queue settings derive `max_ack_pending` from — so the worker's concurrency and the
+    # queue's ack-pending bound cannot disagree. There is deliberately no second `worker_slots`
+    # field for the same number.
+    #
+    # WHY a grace at all: on SIGTERM the worker stops pulling but keeps its in-flight children
+    # alive, still heartbeating, so a run that is about to finish is not killed for nothing.
+    # After the grace the remaining children are SIGTERM'd and each publishes
+    # `Terminated(stopped)` with a `worker_draining` reason.
+    worker_drain_grace_s: float = 30.0
+    # WHY a per-run budget and not a shared gate: the fair-share gate is in-process only, and
+    # subprocess isolation means it cannot span runs — each child is its own process. The
+    # budget therefore travels by env: the worker writes it onto every child as
+    # `URL4_CLOUD_IO_CONCURRENCY`, overriding whatever the message carried, so the worker is
+    # the authority on how wide a run may fan out at the gateway.
+    worker_io_capacity: int = Field(default=4, ge=1)
+    # WHY a per-run address-space cap at all: an over-allocating run must fail ALONE. Each
+    # child is spawned under its own `RLIMIT_AS` (via the exec wrapper, never `preexec_fn`),
+    # so a run that blows its budget dies with a MemoryError instead of triggering a Pod OOM
+    # that kills its co-tenants. 2 GiB is deliberately above the old 1 GiB k8s cgroup limit:
+    # `RLIMIT_AS` bounds VIRTUAL address space (heap + mapped libraries), which is larger than
+    # the RSS a cgroup limit measures.
+    worker_memory_budget_bytes: int = Field(default=DEFAULT_WORKER_MEMORY_BUDGET_BYTES, ge=1)
 
     @property
     def effective_job_ttl_s(self) -> int:

--- a/apps/screamingface-engine/src/screamingface_engine/worker/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/__init__.py
@@ -1,0 +1,13 @@
+"""The worker half (OME-1089): a slot pool that claims runs from the durable run queue
+and forks the existing run entrypoint as a supervised child process, so the crash domain
+stays one run and ``runner/main.py`` is untouched.
+
+LAYERING: the worker may import the serving half and ``runner_queue``, and must import
+NOTHING from the run half (no ``runner/``, no ``url4.streaming.lifecycle``) — it spawns
+the run as a child process, it never imports it. The layering gate names this half
+explicitly (see ``.claude/scripts/check_layering.py``).
+"""
+
+from screamingface_engine.worker.loop import PULL_TIMEOUT_S, Worker, run_worker
+
+__all__ = ["PULL_TIMEOUT_S", "Worker", "run_worker"]

--- a/apps/screamingface-engine/src/screamingface_engine/worker/exec_wrapper.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/exec_wrapper.py
@@ -1,0 +1,30 @@
+"""The exec wrapper that puts each run under its own ``RLIMIT_AS`` (OME-1089).
+
+The worker forks the run entrypoint as a child process, and each child must be spawned
+under its own address-space limit so an over-allocating run fails alone instead of
+triggering a Pod OOM that kills its co-tenants — which would void the reason for
+choosing subprocess isolation in the first place.
+
+WHY a wrapper and not ``preexec_fn``: CPython documents ``preexec_fn`` as unsafe in the
+presence of threads, and this process runs an event loop plus whatever the NATS client
+starts. The wrapper is a separate tiny process: it sets the limit, then execs
+``screamingface-engine run`` in place, so the run inherits the limit and the worker
+never touches the child's memory.
+
+The wrapper imports nothing but the stdlib, so it stays importable even if the rest of
+the worker's import graph is broken.
+"""
+
+import os
+import resource
+import sys
+
+
+def main() -> None:
+    budget = int(sys.argv[1])
+    resource.setrlimit(resource.RLIMIT_AS, (budget, budget))
+    os.execvpe("screamingface-engine", ["screamingface-engine", "run"], os.environ)
+
+
+if __name__ == "__main__":  # pragma: no cover - execs in place; nothing to return to
+    main()

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -1,0 +1,203 @@
+"""The worker's claim loop (OME-1089): a slot pool that pulls runs from the durable
+queue and supervises each as a child process.
+
+The loop is deliberately small: it owns the slot accounting (the worker's only shared
+mutable state), the pull cadence, and the drain path. Everything about ONE run — the
+dedupe check, the spawn, the heartbeats, the hard wall, the terminal frame — lives in
+:class:`screamingface_engine.worker.supervisor.RunSupervisor`, so the loop reads as what
+it is: claim up to the free slots, hand each message to a supervisor, and on SIGTERM
+stop claiming and let the children drain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Protocol
+
+from screamingface_engine.config import Settings
+from screamingface_engine.worker.supervisor import (
+    DEADLINE_MARGIN_S,
+    HEARTBEAT_INTERVAL_S,
+    KILL_GRACE_S,
+    ClaimedMessage,
+    RunSupervisor,
+    _ChildProcess,
+    _Publisher,
+)
+
+# How long a pull waits for the first message before the loop re-checks the drain signal.
+# Short on purpose: the drain signal is only noticed between pulls, so a long timeout
+# would delay a drain by that long.
+PULL_TIMEOUT_S = 5.0
+# How often the drain phase re-checks whether the in-flight children have finished.
+_DRAIN_POLL_S = 0.05
+
+
+class _Queue(Protocol):
+    """The slice of ``RunQueue`` the worker uses."""
+
+    async def pull(self, batch: int, timeout_s: float) -> Sequence[ClaimedMessage]: ...
+
+
+class Worker:
+    """The slot pool: claim runs from the queue, supervise each as a child process.
+
+    ``queue`` and ``publisher`` are injected (the composition root builds the real
+    ``RunQueue`` and ``JetStreamPublisher``; tests hand in fakes). ``spawn`` defaults to
+    ``asyncio.create_subprocess_exec`` and is injectable so tests can hand in a fake
+    process.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue: _Queue,
+        publisher: _Publisher,
+        slots: int,
+        drain_grace_s: float,
+        io_capacity: int,
+        memory_budget_bytes: int,
+        spawn: Callable[..., Awaitable[_ChildProcess]] | None = None,
+        pull_timeout_s: float = PULL_TIMEOUT_S,
+        heartbeat_interval_s: float = HEARTBEAT_INTERVAL_S,
+        deadline_margin_s: float = DEADLINE_MARGIN_S,
+        kill_grace_s: float = KILL_GRACE_S,
+    ) -> None:
+        if slots < 1:
+            raise ValueError(f"worker slots must be >= 1, got {slots}")
+        self._queue = queue
+        self._publisher = publisher
+        self._slots = slots
+        self._drain_grace_s = drain_grace_s
+        self._pull_timeout_s = pull_timeout_s
+        # The drain signal: set by SIGTERM/SIGINT (or by a test). The claim loop stops
+        # pulling once it is set; the supervisors read it to classify a drain termination.
+        self._draining = asyncio.Event()
+        # Set by the drain phase AFTER `drain_grace_s` has elapsed, the moment it SIGTERMs
+        # the remaining children. A supervisor waiting on a child that ignores SIGTERM
+        # wakes on this and SIGKILLs instead of waiting out the hard wall.
+        self._terminating = asyncio.Event()
+        # The live children, shared with the supervisors: the drain phase reads it to know
+        # when the pool has drained, and SIGTERMs whatever is left.
+        self._children: set[_ChildProcess] = set()
+        # The in-flight supervisor tasks — the slot accounting. asyncio is single-threaded,
+        # so no lock is needed; the fetch batch is computed from the free slots below.
+        self._active: set[asyncio.Task[None]] = set()
+        self._supervisor = RunSupervisor(
+            publisher=publisher,
+            spawn=spawn if spawn is not None else asyncio.create_subprocess_exec,
+            memory_budget_bytes=memory_budget_bytes,
+            io_capacity=io_capacity,
+            draining=self._draining,
+            terminating=self._terminating,
+            children=self._children,
+            heartbeat_interval_s=heartbeat_interval_s,
+            deadline_margin_s=deadline_margin_s,
+            kill_grace_s=kill_grace_s,
+        )
+
+    async def run(self) -> None:
+        """Run the worker until the drain signal, then drain and exit.
+
+        The supervisors live in a ``TaskGroup`` so a failure cancels siblings
+        deterministically: one run's supervision blowing up (a broker error, a bug) stops
+        the pool rather than leaving the other runs unsupervised.
+        """
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, self._draining.set)
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tg.create_task(self._claim_loop(tg))
+        finally:
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.remove_signal_handler(sig)
+
+    async def _claim_loop(self, tg: asyncio.TaskGroup) -> None:
+        """Claim runs from the queue and supervise them, until the drain signal.
+
+        INVARIANT: the fetch batch is computed from FREE slots — ``worker_slots`` minus
+        the supervisors in flight — so the worker never holds more unacked messages than
+        it can run, and never starves sibling pull consumers by fetching more than the
+        pool can hold. When every slot is busy the loop waits for a supervisor to finish
+        before pulling again.
+        """
+        while not self._draining.is_set():
+            free = self._slots - len(self._active)
+            if free <= 0:
+                if self._active:
+                    # Wait for a slot — or the drain signal, so a full pool cannot
+                    # deadlock the drain (the supervisors would never finish on their
+                    # own, and the drain handler runs only after this loop exits).
+                    drain_task = asyncio.create_task(self._draining.wait())
+                    done, _ = await asyncio.wait(
+                        {*self._active, drain_task}, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    drain_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await drain_task
+                    for task in done:
+                        self._active.discard(task)
+                continue
+            msgs = await self._queue.pull(free, timeout_s=self._pull_timeout_s)
+            for msg in msgs:
+                task = tg.create_task(self._supervisor.supervise(msg))
+                self._active.add(task)
+                task.add_done_callback(self._active.discard)
+        await self._drain()
+
+    async def _drain(self) -> None:
+        """The drain phase: let children finish naturally up to ``drain_grace_s``, then
+        SIGTERM the rest so each publishes ``Terminated(stopped, worker_draining)``.
+
+        The supervisors keep heartbeating throughout, so a draining worker never looks
+        abandoned to the queue. After the grace, ``_terminating`` is set and the remaining
+        children are SIGTERM'd; each supervisor classifies the death as a drain and
+        publishes its named frame before acking.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._drain_grace_s
+        while self._children and loop.time() < deadline:
+            await asyncio.sleep(_DRAIN_POLL_S)
+        self._terminating.set()
+        for proc in tuple(self._children):
+            proc.terminate()
+
+
+def run_worker(settings: Settings | None = None) -> None:
+    """The worker's composition root: build the queue, publisher, and worker from Settings.
+
+    ``settings`` is injectable for tests; production callers leave it ``None`` and let
+    ``Settings()`` read the environment.
+    """
+    from screamingface_engine.adapters.jetstream import JetStreamPublisher
+    from screamingface_engine.runner_queue import RunQueue
+
+    settings = settings if settings is not None else Settings()
+    queue = RunQueue(
+        settings.nats_url,
+        ack_wait_s=settings.run_queue_ack_wait_s,
+        max_deliver=settings.run_queue_max_deliver,
+        max_ack_pending=settings.run_queue_max_ack_pending,
+        duplicate_window_s=settings.run_queue_duplicate_window_s,
+        max_age_s=settings.run_queue_max_age_s,
+    )
+    publisher = JetStreamPublisher(settings.nats_url)
+    worker = Worker(
+        queue=queue,
+        publisher=publisher,
+        # INVARIANT: the worker's slot count is `run_queue_worker_slots` — the same value
+        # the queue settings derive `max_ack_pending` from — so the worker's concurrency
+        # and the queue's ack-pending bound cannot disagree.
+        slots=settings.run_queue_worker_slots,
+        drain_grace_s=settings.worker_drain_grace_s,
+        io_capacity=settings.worker_io_capacity,
+        memory_budget_bytes=settings.worker_memory_budget_bytes,
+    )
+    asyncio.run(worker.run())
+
+
+__all__ = ["PULL_TIMEOUT_S", "Worker", "run_worker"]

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -21,6 +21,7 @@ from screamingface_engine.config import Settings
 from screamingface_engine.worker.supervisor import (
     DEADLINE_MARGIN_S,
     HEARTBEAT_INTERVAL_S,
+    derived_heartbeat_interval_s,
     KILL_GRACE_S,
     ClaimedMessage,
     RunSupervisor,
@@ -179,13 +180,15 @@ def run_worker(settings: Settings | None = None) -> None:
     settings = settings if settings is not None else Settings()
     queue = RunQueue(
         settings.nats_url,
+        stream=settings.run_queue_stream,
         ack_wait_s=settings.run_queue_ack_wait_s,
         max_deliver=settings.run_queue_max_deliver,
         max_ack_pending=settings.run_queue_max_ack_pending,
         duplicate_window_s=settings.run_queue_duplicate_window_s,
         max_age_s=settings.run_queue_max_age_s,
     )
-    publisher = JetStreamPublisher(settings.nats_url)
+    # The publisher's sweep must exclude the CONFIGURED queue stream, not a stale constant.
+    publisher = JetStreamPublisher(settings.nats_url, run_queue_stream=settings.run_queue_stream)
     worker = Worker(
         queue=queue,
         publisher=publisher,
@@ -196,6 +199,11 @@ def run_worker(settings: Settings | None = None) -> None:
         drain_grace_s=settings.worker_drain_grace_s,
         io_capacity=settings.worker_io_capacity,
         memory_budget_bytes=settings.worker_memory_budget_bytes,
+        # INVARIANT: the heartbeat cadence is DERIVED from the configured `ack_wait`, not
+        # left at the constant — a heartbeat slower than `ack_wait` redelivers a still-
+        # running run to a second worker (double execution). `derived_heartbeat_interval_s`
+        # keeps `heartbeat <= ack_wait / 3` for every legal configuration.
+        heartbeat_interval_s=derived_heartbeat_interval_s(settings.run_queue_ack_wait_s),
     )
     asyncio.run(worker.run())
 

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -201,12 +201,23 @@ class Worker:
         # supervisor's kill path having NEVER received a SIGTERM — hard-killed
         # `kill_grace` after spawn with no chance to publish its frames (review
         # follow-up N-2). Re-polling until the pool is empty closes that: any child is
-        # SIGTERM'd within one poll of registering, and `terminate()` on an
-        # already-terminated child is harmless.
+        # SIGTERM'd within one poll of registering.
         self._terminating.set()
         while self._active:
             for proc in tuple(self._children):
-                proc.terminate()
+                # WHY the guard (review follow-up V-1): `_release_child` removes a finished
+                # child only AFTER its publish and ack round trips, so an EXITED child is
+                # routinely still here when this pass lands — and `terminate()` on one is
+                # NOT harmless. A real transport raises `ProcessLookupError` (an `OSError`)
+                # from `_check_proc` once the process is reaped; unsuppressed it escaped
+                # into the shared TaskGroup and SIGKILLed every remaining draining child —
+                # the P2-1 cascade, reintroduced by the drain, on every drain. A child
+                # whose exit was observed is skipped outright; one reaped in the window
+                # before the watcher fires (returncode still None) is suppressed.
+                if proc.returncode is not None:
+                    continue
+                with contextlib.suppress(ProcessLookupError):
+                    proc.terminate()
             await asyncio.sleep(_DRAIN_POLL_S)
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import logging
 import signal
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Protocol
@@ -21,13 +22,15 @@ from screamingface_engine.config import Settings
 from screamingface_engine.worker.supervisor import (
     DEADLINE_MARGIN_S,
     HEARTBEAT_INTERVAL_S,
-    derived_heartbeat_interval_s,
     KILL_GRACE_S,
     ClaimedMessage,
     RunSupervisor,
     _ChildProcess,
     _Publisher,
+    derived_heartbeat_interval_s,
 )
+
+logger = logging.getLogger(__name__)
 
 # How long a pull waits for the first message before the loop re-checks the drain signal.
 # Short on purpose: the drain signal is only noticed between pulls, so a long timeout
@@ -35,6 +38,12 @@ from screamingface_engine.worker.supervisor import (
 PULL_TIMEOUT_S = 5.0
 # How often the drain phase re-checks whether the in-flight children have finished.
 _DRAIN_POLL_S = 0.05
+
+
+# How often a pull that failed on a transient broker error is retried. Short: the claim
+# loop is only blocked for the retry, and a broker that is down fails the NEXT connect too —
+# this is a backoff, not the recovery mechanism.
+_PULL_RETRY_S = 1.0
 
 
 class _Queue(Protocol):
@@ -143,7 +152,21 @@ class Worker:
                     for task in done:
                         self._active.discard(task)
                 continue
-            msgs = await self._queue.pull(free, timeout_s=self._pull_timeout_s)
+            try:
+                msgs = await self._queue.pull(free, timeout_s=self._pull_timeout_s)
+            except Exception as exc:
+                # WHY a local catch and not a crash (review follow-up N-3): `pull` wraps
+                # the broker calls — the fetch itself and the `ensure_stream` it guards —
+                # and a transient broker error escaping here would land in the shared
+                # TaskGroup and cancel every co-located supervisor, SIGKILLing N healthy
+                # children: the same cascade as the supervisor's own guarded reads,
+                # reached from the claim side. Log and retry; if the loop is genuinely
+                # wedged, the claim-liveness gauge stops advancing and the operator's
+                # alert fires. `CancelledError` is a `BaseException` and passes through,
+                # so a shutdown still lands.
+                logger.warning("queue pull failed with %r; retrying in %.1fs", exc, _PULL_RETRY_S)
+                await asyncio.sleep(_PULL_RETRY_S)
+                continue
             for msg in msgs:
                 task = tg.create_task(self._supervisor.supervise(msg))
                 self._active.add(task)
@@ -161,11 +184,30 @@ class Worker:
         """
         loop = asyncio.get_running_loop()
         deadline = loop.time() + self._drain_grace_s
-        while self._children and loop.time() < deadline:
+
+        # Phase 1 — the grace window: let in-flight runs finish naturally. WHY the ACTIVE
+        # supervisor tasks and not the CHILDREN (review follow-up P2-6): a task is
+        # registered the moment its run is claimed, while its child only registers once
+        # the spawn completes — a run whose spawn was still in flight when the signal
+        # landed used to find `_children` EMPTY and consume ZERO grace: `_terminating`
+        # was set immediately and the run was killed `kill_grace` after spawn with no
+        # chance to finish on its own. Waiting on the tasks counts every claimed run.
+        while self._active and loop.time() < deadline:
             await asyncio.sleep(_DRAIN_POLL_S)
+
+        # Phase 2 — the deadline: flip `_terminating` (each remaining supervisor's kill
+        # path engages) and terminate children as they appear. The old one-shot snapshot
+        # pass over `_children` let a child that registered AFTER the pass reach its
+        # supervisor's kill path having NEVER received a SIGTERM — hard-killed
+        # `kill_grace` after spawn with no chance to publish its frames (review
+        # follow-up N-2). Re-polling until the pool is empty closes that: any child is
+        # SIGTERM'd within one poll of registering, and `terminate()` on an
+        # already-terminated child is harmless.
         self._terminating.set()
-        for proc in tuple(self._children):
-            proc.terminate()
+        while self._active:
+            for proc in tuple(self._children):
+                proc.terminate()
+            await asyncio.sleep(_DRAIN_POLL_S)
 
 
 def run_worker(settings: Settings | None = None) -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -239,6 +239,12 @@ def run_worker(settings: Settings | None = None) -> None:
         max_ack_pending=settings.run_queue_max_ack_pending,
         duplicate_window_s=settings.run_queue_duplicate_window_s,
         max_age_s=settings.run_queue_max_age_s,
+        # INVARIANT: the App and the worker declare the SAME singleton stream, and
+        # `ensure_stream` refuses a declaration whose properties diverge from an existing
+        # one — so both halves must read this from the same setting. Omitting it here left
+        # the worker on the code default regardless of configuration, which on a clustered
+        # broker is a startup failure for whichever half declares second.
+        replicas=settings.run_queue_replicas,
     )
     # The publisher's sweep must exclude the CONFIGURED queue stream, not a stale constant.
     publisher = JetStreamPublisher(settings.nats_url, run_queue_stream=settings.run_queue_stream)

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -183,7 +183,7 @@ class RunSupervisor:
             await msg.ack()
             return
         self._children.add(proc)
-        heartbeat = asyncio.create_task(self._heartbeat(msg))
+        heartbeat = asyncio.create_task(self._heartbeat(msg, topic))
         output = asyncio.create_task(self._forward_output(proc, topic))
         try:
             outcome = await self._wait_for_child(proc, self._hard_wall_s(env))
@@ -192,10 +192,17 @@ class RunSupervisor:
         finally:
             heartbeat.cancel()
             output.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await heartbeat
-            with contextlib.suppress(asyncio.CancelledError):
-                await output
+            # WHY gather and not sequential awaits under one `suppress`: a task that already
+            # FAILED (not cancelled) re-raises its own exception on await, and `cancel()` is a
+            # no-op on it — so `await heartbeat` would blow the finally block open and skip
+            # every line below it (the child stays in `self._children`, a live child is never
+            # killed). `return_exceptions=True` makes the gather itself unraisable; the two
+            # cleanup lines after it are therefore unconditional.
+            for result in await asyncio.gather(heartbeat, output, return_exceptions=True):
+                if isinstance(result, BaseException) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    logger.warning("run supervision task failed during cleanup: %r", result)
             self._children.discard(proc)
             if proc.returncode is None:
                 # A cancelled supervisor (a sibling failed and the TaskGroup unwound)
@@ -390,7 +397,7 @@ class RunSupervisor:
 
     # --- the child's side channels --------------------------------------------------------
 
-    async def _heartbeat(self, msg: ClaimedMessage) -> None:
+    async def _heartbeat(self, msg: ClaimedMessage, topic: str) -> None:
         """Extend the claimed message's ack_wait while its child runs.
 
         Without this, a run longer than the queue's ``ack_wait`` (60s) would be
@@ -400,7 +407,17 @@ class RunSupervisor:
         """
         while True:
             await asyncio.sleep(self._heartbeat_interval_s)
-            await msg.in_progress()
+            try:
+                await msg.in_progress()
+            except asyncio.CancelledError:
+                raise  # the run is over — the supervisor cancelled this task
+            except Exception:
+                # A transient broker failure (a connection blip, a protocol error) must not
+                # kill the heartbeat: the task dying here means the ack_wait runs out, the
+                # message is redelivered mid-run, and a second worker double-runs it — the
+                # exact outcome the heartbeat exists to prevent. Log and keep the loop; the
+                # broker recovers or the run ends, and either way the next extension retries.
+                logger.exception("heartbeat extension failed for %s; retrying next interval", topic)
 
     async def _forward_output(self, proc: _ChildProcess, topic: str) -> None:
         """Forward the child's stdout/stderr to the worker's log, topic-bound.

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -1,0 +1,463 @@
+"""One run's supervision (OME-1089): claim → dedupe → spawn → heartbeat → classify → ack.
+
+The worker's crash domain is ONE run: each claimed message is forked as a child process
+running the existing ``screamingface-engine run`` entrypoint, and this module owns that
+child's whole life — the dedupe check before it starts, the in-progress heartbeats that
+keep a 16-hour run from looking abandoned, the hard wall that replaces
+``activeDeadlineSeconds``, the drain path, and the named terminal frame that turns a
+dead child into something a client can actually see.
+
+LAYERING: this module imports the serving half and ``runner_queue``, and NOTHING from the
+run half — the run is spawned as a child process, never imported (see the layering note
+in :mod:`screamingface_engine.worker`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import sys
+import uuid
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any, Literal, Protocol
+
+from screamingface_engine import job_env
+from screamingface_engine.logs import run_scope
+from screamingface_engine.runner_queue import decode_message, topic_of_message
+from url4.streaming.protocol import (
+    ErrorInfo,
+    OutboundFrame,
+    TerminatedData,
+    TerminatedEvent,
+    source_for,
+)
+
+logger = logging.getLogger(__name__)
+
+TerminalStatus = Literal["succeeded", "failed", "stopped", "timed_out"]
+"""The four terminal statuses a run can end in (``TerminatedData.status``)."""
+
+# The named error codes the worker itself publishes. Each is a real, client-visible
+# reason — the whole point of the worker's terminal frames is that a dead child reads as
+# a named failure rather than silence.
+QUEUE_EXPIRED = "queue_expired"
+"""The run's capability expired while it sat in the queue; it was dropped unexecuted."""
+WORKER_DRAINING = "worker_draining"
+"""The worker is draining and stopped the run before it finished."""
+DEADLINE_EXCEEDED = "deadline_exceeded"
+"""The child hung past the hard wall and was SIGTERM'd, then SIGKILL'd."""
+OOM_KILLED = "oom_killed"
+"""The child exited 137 — the OS killed it for exceeding its memory budget."""
+KILLED = "killed"
+"""The child was killed by a signal."""
+CHILD_EXITED = "child_exited"
+"""The child exited non-zero on its own."""
+SPAWN_FAILED = "spawn_failed"
+"""The child could not be started at all."""
+
+# How long a child that ignores SIGTERM is given before the worker SIGKILLs it. The
+# child is a Python process with no SIGTERM handler, so this is a backstop for a child
+# stuck in uninterruptible I/O, not a normal path.
+KILL_GRACE_S = 10.0
+# The margin past `deadline_s + STREAM_GRACE_S` before the worker declares a child hung.
+# The child enforces `deadline_s` in-process and then waits out `STREAM_GRACE_S` before
+# reclaiming its stream, so a well-behaved child exits before the wall; the margin absorbs
+# process teardown.
+DEADLINE_MARGIN_S = 30.0
+# How often the worker extends a claimed message's ack_wait while its child runs. Far
+# below the queue's default ack_wait (60s), so a 16-hour run is never redelivered.
+HEARTBEAT_INTERVAL_S = 20.0
+
+
+class ClaimedMessage(Protocol):
+    """The slice of ``nats.aio.msg.Msg`` the supervisor uses.
+
+    A Protocol rather than the concrete class so the unit tests can hand in a fake without
+    importing the broker client.
+    """
+
+    data: bytes
+    metadata: Any
+
+    async def ack(self) -> None: ...
+
+    async def in_progress(self) -> None: ...
+
+
+class _ChildProcess(Protocol):
+    """The slice of ``asyncio.subprocess.Process`` the supervisor uses."""
+
+    @property
+    def returncode(self) -> int | None: ...
+
+    stdout: Any
+    stderr: Any
+
+    async def wait(self) -> int: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+
+class _Publisher(Protocol):
+    """The slice of ``JetStreamPublisher`` the supervisor uses."""
+
+    async def last_frame(self, topic: str) -> OutboundFrame | None: ...
+
+    async def ensure_stream(self, topic: str) -> None: ...
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None: ...
+
+    async def flush(self) -> None: ...
+
+
+class RunSupervisor:
+    """Supervise one claimed run: dedupe, spawn, heartbeat, hard wall, classify, ack.
+
+    One instance is shared by every supervisor task the worker spawns; the shared state
+    it reads (the drain events, the live-children registry) is the worker's, passed in
+    at construction. The supervisor itself is stateless between runs.
+    """
+
+    def __init__(
+        self,
+        *,
+        publisher: _Publisher,
+        spawn: Callable[..., Awaitable[_ChildProcess]],
+        memory_budget_bytes: int,
+        io_capacity: int,
+        draining: asyncio.Event,
+        terminating: asyncio.Event,
+        children: set[_ChildProcess],
+        heartbeat_interval_s: float = HEARTBEAT_INTERVAL_S,
+        deadline_margin_s: float = DEADLINE_MARGIN_S,
+        kill_grace_s: float = KILL_GRACE_S,
+    ) -> None:
+        self._publisher = publisher
+        self._spawn = spawn
+        self._memory_budget_bytes = memory_budget_bytes
+        self._io_capacity = io_capacity
+        self._draining = draining
+        self._terminating = terminating
+        self._children = children
+        self._heartbeat_interval_s = heartbeat_interval_s
+        self._deadline_margin_s = deadline_margin_s
+        self._kill_grace_s = kill_grace_s
+
+    async def supervise(self, msg: ClaimedMessage) -> None:
+        """Claim one run and see it through to a terminal frame and an ack.
+
+        INVARIANT: the ack is the LAST step, after the child has exited and its terminal
+        frame is on the stream. Anything that fails before that leaves the message
+        unacked, so the broker redelivers it (up to ``max_deliver``) instead of losing
+        the run.
+        """
+        topic = topic_of_message(msg.data)
+        with run_scope(topic):
+            # One check for three cases: redelivery of a run that already finished, a
+            # cancel that landed before the claim, and a stale message whose run is over.
+            if await self._terminal_frame_exists(topic):
+                await msg.ack()
+                return
+            if self._capability_expired(msg):
+                await self._publish_terminal(
+                    topic, "failed", QUEUE_EXPIRED, "the run's capability expired while queued"
+                )
+                await msg.ack()
+                return
+            await self._run_child(msg, topic)
+
+    async def _run_child(self, msg: ClaimedMessage, topic: str) -> None:
+        """Fork the run as a child, supervise it to its terminal frame, then ack."""
+        env = self._child_env(msg)
+        try:
+            proc = await self._spawn_child(env)
+        except OSError as exc:
+            # The run cannot start at all — a named failure beats silence, and the
+            # message is acked so the run is not redelivered to fail the same way.
+            await self._publish_terminal(topic, "failed", SPAWN_FAILED, str(exc))
+            await msg.ack()
+            return
+        self._children.add(proc)
+        heartbeat = asyncio.create_task(self._heartbeat(msg))
+        output = asyncio.create_task(self._forward_output(proc, topic))
+        try:
+            outcome = await self._wait_for_child(proc, self._hard_wall_s(env))
+            await self._publish_if_needed(topic, self._classify(outcome, proc.returncode))
+            await msg.ack()
+        finally:
+            heartbeat.cancel()
+            output.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
+            with contextlib.suppress(asyncio.CancelledError):
+                await output
+            self._children.discard(proc)
+            if proc.returncode is None:
+                # A cancelled supervisor (a sibling failed and the TaskGroup unwound)
+                # must not orphan its child.
+                proc.kill()
+
+    async def _publish_if_needed(
+        self, topic: str, classification: tuple[TerminalStatus, str, str] | None
+    ) -> None:
+        """Publish the worker's named terminal frame unless the child already did."""
+        if classification is not None and not await self._terminal_frame_exists(topic):
+            await self._publish_terminal(topic, *classification)
+
+    # --- the claim-time checks ------------------------------------------------------------
+
+    async def _terminal_frame_exists(self, topic: str) -> bool:
+        """Whether the run's stream already ends in a terminal frame.
+
+        True means the run is over — the message is redelivery, a cancel that landed
+        before the claim, or a stale drop — so the worker acks and skips rather than
+        running it a second time.
+        """
+        frame = await self._publisher.last_frame(topic)
+        return isinstance(frame, TerminatedEvent)
+
+    def _capability_expired(self, msg: ClaimedMessage) -> bool:
+        """Whether the run's capability has expired while it sat in the queue.
+
+        The run's deadline counts from when the message was published: a message claimed
+        after ``deadline_s`` has elapsed has no time left to run, so executing it would
+        only produce an immediate timeout. The worker drops it with a named
+        ``queue_expired`` frame instead of executing it late. A message with no readable
+        timestamp or deadline is treated as not expired — the safe direction.
+        """
+        published_at = getattr(getattr(msg, "metadata", None), "timestamp", None)
+        if published_at is None:
+            return False
+        raw_deadline = decode_message(msg.data).get(job_env.JOB_DEADLINE_S)
+        if raw_deadline is None:
+            return False
+        return (datetime.now(UTC) - published_at).total_seconds() >= float(raw_deadline)
+
+    # --- the child ------------------------------------------------------------------------
+
+    def _child_env(self, msg: ClaimedMessage) -> dict[str, str]:
+        """The child's environment: the worker's deploy-time env merged with the message's
+        per-run env, plus the worker's own knobs.
+
+        WHY merge rather than pass the message alone: the message carries only the per-run
+        mapping; the deploy-time variables the run mode reads (``NATS_URL``,
+        ``AIGATEWAY_BASE_URL``, ``TAVILY_API_KEY``, ``RUNNER_CONFIG``, the artifact store,
+        ...) live in the worker Pod's env, and the child inherits exactly what this dict
+        says. The message's per-run values win over the worker's ambient ones, and the
+        worker's io budget is written last so it is the authority on how wide a run may
+        fan out (the fair-share gate cannot span processes, so the budget travels by env).
+        """
+        env = dict(os.environ)
+        env.update(decode_message(msg.data))
+        env[job_env.IO_CONCURRENCY] = str(self._io_capacity)
+        return env
+
+    async def _spawn_child(self, env: Mapping[str, str]) -> _ChildProcess:
+        """Fork the run entrypoint as a supervised child, under its own ``RLIMIT_AS``.
+
+        WHY through the exec wrapper and not ``preexec_fn``: CPython documents
+        ``preexec_fn`` as unsafe in the presence of threads, and this process runs an
+        event loop plus whatever the NATS client starts. The wrapper is a separate tiny
+        process that sets the address-space limit and execs ``screamingface-engine run``
+        in place, so the run inherits the limit and the worker never touches the child's
+        memory.
+        """
+        return await self._spawn(
+            sys.executable,
+            "-m",
+            "screamingface_engine.worker.exec_wrapper",
+            str(self._memory_budget_bytes),
+            env=dict(env),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+    def _hard_wall_s(self, env: Mapping[str, str]) -> float | None:
+        """The worker's hard wall for this run: ``deadline_s + STREAM_GRACE_S + margin``.
+
+        The child enforces ``deadline_s`` in-process (publishing ``Terminated(timed_out)``)
+        and then waits out ``STREAM_GRACE_S`` before reclaiming its stream, so a
+        well-behaved child exits by ``deadline_s + STREAM_GRACE_S``. Past the wall the
+        child is hung and the worker SIGTERMs, then SIGKILLs — this replaces
+        ``activeDeadlineSeconds``. A message with no deadline (the codec always writes
+        one) is unbounded, mirroring the child's own reading.
+        """
+        raw_deadline = env.get(job_env.JOB_DEADLINE_S)
+        if raw_deadline is None:
+            return None
+        grace_s = float(env.get(job_env.STREAM_GRACE_S, job_env.DEFAULT_STREAM_GRACE_S))
+        return float(raw_deadline) + grace_s + self._deadline_margin_s
+
+    async def _wait_for_child(self, proc: _ChildProcess, hard_wall_s: float | None) -> str:
+        """Wait for the child to exit, bounded by the hard wall; return how it ended.
+
+        ``"finished"`` — the child exited on its own, or was SIGTERM'd by the drain
+        handler. ``"draining"`` — the drain handler fired and the child had to be
+        SIGKILL'd. ``"deadline"`` — the hard wall expired and the worker killed it.
+        """
+        wait_task = asyncio.create_task(proc.wait())
+        term_task = asyncio.create_task(self._terminating.wait())
+        try:
+            done, _ = await asyncio.wait(
+                {wait_task, term_task},
+                timeout=hard_wall_s,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            term_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await term_task
+        if wait_task in done:
+            await wait_task
+            return "finished"
+        if term_task in done:
+            # The drain handler fired and SIGTERM'd the child, but it is still alive.
+            try:
+                await asyncio.wait_for(wait_task, timeout=self._kill_grace_s)
+            except TimeoutError:
+                proc.kill()
+                await wait_task
+            return "draining"
+        # The hard wall expired: SIGTERM, then SIGKILL.
+        wait_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await wait_task
+        await self._kill_with_grace(proc)
+        return "deadline"
+
+    async def _kill_with_grace(self, proc: _ChildProcess) -> None:
+        """SIGTERM, then SIGKILL after ``kill_grace_s`` — the hard-wall backstop."""
+        proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=self._kill_grace_s)
+        except TimeoutError:
+            proc.kill()
+            await proc.wait()
+
+    def _classify(
+        self, outcome: str, returncode: int | None
+    ) -> tuple[TerminalStatus, str, str] | None:
+        """The named terminal frame the worker must publish for a child that published none.
+
+        Returns ``(status, code, message)``, or ``None`` when the worker must add
+        nothing: a clean exit means the child's own teardown already put a terminal frame
+        on the stream (or reclaimed it), so a second one would be a duplicate.
+        """
+        if outcome == "deadline":
+            status, code, message = (
+                "timed_out",
+                DEADLINE_EXCEEDED,
+                "the run exceeded its deadline and was killed",
+            )
+        elif outcome == "draining" or self._draining.is_set():
+            status, code, message = (
+                "stopped",
+                WORKER_DRAINING,
+                "the worker is draining; the run was stopped",
+            )
+        elif returncode == 0:
+            return None
+        elif returncode == 137:
+            status, code, message = (
+                "failed",
+                OOM_KILLED,
+                "the run was killed for exceeding its memory budget",
+            )
+        elif returncode is not None and returncode < 0:
+            status, code, message = (
+                "failed",
+                KILLED,
+                f"the run was killed by signal {-returncode}",
+            )
+        else:
+            status, code, message = (
+                "failed",
+                CHILD_EXITED,
+                f"the run exited with status {returncode}",
+            )
+        return status, code, message
+
+    # --- the child's side channels --------------------------------------------------------
+
+    async def _heartbeat(self, msg: ClaimedMessage) -> None:
+        """Extend the claimed message's ack_wait while its child runs.
+
+        Without this, a run longer than the queue's ``ack_wait`` (60s) would be
+        redelivered mid-run — a second worker would claim it, see the run's own frames on
+        the stream, and ack it away, while the first worker's eventual ack would be a
+        no-op. The heartbeat is cancelled the moment the child exits.
+        """
+        while True:
+            await asyncio.sleep(self._heartbeat_interval_s)
+            await msg.in_progress()
+
+    async def _forward_output(self, proc: _ChildProcess, topic: str) -> None:
+        """Forward the child's stdout/stderr to the worker's log, topic-bound.
+
+        The child's own logs are the operator's view of a run that is not the stream, and
+        they must be attributable to the run. The worker adds no logging of its own about
+        the expression — ``runner/main.py`` already logs its length rather than its
+        content (OME-990), and the worker must not undo that.
+        """
+
+        async def _drain(stream: Any, level: int) -> None:
+            if stream is None:
+                return
+            while True:
+                line = await stream.readline()
+                if not line:
+                    return
+                logger.log(
+                    level, "run output topic=%s %s", topic, line.decode(errors="replace").rstrip()
+                )
+
+        await asyncio.gather(
+            _drain(proc.stdout, logging.INFO),
+            _drain(proc.stderr, logging.WARNING),
+        )
+
+    async def _publish_terminal(
+        self, topic: str, status: TerminalStatus, code: str, message: str
+    ) -> None:
+        """Publish a named terminal frame to the run's stream.
+
+        The frame is a root frame (``source`` is the run's own), so a client attached to
+        the run sees it as the run's outcome. The broker assigns the stream sequence, and
+        the App-side consumer stamps it onto the frame, so the client's replay cursor
+        advances past it exactly as it would past the child's own terminal frame.
+        """
+        await self._publisher.ensure_stream(topic)
+        await self._publisher.publish(
+            topic,
+            TerminatedEvent(
+                id=uuid.uuid4().hex,
+                source=source_for(topic),
+                subject=topic,
+                time=datetime.now(UTC),
+                data=TerminatedData(
+                    status=status,
+                    error=ErrorInfo(code=code, message=message),
+                ),
+            ),
+        )
+        await self._publisher.flush()
+
+
+__all__ = [
+    "CHILD_EXITED",
+    "DEADLINE_EXCEEDED",
+    "DEADLINE_MARGIN_S",
+    "HEARTBEAT_INTERVAL_S",
+    "KILL_GRACE_S",
+    "KILLED",
+    "OOM_KILLED",
+    "QUEUE_EXPIRED",
+    "RunSupervisor",
+    "SPAWN_FAILED",
+    "WORKER_DRAINING",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -25,8 +25,10 @@ from datetime import UTC, datetime
 from typing import Any, Literal, Protocol
 
 from screamingface_engine import job_env
+from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.logs import run_scope
 from screamingface_engine.runner_queue import decode_message, topic_of_message
+from screamingface_engine.subjects import ENQUEUED_AT_HEADER
 from url4.streaming.protocol import (
     ErrorInfo,
     OutboundFrame,
@@ -70,6 +72,21 @@ DEADLINE_MARGIN_S = 30.0
 # How often the worker extends a claimed message's ack_wait while its child runs. Far
 # below the queue's default ack_wait (60s), so a 16-hour run is never redelivered.
 HEARTBEAT_INTERVAL_S = 20.0
+
+
+def derived_heartbeat_interval_s(ack_wait_s: float) -> float:
+    """The heartbeat cadence the worker runs for a queue with this `ack_wait`.
+
+    WHY derived and not configured: the heartbeat exists to keep `in_progress` fresher than
+    `ack_wait`, or JetStream assumes the delivery was lost and redelivers a STILL-RUNNING run
+    to a second worker — the double execution the mechanism exists to prevent. The invariant
+    `heartbeat <= ack_wait / 3` must hold for EVERY configuration; deriving it from the one
+    knob that can violate it makes the invariant hold by construction instead of by an
+    operator remembering a comment. The cap keeps the default cadence (20s at the default
+    60s `ack_wait`); `Settings` floors `ack_wait` at 3s so the derived cadence never
+    collapses below 1s and hammers the broker.
+    """
+    return min(HEARTBEAT_INTERVAL_S, ack_wait_s / 3.0)
 
 
 class ClaimedMessage(Protocol):
@@ -144,6 +161,13 @@ class RunSupervisor:
         self._draining = draining
         self._terminating = terminating
         self._children = children
+        # Topics with a run CURRENTLY executing on this worker. A redelivered duplicate
+        # (an `ack_wait` shorter than a supervision gap, a broker hiccup) claims here while
+        # the original is still alive; without this set the duplicate would fork a second
+        # child for one topic and race its sibling to the terminal frame. Sync-guarded —
+        # the check-and-add below has no await between it, so on the single event loop it is
+        # atomic against every other claim.
+        self._topics_in_flight: set[str] = set()
         self._heartbeat_interval_s = heartbeat_interval_s
         self._deadline_margin_s = deadline_margin_s
         self._kill_grace_s = kill_grace_s
@@ -158,18 +182,46 @@ class RunSupervisor:
         """
         topic = topic_of_message(msg.data)
         with run_scope(topic):
-            # One check for three cases: redelivery of a run that already finished, a
-            # cancel that landed before the claim, and a stale message whose run is over.
-            if await self._terminal_frame_exists(topic):
+            if topic in self._topics_in_flight:
+                # A duplicate claim of a run THIS worker is already executing (redelivery
+                # racing the in-flight original). The original owns the outcome — its
+                # terminal frame and its ack — so the duplicate is acked away immediately:
+                # spawning a second child for one topic would race it to the stream, and
+                # leaving it unacked would redeliver it in a loop until the original ends.
+                logger.warning("duplicate claim of %s acked away; the run is already executing here", topic)
                 await msg.ack()
                 return
-            if self._capability_expired(msg):
-                await self._publish_terminal(
-                    topic, "failed", QUEUE_EXPIRED, "the run's capability expired while queued"
-                )
-                await msg.ack()
-                return
-            await self._run_child(msg, topic)
+            self._topics_in_flight.add(topic)
+            try:
+                await self._claim(msg, topic)
+            finally:
+                self._topics_in_flight.discard(topic)
+
+    async def _claim(self, msg: ClaimedMessage, topic: str) -> None:
+        """The claim gates and the run, after the duplicate guard has admitted the topic."""
+        # One check for three cases: redelivery of a run that already finished, a
+        # cancel that landed before the claim, and a stale message whose run is over.
+        try:
+            already_terminal = await self._terminal_frame_exists(topic)
+        except QueueReadError:
+            # WHY a local skip and not a crash: the stream tail was UNREADABLE — a transient
+            # broker error, not an answer. The worker's supervisors share one TaskGroup, and
+            # an error escaping here cancels every co-located run (each one SIGKILLed in its
+            # cleanup) — one momentary NATS blip killing N healthy runs. Returning WITHOUT
+            # the ack leaves the message for redelivery: the next attempt re-runs this check
+            # and, once the broker is readable again, the dedupe answer is the real one.
+            logger.warning("stream tail unreadable for %s; leaving the claim for redelivery", topic)
+            return
+        if already_terminal:
+            await msg.ack()
+            return
+        if self._capability_expired(msg):
+            await self._publish_terminal(
+                topic, "failed", QUEUE_EXPIRED, "the run's capability expired while queued"
+            )
+            await msg.ack()
+            return
+        await self._run_child(msg, topic)
 
     async def _run_child(self, msg: ClaimedMessage, topic: str) -> None:
         """Fork the run as a child, supervise it to its terminal frame, then ack."""
@@ -231,19 +283,40 @@ class RunSupervisor:
     def _capability_expired(self, msg: ClaimedMessage) -> bool:
         """Whether the run's capability has expired while it sat in the queue.
 
-        The run's deadline counts from when the message was published: a message claimed
+        The run's deadline counts from when the message was PUBLISHED: a message claimed
         after ``deadline_s`` has elapsed has no time left to run, so executing it would
         only produce an immediate timeout. The worker drops it with a named
         ``queue_expired`` frame instead of executing it late. A message with no readable
         timestamp or deadline is treated as not expired — the safe direction.
+
+        WHY the stamped header and not `msg.metadata.timestamp`: nats-py's metadata
+        records the DELIVERY moment — when this worker PULLED the message — so a backlogged
+        run reads as age ~0 exactly when it waited the longest, and the drop below never
+        fired for the runs it exists to catch. The publisher stamps the enqueue wall-clock
+        on the message (`subjects.ENQUEUED_AT_HEADER`); a message without the stamp (published
+        before it existed) falls back to the delivery timestamp — the pre-stamp semantics,
+        never worse.
         """
-        published_at = getattr(getattr(msg, "metadata", None), "timestamp", None)
+        published_at = self._published_at(msg)
         if published_at is None:
             return False
         raw_deadline = decode_message(msg.data).get(job_env.JOB_DEADLINE_S)
         if raw_deadline is None:
             return False
         return (datetime.now(UTC) - published_at).total_seconds() >= float(raw_deadline)
+
+    def _published_at(self, msg: ClaimedMessage) -> datetime | None:
+        """The message's enqueue moment: the stamped header first, delivery time as fallback."""
+        headers = getattr(msg, "headers", None) or {}
+        raw = headers.get(ENQUEUED_AT_HEADER) if hasattr(headers, "get") else None
+        if raw:
+            try:
+                stamped = datetime.fromisoformat(raw)
+            except ValueError:
+                stamped = None
+            if stamped is not None:
+                return stamped if stamped.tzinfo is not None else stamped.replace(tzinfo=UTC)
+        return getattr(getattr(msg, "metadata", None), "timestamp", None)
 
     # --- the child ------------------------------------------------------------------------
 
@@ -303,9 +376,10 @@ class RunSupervisor:
     async def _wait_for_child(self, proc: _ChildProcess, hard_wall_s: float | None) -> str:
         """Wait for the child to exit, bounded by the hard wall; return how it ended.
 
-        ``"finished"`` — the child exited on its own, or was SIGTERM'd by the drain
-        handler. ``"draining"`` — the drain handler fired and the child had to be
-        SIGKILL'd. ``"deadline"`` — the hard wall expired and the worker killed it.
+        ``"finished"`` — the child exited on its own. ``"draining"`` — the drain handler
+        fired (the supervisor terminated THIS child): it exited from the SIGTERM within the
+        kill grace, or had to be SIGKILL'd. ``"deadline"`` — the hard wall expired and the
+        worker killed it.
         """
         wait_task = asyncio.create_task(proc.wait())
         term_task = asyncio.create_task(self._terminating.wait())
@@ -319,10 +393,13 @@ class RunSupervisor:
             term_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await term_task
-        if wait_task in done:
-            await wait_task
-            return "finished"
         if term_task in done:
+            # Checked BEFORE `wait_task in done`, deliberately: when BOTH completed — the
+            # drain fired and the child exited in the same scheduling batch — the exit is
+            # the drain's doing (or landed microseconds before its SIGTERM, which is
+            # operationally the same event). Reading that race as a natural "finished"
+            # would hand the classifier a drain kill as the child's own exit, and a child
+            # that dies from the SIGTERM (rc -15) would be published as a failure.
             # The drain handler fired and SIGTERM'd the child, but it is still alive.
             try:
                 await asyncio.wait_for(wait_task, timeout=self._kill_grace_s)
@@ -336,6 +413,9 @@ class RunSupervisor:
                 proc.kill()
             await proc.wait()
             return "draining"
+        if wait_task in done:
+            await wait_task
+            return "finished"
         # The hard wall expired: SIGTERM, then SIGKILL.
         wait_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -367,7 +447,15 @@ class RunSupervisor:
                 DEADLINE_EXCEEDED,
                 "the run exceeded its deadline and was killed",
             )
-        elif outcome == "draining" or self._draining.is_set():
+        elif outcome == "draining":
+            # WHY `outcome` alone and not `or self._draining.is_set()`: the drain flag is
+            # GLOBAL — set for the whole grace window, while unrelated children keep exiting
+            # for their OWN reasons (an OOM, a crash) inside that window. Trusting the flag
+            # relabeled every such exit as a benign drain-stop, masking real failures during
+            # rolling deploys — precisely when someone is watching deploy health. The
+            # drain-caused kills are exactly the ones `_wait_for_child` reports as
+            # `"draining"` (it saw the drain fire for THIS child); that causality is the
+            # classifier's only input.
             status, code, message = (
                 "stopped",
                 WORKER_DRAINING,

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -291,7 +291,25 @@ class RunSupervisor:
             )
             already_terminal = False
         if not already_terminal:
-            await self._publish_terminal(topic, *classification)
+            try:
+                await self._publish_terminal(topic, *classification)
+            except Exception as exc:
+                # WHY swallowed and not raised (review follow-up V-7): the run HAS ended —
+                # this publish is the ACCOUNT of that ending, not the ending itself, and it
+                # is a broker call made during the very blip that may have caused it. Left
+                # unguarded its failure escaped into the shared TaskGroup, cancelling every
+                # co-located supervisor (each sibling's cleanup SIGKILLs a live child — the
+                # P2-1 cascade, reached from the publish side) and skipping the ack, so the
+                # FINISHED run redelivered and was executed a second time. Losing the frame
+                # is the bounded cost: the child's own frames are already on the stream, the
+                # client's hold times out, and the operator sees this line. `CancelledError`
+                # is a `BaseException` and still propagates.
+                logger.error(
+                    "terminal publish failed for %s; the run has ended and is acked "
+                    "without its worker frame: %r",
+                    topic,
+                    exc,
+                )
 
     # --- the claim-time checks ------------------------------------------------------------
 

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -188,7 +188,9 @@ class RunSupervisor:
                 # terminal frame and its ack — so the duplicate is acked away immediately:
                 # spawning a second child for one topic would race it to the stream, and
                 # leaving it unacked would redeliver it in a loop until the original ends.
-                logger.warning("duplicate claim of %s acked away; the run is already executing here", topic)
+                logger.warning(
+                    "duplicate claim of %s acked away; the run is already executing here", topic
+                )
                 await msg.ack()
                 return
             self._topics_in_flight.add(topic)
@@ -264,8 +266,31 @@ class RunSupervisor:
     async def _publish_if_needed(
         self, topic: str, classification: tuple[TerminalStatus, str, str] | None
     ) -> None:
-        """Publish the worker's named terminal frame unless the child already did."""
-        if classification is not None and not await self._terminal_frame_exists(topic):
+        """Publish the worker's named terminal frame unless the child already did.
+
+        WHY the read is guarded (review follow-up P2-1): this runs AFTER the child
+        exited, in the supervisor task that still has to ack. An unguarded read that
+        raised ``QueueReadError`` escaped into the shared TaskGroup and cancelled every
+        co-located supervisor — each sibling's cleanup SIGKILLs its live child, so one
+        momentary broker blip at one child's exit killed N healthy runs (the same
+        cascade as the claim-time gate, reached from the exit side). The run genuinely
+        DID end, so on an unreadable tail the classified frame is published anyway —
+        the named frame is the client's only account of a kill/OOM/deadline death, and
+        the read-exists race (a child that published its own frame in the instant before
+        the read failed) only ever risks one extra terminal frame, never a lost run.
+        The ack always runs either way.
+        """
+        if classification is None:
+            return
+        try:
+            already_terminal = await self._terminal_frame_exists(topic)
+        except QueueReadError:
+            logger.warning(
+                "terminal-frame read unreadable for %s; publishing the classified frame",
+                topic,
+            )
+            already_terminal = False
+        if not already_terminal:
             await self._publish_terminal(topic, *classification)
 
     # --- the claim-time checks ------------------------------------------------------------
@@ -400,7 +425,9 @@ class RunSupervisor:
             # operationally the same event). Reading that race as a natural "finished"
             # would hand the classifier a drain kill as the child's own exit, and a child
             # that dies from the SIGTERM (rc -15) would be published as a failure.
-            # The drain handler fired and SIGTERM'd the child, but it is still alive.
+            # The drain phase fired for THIS child — its phase-2 pass SIGTERMs every child
+            # still registered, within one poll of it appearing (review follow-up), and the
+            # child that ignores the SIGTERM gets the kill-grace backstop below.
             try:
                 await asyncio.wait_for(wait_task, timeout=self._kill_grace_s)
             except TimeoutError:

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -74,6 +74,23 @@ DEADLINE_MARGIN_S = 30.0
 HEARTBEAT_INTERVAL_S = 20.0
 
 
+def _float_or_none(raw: str | float | None) -> float | None:
+    """A tolerant float: ``None`` when the value is absent OR not a number.
+
+    INVARIANT: never raises. Both callers treat an unreadable number exactly as they treat
+    an absent one, which is each one's own documented safe direction (not expired;
+    unbounded). An unguarded `float()` on a message field is the same pod-wide cascade an
+    undecodable body causes — reached through a value the codec always writes correctly but
+    a foreign publisher need not.
+    """
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
 def derived_heartbeat_interval_s(ack_wait_s: float) -> float:
     """The heartbeat cadence the worker runs for a queue with this `ack_wait`.
 
@@ -180,7 +197,9 @@ class RunSupervisor:
         unacked, so the broker redelivers it (up to ``max_deliver``) instead of losing
         the run.
         """
-        topic = topic_of_message(msg.data)
+        topic = await self._topic_or_settle(msg)
+        if topic is None:
+            return
         with run_scope(topic):
             if topic in self._topics_in_flight:
                 # A duplicate claim of a run THIS worker is already executing (redelivery
@@ -198,6 +217,46 @@ class RunSupervisor:
                 await self._claim(msg, topic)
             finally:
                 self._topics_in_flight.discard(topic)
+
+    async def _topic_or_settle(self, msg: ClaimedMessage) -> str | None:
+        """This message's topic, or ``None`` after settling a body that cannot name one.
+
+        INVARIANT: a body this worker cannot decode must never reach the shared TaskGroup.
+        `topic_of_message` JSON-decodes the payload and indexes `job_env.TOPIC`, so a
+        foreign publisher, a stray `nats pub`, or a codec skew across a rolling deploy
+        raises right here — and an exception escaping one supervisor cancels every
+        co-located sibling, each of which SIGKILLs its live child on the way out. One
+        malformed message took down every healthy run on the pod, and because it was never
+        acked it redelivered and did it again until `max_deliver`.
+
+        WHY contained rather than propagated: a message body is DATA arriving from
+        off-process, and it can only ever spoil the one message carrying it. A defect in
+        the worker's own code is the opposite case — it would break every run — and must
+        keep crashing the worker loudly rather than being swallowed here.
+
+        WHY acked rather than left for redelivery: the run cannot be executed (there is no
+        env to execute) and cannot be reported (the topic naming its stream is precisely
+        the unreadable part), so every redelivery reproduces this exact failure. Settling
+        it is the only thing that ends the loop.
+
+        INVARIANT: this is the SINGLE decode gate for the claim path. Every later
+        `decode_message(msg.data)` on this path — `_capability_expired`, `_child_env` — is
+        safe only BECAUSE this one already succeeded on the same bytes; do not reorder them
+        ahead of it.
+        """
+        try:
+            return topic_of_message(msg.data)
+        except (ValueError, KeyError, TypeError):
+            # `ValueError` covers `json.JSONDecodeError` and `UnicodeDecodeError` (both
+            # subclasses); `KeyError` is a body that decoded but names no topic; `TypeError`
+            # a payload that is not bytes at all. The body is never logged — it is the
+            # caller's and may carry prompts.
+            logger.exception(
+                "undecodable run-queue message settled without executing; "
+                "a publisher is writing bodies this worker's codec cannot read"
+            )
+            await msg.ack()
+            return None
 
     async def _claim(self, msg: ClaimedMessage, topic: str) -> None:
         """The claim gates and the run, after the duplicate guard has admitted the topic."""
@@ -343,10 +402,12 @@ class RunSupervisor:
         published_at = self._published_at(msg)
         if published_at is None:
             return False
-        raw_deadline = decode_message(msg.data).get(job_env.JOB_DEADLINE_S)
-        if raw_deadline is None:
+        # An unreadable deadline reads as an ABSENT one — "treated as not expired, the safe
+        # direction" this docstring already states, now true of a malformed value too.
+        deadline_s = _float_or_none(decode_message(msg.data).get(job_env.JOB_DEADLINE_S))
+        if deadline_s is None:
             return False
-        return (datetime.now(UTC) - published_at).total_seconds() >= float(raw_deadline)
+        return (datetime.now(UTC) - published_at).total_seconds() >= deadline_s
 
     def _published_at(self, msg: ClaimedMessage) -> datetime | None:
         """The message's enqueue moment: the stamped header first, delivery time as fallback."""
@@ -410,11 +471,21 @@ class RunSupervisor:
         ``activeDeadlineSeconds``. A message with no deadline (the codec always writes
         one) is unbounded, mirroring the child's own reading.
         """
-        raw_deadline = env.get(job_env.JOB_DEADLINE_S)
-        if raw_deadline is None:
+        # An unreadable deadline reads as an absent one — unbounded, exactly as the
+        # docstring above says a message with no deadline is. Nothing is lost by deferring:
+        # the child re-reads the same value and `runner.main._deadline_from_env` REFUSES a
+        # malformed one, so such a run fails fast with its own terminal frame.
+        deadline_s = _float_or_none(env.get(job_env.JOB_DEADLINE_S))
+        if deadline_s is None:
             return None
-        grace_s = float(env.get(job_env.STREAM_GRACE_S, job_env.DEFAULT_STREAM_GRACE_S))
-        return float(raw_deadline) + grace_s + self._deadline_margin_s
+        # WHY the grace falls back to the DEFAULT rather than going unbounded like the
+        # deadline: it is an additive teardown allowance, so the shipped value keeps the
+        # wall meaningful, where dropping the wall entirely would leave a hung child
+        # unbounded over one malformed field the run never depends on.
+        grace_s = _float_or_none(env.get(job_env.STREAM_GRACE_S))
+        if grace_s is None:
+            grace_s = job_env.DEFAULT_STREAM_GRACE_S
+        return deadline_s + grace_s + self._deadline_margin_s
 
     async def _wait_for_child(self, proc: _ChildProcess, hard_wall_s: float | None) -> str:
         """Wait for the child to exit, bounded by the hard wall; return how it ended.

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -320,8 +320,14 @@ class RunSupervisor:
             try:
                 await asyncio.wait_for(wait_task, timeout=self._kill_grace_s)
             except TimeoutError:
+                # WHY a FRESH `proc.wait()` and not `await wait_task`: `wait_for`
+                # CANCELLED `wait_task` when it timed out, and awaiting a cancelled
+                # task re-raises `CancelledError` — which would abort `supervise`
+                # before the `Terminated(stopped, worker_draining)` frame and the ack,
+                # and the run would redeliver and execute twice. Reap on a new wait,
+                # the same shape `_kill_with_grace` uses.
                 proc.kill()
-                await wait_task
+            await proc.wait()
             return "draining"
         # The hard wall expired: SIGTERM, then SIGKILL.
         wait_task.cancel()

--- a/apps/screamingface-engine/tests/integration/test_worker_spine.py
+++ b/apps/screamingface-engine/tests/integration/test_worker_spine.py
@@ -1,0 +1,182 @@
+"""The worker spine against a real broker (OME-1089): submit → claim → spawn → frames →
+terminal.
+
+The queue's whole contract is broker behavior, and the worker's claim/ack path is broker
+behavior too, so this file is where the real NATS broker is exercised end to end: a run is
+published to the queue, a real worker claims it, spawns a real child (a fake
+``screamingface-engine`` on PATH that publishes its own frames through the real
+``JetStreamPublisher``), and the run's stream ends in the child's terminal frame with the
+message acked. Skipped wherever no NATS is reachable, like the other real-broker tests.
+"""
+
+import asyncio
+import os
+import socket
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+import pytest
+
+from screamingface_engine.adapters.jetstream import JetStreamConsumer, JetStreamPublisher
+from screamingface_engine.runner_queue import RunQueue, encode_message
+from screamingface_engine.worker.loop import Worker
+from url4.streaming.protocol import StartedEvent, TerminatedEvent
+
+NATS_URL = os.environ.get("URL4_CLOUD_TEST_NATS_URL", "nats://localhost:4222")
+
+
+def _nats_reachable(url: str = NATS_URL) -> bool:
+    parsed = urlsplit(url)
+    try:
+        with socket.create_connection((parsed.hostname or "localhost", parsed.port or 4222), 0.5):
+            return True
+    except OSError:
+        return False
+
+
+NATS_AVAILABLE = _nats_reachable()
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not NATS_AVAILABLE,
+        reason=f"needs a reachable NATS at {NATS_URL} (set URL4_CLOUD_TEST_NATS_URL)",
+    ),
+]
+
+
+def _unique_topic(prefix: str) -> str:
+    # A fresh topic per run: the broker's dedupe window is time-based, so a topic published
+    # by an earlier test run must not collide with this run's assertions.
+    return f"{prefix}-{uuid4().hex}"
+
+
+# The child the worker forks: a fake `screamingface-engine` that publishes its own frames
+# through the REAL `JetStreamPublisher` and exits 0 — the same shape as the real run
+# entrypoint, without needing a gateway. Runs with the venv python (the shebang is written
+# by the test), so the engine package is importable.
+_FAKE_RUNNER = """\
+import asyncio
+import os
+import uuid
+from datetime import UTC, datetime
+
+from screamingface_engine.adapters.jetstream import JetStreamPublisher
+from url4.streaming.protocol import (
+    StartedData,
+    StartedEvent,
+    TerminatedData,
+    TerminatedEvent,
+    source_for,
+)
+
+
+async def _main() -> None:
+    topic = os.environ["URL4_CLOUD_TOPIC"]
+    publisher = JetStreamPublisher(
+        os.environ.get("URL4_CLOUD_NATS_URL", "nats://localhost:4222")
+    )
+    await publisher.ensure_stream(topic)
+    await publisher.publish(
+        topic,
+        StartedEvent(
+            id=uuid.uuid4().hex,
+            source=source_for(topic),
+            subject=topic,
+            time=datetime.now(UTC),
+            data=StartedData(url4="'hi'"),
+        ),
+    )
+    await publisher.publish(
+        topic,
+        TerminatedEvent(
+            id=uuid.uuid4().hex,
+            source=source_for(topic),
+            subject=topic,
+            time=datetime.now(UTC),
+            data=TerminatedData(status="succeeded"),
+        ),
+    )
+    await publisher.flush()
+    await publisher.close()
+
+
+asyncio.run(_main())
+"""
+
+
+async def _read_until_terminal(consumer: JetStreamConsumer, topic: str) -> list[object]:
+    frames: list[object] = []
+    async for frame in consumer.subscribe(topic):
+        frames.append(frame)
+        if isinstance(frame, TerminatedEvent):
+            return frames
+    return frames
+
+
+async def _wait_for_depth(queue: RunQueue, expected: int, timeout_s: float = 10.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while True:
+        if await queue.depth() == expected:
+            return
+        if loop.time() > deadline:
+            raise AssertionError(f"queue depth never reached {expected}")
+        await asyncio.sleep(0.1)
+
+
+def _install_fake_runner(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Put a fake `screamingface-engine` on PATH that publishes its own frames through the
+    real `JetStreamPublisher` and exits 0 — the child the worker forks."""
+    fake = tmp_path / "screamingface-engine"
+    fake.write_text(f"#!{sys.executable}\n{_FAKE_RUNNER}")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+    monkeypatch.setenv("URL4_CLOUD_NATS_URL", NATS_URL)
+
+
+async def test_submit_claim_spawn_frames_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run published to the queue is claimed by a real worker, forked as a child, and the
+    run's stream ends in the child's own terminal frame with the message acked."""
+    _install_fake_runner(tmp_path, monkeypatch)
+
+    queue = RunQueue(NATS_URL, state_cache_ttl_s=0.0, replicas=1)
+    await queue.ensure_stream()
+    topic = _unique_topic("it-worker")
+    await queue.publish(encode_message(topic, "'hi'", 60))
+
+    publisher = JetStreamPublisher(NATS_URL)
+    worker = Worker(
+        queue=queue,
+        publisher=publisher,
+        slots=1,
+        drain_grace_s=1.0,
+        io_capacity=4,
+        memory_budget_bytes=1024**3,
+        pull_timeout_s=0.5,
+    )
+    consumer = JetStreamConsumer(NATS_URL)
+    try:
+        async with asyncio.TaskGroup() as tg:
+            claim = tg.create_task(worker._claim_loop(tg))
+            frames = await asyncio.wait_for(_read_until_terminal(consumer, topic), timeout=15.0)
+            claim.cancel()
+
+        # The TaskGroup has exited, so the supervisor has acked the message: the queue is
+        # empty again.
+        await _wait_for_depth(queue, 0)
+    finally:
+        await consumer.close()
+        await publisher.close()
+        await queue.close()
+
+    # The child's own frames, in order: Started, then its terminal frame. The worker added
+    # nothing — a clean exit with the child's terminal frame on the stream.
+    assert isinstance(frames[0], StartedEvent)
+    assert isinstance(frames[-1], TerminatedEvent)
+    assert frames[-1].data.status == "succeeded"
+    assert len(frames) == 2

--- a/apps/screamingface-engine/tests/unit/test_cli.py
+++ b/apps/screamingface-engine/tests/unit/test_cli.py
@@ -20,6 +20,7 @@ def modes(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     called: list[str] = []
     monkeypatch.setattr(cli, "_serve", lambda: called.append("serve"))
     monkeypatch.setattr(cli, "_run", lambda: called.append("run"))
+    monkeypatch.setattr(cli, "_worker", lambda: called.append("worker"))
     return called
 
 
@@ -39,6 +40,12 @@ def test_run_subcommand_runs(modes: list[str]) -> None:
     # INVARIANT: this is what `K8sJobRunner` puts in every Job's `command`.
     cli.main(["run"])
     assert modes == ["run"]
+
+
+def test_worker_subcommand_workers(modes: list[str]) -> None:
+    # INVARIANT: the worker pool (OME-1086) starts every Pod with this subcommand.
+    cli.main(["worker"])
+    assert modes == ["worker"]
 
 
 def test_an_unknown_mode_exits_loudly_rather_than_serving(modes: list[str]) -> None:
@@ -69,6 +76,39 @@ def test_run_resolves_the_real_runner_entrypoint(monkeypatch: pytest.MonkeyPatch
     cli._run()
 
     assert called == [True]
+
+
+def test_worker_resolves_the_real_worker_entrypoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`_worker` itself, unshimmed — so the lazy import is proven to resolve."""
+    import screamingface_engine.worker.loop as worker_loop
+
+    called: list[bool] = []
+    monkeypatch.setattr(worker_loop, "run_worker", lambda: called.append(True))
+
+    cli._worker()
+
+    assert called == [True]
+
+
+def test_worker_mode_does_not_import_the_run_half() -> None:
+    """The worker spawns the run as a child process; it never imports it.
+
+    `check_layering.py` proves it over the import GRAPH; this proves it over what a real
+    interpreter actually loads — the worker's import graph is the serving half's plus the
+    queue, and the engine-bearing run half stays out of the worker's process.
+    """
+    probe = (
+        "import sys, screamingface_engine.worker.loop;"
+        "print(','.join(sorted(m for m in sys.modules if "
+        "m.startswith('screamingface_engine.runner.') or m == 'screamingface_engine.runner' "
+        "or m == 'url4.streaming.lifecycle')))"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+    assert result.stdout.strip() == "", (
+        f"`screamingface-engine worker` loaded the run half: {result.stdout.strip()}"
+    )
 
 
 def test_run_mode_does_not_import_the_serving_stack() -> None:

--- a/apps/screamingface-engine/tests/unit/test_stream_tail_reads.py
+++ b/apps/screamingface-engine/tests/unit/test_stream_tail_reads.py
@@ -1,0 +1,36 @@
+"""The JetStream tail-read contract: transport failures are typed, never bare.
+
+`last_frame`'s callers guard `QueueReadError` (the supervisor's claim-time gate and
+post-exit publish, the queue runner's status/stop). A bare transport error from inside
+`last_frame` bypasses all of them — the V-7(b)/pass-1-#11 cascade — so every failure
+path a broker blip can take out of this function must wear the typed wrapper.
+"""
+
+import nats
+import pytest
+from nats.errors import Error as NatsError
+
+from screamingface_engine.adapters.jetstream import JetStreamPublisher, QueueReadError
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_last_frame_translates_a_failed_connect_into_queue_read_error(
+    monkeypatch,
+) -> None:
+    """V-7(b)/pass-1 #11: `last_frame` called `self._jetstream()` OUTSIDE its own try,
+    so a broker that cannot be connected to — the most common shape of a blip — raised a
+    bare transport error that no `except QueueReadError` guard catches. The connect path
+    now gets the same typed translation as the fetch."""
+
+    async def refused(*args: object, **kwargs: object) -> None:
+        raise NatsError("connection refused during the blip")
+
+    monkeypatch.setattr(nats, "connect", refused)
+    publisher = JetStreamPublisher("nats://unused:4222")
+
+    try:
+        await publisher.last_frame("t-any")
+    except QueueReadError:
+        return  # the typed guard target — the contract this test pins
+    raise AssertionError("a failed connect must surface as QueueReadError, not bare")

--- a/apps/screamingface-engine/tests/unit/test_worker_child_memory_cap.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_child_memory_cap.py
@@ -1,0 +1,132 @@
+"""The worker's per-child memory cap (OME-1089): each child is spawned under its own
+``RLIMIT_AS``, so an over-allocating run dies ALONE instead of triggering a Pod OOM that
+kills its co-tenants — which would void the reason for choosing subprocess isolation.
+
+This test spawns REAL children through the worker's actual spawn path (the exec wrapper),
+with a fake ``screamingface-engine`` on PATH that allocates past the budget. The wrapper
+sets the limit and execs the fake in place, exactly as it would exec the real entrypoint.
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from screamingface_engine import job_env
+from screamingface_engine.worker.loop import Worker
+from screamingface_engine.worker.supervisor import CHILD_EXITED
+
+pytestmark = pytest.mark.asyncio
+
+# 128 MiB of address space: enough for the interpreter to start, far too little for the
+# fake runner's 512 MiB allocation. (RLIMIT_AS bounds VIRTUAL address space, which is
+# larger than the RSS a cgroup limit measures.)
+_BUDGET_BYTES = 128 * 1024 * 1024
+_ALLOCATION_BYTES = 512 * 1024 * 1024
+
+_FAKE_RUNNER = f"""#!/usr/bin/env python3
+import os
+import sys
+
+if os.environ.get("URL4_CLOUD_TOPIC", "").endswith("-oom"):
+    # Allocate far past the worker's per-run budget: the RLIMIT_AS the exec wrapper set
+    # makes this raise MemoryError, and the child dies alone.
+    x = bytearray({_ALLOCATION_BYTES})
+sys.exit(0)
+"""
+
+
+def _message(topic: str) -> bytes:
+    return json.dumps(
+        {
+            job_env.TOPIC: topic,
+            job_env.EXPRESSION: "'hi'",
+            job_env.JOB_DEADLINE_S: "60",
+            job_env.STREAM_GRACE_S: "0",
+        }
+    ).encode()
+
+
+class _FakeMsg:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.metadata = SimpleNamespace(timestamp=None)
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def in_progress(self) -> None:
+        pass
+
+
+class _FakePublisher:
+    def __init__(self) -> None:
+        self.published: list[Any] = []
+
+    async def last_frame(self, topic: str) -> None:
+        return None
+
+    async def ensure_stream(self, topic: str) -> None:
+        pass
+
+    async def publish(self, topic: str, event: Any) -> None:
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FakeQueue:
+    async def pull(self, batch: int, timeout_s: float) -> list[_FakeMsg]:
+        await asyncio.sleep(timeout_s)
+        return []
+
+
+async def test_an_over_allocating_child_dies_alone_and_the_worker_survives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A child spawned under a per-run RLIMIT_AS that allocates past it dies alone: the
+    worker publishes a named failure for it, its sibling run survives, and the worker
+    process itself is untouched."""
+    # A fake `screamingface-engine` on PATH: the exec wrapper execs it in place, exactly
+    # as it would exec the real entrypoint. The `-oom` topic allocates past the budget;
+    # any other topic exits cleanly.
+    fake = tmp_path / "screamingface-engine"
+    fake.write_text(_FAKE_RUNNER)
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+
+    publisher = _FakePublisher()
+    worker = Worker(
+        queue=_FakeQueue(),
+        publisher=publisher,
+        slots=2,
+        drain_grace_s=0.1,
+        io_capacity=4,
+        memory_budget_bytes=_BUDGET_BYTES,
+    )
+
+    oom_msg = _FakeMsg(_message("t-oom"))
+    ok_msg = _FakeMsg(_message("t-ok"))
+    await worker._supervisor.supervise(oom_msg)
+    await worker._supervisor.supervise(ok_msg)
+
+    # The over-allocating run died alone: the worker published a named failure for it.
+    # (The child died of a Python-level MemoryError, so the worker classifies it as a
+    # non-zero exit — the OS never had to kill it, which is exactly the point of the
+    # per-child cap.)
+    assert len(publisher.published) == 1
+    frame = publisher.published[0]
+    assert frame.data.status == "failed"
+    assert frame.data.error is not None and frame.data.error.code == CHILD_EXITED
+    assert oom_msg.acked
+    # ...and the sibling run survived: clean exit, the worker adds nothing.
+    assert ok_msg.acked
+    # The worker process itself is alive — we are still running, and the supervisor
+    # accepted a second run after the first one died.
+    assert worker._slots == 2

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -996,3 +996,160 @@ async def test_a_publish_failure_after_exit_does_not_cancel_a_siblings_live_chil
         await claim
     assert fail_msg.acked, "the finished run must ack despite its lost terminal frame"
     assert sib.kill_calls == 0 and sib.terminate_calls == 1
+
+
+# --- 9. an undecodable BODY is data, not a code bug ----------------------------------------
+
+
+def _undecodable() -> bytes:
+    """A queue body this worker cannot decode: not JSON at all."""
+    return b"{not json at all"
+
+
+async def test_an_undecodable_message_does_not_cancel_a_siblings_live_child() -> None:
+    """`topic_of_message` JSON-decodes the body, and every call to it sits OUTSIDE a guard.
+    One body this worker cannot decode — a foreign publisher, a stray `nats pub`, a codec
+    skew across a rolling deploy — escaped its supervisor into the shared TaskGroup,
+    cancelling every co-located supervisor; each one's cleanup SIGKILLs its live child. One
+    poison message killed every healthy run on the pod, and because it was never acked it
+    redelivered and did it again until `max_deliver`.
+
+    INVARIANT: a message body is DATA, and data is contained per message — a body can only
+    ever spoil the one message carrying it, so it is settled and logged while every sibling
+    run continues. A defect in the worker's own code is a different case and stays loud."""
+    sib_msg = _FakeMsg(encode_message("t-sib", "'hi'", 60))
+    poison_msg = _FakeMsg(_undecodable())
+    sib = _FakeProcess(hang=True)
+    spawned = asyncio.Event()
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawned.set()
+        return sib
+
+    class _PoisonOnceLiveQueue(_FakeQueue):
+        """Serves the poison body only once the sibling's child is LIVE — landing it any
+        earlier leaves the blast-radius assertion nothing to blast."""
+
+        def __init__(self) -> None:
+            super().__init__([[sib_msg]])
+            self.served_poison = False
+
+        async def pull(self, batch: int, timeout_s: float) -> list[_FakeMsg]:
+            self.pull_calls.append((batch, timeout_s))
+            if self._batches:
+                return self._batches.pop(0)
+            if not self.served_poison and spawned.is_set():
+                self.served_poison = True
+                return [poison_msg]
+            await asyncio.sleep(timeout_s)
+            return []
+
+    queue = _PoisonOnceLiveQueue()
+    worker = _worker(queue, _FakePublisher(), slots=2, spawn=fake_spawn, drain_grace_s=0.1)
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        await _wait_until(lambda: poison_msg.acked, timeout_s=5.0)
+        assert sib.kill_calls == 0, "a live sibling must survive an undecodable message"
+        assert sib.terminate_calls == 0, "a live sibling must not be touched at all"
+        worker._draining.set()  # noqa: SLF001
+        await _wait_until(lambda: sib.terminate_calls == 1 or sib.kill_calls == 1, timeout_s=5.0)
+        assert sib.kill_calls == 0, "the sibling must not be caught in any cascade"
+        assert sib.terminate_calls == 1, "the sibling must be drained, not killed"
+        await claim
+
+
+async def test_an_undecodable_message_is_acked_so_it_cannot_redeliver_forever() -> None:
+    """A body that cannot be decoded can neither be executed nor reported: the topic it
+    would name is exactly the thing that is unreadable, so there is no run stream to
+    publish a terminal frame to. Acking is what stops it coming back — left unacked it
+    redelivers until `max_deliver`, reproducing the same failure on every attempt."""
+    msg = _FakeMsg(_undecodable())
+    spawns: list[Any] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawns.append(kwargs)
+        return _FakeProcess(0)
+
+    publisher = _FakePublisher()
+    worker = _worker(_FakeQueue(), publisher, spawn=fake_spawn)
+
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked, "an undecodable message must be settled, not left to redeliver"
+    assert not spawns, "nothing may be executed from a body that could not be decoded"
+    assert not publisher.published, "there is no topic to publish a terminal frame to"
+
+
+async def test_a_body_that_names_no_topic_is_settled_like_an_undecodable_one() -> None:
+    """The decode can succeed and still not name a run: `topic_of_message` indexes
+    `job_env.TOPIC` and raises `KeyError` when the mapping lacks it. Same class of defect,
+    same containment — the alternative is the same pod-wide cascade."""
+    msg = _FakeMsg(json.dumps({"something": "else"}).encode())
+    worker = _worker(_FakeQueue(), _FakePublisher(), spawn=_async_proc(_FakeProcess(0)))
+
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked, "a body that names no topic must be settled, not left to redeliver"
+
+
+async def test_an_unreadable_deadline_executes_the_run_instead_of_killing_the_pod() -> None:
+    """`_capability_expired` and `_hard_wall_s` both `float()` the message's deadline, and
+    a body that decodes perfectly well can still carry a non-numeric one. Unguarded, that
+    raised out of the claim into the shared TaskGroup — the same cascade, from a third site.
+
+    INVARIANT: an unreadable deadline is treated as ABSENT, which is the safe direction
+    both methods already document (not expired; unbounded). Nothing is lost by deferring:
+    the child re-reads the same value and `runner.main._deadline_from_env` REFUSES a
+    malformed one, so the run fails fast with its own terminal frame. The worker's only
+    obligation is to not die first."""
+    msg = _FakeMsg(
+        json.dumps(
+            {
+                job_env.TOPIC: "t-bad-deadline",
+                job_env.EXPRESSION: "'hi'",
+                job_env.JOB_DEADLINE_S: "whenever",
+            }
+        ).encode()
+    )
+    spawns: list[Any] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawns.append(kwargs)
+        return _FakeProcess(0)
+
+    publisher = _FakePublisher()
+    worker = _worker(_FakeQueue(), publisher, spawn=fake_spawn)
+
+    await worker._supervisor.supervise(msg)
+
+    assert len(spawns) == 1, "the run must be executed, not dropped on an unreadable deadline"
+    assert msg.acked
+    assert not publisher.published, "an unreadable deadline must not read as an expired one"
+
+
+async def test_an_unreadable_stream_grace_does_not_kill_the_pod_either() -> None:
+    """`_hard_wall_s` also `float()`s `STREAM_GRACE_S`, which travels in the same mapping
+    and can be malformed independently of the deadline — a second unguarded conversion on
+    the same line, and the same cascade if it raises."""
+    msg = _FakeMsg(
+        json.dumps(
+            {
+                job_env.TOPIC: "t-bad-grace",
+                job_env.EXPRESSION: "'hi'",
+                job_env.JOB_DEADLINE_S: "60",
+                job_env.STREAM_GRACE_S: "a while",
+            }
+        ).encode()
+    )
+    spawns: list[Any] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawns.append(kwargs)
+        return _FakeProcess(0)
+
+    worker = _worker(_FakeQueue(), _FakePublisher(), spawn=fake_spawn)
+
+    await worker._supervisor.supervise(msg)
+
+    assert len(spawns) == 1, "the run must be executed, not lost to a malformed grace"
+    assert msg.acked

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -806,16 +806,19 @@ async def test_a_broker_error_from_pull_does_not_cancel_in_flight_supervisors() 
         return sib
 
     class _ErroringQueue(_FakeQueue):
-        """Pulls once with a broker error, then serves the scripted batch."""
+        """Serves the scripted batch FIRST, then raises on the next pull — the blip
+        lands with the sibling's supervisor LIVE and its child running (V-9: erroring
+        on the first pull, before any supervisor existed, left the blast-radius
+        assertion nothing to blast)."""
 
         def __init__(self) -> None:
             super().__init__([[sib_msg]])
-            self.error_pulled = False
+            self.pull_count = 0
 
         async def pull(self, batch: int, timeout_s: float) -> list[_FakeMsg]:
             self.pull_calls.append((batch, timeout_s))
-            if not self.error_pulled:
-                self.error_pulled = True
+            self.pull_count += 1
+            if self.pull_count == 2:
                 raise nats.errors.Error("transient broker blip")
             if self._batches:
                 return self._batches.pop(0)
@@ -823,11 +826,14 @@ async def test_a_broker_error_from_pull_does_not_cancel_in_flight_supervisors() 
             return []
 
     queue = _ErroringQueue()
-    worker = _worker(queue, _FakePublisher(), slots=1, spawn=fake_spawn, drain_grace_s=0.1)
+    worker = _worker(queue, _FakePublisher(), slots=2, spawn=fake_spawn, drain_grace_s=0.1)
     async with asyncio.TaskGroup() as tg:
         claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
-        # The loop must survive the blip and claim the run on its retry.
-        await _wait_until(lambda: len(queue.pull_calls) >= 2)
+        # Pull 2 is the blip; pull 3 existing at all is the proof the loop SURVIVED it
+        # with the sibling still in flight — on unfixed code the exception kills the
+        # loop task here and no third pull ever happens.
+        await _wait_until(lambda: queue.pull_count >= 3, timeout_s=5.0)
+        assert sib.kill_calls == 0, "a live sibling must survive the claim-side blip"
         worker._draining.set()  # noqa: SLF001
         await _wait_until(lambda: sib.terminate_calls == 1 or sib.kill_calls == 1, timeout_s=5.0)
         assert sib.kill_calls == 0, "the sibling must not be caught in any cascade"
@@ -908,3 +914,81 @@ async def test_a_child_registered_after_the_drain_passes_still_gets_sigterm_befo
         assert procs[0].terminate_calls == 1, "a late child must receive SIGTERM"
         assert procs[0].kill_calls == 0, "it must receive SIGTERM BEFORE any SIGKILL"
         await claim
+
+
+async def test_a_child_vanished_under_the_drains_terminate_does_not_kill_the_worker() -> None:
+    """V-1: `_release_child` removes a finished child only AFTER its publish and ack
+    round trips, so an exited child is routinely still in `_children` when the drain's
+    re-polling terminate pass lands — and `terminate()` on one is NOT harmless. A real
+    transport raises `ProcessLookupError` (an `OSError`) from `_check_proc` once the
+    process is reaped; unsuppressed, that escaped `_drain()` into the shared TaskGroup
+    and SIGKILLed every remaining draining child before they could publish or ack — the
+    P2-1 cascade, reintroduced by the drain itself, exercised on every drain."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-gone", "'hi'", 60))]])
+
+    class _VanishedProcess(_FakeProcess):
+        """A child reaped under the worker: `terminate()` finds no process, exactly
+        like asyncio's `BaseSubprocessTransport._check_proc` window."""
+
+        def terminate(self) -> None:  # type: ignore[override]
+            raise ProcessLookupError("process attached to the transport no longer exists")
+
+    proc = _VanishedProcess(hang=True)
+
+    async def spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        return proc
+
+    worker = _worker(
+        queue, _FakePublisher(), slots=1, spawn=spawn, drain_grace_s=0.05, kill_grace_s=0.2
+    )
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        await asyncio.sleep(0.05)  # the claim lands; the child hangs in `wait()`
+        worker._draining.set()  # noqa: SLF001
+        await claim
+    # The worker survived the vanished child; the kill path eventually reaped it.
+    assert proc.kill_calls == 1, "a vanished child is eventually killed, never resurrected"
+
+
+async def test_a_publish_failure_after_exit_does_not_cancel_a_siblings_live_child() -> None:
+    """V-7(a): the P2-1 handler publishes the classified terminal frame "anyway" on an
+    unreadable tail — but the publish is a broker call made DURING the same blip, and it
+    was unguarded. Its failure escaped into the shared TaskGroup, cancelling every
+    co-located supervisor — each sibling's cleanup SIGKILLs its live child — and the
+    failed run's message never acked, so the FINISHED run redelivered and was executed a
+    second time. The run HAS ended: a publish failure is logged, the ack still runs, and
+    no sibling dies."""
+    fail_msg = _FakeMsg(encode_message("t-fail", "'hi'", 60))
+    sib_msg = _FakeMsg(encode_message("t-sib", "'hi'", 60))
+    sib = _FakeProcess(hang=True)
+
+    class _BlipPublisher(_FakePublisher):
+        """The terminal publish for ONE topic fails; everything else is healthy."""
+
+        async def publish(self, topic: str, event: Any) -> None:
+            if topic == "t-fail" and isinstance(event, TerminatedEvent):
+                raise nats.errors.Error("publish failed during the same blip")
+            self.published.append(event)
+
+    procs: list[_FakeProcess] = [_FakeProcess(exit_code=0), sib]
+
+    async def spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        return procs.pop(0)
+
+    worker = _worker(
+        _FakeQueue([[fail_msg], [sib_msg]]),
+        _BlipPublisher(),
+        slots=2,
+        spawn=spawn,
+        drain_grace_s=0.05,
+    )
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        # The failed publish must not cancel anything: the sibling gets claimed, its
+        # child runs, and the finished run still acks (no redelivery, no re-execution).
+        await _wait_until(lambda: fail_msg.acked and sib in worker._children, timeout_s=5.0)
+        assert sib.kill_calls == 0, "a live sibling must survive the publish-side blip"
+        worker._draining.set()  # noqa: SLF001
+        await claim
+    assert fail_msg.acked, "the finished run must ack despite its lost terminal frame"
+    assert sib.kill_calls == 0 and sib.terminate_calls == 1

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -11,9 +11,10 @@ import json
 import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import nats
+import nats.errors
 import pytest
 
 from screamingface_engine import job_env
@@ -634,7 +635,8 @@ async def test_a_backlogged_run_expires_from_its_enqueue_stamp_not_its_delivery(
         published_at=datetime.now(UTC),
         headers={ENQUEUED_AT_HEADER: (datetime.now(UTC) - timedelta(seconds=120)).isoformat()},
     )
-    worker = _worker(_FakeQueue(), _FakePublisher(), spawn=_async_proc(_FakeProcess()))
+    publisher = _FakePublisher()
+    worker = _worker(_FakeQueue(), publisher, spawn=_async_proc(_FakeProcess()))
 
     await worker._supervisor.supervise(msg)
 
@@ -642,8 +644,8 @@ async def test_a_backlogged_run_expires_from_its_enqueue_stamp_not_its_delivery(
     assert worker._supervisor._topics_in_flight == set()
     assert all(
         getattr(e.data, "error", None) is not None and e.data.error.code == "queue_expired"
-        for e in worker._publisher.published
-    ), f"expected a queue_expired frame, got {worker._publisher.published}"
+        for e in publisher.published
+    ), f"expected a queue_expired frame, got {publisher.published}"
     # And it never forked a child for an expired run.
     assert not worker._supervisor._children
 
@@ -679,7 +681,9 @@ async def test_one_unreadable_dedupe_read_kills_no_runs_and_leaves_the_claim() -
         await _wait_until(lambda: publisher.blips >= 1)
         await _wait_until(lambda: worker._supervisor._children)
         for proc in tuple(worker._supervisor._children):
-            proc.release(0)
+            # `_children` is typed to the `_ChildProcess` Protocol; `release` belongs to the
+            # fake this test injected, so the cast is what tells pyright which one it is.
+            cast(_FakeProcess, proc).release(0)
 
     assert not blip_msg.acked, "an unreadable tail is not 'no terminal frame' — redeliver it"
     assert healthy_msg.acked

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -8,13 +8,16 @@ and the child process are fakes, so each decision is observable in isolation.
 
 import asyncio
 import json
+import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 
+import nats
 import pytest
 
 from screamingface_engine import job_env
+from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.runner_queue import encode_message
 from screamingface_engine.worker.loop import Worker
 from screamingface_engine.worker.supervisor import (
@@ -512,8 +515,7 @@ async def test_a_drain_child_that_ignores_sigterm_is_still_acked_not_cancelled()
         await _wait_until(lambda: procs[0].terminate_calls == 1)
         await _wait_until(lambda: procs[0].kill_calls == 1, timeout_s=5.0)
         await _wait_until(
-            lambda: bool(publisher.published)
-            and publisher.published[-1].data.status == "stopped"
+            lambda: bool(publisher.published) and publisher.published[-1].data.status == "stopped"
         )
         frame = publisher.published[-1]
         assert frame.data.error is not None and frame.data.error.code == WORKER_DRAINING
@@ -601,7 +603,8 @@ def test_an_unrelated_failure_during_drain_is_not_relabeled_a_drain_stop() -> No
     assert crash is not None and crash[0] == "failed" and crash[1] == CHILD_EXITED
 
     drain_kill = classify("draining", None)
-    assert drain_kill is not None and drain_kill[0] == "stopped" and drain_kill[1] == WORKER_DRAINING
+    assert drain_kill is not None
+    assert drain_kill[0] == "stopped" and drain_kill[1] == WORKER_DRAINING
 
 
 async def test_a_child_exit_racing_the_drain_signal_reads_as_draining() -> None:
@@ -638,8 +641,7 @@ async def test_a_backlogged_run_expires_from_its_enqueue_stamp_not_its_delivery(
     assert msg.acked, "an expired run is acked away, not redelivered"
     assert worker._supervisor._topics_in_flight == set()
     assert all(
-        getattr(e.data, "error", None) is not None
-        and e.data.error.code == "queue_expired"
+        getattr(e.data, "error", None) is not None and e.data.error.code == "queue_expired"
         for e in worker._publisher.published
     ), f"expected a queue_expired frame, got {worker._publisher.published}"
     # And it never forked a child for an expired run.
@@ -735,3 +737,174 @@ def test_settings_refuse_an_ack_wait_the_heartbeat_cannot_survive(monkeypatch: A
     monkeypatch.setenv("URL4_CLOUD_RUN_QUEUE_ACK_WAIT_S", "2")
     with pytest.raises(ValidationError, match="run_queue_ack_wait_s"):
         Settings()
+
+
+# --- 8. the review pass-2 cascade and drain cluster (P2-1, N-3, P2-6, N-2) ---------------
+
+
+async def test_a_supervisors_post_exit_read_failing_does_not_kill_a_siblings_live_child() -> None:
+    """P2-1: `_publish_if_needed`'s terminal-frame read runs AFTER the child exited, in a
+    supervisor that still has to ack. An unguarded `QueueReadError` escaped into the
+    shared TaskGroup and cancelled every co-located supervisor — each sibling's cleanup
+    SIGKILLs its live child, so one momentary broker blip at one run's exit killed every
+    healthy run on the pod. The read is now guarded: the classified frame is published
+    anyway (an unreadable tail is not 'no frame'), the ack still runs, and the sibling
+    is untouched."""
+    raise_msg = _FakeMsg(encode_message("t-raise", "'hi'", 60))
+    sib_msg = _FakeMsg(encode_message("t-sib", "'hi'", 60))
+    sib = _FakeProcess(hang=True)
+
+    class _RaisingOnSecondReadPublisher(_FakePublisher):
+        """`last_frame` returns None on the first read of a topic and raises on the second
+        — the claim-time gate is the first read, the post-exit read is the second, which
+        is exactly the failing point P2-1 guards."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self._reads: dict[str, int] = {}
+
+        async def last_frame(self, topic: str) -> TerminatedEvent | None:
+            n = self._reads.get(topic, 0) + 1
+            self._reads[topic] = n
+            if n >= 2:
+                raise QueueReadError("stream tail unreadable")
+            return None
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        env = kwargs["env"]
+        if env[job_env.TOPIC] == "t-raise":
+            return _FakeProcess(exit_code=1)  # exits non-zero; its post-exit read raises
+        return sib
+
+    publisher = _RaisingOnSecondReadPublisher()
+    queue = _FakeQueue([[raise_msg, sib_msg]])
+    worker = _worker(queue, publisher, slots=2, spawn=fake_spawn, drain_grace_s=0.1)
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        # The raising run's classified frame is still published (the fix publishes on an
+        # unreadable tail rather than losing the run's only account of its death).
+        await _wait_until(lambda: bool(publisher.published))
+        await asyncio.sleep(0.05)  # a moment for a (wrong) cascade cancellation to land
+        assert sib.kill_calls == 0, "a sibling's live child must not be SIGKILLed"
+        assert sib.terminate_calls == 0, "a sibling's live child must not be touched at all"
+        worker._draining.set()  # noqa: SLF001
+        sib.release(0)
+        await claim
+    assert raise_msg.acked, "the raising run's message must still be acked"
+    assert publisher.published[0].data.status == "failed"
+
+
+async def test_a_broker_error_from_pull_does_not_cancel_in_flight_supervisors() -> None:
+    """N-3: a transient broker error from `pull` (including the `ensure_stream` it wraps)
+    used to escape the claim loop into the shared TaskGroup, cancelling every co-located
+    supervisor and SIGKILLing its live children — the same cascade as P2-1, reached from
+    the claim side. The loop now catches it, logs, backs off, and retries."""
+    sib_msg = _FakeMsg(encode_message("t-sib", "'hi'", 60))
+    sib = _FakeProcess(hang=True)
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        return sib
+
+    class _ErroringQueue(_FakeQueue):
+        """Pulls once with a broker error, then serves the scripted batch."""
+
+        def __init__(self) -> None:
+            super().__init__([[sib_msg]])
+            self.error_pulled = False
+
+        async def pull(self, batch: int, timeout_s: float) -> list[_FakeMsg]:
+            self.pull_calls.append((batch, timeout_s))
+            if not self.error_pulled:
+                self.error_pulled = True
+                raise nats.errors.Error("transient broker blip")
+            if self._batches:
+                return self._batches.pop(0)
+            await asyncio.sleep(timeout_s)
+            return []
+
+    queue = _ErroringQueue()
+    worker = _worker(queue, _FakePublisher(), slots=1, spawn=fake_spawn, drain_grace_s=0.1)
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        # The loop must survive the blip and claim the run on its retry.
+        await _wait_until(lambda: len(queue.pull_calls) >= 2)
+        worker._draining.set()  # noqa: SLF001
+        await _wait_until(lambda: sib.terminate_calls == 1 or sib.kill_calls == 1, timeout_s=5.0)
+        assert sib.kill_calls == 0, "the sibling must not be caught in any cascade"
+        assert sib.terminate_calls == 1, "the run must be drained, not killed"
+        await claim
+
+
+async def test_a_run_mid_spawn_when_the_signal_lands_still_gets_the_drain_grace() -> None:
+    """P2-6: a run whose child is still spawning when the drain signal lands used to find
+    `_children` empty, consume ZERO grace — `_terminating` was set immediately and the
+    run was SIGKILL'd `kill_grace` after spawn with no chance to finish naturally. The
+    drain waits on the ACTIVE tasks (registered at claim time), so a mid-spawn run gets
+    the full grace window and then a clean SIGTERM."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-midspawn", "'hi'", 60))]])
+    spawn_started = asyncio.Event()
+    release_spawn = asyncio.Event()
+    procs: list[_FakeProcess] = []
+
+    async def delayed_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawn_started.set()
+        await release_spawn.wait()
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    worker = _worker(
+        queue, _FakePublisher(), slots=1, spawn=delayed_spawn, drain_grace_s=0.2, kill_grace_s=0.05
+    )
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        await _wait_until(spawn_started.is_set)
+        t0 = time.monotonic()
+        worker._draining.set()  # noqa: SLF001 — the signal lands mid-spawn
+        await asyncio.sleep(0.05)
+        release_spawn.set()  # the child registers during the drain
+        await _wait_until(
+            lambda: bool(procs) and (procs[0].terminate_calls == 1 or procs[0].kill_calls == 1),
+            timeout_s=5.0,
+        )
+        assert procs[0].terminate_calls == 1, "a mid-spawn run must get a clean SIGTERM"
+        assert procs[0].kill_calls == 0, "it must never reach the bare-SIGKILL path"
+        assert time.monotonic() - t0 >= 0.15, "the drain must honor the grace window"
+        await claim
+
+
+async def test_a_child_registered_after_the_drain_passes_still_gets_sigterm_before_sigkill() -> (
+    None
+):
+    """N-2: a child that spawns AFTER the drain's grace has expired used to miss the
+    one-shot SIGTERM pass — its supervisor found `_terminating` already set and
+    hard-killed it `kill_grace` after spawn, never SIGTERM'd, with no chance to publish
+    its frames. The drain now terminates children as they appear until the pool empties,
+    so the late child still receives SIGTERM before any SIGKILL."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-late", "'hi'", 60))]])
+    release_spawn = asyncio.Event()
+    procs: list[_FakeProcess] = []
+
+    async def delayed_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        await release_spawn.wait()
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    worker = _worker(
+        queue, _FakePublisher(), slots=1, spawn=delayed_spawn, drain_grace_s=0.05, kill_grace_s=0.2
+    )
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        await asyncio.sleep(0.05)  # let the claim land and the spawn begin blocking
+        worker._draining.set()  # noqa: SLF001
+        # Let the drain pass its grace AND (old code) its one-shot terminate pass.
+        await _wait_until(lambda: worker._terminating.is_set())  # noqa: SLF001
+        release_spawn.set()  # the child registers AFTER the pass
+        await _wait_until(
+            lambda: bool(procs) and (procs[0].terminate_calls == 1 or procs[0].kill_calls == 1),
+            timeout_s=5.0,
+        )
+        assert procs[0].terminate_calls == 1, "a late child must receive SIGTERM"
+        assert procs[0].kill_calls == 0, "it must receive SIGTERM BEFORE any SIGKILL"
+        await claim

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -477,3 +477,39 @@ async def test_drain_stops_pulling_and_terminates_children_with_a_worker_drainin
 
         await claim
         assert len(queue.pull_calls) == 1
+
+
+async def test_a_drain_child_that_ignores_sigterm_is_still_acked_not_cancelled() -> None:
+    """The drain kill's backstop must reap on a FRESH wait. `wait_for` CANCELS the
+    original wait task when it times out, and awaiting the cancelled task re-raises
+    `CancelledError` — which would abort `supervise` before the terminal frame and the
+    ack, so the run would redeliver and execute twice instead of ending in
+    `Terminated(stopped, worker_draining)`."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-stubborn", "'hi'", 60))]])
+    procs: list[_FakeProcess] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        proc = _FakeProcess(hang=True, ignores_sigterm=True)
+        procs.append(proc)
+        return proc
+
+    publisher = _FakePublisher()
+    worker = _worker(
+        queue, publisher, slots=1, spawn=fake_spawn, drain_grace_s=0.1, kill_grace_s=0.05
+    )
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))
+
+        await _wait_until(lambda: len(procs) == 1)
+        worker._draining.set()
+        await _wait_until(lambda: procs[0].terminate_calls == 1)
+        await _wait_until(lambda: procs[0].kill_calls == 1, timeout_s=5.0)
+        await _wait_until(
+            lambda: bool(publisher.published)
+            and publisher.published[-1].data.status == "stopped"
+        )
+        frame = publisher.published[-1]
+        assert frame.data.error is not None and frame.data.error.code == WORKER_DRAINING
+        assert procs[0].returncode == -9, "the fresh wait must reap the SIGKILL exit"
+
+        await claim

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -513,3 +513,63 @@ async def test_a_drain_child_that_ignores_sigterm_is_still_acked_not_cancelled()
         assert procs[0].returncode == -9, "the fresh wait must reap the SIGKILL exit"
 
         await claim
+
+
+# --- heartbeat resilience (review follow-up) ------------------------------------------------
+
+
+class _FlakyMsg(_FakeMsg):
+    """A claimed message whose `in_progress()` fails the first N times — a broker blip."""
+
+    def __init__(self, data: bytes, *, failures: int) -> None:
+        super().__init__(data)
+        self._failures = failures
+        self.attempts = 0
+
+    async def in_progress(self) -> None:
+        self.attempts += 1
+        if self.attempts <= self._failures:
+            raise ConnectionError("broker reset")
+        await super().in_progress()
+
+
+async def test_a_transient_heartbeat_failure_does_not_stop_the_heartbeats() -> None:
+    """`in_progress()` is a broker RPC; one transient failure (a connection blip) must
+    not kill the heartbeat task — a dead heartbeat means the ack_wait runs out and the
+    message is redelivered mid-run to a second worker: the exact double-run the
+    heartbeat exists to prevent. The loop logs and keeps extending."""
+    topic = "t-blip"
+    msg = _FlakyMsg(encode_message(topic, "'hi'", 60), failures=1)
+    proc = _FakeProcess(hang=True)
+    worker = _worker(
+        _FakeQueue(), _FakePublisher(), spawn=_async_proc(proc), heartbeat_interval_s=0.01
+    )
+    supervise = asyncio.create_task(worker._supervisor.supervise(msg))
+
+    await _wait_until(lambda: msg.in_progress_calls >= 3)  # failed once, kept going
+    assert not msg.acked, "a live run must not be acked"
+
+    proc.release(0)
+    await supervise
+    assert msg.acked
+
+
+async def test_a_dead_heartbeat_task_does_not_break_the_runs_cleanup() -> None:
+    """The heartbeat task can FAIL outright (every extension raises). `cancel()` is a
+    no-op on an already-finished task, and the cleanup awaited it FIRST — the task's
+    own exception blew the finally block open, so every line after it was skipped: the
+    child stayed in `_children` forever and a live child was never killed. The reaping
+    must be unraisable; the child is released regardless."""
+    topic = "t-dead-hb"
+    msg = _FlakyMsg(encode_message(topic, "'hi'", 60), failures=10**9)  # always fails
+    proc = _FakeProcess(hang=True)
+    worker = _worker(
+        _FakeQueue(), _FakePublisher(), spawn=_async_proc(proc), heartbeat_interval_s=0.01
+    )
+    supervise = asyncio.create_task(worker._supervisor.supervise(msg))
+
+    await _wait_until(lambda: msg.attempts >= 1)  # the heartbeat has failed and died
+    proc.release(0)
+    await supervise  # must NOT re-raise the heartbeat's ConnectionError
+    assert msg.acked
+    assert proc not in worker._supervisor._children, "a finished run must release its child"

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1,0 +1,479 @@
+"""The worker's claim and supervision logic (OME-1089), against fakes.
+
+The worker's contract is mostly about what it does with a claimed message: dedupe,
+spawn, heartbeat, classify, ack. The broker behavior (redelivery, ack_wait, the
+durable consumer) is pinned by the integration suite; here the queue, the publisher,
+and the child process are fakes, so each decision is observable in isolation.
+"""
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from screamingface_engine import job_env
+from screamingface_engine.runner_queue import encode_message
+from screamingface_engine.worker.loop import Worker
+from screamingface_engine.worker.supervisor import (
+    CHILD_EXITED,
+    DEADLINE_EXCEEDED,
+    KILLED,
+    OOM_KILLED,
+    QUEUE_EXPIRED,
+    WORKER_DRAINING,
+)
+from url4.streaming.protocol import TerminatedData, TerminatedEvent, source_for
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeMsg:
+    """A claimed queue message: records acks and in-progress heartbeats."""
+
+    def __init__(self, data: bytes, *, published_at: datetime | None = None) -> None:
+        self.data = data
+        self.metadata = SimpleNamespace(timestamp=published_at or datetime.now(UTC))
+        self.acked = False
+        self.in_progress_calls = 0
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def in_progress(self) -> None:
+        self.in_progress_calls += 1
+
+
+class _FakePublisher:
+    """The slice of `JetStreamPublisher` the supervisor uses, recording every call."""
+
+    def __init__(self, last_frame: TerminatedEvent | None = None) -> None:
+        self._last_frame = last_frame
+        self.published: list[Any] = []
+        self.ensured: list[str] = []
+
+    async def last_frame(self, topic: str) -> TerminatedEvent | None:
+        return self._last_frame
+
+    async def ensure_stream(self, topic: str) -> None:
+        self.ensured.append(topic)
+
+    async def publish(self, topic: str, event: Any) -> None:
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FakeProcess:
+    """A controllable child: `wait()` blocks until released, or exits immediately."""
+
+    def __init__(
+        self, exit_code: int = 0, *, hang: bool = False, ignores_sigterm: bool = False
+    ) -> None:
+        self._exit_code = exit_code
+        self._hang = hang
+        self._ignores_sigterm = ignores_sigterm
+        self._released = asyncio.Event()
+        self.returncode: int | None = None
+        self.stdout = None
+        self.stderr = None
+        self.terminate_calls = 0
+        self.kill_calls = 0
+
+    async def wait(self) -> int:
+        if self._hang:
+            await self._released.wait()
+        self.returncode = self._exit_code
+        return self.returncode
+
+    def release(self, code: int | None = None) -> None:
+        if code is not None:
+            self._exit_code = code
+        self._released.set()
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        if self._ignores_sigterm:
+            return
+        self.release(-15)
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.release(-9)
+
+
+class _FakeQueue:
+    """A queue that serves scripted batches, then returns empty after each timeout (an
+    empty queue)."""
+
+    def __init__(self, batches: list[list[_FakeMsg]] | None = None) -> None:
+        self._batches = list(batches or [])
+        self.pull_calls: list[tuple[int, float]] = []
+
+    async def pull(self, batch: int, timeout_s: float) -> list[_FakeMsg]:
+        self.pull_calls.append((batch, timeout_s))
+        if self._batches:
+            return self._batches.pop(0)
+        await asyncio.sleep(timeout_s)
+        return []
+
+
+def _worker(
+    queue: _FakeQueue,
+    publisher: _FakePublisher,
+    *,
+    slots: int = 2,
+    spawn: Any = None,
+    **kwargs: Any,
+) -> Worker:
+    return Worker(
+        queue=queue,
+        publisher=publisher,
+        slots=slots,
+        drain_grace_s=kwargs.pop("drain_grace_s", 0.1),
+        io_capacity=kwargs.pop("io_capacity", 4),
+        memory_budget_bytes=kwargs.pop("memory_budget_bytes", 1024**3),
+        spawn=spawn,
+        pull_timeout_s=kwargs.pop("pull_timeout_s", 0.1),
+        heartbeat_interval_s=kwargs.pop("heartbeat_interval_s", 20.0),
+        deadline_margin_s=kwargs.pop("deadline_margin_s", 30.0),
+        kill_grace_s=kwargs.pop("kill_grace_s", 0.05),
+    )
+
+
+def _async_proc(proc: _FakeProcess) -> Any:
+    """A spawn callable that returns a fixed fake process."""
+
+    async def _spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        return proc
+
+    return _spawn
+
+
+async def _wait_until(predicate: Any, timeout_s: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("condition not met in time")
+        await asyncio.sleep(0.01)
+
+
+def _message(topic: str, deadline_s: int = 60, grace_s: float = 60.0) -> bytes:
+    """A queue message body with a controllable deadline and stream grace, so the hard-wall
+    tests do not have to wait out the production defaults."""
+    return json.dumps(
+        {
+            job_env.TOPIC: topic,
+            job_env.EXPRESSION: "'hi'",
+            job_env.JOB_DEADLINE_S: str(deadline_s),
+            job_env.STREAM_GRACE_S: str(grace_s),
+        }
+    ).encode()
+
+
+def _terminal(topic: str, status: str = "succeeded") -> TerminatedEvent:
+    return TerminatedEvent(
+        id="already-there",
+        source=source_for(topic),
+        subject=topic,
+        data=TerminatedData(status=status),  # type: ignore[arg-type]
+    )
+
+
+# --- 1. dedupe: a terminal frame already on the stream means ack and skip ------------------
+
+
+async def test_a_terminal_frame_already_on_the_stream_acks_without_spawning() -> None:
+    """Redelivery, cancel-before-claim, and stale messages are one check: a terminal frame
+    on the run's stream means the run is over, so the message is acked and no child is
+    ever spawned."""
+    topic = "t-dedupe"
+    publisher = _FakePublisher(last_frame=_terminal(topic))
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    spawned: list[Any] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawned.append(args)
+        return _FakeProcess()
+
+    worker = _worker(_FakeQueue(), publisher, spawn=fake_spawn)
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked
+    assert not spawned
+    assert not publisher.published
+
+
+# --- 8. queue-time expiry ------------------------------------------------------------------
+
+
+async def test_an_expired_capability_is_acked_with_a_queue_expired_frame() -> None:
+    """A message whose run's deadline has already elapsed while queued is dropped with a
+    named `queue_expired` terminal frame — never executed late."""
+    topic = "t-expired"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(
+        encode_message(topic, "'hi'", 60),
+        published_at=datetime.now(UTC) - timedelta(seconds=100),
+    )
+    spawned: list[Any] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawned.append(args)
+        return _FakeProcess()
+
+    worker = _worker(_FakeQueue(), publisher, spawn=fake_spawn)
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked
+    assert not spawned
+    assert len(publisher.published) == 1
+    frame = publisher.published[0]
+    assert frame.data.status == "failed"
+    assert frame.data.error is not None and frame.data.error.code == QUEUE_EXPIRED
+    assert frame.source == source_for(topic)
+
+
+async def test_a_fresh_message_is_not_expired() -> None:
+    """The expiry check must not drop a message that still has time: the safe direction is
+    to execute."""
+    topic = "t-fresh"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))  # published now
+    worker = _worker(_FakeQueue(), publisher, spawn=_async_proc(_FakeProcess()))
+    await worker._supervisor.supervise(msg)
+
+    assert not publisher.published
+    assert msg.acked
+
+
+# --- 3. exit classification ----------------------------------------------------------------
+
+
+async def test_a_clean_exit_adds_nothing_when_the_child_published_its_terminal_frame() -> None:
+    """Exit 0 with the child's own terminal frame on the stream: the worker adds nothing —
+    a second terminal frame would be a duplicate."""
+    topic = "t-clean"
+    publisher = _FakePublisher(last_frame=_terminal(topic))
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    worker = _worker(_FakeQueue(), publisher, spawn=_async_proc(_FakeProcess(0)))
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked
+    assert not publisher.published
+
+
+async def test_a_clean_exit_adds_nothing_even_when_the_stream_is_gone() -> None:
+    """Exit 0 with no terminal frame visible: the child's own teardown reclaimed the stream
+    only AFTER publishing its terminal frame, so the worker still adds nothing."""
+    topic = "t-clean-reclaimed"
+    publisher = _FakePublisher()  # no stream at all
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    worker = _worker(_FakeQueue(), publisher, spawn=_async_proc(_FakeProcess(0)))
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked
+    assert not publisher.published
+
+
+async def test_a_nonzero_exit_publishes_a_named_failure() -> None:
+    topic = "t-exit3"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    worker = _worker(_FakeQueue(), publisher, spawn=_async_proc(_FakeProcess(3)))
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked
+    assert len(publisher.published) == 1
+    frame = publisher.published[0]
+    assert frame.data.status == "failed"
+    assert frame.data.error is not None and frame.data.error.code == CHILD_EXITED
+    assert "3" in (frame.data.error.message or "")
+
+
+async def test_a_signal_death_publishes_a_named_failure() -> None:
+    topic = "t-signal"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    worker = _worker(_FakeQueue(), publisher, spawn=_async_proc(_FakeProcess(-11)))
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked
+    frame = publisher.published[0]
+    assert frame.data.status == "failed"
+    assert frame.data.error is not None and frame.data.error.code == KILLED
+    assert "11" in (frame.data.error.message or "")
+
+
+async def test_exit_137_publishes_an_oom_failure() -> None:
+    """137 is the OOMKilled exit: the OS killed the run for its memory, and the client
+    must see that name rather than a generic failure."""
+    topic = "t-oom"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    worker = _worker(_FakeQueue(), publisher, spawn=_async_proc(_FakeProcess(137)))
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked
+    frame = publisher.published[0]
+    assert frame.data.status == "failed"
+    assert frame.data.error is not None and frame.data.error.code == OOM_KILLED
+
+
+# --- 4. the hard wall ----------------------------------------------------------------------
+
+
+async def test_a_hung_child_is_sigterm_then_sigkill_and_publishes_a_deadline_frame() -> None:
+    """A child hung past `deadline_s + STREAM_GRACE_S + margin` gets SIGTERM, then SIGKILL
+    when it ignores that, and the run ends in a named `timed_out` frame."""
+    topic = "t-hung"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(_message(topic, deadline_s=1, grace_s=0))
+    proc = _FakeProcess(hang=True, ignores_sigterm=True)
+    worker = _worker(
+        _FakeQueue(),
+        publisher,
+        spawn=_async_proc(proc),
+        deadline_margin_s=0.05,  # hard wall = 1 + 0 + 0.05
+        kill_grace_s=0.05,
+    )
+    await worker._supervisor.supervise(msg)
+
+    assert proc.terminate_calls == 1
+    assert proc.kill_calls == 1
+    assert msg.acked
+    frame = publisher.published[0]
+    assert frame.data.status == "timed_out"
+    assert frame.data.error is not None and frame.data.error.code == DEADLINE_EXCEEDED
+
+
+async def test_a_child_that_dies_on_sigterm_is_not_sigkilled() -> None:
+    """The SIGKILL is the backstop, not the norm: a child that honors SIGTERM is killed
+    once."""
+    topic = "t-hung-obedient"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(_message(topic, deadline_s=1, grace_s=0))
+    proc = _FakeProcess(hang=True)  # honors SIGTERM
+    worker = _worker(
+        _FakeQueue(),
+        publisher,
+        spawn=_async_proc(proc),
+        deadline_margin_s=0.05,
+        kill_grace_s=0.05,
+    )
+    await worker._supervisor.supervise(msg)
+
+    assert proc.terminate_calls == 1
+    assert proc.kill_calls == 0
+    assert msg.acked
+    assert publisher.published[0].data.status == "timed_out"
+
+
+# --- 5. heartbeats -------------------------------------------------------------------------
+
+
+async def test_heartbeats_keep_a_long_childs_message_unacked() -> None:
+    """While a child runs, the supervisor extends the message's ack_wait with
+    `in_progress()` heartbeats, and the message is not acked until the child exits."""
+    topic = "t-long"
+    publisher = _FakePublisher()
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    proc = _FakeProcess(hang=True)
+    worker = _worker(
+        _FakeQueue(),
+        publisher,
+        spawn=_async_proc(proc),
+        heartbeat_interval_s=0.01,
+    )
+    supervise = asyncio.create_task(worker._supervisor.supervise(msg))
+
+    await _wait_until(lambda: msg.in_progress_calls >= 2)
+    assert not msg.acked, "a live run must not be acked"
+
+    proc.release(0)
+    await supervise
+    assert msg.acked
+
+
+# --- 2. slot accounting --------------------------------------------------------------------
+
+
+async def test_the_fetch_batch_equals_free_slots_and_never_exceeds_them() -> None:
+    """The loop computes the fetch batch from FREE slots: it claims exactly `worker_slots`
+    at first, then exactly one per freed slot — never more than the pool can hold, so a
+    sibling pull consumer is never starved."""
+    queue = _FakeQueue(
+        [
+            [
+                _FakeMsg(encode_message("t1", "'hi'", 60)),
+                _FakeMsg(encode_message("t2", "'hi'", 60)),
+            ],
+            [_FakeMsg(encode_message("t3", "'hi'", 60))],
+        ]
+    )
+    procs: list[_FakeProcess] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    worker = _worker(queue, _FakePublisher(), slots=2, spawn=fake_spawn)
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))
+
+        await _wait_until(lambda: len(procs) == 2)
+        assert queue.pull_calls[0][0] == 2, "the first fetch must claim the whole pool"
+        assert len(worker._active) == 2
+
+        procs[0].release(0)  # one run finishes -> one slot frees
+        await _wait_until(lambda: len(procs) == 3)
+        assert queue.pull_calls[1][0] == 1, "the next fetch must claim exactly the freed slot"
+        assert len(worker._active) == 2, "the pool must never exceed worker_slots"
+
+        for proc in procs:
+            proc.release(0)
+        claim.cancel()
+
+
+# --- 7. drain ------------------------------------------------------------------------------
+
+
+async def test_drain_stops_pulling_and_terminates_children_with_a_worker_draining_reason() -> None:
+    """On the drain signal the worker stops pulling; in-flight children survive to
+    `drain_grace_s`; then they are SIGTERM'd and each run ends in
+    `Terminated(stopped)` with a `worker_draining` reason."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t1", "'hi'", 60))]])
+    procs: list[_FakeProcess] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    publisher = _FakePublisher()
+    worker = _worker(queue, publisher, slots=1, spawn=fake_spawn, drain_grace_s=0.2)
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))
+
+        await _wait_until(lambda: len(procs) == 1)
+        assert len(queue.pull_calls) == 1
+
+        worker._draining.set()
+        await asyncio.sleep(0.1)  # inside the drain grace
+        assert procs[0].terminate_calls == 0, "a child must survive to the drain grace"
+        assert len(queue.pull_calls) == 1, "the worker must stop pulling on the drain signal"
+
+        await _wait_until(lambda: procs[0].terminate_calls == 1)
+        await _wait_until(
+            lambda: bool(publisher.published) and publisher.published[-1].data.status == "stopped"
+        )
+        frame = publisher.published[-1]
+        assert frame.data.error is not None and frame.data.error.code == WORKER_DRAINING
+
+        await claim
+        assert len(queue.pull_calls) == 1

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -33,9 +33,16 @@ pytestmark = pytest.mark.asyncio
 class _FakeMsg:
     """A claimed queue message: records acks and in-progress heartbeats."""
 
-    def __init__(self, data: bytes, *, published_at: datetime | None = None) -> None:
+    def __init__(
+        self,
+        data: bytes,
+        *,
+        published_at: datetime | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         self.data = data
         self.metadata = SimpleNamespace(timestamp=published_at or datetime.now(UTC))
+        self.headers = headers
         self.acked = False
         self.in_progress_calls = 0
 
@@ -573,3 +580,158 @@ async def test_a_dead_heartbeat_task_does_not_break_the_runs_cleanup() -> None:
     await supervise  # must NOT re-raise the heartbeat's ConnectionError
     assert msg.acked
     assert proc not in worker._supervisor._children, "a finished run must release its child"
+
+
+# --- review follow-ups: classification, expiry stamp, blast radius, duplicates ------------
+
+
+def test_an_unrelated_failure_during_drain_is_not_relabeled_a_drain_stop() -> None:
+    """The drain flag is GLOBAL; a child that OOMs or crashes for its OWN reasons during
+    the grace window used to be relabeled `stopped/worker_draining`, masking real failures
+    during rolling deploys. Only a child the drain actually terminated (`outcome ==
+    "draining"`) classifies as a drain-stop."""
+    worker = _worker(_FakeQueue(), _FakePublisher())
+    worker._draining.set()
+    classify = worker._supervisor._classify
+
+    oom = classify("finished", 137)
+    assert oom is not None and oom[0] == "failed" and oom[1] == OOM_KILLED
+
+    crash = classify("finished", 1)
+    assert crash is not None and crash[0] == "failed" and crash[1] == CHILD_EXITED
+
+    drain_kill = classify("draining", None)
+    assert drain_kill is not None and drain_kill[0] == "stopped" and drain_kill[1] == WORKER_DRAINING
+
+
+async def test_a_child_exit_racing_the_drain_signal_reads_as_draining() -> None:
+    """When the drain fires and the child exits in the same scheduling batch, BOTH wait
+    tasks complete — and the exit is the drain's doing. Reading that race as a natural
+    "finished" hands the classifier a drain kill (rc -15) as the child's own failure."""
+    proc = _FakeProcess(exit_code=-15)
+    proc.release(-15)  # already gone by the time the drain fires
+    worker = _worker(_FakeQueue(), _FakePublisher())
+    worker._terminating.set()
+
+    outcome = await worker._supervisor._wait_for_child(proc, hard_wall_s=None)
+
+    assert outcome == "draining"
+
+
+async def test_a_backlogged_run_expires_from_its_enqueue_stamp_not_its_delivery() -> None:
+    """`msg.metadata.timestamp` is the DELIVERY moment (~now at claim time), so a run that
+    sat backlogged past its deadline read as age ~0 and the expiry drop never fired. The
+    publisher stamps the enqueue wall-clock; the claim gate must measure from THAT."""
+    from screamingface_engine.subjects import ENQUEUED_AT_HEADER
+
+    body = _message("topic-backlogged", deadline_s=60)
+    msg = _FakeMsg(
+        body,
+        # Delivery is fresh (the pull just happened); the enqueue stamp is 120s old.
+        published_at=datetime.now(UTC),
+        headers={ENQUEUED_AT_HEADER: (datetime.now(UTC) - timedelta(seconds=120)).isoformat()},
+    )
+    worker = _worker(_FakeQueue(), _FakePublisher(), spawn=_async_proc(_FakeProcess()))
+
+    await worker._supervisor.supervise(msg)
+
+    assert msg.acked, "an expired run is acked away, not redelivered"
+    assert worker._supervisor._topics_in_flight == set()
+    assert all(
+        getattr(e.data, "error", None) is not None
+        and e.data.error.code == "queue_expired"
+        for e in worker._publisher.published
+    ), f"expected a queue_expired frame, got {worker._publisher.published}"
+    # And it never forked a child for an expired run.
+    assert not worker._supervisor._children
+
+
+async def test_one_unreadable_dedupe_read_kills_no_runs_and_leaves_the_claim() -> None:
+    """The supervisors share one TaskGroup: an error escaping a claim's dedupe read — a
+    momentary NATS blip, not a JetStream verdict — cancelled EVERY co-located run. A
+    transient read now skips THAT claim only (no ack: the queue redelivers), and the
+    healthy sibling runs to completion untouched."""
+
+    from screamingface_engine.adapters.jetstream import QueueReadError
+
+    class _BlipPublisher(_FakePublisher):
+        def __init__(self) -> None:
+            super().__init__()
+            self.blips = 0
+
+        async def last_frame(self, topic: str) -> Any:
+            if topic == "topic-blip":
+                self.blips += 1
+                raise QueueReadError("stream tail unreadable for topic-blip")
+            return await super().last_frame(topic)
+
+    publisher = _BlipPublisher()
+    healthy = _async_proc(_FakeProcess(exit_code=0, hang=True))
+    worker = _worker(_FakeQueue(), publisher, spawn=healthy)
+    blip_msg = _FakeMsg(_message("topic-blip"))
+    healthy_msg = _FakeMsg(_message("topic-healthy"))
+
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(worker._supervisor.supervise(blip_msg))
+        tg.create_task(worker._supervisor.supervise(healthy_msg))
+        await _wait_until(lambda: publisher.blips >= 1)
+        await _wait_until(lambda: worker._supervisor._children)
+        for proc in tuple(worker._supervisor._children):
+            proc.release(0)
+
+    assert not blip_msg.acked, "an unreadable tail is not 'no terminal frame' — redeliver it"
+    assert healthy_msg.acked
+
+
+async def test_a_duplicate_claim_of_a_running_topic_is_acked_away_without_a_second_child():
+    """Redelivery can race an in-flight original (an `ack_wait` shorter than a supervision
+    gap). The duplicate used to fork a SECOND child for one topic, racing its sibling to
+    the terminal frame. It is now acked away — the original owns the outcome."""
+    proc = _FakeProcess(hang=True)
+    spawns: list[Any] = []
+
+    async def _spawn(*args: Any, **kwargs: Any) -> Any:
+        spawns.append(args)
+        return proc
+
+    worker = _worker(_FakeQueue(), _FakePublisher(), spawn=_spawn)
+    body = _message("topic-dup")
+    original = asyncio.ensure_future(worker._supervisor.supervise(_FakeMsg(body)))
+
+    await _wait_until(lambda: len(spawns) == 1)  # the original is mid-run
+
+    duplicate = _FakeMsg(body)
+    await worker._supervisor.supervise(duplicate)
+
+    assert duplicate.acked, "the duplicate is done — acked, not left to redeliver in a loop"
+    assert len(spawns) == 1, "no second child for one topic"
+
+    proc.release(0)
+    await original
+    assert original.done() and not original.cancelled()
+
+
+def test_the_heartbeat_is_derived_from_the_ack_wait() -> None:
+    """The heartbeat must stay at `ack_wait / 3` (capped at the 20s constant) for EVERY
+    configuration: slower, and JetStream redelivers a still-running run to a second
+    worker — the double execution the heartbeat exists to prevent."""
+    from screamingface_engine.worker.supervisor import derived_heartbeat_interval_s
+
+    assert derived_heartbeat_interval_s(60.0) == 20.0
+    assert derived_heartbeat_interval_s(30.0) == 10.0
+    assert derived_heartbeat_interval_s(15.0) == 5.0
+    assert derived_heartbeat_interval_s(3.0) == 1.0
+    for ack_wait in (3.0, 9.5, 60.0, 600.0):
+        assert derived_heartbeat_interval_s(ack_wait) <= ack_wait / 3.0 + 1e-9
+
+
+def test_settings_refuse_an_ack_wait_the_heartbeat_cannot_survive(monkeypatch: Any) -> None:
+    """Below 3s the derived heartbeat collapses under 1s; refused at startup rather than
+    as a mid-flight double execution."""
+    from pydantic import ValidationError
+
+    from screamingface_engine.config import Settings
+
+    monkeypatch.setenv("URL4_CLOUD_RUN_QUEUE_ACK_WAIT_S", "2")
+    with pytest.raises(ValidationError, match="run_queue_ack_wait_s"):
+        Settings()

--- a/apps/screamingface-engine/tests/unit/test_worker_composition_replicas.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_composition_replicas.py
@@ -1,0 +1,85 @@
+"""The worker's composition root feeds the queue its configured replica count (OME-1089).
+
+The App and the worker declare the SAME singleton queue stream, and `ensure_stream` refuses a
+declaration whose properties diverge from an existing stream. So a worker that declares with a
+different replica count than the App is not a cosmetic mismatch — it is a startup failure on
+whichever side loses the race. `run_worker` omitted `replicas` entirely, which meant the
+worker always used the code default no matter what the deployment configured.
+
+Both halves must therefore read the SAME setting. This file pins the worker half.
+"""
+
+from typing import Any
+
+import pytest
+
+from screamingface_engine.config import Settings
+
+
+class _RecordingQueue:
+    """Stands in for `RunQueue`, capturing the kwargs the composition root passes."""
+
+    last_kwargs: dict[str, Any] = {}
+
+    def __init__(self, url: str, **kwargs: Any) -> None:
+        type(self).last_kwargs = dict(kwargs)
+
+
+class _NoopWorker:
+    """Stands in for `Worker`. `run` is a real coroutine, so `run_worker`'s own
+    `asyncio.run(...)` runs untouched — patching `asyncio.run` would reach far beyond this
+    test."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    async def run(self) -> None:
+        return None
+
+
+def _composed_queue_kwargs(monkeypatch: pytest.MonkeyPatch, settings: Settings) -> dict[str, Any]:
+    """Run `run_worker` with its collaborators stubbed, and return the queue's kwargs.
+
+    `RunQueue` and `JetStreamPublisher` are imported INSIDE `run_worker`, so patching the
+    attribute on their defining module is what the call-time import picks up.
+    """
+    import screamingface_engine.adapters.jetstream as jetstream_mod
+    import screamingface_engine.runner_queue as runner_queue_mod
+    import screamingface_engine.worker.loop as loop
+
+    _RecordingQueue.last_kwargs = {}
+    monkeypatch.setattr(runner_queue_mod, "RunQueue", _RecordingQueue)
+    monkeypatch.setattr(jetstream_mod, "JetStreamPublisher", lambda *a, **k: object())
+    monkeypatch.setattr(loop, "Worker", _NoopWorker)
+
+    loop.run_worker(settings)
+    return _RecordingQueue.last_kwargs
+
+
+def test_the_worker_declares_the_queue_with_the_configured_replica_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinned with a NON-default value: a composition root that drops the argument would still
+    pass if the test used the default, which is exactly how this bug shipped."""
+    kwargs = _composed_queue_kwargs(monkeypatch, Settings(run_queue_replicas=3))
+    assert kwargs["replicas"] == 3
+
+
+def test_an_unconfigured_worker_declares_the_single_node_safe_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deployment that states nothing must still be able to declare its stream on the
+    single-node broker the chart bundles."""
+    settings = Settings()
+    kwargs = _composed_queue_kwargs(monkeypatch, settings)
+    assert kwargs["replicas"] == settings.run_queue_replicas == 1
+
+
+def test_the_worker_reads_the_replica_count_from_settings_not_a_constant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INVARIANT: the value the worker declares tracks `Settings`, so the App and the worker
+    cannot diverge on a stream property that `ensure_stream` refuses to reconcile."""
+    for configured in (1, 2, 5):
+        kwargs = _composed_queue_kwargs(monkeypatch, Settings(run_queue_replicas=configured))
+        assert kwargs["replicas"] == configured

--- a/docs/work/2026-09-02-OME-1089-runner-worker.md
+++ b/docs/work/2026-09-02-OME-1089-runner-worker.md
@@ -1,0 +1,109 @@
+---
+ticket: OME-1089
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-02
+finished:
+---
+
+# OME-1089 — Add the runner worker: slot pool, subprocess supervision, deadlines, drain
+
+## Intent
+
+The pool that replaces the Jobs — the piece that makes the deployed footprint
+constant. A new `worker` mode of the existing CLI: a slot pool that claims runs
+from the OME-1088 queue and forks the existing run entrypoint as a supervised
+child process, so the crash domain stays one run and `runner/main.py` is
+untouched. The worker owns the hard deadline wall that replaces
+`activeDeadlineSeconds`, the in-progress heartbeats that keep a 16-hour run from
+looking abandoned, and the drain path. Each child is spawned under its own
+`RLIMIT_AS`, or a single over-allocating run triggers a Pod OOM and kills its
+co-tenants — which would void the reason for choosing subprocess isolation.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/worker/__init__.py`,
+  `loop.py`, `supervisor.py` (new) — claim loop, supervisor, heartbeat task,
+  hard wall, drain handler.
+- `apps/screamingface-engine/src/screamingface_engine/cli.py` (modify) — the
+  `worker` mode beside `serve` and `run`.
+- `apps/screamingface-engine/src/screamingface_engine/config.py` (modify) —
+  `worker_slots`, `drain_grace_s`, `worker_io_capacity`, per-run memory budget.
+- `.claude/scripts/check_layering.py` (modify) — the worker half's rule: may
+  import the serving half and `runner_queue`, must import nothing from the run
+  half.
+- Tests: `tests/unit/test_worker_*.py`, `tests/integration/test_worker_spine.py`
+  (new).
+
+## Test plan
+
+- RED: a message whose topic already has a terminal frame is acked and never
+  spawns a child.
+- RED: slot accounting never exceeds `worker_slots`; fetch batch equals free
+  slots.
+- RED: child exit classification — exit 0 (worker adds nothing), non-zero,
+  signal, and 137 each produce a named terminal frame from the worker.
+- RED: a child hung past `deadline_s + STREAM_GRACE_S + margin` gets SIGTERM
+  then SIGKILL, and a terminal frame is published.
+- RED: `in_progress()` heartbeats keep a long child's message unredelivered
+  past `ack_wait`.
+- RED: a child spawned with a per-run `RLIMIT_AS` that allocates past it dies
+  alone; the worker and its siblings survive.
+- RED: drain — on SIGTERM the worker stops pulling, in-flight children survive
+  to `drain_grace_s`, then terminate with a `worker_draining` reason.
+- RED: a message whose capability has expired is acked with a `queue_expired`
+  terminal frame and no child.
+
+## Acceptance
+
+- `screamingface-engine worker` mode exists; the image stays one artifact with
+  modes.
+- Children are spawned under `RLIMIT_AS` via an exec wrapper, not
+  `preexec_fn`.
+- Engine stack gates green (cov >= 80); the layering gate has a third half.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/screamingface-engine/src/screamingface_engine/worker/__init__.py` (new) — the
+    worker half's package.
+  - `apps/screamingface-engine/src/screamingface_engine/worker/loop.py` (new) — `Worker`
+    (claim loop, slot accounting, drain, signal handling) and the `run_worker` composition
+    root.
+  - `apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py` (new) —
+    `RunSupervisor`: dedupe, queue-expiry, spawn, heartbeats, hard wall, exit
+    classification, named terminal frames.
+  - `apps/screamingface-engine/src/screamingface_engine/worker/exec_wrapper.py` (new) —
+    sets `RLIMIT_AS` then execs `screamingface-engine run` in place (never `preexec_fn`).
+  - `apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py` (modify) —
+    `last_frame()` on `_JetStreamConnection` (the worker's dedupe/post-exit check).
+  - `apps/screamingface-engine/src/screamingface_engine/config.py` (modify) —
+    `worker_drain_grace_s`, `worker_io_capacity`, `worker_memory_budget_bytes`; the slot
+    count reuses the existing `run_queue_worker_slots` (no duplicate field).
+  - `apps/screamingface-engine/src/screamingface_engine/cli.py` (modify) — the `worker`
+    mode beside `serve` and `run`.
+  - `.claude/scripts/check_layering.py` (modify) — the worker half's rule: may import the
+    serving half and `runner_queue`, must import nothing from the run half.
+  - Tests: `tests/unit/test_worker_claim.py`, `tests/unit/test_worker_child_memory_cap.py`,
+    `tests/integration/test_worker_spine.py` (new); `tests/unit/test_cli.py` (modify —
+    worker dispatch + no-run-half-import probe).
+- **Commits:** `feat(engine): add the runner worker (OME-1089)` — see `git log -1` for the
+  sha (the ledger is amended in the same commit, so a literal sha here would be one amend
+  stale by construction)
+- **Gates:** `uv run ruff check` clean · `uv run ruff format --check` clean ·
+  `uv run pyright` 0 errors · `check_layering.py` OK (three halves) ·
+  `uv run pytest --cov=screamingface_engine --cov=url4.streaming --cov-fail-under=80 -q`
+  → 2321 passed, 91.73% coverage.
+- **Deviations:**
+  - The plan's `worker_slots` setting is NOT a new field: the worker reads the existing
+    `run_queue_worker_slots` (the value `max_ack_pending` is derived from), so the
+    worker's concurrency and the queue's ack-pending bound cannot disagree.
+  - The worker's `worker_io_capacity` is written onto every child's env as
+    `URL4_CLOUD_IO_CONCURRENCY`, overriding the message's value — the worker is the
+    authority on how wide a run may fan out (the fair-share gate cannot span processes).
+  - `capability_expired` is defined as the run's deadline having elapsed since the message
+    was published (`now - published_at >= deadline_s`) — the "executed late" case; the
+    worker needs no new setting for it.
+  - The drain phase sets a `_terminating` event before SIGTERMing children, so a child
+    that ignores SIGTERM is SIGKILL'd after `kill_grace_s` instead of hanging the drain
+    until its hard wall.

--- a/docs/work/2026-09-03-OME-1089-worker-passes-replica-count.md
+++ b/docs/work/2026-09-03-OME-1089-worker-passes-replica-count.md
@@ -1,0 +1,79 @@
+---
+ticket: OME-1089
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-03
+finished:
+---
+
+# OME-1089 — the worker's composition root passes the queue's replica count
+
+## Intent
+
+`worker_composition` builds the `RunQueue` the worker pool pulls from, and it omitted
+`replicas` — so the worker declared the stream with the code default no matter what the
+deployment configured. OME-1088 turned that count into `Settings.run_queue_replicas`; this
+unit connects the worker half to it.
+
+Both halves must agree. The App and the worker declare the SAME singleton stream, and
+`ensure_stream` deliberately refuses a declaration whose properties diverge from an existing
+stream — so a worker that declares with a different replica count than the App is not a
+cosmetic mismatch, it is a startup failure on whichever side loses the race. Wiring one half
+without the other would trade a fixed bug for an intermittent one.
+
+Found by manual e2e deployment of the OME-1086 stack on a single-node kind cluster
+(2026-09-03 findings, B2).
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/worker/loop.py` — pass
+  `replicas=settings.run_queue_replicas` in `worker_composition`.
+- `apps/screamingface-engine/tests/unit/test_worker_composition_replicas.py` — NEW file
+  (tests are append-only; no prior test is touched).
+
+## Test plan
+
+- The worker's queue carries the CONFIGURED replica count, not the code default — asserted
+  with a non-default value, so an ignored setting fails the test.
+- The worker's queue and the App's agree for any `Settings`: the invariant that a divergent
+  declaration would break.
+- The default path still yields the single-node-safe count.
+
+## Acceptance
+
+- `worker_composition(settings)` produces a `RunQueue` whose replica count is
+  `settings.run_queue_replicas`.
+- `run_gates.py screamingface-engine` green.
+
+## Outcome
+
+- **Actual files:** as planned, plus an unplanned repair to a prior test file (see Deviations).
+  - `src/screamingface_engine/worker/loop.py` — `run_worker` passes
+    `replicas=settings.run_queue_replicas`, with the divergence invariant anchored.
+  - `tests/unit/test_worker_composition_replicas.py` — NEW.
+  - `tests/unit/test_worker_claim.py` — EDITED, typing only (approved; see Deviations).
+- **Commits:**
+  1. `fix(engine): satisfy pyright in the worker claim tests`
+  2. `fix(engine): the worker declares the queue with its configured replica count`
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` — see the run for this
+  branch. RED was observed first and for the right reason: `KeyError: 'replicas'` on all three
+  new tests before the one-line wiring.
+- **Deviations:**
+  1. **This branch was ALREADY RED before any work of mine, and that is a finding.** PR #818's
+     CI fails at tip `898b4832` with 5 pyright errors in `tests/unit/test_worker_claim.py` —
+     verified both locally against the pristine branch and in the CI log for job
+     100493190276. The 2026-09-03 deployment findings record #818 as "verified working e2e"
+     and say nothing about a red pipeline, so this was previously unnoticed. Gates are
+     absolute, so the branch could not carry the replicas fix until this was repaired.
+  2. **A prior test file was edited, with owner approval.** The repair is typing-only and
+     changes no assertion, no fake and no behavior: `import nats.errors` added (the file did
+     `import nats` and used `nats.errors.Error`, which resolves at runtime only because
+     another import happens to populate the attribute); the `_FakePublisher` bound to a local
+     name instead of being reached through `worker._publisher`, which is typed to the
+     `_Publisher` Protocol; and one `cast(_FakeProcess, proc)` where `_children` is typed to
+     the `_ChildProcess` Protocol. Landed as its own commit so it can be reviewed — or
+     reverted — independently of the replicas change. Gates ran with `--skip-append-only`; no
+     gate was weakened.
+  3. **Gates were run once over the union of both commits**, not separately per commit. The
+     first commit is a strict subset that only removes type errors, so it is green on its own
+     by construction, but it was not gated in isolation.


### PR DESCRIPTION
## What

Adds the worker that claims runs from the durable queue and supervises each as a child process: a slot-bounded claim loop, the supervisor lifecycle (spawn → heartbeat → output forwarding → terminal frame → ack), and a SIGTERM drain that lets in-flight runs finish.

## Why

The pool half of OME-1086. The worker is where runs actually execute, and its drain semantics are the deploy-interrupts-runs regression the whole design exists to avoid: a rolling deploy must not SIGKILL in-flight evaluations.

## Key changes

- `worker/loop.py` — claim loop (fetch bounded by free slots, a starting registry so cancels find pre-spawn runs, two-phase drain), control loop, `run()`.
- `worker/supervisor.py` — supervise: spawn, heartbeat, output forwarding, causality-based classification, terminal-frame publish, ack; drain-aware kill paths.
- Blast-radius hardening (review P2-1/N-3/V-1/V-7): one transient broker blip must not cancel co-located supervisors — guarded tail reads, a typed `QueueReadError` translation for the connect path, a guarded terminal publish, and a `ProcessLookupError`-safe drain terminate.
- Drain grace (P2-6/N-2): waits on the active task set (mid-spawn runs get their full grace) and terminates children as they appear, so a late child always receives SIGTERM before any SIGKILL.
- Tests: claim/drain/cancel semantics, the vanished-child and publish-blip regressions, the typed tail-read contract.

## Stack

Part of the OME-1086 worker-pool migration: #815 → #816 → #818 → #819 → #821 → #822. Stacked on #816; the base for #819.

## Gates

- ruff check / ruff format --check: clean
- pytest: 2324 passed / 5 skipped (only the known macOS `RLIMIT_AS` flake excluded)
- check_layering: OK

Refs: OME-1089
