### PR TITLE
feat(engine): derive run status from the event stream and make cancellation queue-aware

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -124,6 +124,13 @@ def build_job_runner(
                 max_ack_pending=settings.run_queue_max_ack_pending,
                 duplicate_window_s=settings.run_queue_duplicate_window_s,
                 max_age_s=settings.run_queue_max_age_s,
+                # INVARIANT: the same rule as `stream` above, for a property the broker
+                # itself enforces. `ensure_stream` refuses a declaration whose properties
+                # diverge from an existing stream, and the App usually declares FIRST —
+                # it accepts a run before any worker pulls it. An App left on the code
+                # default while the worker reads configuration is therefore a startup
+                # failure for the worker, not a cosmetic mismatch.
+                replicas=settings.run_queue_replicas,
             ),
             # The publisher's sweep must exclude the CONFIGURED queue stream (review
             # follow-up P2-3) — the same rule `run_worker` already applied.

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -112,13 +112,24 @@ def build_job_runner(
         return QueueJobRunner(
             queue=RunQueue(
                 settings.nats_url,
+                # The stream and subject-prefix follow the CONFIGURED settings (review
+                # follow-up P2-2): the App publishes to the same stream and buckets the
+                # worker pulls, so a renamed queue must not split the two sides (a stream
+                # name mismatch makes every admission fail loudly; a prefix mismatch
+                # publishes where no worker listens). `run_worker` passes the same
+                # settings, so the sides agree for any Settings.
+                stream=settings.run_queue_stream,
                 ack_wait_s=settings.run_queue_ack_wait_s,
                 max_deliver=settings.run_queue_max_deliver,
                 max_ack_pending=settings.run_queue_max_ack_pending,
                 duplicate_window_s=settings.run_queue_duplicate_window_s,
                 max_age_s=settings.run_queue_max_age_s,
             ),
-            publisher=JetStreamPublisher(settings.nats_url),
+            # The publisher's sweep must exclude the CONFIGURED queue stream (review
+            # follow-up P2-3) — the same rule `run_worker` already applied.
+            publisher=JetStreamPublisher(
+                settings.nats_url, run_queue_stream=settings.run_queue_stream
+            ),
             control=ControlClient(settings.nats_url),
             clock=lambda: datetime.now(UTC),
             capability_lifetime_s=settings.capability_lifetime_s,

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -7,14 +7,18 @@
 
 import functools
 from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
 from typing import Any, cast
 
+from screamingface_engine.adapters.jetstream import JetStreamPublisher
 from screamingface_engine.adapters.k8s import (
     BatchV1JobsClient,
     CoreV1QuotaClient,
     K8sJobRunner,
 )
+from screamingface_engine.adapters.queue_runner import ControlClient, QueueJobRunner
 from screamingface_engine.config import Settings
+from screamingface_engine.runner_queue import RunQueue
 from url4.streaming.interfaces import JobRunner
 
 # WHY a timeout at all: `K8sJobRunner` offloads its blocking calls to a worker thread, so a
@@ -99,5 +103,26 @@ def build_job_runner(
             job_ttl_s=settings.effective_job_ttl_s,
             extra_models=extra_models,
             io_concurrency=settings.runner_io_concurrency,
+        )
+    if settings.runner == "queue":
+        # The OME-1086 substrate (OME-1090): one durable queue + a fixed worker pool. The
+        # queue, the publisher, and the control client all connect lazily, so building the
+        # runner never dials the broker. The cutover to this backend is OME-1092; the
+        # adapter must exist and be selectable now.
+        return QueueJobRunner(
+            queue=RunQueue(
+                settings.nats_url,
+                ack_wait_s=settings.run_queue_ack_wait_s,
+                max_deliver=settings.run_queue_max_deliver,
+                max_ack_pending=settings.run_queue_max_ack_pending,
+                duplicate_window_s=settings.run_queue_duplicate_window_s,
+                max_age_s=settings.run_queue_max_age_s,
+            ),
+            publisher=JetStreamPublisher(settings.nats_url),
+            control=ControlClient(settings.nats_url),
+            clock=lambda: datetime.now(UTC),
+            capability_lifetime_s=settings.capability_lifetime_s,
+            io_concurrency=settings.runner_io_concurrency,
+            extra_models=extra_models,
         )
     return None

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/jetstream.py
@@ -364,6 +364,17 @@ class _JetStreamConnection:
         except ValidationError:
             return None
 
+    async def stream_exists(self, topic: str) -> bool:
+        """Whether the run's stream is declared on the broker.
+
+        WHY this exists (OME-1090): the queue runner's `stop()` must tell a missing stream
+        (a topic that was never attached, never scheduled — a no-op) apart from an empty
+        one (a queued run whose tombstone must land), and `last_frame` deliberately
+        collapses the two into None.
+        """
+        js = await self._jetstream()
+        return await _stream_exists(js, topic)
+
     async def delete_stream(self, topic: str) -> None:
         """Drop a run's stream entirely, tolerating one that is already gone.
 

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/max_deliveries.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/max_deliveries.py
@@ -29,6 +29,7 @@ from nats.aio.client import Client
 
 from screamingface_engine.adapters.jetstream import JetStreamPublisher, QueueReadError
 from screamingface_engine.runner_queue import topic_of_message
+from screamingface_engine.subjects import RUN_QUEUE_STREAM
 from url4.streaming.protocol import (
     ErrorInfo,
     TerminatedData,
@@ -38,12 +39,24 @@ from url4.streaming.protocol import (
 
 logger = logging.getLogger(__name__)
 
-# The advisory subject for the run queue's durable consumer. The stream and consumer names
-# are the queue's own constants restated here — an advisory subject is a broker-side
-# convention, not a subject we derive, so it is spelled out rather than built.
-MAX_DELIVERIES_ADVISORY_SUBJECT = (
-    "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.url4-runq.url4-runners"
-)
+
+def advisory_subject_for(stream: str) -> str:
+    """The max-deliveries advisory subject for one queue stream's durable consumers.
+
+    Advisories are broker-published on ``$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.
+    <stream>.<consumer>``, so the stream token follows the CONFIGURED queue name — a
+    subscription built on a hardcoded stream matches nothing the moment an operator
+    renames the queue, and every run the queue gives up on ends without a terminal
+    frame (review follow-up P2-4).
+    """
+    return f"$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.{stream}.*"
+
+
+# The advisor's default subject: the default queue stream. The stream token is wildcarded
+# for the CONSUMER — a consumer is `url4-runners-<bucket>`, ONE token (dashes are not NATS
+# separators), so `.*` matches it while `.url4-runners.*` would demand a second token and
+# match nothing.
+MAX_DELIVERIES_ADVISORY_SUBJECT = advisory_subject_for(RUN_QUEUE_STREAM)
 # The named failure code on the frame the advisor publishes: the queue gave up on the run.
 MAX_DELIVERIES = "max_deliveries"
 # How long the subscription loop waits before retrying after a connection failure.
@@ -78,15 +91,29 @@ class MaxDeliveriesAdvisor:
         self,
         nats_url: str,
         *,
+        run_queue_stream: str = RUN_QUEUE_STREAM,
         clock: Callable[[], datetime] | None = None,
     ) -> None:
         self._url = nats_url
+        self._run_queue_stream = run_queue_stream
+        # The advisory subject follows the CONFIGURED stream name (review follow-up P2-4):
+        # a renamed queue publishes advisories on a different subject, and a subscription
+        # on the default would silently stop hearing every max-deliveries event.
+        self._subject = advisory_subject_for(run_queue_stream)
         self._clock = clock if clock is not None else (lambda: datetime.now(UTC))
         self._nc: Client | None = None
         self._publisher: JetStreamPublisher | None = None
 
     async def run(self) -> None:
-        """Serve the advisory subscription for the process's lifetime, retrying failures."""
+        """Serve the advisory subscription for the process's lifetime, retrying failures.
+
+        WHY close and sleep on EVERY iteration (review follow-up P2-5): a dropped
+        subscription ends its `async for` NORMALLY — `_serve` returns without raising —
+        so a closed connection is only distinguishable from a healthy long-running one by
+        the fact that `_serve` returned. Retrying without closing leaked the previous
+        publisher's own lazy NATS connection, and without sleeping, a subscription that
+        died immediately reconnected in a hot loop.
+        """
         while True:
             try:
                 await self._serve()
@@ -97,16 +124,19 @@ class MaxDeliveriesAdvisor:
                     "max-deliveries advisory subscription failed; retrying in %.0fs",
                     RETRY_DELAY_S,
                 )
+            finally:
+                # Runs on the normal-return (disconnect) path too, so the nc/publisher
+                # pair of a dead iteration is always closed before the next connects.
                 await self.aclose()
-                await asyncio.sleep(RETRY_DELAY_S)
+            await asyncio.sleep(RETRY_DELAY_S)
 
     async def _serve(self) -> None:
         """Connect, subscribe, and forward every advisory to `_handle`."""
         nc = await nats.connect(self._url)
         self._nc = nc
-        publisher = JetStreamPublisher(self._url)
+        publisher = JetStreamPublisher(self._url, run_queue_stream=self._run_queue_stream)
         self._publisher = publisher
-        sub = await nc.subscribe(MAX_DELIVERIES_ADVISORY_SUBJECT)
+        sub = await nc.subscribe(self._subject)
         async for msg in sub.messages:
             await self._handle(publisher, msg.data)
 
@@ -138,9 +168,7 @@ class MaxDeliveriesAdvisor:
         try:
             last = await publisher.last_frame(topic)
         except QueueReadError:
-            logger.warning(
-                "max-deliveries advisory for %s skipped: stream tail unreadable", topic
-            )
+            logger.warning("max-deliveries advisory for %s skipped: stream tail unreadable", topic)
             return
         if isinstance(last, TerminatedEvent):
             return
@@ -178,5 +206,6 @@ __all__ = [
     "MAX_DELIVERIES_ADVISORY_SUBJECT",
     "MaxDeliveriesAdvisor",
     "RETRY_DELAY_S",
+    "advisory_subject_for",
     "topic_of_advisory",
 ]

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/max_deliveries.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/max_deliveries.py
@@ -1,0 +1,162 @@
+"""The max-deliveries advisory subscriber (OME-1090): a run the queue gave up on gets a
+named terminal failure on its own event stream.
+
+JetStream publishes `$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.<stream>.<consumer>`
+when a queue message has been redelivered `max_deliver` times without an ack — the queue
+gave up on the run. The App subscribes, decodes the run's topic from the advisory's
+embedded message (the same env-mapping codec the queue carries), and publishes
+`Terminated(failed)` to the run's stream, so the run's status derivation reads that frame
+like any other terminal outcome instead of a silent disappearance.
+
+LAYERING: a shared leaf — it imports only the shared leaves (`adapters.jetstream`,
+`runner_queue`) and the broker client, so both the control plane and the worker half may
+import it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+import nats
+from nats.aio.client import Client
+
+from screamingface_engine.adapters.jetstream import JetStreamPublisher
+from screamingface_engine.runner_queue import topic_of_message
+from url4.streaming.protocol import (
+    ErrorInfo,
+    TerminatedData,
+    TerminatedEvent,
+    source_for,
+)
+
+logger = logging.getLogger(__name__)
+
+# The advisory subject for the run queue's durable consumer. The stream and consumer names
+# are the queue's own constants restated here — an advisory subject is a broker-side
+# convention, not a subject we derive, so it is spelled out rather than built.
+MAX_DELIVERIES_ADVISORY_SUBJECT = (
+    "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.url4-runq.url4-runners"
+)
+# The named failure code on the frame the advisor publishes: the queue gave up on the run.
+MAX_DELIVERIES = "max_deliveries"
+# How long the subscription loop waits before retrying after a connection failure.
+RETRY_DELAY_S = 5.0
+
+
+def topic_of_advisory(payload: bytes) -> str | None:
+    """The run's topic from a max-deliveries advisory; None when unreadable.
+
+    The advisory's `message.data` is the original queue message's body, base64-encoded —
+    the same env mapping `encode_message` wrote — so the topic is read through the queue's
+    own codec, the single source of truth for what a message describes.
+    """
+    try:
+        advisory = json.loads(payload.decode("utf-8"))
+        raw = base64.b64decode(advisory["message"]["data"])
+        return topic_of_message(raw)
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+class MaxDeliveriesAdvisor:
+    """Subscribes to the max-deliveries advisory and publishes a named terminal failure
+    for each run the queue gave up on.
+
+    The subscription is a background task on the App's event loop; a dropped connection is
+    logged and retried, so a broker blip never silently stops the advisor. The publisher
+    and the core connection are this object's own, closed by `aclose` at shutdown.
+    """
+
+    def __init__(
+        self,
+        nats_url: str,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._url = nats_url
+        self._clock = clock if clock is not None else (lambda: datetime.now(UTC))
+        self._nc: Client | None = None
+        self._publisher: JetStreamPublisher | None = None
+
+    async def run(self) -> None:
+        """Serve the advisory subscription for the process's lifetime, retrying failures."""
+        while True:
+            try:
+                await self._serve()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception(
+                    "max-deliveries advisory subscription failed; retrying in %.0fs",
+                    RETRY_DELAY_S,
+                )
+                await self.aclose()
+                await asyncio.sleep(RETRY_DELAY_S)
+
+    async def _serve(self) -> None:
+        """Connect, subscribe, and forward every advisory to `_handle`."""
+        nc = await nats.connect(self._url)
+        self._nc = nc
+        publisher = JetStreamPublisher(self._url)
+        self._publisher = publisher
+        sub = await nc.subscribe(MAX_DELIVERIES_ADVISORY_SUBJECT)
+        async for msg in sub.messages:
+            await self._handle(publisher, msg.data)
+
+    async def _handle(self, publisher: Any, payload: bytes) -> None:
+        """Publish the named terminal failure for one advisory, if it decodes."""
+        topic = topic_of_advisory(payload)
+        if topic is None:
+            return
+        await self._publish_failure(publisher, topic)
+
+    async def _publish_failure(self, publisher: Any, topic: str) -> None:
+        """Publish `Terminated(failed, max_deliveries)` to the run's stream.
+
+        The frame is a root frame (``source`` is the run's own), so a client attached to
+        the run sees it as the run's outcome, exactly like the worker's own terminal
+        frames.
+        """
+        await publisher.ensure_stream(topic)
+        await publisher.publish(
+            topic,
+            TerminatedEvent(
+                id=uuid.uuid4().hex,
+                source=source_for(topic),
+                subject=topic,
+                time=self._clock(),
+                data=TerminatedData(
+                    status="failed",
+                    error=ErrorInfo(
+                        code=MAX_DELIVERIES,
+                        message="the queue gave up on this run after max_deliver attempts",
+                    ),
+                ),
+            ),
+        )
+        await publisher.flush()
+
+    async def aclose(self) -> None:
+        """Close the publisher and the core connection."""
+        if self._publisher is not None:
+            await self._publisher.close()
+            self._publisher = None
+        if self._nc is not None:
+            await self._nc.close()
+            self._nc = None
+
+
+__all__ = [
+    "MAX_DELIVERIES",
+    "MAX_DELIVERIES_ADVISORY_SUBJECT",
+    "MaxDeliveriesAdvisor",
+    "RETRY_DELAY_S",
+    "topic_of_advisory",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/max_deliveries.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/max_deliveries.py
@@ -27,7 +27,7 @@ from typing import Any
 import nats
 from nats.aio.client import Client
 
-from screamingface_engine.adapters.jetstream import JetStreamPublisher
+from screamingface_engine.adapters.jetstream import JetStreamPublisher, QueueReadError
 from screamingface_engine.runner_queue import topic_of_message
 from url4.streaming.protocol import (
     ErrorInfo,
@@ -118,12 +118,32 @@ class MaxDeliveriesAdvisor:
         await self._publish_failure(publisher, topic)
 
     async def _publish_failure(self, publisher: Any, topic: str) -> None:
-        """Publish `Terminated(failed, max_deliveries)` to the run's stream.
+        """Publish `Terminated(failed, max_deliveries)` to the run's stream — only if the
+        stream does not already end in a terminal frame.
 
         The frame is a root frame (``source`` is the run's own), so a client attached to
         the run sees it as the run's outcome, exactly like the worker's own terminal
         frames.
+
+        WHY the terminal check first (review follow-up): the advisory and the run race.
+        A worker on its FINAL redelivery can complete and publish `Terminated(succeeded)`
+        right as the expired `ack_wait` fires this advisory — the run finished, the
+        broker merely did not see the ack in time. Publishing unconditionally appended
+        `failed` AFTER the success, and `status()` — a last-frame read — reported a
+        succeeded run as failed. The check reads the tail like every other terminal
+        writer here (`supervisor._publish_if_needed`, `queue_runner.stop`) so the FIRST
+        real outcome stands. An UNREADABLE tail is not "no frame" — it skips (logged)
+        rather than gambling a failure frame onto a possibly-finished run.
         """
+        try:
+            last = await publisher.last_frame(topic)
+        except QueueReadError:
+            logger.warning(
+                "max-deliveries advisory for %s skipped: stream tail unreadable", topic
+            )
+            return
+        if isinstance(last, TerminatedEvent):
+            return
         await publisher.ensure_stream(topic)
         await publisher.publish(
             topic,

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -233,11 +233,27 @@ class QueueJobRunner(IdentityAwareJobRunner):
         fetch and registration — pathological, and its claim-time gate still catches
         the tombstone once it proceeds. A stream that already ends in a terminal frame,
         or that does not exist at all (never attached, never scheduled), is untouched.
+
+        WHY the tail is RE-READ between the ask and the tombstone (review follow-up):
+        the first read is one control-timeout old by then, and nothing orders `stop()`
+        against the run itself — a fast run can claim, execute, and publish
+        `Terminated(succeeded)` entirely inside the ask's window. Writing the tombstone
+        after that appended `stopped` AFTER the real outcome, and `status()` — a
+        last-frame read on an append-only stream — reported a succeeded run as stopped,
+        forever. The re-read sees the success frame and returns; the residual window
+        (success landing between the re-read and the publish) is two broker round trips
+        wide, and the confirmation ask below still reaches a live worker, whose own
+        publish is suppressed by `_publish_if_needed`'s re-read.
         """
         frame = await self._publisher.last_frame(topic)
         if isinstance(frame, TerminatedEvent):
             return
         if await self._request_control(topic):
+            return
+        # The ask's window is where a run can finish: re-read the tail BEFORE writing the
+        # marker, and a run that completed during the ask keeps its real outcome.
+        frame = await self._publisher.last_frame(topic)
+        if isinstance(frame, TerminatedEvent):
             return
         if frame is None and not await self._publisher.stream_exists(topic):
             return

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -219,21 +219,33 @@ class QueueJobRunner(IdentityAwareJobRunner):
         """Stop the run: reach a running one over the control subject, else tombstone a
         queued one. Idempotent — unknown and already-terminal topics are no-ops.
 
-        The control request goes out FIRST: a reply means a worker owns the run and is
-        SIGTERMing its child, which ends in the worker's own `Terminated(stopped)` — the
-        App must not also write a tombstone, or the run would end in two terminal frames.
-        No reply within `control_timeout_s` means "not running here", and the tombstone
-        covers the queued case. A stream that already ends in a terminal frame, or that
-        does not exist at all (never attached, never scheduled), is left untouched.
+        WHY the tombstone comes BEFORE the final control re-ask, not after the first
+        ask: nothing orders `stop()` against a worker's claim — the worker can claim the
+        queued message in the window between the first ask's timeout and a tombstone
+        written afterwards, and its claim-time gate reads the stream exactly once,
+        before spawning. Writing the marker FIRST closes that window by construction:
+        a claim that lands after it sees the frame at its gate and never executes. The
+        re-ask then reaches a worker that claimed BEFORE the marker (it registers the
+        topic before spawning, so it answers): the cancel is enacted, and the worker's
+        own terminal publish is suppressed by `_publish_if_needed`'s stream re-read —
+        the tombstone stays the run's single terminal frame on every interleave. The
+        residual race needs a worker stalled longer than `control_timeout_s` between
+        fetch and registration — pathological, and its claim-time gate still catches
+        the tombstone once it proceeds. A stream that already ends in a terminal frame,
+        or that does not exist at all (never attached, never scheduled), is untouched.
         """
-        if await self._request_control(topic):
-            return
         frame = await self._publisher.last_frame(topic)
         if isinstance(frame, TerminatedEvent):
+            return
+        if await self._request_control(topic):
             return
         if frame is None and not await self._publisher.stream_exists(topic):
             return
         await self._publish_tombstone(topic)
+        # The confirmation pass: a worker that claimed between the first ask and the
+        # tombstone answers THIS ask (registration precedes spawn), enacts the cancel,
+        # and skips its own terminal frame — the tombstone is the one frame either way.
+        await self._request_control(topic)
 
     async def exists(self, topic: str) -> bool:
         """Whether a run is live: scheduled (queued) or running.

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -40,6 +40,7 @@ from typing import Any, Protocol
 import nats
 from nats.aio.client import Client
 from nats.aio.msg import Msg
+from nats.errors import NoRespondersError
 
 from screamingface_engine.ports import IdentityAwareJobRunner
 from screamingface_engine.runner_queue import DEFAULT_IO_CONCURRENCY, encode_message
@@ -288,7 +289,13 @@ class QueueJobRunner(IdentityAwareJobRunner):
                 control_subject_for(topic), b"", timeout=self._control_timeout_s
             )
             return True
-        except TimeoutError:
+        except (TimeoutError, NoRespondersError):
+            # A timeout is "nobody replied in time". `NoRespondersError` is the SAME
+            # answer delivered faster: the broker itself reports that NOTHING is
+            # subscribed to `url4.runctl.*` — a pool scaled to zero, mid-rollout, or a
+            # worker that is down. nats-py raises it whenever the server advertises
+            # headers (`no_responders`), and it is NOT a `TimeoutError` subclass, so
+            # leaving it uncaught 500s `DELETE /` instead of tombstoning the queued run.
             return False
 
     async def _publish_tombstone(self, topic: str) -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -42,6 +42,7 @@ from nats.aio.client import Client
 from nats.aio.msg import Msg
 from nats.errors import NoRespondersError
 
+from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.ports import IdentityAwareJobRunner
 from screamingface_engine.runner_queue import DEFAULT_IO_CONCURRENCY, encode_message
 from screamingface_engine.subjects import control_subject_for
@@ -65,6 +66,12 @@ CANCELLED = "cancelled"
 # running here". The worker's reply is a local NATS round trip; a second is far beyond it
 # and far below the client's patience for a DELETE.
 CONTROL_TIMEOUT_S = 1.0
+
+# The sentinel `_read_tail` returns for an UNREADABLE stream tail — distinct from "no
+# frame" and from "a terminal frame", because an unreadable broker answers neither
+# question. Every caller treats it as UNKNOWN: no tombstone, no state change (review
+# follow-up P2-10).
+_UNREADABLE_TAIL = object()
 
 
 class _Queue(Protocol):
@@ -244,24 +251,58 @@ class QueueJobRunner(IdentityAwareJobRunner):
         (success landing between the re-read and the publish) is two broker round trips
         wide, and the confirmation ask below still reaches a live worker, whose own
         publish is suppressed by `_publish_if_needed`'s re-read.
+
+        WHY the tail reads are GUARDED (review follow-up P2-10): an unreadable tail is
+        UNKNOWN — neither terminal nor missing — so answering either way would stop a run
+        that might be running or fail to stop one that needs stopping. On a
+        `QueueReadError` the stop degrades to a no-op (no tombstone, no control ask), and
+        retrying the DELETE once the broker is readable reaches the truth.
         """
-        frame = await self._publisher.last_frame(topic)
-        if isinstance(frame, TerminatedEvent):
+        frame = await self._read_tail(topic)
+        if frame is _UNREADABLE_TAIL or isinstance(frame, TerminatedEvent):
             return
         if await self._request_control(topic):
             return
-        # The ask's window is where a run can finish: re-read the tail BEFORE writing the
-        # marker, and a run that completed during the ask keeps its real outcome.
-        frame = await self._publisher.last_frame(topic)
-        if isinstance(frame, TerminatedEvent):
-            return
+        # The ask's window is where a run can finish — and where the tail can become
+        # unreadable. Either way the marker is not written: a run that finished during the
+        # ask keeps its real outcome, and an unknown tail is never trusted with a state
+        # change.
+        if await self._tombstone_queued_run(topic):
+            # The confirmation pass: a worker that claimed between the first ask and the
+            # tombstone answers THIS ask (registration precedes spawn), enacts the cancel,
+            # and skips its own terminal frame — the tombstone is the one frame either way.
+            await self._request_control(topic)
+
+    async def _tombstone_queued_run(self, topic: str) -> bool:
+        """Write the queued-cancel marker unless the run finished (or vanished, or went
+        unreadable) in the ask window; True when a marker was written.
+
+        The re-read is the overwrite guard: the first read is one control-timeout old by
+        now, and a run that completed during the ask must keep its real outcome.
+        """
+        frame = await self._read_tail(topic)
+        if frame is _UNREADABLE_TAIL or isinstance(frame, TerminatedEvent):
+            return False
         if frame is None and not await self._publisher.stream_exists(topic):
-            return
+            return False
         await self._publish_tombstone(topic)
-        # The confirmation pass: a worker that claimed between the first ask and the
-        # tombstone answers THIS ask (registration precedes spawn), enacts the cancel,
-        # and skips its own terminal frame — the tombstone is the one frame either way.
-        await self._request_control(topic)
+        return True
+
+    async def _read_tail(self, topic: str) -> TerminatedEvent | None | object:
+        """The run's stream tail, or the `_UNREADABLE_TAIL` sentinel when the broker
+        cannot be read.
+
+        WHY a sentinel and not a raise (review follow-up P2-10): `JetStreamPublisher.
+        last_frame` translates a transport-level read failure to `QueueReadError` so the
+        caller can distinguish "no frame" from "could not read" — the two have opposite
+        meanings for every terminal-frame decision. Every App-side caller (stop, status,
+        the reaper through them) treats the sentinel as UNKNOWN and takes no action.
+        """
+        try:
+            return await self._publisher.last_frame(topic)
+        except QueueReadError:
+            logger.warning("stream tail unreadable for %s; treating as unknown", topic)
+            return _UNREADABLE_TAIL
 
     async def exists(self, topic: str) -> bool:
         """Whether a run is live: scheduled (queued) or running.
@@ -283,11 +324,16 @@ class QueueJobRunner(IdentityAwareJobRunner):
         Any non-terminal frame counts as running evidence: the runner publishes
         `StartedEvent` first, so a log/span/cost frame means the run started, whatever it
         is doing now.
+
+        WHY an unreadable tail reads as ``running`` (review follow-up P2-10): an unknown
+        tail must never give the reaper a terminal-ish answer — `exists()` is this very
+        status, and a ``not_found`` read would make the reaper stop an unknown run. Assumed
+        alive: the client retries, and the reaper's sweep re-reads on its next tick.
         """
-        frame = await self._publisher.last_frame(topic)
+        frame = await self._read_tail(topic)
         if isinstance(frame, TerminatedEvent):
             return frame.data.status
-        if frame is not None:
+        if frame is not None or frame is _UNREADABLE_TAIL:
             return "running"
         return "scheduled" if self._capability_valid(topic) else "not_found"
 

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -252,14 +252,22 @@ class QueueJobRunner(IdentityAwareJobRunner):
         wide, and the confirmation ask below still reaches a live worker, whose own
         publish is suppressed by `_publish_if_needed`'s re-read.
 
-        WHY the tail reads are GUARDED (review follow-up P2-10): an unreadable tail is
-        UNKNOWN — neither terminal nor missing — so answering either way would stop a run
-        that might be running or fail to stop one that needs stopping. On a
-        `QueueReadError` the stop degrades to a no-op (no tombstone, no control ask), and
-        retrying the DELETE once the broker is readable reaches the truth.
+        WHY an unreadable tail RAISES and does not no-op (review follow-ups P2-10 then
+        V-2/V-3): an unreadable tail is UNKNOWN — neither terminal nor missing — so
+        answering either way would stop a run that might be running or fail to stop one
+        that needs stopping. The first P2-10 fix made this a SILENT no-op, which the
+        reaper read as a successful reap (deadline popped, `reaped_total` incremented,
+        "orphan run reaped" logged) for a run it never touched — the original bug with
+        telemetry asserting the opposite — and which let `DELETE /` fall through to
+        deleting the stream of a possibly-live run. The typed raise keeps "no state
+        change" while making the unknown HONEST: the REST edge answers 503 (retryable),
+        and the reaper's existing guard re-arms the deadline, so a retried stop once the
+        broker is readable reaches the truth.
         """
         frame = await self._read_tail(topic)
-        if frame is _UNREADABLE_TAIL or isinstance(frame, TerminatedEvent):
+        if frame is _UNREADABLE_TAIL:
+            raise QueueReadError(f"stream tail unreadable for {topic}: run state unknown")
+        if isinstance(frame, TerminatedEvent):
             return
         if await self._request_control(topic):
             return
@@ -325,15 +333,20 @@ class QueueJobRunner(IdentityAwareJobRunner):
         `StartedEvent` first, so a log/span/cost frame means the run started, whatever it
         is doing now.
 
-        WHY an unreadable tail reads as ``running`` (review follow-up P2-10): an unknown
-        tail must never give the reaper a terminal-ish answer — `exists()` is this very
-        status, and a ``not_found`` read would make the reaper stop an unknown run. Assumed
-        alive: the client retries, and the reaper's sweep re-reads on its next tick.
+        WHY an unreadable tail RAISES (review follow-ups P2-10 then V-2/V-3): the first
+        fix answered ``running`` — assumed alive — reasoning only about the reaper. But
+        ``exists()`` is this same status, and ``POST /`` used it to answer 409 "a run
+        already exists" for a BRAND-NEW topic on a transient blip: a definitive false
+        claim clients do not retry. Unknown is not a state, for any consumer. The typed
+        raise lets each caller answer honestly — the REST edge 503s (retryable, no state
+        change), and the reaper's guard re-arms for the next sweep.
         """
         frame = await self._read_tail(topic)
         if isinstance(frame, TerminatedEvent):
             return frame.data.status
-        if frame is not None or frame is _UNREADABLE_TAIL:
+        if frame is _UNREADABLE_TAIL:
+            raise QueueReadError(f"stream tail unreadable for {topic}: run state unknown")
+        if frame is not None:
             return "running"
         return "scheduled" if self._capability_valid(topic) else "not_found"
 

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -1,0 +1,353 @@
+"""The queue-backed `JobRunner` (OME-1090): status is a pure function of the run's own
+event stream plus capability validity, and cancellation is queue-aware.
+
+OME-1086 replaces the Kubernetes Job with a durable queue + worker pool. This adapter is
+the App's half of that replacement: `schedule()` publishes the run to the queue,
+`stop()` writes a `Terminated(stopped)` tombstone for a queued run and reaches a running
+one over a core NATS control subject, and `status()`/`exists()` read the run's event
+stream instead of a Job.
+
+WHY status is a pure function of the stream: the stream is the one record every replica
+can read and the worker already writes — a terminal frame IS the run's outcome, a
+`StartedEvent` without one means running, and neither with an unexpired capability means
+the run is accepted but not yet started (queued). `JobStatus.scheduled` already means
+exactly that, so the port needs no new member, and OME-1059's conflation (a Job that
+exists but never starts) is retired structurally: a run that sat queued past its
+capability lifetime reads `not_found`, not a phantom `scheduled`.
+
+WHY cancellation is two paths: a queued run has no worker to ask, so the App writes the
+tombstone itself and the worker later claims the message, sees the terminal frame, acks,
+and never executes — no message deletion by sequence, and the App never learns the
+message's sequence. A running run is owned by exactly one worker, so the App asks over
+`url4.runctl.<topic>`; only the owner replies (and SIGTERMs its child, which ends in the
+worker's own `Terminated(stopped)`), and no reply within a short timeout means "not
+running here", falling back to the tombstone.
+
+LAYERING: a shared leaf — it imports only the shared leaves (`runner_queue`, `subjects`,
+`adapters.jetstream`), the abstract port, and the broker client, so both the control
+plane and the worker half may import it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from typing import Any, Protocol
+
+import nats
+from nats.aio.client import Client
+from nats.aio.msg import Msg
+
+from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.runner_queue import DEFAULT_IO_CONCURRENCY, encode_message
+from screamingface_engine.subjects import control_subject_for
+from url4.streaming.interfaces import JobStatus, job_name
+from url4.streaming.protocol import (
+    CachePolicy,
+    ErrorInfo,
+    OutboundFrame,
+    TerminatedData,
+    TerminatedEvent,
+    source_for,
+)
+
+logger = logging.getLogger(__name__)
+
+# The named reason on the App's queued-cancel tombstone. The worker's control-cancel frame
+# uses the same code (`worker.supervisor.CANCELLED`), so a client sees one reason whether
+# the cancel landed before or after the claim.
+CANCELLED = "cancelled"
+# How long `stop()` waits for a worker to answer the control request before reading "not
+# running here". The worker's reply is a local NATS round trip; a second is far beyond it
+# and far below the client's patience for a DELETE.
+CONTROL_TIMEOUT_S = 1.0
+
+
+class _Queue(Protocol):
+    """The slice of ``RunQueue`` the queue runner uses."""
+
+    async def publish(self, message: bytes) -> None: ...
+
+    async def depth(self) -> int: ...
+
+
+class _Publisher(Protocol):
+    """The slice of ``JetStreamPublisher`` the queue runner uses."""
+
+    async def last_frame(self, topic: str) -> OutboundFrame | None: ...
+
+    async def stream_exists(self, topic: str) -> bool: ...
+
+    async def ensure_stream(self, topic: str) -> None: ...
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None: ...
+
+    async def flush(self) -> None: ...
+
+
+class _ControlClient(Protocol):
+    """The slice of a core NATS client the queue runner uses for the control request."""
+
+    async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any: ...
+
+
+class ControlClient:
+    """A lazy core-NATS client for the run-control request/reply channel.
+
+    WHY lazy, like ``RunQueue``'s own connection: the factory constructs the queue runner
+    synchronously at App build time, and nothing may dial the broker until the first
+    request actually needs it. The lock and the re-check under it are the same
+    single-connection story as ``_JetStreamConnection._jetstream``.
+    """
+
+    def __init__(self, nats_url: str) -> None:
+        self._url = nats_url
+        self._nc: Client | None = None
+        self._lock = asyncio.Lock()
+
+    async def _client(self) -> Client:
+        nc = self._nc
+        if nc is not None and not nc.is_closed:
+            return nc
+        async with self._lock:
+            nc = self._nc
+            if nc is not None and not nc.is_closed:
+                return nc
+            nc = await nats.connect(self._url)
+            self._nc = nc
+            return nc
+
+    async def request(self, subject: str, payload: bytes = b"", *, timeout: float) -> Msg:
+        nc = await self._client()
+        return await nc.request(subject, payload, timeout=timeout)
+
+    async def close(self) -> None:
+        if self._nc is not None:
+            await self._nc.close()
+
+
+class QueueJobRunner(IdentityAwareJobRunner):
+    """Implements `JobRunner` over the durable run queue and the run's own event stream.
+
+    ``queue``, ``publisher`` and ``control`` are injected (the factory builds the real
+    ``RunQueue``, ``JetStreamPublisher`` and ``ControlClient``; tests hand in fakes).
+    ``clock`` and ``capability_lifetime_s`` are the capability-validity inputs: a run with
+    no stream evidence is ``scheduled`` while its capability is unexpired and ``not_found``
+    once it has expired.
+
+    INVARIANT: the schedule-time record is in-memory, like ``InProcessJobRunner._tasks`` —
+    this is not a new store. The terminal and running rows of the status table read the
+    event stream and are correct across App replicas; the scheduled/not_found boundary
+    uses the local record, and a replica that never scheduled the topic answers
+    ``not_found``, which is the conservative direction for the reaper.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue: _Queue,
+        publisher: _Publisher,
+        control: _ControlClient,
+        clock: Callable[[], datetime],
+        capability_lifetime_s: float,
+        control_timeout_s: float = CONTROL_TIMEOUT_S,
+        io_concurrency: int = DEFAULT_IO_CONCURRENCY,
+        extra_models: Callable[[], Sequence[str]] | None = None,
+    ) -> None:
+        self._queue = queue
+        self._publisher = publisher
+        self._control = control
+        self._clock = clock
+        self._capability_lifetime_s = capability_lifetime_s
+        self._control_timeout_s = control_timeout_s
+        self._io_concurrency = io_concurrency
+        # WHY a callable and not a snapshot (OME-880): the admitted-model overlay grows
+        # while the app runs, and a model admitted a second ago must reach the very next
+        # run — the same rule as `K8sJobRunner._extra_models`.
+        self._extra_models = extra_models
+        # topic → when this replica accepted it. The capability-validity input for the
+        # scheduled/not_found boundary; pruned on each schedule so it stays bounded by the
+        # topics accepted within one capability lifetime.
+        self._scheduled_at: dict[str, datetime] = {}
+
+    # --- the JobRunner port ----------------------------------------------------------------
+
+    async def schedule(
+        self,
+        topic: str,
+        url4: str,
+        deadline_s: int,
+        *,
+        traceparent: str | None = None,
+        credential: str | None = None,
+        profile: str | None = None,
+        identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
+    ) -> str:
+        """Publish the run to the queue and return its job name.
+
+        `credential` is accepted for port compatibility and DELIBERATELY DROPPED, exactly
+        as `K8sJobRunner` drops it: the queue message carries the caller's verified
+        identity, never a bearer token (see the k8s adapter's module INVARIANT).
+
+        The broker deduplicates a retried submission of the same topic within
+        `duplicate_window` (`Nats-Msg-Id` is the topic), which is the queue's
+        `JobAlreadyExists` equivalent — the REST pre-check's 409 and the broker's dedupe
+        collapse a race into one run.
+        """
+        message = encode_message(
+            topic,
+            url4,
+            deadline_s,
+            traceparent=traceparent,
+            profile=profile,
+            identity=identity,
+            cache=cache,
+            io_concurrency=self._io_concurrency,
+            extra_models=() if self._extra_models is None else self._extra_models(),
+        )
+        await self._queue.publish(message)
+        self._scheduled_at[topic] = self._clock()
+        self._prune()
+        return job_name(topic)
+
+    async def stop(self, topic: str) -> None:
+        """Stop the run: reach a running one over the control subject, else tombstone a
+        queued one. Idempotent — unknown and already-terminal topics are no-ops.
+
+        The control request goes out FIRST: a reply means a worker owns the run and is
+        SIGTERMing its child, which ends in the worker's own `Terminated(stopped)` — the
+        App must not also write a tombstone, or the run would end in two terminal frames.
+        No reply within `control_timeout_s` means "not running here", and the tombstone
+        covers the queued case. A stream that already ends in a terminal frame, or that
+        does not exist at all (never attached, never scheduled), is left untouched.
+        """
+        if await self._request_control(topic):
+            return
+        frame = await self._publisher.last_frame(topic)
+        if isinstance(frame, TerminatedEvent):
+            return
+        if frame is None and not await self._publisher.stream_exists(topic):
+            return
+        await self._publish_tombstone(topic)
+
+    async def exists(self, topic: str) -> bool:
+        """Whether a run is live: scheduled (queued) or running.
+
+        A terminal run does not exist — the reaper's contract, which is what keeps an
+        audience-loss stop from landing a second terminal frame on a finished run.
+        """
+        return await self.status(topic) in ("scheduled", "running")
+
+    async def status(self, topic: str) -> JobStatus:
+        """The run's status, derived from its event stream plus capability validity.
+
+        | Evidence on the run's event stream | Status |
+        | terminal frame present | its outcome |
+        | StartedEvent, no terminal frame | running |
+        | neither, capability unexpired | scheduled |
+        | neither, capability expired | not_found |
+
+        Any non-terminal frame counts as running evidence: the runner publishes
+        `StartedEvent` first, so a log/span/cost frame means the run started, whatever it
+        is doing now.
+        """
+        frame = await self._publisher.last_frame(topic)
+        if isinstance(frame, TerminatedEvent):
+            return frame.data.status
+        if frame is not None:
+            return "running"
+        return "scheduled" if self._capability_valid(topic) else "not_found"
+
+    async def queue_depth(self) -> int:
+        """How many runs are queued — the position notice's input (OME-1090)."""
+        return await self._queue.depth()
+
+    async def aclose(self) -> None:
+        """Close the control connection. The queue and publisher own their own connections
+        and are closed by their own owners; this runner created only the control client."""
+        close = getattr(self._control, "close", None)
+        if close is not None:
+            await close()
+
+    # --- the two cancel paths --------------------------------------------------------------
+
+    async def _request_control(self, topic: str) -> bool:
+        """Ask `url4.runctl.<topic>` whether a worker owns the run; True when one replied.
+
+        A reply means the owner is SIGTERMing its child right now — the run's
+        `Terminated(stopped)` is on its way from the worker, so the caller must not also
+        write a tombstone. A timeout (or a broker that never delivers) reads as "not
+        running here".
+        """
+        try:
+            await self._control.request(
+                control_subject_for(topic), b"", timeout=self._control_timeout_s
+            )
+            return True
+        except TimeoutError:
+            return False
+
+    async def _publish_tombstone(self, topic: str) -> None:
+        """Write `Terminated(stopped)` to the run's stream — the queued-cancel path.
+
+        The worker later claims the run's message, sees this frame, acks, and never
+        executes. The frame is a root frame (``source`` is the run's own), so a client
+        attached to the run sees it as the run's outcome, exactly like the worker's own
+        terminal frames.
+        """
+        await self._publisher.ensure_stream(topic)
+        await self._publisher.publish(
+            topic,
+            TerminatedEvent(
+                id=uuid.uuid4().hex,
+                source=source_for(topic),
+                subject=topic,
+                time=self._clock(),
+                data=TerminatedData(
+                    status="stopped",
+                    error=ErrorInfo(
+                        code=CANCELLED,
+                        message="the run was cancelled before it started",
+                    ),
+                ),
+            ),
+        )
+        await self._publisher.flush()
+
+    # --- capability validity ---------------------------------------------------------------
+
+    def _capability_valid(self, topic: str) -> bool:
+        """Whether the run's capability is still valid: accepted within
+        `capability_lifetime_s`, on this replica's clock.
+
+        A topic this replica never scheduled has no capability to speak of — `not_found`,
+        the conservative answer for the reaper.
+        """
+        scheduled_at = self._scheduled_at.get(topic)
+        if scheduled_at is None:
+            return False
+        return (self._clock() - scheduled_at).total_seconds() < self._capability_lifetime_s
+
+    def _prune(self) -> None:
+        """Drop schedule records whose capability has expired, so the dict stays bounded by
+        the topics accepted within one capability lifetime."""
+        now = self._clock()
+        expired = [
+            topic
+            for topic, at in self._scheduled_at.items()
+            if (now - at).total_seconds() >= self._capability_lifetime_s
+        ]
+        for topic in expired:
+            del self._scheduled_at[topic]
+
+
+__all__ = [
+    "CANCELLED",
+    "CONTROL_TIMEOUT_S",
+    "ControlClient",
+    "QueueJobRunner",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -311,7 +311,7 @@ def _install_max_deliveries_advisor(app: FastAPI, settings: Settings) -> None:
         return
     from screamingface_engine.adapters.max_deliveries import MaxDeliveriesAdvisor
 
-    advisor = MaxDeliveriesAdvisor(settings.nats_url)
+    advisor = MaxDeliveriesAdvisor(settings.nats_url, run_queue_stream=settings.run_queue_stream)
     app.state.max_deliveries_advisor = advisor
 
     async def _start() -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -12,6 +12,7 @@ import contextlib
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -31,6 +32,10 @@ from screamingface_engine.catalog import build_executable_catalog_service
 from screamingface_engine.catalog.cache import CatalogService
 from screamingface_engine.catalog.port import ModelParameterSource
 from screamingface_engine.config import INSECURE_DEFAULT_JWT_SECRET, Settings
+
+if TYPE_CHECKING:  # the adapter is imported lazily at runtime; only the annotation needs the name
+    from screamingface_engine.adapters.jetstream import JetStreamConsumer
+
 from screamingface_engine.connections import build_connections
 from screamingface_engine.connections.port import Connections
 from screamingface_engine.metrics import (
@@ -349,6 +354,20 @@ def _require_prod_secret(settings: Settings) -> None:
         )
 
 
+def build_stream_consumer(settings: Settings) -> JetStreamConsumer:
+    """The App's event-stream consumer, carrying the CONFIGURED queue stream name.
+
+    V-6: the consumer inherits `_sweep_orphans`, whose exclusion follows the
+    `run_queue_stream` ctor param — a consumer built from the default constant re-arms
+    the sweep against a renamed queue stream, and the sweep deletes what it accepts.
+    Extracted from `create_app_from_env` so the stream-wiring test can hold this root to
+    the same Settings as the worker's and the App's runner.
+    """
+    from screamingface_engine.adapters.jetstream import JetStreamConsumer
+
+    return JetStreamConsumer(settings.nats_url, run_queue_stream=settings.run_queue_stream)
+
+
 def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INFRA rule, spec §11)
     """Production entrypoint (used by `cli.py` via uvicorn's factory mode).
 
@@ -356,11 +375,9 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
     backend, and the catalog service — then wires them into `create_app` and registers their
     shutdown hooks on the App's router.
     """
-    from screamingface_engine.adapters.jetstream import JetStreamConsumer
-
     settings = Settings()
     _require_prod_secret(settings)
-    stream = JetStreamConsumer(settings.nats_url)
+    stream = build_stream_consumer(settings)
     # Catalog first (OME-880): the job runner needs the admitted-model overlay so a
     # dynamically admitted model is routable by the very next scheduled run.
     catalog = build_executable_catalog_service(settings, os.environ)

--- a/apps/screamingface-engine/src/screamingface_engine/app.py
+++ b/apps/screamingface-engine/src/screamingface_engine/app.py
@@ -107,8 +107,7 @@ def create_app(
     # FEATURE: deliver large results in full (OME-892) — the serve side of the spill store.
     # FEATURE: and survive a multi-pod deployment, where that store cannot be a local disk
     # (OME-929).
-    artifact_store = _build_artifact_reader(settings)
-    app.state.artifact_store = artifact_store
+    app.state.artifact_store = _build_artifact_reader(settings)
     # WHY startup + periodic: fetching never deletes (OME-892 review — content addressing means
     # one object backs many tickets, and a Range request must leave the rest fetchable), so TTL
     # is the ONLY cleanup and every redeemed parcel also waits for it. The boot sweep clears the
@@ -118,7 +117,7 @@ def create_app(
     #
     # AIDEV-NOTE: with `artifact_store=s3` the sweeper is a no-op by design — expiry is the
     # bucket's lifecycle rule. See `artifacts.s3.S3ArtifactStore.sweep`.
-    _install_artifact_sweeper(app, artifact_store, settings)
+    _install_artifact_sweeper(app, app.state.artifact_store, settings)
     # WHY: pass a getter, not `catalog` directly — the collector re-reads app.state.catalog on
     # every /metrics scrape rather than capturing the value built here.
     register_catalog_metrics(app.state.metrics, lambda: app.state.catalog)
@@ -128,6 +127,9 @@ def create_app(
     app.state.interest = interest if interest is not None else registry
     # FEATURE: tie a run's lifetime to its audience (OME-890).
     _install_orphan_reaper(app, registry, job_runner, settings)
+    # FEATURE: a run the queue gave up on must end in a named failure, not silence
+    # (OME-1090).
+    _install_max_deliveries_advisor(app, settings)
     if clock is not None:
         app.state.clock = clock
     install_problem_handlers(app)
@@ -170,12 +172,17 @@ def _build_artifact_reader(settings: Settings) -> ArtifactReader:
                 }
             )
         )
-    if settings.runner == "k8s":
+    if settings.runner in ("k8s", "queue"):
+        # WHY both backends: `k8s` schedules each run as a separate Job pod, and `queue`
+        # (OME-1090) runs each run in a worker pod — either way the run executes in a
+        # different pod than this App, whose disk is destroyed with it, so results spilled
+        # to a local directory can never be served back.
         raise ValueError(
-            f"runner='k8s' schedules each run as a separate Job pod, whose disk is destroyed "
-            f"with it, so results spilled to a local directory can never be served back. Set "
-            f"{job_env.ARTIFACT_STORE}=s3 and the {job_env.ARTIFACT_S3_BUCKET} settings, or "
-            f"use runner='none' for a single-process deployment."
+            f"runner='{settings.runner}' runs each run in its own pod, whose disk is "
+            f"destroyed with it, so results spilled to a local directory can never be "
+            f"served back. Set {job_env.ARTIFACT_STORE}=s3 and the "
+            f"{job_env.ARTIFACT_S3_BUCKET} settings, or use runner='none' for a "
+            f"single-process deployment."
         )
     return ArtifactStore(Path(settings.artifacts_dir))
 
@@ -289,6 +296,39 @@ def _install_orphan_reaper(
     app.router.on_shutdown.append(_stop)
 
 
+def _install_max_deliveries_advisor(app: FastAPI, settings: Settings) -> None:
+    """Wire the max-deliveries advisory subscriber: a background task that publishes a
+    named terminal failure for each run the queue gave up on (OME-1090).
+
+    Modelled on `_install_orphan_reaper`: the advisor owns no task, the loop is an asyncio
+    task on the App's own event loop, and shutdown cancels it and closes the advisor's
+    connections so nothing outlives the App. Only the queue backend has a queue to give up
+    on, so a k8s or stream-only App installs nothing.
+    """
+    app.state.max_deliveries_advisor = None
+    app.state.max_deliveries_task = None
+    if settings.runner != "queue":
+        return
+    from screamingface_engine.adapters.max_deliveries import MaxDeliveriesAdvisor
+
+    advisor = MaxDeliveriesAdvisor(settings.nats_url)
+    app.state.max_deliveries_advisor = advisor
+
+    async def _start() -> None:
+        app.state.max_deliveries_task = asyncio.get_running_loop().create_task(advisor.run())
+
+    async def _stop() -> None:
+        task = app.state.max_deliveries_task
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        await advisor.aclose()
+
+    app.router.on_startup.append(_start)
+    app.router.on_shutdown.append(_stop)
+
+
 _MIN_JWT_SECRET_BYTES = 32
 
 
@@ -345,6 +385,13 @@ def create_app_from_env() -> FastAPI:  # pragma: no cover - env/NATS wiring (INF
         benchmarks=BUILTIN_BENCHMARKS,
     )
     app.router.on_shutdown.append(stream.close)
+    if job_runner is not None:
+        # The queue runner owns a control connection of its own (OME-1090); the k8s runner
+        # owns nothing to close. `getattr` rather than an isinstance: the factory returns
+        # the port, and the app must not import a concrete adapter.
+        aclose = getattr(job_runner, "aclose", None)
+        if aclose is not None:
+            app.router.on_shutdown.append(aclose)
     if catalog is not None:
         app.router.on_shutdown.append(catalog.aclose)
     if connections is not None:

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -14,12 +14,14 @@ from screamingface_engine import job_env, runner_queue, subjects
 # in-cluster skew and still ~500x cheaper than the old job_deadline_s-based floor.
 _TTL_SKEW_MARGIN_S = 60
 
-RunnerBackend = Literal["none", "k8s"]
+RunnerBackend = Literal["none", "k8s", "queue"]
 ArtifactStoreBackend = Literal["filesystem", "s3"]
 """Which ``JobRunner`` substrate the deployed App schedules runs on (spec §9).
 
-``k8s`` is prod (namespace-scoped batch/v1 Jobs) and ``none`` a stream-only App that mints tokens
-and bridges NATS but schedules nothing.
+``k8s`` is prod (namespace-scoped batch/v1 Jobs), ``queue`` is the OME-1086 substrate
+(one durable run queue + a fixed worker pool; the adapter exists and is selectable since
+OME-1090, the cutover is OME-1092), and ``none`` a stream-only App that mints tokens and
+bridges NATS but schedules nothing.
 """
 
 # The worker's per-run address-space cap (OME-1089). 2 GiB — see the field's comment for why it

--- a/apps/screamingface-engine/src/screamingface_engine/notices.py
+++ b/apps/screamingface-engine/src/screamingface_engine/notices.py
@@ -51,9 +51,25 @@ def warn(topic: str, clock: Clock, message: str, attributes: LogAttributes) -> L
     )
 
 
+def info(topic: str, clock: Clock, message: str, attributes: LogAttributes) -> LogEvent:
+    """Build an ``info`` ``LogEvent`` for ``topic``'s attached client — advisory, never a nack.
+
+    The informational counterpart of :func:`warn`: the queue-position notice (OME-1090)
+    reports a normal, expected wait, not something the caller stated being dropped, so it
+    is INFO rather than WARN.
+    """
+    return LogEvent(
+        id=uuid4().hex,
+        source=source_for(topic),
+        subject=topic,
+        time=clock(),
+        data=LogData.at("INFO", message, attributes),
+    )
+
+
 def rendered(policy: CachePolicy | None) -> str:
     """A cache intent as a log-attribute value; :data:`NOT_STATED` when there is none."""
     return NOT_STATED if policy is None else policy.model_dump_json(exclude_none=True)
 
 
-__all__ = ["NOT_STATED", "Clock", "LogAttributes", "rendered", "warn"]
+__all__ = ["NOT_STATED", "Clock", "LogAttributes", "info", "rendered", "warn"]

--- a/apps/screamingface-engine/src/screamingface_engine/reaper.py
+++ b/apps/screamingface-engine/src/screamingface_engine/reaper.py
@@ -146,22 +146,29 @@ class RunReaper:
         # atomic step, so a reconnect cannot land between the check and the claim. One arriving
         # afterwards simply finds nothing armed, which is the same end state as a disarm.
         self._deadlines.pop(topic, None)
-        # First guard: the audience came back and the disarm was missed or raced.
-        # Second guard: the run is already terminal. `stop` is idempotent, but on the k8s runner
-        # it DELETEs the Job, which would drop a finished Job before the TTL that is its
-        # single-use replay guard. The order matters: an in-process dict lookup short-circuits
-        # ahead of a possible Kubernetes API call.
-        if await self._audience.has_subscriber(topic) or not await self._job_runner.exists(topic):
-            return False
         try:
+            # First guard: the audience came back and the disarm was missed or raced.
+            # Second guard: the run is already terminal. `stop` is idempotent, but on the k8s runner
+            # it DELETEs the Job, which would drop a finished Job before the TTL that is its
+            # single-use replay guard. The order matters: an in-process dict lookup short-circuits
+            # ahead of a possible Kubernetes API call.
+            #
+            # WHY both guards sit under the try (review follow-up P2-10): `exists` raises
+            # `QueueReadError` on a transient broker failure, and the pop above already
+            # CLAIMED the topic — an unguarded raise aborted the sweep with the deadline
+            # gone and nothing left to re-arm it: the orphan was silently forgotten and
+            # ran to the 16h ceiling, the exact spend this module exists to prevent. A
+            # failure here re-arms like a failed stop below.
+            if not await self._still_armed(topic):
+                return False
             await self._job_runner.stop(topic)
         except Exception:
-            # INVARIANT: a failed stop RE-ARMS rather than gives up, without bound. Abandoning
+            # INVARIANT: a failed action RE-ARMS rather than gives up, without bound. Abandoning
             # the topic would hand the run back to the 16h ceiling, which is the exact spend this
             # module exists to prevent; the per-tick warning is the operator's signal that the
             # runner itself needs attention.
             self._deadlines[topic] = now + self._tick_s
-            _logger.warning("orphan stop failed topic=%s; will retry", topic, exc_info=True)
+            _logger.warning("orphan reap failed topic=%s; will retry", topic, exc_info=True)
             return False
         self._reaped_total += 1
         _logger.info(
@@ -170,3 +177,16 @@ class RunReaper:
             self._grace_s,
         )
         return True
+
+    async def _still_armed(self, topic: str) -> bool:
+        """Whether the expired topic still deserves a reap: nobody is listening AND the run
+        is live.
+
+        The audience lookup is an in-process dict read and short-circuits the `exists`
+        call (a broker RPC on the queue runner), so an audience that returned costs no
+        RPC. `exists` raises `QueueReadError` on a transient broker failure — that raise
+        is caught by `_reap`'s guard try, which re-arms the deadline.
+        """
+        if await self._audience.has_subscriber(topic):
+            return False
+        return await self._job_runner.exists(topic)

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -13,7 +13,7 @@ import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, Protocol, runtime_checkable
 
 from fastapi import APIRouter, Header, Request, Response
 from fastapi.responses import FileResponse
@@ -334,6 +334,39 @@ def _converge_cache(
     return resolution.effective
 
 
+@runtime_checkable
+class _QueueAware(Protocol):
+    """A job runner that can report its queue depth — the queue backend (OME-1090).
+
+    The port has no such method; the queue runner widens it, and the notice is only for
+    that backend, so the route checks structurally rather than importing the adapter.
+    """
+
+    async def queue_depth(self) -> int: ...
+
+
+async def _notify_queue_position(deps: _Deps, topic: str, clock: Callable[[], datetime]) -> None:
+    """Tell the attached client where its run sits in the queue, if the runner is
+    queue-backed (OME-1090).
+
+    The client is already attached while its run is queued, so the wait should be visible
+    instead of silent. The notice travels the WS bridge's existing `add_notifier` path —
+    no protocol change, no stream write — and is superseded once `StartedEvent` arrives.
+    """
+    if not isinstance(deps.job_runner, _QueueAware):
+        return
+    position = await deps.job_runner.queue_depth()
+    deps.sessions.notify(
+        topic,
+        notices.info(
+            topic,
+            clock,
+            f"the run is queued at position {position}",
+            {"queue.position": position},
+        ),
+    )
+
+
 async def _run_sync(deps: _Deps, topic: str, wait_s: float | None) -> Response:
     """Hold the request until the run's terminal frame, or 202-fall-back once the bound elapses.
 
@@ -497,6 +530,7 @@ async def start_run(
         identity=identity,
         cache=_converge_cache(deps, topic, cache_control, clock),
     )
+    await _notify_queue_position(deps, topic, clock)
     pref = _parse_prefer(prefer or "")
     if pref.respond_async:
         return _accepted(topic)

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -346,23 +346,33 @@ class _QueueAware(Protocol):
 
 
 async def _notify_queue_position(deps: _Deps, topic: str, clock: Callable[[], datetime]) -> None:
-    """Tell the attached client where its run sits in the queue, if the runner is
+    """Tell the attached client how many runs the queue holds, if the runner is
     queue-backed (OME-1090).
 
     The client is already attached while its run is queued, so the wait should be visible
     instead of silent. The notice travels the WS bridge's existing `add_notifier` path —
     no protocol change, no stream write — and is superseded once `StartedEvent` arrives.
+
+    INVARIANT: purely advisory — a failure here must never fail the request. This runs
+    AFTER the run is durably queued, so an exception would turn an accepted run into a
+    500 while the run proceeds anyway. The value is also a cached fleet-wide depth that
+    may lag this publish by `state_cache_ttl_s`, so the notice reports a DEPTH, not a
+    promise about this run's exact position.
     """
     if not isinstance(deps.job_runner, _QueueAware):
         return
-    position = await deps.job_runner.queue_depth()
+    try:
+        depth = await deps.job_runner.queue_depth()
+    except Exception:  # noqa: BLE001 - advisory only; the broker blip is not the client's error
+        _logger.debug("queue depth notice skipped: the broker read failed", exc_info=True)
+        return
     deps.sessions.notify(
         topic,
         notices.info(
             topic,
             clock,
-            f"the run is queued at position {position}",
-            {"queue.position": position},
+            f"the run is queued; the queue holds {depth} run(s)",
+            {"queue.depth": depth},
         ),
     )
 

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Header, Request, Response
 from fastapi.responses import FileResponse
 
 from screamingface_engine import job_env, notices
+from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.artifacts import ArtifactStore
 from screamingface_engine.auth import (
     PROBLEM_MEDIA_TYPE,
@@ -172,7 +173,19 @@ async def _schedule(
     the REST edge, re-rendered onto the aigateway call by the Runner. It is deliberately NOT world
     config; a per-run value parked on the shared aigateway configuration would leak across runs.
     """
-    if await deps.job_runner.exists(topic):
+    try:
+        already_exists = await deps.job_runner.exists(topic)
+    except QueueReadError:
+        # V-3: an unreadable queue tail is UNKNOWN, and a 409 would assert — definitively,
+        # in a form clients do not retry — that a run exists for a topic that may be brand
+        # new. 503 says "this server could not read the queue; retry": honest, retryable,
+        # and no state change either way.
+        raise ProblemException(
+            status=503,
+            title="Service Unavailable",
+            detail="the run queue could not be read; retry",
+        ) from None
+    if already_exists:
         raise ProblemException(status=409, title="Conflict", detail="a run already exists")
     try:
         await deps.job_runner.schedule(
@@ -567,7 +580,18 @@ async def stop_run(request: Request, claims: VerifiedClaims, topic: str | None =
             detail="the capability token is not authorized for that topic",
         )
     _logger.info("run stop requested topic=%s", sub)
-    await deps.job_runner.stop(sub)
+    try:
+        await deps.job_runner.stop(sub)
+    except QueueReadError:
+        # V-2: an unreadable tail used to make `stop()` a SILENT no-op, and this handler
+        # fell through to deleting the stream of a possibly-live run while answering 204.
+        # The raise keeps the state unchanged and the answer honest: 503, retryable, and
+        # the stream deletion below does not run.
+        raise ProblemException(
+            status=503,
+            title="Service Unavailable",
+            detail="the run queue could not be read; retry",
+        ) from None
     # WHY delete and not purge: this is the run's terminal teardown, and purging a broker-backed
     # stream empties it but leaves the stream object, its consumer state and its filestore
     # directory behind — one permanent stream per run, forever. `delete_stream` defaults to

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -180,6 +180,21 @@ def topic_of_message(payload: bytes) -> str:
     return decode_message(payload)[job_env.TOPIC]
 
 
+UNDECODABLE_BODY_ERRORS: tuple[type[Exception], ...] = (ValueError, KeyError, TypeError)
+"""What `decode_message`/`topic_of_message` raise on a body this codec cannot read.
+
+`ValueError` covers `json.JSONDecodeError` and `UnicodeDecodeError` (both subclasses);
+`KeyError` is a body that decoded but names no topic; `TypeError` a payload that is not
+bytes at all.
+
+INVARIANT: every caller that decodes a body OFF the settled path — the worker's claim loop
+and its supervisor — catches exactly this tuple. A body arrives from off-process, so a
+foreign publisher or a codec skew across a rolling deploy can produce one at any time; left
+uncaught in either place it escapes into the worker's shared TaskGroup and cancels every
+co-located supervisor, each of which SIGKILLs its live child. Named once here so the two
+call sites cannot drift apart."""
+
+
 STREAM_NAME_IN_USE = 10058
 """JetStream's err_code for "stream name already in use" — the ONE `BadRequestError` the
 queue treats as benign. The type alone cannot say: the server answers a real configuration

--- a/apps/screamingface-engine/src/screamingface_engine/subjects.py
+++ b/apps/screamingface-engine/src/screamingface_engine/subjects.py
@@ -75,9 +75,8 @@ def topic_of(stream_name: str) -> str:
 
 
 __all__ = [
-    "ENQUEUED_AT_HEADER",
-
     "CONTROL_SUBJECT_PREFIX",
+    "ENQUEUED_AT_HEADER",
     "RUN_QUEUE_STREAM",
     "RUN_QUEUE_SUBJECT",
     "RUN_QUEUE_SUBJECT_PREFIX",

--- a/apps/screamingface-engine/src/screamingface_engine/subjects.py
+++ b/apps/screamingface-engine/src/screamingface_engine/subjects.py
@@ -29,6 +29,15 @@ RUN_QUEUE_SUBJECT = f"{RUN_QUEUE_SUBJECT_PREFIX}.work"
 # the pre-stamp semantics, never worse.
 ENQUEUED_AT_HEADER = "Url4-Enqueued-At"
 
+# The run-control channel (OME-1090): a core NATS request/reply subject per run, on which
+# the App asks "is this run running here?" and the owning worker answers by SIGTERMing its
+# child. Every worker subscribes to the wildcard; only the owner replies.
+CONTROL_SUBJECT_PREFIX = "url4.runctl"
+
+
+def control_subject_for(topic: str) -> str:
+    return f"{CONTROL_SUBJECT_PREFIX}.{topic}"
+
 
 def subject_for(topic: str) -> str:
     return f"{PREFIX}.{topic}"
@@ -67,9 +76,12 @@ def topic_of(stream_name: str) -> str:
 
 __all__ = [
     "ENQUEUED_AT_HEADER",
+
+    "CONTROL_SUBJECT_PREFIX",
     "RUN_QUEUE_STREAM",
     "RUN_QUEUE_SUBJECT",
     "RUN_QUEUE_SUBJECT_PREFIX",
+    "control_subject_for",
     "owns_stream",
     "stream_for",
     "subject_for",

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -121,6 +121,11 @@ class Worker:
         # the remaining children. A supervisor waiting on a child that ignores SIGTERM
         # wakes on this and SIGKILLs instead of waiting out the hard wall.
         self._terminating = asyncio.Event()
+        # Set when the drain phase has COMPLETED (the grace window elapsed, the remaining
+        # children were SIGTERM'd, and the pool is empty). The control loop exits on THIS
+        # rather than on `_draining` (review follow-up P2-12): with the signal only, every
+        # `url4.runctl.*` request in the drain window went unanswered — see `_control_loop`.
+        self._drained = asyncio.Event()
         # The live children, shared with the supervisors: the drain phase reads it to know
         # when the pool has drained, and SIGTERMs whatever is left.
         self._children: set[_ChildProcess] = set()
@@ -237,62 +242,74 @@ class Worker:
         answered (the App then writes nothing) and the child is SIGTERM'd; the supervisor
         classifies the death as a cancel and publishes ``Terminated(stopped)``.
 
-        INVARIANT: the loop EXITS on the drain signal, raced against the next message.
-        The subscription's iterator only ends when the CONNECTION closes, and
-        `run_worker` closes the control connection only after `Worker.run()` returns —
-        so a loop that merely awaits the next message keeps the TaskGroup (and the
-        rolling deploy behind it) alive until the kubelet SIGKILLs the pod, which is
-        exactly the deploy-interrupts-runs regression the drain exists to prevent. The
-        drain phase SIGTERMs the remaining children itself, so exiting here loses
-        nothing.
+        INVARIANT: the loop EXITS when the drain phase has COMPLETED — not the moment the
+        drain signal arrives (review follow-up P2-12). The subscription's iterator only
+        ends when the CONNECTION closes, and `run_worker` closes the control connection
+        only after `Worker.run()` returns — so a loop that merely awaits the next message
+        keeps the TaskGroup (and the rolling deploy behind it) alive past the drain, which
+        is the deploy-interrupts-runs regression the drain exists to prevent. But exiting
+        on the SIGNAL used to leave every cancel in the drain window unanswered:
+        `_children_by_topic` stays populated while the drained runs drain, so up to
+        `drain_grace_s` of `url4.runctl.*` requests timed out, the App tombstoned runs
+        that were still executing and still billing, and the caller was told the run
+        stopped when it had not. Serving until `_drained` (set when the drain phase is
+        done and the pool is empty) keeps cancels answerable through the window, and the
+        abandon-on-timeout shape below still ends the TaskGroup.
         """
         control = self._control
         if control is None:
             return
         sub = await control.subscribe(f"{CONTROL_SUBJECT_PREFIX}.*")
         messages = sub.messages.__aiter__()
-        while not self._draining.is_set():
+        while True:
             msg_task = asyncio.ensure_future(messages.__anext__())
-            drain_task = asyncio.create_task(self._draining.wait())
+            drained_task = asyncio.create_task(self._drained.wait())
             try:
                 done, _ = await asyncio.wait(
-                    {msg_task, drain_task}, return_when=asyncio.FIRST_COMPLETED
+                    {msg_task, drained_task}, return_when=asyncio.FIRST_COMPLETED
                 )
             finally:
-                drain_task.cancel()
+                drained_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
-                    await drain_task
+                    await drained_task
             if msg_task not in done:
-                # The drain signal won: abandon the pending fetch and exit.
+                # The drain phase finished: abandon the pending fetch and exit.
                 msg_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await msg_task
                 return
-            msg = msg_task.result()
-            topic = msg.subject.removeprefix(f"{CONTROL_SUBJECT_PREFIX}.")
-            proc = self._children_by_topic.get(topic)
-            if proc is None:
-                if topic in self._starting:
-                    # A run this worker is STARTING: the child has not registered yet, but
-                    # the App must not tombstone a run this worker is about to own — that
-                    # is how a run ends with two terminal frames. Mark the topic cancelled
-                    # and reply; the supervisor enacts the cancel the moment the child
-                    # registers.
-                    #
-                    # WHY the mark BEFORE the reply: `respond` is real network I/O — a
-                    # suspension point. In the other order, the spawn could complete and
-                    # the supervisor's registration check (`if topic in self._cancelled`)
-                    # could run while `respond` was in flight, find the mark absent, and
-                    # let the child run to completion — while the App, already holding
-                    # "ok", wrote no tombstone: the caller believes the run was stopped
-                    # and it never was. By the time the ack is SENT, the cancellation is
-                    # recorded, so the registration check sees it on every schedule order.
-                    self._cancelled.add(topic)
-                    await msg.respond(b"ok")
-                continue
-            self._cancelled.add(topic)
-            proc.terminate()
-            await msg.respond(b"ok")
+            await self._handle_control(msg_task.result())
+
+    async def _handle_control(self, msg: _ControlMessage) -> None:
+        """Answer one control request: SIGTERM the child that owns the topic, or reply to a
+        starting run's cancellation. A request for a topic this worker does not own gets no
+        reply — the App's short timeout reads "not running here" and falls back to the
+        tombstone.
+        """
+        topic = msg.subject.removeprefix(f"{CONTROL_SUBJECT_PREFIX}.")
+        proc = self._children_by_topic.get(topic)
+        if proc is None:
+            if topic in self._starting:
+                # A run this worker is STARTING: the child has not registered yet, but
+                # the App must not tombstone a run this worker is about to own — that
+                # is how a run ends with two terminal frames. Mark the topic cancelled
+                # and reply; the supervisor enacts the cancel the moment the child
+                # registers.
+                #
+                # WHY the mark BEFORE the reply: `respond` is real network I/O — a
+                # suspension point. In the other order, the spawn could complete and
+                # the supervisor's registration check (`if topic in self._cancelled`)
+                # could run while `respond` was in flight, find the mark absent, and
+                # let the child run to completion — while the App, already holding
+                # "ok", wrote no tombstone: the caller believes the run was stopped
+                # and it never was. By the time the ack is SENT, the cancellation is
+                # recorded, so the registration check sees it on every schedule order.
+                self._cancelled.add(topic)
+                await msg.respond(b"ok")
+            return
+        self._cancelled.add(topic)
+        proc.terminate()
+        await msg.respond(b"ok")
 
     async def _drain(self) -> None:
         """The drain phase: let children finish naturally up to ``drain_grace_s``, then
@@ -301,7 +318,8 @@ class Worker:
         The supervisors keep heartbeating throughout, so a draining worker never looks
         abandoned to the queue. After the grace, ``_terminating`` is set and the remaining
         children are SIGTERM'd; each supervisor classifies the death as a drain and
-        publishes its named frame before acking.
+        publishes its named frame before acking. `_drained` is set when the phase is done
+        — the control loop's exit condition (see `_control_loop`).
         """
         loop = asyncio.get_running_loop()
         deadline = loop.time() + self._drain_grace_s
@@ -340,6 +358,9 @@ class Worker:
                 with contextlib.suppress(ProcessLookupError):
                     proc.terminate()
             await asyncio.sleep(_DRAIN_POLL_S)
+        # The drain phase is complete (the pool is empty) — the control loop's exit
+        # signal (see `_control_loop` and P2-12).
+        self._drained.set()
 
 
 def run_worker(settings: Settings | None = None) -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -222,12 +222,39 @@ class Worker:
         running here" and falls back to the tombstone. A request for an owned topic is
         answered (the App then writes nothing) and the child is SIGTERM'd; the supervisor
         classifies the death as a cancel and publishes ``Terminated(stopped)``.
+
+        INVARIANT: the loop EXITS on the drain signal, raced against the next message.
+        The subscription's iterator only ends when the CONNECTION closes, and
+        `run_worker` closes the control connection only after `Worker.run()` returns —
+        so a loop that merely awaits the next message keeps the TaskGroup (and the
+        rolling deploy behind it) alive until the kubelet SIGKILLs the pod, which is
+        exactly the deploy-interrupts-runs regression the drain exists to prevent. The
+        drain phase SIGTERMs the remaining children itself, so exiting here loses
+        nothing.
         """
         control = self._control
         if control is None:
             return
         sub = await control.subscribe(f"{CONTROL_SUBJECT_PREFIX}.*")
-        async for msg in sub.messages:
+        messages = sub.messages.__aiter__()
+        while not self._draining.is_set():
+            msg_task = asyncio.ensure_future(messages.__anext__())
+            drain_task = asyncio.create_task(self._draining.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    {msg_task, drain_task}, return_when=asyncio.FIRST_COMPLETED
+                )
+            finally:
+                drain_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await drain_task
+            if msg_task not in done:
+                # The drain signal won: abandon the pending fetch and exit.
+                msg_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await msg_task
+                return
+            msg = msg_task.result()
             topic = msg.subject.removeprefix(f"{CONTROL_SUBJECT_PREFIX}.")
             proc = self._children_by_topic.get(topic)
             if proc is None:

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -16,11 +16,17 @@ import contextlib
 import logging
 import signal
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 import nats
 
 from screamingface_engine.config import Settings
+
+if (
+    TYPE_CHECKING
+):  # the adapters are imported lazily at runtime; only the annotation needs the names
+    from screamingface_engine.adapters.jetstream import JetStreamPublisher
+    from screamingface_engine.runner_queue import RunQueue
 from screamingface_engine.runner_queue import topic_of_message
 from screamingface_engine.subjects import CONTROL_SUBJECT_PREFIX
 from screamingface_engine.worker.supervisor import (
@@ -363,17 +369,17 @@ class Worker:
         self._drained.set()
 
 
-def run_worker(settings: Settings | None = None) -> None:
-    """The worker's composition root: build the queue, publisher, control channel, and
-    worker from Settings.
+def worker_composition(settings: Settings) -> tuple[RunQueue, JetStreamPublisher]:
+    """The worker's queue and publisher, from Settings.
 
-    ``settings`` is injectable for tests; production callers leave it ``None`` and let
-    ``Settings()`` read the environment.
+    Extracted from `run_worker` (review follow-up V-9) so the stream-wiring test can hold
+    the WORKER's composition root to the same Settings the App's roots answer to — the two
+    sides agreeing on the stream name is the whole P2-2 fix, and a test that only inspects
+    one root cannot see the other drifting.
     """
     from screamingface_engine.adapters.jetstream import JetStreamPublisher
     from screamingface_engine.runner_queue import RunQueue
 
-    settings = settings if settings is not None else Settings()
     queue = RunQueue(
         settings.nats_url,
         stream=settings.run_queue_stream,
@@ -391,6 +397,18 @@ def run_worker(settings: Settings | None = None) -> None:
     )
     # The publisher's sweep must exclude the CONFIGURED queue stream, not a stale constant.
     publisher = JetStreamPublisher(settings.nats_url, run_queue_stream=settings.run_queue_stream)
+    return queue, publisher
+
+
+def run_worker(settings: Settings | None = None) -> None:
+    """The worker's composition root: build the queue, publisher, control channel, and
+    worker from Settings.
+
+    ``settings`` is injectable for tests; production callers leave it ``None`` and let
+    ``Settings()`` read the environment.
+    """
+    settings = settings if settings is not None else Settings()
+    queue, publisher = worker_composition(settings)
 
     async def _main() -> None:
         # The control channel is a core NATS client of its own, like the queue's and the

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -21,6 +21,7 @@ from typing import Protocol
 import nats
 
 from screamingface_engine.config import Settings
+from screamingface_engine.runner_queue import topic_of_message
 from screamingface_engine.subjects import CONTROL_SUBJECT_PREFIX
 from screamingface_engine.worker.supervisor import (
     DEADLINE_MARGIN_S,
@@ -129,6 +130,13 @@ class Worker:
         # Topics a control request has cancelled (OME-1090): the control loop adds a topic
         # before SIGTERMing its child; the supervisors read it to classify the death.
         self._cancelled: set[str] = set()
+        # Runs this worker has CLAIMED but not yet spawned (OME-1090): the control loop
+        # answers from here while a run is starting, so a cancel that lands in the spawn
+        # window gets a reply (and the App writes no tombstone) instead of being ignored
+        # until the child has run to completion — two terminal frames. The claim loop
+        # registers a topic BEFORE creating the supervisor task (closing the scheduling
+        # gap), and the supervisor clears it once the child registers (or fails to).
+        self._starting: set[str] = set()
         # The in-flight supervisor tasks — the slot accounting. asyncio is single-threaded,
         # so no lock is needed; the fetch batch is computed from the free slots below.
         self._active: set[asyncio.Task[None]] = set()
@@ -142,6 +150,7 @@ class Worker:
             children=self._children,
             children_by_topic=self._children_by_topic,
             cancelled=self._cancelled,
+            starting=self._starting,
             heartbeat_interval_s=heartbeat_interval_s,
             deadline_margin_s=deadline_margin_s,
             kill_grace_s=kill_grace_s,
@@ -208,6 +217,11 @@ class Worker:
                 await asyncio.sleep(_PULL_RETRY_S)
                 continue
             for msg in msgs:
+                # Register the run as STARTING before the supervisor task exists: a cancel
+                # that arrives while the claim loop is between pulls must find the topic,
+                # or the control loop ignores it and the App tombstones a run this worker
+                # is about to own (two terminal frames — the race OME-1090's fix closes).
+                self._starting.add(topic_of_message(msg.data))
                 task = tg.create_task(self._supervisor.supervise(msg))
                 self._active.add(task)
                 task.add_done_callback(self._active.discard)
@@ -258,6 +272,14 @@ class Worker:
             topic = msg.subject.removeprefix(f"{CONTROL_SUBJECT_PREFIX}.")
             proc = self._children_by_topic.get(topic)
             if proc is None:
+                if topic in self._starting:
+                    # A run this worker is STARTING: the child has not registered yet, but
+                    # the App must not tombstone a run this worker is about to own — that
+                    # is how a run ends with two terminal frames. Reply now (the App
+                    # writes nothing) and mark the topic cancelled; the supervisor enacts
+                    # the cancel the moment the child registers.
+                    await msg.respond(b"ok")
+                    self._cancelled.add(topic)
                 continue
             await msg.respond(b"ok")
             self._cancelled.add(topic)

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -275,15 +275,24 @@ class Worker:
                 if topic in self._starting:
                     # A run this worker is STARTING: the child has not registered yet, but
                     # the App must not tombstone a run this worker is about to own — that
-                    # is how a run ends with two terminal frames. Reply now (the App
-                    # writes nothing) and mark the topic cancelled; the supervisor enacts
-                    # the cancel the moment the child registers.
-                    await msg.respond(b"ok")
+                    # is how a run ends with two terminal frames. Mark the topic cancelled
+                    # and reply; the supervisor enacts the cancel the moment the child
+                    # registers.
+                    #
+                    # WHY the mark BEFORE the reply: `respond` is real network I/O — a
+                    # suspension point. In the other order, the spawn could complete and
+                    # the supervisor's registration check (`if topic in self._cancelled`)
+                    # could run while `respond` was in flight, find the mark absent, and
+                    # let the child run to completion — while the App, already holding
+                    # "ok", wrote no tombstone: the caller believes the run was stopped
+                    # and it never was. By the time the ack is SENT, the cancellation is
+                    # recorded, so the registration check sees it on every schedule order.
                     self._cancelled.add(topic)
+                    await msg.respond(b"ok")
                 continue
-            await msg.respond(b"ok")
             self._cancelled.add(topic)
             proc.terminate()
+            await msg.respond(b"ok")
 
     async def _drain(self) -> None:
         """The drain phase: let children finish naturally up to ``drain_grace_s``, then

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -27,7 +27,7 @@ if (
 ):  # the adapters are imported lazily at runtime; only the annotation needs the names
     from screamingface_engine.adapters.jetstream import JetStreamPublisher
     from screamingface_engine.runner_queue import RunQueue
-from screamingface_engine.runner_queue import topic_of_message
+from screamingface_engine.runner_queue import UNDECODABLE_BODY_ERRORS, topic_of_message
 from screamingface_engine.subjects import CONTROL_SUBJECT_PREFIX
 from screamingface_engine.worker.supervisor import (
     DEADLINE_MARGIN_S,
@@ -232,7 +232,15 @@ class Worker:
                 # that arrives while the claim loop is between pulls must find the topic,
                 # or the control loop ignores it and the App tombstones a run this worker
                 # is about to own (two terminal frames — the race OME-1090's fix closes).
-                self._starting.add(topic_of_message(msg.data))
+                # INVARIANT: the decode is SUPPRESSED here and settled in `supervise`. This
+                # line runs on the claim loop's own stack, inside the shared TaskGroup, so
+                # an undecodable body raising here cancels every co-located supervisor and
+                # SIGKILLs each one's live child — the cascade the guarded `pull` above
+                # exists to prevent, reached one line later. A body with no readable topic
+                # has no run to register and nothing to cancel, so skipping the
+                # registration is not merely safe, it is the correct entry.
+                with contextlib.suppress(*UNDECODABLE_BODY_ERRORS):
+                    self._starting.add(topic_of_message(msg.data))
                 task = tg.create_task(self._supervisor.supervise(msg))
                 self._active.add(task)
                 task.add_done_callback(self._active.discard)

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -15,10 +15,13 @@ import asyncio
 import contextlib
 import logging
 import signal
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from typing import Protocol
 
+import nats
+
 from screamingface_engine.config import Settings
+from screamingface_engine.subjects import CONTROL_SUBJECT_PREFIX
 from screamingface_engine.worker.supervisor import (
     DEADLINE_MARGIN_S,
     HEARTBEAT_INTERVAL_S,
@@ -52,6 +55,28 @@ class _Queue(Protocol):
     async def pull(self, batch: int, timeout_s: float) -> Sequence[ClaimedMessage]: ...
 
 
+class _ControlMessage(Protocol):
+    """The slice of ``nats.aio.msg.Msg`` the control loop uses."""
+
+    subject: str
+    data: bytes
+
+    async def respond(self, data: bytes) -> None: ...
+
+
+class _ControlSubscription(Protocol):
+    """The slice of ``nats.aio.subscription.Subscription`` the control loop uses."""
+
+    @property
+    def messages(self) -> AsyncIterator[_ControlMessage]: ...
+
+
+class _Control(Protocol):
+    """The slice of a core NATS client the control loop uses."""
+
+    async def subscribe(self, subject: str) -> _ControlSubscription: ...
+
+
 class Worker:
     """The slot pool: claim runs from the queue, supervise each as a child process.
 
@@ -71,6 +96,7 @@ class Worker:
         io_capacity: int,
         memory_budget_bytes: int,
         spawn: Callable[..., Awaitable[_ChildProcess]] | None = None,
+        control: _Control | None = None,
         pull_timeout_s: float = PULL_TIMEOUT_S,
         heartbeat_interval_s: float = HEARTBEAT_INTERVAL_S,
         deadline_margin_s: float = DEADLINE_MARGIN_S,
@@ -83,6 +109,10 @@ class Worker:
         self._slots = slots
         self._drain_grace_s = drain_grace_s
         self._pull_timeout_s = pull_timeout_s
+        # The run-control channel (OME-1090): a core NATS client subscribed to
+        # `url4.runctl.*`. `None` disables the control loop (tests that do not exercise
+        # cancellation).
+        self._control = control
         # The drain signal: set by SIGTERM/SIGINT (or by a test). The claim loop stops
         # pulling once it is set; the supervisors read it to classify a drain termination.
         self._draining = asyncio.Event()
@@ -93,6 +123,12 @@ class Worker:
         # The live children, shared with the supervisors: the drain phase reads it to know
         # when the pool has drained, and SIGTERMs whatever is left.
         self._children: set[_ChildProcess] = set()
+        # The topic → child index (OME-1090): the control loop reads it to find the owner
+        # of a run; the supervisors maintain it alongside `_children`.
+        self._children_by_topic: dict[str, _ChildProcess] = {}
+        # Topics a control request has cancelled (OME-1090): the control loop adds a topic
+        # before SIGTERMing its child; the supervisors read it to classify the death.
+        self._cancelled: set[str] = set()
         # The in-flight supervisor tasks — the slot accounting. asyncio is single-threaded,
         # so no lock is needed; the fetch batch is computed from the free slots below.
         self._active: set[asyncio.Task[None]] = set()
@@ -104,6 +140,8 @@ class Worker:
             draining=self._draining,
             terminating=self._terminating,
             children=self._children,
+            children_by_topic=self._children_by_topic,
+            cancelled=self._cancelled,
             heartbeat_interval_s=heartbeat_interval_s,
             deadline_margin_s=deadline_margin_s,
             kill_grace_s=kill_grace_s,
@@ -122,6 +160,8 @@ class Worker:
         try:
             async with asyncio.TaskGroup() as tg:
                 tg.create_task(self._claim_loop(tg))
+                if self._control is not None:
+                    tg.create_task(self._control_loop(tg))
         finally:
             for sig in (signal.SIGTERM, signal.SIGINT):
                 loop.remove_signal_handler(sig)
@@ -173,6 +213,29 @@ class Worker:
                 task.add_done_callback(self._active.discard)
         await self._drain()
 
+    async def _control_loop(self, tg: asyncio.TaskGroup) -> None:
+        """Serve run-control requests: only the owner of a run replies, and it SIGTERMs
+        its child (OME-1090).
+
+        Every worker subscribes to ``url4.runctl.*``; a request for a topic this worker
+        does not own is ignored — no reply — so the App's short timeout reads "not
+        running here" and falls back to the tombstone. A request for an owned topic is
+        answered (the App then writes nothing) and the child is SIGTERM'd; the supervisor
+        classifies the death as a cancel and publishes ``Terminated(stopped)``.
+        """
+        control = self._control
+        if control is None:
+            return
+        sub = await control.subscribe(f"{CONTROL_SUBJECT_PREFIX}.*")
+        async for msg in sub.messages:
+            topic = msg.subject.removeprefix(f"{CONTROL_SUBJECT_PREFIX}.")
+            proc = self._children_by_topic.get(topic)
+            if proc is None:
+                continue
+            await msg.respond(b"ok")
+            self._cancelled.add(topic)
+            proc.terminate()
+
     async def _drain(self) -> None:
         """The drain phase: let children finish naturally up to ``drain_grace_s``, then
         SIGTERM the rest so each publishes ``Terminated(stopped, worker_draining)``.
@@ -222,7 +285,8 @@ class Worker:
 
 
 def run_worker(settings: Settings | None = None) -> None:
-    """The worker's composition root: build the queue, publisher, and worker from Settings.
+    """The worker's composition root: build the queue, publisher, control channel, and
+    worker from Settings.
 
     ``settings`` is injectable for tests; production callers leave it ``None`` and let
     ``Settings()`` read the environment.
@@ -248,23 +312,35 @@ def run_worker(settings: Settings | None = None) -> None:
     )
     # The publisher's sweep must exclude the CONFIGURED queue stream, not a stale constant.
     publisher = JetStreamPublisher(settings.nats_url, run_queue_stream=settings.run_queue_stream)
-    worker = Worker(
-        queue=queue,
-        publisher=publisher,
-        # INVARIANT: the worker's slot count is `run_queue_worker_slots` — the same value
-        # the queue settings derive `max_ack_pending` from — so the worker's concurrency
-        # and the queue's ack-pending bound cannot disagree.
-        slots=settings.run_queue_worker_slots,
-        drain_grace_s=settings.worker_drain_grace_s,
-        io_capacity=settings.worker_io_capacity,
-        memory_budget_bytes=settings.worker_memory_budget_bytes,
-        # INVARIANT: the heartbeat cadence is DERIVED from the configured `ack_wait`, not
-        # left at the constant — a heartbeat slower than `ack_wait` redelivers a still-
-        # running run to a second worker (double execution). `derived_heartbeat_interval_s`
-        # keeps `heartbeat <= ack_wait / 3` for every legal configuration.
-        heartbeat_interval_s=derived_heartbeat_interval_s(settings.run_queue_ack_wait_s),
-    )
-    asyncio.run(worker.run())
+
+    async def _main() -> None:
+        # The control channel is a core NATS client of its own, like the queue's and the
+        # publisher's: each component owns its connection, and the worker closes the one it
+        # created.
+        nc = await nats.connect(settings.nats_url)
+        try:
+            worker = Worker(
+                queue=queue,
+                publisher=publisher,
+                # INVARIANT: the worker's slot count is `run_queue_worker_slots` — the same value
+                # the queue settings derive `max_ack_pending` from — so the worker's concurrency
+                # and the queue's ack-pending bound cannot disagree.
+                slots=settings.run_queue_worker_slots,
+                drain_grace_s=settings.worker_drain_grace_s,
+                io_capacity=settings.worker_io_capacity,
+                memory_budget_bytes=settings.worker_memory_budget_bytes,
+                control=nc,
+                # INVARIANT: the heartbeat cadence is DERIVED from the configured `ack_wait`, not
+                # left at the constant — a heartbeat slower than `ack_wait` redelivers a still-
+                # running run to a second worker (double execution). `derived_heartbeat_interval_s`
+                # keeps `heartbeat <= ack_wait / 3` for every legal configuration.
+                heartbeat_interval_s=derived_heartbeat_interval_s(settings.run_queue_ack_wait_s),
+            )
+            await worker.run()
+        finally:
+            await nc.close()
+
+    asyncio.run(_main())
 
 
 __all__ = ["PULL_TIMEOUT_S", "Worker", "run_worker"]

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -27,7 +27,11 @@ from typing import Any, Literal, Protocol
 from screamingface_engine import job_env
 from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.logs import run_scope
-from screamingface_engine.runner_queue import decode_message, topic_of_message
+from screamingface_engine.runner_queue import (
+    UNDECODABLE_BODY_ERRORS,
+    decode_message,
+    topic_of_message,
+)
 from screamingface_engine.subjects import ENQUEUED_AT_HEADER
 from url4.streaming.protocol import (
     ErrorInfo,
@@ -274,11 +278,8 @@ class RunSupervisor:
         """
         try:
             return topic_of_message(msg.data)
-        except (ValueError, KeyError, TypeError):
-            # `ValueError` covers `json.JSONDecodeError` and `UnicodeDecodeError` (both
-            # subclasses); `KeyError` is a body that decoded but names no topic; `TypeError`
-            # a payload that is not bytes at all. The body is never logged — it is the
-            # caller's and may carry prompts.
+        except UNDECODABLE_BODY_ERRORS:
+            # The body itself is never logged — it is the caller's and may carry prompts.
             logger.exception(
                 "undecodable run-queue message settled without executing; "
                 "a publisher is writing bodies this worker's codec cannot read"
@@ -287,9 +288,55 @@ class RunSupervisor:
             return None
 
     async def _claim(self, msg: ClaimedMessage, topic: str) -> None:
-        """The claim gates and the run, after the duplicate guard has admitted the topic."""
-        # One check for three cases: redelivery of a run that already finished, a
-        # cancel that landed before the claim, and a stale message whose run is over.
+        """The claim gates and the run, after the duplicate guard has admitted the topic.
+
+        AIDEV-NOTE: kept to ruff's `max-returns = 3` by delegating each gate. Add a new
+        gate as another `_settled_*` helper returning ``bool``, never as a fourth return.
+        """
+        if topic in self._cancelled:
+            await self._enact_accepted_cancel(msg, topic)
+            return
+        if await self._already_settled(msg, topic):
+            return
+        await self._run_child(msg, topic)
+
+    async def _enact_accepted_cancel(self, msg: ClaimedMessage, topic: str) -> None:
+        """Keep the promise made when the control loop accepted a cancel for this topic.
+
+        INVARIANT: an accepted cancel is a PROMISE, and this is where it is kept. The
+        control loop answers `ok` for a topic that is still starting, so
+        `QueueJobRunner.stop()` takes the "a worker owns it" branch and writes NO tombstone
+        — the client already holds a 204 and this worker owes the frame.
+
+        The promise used to live only in the in-memory `_cancelled` set, which
+        `supervise`'s `finally` discards on EVERY exit — including `_already_settled`'s
+        unreadable-tail path, which deliberately does not ack. The message then
+        redelivered, found no terminal frame anywhere (the App wrote none, the worker
+        published none), passed every gate and executed a run the caller was told was
+        stopped.
+
+        WHY this runs BEFORE the tail read rather than beside the other gates: that read is
+        the one step in the claim that can fail on a broker blip, and stranding the promise
+        is exactly what it did. Publishing first also makes the cancel durable for a
+        redelivery that lands on a DIFFERENT worker — the durable consumer is shared, so an
+        in-memory mark could never have covered that case at all.
+
+        WHY no child is spawned: the outcome is already promised, so starting the run only
+        to SIGTERM it would pay for a process, and a model call or two, to arrive back here.
+        """
+        await self._publish_terminal(
+            topic, "stopped", CANCELLED, "the run was cancelled by its owner"
+        )
+        await msg.ack()
+
+    async def _already_settled(self, msg: ClaimedMessage, topic: str) -> bool:
+        """Whether this claim is finished without running: the run is over, or it expired.
+
+        ``True`` means the message has been dealt with — acked, or deliberately left for
+        redelivery — and the caller must not execute it. One read answers three cases: a
+        redelivery of a run that already finished, a cancel that landed before the claim,
+        and a stale message whose run is over.
+        """
         try:
             already_terminal = await self._terminal_frame_exists(topic)
         except QueueReadError:
@@ -300,17 +347,18 @@ class RunSupervisor:
             # the ack leaves the message for redelivery: the next attempt re-runs this check
             # and, once the broker is readable again, the dedupe answer is the real one.
             logger.warning("stream tail unreadable for %s; leaving the claim for redelivery", topic)
-            return
-        if already_terminal:
-            await msg.ack()
-            return
-        if self._capability_expired(msg):
+            return True
+        # Evaluated only when the run is not already over, exactly as the short-circuiting
+        # chain of early returns this replaced did.
+        expired = not already_terminal and self._capability_expired(msg)
+        if not already_terminal and not expired:
+            return False
+        if expired:
             await self._publish_terminal(
                 topic, "failed", QUEUE_EXPIRED, "the run's capability expired while queued"
             )
-            await msg.ack()
-            return
-        await self._run_child(msg, topic)
+        await msg.ack()
+        return True
 
     async def _run_child(self, msg: ClaimedMessage, topic: str) -> None:
         """Fork the run as a child, supervise it to its terminal frame, then ack."""

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -204,6 +204,7 @@ class RunSupervisor:
         # Runs claimed but not yet spawned (OME-1090): the control loop answers from here
         # during the spawn window. `None` keeps direct construction (older tests) working.
         self._starting = starting if starting is not None else set()
+        self._heartbeat_interval_s = heartbeat_interval_s
         self._deadline_margin_s = deadline_margin_s
         self._kill_grace_s = kill_grace_s
 

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -49,6 +49,12 @@ QUEUE_EXPIRED = "queue_expired"
 """The run's capability expired while it sat in the queue; it was dropped unexecuted."""
 WORKER_DRAINING = "worker_draining"
 """The worker is draining and stopped the run before it finished."""
+CANCELLED = "cancelled"
+"""The run was cancelled by its owner over the control subject (OME-1090).
+
+The App's queued-cancel tombstone uses the same code (``adapters.queue_runner``), so a
+client sees one reason whether the cancel landed before or after the claim.
+"""
 DEADLINE_EXCEEDED = "deadline_exceeded"
 """The child hung past the hard wall and was SIGTERM'd, then SIGKILL'd."""
 OOM_KILLED = "oom_killed"
@@ -167,6 +173,8 @@ class RunSupervisor:
         draining: asyncio.Event,
         terminating: asyncio.Event,
         children: set[_ChildProcess],
+        children_by_topic: dict[str, _ChildProcess],
+        cancelled: set[str],
         heartbeat_interval_s: float = HEARTBEAT_INTERVAL_S,
         deadline_margin_s: float = DEADLINE_MARGIN_S,
         kill_grace_s: float = KILL_GRACE_S,
@@ -185,7 +193,13 @@ class RunSupervisor:
         # the check-and-add below has no await between it, so on the single event loop it is
         # atomic against every other claim.
         self._topics_in_flight: set[str] = set()
-        self._heartbeat_interval_s = heartbeat_interval_s
+        # The topic → child index (OME-1090): the worker's control loop reads it to find
+        # the owner of a run, and the supervisor maintains it alongside `_children`.
+        self._children_by_topic = children_by_topic
+        # Topics a control request has cancelled (OME-1090): the worker adds a topic before
+        # SIGTERMing its child, and `_classify` reads it to name the death a cancel rather
+        # than a kill.
+        self._cancelled = cancelled
         self._deadline_margin_s = deadline_margin_s
         self._kill_grace_s = kill_grace_s
 
@@ -296,11 +310,12 @@ class RunSupervisor:
             await msg.ack()
             return
         self._children.add(proc)
+        self._children_by_topic[topic] = proc
         heartbeat = asyncio.create_task(self._heartbeat(msg, topic))
         output = asyncio.create_task(self._forward_output(proc, topic))
         try:
             outcome = await self._wait_for_child(proc, self._hard_wall_s(env))
-            await self._publish_if_needed(topic, self._classify(outcome, proc.returncode))
+            await self._publish_if_needed(topic, self._classify(outcome, proc.returncode, topic))
             await msg.ack()
         finally:
             heartbeat.cancel()
@@ -309,18 +324,28 @@ class RunSupervisor:
             # FAILED (not cancelled) re-raises its own exception on await, and `cancel()` is a
             # no-op on it — so `await heartbeat` would blow the finally block open and skip
             # every line below it (the child stays in `self._children`, a live child is never
-            # killed). `return_exceptions=True` makes the gather itself unraisable; the two
-            # cleanup lines after it are therefore unconditional.
+            # killed). `return_exceptions=True` makes the gather itself unraisable; the
+            # cleanup after it is therefore unconditional.
             for result in await asyncio.gather(heartbeat, output, return_exceptions=True):
                 if isinstance(result, BaseException) and not isinstance(
                     result, asyncio.CancelledError
                 ):
                     logger.warning("run supervision task failed during cleanup: %r", result)
-            self._children.discard(proc)
+            self._release_child(proc, topic)
             if proc.returncode is None:
                 # A cancelled supervisor (a sibling failed and the TaskGroup unwound)
                 # must not orphan its child.
                 proc.kill()
+
+    def _release_child(self, proc: _ChildProcess, topic: str) -> None:
+        """Drop a finished child from every registry the worker shares.
+
+        The cancel mark is per-run: a stale entry would misclassify a LATER run of the
+        same topic whose child died from a signal that was not a cancel.
+        """
+        self._children.discard(proc)
+        self._children_by_topic.pop(topic, None)
+        self._cancelled.discard(topic)
 
     async def _publish_if_needed(
         self, topic: str, classification: tuple[TerminalStatus, str, str] | None
@@ -549,7 +574,7 @@ class RunSupervisor:
             await proc.wait()
 
     def _classify(
-        self, outcome: str, returncode: int | None
+        self, outcome: str, returncode: int | None, topic: str
     ) -> tuple[TerminalStatus, str, str] | None:
         """The named terminal frame the worker must publish for a child that published none.
 
@@ -576,6 +601,15 @@ class RunSupervisor:
                 "stopped",
                 WORKER_DRAINING,
                 "the worker is draining; the run was stopped",
+            )
+        elif topic in self._cancelled and returncode is not None and returncode < 0:
+            # A control request SIGTERM'd this child (OME-1090): the death is a cancel, not
+            # a kill. A child that exited 0 on its own before the request landed is NOT
+            # classified here — its own terminal frame stands.
+            status, code, message = (
+                "stopped",
+                CANCELLED,
+                "the run was cancelled by its owner",
             )
         elif returncode == 0:
             return None
@@ -676,6 +710,7 @@ class RunSupervisor:
 
 
 __all__ = [
+    "CANCELLED",
     "CHILD_EXITED",
     "DEADLINE_EXCEEDED",
     "DEADLINE_MARGIN_S",

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -175,6 +175,7 @@ class RunSupervisor:
         children: set[_ChildProcess],
         children_by_topic: dict[str, _ChildProcess],
         cancelled: set[str],
+        starting: set[str] | None = None,
         heartbeat_interval_s: float = HEARTBEAT_INTERVAL_S,
         deadline_margin_s: float = DEADLINE_MARGIN_S,
         kill_grace_s: float = KILL_GRACE_S,
@@ -200,6 +201,9 @@ class RunSupervisor:
         # SIGTERMing its child, and `_classify` reads it to name the death a cancel rather
         # than a kill.
         self._cancelled = cancelled
+        # Runs claimed but not yet spawned (OME-1090): the control loop answers from here
+        # during the spawn window. `None` keeps direct construction (older tests) working.
+        self._starting = starting if starting is not None else set()
         self._deadline_margin_s = deadline_margin_s
         self._kill_grace_s = kill_grace_s
 
@@ -227,9 +231,18 @@ class RunSupervisor:
                 await msg.ack()
                 return
             self._topics_in_flight.add(topic)
+            # Registered as STARTING from here until the child registers (or fails to):
+            # a cancel that lands in the spawn window is answered from this set, so it is
+            # acknowledged — not ignored while the child runs to a second terminal frame.
+            self._starting.add(topic)
             try:
                 await self._claim(msg, topic)
             finally:
+                self._starting.discard(topic)
+                # The cancel mark is per-run (a stale entry would misclassify a LATER run
+                # of the same topic), and the control loop can now set it for a run with
+                # no child yet — so every exit path clears it, not just `_release_child`.
+                self._cancelled.discard(topic)
                 self._topics_in_flight.discard(topic)
 
     async def _topic_or_settle(self, msg: ClaimedMessage) -> str | None:
@@ -311,6 +324,10 @@ class RunSupervisor:
             return
         self._children.add(proc)
         self._children_by_topic[topic] = proc
+        if topic in self._cancelled:
+            # A cancel was ACKNOWLEDGED while this child was starting (the control loop
+            # replied from the starting registry): enact it the moment the child exists.
+            proc.terminate()
         heartbeat = asyncio.create_task(self._heartbeat(msg, topic))
         output = asyncio.create_task(self._forward_output(proc, topic))
         try:

--- a/apps/screamingface-engine/tests/unit/test_factory_queue_replicas.py
+++ b/apps/screamingface-engine/tests/unit/test_factory_queue_replicas.py
@@ -1,0 +1,98 @@
+"""The App's composition root feeds the queue its configured replica count (OME-1090).
+
+The App and the worker declare the SAME singleton queue stream, and `ensure_stream` refuses a
+declaration whose properties diverge from an existing one. The App usually declares first — it
+accepts a run before any worker pulls it — so an App stuck on the code default while the worker
+reads configuration is a startup failure for the worker, and vice versa.
+
+`build_job_runner` omitted `replicas` entirely. OME-1088 made the count a setting and OME-1089
+wired the worker half; this file pins the App half and, more importantly, the agreement between
+the two.
+"""
+
+from typing import Any
+
+import pytest
+
+from screamingface_engine.config import Settings
+
+
+class _RecordingQueue:
+    """Stands in for `RunQueue`, capturing the kwargs a composition root passes."""
+
+    last_kwargs: dict[str, Any] = {}
+
+    def __init__(self, url: str, **kwargs: Any) -> None:
+        type(self).last_kwargs = dict(kwargs)
+
+
+def _app_queue_kwargs(monkeypatch: pytest.MonkeyPatch, settings: Settings) -> dict[str, Any]:
+    """The kwargs the APP's composition root passes to `RunQueue`.
+
+    `factory` imports `RunQueue`, `JetStreamPublisher` and `ControlClient` at module level, so
+    the patches land on the factory's own namespace.
+    """
+    import screamingface_engine.adapters.factory as factory
+
+    _RecordingQueue.last_kwargs = {}
+    monkeypatch.setattr(factory, "RunQueue", _RecordingQueue)
+    monkeypatch.setattr(factory, "JetStreamPublisher", lambda *a, **k: object())
+    monkeypatch.setattr(factory, "ControlClient", lambda *a, **k: object())
+
+    factory.build_job_runner(settings)
+    return _RecordingQueue.last_kwargs
+
+
+def _worker_queue_kwargs(monkeypatch: pytest.MonkeyPatch, settings: Settings) -> dict[str, Any]:
+    """The kwargs the WORKER's composition root passes to `RunQueue`.
+
+    `worker_composition` — not `run_worker`: the latter opens a real NATS connection for the
+    run-control channel, which a unit test must not drive. `worker_composition` was extracted
+    for precisely this, so both halves can be held to one `Settings` in one test.
+
+    It imports its collaborators INSIDE the function, so these patches land on the defining
+    modules rather than on `loop`'s namespace.
+    """
+    import screamingface_engine.adapters.jetstream as jetstream_mod
+    import screamingface_engine.runner_queue as runner_queue_mod
+    import screamingface_engine.worker.loop as loop
+
+    _RecordingQueue.last_kwargs = {}
+    monkeypatch.setattr(runner_queue_mod, "RunQueue", _RecordingQueue)
+    monkeypatch.setattr(jetstream_mod, "JetStreamPublisher", lambda *a, **k: object())
+
+    loop.worker_composition(settings)
+    return _RecordingQueue.last_kwargs
+
+
+def test_the_app_declares_the_queue_with_the_configured_replica_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pinned with a NON-default value: a composition root that drops the argument still passes
+    a test written against the default, which is how this shipped unnoticed."""
+    settings = Settings(runner="queue", run_queue_replicas=3)
+    assert _app_queue_kwargs(monkeypatch, settings)["replicas"] == 3
+
+
+def test_an_unconfigured_app_declares_the_single_node_safe_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deployment that states nothing must still declare its stream on the single-node broker
+    the chart bundles."""
+    settings = Settings(runner="queue")
+    kwargs = _app_queue_kwargs(monkeypatch, settings)
+    assert kwargs["replicas"] == settings.run_queue_replicas == 1
+
+
+@pytest.mark.parametrize("configured", [1, 2, 5])
+def test_both_composition_roots_declare_the_same_replica_count(
+    configured: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT — the point of this unit: the App and the worker declare ONE stream, and
+    `ensure_stream` refuses a divergent declaration. Reading the same setting on both sides is
+    what makes them agree for ANY configuration, rather than only where the defaults coincide.
+    """
+    settings = Settings(runner="queue", run_queue_replicas=configured)
+    app = _app_queue_kwargs(monkeypatch, settings)["replicas"]
+    worker = _worker_queue_kwargs(monkeypatch, settings)["replicas"]
+    assert app == worker == configured

--- a/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
+++ b/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
@@ -22,7 +22,7 @@ from screamingface_engine.adapters.max_deliveries import (
     topic_of_advisory,
 )
 from screamingface_engine.runner_queue import encode_message
-from url4.streaming.protocol import TerminatedEvent
+from url4.streaming.protocol import TerminatedData, TerminatedEvent, source_for
 
 T0 = datetime(2026, 9, 2, 9, 0, 0, tzinfo=UTC)
 
@@ -64,9 +64,13 @@ def test_topic_of_advisory_returns_none_for_garbage() -> None:
 
 
 class _FakePublisher:
-    def __init__(self) -> None:
+    def __init__(self, last_frame: Any = None) -> None:
         self.published: list[Any] = []
         self.ensured: list[str] = []
+        self._last_frame = last_frame
+
+    async def last_frame(self, topic: str) -> Any:
+        return self._last_frame
 
     async def ensure_stream(self, topic: str) -> None:
         self.ensured.append(topic)
@@ -91,3 +95,31 @@ async def test_the_advisor_publishes_a_named_terminal_failure() -> None:
     assert frame.data.status == "failed"
     assert frame.data.error is not None and frame.data.error.code == MAX_DELIVERIES
     assert frame.source.endswith("t-gave-up")
+
+
+def _terminated(topic: str, status: str) -> TerminatedEvent:
+    return TerminatedEvent(
+        id="x",
+        source=source_for(topic),
+        subject=topic,
+        time=T0,
+        data=TerminatedData(status=status),
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_advisor_never_overwrites_a_run_that_actually_finished() -> None:
+    """The advisory and the run race: a worker on its FINAL redelivery can complete and
+    publish `Terminated(succeeded)` right as the expired ack_wait fires the advisory —
+    the run finished, the broker merely missed the ack. Publishing unconditionally
+    appended `failed` AFTER the success, and status() — a last-frame read — reported a
+    succeeded run as failed. The advisor reads the tail first; a terminal frame means
+    the run already has its outcome."""
+    advisor = MaxDeliveriesAdvisor("nats://localhost:4222", clock=lambda: T0)
+    success = _terminated("t-finished", "succeeded")
+    publisher = _FakePublisher(last_frame=success)
+
+    await advisor._handle(publisher, _advisory("t-finished"))
+
+    assert publisher.published == [], "the run's own outcome stands"
+    assert publisher.ensured == [], "nothing was declared on its account either"

--- a/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
+++ b/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
@@ -12,7 +12,7 @@ import asyncio
 import base64
 import json
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -101,7 +101,9 @@ async def test_the_advisor_publishes_a_named_terminal_failure() -> None:
     assert frame.source.endswith("t-gave-up")
 
 
-def _terminated(topic: str, status: str) -> TerminatedEvent:
+def _terminated(
+    topic: str, status: Literal["succeeded", "failed", "stopped", "timed_out"]
+) -> TerminatedEvent:
     return TerminatedEvent(
         id="x",
         source=source_for(topic),

--- a/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
+++ b/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
@@ -1,0 +1,93 @@
+"""The max-deliveries advisory subscriber (OME-1090): a run the queue gave up on gets a
+named terminal failure on its own event stream.
+
+JetStream publishes `$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.url4-runq.url4-runners`
+when a queue message has been redelivered `max_deliver` times without an ack. The App
+subscribes, decodes the run's topic from the advisory's embedded message, and publishes
+`Terminated(failed)` — the run's status derivation then reads that frame like any other
+terminal outcome.
+"""
+
+import base64
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from screamingface_engine.adapters.max_deliveries import (
+    MAX_DELIVERIES,
+    MAX_DELIVERIES_ADVISORY_SUBJECT,
+    MaxDeliveriesAdvisor,
+    topic_of_advisory,
+)
+from screamingface_engine.runner_queue import encode_message
+from url4.streaming.protocol import TerminatedEvent
+
+T0 = datetime(2026, 9, 2, 9, 0, 0, tzinfo=UTC)
+
+
+def _advisory(topic: str) -> bytes:
+    """A max-deliveries advisory as JetStream publishes it: the original queue message's
+    body base64-encoded under `message.data`."""
+    body = encode_message(topic, "'hi'", 60)
+    return json.dumps(
+        {
+            "type": "io.nats.jetstream.advisory.v1.max_deliver",
+            "stream": "url4-runq",
+            "consumer": "url4-runners",
+            "stream_seq": 1,
+            "deliveries": 2,
+            "message": {
+                "subject": "url4-runq.work",
+                "seq": 1,
+                "data": base64.b64encode(body).decode("utf-8"),
+            },
+        }
+    ).encode("utf-8")
+
+
+def test_the_advisory_subject_names_the_queue_stream_and_consumer() -> None:
+    assert MAX_DELIVERIES_ADVISORY_SUBJECT == (
+        "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.url4-runq.url4-runners"
+    )
+
+
+def test_topic_of_advisory_decodes_the_runs_topic() -> None:
+    assert topic_of_advisory(_advisory("t-advisory")) == "t-advisory"
+
+
+def test_topic_of_advisory_returns_none_for_garbage() -> None:
+    assert topic_of_advisory(b"not json") is None
+    assert topic_of_advisory(b"{}") is None
+    assert topic_of_advisory(b'{"message": {"data": "!!!"}}') is None
+
+
+class _FakePublisher:
+    def __init__(self) -> None:
+        self.published: list[Any] = []
+        self.ensured: list[str] = []
+
+    async def ensure_stream(self, topic: str) -> None:
+        self.ensured.append(topic)
+
+    async def publish(self, topic: str, event: Any) -> None:
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_the_advisor_publishes_a_named_terminal_failure() -> None:
+    advisor = MaxDeliveriesAdvisor("nats://localhost:4222", clock=lambda: T0)
+    publisher = _FakePublisher()
+    await advisor._handle(publisher, _advisory("t-gave-up"))
+
+    assert publisher.ensured == ["t-gave-up"]
+    assert len(publisher.published) == 1
+    frame = publisher.published[0]
+    assert isinstance(frame, TerminatedEvent)
+    assert frame.data.status == "failed"
+    assert frame.data.error is not None and frame.data.error.code == MAX_DELIVERIES
+    assert frame.source.endswith("t-gave-up")

--- a/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
+++ b/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
@@ -8,6 +8,7 @@ subscribes, decodes the run's topic from the advisory's embedded message, and pu
 terminal outcome.
 """
 
+import asyncio
 import base64
 import json
 from datetime import UTC, datetime
@@ -48,8 +49,11 @@ def _advisory(topic: str) -> bytes:
 
 
 def test_the_advisory_subject_names_the_queue_stream_and_consumer() -> None:
+    # The consumer token is wildcarded: consumers are `url4-runners-<bucket>` — ONE token
+    # (dashes are not NATS separators) — so `.*` matches it, while `.url4-runners.*`
+    # would demand a second token and match nothing.
     assert MAX_DELIVERIES_ADVISORY_SUBJECT == (
-        "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.url4-runq.url4-runners"
+        "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.url4-runq.*"
     )
 
 
@@ -123,3 +127,76 @@ async def test_the_advisor_never_overwrites_a_run_that_actually_finished() -> No
 
     assert publisher.published == [], "the run's own outcome stands"
     assert publisher.ensured == [], "nothing was declared on its account either"
+
+
+def test_the_advisory_subject_follows_the_configured_stream_name() -> None:
+    """P2-4: the subject was a hardcoded `url4-runq` literal — a renamed queue publishes
+    advisories on a different subject, and a subscription on the default would silently
+    stop hearing every max-deliveries event (each run the queue gave up on ending
+    without a terminal frame). The subject now comes from the constructor."""
+    advisor = MaxDeliveriesAdvisor("nats://x", run_queue_stream="prod-runq")
+    assert advisor._subject == "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.prod-runq.*"
+    assert MaxDeliveriesAdvisor("nats://x")._subject == MAX_DELIVERIES_ADVISORY_SUBJECT
+
+
+class _connecting_nc:
+    """A connect() replacement whose subscription ends immediately, counting connects
+    and closes. WHY the `sleep(0)` in connect: without it, the UNFIXED run loop (which
+    reconnects without sleeping on a normal `_serve` return) spins through these
+    instantly-completing awaits without ever yielding — starving the event loop so the
+    test HANGS instead of failing. One yield per connect keeps the hot spin observable
+    AND cancellable."""
+
+    connects = 0
+    closes = 0
+
+    class _EndingSub:
+        @property
+        def messages(self) -> Any:
+            async def _end() -> Any:
+                return
+                yield  # pragma: no cover — an immediately-ending async generator
+
+            return _end()
+
+    class _NC:
+        async def subscribe(self, subject: str) -> "_connecting_nc._EndingSub":
+            return _connecting_nc._EndingSub()
+
+        async def close(self) -> None:
+            _connecting_nc.closes += 1
+
+    @classmethod
+    async def connect(cls, _url: str) -> "_connecting_nc._NC":
+        await asyncio.sleep(0)
+        cls.connects += 1
+        return cls._NC()
+
+
+@pytest.mark.asyncio
+async def test_a_normal_serve_return_is_treated_as_a_disconnect(monkeypatch: Any) -> None:
+    """P2-5: a dropped subscription ends `_serve`'s `async for` NORMALLY — `_serve`
+    returns without raising — so `run()` used to reconnect without closing the previous
+    nc/publisher pair (leaking the publisher's own lazy connection every round) and,
+    when the fresh subscription died immediately, spun in a tight loop. Every iteration
+    now closes and backs off."""
+    import contextlib
+
+    import screamingface_engine.adapters.max_deliveries as mod
+
+    real_delay = mod.RETRY_DELAY_S
+    monkeypatch.setattr(mod, "RETRY_DELAY_S", 0.01)
+    monkeypatch.setattr(mod.nats, "connect", _connecting_nc.connect)
+    try:
+        advisor = mod.MaxDeliveriesAdvisor("nats://x")
+        task = asyncio.create_task(advisor.run())
+        try:
+            while _connecting_nc.connects < 2:
+                await asyncio.sleep(0.01)
+            assert _connecting_nc.closes >= 1, "aclose must run between reconnects, never leaked"
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+    finally:
+        monkeypatch.setattr(mod, "RETRY_DELAY_S", real_delay)

--- a/apps/screamingface-engine/tests/unit/test_queue_position_notice.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_position_notice.py
@@ -150,5 +150,7 @@ def test_a_failed_depth_read_never_fails_the_accepted_run() -> None:
             started = client.get(
                 "/", params={"q": "'hi'"}, headers={**cap, "Prefer": "respond-async"}
             )
-            assert started.status_code == 202, "the run was accepted; the notice is not its business"
+            assert started.status_code == 202, (
+                "the run was accepted; the notice is not its business"
+            )
             assert runner.scheduled and runner.scheduled[0][0] == topic

--- a/apps/screamingface-engine/tests/unit/test_queue_position_notice.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_position_notice.py
@@ -71,6 +71,8 @@ class _QueueAwareRunner(IdentityAwareJobRunner):
         return "scheduled"
 
     async def queue_depth(self) -> int:
+        if isinstance(self._depth, Exception):
+            raise self._depth
         return self._depth
 
 
@@ -107,10 +109,12 @@ def test_the_queue_position_notice_reaches_the_attached_socket_and_is_superseded
             assert started.status_code == 202
             assert runner.scheduled and runner.scheduled[0][0] == topic
 
-            # The notice arrives first: a log frame naming the queue position.
+            # The notice arrives first: a log frame naming the queue DEPTH — advisory,
+            # phrased as a depth because the value is a cached snapshot that may lag
+            # this publish, never a promise about this run's exact position.
             notice = OutboundFrameAdapter.validate_python(ws.receive_json())
             assert notice.type == "ai.url4.log"
-            assert "position 3" in notice.data.body
+            assert "the queue holds 3 run(s)" in notice.data.body
 
             # Superseded: the run starts, and the client sees the StartedEvent.
             portal = client.portal
@@ -128,3 +132,23 @@ def test_the_queue_position_notice_reaches_the_attached_socket_and_is_superseded
             )
             started_frame = OutboundFrameAdapter.validate_python(ws.receive_json())
             assert started_frame.type == "ai.url4.started"
+
+
+def test_a_failed_depth_read_never_fails_the_accepted_run() -> None:
+    """The notice is advisory: it runs AFTER the run is durably queued, so a broker blip
+    on the depth read must not turn an accepted run into a 500 — the client would see a
+    failure while the run proceeds anyway."""
+    stream = InMemoryEventStream()
+    runner = _QueueAwareRunner(stream, depth=RuntimeError("stream_info failed"))  # type: ignore[arg-type]
+    app = _make_app(stream, runner)
+    topic = "topic-notice-blip"
+    with TestClient(app) as client:
+        token = _token(topic)
+        cap = {"URL4-Capability": token}
+        with client.websocket_connect(f"/ws?ticket={token}", subprotocols=[SUBPROTOCOL]) as ws:
+            ws.send_json(_attach())
+            started = client.get(
+                "/", params={"q": "'hi'"}, headers={**cap, "Prefer": "respond-async"}
+            )
+            assert started.status_code == 202, "the run was accepted; the notice is not its business"
+            assert runner.scheduled and runner.scheduled[0][0] == topic

--- a/apps/screamingface-engine/tests/unit/test_queue_position_notice.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_position_notice.py
@@ -1,0 +1,130 @@
+"""The queue-position notice (OME-1090): a queued run's position reaches the attached
+socket through the WS bridge's existing `add_notifier` path, and is superseded once
+`StartedEvent` arrives.
+
+No protocol change and no stream write: the notice is a `LogEvent` offered to the topic's
+registered notifiers, exactly like the cache-override notice — the client is already
+attached while its run is queued, so the wait is visible instead of silent.
+"""
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from screamingface_engine.app import create_app
+from screamingface_engine.auth import JwtCodec
+from screamingface_engine.config import Settings
+from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.interfaces import JobStatus, job_name
+from url4.streaming.protocol import (
+    AttachData,
+    AttachEvent,
+    CachePolicy,
+    OutboundFrameAdapter,
+    StartedData,
+    StartedEvent,
+    source_for,
+)
+
+SECRET = "notice-secret"
+WINDOW_S = 60
+LIFETIME_S = 58_800  # capability_lifetime_s (D1, OME-1016)
+T0 = datetime(2026, 9, 2, 9, 0, 0, tzinfo=UTC)
+SUBPROTOCOL = "cloudevents.json"
+
+
+class _QueueAwareRunner(IdentityAwareJobRunner):
+    """A fake queue-backed runner: records schedules, reports a queue depth, and lets the
+    test publish the run's own frames onto the stream."""
+
+    def __init__(self, stream: InMemoryEventStream, *, depth: int = 3) -> None:
+        self._stream = stream
+        self._depth = depth
+        self.scheduled: list[tuple[str, str, int]] = []
+
+    async def schedule(
+        self,
+        topic: str,
+        url4: str,
+        deadline_s: int,
+        *,
+        traceparent: str | None = None,
+        credential: str | None = None,
+        profile: str | None = None,
+        identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
+    ) -> str:
+        self.scheduled.append((topic, url4, deadline_s))
+        return job_name(topic)
+
+    async def stop(self, topic: str) -> None:
+        pass
+
+    async def exists(self, topic: str) -> bool:
+        return False
+
+    async def status(self, topic: str) -> JobStatus:
+        return "scheduled"
+
+    async def queue_depth(self) -> int:
+        return self._depth
+
+
+def _make_app(stream: InMemoryEventStream, runner: _QueueAwareRunner) -> FastAPI:
+    settings = Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S, ws_heartbeat_s=30.0)
+    return create_app(settings, stream=stream, job_runner=runner, clock=lambda: T0)
+
+
+def _token(topic: str) -> str:
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
+
+
+def _attach() -> dict[str, Any]:
+    return AttachEvent(
+        id="att", source="/client", subject="t", data=AttachData(from_sequence=None)
+    ).model_dump(mode="json", by_alias=True)
+
+
+def test_the_queue_position_notice_reaches_the_attached_socket_and_is_superseded() -> None:
+    stream = InMemoryEventStream()
+    runner = _QueueAwareRunner(stream, depth=3)
+    app = _make_app(stream, runner)
+    topic = "topic-notice"
+    with TestClient(app) as client:
+        token = _token(topic)
+        cap = {"URL4-Capability": token}
+        with client.websocket_connect(f"/ws?ticket={token}", subprotocols=[SUBPROTOCOL]) as ws:
+            ws.send_json(_attach())
+            started = client.get(
+                "/", params={"q": "'hi'"}, headers={**cap, "Prefer": "respond-async"}
+            )
+            assert started.status_code == 202
+            assert runner.scheduled and runner.scheduled[0][0] == topic
+
+            # The notice arrives first: a log frame naming the queue position.
+            notice = OutboundFrameAdapter.validate_python(ws.receive_json())
+            assert notice.type == "ai.url4.log"
+            assert "position 3" in notice.data.body
+
+            # Superseded: the run starts, and the client sees the StartedEvent.
+            portal = client.portal
+            assert portal is not None
+            portal.call(
+                stream.publish,
+                topic,
+                StartedEvent(
+                    id="s",
+                    source=source_for(topic),
+                    subject=topic,
+                    time=T0,
+                    data=StartedData(url4="'hi'"),
+                ),
+            )
+            started_frame = OutboundFrameAdapter.validate_python(ws.receive_json())
+            assert started_frame.type == "ai.url4.started"

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -338,11 +338,13 @@ async def test_a_run_completing_inside_the_ask_window_keeps_its_real_outcome() -
     assert await runner.status("t-midask") == "succeeded"
 
 
-async def test_an_unreadable_tail_makes_stop_a_no_op_not_a_500() -> None:
-    """P2-10: `stop()`'s tail reads were unguarded — a `QueueReadError` surfaced as a 500
-    on `DELETE /`. An unreadable tail is UNKNOWN, not a state: stop returns without a
-    tombstone and without a control ask (no state change), and a retried DELETE once the
-    broker is readable reaches the truth."""
+async def test_an_unreadable_tail_makes_stop_raise_without_changing_state() -> None:
+    """P2-10 then V-2/V-3: `stop()`'s tail reads were unguarded (a 500 on `DELETE /`), and
+    the first fix made the unknown a SILENT no-op — which the reaper counted as a
+    successful reap (deadline popped, telemetry asserting it) for a run it never touched,
+    and which let `DELETE /` fall through to deleting a possibly-live run's stream. The
+    unknown now raises the typed error: no tombstone, no control ask, no state change —
+    and every caller can tell "did not act" from "acted"."""
     from screamingface_engine.adapters.jetstream import QueueReadError
 
     class _UnreadablePublisher(_FakePublisher):
@@ -352,6 +354,8 @@ async def test_an_unreadable_tail_makes_stop_a_no_op_not_a_500() -> None:
     control = _FakeControl()
     runner = _runner(_UnreadablePublisher(), control)
 
-    await runner.stop("t-unreadable")  # must not raise
+    with pytest.raises(QueueReadError):
+        await runner.stop("t-unreadable")
 
     assert control.requested == [], "an unknown tail must not even reach the control ask"
+    assert getattr(control, "requested", []) == []

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -300,3 +300,40 @@ async def test_a_claim_landing_mid_stop_is_still_cancelled_with_one_frame() -> N
     # the worker skips — the existing before-claim test's mechanism, now also the fate
     # of any claim that arrives after this stop.
     assert isinstance(await publisher.last_frame("t-raced"), TerminatedEvent)
+
+
+# --- review follow-up: the tombstone must not land after the run's real outcome ------------
+
+
+class _CompletingMidAskPublisher(_FakePublisher):
+    """A run that finishes INSIDE the control ask's window: the entry read saw nothing,
+    but by the time the ask has timed out the run has claimed, executed, and published
+    its genuine `Terminated(succeeded)`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reads = 0
+        self._last_frame = None
+
+    async def last_frame(self, topic: str) -> Any:
+        self.reads += 1
+        if self.reads >= 2:
+            # The run completed during the ask: the stream now ends in success.
+            self._last_frame = _terminated("t-midask", "succeeded")
+        return self._last_frame
+
+
+async def test_a_run_completing_inside_the_ask_window_keeps_its_real_outcome() -> None:
+    """`stop()` used to write the tombstone from an entry-time read one control-timeout
+    old: a fast run could claim, execute, and succeed entirely inside the ask's window,
+    and the tombstone appended `stopped` AFTER the success — `status()`, a last-frame
+    read on an append-only stream, then reported a succeeded run as stopped forever. The
+    tail is re-read before the marker; a completed run is left untouched."""
+    publisher = _CompletingMidAskPublisher()
+    control = _ScriptedControl([TimeoutError("nobody yet"), TimeoutError("gone")])
+    runner = _runner(publisher, control)
+
+    await runner.stop("t-midask")
+
+    assert publisher.published == [], "a run that succeeded needs no second terminal frame"
+    assert await runner.status("t-midask") == "succeeded"

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -1,0 +1,220 @@
+"""Cancellation through the queue runner (OME-1090): a queued run gets a tombstone, a
+running run is reached over the control subject, and an unknown topic is a no-op.
+
+The two cancel paths are the whole point of the unit:
+
+* Queued, unclaimed: `stop()` writes `Terminated(stopped)` to the run's event stream
+  immediately. The worker later claims the message, sees the terminal frame, acks, and
+  never executes — no message deletion by sequence, and the App never learns the
+  message's sequence.
+* Running: `stop()` sends a core NATS request/reply on `url4.runctl.<topic>`. Only the
+  owning worker replies (and SIGTERMs its child, which ends in the worker's own
+  `Terminated(stopped)`); no reply within a short timeout means "not running here", and
+  the tombstone above covers the queued case.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from screamingface_engine.adapters.queue_runner import QueueJobRunner
+from screamingface_engine.runner_queue import encode_message
+from screamingface_engine.worker.supervisor import RunSupervisor
+from url4.streaming.protocol import (
+    StartedData,
+    StartedEvent,
+    TerminatedData,
+    TerminatedEvent,
+    source_for,
+)
+
+pytestmark = pytest.mark.asyncio
+
+CAPABILITY_LIFETIME_S = 100.0
+T0 = datetime(2026, 9, 2, 9, 0, 0, tzinfo=UTC)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = T0
+
+    def __call__(self) -> datetime:
+        return self.now
+
+
+class _FakeQueue:
+    def __init__(self) -> None:
+        self.published: list[bytes] = []
+
+    async def publish(self, message: bytes) -> None:
+        self.published.append(message)
+
+    async def depth(self) -> int:
+        return 0
+
+
+class _FakePublisher:
+    def __init__(self, *, last_frame: Any = None, stream_exists: bool = True) -> None:
+        self._last_frame = last_frame
+        self._stream_exists = stream_exists
+        self.published: list[Any] = []
+        self.ensured: list[str] = []
+
+    async def last_frame(self, topic: str) -> Any:
+        return self._last_frame
+
+    async def stream_exists(self, topic: str) -> bool:
+        return self._stream_exists
+
+    async def ensure_stream(self, topic: str) -> None:
+        self.ensured.append(topic)
+
+    async def publish(self, topic: str, event: Any) -> None:
+        # Mirror the broker: a published frame is the stream's new tail, so a later
+        # `last_frame` read sees it — the worker's dedupe check depends on exactly that.
+        self._last_frame = event
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FakeControl:
+    """A control client that either replies (the run is running here) or times out."""
+
+    def __init__(self, *, reply: bool = True) -> None:
+        self._reply = reply
+        self.requested: list[tuple[str, bytes, float]] = []
+
+    async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any:
+        self.requested.append((subject, payload, timeout))
+        if self._reply:
+            return object()
+        raise TimeoutError()
+
+
+def _runner(publisher: _FakePublisher, control: _FakeControl) -> QueueJobRunner:
+    return QueueJobRunner(
+        queue=_FakeQueue(),
+        publisher=publisher,
+        control=control,
+        clock=_FakeClock(),
+        capability_lifetime_s=CAPABILITY_LIFETIME_S,
+    )
+
+
+def _started(topic: str) -> StartedEvent:
+    return StartedEvent(
+        id="s", source=source_for(topic), subject=topic, data=StartedData(url4="'hi'")
+    )
+
+
+def _terminated(topic: str, status: str) -> TerminatedEvent:
+    return TerminatedEvent(
+        id="t",
+        source=source_for(topic),
+        subject=topic,
+        data=TerminatedData(status=status),  # type: ignore[arg-type]
+    )
+
+
+class _FakeMsg:
+    """A claimed queue message, recording its ack."""
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.metadata = SimpleNamespace(timestamp=datetime.now(UTC))
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def in_progress(self) -> None:
+        pass
+
+
+def _supervisor(publisher: _FakePublisher) -> RunSupervisor:
+    """A supervisor that can never spawn — the cancel-before-claim test must prove it
+    never tries to."""
+
+    async def _never_spawn(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("a cancelled run must never be spawned")
+
+    return RunSupervisor(
+        publisher=publisher,
+        spawn=_never_spawn,
+        memory_budget_bytes=1024**3,
+        io_capacity=4,
+        draining=asyncio.Event(),
+        terminating=asyncio.Event(),
+        children=set(),
+        children_by_topic={},
+        cancelled=set(),
+    )
+
+
+# --- cancel-before-claim -------------------------------------------------------------------
+
+
+async def test_cancel_before_claim_writes_a_tombstone_and_the_worker_skips() -> None:
+    """DELETE / on a queued run: the App writes `Terminated(stopped)`; the worker later
+    claims the message, sees the terminal frame, acks exactly once, and never executes."""
+    publisher = _FakePublisher()
+    control = _FakeControl(reply=False)
+    runner = _runner(publisher, control)
+    await runner.schedule("t", "'hi'", 60)
+    await runner.stop("t")
+
+    # The App's side: the control request went out, got no reply, and the tombstone landed.
+    assert control.requested == [("url4.runctl.t", b"", runner._control_timeout_s)]
+    assert len(publisher.published) == 1
+    frame = publisher.published[0]
+    assert isinstance(frame, TerminatedEvent)
+    assert frame.data.status == "stopped"
+    assert frame.source == source_for("t")
+
+    # The worker's side: claim the message, see the tombstone, ack, skip.
+    msg = _FakeMsg(encode_message("t", "'hi'", 60))
+    await _supervisor(publisher).supervise(msg)
+    assert msg.acked
+    assert len(publisher.published) == 1, "the worker must add no second frame"
+
+
+# --- cancel-while-running ------------------------------------------------------------------
+
+
+async def test_cancel_while_running_reaches_the_owner_and_writes_no_tombstone() -> None:
+    """A running run is reached over the control subject; the App writes nothing — the
+    owning worker's own `Terminated(stopped)` is the one frame."""
+    publisher = _FakePublisher(last_frame=_started("t"))
+    control = _FakeControl(reply=True)
+    runner = _runner(publisher, control)
+    await runner.schedule("t", "'hi'", 60)
+    await runner.stop("t")
+
+    assert control.requested == [("url4.runctl.t", b"", runner._control_timeout_s)]
+    assert publisher.published == [], "a replied control request must not also tombstone"
+
+
+# --- idempotency ---------------------------------------------------------------------------
+
+
+async def test_stop_on_an_unknown_topic_is_a_no_op() -> None:
+    """stop() on a topic with no stream and no schedule record stays idempotent — the
+    DELETE route's 204 must not hide a stream being created for a run that never was."""
+    publisher = _FakePublisher(stream_exists=False)
+    runner = _runner(publisher, _FakeControl(reply=False))
+    await runner.stop("unknown")
+    assert publisher.published == []
+    assert publisher.ensured == []
+
+
+async def test_stop_on_an_already_terminal_run_adds_no_second_frame() -> None:
+    """A run that already ended must not receive a second terminal frame."""
+    publisher = _FakePublisher(last_frame=_terminated("t", "succeeded"))
+    runner = _runner(publisher, _FakeControl(reply=False))
+    await runner.stop("t")
+    assert publisher.published == []

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -19,7 +19,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-
 from nats.errors import NoRespondersError
 
 from screamingface_engine.adapters.queue_runner import QueueJobRunner
@@ -337,3 +336,22 @@ async def test_a_run_completing_inside_the_ask_window_keeps_its_real_outcome() -
 
     assert publisher.published == [], "a run that succeeded needs no second terminal frame"
     assert await runner.status("t-midask") == "succeeded"
+
+
+async def test_an_unreadable_tail_makes_stop_a_no_op_not_a_500() -> None:
+    """P2-10: `stop()`'s tail reads were unguarded — a `QueueReadError` surfaced as a 500
+    on `DELETE /`. An unreadable tail is UNKNOWN, not a state: stop returns without a
+    tombstone and without a control ask (no state change), and a retried DELETE once the
+    broker is readable reaches the truth."""
+    from screamingface_engine.adapters.jetstream import QueueReadError
+
+    class _UnreadablePublisher(_FakePublisher):
+        async def last_frame(self, topic: str) -> Any:
+            raise QueueReadError("stream tail unreadable")
+
+    control = _FakeControl()
+    runner = _runner(_UnreadablePublisher(), control)
+
+    await runner.stop("t-unreadable")  # must not raise
+
+    assert control.requested == [], "an unknown tail must not even reach the control ask"

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -20,6 +20,8 @@ from typing import Any
 
 import pytest
 
+from nats.errors import NoRespondersError
+
 from screamingface_engine.adapters.queue_runner import QueueJobRunner
 from screamingface_engine.runner_queue import encode_message
 from screamingface_engine.worker.supervisor import RunSupervisor
@@ -83,16 +85,21 @@ class _FakePublisher:
 
 
 class _FakeControl:
-    """A control client that either replies (the run is running here) or times out."""
+    """A control client that either replies (the run is running here) or reports
+    "nobody is subscribed" — as a timeout, or as nats-py's faster `NoRespondersError`,
+    which the broker itself raises whenever the server advertises headers."""
 
-    def __init__(self, *, reply: bool = True) -> None:
+    def __init__(self, *, reply: bool = True, no_responders: bool = False) -> None:
         self._reply = reply
+        self._no_responders = no_responders
         self.requested: list[tuple[str, bytes, float]] = []
 
     async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any:
         self.requested.append((subject, payload, timeout))
         if self._reply:
             return object()
+        if self._no_responders:
+            raise NoRespondersError()
         raise TimeoutError()
 
 
@@ -218,3 +225,22 @@ async def test_stop_on_an_already_terminal_run_adds_no_second_frame() -> None:
     runner = _runner(publisher, _FakeControl(reply=False))
     await runner.stop("t")
     assert publisher.published == []
+
+
+async def test_no_responders_reads_as_not_running_here_not_an_error() -> None:
+    """nats-py raises `NoRespondersError` — not a `TimeoutError` subclass — when nothing
+    is subscribed to `url4.runctl.*` (a pool scaled to zero, mid-rollout, a worker that
+    is down). `stop()` must read it as "not running here" and tombstone the queued run;
+    uncaught, it 500s `DELETE /` while the run stays queued."""
+    publisher = _FakePublisher()
+    control = _FakeControl(reply=False, no_responders=True)
+    runner = _runner(publisher, control)
+    await runner.schedule("t", "'hi'", 60)
+
+    await runner.stop("t")  # must not raise
+
+    assert control.requested == [("url4.runctl.t", b"", runner._control_timeout_s)]
+    assert len(publisher.published) == 1
+    frame = publisher.published[0]
+    assert isinstance(frame, TerminatedEvent)
+    assert frame.data.status == "stopped"

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -175,8 +175,12 @@ async def test_cancel_before_claim_writes_a_tombstone_and_the_worker_skips() -> 
     await runner.schedule("t", "'hi'", 60)
     await runner.stop("t")
 
-    # The App's side: the control request went out, got no reply, and the tombstone landed.
-    assert control.requested == [("url4.runctl.t", b"", runner._control_timeout_s)]
+    # The App's side: the control ask went out, got no reply, the tombstone landed, and
+    # the confirmation ask re-checked for a claim racing this stop (no reply again).
+    assert control.requested == [
+        ("url4.runctl.t", b"", runner._control_timeout_s),
+        ("url4.runctl.t", b"", runner._control_timeout_s),
+    ]
     assert len(publisher.published) == 1
     frame = publisher.published[0]
     assert isinstance(frame, TerminatedEvent)
@@ -239,8 +243,60 @@ async def test_no_responders_reads_as_not_running_here_not_an_error() -> None:
 
     await runner.stop("t")  # must not raise
 
-    assert control.requested == [("url4.runctl.t", b"", runner._control_timeout_s)]
+    assert control.requested == [
+        ("url4.runctl.t", b"", runner._control_timeout_s),
+        ("url4.runctl.t", b"", runner._control_timeout_s),
+    ]
     assert len(publisher.published) == 1
     frame = publisher.published[0]
     assert isinstance(frame, TerminatedEvent)
     assert frame.data.status == "stopped"
+
+
+# --- the queued-cancel race (review follow-up) ----------------------------------------------
+
+
+class _ScriptedControl:
+    """A control channel scripted per call: the worker does not own the run when the
+    first ask goes out, but CLAIMS it mid-stop (before the tombstone lands) — so the
+    confirmation ask finds it registered and it answers."""
+
+    def __init__(self, outcomes: list[Any]) -> None:
+        self._outcomes = list(outcomes)
+        self.requested: list[str] = []
+
+    async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any:
+        self.requested.append(subject)
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+async def test_a_claim_landing_mid_stop_is_still_cancelled_with_one_frame() -> None:
+    """Nothing orders `stop()` against a worker's claim: the worker can claim the queued
+    message after the first control ask times out and before a tombstone written
+    afterwards would land — its claim-time gate then reads no terminal frame, the run
+    executes to completion, and the late tombstone adds a SECOND terminal frame to a run
+    the caller was told was cancelled. The tombstone is now written BEFORE the
+    confirmation ask: any claim after it sees the frame at its gate; any claim before it
+    answers the confirmation ask and enacts the cancel, its own terminal publish
+    suppressed by the tombstone already on the stream."""
+    publisher = _FakePublisher()
+    control = _ScriptedControl([TimeoutError("nobody yet"), object()])  # ask, then CLAIMED
+    runner = _runner(publisher, control)
+
+    await runner.stop("t-raced")
+
+    # The confirmation pass happened — the worker that claimed mid-stop was reached.
+    assert len(control.requested) == 2, "stop must re-ask after tombstoning"
+
+    # The marker is durable BEFORE the confirmation ask (the ordering that closes the
+    # race), and it is the run's ONE terminal frame.
+    assert isinstance(publisher.published[0], TerminatedEvent)
+    assert len(publisher.published) == 1
+
+    # And the run stays cancelled: a later claim-time gate read sees the tombstone and
+    # the worker skips — the existing before-claim test's mechanism, now also the fate
+    # of any claim that arrives after this stop.
+    assert isinstance(await publisher.last_frame("t-raced"), TerminatedEvent)

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -22,6 +22,7 @@ import pytest
 from nats.errors import NoRespondersError
 
 from screamingface_engine.adapters.queue_runner import QueueJobRunner
+from screamingface_engine.adapters.queue_runner import _ControlClient as ControlClientProtocol
 from screamingface_engine.runner_queue import encode_message
 from screamingface_engine.worker.supervisor import RunSupervisor
 from url4.streaming.protocol import (
@@ -102,7 +103,10 @@ class _FakeControl:
         raise TimeoutError()
 
 
-def _runner(publisher: _FakePublisher, control: _FakeControl) -> QueueJobRunner:
+def _runner(publisher: _FakePublisher, control: ControlClientProtocol) -> QueueJobRunner:
+    # WHY the Protocol, not `_FakeControl`: `_ScriptedControl` (below) is also passed
+    # here, and both fakes already satisfy the production `_ControlClient` Protocol that
+    # `QueueJobRunner.__init__` itself is typed to.
     return QueueJobRunner(
         queue=_FakeQueue(),
         publisher=publisher,

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
@@ -202,3 +202,20 @@ async def test_exists_is_true_only_for_scheduled_or_running() -> None:
 
     terminal = _runner(clock, _FakePublisher(last_frame=_terminated("t", "succeeded")))
     assert await terminal.exists("t") is False
+
+
+async def test_an_unreadable_tail_reads_as_running_not_a_state() -> None:
+    """P2-10: `status()`'s tail read was unguarded — a `QueueReadError` 500'd the status
+    endpoint. An unreadable tail is UNKNOWN and must never read as terminal-ish: the
+    reaper's `exists()` is this very status, and a `not_found` answer would make it stop
+    an unknown run. It reads "running" — assumed alive — so the reaper leaves it and the
+    client retries."""
+    from screamingface_engine.adapters.jetstream import QueueReadError
+
+    class _UnreadablePublisher(_FakePublisher):
+        async def last_frame(self, topic: str) -> Any:
+            raise QueueReadError("stream tail unreadable")
+
+    runner = _runner(_FakeClock(), _UnreadablePublisher())
+
+    assert await runner.status("t-unreadable") == "running"

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
@@ -204,12 +204,12 @@ async def test_exists_is_true_only_for_scheduled_or_running() -> None:
     assert await terminal.exists("t") is False
 
 
-async def test_an_unreadable_tail_reads_as_running_not_a_state() -> None:
-    """P2-10: `status()`'s tail read was unguarded — a `QueueReadError` 500'd the status
-    endpoint. An unreadable tail is UNKNOWN and must never read as terminal-ish: the
-    reaper's `exists()` is this very status, and a `not_found` answer would make it stop
-    an unknown run. It reads "running" — assumed alive — so the reaper leaves it and the
-    client retries."""
+async def test_an_unreadable_tail_is_an_error_not_a_state() -> None:
+    """P2-10 then V-2/V-3: `status()`'s tail read was unguarded (a 500), and the first fix
+    answered "running" — assumed alive. But `exists()` is this same status, and `POST /`
+    used it to 409 a BRAND-NEW topic on a transient blip: a definitive false claim
+    clients do not retry. Unknown is not a state for ANY consumer — the typed raise lets
+    each caller answer honestly (the REST edge 503s; the reaper re-arms)."""
     from screamingface_engine.adapters.jetstream import QueueReadError
 
     class _UnreadablePublisher(_FakePublisher):
@@ -218,4 +218,7 @@ async def test_an_unreadable_tail_reads_as_running_not_a_state() -> None:
 
     runner = _runner(_FakeClock(), _UnreadablePublisher())
 
-    assert await runner.status("t-unreadable") == "running"
+    with pytest.raises(QueueReadError):
+        await runner.status("t-unreadable")
+    with pytest.raises(QueueReadError):
+        await runner.exists("t-unreadable")

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
@@ -1,0 +1,204 @@
+"""The queue runner's status derivation (OME-1090): a pure function of the run's own
+event stream plus capability validity — no Job, no new store.
+
+| Evidence on the run's event stream | Status |
+| terminal frame present | its outcome (succeeded/failed/timed_out/stopped) |
+| StartedEvent, no terminal frame | running |
+| neither, capability unexpired | scheduled |
+| neither, capability expired | not_found |
+
+The table is the whole contract, so it is pinned one test per row, including the exact
+capability-expiry boundary between `scheduled` and `not_found`.
+"""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from screamingface_engine.adapters.queue_runner import QueueJobRunner
+from url4.streaming.protocol import (
+    LogData,
+    LogEvent,
+    StartedData,
+    StartedEvent,
+    TerminatedData,
+    TerminatedEvent,
+    source_for,
+)
+
+pytestmark = pytest.mark.asyncio
+
+CAPABILITY_LIFETIME_S = 100.0
+T0 = datetime(2026, 9, 2, 9, 0, 0, tzinfo=UTC)
+
+
+class _FakeClock:
+    """A wall clock the test advances by hand."""
+
+    def __init__(self) -> None:
+        self.now = T0
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+class _FakeQueue:
+    def __init__(self) -> None:
+        self.published: list[bytes] = []
+
+    async def publish(self, message: bytes) -> None:
+        self.published.append(message)
+
+    async def depth(self) -> int:
+        return 0
+
+
+class _FakePublisher:
+    """The slice of `JetStreamPublisher` the queue runner reads, scripted per test."""
+
+    def __init__(self, last_frame: Any = None) -> None:
+        self._last_frame = last_frame
+        self.published: list[Any] = []
+        self.ensured: list[str] = []
+
+    async def last_frame(self, topic: str) -> Any:
+        return self._last_frame
+
+    async def stream_exists(self, topic: str) -> bool:
+        return True
+
+    async def ensure_stream(self, topic: str) -> None:
+        self.ensured.append(topic)
+
+    async def publish(self, topic: str, event: Any) -> None:
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FakeControl:
+    async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any:
+        raise TimeoutError()
+
+
+def _runner(clock: _FakeClock, publisher: _FakePublisher) -> QueueJobRunner:
+    return QueueJobRunner(
+        queue=_FakeQueue(),
+        publisher=publisher,
+        control=_FakeControl(),
+        clock=clock,
+        capability_lifetime_s=CAPABILITY_LIFETIME_S,
+    )
+
+
+def _started(topic: str) -> StartedEvent:
+    return StartedEvent(
+        id="s", source=source_for(topic), subject=topic, data=StartedData(url4="'hi'")
+    )
+
+
+def _terminated(topic: str, status: str) -> TerminatedEvent:
+    return TerminatedEvent(
+        id="t",
+        source=source_for(topic),
+        subject=topic,
+        data=TerminatedData(status=status),  # type: ignore[arg-type]
+    )
+
+
+def _log(topic: str) -> LogEvent:
+    return LogEvent(
+        id="l", source=source_for(topic), subject=topic, data=LogData.at("INFO", "working")
+    )
+
+
+# --- row 1: a terminal frame IS the run's outcome ------------------------------------------
+
+
+async def test_a_terminal_frame_maps_to_its_outcome() -> None:
+    """Row 1: whatever terminal frame the stream ends in is the run's status."""
+    clock = _FakeClock()
+    for status in ("succeeded", "failed", "timed_out", "stopped"):
+        runner = _runner(clock, _FakePublisher(last_frame=_terminated("t", status)))
+        assert await runner.status("t") == status
+
+
+# --- row 2: started, not terminal → running -------------------------------------------------
+
+
+async def test_a_started_event_without_a_terminal_frame_is_running() -> None:
+    """Row 2: the run started; it is running."""
+    clock = _FakeClock()
+    runner = _runner(clock, _FakePublisher(last_frame=_started("t")))
+    assert await runner.status("t") == "running"
+
+
+async def test_any_non_terminal_frame_means_running() -> None:
+    """A log/span/cost frame after StartedEvent is the same running evidence — the run
+    started, whatever it is doing now."""
+    clock = _FakeClock()
+    runner = _runner(clock, _FakePublisher(last_frame=_log("t")))
+    assert await runner.status("t") == "running"
+
+
+# --- rows 3 & 4: no evidence → capability decides ------------------------------------------
+
+
+async def test_no_evidence_with_an_unexpired_capability_is_scheduled() -> None:
+    """Row 3: accepted but not yet started — queued. `scheduled` already means exactly
+    that, so `JobStatus` needs no new member."""
+    clock = _FakeClock()
+    runner = _runner(clock, _FakePublisher(last_frame=None))
+    await runner.schedule("t", "'hi'", 60)
+    assert await runner.status("t") == "scheduled"
+
+
+async def test_no_evidence_with_an_expired_capability_is_not_found() -> None:
+    """Row 4: the capability expired while the run sat unstarted — it is gone."""
+    clock = _FakeClock()
+    runner = _runner(clock, _FakePublisher(last_frame=None))
+    await runner.schedule("t", "'hi'", 60)
+    clock.advance(CAPABILITY_LIFETIME_S)
+    assert await runner.status("t") == "not_found"
+
+
+async def test_the_capability_boundary_is_exact() -> None:
+    """The boundary between `scheduled` and `not_found`: unexpired at lifetime-ε, expired
+    at lifetime."""
+    clock = _FakeClock()
+    runner = _runner(clock, _FakePublisher(last_frame=None))
+    await runner.schedule("t", "'hi'", 60)
+    clock.advance(CAPABILITY_LIFETIME_S - 0.001)
+    assert await runner.status("t") == "scheduled"
+    clock.advance(0.001)
+    assert await runner.status("t") == "not_found"
+
+
+async def test_a_topic_never_scheduled_here_is_not_found() -> None:
+    """A topic this replica never scheduled has no capability to speak of — the
+    conservative answer for the reaper, which must not stop a run it cannot see."""
+    clock = _FakeClock()
+    runner = _runner(clock, _FakePublisher(last_frame=None))
+    assert await runner.status("unknown") == "not_found"
+
+
+# --- exists(): the reaper's question -------------------------------------------------------
+
+
+async def test_exists_is_true_only_for_scheduled_or_running() -> None:
+    """`exists` answers the reaper's question: a terminal run does not exist, so an
+    audience-loss stop never lands a second terminal frame on a finished run."""
+    clock = _FakeClock()
+    runner = _runner(clock, _FakePublisher(last_frame=None))
+    await runner.schedule("t", "'hi'", 60)
+    assert await runner.exists("t") is True
+    clock.advance(CAPABILITY_LIFETIME_S)
+    assert await runner.exists("t") is False
+
+    terminal = _runner(clock, _FakePublisher(last_frame=_terminated("t", "succeeded")))
+    assert await terminal.exists("t") is False

--- a/apps/screamingface-engine/tests/unit/test_reaper.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper.py
@@ -391,3 +391,44 @@ async def test_an_unreadable_exists_rearms_rather_than_forgetting_the_topic() ->
 
     assert await reaper.sweep() == ("t",)
     assert runner.stopped == ["t"]
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_read_during_the_reap_rearms_the_real_runner_too() -> None:
+    """V-2 — the COMPOSITION the first P2-10 fix never tested: both halves were verified
+    in isolation (the reaper against a fake whose `stop` raised; `stop()` against the
+    sentinel) and the combination reinstated the bug — the real `stop()` answered the
+    unreadable tail with a SILENT no-op, so `_reap` fell through to `reaped_total += 1`
+    and logged "orphan run reaped" for a run it never touched, with the deadline popped
+    and nothing re-arming it. Unknown must reach the reaper as a FAILURE so its existing
+    re-arm runs: the tail reads fine for `exists` (the run is live) and goes unreadable
+    under `stop` — exactly a reconnect landing between the two reads."""
+    from test_queue_runner_cancel import _FakeControl, _FakePublisher, _runner
+
+    from url4.streaming.protocol import StartedData, StartedEvent, source_for
+
+    class _UnreadableOnTheSecondRead(_FakePublisher):
+        """`exists` reads a live Started frame; `stop`'s re-read lands mid-reconnect."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.reads = 0
+
+        async def last_frame(self, topic: str) -> Any:
+            self.reads += 1
+            if self.reads >= 2:
+                raise QueueReadError("stream tail unreadable")
+            return StartedEvent(
+                id="s", source=source_for(topic), subject=topic, data=StartedData(url4="'hi'")
+            )
+
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _runner(_UnreadableOnTheSecondRead(), _FakeControl())
+    reaper = RunReaper(runner, audience, grace_s=GRACE, clock=clock, tick_s=10.0)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert reaper.armed_count == 1, "an unknown read must re-arm, not count as a reap"
+    assert reaper.reaped_total == 0, "telemetry must not assert a reap that did not happen"

--- a/apps/screamingface-engine/tests/unit/test_reaper.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.adapters.queue_runner import QueueJobRunner
 from screamingface_engine.reaper import RunReaper
 
@@ -44,12 +45,20 @@ class _FakeAudience:
 class _FakeRunner:
     """Records stop calls; `live` is the set of topics `exists` answers True for."""
 
-    def __init__(self, live: set[str] | None = None, fail_on: set[str] | None = None) -> None:
+    def __init__(
+        self,
+        live: set[str] | None = None,
+        fail_on: set[str] | None = None,
+        fail_exists_on: set[str] | None = None,
+    ) -> None:
         self.live = live if live is not None else set()
         self.fail_on = fail_on if fail_on is not None else set()
+        self.fail_exists_on = fail_exists_on if fail_exists_on is not None else set()
         self.stopped: list[str] = []
 
     async def exists(self, topic: str) -> bool:
+        if topic in self.fail_exists_on:
+            raise QueueReadError("stream tail unreadable")
         return topic in self.live
 
     async def stop(self, topic: str) -> None:
@@ -357,3 +366,28 @@ async def test_armed_implies_no_subscriber_across_a_scripted_sequence() -> None:
                 assert not await audience.has_subscriber(topic), (
                     f"{topic} is armed while its audience is present"
                 )
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_exists_rearms_rather_than_forgetting_the_topic() -> None:
+    """P2-10: `_reap` popped the deadline BEFORE the `exists` guard, and the guard was not
+    wrapped — one transient read failure aborted the sweep with the topic already claimed
+    (disarmed) and nothing left to re-arm it: the orphan was silently forgotten and ran
+    to the 16h ceiling, the exact spend the reaper exists to prevent. A guard failure now
+    re-arms like a failed stop."""
+    clock, audience = _FakeClock(), _FakeAudience()
+    runner = _FakeRunner(live={"t"}, fail_exists_on={"t"})
+    reaper = _reaper(clock, audience, runner)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ()
+    assert reaper.armed_count == 1  # re-armed, not forgotten
+    assert runner.stopped == []
+
+    runner.fail_exists_on.clear()
+    clock.advance(reaper.tick_s)
+
+    assert await reaper.sweep() == ("t",)
+    assert runner.stopped == ["t"]

--- a/apps/screamingface-engine/tests/unit/test_reaper.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper.py
@@ -7,8 +7,12 @@ verified against real time would be both slow and flaky, and the grace window it
 measured in minutes.
 """
 
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
 import pytest
 
+from screamingface_engine.adapters.queue_runner import QueueJobRunner
 from screamingface_engine.reaper import RunReaper
 
 GRACE = 120.0
@@ -208,6 +212,82 @@ async def test_a_failed_stop_is_retried_rather_than_abandoned() -> None:
 
     assert await reaper.sweep() == ("t",)
     assert runner.stopped == ["t"]
+
+
+@pytest.mark.asyncio
+async def test_an_audience_loss_stop_reaches_a_queued_run() -> None:
+    """The Job path stopped a queued run by deleting a Job that might never have started;
+    the queue runner must stop a QUEUED run the same way. `exists()` is True for a
+    scheduled (queued) run, so the reaper's stop() lands and writes the tombstone."""
+    clock = _FakeClock()
+    publisher = _FakePublisher()
+    runner = QueueJobRunner(
+        queue=_FakeQueue(),
+        publisher=publisher,
+        control=_FakeControl(),
+        clock=_QueueClock(),
+        capability_lifetime_s=100.0,
+    )
+    await runner.schedule("t", "'hi'", 60)
+    reaper = RunReaper(runner, _FakeAudience(), grace_s=GRACE, clock=clock, tick_s=10.0)
+
+    reaper.audience_left("t")
+    clock.advance(GRACE)
+
+    assert await reaper.sweep() == ("t",)
+    assert reaper.reaped_total == 1
+    assert len(publisher.published) == 1
+    assert publisher.published[0].data.status == "stopped"
+
+
+class _QueueClock:
+    """A wall clock for the queue runner, independent of the reaper's monotonic one."""
+
+    def __init__(self) -> None:
+        self.now = datetime(2026, 9, 2, 9, 0, 0, tzinfo=UTC)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+class _FakeQueue:
+    def __init__(self) -> None:
+        self.published: list[bytes] = []
+
+    async def publish(self, message: bytes) -> None:
+        self.published.append(message)
+
+    async def depth(self) -> int:
+        return 0
+
+
+class _FakePublisher:
+    def __init__(self) -> None:
+        self.published: list[Any] = []
+        self.ensured: list[str] = []
+
+    async def last_frame(self, topic: str) -> Any:
+        return None
+
+    async def stream_exists(self, topic: str) -> bool:
+        return True
+
+    async def ensure_stream(self, topic: str) -> None:
+        self.ensured.append(topic)
+
+    async def publish(self, topic: str, event: Any) -> None:
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FakeControl:
+    async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any:
+        raise TimeoutError()
 
 
 @pytest.mark.asyncio

--- a/apps/screamingface-engine/tests/unit/test_rest.py
+++ b/apps/screamingface-engine/tests/unit/test_rest.py
@@ -308,3 +308,50 @@ async def test_delete_topic_mismatch_is_403() -> None:
     assert resp.status_code == 403
     assert resp.headers["content-type"].startswith("application/problem+json")
     assert runner.stopped == []
+
+
+@pytest.mark.asyncio
+async def test_get_when_the_queue_is_unreadable_is_503_not_a_false_409() -> None:
+    """V-3: `POST /` (the GET handler) pre-checks `exists()` to answer 409 for a live
+    topic. An unreadable queue tail used to surface from `status()` as "running", so a
+    BRAND-NEW topic on a transient broker blip got 409 "a run already exists" — a
+    definitive false claim that clients do not retry. Unknown is not a state: the handler
+    answers a retryable 503 and schedules nothing."""
+    from screamingface_engine.adapters.jetstream import QueueReadError
+
+    class _UnreadableRunner(RecordingJobRunner):
+        async def exists(self, topic: str) -> bool:
+            raise QueueReadError("stream tail unreadable")
+
+    runner = _UnreadableRunner()
+    app = _make_app(job_runner=runner, gate_present=True)
+    async with _client(app) as client:
+        resp = await client.get("/", params={"q": "gpt()"}, headers=_cap("topic-unread"))
+
+    assert resp.status_code == 503
+    assert resp.headers["content-type"].startswith("application/problem+json")
+    assert runner.scheduled == [], "no run may be scheduled on an unreadable queue"
+
+
+@pytest.mark.asyncio
+async def test_delete_when_the_queue_is_unreadable_is_503_and_purges_nothing() -> None:
+    """V-2/V-3: with `stop()` silently no-op'ing on an unreadable tail, `DELETE /` fell
+    through to `delete_stream` — purging the stream of a possibly-live run — while
+    answering a confident 204. The unknown now raises through: the handler answers 503,
+    and the stream is left exactly as it was."""
+    from screamingface_engine.adapters.jetstream import QueueReadError
+
+    class _UnreadableStopRunner(RecordingJobRunner):
+        async def stop(self, topic: str) -> None:
+            raise QueueReadError("stream tail unreadable")
+
+    topic = "topic-del503"
+    stream = InMemoryEventStream()
+    await stream.publish(topic, _started(topic, "gpt()"))
+    runner = _UnreadableStopRunner()
+    app = _make_app(stream=stream, job_runner=runner, gate_present=True)
+    async with _client(app) as client:
+        resp = await client.delete("/", params={"topic": topic}, headers=_cap(topic))
+
+    assert resp.status_code == 503
+    assert stream._log[topic] != [], "the stream must NOT be deleted on an unknown state"  # noqa: SLF001

--- a/apps/screamingface-engine/tests/unit/test_run_queue_sweeper_exclusion.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_sweeper_exclusion.py
@@ -69,25 +69,41 @@ def test_owns_stream_follows_the_configured_queue_name() -> None:
     """The exclusion must follow the CONFIGURED stream name, not the default constant
     (review follow-up): the name is a Settings field, and an operator who renames the
     queue must not have the sweep re-armed against the renamed stream by a stale constant
-    — that deletes the one stream an accepted run may not be lost from."""
-    assert not owns_stream("prod-runq", run_queue_stream="prod-runq")
+    — that deletes the one stream an accepted run may not be lost from.
+
+    V-9: the names are `url4-cloud_`-shaped, the only shape where the exclusion does
+    REAL work — `owns_stream` refuses every other name at the prefix check anyway, so an
+    earlier draft asserting on "prod-runq" pinned the signature, not the behaviour.
+    (`Settings` itself refuses a `url4-cloud_` queue name at startup — the V-8 validator —
+    so this function-level exclusion is the defence-in-depth layer for callers that do
+    not come from Settings.)"""
+    # The configured queue is excluded by NAME, even in the sweepable prefix.
+    assert not owns_stream("url4-cloud_myqueue", run_queue_stream="url4-cloud_myqueue")
+    # The exclusion is EXACT-match: a sibling in the prefix is still owned — and swept.
+    assert owns_stream("url4-cloud_other", run_queue_stream="url4-cloud_myqueue")
     # The default constant is still excluded for callers that pass nothing.
     assert not owns_stream(RUN_QUEUE_STREAM)
+    # A non-prefixed rename needs no exclusion — the prefix check refuses it.
+    assert not owns_stream("prod-runq", run_queue_stream="prod-runq")
 
 
 @pytest.mark.asyncio
 async def test_a_sweep_with_a_renamed_queue_leaves_it_alive() -> None:
     """The full path, not just the predicate: a connection configured with a renamed queue
-    stream must skip it during reclamation exactly as it skips the default name."""
+    stream must skip it during reclamation exactly as it skips the default name. V-9: the
+    renamed queue is `url4-cloud_`-shaped — WITHOUT the exclusion the sweep would accept
+    it on the prefix check alone and delete it (a "prod-runq" rename proved nothing: the
+    prefix check refuses it whether wired or not). Its `url4-cloud_` sibling is swept."""
     js = _FakeJetStream(
         infos=[
-            _info("prod-runq", messages=0, last_seq=42),
+            _info("url4-cloud_myqueue", messages=0, last_seq=42),
+            _info("url4-cloud_orphan", messages=0, last_seq=7),
             _info(stream_for("dead"), messages=0, last_seq=9),
         ]
     )
-    stream = JetStreamConsumer("nats://unused:4222", run_queue_stream="prod-runq")
+    stream = JetStreamConsumer("nats://unused:4222", run_queue_stream="url4-cloud_myqueue")
     stream._js = cast(JetStreamContext, js)  # noqa: SLF001
 
     await stream._sweep_orphans(cast(JetStreamContext, js))  # noqa: SLF001
 
-    assert js.deleted == [stream_for("dead")]
+    assert js.deleted == ["url4-cloud_orphan", stream_for("dead")]

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -6,6 +6,7 @@ from _k8s_fakes import FakeCoreV1, FakeCreatedJob
 
 from screamingface_engine.adapters.factory import build_job_runner
 from screamingface_engine.adapters.k8s import K8sJobRunner
+from screamingface_engine.adapters.queue_runner import QueueJobRunner
 from screamingface_engine.config import Settings
 
 
@@ -65,6 +66,24 @@ def test_k8s_runner_is_built_from_settings() -> None:
 def test_unknown_runner_is_rejected_at_settings_construction() -> None:
     with pytest.raises(ValueError):
         Settings(runner="kubernetes")  # type: ignore[arg-type]
+
+
+def test_queue_runner_is_built_from_settings() -> None:
+    """The queue backend is selectable (OME-1090); the cutover to it is OME-1092, but the
+    adapter must exist and be wired. Nothing connects at construction — the queue, the
+    publisher, and the control client are all lazy."""
+    settings = Settings(
+        runner="queue",
+        nats_url="nats://localhost:4222",
+        runner_io_concurrency=7,
+        capability_lifetime_s=1234,
+    )
+
+    runner = build_job_runner(settings)
+
+    assert isinstance(runner, QueueJobRunner)
+    assert runner._io_concurrency == 7
+    assert runner._capability_lifetime_s == 1234
 
 
 def test_k8s_runner_receives_deployment_scheduling() -> None:

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -163,3 +163,44 @@ def test_the_queue_runner_wires_the_configured_stream_and_prefix_everywhere() ->
 
     assert runner._queue._stream == "prod-runq"
     assert runner._publisher._run_queue_stream == "prod-runq"
+
+
+def test_every_composition_root_wires_the_same_stream_name() -> None:
+    """V-9/V-6: the stream-wiring test asserted only `build_job_runner`'s output — it
+    could not see the App's consumer (whose sweep deletes what it accepts), the advisor
+    (whose advisory subject carries the stream name), or the worker's root, and a fourth
+    unwired consumer site (app.py) survived exactly that blindness. All four roots are
+    now held to ONE Settings: a mismatch anywhere is a split that fails loudly or a
+    sweep that deletes the queue."""
+    from fastapi import FastAPI
+
+    from screamingface_engine.app import _install_max_deliveries_advisor as _register_queue_advisor
+    from screamingface_engine.app import build_stream_consumer
+    from screamingface_engine.worker.loop import worker_composition
+
+    settings = Settings(
+        runner="queue",
+        nats_url="nats://localhost:4222",
+        run_queue_stream="prod-runq",
+    )
+
+    # The App's runner: the queue and its publisher agree with Settings.
+    runner = build_job_runner(settings)
+    assert runner._queue._stream == "prod-runq"  # noqa: SLF001
+    assert runner._publisher._run_queue_stream == "prod-runq"  # noqa: SLF001
+
+    # The App's event-stream consumer: the sweep's exclusion follows this name (V-6).
+    consumer = build_stream_consumer(settings)
+    assert consumer._run_queue_stream == "prod-runq"  # noqa: SLF001
+
+    # The advisor: its advisory subject must carry the configured stream name.
+    app = FastAPI()
+    _register_queue_advisor(app, settings)
+    advisor = app.state.max_deliveries_advisor
+    assert advisor._run_queue_stream == "prod-runq"  # noqa: SLF001
+    assert "prod-runq" in advisor._subject  # noqa: SLF001
+
+    # The worker: it must pull the same stream the App publishes to.
+    queue, publisher = worker_composition(settings)
+    assert queue._stream == "prod-runq"  # noqa: SLF001
+    assert publisher._run_queue_stream == "prod-runq"  # noqa: SLF001

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -1,13 +1,15 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from _k8s_fakes import FakeCoreV1, FakeCreatedJob
 
 from screamingface_engine.adapters.factory import build_job_runner
+from screamingface_engine.adapters.jetstream import JetStreamPublisher
 from screamingface_engine.adapters.k8s import K8sJobRunner
 from screamingface_engine.adapters.queue_runner import QueueJobRunner
 from screamingface_engine.config import Settings
+from screamingface_engine.runner_queue import RunQueue
 
 
 class _FakeBatchApi:
@@ -161,8 +163,16 @@ def test_the_queue_runner_wires_the_configured_stream_and_prefix_everywhere() ->
 
     runner = build_job_runner(settings)
 
-    assert runner._queue._stream == "prod-runq"
-    assert runner._publisher._run_queue_stream == "prod-runq"
+    # `build_job_runner` returns `JobRunner | None`; narrow to the concrete queue-backed
+    # runner before reaching for its private collaborators. `_queue`/`_publisher` are
+    # themselves typed to the narrow `_Queue`/`_Publisher` Protocols the runner depends
+    # on, which rightly do not declare `RunQueue`/`JetStreamPublisher`'s own private
+    # attributes — the factory always builds those concrete types for `runner="queue"`.
+    assert isinstance(runner, QueueJobRunner)
+    queue = cast(RunQueue, runner._queue)
+    publisher = cast(JetStreamPublisher, runner._publisher)
+    assert queue._stream == "prod-runq"
+    assert publisher._run_queue_stream == "prod-runq"
 
 
 def test_every_composition_root_wires_the_same_stream_name() -> None:
@@ -186,8 +196,11 @@ def test_every_composition_root_wires_the_same_stream_name() -> None:
 
     # The App's runner: the queue and its publisher agree with Settings.
     runner = build_job_runner(settings)
-    assert runner._queue._stream == "prod-runq"  # noqa: SLF001
-    assert runner._publisher._run_queue_stream == "prod-runq"  # noqa: SLF001
+    assert isinstance(runner, QueueJobRunner)
+    root_queue = cast(RunQueue, runner._queue)  # see the cast note above
+    root_publisher = cast(JetStreamPublisher, runner._publisher)
+    assert root_queue._stream == "prod-runq"  # noqa: SLF001
+    assert root_publisher._run_queue_stream == "prod-runq"  # noqa: SLF001
 
     # The App's event-stream consumer: the sweep's exclusion follows this name (V-6).
     consumer = build_stream_consumer(settings)

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -144,3 +144,22 @@ def test_k8s_runner_receives_the_core_client() -> None:
 
     assert isinstance(runner, K8sJobRunner)
     assert isinstance(runner._core_client, FakeCoreV1)
+
+
+def test_the_queue_runner_wires_the_configured_stream_and_prefix_everywhere() -> None:
+    """P2-2/3: `run_queue_stream` and `run_queue_subject_prefix` were honoured by the
+    worker's composition root but ignored at the App's — the App published to the
+    DEFAULT stream while the worker pulled the configured one (a split that fails loudly
+    on every admission), and the App-side publisher's sweep used a stale constant. All
+    composition roots must agree for any Settings. (`run_queue_subject_prefix` lands
+    with the per-caller buckets at OME-1091, where `RunQueue` gains the parameter.)"""
+    settings = Settings(
+        runner="queue",
+        nats_url="nats://localhost:4222",
+        run_queue_stream="prod-runq",
+    )
+
+    runner = build_job_runner(settings)
+
+    assert runner._queue._stream == "prod-runq"
+    assert runner._publisher._run_queue_stream == "prod-runq"

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -599,13 +599,13 @@ def test_an_unrelated_failure_during_drain_is_not_relabeled_a_drain_stop() -> No
     worker._draining.set()
     classify = worker._supervisor._classify
 
-    oom = classify("finished", 137)
+    oom = classify("finished", 137, "topic-oom")
     assert oom is not None and oom[0] == "failed" and oom[1] == OOM_KILLED
 
-    crash = classify("finished", 1)
+    crash = classify("finished", 1, "topic-crash")
     assert crash is not None and crash[0] == "failed" and crash[1] == CHILD_EXITED
 
-    drain_kill = classify("draining", None)
+    drain_kill = classify("draining", None, "topic-drain")
     assert drain_kill is not None
     assert drain_kill[0] == "stopped" and drain_kill[1] == WORKER_DRAINING
 

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1267,7 +1267,11 @@ async def test_a_cancel_during_the_spawn_window_is_answered_and_enacted() -> Non
     expired and it tombstoned the queued run, and the child ran to completion and
     published its own terminal frame: TWO terminal frames for one run. The control loop
     now answers from the starting registry (so the App writes nothing) and the supervisor
-    enacts the cancel the moment the child exists."""
+    enacts the cancel the moment the child exists.
+
+    WHY the complexity is accepted rather than split: this is one linear scenario — a
+    cancel fed mid-spawn, answered, then enacted at registration. Carving the assertions
+    into helpers would obscure exactly the ordering under test; the story is the test."""
     queue = _FakeQueue([[_FakeMsg(encode_message("t-race", "'hi'", 60))]])
     procs: list[_FakeProcess] = []
     spawn_entered = asyncio.Event()
@@ -1298,8 +1302,7 @@ async def test_a_cancel_during_the_spawn_window_is_answered_and_enacted() -> Non
         release_spawn.set()
         await _wait_until(lambda: procs and procs[0].terminate_calls == 1)
         await _wait_until(
-            lambda: bool(publisher.published)
-            and publisher.published[-1].data.status == "stopped"
+            lambda: bool(publisher.published) and publisher.published[-1].data.status == "stopped"
         )
         assert len(publisher.published) == 1, "exactly one terminal frame"
         frame = publisher.published[0]
@@ -1364,8 +1367,10 @@ async def test_a_cancel_acked_during_a_slow_respond_is_still_enacted() -> None:
         # terminal frame is the observable, not the transient registry entry.)
         spawn_gate.set()
         await _wait_until(
-            lambda: worker._publisher.published
-            and worker._publisher.published[-1].data.status == "stopped"
+            lambda: (
+                worker._publisher.published
+                and worker._publisher.published[-1].data.status == "stopped"
+            )
         )
         frame = worker._publisher.published[-1]
         assert frame.data.error is not None and frame.data.error.code == CANCELLED
@@ -1383,3 +1388,42 @@ def topic_starting(worker: Worker) -> bool:
 
 def topic_cancelled(worker: Worker) -> bool:
     return "t-slowresp" in worker._cancelled
+
+
+async def test_cancels_stay_answered_through_the_drain_window() -> None:
+    """P2-12: the control loop used to exit the instant the drain signal fired, while
+    `_children_by_topic` stayed populated for the whole `drain_grace_s` window — every
+    `url4.runctl.*` request in that window timed out, the App tombstoned a run that was
+    still executing and still billing, and the caller was told the run stopped when it
+    had not. The loop now serves until the drain phase completes, so a cancel issued
+    mid-drain is answered and enacted."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-drainctl", "'hi'", 60))]])
+    procs: list[_FakeProcess] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    publisher = _FakePublisher()
+    control = _FakeControl()
+    worker = _worker(
+        queue, publisher, slots=1, spawn=fake_spawn, control=control, drain_grace_s=0.3
+    )
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))  # noqa: SLF001
+        ctl = tg.create_task(worker._control_loop(tg))  # noqa: SLF001
+
+        await _wait_until(lambda: len(procs) == 1)
+        worker._draining.set()  # noqa: SLF001 — the drain signal fires; the run is draining
+        # Let the signal resolve the control loop's pending wait BY ITSELF first: feeding
+        # in the same tick lets a drain-exiting loop observe both waiters done and handle
+        # the request anyway — the exact schedule-order dependence the fix removes.
+        await asyncio.sleep(0.05)
+        msg = _FakeControlMessage("url4.runctl.t-drainctl")
+        control.feed(msg)
+        await _wait_until(lambda: bool(msg.replied))
+        assert procs[0].terminate_calls == 1, "the mid-drain request must SIGTERM the child"
+        assert msg.replied == [b"ok"]
+        await claim
+        await ctl

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -22,6 +22,7 @@ from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.runner_queue import encode_message
 from screamingface_engine.worker.loop import Worker
 from screamingface_engine.worker.supervisor import (
+    CANCELLED,
     CHILD_EXITED,
     DEADLINE_EXCEEDED,
     KILLED,
@@ -152,6 +153,7 @@ def _worker(
         heartbeat_interval_s=kwargs.pop("heartbeat_interval_s", 20.0),
         deadline_margin_s=kwargs.pop("deadline_margin_s", 30.0),
         kill_grace_s=kwargs.pop("kill_grace_s", 0.05),
+        control=kwargs.pop("control", None),
     )
 
 
@@ -1153,3 +1155,76 @@ async def test_an_unreadable_stream_grace_does_not_kill_the_pod_either() -> None
 
     assert len(spawns) == 1, "the run must be executed, not lost to a malformed grace"
     assert msg.acked
+
+
+# --- 10. the control subject (OME-1090) ----------------------------------------------------
+
+
+class _FakeControlMessage:
+    """A control request: records whether (and how) the worker replied."""
+
+    def __init__(self, subject: str) -> None:
+        self.subject = subject
+        self.data = b""
+        self.replied: list[bytes] = []
+
+    async def respond(self, data: bytes = b"") -> None:
+        self.replied.append(data)
+
+
+class _FakeControl:
+    """A control channel the test feeds requests into, one at a time."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[_FakeControlMessage] = asyncio.Queue()
+
+    def feed(self, msg: _FakeControlMessage) -> None:
+        self._queue.put_nowait(msg)
+
+    async def subscribe(self, subject: str) -> Any:
+        async def _messages() -> Any:
+            while True:
+                yield await self._queue.get()
+
+        return SimpleNamespace(messages=_messages())
+
+
+async def test_the_control_request_reaches_only_the_owning_worker() -> None:
+    """A control request for a topic this worker owns is answered and SIGTERMs the child;
+    a request for a topic it does not own is ignored — no reply, so the App's timeout
+    falls back to the tombstone."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t1", "'hi'", 60))]])
+    procs: list[_FakeProcess] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    publisher = _FakePublisher()
+    control = _FakeControl()
+    worker = _worker(queue, publisher, slots=1, spawn=fake_spawn, control=control)
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))
+        ctl = tg.create_task(worker._control_loop(tg))
+
+        await _wait_until(lambda: len(procs) == 1)
+        owned = _FakeControlMessage("url4.runctl.t1")
+        foreign = _FakeControlMessage("url4.runctl.t2")
+        control.feed(owned)
+        control.feed(foreign)
+
+        await _wait_until(lambda: bool(owned.replied))
+        assert not foreign.replied, "a non-owner must not reply"
+        assert procs[0].terminate_calls == 1
+
+        # The child died on SIGTERM; the supervisor classifies the death as a cancel and
+        # publishes the one `Terminated(stopped)` frame.
+        await _wait_until(
+            lambda: bool(publisher.published) and publisher.published[-1].data.status == "stopped"
+        )
+        frame = publisher.published[-1]
+        assert frame.data.error is not None and frame.data.error.code == CANCELLED
+
+        claim.cancel()
+        ctl.cancel()

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1260,6 +1260,7 @@ async def test_run_completes_after_the_drain_signal_with_a_control_channel_attac
     assert publisher.published[-1].data.status == "stopped"
 
 
+
 async def test_a_cancel_during_the_spawn_window_is_answered_and_enacted() -> None:
     """A cancel that lands between the supervisor's terminal-frame check and the child's
     registration used to get NO reply — the control loop ignored it, the App's timeout
@@ -1306,3 +1307,79 @@ async def test_a_cancel_during_the_spawn_window_is_answered_and_enacted() -> Non
 
         claim.cancel()
         ctl.cancel()
+
+
+# --- review follow-up: the cancel must be recorded before the ack that promises it ----------
+
+
+class _GatedRespondControlMessage(_FakeControlMessage):
+    """A control request whose `respond` SUSPENDS until released — the network I/O window
+    the old ordering raced in."""
+
+    def __init__(self, subject: str, gate: asyncio.Event) -> None:
+        super().__init__(subject)
+        self._gate = gate
+
+    async def respond(self, data: bytes = b"") -> None:
+        await self._gate.wait()
+        await super().respond(data)
+
+
+async def test_a_cancel_acked_during_a_slow_respond_is_still_enacted() -> None:
+    """`respond` is real network I/O — a suspension point. The old order (ack, THEN
+    record the cancel) let the spawn complete and the supervisor's registration check
+    (`if topic in self._cancelled`) run inside that window: the mark was absent, the
+    child was never terminated, and the App — already holding "ok" — wrote no tombstone:
+    the caller believed the run was stopped while it ran to completion. The mark now
+    precedes the ack, so the registration check sees it on every schedule order."""
+
+    spawn_gate = asyncio.Event()
+    respond_gate = asyncio.Event()
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> Any:
+        await spawn_gate.wait()  # mid-spawn (fork/exec) until the test releases it
+        return proc
+
+    proc = _FakeProcess(hang=True)
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-slowresp", "'hi'", 60))]])
+    control = _FakeControl()
+    worker = _worker(queue, _FakePublisher(), slots=1, spawn=fake_spawn, control=control)
+
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))
+        ctl = tg.create_task(worker._control_loop(tg))
+
+        # The run is STARTING (spawn suspended); the cancel arrives mid-spawn.
+        await _wait_until(lambda: "t-slowresp" in worker._starting)
+        cancel = _GatedRespondControlMessage("url4.runctl.t-slowresp", respond_gate)
+        control.feed(cancel)
+        # The control loop is now suspended INSIDE respond() — with the mark already
+        # recorded (the fix); in the old order the mark did not exist yet.
+        await _wait_until(lambda: "t-slowresp" in worker._cancelled)
+
+        # The spawn completes while the ack is still in flight: the registration check
+        # runs HERE, on every schedule order — and with the mark already recorded it
+        # terminates the child the moment it exists. (The whole post-spawn chain is one
+        # scheduling step — no await between register and terminate — so the DURABLE
+        # terminal frame is the observable, not the transient registry entry.)
+        spawn_gate.set()
+        await _wait_until(
+            lambda: worker._publisher.published
+            and worker._publisher.published[-1].data.status == "stopped"
+        )
+        frame = worker._publisher.published[-1]
+        assert frame.data.error is not None and frame.data.error.code == CANCELLED
+
+        respond_gate.set()  # the ack finally leaves — AFTER the cancel was already enacted
+        await _wait_until(lambda: cancel.replied == [b"ok"])
+
+        claim.cancel()
+        ctl.cancel()
+
+
+def topic_starting(worker: Worker) -> bool:
+    return "t-slowresp" in worker._starting
+
+
+def topic_cancelled(worker: Worker) -> bool:
+    return "t-slowresp" in worker._cancelled

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1228,3 +1228,33 @@ async def test_the_control_request_reaches_only_the_owning_worker() -> None:
 
         claim.cancel()
         ctl.cancel()
+
+
+async def test_run_completes_after_the_drain_signal_with_a_control_channel_attached() -> None:
+    """`Worker.run()` must RETURN once the drain signal fires — even with the control
+    channel attached. The TaskGroup awaits `_control_loop`, whose message iterator only
+    ends when the connection closes, and `run_worker` closes that only AFTER `run()`
+    returns: a control loop that cannot exit turns every rolling deploy into a hang
+    until the kubelet SIGKILLs the pod — the deploy-interrupts-runs regression the
+    drain exists to prevent."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-run", "'hi'", 60))]])
+    procs: list[_FakeProcess] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    publisher = _FakePublisher()
+    control = _FakeControl()
+    worker = _worker(
+        queue, publisher, slots=1, spawn=fake_spawn, control=control, drain_grace_s=0.05
+    )
+    run_task = asyncio.create_task(worker.run())
+
+    await _wait_until(lambda: len(procs) == 1)
+    worker._draining.set()  # exactly what the SIGTERM handler in run() does
+    await asyncio.wait_for(run_task, timeout=5.0)  # must COMPLETE, not hang
+
+    assert procs[0].terminate_calls == 1
+    assert publisher.published[-1].data.status == "stopped"

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1345,7 +1345,10 @@ async def test_a_cancel_acked_during_a_slow_respond_is_still_enacted() -> None:
     proc = _FakeProcess(hang=True)
     queue = _FakeQueue([[_FakeMsg(encode_message("t-slowresp", "'hi'", 60))]])
     control = _FakeControl()
-    worker = _worker(queue, _FakePublisher(), slots=1, spawn=fake_spawn, control=control)
+    # Bound to a local instead of read back via `worker._publisher` (typed to the
+    # `_Publisher` Protocol, which rightly does not declare `published`).
+    publisher = _FakePublisher()
+    worker = _worker(queue, publisher, slots=1, spawn=fake_spawn, control=control)
 
     async with asyncio.TaskGroup() as tg:
         claim = tg.create_task(worker._claim_loop(tg))
@@ -1366,12 +1369,9 @@ async def test_a_cancel_acked_during_a_slow_respond_is_still_enacted() -> None:
         # terminal frame is the observable, not the transient registry entry.)
         spawn_gate.set()
         await _wait_until(
-            lambda: (
-                worker._publisher.published
-                and worker._publisher.published[-1].data.status == "stopped"
-            )
+            lambda: publisher.published and publisher.published[-1].data.status == "stopped"
         )
-        frame = worker._publisher.published[-1]
+        frame = publisher.published[-1]
         assert frame.data.error is not None and frame.data.error.code == CANCELLED
 
         respond_gate.set()  # the ack finally leaves — AFTER the cancel was already enacted

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1260,8 +1260,7 @@ async def test_run_completes_after_the_drain_signal_with_a_control_channel_attac
     assert publisher.published[-1].data.status == "stopped"
 
 
-
-async def test_a_cancel_during_the_spawn_window_is_answered_and_enacted() -> None:
+async def test_a_cancel_during_the_spawn_window_is_answered_and_enacted() -> None:  # noqa: PLR0915
     """A cancel that lands between the supervisor's terminal-frame check and the child's
     registration used to get NO reply — the control loop ignored it, the App's timeout
     expired and it tombstoned the queued run, and the child ran to completion and

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1258,3 +1258,51 @@ async def test_run_completes_after_the_drain_signal_with_a_control_channel_attac
 
     assert procs[0].terminate_calls == 1
     assert publisher.published[-1].data.status == "stopped"
+
+
+async def test_a_cancel_during_the_spawn_window_is_answered_and_enacted() -> None:
+    """A cancel that lands between the supervisor's terminal-frame check and the child's
+    registration used to get NO reply — the control loop ignored it, the App's timeout
+    expired and it tombstoned the queued run, and the child ran to completion and
+    published its own terminal frame: TWO terminal frames for one run. The control loop
+    now answers from the starting registry (so the App writes nothing) and the supervisor
+    enacts the cancel the moment the child exists."""
+    queue = _FakeQueue([[_FakeMsg(encode_message("t-race", "'hi'", 60))]])
+    procs: list[_FakeProcess] = []
+    spawn_entered = asyncio.Event()
+    release_spawn = asyncio.Event()
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawn_entered.set()
+        await release_spawn.wait()  # the cancel lands HERE, mid-spawn
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    publisher = _FakePublisher()
+    control = _FakeControl()
+    worker = _worker(queue, publisher, slots=1, spawn=fake_spawn, control=control)
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))
+        ctl = tg.create_task(worker._control_loop(tg))
+
+        await _wait_until(lambda: spawn_entered.is_set())
+        assert worker._starting == {"t-race"}, "the claim loop registers the run before spawn"
+
+        cancel = _FakeControlMessage("url4.runctl.t-race")
+        control.feed(cancel)
+        await _wait_until(lambda: bool(cancel.replied))
+        assert "t-race" in worker._cancelled, "the cancel is acknowledged, not ignored"
+
+        release_spawn.set()
+        await _wait_until(lambda: procs and procs[0].terminate_calls == 1)
+        await _wait_until(
+            lambda: bool(publisher.published)
+            and publisher.published[-1].data.status == "stopped"
+        )
+        assert len(publisher.published) == 1, "exactly one terminal frame"
+        frame = publisher.published[0]
+        assert frame.data.error is not None and frame.data.error.code == CANCELLED
+
+        claim.cancel()
+        ctl.cancel()

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1426,3 +1426,73 @@ async def test_cancels_stay_answered_through_the_drain_window() -> None:
         assert msg.replied == [b"ok"]
         await claim
         await ctl
+
+
+# --- 11. a cancel accepted in the starting window is a PROMISE (pass-3 #3) -----------------
+
+
+async def test_a_cancel_accepted_while_starting_is_enacted_not_lost_to_an_unreadable_tail() -> None:
+    """Pass-3 #3: the control loop answers `ok` for a topic in `_starting`, so
+    `QueueJobRunner.stop()` takes the "a worker owns it" branch and writes NO tombstone —
+    the worker now owns the promise that the run is stopped, and the client already has its
+    204. That promise lived only in the in-memory `_cancelled` set, and `supervise`'s
+    `finally` discards it on EVERY exit — including `_claim`'s early return on an
+    unreadable tail, which does not ack. The message then redelivered, found no terminal
+    frame anywhere (the App wrote none, the worker published none), passed every claim
+    gate, and executed the run to completion — a run the caller was told was stopped.
+
+    INVARIANT: the cancel is enacted BEFORE the tail read, and the terminal frame is what
+    makes it durable. A redelivery — to this worker or, since the durable consumer is
+    shared, to any other — sees the frame at its own claim gate and acks it away."""
+    topic = "t-cancel-starting"
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    spawns: list[Any] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawns.append(kwargs)
+        return _FakeProcess(0)
+
+    class _UnreadableTailPublisher(_FakePublisher):
+        """The tail read fails — the blip that used to strand the promise."""
+
+        async def last_frame(self, topic: str) -> TerminatedEvent | None:
+            raise QueueReadError("stream tail unreadable")
+
+    publisher = _UnreadableTailPublisher()
+    worker = _worker(_FakeQueue(), publisher, spawn=fake_spawn)
+    # What the control loop does when a cancel lands on a topic that is still starting.
+    worker._cancelled.add(topic)  # noqa: SLF001
+
+    await worker._supervisor.supervise(msg)
+
+    assert not spawns, "a run already cancelled must never be spawned"
+    assert len(publisher.published) == 1, "the accepted cancel must leave a terminal frame"
+    frame = publisher.published[0]
+    assert frame.data.status == "stopped"
+    assert frame.data.error is not None and frame.data.error.code == CANCELLED
+    assert msg.acked, "the settled cancel must not redeliver into an execution"
+
+
+async def test_a_run_cancelled_before_it_starts_is_stopped_without_spawning() -> None:
+    """The same promise on the ordinary path, with a perfectly readable stream: a cancel
+    accepted while the topic was starting means there is nothing to execute. Spawning the
+    child and letting the control loop SIGTERM it afterwards would pay for a process, and
+    a model call or two, to reach the outcome already promised."""
+    topic = "t-cancel-clean"
+    msg = _FakeMsg(encode_message(topic, "'hi'", 60))
+    spawns: list[Any] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawns.append(kwargs)
+        return _FakeProcess(0)
+
+    publisher = _FakePublisher()
+    worker = _worker(_FakeQueue(), publisher, spawn=fake_spawn)
+    worker._cancelled.add(topic)  # noqa: SLF001
+
+    await worker._supervisor.supervise(msg)
+
+    assert not spawns, "a cancelled run must not be spawned"
+    assert len(publisher.published) == 1
+    assert publisher.published[0].data.status == "stopped"
+    assert msg.acked

--- a/apps/screamingface-engine/tests/unit/test_worker_composition_replicas.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_composition_replicas.py
@@ -25,23 +25,17 @@ class _RecordingQueue:
         type(self).last_kwargs = dict(kwargs)
 
 
-class _NoopWorker:
-    """Stands in for `Worker`. `run` is a real coroutine, so `run_worker`'s own
-    `asyncio.run(...)` runs untouched — patching `asyncio.run` would reach far beyond this
-    test."""
-
-    def __init__(self, **kwargs: Any) -> None:
-        pass
-
-    async def run(self) -> None:
-        return None
-
-
 def _composed_queue_kwargs(monkeypatch: pytest.MonkeyPatch, settings: Settings) -> dict[str, Any]:
-    """Run `run_worker` with its collaborators stubbed, and return the queue's kwargs.
+    """Build the worker's queue from Settings and return the kwargs it was given.
 
-    `RunQueue` and `JetStreamPublisher` are imported INSIDE `run_worker`, so patching the
-    attribute on their defining module is what the call-time import picks up.
+    AIDEV-NOTE: this drove `run_worker` when it was written (OME-1089). OME-1090 gave
+    `run_worker` a real `nats.connect` for the run-control channel, so calling it from a unit
+    test now blocks on a live broker — the tests hung rather than failed. That same change
+    extracted `worker_composition` for exactly this purpose, so the test targets the seam the
+    branch created. Every assertion below is unchanged; only the entry point moved.
+
+    `RunQueue` and `JetStreamPublisher` are imported INSIDE `worker_composition`, so patching
+    the attribute on their defining module is what the call-time import picks up.
     """
     import screamingface_engine.adapters.jetstream as jetstream_mod
     import screamingface_engine.runner_queue as runner_queue_mod
@@ -50,9 +44,8 @@ def _composed_queue_kwargs(monkeypatch: pytest.MonkeyPatch, settings: Settings) 
     _RecordingQueue.last_kwargs = {}
     monkeypatch.setattr(runner_queue_mod, "RunQueue", _RecordingQueue)
     monkeypatch.setattr(jetstream_mod, "JetStreamPublisher", lambda *a, **k: object())
-    monkeypatch.setattr(loop, "Worker", _NoopWorker)
 
-    loop.run_worker(settings)
+    loop.worker_composition(settings)
     return _RecordingQueue.last_kwargs
 
 

--- a/docs/work/2026-09-02-OME-1090-status-and-cancellation.md
+++ b/docs/work/2026-09-02-OME-1090-status-and-cancellation.md
@@ -1,0 +1,88 @@
+---
+ticket: OME-1090
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-02
+finished:
+---
+
+# OME-1090 — Derive run status from the event stream and make cancellation queue-aware
+
+## Intent
+
+Status and cancellation currently read and mutate a Kubernetes Job. With no Job,
+both need a new source of truth — and the honest one already exists: the run's
+own event stream. Status becomes a pure function of the event stream plus
+capability validity (terminal frame → its outcome; `StartedEvent` without one →
+running; neither, capability unexpired → scheduled; neither, capability expired
+→ not_found). No new store, correct across App replicas, and it retires
+OME-1059's conflation structurally. Cancellation of a queued run writes
+`Terminated(stopped)` so the worker later claims, sees it, and never executes; a
+running run is reached over a control subject.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py`
+  (new) — `QueueJobRunner(IdentityAwareJobRunner)`: `schedule()` publishes;
+  `stop()` writes the tombstone and sends the control request; `status()` /
+  `exists()` derive from the event stream plus capability validity.
+- `apps/screamingface-engine/src/screamingface_engine/adapters/factory.py`
+  (modify) — select it.
+- `apps/screamingface-engine/src/screamingface_engine/worker/loop.py` (modify) —
+  control subscription (`url4.runctl.*`; only the owner replies).
+- `apps/screamingface-engine/src/screamingface_engine/app.py` (modify) —
+  subscribe to `$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.*` and publish a
+  named terminal failure for a run the queue gave up on.
+- `apps/screamingface-engine/src/screamingface_engine/ws/bridge.py` (modify) —
+  queue-position notice through the existing `add_notifier` path.
+- Tests: `tests/unit/test_queue_runner_*.py` (new).
+
+## Test plan
+
+- RED: the spec's status truth table, one test per row, including the
+  capability-expiry boundary between `scheduled` and `not_found`.
+- RED: cancel-before-claim — `DELETE /` writes `Terminated(stopped)`; the worker
+  then claims, skips, and acks exactly once.
+- RED: cancel-while-running — the control request reaches only the owning
+  worker; the child is terminated; `Terminated(stopped)` appears once.
+- RED: `stop()` on an unknown topic stays idempotent and `DELETE /` still
+  returns 204.
+- RED: `RunReaper` audience loss cancels a queued run.
+- RED: the queue-position notice reaches an attached socket and is superseded
+  once `StartedEvent` arrives.
+
+## Acceptance
+
+- `QueueJobRunner` implements `IdentityAwareJobRunner` with no port changes.
+- Status is a pure function of the event stream; no new store.
+- Engine stack gates green (cov >= 80).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - New: `src/screamingface_engine/adapters/queue_runner.py` (`QueueJobRunner` +
+    `ControlClient`), `src/screamingface_engine/adapters/max_deliveries.py`
+    (`MaxDeliveriesAdvisor`), `tests/unit/test_queue_runner_status.py`,
+    `tests/unit/test_queue_runner_cancel.py`, `tests/unit/test_queue_position_notice.py`,
+    `tests/unit/test_max_deliveries_advisory.py`.
+  - Modified: `adapters/factory.py` (selects the queue backend), `adapters/jetstream.py`
+    (`stream_exists`), `app.py` (advisor installer + queue-runner `aclose` wiring),
+    `config.py` (`RunnerBackend` gains `"queue"`), `notices.py` (`info`),
+    `rest/routes.py` (queue-position notice), `subjects.py` (`url4.runctl`),
+    `worker/loop.py` (control subscription), `worker/supervisor.py` (`CANCELLED`,
+    `children_by_topic`, `cancelled`), `tests/unit/test_worker_claim.py`,
+    `tests/unit/test_reaper.py`, `tests/unit/test_runners_factory.py`.
+- **Commits:** <sha — message>
+- **Gates:** ruff check/format clean, pyright 0 errors, layering OK, pytest
+  `2333 passed, 8 skipped` at 90.96% coverage (floor 80%).
+- **Deviations:**
+  - `exists()` answers True only for `scheduled`/`running` (a terminal run does not
+    exist) — the reaper's contract, which keeps an audience-loss stop from landing a
+    second terminal frame on a finished run. This matches the in-process runner and
+    differs from k8s (where a finished Job exists until TTL).
+  - The capability-validity input is an in-memory schedule-time record (like
+    `InProcessJobRunner._tasks`), not a durable store; the terminal/running rows are
+    cross-replica correct, the scheduled/not_found boundary is local (documented in the
+    adapter docstring).
+  - `_build_artifact_reader` now refuses filesystem storage for `runner="queue"` too
+    (the run executes in a worker pod, not this App's disk).

--- a/docs/work/2026-09-03-OME-1090-app-passes-replica-count.md
+++ b/docs/work/2026-09-03-OME-1090-app-passes-replica-count.md
@@ -1,0 +1,102 @@
+---
+ticket: OME-1090
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-03
+finished:
+---
+
+# OME-1090 — the App's composition root passes the queue's replica count
+
+## Intent
+
+`build_job_runner` builds the `QueueJobRunner`'s `RunQueue` for the serving half, and it
+omitted `replicas` — so the App declared the queue stream with the code default regardless of
+configuration. OME-1088 made the count a setting and OME-1089 wired the worker half; this
+completes the pair.
+
+The App half is the one that usually declares the stream first, because the App accepts a run
+before any worker pulls it. `ensure_stream` refuses a declaration whose properties diverge
+from an existing stream, so leaving this half unwired means the App and the worker can
+disagree — and on a clustered broker the second declarer fails at startup.
+
+Found by manual e2e deployment of the OME-1086 stack on a single-node kind cluster
+(2026-09-03 findings, B2).
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/adapters/factory.py` — pass
+  `replicas=settings.run_queue_replicas` in the `queue` branch of `build_job_runner`.
+- `apps/screamingface-engine/tests/unit/test_factory_queue_replicas.py` — NEW file
+  (tests are append-only; no prior test is touched).
+
+## Test plan
+
+- The App's queue carries the CONFIGURED replica count, asserted with a non-default value so
+  a dropped argument cannot pass.
+- The default path yields the single-node-safe count.
+- The invariant that matters: for any `Settings`, the App half and the worker half declare the
+  SAME replica count — the property whose absence `ensure_stream` turns into a startup failure.
+
+## Acceptance
+
+- `build_job_runner(settings)` produces a runner whose queue uses `settings.run_queue_replicas`.
+- `run_gates.py screamingface-engine` green.
+
+## Outcome
+
+- **Actual files:** as planned, plus a typing-only repair to four prior test files
+  (see Deviations).
+  - `src/screamingface_engine/adapters/factory.py` — the `queue` branch passes
+    `replicas=settings.run_queue_replicas`, with the declare-order invariant anchored.
+  - `tests/unit/test_factory_queue_replicas.py` — NEW.
+  - `tests/unit/test_max_deliveries_advisory.py`, `test_queue_runner_cancel.py`,
+    `test_runners_factory.py`, `test_worker_claim.py` — EDITED, typing only.
+- **Commits:**
+  1. `fix(engine): satisfy pyright across the queue and worker tests`
+  2. `fix(engine): the App declares the queue with its configured replica count`
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only`. RED was observed first
+  and for the right reason: `KeyError: 'replicas'` on all five new tests. Notably the
+  cross-half test failed on the APP side only, confirming OME-1089 had already wired the
+  worker.
+- **Deviations:**
+  1. **This branch carried 14 pyright errors of its own**, on top of the 5 fixed on
+     OME-1089 — in `test_max_deliveries_advisory.py`, `test_queue_runner_cancel.py`,
+     `test_runners_factory.py` and `test_worker_claim.py`. Measured across the stack, the
+     breakage is systemic: #819 red, #821 at 22 errors, #822 at 23. **No PR from #818
+     upward has ever had a green CI run.** The owner was shown these numbers and gave a
+     blanket approval to repair them per branch as typing-only commits.
+  2. **Four prior test files were edited, typing only.** No assertion, fake behavior or
+     test meaning changed: a `Literal` status parameter, a helper widened to the production
+     `_ControlClient` Protocol (rather than a union — both fakes already satisfy it), an
+     `assert isinstance(runner, QueueJobRunner)` narrowing plus casts where the tests reach
+     private collaborators through Protocol-typed attributes, and one fake bound to a local
+     instead of read back through a Protocol-typed field. No `# type: ignore` was used
+     anywhere — the stack card forbids it. Landed as its own commit for independent review.
+  3. **The mechanical repair was delegated** to an implementer subagent against an explicit
+     error list and fix-pattern spec; its diff was reviewed line by line here before being
+     accepted. The substantive wiring and its tests were written in the main loop.
+  4. **The delegated agent's work was silently lost and had to be recovered.** It ran
+     `git stash` instead of leaving changes in the tree, and the stash stack is shared across
+     every worktree in the clone — so 14 reviewed-and-accepted fixes vanished from this
+     worktree with nothing in `git status` or `git log` to show it. The gate re-reporting the
+     original 14 errors is what caught it. Recovered by matching the stash entry to this
+     worktree's HEAD, verifying its contents, and `git stash apply` BY SHA (never `pop`:
+     `stash@{1}` and `{2}` belong to other sessions). Delegation prompts must forbid `git
+     stash` explicitly, not just `git commit`.
+  5. **`test_worker_composition_replicas.py` was retargeted** from `run_worker` to
+     `worker_composition`. It is a prior test — authored on OME-1089 one commit below — and it
+     did not merely fail here, it HUNG: OME-1090 gives `run_worker` a real
+     `nats.connect(settings.nats_url)` for the run-control channel, so a unit test driving it
+     blocks on a live broker. The same OME-1090 change extracted `worker_composition` for
+     exactly this reason (its own docstring says so), which is the seam the test now uses.
+     **No assertion, parameter or expected value changed** — only the entry point — so this
+     adapts a test to a legitimate refactor rather than weakening it to make new code pass.
+     An `AIDEV-NOTE` at the helper records the move and why.
+
+## Follow-ups surfaced (not in this unit)
+
+- The stack's test suite reaches into private collaborators (`runner._queue._stream`) in
+  several places, which is what makes it fragile under pyright. A cleaner seam — exposing
+  what the tests actually need to assert — would be worth considering, but changing test
+  structure is out of scope for a blocker fix.


### PR DESCRIPTION
## What

Makes run status and cancellation work without a Job object: status is derived from the run's event stream, stopping a run reaches the worker that owns it over a control channel (or tombstones a queued one), the orphan reaper stops runs whose audience vanished, and the configured stream name is wired to every composition root.

## Why

With the worker pool, the App no longer owns the k8s Job — it cannot read status from the cluster or stop a run by deleting a Job. Status must come from the run's own event stream, and a stop must be enacted by the worker that is running the child.

## Key changes

- Status from the event stream: a terminal frame is the outcome; a `Started` frame means running; neither means scheduled (or not_found once the capability expires).
- Control loop answers `url4.runctl.<topic>` through the whole drain window (P2-12), so a cancel issued mid-drain is answered and enacted instead of timing out while the App tombstones a still-billing run.
- `stop()`: tombstone-before-ask ordering closes the claim race; the re-read guard keeps a run that finished during the ask its real outcome; an unreadable tail is a typed error, not a silent no-op (V-2/V-3) — the REST edge answers a retryable 503 and the reaper re-arms instead of counting a false reap.
- The orphan reaper: pop-first claim with re-arm on any failure.
- The stream-name wiring cluster (P2-2/3/4/6): `run_queue_stream` and `run_queue_subject_prefix` reach the App's queue, every publisher, the max-deliveries advisor, and the event-stream consumer — one `Settings` drives all roots.
- Advisor reconnect leak (P2-5): every `run()` iteration closes the previous connection pair.
- Tests: status derivation, cancel-through-drain, tombstone ordering, reaper re-arm (including the real-composition case), the 503-not-409 routes, the all-roots wiring test.

## Stack

Part of the OME-1086 worker-pool migration: #815 → #816 → #818 → #819 → #821 → #822. Stacked on #818; the base for #821.

## Gates

- ruff check / ruff format --check: clean
- pytest: 2363 passed / 5 skipped (only the known macOS `RLIMIT_AS` flake excluded)
- check_layering: OK

Refs: OME-1090
