### PR TITLE
feat(engine): admit runs on queue depth and fair-schedule them per caller

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -119,6 +119,7 @@ def build_job_runner(
                 # publishes where no worker listens). `run_worker` passes the same
                 # settings, so the sides agree for any Settings.
                 stream=settings.run_queue_stream,
+                subject_prefix=settings.run_queue_subject_prefix,
                 ack_wait_s=settings.run_queue_ack_wait_s,
                 max_deliver=settings.run_queue_max_deliver,
                 max_ack_pending=settings.run_queue_max_ack_pending,

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/factory.py
@@ -124,6 +124,7 @@ def build_job_runner(
                 max_ack_pending=settings.run_queue_max_ack_pending,
                 duplicate_window_s=settings.run_queue_duplicate_window_s,
                 max_age_s=settings.run_queue_max_age_s,
+                bucket_count=settings.run_queue_bucket_count,
                 # INVARIANT: the same rule as `stream` above, for a property the broker
                 # itself enforces. `ensure_stream` refuses a declaration whose properties
                 # diverge from an existing stream, and the App usually declares FIRST —
@@ -142,5 +143,7 @@ def build_job_runner(
             capability_lifetime_s=settings.capability_lifetime_s,
             io_concurrency=settings.runner_io_concurrency,
             extra_models=extra_models,
+            depth_ceiling=settings.run_queue_depth_ceiling,
+            caller_inflight_cap=settings.run_queue_caller_inflight_cap,
         )
     return None

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -267,9 +267,15 @@ class QueueJobRunner(IdentityAwareJobRunner):
                 extra_models=() if self._extra_models is None else self._extra_models(),
             )
             await self._queue.publish(message, identity=identity)
-        except Exception:
-            # The reservation was for a run that was not durably accepted — release it so the
-            # next schedule in this window is not refused for a run that never queued.
+        except BaseException:
+            # WHY BaseException and not Exception: a task cancelled mid-publish (a client
+            # disconnect, an upstream timeout) raises `CancelledError`, which since 3.8 is
+            # NOT an Exception — the release below was skipped and the reservation leaked
+            # forever: the caller's in-flight dict accumulated dead topics until every
+            # later schedule was refused for runs that never queued. Cleanup runs on the
+            # cancellation path too; the bare `raise` still propagates the cancellation.
+            # (BaseException also covers KeyboardInterrupt/SystemExit reaching this await —
+            # releasing there is harmless, and they still propagate.)
             await self._release_reservation(topic)
             raise
         self._scheduled_at[topic] = self._clock()

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -31,6 +31,7 @@ plane and the worker half may import it.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
 import time
@@ -212,16 +213,30 @@ class QueueJobRunner(IdentityAwareJobRunner):
         # counts runs admitted since the last refresh — it closes the read-modify-write race
         # when two `schedule()` calls land in one refresh window. The lock makes refresh +
         # check + reserve atomic.
+        #
+        # SCOPE (review follow-up): PER-PROCESS, and that is a deploy constraint, not an
+        # accident. The App currently runs `replicaCount: 1` (the WS-subscriber registry is
+        # in-process; see the Helm values' note) — one process, so one counter IS the fleet
+        # counter. Lifting replicas without first moving this state to a shared counter (a
+        # NATS KV bucket keyed by caller is the natural fit alongside the queue) re-opens the
+        # TOCTOU race across replicas: each admits against its own snapshot, the fleet exceeds
+        # the depth ceiling and the per-caller cap by up to one run per replica per window.
+        # Do NOT build that shared counter speculatively — it belongs to the ticket that
+        # lifts the replica gate, which is the same ticket that fixes the WS registry.
         self._depth_snapshot: int | None = None
         self._oldest_age: float | None = None
         self._depth_cache_time: float | None = None
         self._reserved = 0
         self._admission_lock = asyncio.Lock()
-        # The per-caller in-flight tracking: caller → {topic: admitted_at}, plus the reverse
-        # index for the observed-terminal decrement. A run counts until the runner sees its
-        # terminal frame (the reaper's polls, a re-schedule pre-check) or its capability
-        # expires — the runner cannot observe a finish any other way.
-        self._in_flight_by_caller: dict[str, dict[str, datetime]] = {}
+        # The per-caller in-flight tracking: caller → {topic: [admitted_at, ...]} — a LIST,
+        # because one caller CAN legitimately re-schedule a live topic (a client retry outside
+        # the broker's dedupe window) and each admission is its own reservation, released only
+        # by the schedule attempt that minted it (see `_release_reservation`). A run counts
+        # until the runner sees its terminal frame (the reaper's polls, a re-schedule
+        # pre-check) or its capability expires — the runner cannot observe a finish any other
+        # way. Per-process scope: same replica constraint and same future shared-counter
+        # design as `_reserved` above.
+        self._in_flight_by_caller: dict[str, dict[str, list[datetime]]] = {}
         self._caller_of_topic: dict[str, str] = {}
 
     # --- the JobRunner port ----------------------------------------------------------------
@@ -253,7 +268,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
             JobRunnerAtCapacity: the queue is at its depth ceiling, or the caller has too
                 many runs in flight (503 + `Retry-After` at the REST edge).
         """
-        await self._admit_or_raise(identity, topic)
+        reservation = await self._admit_or_raise(identity, topic)
         try:
             message = encode_message(
                 topic,
@@ -276,7 +291,13 @@ class QueueJobRunner(IdentityAwareJobRunner):
             # cancellation path too; the bare `raise` still propagates the cancellation.
             # (BaseException also covers KeyboardInterrupt/SystemExit reaching this await —
             # releasing there is harmless, and they still propagate.)
-            await self._release_reservation(topic, caller_key(identity))
+            # WHY the reservation TOKEN and not the (caller, topic) pair: a caller can
+            # re-schedule a topic that is STILL LIVE (a client retry outside the broker's
+            # dedupe window) — the retry mints its own reservation — and when THAT retry
+            # fails, releasing "whatever the caller holds for the topic" would erase the
+            # FIRST, still-running admission too, under-counting the caller from then on.
+            # The release removes exactly the reservation this attempt minted.
+            await self._release_reservation(topic, caller_key(identity), reservation)
             raise
         self._scheduled_at[topic] = self._clock()
         return job_name(topic)
@@ -477,9 +498,15 @@ class QueueJobRunner(IdentityAwareJobRunner):
 
     # --- depth-based admission (OME-1091) ---------------------------------------------------
 
-    async def _admit_or_raise(self, identity: Mapping[str, str] | None, topic: str) -> None:
+    async def _admit_or_raise(
+        self, identity: Mapping[str, str] | None, topic: str
+    ) -> datetime:
         """Admission gate: refresh the depth snapshot, refuse if the queue is at the ceiling
         or the caller is at its in-flight cap, else reserve.
+
+        Returns the reservation TOKEN (the admission moment) — `schedule`'s failure path
+        releases by that token, never by position, so a failed retry of a live topic
+        cannot erase the first admission's accounting.
 
         Raises:
             JobRunnerAtCapacity: the queue is at its depth ceiling, or the caller has too
@@ -499,26 +526,33 @@ class QueueJobRunner(IdentityAwareJobRunner):
                     self._depth_ceiling,
                     retry_after_s=self._drain_estimate_s(),
                 )
-            count = len(self._in_flight_by_caller.get(caller, {}))
+            count = sum(
+                len(topics) for topics in self._in_flight_by_caller.get(caller, {}).values()
+            )
             if count >= self._caller_inflight_cap:
                 raise JobRunnerAtCapacity(
                     count, self._caller_inflight_cap, retry_after_s=self._drain_estimate_s()
                 )
+            token = self._clock()
             self._reserved += 1
-            self._in_flight_by_caller.setdefault(caller, {})[topic] = self._clock()
+            self._in_flight_by_caller.setdefault(caller, {}).setdefault(topic, []).append(token)
             self._caller_of_topic[topic] = caller
+            return token
 
-    async def _release_reservation(self, topic: str, caller: str) -> None:
-        """Release THIS caller's reservation for a run that was not durably accepted
-        (a publish failure or a cancellation mid-publish).
+    async def _release_reservation(
+        self, topic: str, caller: str, token: datetime
+    ) -> None:
+        """Release the ONE reservation `token` identifies, for a run that was not durably
+        accepted (a publish failure or a cancellation mid-publish).
 
-        WHY a targeted pop and not `_forget_in_flight`: the shared helper wipes the topic
-        from EVERY caller that holds it — the right tool for "the run is over", the wrong
-        one for "this schedule attempt never landed". A re-scheduled topic can be held by
-        a second identity (admission overwrites `_caller_of_topic` but not the first
-        caller's dict entry); a failed publish under the second identity would then also
-        erase the FIRST caller's still-live admission — an under-count that lets that
-        caller exceed its in-flight cap. Only the pair that was reserved is released.
+        WHY a token and not the (caller, topic) pair (review follow-up): a caller can
+        re-schedule a STILL-LIVE topic — a client retry outside the broker's dedupe window,
+        whose publish then fails — and the pair-held entry at that moment is the FIRST
+        admission's. Releasing "whatever the caller holds for the topic" erased the live
+        admission with the failed retry: the caller's in-flight count dropped by one for
+        the rest of that run's lifetime, letting it exceed `caller_inflight_cap` by exactly
+        that much. The token removes only the reservation this `schedule` attempt minted;
+        the first admission's token survives, in order, in the same list.
         """
         async with self._admission_lock:
             # WHY the floor: `_refresh_if_stale` RESETS the counter on every refresh, and
@@ -529,10 +563,13 @@ class QueueJobRunner(IdentityAwareJobRunner):
             # already accounted for this reservation; clamp, and the counter stays honest.
             self._reserved = max(0, self._reserved - 1)
             by_caller = self._in_flight_by_caller.get(caller)
-            if by_caller is not None:
-                by_caller.pop(topic, None)
-                if not by_caller:
-                    del self._in_flight_by_caller[caller]
+            if by_caller is not None and topic in by_caller:
+                with contextlib.suppress(ValueError):
+                    by_caller[topic].remove(token)
+                if not by_caller[topic]:
+                    del by_caller[topic]
+            if by_caller is not None and not by_caller:
+                del self._in_flight_by_caller[caller]
             if not any(topic in topics for topics in self._in_flight_by_caller.values()):
                 self._caller_of_topic.pop(topic, None)
 
@@ -579,8 +616,8 @@ class QueueJobRunner(IdentityAwareJobRunner):
         ``frame`` guards the observed-terminal path against a stale observation: a topic
         re-scheduled after its first run finished still shows the FIRST run's terminal frame,
         and forgetting on that sighting would release the SECOND run's slot. A frame older
-        than a tracked admission is that stale sighting and is ignored — checked PER CALLER,
-        because more than one caller can hold the topic (below).
+        than a tracked admission is that stale sighting and is ignored — checked PER CALLER
+        and PER RESERVATION (one caller can hold several for a re-scheduled topic).
 
         WHY every caller and not `_caller_of_topic[topic]`: admission OVERWRITES that
         mapping when a re-scheduled topic is admitted under a second identity, so the
@@ -589,12 +626,20 @@ class QueueJobRunner(IdentityAwareJobRunner):
         eventually as spurious 503s for a caller whose runs have all finished.
         """
         for by_caller in self._in_flight_by_caller.values():
-            admitted_at = by_caller.get(topic)
-            if admitted_at is None:
+            tokens = by_caller.get(topic)
+            if not tokens:
                 continue
-            if frame is not None and frame.time is not None and frame.time < admitted_at:
-                continue  # a stale sighting of the FIRST run — this admission is still live
-            by_caller.pop(topic, None)
+            # Keep only reservations minted AFTER the sighting — those are live runs the
+            # frame cannot speak for. No frame (expiry, never-admitted) keeps nothing.
+            kept = [
+                t
+                for t in tokens
+                if frame is not None and frame.time is not None and frame.time < t
+            ]
+            if kept:
+                by_caller[topic] = kept
+            else:
+                del by_caller[topic]
         if not any(topic in topics for topics in self._in_flight_by_caller.values()):
             self._caller_of_topic.pop(topic, None)
         # Drop callers left with no in-flight topics — the cleanup the single-caller path

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -276,7 +276,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
             # cancellation path too; the bare `raise` still propagates the cancellation.
             # (BaseException also covers KeyboardInterrupt/SystemExit reaching this await —
             # releasing there is harmless, and they still propagate.)
-            await self._release_reservation(topic)
+            await self._release_reservation(topic, caller_key(identity))
             raise
         self._scheduled_at[topic] = self._clock()
         return job_name(topic)
@@ -508,8 +508,18 @@ class QueueJobRunner(IdentityAwareJobRunner):
             self._in_flight_by_caller.setdefault(caller, {})[topic] = self._clock()
             self._caller_of_topic[topic] = caller
 
-    async def _release_reservation(self, topic: str) -> None:
-        """Release a reservation whose run was not durably accepted (a publish failure)."""
+    async def _release_reservation(self, topic: str, caller: str) -> None:
+        """Release THIS caller's reservation for a run that was not durably accepted
+        (a publish failure or a cancellation mid-publish).
+
+        WHY a targeted pop and not `_forget_in_flight`: the shared helper wipes the topic
+        from EVERY caller that holds it — the right tool for "the run is over", the wrong
+        one for "this schedule attempt never landed". A re-scheduled topic can be held by
+        a second identity (admission overwrites `_caller_of_topic` but not the first
+        caller's dict entry); a failed publish under the second identity would then also
+        erase the FIRST caller's still-live admission — an under-count that lets that
+        caller exceed its in-flight cap. Only the pair that was reserved is released.
+        """
         async with self._admission_lock:
             # WHY the floor: `_refresh_if_stale` RESETS the counter on every refresh, and
             # the refresh can land between this run's reserve and its release (a sibling
@@ -518,7 +528,13 @@ class QueueJobRunner(IdentityAwareJobRunner):
             # every subsequent admission check. A release below zero is the refresh having
             # already accounted for this reservation; clamp, and the counter stays honest.
             self._reserved = max(0, self._reserved - 1)
-            self._forget_in_flight(topic)
+            by_caller = self._in_flight_by_caller.get(caller)
+            if by_caller is not None:
+                by_caller.pop(topic, None)
+                if not by_caller:
+                    del self._in_flight_by_caller[caller]
+            if not any(topic in topics for topics in self._in_flight_by_caller.values()):
+                self._caller_of_topic.pop(topic, None)
 
     async def _refresh_if_stale(self) -> None:
         """Re-read the queue's depth and oldest-message age when the cache is stale.

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -76,6 +76,10 @@ CANCELLED = "cancelled"
 # running here". The worker's reply is a local NATS round trip; a second is far beyond it
 # and far below the client's patience for a DELETE.
 CONTROL_TIMEOUT_S = 1.0
+# The floor for a caller-cap `Retry-After` estimate (review follow-up P2-11): tens of
+# seconds, so a well-behaved client honouring the header cannot be turned into a hot
+# loop against the API for up to the 16h run ceiling.
+CALLER_RETRY_FLOOR_S = 30
 
 # The sentinel `_read_tail` returns for an UNREADABLE stream tail — distinct from "no
 # frame" and from "a terminal frame", because an unreadable broker answers neither
@@ -498,9 +502,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
 
     # --- depth-based admission (OME-1091) ---------------------------------------------------
 
-    async def _admit_or_raise(
-        self, identity: Mapping[str, str] | None, topic: str
-    ) -> datetime:
+    async def _admit_or_raise(self, identity: Mapping[str, str] | None, topic: str) -> datetime:
         """Admission gate: refresh the depth snapshot, refuse if the queue is at the ceiling
         or the caller is at its in-flight cap, else reserve.
 
@@ -530,8 +532,15 @@ class QueueJobRunner(IdentityAwareJobRunner):
                 len(topics) for topics in self._in_flight_by_caller.get(caller, {}).values()
             )
             if count >= self._caller_inflight_cap:
+                # WHY not the drain estimate (review follow-up P2-11): the cap branch is
+                # reached precisely when the queue is NOT at its ceiling, so the drain
+                # formula underflows to its floor — a caller behind a long evaluation was
+                # told to retry every second. This caller's own runs are what hold the
+                # slot; the estimate comes from them.
                 raise JobRunnerAtCapacity(
-                    count, self._caller_inflight_cap, retry_after_s=self._drain_estimate_s()
+                    count,
+                    self._caller_inflight_cap,
+                    retry_after_s=self._caller_retry_after_s(caller),
                 )
             token = self._clock()
             self._reserved += 1
@@ -539,9 +548,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
             self._caller_of_topic[topic] = caller
             return token
 
-    async def _release_reservation(
-        self, topic: str, caller: str, token: datetime
-    ) -> None:
+    async def _release_reservation(self, topic: str, caller: str, token: datetime) -> None:
         """Release the ONE reservation `token` identifies, for a run that was not durably
         accepted (a publish failure or a cancellation mid-publish).
 
@@ -592,6 +599,25 @@ class QueueJobRunner(IdentityAwareJobRunner):
         self._depth_cache_time = now
         self._reserved = 0
 
+    def _caller_retry_after_s(self, caller: str) -> int | None:
+        """`Retry-After` for a caller refused at its in-flight cap: the age of its OLDEST
+        in-flight run, floored at `CALLER_RETRY_FLOOR_S`.
+
+        The reservation tokens ARE admission timestamps, so the oldest token is the
+        caller's longest-running run — the closest to done under roughly-equal durations,
+        and the only basis available without per-run duration data. `None` when the
+        caller holds no reservations (the REST edge falls back to its constant).
+        """
+        tokens = [
+            token
+            for topics in self._in_flight_by_caller.get(caller, {}).values()
+            for token in topics
+        ]
+        if not tokens:
+            return None
+        age_s = (self._clock() - min(tokens)).total_seconds()
+        return max(CALLER_RETRY_FLOOR_S, math.ceil(age_s))
+
     def _drain_estimate_s(self) -> int | None:
         """Seconds until the queue drains below the ceiling, from the pool's observed
         throughput — the `Retry-After` the REST edge forwards.
@@ -632,9 +658,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
             # Keep only reservations minted AFTER the sighting — those are live runs the
             # frame cannot speak for. No frame (expiry, never-admitted) keeps nothing.
             kept = [
-                t
-                for t in tokens
-                if frame is not None and frame.time is not None and frame.time < t
+                t for t in tokens if frame is not None and frame.time is not None and frame.time < t
             ]
             if kept:
                 by_caller[topic] = kept

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
+import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
 from datetime import datetime
@@ -44,9 +46,16 @@ from nats.errors import NoRespondersError
 
 from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.ports import IdentityAwareJobRunner
-from screamingface_engine.runner_queue import DEFAULT_IO_CONCURRENCY, encode_message
+from screamingface_engine.runner_queue import (
+    DEFAULT_CALLER_INFLIGHT_CAP,
+    DEFAULT_DEPTH_CEILING,
+    DEFAULT_IO_CONCURRENCY,
+    DEFAULT_STATE_CACHE_TTL_S,
+    caller_key,
+    encode_message,
+)
 from screamingface_engine.subjects import control_subject_for
-from url4.streaming.interfaces import JobStatus, job_name
+from url4.streaming.interfaces import JobRunnerAtCapacity, JobStatus, job_name
 from url4.streaming.protocol import (
     CachePolicy,
     ErrorInfo,
@@ -77,9 +86,13 @@ _UNREADABLE_TAIL = object()
 class _Queue(Protocol):
     """The slice of ``RunQueue`` the queue runner uses."""
 
-    async def publish(self, message: bytes) -> None: ...
+    async def publish(
+        self, message: bytes, *, identity: Mapping[str, str] | None = None
+    ) -> None: ...
 
     async def depth(self) -> int: ...
+
+    async def oldest_age(self) -> float | None: ...
 
 
 class _Publisher(Protocol):
@@ -164,6 +177,17 @@ class QueueJobRunner(IdentityAwareJobRunner):
         control_timeout_s: float = CONTROL_TIMEOUT_S,
         io_concurrency: int = DEFAULT_IO_CONCURRENCY,
         extra_models: Callable[[], Sequence[str]] | None = None,
+        # FEATURE (OME-1091): depth-based admission. The queue refuses a run when its depth is
+        # at the ceiling — the substrate is saturated, and the REST edge maps the refusal to
+        # 503 + a `Retry-After` derived from the drain estimate.
+        depth_ceiling: int = DEFAULT_DEPTH_CEILING,
+        # FEATURE (OME-1091): the per-caller in-flight cap — how many of one caller's runs may
+        # be admitted at once, so one caller's 9-candidate evaluation cannot occupy every slot.
+        caller_inflight_cap: int = DEFAULT_CALLER_INFLIGHT_CAP,
+        # FEATURE (OME-1091): how long a depth reading stays fresh before the next refresh. The
+        # queue itself caches its `stream_info` reading; this is the runner's own window, which
+        # is what the reservation counter covers.
+        state_cache_ttl_s: float = DEFAULT_STATE_CACHE_TTL_S,
     ) -> None:
         self._queue = queue
         self._publisher = publisher
@@ -176,10 +200,29 @@ class QueueJobRunner(IdentityAwareJobRunner):
         # while the app runs, and a model admitted a second ago must reach the very next
         # run — the same rule as `K8sJobRunner._extra_models`.
         self._extra_models = extra_models
+        self._depth_ceiling = depth_ceiling
+        self._caller_inflight_cap = caller_inflight_cap
+        self._state_cache_ttl_s = state_cache_ttl_s
         # topic → when this replica accepted it. The capability-validity input for the
         # scheduled/not_found boundary; pruned on each schedule so it stays bounded by the
         # topics accepted within one capability lifetime.
         self._scheduled_at: dict[str, datetime] = {}
+        # FEATURE (OME-1091): the OME-1065 cache-plus-reservation shape, carried over. The
+        # counted resource changed (quota headroom → queue depth); the race did not. `_reserved`
+        # counts runs admitted since the last refresh — it closes the read-modify-write race
+        # when two `schedule()` calls land in one refresh window. The lock makes refresh +
+        # check + reserve atomic.
+        self._depth_snapshot: int | None = None
+        self._oldest_age: float | None = None
+        self._depth_cache_time: float | None = None
+        self._reserved = 0
+        self._admission_lock = asyncio.Lock()
+        # The per-caller in-flight tracking: caller → {topic: admitted_at}, plus the reverse
+        # index for the observed-terminal decrement. A run counts until the runner sees its
+        # terminal frame (the reaper's polls, a re-schedule pre-check) or its capability
+        # expires — the runner cannot observe a finish any other way.
+        self._in_flight_by_caller: dict[str, dict[str, datetime]] = {}
+        self._caller_of_topic: dict[str, str] = {}
 
     # --- the JobRunner port ----------------------------------------------------------------
 
@@ -205,21 +248,31 @@ class QueueJobRunner(IdentityAwareJobRunner):
         `duplicate_window` (`Nats-Msg-Id` is the topic), which is the queue's
         `JobAlreadyExists` equivalent — the REST pre-check's 409 and the broker's dedupe
         collapse a race into one run.
+
+        Raises:
+            JobRunnerAtCapacity: the queue is at its depth ceiling, or the caller has too
+                many runs in flight (503 + `Retry-After` at the REST edge).
         """
-        message = encode_message(
-            topic,
-            url4,
-            deadline_s,
-            traceparent=traceparent,
-            profile=profile,
-            identity=identity,
-            cache=cache,
-            io_concurrency=self._io_concurrency,
-            extra_models=() if self._extra_models is None else self._extra_models(),
-        )
-        await self._queue.publish(message)
+        await self._admit_or_raise(identity, topic)
+        try:
+            message = encode_message(
+                topic,
+                url4,
+                deadline_s,
+                traceparent=traceparent,
+                profile=profile,
+                identity=identity,
+                cache=cache,
+                io_concurrency=self._io_concurrency,
+                extra_models=() if self._extra_models is None else self._extra_models(),
+            )
+            await self._queue.publish(message, identity=identity)
+        except Exception:
+            # The reservation was for a run that was not durably accepted — release it so the
+            # next schedule in this window is not refused for a run that never queued.
+            await self._release_reservation(topic)
+            raise
         self._scheduled_at[topic] = self._clock()
-        self._prune()
         return job_name(topic)
 
     async def stop(self, topic: str) -> None:
@@ -343,6 +396,10 @@ class QueueJobRunner(IdentityAwareJobRunner):
         """
         frame = await self._read_tail(topic)
         if isinstance(frame, TerminatedEvent):
+            # The run is over — release the caller's in-flight slot so the cap reflects what
+            # is actually running, not what once was. Guarded against a stale observation of a
+            # PRIOR run of a re-scheduled topic (see `_forget_in_flight`).
+            self._forget_in_flight(topic, frame)
             return frame.data.status
         if frame is _UNREADABLE_TAIL:
             raise QueueReadError(f"stream tail unreadable for {topic}: run state unknown")
@@ -412,6 +469,107 @@ class QueueJobRunner(IdentityAwareJobRunner):
         )
         await self._publisher.flush()
 
+    # --- depth-based admission (OME-1091) ---------------------------------------------------
+
+    async def _admit_or_raise(self, identity: Mapping[str, str] | None, topic: str) -> None:
+        """Admission gate: refresh the depth snapshot, refuse if the queue is at the ceiling
+        or the caller is at its in-flight cap, else reserve.
+
+        Raises:
+            JobRunnerAtCapacity: the queue is at its depth ceiling, or the caller has too
+                many runs in flight. The exception carries the drain estimate so the REST edge
+                can derive `Retry-After`.
+        """
+        caller = caller_key(identity)
+        async with self._admission_lock:
+            self._prune()
+            await self._refresh_if_stale()
+            if (
+                self._depth_snapshot is not None
+                and self._depth_snapshot + self._reserved >= self._depth_ceiling
+            ):
+                raise JobRunnerAtCapacity(
+                    self._depth_snapshot + self._reserved,
+                    self._depth_ceiling,
+                    retry_after_s=self._drain_estimate_s(),
+                )
+            count = len(self._in_flight_by_caller.get(caller, {}))
+            if count >= self._caller_inflight_cap:
+                raise JobRunnerAtCapacity(
+                    count, self._caller_inflight_cap, retry_after_s=self._drain_estimate_s()
+                )
+            self._reserved += 1
+            self._in_flight_by_caller.setdefault(caller, {})[topic] = self._clock()
+            self._caller_of_topic[topic] = caller
+
+    async def _release_reservation(self, topic: str) -> None:
+        """Release a reservation whose run was not durably accepted (a publish failure)."""
+        async with self._admission_lock:
+            self._reserved -= 1
+            self._forget_in_flight(topic)
+
+    async def _refresh_if_stale(self) -> None:
+        """Re-read the queue's depth and oldest-message age when the cache is stale.
+
+        The queue itself caches its `stream_info` reading (~2s), so this is one cheap read;
+        the runner's own window is what the reservation counter covers. The depth now reflects
+        everything older than the window, so the window's reservations are reset — the counter
+        only covers the gap between refreshes.
+        """
+        now = time.monotonic()
+        if (
+            self._depth_cache_time is not None
+            and now - self._depth_cache_time < self._state_cache_ttl_s
+        ):
+            return
+        self._depth_snapshot = await self._queue.depth()
+        self._oldest_age = await self._queue.oldest_age()
+        self._depth_cache_time = now
+        self._reserved = 0
+
+    def _drain_estimate_s(self) -> int | None:
+        """Seconds until the queue drains below the ceiling, from the pool's observed
+        throughput — the `Retry-After` the REST edge forwards.
+
+        The oldest message's wait implies the drain rate: in a FIFO queue at depth `d` whose
+        oldest message has waited `age`, the pool drains at about `d / age` per second, so the
+        queue reaches the ceiling in `(depth - ceiling) / rate` seconds. `None` when there is
+        no basis (no depth, no age) — the caller falls back to the constant 1.
+        """
+        depth = self._depth_snapshot
+        age = self._oldest_age
+        if depth is None or age is None or depth <= 0 or age <= 0:
+            return None
+        rate = depth / age
+        retry = (depth - self._depth_ceiling) / rate
+        return max(1, math.ceil(retry))
+
+    def _forget_in_flight(self, topic: str, frame: TerminatedEvent | None = None) -> None:
+        """Drop a topic from the per-caller in-flight tracking: the run is over (a terminal
+        frame was observed), was never admitted (a publish failure), or its capability expired.
+
+        ``frame`` guards the observed-terminal path against a stale observation: a topic
+        re-scheduled after its first run finished still shows the FIRST run's terminal frame,
+        and forgetting on that sighting would release the SECOND run's slot. A frame older than
+        the tracked admission is that stale sighting and is ignored.
+        """
+        caller = self._caller_of_topic.get(topic)
+        if caller is None:
+            return
+        admitted_at = self._in_flight_by_caller[caller].get(topic)
+        if (
+            frame is not None
+            and frame.time is not None
+            and admitted_at is not None
+            and frame.time < admitted_at
+        ):
+            return
+        self._caller_of_topic.pop(topic, None)
+        by_caller = self._in_flight_by_caller[caller]
+        by_caller.pop(topic, None)
+        if not by_caller:
+            del self._in_flight_by_caller[caller]
+
     # --- capability validity ---------------------------------------------------------------
 
     def _capability_valid(self, topic: str) -> bool:
@@ -428,7 +586,8 @@ class QueueJobRunner(IdentityAwareJobRunner):
 
     def _prune(self) -> None:
         """Drop schedule records whose capability has expired, so the dict stays bounded by
-        the topics accepted within one capability lifetime."""
+        the topics accepted within one capability lifetime — and release their in-flight
+        slots, so the per-caller cap reflects only live runs."""
         now = self._clock()
         expired = [
             topic
@@ -437,6 +596,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
         ]
         for topic in expired:
             del self._scheduled_at[topic]
+            self._forget_in_flight(topic)
 
 
 __all__ = [

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -505,7 +505,13 @@ class QueueJobRunner(IdentityAwareJobRunner):
     async def _release_reservation(self, topic: str) -> None:
         """Release a reservation whose run was not durably accepted (a publish failure)."""
         async with self._admission_lock:
-            self._reserved -= 1
+            # WHY the floor: `_refresh_if_stale` RESETS the counter on every refresh, and
+            # the refresh can land between this run's reserve and its release (a sibling
+            # `schedule()` raced it). Decrementing from the reset baseline drove the counter
+            # to -1, under-counting depth FOREVER after — one extra run past the ceiling on
+            # every subsequent admission check. A release below zero is the refresh having
+            # already accounted for this reservation; clamp, and the counter stays honest.
+            self._reserved = max(0, self._reserved - 1)
             self._forget_in_flight(topic)
 
     async def _refresh_if_stale(self) -> None:
@@ -550,24 +556,28 @@ class QueueJobRunner(IdentityAwareJobRunner):
 
         ``frame`` guards the observed-terminal path against a stale observation: a topic
         re-scheduled after its first run finished still shows the FIRST run's terminal frame,
-        and forgetting on that sighting would release the SECOND run's slot. A frame older than
-        the tracked admission is that stale sighting and is ignored.
+        and forgetting on that sighting would release the SECOND run's slot. A frame older
+        than a tracked admission is that stale sighting and is ignored — checked PER CALLER,
+        because more than one caller can hold the topic (below).
+
+        WHY every caller and not `_caller_of_topic[topic]`: admission OVERWRITES that
+        mapping when a re-scheduled topic is admitted under a second identity, so the
+        first caller's entry would never be reached again — `_prune` routes through here
+        too — and that caller permanently loses one of its in-flight slots, surfacing
+        eventually as spurious 503s for a caller whose runs have all finished.
         """
-        caller = self._caller_of_topic.get(topic)
-        if caller is None:
-            return
-        admitted_at = self._in_flight_by_caller[caller].get(topic)
-        if (
-            frame is not None
-            and frame.time is not None
-            and admitted_at is not None
-            and frame.time < admitted_at
-        ):
-            return
-        self._caller_of_topic.pop(topic, None)
-        by_caller = self._in_flight_by_caller[caller]
-        by_caller.pop(topic, None)
-        if not by_caller:
+        for by_caller in self._in_flight_by_caller.values():
+            admitted_at = by_caller.get(topic)
+            if admitted_at is None:
+                continue
+            if frame is not None and frame.time is not None and frame.time < admitted_at:
+                continue  # a stale sighting of the FIRST run — this admission is still live
+            by_caller.pop(topic, None)
+        if not any(topic in topics for topics in self._in_flight_by_caller.values()):
+            self._caller_of_topic.pop(topic, None)
+        # Drop callers left with no in-flight topics — the cleanup the single-caller path
+        # always did, so the map stays bounded by callers with live runs.
+        for caller in [c for c, topics in self._in_flight_by_caller.items() if not topics]:
             del self._in_flight_by_caller[caller]
 
     # --- capability validity ---------------------------------------------------------------

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -80,6 +80,11 @@ CONTROL_TIMEOUT_S = 1.0
 # seconds, so a well-behaved client honouring the header cannot be turned into a hot
 # loop against the API for up to the 16h run ceiling.
 CALLER_RETRY_FLOOR_S = 30
+# V-10: the caller retry estimate's upper clamp. The estimate is the age of the caller's
+# OLDEST in-flight run, which can reach the 16h run ceiling — but the slot frees when ANY
+# of the caller's runs ends, and a `Retry-After` of hours tells a well-behaved client to
+# give up or poll at a useless cadence. The cap is a poll cadence, not a deadline.
+CALLER_RETRY_MAX_S = 300
 
 # The sentinel `_read_tail` returns for an UNREADABLE stream tail — distinct from "no
 # frame" and from "a terminal frame", because an unreadable broker answers neither
@@ -616,7 +621,8 @@ class QueueJobRunner(IdentityAwareJobRunner):
         if not tokens:
             return None
         age_s = (self._clock() - min(tokens)).total_seconds()
-        return max(CALLER_RETRY_FLOOR_S, math.ceil(age_s))
+        # V-10: clamped above as well as floored — see `CALLER_RETRY_MAX_S`.
+        return min(CALLER_RETRY_MAX_S, max(CALLER_RETRY_FLOOR_S, math.ceil(age_s)))
 
     def _drain_estimate_s(self) -> int | None:
         """Seconds until the queue drains below the ceiling, from the pool's observed
@@ -631,6 +637,13 @@ class QueueJobRunner(IdentityAwareJobRunner):
         age = self._oldest_age
         if depth is None or age is None or depth <= 0 or age <= 0:
             return None
+        # V-10: the admission check admits on `depth + reservations` — reservations that
+        # pushed the queue past the ceiling are not yet visible in `_depth_snapshot`, so
+        # the raw depth underflowed the formula and the refusal answered `Retry-After: 1`
+        # on a genuinely full queue. The estimate uses the same effective depth the
+        # admission decision used. (Called under `_admission_lock`, so `_reserved` is
+        # stable for the read.)
+        depth = depth + self._reserved
         rate = depth / age
         retry = (depth - self._depth_ceiling) / rate
         return max(1, math.ceil(retry))

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -305,18 +305,20 @@ class Settings(BaseSettings):
     # WHY a ceiling at all: the serving half must stop accepting when the queue is deeper than
     # the fleet can drain in a reasonable time, rather than piling up unbounded work. THIS unit
     # only declares the setting; the admission decision lands with the cutover (OME-1086).
-    run_queue_depth_ceiling: int = runner_queue.DEFAULT_DEPTH_CEILING
+    run_queue_depth_ceiling: int = Field(default=runner_queue.DEFAULT_DEPTH_CEILING, ge=1)
     # FEATURE (OME-1091): how many bucket subjects the queue is split into for per-caller
     # fairness. The worker pulls round-robin across buckets, so one caller's runs cannot be
     # claimed ahead of another's; more buckets mean fewer caller collisions (two callers
     # sharing a bucket share its cap and its round-robin slot), at the cost of more subjects
     # the worker must poll each pull.
-    run_queue_bucket_count: int = runner_queue.DEFAULT_BUCKET_COUNT
+    run_queue_bucket_count: int = Field(default=runner_queue.DEFAULT_BUCKET_COUNT, ge=1)
     # FEATURE (OME-1091): the per-caller in-flight cap — how many of one caller's runs may be
     # admitted at once, so one caller's 9-candidate evaluation cannot occupy every slot. 8
     # matches the Client's fan-out, so one ordinary Evaluation fits while a second concurrent
     # one is refused until the first's runs finish.
-    run_queue_caller_inflight_cap: int = runner_queue.DEFAULT_CALLER_INFLIGHT_CAP
+    run_queue_caller_inflight_cap: int = Field(
+        default=runner_queue.DEFAULT_CALLER_INFLIGHT_CAP, ge=1
+    )
 
     # --- worker (OME-1089) -----------------------------------------------------------------
     # WHY a worker at all: OME-1086 replaces one-Job-per-run scheduling with a fixed pool of

--- a/apps/screamingface-engine/src/screamingface_engine/config.py
+++ b/apps/screamingface-engine/src/screamingface_engine/config.py
@@ -306,6 +306,17 @@ class Settings(BaseSettings):
     # the fleet can drain in a reasonable time, rather than piling up unbounded work. THIS unit
     # only declares the setting; the admission decision lands with the cutover (OME-1086).
     run_queue_depth_ceiling: int = runner_queue.DEFAULT_DEPTH_CEILING
+    # FEATURE (OME-1091): how many bucket subjects the queue is split into for per-caller
+    # fairness. The worker pulls round-robin across buckets, so one caller's runs cannot be
+    # claimed ahead of another's; more buckets mean fewer caller collisions (two callers
+    # sharing a bucket share its cap and its round-robin slot), at the cost of more subjects
+    # the worker must poll each pull.
+    run_queue_bucket_count: int = runner_queue.DEFAULT_BUCKET_COUNT
+    # FEATURE (OME-1091): the per-caller in-flight cap — how many of one caller's runs may be
+    # admitted at once, so one caller's 9-candidate evaluation cannot occupy every slot. 8
+    # matches the Client's fan-out, so one ordinary Evaluation fits while a second concurrent
+    # one is refused until the first's runs finish.
+    run_queue_caller_inflight_cap: int = runner_queue.DEFAULT_CALLER_INFLIGHT_CAP
 
     # --- worker (OME-1089) -----------------------------------------------------------------
     # WHY a worker at all: OME-1086 replaces one-Job-per-run scheduling with a fixed pool of

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -214,11 +214,17 @@ async def _schedule(
         # saturate, and why retrying is safe, is `JobRunnerAtCapacity`'s own contract (the
         # shapes: one shared event loop, a queue-depth ceiling, a scheduler's exhausted quota)
         # — this handler maps, it does not restate; the port's docstring stays the one source.
+        #
+        # WHY a derived `Retry-After` (OME-1091): the queue-backed runner attaches its drain
+        # estimate — how long until the queue has room, from depth and observed throughput — so a
+        # client told to retry in 1 second when the true wait is minutes does not retry into a
+        # wall. A runner with no estimate (the in-process and k8s ones) keeps the constant 1.
+        retry_after = exc.retry_after_s
         raise ProblemException(
             status=503,
             title="Service Unavailable",
             detail="the runner is at capacity — retry shortly",
-            headers={"Retry-After": "1"},
+            headers={"Retry-After": str(retry_after) if retry_after is not None else "1"},
         ) from exc
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -10,6 +10,7 @@ observe the run) lives elsewhere; this module only schedules work onto it via
 
 import asyncio
 import logging
+import math
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -224,7 +225,13 @@ async def _schedule(
             status=503,
             title="Service Unavailable",
             detail="the runner is at capacity — retry shortly",
-            headers={"Retry-After": str(retry_after) if retry_after is not None else "1"},
+            # CEIL at the boundary, not trust in the producer: `Retry-After` is
+            # delta-seconds per RFC 7231 — a non-negative decimal INTEGER. The port
+            # types the estimate as `int | None` and today's only producer ceils, but
+            # the header is where the value becomes protocol, so the boundary renders
+            # ANY future adapter's fractional estimate as a valid integer — rounding
+            # UP, so a caller is never told to retry sooner than the estimate.
+            headers={"Retry-After": str(math.ceil(retry_after)) if retry_after is not None else "1"},
         ) from exc
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -231,7 +231,9 @@ async def _schedule(
             # the header is where the value becomes protocol, so the boundary renders
             # ANY future adapter's fractional estimate as a valid integer — rounding
             # UP, so a caller is never told to retry sooner than the estimate.
-            headers={"Retry-After": str(math.ceil(retry_after)) if retry_after is not None else "1"},
+            headers={
+                "Retry-After": str(math.ceil(retry_after)) if retry_after is not None else "1"
+            },
         ) from exc
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -525,9 +525,44 @@ class RunQueue:
             subject = subjects[(self._rr_index + slot) % rotation]
             sub = await self._bound_subscription(js, subject)
             want = min(batch - len(collected), per_visit)
-            collected.extend(await self._fetch_from(sub, subject, want, window))
+            fetched = await self._visit(sub, subject, want, window, have=len(collected))
+            if fetched is None:
+                break
+            collected.extend(fetched)
         self._rr_index = (self._rr_index + 1) % rotation
         return collected
+
+    async def _visit(
+        self, sub: Any, subject: str, want: int, window: float, *, have: int
+    ) -> list[Any] | None:
+        """One bucket visit's messages, or ``None`` when a blip should end the rotation.
+
+        INVARIANT: a delivery attempt is never spent for nothing. `_fetch_from` re-raises a
+        non-timeout broker error, and `pull` accumulates across buckets — so letting that
+        escape discarded every message the earlier buckets had already yielded, along with
+        the stack frame holding them. Those messages had been DELIVERED: neither acked nor
+        NAK'd, they sat out the whole `ack_wait` and came back as their FINAL delivery
+        (`DEFAULT_MAX_DELIVER` is 2), where one further blip ends those runs as
+        `max_deliveries` instead of executing them.
+
+        WHY a visit that follows NOTHING still raises (`have == 0`): the claim loop counts
+        pull failures and backs off on them, so swallowing unconditionally would turn a
+        broker outage into a silent hot loop indistinguishable from an idle queue. With
+        work in hand the blip is simply left to the next pull, against the same broker.
+        """
+        try:
+            return await self._fetch_from(sub, subject, want, window)
+        except nats.errors.Error:
+            if not have:
+                raise
+            logger.warning(
+                "run-queue pull stopped early on %s after collecting %d message(s); "
+                "returning them and leaving the blip to the next pull",
+                subject,
+                have,
+                exc_info=True,
+            )
+            return None
 
     async def _fetch_from(self, sub: Any, subject: str, want: int, window: float) -> list[Any]:
         """One bucket visit: fetch up to `want` messages, clamped to `want`.

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -26,6 +26,14 @@ from datetime import UTC, datetime
 from typing import Any
 
 import nats
+
+# WHY imported explicitly rather than reached through `nats`: `nats.errors` is a SUBMODULE, so
+# `import nats` does not bind it. `except nats.errors.Error` in `_fetch` resolves today only
+# because `nats.aio.client` below happens to import it as a side effect. That is an accident of
+# the dependency's internals, and if it ever changes the `except` clause raises AttributeError
+# WHILE HANDLING A BROKER ERROR — turning the guard that keeps one pull blip local into the
+# failure itself.
+import nats.errors
 from nats.aio.client import Client
 from nats.aio.msg import Msg
 from nats.js import JetStreamContext

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -23,6 +23,7 @@ import logging
 import time
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
+from typing import Any
 
 import nats
 from nats.aio.client import Client
@@ -75,6 +76,18 @@ DEFAULT_STATE_CACHE_TTL_S = 2.0
 # More buckets mean fewer caller collisions (two callers sharing a bucket share its cap and its
 # round-robin slot), at the cost of more subjects the worker must poll each pull.
 DEFAULT_BUCKET_COUNT = 16
+# The per-bucket fetch cap per rotation visit (review follow-up P2-7): ONE message per
+# bucket per visit let a single caller's burst drain at ~1 run per poll — with the default
+# bucket count the rest of the rotation burned the poll's budget on empty buckets while the
+# burst sat in its bucket. A cap > 1 lets a burst drain several messages per visit while
+# round-robin fairness survives: a bucket takes at most this many (or its fair share of a
+# larger batch) per visit, never the whole poll. Pending production numbers from the sized
+# fleet; the levers are this cap and `PULL_FAST_PASS_S` below.
+PULL_BUCKET_BATCH = 2
+# The fast pass's total budget: one rotation with a short per-bucket window, so messages
+# that are IMMEDIATELY available are collected before the poll spends its budget waiting
+# on empty buckets. Bounded by `timeout_s` so a short poll never over-waits.
+PULL_FAST_PASS_S = 1.0
 # The per-caller in-flight cap (OME-1091): how many of one caller's runs may be admitted at
 # once. 8 matches the Client's fan-out (`_MAX_CANDIDATES_IN_FLIGHT`), so one ordinary
 # Evaluation fits while a second concurrent one is refused until the first's runs finish.
@@ -427,12 +440,18 @@ class RunQueue:
         subjects: Sequence[str] | None = None,
     ) -> list[Msg]:
         """Pull up to `batch` queued messages, round-robin across `subjects` (default: every
-        bucket), waiting up to `timeout_s` in total for the first.
+        bucket), waiting up to `timeout_s` in total.
 
-        The round-robin is one message per bucket per cycle: a busy caller cannot drain ahead
-        of a quieter one within a single pull, and the rotation index advances so no bucket is
-        permanently first. Each bucket gets a share of the timeout, so an empty queue still
-        returns within `timeout_s` overall.
+        The round-robin visits every bucket in rotation, up to `PULL_BUCKET_BATCH`
+        messages (or the batch's fair share, whichever is larger) per bucket per visit, in
+        TWO phases: a FAST pass whose short per-bucket windows collect what is immediately
+        available — a burst sitting in one bucket — and a slow pass that spends the
+        remaining budget on a second rotation, so a message that is not there yet still
+        has a window to land. A busy caller cannot drain ahead of a quieter one WITHIN a
+        pull (the per-visit cap sees to that), and the rotation index advances so no
+        bucket is permanently first. A poll against an empty queue returns within
+        `timeout_s` overall: the fast pass is capped at `PULL_FAST_PASS_S`, and the slow
+        pass only re-splits what remains.
 
         Returns the raw NATS messages; the caller acks each after processing. Under the
         EXPLICIT ack policy an unacked message is redelivered after `ack_wait`, up to
@@ -448,20 +467,22 @@ class RunQueue:
         reconnect clears it — the subscriptions died with the connection.
 
         THE RPC ACCOUNTING (review follow-up, recorded so the tradeoff is a decision, not
-        an accident): one pull costs one `fetch(1)` per bucket VISITED — up to
-        `max(batch, len(subjects))` per poll, 16 with the default bucket count — against
-        one `fetch(batch)` for a single-subject consumer. That multiplier is the price of
+        an accident): one pull costs one `fetch` per bucket VISITED — the fast pass
+        always costs a full rotation (16 with the default bucket count); the slow pass
+        only runs while the batch is unfilled and budget remains — against one
+        `fetch(batch)` for a single-subject consumer. That multiplier is the price of
         per-caller fairness: JetStream dispatches one consumer in stream order, so a
         single wildcard consumer would collapse the buckets back into FIFO — the exact
         head-of-line unfairness the bucket rotation exists to break. Two properties keep
-        the cost bounded: each fetch window is `timeout_s / visits` (an empty queue never
-        holds a worker longer than `timeout_s`), and an empty bucket's fetch returns as
-        soon as its own short window expires, so a poll against an empty queue is 16
-        cheap timeouts, not 16 long ones. Revisit only with production RPC-budget numbers
-        from the sized fleet (worker pods x polls/second x buckets vs what the broker
-        absorbs); the levers, in order of preference, are a smaller `bucket_count`, more
-        than one message per bucket visit, or a server-side fair consumer if JetStream
-        ever ships one — never a silent fallback to the wildcard.
+        the cost bounded: the fast pass's windows total `min(PULL_FAST_PASS_S,
+        timeout_s)`, and an empty bucket's fetch returns as soon as its own short window
+        expires, so a poll against an empty queue is 16 cheap timeouts plus at most one
+        more rotation of the REMAINING budget — never more than `timeout_s` overall.
+        Revisit only with production RPC-budget numbers from the sized fleet (worker pods
+        x polls/second x buckets vs what the broker absorbs); the levers, in order of
+        preference, are a smaller `bucket_count`, the per-visit cap, or a server-side
+        fair consumer if JetStream ever ships one — never a silent fallback to the
+        wildcard.
         """
         subjects = list(subjects) if subjects is not None else self.bucket_subjects()
         if not subjects or batch <= 0:
@@ -469,28 +490,26 @@ class RunQueue:
         await self.ensure_stream()
         js = await self._jetstream()
         collected: list[Msg] = []
-        # The round-robin visits every bucket in rotation, one message per bucket per cycle,
-        # cycling until the batch is filled — so a busy caller cannot drain ahead of a quieter
-        # one, and a message is found wherever it sits. Each bucket gets a share of the
-        # timeout, so the total wait stays within `timeout_s` even when every bucket is empty.
-        per_bucket = timeout_s / max(batch, len(subjects))
-        for slot in range(max(batch, len(subjects))):
+        # TWO PHASES over the same rotation (review follow-up P2-7). The FAST pass (the
+        # first rotation) gives each bucket a short window so messages that are already
+        # there — a burst sitting in one bucket — are collected before the budget is
+        # spent waiting on empty buckets; the SLOW pass spends the remaining budget on a
+        # second rotation, so a message that lands mid-poll still has a window. Each
+        # visit fetches at most `per_visit` messages, so a busy caller cannot drain ahead
+        # of a quieter one WITHIN a pull, and the total wait never exceeds `timeout_s`.
+        rotation = len(subjects)
+        per_visit = max(PULL_BUCKET_BATCH, -(-batch // rotation))
+        fast_window = min(PULL_FAST_PASS_S, timeout_s) / rotation
+        deadline = time.monotonic() + timeout_s
+        for slot in range(max(batch, 2 * rotation)):
             if len(collected) >= batch:
                 break
-            subject = subjects[(self._rr_index + slot) % len(subjects)]
-            sub = self._pull_subs.get(subject)
-            if sub is None:
-                sub = await js.pull_subscribe(
-                    subject,
-                    durable=_consumer_for(subject),
-                    stream=self._stream,
-                    config=_work_queue_consumer_config(
-                        ack_wait_s=self._ack_wait_s,
-                        max_deliver=self._max_deliver,
-                        max_ack_pending=self._max_ack_pending,
-                    ),
-                )
-                self._pull_subs[subject] = sub
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            window = fast_window if slot < rotation else remaining / rotation
+            subject = subjects[(self._rr_index + slot) % rotation]
+            sub = await self._bound_subscription(js, subject)
             try:
                 # INVARIANT: an empty bucket is a RESULT, not an error. nats-py's `fetch`
                 # RAISES `nats.errors.TimeoutError` (or its `FetchTimeoutError` subclass)
@@ -500,13 +519,36 @@ class RunQueue:
                 # pool; with 16 buckets most rotations visit empty buckets before the
                 # one that holds a message. A timed-out HELD subscription stays usable —
                 # the next fetch on it is an independent request.
-                msgs = await sub.fetch(1, timeout=per_bucket)
+                want = min(batch - len(collected), per_visit)
+                msgs = await sub.fetch(want, timeout=window)
             except TimeoutError:
                 continue
-            if msgs:
-                collected.append(msgs[0])
-        self._rr_index = (self._rr_index + 1) % len(subjects)
+            collected.extend(msgs)
+        self._rr_index = (self._rr_index + 1) % rotation
         return collected
+
+    async def _bound_subscription(self, js: Any, subject: str) -> Any:
+        """The HELD pull subscription for one bucket subject, bound on first use.
+
+        WHY held and not per-cycle: binding a durable consumer costs a `consumer_info`
+        round trip, and the claim loop pulls in a tight loop — per-cycle binding paid
+        that once per bucket PER POLL, even against an empty queue. The cache is bounded
+        by the configured bucket list and cleared on reconnect (the subscriptions died
+        with the connection)."""
+        sub = self._pull_subs.get(subject)
+        if sub is None:
+            sub = await js.pull_subscribe(
+                subject,
+                durable=_consumer_for(subject),
+                stream=self._stream,
+                config=_work_queue_consumer_config(
+                    ack_wait_s=self._ack_wait_s,
+                    max_deliver=self._max_deliver,
+                    max_ack_pending=self._max_ack_pending,
+                ),
+            )
+            self._pull_subs[subject] = sub
+        return sub
 
     async def _state(self) -> tuple[int, str | None]:
         """(queued message count, first message's publish timestamp) from one stream-info round
@@ -571,6 +613,8 @@ __all__ = [
     "DEFAULT_QUEUE_MAX_AGE_S",
     "DEFAULT_STATE_CACHE_TTL_S",
     "DEFAULT_WORKER_SLOTS",
+    "PULL_BUCKET_BATCH",
+    "PULL_FAST_PASS_S",
     "QUEUE_CONSUMER",
     "QUEUE_REPLICAS",
     "RunQueue",

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -88,6 +88,13 @@ PULL_BUCKET_BATCH = 2
 # that are IMMEDIATELY available are collected before the poll spends its budget waiting
 # on empty buckets. Bounded by `timeout_s` so a short poll never over-waits.
 PULL_FAST_PASS_S = 1.0
+# V-5: how long a held pull subscription is trusted before it is re-bound. The durable
+# consumer can be deleted/recreated server-side (the note above says that is required to
+# change `max_ack_pending`), and a stale sub can fail SILENTLY — nats-py's `_fetch_n`
+# returns [] on a deleted consumer rather than raising — which no error path can catch.
+# The TTL bounds the silent wedge to one refresh interval; the cost is one bind per
+# bucket per interval, against the per-poll bind the cache exists to avoid.
+PULL_SUB_TTL_S = 300.0
 # The per-caller in-flight cap (OME-1091): how many of one caller's runs may be admitted at
 # once. 8 matches the Client's fan-out (`_MAX_CANDIDATES_IN_FLIGHT`), so one ordinary
 # Evaluation fits while a second concurrent one is refused until the first's runs finish.
@@ -273,10 +280,8 @@ class RunQueue:
         nats_url: str,
         *,
         stream: str = subjects.RUN_QUEUE_STREAM,
-        # The legacy single subject, kept for backward compatibility: the stream is declared
-        # with the wildcard `url4-runq.>` (so every bucket subject lands in it), and the
-        # per-caller buckets derive from `subject_prefix`.
-        subject: str = subjects.RUN_QUEUE_SUBJECT,
+        # The stream is declared with the wildcard `<prefix>.>` (so every bucket subject
+        # lands in it); the per-caller buckets derive from `subject_prefix`.
         subject_prefix: str = subjects.RUN_QUEUE_SUBJECT_PREFIX,
         bucket_count: int = DEFAULT_BUCKET_COUNT,
         duplicate_window_s: float = DEFAULT_DUPLICATE_WINDOW_S,
@@ -294,7 +299,6 @@ class RunQueue:
     ) -> None:
         self._url = nats_url
         self._stream = stream
-        self._subject = subject
         self._subject_prefix = subject_prefix
         self._bucket_count = bucket_count
         self._duplicate_window_s = duplicate_window_s
@@ -320,6 +324,7 @@ class RunQueue:
         # set of subjects is the FIXED configured bucket list (or an explicit caller's
         # list), so the cache is bounded by that, not by callers or messages.
         self._pull_subs: dict[str, Any] = {}
+        self._pull_subs_bound: dict[str, float] = {}
 
     async def _jetstream(self) -> JetStreamContext:
         js = self._js
@@ -337,6 +342,7 @@ class RunQueue:
             self._ensured = False
             # Held subscriptions died with it too — rebind on the next pull.
             self._pull_subs.clear()
+            self._pull_subs_bound.clear()
             return js
 
     def _is_closed(self) -> bool:
@@ -510,22 +516,48 @@ class RunQueue:
             window = fast_window if slot < rotation else remaining / rotation
             subject = subjects[(self._rr_index + slot) % rotation]
             sub = await self._bound_subscription(js, subject)
-            try:
-                # INVARIANT: an empty bucket is a RESULT, not an error. nats-py's `fetch`
-                # RAISES `nats.errors.TimeoutError` (or its `FetchTimeoutError` subclass)
-                # when no message arrives within the window — it never returns an empty
-                # list — and both subclass `TimeoutError`. Left uncaught, the first empty
-                # bucket in the rotation unwinds the worker's claim loop and kills the
-                # pool; with 16 buckets most rotations visit empty buckets before the
-                # one that holds a message. A timed-out HELD subscription stays usable —
-                # the next fetch on it is an independent request.
-                want = min(batch - len(collected), per_visit)
-                msgs = await sub.fetch(want, timeout=window)
-            except TimeoutError:
-                continue
-            collected.extend(msgs)
+            want = min(batch - len(collected), per_visit)
+            collected.extend(await self._fetch_from(sub, subject, want, window))
         self._rr_index = (self._rr_index + 1) % rotation
         return collected
+
+    async def _fetch_from(self, sub: Any, subject: str, want: int, window: float) -> list[Any]:
+        """One bucket visit: fetch up to `want` messages, clamped to `want`.
+
+        INVARIANT: an empty bucket is a RESULT, not an error. nats-py's `fetch` RAISES
+        `nats.errors.TimeoutError` (or its `FetchTimeoutError` subclass) when no message
+        arrives within the window — it never returns an empty list — and both subclass
+        `TimeoutError`. Left uncaught, the first empty bucket in the rotation unwinds the
+        worker's claim loop and kills the pool; with 16 buckets most rotations visit
+        empty buckets before the one that holds a message. A timed-out HELD subscription
+        stays usable — the next fetch on it is an independent request.
+
+        V-4: nats-py's `_fetch_n` (want >= 2) drains the subscription's PENDING queue
+        with no `needed` guard, so a held sub carrying late deliveries from a previous
+        poll can return MORE than `want` — and the claim loop spawns one supervisor per
+        returned message, so an unclamped extend over-subscribed the pod past
+        `worker_slots`, breaking the loop's stated invariant. The surplus is NAK'd —
+        returned to the queue for the next pull — not dropped and not acked away.
+
+        V-5: a held subscription can be broken server-side — the durable consumer deleted
+        or recreated (the note above says that is required to change `max_ack_pending`)
+        — and a broken sub never self-heals: `_fetch_one` raises, `_fetch_n` returns []
+        silently. A non-timeout error drops the cache entry so the next pull re-binds;
+        the claim loop's guard logs and retries, and the wedge is bounded to one poll.
+        """
+        try:
+            msgs = await sub.fetch(want, timeout=window)
+        except TimeoutError:
+            return []
+        except nats.errors.Error:
+            self._pull_subs.pop(subject, None)
+            self._pull_subs_bound.pop(subject, None)
+            raise
+        if len(msgs) > want:
+            surplus, msgs = msgs[want:], msgs[:want]
+            for extra in surplus:
+                await extra.nak()
+        return msgs
 
     async def _bound_subscription(self, js: Any, subject: str) -> Any:
         """The HELD pull subscription for one bucket subject, bound on first use.
@@ -536,6 +568,14 @@ class RunQueue:
         by the configured bucket list and cleared on reconnect (the subscriptions died
         with the connection)."""
         sub = self._pull_subs.get(subject)
+        if (
+            sub is not None
+            and time.monotonic() - self._pull_subs_bound.get(subject, 0.0) > PULL_SUB_TTL_S
+        ):
+            # V-5: the TTL refresh — a stale sub can fail silently (see the constant), so
+            # it is re-bound on a schedule rather than only on a visible error.
+            self._pull_subs.pop(subject, None)
+            sub = None
         if sub is None:
             sub = await js.pull_subscribe(
                 subject,
@@ -548,6 +588,7 @@ class RunQueue:
                 ),
             )
             self._pull_subs[subject] = sub
+            self._pull_subs_bound[subject] = time.monotonic()
         return sub
 
     async def _state(self) -> tuple[int, str | None]:

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -446,6 +446,22 @@ class RunQueue:
         reduces each cycle to the `fetch` alone; the cache is bounded by the configured
         bucket list (or the caller's explicit list), never by callers or messages, and a
         reconnect clears it — the subscriptions died with the connection.
+
+        THE RPC ACCOUNTING (review follow-up, recorded so the tradeoff is a decision, not
+        an accident): one pull costs one `fetch(1)` per bucket VISITED — up to
+        `max(batch, len(subjects))` per poll, 16 with the default bucket count — against
+        one `fetch(batch)` for a single-subject consumer. That multiplier is the price of
+        per-caller fairness: JetStream dispatches one consumer in stream order, so a
+        single wildcard consumer would collapse the buckets back into FIFO — the exact
+        head-of-line unfairness the bucket rotation exists to break. Two properties keep
+        the cost bounded: each fetch window is `timeout_s / visits` (an empty queue never
+        holds a worker longer than `timeout_s`), and an empty bucket's fetch returns as
+        soon as its own short window expires, so a poll against an empty queue is 16
+        cheap timeouts, not 16 long ones. Revisit only with production RPC-budget numbers
+        from the sized fleet (worker pods x polls/second x buckets vs what the broker
+        absorbs); the levers, in order of preference, are a smaller `bucket_count`, more
+        than one message per bucket visit, or a server-side fair consumer if JetStream
+        ever ships one — never a silent fallback to the wildcard.
         """
         subjects = list(subjects) if subjects is not None else self.bucket_subjects()
         if not subjects or batch <= 0:

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -300,6 +300,13 @@ class RunQueue:
         # The round-robin pull's rotation: which bucket the next pull starts at. Advancing by
         # one per pull means no bucket is permanently first (or last) in the rotation.
         self._rr_index = 0
+        # HELD pull subscriptions, one per distinct subject (review follow-up): binding a
+        # durable consumer costs a `consumer_info` round trip, and the claim loop pulls in
+        # a tight loop whenever slots are free — binding per bucket per cycle multiplied
+        # that cost by the bucket count on EVERY poll, even when the queue was empty. The
+        # set of subjects is the FIXED configured bucket list (or an explicit caller's
+        # list), so the cache is bounded by that, not by callers or messages.
+        self._pull_subs: dict[str, Any] = {}
 
     async def _jetstream(self) -> JetStreamContext:
         js = self._js
@@ -315,6 +322,8 @@ class RunQueue:
             self._js = js
             # The declarations belonged to the connection that just died; the new one has none.
             self._ensured = False
+            # Held subscriptions died with it too — rebind on the next pull.
+            self._pull_subs.clear()
             return js
 
     def _is_closed(self) -> bool:
@@ -429,10 +438,14 @@ class RunQueue:
         EXPLICIT ack policy an unacked message is redelivered after `ack_wait`, up to
         `max_deliver` times.
 
-        WHY a fresh subscription per call: the durable consumers (`url4-runners-<bucket>`) are
-        server-side and persist, so binding and unbinding a client subscription per pull is
-        idempotent and costs one `consumer_info` round trip. A worker that wants to avoid even
-        that can hold the subscription itself.
+        WHY subscriptions are HELD: the durable consumers (`url4-runners-<bucket>`) are
+        server-side and persist, so binding a client subscription is idempotent — and
+        doing it per bucket PER CYCLE cost a `consumer_info` round trip each way on every
+        poll, multiplied by the bucket count, paid even when the queue was empty and the
+        claim loop is polling flat out. Holding one subscription per distinct subject
+        reduces each cycle to the `fetch` alone; the cache is bounded by the configured
+        bucket list (or the caller's explicit list), never by callers or messages, and a
+        reconnect clears it — the subscriptions died with the connection.
         """
         subjects = list(subjects) if subjects is not None else self.bucket_subjects()
         if not subjects or batch <= 0:
@@ -449,16 +462,19 @@ class RunQueue:
             if len(collected) >= batch:
                 break
             subject = subjects[(self._rr_index + slot) % len(subjects)]
-            sub = await js.pull_subscribe(
-                subject,
-                durable=_consumer_for(subject),
-                stream=self._stream,
-                config=_work_queue_consumer_config(
-                    ack_wait_s=self._ack_wait_s,
-                    max_deliver=self._max_deliver,
-                    max_ack_pending=self._max_ack_pending,
-                ),
-            )
+            sub = self._pull_subs.get(subject)
+            if sub is None:
+                sub = await js.pull_subscribe(
+                    subject,
+                    durable=_consumer_for(subject),
+                    stream=self._stream,
+                    config=_work_queue_consumer_config(
+                        ack_wait_s=self._ack_wait_s,
+                        max_deliver=self._max_deliver,
+                        max_ack_pending=self._max_ack_pending,
+                    ),
+                )
+                self._pull_subs[subject] = sub
             try:
                 # INVARIANT: an empty bucket is a RESULT, not an error. nats-py's `fetch`
                 # RAISES `nats.errors.TimeoutError` (or its `FetchTimeoutError` subclass)
@@ -466,12 +482,11 @@ class RunQueue:
                 # list — and both subclass `TimeoutError`. Left uncaught, the first empty
                 # bucket in the rotation unwinds the worker's claim loop and kills the
                 # pool; with 16 buckets most rotations visit empty buckets before the
-                # one that holds a message.
+                # one that holds a message. A timed-out HELD subscription stays usable —
+                # the next fetch on it is an independent request.
                 msgs = await sub.fetch(1, timeout=per_bucket)
             except TimeoutError:
                 continue
-            finally:
-                await sub.unsubscribe()
             if msgs:
                 collected.append(msgs[0])
         self._rr_index = (self._rr_index + 1) % len(subjects)

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -372,7 +372,17 @@ class RunQueue:
             # its config (replicas, retention — those are the declaring replica's business).
             info = await js.stream_info(self._stream)
             if info.config.subjects != [self._stream_subject]:
-                await js.update_stream(name=self._stream, subjects=[self._stream_subject])
+                # INVARIANT: the update starts from the LIVE config, not from kwargs.
+                # nats-py's `update_stream` builds a FRESH `StreamConfig()` and evolves
+                # only the given kwargs, so `update_stream(name=..., subjects=...)`
+                # resets everything not named — retention (WorkQueue -> Limits),
+                # `num_replicas`, `max_age`, `duplicate_window` — to defaults. Against a
+                # legacy narrow-subject stream the server then REJECTS the retention
+                # change and `ensure_stream` raises on every publish; if it were
+                # accepted, the dedupe window and replica count would be silently gone.
+                config = info.config
+                config.subjects = [self._stream_subject]
+                await js.update_stream(config)
         self._ensured = True
 
     async def publish(self, message: bytes, *, identity: Mapping[str, str] | None = None) -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -17,6 +17,7 @@ worker half (which pulls), so it imports nothing from the run half — only the 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import time
@@ -70,6 +71,42 @@ DEFAULT_MAX_ACK_PENDING = 256
 DEFAULT_DEPTH_CEILING = 10_000
 DEFAULT_IO_CONCURRENCY = 4
 DEFAULT_STATE_CACHE_TTL_S = 2.0
+# The per-caller fairness seam (OME-1091): how many bucket subjects the queue is split into.
+# More buckets mean fewer caller collisions (two callers sharing a bucket share its cap and its
+# round-robin slot), at the cost of more subjects the worker must poll each pull.
+DEFAULT_BUCKET_COUNT = 16
+# The per-caller in-flight cap (OME-1091): how many of one caller's runs may be admitted at
+# once. 8 matches the Client's fan-out (`_MAX_CANDIDATES_IN_FLIGHT`), so one ordinary
+# Evaluation fits while a second concurrent one is refused until the first's runs finish.
+DEFAULT_CALLER_INFLIGHT_CAP = 8
+# The anonymous caller's key: a run with no verified identity is its own caller, so it cannot
+# hide behind another caller's footprint.
+_ANONYMOUS_CALLER = "anonymous"
+
+
+def caller_key(identity: Mapping[str, str] | None) -> str:
+    """The caller's identity value — the verified email — or the anonymous sentinel.
+
+    The bucket key and the per-caller in-flight counter both derive from this one value, so a
+    caller is one caller everywhere. The identity mapping is canonical header name → value
+    (:func:`screamingface_engine.job_env.identity_from_headers`); there is exactly one
+    identity header today, so the value is the mapping's single member.
+    """
+    if not identity:
+        return _ANONYMOUS_CALLER
+    return next(iter(identity.values()), _ANONYMOUS_CALLER)
+
+
+def _consumer_for(subject: str) -> str:
+    """The durable consumer for one bucket subject: `url4-runners-<bucket>`.
+
+    WHY per-bucket rather than one shared name: a durable consumer is identified by
+    (stream, name) and its filter subject is part of its config — reusing one name across
+    buckets would UPDATE the filter on every pull, and messages pending under the old filter
+    would be re-evaluated against the new one. One consumer per bucket keeps each bucket's
+    ack state stable.
+    """
+    return f"{QUEUE_CONSUMER}-{subject.rsplit('.', 1)[-1]}"
 
 
 def _work_queue_consumer_config(
@@ -223,7 +260,12 @@ class RunQueue:
         nats_url: str,
         *,
         stream: str = subjects.RUN_QUEUE_STREAM,
+        # The legacy single subject, kept for backward compatibility: the stream is declared
+        # with the wildcard `url4-runq.>` (so every bucket subject lands in it), and the
+        # per-caller buckets derive from `subject_prefix`.
         subject: str = subjects.RUN_QUEUE_SUBJECT,
+        subject_prefix: str = subjects.RUN_QUEUE_SUBJECT_PREFIX,
+        bucket_count: int = DEFAULT_BUCKET_COUNT,
         duplicate_window_s: float = DEFAULT_DUPLICATE_WINDOW_S,
         max_age_s: float = DEFAULT_QUEUE_MAX_AGE_S,
         ack_wait_s: float = DEFAULT_ACK_WAIT_S,
@@ -240,6 +282,8 @@ class RunQueue:
         self._url = nats_url
         self._stream = stream
         self._subject = subject
+        self._subject_prefix = subject_prefix
+        self._bucket_count = bucket_count
         self._duplicate_window_s = duplicate_window_s
         self._max_age_s = max_age_s
         self._ack_wait_s = ack_wait_s
@@ -253,6 +297,9 @@ class RunQueue:
         self._ensured = False
         # (monotonic time of the read, (depth, first_ts)) — see `_state`.
         self._state_cache: tuple[float, tuple[int, str | None]] | None = None
+        # The round-robin pull's rotation: which bucket the next pull starts at. Advancing by
+        # one per pull means no bucket is permanently first (or last) in the rotation.
+        self._rr_index = 0
 
     async def _jetstream(self) -> JetStreamContext:
         js = self._js
@@ -274,6 +321,25 @@ class RunQueue:
         nc = self._nc
         return nc is not None and nc.is_closed
 
+    @property
+    def _stream_subject(self) -> str:
+        """The stream's subject set: the wildcard over every bucket subject, so one stream
+        holds every caller's runs."""
+        return f"{self._subject_prefix}.>"
+
+    def bucket_subject(self, identity: Mapping[str, str] | None) -> str:
+        """The per-caller queue subject for one caller: a stable hash of the identity VALUE,
+        not the raw address — a subject name is readable by anything with broker access, so
+        the caller's email must never appear in it (spec open question 1).
+        """
+        digest = hashlib.sha256(caller_key(identity).encode("utf-8")).hexdigest()
+        bucket = int(digest[:8], 16) % self._bucket_count
+        return f"{self._subject_prefix}.{bucket:02x}"
+
+    def bucket_subjects(self) -> list[str]:
+        """Every bucket subject, in order — the round-robin pull's rotation."""
+        return [f"{self._subject_prefix}.{i:02x}" for i in range(self._bucket_count)]
+
     async def ensure_stream(self) -> None:
         """Declare the queue stream, tolerating one that already exists.
 
@@ -287,7 +353,7 @@ class RunQueue:
         try:
             await js.add_stream(
                 name=self._stream,
-                subjects=[self._subject],
+                subjects=[self._stream_subject],
                 retention=RetentionPolicy.WORK_QUEUE,
                 storage=StorageType.FILE,
                 num_replicas=self._replicas,
@@ -300,12 +366,17 @@ class RunQueue:
                 # diverged from what this code declares. NOT "already declared": raising here
                 # surfaces the mismatch at startup instead of running on it silently.
                 raise
-            # Already declared — by another replica, or by an earlier connection.
-            pass
+            # Already declared — by another replica, or by an earlier connection. A stream
+            # declared before per-caller buckets (OME-1091) holds only the single work subject;
+            # widen it to the wildcard so bucket publishes land, without touching the rest of
+            # its config (replicas, retention — those are the declaring replica's business).
+            info = await js.stream_info(self._stream)
+            if info.config.subjects != [self._stream_subject]:
+                await js.update_stream(name=self._stream, subjects=[self._stream_subject])
         self._ensured = True
 
-    async def publish(self, message: bytes) -> None:
-        """Publish one run submission, durably.
+    async def publish(self, message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
+        """Publish one run submission to its caller's bucket, durably.
 
         INVARIANT: `Nats-Msg-Id` is the run's TOPIC, read from the message body itself, so a
         retried submission of the same topic is deduplicated by the broker within
@@ -321,7 +392,7 @@ class RunQueue:
         await self.ensure_stream()
         js = await self._jetstream()
         await js.publish(
-            self._subject,
+            self.bucket_subject(identity),
             message,
             headers={
                 "Nats-Msg-Id": topic_of_message(message),
@@ -329,41 +400,72 @@ class RunQueue:
             },
         )
 
-    async def pull(self, batch: int, timeout_s: float) -> list[Msg]:
-        """Pull up to `batch` queued messages, waiting up to `timeout_s` for the first.
+    async def pull(
+        self,
+        batch: int,
+        timeout_s: float,
+        *,
+        subjects: Sequence[str] | None = None,
+    ) -> list[Msg]:
+        """Pull up to `batch` queued messages, round-robin across `subjects` (default: every
+        bucket), waiting up to `timeout_s` in total for the first.
+
+        The round-robin is one message per bucket per cycle: a busy caller cannot drain ahead
+        of a quieter one within a single pull, and the rotation index advances so no bucket is
+        permanently first. Each bucket gets a share of the timeout, so an empty queue still
+        returns within `timeout_s` overall.
 
         Returns the raw NATS messages; the caller acks each after processing. Under the
         EXPLICIT ack policy an unacked message is redelivered after `ack_wait`, up to
         `max_deliver` times.
 
-        WHY a fresh subscription per call: the durable consumer (`url4-runners`) is server-side
-        and persists, so binding and unbinding a client subscription per pull is idempotent and
-        costs one `consumer_info` round trip. A worker that wants to avoid even that can hold
-        the subscription itself.
+        WHY a fresh subscription per call: the durable consumers (`url4-runners-<bucket>`) are
+        server-side and persist, so binding and unbinding a client subscription per pull is
+        idempotent and costs one `consumer_info` round trip. A worker that wants to avoid even
+        that can hold the subscription itself.
         """
+        subjects = list(subjects) if subjects is not None else self.bucket_subjects()
+        if not subjects or batch <= 0:
+            return []
         await self.ensure_stream()
         js = await self._jetstream()
-        sub = await js.pull_subscribe(
-            self._subject,
-            durable=QUEUE_CONSUMER,
-            stream=self._stream,
-            config=_work_queue_consumer_config(
-                ack_wait_s=self._ack_wait_s,
-                max_deliver=self._max_deliver,
-                max_ack_pending=self._max_ack_pending,
-            ),
-        )
-        try:
-            return await sub.fetch(batch, timeout=timeout_s)
-        except TimeoutError:
-            # INVARIANT: an idle poll is a RESULT, not an error. nats-py's `fetch` RAISES
-            # `nats.errors.TimeoutError` (or its `FetchTimeoutError` subclass) when no
-            # message arrives within the window — it never returns an empty list — and
-            # both subclass `TimeoutError`. Left uncaught, the first empty poll unwinds
-            # the worker's claim loop and kills the pool on an idle queue.
-            return []
-        finally:
-            await sub.unsubscribe()
+        collected: list[Msg] = []
+        # The round-robin visits every bucket in rotation, one message per bucket per cycle,
+        # cycling until the batch is filled — so a busy caller cannot drain ahead of a quieter
+        # one, and a message is found wherever it sits. Each bucket gets a share of the
+        # timeout, so the total wait stays within `timeout_s` even when every bucket is empty.
+        per_bucket = timeout_s / max(batch, len(subjects))
+        for slot in range(max(batch, len(subjects))):
+            if len(collected) >= batch:
+                break
+            subject = subjects[(self._rr_index + slot) % len(subjects)]
+            sub = await js.pull_subscribe(
+                subject,
+                durable=_consumer_for(subject),
+                stream=self._stream,
+                config=_work_queue_consumer_config(
+                    ack_wait_s=self._ack_wait_s,
+                    max_deliver=self._max_deliver,
+                    max_ack_pending=self._max_ack_pending,
+                ),
+            )
+            try:
+                # INVARIANT: an empty bucket is a RESULT, not an error. nats-py's `fetch`
+                # RAISES `nats.errors.TimeoutError` (or its `FetchTimeoutError` subclass)
+                # when no message arrives within the window — it never returns an empty
+                # list — and both subclass `TimeoutError`. Left uncaught, the first empty
+                # bucket in the rotation unwinds the worker's claim loop and kills the
+                # pool; with 16 buckets most rotations visit empty buckets before the
+                # one that holds a message.
+                msgs = await sub.fetch(1, timeout=per_bucket)
+            except TimeoutError:
+                continue
+            finally:
+                await sub.unsubscribe()
+            if msgs:
+                collected.append(msgs[0])
+        self._rr_index = (self._rr_index + 1) % len(subjects)
+        return collected
 
     async def _state(self) -> tuple[int, str | None]:
         """(queued message count, first message's publish timestamp) from one stream-info round
@@ -418,6 +520,8 @@ class RunQueue:
 
 __all__ = [
     "DEFAULT_ACK_WAIT_S",
+    "DEFAULT_BUCKET_COUNT",
+    "DEFAULT_CALLER_INFLIGHT_CAP",
     "DEFAULT_DEPTH_CEILING",
     "DEFAULT_DUPLICATE_WINDOW_S",
     "DEFAULT_IO_CONCURRENCY",
@@ -429,6 +533,7 @@ __all__ = [
     "QUEUE_CONSUMER",
     "QUEUE_REPLICAS",
     "RunQueue",
+    "caller_key",
     "decode_message",
     "encode_message",
     "topic_of_message",

--- a/apps/screamingface-engine/src/screamingface_engine/subjects.py
+++ b/apps/screamingface-engine/src/screamingface_engine/subjects.py
@@ -14,8 +14,10 @@ PREFIX = "url4-cloud"
 
 # The durable run queue (OME-1088): ONE stream for every run, unlike the per-run event streams,
 # so it is named OUTSIDE the per-run `url4-cloud_` prefix — see `owns_stream` for why that is
-# load-bearing. Per-caller subjects (`url4-runq.<bucket>`) are the fairness seam; they land in
-# OME-1091, so this unit uses the single `url4-runq.work` subject.
+# load-bearing. Per-caller subjects (`url4-runq.<bucket>`, a stable hash of the caller's identity
+# value) are the fairness seam (OME-1091): the stream is declared with the wildcard `url4-runq.>`
+# and the worker pulls round-robin across buckets. `RUN_QUEUE_SUBJECT` is the legacy single
+# subject, kept for backward compatibility.
 RUN_QUEUE_STREAM = "url4-runq"
 RUN_QUEUE_SUBJECT_PREFIX = "url4-runq"
 RUN_QUEUE_SUBJECT = f"{RUN_QUEUE_SUBJECT_PREFIX}.work"

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -396,6 +396,7 @@ def worker_composition(settings: Settings) -> tuple[RunQueue, JetStreamPublisher
         max_ack_pending=settings.run_queue_max_ack_pending,
         duplicate_window_s=settings.run_queue_duplicate_window_s,
         max_age_s=settings.run_queue_max_age_s,
+        bucket_count=settings.run_queue_bucket_count,
         # INVARIANT: the App and the worker declare the SAME singleton stream, and
         # `ensure_stream` refuses a declaration whose properties diverge from an existing
         # one — so both halves must read this from the same setting. Omitting it here left

--- a/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/loop.py
@@ -391,6 +391,7 @@ def worker_composition(settings: Settings) -> tuple[RunQueue, JetStreamPublisher
     queue = RunQueue(
         settings.nats_url,
         stream=settings.run_queue_stream,
+        subject_prefix=settings.run_queue_subject_prefix,
         ack_wait_s=settings.run_queue_ack_wait_s,
         max_deliver=settings.run_queue_max_deliver,
         max_ack_pending=settings.run_queue_max_ack_pending,

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -188,6 +188,11 @@ class RunSupervisor:
         self._spawn = spawn
         self._memory_budget_bytes = memory_budget_bytes
         self._io_capacity = io_capacity
+        # Spawns committed-to but not yet registered in `_children` (review follow-up):
+        # the io budget's denominator counts these, so a batch of concurrent spawns
+        # divides capacity by every spawn already committed — not just the ones whose
+        # subprocess finished starting.
+        self._spawning = 0
         self._draining = draining
         self._terminating = terminating
         self._children = children
@@ -362,46 +367,61 @@ class RunSupervisor:
 
     async def _run_child(self, msg: ClaimedMessage, topic: str) -> None:
         """Fork the run as a child, supervise it to its terminal frame, then ack."""
-        env = self._child_env(msg)
+        # Reserve the spawn slot SYNCHRONOUSLY, before the budget read below: every
+        # `await` is a preemption point, and the old order (budget → await spawn →
+        # register) let two batch siblings both read `len(self._children) == 0` and both
+        # take the FULL io capacity — the exact burst the fair share exists to divide.
+        # The reserve→read pair has no await between it, so on the single event loop it
+        # is atomic: a later sibling's budget always counts every spawn already
+        # committed-to, whether or not its process has finished starting.
+        self._spawning += 1
+        promoted = False
         try:
-            proc = await self._spawn_child(env)
-        except OSError as exc:
-            # The run cannot start at all — a named failure beats silence, and the
-            # message is acked so the run is not redelivered to fail the same way.
-            await self._publish_terminal(topic, "failed", SPAWN_FAILED, str(exc))
-            await msg.ack()
-            return
-        self._children.add(proc)
-        self._children_by_topic[topic] = proc
-        if topic in self._cancelled:
-            # A cancel was ACKNOWLEDGED while this child was starting (the control loop
-            # replied from the starting registry): enact it the moment the child exists.
-            proc.terminate()
-        heartbeat = asyncio.create_task(self._heartbeat(msg, topic))
-        output = asyncio.create_task(self._forward_output(proc, topic))
-        try:
-            outcome = await self._wait_for_child(proc, self._hard_wall_s(env))
-            await self._publish_if_needed(topic, self._classify(outcome, proc.returncode, topic))
-            await msg.ack()
+            env = self._child_env(msg)
+            try:
+                proc = await self._spawn_child(env)
+            except OSError as exc:
+                # The run cannot start at all — a named failure beats silence, and the
+                # message is acked so the run is not redelivered to fail the same way.
+                await self._publish_terminal(topic, "failed", SPAWN_FAILED, str(exc))
+                await msg.ack()
+                return
+            self._children.add(proc)
+            self._spawning -= 1  # the registries count this spawn from here — no double count
+            promoted = True
+            self._children_by_topic[topic] = proc
+            if topic in self._cancelled:
+                # A cancel was ACKNOWLEDGED while this child was starting (the control loop
+                # replied from the starting registry): enact it the moment the child exists.
+                proc.terminate()
+            heartbeat = asyncio.create_task(self._heartbeat(msg, topic))
+            output = asyncio.create_task(self._forward_output(proc, topic))
+            try:
+                outcome = await self._wait_for_child(proc, self._hard_wall_s(env))
+                await self._publish_if_needed(topic, self._classify(outcome, proc.returncode, topic))
+                await msg.ack()
+            finally:
+                heartbeat.cancel()
+                output.cancel()
+                # WHY gather and not sequential awaits under one `suppress`: a task that already
+                # FAILED (not cancelled) re-raises its own exception on await, and `cancel()` is a
+                # no-op on it — so `await heartbeat` would blow the finally block open and skip
+                # every line below it (the child stays in `self._children`, a live child is never
+                # killed). `return_exceptions=True` makes the gather itself unraisable; the
+                # cleanup after it is therefore unconditional.
+                for result in await asyncio.gather(heartbeat, output, return_exceptions=True):
+                    if isinstance(result, BaseException) and not isinstance(
+                        result, asyncio.CancelledError
+                    ):
+                        logger.warning("run supervision task failed during cleanup: %r", result)
+                self._release_child(proc, topic)
+                if proc.returncode is None:
+                    # A cancelled supervisor (a sibling failed and the TaskGroup unwound)
+                    # must not orphan its child.
+                    proc.kill()
         finally:
-            heartbeat.cancel()
-            output.cancel()
-            # WHY gather and not sequential awaits under one `suppress`: a task that already
-            # FAILED (not cancelled) re-raises its own exception on await, and `cancel()` is a
-            # no-op on it — so `await heartbeat` would blow the finally block open and skip
-            # every line below it (the child stays in `self._children`, a live child is never
-            # killed). `return_exceptions=True` makes the gather itself unraisable; the
-            # cleanup after it is therefore unconditional.
-            for result in await asyncio.gather(heartbeat, output, return_exceptions=True):
-                if isinstance(result, BaseException) and not isinstance(
-                    result, asyncio.CancelledError
-                ):
-                    logger.warning("run supervision task failed during cleanup: %r", result)
-            self._release_child(proc, topic)
-            if proc.returncode is None:
-                # A cancelled supervisor (a sibling failed and the TaskGroup unwound)
-                # must not orphan its child.
-                proc.kill()
+            if not promoted:
+                self._spawning -= 1  # the spawn never registered — release its reservation
 
     def _release_child(self, proc: _ChildProcess, topic: str) -> None:
         """Drop a finished child from every registry the worker shares.
@@ -533,7 +553,7 @@ class RunSupervisor:
         return env
 
     def _io_budget(self) -> int:
-        """The spawn-time io budget: `io_capacity / active_children` (the new child included),
+        """The spawn-time io budget: `io_capacity / (active children + committed spawns)`,
         floored at 1 — the deployed half of OME-908's fair share.
 
         WHY a division rather than the static `io_capacity`: with `N` children running, each
@@ -541,9 +561,13 @@ class RunSupervisor:
         cannot monopolize it. WHY FIXED at spawn: the budget travels by env and the child is a
         separate process — it does not rebalance when a sibling exits (the dynamic
         `FairShareGate` is local-mode only; a cross-process control socket is the declared
-        follow-up).
+        follow-up). The caller's OWN reservation is included (`_run_child` reserves before
+        reading this — synchronously, no await between — so two siblings spawning in one
+        claim batch cannot both divide by one and take the full capacity each); the first
+        spawn of a batch keeps the whole budget because its budget was fixed before any
+        sibling committed — the same spawn-fixed limitation as sibling exits.
         """
-        return max(1, self._io_capacity // max(1, len(self._children) + 1))
+        return max(1, self._io_capacity // max(1, len(self._children) + self._spawning))
 
     async def _spawn_child(self, env: Mapping[str, str]) -> _ChildProcess:
         """Fork the run entrypoint as a supervised child, under its own ``RLIMIT_AS``.

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -529,8 +529,21 @@ class RunSupervisor:
         """
         env = dict(os.environ)
         env.update(decode_message(msg.data))
-        env[job_env.IO_CONCURRENCY] = str(self._io_capacity)
+        env[job_env.IO_CONCURRENCY] = str(self._io_budget())
         return env
+
+    def _io_budget(self) -> int:
+        """The spawn-time io budget: `io_capacity / active_children` (the new child included),
+        floored at 1 — the deployed half of OME-908's fair share.
+
+        WHY a division rather than the static `io_capacity`: with `N` children running, each
+        gets `io_capacity / N` of the gateway's downstream capacity, so one benchmark-sized run
+        cannot monopolize it. WHY FIXED at spawn: the budget travels by env and the child is a
+        separate process — it does not rebalance when a sibling exits (the dynamic
+        `FairShareGate` is local-mode only; a cross-process control socket is the declared
+        follow-up).
+        """
+        return max(1, self._io_capacity // max(1, len(self._children) + 1))
 
     async def _spawn_child(self, env: Mapping[str, str]) -> _ChildProcess:
         """Fork the run entrypoint as a supervised child, under its own ``RLIMIT_AS``.

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -366,7 +366,12 @@ class RunSupervisor:
         return True
 
     async def _run_child(self, msg: ClaimedMessage, topic: str) -> None:
-        """Fork the run as a child, supervise it to its terminal frame, then ack."""
+        """Fork the run as a child, supervise it to its terminal frame, then ack.
+
+        The spawn slot is reserved and released HERE; everything after a successful
+        spawn belongs to `_supervise_live_child` — the split is what keeps each half
+        inside the house complexity limits without burying the invariants.
+        """
         # Reserve the spawn slot SYNCHRONOUSLY, before the budget read below: every
         # `await` is a preemption point, and the old order (budget → await spawn →
         # register) let two batch siblings both read `len(self._children) == 0` and both
@@ -389,39 +394,51 @@ class RunSupervisor:
             self._children.add(proc)
             self._spawning -= 1  # the registries count this spawn from here — no double count
             promoted = True
-            self._children_by_topic[topic] = proc
-            if topic in self._cancelled:
-                # A cancel was ACKNOWLEDGED while this child was starting (the control loop
-                # replied from the starting registry): enact it the moment the child exists.
-                proc.terminate()
-            heartbeat = asyncio.create_task(self._heartbeat(msg, topic))
-            output = asyncio.create_task(self._forward_output(proc, topic))
-            try:
-                outcome = await self._wait_for_child(proc, self._hard_wall_s(env))
-                await self._publish_if_needed(topic, self._classify(outcome, proc.returncode, topic))
-                await msg.ack()
-            finally:
-                heartbeat.cancel()
-                output.cancel()
-                # WHY gather and not sequential awaits under one `suppress`: a task that already
-                # FAILED (not cancelled) re-raises its own exception on await, and `cancel()` is a
-                # no-op on it — so `await heartbeat` would blow the finally block open and skip
-                # every line below it (the child stays in `self._children`, a live child is never
-                # killed). `return_exceptions=True` makes the gather itself unraisable; the
-                # cleanup after it is therefore unconditional.
-                for result in await asyncio.gather(heartbeat, output, return_exceptions=True):
-                    if isinstance(result, BaseException) and not isinstance(
-                        result, asyncio.CancelledError
-                    ):
-                        logger.warning("run supervision task failed during cleanup: %r", result)
-                self._release_child(proc, topic)
-                if proc.returncode is None:
-                    # A cancelled supervisor (a sibling failed and the TaskGroup unwound)
-                    # must not orphan its child.
-                    proc.kill()
+            await self._supervise_live_child(msg, topic, proc, env)
         finally:
             if not promoted:
                 self._spawning -= 1  # the spawn never registered — release its reservation
+
+    async def _supervise_live_child(
+        self, msg: ClaimedMessage, topic: str, proc: _ChildProcess, env: Mapping[str, str]
+    ) -> None:
+        """Carry a REGISTERED child to its terminal frame and the ack.
+
+        Registration, the pre-registered cancel, the side-channel tasks, the hard wall,
+        and the cleanup that must run even when a sibling's failure cancels this
+        supervisor mid-run.
+        """
+        self._children_by_topic[topic] = proc
+        if topic in self._cancelled:
+            # A cancel was ACKNOWLEDGED while this child was starting (the control loop
+            # replied from the starting registry): enact it the moment the child exists.
+            proc.terminate()
+        heartbeat = asyncio.create_task(self._heartbeat(msg, topic))
+        output = asyncio.create_task(self._forward_output(proc, topic))
+        try:
+            outcome = await self._wait_for_child(proc, self._hard_wall_s(env))
+            classification = self._classify(outcome, proc.returncode, topic)
+            await self._publish_if_needed(topic, classification)
+            await msg.ack()
+        finally:
+            heartbeat.cancel()
+            output.cancel()
+            # WHY gather and not sequential awaits under one `suppress`: a task that already
+            # FAILED (not cancelled) re-raises its own exception on await, and `cancel()` is a
+            # no-op on it — so `await heartbeat` would blow the finally block open and skip
+            # every line below it (the child stays in `self._children`, a live child is never
+            # killed). `return_exceptions=True` makes the gather itself unraisable; the
+            # cleanup after it is therefore unconditional.
+            for result in await asyncio.gather(heartbeat, output, return_exceptions=True):
+                if isinstance(result, BaseException) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    logger.warning("run supervision task failed during cleanup: %r", result)
+            self._release_child(proc, topic)
+            if proc.returncode is None:
+                # A cancelled supervisor (a sibling failed and the TaskGroup unwound)
+                # must not orphan its child.
+                proc.kill()
 
     def _release_child(self, proc: _ChildProcess, topic: str) -> None:
         """Drop a finished child from every registry the worker shares.

--- a/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
+++ b/apps/screamingface-engine/tests/unit/test_max_deliveries_advisory.py
@@ -49,9 +49,9 @@ def _advisory(topic: str) -> bytes:
 
 
 def test_the_advisory_subject_names_the_queue_stream_and_consumer() -> None:
-    # The consumer token is wildcarded: consumers are `url4-runners-<bucket>` — ONE token
-    # (dashes are not NATS separators) — so `.*` matches it, while `.url4-runners.*`
-    # would demand a second token and match nothing.
+    # The trailing wildcard covers the per-bucket durable consumers (`url4-runners-<bucket>`,
+    # ONE token — dashes are not NATS separators): `.*` matches every bucket's consumer,
+    # while `.url4-runners.*` would demand a second token and match nothing.
     assert MAX_DELIVERIES_ADVISORY_SUBJECT == (
         "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.url4-runq.*"
     )

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -451,3 +451,31 @@ async def test_a_failed_readmission_releases_only_its_own_callers_slot() -> None
     # (`_caller_of_topic` is write-only bookkeeping — the wipe scans every caller — so its
     # stale B entry is harmless; the in-flight maps above are the contract.)
     assert runner._reserved == 1, "exactly one live reservation remains"
+
+
+# --- 8. the Retry-After header is always delta-seconds (review follow-up) --------------------
+
+
+class _FractionalRunner(_AtCapacityRunner):
+    """A runner whose drain estimate is a fractional float — legal at runtime even though
+    the port types it `int | None`; the HTTP boundary must not care."""
+
+    async def schedule(self, *args: Any, **kwargs: Any) -> str:
+        raise JobRunnerAtCapacity(2, 10, retry_after_s=2.5)  # type: ignore[arg-type]
+
+
+async def test_a_fractional_estimate_is_ceiled_into_a_valid_retry_after_header() -> None:
+    """`Retry-After` is delta-seconds per RFC 7231 — a non-negative decimal INTEGER. The
+    header used `str(retry_after)`; today's only producer happens to ceil, but any future
+    adapter returning a float (an averaged latency, say) would emit "2.5" — malformed,
+    which clients reject or ignore. The boundary ceils: 2.5 renders as "3", rounding UP
+    so the caller is never told to retry sooner than the estimate."""
+    app = _make_app(_FractionalRunner())
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/", params={"q": "gpt()"}, headers={"URL4-Capability": _token("topic-frac")}
+        )
+
+    assert resp.status_code == 503
+    assert resp.headers["Retry-After"] == "3"

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -282,3 +282,84 @@ async def test_the_rest_edge_answers_503_with_a_derived_retry_after() -> None:
     assert resp.status_code == 503
     assert resp.headers["Retry-After"] == "42"
     assert resp.headers["Retry-After"] != "1"
+
+
+# --- 5. the reservation counter's floor (review follow-up) ---------------------------------
+
+
+async def test_a_release_racing_a_refresh_cannot_drive_the_counter_negative() -> None:
+    """`_refresh_if_stale` RESETS `_reserved` on every refresh, and a sibling `schedule()`
+    can land its refresh between this run's RESERVE and its RELEASE (the publish failed).
+    Decrementing from the reset baseline drove the counter to -1 — under-counting depth
+    forever after, so one extra run slips past the ceiling on every later admission. The
+    release clamps at zero: a release below zero is a refresh that already accounted for
+    the reservation."""
+    clock = _FakeClock()
+    queue = _FakeQueue(depth=9)
+    runner = QueueJobRunner(
+        queue=queue,
+        publisher=_FakePublisher(),
+        control=_FakeControl(),
+        clock=clock,
+        capability_lifetime_s=CAPABILITY_LIFETIME_S,
+        depth_ceiling=10,
+        state_cache_ttl_s=0.0,  # every check refreshes — the racing refresh is the point
+    )
+
+    async def refresh_then_fail(message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
+        # The racing sibling's refresh, landing between this run's reserve and release:
+        # the depth now accounts for everything older than the window, so the counter
+        # RESETS — and the release that follows must not decrement from that baseline.
+        await runner._refresh_if_stale()
+        raise OSError("broker unavailable")
+
+    queue.publish = refresh_then_fail  # type: ignore[method-assign]
+
+    with pytest.raises(OSError):
+        await runner.schedule("t-race", "'hi'", 60, identity=CALLER_A)
+
+    assert runner._reserved == 0, "a release must never drive the counter negative"
+
+    # The clamp is load-bearing: with the counter at -1 this admission check reads
+    # depth 10 + (-1) < 10 and lets a run PAST the ceiling.
+    queue._depth = 10
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule("t-next", "'hi'", 60, identity=CALLER_A)
+
+
+async def test_a_readmitted_topic_does_not_orphan_the_first_callers_slot() -> None:
+    """`_caller_of_topic[topic]` is OVERWRITTEN when a re-scheduled topic is admitted
+    under a second identity, and `_forget_in_flight` used to resolve the caller through
+    that mapping — so the FIRST caller's entry was never reached again (`_prune` routes
+    through it too) and that caller permanently lost one of its in-flight slots,
+    surfacing later as spurious 503s for a caller with no live runs. The forget now
+    removes the topic from every caller that holds it."""
+    from url4.streaming.protocol import TerminatedData, TerminatedEvent, source_for
+
+    runner = _runner(_FakeQueue(), caller_inflight_cap=2, clock=_FakeClock())
+    key_a = "a@example.com"
+    key_b = "b@example.com"
+
+    await runner.schedule("t-shared", "'hi'", 60, identity=CALLER_A)
+    await runner.schedule("t-shared", "'hi'", 60, identity=CALLER_B)  # the overwrite
+
+    assert runner._caller_of_topic["t-shared"] == key_b
+    assert "t-shared" in runner._in_flight_by_caller[key_a], "both callers hold the topic"
+
+    # The run ends: a terminal frame NEWER than both admissions reaches the forget.
+    frame = TerminatedEvent(
+        id="t",
+        source=source_for("t-shared"),
+        subject="t-shared",
+        time=T0 + timedelta(seconds=5),
+        data=TerminatedData(status="succeeded"),
+    )
+    runner._forget_in_flight("t-shared", frame)
+
+    assert key_a not in runner._in_flight_by_caller, "A's slot must be released, not orphaned"
+    assert key_b not in runner._in_flight_by_caller
+    assert "t-shared" not in runner._caller_of_topic
+
+    # And A keeps its full cap — the orphaned entry used to eat one slot forever.
+    await runner.schedule("a-1", "'hi'", 60, identity=CALLER_A)
+    await runner.schedule("a-2", "'hi'", 60, identity=CALLER_A)

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -479,3 +479,47 @@ async def test_a_fractional_estimate_is_ceiled_into_a_valid_retry_after_header()
 
     assert resp.status_code == 503
     assert resp.headers["Retry-After"] == "3"
+
+
+# --- 9. a failed retry of a LIVE topic releases only its own reservation (review follow-up) --
+
+
+class _FailsSecondPublishQueue(_FakeQueue):
+    """Publishes the first submission of a topic; rejects the retry — a client retry
+    outside the broker's dedupe window meeting a transient broker error."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._failed_once = False
+
+    async def publish(
+        self, message: bytes, *, identity: Mapping[str, str] | None = None
+    ) -> None:
+        from screamingface_engine.runner_queue import topic_of_message
+
+        if topic_of_message(message) == "t-retry" and self.published:
+            self._failed_once = True
+            raise OSError("broker unavailable")
+        await super().publish(message, identity=identity)
+
+
+async def test_a_failed_retry_of_a_live_topic_keeps_the_first_admission_counted() -> None:
+    """A caller's client can re-schedule a STILL-LIVE topic — a retry outside the
+    broker's dedupe window — and that retry's publish can fail. Releasing by the
+    (caller, topic) pair erased the FIRST admission's accounting with the failed
+    retry: the caller's in-flight count silently dropped by one for the rest of the
+    run's lifetime, letting it exceed its cap by exactly that much. The release now
+    removes only the reservation the retry itself minted."""
+    queue = _FailsSecondPublishQueue()
+    runner = _runner(queue, caller_inflight_cap=2)
+    identity = {"sub": "caller-a"}
+
+    await runner.schedule("t-retry", "'hi'", 60, identity=identity)  # live admission
+    with pytest.raises(OSError):
+        await runner.schedule("t-retry", "'hi'", 60, identity=identity)  # retry fails
+    await runner.schedule("t-other", "'hi'", 60, identity=identity)  # count: 2 — at cap
+
+    with pytest.raises(JobRunnerAtCapacity):
+        # If the failed retry had erased the first admission, this would be admitted
+        # (count read 1) — one run PAST the caller's cap.
+        await runner.schedule("t-third", "'hi'", 60, identity=identity)

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -1,0 +1,284 @@
+"""Depth-based admission (OME-1091): the queue runner refuses at the depth ceiling with
+`JobRunnerAtCapacity`, the reservation counter closes the read-modify-write race between
+two admissions in one refresh window, the per-caller in-flight cap bounds one caller's
+footprint, and the REST edge derives `Retry-After` from a drain estimate instead of the
+constant 1.
+
+The counted resource changed from OME-1065 (quota headroom → queue depth); the
+cache-plus-reservation shape did not. Depth and oldest-message age come from the queue's
+cached `stream_info` reading; the runner's own refresh window plus the reservation counter
+close the race when two `schedule()` calls land between refreshes.
+"""
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+
+from screamingface_engine.adapters.queue_runner import QueueJobRunner
+from screamingface_engine.app import create_app
+from screamingface_engine.auth import JwtCodec
+from screamingface_engine.config import Settings
+from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.interfaces import JobRunnerAtCapacity, JobStatus, job_name
+from url4.streaming.protocol import CachePolicy
+
+pytestmark = pytest.mark.asyncio
+
+CAPABILITY_LIFETIME_S = 100.0
+T0 = datetime(2026, 9, 2, 9, 0, 0, tzinfo=UTC)
+SECRET = "admission-secret"
+WINDOW_S = 60
+LIFETIME_S = 58_800
+
+CALLER_A: Mapping[str, str] = {"X-User-Email": "a@example.com"}
+CALLER_B: Mapping[str, str] = {"X-User-Email": "b@example.com"}
+
+
+class _FakeClock:
+    """A wall clock the test advances by hand."""
+
+    def __init__(self) -> None:
+        self.now = T0
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+class _FakeQueue:
+    """The slice of `RunQueue` the queue runner uses, scripted per test."""
+
+    def __init__(self, *, depth: int = 0, oldest_age: float | None = None) -> None:
+        self._depth = depth
+        self._oldest_age = oldest_age
+        self.published: list[tuple[bytes, Mapping[str, str] | None]] = []
+
+    async def publish(self, message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
+        self.published.append((message, identity))
+
+    async def depth(self) -> int:
+        return self._depth
+
+    async def oldest_age(self) -> float | None:
+        return self._oldest_age
+
+
+class _FakePublisher:
+    """The slice of `JetStreamPublisher` the queue runner reads, scripted per test."""
+
+    def __init__(self, last_frame: Any = None) -> None:
+        self._last_frame = last_frame
+        self.published: list[Any] = []
+        self.ensured: list[str] = []
+
+    async def last_frame(self, topic: str) -> Any:
+        return self._last_frame
+
+    async def stream_exists(self, topic: str) -> bool:
+        return True
+
+    async def ensure_stream(self, topic: str) -> None:
+        self.ensured.append(topic)
+
+    async def publish(self, topic: str, event: Any) -> None:
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _FakeControl:
+    async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any:
+        raise TimeoutError()
+
+
+def _runner(
+    queue: _FakeQueue,
+    *,
+    depth_ceiling: int = 10,
+    caller_inflight_cap: int = 8,
+    clock: _FakeClock | None = None,
+) -> QueueJobRunner:
+    return QueueJobRunner(
+        queue=queue,
+        publisher=_FakePublisher(),
+        control=_FakeControl(),
+        clock=clock or _FakeClock(),
+        capability_lifetime_s=CAPABILITY_LIFETIME_S,
+        depth_ceiling=depth_ceiling,
+        caller_inflight_cap=caller_inflight_cap,
+    )
+
+
+# --- 1. depth at the ceiling refuses -------------------------------------------------------
+
+
+async def test_depth_at_the_ceiling_raises_job_runner_at_capacity() -> None:
+    """A queue as deep as the ceiling refuses the run with `JobRunnerAtCapacity` — the
+    substrate is saturated, and an identical retry later succeeds."""
+    queue = _FakeQueue(depth=10)
+    runner = _runner(queue, depth_ceiling=10)
+
+    with pytest.raises(JobRunnerAtCapacity) as exc:
+        await runner.schedule("t", "'hi'", 60)
+
+    assert exc.value.limit == 10
+    assert queue.published == []
+
+
+async def test_depth_below_the_ceiling_is_admitted() -> None:
+    """One below the ceiling is admitted — the ceiling is a bound, not a cliff."""
+    queue = _FakeQueue(depth=9)
+    runner = _runner(queue, depth_ceiling=10)
+
+    name = await runner.schedule("t", "'hi'", 60)
+
+    assert name == job_name("t")
+    assert len(queue.published) == 1
+
+
+async def test_the_drain_estimate_derives_retry_after_from_depth_and_throughput() -> None:
+    """`Retry-After` is derived from the pool's observed throughput — the oldest message's
+    wait implies the drain rate (`depth / oldest_age`) — so the client is told when the
+    queue will actually have room, not the constant 1."""
+    runner = _runner(_FakeQueue(depth=100, oldest_age=600.0), depth_ceiling=10)
+
+    with pytest.raises(JobRunnerAtCapacity) as exc:
+        await runner.schedule("t", "'hi'", 60)
+
+    # rate = 100 / 600 = 1/6 per second; (100 - 10) / (1/6) = 540 seconds.
+    assert exc.value.retry_after_s == 540
+
+
+# --- 2. the reservation counter closes the race -------------------------------------------
+
+
+async def test_two_admissions_racing_the_last_slot_cannot_both_pass() -> None:
+    """Two admissions inside one refresh window both read the same cached depth; the
+    reservation counter (OME-1065, carried over) makes the second see the first's
+    reservation and refuse — the read-modify-write race does not survive the change of
+    counted resource."""
+    queue = _FakeQueue(depth=9)
+    runner = _runner(queue, depth_ceiling=10)
+
+    results = await asyncio.gather(
+        runner.schedule("t1", "'hi'", 60),
+        runner.schedule("t2", "'hi'", 60),
+        return_exceptions=True,
+    )
+
+    accepted = [r for r in results if isinstance(r, str)]
+    refused = [r for r in results if isinstance(r, JobRunnerAtCapacity)]
+    assert len(accepted) == 1
+    assert len(refused) == 1
+    assert len(queue.published) == 1
+
+
+# --- 3. the per-caller in-flight cap -------------------------------------------------------
+
+
+async def test_the_per_caller_inflight_cap_refuses_caller_as_n_plus_one() -> None:
+    """A caller at its in-flight cap is refused, while another caller is still admitted —
+    one caller's 9-candidate evaluation cannot occupy every slot."""
+    runner = _runner(_FakeQueue(), caller_inflight_cap=2)
+
+    await runner.schedule("a1", "'hi'", 60, identity=CALLER_A)
+    await runner.schedule("a2", "'hi'", 60, identity=CALLER_A)
+
+    with pytest.raises(JobRunnerAtCapacity) as exc:
+        await runner.schedule("a3", "'hi'", 60, identity=CALLER_A)
+    assert exc.value.limit == 2
+
+    # Caller B is unaffected by caller A's footprint.
+    name = await runner.schedule("b1", "'hi'", 60, identity=CALLER_B)
+    assert name == job_name("b1")
+
+
+async def test_an_anonymous_caller_has_its_own_cap() -> None:
+    """A caller with no identity is its own caller — the anonymous bucket — so it cannot
+    hide behind another caller's footprint."""
+    runner = _runner(_FakeQueue(), caller_inflight_cap=1)
+
+    await runner.schedule("anon1", "'hi'", 60)
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule("anon2", "'hi'", 60)
+    await runner.schedule("a1", "'hi'", 60, identity=CALLER_A)  # a named caller is separate
+
+
+# --- 4. the REST edge derives Retry-After --------------------------------------------------
+
+
+class _AtCapacityRunner(IdentityAwareJobRunner):
+    """A fake runner that refuses every schedule with a derived drain estimate."""
+
+    async def schedule(
+        self,
+        topic: str,
+        url4: str,
+        deadline_s: int,
+        *,
+        traceparent: str | None = None,
+        credential: str | None = None,
+        profile: str | None = None,
+        identity: Mapping[str, str] | None = None,
+        cache: CachePolicy | None = None,
+    ) -> str:
+        raise JobRunnerAtCapacity(active=100, limit=10, retry_after_s=42)
+
+    async def stop(self, topic: str) -> None:
+        pass
+
+    async def exists(self, topic: str) -> bool:
+        return False
+
+    async def status(self, topic: str) -> JobStatus:
+        return "scheduled"
+
+
+def _token(topic: str) -> str:
+    return JwtCodec(secret=SECRET, iat_window_s=WINDOW_S, capability_lifetime_s=LIFETIME_S).sign(
+        topic, T0
+    )
+
+
+def _make_app(runner: IdentityAwareJobRunner) -> FastAPI:
+    settings = Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S)
+    return create_app(
+        settings,
+        stream=InMemoryEventStream(),
+        job_runner=runner,
+        clock=lambda: T0,
+        interest=FixedGate(True),
+    )
+
+
+class FixedGate:
+    def __init__(self, present: bool = True) -> None:
+        self._present = present
+
+    async def has_subscriber(self, topic: str) -> bool:
+        return self._present
+
+
+async def test_the_rest_edge_answers_503_with_a_derived_retry_after() -> None:
+    """The 503 + `Retry-After` mapping is unchanged in shape, but the value is the drain
+    estimate the runner attached to the refusal — not the constant 1."""
+    app = _make_app(_AtCapacityRunner())
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/", params={"q": "gpt()"}, headers={"URL4-Capability": _token("topic-cap")}
+        )
+
+    assert resp.status_code == 503
+    assert resp.headers["Retry-After"] == "42"
+    assert resp.headers["Retry-After"] != "1"

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -306,7 +306,9 @@ async def test_a_release_racing_a_refresh_cannot_drive_the_counter_negative() ->
         state_cache_ttl_s=0.0,  # every check refreshes — the racing refresh is the point
     )
 
-    async def refresh_then_fail(message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
+    async def refresh_then_fail(
+        message: bytes, *, identity: Mapping[str, str] | None = None
+    ) -> None:
         # The racing sibling's refresh, landing between this run's reserve and release:
         # the depth now accounts for everything older than the window, so the counter
         # RESETS — and the release that follows must not decrement from that baseline.
@@ -376,9 +378,7 @@ class _HangingQueue(_FakeQueue):
         super().__init__()
         self._release = asyncio.Event()
 
-    async def publish(
-        self, message: bytes, *, identity: Mapping[str, str] | None = None
-    ) -> None:
+    async def publish(self, message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
         await self._release.wait()
 
     def finish(self) -> None:
@@ -418,9 +418,7 @@ class _FailingQueue(_FakeQueue):
         super().__init__()
         self.fail_next = False
 
-    async def publish(
-        self, message: bytes, *, identity: Mapping[str, str] | None = None
-    ) -> None:
+    async def publish(self, message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
         if self.fail_next:
             self.fail_next = False
             raise OSError("broker unavailable")
@@ -492,9 +490,7 @@ class _FailsSecondPublishQueue(_FakeQueue):
         super().__init__()
         self._failed_once = False
 
-    async def publish(
-        self, message: bytes, *, identity: Mapping[str, str] | None = None
-    ) -> None:
+    async def publish(self, message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
         from screamingface_engine.runner_queue import topic_of_message
 
         if topic_of_message(message) == "t-retry" and self.published:
@@ -523,3 +519,22 @@ async def test_a_failed_retry_of_a_live_topic_keeps_the_first_admission_counted(
         # If the failed retry had erased the first admission, this would be admitted
         # (count read 1) — one run PAST the caller's cap.
         await runner.schedule("t-third", "'hi'", 60, identity=identity)
+
+
+async def test_a_cap_refusals_retry_after_reflects_the_callers_oldest_run() -> None:
+    """P2-11: the caller-cap refusal reused the QUEUE-drain estimate, which answered 1
+    exactly when the cap branch fires — the branch is reached precisely when the queue
+    is NOT at its ceiling, so the drain formula underflows to its floor. A caller
+    sitting at its cap behind a long evaluation was told to retry every second, for up
+    to the 16h run ceiling — a hot loop for any well-behaved client. The estimate now
+    comes from the caller's own oldest in-flight run, floored."""
+    clock = _FakeClock()
+    runner = _runner(_FakeQueue(), caller_inflight_cap=2, clock=clock)  # empty queue
+    await runner.schedule("a1", "'hi'", 60, identity=CALLER_A)
+    await runner.schedule("a2", "'hi'", 60, identity=CALLER_A)
+    clock.advance(90)  # the caller's runs have been in flight 90s
+
+    with pytest.raises(JobRunnerAtCapacity) as exc:
+        await runner.schedule("a3", "'hi'", 60, identity=CALLER_A)
+
+    assert exc.value.retry_after_s == 90, "the oldest run's age, not the queue's '1'"

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -405,3 +405,49 @@ async def test_a_schedule_cancelled_mid_publish_releases_its_reservation() -> No
     key_a = "a@example.com"
     assert key_a not in runner._in_flight_by_caller, "no dead topic may linger"
     queue.finish()
+
+
+# --- 7. a failed re-admission may not erase the first caller's slot (review follow-up) ------
+
+
+class _FailingQueue(_FakeQueue):
+    """A queue that publishes fine until armed, then rejects — the transient broker error
+    that leaves an admitted-but-unpublished run behind."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.fail_next = False
+
+    async def publish(
+        self, message: bytes, *, identity: Mapping[str, str] | None = None
+    ) -> None:
+        if self.fail_next:
+            self.fail_next = False
+            raise OSError("broker unavailable")
+        await super().publish(message, identity=identity)
+
+
+async def test_a_failed_readmission_releases_only_its_own_callers_slot() -> None:
+    """A re-scheduled topic can be held by TWO callers at once (admission overwrites
+    `_caller_of_topic` but not the first caller's dict entry). The release used the shared
+    `_forget_in_flight`, whose no-frame path wipes EVERY caller holding the topic — so a
+    failed publish under the SECOND identity also erased the FIRST caller's still-live
+    admission, under-counting it and letting it exceed its in-flight cap. The release now
+    pops exactly the caller/topic pair it reserved."""
+    key_a = "a@example.com"
+    key_b = "b@example.com"
+    queue = _FailingQueue()
+    runner = _runner(queue, caller_inflight_cap=2)
+
+    # Caller A's admission of the shared topic — durable, still live.
+    await runner.schedule("t-shared", "'hi'", 60, identity=CALLER_A)
+    # Caller B re-admits the same topic, then its publish fails.
+    queue.fail_next = True
+    with pytest.raises(OSError):
+        await runner.schedule("t-shared", "'hi'", 60, identity=CALLER_B)
+
+    assert "t-shared" in runner._in_flight_by_caller[key_a], "A's slot must survive B's failure"
+    assert key_b not in runner._in_flight_by_caller, "B's own failed entry is released"
+    # (`_caller_of_topic` is write-only bookkeeping — the wipe scans every caller — so its
+    # stale B entry is harmless; the in-flight maps above are the contract.)
+    assert runner._reserved == 1, "exactly one live reservation remains"

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -538,3 +538,40 @@ async def test_a_cap_refusals_retry_after_reflects_the_callers_oldest_run() -> N
         await runner.schedule("a3", "'hi'", 60, identity=CALLER_A)
 
     assert exc.value.retry_after_s == 90, "the oldest run's age, not the queue's '1'"
+
+
+def test_a_depth_refusal_retry_after_counts_the_reservations() -> None:
+    """V-10: the ceiling check admits on `depth + reservations`, but `_drain_estimate_s`
+    used the RAW depth — reservations that pushed the queue past the ceiling are not yet
+    visible in the snapshot, so the formula underflowed to its floor and the refusal
+    answered `Retry-After: 1` on a genuinely full queue. The estimate must use the same
+    effective depth the admission decision used. (White-box: the refusal fires at
+    `effective == ceiling` in every reachable schedule order, so the formula itself is
+    the only place the reservation term is observable.)"""
+    runner = _runner(_FakeQueue(depth=9, oldest_age=90.0), depth_ceiling=10)
+    runner._depth_snapshot = 9  # noqa: SLF001
+    runner._reserved = 2  # noqa: SLF001
+    runner._oldest_age = 90.0  # noqa: SLF001
+
+    # effective depth 11, rate 11/90 → (11 - 10) / (11/90) = 8.18 → 9s. The raw-depth
+    # formula answered 1 here.
+    assert runner._drain_estimate_s() == 9  # noqa: SLF001
+
+
+def test_a_cap_refusals_retry_after_is_clamped_above() -> None:
+    """V-10: the caller estimate is the age of the caller's OLDEST in-flight run, which
+    can reach the 16h run ceiling — but the slot frees when ANY of the caller's runs
+    ends, and a `Retry-After` of hours tells a well-behaved client to give up or poll at
+    a useless cadence. The estimate is clamped to `CALLER_RETRY_MAX_S`. (White-box: the
+    harness's 100s capability lifetime prunes any token old enough to exceed the clamp,
+    so the formula is pinned directly.)"""
+    from datetime import timedelta
+
+    from screamingface_engine.adapters.queue_runner import CALLER_RETRY_MAX_S, caller_key
+
+    clock = _FakeClock()
+    runner = _runner(_FakeQueue(), caller_inflight_cap=2, clock=clock)
+    old = clock.now - timedelta(hours=15)
+    runner._in_flight_by_caller[caller_key(CALLER_A)] = {"a1": [old], "a2": [old]}  # noqa: SLF001
+
+    assert runner._caller_retry_after_s(caller_key(CALLER_A)) == CALLER_RETRY_MAX_S  # noqa: SLF001

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -363,3 +363,45 @@ async def test_a_readmitted_topic_does_not_orphan_the_first_callers_slot() -> No
     # And A keeps its full cap — the orphaned entry used to eat one slot forever.
     await runner.schedule("a-1", "'hi'", 60, identity=CALLER_A)
     await runner.schedule("a-2", "'hi'", 60, identity=CALLER_A)
+
+
+# --- 6. a cancelled schedule must not leak its reservation (review follow-up) ---------------
+
+
+class _HangingQueue(_FakeQueue):
+    """A queue whose publish hangs until the test releases it — the cancellation lands
+    mid-publish, exactly the window a client disconnect or upstream timeout hits."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._release = asyncio.Event()
+
+    async def publish(
+        self, message: bytes, *, identity: Mapping[str, str] | None = None
+    ) -> None:
+        await self._release.wait()
+
+    def finish(self) -> None:
+        self._release.set()
+
+
+async def test_a_schedule_cancelled_mid_publish_releases_its_reservation() -> None:
+    """`CancelledError` is a BaseException, not an Exception — since 3.8 precisely so
+    `except Exception` cannot swallow it. The release-on-failure clause never ran on a
+    cancelled publish: the reservation leaked (`_reserved` stuck, the caller's in-flight
+    entry a dead topic forever), and a caller whose clients keep disconnecting under
+    load ends up permanently refused for runs that never queued. Cleanup must run on the
+    cancellation path too — with the cancellation still propagating."""
+    queue = _HangingQueue()
+    runner = _runner(queue)
+
+    task = asyncio.create_task(runner.schedule("t-hang", "'hi'", 60, identity=CALLER_A))
+    await asyncio.sleep(0)  # let the task reach the hanging publish
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert runner._reserved == 0, "a cancelled schedule must release its reservation"
+    key_a = "a@example.com"
+    assert key_a not in runner._in_flight_by_caller, "no dead topic may linger"
+    queue.finish()

--- a/apps/screamingface-engine/tests/unit/test_queue_fairness.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_fairness.py
@@ -28,7 +28,11 @@ CALLER_B: Mapping[str, str] = {"X-User-Email": "alice@example.com"}
 
 class _FakeSub:
     """A pull subscription that serves the SHARED per-subject message list — a message
-    claimed by one subscription is gone for the next, like the broker's consumer state."""
+    claimed by one subscription is gone for the next, like the broker's consumer state.
+
+    An EMPTY window RAISES, exactly like the real broker: nats-py's `fetch` never
+    returns an empty list, it raises `nats.errors.TimeoutError` (a `TimeoutError`
+    subclass). A fake returning `[]` masks an uncaught-timeout crash in `pull`."""
 
     def __init__(self, messages: list[bytes]) -> None:
         self._messages = messages
@@ -37,6 +41,8 @@ class _FakeSub:
     async def fetch(self, batch: int, timeout: float) -> list[Any]:
         out = self._messages[:batch]
         del self._messages[:batch]
+        if not out:
+            raise TimeoutError("nats: timeout")
         return [SimpleNamespace(data=payload) for payload in out]
 
     async def unsubscribe(self) -> None:

--- a/apps/screamingface-engine/tests/unit/test_queue_fairness.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_fairness.py
@@ -34,11 +34,15 @@ class _FakeSub:
     returns an empty list, it raises `nats.errors.TimeoutError` (a `TimeoutError`
     subclass). A fake returning `[]` masks an uncaught-timeout crash in `pull`."""
 
-    def __init__(self, messages: list[bytes]) -> None:
+    def __init__(self, messages: list[bytes], fetch_log: list[str] | None = None, subject: str = "") -> None:
         self._messages = messages
         self.unsubscribed = False
+        self._fetch_log = fetch_log
+        self._subject = subject
 
     async def fetch(self, batch: int, timeout: float) -> list[Any]:
+        if self._fetch_log is not None:
+            self._fetch_log.append(self._subject)
         out = self._messages[:batch]
         del self._messages[:batch]
         if not out:
@@ -57,6 +61,8 @@ class _FakeJetStream:
         self._messages: dict[str, list[bytes]] = {}
         self.published: list[tuple[str, bytes]] = []
         self.pull_subjects: list[str] = []
+        self.bound_subjects: list[str] = []
+        self.fetches: list[str] = []
         self._prefix = "$JS.API"
 
     async def add_stream(self, **kwargs: Any) -> object:
@@ -80,7 +86,8 @@ class _FakeJetStream:
         config: Any = None,
     ) -> _FakeSub:
         self.pull_subjects.append(subject)
-        return _FakeSub(self._messages.get(subject, []))
+        self.bound_subjects.append(subject)
+        return _FakeSub(self._messages.get(subject, []), fetch_log=self.fetches, subject=subject)
 
 
 def _queue(fake: _FakeJetStream, **kwargs: Any) -> RunQueue:
@@ -137,10 +144,16 @@ async def test_a_pull_that_finds_nothing_returns_within_the_timeout() -> None:
     pulled = await queue.pull(4, timeout_s=0.2)
 
     assert pulled == []
-    # The pull cycled through both buckets (one visit per slot, four slots).
-    assert fake.pull_subjects == [
+    # The pull still cycled both buckets every slot — four FETCHES — but bound each
+    # bucket's durable subscription ONCE: the held-subscription cache (review
+    # follow-up) removes the per-cycle bind/unbind round trip from every poll.
+    assert fake.fetches == [
         queue.bucket_subjects()[0],
         queue.bucket_subjects()[1],
+        queue.bucket_subjects()[0],
+        queue.bucket_subjects()[1],
+    ]
+    assert fake.bound_subjects == [
         queue.bucket_subjects()[0],
         queue.bucket_subjects()[1],
     ]
@@ -250,3 +263,24 @@ async def test_the_spawn_time_io_budget_is_io_capacity_over_active_children() ->
             proc.release()
         await first
         await second
+
+
+# --- held pull subscriptions (review follow-up) ----------------------------------------------
+
+
+async def test_pulls_bind_each_bucket_once_and_reuse_their_subscription() -> None:
+    """The claim loop polls flat out whenever slots are free, and the old pull bound a
+    FRESH subscription per bucket PER CYCLE — a `consumer_info` round trip each way,
+    multiplied by the bucket count, paid on every poll even when the queue was empty.
+    Bind-per-cycle was a multiplicative cost with no correctness benefit: the durable
+    consumers are server-side and persist. Subscriptions are now HELD (bounded by the
+    configured bucket list; cleared on reconnect), so every poll after the first costs
+    the `fetch` alone."""
+    fake = _FakeJetStream()
+    queue = _queue(fake, bucket_count=2)
+
+    for _ in range(3):
+        await queue.pull(1, timeout_s=0.01)
+
+    assert len(fake.bound_subjects) == 2, "one bind per bucket for the queue's lifetime"
+    assert len(fake.fetches) == 6, "each pull still fetches per slot of the rotation"

--- a/apps/screamingface-engine/tests/unit/test_queue_fairness.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_fairness.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 
+import nats.errors
 import pytest
 
 from screamingface_engine import job_env
@@ -378,3 +379,80 @@ async def test_the_fast_pass_uses_short_windows_and_the_slow_pass_the_remainder(
     # The slow pass re-visits with the remaining budget split across the rotation.
     slow_windows = [s.timeouts[1] for s in fake.subs]
     assert all(w > fast_windows[0] for w in slow_windows), "the slow pass must spend the remainder"
+
+
+# --- 6. a blip mid-rotation must not discard what the rotation already collected ----------
+
+
+class _ErroringJetStream(_FakeJetStream):
+    """One nominated bucket's fetch fails with a real broker error; every other bucket
+    behaves normally. Set `failing` AFTER publishing, so the test can pick the bucket the
+    message did NOT land in."""
+
+    failing: str | None = None
+
+    async def pull_subscribe(
+        self,
+        subject: str,
+        durable: str | None = None,
+        stream: str | None = None,
+        config: Any = None,
+    ) -> _FakeSub:
+        sub = await super().pull_subscribe(subject, durable, stream, config)
+        if subject == self.failing:
+
+            async def _boom(batch: int, timeout: float) -> list[Any]:
+                raise nats.errors.Error("broker blip mid-rotation")
+
+            sub.fetch = _boom  # type: ignore[method-assign]
+        return sub
+
+
+def _bucket_index(subject: str) -> int:
+    """The bucket ordinal encoded in a run-queue subject (`url4-runq.0a` -> 10)."""
+    return int(subject.rsplit(".", 1)[1], 16)
+
+
+async def test_a_blip_mid_rotation_keeps_the_messages_already_collected() -> None:
+    """`_fetch_from` re-raises a non-timeout `nats.errors.Error` after invalidating the
+    subscription, and `pull` extends `collected` bucket by bucket — so a blip on a LATER
+    bucket discarded every message the earlier buckets had already yielded, along with the
+    stack frame holding them. Those messages had been DELIVERED: they were never acked and
+    never NAK'd, so they sat out the full `ack_wait` and came back as their FINAL delivery
+    (`DEFAULT_MAX_DELIVER` is 2). One more blip on that redelivery ends the run as
+    `max_deliveries` instead of executing it.
+
+    INVARIANT: a delivery attempt is expensive and must never be spent for nothing. Work
+    already in hand is returned; the blip is reported by the NEXT pull, which hits the same
+    broker. Only a pull that collected NOTHING propagates, so the claim loop keeps its
+    backoff signal for a genuinely unproductive poll."""
+    fake = _ErroringJetStream()
+    queue = _queue(fake, bucket_count=2)
+    await queue.publish(encode_message("a1", "'hi'", 60), identity=CALLER_A)
+
+    landed = fake.published[0][0]
+    # Fail the OTHER bucket, and start the rotation on the one holding the message so the
+    # blip lands with something already collected.
+    fake.failing = f"url4-runq.{(_bucket_index(landed) + 1) % 2:02x}"
+    queue._rr_index = _bucket_index(landed)  # noqa: SLF001
+
+    pulled = await queue.pull(2, timeout_s=1.0)
+
+    assert [topic_of_message(msg.data) for msg in pulled] == ["a1"], (
+        "the message collected before the blip must be returned, not dropped"
+    )
+    assert all(not sub.nakked for sub in fake.subs), (
+        "a collected message must not spend a delivery attempt on a NAK either"
+    )
+
+
+async def test_a_blip_with_nothing_collected_still_propagates() -> None:
+    """The claim loop counts pull failures and backs off on them, so a poll that produced
+    NO work must still report the blip. Swallowing it unconditionally would turn a broker
+    outage into a silent hot loop that looks exactly like an idle queue."""
+    fake = _ErroringJetStream()
+    queue = _queue(fake, bucket_count=1)
+    fake.failing = "url4-runq.00"
+
+    with pytest.raises(nats.errors.Error):
+        await queue.pull(2, timeout_s=1.0)

--- a/apps/screamingface-engine/tests/unit/test_queue_fairness.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_fairness.py
@@ -34,7 +34,9 @@ class _FakeSub:
     returns an empty list, it raises `nats.errors.TimeoutError` (a `TimeoutError`
     subclass). A fake returning `[]` masks an uncaught-timeout crash in `pull`."""
 
-    def __init__(self, messages: list[bytes], fetch_log: list[str] | None = None, subject: str = "") -> None:
+    def __init__(
+        self, messages: list[bytes], fetch_log: list[str] | None = None, subject: str = ""
+    ) -> None:
         self._messages = messages
         self.unsubscribed = False
         self._fetch_log = fetch_log
@@ -104,8 +106,11 @@ def _queue(fake: _FakeJetStream, **kwargs: Any) -> RunQueue:
 
 
 async def test_round_robin_pull_interleaves_two_callers_runs() -> None:
-    """Round-robin pull serves one message per bucket per cycle, so two callers' runs
-    interleave instead of one caller draining first."""
+    """Round-robin pull serves at most `PULL_BUCKET_BATCH` (or the batch's fair share)
+    per bucket per visit, so two callers SHARE a pull instead of one draining first —
+    the per-visit cap, not strict one-per-bucket alternation, is the fairness property
+    (review follow-up P2-7: the cap lets a single caller's burst drain several messages
+    per poll instead of ~1 per poll)."""
     fake = _FakeJetStream()
     queue = _queue(fake, bucket_count=2)
     await queue.publish(encode_message("a1", "'hi'", 60), identity=CALLER_A)
@@ -119,8 +124,11 @@ async def test_round_robin_pull_interleaves_two_callers_runs() -> None:
     pulled = await queue.pull(4, timeout_s=1.0)
     topics = [topic_of_message(msg.data) for msg in pulled]
 
+    # Each visit takes at most ceil(4/2) = 2 from one bucket, so the pull is two
+    # consecutive visits — each caller's pair — and NEITHER caller can take more than
+    # its pair before the other is served.
     caller_of = {"a1": "A", "a2": "A", "b1": "B", "b2": "B"}
-    assert [caller_of[t] for t in topics] in (["A", "B", "A", "B"], ["B", "A", "B", "A"])
+    assert [caller_of[t] for t in topics] in (["A", "A", "B", "B"], ["B", "B", "A", "A"])
 
 
 async def test_the_bucket_key_is_a_stable_hash_of_the_identity_value() -> None:
@@ -283,4 +291,24 @@ async def test_pulls_bind_each_bucket_once_and_reuse_their_subscription() -> Non
         await queue.pull(1, timeout_s=0.01)
 
     assert len(fake.bound_subjects) == 2, "one bind per bucket for the queue's lifetime"
-    assert len(fake.fetches) == 6, "each pull still fetches per slot of the rotation"
+    # Each pull fetches per bucket VISIT: the fast pass always visits every bucket once,
+    # and (against these instant fakes, where budget remains) the slow pass visits them
+    # again — 2 buckets x 2 phases x 3 pulls. The BIND count above is the cost fix this
+    # test pins; the fetch count only documents the visit structure.
+    assert len(fake.fetches) == 12, "each pull fetches per bucket visit of both phases"
+
+
+async def test_one_callers_burst_fills_the_batch_from_one_bucket() -> None:
+    """P2-7: one message per bucket per visit let a single caller's burst drain at ~1
+    run per poll — the rest of the rotation burned the budget on empty buckets while the
+    burst sat in its bucket, capping the caller at ~1 run per `timeout_s` per worker
+    regardless of free slots. The per-visit fetch cap lets a burst fill the batch from
+    one bucket while the rotation (and the cap) still bounds its share of a shared pull."""
+    fake = _FakeJetStream()
+    queue = _queue(fake, bucket_count=16)
+    for i in range(8):
+        await queue.publish(encode_message(f"burst-{i}", "'hi'", 60), identity=CALLER_A)
+
+    pulled = await queue.pull(4, timeout_s=0.5)
+
+    assert len(pulled) == 4, "a single caller's burst must fill the batch, not trickle 1 per poll"

--- a/apps/screamingface-engine/tests/unit/test_queue_fairness.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_fairness.py
@@ -41,15 +41,21 @@ class _FakeSub:
         self.unsubscribed = False
         self._fetch_log = fetch_log
         self._subject = subject
+        self.nakked: list[Any] = []
+        self.timeouts: list[float] = []
 
     async def fetch(self, batch: int, timeout: float) -> list[Any]:
         if self._fetch_log is not None:
             self._fetch_log.append(self._subject)
+        self.timeouts.append(timeout)
         out = self._messages[:batch]
         del self._messages[:batch]
         if not out:
             raise TimeoutError("nats: timeout")
-        return [SimpleNamespace(data=payload) for payload in out]
+        return [SimpleNamespace(data=payload, nak=self._record_nak) for payload in out]
+
+    async def _record_nak(self) -> None:
+        self.nakked.append(1)
 
     async def unsubscribe(self) -> None:
         self.unsubscribed = True
@@ -65,6 +71,7 @@ class _FakeJetStream:
         self.pull_subjects: list[str] = []
         self.bound_subjects: list[str] = []
         self.fetches: list[str] = []
+        self.subs: list[_FakeSub] = []
         self._prefix = "$JS.API"
 
     async def add_stream(self, **kwargs: Any) -> object:
@@ -89,7 +96,9 @@ class _FakeJetStream:
     ) -> _FakeSub:
         self.pull_subjects.append(subject)
         self.bound_subjects.append(subject)
-        return _FakeSub(self._messages.get(subject, []), fetch_log=self.fetches, subject=subject)
+        sub = _FakeSub(self._messages.get(subject, []), fetch_log=self.fetches, subject=subject)
+        self.subs.append(sub)
+        return sub
 
 
 def _queue(fake: _FakeJetStream, **kwargs: Any) -> RunQueue:
@@ -312,3 +321,60 @@ async def test_one_callers_burst_fills_the_batch_from_one_bucket() -> None:
     pulled = await queue.pull(4, timeout_s=0.5)
 
     assert len(pulled) == 4, "a single caller's burst must fill the batch, not trickle 1 per poll"
+
+
+async def test_a_pull_that_over_returns_clamps_and_naks_the_surplus() -> None:
+    """V-4: nats-py's `_fetch_n` (want >= 2) drains the subscription's PENDING queue with
+    no `needed` guard, so a held sub carrying late deliveries from a previous poll can
+    return MORE than asked — and the claim loop spawns one supervisor per returned
+    message, so an unclamped extend over-subscribed the pod past `worker_slots`. The
+    pull must clamp to the per-visit cap and NAK the surplus back to the queue — not
+    drop it, and not ack it away."""
+    fake = _FakeJetStream()
+
+    class _OverReturningSub(_FakeSub):
+        """Serves one more than asked — the `_fetch_n` pending-queue drain shape."""
+
+        async def fetch(self, batch: int, timeout: float) -> list[Any]:
+            return await super().fetch(batch + 1, timeout)
+
+    sub = _OverReturningSub([b"m1", b"m2", b"m3"], subject="url4-runq.0")
+    fake.pull_subscribe = _pull_subscribe_returning(sub)  # type: ignore[method-assign]
+
+    queue = _queue(fake, bucket_count=1)
+    msgs = await queue.pull(2, timeout_s=1.0)
+
+    assert len(msgs) == 2, "the pull must clamp to the batch, never over-return"
+    assert len(sub.nakked) == 1, "the surplus must be NAK'd back to the queue"
+
+
+def _pull_subscribe_returning(sub: _FakeSub) -> Any:
+    async def _pull_subscribe(
+        subject: str, durable: str | None = None, stream: str | None = None, config: Any = None
+    ) -> _FakeSub:
+        return sub
+
+    return _pull_subscribe
+
+
+async def test_the_fast_pass_uses_short_windows_and_the_slow_pass_the_remainder() -> None:
+    """V-9: `_FakeSub.fetch` ignored `timeout`, so the P2-7 fast/slow split was
+    unexercised — the test could not tell a two-phase pull from a uniform one. The fake
+    now records every window: the first rotation's windows must total
+    `PULL_FAST_PASS_S` (short, burst-collecting), and the slow pass must spend the
+    REMAINING budget on a second rotation."""
+    from screamingface_engine.runner_queue import PULL_FAST_PASS_S
+
+    fake = _FakeJetStream()
+    queue = _queue(fake, bucket_count=4)
+    await queue.publish(encode_message("a1", "'hi'", 60), identity=CALLER_A)
+
+    await queue.pull(4, timeout_s=5.0)
+
+    assert len(fake.subs) == 4
+    # The first rotation (fast pass) is one short window per bucket.
+    fast_windows = [s.timeouts[0] for s in fake.subs]
+    assert all(w == pytest.approx(min(PULL_FAST_PASS_S, 5.0) / 4) for w in fast_windows)
+    # The slow pass re-visits with the remaining budget split across the rotation.
+    slow_windows = [s.timeouts[1] for s in fake.subs]
+    assert all(w > fast_windows[0] for w in slow_windows), "the slow pass must spend the remainder"

--- a/apps/screamingface-engine/tests/unit/test_queue_fairness.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_fairness.py
@@ -1,0 +1,246 @@
+"""Run-level and fetch-level fairness (OME-1091, the deployed half of OME-908).
+
+Run-level: per-caller queue subjects (`url4-runq.<bucket>`, a stable hash of the identity
+value — never the raw address, which a subject name would expose to anyone with broker
+access) with round-robin pull, so one caller's 9-candidate evaluation cannot drain ahead of
+another caller's runs. Fetch-level: the worker's spawn-time io budget
+(`worker_io_capacity / active_children`) travels to the child as
+`URL4_CLOUD_IO_CONCURRENCY`, fixed at spawn.
+"""
+
+import asyncio
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from screamingface_engine import job_env
+from screamingface_engine.runner_queue import RunQueue, encode_message, topic_of_message
+from screamingface_engine.worker.supervisor import RunSupervisor
+
+pytestmark = pytest.mark.asyncio
+
+CALLER_A: Mapping[str, str] = {"X-User-Email": "a@example.com"}
+CALLER_B: Mapping[str, str] = {"X-User-Email": "alice@example.com"}
+
+
+class _FakeSub:
+    """A pull subscription that serves the SHARED per-subject message list — a message
+    claimed by one subscription is gone for the next, like the broker's consumer state."""
+
+    def __init__(self, messages: list[bytes]) -> None:
+        self._messages = messages
+        self.unsubscribed = False
+
+    async def fetch(self, batch: int, timeout: float) -> list[Any]:
+        out = self._messages[:batch]
+        del self._messages[:batch]
+        return [SimpleNamespace(data=payload) for payload in out]
+
+    async def unsubscribe(self) -> None:
+        self.unsubscribed = True
+
+
+class _FakeJetStream:
+    """The slice of `JetStreamContext` the queue uses, subject-aware: publishes land on the
+    subject they were given, and each pull subscription serves that subject's messages."""
+
+    def __init__(self) -> None:
+        self._messages: dict[str, list[bytes]] = {}
+        self.published: list[tuple[str, bytes]] = []
+        self.pull_subjects: list[str] = []
+        self._prefix = "$JS.API"
+
+    async def add_stream(self, **kwargs: Any) -> object:
+        return object()
+
+    async def publish(
+        self, subject: str, payload: bytes = b"", headers: dict[str, str] | None = None, **_: Any
+    ) -> object:
+        self.published.append((subject, payload))
+        self._messages.setdefault(subject, []).append(payload)
+        return SimpleNamespace(stream="url4-runq", seq=len(self.published))
+
+    async def _api_request(self, subject: str, req: bytes = b"", **_: Any) -> dict[str, Any]:
+        return {"state": {"messages": 0, "first_ts": None}}
+
+    async def pull_subscribe(
+        self,
+        subject: str,
+        durable: str | None = None,
+        stream: str | None = None,
+        config: Any = None,
+    ) -> _FakeSub:
+        self.pull_subjects.append(subject)
+        return _FakeSub(self._messages.get(subject, []))
+
+
+def _queue(fake: _FakeJetStream, **kwargs: Any) -> RunQueue:
+    queue = RunQueue("nats://unused:4222", **kwargs)
+
+    async def _fake_jetstream() -> _FakeJetStream:
+        return fake
+
+    queue._jetstream = _fake_jetstream  # type: ignore[assignment,method-assign]
+    return queue
+
+
+# --- 1. round-robin pull interleaves two callers -------------------------------------------
+
+
+async def test_round_robin_pull_interleaves_two_callers_runs() -> None:
+    """Round-robin pull serves one message per bucket per cycle, so two callers' runs
+    interleave instead of one caller draining first."""
+    fake = _FakeJetStream()
+    queue = _queue(fake, bucket_count=2)
+    await queue.publish(encode_message("a1", "'hi'", 60), identity=CALLER_A)
+    await queue.publish(encode_message("a2", "'hi'", 60), identity=CALLER_A)
+    await queue.publish(encode_message("b1", "'hi'", 60), identity=CALLER_B)
+    await queue.publish(encode_message("b2", "'hi'", 60), identity=CALLER_B)
+
+    # The two callers must land in different buckets for the interleaving to be visible.
+    assert len({subject for subject, _ in fake.published}) == 2
+
+    pulled = await queue.pull(4, timeout_s=1.0)
+    topics = [topic_of_message(msg.data) for msg in pulled]
+
+    caller_of = {"a1": "A", "a2": "A", "b1": "B", "b2": "B"}
+    assert [caller_of[t] for t in topics] in (["A", "B", "A", "B"], ["B", "A", "B", "A"])
+
+
+async def test_the_bucket_key_is_a_stable_hash_of_the_identity_value() -> None:
+    """The bucket key is a stable hash of the identity VALUE, not the raw address — a
+    subject name is readable by anything with broker access, so the caller's email must
+    not appear in it."""
+    queue = _queue(_FakeJetStream(), bucket_count=16)
+    subject = queue.bucket_subject(CALLER_A)
+
+    assert subject.startswith("url4-runq.")
+    assert "a@example.com" not in subject
+    assert subject == queue.bucket_subject(CALLER_A)  # stable across calls
+
+
+async def test_a_pull_that_finds_nothing_returns_within_the_timeout() -> None:
+    """An empty queue still returns within the pull timeout — each bucket gets a share of
+    the budget, so no single bucket can hold the pull open."""
+    fake = _FakeJetStream()
+    queue = _queue(fake, bucket_count=2)
+
+    pulled = await queue.pull(4, timeout_s=0.2)
+
+    assert pulled == []
+    # The pull cycled through both buckets (one visit per slot, four slots).
+    assert fake.pull_subjects == [
+        queue.bucket_subjects()[0],
+        queue.bucket_subjects()[1],
+        queue.bucket_subjects()[0],
+        queue.bucket_subjects()[1],
+    ]
+
+
+# --- 2. the spawn-time io budget -----------------------------------------------------------
+
+
+class _FakeMsg:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.metadata = SimpleNamespace(timestamp=datetime.now(UTC))
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+    async def in_progress(self) -> None:
+        pass
+
+
+class _FakeProcess:
+    def __init__(self, *, hang: bool = True) -> None:
+        self._hang = hang
+        self._released = asyncio.Event()
+        self.returncode: int | None = None
+        self.stdout = None
+        self.stderr = None
+
+    async def wait(self) -> int:
+        if self._hang:
+            await self._released.wait()
+        self.returncode = 0
+        return 0
+
+    def release(self) -> None:
+        self._released.set()
+
+    def terminate(self) -> None:
+        self.release()
+
+    def kill(self) -> None:
+        self.release()
+
+
+class _FakePublisher:
+    async def last_frame(self, topic: str) -> Any:
+        return None
+
+    async def ensure_stream(self, topic: str) -> None:
+        pass
+
+    async def publish(self, topic: str, event: Any) -> None:
+        pass
+
+    async def flush(self) -> None:
+        pass
+
+
+async def _wait_until(predicate: Any, timeout_s: float = 2.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("condition not met in time")
+        await asyncio.sleep(0.01)
+
+
+def _supervisor(spawn: Any, *, io_capacity: int = 4) -> RunSupervisor:
+    return RunSupervisor(
+        publisher=_FakePublisher(),
+        spawn=spawn,
+        memory_budget_bytes=1024**3,
+        io_capacity=io_capacity,
+        draining=asyncio.Event(),
+        terminating=asyncio.Event(),
+        children=set(),
+        children_by_topic={},
+        cancelled=set(),
+    )
+
+
+async def test_the_spawn_time_io_budget_is_io_capacity_over_active_children() -> None:
+    """The worker's io budget is `io_capacity / active_children` (the new child included),
+    written onto the child env as `URL4_CLOUD_IO_CONCURRENCY` — a solo child gets the full
+    capacity, the second child gets half, and the budget is fixed at spawn."""
+    envs: list[dict[str, str]] = []
+    procs: list[_FakeProcess] = []
+
+    async def fake_spawn(*args: Any, **kwargs: Any) -> _FakeProcess:
+        envs.append(kwargs["env"])
+        proc = _FakeProcess(hang=True)
+        procs.append(proc)
+        return proc
+
+    supervisor = _supervisor(fake_spawn, io_capacity=4)
+    async with asyncio.TaskGroup() as tg:
+        first = tg.create_task(supervisor.supervise(_FakeMsg(encode_message("t1", "'hi'", 60))))
+        await _wait_until(lambda: len(procs) == 1)
+        second = tg.create_task(supervisor.supervise(_FakeMsg(encode_message("t2", "'hi'", 60))))
+        await _wait_until(lambda: len(procs) == 2)
+
+        assert envs[0][job_env.IO_CONCURRENCY] == "4"  # solo: 4 / 1
+        assert envs[1][job_env.IO_CONCURRENCY] == "2"  # two active: 4 / 2
+
+        for proc in procs:
+            proc.release()
+        await first
+        await second

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_cancel.py
@@ -51,11 +51,14 @@ class _FakeQueue:
     def __init__(self) -> None:
         self.published: list[bytes] = []
 
-    async def publish(self, message: bytes) -> None:
+    async def publish(self, message: bytes, *, identity: Any = None) -> None:
         self.published.append(message)
 
     async def depth(self) -> int:
         return 0
+
+    async def oldest_age(self) -> float | None:
+        return None
 
 
 class _FakePublisher:

--- a/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_runner_status.py
@@ -50,11 +50,14 @@ class _FakeQueue:
     def __init__(self) -> None:
         self.published: list[bytes] = []
 
-    async def publish(self, message: bytes) -> None:
+    async def publish(self, message: bytes, *, identity: Any = None) -> None:
         self.published.append(message)
 
     async def depth(self) -> int:
         return 0
+
+    async def oldest_age(self) -> float | None:
+        return None
 
 
 class _FakePublisher:

--- a/apps/screamingface-engine/tests/unit/test_reaper.py
+++ b/apps/screamingface-engine/tests/unit/test_reaper.py
@@ -266,11 +266,14 @@ class _FakeQueue:
     def __init__(self) -> None:
         self.published: list[bytes] = []
 
-    async def publish(self, message: bytes) -> None:
+    async def publish(self, message: bytes, *, identity: Any = None) -> None:
         self.published.append(message)
 
     async def depth(self) -> int:
         return 0
+
+    async def oldest_age(self) -> float | None:
+        return None
 
 
 class _FakePublisher:

--- a/apps/screamingface-engine/tests/unit/test_run_queue_bucket_bounds.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_bucket_bounds.py
@@ -1,0 +1,74 @@
+"""The fairness knobs are bounded at the boundary, not at the division (OME-1091).
+
+`run_queue_bucket_count` reaches `RunQueue.bucket_subject` as the modulus of
+`int(digest, 16) % bucket_count`, so a zero raises `ZeroDivisionError` inside `schedule()`
+— a 500 on EVERY run, from a value that looked like ordinary configuration when it was
+set. Its two siblings are the same shape: a zero (or negative) depth ceiling refuses every
+run, and a zero per-caller in-flight cap admits none. Each is a settings-time refusal in
+this file: the process must fail at startup, where the operator is still watching, rather
+than at the first request.
+
+Self-contained fixtures rather than imports from a sibling test module: the append-only
+rule means each cycle brings its own, so a later edit here cannot break a prior file.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from screamingface_engine import runner_queue
+from screamingface_engine.config import Settings
+from screamingface_engine.runner_queue import RunQueue
+
+# The three fairness/admission knobs that are all >= 1 by construction, with the attribute
+# name each one carries on `Settings`. Parametrized rather than repeated: the boundary is
+# one rule, and a knob added to this family without its bound should be a one-line addition
+# here that fails until the bound exists.
+BOUNDED_AT_ONE = [
+    "run_queue_bucket_count",
+    "run_queue_depth_ceiling",
+    "run_queue_caller_inflight_cap",
+]
+
+
+@pytest.mark.parametrize("field", BOUNDED_AT_ONE)
+@pytest.mark.parametrize("bad", [0, -1])
+def test_a_non_positive_value_is_refused_at_startup(field: str, bad: int) -> None:
+    """INVARIANT: refused where it is READ, not where it is used. `bucket_count=0` is the
+    sharpest case — it divides — but all three describe counts of things, and a
+    configuration error must surface while the operator is still watching the rollout."""
+    # `model_validate` rather than `Settings(**{...})`: a dynamic kwarg name is unresolvable
+    # to the type checker, which then checks the value against EVERY field.
+    with pytest.raises(ValidationError):
+        Settings.model_validate({field: bad})
+
+
+@pytest.mark.parametrize("field", BOUNDED_AT_ONE)
+def test_one_is_accepted_as_the_floor(field: str) -> None:
+    """The bound is a floor, not a minimum-of-two: a single bucket is a legitimate
+    (fairness-free) deployment, and so is admitting one run per caller at a time."""
+    assert getattr(Settings.model_validate({field: 1}), field) == 1
+
+
+def test_the_defaults_satisfy_their_own_bound() -> None:
+    """A default below its own bound would make the shipped configuration unloadable —
+    the failure mode a bound is least expected to introduce."""
+    settings = Settings()
+    for field in BOUNDED_AT_ONE:
+        assert getattr(settings, field) >= 1
+
+
+def test_a_zero_bucket_count_is_what_the_bound_prevents() -> None:
+    """The concrete failure the bound exists for, pinned so the reason cannot be
+    refactored away: with no bound, `bucket_subject` divides by the count on the
+    scheduling hot path, so every single run 500s."""
+    queue = RunQueue("nats://unused:4222", bucket_count=0)
+
+    with pytest.raises(ZeroDivisionError):
+        queue.bucket_subject({"X-User-Email": "a@example.com"})
+
+
+def test_the_default_bucket_count_is_the_modules_own() -> None:
+    """The setting must not fork its default from the queue's — the worker builds its
+    `RunQueue` from `Settings`, so two defaults that drift would split the App's publish
+    buckets from the buckets the worker polls."""
+    assert Settings().run_queue_bucket_count == runner_queue.DEFAULT_BUCKET_COUNT

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -332,4 +332,3 @@ async def test_widening_a_legacy_stream_preserves_its_own_config() -> None:
     assert config.num_replicas == 3
     assert config.duplicate_window == 120.0
     assert config.max_age == 86_400.0
-

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from nats.js.api import RetentionPolicy, StorageType
+from nats.js.api import RetentionPolicy, StorageType, StreamConfig
 from nats.js.errors import BadRequestError
 from pydantic import ValidationError
 
@@ -20,6 +20,7 @@ from screamingface_engine.config import Settings
 from screamingface_engine.runner_queue import RunQueue, encode_message
 from screamingface_engine.subjects import (
     RUN_QUEUE_STREAM,
+    RUN_QUEUE_SUBJECT,
     RUN_QUEUE_SUBJECT_PREFIX,
 )
 
@@ -43,6 +44,8 @@ class _FakeJetStream:
 
     def __init__(self) -> None:
         self.added: list[dict[str, Any]] = []
+        self.updates: list[Any] = []
+        self.legacy: Any = None  # set to a StreamConfig to simulate a pre-1091 stream
         self.published: list[tuple[str, bytes, dict[str, str]]] = []
         self.api_calls = 0
         self._state: dict[str, Any] = {"messages": 0, "first_ts": None}
@@ -53,7 +56,26 @@ class _FakeJetStream:
         return self.pull_sub
 
     async def add_stream(self, **kwargs: Any) -> object:
+        if self.legacy is not None:
+            # The real server's answer to re-declaring an existing stream: a 400 whose
+            # JetStream err_code is the name-in-use code (see STREAM_NAME_IN_USE).
+            raise BadRequestError(
+                code=400, err_code=10_058, description="stream name already in use"
+            )
         self.added.append(kwargs)
+        return object()
+
+    async def stream_info(self, name: str) -> Any:
+        return SimpleNamespace(config=self.legacy)
+
+    async def update_stream(self, config: Any = None, **params: Any) -> object:
+        # The REAL client's contract: a FRESH config evolved from the given kwargs —
+        # anything not passed resets to its default. That reset is what the widening
+        # must not trigger.
+        fresh = config if config is not None else StreamConfig()
+        for key, value in params.items():
+            setattr(fresh, key, value)
+        self.updates.append(fresh)
         return object()
 
     async def publish(
@@ -274,3 +296,33 @@ def test_settings_rejects_a_sweepable_run_queue_stream_name() -> None:
     # The default and an ordinary rename stay legal.
     assert Settings().run_queue_stream == RUN_QUEUE_STREAM
     assert Settings(run_queue_stream="prod-runq").run_queue_stream == "prod-runq"
+
+
+async def test_widening_a_legacy_stream_preserves_its_own_config() -> None:
+    """A stream declared before per-caller buckets holds the single work subject;
+    widening it must change ONLY the subjects. nats-py's `update_stream` evolves a
+    FRESH config from the given kwargs, so a kwargs-only update resets retention,
+    replicas, max_age and the dedupe window to defaults — the server rejects the
+    retention change outright (every publish then fails), and were it accepted the
+    dedupe window would be silently gone. The update must carry the LIVE config."""
+    fake = _FakeJetStream()
+    fake.legacy = StreamConfig(
+        name=RUN_QUEUE_STREAM,
+        subjects=[RUN_QUEUE_SUBJECT],
+        retention=RetentionPolicy.WORK_QUEUE,
+        storage=StorageType.FILE,
+        num_replicas=3,
+        max_age=86_400.0,
+        duplicate_window=120.0,
+    )
+    await _queue(fake).ensure_stream()
+
+    assert len(fake.updates) == 1, "the narrow subject must trigger exactly one widening"
+    config = fake.updates[0]
+    assert config.subjects == [f"{RUN_QUEUE_SUBJECT_PREFIX}.>"], "widened to the bucket wildcard"
+    # Everything the DECLARING replica set survives the update:
+    assert config.retention is RetentionPolicy.WORK_QUEUE
+    assert config.storage is StorageType.FILE
+    assert config.num_replicas == 3
+    assert config.duplicate_window == 120.0
+    assert config.max_age == 86_400.0

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -18,7 +18,10 @@ from pydantic import ValidationError
 
 from screamingface_engine.config import Settings
 from screamingface_engine.runner_queue import RunQueue, encode_message
-from screamingface_engine.subjects import RUN_QUEUE_STREAM, RUN_QUEUE_SUBJECT
+from screamingface_engine.subjects import (
+    RUN_QUEUE_STREAM,
+    RUN_QUEUE_SUBJECT_PREFIX,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -91,7 +94,9 @@ async def test_the_queue_stream_is_declared_with_the_spec_properties() -> None:
     added = fake.added[0]
     assert added["name"] == RUN_QUEUE_STREAM
     assert not added["name"].startswith("url4-cloud_")
-    assert added["subjects"] == [RUN_QUEUE_SUBJECT]
+    # The stream is declared with the wildcard over every per-caller bucket subject
+    # (OME-1091), so one stream holds every caller's runs.
+    assert added["subjects"] == [f"{RUN_QUEUE_SUBJECT_PREFIX}.>"]
     assert added["retention"] is RetentionPolicy.WORK_QUEUE
     assert added["storage"] is StorageType.FILE
     assert added["num_replicas"] == 1
@@ -112,7 +117,11 @@ async def test_duplicate_publish_carries_the_same_dedupe_key() -> None:
     await queue.publish(message)
 
     assert [headers["Nats-Msg-Id"] for _, _, headers in fake.published] == ["topic-a", "topic-a"]
-    assert [subject for subject, _, _ in fake.published] == [RUN_QUEUE_SUBJECT] * 2
+    # An identity-less run lands in the anonymous caller's bucket — the same bucket both times,
+    # so the dedupe key still collapses the retry.
+    subjects = [subject for subject, _, _ in fake.published]
+    assert subjects == [subjects[0], subjects[0]]
+    assert subjects[0].startswith(f"{RUN_QUEUE_SUBJECT_PREFIX}.")
 
 
 async def test_publish_awaits_the_broker_acknowledgement() -> None:

--- a/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
+++ b/apps/screamingface-engine/tests/unit/test_run_queue_stream_config.py
@@ -224,6 +224,12 @@ class _ConflictingStreamJS(_FakeJetStream):
     def __init__(self, err_code: int) -> None:
         super().__init__()
         self._err_code = err_code
+        # The benign path (10058) continues into the widening check — an already-wide
+        # stream answers "no widening needed".
+        self.legacy = StreamConfig(
+            name=RUN_QUEUE_STREAM,
+            subjects=[f"{RUN_QUEUE_SUBJECT_PREFIX}.>"],
+        )
 
     async def add_stream(self, **kwargs: Any) -> object:
         raise BadRequestError(
@@ -326,3 +332,4 @@ async def test_widening_a_legacy_stream_preserves_its_own_config() -> None:
     assert config.num_replicas == 3
     assert config.duplicate_window == 120.0
     assert config.max_age == 86_400.0
+

--- a/apps/screamingface-engine/tests/unit/test_runners_factory.py
+++ b/apps/screamingface-engine/tests/unit/test_runners_factory.py
@@ -153,12 +153,14 @@ def test_the_queue_runner_wires_the_configured_stream_and_prefix_everywhere() ->
     worker's composition root but ignored at the App's — the App published to the
     DEFAULT stream while the worker pulled the configured one (a split that fails loudly
     on every admission), and the App-side publisher's sweep used a stale constant. All
-    composition roots must agree for any Settings. (`run_queue_subject_prefix` lands
-    with the per-caller buckets at OME-1091, where `RunQueue` gains the parameter.)"""
+    composition roots must agree for any Settings. The
+    per-caller subject prefix rides along — a prefix mismatch would publish where no
+    worker listens."""
     settings = Settings(
         runner="queue",
         nats_url="nats://localhost:4222",
         run_queue_stream="prod-runq",
+        run_queue_subject_prefix="prod-prefix",
     )
 
     runner = build_job_runner(settings)
@@ -172,6 +174,7 @@ def test_the_queue_runner_wires_the_configured_stream_and_prefix_everywhere() ->
     queue = cast(RunQueue, runner._queue)
     publisher = cast(JetStreamPublisher, runner._publisher)
     assert queue._stream == "prod-runq"
+    assert queue._subject_prefix == "prod-prefix"
     assert publisher._run_queue_stream == "prod-runq"
 
 

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1522,9 +1522,7 @@ async def test_concurrent_spawns_from_one_claim_batch_divide_the_io_budget() -> 
         return proc
 
     msgs = [_FakeMsg(encode_message(f"t-io-{i}", "'hi'", 60)) for i in range(2)]
-    worker = _worker(
-        _FakeQueue([msgs]), _FakePublisher(), slots=2, spawn=slow_spawn, io_capacity=8
-    )
+    worker = _worker(_FakeQueue([msgs]), _FakePublisher(), slots=2, spawn=slow_spawn, io_capacity=8)
     async with asyncio.TaskGroup() as tg:
         claim = tg.create_task(worker._claim_loop(tg))
         await _wait_until(lambda: len(budgets) == 2)

--- a/apps/screamingface-engine/tests/unit/test_worker_claim.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_claim.py
@@ -1496,3 +1496,39 @@ async def test_a_run_cancelled_before_it_starts_is_stopped_without_spawning() ->
     assert len(publisher.published) == 1
     assert publisher.published[0].data.status == "stopped"
     assert msg.acked
+
+
+# --- the spawn-time io budget counts committed spawns (review follow-up) --------------------
+
+
+async def test_concurrent_spawns_from_one_claim_batch_divide_the_io_budget() -> None:
+    """The claim loop hands several claimed messages to several tasks at once, and each
+    computes its child's io budget BEFORE awaiting the spawn — every `await` is a
+    preemption point, so two siblings both read `len(children) == 0` and both took the
+    FULL capacity: the exact burst the fair share exists to divide. The reservation is
+    now taken synchronously before the read, so each later sibling's budget counts every
+    spawn already committed (the first of the batch keeps the whole budget — its budget
+    was fixed before any sibling committed, the same spawn-fixed limitation as sibling
+    exits)."""
+    from screamingface_engine import job_env
+
+    budgets: list[int] = []
+
+    async def slow_spawn(*args: Any, env: Any = None, **kwargs: Any) -> _FakeProcess:
+        await asyncio.sleep(0)  # the preemption point: the sibling reserves and reads now
+        budgets.append(int(env[job_env.IO_CONCURRENCY]))  # type: ignore[index]
+        proc = _FakeProcess(exit_code=0)
+        proc.release(0)
+        return proc
+
+    msgs = [_FakeMsg(encode_message(f"t-io-{i}", "'hi'", 60)) for i in range(2)]
+    worker = _worker(
+        _FakeQueue([msgs]), _FakePublisher(), slots=2, spawn=slow_spawn, io_capacity=8
+    )
+    async with asyncio.TaskGroup() as tg:
+        claim = tg.create_task(worker._claim_loop(tg))
+        await _wait_until(lambda: len(budgets) == 2)
+        claim.cancel()
+
+    assert budgets[0] == 8, "the first spawn of the batch has the pool to itself"
+    assert budgets[1] == 4, "the second must divide against its sibling's committed spawn"

--- a/docs/tasks/2026-08-26-OME-908-fair-run-scheduling.md
+++ b/docs/tasks/2026-08-26-OME-908-fair-run-scheduling.md
@@ -39,3 +39,15 @@ every Runner Job (`URL4_CLOUD_IO_CONCURRENCY`, default 4 — written uncondition
 work-conserving fewest-in-flight gate for local runs (`local_io_capacity`, default 32).
 Layer 2 remains the companion gateway ticket — text drafted in the work ledger, filing
 pending the owner (Linear writes are owner/MCP actions).
+
+## OME-1091 — the deployed half lands (2026-09-02)
+
+OME-1091 delivers the RUN-LEVEL half of this issue for the queue substrate (OME-1086):
+per-caller queue subjects (`url4-runq.<bucket>`, a stable hash of the caller's identity
+value) with round-robin pull, a per-caller in-flight cap at admission, and a spawn-time io
+budget (`worker_io_capacity / active_children` via `URL4_CLOUD_IO_CONCURRENCY`) that
+replaces the static 4 for queue-backed runs. What remains OPEN, explicitly a follow-up and
+NOT delivered here: dynamic rebalancing — the spawn-time budget is FIXED at spawn and does
+not rebalance when a sibling exits; the work-conserving `FairShareGate` is local-mode only,
+and a cross-process control socket from each child to a parent-held gate is the declared
+follow-up. This issue must not read as fully delivered until that half lands.

--- a/docs/work/2026-09-02-OME-1091-admission-and-fairness.md
+++ b/docs/work/2026-09-02-OME-1091-admission-and-fairness.md
@@ -1,0 +1,98 @@
+---
+ticket: OME-1091
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-02
+finished:
+---
+
+# OME-1091 — Admit runs on queue depth and fair-schedule them per caller
+
+## Intent
+
+Admission moves from namespace quota headroom to queue depth, keeping the
+reservation counter OME-1065 built because the read-modify-write race survives
+the change of resource. `Retry-After` becomes a drain estimate instead of a
+hard-coded 1. Fairness lands as per-caller subjects with round-robin pull plus a
+per-caller in-flight cap — the run-level half of OME-908 — and a spawn-time io
+budget; dynamic rebalancing via a parent-held gate stays a declared follow-up.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py`
+  (modify) — depth-based admission raising `JobRunnerAtCapacity`; per-caller
+  in-flight cap.
+- `apps/screamingface-engine/src/screamingface_engine/runner_queue.py` (modify)
+  — per-caller buckets (stable hash of the identity, not the raw address),
+  round-robin pull.
+- `apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py`
+  (modify) — spawn-time io budget `worker_io_capacity / max(1, active_children)`
+  via `URL4_CLOUD_IO_CONCURRENCY`.
+- `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` (modify)
+  — derived `Retry-After` from a drain estimate.
+- Tests: `tests/unit/test_queue_admission.py`, `tests/unit/test_queue_fairness.py`
+  (new).
+
+## Test plan
+
+- RED: depth at ceiling raises `JobRunnerAtCapacity`, and the REST edge answers
+  503 with a `Retry-After` derived from depth and throughput, not the constant 1.
+- RED: two admissions racing the last slot inside one refresh window cannot both
+  pass — the reservation counter carried over from OME-1065.
+- RED: a per-caller in-flight cap refuses caller A's N+1 run while caller B is
+  still admitted.
+- RED: round-robin pull interleaves two callers' runs instead of draining one
+  caller first.
+- RED: the spawn-time io budget equals `worker_io_capacity / active_children`
+  and appears in the child env as `URL4_CLOUD_IO_CONCURRENCY`.
+
+## Acceptance
+
+- Admission has one authority (queue depth); `Retry-After` is derived.
+- One caller's 9-candidate evaluation cannot occupy every slot.
+- Engine stack gates green (cov >= 80).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `apps/screamingface-engine/src/screamingface_engine/runner_queue.py` (modify) — per-caller
+    buckets (`url4-runq.<bucket>`, stable hash of the identity value), wildcard stream
+    declaration with on-exists subject migration, round-robin pull (one message per bucket per
+    cycle, bounded total timeout), per-bucket durable consumers.
+  - `apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py` (modify) —
+    depth-based admission raising `JobRunnerAtCapacity` with a derived `retry_after_s`; the
+    OME-1065 reservation counter carried over; per-caller in-flight cap with
+    observed-terminal + capability-expiry release.
+  - `apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py` (modify) —
+    spawn-time io budget `worker_io_capacity / max(1, active_children)` via
+    `URL4_CLOUD_IO_CONCURRENCY`.
+  - `apps/screamingface-engine/src/screamingface_engine/rest/routes.py` (modify) — derived
+    `Retry-After` from the exception's drain estimate, constant 1 as fallback.
+  - `apps/screamingface-engine/src/screamingface_engine/config.py` (modify) —
+    `run_queue_bucket_count`, `run_queue_caller_inflight_cap`.
+  - `apps/screamingface-engine/src/screamingface_engine/adapters/factory.py`,
+    `worker/loop.py` (modify) — wire the new settings.
+  - `apps/screamingface-engine/src/screamingface_engine/adapters/max_deliveries.py` (modify) —
+    advisory subject wildcard for per-bucket consumers.
+  - `apps/screamingface-engine/src/screamingface_engine/subjects.py` (modify) — comment only.
+  - `packages/url4/src/url4/streaming/interfaces/jobs.py` (modify) — `JobRunnerAtCapacity`
+    gains optional `retry_after_s`.
+  - Tests: `tests/unit/test_queue_admission.py`, `tests/unit/test_queue_fairness.py` (new);
+    fakes updated in `test_queue_runner_status.py`, `test_queue_runner_cancel.py`,
+    `test_reaper.py`; stream-config and advisory tests updated.
+  - `docs/tasks/2026-08-26-OME-908-fair-run-scheduling.md` (modify) — comment stating which
+    half OME-1091 closes and which remains (dynamic rebalancing).
+- **Commits:** feat(engine): admit runs on queue depth and fair-schedule them per caller
+  (branch tip; squash-merge sha recorded in the Linear close, per the repo's ledger pattern)
+- **Gates:** ruff check clean; ruff format clean; pyright 0 errors; layering OK;
+  pytest 2344 passed, 8 skipped (NATS-dependent integration), coverage 90.93% (>= 80).
+- **Deviations:**
+  - The per-caller in-flight count is released when the runner OBSERVES a terminal frame
+    (reaper polls, re-schedule pre-checks) or the capability expires — the runner cannot
+    observe a finish any other way; a run that finishes while its client stays attached
+    counts until the next observation. Documented in the code.
+  - The drain estimate is `(depth - ceiling) / (depth / oldest_age)`, floored at 1 — the
+    pool's throughput inferred from the oldest message's wait; no separate throughput
+    counter was added.
+  - `JobRunnerAtCapacity` (shared package) gained an optional `retry_after_s` field so the
+    estimate travels with the refusal.

--- a/docs/work/2026-09-03-OME-1091-explicit-nats-errors-import.md
+++ b/docs/work/2026-09-03-OME-1091-explicit-nats-errors-import.md
@@ -1,0 +1,70 @@
+---
+ticket: OME-1091
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-03
+finished:
+---
+
+# OME-1091 — import `nats.errors` explicitly in the run queue
+
+## Intent
+
+`runner_queue.py` catches `nats.errors.Error` in the pull path (`:537`) while importing only
+the `nats` package. `nats.errors` is a SUBMODULE: `import nats` does not bind it. The name
+resolves today purely because `from nats.aio.client import Client` on the next line happens to
+import `nats.errors` as a side effect, which populates the attribute on the parent package.
+
+That is an accident, not a contract. If `nats.aio.client`'s own imports change in any future
+version, this `except` clause raises `AttributeError` — **while handling an error**, on the
+broker-failure path, which is the worst possible place to discover it. The pull guard that
+exists to keep one blip local would itself become the failure.
+
+Surfaced by the pyright gate while rebasing this branch onto the fixed OME-1090. It is the last
+error standing between this branch and a green gate; the rest of the stack's pyright breakage
+was repaired on OME-1089 and OME-1090.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/runner_queue.py` — add
+  `import nats.errors` beside the existing `import nats`.
+
+## Test plan
+
+No new test. The change binds a name that already resolves at runtime, so there is no
+behavior a test could distinguish before and after — the existing pull-path tests on this
+branch already cover the `nats.errors.Error` branch they exercise. The pyright gate is the
+driver here, and it is the thing that would regress.
+
+## Acceptance
+
+- `uv run pyright` reports 0 errors on this branch.
+- `run_gates.py screamingface-engine` green, with the whole prior suite unchanged.
+
+## Outcome
+
+- **Actual files:** as planned — `src/screamingface_engine/runner_queue.py` only.
+- **Commits:** `fix(engine): import nats.errors explicitly in the run queue`
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` — ALL GATES GREEN
+  (ruff check · ruff format --check · pyright · check_layering · pytest --cov ≥80). Green on
+  the first attempt.
+- **Deviations:**
+  1. **This branch needed no B2 wiring of its own.** The replica-count changes reached it
+     through the rebase onto OME-1090, which is the intended behaviour of a stacked series.
+     Its only change is the import above.
+  2. **The rebase onto the fixed OME-1090 hit two conflicts, both resolved by keeping BOTH
+     sides** — never by dropping either:
+     - `factory.py` and `worker/loop.py`: this branch adds `bucket_count=` at the same
+       position where OME-1090 added `replicas=`. Both kwargs are now passed.
+     - `test_runners_factory.py`: this branch adds an `assert ..._subject_prefix` where
+       OME-1090 introduced the `isinstance` narrowing and casts. The new assertion is kept,
+       expressed through the narrowed locals.
+  3. **`--skip-append-only` was used** because the branch carries the owner-approved
+     prior-test edits from OME-1089/OME-1090 beneath it. No prior test was edited in THIS
+     unit beyond the conflict resolution above, which preserves this branch's own assertion.
+
+## Follow-ups surfaced (not in this unit)
+
+- The same latent shape may exist elsewhere: any module doing `import nats` and then reaching
+  `nats.errors` / `nats.js.errors` through the parent package works only by transitive-import
+  accident. Worth a sweep, but out of scope for a blocker fix.

--- a/packages/url4/src/url4/streaming/interfaces/jobs.py
+++ b/packages/url4/src/url4/streaming/interfaces/jobs.py
@@ -46,9 +46,14 @@ class JobRunnerAtCapacity(Exception):
     ``retry_after_s`` is the substrate's own drain estimate — how long the caller should wait
     before retrying — when it can compute one (the queue-backed runner derives it from depth and
     observed throughput). ``None`` means the caller falls back to its own constant.
+
+    DELTA-SECONDS, an integer: this value crosses to HTTP as the ``Retry-After`` header,
+    which RFC 7231 defines as a non-negative decimal integer (or an HTTP-date). An
+    adapter computing the estimate must CEIL it — never round down, or the caller
+    retries sooner than the substrate's own estimate.
     """
 
-    def __init__(self, active: int, limit: int, *, retry_after_s: float | None = None) -> None:
+    def __init__(self, active: int, limit: int, *, retry_after_s: int | None = None) -> None:
         super().__init__(f"runner at capacity: {active} run(s) in flight, limit {limit}")
         self.active = active
         self.limit = limit

--- a/packages/url4/src/url4/streaming/interfaces/jobs.py
+++ b/packages/url4/src/url4/streaming/interfaces/jobs.py
@@ -42,12 +42,17 @@ class JobRunnerAtCapacity(Exception):
     raises it when its queue depth hits the ceiling; a cluster scheduler raises it when its
     resource quota is exhausted. The port names the substrate SHAPES, not adapter classes — an
     adapter is bound to this contract by its own tests, not by being enumerated here.
+
+    ``retry_after_s`` is the substrate's own drain estimate — how long the caller should wait
+    before retrying — when it can compute one (the queue-backed runner derives it from depth and
+    observed throughput). ``None`` means the caller falls back to its own constant.
     """
 
-    def __init__(self, active: int, limit: int) -> None:
+    def __init__(self, active: int, limit: int, *, retry_after_s: float | None = None) -> None:
         super().__init__(f"runner at capacity: {active} run(s) in flight, limit {limit}")
         self.active = active
         self.limit = limit
+        self.retry_after_s = retry_after_s
 
 
 def job_name(topic: str) -> str:


### PR DESCRIPTION
## What

Adds the serving half: the queue runner refuses runs at a depth ceiling and a per-caller in-flight cap with honest `Retry-After` values, and the pull round-robins per-caller buckets with a per-visit cap so one caller's burst cannot starve another.

## Why

The fleet can only drain so fast: admission must stop accepting when the queue is deeper than the pool can drain in reasonable time, and per-caller fairness prevents a 9-candidate evaluation from head-of-line blocking everyone else.

## Key changes

- Admission: depth ceiling + per-caller in-flight cap; reservations are tokens (the admission moment), released exactly on failure/cancel; `Retry-After` for a capped caller comes from that caller's own oldest in-flight run (P2-11), floored and clamped (V-10).
- Pull: two-phase (fast pass collects the burst, slow pass spends the remaining budget) with a per-visit cap (P2-7); held subscriptions with a TTL and drop-on-error so a stale consumer cannot wedge the worker silently (V-5); the fetch is clamped to the batch and the surplus NAK'd (V-4).
- `_drain_estimate_s` uses the same effective depth the admission decision used (V-10).
- Tests: admission refusal paths, reservation release semantics, burst-fills-batch, cap retry-after, the fast/slow split, the over-return clamp.

## Stack

Part of the OME-1086 worker-pool migration: #815 → #816 → #818 → #819 → #821 → #822. Stacked on #819; the base for #822.

## Gates

- ruff check / ruff format --check: clean
- pytest: 2389 passed / 5 skipped (only the known macOS `RLIMIT_AS` flake excluded)
- check_layering: OK

Refs: OME-1091
