### PR TITLE
test(screamingface-engine): derive the benchmark board tuples from the registry

### DIFF
--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import re
+import sys
+from dataclasses import replace
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import pytest
@@ -29,6 +32,7 @@ from screamingface_engine.benchmarks.healthbench.prepare import (
 from screamingface_engine.benchmarks.ifeval.prepare import PrepareError as IFEvalPrepareError
 from screamingface_engine.benchmarks.registry import DEFAULT_BENCHMARK_ASSETS_ROOT
 from url4 import Text
+from url4.peer.server import Url4Node
 
 # WHY resolved + checked: the workflow guard reads a file OUTSIDE this app. In a standalone
 # engine checkout the monorepo siblings are simply absent, and a guard that cannot see its
@@ -192,21 +196,90 @@ def test_asset_bundle_ids_are_safe_directory_names(bundle_id: str) -> None:
         BenchmarkAssetBundle(id=bundle_id, prepare=lambda _out: {})
 
 
-def test_builtins_are_registered_with_their_physical_asset_bundles() -> None:
-    registrations = {
-        registration.benchmark.id: registration.asset_bundle.id
-        for registration in BUILTIN_DEPLOYMENT.registrations
-    }
-
+def test_the_runtime_registry_is_the_deployments_own_registrations() -> None:
     assert BUILTIN_DEPLOYMENT.benchmarks is BUILTIN_BENCHMARKS
-    assert registrations == {
-        "draco": "draco",
-        "draco-3pass": "draco",
-        "gdpval-text": "gdpval",
-        "ifeval": "ifeval",
-        "healthbench-worst30": "healthbench",
-        "healthbench-professional": "healthbench",
-    }
+
+
+def _installer_bundle_id(registration: BenchmarkRegistration) -> str | None:
+    """The bundle directory the board's OWN installer reads, or None when it declares none.
+
+    A board's installer is defined in its family module beside that family's
+    ``ASSET_BUNDLE_ID`` constant, and reads ``assets_root / ASSET_BUNDLE_ID`` — see
+    ``benchmarks/gdpval/exam.py``. So the constant exported next to the installer is the
+    directory the board actually opens at runtime, read here from the board itself rather
+    than from a second list.
+    """
+
+    module = sys.modules.get(registration.benchmark.install.__module__)
+    return getattr(module, "ASSET_BUNDLE_ID", None)
+
+
+def _family_package(registration: BenchmarkRegistration) -> str:
+    """The family package a board's installer lives in — ``...benchmarks.<family>.<module>``."""
+
+    return registration.benchmark.install.__module__.split(".")[-2]
+
+
+@pytest.mark.parametrize(
+    "registration",
+    BUILTIN_DEPLOYMENT.registrations,
+    ids=lambda registration: registration.benchmark.id,
+)
+def test_every_board_is_registered_against_the_bundle_its_installer_reads(
+    registration: BenchmarkRegistration,
+) -> None:
+    """INVARIANT: the deployment bakes the directory the board goes on to open.
+
+    WHY derived rather than a hand-written board->bundle map (OME-1095): the map had to be
+    edited for every new board, and it could only ever restate what the registration already
+    says. Registering a board against another family's bundle bakes one directory and reads
+    another — the board's assets are simply absent at runtime — and that is what this catches
+    for a board nobody has written yet.
+    """
+
+    declared = _installer_bundle_id(registration)
+
+    assert declared is not None, (
+        f"{registration.benchmark.id} installs from "
+        f"{registration.benchmark.install.__module__}, which exports no ASSET_BUNDLE_ID; "
+        "a board must name the asset directory it reads next to the installer that reads it"
+    )
+    assert declared == registration.asset_bundle.id, (
+        f"{registration.benchmark.id} is registered against bundle "
+        f"{registration.asset_bundle.id!r} but its installer reads {declared!r}"
+    )
+
+
+def test_the_bundle_provenance_check_covers_a_board_the_registry_has_never_seen(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The deletion test, made measurable: the check is a pure function of a registration.
+
+    A throwaway board declared here — never added to ``BUILTIN_DEPLOYMENT`` — is checked by
+    the same function the built-ins go through, which is what "a seventh board extends the
+    suite by existing" means in practice.
+    """
+
+    family = ModuleType("screamingface_engine.benchmarks.throwaway.exam")
+    family.ASSET_BUNDLE_ID = "throwaway"  # type: ignore[attr-defined]
+
+    def install(_node: Url4Node, _assets: Path) -> None:
+        """The board's installer, defined in its family module beside the constant above."""
+
+    install.__module__ = family.__name__
+    monkeypatch.setitem(sys.modules, family.__name__, family)
+    bundle = BenchmarkAssetBundle(id="throwaway", prepare=lambda _out: {})
+    board = replace(_benchmark("throwaway-text"), install=install)
+
+    matched = BenchmarkRegistration(board, asset_bundle=bundle)
+    assert _installer_bundle_id(matched) == matched.asset_bundle.id
+    assert _family_package(matched) == "throwaway"
+
+    borrowed = BenchmarkRegistration(
+        board,
+        asset_bundle=BenchmarkAssetBundle(id="someone-elses", prepare=lambda _out: {}),
+    )
+    assert _installer_bundle_id(borrowed) != borrowed.asset_bundle.id
 
 
 def test_benchmark_image_invokes_only_the_registered_asset_orchestrator() -> None:
@@ -289,9 +362,17 @@ def test_the_family_guard_does_not_flag_the_orchestrator_itself() -> None:
 
 
 def test_the_family_guard_covers_every_family_preparer_package() -> None:
-    """WHY: a guard derived from a mistyped path would match nothing and pass in silence."""
+    """WHY: a guard derived from a mistyped path would match nothing and pass in silence.
 
-    assert set(FAMILY_PACKAGES) == {"draco", "gdpval", "healthbench", "ifeval"}
+    Both sides are derived (OME-1095): the families found on disk must be exactly the
+    families the registered boards install from, so a preparer package nobody deploys — or a
+    deployed family whose preparer vanished — fails here instead of going unguarded.
+    """
+
+    assert FAMILY_PACKAGES
+    assert set(FAMILY_PACKAGES) == {
+        _family_package(registration) for registration in BUILTIN_DEPLOYMENT.registrations
+    }
     for family in FAMILY_PACKAGES:
         assert _FAMILY_PREPARER.search(f"-m screamingface_engine.benchmarks.{family}.prepare")
 

--- a/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_deployment.py
@@ -13,10 +13,7 @@ from typing import Any
 import pytest
 
 from screamingface_engine.benchmarks import prepare as prepare_module
-from screamingface_engine.benchmarks.builtins import (
-    BUILTIN_BENCHMARKS,
-    BUILTIN_DEPLOYMENT,
-)
+from screamingface_engine.benchmarks.builtins import BUILTIN_DEPLOYMENT
 from screamingface_engine.benchmarks.definition import Benchmark
 from screamingface_engine.benchmarks.deployment import (
     BenchmarkAssetBundle,
@@ -196,10 +193,6 @@ def test_asset_bundle_ids_are_safe_directory_names(bundle_id: str) -> None:
         BenchmarkAssetBundle(id=bundle_id, prepare=lambda _out: {})
 
 
-def test_the_runtime_registry_is_the_deployments_own_registrations() -> None:
-    assert BUILTIN_DEPLOYMENT.benchmarks is BUILTIN_BENCHMARKS
-
-
 def _installer_bundle_id(registration: BenchmarkRegistration) -> str | None:
     """The bundle directory the board's OWN installer reads, or None when it declares none.
 
@@ -253,11 +246,12 @@ def test_every_board_is_registered_against_the_bundle_its_installer_reads(
 def test_the_bundle_provenance_check_covers_a_board_the_registry_has_never_seen(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The deletion test, made measurable: the check is a pure function of a registration.
+    """The check is a pure function of a registration — it holds no board ids of its own.
 
-    A throwaway board declared here — never added to ``BUILTIN_DEPLOYMENT`` — is checked by
-    the same function the built-ins go through, which is what "a seventh board extends the
-    suite by existing" means in practice.
+    A throwaway board declared here, never added to ``BUILTIN_DEPLOYMENT``, goes through the
+    same helper the built-ins do, and the helper both accepts the matched bundle and rejects
+    a borrowed one. That is the property this test claims and nothing more: it exercises the
+    helper, not a real board's runtime — an actual seventh board is only proven by adding one.
     """
 
     family = ModuleType("screamingface_engine.benchmarks.throwaway.exam")

--- a/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI
 
 from screamingface_engine.app import create_app
 from screamingface_engine.benchmarks import Benchmark, BenchmarkRegistry, candidate
-from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
+from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS, BUILTIN_DEPLOYMENT
 from screamingface_engine.config import Settings
 from screamingface_engine.testing import InMemoryEventStream
 
@@ -104,33 +104,53 @@ async def test_a_dataset_link_that_is_not_an_absolute_web_url_is_refused(referen
         _benchmark(dataset_url=reference)
 
 
-async def test_every_installed_benchmark_publishes_a_focus_line() -> None:
+@pytest.mark.parametrize(
+    "benchmark",
+    tuple(BUILTIN_BENCHMARKS),
+    ids=lambda benchmark: benchmark.id,
+)
+async def test_every_installed_benchmark_publishes_a_focus_line(benchmark: Benchmark) -> None:
     # STORY: the portal's "Focus" column is filled from the Engine, not hand-copied into a chart.
-    assert {benchmark.id: benchmark.focus for benchmark in BUILTIN_BENCHMARKS} == {
-        "draco": "Research reports with citations",
-        # Same dataset and subject as the canonical board — the judge-pass count is the only
-        # thing that separates them, so that is what a reader needs in the Focus column.
-        "draco-3pass": "Research reports, three judge passes",
-        "gdpval-text": "Real professional work, prose deliverables",
-        # The two HealthBench boards share a dataset, so their focus lines have to separate
-        # them at a glance — that is the only place a reader sees the difference.
-        "healthbench-professional": "Clinical safety, full official exam",
-        "healthbench-worst30": "Clinical safety, hardest cases",
-        "ifeval": "Instruction following",
-    }
+    # WHY not a table of the exact lines (OME-1095): the wording is authored in the board's own
+    # definition module and reviewed in that diff; a second copy here would only have to be
+    # edited by hand for every new board. What the shared suite owns is that the column is
+    # never empty for a registered board.
+    assert benchmark.focus
 
 
-async def test_only_the_benchmarks_with_a_public_dataset_publish_a_link() -> None:
-    # WHY IFEval has none: its dataset is vendored inside the Engine
-    # (screamingface_engine.benchmarks.ifeval.vendor), so no single public URL is authoritative.
-    assert {benchmark.id: benchmark.dataset_url for benchmark in BUILTIN_BENCHMARKS} == {
-        "draco": "https://huggingface.co/datasets/perplexity-ai/draco",
-        "draco-3pass": "https://huggingface.co/datasets/perplexity-ai/draco",
-        "gdpval-text": "https://huggingface.co/datasets/openai/gdpval",
-        "healthbench-professional": "https://huggingface.co/datasets/openai/healthbench",
-        "healthbench-worst30": "https://huggingface.co/datasets/openai/healthbench",
-        "ifeval": None,
-    }
+async def test_no_two_boards_are_published_under_the_same_focus_line() -> None:
+    """INVARIANT: the Focus column is where a reader tells two boards over one dataset apart.
+
+    The two HealthBench boards share a dataset and the two DRACO boards share cases, rubrics
+    and dataset alike — the focus line is the only place the leaderboard shows the difference.
+    Two boards sharing one line leaves a reader with two indistinguishable rows.
+    """
+
+    lines = [benchmark.focus for benchmark in BUILTIN_BENCHMARKS]
+
+    assert len(set(lines)) == len(lines), f"duplicate focus lines across boards: {lines}"
+
+
+async def test_boards_baked_from_one_asset_bundle_publish_one_dataset_link() -> None:
+    """INVARIANT: one physical dataset, one published link — derived, not hand-listed.
+
+    A board's dataset link is a fact about the assets it reads, and boards that share an
+    asset bundle read the same baked files. Two links under one bundle means at least one
+    board sends a reader to a dataset it was not built from.
+
+    WHY nothing here asserts which boards have a link at all: that is a per-board editorial
+    fact (IFEval publishes none because its dataset is vendored inside the Engine, so no
+    public URL is authoritative), owned by the board's definition module.
+    """
+
+    published: dict[str, set[str | None]] = {}
+    for registration in BUILTIN_DEPLOYMENT.registrations:
+        published.setdefault(registration.asset_bundle.id, set()).add(
+            registration.benchmark.dataset_url
+        )
+
+    conflicting = {bundle: links for bundle, links in published.items() if len(links) > 1}
+    assert not conflicting, f"one asset bundle, more than one dataset link: {conflicting}"
 
 
 async def test_the_catalog_publishes_the_computed_revision_untouched_by_display_metadata() -> None:

--- a/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
@@ -39,7 +39,12 @@ async def test_the_public_catalogue_publishes_exactly_the_registered_boards() ->
     place a board is declared, and a second list here had to be edited by hand for every new
     board — the exact cost this epic removes. What is load bearing is the relationship: what
     an operator registered is what a client can discover, under the ids it was registered
-    with, each exactly once.
+    with.
+
+    WHAT THIS DOES NOT COVER: membership. Both sides derive from the same registrations, so
+    deleting a board from `builtins.py` makes it vanish from both and passes here. That a
+    given board is public is pinned in the board's own definition test — see
+    `test_both_draco_boards_are_registered_under_their_own_ids` and its siblings.
     """
 
     registered = sorted(
@@ -59,7 +64,6 @@ async def test_the_public_catalogue_publishes_exactly_the_registered_boards() ->
     published = [entry["id"] for entry in entries]
 
     assert sorted(published) == registered
-    assert len(set(published)) == len(published)
 
 
 def test_canonical_draco_limit_changes_cases_only_not_grading_strength() -> None:

--- a/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_protocol.py
@@ -6,9 +6,11 @@ import asyncio
 import hashlib
 import json
 
+import httpx
 import pytest
 
-from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
+from screamingface_engine.app import create_app
+from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS, BUILTIN_DEPLOYMENT
 from screamingface_engine.benchmarks.case_execution import (
     CASE_EXECUTION_SCHEMA,
     install_case_execution,
@@ -22,24 +24,42 @@ from screamingface_engine.benchmarks.protocol import (
     build_evaluation_protocol,
     preserve_candidate_outcome,
 )
+from screamingface_engine.config import Settings
+from screamingface_engine.testing import InMemoryEventStream
 from url4 import RelExpr, Text, expr, render, src, struct
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
 
 
-def test_public_catalogue_contains_exactly_the_six_product_benchmarks() -> None:
-    # OME-903 added the professional board beside the worst-30% challenge; the 3-pass DRACO
-    # board joined the canonical one; all are complete, independently meaningful benchmark
-    # identities over one baked answer key.
-    assert tuple(benchmark.id for benchmark in BUILTIN_BENCHMARKS) == (
-        "draco",
-        "draco-3pass",
-        # OME-971 added the GDPval text subset — the prose-only slice of the open gold set.
-        "gdpval-text",
-        "healthbench-professional",
-        "healthbench-worst30",
-        "ifeval",
+@pytest.mark.asyncio
+async def test_the_public_catalogue_publishes_exactly_the_registered_boards() -> None:
+    """Every board this deployment registers is discoverable on the wire, and nothing else is.
+
+    WHY derived rather than a hand-typed tuple of ids (OME-1095): the deployment is the ONE
+    place a board is declared, and a second list here had to be edited by hand for every new
+    board — the exact cost this epic removes. What is load bearing is the relationship: what
+    an operator registered is what a client can discover, under the ids it was registered
+    with, each exactly once.
+    """
+
+    registered = sorted(
+        registration.benchmark.id for registration in BUILTIN_DEPLOYMENT.registrations
     )
+    app = create_app(
+        Settings(jwt_secret="s"),
+        stream=InMemoryEventStream(),
+        benchmarks=BUILTIN_BENCHMARKS,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://engine.test",
+    ) as client:
+        entries = (await client.get("/v1/benchmarks")).json()["data"]
+
+    published = [entry["id"] for entry in entries]
+
+    assert sorted(published) == registered
+    assert len(set(published)) == len(published)
 
 
 def test_canonical_draco_limit_changes_cases_only_not_grading_strength() -> None:

--- a/apps/screamingface-engine/tests/unit/test_draco_3pass_definition.py
+++ b/apps/screamingface-engine/tests/unit/test_draco_3pass_definition.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 from benchmark_support import install_benchmarks
 
+from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.case_execution import case_execution_payload
 from screamingface_engine.benchmarks.contract import encode_candidate_invocation
 from screamingface_engine.benchmarks.draco import aggregate as agg
@@ -58,6 +59,28 @@ def _url4(benchmark, limit: int | None = None) -> str:
 def test_the_canonical_revision_is_frozen_against_refactors() -> None:
     assert DRACO.revision == CANONICAL_REVISION
     assert CANONICAL_EXAM.revision == CANONICAL_REVISION
+
+
+def test_both_draco_boards_are_registered_under_their_own_ids() -> None:
+    """INVARIANT: these boards are PUBLIC — dropping one is a leaderboard regression.
+
+    WHY here and not in a shared test (OME-1095): the shared suite iterates the registry, so
+    a board deleted from `builtins.py` simply stops being iterated and every cross-benchmark
+    test still passes. Membership can only be pinned by a test that names the board, and the
+    board's own definition module is where that costs one line per new board instead of an
+    edit to every shared test.
+    """
+
+    assert BUILTIN_BENCHMARKS.get("draco") is DRACO
+    assert BUILTIN_BENCHMARKS.get("draco-3pass") is DRACO_3PASS
+
+
+def test_both_draco_boards_link_the_perplexity_dataset() -> None:
+    # WHY the literal, on both boards: the leaderboard renders this as a clickable target for
+    # the public. The shared suite can only check that boards sharing a bundle agree — and
+    # both DRACO boards read one constant, so they would agree on a wrong value too.
+    assert DRACO.dataset_url == "https://huggingface.co/datasets/perplexity-ai/draco"
+    assert DRACO_3PASS.dataset_url == DRACO.dataset_url
 
 
 def test_the_three_pass_board_has_its_own_identity() -> None:

--- a/apps/screamingface-engine/tests/unit/test_gdpval_definition.py
+++ b/apps/screamingface-engine/tests/unit/test_gdpval_definition.py
@@ -7,6 +7,7 @@ keeping its addresses — would silently re-grade published submissions.
 
 from __future__ import annotations
 
+from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.gdpval.definition import (
     GDPVAL_TEXT,
     TEXT_CASE_COUNT,
@@ -23,6 +24,23 @@ _BASE = {
     "selection_sha": subset_sha(),
     "scoring": "rubric-mean-v1",
 }
+
+
+def test_the_text_board_is_registered_under_its_id() -> None:
+    """INVARIANT: this board is PUBLIC — dropping it is a leaderboard regression.
+
+    The shared cross-benchmark tests iterate the registry, so a board deleted from
+    `builtins.py` stops being iterated and they all still pass (OME-1095). Membership is
+    pinned here, in the board's own module, where a new board costs one line.
+    """
+
+    assert BUILTIN_BENCHMARKS.get("gdpval-text") is GDPVAL_TEXT
+
+
+def test_the_text_board_links_the_openai_gdpval_dataset() -> None:
+    # WHY the literal: the leaderboard renders this as a clickable target for the public, and
+    # the shared suite can only check that boards sharing a bundle agree on it.
+    assert GDPVAL_TEXT.dataset_url == "https://huggingface.co/datasets/openai/gdpval"
 
 
 def test_the_board_serves_the_frozen_selection() -> None:

--- a/apps/screamingface-engine/tests/unit/test_healthbench_definition.py
+++ b/apps/screamingface-engine/tests/unit/test_healthbench_definition.py
@@ -114,6 +114,14 @@ def test_the_worst30_revision_is_frozen_against_refactors() -> None:
     assert WORST30_EXAM.revision == "39cfd96b068f7230"
 
 
+def test_both_healthbench_boards_link_the_openai_healthbench_dataset() -> None:
+    # WHY the literal, on both boards: the leaderboard renders this as a clickable target for
+    # the public. The shared suite can only check that boards sharing a bundle agree — and
+    # both boards read one constant, so they would agree on a wrong value too (OME-1095).
+    assert HEALTHBENCH_WORST30.dataset_url == "https://huggingface.co/datasets/openai/healthbench"
+    assert HEALTHBENCH_PROFESSIONAL.dataset_url == HEALTHBENCH_WORST30.dataset_url
+
+
 def test_a_limit_slices_the_worst30_run() -> None:
     limited = HEALTHBENCH_WORST30.resource(3)
     assert limited["case_count"] == 157

--- a/apps/screamingface-engine/tests/unit/test_ifeval_official_identity.py
+++ b/apps/screamingface-engine/tests/unit/test_ifeval_official_identity.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.case_execution import case_execution_payload
 from screamingface_engine.benchmarks.contract import encode_candidate_invocation
 from screamingface_engine.benchmarks.ifeval.aggregate import (
@@ -22,6 +23,7 @@ from screamingface_engine.benchmarks.ifeval.aggregate import (
     load_case_order,
 )
 from screamingface_engine.benchmarks.ifeval.case_evaluation import bind_case_evaluation
+from screamingface_engine.benchmarks.ifeval.definition import IFEVAL
 from screamingface_engine.benchmarks.ifeval.prepare import (
     KNOWN_DIVERGENT_KEYS,
     PrepareError,
@@ -29,6 +31,26 @@ from screamingface_engine.benchmarks.ifeval.prepare import (
     official_rows,
     verify_against_official,
 )
+
+
+def test_the_ifeval_board_is_registered_under_its_id() -> None:
+    """INVARIANT: this board is PUBLIC — dropping it is a leaderboard regression.
+
+    The shared cross-benchmark tests iterate the registry, so a board deleted from
+    `builtins.py` stops being iterated and they all still pass (OME-1095). Membership is
+    pinned here, in the board's own module, where a new board costs one line.
+    """
+
+    assert BUILTIN_BENCHMARKS.get("ifeval") is IFEVAL
+
+
+def test_the_ifeval_board_publishes_no_dataset_link() -> None:
+    # WHY none: the dataset is vendored inside the Engine
+    # (screamingface_engine.benchmarks.ifeval.vendor), so no single public URL is
+    # authoritative. The shared suite cannot express this — "which boards have a link" is a
+    # per-board editorial fact, so it is pinned beside the board that decides it.
+    assert IFEVAL.dataset_url is None
+    assert IFEVAL.focus
 
 
 def _official(key: int) -> dict[str, object]:

--- a/docs/tasks/2026-09-03-OME-1095-registry-derived-board-tests.md
+++ b/docs/tasks/2026-09-03-OME-1095-registry-derived-board-tests.md
@@ -1,0 +1,36 @@
+---
+id: OME-1095
+linear_url: https://linear.app/openmined/issue/OME-1095/derive-the-hand-listed-benchmark-board-tuples-in-engine-tests-from-the
+status: in_progress
+type:
+priority: high
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+created: 2026-09-03
+closed:
+---
+
+# Derive the hand-listed benchmark board tuples in engine tests from the registry
+
+The engine has one registry of benchmark boards (`BUILTIN_BENCHMARKS` / `BUILTIN_DEPLOYMENT`
+in `benchmarks/builtins.py`). Four engine test files kept their own copies of that list: an
+exact six-id tuple, a board -> asset-bundle map, a board -> focus map and a board -> dataset
+map. Every new board meant editing them by hand, which is the opposite of the epic's promise
+(one author module plus a dataset mapping, zero edits to shared tests).
+
+This unit makes the cross-benchmark tests iterate the registry and assert per-board
+invariants derived from each board's own registration, so a seventh board extends the suite
+by existing.
+
+Scope guard: tests only, no production code. The e2e `BOARDS` list in
+`packages/screamingface/tests/e2e/test_boards.py` is out of scope (OME-1098).
+
+## Acceptance
+
+- No engine test file contains a hand-typed tuple or map of board ids.
+- The per-board checks are pure functions of a registration, proven by running them over a
+  throwaway board the registry has never seen.
+- The "exactly the registered boards are public" guarantee survives as a registry-derived
+  assertion.

--- a/docs/work/2026-09-03-OME-1095-registry-derived-board-tests.md
+++ b/docs/work/2026-09-03-OME-1095-registry-derived-board-tests.md
@@ -1,0 +1,66 @@
+---
+ticket: OME-1095
+stack: screamingface-engine
+status: done
+started: 2026-09-03
+finished: 2026-09-03
+---
+
+# OME-1095 — Derive the hand-listed benchmark board tuples in engine tests from the registry
+
+## Intent
+
+Cross-benchmark engine tests carry their own copies of the board list — an exact six-id
+tuple plus board->bundle, board->focus and board->dataset maps. Adding a board means editing
+them by hand, so the epic's deletion test ("a new benchmark is one author module and a
+dataset mapping, zero edits to shared tests") is unmeasurable. Make the shared tests iterate
+`BUILTIN_DEPLOYMENT` / `BUILTIN_BENCHMARKS` and assert invariants derived from each board's
+own registration.
+
+## Planned changes
+
+- `apps/screamingface-engine/tests/unit/test_benchmark_protocol.py` — the six-id tuple becomes
+  a registry-derived "the catalogue publishes exactly the registered boards, in stable id
+  order" assertion.
+- `apps/screamingface-engine/tests/unit/test_benchmark_deployment.py` — the board->bundle map
+  becomes a parametrized provenance check (a board's bundle is the `ASSET_BUNDLE_ID` exported
+  by the module that defines its installer, i.e. the directory the board actually reads), plus
+  a throwaway-board test proving the check is a pure function of a registration; the
+  hand-typed `FAMILY_PACKAGES` set becomes the families of the registered boards' installers.
+- `apps/screamingface-engine/tests/unit/test_benchmark_display_metadata.py` — the focus and
+  dataset maps become per-board invariants: every board declares a focus, focus lines are
+  unique across boards (that is what separates two boards over one dataset), and boards that
+  share an asset bundle declare the same dataset link.
+
+## Test plan
+
+Tests are the deliverable. Each replacement must fail for the reason it names:
+- catalogue vs registry: a registered board missing from the catalogue, or an unsorted id order.
+- bundle provenance: a board registered against another family's bundle.
+- family guard: a family package with a `prepare.py` that no registered board uses.
+- display: a board without a focus; two boards sharing a focus line; two boards on one bundle
+  declaring different dataset links.
+Verified by running the four affected test modules (free, no paid models).
+
+## Acceptance
+
+- No engine test file contains a hand-typed tuple or map of board ids.
+- Per-board checks run over a throwaway registration without edits.
+- No production code changes.
+
+## Outcome
+
+- **Actual files:** as planned — `tests/unit/test_benchmark_protocol.py`,
+  `tests/unit/test_benchmark_deployment.py`, `tests/unit/test_benchmark_display_metadata.py`.
+  No production code touched.
+- **Commits:** see the PR (`OME-1095-registry-derived-board-tests`).
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` — ALL GATES GREEN
+  (2280 passed, 5 skipped). The append-only check is skipped BY DESIGN for this unit: rewriting
+  the hand-listed prior tests IS the deliverable the ticket approves, and the skip flag is the
+  runner's own escape hatch rather than an edit to the gate.
+- **Deviations:** each replacement was mutation-verified rather than trusted — a board
+  registered against another family's bundle, an orphan preparer family, two boards sharing a
+  focus line, two dataset links under one bundle, and a board dropped by the catalogue route
+  each fail exactly one new test. The first draft's registry-vs-catalogue assertion was
+  tautological (the registry derives from the registrations and sorts its own ids), so it now
+  reads the catalogue over HTTP, where a route that drops a board is caught.

--- a/docs/work/2026-09-03-OME-1095-registry-derived-board-tests.md
+++ b/docs/work/2026-09-03-OME-1095-registry-derived-board-tests.md
@@ -58,6 +58,18 @@ Verified by running the four affected test modules (free, no paid models).
   (2280 passed, 5 skipped). The append-only check is skipped BY DESIGN for this unit: rewriting
   the hand-listed prior tests IS the deliverable the ticket approves, and the skip flag is the
   runner's own escape hatch rather than an edit to the gate.
+- **Review round 1 (request-changes), both blockers closed:** removing the six-id tuple left
+  board MEMBERSHIP uncovered — deleting `draco-3pass` from `builtins.py` passed the whole
+  suite, because the catalogue test compares the route against the same registrations the
+  registry is built from. And "one bundle, one dataset link" could not catch a family-wide
+  wrong value, since each family declares one shared `*_DATASET_URL` its boards both read.
+  Both facts are per-board, so both are now pinned in each board's OWN definition test
+  (`test_draco_3pass_definition.py`, `test_gdpval_definition.py`,
+  `test_ifeval_official_identity.py`, `test_healthbench_definition.py`) — one line per new
+  board in the author's module, so the deletion test still holds. Verified: unregistering
+  `draco-3pass` or `gdpval-text`, pointing `DRACO_DATASET_URL` at another dataset, and giving
+  IFEval a link each now fail. Two vacuous assertions were deleted and one over-claiming
+  docstring corrected in the same round.
 - **Deviations:** each replacement was mutation-verified rather than trusted — a board
   registered against another family's bundle, an orphan preparer family, two boards sharing a
   focus line, two dataset links under one bundle, and a board dropped by the catalogue route


### PR DESCRIPTION
Closes OME-1095. Cross-benchmark engine tests now iterate the board registry instead of keeping their own copy of it. Tests only — no production code changed.

## Before / After

### Before
- Trigger: a dev adds or removes a benchmark board.
- Today: three shared test files hand-list the boards — an exact six-id tuple, a board→asset-bundle map, a board→focus map and a board→dataset map — and every one of them has to be edited by hand. Adding `gdpval-text` two weeks ago meant editing each; the e2e board list was simply forgotten, so a registered board sat with no e2e coverage and nothing noticed.
- Cost: "add a board" is really "edit five test files", the opposite of what this epic promises (one author module plus a dataset mapping, zero edits to shared tests). Stale lists also hide that a board has no coverage at all.

### After
- Same trigger.
- Now: the shared tests iterate `BUILTIN_DEPLOYMENT` / `BUILTIN_BENCHMARKS` and assert invariants read from each board's own registration. A seventh board extends the suite by existing.
- Win: the deletion test this epic is graded on becomes measurable in CI — adding a board changes no shared test.

### Don't regress
- "Exactly the registered boards are public" survives, now checked over the wire: the catalogue served at `/v1/benchmarks` must list exactly the deployment's registrations, each once.
- The two DRACO boards and the two HealthBench boards stay distinguishable to a leaderboard reader (unique focus lines).
- No production code changes.

## What replaced what

| Hand-typed before | Derived now | Fails when |
|---|---|---|
| six-id tuple (`test_benchmark_protocol.py`) | catalogue response vs `BUILTIN_DEPLOYMENT.registrations` | a route drops or aliases a registered board |
| board→bundle map (`test_benchmark_deployment.py`) | a board's bundle vs the `ASSET_BUNDLE_ID` exported beside its installer — the directory the board actually opens | a board is registered against another family's bundle (bakes one directory, reads another) |
| `{"draco", "gdpval", "healthbench", "ifeval"}` family set | the families the registered boards' installers live in | a preparer package nobody deploys, or a deployed family whose preparer vanished |
| board→focus map (`test_benchmark_display_metadata.py`) | every board declares a focus; no two boards share a focus line | a board ships with an empty Focus column, or two boards over one dataset become indistinguishable rows |
| board→dataset map | boards sharing an asset bundle publish one dataset link | a board links a dataset it was not built from |

Exact blurb wording is no longer restated here — it is authored in the board's definition module and reviewed in that diff, which is the duplication this ticket removes.

## Verification

Every replacement was mutation-tested, not trusted. Each of these fails exactly one new test and nothing else: `gdpval-text` registered against the DRACO bundle; the GDPval board unregistered while its preparer stays on disk; `draco-3pass` given DRACO's focus line; `draco-3pass` pointed at another dataset; `ifeval` filtered out of the catalogue route.

Gates: `run_gates.py screamingface-engine --skip-append-only` — all green (2286 passed, 5 skipped). The append-only check is skipped deliberately: rewriting these prior tests IS the approved deliverable, and `--skip-append-only` is the runner's own flag, not an edit to the gate.

## Out of scope

The e2e `BOARDS` list in `packages/screamingface/tests/e2e/test_boards.py` — that lands with the goldens ticket (OME-1098).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
