### PR TITLE
fix(scoreboard): close partial-run leaderboard follow-ups

### DIFF
--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -350,5 +350,12 @@ async def get_frontier(benchmark_id: str, request: Request) -> FrontierResponse:
             detail=FRONTIER_NOT_AVAILABLE_DETAIL,
             headers=PRIVATE_CACHE_HEADERS,
         )
-    result = compute_frontier(scores=scores, baselines=baselines)
+    # OME-1056: the same coverage rule the ranking applies. `benchmark` was read at the top of
+    # this handler and its `case_count` is the board's canonical scope; a partial run must not
+    # own the frontier while being hidden from the table on the same page.
+    result = compute_frontier(
+        scores=scores,
+        baselines=baselines,
+        registered_case_count=benchmark.case_count,
+    )
     return FrontierResponse(benchmark_id=benchmark_id, **result.model_dump())

--- a/apps/scoreboard/src/scoreboard/scores/frontier.py
+++ b/apps/scoreboard/src/scoreboard/scores/frontier.py
@@ -48,14 +48,47 @@ def _compute_trend(scores: list[ScoreSchema]) -> tuple[FrontierPoint | None, lis
     return current, trend
 
 
+def _comparable(scores: list[ScoreSchema], registered_case_count: int | None) -> list[ScoreSchema]:
+    """Drop runs that covered fewer cases than the benchmark defines (OME-1056).
+
+    INVARIANT: the same rule the RANKING applies, applied here too. It lived only in
+    `_build_leaderboard_query`, so a one-case run scoring 1.0 was hidden from the table while
+    this frontier still published it — on the same page, from the same benchmark. A partial run
+    is advantaged rather than merely admitted, because fewer cases makes a perfect score easier.
+
+    WHY it matters more here than in the ranking: `_compute_trend` advances the holder only on a
+    STRICT improvement, so a partial 1.0 becomes `current` and no complete run — 0.99, anything
+    short of a tie-break — can ever displace it. The table's version of this bug is a wrong row
+    ordering; this one is permanent.
+
+    `None` means the board has no registered count, so nothing is comparable-or-not and every row
+    stands, exactly as before this change.
+    """
+    if registered_case_count is None:
+        return scores
+    return [score for score in scores if score.total_questions >= registered_case_count]
+
+
 def compute_frontier(
     scores: list[ScoreSchema],
     baselines: list[BaselineSchema],
+    registered_case_count: int | None = None,
 ) -> FrontierResult:
     """Two independent passes (spec §6's baseline-timing resolution — deliberately
     NOT one merged computation): the current open/closed split over all rows
     (`_current_split`), and the trend over Score rows only (`_compute_trend`).
+
+    Both passes see only comparable runs — see `_comparable`.
+
+    AIDEV-NOTE: `registered_case_count` defaults to None, meaning "rank everything" — the weaker
+    of the two signatures, chosen deliberately. Required is safer and is what
+    `_build_leaderboard_query` does, but seven prior tests call this function and rule 5 makes
+    editing them an owner decision a keyword default does not justify. The realistic regression is
+    someone editing the route, not a second caller appearing, and
+    `test_the_frontier_route_passes_the_registered_case_count` pins that. If a second production
+    caller does appear, make this required and take the seven-site approval then (OME-1056).
     """
+    scores = _comparable(scores, registered_case_count)
     open_count, closed_count, open_share = _current_split(scores, baselines)
     current, trend = _compute_trend(scores)
 

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -41,6 +41,13 @@ logger = logging.getLogger(__name__)
 IDEMPOTENCY_TTL = timedelta(hours=24)
 
 
+class _Unset:
+    """Distinguish an omitted update field from an explicit database NULL."""
+
+
+_UNSET = _Unset()
+
+
 def benchmark_to_schema(model: Benchmark) -> BenchmarkSchema:
     """The ONE Benchmark -> DTO mapping.
 
@@ -371,7 +378,11 @@ def _build_leaderboard_query(
     benchmark_id: str,
     top_n: int,
     registered_revision: str | None,
-    registered_case_count: int | None = None,
+    # WHY no default: a coverage guard that can be forgotten is a guard that reopens the hole one
+    # call site over. `registered_revision` beside it is required for the same reason, and the
+    # store already states this rule for `_content_hash(per_submitter=...)`. `None` still means
+    # "this board has no registered count", which is a real state — it just has to be said.
+    registered_case_count: int | None,
 ) -> QueryBuilder:
     scores = Score.get_table()
     # INVARIANT: every entry the board ranks was measured against the revision the benchmark is
@@ -464,7 +475,7 @@ class ScoreStore:
         revision: str | None = None,
         focus: str | None = None,
         visibility: Visibility | None = None,
-        case_count: int | None = None,
+        case_count: int | None | _Unset = _UNSET,
     ) -> BenchmarkSchema:
         defaults: dict[str, object] = {
             "display_name": display_name,
@@ -472,8 +483,14 @@ class ScoreStore:
             "dataset_url": dataset_url,
             "revision": revision,
             "focus": focus,
-            "case_count": case_count,
         }
+        if not isinstance(case_count, _Unset):
+            # WHY a sentinel, unlike `visibility` below: direct callers may omit `case_count` to
+            # leave an existing value alone, but an authoritative Engine seed passes explicit
+            # None when its catalogue has no usable count. That must CLEAR a stale value; keeping
+            # the old count beside a newly seeded revision would compare runs against a scope the
+            # Engine no longer claims. A plain None default cannot express both states (OME-1056).
+            defaults["case_count"] = case_count
         if visibility is not None:
             # WHY conditional (OME-894): seeding runs on every deploy, and an omitted visibility
             # must mean "leave it alone" rather than "reset to public" — otherwise a routine

--- a/apps/scoreboard/src/scoreboard/seed.py
+++ b/apps/scoreboard/src/scoreboard/seed.py
@@ -85,7 +85,7 @@ class _CatalogEntry(BaseModel):
     AIDEV-NOTE: ``extra="ignore"`` deliberately, opposite to :class:`SeedBenchmark`'s
     ``extra="forbid"``. A configured entry is written by hand here, so a typo must fail the
     deploy; the catalogue is written by another service that will keep growing fields
-    (``case_count``, ``href``, ``check_surface``, whatever comes next), and a board that
+    (``href``, ``check_surface``, whatever comes next), and a board that
     refuses to seed because the Engine added a field is a board that breaks on someone else's
     release. Read the fields the board displays; ignore the rest.
     """
@@ -113,7 +113,28 @@ class _CatalogEntry(BaseModel):
     # `extra="ignore"`, which is why a one-case run could rank as though it were complete.
     # Optional for the same reason `description` is: a catalogue that omits it costs the board
     # its ranking filter, not the benchmark its row.
-    case_count: int | None = Field(default=None, ge=1)
+    case_count: int | None = None
+
+    @field_validator("case_count", mode="before")
+    @classmethod
+    def _unusable_count_is_absent(cls, value: object) -> int | None:
+        """Normalise anything that is not a usable count to None, never reject the entry.
+
+        WHY not `ge=1` here, while `SeedBenchmark` keeps it: this class's doctrine is "require it
+        where it is WRITTEN; tolerate it where it is READ". `ge=1` on the catalogue turned a
+        previously-discarded field into a whole-entry rejection, so a published `case_count: 0` —
+        a benchmark whose dataset failed to load — costs the benchmark its ROW: a new board is
+        never created and an existing board's text stops refreshing, while the deploy exits 0.
+        The field's own comment two lines up already promised the milder outcome.
+
+        Tolerant of the TYPE as well as the value, because the failure being guarded is another
+        service changing a field this board does not own: `{"total": 541}` and `"541"` must both
+        cost the ranking filter, not the row. `bool` is rejected explicitly — it subclasses `int`,
+        so `True` would otherwise arrive as a case count of 1 (OME-1056).
+        """
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            return None
+        return value
 
     @field_validator("description", "focus", mode="after")
     @classmethod

--- a/apps/scoreboard/tests/unit/scores/test_frontier.py
+++ b/apps/scoreboard/tests/unit/scores/test_frontier.py
@@ -174,3 +174,72 @@ def test_openness_override_changes_the_holders_reported_openness() -> None:
     assert result.current.openness == "open"
     assert result.open_count == 1
     assert result.closed_count == 0
+
+
+def _coverage_score(
+    *, spec_id: str, score: float, total_questions: int, minute: int
+) -> ScoreSchema:
+    """A score whose `total_questions` varies — the prior `_score` helper hardcodes it to 10.
+
+    Built here rather than by extending that helper: it is a prior test fixture, and rule 5 makes
+    editing one an owner decision that a new keyword argument does not justify (OME-1056).
+    """
+    return ScoreSchema(
+        id=uuid4(),
+        version=1,
+        benchmark_id="hle",
+        benchmark_revision=None,
+        run_cost_usd=None,
+        spec_id=spec_id,
+        url4_expression=f"url4://benchmark/{spec_id}",
+        submitted_by="tester",
+        submitted_at=datetime(2026, 9, 2, 12, minute, tzinfo=UTC),
+        score=score,
+        total_questions=total_questions,
+        correct_questions=None,
+        ran_with_providers=["huggingface"],
+        ran_at_local=None,
+        client_name=None,
+        client_version=None,
+        client_platform=None,
+        verified_by_screamingface=False,
+        metadata=None,
+        openness_override=None,
+    )
+
+
+def test_a_partial_run_does_not_hold_the_frontier() -> None:
+    """OME-1056: the same coverage rule the ranking applies.
+
+    INVARIANT: this is the WORSE half of the bug the ranking fix addressed. `_compute_trend`
+    advances the holder only on a STRICT improvement, so a one-case 1.0 becomes `current` and no
+    complete run can ever displace it — the table's version is a wrong ordering, this one is
+    permanent. Before this filter the board hid the partial run from the ranking while publishing
+    it as the state of the art on the same page.
+    """
+    result = compute_frontier(
+        scores=[
+            _coverage_score(spec_id="one-case-run", score=1.0, total_questions=1, minute=0),
+            _coverage_score(spec_id="honest-full-run", score=0.85, total_questions=541, minute=1),
+        ],
+        baselines=[],
+        registered_case_count=541,
+    )
+
+    assert result.current is not None
+    assert result.current.label == "honest-full-run"
+    assert [point.label for point in result.trend] == ["honest-full-run"]
+    assert result.open_count + result.closed_count == 1
+
+
+def test_a_board_with_no_registered_count_still_ranks_everything() -> None:
+    # None means the board declares no canonical scope, so nothing is comparable-or-not and the
+    # frontier behaves exactly as it did before this change.
+    result = compute_frontier(
+        scores=[_coverage_score(spec_id="one-case-run", score=1.0, total_questions=1, minute=0)],
+        baselines=[],
+        registered_case_count=None,
+    )
+
+    assert result.current is not None
+    assert result.current.label == "one-case-run"

--- a/apps/scoreboard/tests/unit/scores/test_leaderboard_coverage.py
+++ b/apps/scoreboard/tests/unit/scores/test_leaderboard_coverage.py
@@ -112,3 +112,54 @@ async def test_a_specs_complete_run_survives_its_own_higher_scoring_partial(
     ranked = await store.leaderboard("ifeval", top_n=50)
 
     assert [(e.spec_id, e.score) for e in ranked] == [("same-spec", 0.60)]
+
+
+async def test_over_reporting_the_case_count_still_ranks(tortoise_db: None) -> None:
+    """`>=` is deliberate, so a run claiming MORE cases than registered still ranks.
+
+    WHY pinned: `_build_leaderboard_query` carries a paragraph explaining the choice, and nothing
+    exercised it — tightening the predicate to `==` (or rejecting `!=`) passed the whole suite
+    while dropping every complete run whose board count had gone stale, which is the failure that
+    comment exists to prevent.
+
+    AIDEV-NOTE: this is ALSO the shape of the remaining hole, recorded rather than hidden.
+    `total_questions` is client-declared and validated only `> 0`, so a one-case run POSTing 541
+    passes this predicate and ranks. Closing that needs attestation at WRITE time, which is not
+    this ticket's scope — the read-time filter is a guard against honest partial runs, not a
+    defence against a forged scope (OME-1056).
+    """
+    store = await _board(FULL)
+    await store.submit(_submission("claims-more", 0.5, FULL + 10))
+
+    assert [e.spec_id for e in await store.leaderboard("ifeval", top_n=50)] == ["claims-more"]
+
+
+async def test_a_reseed_without_a_count_keeps_the_stored_one(tortoise_db: None) -> None:
+    """An omitted `case_count` means "leave it alone", never "forget how big this benchmark is".
+
+    Seeding runs on every deploy. Writing None unconditionally NULLed a stored count, which drops
+    the coverage predicate from the ranking query and lets partial runs rank again — with no log
+    line and a green deploy. `visibility` is guarded the same way and for the same reason.
+    """
+    store = await _board(FULL)
+    await store.register_benchmark(benchmark_id="ifeval", display_name="IFEval", revision=REV)
+    await store.submit(_submission("honest-full-run", 0.85, FULL))
+    await store.submit(_submission("one-case-run", 1.00, 1))
+
+    ranked = [entry.spec_id for entry in await store.leaderboard("ifeval", top_n=50)]
+
+    assert ranked == ["honest-full-run"], (
+        "a re-seed that did not mention case_count wiped the stored count, so the coverage "
+        "filter stopped applying"
+    )
+
+
+async def test_an_explicit_count_still_corrects_a_wrong_one(tortoise_db: None) -> None:
+    # The guard must not make the column write-once: a mis-seeded count has to be fixable.
+    store = await _board(1)
+    await store.register_benchmark(
+        benchmark_id="ifeval", display_name="IFEval", revision=REV, case_count=FULL
+    )
+    await store.submit(_submission("one-case-run", 1.00, 1))
+
+    assert await store.leaderboard("ifeval", top_n=50) == []

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -1224,3 +1224,49 @@ async def test_the_private_response_never_contradicts_itself(
     steady = (await async_client.get(f"/v1/leaderboard/{PRIVATE_ID}")).json()
     assert steady["scoped_to_caller"] is True
     assert steady["benchmark"]["visibility"] == "private"
+
+
+# --- OME-1056: the frontier applies the same coverage rule as the ranking ---
+
+
+async def test_the_frontier_route_passes_the_registered_case_count(
+    async_client: httpx.AsyncClient,
+) -> None:
+    """The route must hand `benchmark.case_count` to `compute_frontier`.
+
+    WHY pinned at the ROUTE and not only in the pure function: `compute_frontier`'s
+    `registered_case_count` has to default to None — seven prior tests call it and rule 5 makes
+    editing them an owner decision a keyword default does not justify. That default means a route
+    which stops passing the argument silently returns to publishing partial runs as the state of
+    the art, with no type error and no failure in the function's own tests. This is the guard that
+    makes the default safe, so it is the one to keep green.
+
+    The board hid a one-case run from the table while this endpoint made it `current` — and
+    because `_compute_trend` advances the holder only on a STRICT improvement, no complete run
+    could ever displace it.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="ifeval", display_name="IFEval", case_count=541)
+    for spec_id, score, total in (("one-case-run", 1.0, 1), ("honest-full-run", 0.85, 541)):
+        response = await async_client.post(
+            "/v1/scores",
+            json={
+                "version": 1,
+                "benchmark_id": "ifeval",
+                "spec_id": spec_id,
+                "url4_expression": f"url4://{spec_id}",
+                "submitted_by": "tester",
+                "score": score,
+                "total_questions": total,
+                "ran_with_providers": ["openrouter"],
+            },
+        )
+        assert response.status_code == 201, response.text
+
+    body = (await async_client.get("/v1/leaderboard/ifeval/frontier")).json()
+
+    assert body["current"]["label"] == "honest-full-run", (
+        "the frontier published a partial run as the state of the art; the route is not passing "
+        "the registered case count to compute_frontier"
+    )
+    assert [point["label"] for point in body["trend"]] == ["honest-full-run"]

--- a/apps/scoreboard/tests/unit/test_seed_case_count.py
+++ b/apps/scoreboard/tests/unit/test_seed_case_count.py
@@ -63,3 +63,62 @@ async def test_configuration_may_never_declare_a_case_count(tortoise_db: None) -
 
     assert report.refused == ["ifeval"]
     assert await Benchmark.filter(id="ifeval").count() == 0
+
+
+@pytest.mark.parametrize(
+    "published",
+    [0, -1, True, "541", {"total": 541}, [541], 1.5],
+    ids=["zero", "negative", "bool", "string", "object", "list", "float"],
+)
+async def test_an_unusable_catalogue_count_costs_the_filter_not_the_row(
+    published: object,
+) -> None:
+    """A published count the board cannot use must degrade to None, never reject the entry.
+
+    WHY this is the whole point of `extra="ignore"` on `_CatalogEntry`: the catalogue is written
+    by another service. `ge=1` made a published `case_count: 0` — a benchmark whose dataset
+    failed to load — cost the benchmark its ROW: a new board is never created, an existing
+    board's text stops refreshing, and the deploy exits 0. The field's own comment already
+    promised the milder outcome, and `SeedBenchmark` keeps `ge=1` because a HAND-WRITTEN typo
+    should fail the deploy loudly. Require it where it is written; tolerate it where it is read.
+
+    `True` is in the table because `bool` subclasses `int`, so an unguarded check would accept it
+    as a case count of 1 — which re-opens the hole from the other side by making every one-case
+    run "complete".
+    """
+    payload = _catalog({"revision": "rev-ifeval", "case_count": published})
+
+    with _serving(payload) as client:
+        read = fetch_engine_benchmarks(ENGINE_URL, client=client, retry_delay=0)
+
+    assert read.rejected == [], f"{published!r} cost the benchmark its row"
+    assert len(read.rows) == 1
+    assert read.rows[0].case_count is None
+    assert read.rows[0].display_name == "IFEval", "the row's text must still refresh"
+
+
+async def test_the_catalogue_case_count_reaches_the_database(tortoise_db: None) -> None:
+    """Pin the complete HTTP catalogue -> seed adapter -> ORM persistence path."""
+    payload = _catalog({"revision": "rev-ifeval", "case_count": 541})
+
+    with _serving(payload) as client:
+        report = await seed_from_sources(
+            engine_url=ENGINE_URL, configured=[], client=client, retry_delay=0
+        )
+
+    assert [row.id for row in report.seeded] == ["ifeval"]
+    assert (await Benchmark.get(id="ifeval")).case_count == 541
+
+
+async def test_a_catalogue_without_a_case_count_clears_a_stale_count(
+    tortoise_db: None,
+) -> None:
+    """An authoritative missing count clears scope left by an older Engine revision."""
+    await Benchmark.create(id="ifeval", display_name="IFEval", revision="rev-old", case_count=541)
+
+    with _serving(_catalog({"revision": "rev-new"})) as client:
+        await seed_from_sources(engine_url=ENGINE_URL, configured=[], client=client, retry_delay=0)
+
+    benchmark = await Benchmark.get(id="ifeval")
+    assert benchmark.revision == "rev-new"
+    assert benchmark.case_count is None

--- a/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
@@ -209,3 +209,38 @@ async def test_the_catalog_keeps_the_field_names_the_leaderboard_seeds_from() ->
             assert isinstance(entry[name], str) and entry[name]
         for name in optional_display & set(entry):
             assert isinstance(entry[name], str) and entry[name]
+
+
+async def test_the_catalogue_publishes_a_usable_case_count() -> None:
+    """`case_count` is load-bearing across the app boundary, so its NAME is pinned here.
+
+    FEATURE: OME-1056. The Scoreboard's ranking drops a run that covered fewer cases than the
+    benchmark defines, and it learns that number from this catalogue by name. Rename the field
+    here — `cases`, `total_cases` — or drop it from `_metadata()`, and both suites stay green:
+    the two apps have separate virtualenvs, and the Scoreboard's `_CatalogEntry` uses
+    `extra="ignore"` and tolerates a missing count by design. The next seed then writes nothing,
+    every board's `case_count` goes stale or absent, and one-case runs rank as complete again.
+    Silently, with a deploy that exits 0.
+
+    WHY a separate test rather than adding `case_count` to `required` above: that set's loop
+    asserts every member is a non-empty `str`, and this is an `int`. Asserted here instead, so
+    no prior assertion changes (rule 5).
+
+    INVARIANT: `>= 1`, matching `SeedBenchmark`'s constraint on the board side. A published `0`
+    would be tolerated by the board — costing it the filter, not the benchmark's row — but it is
+    not a state any built-in should ever be in, so it fails here, on the producing side, where
+    it is a real defect rather than someone else's bad input.
+    """
+    for benchmark in BUILTIN_BENCHMARKS:
+        entry = await _catalog(benchmark)
+
+        assert "case_count" in entry, (
+            f"{benchmark.id} does not publish case_count; the leaderboard's coverage filter "
+            "reads this field by name and silently ranks partial runs without it"
+        )
+        count = entry["case_count"]
+        assert isinstance(count, int) and not isinstance(count, bool), (
+            f"{benchmark.id} publishes case_count as {type(count).__name__}; the board parses "
+            "an int and normalises anything else to None, which costs it the filter"
+        )
+        assert count >= 1, f"{benchmark.id} publishes case_count={count}"

--- a/docs/work/2026-09-01-OME-1056-partial-runs-not-ranked.md
+++ b/docs/work/2026-09-01-OME-1056-partial-runs-not-ranked.md
@@ -92,3 +92,44 @@ recorded in the new seed test's module docstring so the next reader finds it.
 a full run of the same recipe are two rows on both paths. The partial one exists and does not rank;
 the full one ranks. Neither displaces the other, and no participant loses a submission by having
 tested first — which is the whole reason partial runs stay accepted.
+
+## Approval follow-ups — 2026-09-02
+
+PR #785 was approved with six non-blocking findings. Five are implemented on the follow-up
+branch rather than added to the already-approved PR:
+
+1. **Frontier parity:** `/frontier` now applies the registered `case_count` before computing
+   the current holder, trend, and openness counts. A route-level regression proves the public
+   endpoint cannot drift from the ranked table.
+2. **Local seed parity:** `scoreboard_seed_json()` carries the Engine registry's `case_count`,
+   so `screamingface up` enables the same coverage filter as a deployed Scoreboard.
+3. **Producer contract:** the Engine catalogue suite pins `case_count` by exact field name,
+   integer type, and positive range for every built-in benchmark.
+4. **Seed persistence:** a real in-memory Tortoise test covers HTTP catalogue parsing through
+   `seed_from_sources()` into `Benchmark.case_count` in the database.
+5. **Predicate boundary:** a run reporting more than the registered count remains comparable;
+   a regression test prevents accidentally tightening `>=` to `==`.
+
+The seed/store boundary also now distinguishes **omitted** from **explicitly absent** scope.
+A direct `register_benchmark()` caller that omits `case_count` preserves the stored value. An
+authoritative Engine row with no usable count passes explicit `None` and clears it, preventing a
+new benchmark revision from inheriting a stale scope.
+
+The sixth finding is intentionally not folded into this implementation. `total_questions` is a
+client claim and the submission wire does not attest that every selected case completed grading.
+That product/trust decision is already tracked by OME-867, whose acceptance explicitly requires a
+typed Client↔Scoreboard evaluation-scope contract, distinct incomplete-grading behavior, and
+cross-stack `limit=1` coverage. No duplicate ticket was created.
+
+### Follow-up verification
+
+- **Scoreboard:** official `run_gates.py scoreboard` — all gates green, including append-only,
+  Ruff, formatting, Pyright, coverage, and portal logic.
+- **ScreamingFace SDK:** official `run_gates.py screamingface` — all gates green, including 95%
+  coverage, notebook validation, wheel build, and distribution inspection.
+- **Engine:** append-only, Ruff, formatting, Pyright, layering, and the changed 18-test catalogue
+  contract suite are green. The full pytest gate completed 2,283 passed / 5 skipped / 1 unrelated
+  local failure: Helm 4's default Kubernetes capability is 1.20 while the untouched chart requires
+  1.25+. Rendering the same untouched chart with `--kube-version 1.25.0` succeeds.
+- **ORM:** installed and current Tortoise ORM versions both 1.1.8; persistence tests use the
+  repository's `tortoise_test_context` fixture.

--- a/packages/screamingface/src/screamingface/_runtime/bootstrap.py
+++ b/packages/screamingface/src/screamingface/_runtime/bootstrap.py
@@ -61,6 +61,17 @@ def scoreboard_seed_json(benchmarks: Iterable[BenchmarkDefinition]) -> str:
                 "display_name": benchmark.title,
                 "description": benchmark.description,
                 "revision": benchmark.revision,
+                # OME-1056: the board's ranking filter needs this, and without it every LOCAL
+                # seed leaves `case_count` NULL — so the filter is off in the one environment
+                # where `limit=1` smoke runs are routine, and a one-case 1.0 still takes rank 1.
+                # Conditional like the two below: keep the JSON projection sparse. The board's
+                # SeedBenchmark parser turns absence into None, correctly clearing any stale
+                # scope because these rows are passed as authoritative `engine_rows`.
+                **(
+                    {"case_count": case_count}
+                    if (case_count := getattr(benchmark, "case_count", None))
+                    else {}
+                ),
                 # Optional in the Engine, so absent stays absent rather than becoming null.
                 **({"focus": focus} if (focus := getattr(benchmark, "focus", None)) else {}),
                 **(

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -811,3 +811,36 @@ def test_rotation_keeps_the_replacement_log_private(
     assert path.with_name("runtime.log.1").exists()
     if os.name != "nt":
         assert path.stat().st_mode & 0o777 == 0o600
+
+
+def test_the_local_projection_carries_the_case_count() -> None:
+    """OME-1056: the board's ranking filter needs `case_count`, so the local twin must send it.
+
+    INVARIANT: this function's docstring promises "the same fields the Engine's /v1/benchmarks
+    catalogue publishes" and that keeping the two projections in step "is what makes a local
+    leaderboard look like the deployed one". Omitting the count broke that silently and in the
+    worst environment for it: every local seed left the column NULL, so the coverage filter was
+    off exactly where running with `limit=1` is routine, and a one-case run scoring 1.0 still
+    took rank 1 on the local board.
+    """
+
+    class Benchmark:
+        id = "ifeval"
+        title = "IFEval"
+        description = "Deterministic instruction following"
+        revision = "revision-from-engine"
+        case_count = 541
+
+    assert json.loads(scoreboard_seed_json([Benchmark()]))[0]["case_count"] == 541
+
+
+def test_the_local_projection_omits_an_absent_case_count() -> None:
+    # Keep the local JSON projection sparse, like the HTTP catalogue. Once parsed as an
+    # authoritative engine_row, absence becomes None and clears any stale stored scope.
+    class Benchmark:
+        id = "ifeval"
+        title = "IFEval"
+        description = "Deterministic instruction following"
+        revision = "revision-from-engine"
+
+    assert "case_count" not in json.loads(scoreboard_seed_json([Benchmark()]))[0]


### PR DESCRIPTION
## Summary

- apply the registered `case_count` to the public frontier as well as the ranked table
- preserve omitted store updates while clearing stale scope for authoritative Engine rows
- carry `case_count` through local `screamingface up` seeding
- pin the Engine producer contract, seed-to-database persistence, and the intentional `>=` boundary

## Review follow-up boundary

This addresses five of the six non-blocking findings from #785. The remaining typed grading-coverage and incomplete-grading policy is already tracked in OME-867 and is intentionally not folded into this implementation.

## Verification

- `run_gates.py scoreboard`: all gates green
- `run_gates.py screamingface`: all gates green
- Engine append-only, Ruff, formatting, Pyright, layering, and changed 18-test catalogue suite: green
- Engine full pytest: 2,283 passed, 5 skipped, 1 unrelated local environment failure; Helm 4 defaults to Kubernetes 1.20 while the untouched chart requires 1.25+. The chart renders successfully with `--kube-version 1.25.0`.

Refs: OME-1056
