### PR TITLE
feat(studio): recipe-native fusion builder with a node-diagram UI and live url4 (OME-1077)

### DIFF
--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1095,6 +1095,9 @@ function RunsPanel({
   const [benchmarkId, setBenchmarkId] = useState("gpqa");
   const [sampleSize, setSampleSize] = useState(100);
   const [full, setFull] = useState(false);
+  const [custom, setCustom] = useState(false);
+  const [useCache, setUseCache] = useState(true);
+  const [saveCache, setSaveCache] = useState(true);
   const [compute, setCompute] = useState<"om" | "own">("om");
   const [running, setRunning] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -1198,6 +1201,8 @@ function RunsPanel({
           benchmarkName: benchmark.name,
           sampleSize: full ? benchmark.questions : sampleSize,
           full,
+          useCache,
+          saveCache,
           compute: effectiveCompute,
           score,
           baseline,
@@ -1414,23 +1419,41 @@ function RunsPanel({
             <section>
               <p className="mb-3 text-xs text-muted-foreground">Sample Size</p>
               <div className="flex flex-wrap gap-2">
-                {[25, 50, 100, 200].map((size) => (
-                  <Button
-                    key={size}
-                    type="button"
-                    size="sm"
-                    aria-pressed={!full && sampleSize === size}
-                    variant={!full && sampleSize === size ? "default" : "outline"}
-                    disabled={running}
-                    className="font-mono"
-                    onClick={() => {
-                      setSampleSize(size);
-                      setFull(false);
-                    }}
-                  >
-                    {size}q
-                  </Button>
-                ))}
+                {[1, 50, 100].map((size) => {
+                  const active = !full && !custom && sampleSize === size;
+                  return (
+                    <Button
+                      key={size}
+                      type="button"
+                      size="sm"
+                      aria-pressed={active}
+                      variant={active ? "default" : "outline"}
+                      disabled={running}
+                      className="font-mono"
+                      onClick={() => {
+                        setSampleSize(size);
+                        setFull(false);
+                        setCustom(false);
+                      }}
+                    >
+                      {size}q
+                    </Button>
+                  );
+                })}
+                <Button
+                  type="button"
+                  size="sm"
+                  aria-pressed={!full && custom}
+                  variant={!full && custom ? "default" : "outline"}
+                  disabled={running}
+                  className="font-mono"
+                  onClick={() => {
+                    setCustom(true);
+                    setFull(false);
+                  }}
+                >
+                  Custom
+                </Button>
                 <Button
                   type="button"
                   size="sm"
@@ -1438,11 +1461,32 @@ function RunsPanel({
                   variant={full ? "default" : "outline"}
                   disabled={running}
                   className="font-mono"
-                  onClick={() => setFull(true)}
+                  onClick={() => {
+                    setFull(true);
+                    setCustom(false);
+                  }}
                 >
                   Full
                 </Button>
               </div>
+              {!full && custom && (
+                <div className="mt-3 flex items-center gap-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    inputMode="numeric"
+                    value={sampleSize}
+                    disabled={running}
+                    aria-label="Custom sample size"
+                    className="h-8 w-28 font-mono"
+                    onChange={(event) => {
+                      const next = Number.parseInt(event.target.value, 10);
+                      setSampleSize(Number.isNaN(next) ? 1 : Math.max(1, next));
+                    }}
+                  />
+                  <span className="text-xs text-muted-foreground">questions</span>
+                </div>
+              )}
               {full && (
                 <p className="mt-2 text-xs text-muted-foreground">
                   Full benchmark — {benchmark.questions.toLocaleString()} questions.
@@ -1507,6 +1551,55 @@ function RunsPanel({
                   </p>
                 </div>
               )}
+            </section>
+            <section>
+              <p className="mb-3 text-xs text-muted-foreground">Cache</p>
+              <div className="flex flex-col gap-2">
+                <label
+                  htmlFor="run-use-cache"
+                  className={cn(
+                    "flex cursor-pointer items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition-colors",
+                    running && "cursor-not-allowed opacity-50",
+                    useCache ? "border-primary/50 bg-primary/5" : "hover:bg-muted/20",
+                  )}
+                >
+                  <span>
+                    <span className="block text-xs font-medium">Use cache</span>
+                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                      Reuse cached answers when a matching request already ran.
+                    </span>
+                  </span>
+                  <Switch
+                    id="run-use-cache"
+                    checked={useCache}
+                    disabled={running}
+                    onCheckedChange={setUseCache}
+                    aria-label="Use cache"
+                  />
+                </label>
+                <label
+                  htmlFor="run-save-cache"
+                  className={cn(
+                    "flex cursor-pointer items-center justify-between gap-3 rounded-xl border px-4 py-3 text-left transition-colors",
+                    running && "cursor-not-allowed opacity-50",
+                    saveCache ? "border-primary/50 bg-primary/5" : "hover:bg-muted/20",
+                  )}
+                >
+                  <span>
+                    <span className="block text-xs font-medium">Save cache</span>
+                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                      Store this run&apos;s answers so future runs can reuse them.
+                    </span>
+                  </span>
+                  <Switch
+                    id="run-save-cache"
+                    checked={saveCache}
+                    disabled={running}
+                    onCheckedChange={setSaveCache}
+                    aria-label="Save cache"
+                  />
+                </label>
+              </div>
             </section>
           </div>
         </div>

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -6,7 +6,6 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
-  Copy,
   Cpu,
   BarChart3,
   Globe,
@@ -2588,19 +2587,6 @@ function EnsembleComposer() {
               <p className="mt-1.5 text-[11px] text-muted-foreground">
                 Structural preview — the engine emits the canonical url4 at run time.
               </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-2 w-full"
-                onClick={copyRecipe}
-              >
-                {copied ? (
-                  <Check className="size-3.5 text-accent" />
-                ) : (
-                  <Copy className="size-3.5" />
-                )}
-                {copied ? "Copied" : "Copy"}
-              </Button>
             </div>
 
             <div>

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -20,8 +20,6 @@ import {
   Scale,
   Share2,
   Upload,
-  Columns3,
-  Rows3,
   X,
   ZoomIn,
   ZoomOut,
@@ -1731,35 +1729,30 @@ function buildDraft(
   };
 }
 
-type Orientation = "vertical" | "horizontal";
-
 type NodeRole = "root" | "member" | "stage" | "synthesizer";
 
-const RECIPE_KINDS: { kind: RecipeKind; label: string }[] = [
-  { kind: "solo", label: "Solo" },
-  { kind: "fusion", label: "Fusion" },
-  { kind: "pipeline", label: "Pipeline" },
-];
+function kindLabel(kind: RecipeKind): string {
+  return kind === "solo" ? "Solo" : kind === "fusion" ? "Fusion" : "Pipeline";
+}
 
 function nodeChrome(depth: number, role: NodeRole): string {
   if (role === "synthesizer") {
-    return depth === 0
-      ? "rounded-xl border border-accent/40 bg-accent/5 p-3.5"
-      : "rounded-lg bg-accent/5 ring-1 ring-inset ring-accent/15 p-2.5";
+    return "rounded-lg border border-accent/40 bg-accent/5 p-3";
   }
   return depth === 0
     ? "rounded-xl border bg-card p-3.5 shadow-sm"
-    : "rounded-lg bg-muted/30 ring-1 ring-inset ring-border/40 p-2.5";
+    : "rounded-lg border border-border/60 bg-card p-3";
 }
 
 function roleTagClass(role: NodeRole): string {
   return cn(
-    "shrink-0 font-mono text-[11px] uppercase tracking-wide",
+    "shrink-0 font-mono text-[10px] uppercase tracking-wider",
     role === "synthesizer" ? "text-accent" : "text-muted-foreground",
   );
 }
 
-function KindSwitch({
+// Compact type selector — replaces the wide 3-segment switch that crowded nested cards.
+function KindDropdown({
   node,
   onChange,
 }: {
@@ -1767,28 +1760,46 @@ function KindSwitch({
   onChange: (next: RecipeNode) => void;
 }) {
   return (
-    <div className="inline-flex overflow-hidden rounded-lg border">
-      {RECIPE_KINDS.map(({ kind, label }) => (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
         <button
-          key={kind}
           type="button"
-          aria-pressed={node.kind === kind}
-          onClick={() => onChange(convertKind(node, kind))}
-          className={cn(
-            "px-2 py-0.5 text-[11px] font-medium transition-colors",
-            node.kind === kind
-              ? "bg-primary text-primary-foreground"
-              : "text-muted-foreground hover:bg-muted/40",
-          )}
+          className="inline-flex h-6 shrink-0 items-center gap-0.5 rounded-md border px-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/40"
         >
-          {label}
+          {kindLabel(node.kind)}
+          <ChevronDown className="size-3" />
         </button>
-      ))}
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[8rem]">
+        <DropdownMenuRadioGroup
+          value={node.kind}
+          onValueChange={(value) => onChange(convertKind(node, value as RecipeKind))}
+        >
+          <DropdownMenuRadioItem value="solo">Solo model</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="fusion">Fusion</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="pipeline">Pipeline</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
-// Prompt + parameters — only shown for a solo that already has a model, and collapsible.
+function RemoveButton({ onRemove }: { onRemove: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="size-6 shrink-0 text-muted-foreground"
+      aria-label="Remove element"
+      onClick={onRemove}
+    >
+      <X className="size-3.5" />
+    </Button>
+  );
+}
+
+// Prompt + params (+ change model) for a solo that already has a model.
 function SoloConfig({
   node,
   onChange,
@@ -1807,7 +1818,7 @@ function SoloConfig({
         className="resize-none text-xs"
         onChange={(event) => onChange({ ...node, prompt: event.target.value })}
       />
-      <div>
+      <div className="flex items-center justify-between gap-2">
         <Button
           type="button"
           variant="ghost"
@@ -1821,190 +1832,125 @@ function SoloConfig({
           />
           Parameters{paramCount > 0 ? ` (${paramCount})` : ""}
         </Button>
-        {showParams && (
-          <ParamEditor
-            params={node.params ?? []}
-            onChange={(next) => onChange({ ...node, params: next })}
-          />
-        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs text-muted-foreground"
+          onClick={() => onChange({ ...node, model: null })}
+        >
+          Change model
+        </Button>
       </div>
-    </div>
-  );
-}
-
-function GroupBox({
-  label,
-  tone = "muted",
-  orientation,
-  children,
-}: {
-  label: string;
-  tone?: "muted" | "accent";
-  orientation: Orientation;
-  children: React.ReactNode;
-}) {
-  if (orientation === "vertical") {
-    return (
-      <div
-        className={cn(
-          "flex flex-col gap-2.5 border-l-2 pl-3",
-          tone === "accent" ? "border-accent/30" : "border-border/40",
-        )}
-      >
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          {label}
-        </p>
-        {children}
-      </div>
-    );
-  }
-  return (
-    <div
-      className={cn(
-        "rounded-lg border border-dashed p-2.5",
-        tone === "accent" ? "border-accent/40" : "border-border/50",
+      {showParams && (
+        <ParamEditor
+          params={node.params ?? []}
+          onChange={(next) => onChange({ ...node, params: next })}
+        />
       )}
-    >
-      <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-        {label}
-      </p>
-      {children}
     </div>
   );
 }
 
+// Fusion: members stacked in parallel on a rail, converging into the synthesizer below.
 function FusionBody({
   node,
   onChange,
   providers,
   onUseModels,
   depth,
-  orientation,
 }: {
   node: FusionNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
   depth: number;
-  orientation: Orientation;
 }) {
-  const horizontal = orientation === "horizontal";
   const setMembers = (members: RecipeNode[]) => onChange({ ...node, members });
   return (
     <div className="flex flex-col gap-2.5">
-      <GroupBox label="Members · parallel" orientation={orientation}>
-        <div
-          className={cn(
-            horizontal
-              ? "flex flex-row flex-wrap items-start gap-2.5"
-              : "flex flex-col gap-2.5",
-          )}
+      <div className="flex flex-col gap-2 border-l-2 border-border/40 pl-3">
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
+          Parallel members
+        </p>
+        {node.members.map((member, index) => (
+          <RecipeNodeCard
+            key={member.id}
+            node={member}
+            index={index}
+            depth={depth + 1}
+            role="member"
+            providers={providers}
+            onUseModels={onUseModels}
+            onChange={(next) =>
+              setMembers(node.members.map((item, i) => (i === index ? next : item)))
+            }
+            onRemove={
+              node.members.length > 1
+                ? () => setMembers(node.members.filter((_, i) => i !== index))
+                : undefined
+            }
+          />
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 self-start text-xs"
+          onClick={() => setMembers([...node.members, createSolo()])}
         >
-          {node.members.map((member, index) => (
-            <div
-              key={member.id}
-              className={horizontal ? "grow basis-[16rem] min-w-[16rem]" : undefined}
-            >
-              <RecipeNodeCard
-                node={member}
-                index={index}
-                depth={depth + 1}
-                role="member"
-                orientation={orientation}
-                providers={providers}
-                onUseModels={onUseModels}
-                onChange={(next) =>
-                  setMembers(node.members.map((item, i) => (i === index ? next : item)))
-                }
-                onRemove={
-                  node.members.length > 1
-                    ? () => setMembers(node.members.filter((_, i) => i !== index))
-                    : undefined
-                }
-              />
-            </div>
-          ))}
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className={cn("h-7 text-xs", horizontal ? "self-center" : "self-start")}
-            onClick={() => setMembers([...node.members, createSolo()])}
-          >
-            <Plus className="size-3.5" />
-            Add member
-          </Button>
-        </div>
-      </GroupBox>
-      <div className="flex items-center gap-1.5 pl-1 text-[11px] text-muted-foreground">
+          <Plus className="size-3.5" />
+          Add member
+        </Button>
+      </div>
+      <div className="flex items-center gap-1.5 pl-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
         <ArrowDown className="size-3.5" />
         synthesize
       </div>
-      <GroupBox label="Synthesizer" tone="accent" orientation={orientation}>
-        <RecipeNodeCard
-          node={node.synthesizer}
-          depth={depth + 1}
-          role="synthesizer"
-          orientation={orientation}
-          providers={providers}
-          onUseModels={onUseModels}
-          onChange={(next) => onChange({ ...node, synthesizer: next })}
-        />
-      </GroupBox>
+      <RecipeNodeCard
+        node={node.synthesizer}
+        depth={depth + 1}
+        role="synthesizer"
+        providers={providers}
+        onUseModels={onUseModels}
+        onChange={(next) => onChange({ ...node, synthesizer: next })}
+      />
     </div>
   );
 }
 
+// Pipeline: stages on a left-to-right timeline; the row scrolls when it gets long.
 function PipelineBody({
   node,
   onChange,
   providers,
   onUseModels,
   depth,
-  orientation,
 }: {
   node: PipelineNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
   depth: number;
-  orientation: Orientation;
 }) {
-  const horizontal = orientation === "horizontal";
   const setStages = (stages: RecipeNode[]) => onChange({ ...node, stages });
   return (
-    <GroupBox label="Stages · sequence" orientation={orientation}>
-      <div
-        className={cn(
-          horizontal
-            ? "flex flex-row flex-wrap items-stretch gap-2"
-            : "flex flex-col gap-2.5",
-        )}
-      >
+    <div className="flex flex-col gap-1.5">
+      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
+        Sequence
+      </p>
+      <div className="flex flex-row items-start gap-1.5 pb-1">
         {node.stages.map((stage, index) => (
-          <div
-            key={stage.id}
-            className={cn("flex gap-2", horizontal ? "items-stretch" : "flex-col")}
-          >
+          <div key={stage.id} className="flex items-start gap-1.5">
             {index > 0 && (
-              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                {horizontal ? (
-                  <ArrowRight className="size-4" />
-                ) : (
-                  <>
-                    <ArrowDown className="size-3.5" />
-                    then
-                  </>
-                )}
-              </div>
+              <ArrowRight className="mt-3 size-4 shrink-0 text-muted-foreground/70" />
             )}
-            <div className={horizontal ? "min-w-[16rem]" : undefined}>
+            <div className="min-w-[16rem] shrink-0">
               <RecipeNodeCard
                 node={stage}
                 index={index}
                 depth={depth + 1}
                 role="stage"
-                orientation={orientation}
                 providers={providers}
                 onUseModels={onUseModels}
                 onChange={(next) =>
@@ -2019,33 +1965,21 @@ function PipelineBody({
             </div>
           </div>
         ))}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className={cn("h-7 text-xs", horizontal ? "self-center" : "self-start")}
-          onClick={() => setStages([...node.stages, createSolo()])}
-        >
-          <Plus className="size-3.5" />
-          Add stage
-        </Button>
+        <div className="flex items-center gap-1.5 self-center">
+          <ArrowRight className="size-4 shrink-0 text-muted-foreground/70" />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => setStages([...node.stages, createSolo()])}
+          >
+            <Plus className="size-3.5" />
+            Add stage
+          </Button>
+        </div>
       </div>
-    </GroupBox>
-  );
-}
-
-function RemoveButton({ onRemove }: { onRemove: () => void }) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      className="size-6 text-muted-foreground"
-      aria-label="Remove element"
-      onClick={onRemove}
-    >
-      <X className="size-3.5" />
-    </Button>
+    </div>
   );
 }
 
@@ -2058,7 +1992,6 @@ function RecipeNodeCard({
   role = "root",
   index,
   depth = 0,
-  orientation = "vertical",
 }: {
   node: RecipeNode;
   onChange: (next: RecipeNode) => void;
@@ -2068,7 +2001,6 @@ function RecipeNodeCard({
   role?: NodeRole;
   index?: number;
   depth?: number;
-  orientation?: Orientation;
 }) {
   const [collapsed, setCollapsed] = useState(
     () => node.kind === "solo" && Boolean((node as SoloNode).model),
@@ -2081,11 +2013,17 @@ function RecipeNodeCard({
         : role === "synthesizer"
           ? "Synthesizer"
           : "Recipe";
+  const controls = (
+    <div className="flex shrink-0 items-center gap-1">
+      <KindDropdown node={node} onChange={onChange} />
+      {onRemove && <RemoveButton onRemove={onRemove} />}
+    </div>
+  );
 
   if (node.kind === "solo") {
     const model = node.model;
     return (
-      <article className={cn("h-full", nodeChrome(depth, role))}>
+      <article className={cn("min-w-[16rem]", nodeChrome(depth, role))}>
         <div className="flex items-center justify-between gap-2">
           {model ? (
             <button
@@ -2108,28 +2046,13 @@ function RecipeNodeCard({
             </button>
           ) : (
             <span className="flex min-w-0 flex-1 items-center gap-1.5">
-              <span
-                aria-hidden="true"
-                className="ml-1 size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
-              />
               <span className={roleTagClass(role)}>{roleLabel}</span>
+              <span className="truncate text-xs text-muted-foreground/70">
+                · pick a model
+              </span>
             </span>
           )}
-          <div className="flex shrink-0 items-center gap-1">
-            {model && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="h-6 px-2 text-[11px] text-muted-foreground"
-                onClick={() => onChange({ ...node, model: null })}
-              >
-                Change
-              </Button>
-            )}
-            <KindSwitch node={node} onChange={onChange} />
-            {onRemove && <RemoveButton onRemove={onRemove} />}
-          </div>
+          {controls}
         </div>
         {!model && (
           <div className="mt-2.5">
@@ -2153,7 +2076,7 @@ function RecipeNodeCard({
   }
 
   return (
-    <article className={cn("h-full", nodeChrome(depth, role))}>
+    <article className={cn("min-w-[16rem]", nodeChrome(depth, role))}>
       <div className="flex items-center justify-between gap-2">
         <button
           type="button"
@@ -2168,16 +2091,16 @@ function RecipeNodeCard({
             )}
           />
           <span className={roleTagClass(role)}>{roleLabel}</span>
+          <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {kindLabel(node.kind)}
+          </span>
           {collapsed && (
-            <span className="min-w-0 truncate rounded-md bg-background/70 px-1.5 py-0.5 font-mono text-[11px] text-foreground/80">
+            <span className="min-w-0 truncate font-mono text-[11px] text-foreground/70">
               {describeRecipe(node)}
             </span>
           )}
         </button>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <KindSwitch node={node} onChange={onChange} />
-          {onRemove && <RemoveButton onRemove={onRemove} />}
-        </div>
+        {controls}
       </div>
       {!collapsed && (
         <div className="mt-3">
@@ -2188,7 +2111,6 @@ function RecipeNodeCard({
               providers={providers}
               onUseModels={onUseModels}
               depth={depth}
-              orientation={orientation}
             />
           ) : (
             <PipelineBody
@@ -2197,7 +2119,6 @@ function RecipeNodeCard({
               providers={providers}
               onUseModels={onUseModels}
               depth={depth}
-              orientation={orientation}
             />
           )}
         </div>
@@ -2231,7 +2152,7 @@ function EnsembleComposer() {
   const [tab, setTab] = useState<"compose" | "runs">("compose");
   const [copied, setCopied] = useState(false);
   const [zoom, setZoom] = useState(1);
-  const [orientation, setOrientation] = useState<"vertical" | "horizontal">("horizontal");
+  const canvasRef = useRef<HTMLDivElement>(null);
   const [autoSave, setAutoSave] = useState(true);
   const [loadedEnsembleId, setLoadedEnsembleId] = useState<string | null>(null);
   const [savedSnapshot, setSavedSnapshot] = useState("");
@@ -2484,96 +2405,86 @@ function EnsembleComposer() {
         value="compose"
         className="m-0 flex min-h-0 flex-1 overflow-hidden"
       >
-          <main className="min-w-0 flex-1 overflow-auto px-6 py-6 lg:px-10">
-            <div
-              className={cn(
-                "mx-auto flex flex-col gap-3",
-                orientation === "horizontal" ? "max-w-none" : "max-w-2xl",
-              )}
-            >
-              <div className="flex flex-wrap items-center justify-between gap-2">
-                <p className="text-xs text-muted-foreground">
-                  A unit can be a solo model, a fusion (parallel members + a required
-                  synthesizer), or a pipeline (serial stages) — nest to any depth.
-                </p>
-                <div className="flex shrink-0 items-center gap-1.5">
-                  <div className="inline-flex overflow-hidden rounded-lg border">
-                    <button
-                      type="button"
-                      aria-label="Horizontal layout"
-                      aria-pressed={orientation === "horizontal"}
-                      onClick={() => setOrientation("horizontal")}
-                      className={cn(
-                        "grid size-7 place-items-center transition-colors",
-                        orientation === "horizontal"
-                          ? "bg-primary text-primary-foreground"
-                          : "text-muted-foreground hover:bg-muted/40",
-                      )}
-                    >
-                      <Columns3 className="size-3.5" />
-                    </button>
-                    <button
-                      type="button"
-                      aria-label="Vertical layout"
-                      aria-pressed={orientation === "vertical"}
-                      onClick={() => setOrientation("vertical")}
-                      className={cn(
-                        "grid size-7 place-items-center transition-colors",
-                        orientation === "vertical"
-                          ? "bg-primary text-primary-foreground"
-                          : "text-muted-foreground hover:bg-muted/40",
-                      )}
-                    >
-                      <Rows3 className="size-3.5" />
-                    </button>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="size-7"
-                      aria-label="Zoom out"
-                      disabled={zoom <= 0.5}
-                      onClick={() =>
-                        setZoom((value) => Math.max(0.5, Math.round((value - 0.1) * 10) / 10))
-                      }
-                    >
-                      <ZoomOut className="size-3.5" />
-                    </Button>
-                    <button
-                      type="button"
-                      className="w-11 text-center font-mono text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
-                      title="Reset zoom"
-                      onClick={() => setZoom(1)}
-                    >
-                      {Math.round(zoom * 100)}%
-                    </button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      className="size-7"
-                      aria-label="Zoom in"
-                      disabled={zoom >= 1.3}
-                      onClick={() =>
-                        setZoom((value) => Math.min(1.3, Math.round((value + 0.1) * 10) / 10))
-                      }
-                    >
-                      <ZoomIn className="size-3.5" />
-                    </Button>
-                  </div>
+          <main className="flex min-w-0 flex-1 flex-col overflow-hidden px-6 py-6 lg:px-10">
+            <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+              <p className="text-xs text-muted-foreground">
+                A unit is a solo model, a fusion (parallel members → a synthesizer), or a
+                pipeline (sequential stages). Nest to any depth.
+              </p>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <div className="flex items-center gap-1">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-7"
+                    aria-label="Scroll left"
+                    onClick={() =>
+                      canvasRef.current?.scrollBy({ left: -360, behavior: "smooth" })
+                    }
+                  >
+                    <ChevronLeft className="size-3.5" />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-7"
+                    aria-label="Scroll right"
+                    onClick={() =>
+                      canvasRef.current?.scrollBy({ left: 360, behavior: "smooth" })
+                    }
+                  >
+                    <ChevronRight className="size-3.5" />
+                  </Button>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-7"
+                    aria-label="Zoom out"
+                    disabled={zoom <= 0.5}
+                    onClick={() =>
+                      setZoom((value) => Math.max(0.5, Math.round((value - 0.1) * 10) / 10))
+                    }
+                  >
+                    <ZoomOut className="size-3.5" />
+                  </Button>
+                  <button
+                    type="button"
+                    className="w-11 text-center font-mono text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+                    title="Reset zoom"
+                    onClick={() => setZoom(1)}
+                  >
+                    {Math.round(zoom * 100)}%
+                  </button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-7"
+                    aria-label="Zoom in"
+                    disabled={zoom >= 1.3}
+                    onClick={() =>
+                      setZoom((value) => Math.min(1.3, Math.round((value + 0.1) * 10) / 10))
+                    }
+                  >
+                    <ZoomIn className="size-3.5" />
+                  </Button>
                 </div>
               </div>
+            </div>
+            <div ref={canvasRef} className="min-h-0 flex-1 overflow-auto">
               <div
-                className="transition-transform"
-                style={{ transform: `scale(${zoom})`, transformOrigin: "top center" }}
+                className="w-max min-w-full pb-6 pr-6 transition-transform"
+                style={{ transform: `scale(${zoom})`, transformOrigin: "top left" }}
               >
                 <RecipeNodeCard
                   node={root}
                   role="root"
                   depth={0}
-                  orientation={orientation}
                   providers={providers}
                   onUseModels={(models) => addLibraryModels(models)}
                   onChange={setRoot}

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   ChevronDown,
   ChevronLeft,
+  ChevronRight,
   Copy,
   Cpu,
   BarChart3,
@@ -20,6 +21,8 @@ import {
   Share2,
   Upload,
   X,
+  ZoomIn,
+  ZoomOut,
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -1732,6 +1735,19 @@ const RECIPE_KINDS: { kind: RecipeKind; label: string }[] = [
   { kind: "pipeline", label: "Pipeline" },
 ];
 
+type NodeRole = "root" | "member" | "stage" | "synthesizer";
+
+function nodeChrome(depth: number, role: NodeRole): string {
+  if (role === "synthesizer") {
+    return depth === 0
+      ? "rounded-xl border border-accent/40 bg-accent/5 p-3.5"
+      : "rounded-lg bg-accent/5 ring-1 ring-inset ring-accent/15 p-3";
+  }
+  return depth === 0
+    ? "rounded-xl border bg-card p-3.5 shadow-sm"
+    : "rounded-lg bg-muted/30 ring-1 ring-inset ring-border/40 p-3";
+}
+
 function KindSwitch({
   node,
   onChange,
@@ -1748,7 +1764,7 @@ function KindSwitch({
           aria-pressed={node.kind === kind}
           onClick={() => onChange(convertKind(node, kind))}
           className={cn(
-            "px-2.5 py-1 text-xs transition-colors",
+            "px-2 py-0.5 text-[11px] font-medium transition-colors",
             node.kind === kind
               ? "bg-primary text-primary-foreground"
               : "text-muted-foreground hover:bg-muted/40",
@@ -1813,12 +1829,12 @@ function SoloBody({
           type="button"
           variant="ghost"
           size="sm"
-          className="text-xs text-muted-foreground"
+          className="h-7 px-2 text-xs text-muted-foreground"
           aria-expanded={showParams}
           onClick={() => setShowParams((value) => !value)}
         >
-          <ChevronDown
-            className={cn("size-3.5 transition-transform", showParams && "rotate-180")}
+          <ChevronRight
+            className={cn("size-3.5 transition-transform", showParams && "rotate-90")}
           />
           Parameters{paramCount > 0 ? ` (${paramCount})` : ""}
         </Button>
@@ -1833,62 +1849,89 @@ function SoloBody({
   );
 }
 
+function ChildRail({
+  tone = "muted",
+  children,
+}: {
+  tone?: "muted" | "accent";
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2.5 border-l-2 pl-3",
+        tone === "accent" ? "border-accent/30" : "border-border/40",
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
 function FusionBody({
   node,
   onChange,
   providers,
   onUseModels,
+  depth,
 }: {
   node: FusionNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
+  depth: number;
 }) {
   const setMembers = (members: RecipeNode[]) => onChange({ ...node, members });
   return (
     <div className="flex flex-col gap-2.5">
-      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
-        Members · run in parallel
-      </p>
-      {node.members.map((member, index) => (
-        <RecipeNodeCard
-          key={member.id}
-          node={member}
-          index={index}
-          role="member"
-          providers={providers}
-          onUseModels={onUseModels}
-          onChange={(next) =>
-            setMembers(node.members.map((item, i) => (i === index ? next : item)))
-          }
-          onRemove={
-            node.members.length > 1
-              ? () => setMembers(node.members.filter((_, i) => i !== index))
-              : undefined
-          }
-        />
-      ))}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="self-start"
-        onClick={() => setMembers([...node.members, createSolo()])}
-      >
-        <Plus className="size-3.5" />
-        Add member
-      </Button>
-      <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground">
+      <ChildRail>
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          Members · parallel
+        </p>
+        {node.members.map((member, index) => (
+          <RecipeNodeCard
+            key={member.id}
+            node={member}
+            index={index}
+            depth={depth + 1}
+            role="member"
+            providers={providers}
+            onUseModels={onUseModels}
+            onChange={(next) =>
+              setMembers(node.members.map((item, i) => (i === index ? next : item)))
+            }
+            onRemove={
+              node.members.length > 1
+                ? () => setMembers(node.members.filter((_, i) => i !== index))
+                : undefined
+            }
+          />
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 self-start text-xs"
+          onClick={() => setMembers([...node.members, createSolo()])}
+        >
+          <Plus className="size-3.5" />
+          Add member
+        </Button>
+      </ChildRail>
+      <div className="flex items-center gap-1.5 pl-3 text-[11px] text-muted-foreground">
         <ArrowDown className="size-3.5" />
         synthesize
       </div>
-      <RecipeNodeCard
-        node={node.synthesizer}
-        role="synthesizer"
-        providers={providers}
-        onUseModels={onUseModels}
-        onChange={(next) => onChange({ ...node, synthesizer: next })}
-      />
+      <ChildRail tone="accent">
+        <RecipeNodeCard
+          node={node.synthesizer}
+          depth={depth + 1}
+          role="synthesizer"
+          providers={providers}
+          onUseModels={onUseModels}
+          onChange={(next) => onChange({ ...node, synthesizer: next })}
+        />
+      </ChildRail>
     </div>
   );
 }
@@ -1898,53 +1941,58 @@ function PipelineBody({
   onChange,
   providers,
   onUseModels,
+  depth,
 }: {
   node: PipelineNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
+  depth: number;
 }) {
   const setStages = (stages: RecipeNode[]) => onChange({ ...node, stages });
   return (
     <div className="flex flex-col gap-2.5">
-      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
-        Stages · run in sequence
-      </p>
-      {node.stages.map((stage, index) => (
-        <div key={stage.id} className="flex flex-col gap-2.5">
-          {index > 0 && (
-            <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground">
-              <ArrowDown className="size-3.5" />
-              then
-            </div>
-          )}
-          <RecipeNodeCard
-            node={stage}
-            index={index}
-            role="stage"
-            providers={providers}
-            onUseModels={onUseModels}
-            onChange={(next) =>
-              setStages(node.stages.map((item, i) => (i === index ? next : item)))
-            }
-            onRemove={
-              node.stages.length > 1
-                ? () => setStages(node.stages.filter((_, i) => i !== index))
-                : undefined
-            }
-          />
-        </div>
-      ))}
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="self-start"
-        onClick={() => setStages([...node.stages, createSolo()])}
-      >
-        <Plus className="size-3.5" />
-        Add stage
-      </Button>
+      <ChildRail>
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          Stages · sequence
+        </p>
+        {node.stages.map((stage, index) => (
+          <div key={stage.id} className="flex flex-col gap-2.5">
+            {index > 0 && (
+              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                <ArrowDown className="size-3.5" />
+                then
+              </div>
+            )}
+            <RecipeNodeCard
+              node={stage}
+              index={index}
+              depth={depth + 1}
+              role="stage"
+              providers={providers}
+              onUseModels={onUseModels}
+              onChange={(next) =>
+                setStages(node.stages.map((item, i) => (i === index ? next : item)))
+              }
+              onRemove={
+                node.stages.length > 1
+                  ? () => setStages(node.stages.filter((_, i) => i !== index))
+                  : undefined
+              }
+            />
+          </div>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 self-start text-xs"
+          onClick={() => setStages([...node.stages, createSolo()])}
+        >
+          <Plus className="size-3.5" />
+          Add stage
+        </Button>
+      </ChildRail>
     </div>
   );
 }
@@ -1957,15 +2005,19 @@ function RecipeNodeCard({
   onRemove,
   role = "root",
   index,
+  depth = 0,
 }: {
   node: RecipeNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
   onRemove?: () => void;
-  role?: "root" | "member" | "stage" | "synthesizer";
+  role?: NodeRole;
   index?: number;
+  depth?: number;
 }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const collapsible = node.kind !== "solo";
   const roleLabel =
     role === "member"
       ? `Member ${(index ?? 0) + 1}`
@@ -1975,21 +2027,44 @@ function RecipeNodeCard({
           ? "Synthesizer · required"
           : "Recipe";
   return (
-    <article
-      className={cn(
-        "rounded-xl border bg-card p-3.5",
-        role === "synthesizer" && "border-accent/40 bg-accent/5",
-      )}
-    >
-      <div className="mb-3 flex items-center justify-between gap-2">
-        <span
-          className={cn(
-            "font-mono text-[11px] uppercase tracking-wide",
-            role === "synthesizer" ? "text-accent" : "text-muted-foreground",
+    <article className={cn(nodeChrome(depth, role))}>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {collapsible ? (
+            <button
+              type="button"
+              aria-label={collapsed ? "Expand" : "Collapse"}
+              aria-expanded={!collapsed}
+              onClick={() => setCollapsed((value) => !value)}
+              className="grid size-5 shrink-0 place-items-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+            >
+              <ChevronRight
+                className={cn("size-3.5 transition-transform", !collapsed && "rotate-90")}
+              />
+            </button>
+          ) : (
+            <span
+              aria-hidden="true"
+              className={cn(
+                "ml-1.5 mr-0.5 size-1.5 shrink-0 rounded-full",
+                role === "synthesizer" ? "bg-accent/60" : "bg-muted-foreground/40",
+              )}
+            />
           )}
-        >
-          {roleLabel}
-        </span>
+          <span
+            className={cn(
+              "shrink-0 font-mono text-[11px] uppercase tracking-wide",
+              role === "synthesizer" ? "text-accent" : "text-muted-foreground",
+            )}
+          >
+            {roleLabel}
+          </span>
+          {collapsed && (
+            <span className="min-w-0 truncate rounded-md bg-background/70 px-1.5 py-0.5 font-mono text-[11px] text-foreground/80">
+              {describeRecipe(node)}
+            </span>
+          )}
+        </div>
         <div className="flex shrink-0 items-center gap-1.5">
           <KindSwitch node={node} onChange={onChange} />
           {onRemove && (
@@ -1997,7 +2072,7 @@ function RecipeNodeCard({
               type="button"
               variant="ghost"
               size="icon"
-              className="size-7 text-muted-foreground"
+              className="size-6 text-muted-foreground"
               aria-label="Remove element"
               onClick={onRemove}
             >
@@ -2006,27 +2081,33 @@ function RecipeNodeCard({
           )}
         </div>
       </div>
-      {node.kind === "solo" ? (
-        <SoloBody
-          node={node}
-          onChange={onChange}
-          providers={providers}
-          onUseModels={onUseModels}
-        />
-      ) : node.kind === "fusion" ? (
-        <FusionBody
-          node={node}
-          onChange={onChange}
-          providers={providers}
-          onUseModels={onUseModels}
-        />
-      ) : (
-        <PipelineBody
-          node={node}
-          onChange={onChange}
-          providers={providers}
-          onUseModels={onUseModels}
-        />
+      {!collapsed && (
+        <div className="mt-3">
+          {node.kind === "solo" ? (
+            <SoloBody
+              node={node}
+              onChange={onChange}
+              providers={providers}
+              onUseModels={onUseModels}
+            />
+          ) : node.kind === "fusion" ? (
+            <FusionBody
+              node={node}
+              onChange={onChange}
+              providers={providers}
+              onUseModels={onUseModels}
+              depth={depth}
+            />
+          ) : (
+            <PipelineBody
+              node={node}
+              onChange={onChange}
+              providers={providers}
+              onUseModels={onUseModels}
+              depth={depth}
+            />
+          )}
+        </div>
       )}
     </article>
   );
@@ -2056,6 +2137,7 @@ function EnsembleComposer() {
   const [runHistory, setRunHistory] = useState<SavedRun[]>([]);
   const [tab, setTab] = useState<"compose" | "runs">("compose");
   const [copied, setCopied] = useState(false);
+  const [zoom, setZoom] = useState(1);
   const [autoSave, setAutoSave] = useState(true);
   const [loadedEnsembleId, setLoadedEnsembleId] = useState<string | null>(null);
   const [savedSnapshot, setSavedSnapshot] = useState("");
@@ -2308,20 +2390,63 @@ function EnsembleComposer() {
         value="compose"
         className="m-0 flex min-h-0 flex-1 overflow-hidden"
       >
-          <main className="min-w-0 flex-1 overflow-y-auto px-6 py-6 lg:px-10">
+          <main className="min-w-0 flex-1 overflow-auto px-6 py-6 lg:px-10">
             <div className="mx-auto flex max-w-2xl flex-col gap-3">
-              <p className="text-xs text-muted-foreground">
-                Compose your fusion — a unit can be a solo model, a fusion (parallel
-                members with a required synthesizer), or a pipeline (serial stages). Nest
-                them to any depth.
-              </p>
-              <RecipeNodeCard
-                node={root}
-                role="root"
-                providers={providers}
-                onUseModels={(models) => addLibraryModels(models)}
-                onChange={setRoot}
-              />
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs text-muted-foreground">
+                  A unit can be a solo model, a fusion (parallel members + a required
+                  synthesizer), or a pipeline (serial stages) — nest to any depth.
+                </p>
+                <div className="flex shrink-0 items-center gap-1">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-7"
+                    aria-label="Zoom out"
+                    disabled={zoom <= 0.5}
+                    onClick={() =>
+                      setZoom((value) => Math.max(0.5, Math.round((value - 0.1) * 10) / 10))
+                    }
+                  >
+                    <ZoomOut className="size-3.5" />
+                  </Button>
+                  <button
+                    type="button"
+                    className="w-11 text-center font-mono text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+                    title="Reset zoom"
+                    onClick={() => setZoom(1)}
+                  >
+                    {Math.round(zoom * 100)}%
+                  </button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-7"
+                    aria-label="Zoom in"
+                    disabled={zoom >= 1.3}
+                    onClick={() =>
+                      setZoom((value) => Math.min(1.3, Math.round((value + 0.1) * 10) / 10))
+                    }
+                  >
+                    <ZoomIn className="size-3.5" />
+                  </Button>
+                </div>
+              </div>
+              <div
+                className="transition-transform"
+                style={{ transform: `scale(${zoom})`, transformOrigin: "top center" }}
+              >
+                <RecipeNodeCard
+                  node={root}
+                  role="root"
+                  depth={0}
+                  providers={providers}
+                  onUseModels={(models) => addLibraryModels(models)}
+                  onChange={setRoot}
+                />
+              </div>
             </div>
           </main>
 

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -37,7 +37,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Slider } from "@/components/ui/slider";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
@@ -56,15 +55,24 @@ import {
   useModelStore,
 } from "@/lib/model-store";
 import { useOpenMinedStore } from "@/lib/openmined-store";
-import { useScriptStore } from "@/lib/script-store";
+import {
+  type FusionNode,
+  type PipelineNode,
+  type RecipeKind,
+  type RecipeNode,
+  type SoloNode,
+  collectSolos,
+  convertKind,
+  createFusion,
+  createSolo,
+  describeRecipe,
+  fusionFromSlots,
+  memberSolos,
+  recipeToUrl4,
+  rootSynthesizerSolo,
+} from "@/lib/recipe";
 import { cn } from "@/lib/utils";
 import { createUuid } from "@/lib/uuid";
-
-type ReduceStrategy =
-  | "majority_vote"
-  | "weighted_avg"
-  | "best_of_n"
-  | "merge";
 
 type Model = SavedModel;
 
@@ -104,33 +112,6 @@ function defaultParamValue(
   if (entry.kind === "text") return "";
   return String(entry.min ?? 0);
 }
-
-const strategies: {
-  value: ReduceStrategy;
-  label: string;
-  description: string;
-}[] = [
-  {
-    value: "majority_vote",
-    label: "Majority Vote",
-    description: "Judge picks the most common answer",
-  },
-  {
-    value: "weighted_avg",
-    label: "Weighted Average",
-    description: "Blend answers weighted by confidence",
-  },
-  {
-    value: "best_of_n",
-    label: "Best-of-N",
-    description: "Judge ranks and selects the top response",
-  },
-  {
-    value: "merge",
-    label: "Merge",
-    description: "Judge merges every answer into one",
-  },
-];
 
 const benchmarks = [
   {
@@ -431,23 +412,9 @@ function parseRecipe(raw: string) {
       systemPrompt: "",
       weight: 0.5,
     }));
-  const reduce = params.get("reduce") as ReduceStrategy | null;
-  const reduceScriptId = reduce?.startsWith("script:")
-    ? reduce.slice(7)
-    : null;
-  const loop = params.get("loop");
-  const loopScriptId = loop?.startsWith("script:") ? loop.slice(7) : null;
   return {
     name: decodeURIComponent(match[1]).replace(/\s+/g, "-").toLowerCase(),
     slots,
-    strategy: strategies.some((item) => item.value === reduce)
-      ? reduce!
-      : ("majority_vote" as ReduceStrategy),
-    customReduce: Boolean(reduceScriptId),
-    reduceScriptId,
-    loopMode: loopScriptId ? ("custom" as const) : ("parallel" as const),
-    loopScriptId,
-    judgeId: params.get("judge"),
   };
 }
 
@@ -1715,6 +1682,356 @@ function RunsPanel({
   );
 }
 
+function deriveSlots(root: RecipeNode): Slot[] {
+  return memberSolos(root)
+    .filter((solo) => solo.model)
+    .map((solo) => ({
+      id: solo.id,
+      model: solo.model as Model,
+      systemPrompt: solo.prompt,
+      weight: 0.5,
+      params: solo.params,
+    }));
+}
+
+function deriveJudge(root: RecipeNode): Slot | null {
+  const synth = rootSynthesizerSolo(root);
+  return synth
+    ? { id: synth.id, model: synth.model as Model, systemPrompt: synth.prompt, weight: 0 }
+    : null;
+}
+
+function buildDraft(
+  id: string,
+  name: string,
+  root: RecipeNode,
+  runHistory: SavedRun[],
+): SavedEnsemble {
+  const judge = deriveJudge(root);
+  return {
+    id,
+    name,
+    root,
+    slots: deriveSlots(root),
+    strategy: "majority_vote",
+    customReduce: false,
+    reduceScriptId: null,
+    loopMode: "parallel",
+    loopScriptId: null,
+    judge,
+    judgeId: judge?.model.id ?? null,
+    runs: runHistory.length,
+    runHistory,
+    updatedAt: 0,
+  };
+}
+
+const RECIPE_KINDS: { kind: RecipeKind; label: string }[] = [
+  { kind: "solo", label: "Solo" },
+  { kind: "fusion", label: "Fusion" },
+  { kind: "pipeline", label: "Pipeline" },
+];
+
+function KindSwitch({
+  node,
+  onChange,
+}: {
+  node: RecipeNode;
+  onChange: (next: RecipeNode) => void;
+}) {
+  return (
+    <div className="inline-flex overflow-hidden rounded-lg border">
+      {RECIPE_KINDS.map(({ kind, label }) => (
+        <button
+          key={kind}
+          type="button"
+          aria-pressed={node.kind === kind}
+          onClick={() => onChange(convertKind(node, kind))}
+          className={cn(
+            "px-2.5 py-1 text-xs transition-colors",
+            node.kind === kind
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-muted/40",
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function SoloBody({
+  node,
+  onChange,
+  providers,
+  onUseModels,
+}: {
+  node: SoloNode;
+  onChange: (next: RecipeNode) => void;
+  providers: ModelProvider[];
+  onUseModels: (models: Model[]) => void;
+}) {
+  const [showParams, setShowParams] = useState((node.params?.length ?? 0) > 0);
+  const paramCount = node.params?.length ?? 0;
+  return (
+    <div className="flex flex-col gap-2.5">
+      {node.model ? (
+        <div className="flex items-center justify-between gap-2 rounded-lg border bg-background px-3 py-2">
+          <span className="flex min-w-0 items-center gap-2">
+            <ProviderDot provider={node.model.providerId} />
+            <span className="truncate font-mono text-sm">{node.model.name}</span>
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground"
+            onClick={() => onChange({ ...node, model: null })}
+          >
+            Change
+          </Button>
+        </div>
+      ) : (
+        <InlineModelPicker
+          providers={providers}
+          onAdd={(model) => {
+            onChange({ ...node, model });
+            onUseModels([model]);
+          }}
+        />
+      )}
+      <Textarea
+        rows={2}
+        value={node.prompt}
+        placeholder="System prompt (optional) — You are a helpful assistant specializing in…"
+        className="resize-none text-xs"
+        onChange={(event) => onChange({ ...node, prompt: event.target.value })}
+      />
+      <div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="text-xs text-muted-foreground"
+          aria-expanded={showParams}
+          onClick={() => setShowParams((value) => !value)}
+        >
+          <ChevronDown
+            className={cn("size-3.5 transition-transform", showParams && "rotate-180")}
+          />
+          Parameters{paramCount > 0 ? ` (${paramCount})` : ""}
+        </Button>
+        {showParams && (
+          <ParamEditor
+            params={node.params ?? []}
+            onChange={(next) => onChange({ ...node, params: next })}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FusionBody({
+  node,
+  onChange,
+  providers,
+  onUseModels,
+}: {
+  node: FusionNode;
+  onChange: (next: RecipeNode) => void;
+  providers: ModelProvider[];
+  onUseModels: (models: Model[]) => void;
+}) {
+  const setMembers = (members: RecipeNode[]) => onChange({ ...node, members });
+  return (
+    <div className="flex flex-col gap-2.5">
+      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+        Members · run in parallel
+      </p>
+      {node.members.map((member, index) => (
+        <RecipeNodeCard
+          key={member.id}
+          node={member}
+          index={index}
+          role="member"
+          providers={providers}
+          onUseModels={onUseModels}
+          onChange={(next) =>
+            setMembers(node.members.map((item, i) => (i === index ? next : item)))
+          }
+          onRemove={
+            node.members.length > 1
+              ? () => setMembers(node.members.filter((_, i) => i !== index))
+              : undefined
+          }
+        />
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="self-start"
+        onClick={() => setMembers([...node.members, createSolo()])}
+      >
+        <Plus className="size-3.5" />
+        Add member
+      </Button>
+      <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground">
+        <ArrowDown className="size-3.5" />
+        synthesize
+      </div>
+      <RecipeNodeCard
+        node={node.synthesizer}
+        role="synthesizer"
+        providers={providers}
+        onUseModels={onUseModels}
+        onChange={(next) => onChange({ ...node, synthesizer: next })}
+      />
+    </div>
+  );
+}
+
+function PipelineBody({
+  node,
+  onChange,
+  providers,
+  onUseModels,
+}: {
+  node: PipelineNode;
+  onChange: (next: RecipeNode) => void;
+  providers: ModelProvider[];
+  onUseModels: (models: Model[]) => void;
+}) {
+  const setStages = (stages: RecipeNode[]) => onChange({ ...node, stages });
+  return (
+    <div className="flex flex-col gap-2.5">
+      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+        Stages · run in sequence
+      </p>
+      {node.stages.map((stage, index) => (
+        <div key={stage.id} className="flex flex-col gap-2.5">
+          {index > 0 && (
+            <div className="flex items-center justify-center gap-2 py-1 text-xs text-muted-foreground">
+              <ArrowDown className="size-3.5" />
+              then
+            </div>
+          )}
+          <RecipeNodeCard
+            node={stage}
+            index={index}
+            role="stage"
+            providers={providers}
+            onUseModels={onUseModels}
+            onChange={(next) =>
+              setStages(node.stages.map((item, i) => (i === index ? next : item)))
+            }
+            onRemove={
+              node.stages.length > 1
+                ? () => setStages(node.stages.filter((_, i) => i !== index))
+                : undefined
+            }
+          />
+        </div>
+      ))}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="self-start"
+        onClick={() => setStages([...node.stages, createSolo()])}
+      >
+        <Plus className="size-3.5" />
+        Add stage
+      </Button>
+    </div>
+  );
+}
+
+function RecipeNodeCard({
+  node,
+  onChange,
+  providers,
+  onUseModels,
+  onRemove,
+  role = "root",
+  index,
+}: {
+  node: RecipeNode;
+  onChange: (next: RecipeNode) => void;
+  providers: ModelProvider[];
+  onUseModels: (models: Model[]) => void;
+  onRemove?: () => void;
+  role?: "root" | "member" | "stage" | "synthesizer";
+  index?: number;
+}) {
+  const roleLabel =
+    role === "member"
+      ? `Member ${(index ?? 0) + 1}`
+      : role === "stage"
+        ? `Stage ${(index ?? 0) + 1}`
+        : role === "synthesizer"
+          ? "Synthesizer · required"
+          : "Recipe";
+  return (
+    <article
+      className={cn(
+        "rounded-xl border bg-card p-3.5",
+        role === "synthesizer" && "border-accent/40 bg-accent/5",
+      )}
+    >
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <span
+          className={cn(
+            "font-mono text-[11px] uppercase tracking-wide",
+            role === "synthesizer" ? "text-accent" : "text-muted-foreground",
+          )}
+        >
+          {roleLabel}
+        </span>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <KindSwitch node={node} onChange={onChange} />
+          {onRemove && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 text-muted-foreground"
+              aria-label="Remove element"
+              onClick={onRemove}
+            >
+              <X className="size-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+      {node.kind === "solo" ? (
+        <SoloBody
+          node={node}
+          onChange={onChange}
+          providers={providers}
+          onUseModels={onUseModels}
+        />
+      ) : node.kind === "fusion" ? (
+        <FusionBody
+          node={node}
+          onChange={onChange}
+          providers={providers}
+          onUseModels={onUseModels}
+        />
+      ) : (
+        <PipelineBody
+          node={node}
+          onChange={onChange}
+          providers={providers}
+          onUseModels={onUseModels}
+        />
+      )}
+    </article>
+  );
+}
+
 function EnsembleComposer() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -1733,25 +2050,9 @@ function EnsembleComposer() {
   );
   const providers = useModelStore((state) => state.providers);
   const addLibraryModels = useModelStore((state) => state.addLibraryModels);
-  const scripts = useScriptStore((state) => state.scripts);
-  const loopScripts = useMemo(
-    () => scripts.filter((script) => script.kind === "loop"),
-    [scripts],
-  );
-  const reduceScripts = useMemo(
-    () => scripts.filter((script) => script.kind === "reduce"),
-    [scripts],
-  );
   const [name, setName] = useState("fusion-1");
   const [editingName, setEditingName] = useState(false);
-  const [slots, setSlots] = useState<Slot[]>([]);
-  const [strategy, setStrategy] =
-    useState<ReduceStrategy>("majority_vote");
-  const [customReduce, setCustomReduce] = useState(false);
-  const [reduceScriptId, setReduceScriptId] = useState<string | null>(null);
-  const [loopMode, setLoopMode] = useState<"parallel" | "custom">("parallel");
-  const [loopScriptId, setLoopScriptId] = useState<string | null>(null);
-  const [judge, setJudge] = useState<Slot | null>(null);
+  const [root, setRoot] = useState<RecipeNode>(() => createFusion());
   const [runHistory, setRunHistory] = useState<SavedRun[]>([]);
   const [tab, setTab] = useState<"compose" | "runs">("compose");
   const [copied, setCopied] = useState(false);
@@ -1770,109 +2071,37 @@ function EnsembleComposer() {
     const frame = window.requestAnimationFrame(() => {
       if (saved) {
         const savedRunHistory = saved.runHistory ?? [];
-        const nextSlots = saved.slots.map((slot) => ({
-          ...slot,
-          id: slot.id ?? createUuid(),
-        }));
-        const nextJudge =
-          saved.judge ??
-          (saved.judgeId
-            ? (() => {
-                const model =
-                  nextSlots.find((slot) => slot.model.id === saved.judgeId)
-                    ?.model ??
-                  ALL_MODELS.find((item) => item.id === saved.judgeId);
-                return model
-                  ? {
-                      id: createUuid(),
-                      model,
-                      systemPrompt: "",
-                      weight: 0,
-                    }
-                  : null;
-              })()
-            : null);
+        const nextRoot =
+          saved.root ?? fusionFromSlots(saved.slots, saved.judge ?? null);
         setName(saved.name);
-        setSlots(nextSlots);
-        addLibraryModels(nextSlots.map((slot) => slot.model));
-        setStrategy(saved.strategy);
-        setCustomReduce(saved.customReduce);
-        setReduceScriptId(saved.reduceScriptId ?? null);
-        setLoopMode(saved.loopMode);
-        setLoopScriptId(saved.loopScriptId ?? null);
-        setJudge(nextJudge);
+        setRoot(nextRoot);
+        addLibraryModels(
+          collectSolos(nextRoot)
+            .map((solo) => solo.model)
+            .filter((model): model is Model => Boolean(model)),
+        );
         setRunHistory(savedRunHistory);
         setSavedSnapshot(
-          JSON.stringify({
-            ...saved,
-            slots: nextSlots,
-            reduceScriptId: saved.reduceScriptId ?? null,
-            loopScriptId: saved.loopScriptId ?? null,
-            judge: nextJudge,
-            judgeId: nextJudge?.model.id ?? null,
-            runs: savedRunHistory.length,
-            runHistory: savedRunHistory,
-            updatedAt: 0,
-          }),
+          JSON.stringify(buildDraft(ensembleId, saved.name, nextRoot, savedRunHistory)),
         );
       } else if (parsed) {
-        const nextSlots = parsed.slots.map((slot) => ({
-          ...slot,
-          id: slot.id ?? createUuid(),
-        }));
-        const nextJudge = parsed.judgeId
-          ? (() => {
-              const model =
-                nextSlots.find((slot) => slot.model.id === parsed.judgeId)
-                  ?.model ??
-                ALL_MODELS.find((item) => item.id === parsed.judgeId);
-              return model
-                ? {
-                    id: createUuid(),
-                    model,
-                    systemPrompt: "",
-                    weight: 0,
-                  }
-                : null;
-            })()
-          : null;
+        const nextRoot = fusionFromSlots(parsed.slots, null);
         setName(parsed.name);
-        setSlots(nextSlots);
-        addLibraryModels(nextSlots.map((slot) => slot.model));
-        setStrategy(parsed.strategy);
-        setCustomReduce(parsed.customReduce);
-        setReduceScriptId(parsed.reduceScriptId);
-        setLoopMode(parsed.loopMode);
-        setLoopScriptId(parsed.loopScriptId);
-        setJudge(nextJudge);
+        setRoot(nextRoot);
+        addLibraryModels(
+          collectSolos(nextRoot)
+            .map((solo) => solo.model)
+            .filter((model): model is Model => Boolean(model)),
+        );
         setRunHistory([]);
         setSavedSnapshot("");
       } else {
+        const nextRoot = createFusion();
         setName("fusion-1");
-        setSlots([]);
-        setStrategy("majority_vote");
-        setCustomReduce(false);
-        setReduceScriptId(null);
-        setLoopMode("parallel");
-        setLoopScriptId(null);
-        setJudge(null);
+        setRoot(nextRoot);
         setRunHistory([]);
         setSavedSnapshot(
-          JSON.stringify({
-            id: ensembleId,
-            name: "fusion-1",
-            slots: [],
-            strategy: "majority_vote",
-            customReduce: false,
-            reduceScriptId: null,
-            loopMode: "parallel",
-            loopScriptId: null,
-            judge: null,
-            judgeId: null,
-            runs: 0,
-            runHistory: [],
-            updatedAt: 0,
-          }),
+          JSON.stringify(buildDraft(ensembleId, "fusion-1", nextRoot, [])),
         );
       }
       setActiveEnsemble(ensembleId);
@@ -1888,55 +2117,12 @@ function EnsembleComposer() {
     storeHasHydrated,
   ]);
 
-  const selectedStrategy = strategies.find((item) => item.value === strategy)!;
-  const resolvedLoopScriptId = useMemo(
-    () =>
-      loopMode === "custom"
-        ? loopScripts.some((script) => script.id === loopScriptId)
-          ? loopScriptId
-          : loopScripts[0]?.id ?? null
-        : null,
-    [loopMode, loopScriptId, loopScripts],
-  );
-  const resolvedReduceScriptId = useMemo(
-    () =>
-      customReduce
-        ? reduceScripts.some((script) => script.id === reduceScriptId)
-          ? reduceScriptId
-          : reduceScripts[0]?.id ?? null
-        : null,
-    [customReduce, reduceScriptId, reduceScripts],
-  );
-  const weightSum = slots.reduce((sum, slot) => sum + slot.weight, 0);
-  const recipe = `url4://${name}?models=${slots.map((slot) => slot.model.id).join("+")}&reduce=${customReduce ? `script:${resolvedReduceScriptId ?? "custom"}` : strategy}&loop=${loopMode === "custom" ? `script:${resolvedLoopScriptId ?? "custom"}` : "parallel"}${!customReduce && judge ? `&judge=${judge.model.id}` : ""}`;
+  const slots = useMemo(() => deriveSlots(root), [root]);
+  const judge = useMemo(() => deriveJudge(root), [root]);
+  const recipe = useMemo(() => recipeToUrl4(root), [root]);
   const draft = useMemo<SavedEnsemble>(
-    () => ({
-      id: ensembleId,
-      name,
-      slots,
-      strategy,
-      customReduce,
-      reduceScriptId: resolvedReduceScriptId,
-      loopMode,
-      loopScriptId: resolvedLoopScriptId,
-      judge,
-      judgeId: judge?.model.id ?? null,
-      runs: runHistory.length,
-      runHistory,
-      updatedAt: 0,
-    }),
-    [
-      customReduce,
-      ensembleId,
-      judge,
-      loopMode,
-      name,
-      resolvedLoopScriptId,
-      resolvedReduceScriptId,
-      runHistory,
-      slots,
-      strategy,
-    ],
+    () => buildDraft(ensembleId, name, root, runHistory),
+    [ensembleId, name, root, runHistory],
   );
   const draftSnapshot = JSON.stringify(draft);
   const ready = loadedEnsembleId === ensembleId;
@@ -1948,10 +2134,9 @@ function EnsembleComposer() {
       upsertEnsemble({ ...draft, updatedAt: Date.now() });
       setSavedSnapshot(draftSnapshot);
       if (!requestedId) {
-        router.replace(
-          `/ensembles/new/?id=${encodeURIComponent(ensembleId)}`,
-          { scroll: false },
-        );
+        router.replace(`/ensembles/new/?id=${encodeURIComponent(ensembleId)}`, {
+          scroll: false,
+        });
       }
     }, 250);
     return () => window.clearTimeout(timer);
@@ -1971,10 +2156,9 @@ function EnsembleComposer() {
     upsertEnsemble({ ...draft, updatedAt: Date.now() });
     setSavedSnapshot(draftSnapshot);
     if (!requestedId) {
-      router.replace(
-        `/ensembles/new/?id=${encodeURIComponent(ensembleId)}`,
-        { scroll: false },
-      );
+      router.replace(`/ensembles/new/?id=${encodeURIComponent(ensembleId)}`, {
+        scroll: false,
+      });
     }
     setSavedFlash(true);
     window.setTimeout(() => setSavedFlash(false), 1500);
@@ -1991,10 +2175,9 @@ function EnsembleComposer() {
     upsertEnsemble({ ...savedDraft, updatedAt: Date.now() });
     setSavedSnapshot(JSON.stringify(savedDraft));
     if (!requestedId) {
-      router.replace(
-        `/ensembles/new/?id=${encodeURIComponent(ensembleId)}`,
-        { scroll: false },
-      );
+      router.replace(`/ensembles/new/?id=${encodeURIComponent(ensembleId)}`, {
+        scroll: false,
+      });
     }
   }
 
@@ -2010,33 +2193,6 @@ function EnsembleComposer() {
     setRunHistory(nextRunHistory);
     upsertEnsemble({ ...savedDraft, updatedAt: Date.now() });
     setSavedSnapshot(JSON.stringify(savedDraft));
-  }
-
-  function addMember(model: Model) {
-    setSlots((current) => [
-      ...current,
-      { id: createUuid(), model, systemPrompt: "", weight: 0.5 },
-    ]);
-  }
-
-  function removeMember(id: string) {
-    setSlots((current) => current.filter((slot) => slot.id !== id));
-  }
-
-  function updateSlotParams(id: string, next: ModelParam[]) {
-    setSlots((current) =>
-      current.map((slot) =>
-        slot.id === id ? { ...slot, params: next } : slot,
-      ),
-    );
-  }
-
-  function setJudgeModel(model: Model) {
-    setJudge({ id: createUuid(), model, systemPrompt: "", weight: 0 });
-  }
-
-  function removeJudge() {
-    setJudge(null);
   }
 
   async function copyRecipe() {
@@ -2153,390 +2309,61 @@ function EnsembleComposer() {
         className="m-0 flex min-h-0 flex-1 overflow-hidden"
       >
           <main className="min-w-0 flex-1 overflow-y-auto px-6 py-6 lg:px-10">
-            <div className="mx-auto flex max-w-2xl flex-col">
-              <section className="rounded-xl border bg-card">
-                <div className="flex items-center justify-between border-b px-4 py-3">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="grid size-5 shrink-0 place-items-center rounded-md bg-muted font-mono text-xs font-medium text-muted-foreground">
-                      1
-                    </span>
-                    <span className="text-sm font-medium">Loop</span>
-                    <span className="truncate text-xs text-muted-foreground">
-                      · the members that answer each question
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <StageSelect
-                      value={loopMode}
-                      options={[
-                        {
-                          value: "parallel",
-                          label: "Parallel",
-                          description: "Run every model on each question",
-                        },
-                        {
-                          value: "custom",
-                          label: "Custom script…",
-                          description: "Plug in a loop script",
-                        },
-                      ]}
-                      onChange={(value) => {
-                        const nextMode = value as "parallel" | "custom";
-                        setLoopMode(nextMode);
-                        setLoopScriptId(
-                          nextMode === "custom"
-                            ? resolvedLoopScriptId
-                            : null,
-                        );
-                      }}
-                    />
-                    {loopMode === "custom" && loopScripts.length > 0 && (
-                      <StageSelect
-                        value={resolvedLoopScriptId ?? loopScripts[0].id}
-                        options={loopScripts.map((script) => ({
-                          value: script.id,
-                          label: script.name,
-                          description: "Custom response loop",
-                        }))}
-                        onChange={setLoopScriptId}
-                      />
-                    )}
-                    {loopMode === "custom" && loopScripts.length === 0 && (
-                      <span className="text-xs text-muted-foreground/70">
-                        No loop scripts — add one in Scripts
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex flex-col gap-2.5 px-4 py-4">
-                  {slots.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-border/40 py-12 text-muted-foreground">
-                      <Plus className="size-5 opacity-20" />
-                      <span className="text-sm opacity-50">
-                        Add models with <strong>+ Add model</strong> below
-                      </span>
-                    </div>
-                  ) : (
-                    slots.map((slot, index) => (
-                      <article
-                        key={slot.id}
-                        className="rounded-xl border bg-card p-3.5"
-                      >
-                        <div className="mb-2.5 flex items-center justify-between gap-2">
-                          <div className="flex min-w-0 items-center gap-2.5">
-                            <span className="w-4 shrink-0 font-mono text-xs text-muted-foreground/60">
-                              {index + 1}
-                            </span>
-                            <ProviderDot provider={slot.model.providerId} />
-                            <span className="truncate font-mono text-sm">
-                              {slot.model.name}
-                            </span>
-                          </div>
-                          <div className="flex shrink-0 items-center gap-1.5">
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="size-7 text-muted-foreground"
-                              aria-label={`Remove ${slot.model.name}`}
-                              onClick={() => removeMember(slot.id)}
-                            >
-                              <X className="size-3.5" />
-                            </Button>
-                          </div>
-                        </div>
-
-                        <Textarea
-                          rows={2}
-                          value={slot.systemPrompt}
-                          placeholder="System prompt (optional) — You are a helpful assistant specializing in…"
-                          className="resize-none text-xs"
-                          onChange={(event) =>
-                            setSlots((current) =>
-                              current.map((item) =>
-                                item.id === slot.id
-                                  ? {
-                                      ...item,
-                                      systemPrompt: event.target.value,
-                                    }
-                                  : item,
-                              ),
-                            )
-                          }
-                        />
-
-                        <ParamEditor
-                          params={slot.params ?? []}
-                          onChange={(next) =>
-                            updateSlotParams(slot.id, next)
-                          }
-                        />
-
-                        {strategy === "weighted_avg" && (
-                          <div className="mt-3 flex items-center gap-3">
-                            <span className="shrink-0 text-xs text-muted-foreground">
-                              Weight
-                            </span>
-                            <Slider
-                              min={0}
-                              max={1}
-                              step={0.05}
-                              value={[slot.weight]}
-                              className="flex-1"
-                              onValueChange={([value]) =>
-                                setSlots((current) =>
-                                  current.map((item) =>
-                                    item.id === slot.id
-                                      ? {
-                                          ...item,
-                                          weight: value,
-                                        }
-                                      : item,
-                                  ),
-                                )
-                              }
-                            />
-                            <span className="w-7 text-right font-mono text-xs text-muted-foreground">
-                              {slot.weight.toFixed(2)}
-                            </span>
-                            <span className="w-12 text-right font-mono text-xs">
-                              {weightSum
-                                ? `${Math.round((slot.weight / weightSum) * 100)}%`
-                                : "—"}
-                            </span>
-                          </div>
-                        )}
-                      </article>
-                    ))
-                  )}
-
-                  <InlineModelPicker
-                    providers={providers}
-                    onAdd={(model) => {
-                      addMember(model);
-                      addLibraryModels([model]);
-                    }}
-                  />
-                </div>
-              </section>
-
-              <div className="flex items-center justify-center gap-2 py-2 text-xs text-muted-foreground">
-                <ArrowDown className="size-3.5" />
-                answers
-              </div>
-
-              <section className="rounded-xl border bg-card">
-                <div className="flex items-center justify-between border-b px-4 py-3">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className="grid size-5 shrink-0 place-items-center rounded-md bg-muted font-mono text-xs font-medium text-muted-foreground">
-                      2
-                    </span>
-                    <span className="text-sm font-medium">Reduce</span>
-                    <span className="truncate text-xs text-muted-foreground">
-                      · combines the members into one answer
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <StageSelect
-                      value={customReduce ? "custom" : strategy}
-                      options={[
-                        ...strategies,
-                        {
-                          value: "custom",
-                          label: "Custom script…",
-                          description: "Plug in a reduce script",
-                        },
-                      ]}
-                      onChange={(value) => {
-                        if (value === "custom") {
-                          setCustomReduce(true);
-                          setReduceScriptId(resolvedReduceScriptId);
-                        } else {
-                          setCustomReduce(false);
-                          setReduceScriptId(null);
-                          setStrategy(value as ReduceStrategy);
-                        }
-                      }}
-                    />
-                    {customReduce && reduceScripts.length > 0 && (
-                      <StageSelect
-                        value={resolvedReduceScriptId ?? reduceScripts[0].id}
-                        options={reduceScripts.map((script) => ({
-                          value: script.id,
-                          label: script.name,
-                          description: "Custom reduce script",
-                        }))}
-                        onChange={setReduceScriptId}
-                      />
-                    )}
-                    {customReduce && reduceScripts.length === 0 && (
-                      <span className="text-xs text-muted-foreground/70">
-                        No reduce scripts — add one in Scripts
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div className="flex flex-col gap-4 px-4 py-4">
-                  <div className="flex items-center gap-3">
-                    <div className="grid size-8 shrink-0 place-items-center rounded-lg bg-accent/10">
-                      <Scale className="size-4 text-accent" />
-                    </div>
-                    <div className="min-w-0">
-                      <h3 className="truncate text-sm font-medium">
-                        {customReduce
-                          ? reduceScripts.find(
-                              (script) => script.id === resolvedReduceScriptId,
-                            )?.name ?? "Choose a script"
-                          : selectedStrategy.label}
-                      </h3>
-                      <p className="truncate text-xs text-muted-foreground">
-                        {customReduce
-                          ? "Custom reduce script"
-                          : selectedStrategy.description}
-                      </p>
-                    </div>
-                  </div>
-
-                  {customReduce ? (
-                    <p className="rounded-xl border border-border/60 bg-muted/20 px-4 py-3 text-xs text-muted-foreground">
-                      A custom reduce script handles arbitration — no separate
-                      judge needed.
-                    </p>
-                  ) : (
-                    <div className="flex flex-col gap-2.5">
-                      <span className="text-sm font-medium">
-                        Judge{" "}
-                        <span className="text-muted-foreground">
-                          (optional)
-                        </span>
-                      </span>
-                      {judge ? (
-                        <article className="rounded-xl border bg-card p-3.5">
-                          <div className="mb-2.5 flex items-center justify-between gap-2">
-                            <div className="flex min-w-0 items-center gap-2.5">
-                              <ProviderDot provider={judge.model.providerId} />
-                              <span className="truncate font-mono text-sm">
-                                {judge.model.name}
-                              </span>
-                            </div>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="size-7 text-muted-foreground"
-                              aria-label="Remove judge"
-                              onClick={removeJudge}
-                            >
-                              <X className="size-3.5" />
-                            </Button>
-                          </div>
-                          <Textarea
-                            rows={2}
-                            value={judge.systemPrompt}
-                            placeholder="System prompt (optional) — Judge the candidate answers and pick the best…"
-                            className="resize-none text-xs"
-                            onChange={(event) =>
-                              setJudge((current) =>
-                                current
-                                  ? {
-                                      ...current,
-                                      systemPrompt: event.target.value,
-                                    }
-                                  : current,
-                              )
-                            }
-                          />
-                        </article>
-                      ) : (
-                        <InlineModelPicker
-                          providers={providers}
-                          label="Add model"
-                          onAdd={(model) => {
-                            setJudgeModel(model);
-                            addLibraryModels([model]);
-                          }}
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
-              </section>
-
-              <div className="flex items-center justify-center gap-2 py-2 text-xs text-muted-foreground">
-                <ArrowDown className="size-3.5" />
-                final answer
-              </div>
+            <div className="mx-auto flex max-w-2xl flex-col gap-3">
+              <p className="text-xs text-muted-foreground">
+                Compose your fusion — a unit can be a solo model, a fusion (parallel
+                members with a required synthesizer), or a pipeline (serial stages). Nest
+                them to any depth.
+              </p>
+              <RecipeNodeCard
+                node={root}
+                role="root"
+                providers={providers}
+                onUseModels={(models) => addLibraryModels(models)}
+                onChange={setRoot}
+              />
             </div>
           </main>
 
           <aside className="flex w-80 shrink-0 flex-col gap-6 overflow-y-auto border-l bg-muted/10 px-5 py-6">
             <div>
               <p className="mb-3 font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
-                Pipeline
+                Recipe
               </p>
-              {slots.length > 0 ? (
-                <div className="flex flex-col gap-1.5">
-                  <p className="flex items-center gap-1.5 text-xs">
-                    <span className="font-mono text-muted-foreground">①</span>
-                    <span>
-                      Loop · {slots.length} member
-                      {slots.length === 1 ? "" : "s"} ·{" "}
-                      {loopMode === "custom" ? "custom" : "parallel"}
-                    </span>
-                  </p>
-                  <span className="pl-0.5 text-xs text-muted-foreground">↓</span>
-                  <p className="flex items-center gap-1.5 text-xs">
-                    <span className="font-mono text-muted-foreground">②</span>
-                    <span className="min-w-0 truncate">
-                      Reduce ·{" "}
-                      {customReduce
-                        ? reduceScripts.find(
-                            (script) => script.id === resolvedReduceScriptId,
-                          )?.name ?? "custom"
-                        : selectedStrategy.label}
-                    </span>
-                  </p>
-                  {!customReduce && judge && (
-                    <p className="flex items-center gap-1.5 pl-5 text-xs text-muted-foreground">
-                      <ProviderDot provider={judge.model.providerId} />
-                      <span className="min-w-0 truncate">
-                        Judge · {judge.model.name}
-                      </span>
-                    </p>
-                  )}
-                  <span className="pl-0.5 text-xs text-muted-foreground">↓</span>
-                  <p className="text-xs text-accent">Final answer</p>
-                </div>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  Add members to build your fusion.
-                </p>
-              )}
+              <p className="text-xs">
+                <span className="font-mono text-primary">{describeRecipe(root)}</span>
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {slots.length} model{slots.length === 1 ? "" : "s"} in play
+              </p>
             </div>
 
-            {slots.length > 0 && (
-              <div>
-                <p className="mb-3 font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
-                  url4 Recipe
-                </p>
-                <div className="rounded-lg border bg-card p-2">
-                  <code className="block break-all font-mono text-[11px] text-primary/90">
-                    {recipe}
-                  </code>
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="mt-2 w-full"
-                  onClick={copyRecipe}
-                >
-                  {copied ? (
-                    <Check className="size-3.5 text-accent" />
-                  ) : (
-                    <Copy className="size-3.5" />
-                  )}
-                  {copied ? "Copied" : "Copy"}
-                </Button>
+            <div>
+              <p className="mb-3 font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+                url4 preview
+              </p>
+              <div className="rounded-lg border bg-card p-2">
+                <code className="block break-all font-mono text-[11px] text-primary/90">
+                  {recipe}
+                </code>
               </div>
-            )}
+              <p className="mt-1.5 text-[11px] text-muted-foreground">
+                Structural preview — the engine emits the canonical url4 at run time.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                className="mt-2 w-full"
+                onClick={copyRecipe}
+              >
+                {copied ? (
+                  <Check className="size-3.5 text-accent" />
+                ) : (
+                  <Copy className="size-3.5" />
+                )}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
 
             <div>
               <Button
@@ -2555,7 +2382,7 @@ function EnsembleComposer() {
       >
         <RunsPanel
           slots={slots}
-          judge={customReduce ? null : judge}
+          judge={judge}
           runs={runHistory}
           ensembleName={name}
           onComplete={completeRun}

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1932,7 +1932,7 @@ function PipelineBody({
   return (
     <div className="flex flex-row items-center gap-1.5 pb-1">
       {node.stages.map((stage, index) => (
-        <div key={stage.id} className="flex items-start gap-1.5">
+        <div key={stage.id} className="flex items-center gap-1.5">
           {index > 0 && (
             <ArrowRight className="size-4 shrink-0 text-muted-foreground/70" />
           )}
@@ -2140,7 +2140,12 @@ function RecipeNodeCard({
 
   // Fusion / Pipeline — a bare structural grouping.
   return (
-    <div className={cn("flex flex-col gap-2", depth > 0 && "pl-0.5")}>
+    <div
+      className={cn(
+        "flex flex-col gap-2",
+        depth > 0 && "rounded-xl border border-border/60 bg-muted/10 p-3",
+      )}
+    >
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <button

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -20,6 +20,8 @@ import {
   Scale,
   Share2,
   Upload,
+  Columns3,
+  Rows3,
   X,
   ZoomIn,
   ZoomOut,
@@ -1729,13 +1731,13 @@ function buildDraft(
   };
 }
 
+type Orientation = "vertical" | "horizontal";
+
 const RECIPE_KINDS: { kind: RecipeKind; label: string }[] = [
   { kind: "solo", label: "Solo" },
   { kind: "fusion", label: "Fusion" },
   { kind: "pipeline", label: "Pipeline" },
 ];
-
-type NodeRole = "root" | "member" | "stage" | "synthesizer";
 
 function nodeChrome(depth: number, role: NodeRole): string {
   if (role === "synthesizer") {
@@ -1747,6 +1749,8 @@ function nodeChrome(depth: number, role: NodeRole): string {
     ? "rounded-xl border bg-card p-3.5 shadow-sm"
     : "rounded-lg bg-muted/30 ring-1 ring-inset ring-border/40 p-3";
 }
+
+type NodeRole = "root" | "member" | "stage" | "synthesizer";
 
 function KindSwitch({
   node,
@@ -1849,20 +1853,42 @@ function SoloBody({
   );
 }
 
-function ChildRail({
+function GroupBox({
+  label,
   tone = "muted",
+  orientation,
   children,
 }: {
+  label: string;
   tone?: "muted" | "accent";
+  orientation: Orientation;
   children: React.ReactNode;
 }) {
+  if (orientation === "vertical") {
+    return (
+      <div
+        className={cn(
+          "flex flex-col gap-2.5 border-l-2 pl-3",
+          tone === "accent" ? "border-accent/30" : "border-border/40",
+        )}
+      >
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          {label}
+        </p>
+        {children}
+      </div>
+    );
+  }
   return (
     <div
       className={cn(
-        "flex flex-col gap-2.5 border-l-2 pl-3",
-        tone === "accent" ? "border-accent/30" : "border-border/40",
+        "rounded-lg border border-dashed p-2.5",
+        tone === "accent" ? "border-accent/40" : "border-border/50",
       )}
     >
+      <p className="mb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </p>
       {children}
     </div>
   );
@@ -1874,64 +1900,78 @@ function FusionBody({
   providers,
   onUseModels,
   depth,
+  orientation,
 }: {
   node: FusionNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
   depth: number;
+  orientation: Orientation;
 }) {
+  const horizontal = orientation === "horizontal";
   const setMembers = (members: RecipeNode[]) => onChange({ ...node, members });
   return (
     <div className="flex flex-col gap-2.5">
-      <ChildRail>
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Members · parallel
-        </p>
-        {node.members.map((member, index) => (
-          <RecipeNodeCard
-            key={member.id}
-            node={member}
-            index={index}
-            depth={depth + 1}
-            role="member"
-            providers={providers}
-            onUseModels={onUseModels}
-            onChange={(next) =>
-              setMembers(node.members.map((item, i) => (i === index ? next : item)))
-            }
-            onRemove={
-              node.members.length > 1
-                ? () => setMembers(node.members.filter((_, i) => i !== index))
-                : undefined
-            }
-          />
-        ))}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-7 self-start text-xs"
-          onClick={() => setMembers([...node.members, createSolo()])}
+      <GroupBox label="Members · parallel" orientation={orientation}>
+        <div
+          className={cn(
+            horizontal
+              ? "flex flex-row flex-wrap items-start gap-2.5"
+              : "flex flex-col gap-2.5",
+          )}
         >
-          <Plus className="size-3.5" />
-          Add member
-        </Button>
-      </ChildRail>
-      <div className="flex items-center gap-1.5 pl-3 text-[11px] text-muted-foreground">
+          {node.members.map((member, index) => (
+            <div
+              key={member.id}
+              className={horizontal ? "grow basis-[16rem] min-w-[16rem]" : undefined}
+            >
+              <RecipeNodeCard
+                node={member}
+                index={index}
+                depth={depth + 1}
+                role="member"
+                orientation={orientation}
+                providers={providers}
+                onUseModels={onUseModels}
+                onChange={(next) =>
+                  setMembers(node.members.map((item, i) => (i === index ? next : item)))
+                }
+                onRemove={
+                  node.members.length > 1
+                    ? () => setMembers(node.members.filter((_, i) => i !== index))
+                    : undefined
+                }
+              />
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn("h-7 text-xs", horizontal ? "self-center" : "self-start")}
+            onClick={() => setMembers([...node.members, createSolo()])}
+          >
+            <Plus className="size-3.5" />
+            Add member
+          </Button>
+        </div>
+      </GroupBox>
+      <div className="flex items-center gap-1.5 pl-1 text-[11px] text-muted-foreground">
         <ArrowDown className="size-3.5" />
         synthesize
       </div>
-      <ChildRail tone="accent">
+      <GroupBox label="Synthesizer" tone="accent" orientation={orientation}>
         <RecipeNodeCard
           node={node.synthesizer}
           depth={depth + 1}
           role="synthesizer"
+          orientation={orientation}
           providers={providers}
           onUseModels={onUseModels}
           onChange={(next) => onChange({ ...node, synthesizer: next })}
         />
-      </ChildRail>
+      </GroupBox>
     </div>
   );
 }
@@ -1942,58 +1982,79 @@ function PipelineBody({
   providers,
   onUseModels,
   depth,
+  orientation,
 }: {
   node: PipelineNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
   depth: number;
+  orientation: Orientation;
 }) {
+  const horizontal = orientation === "horizontal";
   const setStages = (stages: RecipeNode[]) => onChange({ ...node, stages });
   return (
-    <div className="flex flex-col gap-2.5">
-      <ChildRail>
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Stages · sequence
-        </p>
+    <GroupBox label="Stages · sequence" orientation={orientation}>
+      <div
+        className={cn(
+          horizontal
+            ? "flex flex-row flex-wrap items-stretch gap-2"
+            : "flex flex-col gap-2.5",
+        )}
+      >
         {node.stages.map((stage, index) => (
-          <div key={stage.id} className="flex flex-col gap-2.5">
+          <div
+            key={stage.id}
+            className={cn(
+              "flex gap-2",
+              horizontal ? "items-stretch" : "flex-col",
+            )}
+          >
             {index > 0 && (
               <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                <ArrowDown className="size-3.5" />
-                then
+                {horizontal ? (
+                  <ArrowRight className="size-4" />
+                ) : (
+                  <>
+                    <ArrowDown className="size-3.5" />
+                    then
+                  </>
+                )}
               </div>
             )}
-            <RecipeNodeCard
-              node={stage}
-              index={index}
-              depth={depth + 1}
-              role="stage"
-              providers={providers}
-              onUseModels={onUseModels}
-              onChange={(next) =>
-                setStages(node.stages.map((item, i) => (i === index ? next : item)))
-              }
-              onRemove={
-                node.stages.length > 1
-                  ? () => setStages(node.stages.filter((_, i) => i !== index))
-                  : undefined
-              }
-            />
+            <div className={horizontal ? "min-w-[16rem]" : undefined}>
+              <RecipeNodeCard
+                node={stage}
+                index={index}
+                depth={depth + 1}
+                role="stage"
+                orientation={orientation}
+                providers={providers}
+                onUseModels={onUseModels}
+                onChange={(next) =>
+                  setStages(node.stages.map((item, i) => (i === index ? next : item)))
+                }
+                onRemove={
+                  node.stages.length > 1
+                    ? () => setStages(node.stages.filter((_, i) => i !== index))
+                    : undefined
+                }
+              />
+            </div>
           </div>
         ))}
         <Button
           type="button"
           variant="outline"
           size="sm"
-          className="h-7 self-start text-xs"
+          className={cn("h-7 text-xs", horizontal ? "self-center" : "self-start")}
           onClick={() => setStages([...node.stages, createSolo()])}
         >
           <Plus className="size-3.5" />
           Add stage
         </Button>
-      </ChildRail>
-    </div>
+      </div>
+    </GroupBox>
   );
 }
 
@@ -2006,6 +2067,7 @@ function RecipeNodeCard({
   role = "root",
   index,
   depth = 0,
+  orientation = "vertical",
 }: {
   node: RecipeNode;
   onChange: (next: RecipeNode) => void;
@@ -2015,6 +2077,7 @@ function RecipeNodeCard({
   role?: NodeRole;
   index?: number;
   depth?: number;
+  orientation?: Orientation;
 }) {
   const [collapsed, setCollapsed] = useState(false);
   const collapsible = node.kind !== "solo";
@@ -2027,7 +2090,7 @@ function RecipeNodeCard({
           ? "Synthesizer · required"
           : "Recipe";
   return (
-    <article className={cn(nodeChrome(depth, role))}>
+    <article className={cn("h-full", nodeChrome(depth, role))}>
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-1.5">
           {collapsible ? (
@@ -2097,6 +2160,7 @@ function RecipeNodeCard({
               providers={providers}
               onUseModels={onUseModels}
               depth={depth}
+              orientation={orientation}
             />
           ) : (
             <PipelineBody
@@ -2105,6 +2169,7 @@ function RecipeNodeCard({
               providers={providers}
               onUseModels={onUseModels}
               depth={depth}
+              orientation={orientation}
             />
           )}
         </div>
@@ -2138,6 +2203,7 @@ function EnsembleComposer() {
   const [tab, setTab] = useState<"compose" | "runs">("compose");
   const [copied, setCopied] = useState(false);
   const [zoom, setZoom] = useState(1);
+  const [orientation, setOrientation] = useState<"vertical" | "horizontal">("horizontal");
   const [autoSave, setAutoSave] = useState(true);
   const [loadedEnsembleId, setLoadedEnsembleId] = useState<string | null>(null);
   const [savedSnapshot, setSavedSnapshot] = useState("");
@@ -2391,47 +2457,84 @@ function EnsembleComposer() {
         className="m-0 flex min-h-0 flex-1 overflow-hidden"
       >
           <main className="min-w-0 flex-1 overflow-auto px-6 py-6 lg:px-10">
-            <div className="mx-auto flex max-w-2xl flex-col gap-3">
+            <div
+              className={cn(
+                "mx-auto flex flex-col gap-3",
+                orientation === "horizontal" ? "max-w-none" : "max-w-2xl",
+              )}
+            >
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <p className="text-xs text-muted-foreground">
                   A unit can be a solo model, a fusion (parallel members + a required
                   synthesizer), or a pipeline (serial stages) — nest to any depth.
                 </p>
-                <div className="flex shrink-0 items-center gap-1">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    className="size-7"
-                    aria-label="Zoom out"
-                    disabled={zoom <= 0.5}
-                    onClick={() =>
-                      setZoom((value) => Math.max(0.5, Math.round((value - 0.1) * 10) / 10))
-                    }
-                  >
-                    <ZoomOut className="size-3.5" />
-                  </Button>
-                  <button
-                    type="button"
-                    className="w-11 text-center font-mono text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
-                    title="Reset zoom"
-                    onClick={() => setZoom(1)}
-                  >
-                    {Math.round(zoom * 100)}%
-                  </button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    className="size-7"
-                    aria-label="Zoom in"
-                    disabled={zoom >= 1.3}
-                    onClick={() =>
-                      setZoom((value) => Math.min(1.3, Math.round((value + 0.1) * 10) / 10))
-                    }
-                  >
-                    <ZoomIn className="size-3.5" />
-                  </Button>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <div className="inline-flex overflow-hidden rounded-lg border">
+                    <button
+                      type="button"
+                      aria-label="Horizontal layout"
+                      aria-pressed={orientation === "horizontal"}
+                      onClick={() => setOrientation("horizontal")}
+                      className={cn(
+                        "grid size-7 place-items-center transition-colors",
+                        orientation === "horizontal"
+                          ? "bg-primary text-primary-foreground"
+                          : "text-muted-foreground hover:bg-muted/40",
+                      )}
+                    >
+                      <Columns3 className="size-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label="Vertical layout"
+                      aria-pressed={orientation === "vertical"}
+                      onClick={() => setOrientation("vertical")}
+                      className={cn(
+                        "grid size-7 place-items-center transition-colors",
+                        orientation === "vertical"
+                          ? "bg-primary text-primary-foreground"
+                          : "text-muted-foreground hover:bg-muted/40",
+                      )}
+                    >
+                      <Rows3 className="size-3.5" />
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      className="size-7"
+                      aria-label="Zoom out"
+                      disabled={zoom <= 0.5}
+                      onClick={() =>
+                        setZoom((value) => Math.max(0.5, Math.round((value - 0.1) * 10) / 10))
+                      }
+                    >
+                      <ZoomOut className="size-3.5" />
+                    </Button>
+                    <button
+                      type="button"
+                      className="w-11 text-center font-mono text-xs tabular-nums text-muted-foreground transition-colors hover:text-foreground"
+                      title="Reset zoom"
+                      onClick={() => setZoom(1)}
+                    >
+                      {Math.round(zoom * 100)}%
+                    </button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="icon"
+                      className="size-7"
+                      aria-label="Zoom in"
+                      disabled={zoom >= 1.3}
+                      onClick={() =>
+                        setZoom((value) => Math.min(1.3, Math.round((value + 0.1) * 10) / 10))
+                      }
+                    >
+                      <ZoomIn className="size-3.5" />
+                    </Button>
+                  </div>
                 </div>
               </div>
               <div
@@ -2442,6 +2545,7 @@ function EnsembleComposer() {
                   node={root}
                   role="root"
                   depth={0}
+                  orientation={orientation}
                   providers={providers}
                   onUseModels={(models) => addLibraryModels(models)}
                   onChange={setRoot}

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1736,17 +1736,12 @@ function kindLabel(kind: RecipeKind): string {
 
 // Only leaf model units (and the synthesizer) are drawn as blocks; fusions/pipelines are
 // bare structural groupings, so the composition reads like a node diagram.
-function soloChrome(role: NodeRole): string {
-  return role === "synthesizer"
-    ? "rounded-lg border border-accent/50 bg-accent/5 p-2.5 shadow-sm"
-    : "rounded-lg border bg-card p-2.5 shadow-sm";
+function soloChrome(): string {
+  return "rounded-lg border bg-card p-2.5 shadow-sm";
 }
 
-function roleTagClass(role: NodeRole): string {
-  return cn(
-    "shrink-0 font-mono text-[10px] uppercase tracking-wider",
-    role === "synthesizer" ? "text-accent" : "text-muted-foreground",
-  );
+function roleTagClass(): string {
+  return "shrink-0 font-mono text-[10px] uppercase tracking-wider text-muted-foreground";
 }
 
 function KindDropdown({
@@ -1864,7 +1859,7 @@ function FusionBody({
 }) {
   const setMembers = (members: RecipeNode[]) => onChange({ ...node, members });
   return (
-    <div className="flex flex-row items-start gap-1.5">
+    <div className="flex flex-row items-center gap-1.5">
       <div className="flex shrink-0 flex-col gap-2 rounded-lg border border-dashed border-border/60 p-2">
         <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
           Parallel members
@@ -1899,7 +1894,7 @@ function FusionBody({
           Add member
         </Button>
       </div>
-      <div className="mt-3 flex shrink-0 flex-col items-center">
+      <div className="flex shrink-0 flex-col items-center">
         <ArrowRight className="size-4 text-muted-foreground/70" />
         <span className="mt-0.5 text-[9px] font-medium uppercase tracking-wider text-muted-foreground/70">
           synthesize
@@ -1935,11 +1930,11 @@ function PipelineBody({
 }) {
   const setStages = (stages: RecipeNode[]) => onChange({ ...node, stages });
   return (
-    <div className="flex flex-row items-start gap-1.5 pb-1">
+    <div className="flex flex-row items-center gap-1.5 pb-1">
       {node.stages.map((stage, index) => (
         <div key={stage.id} className="flex items-start gap-1.5">
           {index > 0 && (
-            <ArrowRight className="mt-3 size-4 shrink-0 text-muted-foreground/70" />
+            <ArrowRight className="size-4 shrink-0 text-muted-foreground/70" />
           )}
           <div className="min-w-[16rem] shrink-0">
             <RecipeNodeCard
@@ -2019,7 +2014,7 @@ function RecipeNodeCard({
   if (node.kind === "solo") {
     const model = node.model;
     return (
-      <article className={cn("min-w-[16rem]", soloChrome(role))}>
+      <article className={cn("min-w-[16rem]", soloChrome())}>
         <div className="flex items-center justify-between gap-2">
           {model ? (
             <button
@@ -2034,7 +2029,7 @@ function RecipeNodeCard({
                   !collapsed && "rotate-90",
                 )}
               />
-              <span className={roleTagClass(role)}>{roleLabel}</span>
+              <span className={roleTagClass()}>{roleLabel}</span>
               <ProviderDot provider={model.providerId} />
               <span className="truncate font-mono text-xs text-foreground/90">
                 {model.name}
@@ -2042,7 +2037,7 @@ function RecipeNodeCard({
             </button>
           ) : (
             <span className="flex min-w-0 flex-1 items-center gap-1.5">
-              <span className={roleTagClass(role)}>{roleLabel}</span>
+              <span className={roleTagClass()}>{roleLabel}</span>
               <span className="truncate text-xs text-muted-foreground/70">
                 · pick a model
               </span>
@@ -2087,7 +2082,7 @@ function RecipeNodeCard({
               !collapsed && "rotate-90",
             )}
           />
-          <span className={roleTagClass(role)}>{roleLabel}</span>
+          <span className={roleTagClass()}>{roleLabel}</span>
           <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             {kindLabel(node.kind)}
           </span>

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -2062,9 +2062,13 @@ function RecipeNodeCard({
         : role === "synthesizer"
           ? "Synthesizer"
           : "Recipe";
+  const handleKindChange = (next: RecipeNode) => {
+    setCollapsed(false);
+    onChange(next);
+  };
   const controls = (
     <div className="flex shrink-0 items-center gap-1">
-      <KindDropdown node={node} onChange={onChange} />
+      <KindDropdown node={node} onChange={handleKindChange} />
       {onRemove && <RemoveButton onRemove={onRemove} />}
     </div>
   );
@@ -2120,7 +2124,7 @@ function RecipeNodeCard({
               onAdd={(picked) => {
                 onChange({ ...node, model: picked });
                 onUseModels([picked]);
-                setCollapsed(true);
+                setCollapsed(false);
               }}
             />
           </div>

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1973,6 +1973,65 @@ function PipelineBody({
   );
 }
 
+function NodeLabel({
+  node,
+  roleLabel,
+  onChange,
+}: {
+  node: RecipeNode;
+  roleLabel: string;
+  onChange: (next: RecipeNode) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const named = Boolean(node.name && node.name.trim());
+  if (editing) {
+    return (
+      <Input
+        autoFocus
+        value={node.name ?? ""}
+        placeholder={roleLabel}
+        aria-label="Rename"
+        className="h-6 w-36 px-2 text-xs"
+        onClick={(event) => event.stopPropagation()}
+        onChange={(event) => onChange({ ...node, name: event.target.value })}
+        onBlur={() => setEditing(false)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === "Escape") {
+            event.preventDefault();
+            event.currentTarget.blur();
+          }
+        }}
+      />
+    );
+  }
+  return (
+    <span className="group/label flex min-w-0 items-center gap-1">
+      <span
+        className={cn(
+          "min-w-0 truncate",
+          named
+            ? "max-w-[11rem] text-xs font-medium text-foreground/90"
+            : roleTagClass(),
+        )}
+      >
+        {named ? node.name : roleLabel}
+      </span>
+      <button
+        type="button"
+        aria-label="Rename"
+        title="Rename"
+        onClick={(event) => {
+          event.stopPropagation();
+          setEditing(true);
+        }}
+        className="shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover/label:opacity-100"
+      >
+        <Pencil className="size-3" />
+      </button>
+    </span>
+  );
+}
+
 function RecipeNodeCard({
   node,
   onChange,
@@ -2016,33 +2075,42 @@ function RecipeNodeCard({
     return (
       <article className={cn("min-w-[16rem]", soloChrome())}>
         <div className="flex items-center justify-between gap-2">
-          {model ? (
-            <button
-              type="button"
-              onClick={() => setCollapsed((value) => !value)}
-              aria-expanded={!collapsed}
-              className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-            >
-              <ChevronRight
-                className={cn(
-                  "size-3.5 shrink-0 text-muted-foreground transition-transform",
-                  !collapsed && "rotate-90",
-                )}
-              />
-              <span className={roleTagClass()}>{roleLabel}</span>
-              <ProviderDot provider={model.providerId} />
-              <span className="truncate font-mono text-xs text-foreground/90">
-                {model.name}
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            {model ? (
+              <button
+                type="button"
+                aria-label={collapsed ? "Expand" : "Collapse"}
+                aria-expanded={!collapsed}
+                onClick={() => setCollapsed((value) => !value)}
+                className="grid size-5 shrink-0 place-items-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+              >
+                <ChevronRight
+                  className={cn("size-3.5 transition-transform", !collapsed && "rotate-90")}
+                />
+              </button>
+            ) : (
+              <span className="grid size-5 shrink-0 place-items-center">
+                <span className="size-1.5 rounded-full bg-muted-foreground/40" />
               </span>
-            </button>
-          ) : (
-            <span className="flex min-w-0 flex-1 items-center gap-1.5">
-              <span className={roleTagClass()}>{roleLabel}</span>
+            )}
+            <NodeLabel node={node} roleLabel={roleLabel} onChange={onChange} />
+            {model ? (
+              <button
+                type="button"
+                onClick={() => setCollapsed((value) => !value)}
+                className="flex min-w-0 items-center gap-1.5"
+              >
+                <ProviderDot provider={model.providerId} />
+                <span className="truncate font-mono text-xs text-foreground/90">
+                  {model.name}
+                </span>
+              </button>
+            ) : (
               <span className="truncate text-xs text-muted-foreground/70">
                 · pick a model
               </span>
-            </span>
-          )}
+            )}
+          </div>
           {controls}
         </div>
         {!model && (
@@ -2066,24 +2134,24 @@ function RecipeNodeCard({
     );
   }
 
-  // Fusion / Pipeline — a bare structural grouping (no card chrome).
+  // Fusion / Pipeline — a bare structural grouping.
   return (
     <div className={cn("flex flex-col gap-2", depth > 0 && "pl-0.5")}>
       <div className="flex items-center justify-between gap-2">
-        <button
-          type="button"
-          onClick={() => setCollapsed((value) => !value)}
-          aria-expanded={!collapsed}
-          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
-        >
-          <ChevronRight
-            className={cn(
-              "size-3.5 shrink-0 text-muted-foreground transition-transform",
-              !collapsed && "rotate-90",
-            )}
-          />
-          <span className={roleTagClass()}>{roleLabel}</span>
-          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
+          <button
+            type="button"
+            aria-label={collapsed ? "Expand" : "Collapse"}
+            aria-expanded={!collapsed}
+            onClick={() => setCollapsed((value) => !value)}
+            className="grid size-5 shrink-0 place-items-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+          >
+            <ChevronRight
+              className={cn("size-3.5 transition-transform", !collapsed && "rotate-90")}
+            />
+          </button>
+          <NodeLabel node={node} roleLabel={roleLabel} onChange={onChange} />
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             {kindLabel(node.kind)}
           </span>
           {collapsed && (
@@ -2091,7 +2159,7 @@ function RecipeNodeCard({
               {describeRecipe(node)}
             </span>
           )}
-        </button>
+        </div>
         {controls}
       </div>
       {!collapsed && (

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1936,7 +1936,7 @@ function PipelineBody({
           {index > 0 && (
             <ArrowRight className="size-4 shrink-0 text-muted-foreground/70" />
           )}
-          <div className="min-w-[16rem] shrink-0">
+          <div className="min-w-[14rem] shrink-0">
             <RecipeNodeCard
               node={stage}
               index={index}
@@ -2077,7 +2077,7 @@ function RecipeNodeCard({
   if (node.kind === "solo") {
     const model = node.model;
     return (
-      <article className={cn("min-w-[16rem]", soloChrome())}>
+      <article className={cn("min-w-[14rem]", soloChrome())}>
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 flex-1 items-center gap-1.5">
             {model ? (
@@ -2098,18 +2098,7 @@ function RecipeNodeCard({
               </span>
             )}
             <NodeLabel node={node} roleLabel={roleLabel} onChange={onChange} />
-            {model ? (
-              <button
-                type="button"
-                onClick={() => setCollapsed((value) => !value)}
-                className="flex min-w-0 items-center gap-1.5"
-              >
-                <ProviderDot provider={model.providerId} />
-                <span className="truncate font-mono text-xs text-foreground/90">
-                  {model.name}
-                </span>
-              </button>
-            ) : (
+            {!model && (
               <span className="truncate text-xs text-muted-foreground/70">
                 · pick a model
               </span>
@@ -2117,6 +2106,18 @@ function RecipeNodeCard({
           </div>
           {controls}
         </div>
+        {model && (
+          <button
+            type="button"
+            onClick={() => setCollapsed((value) => !value)}
+            className="mt-1.5 flex w-full min-w-0 items-center gap-1.5 text-left"
+          >
+            <ProviderDot provider={model.providerId} />
+            <span className="truncate font-mono text-xs text-foreground/90">
+              {model.name}
+            </span>
+          </button>
+        )}
         {!model && (
           <div className="mt-2.5">
             <InlineModelPicker

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1752,6 +1752,13 @@ function nodeChrome(depth: number, role: NodeRole): string {
     : "rounded-lg bg-muted/30 ring-1 ring-inset ring-border/40 p-2.5";
 }
 
+function roleTagClass(role: NodeRole): string {
+  return cn(
+    "shrink-0 font-mono text-[11px] uppercase tracking-wide",
+    role === "synthesizer" ? "text-accent" : "text-muted-foreground",
+  );
+}
+
 function KindSwitch({
   node,
   onChange,
@@ -1781,49 +1788,18 @@ function KindSwitch({
   );
 }
 
-function SoloBody({
+// Prompt + parameters — only shown for a solo that already has a model, and collapsible.
+function SoloConfig({
   node,
   onChange,
-  providers,
-  onUseModels,
-  onModelChosen,
 }: {
   node: SoloNode;
   onChange: (next: RecipeNode) => void;
-  providers: ModelProvider[];
-  onUseModels: (models: Model[]) => void;
-  onModelChosen?: () => void;
 }) {
   const [showParams, setShowParams] = useState((node.params?.length ?? 0) > 0);
   const paramCount = node.params?.length ?? 0;
   return (
     <div className="flex flex-col gap-2.5">
-      {node.model ? (
-        <div className="flex items-center justify-between gap-2 rounded-lg border bg-background px-3 py-2">
-          <span className="flex min-w-0 items-center gap-2">
-            <ProviderDot provider={node.model.providerId} />
-            <span className="truncate font-mono text-sm">{node.model.name}</span>
-          </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="text-xs text-muted-foreground"
-            onClick={() => onChange({ ...node, model: null })}
-          >
-            Change
-          </Button>
-        </div>
-      ) : (
-        <InlineModelPicker
-          providers={providers}
-          onAdd={(model) => {
-            onChange({ ...node, model });
-            onUseModels([model]);
-            onModelChosen?.();
-          }}
-        />
-      )}
       <Textarea
         rows={2}
         value={node.prompt}
@@ -2058,6 +2034,21 @@ function PipelineBody({
   );
 }
 
+function RemoveButton({ onRemove }: { onRemove: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="size-6 text-muted-foreground"
+      aria-label="Remove element"
+      onClick={onRemove}
+    >
+      <X className="size-3.5" />
+    </Button>
+  );
+}
+
 function RecipeNodeCard({
   node,
   onChange,
@@ -2079,9 +2070,8 @@ function RecipeNodeCard({
   depth?: number;
   orientation?: Orientation;
 }) {
-  const isSolo = node.kind === "solo";
   const [collapsed, setCollapsed] = useState(
-    () => isSolo && Boolean((node as SoloNode).model),
+    () => node.kind === "solo" && Boolean((node as SoloNode).model),
   );
   const roleLabel =
     role === "member"
@@ -2091,6 +2081,77 @@ function RecipeNodeCard({
         : role === "synthesizer"
           ? "Synthesizer"
           : "Recipe";
+
+  if (node.kind === "solo") {
+    const model = node.model;
+    return (
+      <article className={cn("h-full", nodeChrome(depth, role))}>
+        <div className="flex items-center justify-between gap-2">
+          {model ? (
+            <button
+              type="button"
+              onClick={() => setCollapsed((value) => !value)}
+              aria-expanded={!collapsed}
+              className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+            >
+              <ChevronRight
+                className={cn(
+                  "size-3.5 shrink-0 text-muted-foreground transition-transform",
+                  !collapsed && "rotate-90",
+                )}
+              />
+              <span className={roleTagClass(role)}>{roleLabel}</span>
+              <ProviderDot provider={model.providerId} />
+              <span className="truncate font-mono text-xs text-foreground/90">
+                {model.name}
+              </span>
+            </button>
+          ) : (
+            <span className="flex min-w-0 flex-1 items-center gap-1.5">
+              <span
+                aria-hidden="true"
+                className="ml-1 size-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+              />
+              <span className={roleTagClass(role)}>{roleLabel}</span>
+            </span>
+          )}
+          <div className="flex shrink-0 items-center gap-1">
+            {model && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-[11px] text-muted-foreground"
+                onClick={() => onChange({ ...node, model: null })}
+              >
+                Change
+              </Button>
+            )}
+            <KindSwitch node={node} onChange={onChange} />
+            {onRemove && <RemoveButton onRemove={onRemove} />}
+          </div>
+        </div>
+        {!model && (
+          <div className="mt-2.5">
+            <InlineModelPicker
+              providers={providers}
+              onAdd={(picked) => {
+                onChange({ ...node, model: picked });
+                onUseModels([picked]);
+                setCollapsed(true);
+              }}
+            />
+          </div>
+        )}
+        {model && !collapsed && (
+          <div className="mt-2.5">
+            <SoloConfig node={node} onChange={onChange} />
+          </div>
+        )}
+      </article>
+    );
+  }
+
   return (
     <article className={cn("h-full", nodeChrome(depth, role))}>
       <div className="flex items-center justify-between gap-2">
@@ -2106,61 +2167,21 @@ function RecipeNodeCard({
               !collapsed && "rotate-90",
             )}
           />
-          <span
-            className={cn(
-              "shrink-0 font-mono text-[11px] uppercase tracking-wide",
-              role === "synthesizer" ? "text-accent" : "text-muted-foreground",
-            )}
-          >
-            {roleLabel}
-          </span>
-          {isSolo && collapsed ? (
-            (node as SoloNode).model ? (
-              <span className="flex min-w-0 items-center gap-1.5">
-                <ProviderDot provider={(node as SoloNode).model!.providerId} />
-                <span className="truncate font-mono text-xs text-foreground/80">
-                  {(node as SoloNode).model!.name}
-                </span>
-              </span>
-            ) : (
-              <span className="truncate text-xs text-muted-foreground/70">
-                Choose a model…
-              </span>
-            )
-          ) : null}
-          {!isSolo && collapsed ? (
+          <span className={roleTagClass(role)}>{roleLabel}</span>
+          {collapsed && (
             <span className="min-w-0 truncate rounded-md bg-background/70 px-1.5 py-0.5 font-mono text-[11px] text-foreground/80">
               {describeRecipe(node)}
             </span>
-          ) : null}
+          )}
         </button>
         <div className="flex shrink-0 items-center gap-1.5">
           <KindSwitch node={node} onChange={onChange} />
-          {onRemove && (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="size-6 text-muted-foreground"
-              aria-label="Remove element"
-              onClick={onRemove}
-            >
-              <X className="size-3.5" />
-            </Button>
-          )}
+          {onRemove && <RemoveButton onRemove={onRemove} />}
         </div>
       </div>
       {!collapsed && (
         <div className="mt-3">
-          {node.kind === "solo" ? (
-            <SoloBody
-              node={node}
-              onChange={onChange}
-              providers={providers}
-              onUseModels={onUseModels}
-              onModelChosen={() => setCollapsed(true)}
-            />
-          ) : node.kind === "fusion" ? (
+          {node.kind === "fusion" ? (
             <FusionBody
               node={node}
               onChange={onChange}

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  ArrowDown,
   ArrowRight,
   Check,
   ChevronDown,
@@ -1735,13 +1734,12 @@ function kindLabel(kind: RecipeKind): string {
   return kind === "solo" ? "Solo" : kind === "fusion" ? "Fusion" : "Pipeline";
 }
 
-function nodeChrome(depth: number, role: NodeRole): string {
-  if (role === "synthesizer") {
-    return "rounded-lg border border-accent/40 bg-accent/5 p-3";
-  }
-  return depth === 0
-    ? "rounded-xl border bg-card p-3.5 shadow-sm"
-    : "rounded-lg border border-border/60 bg-card p-3";
+// Only leaf model units (and the synthesizer) are drawn as blocks; fusions/pipelines are
+// bare structural groupings, so the composition reads like a node diagram.
+function soloChrome(role: NodeRole): string {
+  return role === "synthesizer"
+    ? "rounded-lg border border-accent/50 bg-accent/5 p-2.5 shadow-sm"
+    : "rounded-lg border bg-card p-2.5 shadow-sm";
 }
 
 function roleTagClass(role: NodeRole): string {
@@ -1751,7 +1749,6 @@ function roleTagClass(role: NodeRole): string {
   );
 }
 
-// Compact type selector — replaces the wide 3-segment switch that crowded nested cards.
 function KindDropdown({
   node,
   onChange,
@@ -1799,7 +1796,6 @@ function RemoveButton({ onRemove }: { onRemove: () => void }) {
   );
 }
 
-// Prompt + params (+ change model) for a solo that already has a model.
 function SoloConfig({
   node,
   onChange,
@@ -1852,7 +1848,7 @@ function SoloConfig({
   );
 }
 
-// Fusion: members stacked in parallel on a rail, converging into the synthesizer below.
+// Fusion: parallel member blocks on a rail, converging into the synthesizer block.
 function FusionBody({
   node,
   onChange,
@@ -1868,9 +1864,9 @@ function FusionBody({
 }) {
   const setMembers = (members: RecipeNode[]) => onChange({ ...node, members });
   return (
-    <div className="flex flex-col gap-2.5">
-      <div className="flex flex-col gap-2 border-l-2 border-border/40 pl-3">
-        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
+    <div className="flex flex-row items-start gap-1.5">
+      <div className="flex shrink-0 flex-col gap-2 rounded-lg border border-dashed border-border/60 p-2">
+        <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
           Parallel members
         </p>
         {node.members.map((member, index) => (
@@ -1903,23 +1899,27 @@ function FusionBody({
           Add member
         </Button>
       </div>
-      <div className="flex items-center gap-1.5 pl-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
-        <ArrowDown className="size-3.5" />
-        synthesize
+      <div className="mt-3 flex shrink-0 flex-col items-center">
+        <ArrowRight className="size-4 text-muted-foreground/70" />
+        <span className="mt-0.5 text-[9px] font-medium uppercase tracking-wider text-muted-foreground/70">
+          synthesize
+        </span>
       </div>
-      <RecipeNodeCard
-        node={node.synthesizer}
-        depth={depth + 1}
-        role="synthesizer"
-        providers={providers}
-        onUseModels={onUseModels}
-        onChange={(next) => onChange({ ...node, synthesizer: next })}
-      />
+      <div className="shrink-0">
+        <RecipeNodeCard
+          node={node.synthesizer}
+          depth={depth + 1}
+          role="synthesizer"
+          providers={providers}
+          onUseModels={onUseModels}
+          onChange={(next) => onChange({ ...node, synthesizer: next })}
+        />
+      </div>
     </div>
   );
 }
 
-// Pipeline: stages on a left-to-right timeline; the row scrolls when it gets long.
+// Pipeline: stage blocks on a left-to-right timeline.
 function PipelineBody({
   node,
   onChange,
@@ -1935,49 +1935,44 @@ function PipelineBody({
 }) {
   const setStages = (stages: RecipeNode[]) => onChange({ ...node, stages });
   return (
-    <div className="flex flex-col gap-1.5">
-      <p className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
-        Sequence
-      </p>
-      <div className="flex flex-row items-start gap-1.5 pb-1">
-        {node.stages.map((stage, index) => (
-          <div key={stage.id} className="flex items-start gap-1.5">
-            {index > 0 && (
-              <ArrowRight className="mt-3 size-4 shrink-0 text-muted-foreground/70" />
-            )}
-            <div className="min-w-[16rem] shrink-0">
-              <RecipeNodeCard
-                node={stage}
-                index={index}
-                depth={depth + 1}
-                role="stage"
-                providers={providers}
-                onUseModels={onUseModels}
-                onChange={(next) =>
-                  setStages(node.stages.map((item, i) => (i === index ? next : item)))
-                }
-                onRemove={
-                  node.stages.length > 1
-                    ? () => setStages(node.stages.filter((_, i) => i !== index))
-                    : undefined
-                }
-              />
-            </div>
+    <div className="flex flex-row items-start gap-1.5 pb-1">
+      {node.stages.map((stage, index) => (
+        <div key={stage.id} className="flex items-start gap-1.5">
+          {index > 0 && (
+            <ArrowRight className="mt-3 size-4 shrink-0 text-muted-foreground/70" />
+          )}
+          <div className="min-w-[16rem] shrink-0">
+            <RecipeNodeCard
+              node={stage}
+              index={index}
+              depth={depth + 1}
+              role="stage"
+              providers={providers}
+              onUseModels={onUseModels}
+              onChange={(next) =>
+                setStages(node.stages.map((item, i) => (i === index ? next : item)))
+              }
+              onRemove={
+                node.stages.length > 1
+                  ? () => setStages(node.stages.filter((_, i) => i !== index))
+                  : undefined
+              }
+            />
           </div>
-        ))}
-        <div className="flex items-center gap-1.5 self-center">
-          <ArrowRight className="size-4 shrink-0 text-muted-foreground/70" />
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 text-xs"
-            onClick={() => setStages([...node.stages, createSolo()])}
-          >
-            <Plus className="size-3.5" />
-            Add stage
-          </Button>
         </div>
+      ))}
+      <div className="flex items-center gap-1.5 self-center">
+        <ArrowRight className="size-4 shrink-0 text-muted-foreground/70" />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 text-xs"
+          onClick={() => setStages([...node.stages, createSolo()])}
+        >
+          <Plus className="size-3.5" />
+          Add stage
+        </Button>
       </div>
     </div>
   );
@@ -2020,10 +2015,11 @@ function RecipeNodeCard({
     </div>
   );
 
+  // Solo — a drawn block.
   if (node.kind === "solo") {
     const model = node.model;
     return (
-      <article className={cn("min-w-[16rem]", nodeChrome(depth, role))}>
+      <article className={cn("min-w-[16rem]", soloChrome(role))}>
         <div className="flex items-center justify-between gap-2">
           {model ? (
             <button
@@ -2075,8 +2071,9 @@ function RecipeNodeCard({
     );
   }
 
+  // Fusion / Pipeline — a bare structural grouping (no card chrome).
   return (
-    <article className={cn("min-w-[16rem]", nodeChrome(depth, role))}>
+    <div className={cn("flex flex-col gap-2", depth > 0 && "pl-0.5")}>
       <div className="flex items-center justify-between gap-2">
         <button
           type="button"
@@ -2091,7 +2088,7 @@ function RecipeNodeCard({
             )}
           />
           <span className={roleTagClass(role)}>{roleLabel}</span>
-          <span className="rounded bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
             {kindLabel(node.kind)}
           </span>
           {collapsed && (
@@ -2103,7 +2100,7 @@ function RecipeNodeCard({
         {controls}
       </div>
       {!collapsed && (
-        <div className="mt-3">
+        <div>
           {node.kind === "fusion" ? (
             <FusionBody
               node={node}
@@ -2123,7 +2120,7 @@ function RecipeNodeCard({
           )}
         </div>
       )}
-    </article>
+    </div>
   );
 }
 

--- a/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/ensembles/new/page.tsx
@@ -1733,6 +1733,8 @@ function buildDraft(
 
 type Orientation = "vertical" | "horizontal";
 
+type NodeRole = "root" | "member" | "stage" | "synthesizer";
+
 const RECIPE_KINDS: { kind: RecipeKind; label: string }[] = [
   { kind: "solo", label: "Solo" },
   { kind: "fusion", label: "Fusion" },
@@ -1743,14 +1745,12 @@ function nodeChrome(depth: number, role: NodeRole): string {
   if (role === "synthesizer") {
     return depth === 0
       ? "rounded-xl border border-accent/40 bg-accent/5 p-3.5"
-      : "rounded-lg bg-accent/5 ring-1 ring-inset ring-accent/15 p-3";
+      : "rounded-lg bg-accent/5 ring-1 ring-inset ring-accent/15 p-2.5";
   }
   return depth === 0
     ? "rounded-xl border bg-card p-3.5 shadow-sm"
-    : "rounded-lg bg-muted/30 ring-1 ring-inset ring-border/40 p-3";
+    : "rounded-lg bg-muted/30 ring-1 ring-inset ring-border/40 p-2.5";
 }
-
-type NodeRole = "root" | "member" | "stage" | "synthesizer";
 
 function KindSwitch({
   node,
@@ -1786,11 +1786,13 @@ function SoloBody({
   onChange,
   providers,
   onUseModels,
+  onModelChosen,
 }: {
   node: SoloNode;
   onChange: (next: RecipeNode) => void;
   providers: ModelProvider[];
   onUseModels: (models: Model[]) => void;
+  onModelChosen?: () => void;
 }) {
   const [showParams, setShowParams] = useState((node.params?.length ?? 0) > 0);
   const paramCount = node.params?.length ?? 0;
@@ -1818,6 +1820,7 @@ function SoloBody({
           onAdd={(model) => {
             onChange({ ...node, model });
             onUseModels([model]);
+            onModelChosen?.();
           }}
         />
       )}
@@ -2005,10 +2008,7 @@ function PipelineBody({
         {node.stages.map((stage, index) => (
           <div
             key={stage.id}
-            className={cn(
-              "flex gap-2",
-              horizontal ? "items-stretch" : "flex-col",
-            )}
+            className={cn("flex gap-2", horizontal ? "items-stretch" : "flex-col")}
           >
             {index > 0 && (
               <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
@@ -2079,41 +2079,33 @@ function RecipeNodeCard({
   depth?: number;
   orientation?: Orientation;
 }) {
-  const [collapsed, setCollapsed] = useState(false);
-  const collapsible = node.kind !== "solo";
+  const isSolo = node.kind === "solo";
+  const [collapsed, setCollapsed] = useState(
+    () => isSolo && Boolean((node as SoloNode).model),
+  );
   const roleLabel =
     role === "member"
       ? `Member ${(index ?? 0) + 1}`
       : role === "stage"
         ? `Stage ${(index ?? 0) + 1}`
         : role === "synthesizer"
-          ? "Synthesizer · required"
+          ? "Synthesizer"
           : "Recipe";
   return (
     <article className={cn("h-full", nodeChrome(depth, role))}>
       <div className="flex items-center justify-between gap-2">
-        <div className="flex min-w-0 items-center gap-1.5">
-          {collapsible ? (
-            <button
-              type="button"
-              aria-label={collapsed ? "Expand" : "Collapse"}
-              aria-expanded={!collapsed}
-              onClick={() => setCollapsed((value) => !value)}
-              className="grid size-5 shrink-0 place-items-center rounded text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
-            >
-              <ChevronRight
-                className={cn("size-3.5 transition-transform", !collapsed && "rotate-90")}
-              />
-            </button>
-          ) : (
-            <span
-              aria-hidden="true"
-              className={cn(
-                "ml-1.5 mr-0.5 size-1.5 shrink-0 rounded-full",
-                role === "synthesizer" ? "bg-accent/60" : "bg-muted-foreground/40",
-              )}
-            />
-          )}
+        <button
+          type="button"
+          onClick={() => setCollapsed((value) => !value)}
+          aria-expanded={!collapsed}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+        >
+          <ChevronRight
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              !collapsed && "rotate-90",
+            )}
+          />
           <span
             className={cn(
               "shrink-0 font-mono text-[11px] uppercase tracking-wide",
@@ -2122,12 +2114,26 @@ function RecipeNodeCard({
           >
             {roleLabel}
           </span>
-          {collapsed && (
+          {isSolo && collapsed ? (
+            (node as SoloNode).model ? (
+              <span className="flex min-w-0 items-center gap-1.5">
+                <ProviderDot provider={(node as SoloNode).model!.providerId} />
+                <span className="truncate font-mono text-xs text-foreground/80">
+                  {(node as SoloNode).model!.name}
+                </span>
+              </span>
+            ) : (
+              <span className="truncate text-xs text-muted-foreground/70">
+                Choose a model…
+              </span>
+            )
+          ) : null}
+          {!isSolo && collapsed ? (
             <span className="min-w-0 truncate rounded-md bg-background/70 px-1.5 py-0.5 font-mono text-[11px] text-foreground/80">
               {describeRecipe(node)}
             </span>
-          )}
-        </div>
+          ) : null}
+        </button>
         <div className="flex shrink-0 items-center gap-1.5">
           <KindSwitch node={node} onChange={onChange} />
           {onRemove && (
@@ -2152,6 +2158,7 @@ function RecipeNodeCard({
               onChange={onChange}
               providers={providers}
               onUseModels={onUseModels}
+              onModelChosen={() => setCollapsed(true)}
             />
           ) : node.kind === "fusion" ? (
             <FusionBody

--- a/apps/screamingface-studio/frontend/src/app/(studio)/models/page.tsx
+++ b/apps/screamingface-studio/frontend/src/app/(studio)/models/page.tsx
@@ -537,6 +537,15 @@ export default function ModelsPage() {
           </div>
         </main>
       </div>
+
+      <footer className="flex shrink-0 items-center justify-end border-t px-6 py-4 sm:px-8">
+        <Button asChild className="rounded-xl">
+          <Link href="/ensembles/new/" prefetch={false}>
+            <Boxes className="size-4" />
+            Start building a fusion
+          </Link>
+        </Button>
+      </footer>
     </div>
   );
 }

--- a/apps/screamingface-studio/frontend/src/components/app-sidebar.tsx
+++ b/apps/screamingface-studio/frontend/src/components/app-sidebar.tsx
@@ -4,7 +4,6 @@ import {
   ArrowRight,
   Boxes,
   Cpu,
-  FileCode,
   Flame,
   Hash,
   Key,
@@ -40,13 +39,11 @@ import {
   OPENMINED_BUDGET_TOTAL,
   useOpenMinedStore,
 } from "@/lib/openmined-store";
-import { useScriptStore } from "@/lib/script-store";
 
 const navigation = [
   { label: "Fusions", href: "/ensembles/", Icon: Boxes },
   { label: "Models", href: "/models/", Icon: Layers },
   { label: "Leaderboard", href: "/leaderboard/", Icon: Trophy },
-  { label: "Scripts", href: "/scripts/", Icon: FileCode },
 ];
 
 function MonsterFusionCard() {
@@ -104,7 +101,6 @@ export function AppSidebar() {
       state.providers.filter((provider) => provider.connected).length,
   );
   const omConnected = useOpenMinedStore((state) => state.connected);
-  const scriptCount = useScriptStore((state) => state.scripts.length);
   const authOpen = useOpenMinedStore((state) => state.authOpen);
   const authorizing = useOpenMinedStore((state) => state.authorizing);
   const setAuthOpen = useOpenMinedStore((state) => state.setAuthOpen);
@@ -131,9 +127,7 @@ export function AppSidebar() {
               const visibleBadge =
                 label === "Models" && connectedProviders > 0
                   ? String(connectedProviders)
-                  : label === "Scripts" && scriptCount > 0
-                    ? String(scriptCount)
-                    : undefined;
+                  : undefined;
               return (
                 <SidebarMenuItem key={label}>
                   <SidebarMenuButton

--- a/apps/screamingface-studio/frontend/src/lib/ensemble-store.ts
+++ b/apps/screamingface-studio/frontend/src/lib/ensemble-store.ts
@@ -34,6 +34,8 @@ export type SavedRun = {
   benchmarkName: string;
   sampleSize: number;
   full: boolean;
+  useCache: boolean;
+  saveCache: boolean;
   compute: "own" | "om";
   score: number;
   baseline: number;

--- a/apps/screamingface-studio/frontend/src/lib/ensemble-store.ts
+++ b/apps/screamingface-studio/frontend/src/lib/ensemble-store.ts
@@ -3,6 +3,8 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
+import type { RecipeNode } from "./recipe";
+
 export type SavedModel = {
   id: string;
   name: string;
@@ -47,6 +49,10 @@ export type SavedRun = {
 export type SavedEnsemble = {
   id: string;
   name: string;
+  // The recipe-native builder tree — the source of truth for the composer. Optional so
+  // ensembles persisted before the recipe rework still hydrate (migrated on load from
+  // `slots`/`judge` via `fusionFromSlots`).
+  root?: RecipeNode;
   slots: SavedSlot[];
   strategy: "majority_vote" | "weighted_avg" | "best_of_n" | "merge";
   customReduce: boolean;

--- a/apps/screamingface-studio/frontend/src/lib/recipe.ts
+++ b/apps/screamingface-studio/frontend/src/lib/recipe.ts
@@ -1,0 +1,214 @@
+// Recipe-native model for the Studio builder.
+//
+// Mirrors ScreamingFace's real artifacts (packages/screamingface):
+//   - Solo:     one Model (a "unit") — model route + optional prompt + params
+//   - Fusion:   parallel `members` + a REQUIRED `synthesizer` (itself a Recipe)
+//   - Pipeline: serial `stages` (only the last stage is graded)
+// These nest arbitrarily. There is no "reduce" primitive — reduction IS the synthesizer.
+//
+// `recipeToUrl4` renders a structurally-faithful url4 PREVIEW as the user builds. It is not
+// the engine's byte-canonical string (that comes from the engine at run time); it captures
+// the topology in url4's `(sources)!intent` shape, modelled on the compiled Fusion example
+// in the walkthrough notebook.
+
+import type { ModelParam, SavedModel, SavedSlot } from "./ensemble-store";
+import { createUuid } from "./uuid";
+
+export type RecipeKind = "solo" | "fusion" | "pipeline";
+
+export type SoloNode = {
+  kind: "solo";
+  id: string;
+  model: SavedModel | null;
+  prompt: string;
+  params: ModelParam[];
+};
+
+export type FusionNode = {
+  kind: "fusion";
+  id: string;
+  name?: string;
+  members: RecipeNode[];
+  synthesizer: RecipeNode;
+};
+
+export type PipelineNode = {
+  kind: "pipeline";
+  id: string;
+  name?: string;
+  stages: RecipeNode[];
+};
+
+export type RecipeNode = SoloNode | FusionNode | PipelineNode;
+
+// ── Factories ────────────────────────────────────────────────────────────────
+
+export function createSolo(model: SavedModel | null = null): SoloNode {
+  return { kind: "solo", id: createUuid(), model, prompt: "", params: [] };
+}
+
+export function createFusion(): FusionNode {
+  return {
+    kind: "fusion",
+    id: createUuid(),
+    members: [createSolo(), createSolo()],
+    synthesizer: createSolo(),
+  };
+}
+
+export function createPipeline(): PipelineNode {
+  return {
+    kind: "pipeline",
+    id: createUuid(),
+    stages: [createSolo(), createSolo()],
+  };
+}
+
+export function createNode(kind: RecipeKind): RecipeNode {
+  if (kind === "fusion") return createFusion();
+  if (kind === "pipeline") return createPipeline();
+  return createSolo();
+}
+
+// Switch a node's kind in place (keeps its id so it stays put in its parent). A solo that
+// already has a model is preserved as the first member/stage when expanding, so configuration
+// isn't lost when a unit grows into a fusion or pipeline.
+export function convertKind(node: RecipeNode, kind: RecipeKind): RecipeNode {
+  if (node.kind === kind) return node;
+  const carry: RecipeNode | null =
+    node.kind === "solo" && node.model ? { ...node, id: createUuid() } : null;
+  if (kind === "solo") return { ...createSolo(), id: node.id };
+  if (kind === "fusion") {
+    const base = createFusion();
+    return {
+      ...base,
+      id: node.id,
+      members: carry ? [carry, createSolo()] : base.members,
+    };
+  }
+  const base = createPipeline();
+  return {
+    ...base,
+    id: node.id,
+    stages: carry ? [carry, createSolo()] : base.stages,
+  };
+}
+
+// ── Traversal ────────────────────────────────────────────────────────────────
+
+export function collectSolos(node: RecipeNode): SoloNode[] {
+  if (node.kind === "solo") return [node];
+  if (node.kind === "fusion") {
+    return [...node.members.flatMap(collectSolos), ...collectSolos(node.synthesizer)];
+  }
+  return node.stages.flatMap(collectSolos);
+}
+
+// Solos that "answer" (everything except a fusion root's own synthesizer) — used to feed the
+// mock RunsPanel's member list without double-counting the synthesizer.
+export function memberSolos(root: RecipeNode): SoloNode[] {
+  if (root.kind === "fusion") return root.members.flatMap(collectSolos);
+  return collectSolos(root);
+}
+
+// The root fusion's synthesizer, when it is a single Model — surfaced as the run's synthesis
+// step. Nested / composite synthesizers return null (the mock simply omits the step).
+export function rootSynthesizerSolo(root: RecipeNode): SoloNode | null {
+  if (root.kind === "fusion" && root.synthesizer.kind === "solo" && root.synthesizer.model) {
+    return root.synthesizer;
+  }
+  return null;
+}
+
+// ── Legacy migration (flat slots + optional judge → a Fusion) ─────────────────
+
+export function fusionFromSlots(
+  slots: SavedSlot[] | undefined,
+  judge: SavedSlot | null,
+): FusionNode {
+  const members = (slots ?? []).map((slot) => ({
+    ...createSolo(slot.model),
+    prompt: slot.systemPrompt ?? "",
+    params: slot.params ?? [],
+  }));
+  const synthesizer = judge
+    ? { ...createSolo(judge.model), prompt: judge.systemPrompt ?? "" }
+    : createSolo();
+  return {
+    kind: "fusion",
+    id: createUuid(),
+    members: members.length > 0 ? members : [createSolo()],
+    synthesizer,
+  };
+}
+
+// ── url4 preview ──────────────────────────────────────────────────────────────
+
+function quoteIntent(text: string): string {
+  const oneLine = text.replace(/\s+/g, " ").trim();
+  return `'${oneLine.replace(/'/g, "\\'")}'`;
+}
+
+function paramQuery(params: ModelParam[]): string {
+  const kv = params
+    .filter((param) => param.key && param.value !== "")
+    .map((param) => `${param.key}=${param.value}`);
+  return kv.length ? `?${kv.join("&")}` : "";
+}
+
+export function recipeToUrl4(root: RecipeNode): string {
+  const sources: string[] = [];
+  const counters = { model: 0, synthesis: 0 };
+
+  function emit(
+    node: RecipeNode,
+    context: string,
+    role: "answer" | "synthesis",
+  ): string {
+    if (node.kind === "solo") {
+      const prefix = role === "synthesis" ? "synthesis" : "model";
+      const index = role === "synthesis" ? ++counters.synthesis : ++counters.model;
+      const name = `${prefix}_${index}`;
+      const path = node.model ? `/${node.model.name}` : "/‹model›";
+      const intent = node.prompt
+        ? quoteIntent(node.prompt)
+        : role === "synthesis"
+          ? "'Synthesize the member answers into one final answer.'"
+          : "'Answer.'";
+      sources.push(`${name}:0.0:${path}${paramQuery(node.params)}(${context})!${intent}`);
+      return name;
+    }
+    if (node.kind === "fusion") {
+      const memberRefs = node.members.map((member) => emit(member, "$input", "answer"));
+      const outputs = memberRefs
+        .map((ref, i) => `member_${i + 1}: '$${ref}'`)
+        .join(", ");
+      const synthContext = `{input: '$input', outputs: {${outputs}}}`;
+      return emit(node.synthesizer, synthContext, "synthesis");
+    }
+    // pipeline — each stage consumes the previous stage's output
+    let ctx = context;
+    let last = "";
+    for (const stage of node.stages) {
+      last = emit(stage, ctx, "answer");
+      ctx = `$${last}`;
+    }
+    return last || (context.startsWith("$") ? context.slice(1) : "input");
+  }
+
+  const rootRef = emit(root, "$input", "answer");
+  return `(${sources.join(", ")})!'$${rootRef}'`;
+}
+
+// A short human-readable one-line shape, e.g. "Fusion(2 members → synthesizer)".
+export function describeRecipe(node: RecipeNode): string {
+  if (node.kind === "solo") {
+    return node.model ? node.model.name : "unset model";
+  }
+  if (node.kind === "fusion") {
+    return `Fusion(${node.members.length} member${
+      node.members.length === 1 ? "" : "s"
+    } → synthesizer)`;
+  }
+  return `Pipeline(${node.stages.length} stage${node.stages.length === 1 ? "" : "s"})`;
+}

--- a/apps/screamingface-studio/frontend/src/lib/recipe.ts
+++ b/apps/screamingface-studio/frontend/src/lib/recipe.ts
@@ -19,6 +19,7 @@ export type RecipeKind = "solo" | "fusion" | "pipeline";
 export type SoloNode = {
   kind: "solo";
   id: string;
+  name?: string;
   model: SavedModel | null;
   prompt: string;
   params: ModelParam[];
@@ -77,12 +78,13 @@ export function convertKind(node: RecipeNode, kind: RecipeKind): RecipeNode {
   if (node.kind === kind) return node;
   const carry: RecipeNode | null =
     node.kind === "solo" && node.model ? { ...node, id: createUuid() } : null;
-  if (kind === "solo") return { ...createSolo(), id: node.id };
+  if (kind === "solo") return { ...createSolo(), id: node.id, name: node.name };
   if (kind === "fusion") {
     const base = createFusion();
     return {
       ...base,
       id: node.id,
+      name: node.name,
       members: carry ? [carry, createSolo()] : base.members,
     };
   }
@@ -90,6 +92,7 @@ export function convertKind(node: RecipeNode, kind: RecipeKind): RecipeNode {
   return {
     ...base,
     id: node.id,
+    name: node.name,
     stages: carry ? [carry, createSolo()] : base.stages,
   };
 }

--- a/docs/tasks/2026-09-02-studio-recipe-native-builder.md
+++ b/docs/tasks/2026-09-02-studio-recipe-native-builder.md
@@ -1,0 +1,22 @@
+---
+id: OME-1077
+linear_url: https://linear.app/openmined/issue/OME-1077/make-the-studio-compose-builder-recipe-native-solofusionpipeline-with
+status: in_progress
+type: feature
+priority: 3   # Medium
+labels: [desktop/ensemble, agentic, autonomous]
+created: 2026-09-02
+closed:
+---
+
+# OME-1077 — Make the Studio compose builder recipe-native (solo/fusion/pipeline) with live url4
+
+Reshape `apps/screamingface-studio/frontend`'s compose panel from the flat "Loop + Reduce /
+strategy / judge" model to a recipe-native builder (Solo / Fusion+required-synthesizer /
+Pipeline, nested arbitrarily) that generates url4 live, plus UX cleanup (nav, run controls,
+templates). Frontend-only / mock this pass. Delivered as lightweight live iteration under one
+ticket. Ledger: `docs/work/2026-09-02-OME-1077-studio-recipe-native-builder.md`.
+
+**Temporary label** `desktop/ensemble` — Studio has no landing leaf yet; owner to create
+`screamingface-studio` and relabel. **Before PR:** register the stack in `.claude/sdlc.local.md`,
+add a vitest/Testing-Library harness + `typecheck` script, run gates green.

--- a/docs/work/2026-09-02-OME-1077-studio-recipe-native-builder.md
+++ b/docs/work/2026-09-02-OME-1077-studio-recipe-native-builder.md
@@ -1,0 +1,57 @@
+---
+ticket: OME-1077
+stack: screamingface-studio   # NOT yet registered in .claude/sdlc.local.md (sdlc-react); gates TBD before PR
+status: in_progress   # planned | in_progress | done | blocked
+started: 2026-09-02
+finished:
+---
+
+# OME-1077 — Make the Studio compose builder recipe-native (solo/fusion/pipeline) with live url4
+
+## Intent
+
+Reshape the ScreamingFace Studio frontend so the compose panel matches ScreamingFace's real
+artifacts (Solo / Fusion+required-synthesizer / Pipeline, nested arbitrarily; reduction is the
+synthesizer, not a separate primitive) and generates url4 live as the user builds — plus a set
+of UX improvements (nav cleanup, run controls). Frontend-only / mock this pass; url4 is a
+structurally-faithful TypeScript preview, not the engine's canonical string. Delivered as
+lightweight live iteration under this single ticket.
+
+## Planned changes
+
+**Phase 1 — quick wins**
+- `src/components/app-sidebar.tsx` — remove the Scripts nav entry + badge + `useScriptStore` use
+  (keep `scripts/page.tsx` + `script-store.ts` on disk). Nav → Fusions · Models · Leaderboard.
+- `src/app/(studio)/models/page.tsx` — lower-right "Start building a fusion" button → `/ensembles/new/`.
+- `src/app/(studio)/ensembles/new/page.tsx` — sample size 1/50/100/Custom (keep Full); add
+  `useCache` + `saveCache` run toggles (saveCache defaults ON).
+- `src/lib/ensemble-store.ts` — extend `SavedRun` with `useCache` / `saveCache`.
+
+**Phase 2 — recipe-native builder + live url4** (later units in this ticket)
+- New `src/lib/recipe.ts` — recursive `RecipeNode` union + `recipeToUrl4`.
+- `src/lib/ensemble-store.ts` — `root: RecipeNode` + persist migration.
+- New `src/components/builder/*` — recursive builder UI; remove Loop/Reduce/strategy/judge.
+- New `src/lib/recipe-templates.ts` + template picker.
+
+## Test plan
+
+Studio has no test harness yet. Before PR: register the stack, add vitest + Testing-Library +
+a `typecheck` script, then cover (RED-first): `recipeToUrl4` structural output, the
+`ensemble-store` migration (legacy slots → Fusion), and builder add/nest/remove actions.
+During live iteration: manual verification against the running dev server.
+
+## Acceptance
+
+- Nav shows only Fusions/Models/Leaderboard; `/scripts/` no longer linked.
+- Models page has a lower-right "Start building a fusion" opening an empty builder.
+- Sample size offers 1/50/100/Custom (+Full); cache toggles present, saveCache on by default.
+- Builder is recipe-native: start from Fusion or Pipeline, nest to any depth, every Fusion has a
+  required configurable synthesizer, Solo exposes model + system prompt + a Parameters drawer; a
+  live url4 preview reflects the tree; templates seed prebuilt recipes. No Reduce/strategy/judge UI.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">


### PR DESCRIPTION
## Summary

  Reshapes the Studio compose experience (`apps/screamingface-studio/frontend`) from a flat
  "Loop + Reduce / strategy / judge" form into a **recipe-native, node-diagram builder** that
  matches ScreamingFace's real artifacts — **Solo** (a unit), **Fusion** (parallel members +
  a required **synthesizer**), **Pipeline** (sequential stages), nested to any depth — and
  generates a **live url4 preview** as you build. Also cleans up the Studio IA and run controls.

  ## What's in it

  **IA + run controls**
  - Hide the Scripts nav item (page kept on disk) → nav is Fusions · Models · Leaderboard.
  - "Start building a fusion" button on the Models page.
  - Sample size 1 / 50 / 100 / Custom (+ Full); `Use cache` / `Save cache` run toggles
    (Save cache on by default), persisted on `SavedRun`.
    
  **Recipe-native builder**
  - New `src/lib/recipe.ts`: recursive `RecipeNode` model (Solo | Fusion+synthesizer |
    Pipeline), factories, kind-switch, traversal, legacy slot→fusion migration, and a
    structurally-faithful **url4 preview serializer**.
  - Compose tab rebuilt as a **node diagram**: only model units + the synthesizer render as
    blocks; fusions/pipelines are bare structural groupings. Uniform sequential-steps flow —
    a fusion is `[parallel members] → [synthesizer]`, a pipeline is `[stage] → [stage]`.
  - Per-node: model picker + system prompt + a Parameters drawer (from the existing catalog);
    collapse to a compact chip (model name on its own row); **rename any node**; add/remove
    members & stages; boundary lines on nested groupings.
  - Canvas **zoom** + horizontal **pan** controls. `SavedEnsemble` gains `root`; `slots`/`judge`
    are derived from the tree so the Runs panel and persistence keep working.
    
  ## Scope / decisions

  - **Frontend-only / mock** this pass — the url4 preview is a structural TypeScript render, not
    the engine's canonical string; params come from the static catalog; runs & leaderboard stay
    mock. Real engine/leaderboard/param-discovery wiring is a separate effort.