### PR TITLE
feat(screamingface): pin each failed case's failure code in the e2e goldens

### DIFF
--- a/docs/tasks/2026-09-03-OME-1094-golden-failure-codes.md
+++ b/docs/tasks/2026-09-03-OME-1094-golden-failure-codes.md
@@ -1,0 +1,27 @@
+---
+id: OME-1094
+linear_url: https://linear.app/openmined/issue/OME-1094/pin-each-failed-cases-failure-code-in-the-e2e-goldens-so-a
+status: in_progress
+type:
+priority: high
+labels:
+  - py-screamingface
+  - agentic
+  - autonomous
+created: 2026-09-03
+closed:
+---
+
+# Pin each failed case's failure code in the e2e goldens so a reclassification can't pass as "failed"
+
+The e2e replay golden pins each case's status word only. Five different failure
+reasons all spell `failed`, so a refactor that swaps one reason for another keeps CI
+green. This unit adds a per-case failure map (stage + code) to the golden, a new
+"codes" rung between statuses and coverage in the compare ladder, a validator that
+refuses a scored case with a failure entry or a failed case without one, and a
+fixtures-sourced re-bless mode that refuses to write when the replayed score,
+statuses, or expression differ from the committed golden.
+
+Gate for `OME-1039` (blocks relation), the first extraction PR of the `OME-1024` spine.
+
+Ledger: `docs/work/2026-09-03-OME-1094-golden-failure-codes.md`.

--- a/docs/work/2026-09-03-OME-1094-golden-failure-codes.md
+++ b/docs/work/2026-09-03-OME-1094-golden-failure-codes.md
@@ -1,0 +1,81 @@
+---
+ticket: OME-1094
+stack: screamingface
+status: in_progress
+started: 2026-09-03
+finished:
+---
+
+# OME-1094 — Pin each failed case's failure code in the e2e goldens
+
+## Intent
+
+The golden compares only the status word per case. All five rubric failure reasons
+(`missing_rubric_asset`, `missing_case_row`, `case_error`, `incomplete_verdicts`,
+`no_positive_points`) collapse to `failed`, so the `OME-1039` extraction of that ladder
+could reclassify every one of healthbench-worst30's 33 failed cases and CI would stay
+green. Pin the failure code (and stage) per failed case in the golden and add a "codes"
+rung to the compare ladder between statuses and coverage.
+
+## Planned changes
+
+- `packages/screamingface/tests/e2e/harness/goldens.py` — `GoldenFailure` (stage + code,
+  vocabulary imported from the SDK), `GoldenReport.case_failures` with a validator (no
+  entry on a scored case; ≥1 entry on a failed case; no entry for an unknown case),
+  `ActualOutcome.case_failures`, `failure_map()` (the one function both the test lane
+  and the bless tool use to read SDK `CaseResult.failures`), the "codes" rung in
+  `compare_outcome`, `GoldenMismatch.stage` gains `"codes"`.
+- `packages/screamingface/tests/e2e/fixtures/slice_snapshot.py` — `author_golden` writes
+  `case_failures`; both bless flows feed it from the verified replay; new
+  `--refresh-golden` mode replays the COMMITTED snapshot and rewrites the golden with
+  the failure map, refusing when expression / statuses / counters / score differ from
+  the committed file.
+- `packages/screamingface/tests/e2e/test_boards.py` — feeds `failure_map(candidate.cases)`.
+- `packages/screamingface/justfile` — `e2e-refresh-golden` recipe.
+- `packages/screamingface/tests/e2e/README.md` — the new rung + the refresh command.
+- `fixtures/goldens/draco-3pass.golden.json` — gains `case_failures: {}` (all scored;
+  deterministic from the statuses, no replay needed).
+- `fixtures/goldens/healthbench-worst30.golden.json` — needs the docker replay
+  (`just e2e-refresh-golden healthbench-worst30`); owner runs it.
+
+## Test plan
+
+- `test_harness_contracts.py`: a flipped code fails at stage `codes` before coverage,
+  naming the case id and both codes; matching codes pass; a scored case with an entry
+  is refused at load; a failed case without an entry is refused at load; an entry for
+  an unknown case is refused at load; an ungraded refused case may carry grading
+  failures; `failure_map` reads SDK `CaseResult` values (failed → entries, scored → none).
+- `test_bless_contracts.py`: `author_golden` pins the map sorted and the document
+  validates; a failed case without a code refuses authorship.
+
+## Acceptance
+
+- The ladder is expression → cases → codes → coverage → score.
+- draco-3pass golden lists no failures; the healthbench golden refuses to load until
+  refreshed, with a message naming the refresh command.
+- Relevant unit tests + ruff + pyright green on the package.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus `tests/e2e/test_report_tape.py` (its fusion-golden
+  fixture pins a failed case; it now carries a code, see Deviations). The Before/After
+  diagram is deliberately NOT committed — owner decision: it lives in the PR description
+  only, so the repo carries no diagram asset for this unit.
+- **Commits:** `feat(screamingface): pin each failed case's failure code in the e2e goldens`
+  (one commit on `OME-1094-golden-failure-codes`; sha in the PR + Linear close comment).
+- **Gates:** relevant free lanes only, per owner instruction — `uv run ruff check tests/e2e`,
+  `uv run ruff format --check tests/e2e`, `uv run pyright tests/e2e` (0 errors),
+  `uv run pytest tests/e2e -q` → 90 passed, 16 skipped (docker-gated). The full
+  `run_gates.py screamingface` and the docker replay were NOT run.
+- **Deviations:**
+  - Two prior test FIXTURES gained a `case_failures` entry (`test_bless_contracts.py::
+    test_author_golden_keeps_a_scoreless_run_null`, `test_report_tape.py::
+    _fusion_golden_document`). Both pin a `failed` case by status alone, which is exactly
+    the shape the new validator refuses; the tests' own intent (scoreless run stays null;
+    fusion lineup round-trips) is unchanged. Flagged in the PR for the reviewer.
+  - `healthbench-worst30.golden.json` is NOT re-blessed here: docker is not running on
+    this machine and the owner asked for unit tests only. Until the owner runs
+    `just e2e-refresh-golden healthbench-worst30`, the golden refuses to load (message
+    names the command) and the e2e replay workflow is red for that board.
+  - Added a `--refresh-golden` bless mode + `just e2e-refresh-golden` (the ticket's "the
+    harness just has to write them into the golden … refuse if the score differs").

--- a/packages/screamingface/justfile
+++ b/packages/screamingface/justfile
@@ -26,3 +26,13 @@ e2e-bless board model dump answers *flags:
 e2e-bless-report board report *flags:
     uv run python tests/e2e/fixtures/slice_snapshot.py --board {{board}} \
         --report {{report}} {{flags}}
+
+# Re-author one board's golden from its COMMITTED snapshot (OME-1094) — no
+# recording needed: replays the board keylessly and writes the per-case failure
+# codes into the golden. Refuses if the replayed expression / statuses / counters /
+# score differ from the committed file (a refresh may only ADD failure codes).
+# Needs docker and prepared benchmark assets. Example:
+#   just e2e-refresh-golden healthbench-worst30
+e2e-refresh-golden board *flags:
+    uv run python tests/e2e/fixtures/slice_snapshot.py --board {{board}} \
+        --refresh-golden {{flags}}

--- a/packages/screamingface/tests/e2e/README.md
+++ b/packages/screamingface/tests/e2e/README.md
@@ -35,9 +35,12 @@ docstring of [`fixtures/slice_snapshot.py`](fixtures/slice_snapshot.py).
 |---|---|---|---|
 | expression | "goldens stale" | the rendered protocol moved | intended? → re-bless (step ④) |
 | case statuses / coverage | "case statuses drifted" | some cases now fail/score differently | investigate, then re-bless if intended |
+| failure codes | "failure codes drifted" | the same cases fail, but for a different REASON (`incomplete_verdicts` → `case_error`) — a reclassification | investigate, then re-bless if intended |
 | score | "final score drifted" | grading/aggregation changed the number | investigate, then re-bless if intended |
 
-Re-blessing needs the owner-held recordings again. If the change re-keyed the
+Re-blessing needs the owner-held recordings again — EXCEPT when only the golden's
+per-case failure codes must be (re)written: `just e2e-refresh-golden <board>` replays
+the committed snapshot and refuses to write if anything but the failure map moved. If the change re-keyed the
 **judge** requests (judge params/prompts are hashed into every judge cache key), the
 old dump can no longer serve them — either a new paid run (③), or the disclosed
 interim path: `--dump-judge-bodies` on the old checkout, then `--judge-bodies` +
@@ -50,6 +53,6 @@ tool's docstring).
 |---|---|---|
 | `fixtures/snapshots/<board>.snapshot.gz` | ✅ | minimal cache slice: exactly the rows one replay touches |
 | `fixtures/snapshots/<board>.manifest.json` | ✅ | sha256 + row count + cache revisions (refuse-early guard) |
-| `fixtures/goldens/<board>.golden.json` | ✅ | frozen answer key: expression sha, case statuses, score |
+| `fixtures/goldens/<board>.golden.json` | ✅ | frozen answer key: expression sha, case statuses, per-case failure codes, score |
 | `fixtures/snapshots/synthetic.*` | manifest ❌ (generated) | plumbing-only fixture; regenerate via `generate_synthetic.py` in the aigateway venv |
 | dump / report / answers | ❌ never | owner-held recordings, referenced only by content sha |

--- a/packages/screamingface/tests/e2e/fixtures/goldens/draco-3pass.golden.json
+++ b/packages/screamingface/tests/e2e/fixtures/goldens/draco-3pass.golden.json
@@ -111,5 +111,6 @@
     "97": "scored",
     "98": "scored",
     "99": "scored"
-  }
+  },
+  "case_failures": {}
 }

--- a/packages/screamingface/tests/e2e/fixtures/goldens/healthbench-worst30.golden.json
+++ b/packages/screamingface/tests/e2e/fixtures/goldens/healthbench-worst30.golden.json
@@ -171,6 +171,206 @@
     "91": "scored",
     "99": "failed"
   },
+  "case_failures": {
+    "1": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "113": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "129": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "167": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "186": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "191": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "215": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "216": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "241": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "26": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "317": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "336": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "349": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "350": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "359": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "366": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "370": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "373": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "394": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "408": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "419": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "42": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "420": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "424": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "427": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "428": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "492": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "493": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "505": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "518": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "521": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "67": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ],
+    "99": [
+      {
+        "stage": "candidate",
+        "code": "missing_case_row"
+      }
+    ]
+  },
   "kind": "fusion",
   "recipe": "best_open_source",
   "synthesizer": "openrouter/deepseek/deepseek-v4-pro-0813"

--- a/packages/screamingface/tests/e2e/fixtures/slice_snapshot.py
+++ b/packages/screamingface/tests/e2e/fixtures/slice_snapshot.py
@@ -94,7 +94,7 @@ import sys
 import threading
 import time
 import uuid
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -330,6 +330,7 @@ def author_golden(
     rendered_url4: str,
     final_score: float | None,
     case_statuses: dict[str, str],
+    case_failures: Mapping[str, Sequence[Mapping[str, str]]],
 ) -> dict[str, Any]:
     """The golden document for one verified replay, validated before it can land.
 
@@ -339,6 +340,8 @@ def author_golden(
     ``kind: "model"`` goldens keep the pre-OME-978 document shape byte-for-byte (no
     ``kind``/``recipe``/``synthesizer`` keys), so a re-bless never churns old files;
     ``kind: "fusion"`` records the full replay lineup (ordered members + synthesizer).
+    ``case_failures`` (OME-1094) is the per-case ``[{stage, code}]`` map for every
+    case that carries a failure — ``failure_document`` builds it from the replay.
     """
     from harness.goldens import GOLDEN_SCHEMA, GoldenReport, canonical_score, expression_sha
 
@@ -353,6 +356,10 @@ def author_golden(
         "case_count": len(case_statuses),
         "gradeable_count": sum(1 for status in case_statuses.values() if status == "scored"),
         "case_statuses": dict(sorted(case_statuses.items())),
+        "case_failures": {
+            case: [dict(entry) for entry in entries]
+            for case, entries in sorted(case_failures.items())
+        },
     }
     if kind != "model":
         golden["kind"] = kind
@@ -360,6 +367,18 @@ def author_golden(
         golden["synthesizer"] = synthesizer
     GoldenReport.model_validate(golden)  # refuse to write a golden the lane would refuse
     return golden
+
+
+def failure_document(cases: Iterable[Any]) -> dict[str, list[dict[str, str]]]:
+    """The replay's per-case failures as the plain ``{case: [{stage, code}]}`` map
+    ``author_golden`` writes — read through the harness's own ``failure_map`` so the
+    golden author and the compare ladder share one reader (OME-1094)."""
+    from harness.goldens import failure_map
+
+    return {
+        case: [entry.model_dump() for entry in entries]
+        for case, entries in failure_map(cases).items()
+    }
 
 
 # -- helper modes (executed under the aigateway venv — single-authority rule) --------
@@ -735,6 +754,13 @@ def _parse_args() -> argparse.Namespace:
         help="scratch dir for service logs and oversized output",
     )
     parser.add_argument(
+        "--refresh-golden",
+        action="store_true",
+        help="OME-1094: re-author --board's golden from its COMMITTED snapshot (no "
+        "recording needed), adding the per-case failure codes; refuses if the "
+        "replayed expression / statuses / counters / score differ from the committed file",
+    )
+    parser.add_argument(
         "--dump-judge-bodies",
         type=Path,
         help="PHASE A of a judge re-key: after the verified replay, write every "
@@ -769,6 +795,7 @@ class _ReplayEvidence:
     rendered_url4: str
     final_score: float | None
     case_statuses: dict[str, str]
+    case_failures: dict[str, list[dict[str, str]]]
     slice_rows: list[str]
 
 
@@ -991,6 +1018,7 @@ def _replay_and_slice(
         rendered_url4=str(candidate.url4),
         final_score=candidate.score,
         case_statuses=statuses,
+        case_failures=failure_document(candidate.cases),
         slice_rows=[line for line in slice_output.split("\n") if line and not line.isspace()],
     )
 
@@ -1084,6 +1112,7 @@ def _bless(args: argparse.Namespace) -> None:
         rendered_url4=evidence.rendered_url4,
         final_score=evidence.final_score,
         case_statuses=evidence.case_statuses,
+        case_failures=evidence.case_failures,
     )
     header = _snapshot_header(
         args.board,
@@ -1337,6 +1366,7 @@ def _report_replay_and_slice(
         rendered_url4=str(candidate.url4),
         final_score=candidate.score,
         case_statuses=statuses,
+        case_failures=failure_document(candidate.cases),
         slice_rows=[line for line in slice_output.split("\n") if line and not line.isspace()],
     )
 
@@ -1369,8 +1399,128 @@ def _bless_from_report(args: argparse.Namespace) -> None:
         rendered_url4=evidence.rendered_url4,
         final_score=evidence.final_score,
         case_statuses=evidence.case_statuses,
+        case_failures=evidence.case_failures,
     )
     _write_fixtures(args, evidence, _report_header(args.board, report_sha), golden)
+
+
+# -- the fixtures-sourced refresh (OME-1094) -----------------------------------------
+
+#: Every outcome fact the committed golden already pins. A refresh may ADD the
+#: failure map; none of these may move, or it is a re-bless smuggling in a drift.
+_REFRESH_PINNED_KEYS = (
+    "revision",
+    "expression_sha",
+    "case_statuses",
+    "case_count",
+    "gradeable_count",
+    "final_score",
+)
+
+
+def _differing(committed: Any, replayed: Any) -> str:
+    """Compact drift for the refusal message — only the keys that moved, for maps."""
+    if isinstance(committed, dict) and isinstance(replayed, dict):
+        drifted = {
+            key: (committed.get(key), replayed.get(key))
+            for key in committed.keys() | replayed.keys()
+            if committed.get(key) != replayed.get(key)
+        }
+        return f"(committed, replay) per case: {drifted}"
+    return f"committed {committed!r}, replay {replayed!r}"
+
+
+def _refresh_golden(args: argparse.Namespace) -> None:
+    """Re-author one board's golden from its COMMITTED snapshot — no recording needed.
+
+    Mental model: re-mark the exam from the recording already in the repo and copy
+    each failed student's REASON onto the answer sheet — but refuse if any mark
+    itself moved. Stages, in execution order:
+
+    1. **Read the committed golden RAW.** A golden blessed before the codes rung
+       refuses at ``load_golden`` (failed cases with no code), so only its replay
+       INPUTS (kind, models, recipe, synthesizer, limit) are trusted at this point;
+       the outcome fields are compared after the replay.
+    2. **Replay** the board from the committed snapshot exactly like ``test_boards``
+       does — real gateway, real engine, zero provider keys.
+    3. **Author** the new golden from that replay (statuses, counters, score AND the
+       failure map).
+    4. **Refuse** unless every fact the committed golden pinned is identical
+       (``_REFRESH_PINNED_KEYS``): a refresh may add failure codes, never change a
+       score. Investigating the drift is the owner's job, not this tool's.
+    5. **Write** in place.
+    """
+    sys.path.insert(0, str(_E2E_DIR))
+    from harness._gating import GOLDENS_DIR, SNAPSHOTS_DIR
+    from harness.cache_seeded import CacheSeededGateway
+    from harness.goldens import GoldenReport, build_candidate
+    from harness.stack import replay_stack
+
+    golden_path = GOLDENS_DIR / f"{args.board}.golden.json"
+    snapshot = SNAPSHOTS_DIR / f"{args.board}.snapshot.gz"
+    manifest = SNAPSHOTS_DIR / f"{args.board}.manifest.json"
+    if not golden_path.exists() or not snapshot.exists():
+        raise SystemExit(
+            f"board {args.board!r} has no committed golden + snapshot to refresh from "
+            f"({golden_path}, {snapshot})"
+        )
+    committed = json.loads(golden_path.read_text(encoding="utf-8"))
+    # Stage 1 — WHY the blanked outcome: only the replay inputs are needed here, and a
+    # pre-OME-1094 golden would refuse validation on its status-only failed cases.
+    inputs = GoldenReport.model_validate(
+        {
+            **committed,
+            "case_statuses": {},
+            "case_failures": {},
+            "case_count": 0,
+            "gradeable_count": 0,
+        }
+    )
+    assets_root = _require_assets(args.board)
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 2 — the same boot the e2e lane uses.
+    backend = CacheSeededGateway(
+        snapshot=snapshot,
+        manifest=manifest if manifest.exists() else None,
+        work_dir=args.work_dir,
+    )
+    print(f"[refresh] replaying {args.board} from {snapshot.name} keylessly…", flush=True)
+    with replay_stack(backend, work_dir=args.work_dir, assets_dir=assets_root) as stack:
+        report = _evaluate(stack.engine_url, build_candidate(inputs), args.board, inputs.limit)
+    candidate = report.candidates.only
+
+    # Stage 3 — author from the replay.
+    golden = author_golden(
+        board=args.board,
+        revision=report.benchmark.revision,
+        model=inputs.models[0] if inputs.kind == "model" else None,
+        kind=inputs.kind,
+        recipe=inputs.recipe,
+        members=list(inputs.models),
+        synthesizer=inputs.synthesizer,
+        limit=inputs.limit,
+        rendered_url4=str(candidate.url4),
+        final_score=candidate.score,
+        case_statuses={str(case.case_id): str(case.status) for case in candidate.cases},
+        case_failures=failure_document(candidate.cases),
+    )
+    # Stage 4 — INVARIANT: only the failure map may be new.
+    for key in _REFRESH_PINNED_KEYS:
+        if golden[key] != committed.get(key):
+            raise SystemExit(
+                f"REFRESH REFUSED — replayed {key} differs from the committed golden: "
+                f"{_differing(committed.get(key), golden[key])}. A refresh may only add "
+                f"failure codes; investigate the drift, then re-bless from the recordings."
+            )
+    # Stage 5 — write.
+    golden_path.write_text(json.dumps(golden, indent=2) + "\n")
+    pinned = sum(len(entries) for entries in golden["case_failures"].values())
+    print(
+        f"[refresh] {args.board}: {len(golden['case_failures'])} cases pinned with "
+        f"{pinned} failure codes, score={golden['final_score']} unchanged → {golden_path}",
+        flush=True,
+    )
 
 
 def main() -> None:
@@ -1378,21 +1528,48 @@ def main() -> None:
     if args.helper is not None:
         {"keys": _helper_keys, "revisions": _helper_revisions}[args.helper]()
         return
+    if args.refresh_golden:
+        _run_exclusive_mode(
+            args,
+            flag="--refresh-golden",
+            recording="the committed snapshot",
+            excluded=("model", "dump", "answers", "report", "judge_bodies", "dump_judge_bodies"),
+            run=_refresh_golden,
+        )
+        return
     if args.report is not None:
-        if args.board is None:
-            raise SystemExit("--board is required with --report")
-        for excluded in ("model", "dump", "answers", "judge_bodies", "dump_judge_bodies"):
-            if getattr(args, excluded) is not None:
-                raise SystemExit(
-                    f"--{excluded.replace('_', '-')} cannot be combined with --report — "
-                    f"the report is the only recording in this mode"
-                )
-        _bless_from_report(args)
+        _run_exclusive_mode(
+            args,
+            flag="--report",
+            recording="the report",
+            excluded=("model", "dump", "answers", "judge_bodies", "dump_judge_bodies"),
+            run=_bless_from_report,
+        )
         return
     for required in ("board", "model", "dump", "answers"):
         if getattr(args, required) is None:
             raise SystemExit(f"--{required} is required (unless running a --helper mode)")
     _bless(args)
+
+
+def _run_exclusive_mode(
+    args: argparse.Namespace,
+    *,
+    flag: str,
+    recording: str,
+    excluded: tuple[str, ...],
+    run: Any,
+) -> None:
+    """A mode with ONE recording source: needs ``--board``, refuses every other source."""
+    if args.board is None:
+        raise SystemExit(f"--board is required with {flag}")
+    for name in excluded:
+        if getattr(args, name) is not None:
+            raise SystemExit(
+                f"--{name.replace('_', '-')} cannot be combined with {flag} — "
+                f"{recording} is the only recording in this mode"
+            )
+    run(args)
 
 
 if __name__ == "__main__":

--- a/packages/screamingface/tests/e2e/harness/goldens.py
+++ b/packages/screamingface/tests/e2e/harness/goldens.py
@@ -10,21 +10,27 @@ STAGED walk, and THE ORDER IS THE CONTRACT:
    goldens stale" and deliberately says nothing about scores.
 2. **cases** — the per-case status map (``scored`` / ``refused`` / ``failed``) must
    match. Statuses drifting with the expression intact means the replay itself broke.
-3. **coverage** — the REPORT'S OWN coverage figure must equal what the golden's
+3. **codes** — the per-case failure map (``stage`` + ``code`` for every case that
+   carries a failure) must match (OME-1094). Five rubric failure reasons all spell
+   ``failed``; this rung is what makes a reclassification (``incomplete_verdicts`` →
+   ``case_error``) fail by name instead of hiding behind an unchanged status word.
+4. **coverage** — the REPORT'S OWN coverage figure must equal what the golden's
    counters imply (``gradeable_count / case_count``). Stage 2 already pins the raw
    statuses, so this stage deliberately checks the one thing statuses cannot see: the
    report's independently derived aggregation. Matching statuses with a contradicting
    coverage figure means the SDK's aggregation math drifted — a different bug than a
    replay drift, named separately.
-4. **score** — last, the final score, compared as DECIMAL STRINGS. The SDK reports a
+5. **score** — last, the final score, compared as DECIMAL STRINGS. The SDK reports a
    float; ``canonical_score`` renders it as the shortest round-trip decimal (`repr`), so
    the golden holds ``"0.5"``, not a float that two JSON writers could disagree about.
 
 Worked example: golden ``final_score="0.5"``, ``case_statuses={"c1": "scored",
-"c2": "refused"}``, so ``case_count=2`` and ``gradeable_count=1`` (only ``c1`` carries a
-grade). A run whose expression drifted fails at stage 1 even if it also scored 0.0; a
-run with the right expression but ``c1: "failed"`` fails at stage 2; only a run clean
-through stages 1–3 can ever fail on the score.
+"c2": "failed"}``, ``case_failures={"c2": [{"stage": "grading", "code":
+"incomplete_verdicts"}]}``, so ``case_count=2`` and ``gradeable_count=1`` (only ``c1``
+carries a grade). A run whose expression drifted fails at stage 1 even if it also
+scored 0.0; a run with the right expression but ``c1: "failed"`` fails at stage 2; a
+run where ``c2`` still fails but now as ``case_error`` fails at stage 3; only a run
+clean through stages 1–4 can ever fail on the score.
 
 Deliberately absent: progress or stream fields (``extra="forbid"`` enforces it), floats
 anywhere in the file, and timestamps/run ids (nondeterministic by nature).
@@ -34,21 +40,25 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 # The SDK's OWN status vocabulary — imported, not mirrored, so it cannot drift
-# (owner review finding on OME-961).
-from screamingface.case_result import CaseStatus
+# (owner review finding on OME-961). Same rule for the failure-stage vocabulary
+# (OME-1094): ``FailureStage`` lives in the SDK's report primitives.
+from screamingface._report_primitives import FailureStage
+from screamingface.case_result import CaseResult, CaseStatus
 
 GOLDEN_SCHEMA: Final = "screamingface.golden-report.v1"
 
 _SHA256_HEX = r"^[0-9a-f]{64}$"
 
 _GRADEABLE: Final = "scored"
+_FAILED: Final = "failed"
 
 #: The SDK rounds its coverage figure to 4 places (``report._coverage``); the stage-3
 #: compare rounds identically so the two sides speak the same precision.
@@ -58,9 +68,27 @@ _COVERAGE_PLACES: Final = 4
 class GoldenMismatch(AssertionError):
     """One staged comparison failed; ``stage`` names which rung of the ladder."""
 
-    def __init__(self, stage: Literal["expression", "cases", "coverage", "score"], message: str):
+    def __init__(
+        self,
+        stage: Literal["expression", "cases", "codes", "coverage", "score"],
+        message: str,
+    ):
         self.stage = stage
         super().__init__(message)
+
+
+class GoldenFailure(BaseModel):
+    """One pinned failure on one case: WHY it failed (``code``) and WHERE (``stage``).
+
+    The message is deliberately absent — it is prose the engine may reword freely;
+    the code is the published vocabulary a researcher acts on (retry / raise a budget
+    / report a broken benchmark), so the code is what the golden freezes.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    stage: FailureStage
+    code: str = Field(min_length=1)
 
 
 class GoldenReport(BaseModel):
@@ -90,6 +118,36 @@ class GoldenReport(BaseModel):
     case_count: int = Field(ge=0)
     gradeable_count: int = Field(ge=0)
     case_statuses: dict[str, CaseStatus]
+    #: Per-case failures, keyed like ``case_statuses``, for every case that carries
+    #: any (OME-1094). Absent in goldens blessed before the codes rung — those load
+    #: only if no case failed, so an all-scored golden never needs a replay to be
+    #: re-blessed and a golden with a status-only failed case refuses at load.
+    case_failures: dict[str, tuple[GoldenFailure, ...]] = {}
+
+    @model_validator(mode="after")
+    def _failures_agree_with_statuses(self) -> GoldenReport:
+        # INVARIANT: the failure map and the status map tell one story. A scored case
+        # carries no failure (the SDK's own contract); a failed case MUST name its
+        # reason — a failed case pinned by status alone is exactly the hole this
+        # rung closes, so it is refused rather than tolerated.
+        for case in self.case_failures:
+            if case not in self.case_statuses:
+                raise ValueError(
+                    f"case_failures pins case {case!r} that case_statuses does not list"
+                )
+        for case, entries in self.case_failures.items():
+            if self.case_statuses[case] == _GRADEABLE and entries:
+                raise ValueError(
+                    f"case {case!r} is '{_GRADEABLE}' but case_failures pins a failure for it"
+                )
+        for case, status in self.case_statuses.items():
+            if status == _FAILED and not self.case_failures.get(case):
+                raise ValueError(
+                    f"case {case!r} is '{_FAILED}' but case_failures pins no failure code "
+                    f"for it — re-bless this golden from its committed snapshot "
+                    f"(`just e2e-refresh-golden {self.board}`)"
+                )
+        return self
 
     @model_validator(mode="after")
     def _fusion_lineup_is_complete(self) -> GoldenReport:
@@ -129,17 +187,43 @@ class GoldenReport(BaseModel):
 
 @dataclass(frozen=True, slots=True)
 class ActualOutcome:
-    """What one fresh replay actually produced — the four facts the ladder checks.
+    """What one fresh replay actually produced — the five facts the ladder checks.
 
     ``coverage`` is the report's OWN aggregated figure (``CandidateResult.coverage``),
     passed through rather than re-derived from ``case_statuses`` — that independence is
-    what makes stage 3 a real check instead of a restatement of stage 2.
+    what makes the coverage stage a real check instead of a restatement of the
+    statuses stage. ``case_failures`` comes from ``failure_map`` (the same reader the
+    bless tool authors the golden with); it defaults to "nothing failed" so a replay
+    whose cases all scored needs no extra plumbing.
     """
 
     rendered_url4: str
     final_score: float | None
     case_statuses: dict[str, str]
     coverage: float
+    case_failures: Mapping[str, tuple[GoldenFailure, ...]] = field(default_factory=dict)
+
+
+def failure_map(cases: Iterable[CaseResult]) -> dict[str, tuple[GoldenFailure, ...]]:
+    """Read every case's pinned failures off the SDK ``CaseResult`` values.
+
+    ONE reader for both sides — the bless tool authors the golden through it and
+    ``test_boards`` builds the actual outcome through it — so the golden and the
+    compare can never disagree about how a failure is spelled. Cases with no
+    failures are absent (not an empty tuple), matching the golden's on-disk shape.
+    """
+    return {
+        str(case.case_id): tuple(
+            GoldenFailure(stage=failure.stage, code=failure.code) for failure in case.failures
+        )
+        for case in cases
+        if case.failures
+    }
+
+
+def _spell_failures(entries: tuple[GoldenFailure, ...] | None) -> tuple[str, ...] | None:
+    """``("grading:incomplete_verdicts",)`` — the human-readable form for a drift message."""
+    return None if entries is None else tuple(f"{entry.stage}:{entry.code}" for entry in entries)
 
 
 def build_candidate(golden: GoldenReport):  # -> sf.Model | sf.Fusion
@@ -188,8 +272,10 @@ def compare_outcome(golden: GoldenReport, actual: ActualOutcome) -> None:
 
     Stage 1 — expression: a drifted expression is reported as stale goldens and the
     message never mentions a number, because none of the numbers are comparable.
-    Stage 2 — case statuses. Stage 3 — the report's own coverage figure against the
-    golden's counters. Stage 4 — score as decimal strings.
+    Stage 2 — case statuses. Stage 3 — per-case failure codes, compared as a whole
+    map so a swapped, added or vanished failure is all the same drift. Stage 4 — the
+    report's own coverage figure against the golden's counters. Stage 5 — score as
+    decimal strings.
     """
     actual_sha = expression_sha(actual.rendered_url4)
     if actual_sha != golden.expression_sha:
@@ -207,7 +293,21 @@ def compare_outcome(golden: GoldenReport, actual: ActualOutcome) -> None:
             if golden.case_statuses.get(case) != actual.case_statuses.get(case)
         }
         raise GoldenMismatch("cases", f"case statuses drifted (golden, actual): {drifted}")
-    # Stage 3 — deliberately NOT re-counting actual.case_statuses (stage 2 pinned those
+    # Stage 3 — failure codes. Statuses matched, so every drift here is a case that
+    # failed for a DIFFERENT REASON than the blessed run — the reclassification the
+    # status word cannot see (OME-1094).
+    actual_failures = dict(actual.case_failures)
+    if actual_failures != golden.case_failures:
+        drifted_codes = {
+            case: (
+                _spell_failures(golden.case_failures.get(case)),
+                _spell_failures(actual_failures.get(case)),
+            )
+            for case in golden.case_failures.keys() | actual_failures.keys()
+            if golden.case_failures.get(case) != actual_failures.get(case)
+        }
+        raise GoldenMismatch("codes", f"failure codes drifted (golden, actual): {drifted_codes}")
+    # Stage 4 — deliberately NOT re-counting actual.case_statuses (stage 2 pinned those
     # exactly; a re-count could never fire). The report's own aggregated figure is the
     # independent fact: it must equal what the golden's counters imply.
     expected_coverage = (

--- a/packages/screamingface/tests/e2e/test_bless_contracts.py
+++ b/packages/screamingface/tests/e2e/test_bless_contracts.py
@@ -187,6 +187,7 @@ def test_author_golden_conforms_and_derives_counters() -> None:
         rendered_url4="url4://example/expression",
         final_score=0.5,
         case_statuses={"1": "scored", "2": "refused"},
+        case_failures={},
     )
     # ``load_golden`` must accept every blessed file — validate through the SAME
     # model the test lane loads with, counters derived, score canonicalized.
@@ -208,6 +209,8 @@ def test_author_golden_keeps_a_scoreless_run_null() -> None:
         rendered_url4="expr",
         final_score=None,
         case_statuses={"1": "failed"},
+        # OME-1094: a failed case must name its reason or the author refuses.
+        case_failures={"1": [{"stage": "grading", "code": "case_error"}]},
     )
     assert golden["final_score"] is None
     assert GoldenReport.model_validate(golden).gradeable_count == 0
@@ -251,3 +254,37 @@ def test_collect_payloads_for_keys_refuses_a_key_the_dump_cannot_serve() -> None
     # never recorded — splicing the rest would bless a fixture with a hole in it.
     with pytest.raises(ValueError, match="k9"):
         collect_payloads_for_keys(iter([]), model="judge/model", wanted_keys={"k9"})
+
+
+def test_author_golden_pins_failure_codes_per_failed_case() -> None:
+    golden = author_golden(
+        board="healthbench-worst30",
+        revision="39cfd96b068f7230",
+        model="m",
+        limit=None,
+        rendered_url4="expr",
+        final_score=-0.091,
+        case_statuses={"2": "failed", "1": "scored"},
+        case_failures={"2": [{"stage": "grading", "code": "incomplete_verdicts"}]},
+    )
+    # Sorted like case_statuses, so a re-bless never churns the file's ordering.
+    assert list(golden["case_failures"]) == ["2"]
+    assert golden["case_failures"]["2"] == [{"stage": "grading", "code": "incomplete_verdicts"}]
+    report = GoldenReport.model_validate(golden)
+    assert report.case_failures["2"][0].code == "incomplete_verdicts"
+
+
+def test_author_golden_refuses_a_failed_case_without_a_code() -> None:
+    # The bless tool must never write a golden the lane would refuse — and the lane
+    # refuses a failed case pinned by status alone (OME-1094).
+    with pytest.raises(Exception, match="1"):
+        author_golden(
+            board="draco-3pass",
+            revision="b8c8afd8f9dddca0",
+            model="m",
+            limit=1,
+            rendered_url4="expr",
+            final_score=None,
+            case_statuses={"1": "failed"},
+            case_failures={},
+        )

--- a/packages/screamingface/tests/e2e/test_boards.py
+++ b/packages/screamingface/tests/e2e/test_boards.py
@@ -5,7 +5,8 @@ The real user path, driven exactly like a notebook: ``sf.Client(engine_url=...)`
 ``Report`` — against the real engine and the real gateway whose only answers come from
 that board's recorded cache snapshot. Deterministic, free (zero provider keys), and
 compared against the board's golden with the R11 ladder: expression SHA first, then
-case statuses, then coverage counters, then the score as a decimal string.
+case statuses, then per-case failure codes, then coverage counters, then the score as
+a decimal string.
 
 SKIP DISCIPLINE — a board with no fixtures SKIPS LOUDLY, naming exactly what is
 missing; it never fake-passes. Three prerequisites per board:
@@ -31,6 +32,7 @@ from harness.goldens import (
     GoldenReport,
     build_candidate,
     compare_outcome,
+    failure_map,
     load_golden,
 )
 from harness.stack import replay_stack
@@ -125,5 +127,7 @@ def test_board_replays_end_to_end_and_matches_its_golden(board: str, tmp_path) -
             final_score=candidate.score,
             case_statuses={str(case.case_id): str(case.status) for case in candidate.cases},
             coverage=candidate.coverage,
+            # OME-1094: WHY a case failed, not just that it did — the codes rung.
+            case_failures=failure_map(candidate.cases),
         ),
     )

--- a/packages/screamingface/tests/e2e/test_harness_contracts.py
+++ b/packages/screamingface/tests/e2e/test_harness_contracts.py
@@ -21,10 +21,12 @@ import pytest
 from harness.goldens import (
     GOLDEN_SCHEMA,
     ActualOutcome,
+    GoldenFailure,
     GoldenMismatch,
     GoldenReport,
     canonical_score,
     compare_outcome,
+    failure_map,
     load_golden,
 )
 from harness.tape import TAPE_SCHEMA, NormalizedRequest, load_tape
@@ -312,3 +314,151 @@ def test_the_rendered_string_round_trips_to_the_exact_float() -> None:
 
 def test_absent_scores_stay_absent() -> None:
     assert canonical_score(None) is None
+
+
+# ---- Failure codes: the "codes" rung (OME-1094) ----
+# INVARIANT: a failed case is pinned by its failure code (and stage), not just the
+# word "failed" — five rubric failure reasons all spell "failed", so a refactor that
+# swaps one reason for another must fail CI by name.
+_INCOMPLETE = GoldenFailure(stage="grading", code="incomplete_verdicts")
+_CASE_ERROR = GoldenFailure(stage="grading", code="case_error")
+
+
+def _failed_golden_document() -> dict[str, object]:
+    return _golden_document(
+        case_statuses={"case_1": "scored", "case_2": "failed"},
+        case_failures={"case_2": [{"stage": "grading", "code": "incomplete_verdicts"}]},
+    )
+
+
+def test_a_flipped_failure_code_fails_at_the_codes_rung_naming_both_codes() -> None:
+    golden = GoldenReport.model_validate(_failed_golden_document())
+    actual = ActualOutcome(
+        rendered_url4="rendered expression",
+        final_score=0.5,
+        case_statuses={"case_1": "scored", "case_2": "failed"},
+        # Same status word, different reason — exactly the hole the rung closes.
+        case_failures={"case_2": (_CASE_ERROR,)},
+        coverage=1.0,  # also wrong on purpose — codes are checked BEFORE coverage
+    )
+
+    with pytest.raises(GoldenMismatch) as failure:
+        compare_outcome(golden, actual)
+
+    assert failure.value.stage == "codes"
+    message = str(failure.value)
+    assert "case_2" in message
+    assert "incomplete_verdicts" in message and "case_error" in message
+
+
+def test_matching_failure_codes_pass_the_codes_rung() -> None:
+    golden = GoldenReport.model_validate(_failed_golden_document())
+    actual = ActualOutcome(
+        rendered_url4="rendered expression",
+        final_score=0.5,
+        case_statuses={"case_1": "scored", "case_2": "failed"},
+        case_failures={"case_2": (_INCOMPLETE,)},
+        coverage=0.5,
+    )
+
+    compare_outcome(golden, actual)  # must not raise
+
+
+def test_a_failure_entry_that_appears_or_vanishes_is_a_codes_drift() -> None:
+    # A failed case that now carries NO failure entry at all (or one more than the
+    # golden) is the same drift as a swapped code — the map is compared whole.
+    golden = GoldenReport.model_validate(_failed_golden_document())
+    actual = ActualOutcome(
+        rendered_url4="rendered expression",
+        final_score=0.5,
+        case_statuses={"case_1": "scored", "case_2": "failed"},
+        case_failures={"case_2": (_INCOMPLETE, _CASE_ERROR)},
+        coverage=0.5,
+    )
+
+    with pytest.raises(GoldenMismatch) as failure:
+        compare_outcome(golden, actual)
+
+    assert failure.value.stage == "codes"
+
+
+def test_a_scored_case_with_a_failure_entry_is_refused_at_load() -> None:
+    document = _golden_document(
+        case_failures={"case_1": [{"stage": "grading", "code": "case_error"}]},
+    )
+
+    with pytest.raises(Exception, match="case_1"):
+        GoldenReport.model_validate(document)
+
+
+def test_a_failed_case_without_a_failure_entry_is_refused_at_load() -> None:
+    # The pre-OME-1094 golden shape: a failed case pinned by status alone. Refusing
+    # it at load is what forces the re-bless instead of leaving the hole open.
+    document = _golden_document(case_statuses={"case_1": "scored", "case_2": "failed"})
+
+    with pytest.raises(Exception, match="case_2"):
+        GoldenReport.model_validate(document)
+
+
+def test_a_failure_entry_for_an_unknown_case_is_refused_at_load() -> None:
+    document = _golden_document(
+        case_failures={"case_9": [{"stage": "grading", "code": "case_error"}]},
+    )
+
+    with pytest.raises(Exception, match="case_9"):
+        GoldenReport.model_validate(document)
+
+
+def test_an_ungraded_refused_case_may_carry_grading_failures() -> None:
+    # The SDK contract: an ungraded refused Case carries only grading failures, so
+    # the golden must be able to pin them — refused is neither scored nor failed.
+    document = _golden_document(
+        case_failures={"case_2": [{"stage": "grading", "code": "incomplete_verdicts"}]},
+    )
+
+    report = GoldenReport.model_validate(document)
+
+    assert report.case_failures == {"case_2": (_INCOMPLETE,)}
+
+
+def test_goldens_blessed_before_the_codes_rung_still_load_when_nothing_failed() -> None:
+    # draco-3pass shape: no ``case_failures`` key and no failed case — loads as an
+    # empty map, so an all-scored golden never needs a replay to be re-blessed.
+    report = GoldenReport.model_validate(_golden_document())
+
+    assert report.case_failures == {}
+
+
+def test_failure_map_reads_the_sdk_case_results() -> None:
+    # The ONE function both the test lane and the bless tool use to read
+    # ``CaseResult.failures`` — so the golden author and the compare can never
+    # disagree about how a failure is spelled.
+    import screamingface as sf
+
+    scored = sf.CaseResult(
+        case_id=1,
+        input="the prompt",
+        output="the answer",
+        finish_reason="stop",
+        grade=sf.CaseGrade(method="rubric", score=0.8, metrics={}, checks=[]),
+        failures=[],
+        metadata={},
+    )
+    failed = sf.CaseResult(
+        case_id=2,
+        input="the prompt",
+        output=None,
+        finish_reason=None,
+        grade=None,
+        failures=[
+            sf.Failure(
+                stage="grading",
+                code="incomplete_verdicts",
+                message="not every rubric item received a valid judge verdict",
+                case_id=2,
+            )
+        ],
+        metadata={},
+    )
+
+    assert failure_map([scored, failed]) == {"2": (_INCOMPLETE,)}

--- a/packages/screamingface/tests/e2e/test_report_tape.py
+++ b/packages/screamingface/tests/e2e/test_report_tape.py
@@ -453,6 +453,8 @@ def _fusion_golden_document() -> dict:
         "case_count": 2,
         "gradeable_count": 1,
         "case_statuses": {"1": "scored", "3": "failed"},
+        # OME-1094: a failed case must name its reason or the golden refuses to load.
+        "case_failures": {"3": [{"stage": "grading", "code": "case_error"}]},
     }
 
 


### PR DESCRIPTION
The e2e replay golden now records **why** each failed case failed, not just that it did — so a refactor that swaps one failure reason for another goes red in CI by name.

## Before / After

### Before
- Trigger: a dev refactors the rubric failure ladder (the `OME-1024` spine work, first landing in `OME-1039`) and a healthbench case that used to fail as `incomplete_verdicts` now fails as `case_error`.
- Today: the golden pins only the status word. Both outcomes are `failed`, so the replay lane stays green while the published failure reason changed for any (or all) of healthbench-worst30's 33 failed cases.
- Cost: the one guard the spine refactor relies on has a hole in the exact place the first refactor ticket lands.

### After
- Same trigger.
- Now: the golden carries a per-case failure map (`stage` + `code`) and the compare ladder gains a **codes** rung between statuses and coverage. The failure message names the case and both codes.
- Win: a reclassification fails CI by name; a same-behaviour refactor stays green.

### Don't regress
- A scored case can never carry a failure entry, and a failed case can never lack one — the golden validator refuses both at load.
- The existing rungs and their order are unchanged apart from the new one: expression → statuses → **codes** → coverage → score.
- Re-blessing needs no paid run: `just e2e-refresh-golden <board>` replays the committed snapshot (docker, zero keys) and refuses to write if anything but the failure map moved.
- Goldens blessed before this change still load when nothing failed (draco-3pass: `case_failures: {}`).

<!-- BEFORE/AFTER DIAGRAM GOES HERE: drag the PNG into this description in the GitHub editor, then set width="900" on the <img> GitHub inserts. -->

## What changed

- `tests/e2e/harness/goldens.py` — `GoldenFailure`, `GoldenReport.case_failures` + validator, `ActualOutcome.case_failures`, `failure_map()` (the one reader both the bless tool and `test_boards` use), the codes rung in `compare_outcome`.
- `tests/e2e/fixtures/slice_snapshot.py` — `author_golden` writes the map; both bless flows feed it from the verified replay; new `--refresh-golden` mode (`just e2e-refresh-golden <board>`).
- `tests/e2e/test_boards.py` — feeds the map from the SDK `CaseResult.failures`. No SDK change.
- `fixtures/goldens/draco-3pass.golden.json` — gains `case_failures: {}` (all 100 cases scored; deterministic from the statuses, no replay needed).
- `tests/e2e/README.md` — the new rung + the refresh command.

## ⚠️ Owner step before marking ready

`fixtures/goldens/healthbench-worst30.golden.json` is **not** re-blessed in this PR (docker was not running here; only free unit tests were run). Until it is, the golden refuses to load with a message naming the fix, and the `ScreamingFace E2E Replay` workflow is red for that board. To finish:

```sh
cd packages/screamingface
just e2e-refresh-golden healthbench-worst30   # docker + prepared assets; no API keys; refuses on any score/status drift
git add tests/e2e/fixtures/goldens/healthbench-worst30.golden.json && git commit -m "chore(screamingface): re-bless healthbench-worst30 golden with failure codes" -m "Refs: OME-1094"
```

Expected result: 33 entries in `case_failures`, everything else in the file byte-identical.

## Reviewer notes

- Two prior test **fixtures** were touched, both because they pinned a `failed` case by status alone (the shape the new validator refuses): `test_bless_contracts.py::test_author_golden_keeps_a_scoreless_run_null` and `test_report_tape.py::_fusion_golden_document`. Each gained one `case_failures` entry; the invariant each test defends is unchanged.
- An ungraded **refused** case may carry grading failures (the SDK's own contract), so the validator only forbids entries on `scored` cases and only requires them on `failed` ones.

## Test plan

- [x] `uv run pytest tests/e2e -q` → 90 passed, 16 skipped (docker-gated)
- [x] `uv run ruff check` / `ruff format --check` / `pyright` on `tests/e2e`
- [x] New tests: a flipped code fails at stage `codes` (before coverage) naming the case id and both codes; matching codes pass; scored-with-entry, failed-without-entry and unknown-case entries are refused at load; refused-with-grading-failures loads; `failure_map` reads real `sf.CaseResult` values; `author_golden` pins the sorted map and refuses a failed case without a code.
- [ ] Owner: `just e2e-refresh-golden healthbench-worst30`, commit, then `ScreamingFace E2E Replay` green for both boards.

Refs: OME-1094

