### PR TITLE
docs(ome-898): align SDLC with product and documentation flows [epic]

### DIFF
--- a/public-docs/ome-898/01-writing-docs/dogfood/RESULTS.md
+++ b/public-docs/ome-898/01-writing-docs/dogfood/RESULTS.md
@@ -1,0 +1,104 @@
+---
+title: "writing-docs: dogfood results"
+ticket: OME-898 (child 1, not yet filed)
+spec: ../spec.md
+plan: ../plan.md
+review output: ./public-docs-review.md
+status: draft
+date: 2026-09-02
+---
+
+# Dogfood results
+
+The record of the exercise. What was run, what it proved, what it changed. The findings
+about the documentation set itself are a separate document, `public-docs-review.md`.
+
+## Setup
+
+| | |
+|---|---|
+| Skill under test | `writing-docs`, as built in `../writing-docs/` |
+| Installed at | `~/.claude/skills/writing-docs/` |
+| Target | the Client documentation site, at the commit its own sidebar names, `90a104e3` |
+| Reader path | landing page, Overview, Installation, Your first fusion, plus the navigation tree and router |
+| Reader, goal, time budget | senior researcher composing multiple models, install to a working composition, 30 minutes |
+| Runtime available | none. No Python, no credentials, no network to a provider |
+| Runs | two: one with no context skill loaded, one with the project's canonical terminology loaded |
+
+Two runs rather than one, because the difference between them is the thing the spec's
+verification section actually asks about.
+
+## Verification results
+
+Against `spec.md` §9.
+
+| Check | Result | Evidence |
+|---|---|---|
+| names a mode conflict on a page that mixes types and proposes the split | **pass** | Installation is filed under Tutorials and is roughly forty percent reference and troubleshooting. The skill proposed moving the seven-item FAQ to a how-to rather than trimming it |
+| produces a friction log with quoted locations and at least one paste-ready diagram | **pass** | sixteen friction entries, each with a file and line, and three Mermaid diagrams using the site's own terms |
+| with nothing loaded, produces guidance and reports unknown slots rather than inventing | **pass** | six of nine slots reported unavailable at the top of the report, and every product statement marked as a claim the docs make rather than a verified fact |
+| with a context skill loaded, applies it and keeps its specifics out of the skill | **pass** | the second run produced three findings the first could not reach. Nothing from the project entered the skill: the name and dash checks still return zero |
+| review angles usable by someone who did not write them | **not run** | needs a second person |
+| runs against a project in a different domain | **not run** | see gaps below |
+
+## What the two runs proved about the context contract
+
+The no-context run found structure, ordering, terminology drift internal to the docs,
+missing example outputs, and missing diagrams.
+
+The context-loaded run found a possible claims-policy breach, a benchmark id absent from the
+canonical supported list, and a word the project has explicitly reserved for a narrower
+meaning.
+
+Neither run found the other's findings. That is the strongest evidence from this exercise
+that the contract belongs in the skill rather than being an optional extra, and that a docs
+review run with nothing loaded should not be called finished.
+
+It is also evidence the degradation path works as specified. The first run had every
+opportunity to guess at the product's claims policy and did not.
+
+## What the exercise changed in the skill
+
+| Change | Reason |
+|---|---|
+| `review-angles.md`: a rule for when the examples cannot be run | The rule said only "run the code". This run had no runtime, so a reviewer following it literally would either stall or quietly imply they ran something. It now says to mark examples unverified and names four things checkable without running anything |
+| `PROVENANCE.md`: a "changes from use" table | So the reason behind a rule survives the person who added it |
+
+One change from one run is a low yield, which is itself informative: the skill's content
+held up under first contact better than expected. The next two runs are the ones that will
+say whether that holds.
+
+## Highest-value findings handed back
+
+Full list in the review. These three are the ones that need a person rather than an edit:
+
+1. **The claims-policy question.** Canon requires a result on a self-authored benchmark to
+   name that fact in the sentence naming the result, and bars a state-of-the-art claim on
+   such a benchmark. The Overview's headline result carries no such disclosure, and a
+   navigation entry reads "Reproduce DRACO state-of-the-art". Flagged, deliberately not
+   rewritten.
+2. **An advertised benchmark id that canon does not list.** Either canon is behind a shipped
+   variant or the docs advertise something unsupported. Someone who knows which needs to say.
+3. **"Reproducible" against "auditable".** Canon reserves the second word for held-out
+   results. Two adjacent Overview bullets claim the first.
+
+Everything else is a docs edit: the Quickstart naming, the missing tutorial outputs, the
+invitation gate placement, the provider-keys contradiction, the Installation split, the three
+diagrams, one benchmark on the reader path, the install check, a stability statement, and 43
+em-dashes across 18 of 37 pages.
+
+## Gaps in this exercise
+
+- **No execution.** No example was run. Every code finding is a consistency finding, and the
+  review says so rather than implying otherwise.
+- **Four pages, not the whole set.** The reader path only. The API reference tab, the learn
+  section, and the guides were not read, so the review says nothing about them. A full sweep
+  would likely raise more terminology drift, since that is what drift does.
+- **One reader.** The scorecard is scored for a researcher evaluating adoption. A different
+  reader, for instance someone maintaining an existing integration, would score reference
+  navigability and stability differently.
+- **Single reviewer.** The review angles were run by the same party that wrote them, which is
+  the weakest possible test of whether they are usable by anyone else.
+- **Different-domain run outstanding.** Until the skill is run against a documentation set
+  from another domain, the claim that it is product-agnostic rests on the name and dash checks
+  rather than on evidence.

--- a/public-docs/ome-898/01-writing-docs/dogfood/public-docs-review.md
+++ b/public-docs/ome-898/01-writing-docs/dogfood/public-docs-review.md
@@ -1,0 +1,342 @@
+# Dogfood run: the Client documentation site
+
+First real use of the `writing-docs` skill. Target: the `public-docs` site, reader path from
+the landing page through Overview, Installation, and Your first fusion, plus the navigation
+tree and router.
+
+Run on 2026-09-02 against commit `90a104e3` as named in the sidebar footer.
+
+## Context slots: what was and was not available
+
+No context skill was loaded for this run, which makes it the degradation case as well as the
+dogfood.
+
+| Slot | Available | Source |
+|---|---|---|
+| the reader | yes | supplied in the commissioning prompt: a senior researcher composing multiple models, evaluating adoption |
+| the time budget | yes | 30 minutes, from the same prompt |
+| operational metrics | yes | cost, accuracy, speed, from the same prompt |
+| product facts | **no** | taken from the docs themselves and not independently verified |
+| terminology casing | **no** | drift is reported where the docs disagree with themselves, not against an external list |
+| positioning language | **no** | not checked |
+| house voice, target voice | **no** | one house rule was supplied separately by the owner: no em-dashes |
+| house writing skill | **no** | its AI-tell pass did not run |
+
+Everything below that describes the product is therefore a claim the docs make, not a fact
+this review confirmed. That distinction is the behaviour the skill is supposed to have when
+it runs with nothing loaded, and it held.
+
+## Verdict
+
+This reader would adopt. The Overview does the hardest job well: it says what the thing is,
+names the effect it is built around, and supports the headline claim with a citation and a
+second piece of literature rather than an adjective. Cost is treated as a first-class
+quantity throughout, which is exactly what this reader came to check.
+
+Understanding breaks in the first ten minutes, and all three breaks are avoidable. The
+fastest path is gated by an invitation the reader only learns about halfway down a tab body.
+The tutorial never shows what success looks like, so a reader cannot tell whether their run
+worked. And the page the whole site calls "Quickstart" is titled something else and appears
+under that other name in the sidebar, so the most-linked page in the docs cannot be found by
+the name it is linked by.
+
+Structurally the site is in better shape than most: it declares the four page types in its
+own navigation and mostly honours them. The exception is Installation, which is filed as a
+tutorial and is about forty percent reference material.
+
+## Friction log
+
+Chronological, following the reader path.
+
+| # | Location | What happened |
+|---|---|---|
+| 1 | `Index.vue:84` | "**Your own providers.** You connect the API keys you already have" reads as unconditional. Two pages later the hosted path says the opposite. Noted as a promise; it turns out to apply only to the local path |
+| 2 | `Index.vue:30` | `benchmark="draco-3pass"` appears with no explanation of what `draco-3pass` is or how it relates to `draco`. Guessed it was a benchmark id |
+| 3 | `Index.vue:142` | "Two ways to run" is a decision with two topologies, in prose. Had to hold both in mind to compare them |
+| 4 | `InstallationPage.vue:20` | The install check is `len(sf.__all__) # 56`. If it prints 57 I do not know whether I have a problem. It verifies a count, not that anything works |
+| 5 | `InstallationPage.vue:107` | "The fastest start" |
+| 6 | `InstallationPage.vue:109` | "Hosted access is currently by invitation. If you haven't been approved yet, use the local engine tab below while you wait." This is the single most important fact for a new reader and it arrives after the path was called the fastest start. My 30 minutes just changed shape |
+| 7 | `InstallationPage.vue:107` | "no provider key of your own: the hosted engine does not take one". Direct contradiction of friction 1. Scrolled back to re-read the Overview bullet |
+| 8 | `InstallationPage.vue:127` | "The **Quickstart** takes it from here", linking to `/sf-client/first-fusion`. There is no Quickstart in the sidebar. Looked for one |
+| 9 | `InstallationPage.vue:146` | `prepare draco` takes a family, but the Overview example used `draco-3pass`. Cannot tell whether preparing `draco` covers `draco-3pass` |
+| 10 | `InstallationPage.vue:176` | An FAQ with seven collapsibles opens inside what the nav calls a tutorial. Ports, TLS certificates, provider enablement, web-search keys. None of it is the task I came to do |
+| 11 | `FirstFusionPage.vue:39` | Prerequisites say the Client must be installed. They do not say the engine must be pointed at, which Installation established as mandatory. Guessed that `sf.connect()` implies a configured engine |
+| 12 | `FirstFusionPage.vue:63` | `sf.connect()`, with no preceding `sf.configure()`. Third distinct entry point after `sf.configure()` and `client.login()`. Unclear which I should be using |
+| 13 | `FirstFusionPage.vue:88` | The tutorial runs `ifeval`; the Overview example ran `draco-3pass`. Neither says why they differ |
+| 14 | `FirstFusionPage.vue:95` to `:107` | Five cells, no expected output on any of them. I cannot tell whether my run succeeded. The Overview, which is not the tutorial, is the only page that shows a result |
+| 15 | `FirstFusionPage.vue:118` | Fan-out, synthesizer, pipeline, and nesting are introduced as prose in one section. Four structural ideas, no picture |
+| 16 | `router/index.ts:27` | The Reproduce DRACO route renders `QuickstartPage.vue`. A file named for one page serving another |
+
+## Flow map
+
+**Ordering defects**
+
+- `sf.configure()` is established as mandatory in Installation, then omitted from the
+  tutorial's prerequisites and never called in its cells. The tutorial depends on a step it
+  does not state.
+- `url4` is linked from the Overview before it is defined, then defined one paragraph later.
+  Harmless, but the link invites a detour before the definition arrives.
+- `synthesizer` is used as a `Fusion` argument in the Overview example and only explained in
+  the tutorial's step 3.
+
+**Terminology drift**
+
+| Concept | Names in use |
+|---|---|
+| the tutorial page | "Quickstart" in four link texts, "Your first fusion" as the page title and sidebar entry |
+| the deep-research benchmark | `draco`, `draco-3pass` |
+| the medical benchmark | `healthbench`, `healthbench-worst30` |
+| connecting | `sf.configure()`, `client.login()`, `sf.connect()` |
+
+The first row is the expensive one. "Quickstart" is the label on the primary call to action
+on the landing page, and the word appears nowhere a reader can land.
+
+**Arc**
+
+The Overview follows the intended arc closely: what it is, why it exists, what it provides,
+how it works, the choice, then the smallest example. The break is that its smallest example
+uses a different benchmark from the tutorial that follows it, so the two do not compose into
+one path.
+
+**Page types**
+
+| Page | Declared | Actually |
+|---|---|---|
+| Overview | overview | explanation, plus a runnable example at the end |
+| Installation | tutorial | tutorial for the first half, reference and troubleshooting for the second |
+| Your first fusion | tutorial | tutorial, correctly, apart from the missing outputs |
+
+## Scorecard
+
+| # | Item | Score | Evidence |
+|---|---|---|---|
+| 1 | first contact | 4 | "open, Python-first infrastructure for composing model ensembles", with 68.6 against 60.2 and a citation |
+| 2 | time to first success | 2 | five tutorial cells, zero expected outputs, and the fast path gated by invitation |
+| 3 | concept ordering | 3 | the tutorial never states the engine step that Installation made mandatory |
+| 4 | learning-curve shape | 4 | steps are small and the tutorial is genuinely short |
+| 5 | example quality | 3 | runnable and realistic, but two benchmarks across two pages and `len(sf.__all__) # 56` as a check |
+| 6 | reference navigability | 4 | reference is its own navbar tab, and every public symbol has one home |
+| 7 | terminology discipline | 2 | "Quickstart" in four places for a page called "Your first fusion" |
+| 8 | honest operations | 4 | cost next to accuracy, cited numbers, and stated limits such as "the cache starts empty and you pay for the compute". No stability statement, changelog, or migration notes |
+| 9 | visual clarity | 3 | one accurate diagram with real alt text and a caption, against three prose-only structural concepts |
+
+## Trust check
+
+**Holding up.** The headline claim carries a link to published results and a second citation
+from the literature. Limits are stated plainly where the choice is made, for instance that a
+local engine starts with an empty cache and bills you for compute, and that the hosted
+engine runs your prompts on infrastructure the project operates. Cost appears next to
+accuracy rather than in an appendix. No marketing superlatives were found in the pages read.
+
+**Not holding up.** There is no stability or versioning statement. The sidebar reads "Based
+on state at commit 90a104e3", which is honest about what the docs were checked against but
+tells a reader nothing about whether the API will move under them. No changelog, no
+migration notes, and no contribution path was reachable from the pages on the reader path.
+For a project asking a researcher to build on it, those are the signals of being safe to
+depend on, and their absence is the one thing that would make this reader hesitate.
+
+One sentence to rewrite, at `InstallationPage.vue:107`:
+
+> "The fastest start."
+
+It is not the fastest start if it is gated. Something like: "The shortest path once you have
+access. Hosted access is currently by invitation; the local engine has no waiting."
+
+## Diagram plan
+
+Three gaps, in priority order.
+
+**1. Fusion topology.** `FirstFusionPage.vue:118`, the "How far this goes" section. Answers:
+how does a fusion actually route a question? Four structural ideas currently arrive as
+prose.
+
+```mermaid
+graph LR
+  Q[Benchmark case] --> M1[Member: gpt-5.5]
+  Q --> M2[Member: gemini-3-flash-preview]
+  M1 --> S[Synthesizer: gpt-5.5]
+  M2 --> S
+  S --> A[One graded answer]
+```
+
+**2. Fusion against pipeline.** Same section. Answers: what is the difference between the
+two ways recipes compose? Keep it to the contrast and nothing else.
+
+```mermaid
+graph TB
+  subgraph Fusion [Fusion: parallel]
+    FQ[Case] --> FA[Member A]
+    FQ --> FB[Member B]
+    FA --> FS[Synthesizer]
+    FB --> FS
+    FS --> FR[Answer]
+  end
+  subgraph Pipeline [Pipeline: serial]
+    PQ[Case] --> P1[Stage 1]
+    P1 --> P2[Stage 2 refines stage 1]
+    P2 --> PR[Answer]
+  end
+```
+
+**3. Which engine to run.** `Index.vue:142`, "Two ways to run". Answers: which engine should
+I point at? This replaces a two-bullet comparison the reader has to hold in their head, and
+it is where the invitation gate belongs.
+
+```mermaid
+graph TD
+  Start{Do you have hosted access?}
+  Start -- "no, or not yet" --> Local[Local engine]
+  Start -- yes --> Keys{Use your own provider keys?}
+  Keys -- yes --> Local
+  Keys -- no --> Hosted[Hosted engine]
+  Local --> LocalNote[Your keys, your machine, empty cache, you pay compute]
+  Hosted --> HostedNote[Shared credits, shared cache, prompts run on operated infrastructure]
+```
+
+Every label above uses the site's own terms. If any of them is wrong, the prose should
+change with the diagram rather than the diagram alone.
+
+## Top fixes
+
+Ordered by effect on time to understanding.
+
+**1. Show the expected output on every tutorial cell.** `FirstFusionPage.vue`, cells 1 to 5.
+Blocks flow because a reader following a tutorial has no way to tell success from failure,
+which is the whole point of a tutorial. The Overview already does this well, so the pattern
+exists and only needs applying. At minimum, cell 5 should show a score.
+
+**2. Rename "Quickstart" or rename the page.** Four link texts say Quickstart and point at a
+page titled "Your first fusion". Pick one name and use it in the sidebar, the page title,
+the landing-page button, and all four links. Cheapest fix here with the largest effect on
+finding anything.
+
+**3. Move the invitation gate to where the choice is made.** `Index.vue:142` and
+`InstallationPage.vue:107`. Before, at 107: "The fastest start." After: "The shortest path
+once you have access. Hosted access is currently by invitation; the local engine has no
+waiting." And state it in the Overview's two-ways section, not only inside a tab.
+
+**4. Fix the provider-keys contradiction.** `Index.vue:84`. Before: "**Your own providers.**
+You connect the API keys you already have, and calls are billed to your own accounts rather
+than resold to you." After: "**Your own providers, on a local engine.** Connect the API keys
+you already have and calls are billed to your own accounts rather than resold to you. The
+hosted engine supplies shared credits instead and takes no key of yours."
+
+**5. Split Installation.** Keep install and point-at-an-engine as the tutorial. Move the
+seven-item FAQ, which is ports, TLS, provider enablement, and web-search keys, into a how-to
+called something like "Troubleshoot a local runtime". The material is good and it is in the
+wrong page type. This is the split remedy, not a trim.
+
+**6. Add the three diagrams above.**
+
+**7. Use one benchmark on the reader path.** The Overview example and the tutorial should run
+the same one, or the Overview should say in one clause why it differs. Also say once whether
+`prepare draco` covers `draco-3pass`.
+
+**8. Replace the install check.** Before: `len(sf.__all__) # 56`. After: something that
+fails loudly and does not drift, for example printing the version, or a call that proves the
+Client can reach its engine.
+
+**9. State stability and versioning.** One short section, or a line in the sidebar footer
+beyond the commit: what may change, what will not, and where the changelog lives.
+
+**10. Remove em-dashes.** 43 of them across 18 of 37 pages. This is the owner's house rule
+and it is currently unenforced in the docs. Mechanical, but do it with judgement: each one
+becomes a comma, a colon, parentheses, or a full stop depending on what the sentence is
+doing.
+
+## What already works, so nobody improves it away
+
+- **The Overview's opening two paragraphs.** They state what the thing is, then support the
+  central claim with a number, a citation, and a second piece of literature, and then say
+  plainly that the effect is not new and name what the project actually adds. That last move
+  is rare and it is the reason this reader kept reading.
+- **The local-flow diagram** at `Index.vue:130`. Accurate, one idea, real alt text, and a
+  caption that repeats the claim in words. It is the model the three proposed diagrams should
+  follow.
+- **Cost as a first-class subject.** Named in the Overview's feature list, explained in the
+  caching bullet with the reason it matters when comparing candidates, and reported per model
+  and per fusion.
+- **The navigation.** It declares the four page types and separates reference into its own
+  tab. Most sites do not get this far, and it is why the page-type findings above are three
+  fixes rather than a restructure.
+- **The FAQ content itself.** The provider-key answer explains that the error names the
+  credential rather than the configuration, which is precisely the sentence that saves
+  someone an hour. Move it, do not cut it.
+
+## What this run says about the skill
+
+Findings the skill produced that a plain read would likely have missed: the page-type
+mismatch on Installation, which came from the nav declaring the type and the page not
+honouring it; the three diagram gaps, which came from the concept-to-diagram table rather
+than from noticing an absence; and the trust-check gap on versioning, which is easy to
+overlook because nothing on the page is wrong.
+
+One weakness found in the skill: `review-angles.md` says to run the code and report real
+output, but gives no guidance for a docs set whose examples cannot be run in the review
+environment. This run could not execute any Python. The file should say what to do in that
+case, which is to mark the examples unverified and check them for internal consistency
+instead, rather than staying silent.
+
+That rule is now in the skill, and the change is recorded in `PROVENANCE.md`.
+
+## Second run: with the context skill loaded
+
+The same reader path, re-read with the project's canonical terminology loaded. Everything
+here is a finding the first run could not produce, because it needs an external authority on
+what is true and what may be claimed. In the first run these slots were reported as
+unavailable rather than guessed, which is the behaviour under test.
+
+Caveat on both directions: canon is stamped as current to 2026-08-29 and the docs are
+checked against commit `90a104e3`. Either can be the stale one, so each item below is a
+reconciliation, not a verdict that the docs are wrong.
+
+**1. A benchmark id that is not in canon.** Canon names the supported set as `draco`,
+`ifeval`, `healthbench`, and the `healthbench-worst30` variant. The Overview's smallest
+example runs `benchmark="draco-3pass"`, which appears nowhere in that list. Either canon is
+behind a shipped variant, or the docs are advertising something unsupported. This also
+sharpens friction 9: a reader cannot tell whether `prepare draco` covers it.
+
+**2. A disclosure rule the Overview does not satisfy.** Canon records that a result on a
+benchmark the organisation authored or hosts must name that fact in the same sentence as the
+result, and separately that no state-of-the-art claim may be made on a benchmark the
+organisation authored. Canon also lists DRACO among the boards the organisation would build
+and own because no authoritative one exists.
+
+The Overview states "A reproduction of the DRACO deep-research benchmark put the best fusion
+at 68.6% against 60.2% for the best single model" with no such disclosure. And the tutorial
+listed in the navigation is titled "Reproduce DRACO state-of-the-art".
+
+This is the highest-value finding of either run, and it is exactly the kind a purely
+structural review cannot reach. It needs a person who owns the claims policy, not a docs
+fix. Flagging, not rewriting.
+
+**3. "Reproducible" against "auditable".** Canon says results on held-out benchmarks are to
+be described as auditable rather than reproducible. Two adjacent Overview bullets say
+"**Held-out grading**" and "**A reproducible artifact for every run** ... Anyone holding it
+can run the same evaluation". Read together they claim the thing canon reserves. The
+distinction canon draws is real and worth keeping: the url4 expression is reproducible, the
+score on held-out data is auditable.
+
+**4. Product-name casing.** Canon treats Client, Studio, Engine, Leaderboard, and Toolkit as
+product names. The docs write "engine" and "leaderboard" in lower case through most of the
+prose while also using "ScreamingFace Leaderboard" in one FAQ answer. Minor, and the docs
+are internally almost consistent, so the fix is to pick canon's casing or to record a
+deliberate exception.
+
+**5. Canon's own confidence.** The top term carries status "Needs Review", with a note that
+provisional wording should not ship in external copy unchecked. The Overview's opening is
+external copy. Worth knowing before treating any of the above as settled.
+
+**What went right.** The docs do not mention the parent organisation anywhere on the reader
+path, which matches canon's rule against leading with that connection. Nothing on the path
+contradicted it.
+
+## What the two runs together say
+
+The no-context run found structure, ordering, terminology drift inside the docs, missing
+outputs, and missing diagrams. The context-loaded run found a possible claims-policy breach,
+an unsupported benchmark id, and a word the project has explicitly reserved.
+
+Neither run found the other's findings. That is the argument for the context contract being
+part of the skill rather than an optional extra, and it is also the argument against running
+a docs review with nothing loaded and calling it done.

--- a/public-docs/ome-898/01-writing-docs/dogfood/syft-space-hub-review.md
+++ b/public-docs/ome-898/01-writing-docs/dogfood/syft-space-hub-review.md
@@ -1,0 +1,120 @@
+---
+title: "writing-docs: different-domain verification run"
+ticket: OME-898 (child 1, not yet filed)
+results: ./RESULTS.md
+status: draft
+date: 2026-09-02
+---
+
+# Different-domain run: the SyftHub SDK documentation
+
+Purpose is verification, not a commissioned review: does the skill produce useful findings
+on a documentation set it was not written for, without leaning on anything from the first
+project?
+
+Target: the SDK section of the Syft Space Hub docs site. Reader path is the section's own
+Getting Started order, plus its navigation tree.
+
+**Caveat on how different this is.** The first target was ported from this codebase, so the
+two share chrome, layout components, and navigation shape. This tests a different product,
+a different reader, and a different domain. It does not test a different framework or a
+different organisation. Findings marked *inherited* appear in both sites and may come from
+the shared lineage rather than from independent decisions.
+
+## Context slots
+
+None available. There is no context skill for this product, and this reviewer knows nothing
+about it beyond what the pages say.
+
+| Slot | Available |
+|---|---|
+| the reader | **no**. Inferred from the section itself: a developer integrating an SDK. Stated as an inference, not a fact |
+| the time budget | **no** |
+| operational metrics | **no** |
+| product facts, terminology casing, positioning | **no** |
+| house voice, target voice, house writing skill | **no** |
+
+So nothing below asserts what the product is or does. Every product statement is what the
+page claims.
+
+## Findings
+
+**1. Installation is filed as onboarding and is almost pure reference.** The navigation puts
+it under "Getting Started", between Overview and Quick Start. The page contains an
+environment-variable table, a constructor with every optional parameter enumerated in
+comments, a requirements block, and a resource-cleanup section. It contains no numbered
+steps, no narrative, and no single path a newcomer can follow start to finish.
+
+This is the sharpest page-type violation in either run. The remedy is the split, not a trim:
+a short tutorial that installs the package, sets one URL, and makes one successful call,
+with the table and the full option list moving to a reference page.
+
+**2. The page opens with no prose.** The first element after the title is `<h2>Installing the
+SDK</h2>` followed immediately by a code block. No sentence says what the SDK is for, what
+the reader needs first, or what will be true when they finish. First contact has nothing to
+work with.
+
+**3. Two languages in tabs, with real divergences and no map.** Every block offers Python and
+TypeScript. Three differences are load-bearing:
+
+| Difference | Where it is stated |
+|---|---|
+| `timeout` is seconds in Python, milliseconds in TypeScript | a callout box, correctly |
+| accounting email and password are Python only | one column of the env-var table |
+| `login` takes keywords in Python and positional arguments in TypeScript | nowhere |
+
+Tabs imply parity. Where parity does not hold, a reader who switches languages carries
+assumptions that are quietly wrong. The timeout callout shows the team knows this and does
+it well once. It needs to be done for every divergence, in one place a reader can check.
+
+**4. The documented pattern puts a password in source.** The client constructor example
+passes `accounting_password="your-password"` inline, and the cleanup example hard-codes
+`login(username="alice", password="secret123")`. The env-var route exists on the same page
+and should lead, with the inline form either removed or shown as the thing not to do. A
+reader copying the first example they see is copying the wrong one.
+
+**5. The section has three of the four page types and no explanation at all.** Getting
+Started, User Guides, and Reference are all present. Nothing in the section answers why the
+thing exists or why it is built this way. For a product in this domain that is the question a
+new reader most needs answered, and there is no page for it.
+
+**6. Decorative glyphs on every navigation entry.** Nine entries, nine symbols, several of
+them obscure. They carry no information the label does not, and the prose rules treat
+decoration as noise. Minor, and *inherited*: the same pattern shape appears on the other
+site.
+
+**7. The verify step prints a version and shows no expected output.** *Inherited*, in a
+different shape. Better than the other site's magic count, because a version cannot drift
+into a wrong assertion, but a reader still cannot tell whether what they saw was right.
+
+## Out of scope, and correctly so
+
+The pages carry hard-coded colour utilities, for example `text-yellow-400` and `bg-zinc-900`,
+rather than theme tokens. That is a design-system concern about component-level presentation,
+which the skill explicitly cedes. Noting it here only to record that the boundary rule fired
+rather than being ignored.
+
+## Verification result
+
+**Pass.** The skill produced seven findings on a documentation set it was not built for. Five
+are specific to this set and could not have come from the first run: the near-total absence
+of tutorial content in a page filed as onboarding, the missing opening prose, the
+two-language asymmetry, credentials in source, and a whole page type missing from the
+section. Two are marked inherited and discounted accordingly.
+
+Nothing in the output assumed anything about the first project. No concept, name, or metric
+from it appears. With no context skill available the run reported every slot as unavailable
+and made no claim about what this product is.
+
+## What this run changed in the skill
+
+One gap found. The skill has nothing to say about documentation that covers two
+implementations in parallel, which is common for an SDK shipped in more than one language.
+The page-type model does not reach it, because the problem is not which type the page is; it
+is that a tabbed interface asserts parity that the APIs do not have.
+
+Rule added to `reference/prose-tells.md`, in the structure table:
+
+> **NEVER** present two implementations in parallel tabs without stating where they diverge.
+> **INSTEAD** keep one list of the differences, and repeat any divergence that changes a
+> call signature, a unit, or an availability at the point of use.

--- a/public-docs/ome-898/01-writing-docs/plan.md
+++ b/public-docs/ome-898/01-writing-docs/plan.md
@@ -1,0 +1,102 @@
+---
+title: "writing-docs: implementation plan"
+ticket: OME-898 (child 1, not yet filed)
+spec: ./spec.md
+status: draft
+date: 2026-08-20
+---
+
+# writing-docs: implementation plan
+
+Builds the skill described in `spec.md`. Nothing in the deliverable names a product, an
+organisation, or a repository. Everything specific arrives through the context contract.
+
+## Where the work happens
+
+The work item is a Linear `OME-N` issue, so its spec, plan, and ledger belong to this
+monorepo's artifact trail. The skill itself does not: it is authored standalone and
+installed as a plugin. Worth stating plainly, because the worktree-per-unit rule applies to
+a repository this unit does not write to. The branch and PR happen where the skill lives.
+The ledger and this plan stay here.
+
+## Steps
+
+**1. Survey candidate sources.**
+Look at what documentation skills already exist: the divio skill, the humanizer repository,
+and anything else worth pulling from. Output is a table in `reference/PROVENANCE.md` with
+each candidate marked adopted or rejected, and a reason. This is what makes the survey
+finish instead of running indefinitely.
+
+**2. Check licences.**
+For every source that gets distilled, record the licence and the attribution line in
+`PROVENANCE.md` before any of its content is written down. Distilled rules with credit, not
+copied text. Add a drift check per source, so a later divergence is detectable.
+
+**3. `reference/divio.md`.**
+The four modes, each with who the reader is and what breaks when the page mixes modes. The
+one-page-one-mode rule, and the remedy: split, do not balance.
+
+**4. `reference/prose-tells.md`.**
+The `NEVER` / `INSTEAD` tables, craft rules only. Every prohibition gets a replacement,
+because a rule with no replacement gets ignored under deadline. State at the top that the
+file is authoritative on its own and defers to nothing, and that duplication with a house
+writing skill is accepted rather than avoided.
+
+**5. `reference/diagrams.md`.**
+The table of concepts that need a picture, the four hard rules, how to specify a missing
+diagram, and paste-ready starting points for each diagram type.
+
+**6. `reference/review-angles.md`.**
+Distil the owner's reviewer prompt into three passes, the nine-item scorecard with anchors,
+the trust check, the output format, and the review rules. The de-specification is the work
+here: the source prompt carries one product, one reader persona, and one metric triad, and
+each of those becomes a contract slot rather than text in the file.
+
+**7. `SKILL.md`.**
+In this order: the two modes; load the context; pick the page type first; shape the page;
+decide what to draw; write the prose; then the review flow and what the skill does not
+cover. Frontmatter carries `description` and `user_invocable: true`.
+
+**8. Checks.**
+Grep the whole skill, `reference/` included, for product names, organisation names,
+repository paths, and design-system names. Then grep for em-dashes and en-dashes. Then check
+that no reference file depends on another skill being loaded. All three expect zero hits. These run before review rather than after, because they are the checks
+that caught two coupling leaks and a punctuation breach in the drafts.
+
+**9. Ship it.**
+Land the skill, then confirm it installs through the host's plugin mechanism and is
+invocable as `/writing-docs`.
+
+## Verification
+
+Run the checks in `spec.md` §9. The three that decide whether it is finished:
+
+- **With nothing loaded**, the skill produces structure, prose, and diagram guidance and
+  refuses to assert product claims, reporting the reader and metric slots as unknown. If it
+  invents a claim here, it is not done.
+- **With a context skill loaded**, that project's reader, metrics, and terminology are
+  applied, and none of its specifics appear inside the skill.
+- **Against a project in a different domain**, nothing in the output assumes the first
+  project.
+
+The rest is dogfooding: pick a real page that mixes modes and check the skill catches it,
+then run the full review against a real documentation set to confirm it yields a friction
+log with quoted locations and a paste-ready diagram rather than adjectives.
+
+## Adoption here
+
+Deliberately not part of this unit. Installing the plugin and adding the routing note is
+`.claude/` work, and the epic already has a child that owns the `.claude/` flow. Folding it
+there keeps this unit from reaching into a product repository, which is the whole point of
+building the skill standalone.
+
+## Sequence
+
+```
+1 survey -> 2 licences -+-> 3 divio ---------+
+                        +-> 4 prose tells ---+
+                        +-> 5 diagrams ------+-> 7 SKILL.md -> 8 checks -> 9 ship
+                        +-> 6 review angles -+
+```
+
+Steps 3 through 6 are independent and can be written in any order. Step 7 wants all four.

--- a/public-docs/ome-898/01-writing-docs/spec.md
+++ b/public-docs/ome-898/01-writing-docs/spec.md
@@ -1,0 +1,313 @@
+---
+title: "writing-docs: a documentation-writing skill"
+ticket: OME-898 (child 1, not yet filed)
+plan: ./plan.md
+status: draft
+date: 2026-08-20
+---
+
+# writing-docs
+
+A skill that tells whoever works on documentation, person or agent, what shape a page should
+take, how the prose should read, when a concept needs a picture, and how to review a page
+someone else wrote.
+
+It exists because documentation gets written to whatever shape the writer had in mind that
+day. Reference detail lands in a tutorial, a how-to stops to teach, structure that wants a
+diagram arrives as three paragraphs of prose, and the writing carries the usual generated
+tells. There is no shared answer to "what kind of page is this?", so every writer invents
+one.
+
+**The skill is completely agnostic.** It names no product, no organisation, no repository,
+and no file path. Everything specific to whoever installs it, house voice included, arrives
+through the contract in §5 and is resolved at runtime. A skill that hard-codes one project's
+conventions is that project's skill with a general label on it.
+
+Parent: `OME-898`.
+
+## 1. Two entry points
+
+The skill does two jobs, and they share the same reference material.
+
+| Mode | Question | Uses |
+|---|---|---|
+| **write** | I am about to write or change a page | §4.1 page shape · §4.2 prose · §4.3 diagrams |
+| **review** | I am reading a page someone else wrote | §4.4 review angles, which lean on all three |
+
+Keeping them in one skill is deliberate: a review that judges a page against different
+rules than the writer was given is a review nobody can act on.
+
+## 2. Non-goals
+
+- **No CI gate and no lint script.** Advisory only (owner, 2026-09-02).
+- **No product facts, no house voice rules, no positioning language.** All of it belongs to
+  a context skill (§5). A rule naming a product or an organisation cannot ship here,
+  however small it is.
+- **Not a docs generator.** This governs documentation a person or agent writes, not docs
+  derived from a diff.
+- **Not for internal engineering artifacts.** See §3.
+- **No repository, path, or toolchain assumptions.** The skill must work in a project it has
+  never seen.
+
+## 3. Scope
+
+Scope is a class of document, not a location.
+
+**In scope, anything written for a reader outside the authoring team:** documentation pages,
+READMEs, narrative or tutorial notebooks, release notes and changelog prose.
+
+**Out of scope:**
+
+| Excluded | Why |
+|---|---|
+| specs, plans, ledgers, design docs | written for the team, and the four modes in §4.1 do not describe them |
+| generated API reference | derived from source, so a toolchain concern rather than a prose one |
+| issue bodies, pull-request text, commit messages | governed by a project's own process conventions |
+
+The boundary is the reader. If someone outside the team reads it, this skill applies.
+
+## 4. What the skill composes
+
+Three distilled inputs, and nothing else. The skill calls no other skill. Everything that is
+project specific is a §5 slot.
+
+| Input | Answers | Origin |
+|---|---|---|
+| divio | what shape is this page? | the divio documentation system |
+| prose tells | does this read like a person wrote it? | `github.com/blader/humanizer` |
+| review angles | what is wrong with the page in front of me? | the owner's reviewer prompt |
+
+### 4.1 divio: page shape
+
+Four modes, and the rule that **one page serves exactly one mode**:
+
+| mode | serves | reader is | what breaks when mixed |
+|---|---|---|---|
+| tutorial | learning | a beginner following along | reference detail stalls the beginner |
+| how-to | a goal | someone with a task in hand | teaching interrupts the task |
+| reference | lookup | someone who knows what they want | narrative buries the fact |
+| explanation | understanding | someone asking why | how-to steps derail the argument |
+
+Mixing modes on one page is the most common documentation failure, so mode selection comes
+first, and a mixed page is a defect to split rather than a style preference to discuss.
+
+### 4.2 Prose tells: how it reads
+
+Throat-clearing openers, the "it's not just X, it's Y" construction, reflexive triads,
+stacked hedging, over-signposting, and closing paragraphs that summarise what the reader
+just read. Written as a `NEVER` / `INSTEAD` table so every prohibition carries a
+replacement. A rule with no replacement gets ignored under deadline.
+
+These are craft rules, true in any project. Register conventions that vary by house, such as
+whether contractions are allowed, are not here. They are the house-voice slot in §5.
+
+Two rules from the review angles live here rather than being stated twice: **numbers over
+adjectives** (a performance claim without methodology is not a fact) and **prefer
+deletion** (clarity is usually fewer words, so a fix that adds text has to justify itself).
+
+### 4.3 Diagrams: when prose is the wrong medium
+
+The test: *is the reader being asked to assemble a picture in their head that the page
+should have drawn?* Structure, flow, sequence, state, and decisions are all cheaper to see
+than to read.
+
+Concepts that need a diagram unless they are trivial:
+
+| Concept | Diagram | The question it answers |
+|---|---|---|
+| components and boundaries | component | what are the pieces, and what talks to what? |
+| request or data flow | flow or sequence | what happens on one call, and where does cost accumulate? |
+| composition topology | topology | how do parts chain, fan out, or fall back, and where do errors travel? |
+| lifecycle | state | what states exist, and what moves between them? |
+| "use X when, use Y when" | decision tree or matrix | which one do I pick? |
+| tradeoff space | annotated chart or table | where does each configuration land? |
+
+Four hard rules:
+
+- **One idea per diagram.** A figure needing a paragraph to explain it has failed. Split
+  overloaded figures, cut decorative ones.
+- **Diagrams as code.** A text format that lives in the repo and is reviewed in the PR.
+- **Text and picture agree.** Every label uses the exact name the prose and the API use. If
+  the diagram forces better names, rename the prose too.
+- **A stale diagram is worse than none.** It teaches a wrong model, confidently.
+
+### 4.4 Review angles: reading a page as its reader
+
+A review procedure, in three passes. Its value is that it is done as a specific reader with
+a specific goal and a real time budget, not as a copyeditor.
+
+**Pass 1, the naive read.** Read in the order the docs present. Do not skip ahead, and do
+not use knowledge the docs have not given you. Log every point of friction with its
+location and the exact sentence: a re-read to parse, a term used before it is defined, a
+scroll back to check something, a guess at what a parameter does, an unanswered "why this
+way?", a sample that would not run as written, and any sudden jump in difficulty. Small
+frictions count, because they compound into abandonment.
+
+**Pass 2, the structural read.** Map what each section assumes and where that was
+introduced: forward references, orphaned concepts, redundant re-explanations, terminology
+drift. Then check the arc (what it is → why it exists → smallest working thing → core
+abstractions → how they compose → operational reality → limits) and note where the page
+jumps, backtracks, or stalls. Check whether examples grow minimal → realistic →
+production-shaped, one new idea at a time.
+
+**Pass 3, the visual pass.** For every concept, mark it: has a diagram that works; has one
+that fails (decorative, overloaded, stale, or labelled differently from the text); or needs
+one and lacks it. For each gap, say what the reader needs to see: the boxes, the arrows, the
+labels, and the one question it answers.
+
+**Scorecard**, each scored 1 to 5 with quoted evidence: first contact · time to first
+success · concept ordering · learning-curve shape · example quality · reference
+navigability · terminology discipline · honest operations · visual clarity.
+
+**Trust check.** Limitations and "when not to use this" stated plainly rather than buried;
+claims carrying methodology; operational tradeoffs surfaced where the design decisions are
+made rather than in an appendix; no unverifiable superlatives; and the signs of a project
+expecting to be depended on, meaning versioning, changelog, migration notes, a contribution
+path. Every sentence that erodes trust gets quoted **and rewritten**.
+
+**Output**: verdict · friction log · flow map · scorecard · diagram plan with paste-ready
+diagram source · top fixes as before and after · what already works, so nobody fixes it
+away.
+
+**Rules that make the review usable:** be specific and quote the location; rewrite rather
+than critique; run the code if you can and report real output; do not grade on a curve,
+because "fine for docs" is not the bar.
+
+### 4.5 The survey
+
+The epic asks for a look at what other documentation skills exist. It terminates by
+construction: every candidate is recorded in `reference/PROVENANCE.md` as adopted, or
+rejected with a reason. An unsurveyed candidate is not a defect. An undocumented decision
+is.
+
+### 4.6 Independence, and accepted duplication
+
+The skill calls no other skill. `reference/prose-tells.md` is authoritative on its own and
+does not defer to a house writing skill, even where a house skill carries the same rule.
+
+That duplication is deliberate (owner, 2026-09-02). A skill that only works properly
+alongside another one is not independent, whatever its own files say. The cost is real and
+named: two copies of a rule can drift apart, and the drift check in `PROVENANCE.md` is the
+only thing watching for it.
+
+## 5. The context contract
+
+The skill holds no project or organisation knowledge. It declares what a context skill must
+supply and consumes whatever the host has.
+
+The review procedure is what makes this contract load-bearing rather than decorative. Pass 1
+cannot be run without knowing who the reader is and what they came to do.
+
+| Slot | Supplies | Used by |
+|---|---|---|
+| house voice | register conventions the house holds to, beyond the craft rules | write, trust check |
+| product facts | what the thing is, what its parts are called | write and review |
+| terminology casing | exact casing of names | write and review |
+| positioning language | how the project describes itself | write |
+| the reader | who the newcomer is, and what they came to do | review pass 1 |
+| the time budget | how long they will spend before giving up | review pass 1 |
+| operational metrics | the numbers this project's readers judge it by | scorecard, trust check |
+| target voice | the voice a rewrite should land in | trust check |
+
+More than one skill may fill the contract: one supplying house voice, another product facts.
+The skill consumes whatever is loaded and does not care how many there are.
+
+**Resolution.** Before writing or reviewing, look for loaded context skills and apply them.
+Loading happens through the host's own plugin mechanism. This skill does not name, install,
+or import one.
+
+**Degradation is the load-bearing part.** With nothing loaded, the skill produces page
+structure, prose craft, and diagram guidance, and **flags every product claim and voice
+choice as unverified rather than inventing one**. The review still runs, with the reader and
+metric slots reported as unknown rather than assumed. A skill that guesses at positioning is
+worse than one that says it does not know.
+
+## 6. Layout
+
+```
+writing-docs/
+  SKILL.md                      the two modes, mode selection, the anti-rules table,
+                                the context contract, the degradation path
+  reference/divio.md            the four modes, distilled
+  reference/prose-tells.md      the NEVER / INSTEAD tables
+  reference/diagrams.md         which concepts need a picture, and the four hard rules
+  reference/review-angles.md    the three passes, scorecard, trust check, output, rules
+  reference/PROVENANCE.md       source, licence, retrieval date, and drift check per
+                                source, plus what the survey rejected and why
+```
+
+`diagrams.md` is its own file rather than part of the review angles because it is needed
+when writing a page, not only when reviewing one.
+
+**Before distilling:** check the licence on each source and record attribution in
+`PROVENANCE.md`. Distilled rules with credit, not wholesale copies of someone's text.
+
+## 7. Decisions
+
+Owner, 2026-09-02:
+
+- **Advisory only.** No lint, no CI gate in this unit.
+- **Completely agnostic.** No product and no organisation specifics in the skill. All of it
+  arrives through §5.
+- **The skill is independent, and duplication is accepted.** This reverses an earlier
+  instruction on the same day. An intermediate version ran a house writing skill's passes and
+  let it win on conflict; that is removed. Where this skill's prose rules restate rules a
+  house skill also carries, the duplication stands. It also means the epic's "should use that
+  skill because it will evolve" is knowingly not satisfied: the owner chose independence over
+  inheritance. See §4.6.
+
+Recorded so they are not re-opened:
+
+- **Scope is a document class, not a path** (§3), read from the epic's two constraints:
+  product reviews docs manually at release, and docs must match product voice. Both point at
+  prose a reader outside the team sees.
+- **The review angles are de-specified into a procedure plus context slots** (§5). The source
+  prompt was written for one product, one reader, and one metric triad. The passes, scorecard,
+  and rules all survive removing those, and the specifics become contract slots.
+- **Name: `writing-docs`.** Reads as an action at the invocation site, and carries no product
+  noun.
+- **No design-system precedence section.** An earlier draft carried a rule about which
+  system wins on component copy. It was generic in wording but existed only because of one
+  specific design system, which is the coupling this decision forbids. Cut.
+
+Mine rather than the epic's, and flagged as such:
+
+- **The skill is authored and published standalone rather than inside a product
+  repository.** It follows from agnosticism but the epic does not say it. Authoring it inside
+  a product repo is what made the first draft of this spec fail: repository paths, a named
+  design system, and a hard dependency on one context skill all crept in. Where it is
+  published is a distribution question and does not appear anywhere in the skill's content.
+
+## 8. Acceptance
+
+- The skill exists with a `description` and `user_invocable: true`, and installs through the
+  host's plugin mechanism.
+- **Agnosticism check:** no product name, organisation name, repository path, or
+  design-system name appears anywhere in the skill, `reference/` included. The only
+  context-shaped thing is the §5 contract, which names nothing.
+- **Punctuation check:** no em-dashes or en-dashes anywhere in the skill.
+- The four modes are stated with the one-mode rule and the remedy for a mixed page.
+- A `NEVER` / `INSTEAD` table for the prose tells, holding craft rules only, with no house
+  register conventions.
+- The diagram table and the four diagram rules, including diagrams-as-code.
+- The three review passes, the nine-item scorecard, the trust check, and the output format.
+- **Independence check:** the skill references no other skill by name or by role, and every
+  reference file is complete on its own.
+- `PROVENANCE.md` records source, licence, retrieval date, and a drift check for each
+  distilled source, plus the survey's verdicts.
+- The degradation path is written down and says to flag unverified claims rather than invent
+  them.
+
+## 9. Verification
+
+- Take a page that mixes modes. The skill names the conflict and proposes the split.
+- Run the review against a real documentation set. It produces a friction log with quoted
+  locations and at least one paste-ready diagram, not a list of adjectives.
+- Run it with no context skill loaded: it produces structure, prose, and diagram guidance,
+  and reports the reader and metric slots as unknown rather than assuming them.
+- Run it with a context skill loaded: the reader, the metrics, and the terminology are
+  applied, and none of that project's specifics appear inside `writing-docs` itself.
+- Hand `reference/review-angles.md` to someone who did not write it. They find a real gap
+  using only that checklist.
+- Run it against a project it was not written for, in a different domain. Nothing in the
+  output assumes the first project.

--- a/public-docs/ome-898/01-writing-docs/writing-docs/SKILL.md
+++ b/public-docs/ome-898/01-writing-docs/writing-docs/SKILL.md
@@ -1,0 +1,140 @@
+---
+description: How to write and review documentation that reads well and is shaped right. Pick the page type (tutorial, how-to, reference, explanation), keep prose free of generated tells, decide when a concept needs a diagram, and review a page as the reader it was written for. Use when writing or changing any documentation page, README, tutorial notebook, or release notes; when reviewing docs someone else wrote; or when deciding how a documentation set should be organised.
+user_invocable: true
+---
+
+# writing-docs
+
+Two jobs, one set of rules.
+
+| Mode | You are | Go to |
+|---|---|---|
+| **write** | about to write or change a page | §2 |
+| **review** | reading a page someone else wrote | §3 |
+
+A review that judges a page against different rules than the writer was given is a review
+nobody can act on, so both modes read from the same four reference files.
+
+| File | Holds |
+|---|---|
+| `reference/divio.md` | the four page types and how to pick one |
+| `reference/prose-tells.md` | the `NEVER` / `INSTEAD` table |
+| `reference/diagrams.md` | which concepts need a picture |
+| `reference/review-angles.md` | the three review passes, scorecard, trust check |
+
+## 1. Step zero: load the context
+
+This skill holds no knowledge about any particular product, project, or house style. Before
+writing or reviewing, look for a loaded context skill and read these slots from it.
+
+| Slot | Supplies | Needed for |
+|---|---|---|
+| house voice | register conventions this house holds to, beyond the craft rules | write, rewrite |
+| product facts | what the thing is, what its parts are called | write, review |
+| terminology casing | the exact casing of every name | write, review |
+| positioning language | how the project describes itself | write |
+| the reader | who the newcomer is and what they came to do | review pass 1 |
+| the time budget | how long they will spend before giving up | review pass 1 |
+| operational metrics | the numbers this project's readers judge it by | scorecard, trust check |
+| target voice | the voice a rewrite should land in | trust check |
+
+More than one skill may fill these. Read whatever is loaded. Do not install or import
+anything.
+
+**If nothing is loaded, do not invent it.** Produce page structure, prose craft, and diagram
+guidance as normal, then:
+
+- state which slots were unavailable
+- mark every product claim you cannot verify as unverified, rather than writing a plausible one
+- in review, report the reader and the metrics as unknown rather than assuming a persona
+
+Guessing at what a product is, or at how it describes itself, produces confident and wrong
+documentation. Saying you do not know produces a question someone can answer in a minute.
+
+## 2. Write mode
+
+### 2.1 Pick the page type first
+
+One page serves exactly one type. Read `reference/divio.md` and choose before writing a
+sentence.
+
+| type | serves | reader is |
+|---|---|---|
+| tutorial | learning | a beginner following along |
+| how-to | a goal | someone with a task in hand |
+| reference | lookup | someone who knows what they want |
+| explanation | understanding | someone asking why |
+
+If the page you are changing already serves two types, that is a defect. **Split it.** Do not
+balance the two.
+
+### 2.2 Shape the page
+
+Within a type, build the reader's model in layers: what this is, why it exists, the smallest
+thing that works, the core abstractions, how they compose, the operational reality, then the
+limits. Examples grow from minimal to realistic to production-shaped, one new idea at a
+time.
+
+Two rules catch most structural damage.
+
+- **Nothing is used before it is introduced.** If a term appears before its definition, move
+  one of them.
+- **One name per concept, everywhere.** Two names for one thing cost the reader more than
+  any prose flaw.
+
+### 2.3 Decide what to draw
+
+Ask at every concept: *am I asking the reader to assemble a picture in their head that this
+page should have drawn?* Structure, flow, sequence, state, and decisions are all cheaper to
+see than to read. `reference/diagrams.md` has the table and the four hard rules.
+
+### 2.4 Then write the prose
+
+`reference/prose-tells.md` in full. The rules that matter most often:
+
+| NEVER | INSTEAD |
+|---|---|
+| Announce what the section will do. "Let's dive in", "In this section we will…" | Start with the content. The heading already announced it. |
+| Close with a summary of what the reader just read, or a generic outlook. | End on the last real point. |
+| Adjectives for performance. "fast", "lightweight", "scalable". | The number, the method, and the conditions. |
+| Stacked hedging. "may potentially, in some cases". | One hedge, or none. |
+| A forced triad because three sounds complete. | As many items as are true. |
+| Sales register. "seamlessly", "powerful", "nestled within". | Say what it does. |
+| Em-dashes. | A comma, a colon, parentheses, or a full stop. |
+
+**Prefer deletion.** Clarity is usually fewer words. A fix that adds text has to justify
+itself.
+
+## 3. Review mode
+
+Run `reference/review-angles.md` end to end. In outline:
+
+**Pass 1, the naive read.** Read in the order the docs present, as the reader from §1, with
+their time budget. Do not skip ahead, and do not use knowledge the docs have not given you.
+Log every friction with its location and the exact sentence.
+
+**Pass 2, the structural read.** Map what each section assumes and where that was
+introduced. Find forward references, orphaned concepts, terminology drift, and the places
+where the arc jumps, backtracks, or stalls.
+
+**Pass 3, the visual pass.** For every concept: has a diagram that works, has one that
+fails, or needs one and lacks it. For each gap, specify the boxes, the arrows, the labels,
+and the one question it answers.
+
+Then score the nine rubric items, run the trust check, and produce the output in the order
+`reference/review-angles.md` specifies. Four rules separate a review someone acts on from
+one they ignore.
+
+- **Quote the location.** "The quickstart is confusing" is not a finding.
+- **Rewrite, do not critique.** Show the replacement text or the diagram source.
+- **Run the code.** Report real errors and real output, not assumptions.
+- **Do not grade on a curve.** "Fine for docs" is not the bar.
+
+## 4. What this skill does not cover
+
+- **Internal engineering artifacts:** specs, plans, design docs, ledgers. They are written
+  for the team, and the four page types do not describe them.
+- **Generated API reference.** That is a toolchain question.
+- **Issue, pull-request, and commit text.** Each project has its own conventions.
+- **Component-level copy** where a design system governs it: labels, buttons, chart legends,
+  badges. That system wins inside a component. This skill governs the prose around it.

--- a/public-docs/ome-898/01-writing-docs/writing-docs/reference/PROVENANCE.md
+++ b/public-docs/ome-898/01-writing-docs/writing-docs/reference/PROVENANCE.md
@@ -1,0 +1,70 @@
+# Provenance
+
+What this skill is built from, under what terms, and what was considered and left out.
+
+## Distilled sources
+
+| Source | Author | Licence | Retrieved | Used in | How |
+|---|---|---|---|---|---|
+| Diátaxis, the four-document framework | Daniele Procida, `diataxis.fr` | not stated on the site or its colophon (checked on retrieval) | 2026-09-02 | `divio.md` | described in our own words; no text reproduced |
+| humanizer | `github.com/blader/humanizer` | MIT | 2026-09-02 | `prose-tells.md` | pattern list reorganised into rule-and-replacement form, then extended |
+| documentation reviewer prompt | supplied by the owner of this skill | internal | 2026-09-02 | `review-angles.md`, `diagrams.md` | de-specified: one product, one reader, and one metric set removed and replaced by context slots |
+
+Because the Diátaxis licence is unstated, `divio.md` paraphrases the framework and cites it
+rather than copying any of its wording. If the licence is later published and permits
+reproduction, that file can be tightened against the original.
+
+## Drift check
+
+Each distilled source can move. To check whether this skill has fallen behind:
+
+| Source | Check | Expected |
+|---|---|---|
+| Diátaxis | re-read `diataxis.fr` and compare the four types and their definitions against `divio.md` | four types, same distinctions |
+| humanizer | re-read its pattern list and diff against the four tables in `prose-tells.md` | every upstream pattern has a row, or a recorded reason it does not |
+| reviewer prompt | compare against `review-angles.md`: three passes, nine rubric items, the trust check, the output order | all present, none carrying a product name |
+
+Run the drift check when a source publishes a new version, and record the date here.
+
+## Survey: what else was considered
+
+The brief asked for a look at other documentation skills worth pulling from. Candidates are
+recorded by role rather than by name, so that this file stays free of any one organisation's
+vocabulary. The named detail lives in the work item that commissioned the skill.
+
+| Candidate | Verdict | Reason |
+|---|---|---|
+| a house content-writing skill (voice, AI-tell scrubbing, terminology, personas, revision passes) | **not referenced; duplication accepted** | this skill stays independent by decision. Where its prose rules restate rules such a skill also carries, the duplication stands, because a skill that only works properly alongside another one is not independent. Its audience-first principle is adopted on the merits: the reader is fixed before any prose. |
+| a product-context skill (product facts, personas, positioning, freshness ranking) | **pattern adopted** | the idea that product facts and personas are loaded rather than assumed became the context contract in `SKILL.md` §1. |
+| a design-system skill (tokens, brand assets, component copy) | **boundary drawn** | component-level copy belongs to whatever design system a project runs. This skill governs body prose. |
+| publishing and distribution skills | **out of scope** | they move a finished document; they say nothing about how it is written or shaped. |
+| a single-purpose content skill (event material, cheat sheets) | **rejected** | one document type, not documentation architecture. |
+| a skill-authoring template and contribution skill | **used as process, not content** | governs how a skill is added to a marketplace, not what belongs in this one. |
+
+**The finding that shaped this skill:** nothing surveyed covers documentation architecture.
+No page-type model, and nothing on when a concept needs a diagram. That gap is what this
+skill fills, and it carries page types, page shaping, diagrams, and the review procedure in
+full.
+
+It runs standalone by design, not as a fallback. It references no other skill, and every
+reference file is complete on its own. With nothing loaded, the prose rules apply in full and
+the review still runs, with the unavailable slots reported as unknown.
+
+The accepted cost of that independence: where a rule here also exists in some other skill,
+the two copies can drift apart, and the drift check above is the only thing watching.
+
+## Changes from use
+
+Findings from running the skill, recorded so the reason for each rule survives.
+
+| Date | Change | Why |
+|---|---|---|
+| 2026-09-02 | `review-angles.md`: added the rule for when the examples cannot be run | The first real review ran in an environment with no runtime, and the file said only "run the code". A reviewer following it literally either stalls or quietly implies they ran something. The rule now names what to check instead. |
+| 2026-09-02 | `prose-tells.md`: added the rule on parallel implementations in tabs | A second review, on a set documenting one SDK in two languages, found three divergences that a tabbed layout hid: a unit difference, an availability difference, and a call-signature difference. Only the first was stated. The page-type model does not reach this, because the defect is the layout asserting parity rather than the page being the wrong type. |
+
+## Agnosticism
+
+No product name, organisation name, repository path, or design-system name appears in this
+skill, including this file. Every project-specific input arrives through the context slots
+listed in `SKILL.md` §1. Adding a name here, however convenient, turns a reusable skill into
+one project's skill wearing a general label.

--- a/public-docs/ome-898/01-writing-docs/writing-docs/reference/diagrams.md
+++ b/public-docs/ome-898/01-writing-docs/writing-docs/reference/diagrams.md
@@ -1,0 +1,137 @@
+# Diagrams
+
+## The test
+
+At every concept, ask: *am I asking the reader to assemble a picture in their head that this
+page should have drawn?*
+
+A wall of prose describing a pipeline is a puzzle the reader has to solve. The same pipeline
+drawn once is handed over already assembled. Structure, flow, sequence, state, and decisions
+are all cheaper to see than to read.
+
+## Which concepts need one
+
+| Concept in the prose | Diagram | The one question it answers |
+|---|---|---|
+| components and their boundaries | component | what are the pieces, and what talks to what? |
+| the journey of one call or one record | flow or sequence | what happens on a single request, and where does cost or latency accumulate? |
+| how parts chain, fan out, cascade, or vote | topology | how is work composed, and where do errors travel? |
+| anything with states and transitions: sessions, jobs, retries, circuit breakers | state | what states exist, and what moves between them? |
+| "use X when…, use Y when…" | decision tree or comparison matrix | which one do I pick? |
+| a tradeoff space across configurations | annotated chart or table | where does each option land relative to the others? |
+
+If a concept in that left column appears as prose only, that is a finding, not a preference.
+
+Three cases do not need a diagram: a linear list of two or three steps, a single component
+with no collaborators, and anything the reader can hold in one sentence.
+
+## Four hard rules
+
+**One idea per diagram.** A figure that needs a paragraph of explanation has failed. Three
+ideas in one figure means three figures. Split overloaded diagrams; delete decorative ones.
+
+**Diagrams as code.** Author them in a text format that lives beside the prose and is
+reviewed in the same change. A picture that cannot be diffed will drift.
+
+**Text and picture agree.** Every label uses the exact name the prose and the API use, with
+the exact casing. If drawing the diagram reveals a better name, rename the prose too rather
+than letting the two diverge.
+
+**A stale diagram is worse than none.** An absent diagram leaves the reader working. A wrong
+one teaches a wrong model, confidently, and they will trust it over the text.
+
+## Specifying a missing diagram
+
+Never write "add a diagram here". A finding is actionable only if it names four things:
+
+1. **the boxes**, using the exact terms from the prose
+2. **the arrows**, and what flows along each one
+3. **the labels** on both, including units where a number crosses an arrow
+4. **the one question** the reader has when they arrive at that point in the page
+
+Then supply the source, ready to paste.
+
+## Paste-ready starting points
+
+Component boundaries:
+
+```mermaid
+graph LR
+  Client[Client] --> Api[API]
+  Api --> Core[Core]
+  Core --> StoreA[(Store)]
+  Core --> Extern{{External service}}
+```
+
+One request, with cost accumulating per hop:
+
+```mermaid
+sequenceDiagram
+  participant Caller
+  participant Api
+  participant Worker
+  participant Extern as External service
+  Caller->>Api: request
+  Api->>Worker: dispatch
+  Worker->>Extern: call (cost: N units)
+  Extern-->>Worker: result
+  Worker-->>Api: result (latency: M ms)
+  Api-->>Caller: response
+```
+
+Composition topology, including where an error can propagate:
+
+```mermaid
+graph TD
+  In[Input] --> Split{Fan out}
+  Split --> A[Branch A]
+  Split --> B[Branch B]
+  A --> Merge[Reduce]
+  B --> Merge
+  Merge --> Out[Output]
+  A -. failure .-> Fallback[Fallback path]
+  Fallback --> Merge
+```
+
+Lifecycle:
+
+```mermaid
+stateDiagram-v2
+  [*] --> Pending
+  Pending --> Running: accepted
+  Running --> Succeeded: complete
+  Running --> Failed: error
+  Failed --> Running: retry (bounded)
+  Failed --> [*]: attempts exhausted
+  Succeeded --> [*]
+```
+
+Decision guidance, replacing "use X when" prose:
+
+```mermaid
+graph TD
+  Q1{Do you need the result now?}
+  Q1 -- yes --> Q2{Is one call enough?}
+  Q1 -- no --> Batch[Use the batch path]
+  Q2 -- yes --> Single[Use the single call]
+  Q2 -- no --> Compose[Use the composed path]
+```
+
+For a tradeoff space, a table beats three paragraphs, and a plot beats the table once there
+are more than about six options. Either way, label the axes with the metric and its unit,
+and mark the baseline the reader is comparing against.
+
+## Reviewing a diagram that already exists
+
+Mark each one:
+
+| Verdict | Test |
+|---|---|
+| works | matches the prose, one idea, same names, current with the API |
+| decorative | removing it loses the reader nothing |
+| overloaded | more than one idea, or needs a paragraph to read |
+| stale | contradicts the current API, the current names, or the current flow |
+| drifting labels | the picture and the text call the same thing different names |
+
+Decorative and stale both get deleted. Overloaded gets split. Drifting labels get one name
+chosen and applied in both places.

--- a/public-docs/ome-898/01-writing-docs/writing-docs/reference/divio.md
+++ b/public-docs/ome-898/01-writing-docs/writing-docs/reference/divio.md
@@ -1,0 +1,66 @@
+# The four page types
+
+A documentation set serves four different needs, and a page that tries to serve two serves
+neither. Pick one before writing.
+
+| type | serves | reader is | reader's question | what it must not do |
+|---|---|---|---|---|
+| **tutorial** | learning | a beginner following along | "teach me how this works" | stop to enumerate options or list parameters |
+| **how-to** | a goal | someone with a task in hand | "help me do this specific thing" | teach concepts they did not ask about |
+| **reference** | lookup | someone who already knows what they want | "what exactly does this do?" | narrate, persuade, or teach |
+| **explanation** | understanding | someone asking why | "why is it built this way?" | give steps to follow |
+
+## Which one am I writing?
+
+Two questions settle it almost every time.
+
+**Does the reader arrive knowing what they want?** No means tutorial or explanation. Yes
+means how-to or reference.
+
+**Do they want to act, or to understand?** Act means tutorial or how-to. Understand means
+reference or explanation.
+
+|  | wants to act | wants to understand |
+|---|---|---|
+| **does not know what they want** | tutorial | explanation |
+| **knows what they want** | how-to | reference |
+
+## What breaks when types mix
+
+Mixing is the most common documentation failure, and each pairing fails in its own way.
+
+| mixture | how it fails |
+|---|---|
+| tutorial + reference | the beginner hits a parameter table and stops following |
+| tutorial + explanation | design rationale interrupts the thing they were doing |
+| how-to + tutorial | a reader with a task is taught material they did not ask for |
+| how-to + explanation | steps stall while the page argues for the approach |
+| reference + explanation | the fact the reader came for is buried in an argument |
+| reference + tutorial | a lookup page assumes a starting state |
+
+## The remedy is a split, not a balance
+
+A mixed page cannot be fixed by trimming the intruding material until it feels
+proportionate. That material is usually worth keeping. It is in the wrong place.
+
+1. Name the two types the page currently serves.
+2. Decide which one the page's title and location promise.
+3. Move the other material to its own page of that type.
+4. Link between them once, in the direction the reader travels.
+
+A tutorial links forward to reference. Reference links back to explanation. How-to links to
+both. Explanation links to nothing operational, because a reader who wants to act has left
+already.
+
+## Signals that a page is mixed
+
+- a parameter or options table inside a numbered walkthrough
+- the word "why" appearing in a page of steps
+- a step that says "for the full list of options, see below", and then supplies it
+- a reference entry whose worked example is longer than its description
+- an explanation page whose last section is called "getting started"
+
+## Attribution
+
+The four-type model is Diátaxis, by Daniele Procida (`diataxis.fr`). It is described here in
+our own words. Nothing is reproduced from it. See `PROVENANCE.md`.

--- a/public-docs/ome-898/01-writing-docs/writing-docs/reference/prose-tells.md
+++ b/public-docs/ome-898/01-writing-docs/writing-docs/reference/prose-tells.md
@@ -1,0 +1,81 @@
+# Prose tells
+
+Patterns that mark text as generated, as marketing, or as padded. Every rule carries a
+replacement, because a prohibition without one gets ignored under deadline.
+
+These are craft rules and hold in any project. **This file is authoritative on its own.** It
+does not defer to another skill and does not need one loaded to be complete. Some of what is
+here will duplicate rules a house writing skill also carries, and that is accepted: a skill
+that only works alongside another one is not independent.
+
+The one thing that still comes from outside is a house's own arbitrary conventions, such as
+whether contractions are allowed or how deep headings may nest. Those arrive through the
+house-voice slot in the context contract, and they are additions rather than overrides.
+
+## Content
+
+| NEVER | INSTEAD |
+|---|---|
+| Inflate importance. "marks a pivotal moment", "a testament to" | State what changed, and what it changed from. |
+| Name-drop a source without saying what it contributes. | Say what it contributes, or cut the reference. |
+| Attribute vaguely. "experts believe", "it is widely considered" | Name who says it, or drop the claim. |
+| Sales register. "seamlessly", "powerful", "nestled within the breathtaking" | Describe what the thing does. |
+| The formulaic contrast. "Despite challenges, X continues to thrive." | State the difficulty and the outcome as separate facts, with numbers. |
+| Adjectives standing in for measurement. "fast", "lightweight", "scalable" | The number, the method, the conditions. Without methodology it is not a fact. |
+
+## Language
+
+| NEVER | INSTEAD |
+|---|---|
+| Filler connectives and vogue nouns: "actually", "additionally", "landscape", "showcasing", "testament", "delve" | Delete, or use a plain verb. |
+| Circumlocution. "serves as", "acts as a mechanism for" | "is", "does". |
+| False progression. "from configuration to deployment", when it is a list rather than a journey | List the items. |
+| A forced triad because three sounds complete. "innovation, inspiration, and insight" | As many items as are true. Two is fine. |
+| The same sentence opener, or the same proper noun, three times running. | Vary the opener. Use a pronoun. |
+| Stacked hedging. "may potentially, in some cases, be able to" | One hedge, or none. |
+
+## Punctuation and typography
+
+| NEVER | INSTEAD |
+|---|---|
+| **Em-dashes.** Not as an aside, not as a connector, not once. | A comma, a colon, parentheses, or a full stop. Each of those says something more specific than a dash does. |
+| En-dashes as connectors. Ranges are the only exception, and "1 to 5" reads better anyway. | "to", or a comma. |
+| Bold sprayed across a paragraph, or emoji as decoration. | At most one bolded phrase, where it carries weight. Emoji only where it is data. |
+| Title Case In Headings. | Sentence case. |
+
+The dash ban is worth its own row because a dash is the punctuation mark that hides the
+writer's decision. Reaching for one usually means the relationship between the two halves
+of the sentence was never settled. Choosing a comma, a colon, or a full stop settles it.
+
+## Voice and residue
+
+| NEVER | INSTEAD |
+|---|---|
+| Assistant remnants. "I hope this helps!", "Great question!" | Delete. |
+| Knowledge disclaimers. "While details are limited…", "As of my last update…" | Say what is known. If nothing is known, say that and stop. |
+
+## Structure
+
+| NEVER | INSTEAD |
+|---|---|
+| Announce the section before delivering it. "Let's dive in", "In this section we will…" | Start with the content. The heading already announced it. |
+| The fake-candid opener. "Honestly? It depends." | Answer, then qualify. |
+| Invent an objection in order to knock it down. "A tempting option would be…" | Address a real objection, or none. |
+| A closing paragraph that restates the page. | End on the last real point. |
+| The generic outlook. "The future looks bright." | Delete. |
+| Over-signposting. "as mentioned above", "as we will see later" | Let the headings carry the structure. |
+| Present two implementations in parallel tabs without saying where they diverge. Tabs assert parity. | Keep one list of the differences, and repeat any divergence at the point of use when it changes a call signature, a unit, or whether something exists at all. |
+
+## Two rules above the tables
+
+**Numbers over adjectives.** Any performance, accuracy, or cost claim carries its
+methodology and its conditions, or it is not a claim.
+
+**Prefer deletion.** Clarity is usually fewer words, not more explanation. A fix that adds
+text has to justify itself.
+
+## Attribution
+
+The pattern list is distilled from the humanizer skill (`github.com/blader/humanizer`, MIT),
+reorganised into rule-and-replacement form and extended with the punctuation section and the
+two rules above. See `PROVENANCE.md`.

--- a/public-docs/ome-898/01-writing-docs/writing-docs/reference/review-angles.md
+++ b/public-docs/ome-898/01-writing-docs/writing-docs/reference/review-angles.md
@@ -1,0 +1,149 @@
+# Reviewing a documentation set
+
+A review procedure, run as a specific reader with a specific goal and a real time budget.
+Its value comes from that constraint. A copyeditor's pass finds typos. This finds the places
+a reader gives up.
+
+## Before you start
+
+From the context slots, fix three things and write them at the top of the report:
+
+- **the reader**: who they are and what they already know
+- **their goal**: the concrete thing they came to accomplish, stated as a task
+- **their time budget**: how long they will spend before abandoning it
+
+If those slots are unavailable, say so and report them as unknown. Do not invent a persona.
+A review run as an imaginary reader produces findings nobody can act on.
+
+Also fix **the operational metrics** this project's readers judge it by, since two of the
+nine rubric items depend on them.
+
+## Pass 1: the naive read
+
+Read in the exact order the docs present. Do not skip ahead. Do not use knowledge the docs
+have not given you, including anything you know about the project from elsewhere. If the
+docs do not say it, you do not know it.
+
+Keep a friction log. Record the location and the exact sentence every time you:
+
+- pause and re-read something to parse it
+- meet a term, acronym, or abstraction before it has been defined
+- scroll back to check something you were expected to remember
+- have to guess what a parameter, return value, or option does
+- ask "why would I do it this way?" and get no answer
+- hit a code sample that would not run as written: missing imports, undefined variables, a
+  stale API
+- feel the difficulty jump rather than step
+
+Every entry is data. Do not filter out the small ones. Small frictions compound into
+abandonment, and the reader who leaves does not file a complaint.
+
+## Pass 2: the structural read
+
+Now read as an architect of the reader's understanding.
+
+**Concept dependency map.** For each section, list what it assumes the reader knows and
+where that was introduced. Flag:
+
+| Problem | What it looks like |
+|---|---|
+| forward reference | a term used before its definition |
+| orphan | a concept introduced and never used again |
+| redundant re-explanation | the same idea taught twice, differently |
+| terminology drift | one thing under two names, or two things under one name |
+
+**Narrative arc.** A documentation set that clicks builds the model in layers: what this is,
+why it exists, the smallest working thing, the core abstractions, how they compose, the
+operational reality, then the edge cases and limits. Note every place the actual docs jump a
+layer, backtrack to an earlier one, or stall.
+
+**Example progression.** Do examples grow minimal, then realistic, then production-shaped,
+each adding exactly one new idea? Or does one leap several ideas at once?
+
+## Pass 3: the visual pass
+
+For every concept, mark one of three verdicts:
+
+- **has a diagram, and it works**: matches the prose, same terminology, one idea, current
+- **has a diagram, and it fails**: decorative, overloaded, stale, or labelled differently
+  from the text
+- **needs a diagram and lacks one**: the prose describes structure, flow, sequence, state,
+  or a decision, and the reader must assemble it mentally
+
+For each failure and each gap, specify what the reader needs to see: the boxes, the arrows,
+the labels, and the one question it answers. Then supply paste-ready source. See
+`diagrams.md` for the concept-to-diagram table and the starting points.
+
+## Scorecard
+
+Nine items, each scored 1 to 5, each with a quoted line of evidence. A score without a quote
+is an opinion.
+
+| # | Item | 1 | 5 |
+|---|---|---|---|
+| 1 | **first contact** | after a minute on the landing page you cannot say what this is or who it is for | you can state what it does, who it is for, and what it improves on |
+| 2 | **time to first success** | no runnable example, or one that fails | a minimal copy-pasteable example early, with its expected output shown |
+| 3 | **concept ordering** | terms are routinely used before they are defined | nothing is used before it is introduced |
+| 4 | **learning-curve shape** | cliffs: whole layers skipped between pages | difficulty rises in steps you can climb |
+| 5 | **example quality** | toy examples that no real use resembles | minimal, realistic, runnable, progressive |
+| 6 | **reference navigability** | you know what you want and still cannot find it | one or two hops from question to answer |
+| 7 | **terminology discipline** | the same thing has three names | one name per concept, everywhere |
+| 8 | **honest operations** | the operational metrics appear as adjectives, or not at all | numbers with methodology, versions, and conditions |
+| 9 | **visual clarity** | structure and flow are prose-only, or diagrams contradict the text | every structural concept is drawn well or is simple enough not to need it |
+
+Do not grade on a curve. "Fine for docs" is not the bar. The bar is that it clicks.
+
+## Trust check
+
+Documentation should read as though written by an engineer talking to an engineer, and it
+should be honest about what the thing costs.
+
+| Check | Failing looks like |
+|---|---|
+| plain honesty about limits | no "when not to use this", or it is buried in an appendix |
+| numbers over adjectives | "fast", "efficient", "scalable" with no measurement |
+| operational reality where decisions are made | the costs of the design surfaced far away from the page where you choose it |
+| no marketing residue | unverifiable superlatives, landing-page sentences |
+| a project expecting to be depended on | no versioning or stability statement, no changelog, no migration notes, no contribution path |
+
+For every sentence that erodes trust, quote it **and rewrite it** in the target voice from
+the context slots. A quoted complaint is half a finding.
+
+## Output
+
+One report, these sections, this order.
+
+1. **Verdict.** Three to five sentences. Would this reader adopt it on the strength of the
+   docs alone? Where did understanding flow, and where did it break?
+2. **Friction log.** Chronological, with locations and quotes.
+3. **Flow map.** Concept-ordering and arc problems, as a dependency list.
+4. **Scorecard.** Nine items, each with its score and one line of quoted evidence.
+5. **Diagram plan.** Every missing or failing diagram, prioritised. Each entry: exact
+   location, the concept, the diagram type, the one question it answers, and paste-ready
+   source using the project's exact terminology.
+6. **Top fixes.** Prioritised by impact on time-to-understanding, drawn from both the prose
+   and the diagram plan. Each one: exact location, why it blocks flow, and a concrete before
+   and after.
+7. **What already works.** The sections, examples, and diagrams that click, so nobody
+   improves them away.
+
+## Rules
+
+- **Be specific.** Every finding quotes the exact text and names its location. "The
+  quickstart is confusing" is not a finding.
+- **Rewrite, do not critique.** Show the fix, in the target voice.
+- **Prefer deletion.** Clarity is usually fewer words. A fix that adds text has to justify
+  itself.
+- **Run the code.** Report actual errors and actual output, not assumptions.
+- **When you cannot run it, say so and check it another way.** Some review environments
+  cannot execute the examples: no credentials, no network, no runtime. Mark every example
+  unverified rather than implying you ran it, then check what is checkable without running
+  anything. Do the imports match what is used? Do the names match the reference pages? Does
+  the same example appear elsewhere with different arguments? Does the page show what
+  success looks like? An example with no expected output is a finding whether or not you
+  could run it.
+- **One reader, one goal.** Judge everything against the reader and the goal you fixed at
+  the start. Anything that does not serve them is a candidate for restructuring.
+- **One idea per diagram.** A diagram needing a paragraph to explain it has failed.
+- **Text and picture must agree.** Every proposed label uses the exact names the prose and
+  the API use. If the diagram forces better names, propose renaming the prose too.

--- a/public-docs/ome-898/02-product-context-skill/README.md
+++ b/public-docs/ome-898/02-product-context-skill/README.md
@@ -1,0 +1,38 @@
+# 02: product and brand context skill
+
+Status: spec drafted, see `spec.md`. Evidence in `findings.md`. No plan yet.
+
+Named `product-context` to avoid colliding with the marketplace skill of a similar name.
+
+## Scope, from the ticket
+
+- Review the `screamingface-context` skill in the openmined marketplace and re-use that
+  context.
+- Add anything missing from the brand-positioning and product-positioning documents.
+- Land a single source of truth that informs engineering tickets, copy, and documentation.
+- Remove or update outdated skills that confuse. `docs/positioning.md` is explicitly not to
+  remain a source of truth.
+- Today engineers rely only on what the repository's own skills carry, not on the context
+  skill. Closing that gap is the point.
+
+## What it feeds
+
+This is what fills the context contract that child 01's skill declares: product facts,
+terminology casing, positioning language, the reader, and the operational metrics.
+
+## Not blocked
+
+An earlier draft of this file recorded the two positioning Google Docs as a blocker needing
+someone's access. They are not. The upstream context skill already mirrors them into the
+marketplace repository, alongside the strategy doc, the canonical terminology, the four
+personas, and the launch deck, and all of it is readable with `gh`.
+
+What that means for this child: the content exists, so the work is reconciling it against
+what the repository currently carries, deciding what becomes canonical, and retiring the
+rest. There is nothing to wait for.
+
+## Expected contents
+
+- `spec.md`
+- `plan.md`
+- the deliverable, or a pointer to where it landed

--- a/public-docs/ome-898/02-product-context-skill/findings.md
+++ b/public-docs/ome-898/02-product-context-skill/findings.md
@@ -1,0 +1,72 @@
+---
+title: "Child 02: what the two sources actually disagree about"
+ticket: OME-898 (child 2, not yet filed)
+status: draft
+date: 2026-09-02
+---
+
+# Findings
+
+Before specifying anything, here is what the two existing sources say. The ticket asks for a
+single source of truth and says `docs/positioning.md` must stop being one. These are the
+grounds.
+
+## The two sources
+
+| | `docs/positioning.md` | the mirrored context sources |
+|---|---|---|
+| where | in the monorepo, 194 lines | a marketplace plugin, five mirrored files |
+| currency | "aligned to delivery 2026-07-31" | "canon as of 2026-08-28" and "2026-08-29" |
+| authority it claims | "the canonical product-narrative / messaging doc" | "Notion is the source of truth, so this is the authority on what a term means, even when a mirrored deck or Doc is older" |
+| who can see it | every engineer with a checkout | only people who have installed the plugin |
+
+Both call themselves canonical. That is the problem in one line.
+
+## Where they disagree
+
+Not stylistic. Each row changes what an engineer would write.
+
+| Subject | The repo doc | Canon |
+|---|---|---|
+| **personas** | two, named: Rahul the developer as primary, Helen the policy mover as secondary, sourced from a July 2026 newsletter deck | four, in priority order, with Applied ML Researchers and Public Result Builders at top priority. Register differs sharply per persona |
+| **the one-liner** | "the engine that runs model ensembles locally, the place to find, prove, and share state-of-the-art model ensembles, with no middleman taking a cut of every call" | "combines the best AI models into fusion models that are more intelligent, cost less, and proves it on a live leaderboard" |
+| **the differentiator** | local execution and no middleman, plus "the hub for ensembles" | intelligence per dollar and public verification. Canon explicitly records that differentiating on composition is now contested ground because routing services ship composition features |
+| **the word for the thing** | "ensembles" throughout | "fusions". The docs site also says fusions |
+| **supported benchmarks** | DRACO, Healthbench, IFEval, MedX, GDPval, ContractEval, and more | draco, ifeval, healthbench, and the healthbench-worst30 variant. Nothing else, and canon warns against describing anything else as supported |
+| **claims policy** | an honesty table of shipped against arriving, and "say no middleman on the local path, not free forever" | a claims boundary: no state-of-the-art claim on a benchmark the organisation authored, disclosure in the same sentence when a benchmark is ours, and held-out results described as auditable rather than reproducible |
+| **launch state** | gates dated 7 and 14 August, with the public claim marked pending | the August dates have passed |
+
+## What follows
+
+**The repo doc is not merely stale, it is contradictory.** An engineer following it would use
+the wrong word for the core object, aim at a persona canon does not list first, lead with a
+differentiator canon has stepped back from, and name benchmarks the product does not
+support. It is also the only one of the two that a fresh checkout can see.
+
+**This is already leaking into shipped documentation.** The dogfood review of the Client docs
+found a benchmark id that is not in canon's list and a headline claim that does not carry the
+disclosure canon requires. Both are the predictable result of two sources disagreeing while
+only one is visible to whoever is writing.
+
+**Canon is not fully settled either.** The top terminology entry is marked "Needs Review",
+and the personas file says the set is still being refined and warns against treating entries
+as settled. So the answer is not "canon wins, copy it in". Whatever lands has to carry
+status alongside content, or it recreates the same problem one month later.
+
+## The fork this needs decided
+
+Canon lives in Notion, is mirrored into a marketplace plugin, and the plugin installs per
+user. Engineers only reliably see the repo. So: how does an engineer get the truth?
+
+| Option | How | Cost |
+|---|---|---|
+| **A. Pointer only** | the repo carries no positioning content, just a note naming the plugin and telling you to install it | zero drift, but useless to anyone who has not installed it, and useless to a fresh agent session |
+| **B. Declared dependency** | the repo declares the marketplace and plugin in its own settings, so every checkout resolves it | no copy, no drift, and it works for agents. Depends on the plugin staying available and on that declaration being honoured |
+| **C. Synced mirror** | a script pulls the mirrored files into the repo, stamped with their sync date | visible to everyone with no install. Creates a third copy, and a third copy is what we are trying to stop |
+
+Recommendation is **B**, with `docs/positioning.md` deleted and replaced by a short pointer
+that names what replaced it and why. A is not enough for agents, which is the case the ticket
+actually complains about. C reintroduces the failure mode.
+
+Not decided here. This needs the owner, because it commits the repo to a dependency on a
+plugin.

--- a/public-docs/ome-898/02-product-context-skill/plan.md
+++ b/public-docs/ome-898/02-product-context-skill/plan.md
@@ -1,0 +1,103 @@
+---
+title: "product-context: implementation plan"
+ticket: OME-898 (child 2, not yet filed)
+spec: ./spec.md
+findings: ./findings.md
+status: draft
+date: 2026-09-02
+---
+
+# product-context: implementation plan
+
+Builds the skill in `spec.md`. Unlike child 01, this lands in this monorepo, because the
+content is product-specific and the ticket's complaint is that engineers see only repository
+skills.
+
+## Where the work happens
+
+The repo is public and protected, so this needs a work item, a worktree, a branch, and a PR.
+None of that exists yet. So the skill is built here in the staging directory first, reviewed,
+and moved into a worktree when the child issue is filed. Nothing is written into the shared
+checkout on the way.
+
+## Steps
+
+**1. Read every canonical source in full.**
+Five mirrored files: terminology, personas, positioning, the strategy document, and the
+deck. Two have been read in part; the rest have not. Record the sync date stamped on each,
+because those dates become the per-item dates in the skill.
+
+**2. Reconcile against what actually ships.**
+Canon is a marketing artifact and can lead or lag the code. For each product fact, check the
+repo: the package name, the module surface, the benchmark identifiers the engine publishes,
+the app names. Where canon and the code disagree, record both and mark the item open rather
+than picking a winner. The benchmark list is the one to be most careful with, because the
+docs site already advertises an id canon does not list.
+
+**3. Write the six sections.**
+What this is, terminology, who we write for, what we may claim, what ships, what is
+unsettled. Each item gets a status, a date, and an owner. Shape the personas so they read as
+"the reader", and the claims material as rules rather than argument, because that is what the
+documentation skill pulls.
+
+**4. Add the stale-by date and the refresh trigger.**
+At the top, with the named owner. An expired date is a prompt, not a failure.
+
+**5. Quarantine the three items that need a yes.**
+Write them, keep them out of the skill until the yes lands, and record who owes it. Do not
+merge them by default.
+
+**6. Retire `docs/positioning.md`.**
+Delete it and leave a pointer naming the skill that superseded it, the date, and the reason.
+
+Six files reference its path, and they split two ways:
+
+| Reference | Action |
+|---|---|
+| `docs/scream-lisbon-digest.md` | live guidance, update the reference |
+| `docs/screamingface-v1-launch-plan.md` | live guidance, update the reference |
+| `docs/tasks/2026-07-31-OME-717-*` | historical, leave alone |
+| `docs/work/2026-07-31-OME-717-*` | historical, leave alone |
+| `docs/work/2026-08-22-OME-936-*` | historical, leave alone |
+| `docs/work/2026-07-28-OME-655-*` | historical, leave alone |
+
+Task mirrors and work ledgers are records of what was true when they were written. Rewriting
+them to point at a document that did not exist yet falsifies the record. The pointer left in
+place of the deleted file is what keeps those links meaningful.
+
+**7. Handle the other five stale files.**
+Two get dated headers. Three need a decision from whoever owns them, so open those as
+questions with named people rather than editing them. Do not quietly rewrite someone else's
+document.
+
+**8. Checks.**
+No dashes. Every item has status, date, and owner. The skill loads with the marketplace
+plugin absent. No reference to that plugin as a dependency.
+
+**9. Re-run child 01 against it.**
+The context-loaded review currently runs against the mirrored files read by hand. Redo it
+against this skill. If 01's slots do not fill without hand-assembly, that is a finding about
+one of the two, and the point of doing them in this order.
+
+## Verification
+
+The nine checks in `spec.md` §9. The three that decide it:
+
+- **Ask it the name of the core object with nothing else installed.** It answers with
+  canon's word. If it says the retired doc's word, the whole unit failed.
+- **Ask it which benchmarks are supported.** Canon's four, no others.
+- **Ask it something canon marks provisional.** It answers and says the status is
+  provisional. A skill that presents provisional material as settled has inherited the
+  problem it was built to remove.
+
+## Sequence
+
+```
+1 read sources -> 2 reconcile with code -+-> 3 write sections -> 4 stale-by -> 8 checks -> 9 re-run 01
+                                         +-> 5 quarantine (blocked on named yes)
+                                         +-> 6 retire positioning.md
+                                         +-> 7 the other five files (three blocked on owners)
+```
+
+Steps 5 and 7 have external blockers and must not hold up 3, 4, 6, 8, and 9. The skill ships
+without the quarantined items.

--- a/public-docs/ome-898/02-product-context-skill/product-context/SKILL.md
+++ b/public-docs/ome-898/02-product-context-skill/product-context/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: product-context
+description: The single source of truth for what ScreamingFace is, what its parts are called, who we write for, and what we are allowed to claim. Use before writing any ticket, documentation page, release note, or copy, and whenever a term, a persona, a benchmark name, or a claim is in question. Supersedes docs/positioning.md.
+user_invocable: true
+owner: unassigned, see "Keeping this current"
+stale_by: 2026-10-02
+---
+
+# ScreamingFace product context
+
+Read this before writing anything that a reader outside the team will see, and before
+writing a ticket that describes product behaviour.
+
+## How to read the statuses
+
+Every item below carries one. An item with no status is a defect in this file.
+
+| Status | Means |
+|---|---|
+| **canonical** | settled. Use as written |
+| **provisional** | current best definition, not final. Use it, and do not present the wording as settled |
+| **open** | contested or unowned. Do not resolve it yourself. Ask the named owner |
+
+Dates are the date of the source that supplied the item, not the date this file was edited.
+
+## What this is
+
+**canonical, 2026-08-29.** ScreamingFace is the open ecosystem for fusing many models into
+measurably smarter AI systems, delivering more intelligence per dollar than any single
+model. Other tools compose and other boards rank. What ScreamingFace adds is that it
+verifies the result in public and hands you the recipe to re-run it yourself.
+
+The name spans the products, the url4 protocol, and the community program.
+
+**The product family, canonical, 2026-08-29.**
+
+| Name | What it is |
+|---|---|
+| ScreamingFace Toolkit | the Client plus Studio plus a local Engine |
+| ScreamingFace Client | the Python library. `pip install screamingface`. Composes models into a fusion, runs a benchmark, returns the score, the bill, and the url4 line that reruns it |
+| ScreamingFace Studio | the desktop half of the Toolkit |
+| ScreamingFace Engine | the execution engine for url4 recipes. Holds keys encrypted, holds benchmark answer keys, does the grading, and is the only component that talks to a model provider. Same software in three modes: local, community-hosted, institutional. Only the engine URL changes |
+| Leaderboard | the verified board. A submission is validated, deduplicated by content hash, and independently re-run before it ranks |
+| url4 | the grammar for expressing a composition, in one line |
+
+**Casing matters.** The product names above are capitalised. `url4` is always lower case,
+including at the start of a sentence.
+
+## Terminology
+
+**Lead term, canonical, 2026-08-29.** A **fusion** is the lead category noun. It is a
+composed AI system built from many models used together for greater accuracy, speed, or
+lower cost than any single member.
+
+**A fusion is a system, never a "fusion model".** We train no models, and claim language
+must not imply that we do.
+
+**ensemble** is canonical too, as the technical synonym, for research, documentation, and
+academic contexts. Fusion is the public, marketing-first term. Decided 2026-08-10. So a docs
+page saying "ensemble" is correct; a launch post should say fusion.
+
+| Term | Status | In brief |
+|---|---|---|
+| fusion | canonical | the lead noun. A composed system, not a model |
+| ensemble | canonical | technical synonym, for research and docs registers |
+| url4 | canonical | the one-line grammar for a composition. Always lower case |
+| Benchmark | provisional | the exam: prompts plus grading criteria. Not the software that runs it |
+| Evaluation harness | provisional | the proctor: the software that runs the exam. "eval harness" is fine in developer registers, "evaluation harness" in institutional ones |
+| Leaderboard | provisional | the verified board. Re-run before ranking |
+| SOTA | provisional | the best published result on a benchmark. A fusion is SOTA outright when it beats every single model including frontier models |
+| Pareto-frontier SOTA | canonical | the best result at its cost. A fusion can hold this without being SOTA outright: worse than the top model, cheaper and better than anything at its price |
+| Market blindness | canonical | nobody can see what intelligence costs or delivers for a task. This is the antagonist of the story |
+| Neighbor | canonical | one of five kinds of adjacent tool. A kind, never a named company |
+| Network-Sourced AI | provisional | vision-tier term. Intelligence composed live over a network. See the caution below |
+| Reasoning routing | provisional | which models answer |
+| Context routing | provisional | which knowledge is consulted |
+| BYOK | provisional | bring your own key. The user supplies their own provider credentials |
+| DRACO | provisional | the third-party public research benchmark we reproduce first. Not created by us |
+| Fusion Monsters | provisional | the community program. The people, never the product. The external name is not final |
+| STUB submissions | provisional | fake leaderboard entries used to test the board |
+
+**Two cautions.**
+
+Network-Sourced AI is the parent organisation's vocabulary. Make the ScreamingFace case on
+fusions, verification, and intelligence per dollar. Leave the network-sourced framing to the
+parent's own voice.
+
+A neighbor is a kind of tool, never a company. Never attack an incumbent; adjacent tools
+existing validates that composition matters.
+
+## Who we write for
+
+Four personas, in priority order. **provisional, 2026-08-28**: the set is still being
+refined, and each entry is the current best definition rather than settled.
+
+Identify which one the work is for, then match its register. The registers differ sharply,
+and a community post, a researcher-facing result, and a consumer explainer are not the same
+voice.
+
+| Priority | Persona | Register | Surfaces they touch |
+|---|---|---|---|
+| 0, top | Applied ML researchers and public result builders | neutral and rigorous, academic or governmental | Client, Leaderboard, Studio, Fusion Monsters, Engine |
+| 1, high | Technical developers and benchmark enthusiasts | direct and technical | Studio, Client, Leaderboard, Fusion Monsters, url4 |
+| 1, high | Current or aspiring AI researchers | fully playful, community | Client, Leaderboard, Studio, Fusion Monsters |
+| 1, high | Everyday AI users and general token payers | plain-language consumer | Leaderboard, Reports, the website |
+
+**The top persona in one line.** Give me a credible baseline, an inspectable fusion, and a
+fair way to submit and publish, so I earn public credit for work that survives scrutiny.
+
+What they need to believe, and therefore what documentation for them must supply: the
+benchmark and baseline are named and meaningful; the result is reproducible or its limits are
+explicit; they can inspect and change enough of the recipe to make a defensible
+contribution; the verification, submission, and attribution rules are clear before they
+invest time; and the cost and key requirements are known up front.
+
+If the work addresses someone outside these four, say so rather than forcing a fit.
+
+## What we may claim
+
+Rules, not argument. Each one is a gate on published copy.
+
+| Rule | Status |
+|---|---|
+| No state-of-the-art claim on a benchmark we authored | canonical, 2026-08-28 |
+| A result on a benchmark we authored or host names that fact in the same sentence as the result | canonical, 2026-08-28 |
+| Results on held-out benchmarks are described as **auditable**, never reproducible. The url4 line is reproducible; a held-out score is auditable | canonical, 2026-08-28 |
+| Results on privately held benchmarks publish as measurements, named with their owner and method | canonical, 2026-08-28 |
+| We build a board only where no authoritative one exists | canonical, 2026-08-28 |
+| The one thing we publish is the recipe | canonical, 2026-08-28 |
+| A SOTA claim carries "no new models trained" in the same breath in safety-adjacent contexts | provisional |
+| Never imply we train models. A fusion is a system | canonical |
+| Disclosure about the parent organisation: do not lead with the connection; if asked, the answer is a plain factual yes | canonical, 2026-08-28 |
+| No performance or accuracy claim without its methodology and conditions | canonical |
+
+**Benchmark scores need provenance.** Two things a number does not reveal: who chose the
+benchmark, and whether the system was tuned to it. A shared board where everyone is measured
+on the same benchmarks answers the first. It does not answer the second. Do not collapse
+selection, optimization, and contamination into "benchmarks are gamed"; they are three
+failure modes with three remedies.
+
+## What ships
+
+**For benchmark ids the code is the authority, not this file and not canon.** Canon itself
+says product facts belong to the product owners, and this was tested: canon's list omits
+`draco-3pass`, while the engine defines it and carries a dedicated test for its definition.
+Canon was behind. Verify an id against the engine before writing it into copy.
+
+**Benchmark families, canonical as of 2026-08-28, verified against the engine 2026-09-02:**
+`draco`, `ifeval`, `healthbench`.
+
+| Id | Status | Note |
+|---|---|---|
+| `draco` | canonical | the deep-research benchmark. A third-party benchmark, not authored by us |
+| `draco-3pass` | canonical, code-verified | defined in the engine with its own test. Absent from canon's list, which is behind |
+| `ifeval` | canonical | instruction following |
+| `healthbench` | canonical | the family |
+| `healthbench-worst30` | canonical | the variant. Spelled with a hyphen, not `healthbench/worst30` |
+
+Anything not listed here is not a supported benchmark. Entries visible on a hosted board that
+are not in this table are leftovers and must never be described externally as supported.
+
+**The lite variant is `draco-lite`** (owner, 2026-09-03). Use that name in copy.
+
+**Open:** the code and the docs do not agree with it. The engine carries `draco-3pass` with
+its own definition test, the Client docs advertise `benchmark="draco-3pass"` in four places,
+and canon's list has neither. `draco-lite` appears only as `draco-lite@1` in a July task
+mirror and in a notebook filename, `05_draco_lite_e2e.ipynb`, which a live docs page links to
+and which is no longer in the examples directory.
+
+So three sources give three answers, and this file is not the place that settles it. Owner:
+whoever owns the supported-benchmark list. Until then, write `draco-lite` per the line above
+and do not assume the engine id matches it.
+
+**Open, 2026-09-02:** canon names DRACO twice with different provenance, once as a
+third-party benchmark explicitly not created by us, and once as a board we would build and
+own. The claims rules about self-authored benchmarks apply only to the second. Which one a
+given result refers to has to be settled before a claim about it is published. Owner: brand.
+
+## What is unsettled
+
+Do not resolve these. They are recorded so nobody has to rediscover them.
+
+| Item | Status | Owner |
+|---|---|---|
+| The ScreamingFace one-liner says we combine models into "fusion models", while the Fusion entry forbids exactly that phrase and the claim it implies. Canon contradicts itself on the core term | **open** | brand |
+| Public claim language for benchmarks we authored has not been approved | **open** | claims |
+| The external name of the community program is not final | **provisional** | brand and GTM |
+| The persona set is still being refined | **provisional** | brand |
+| The top terminology entry is marked as needing review | **provisional** | brand |
+| Whether the token-buyer audience is covered by the researcher personas | **open** | brand |
+
+## Not in this file
+
+**Two sections of the source are marked "do not put in public copy"** by the people who own
+it: a strategic question under reasoning routing, and one under context routing. They are
+deliberately absent. This file is in a public repository.
+
+Also absent, pending a named approval: claim language recorded as unapproved, quotes
+attributed to named individuals from private discussion, and benchmark authorship and funder
+material. None of it is needed to write documentation.
+
+**Elsewhere by design:** colour, type, spacing, and component-level copy belong to the design
+system. Page shape and prose craft belong to the documentation-writing skill. Launch
+sequencing and shipped-state reporting belong to their own documents.
+
+## Keeping this current
+
+This file is a copy. It does not sync, so it goes stale when the sources change.
+
+- **Owner: unassigned.** This needs one named person, not a team. Until it is filled in,
+  treat every date above as the only signal of freshness.
+- **Refresh trigger:** at each release, and whenever a positioning document or the
+  terminology database changes materially, whichever comes first.
+- **Stale-by** is in the frontmatter. An expired date is a prompt to refresh, not a reason to
+  stop using the file.
+
+## Sources
+
+Read once as material, on 2026-09-02, and not depended on at runtime:
+
+| Source | Stamped |
+|---|---|
+| terminology database, 26 entries | canon as of 2026-08-29 |
+| target personas, four entries | canon as of 2026-08-28 |
+| product-positioning document | source edited 2026-08-28, mirrored 2026-08-31 |
+| brand-positioning document | via the terminology entries that cite it |
+
+Where this file and those sources disagree, they are newer. Refresh rather than arguing with
+this copy.

--- a/public-docs/ome-898/02-product-context-skill/spec.md
+++ b/public-docs/ome-898/02-product-context-skill/spec.md
@@ -1,0 +1,179 @@
+---
+title: "product-context: a single source of truth for product and brand"
+ticket: OME-898 (child 2, not yet filed)
+findings: ./findings.md
+status: draft
+date: 2026-09-02
+---
+
+# product-context
+
+A repo skill that answers, for anyone writing a ticket, a docs page, or any copy: what is
+this product, what do we call its parts, who are we writing for, and what are we allowed to
+claim.
+
+It exists because there are two answers to those questions today and they disagree.
+`docs/positioning.md` sits in the repo, is three weeks stale, and contradicts the marketing
+canon on seven counts, including the word for the core object. The canon is correct and
+almost nobody has it, because it installs per person. Engineers and agent sessions see only
+the repo, so the repo's wrong answer is the one that gets used. `findings.md` has the
+evidence.
+
+**Name.** `product-context`, not `screamingface-context`. The marketplace already has a skill
+by that name, and two skills with one name is the confusion this unit is meant to end.
+
+## 1. Non-goals
+
+- **Not a dependency on the marketplace skill.** No install, no import, no deferral. Its
+  mirrored files were read once as source material, the way a spec reads any source. Where
+  content overlaps, the duplication is accepted (owner, 2026-09-02).
+- **Not an arbiter.** Where canon says a fact is owned by a named person, this skill records
+  the fact, the owner, and the date. It does not decide.
+- **Not a sync target.** No script pulls from Notion. See §6 for what replaces that.
+- **Not brand visual law.** Colour, type, and component copy stay with the design skill.
+- **Not a launch plan or a status report.** Those are separate documents with separate
+  lifetimes.
+
+## 2. Everything in it is public
+
+Decided by the owner, 2026-09-02: the content is publishable, and the skill lands in the
+public monorepo.
+
+That is a change of posture, not just a move, so it is worth stating what becomes public:
+the terminology and its status, the personas and their registers, the positioning line and
+what it replaced, the claims boundary, the supported benchmark list, and the relationship
+disclosure policy.
+
+**Three items need a named yes before merge, not before writing.** They are not ours to
+publish and publishing them cannot be undone:
+
+| Item | Why it needs a yes | Who |
+|---|---|---|
+| claim language canon records as not yet approved | publishing unapproved claim wording makes it look approved | whoever owns claims |
+| quotes attributed to named people, with dates, from private Slack | attribution of private discussion to individuals | the people quoted |
+| benchmark authorship and funder material | commercial and partner sensitivity | brand and product owners |
+
+The rest can be written and reviewed without waiting. If a yes does not come, those three
+are dropped and the skill still stands, because none of them is needed to write a docs page.
+
+## 3. What it contains
+
+Organised by what a reader needs, and shaped so the documentation skill can pull from it.
+That skill declares slots; this content has to be findable as those slots rather than as a
+narrative.
+
+| Section | Contents | Fills |
+|---|---|---|
+| **What this is** | the one-line positioning, and the product family with each part named | product facts |
+| **Terminology** | every canonical term, its definition, its exact casing, and terms we avoid | terminology casing |
+| **Who we write for** | the personas in priority order, each with its register, goals, and pain points | the reader |
+| **What we may claim** | the claims boundary, the disclosure rules, and the words reserved for narrower meanings | positioning language, target voice |
+| **What ships** | the supported benchmark list, and what must not be described as supported | product facts |
+| **What is unsettled** | every item whose status is provisional or whose owner has not signed off | all of the above |
+
+**Every item carries a status.** Canonical, provisional, or open. Canon's own top terminology
+entry is marked as needing review and its persona set is described as still being refined,
+so a skill that presents all of it as settled would be wrong on its first day. An item with
+no status is a defect.
+
+**Every item carries a date and an owner.** Not a general provenance note at the bottom. Per
+item, because they go stale at different rates and are owned by different people.
+
+## 4. What gets retired
+
+The ticket says skills plural and gives one example. This is the enumeration, with evidence.
+
+| File | Last touched | Verdict | Why |
+|---|---|---|---|
+| `docs/positioning.md` | 2026-08-10 | **delete**, replace with a pointer | claims to be canonical, contradicts canon on seven counts, and references `narrative-funnel-chapter-guide.md`, which does not exist |
+| `docs/screamingface-v1-launch-plan.md` | 2026-08-10 | **needs an owner's call** | its gates are dated 7 and 14 August and have passed. Either archive it or restate it |
+| `docs/scream-lisbon-digest.md` | 2026-08-10 | **keep, mark dated** | a point-in-time event digest. Correct as a record, wrong as guidance. Say which it is at the top |
+| `docs/PROJECT-OVERVIEW.md` | 2026-08-10 | **needs an owner's call** | `positioning.md` names it the "companion of record for what's shipped", and it is three weeks old. Whatever replaces that role must be current or must stop claiming the role |
+| `docs/ISSUES.md` | 2026-08-10 | **needs an owner's call** | same, cited for verified shipped state |
+| `.claude/README.md`, product-context section | 2026-07-08 | **replace with a pointer** | says "Team: TBD, to be settled in the next couple of days (2026-07-08)", and uses "Ensemble" where canon says fusion |
+
+`positioning.md` is the only outright deletion. The rest either get a dated header or a
+decision from whoever owns them, and this spec does not pretend to make those calls.
+
+**The pointer that replaces `positioning.md`** names the skill that supersedes it, the date,
+and the reason, so anyone arriving via an old link learns where truth moved rather than
+finding a blank.
+
+## 5. What this fixes downstream
+
+Two defects already shipped because the wrong source was the visible one. Both were found by
+the documentation review in child 01, and both are symptoms rather than causes:
+
+- a benchmark id advertised on the docs site that is not in canon's supported list
+- a headline result carrying no disclosure, against a rule requiring it in the same sentence
+
+Neither is fixed by this unit. They are fixed by whoever owns the docs, using this skill.
+Listed here so the connection is on the record.
+
+## 6. Staying current without a sync
+
+There is no script, so the copy goes stale when Notion changes. Two things instead:
+
+- **A named owner** for the skill, whose job is the refresh. Not "the team".
+- **A stated trigger**: refresh at each release, and whenever a positioning document or the
+  terminology database changes materially. Whichever comes first.
+
+**A stale-by** date at the top of the skill, so a reader can see the content has aged rather
+than having to guess. An expired date is not a failure, it is a prompt.
+
+This is the accepted cost of independence. Stated plainly here so nobody is surprised by it
+later.
+
+## 7. Decisions
+
+Owner, 2026-09-02:
+
+- **Everything is publishable**, and the skill lands in the public monorepo. §2 lists the
+  three items that still need a named yes before merge.
+- **Independent of the marketplace skill.** Content copied, not referenced. Duplication
+  accepted.
+
+Recorded so they are not re-opened:
+
+- **It lives in this monorepo**, because the ticket's complaint is that engineers see only
+  repository skills. Unlike child 01, this content is product-specific, so the repo is its
+  natural home.
+- **Named `product-context`** to avoid colliding with the marketplace skill's name.
+- **Status per item, not per document.** Canon is partly provisional, and a skill that hides
+  that inherits the problem it was built to fix.
+- **`positioning.md` is deleted rather than edited.** Editing it keeps a second canonical
+  document alive, which is the thing being removed.
+
+## 8. Acceptance
+
+- The skill exists in the repo, with a description and a stale-by date, and it loads without
+  the marketplace plugin installed.
+- Every item carries a status, a date, and an owner. An item missing any of the three is a
+  defect.
+- Terminology gives exact casing for every product name, including the core object, and lists
+  the terms we avoid.
+- Personas appear in priority order, each with its register, and each readable as "the
+  reader" by the documentation skill.
+- The claims boundary and the disclosure rules are stated as rules, not as argument.
+- The supported benchmark list is present, with the note about what must not be described as
+  supported.
+- `docs/positioning.md` is gone and a pointer stands in its place naming what superseded it.
+- Every file in §4 is either changed, dated, or listed with a named person who owes a
+  decision.
+- The three items in §2 are either published with a recorded yes, or absent.
+
+## 9. Verification
+
+- Ask the skill, with the marketplace plugin not installed, what the core object is called.
+  It answers with canon's word, not the old one.
+- Ask it which benchmarks are supported. It gives canon's four and no others.
+- Ask it who the primary reader is. It gives canon's top-priority persona, not the one from
+  the retired doc.
+- Ask it whether a state-of-the-art claim can be made on a benchmark we authored. It says no
+  and names the rule.
+- Ask it something canon marks provisional. It answers and says the status is provisional.
+- Re-run child 01's context-loaded review against this skill instead of the mirrored files.
+  Its slots fill from this content with no hand-assembly. If they do not, that is a finding
+  about one of the two.
+- Grep the repo for the retired doc's path. Every reference either goes to the pointer or is
+  updated.

--- a/public-docs/ome-898/03-sdlc-flow-update/README.md
+++ b/public-docs/ome-898/03-sdlc-flow-update/README.md
@@ -1,0 +1,28 @@
+# 03: SDLC flow update
+
+Status: not started. No spec, no plan.
+
+This child carries the epic's stated Done when, so the epic closes on this one.
+
+## Scope, from the ticket
+
+- Review and update `.claude/`.
+- Folder-scoped routing: working in this folder means using this skill.
+- Route documentation and copy work to the new skills from children 01 and 02.
+- Retire or refresh skills that are outdated or confusing.
+
+## Also folded in here
+
+Installing child 01's skill in this repository. That was deliberately kept out of child 01
+so the skill itself never reaches into a product repository, which is what keeps it
+agnostic.
+
+## Depends on
+
+Children 01 and 02, because the routing has to point at skills that exist.
+
+## Expected contents
+
+- `spec.md`
+- `plan.md`
+- the `.claude/` changes, or a pointer to the PR

--- a/public-docs/ome-898/04-docs-in-every-pr/README.md
+++ b/public-docs/ome-898/04-docs-in-every-pr/README.md
@@ -1,0 +1,29 @@
+# 04: documentation as part of every PR
+
+Status: not started. No spec, no plan.
+
+## Scope, from the ticket
+
+Whenever a PR is made, documentation is part of it, automatically generated.
+
+## The decision this needs first
+
+The line admits at least three incompatible readings, and they cost very different amounts:
+
+| Mechanism | What it does | Cost |
+|---|---|---|
+| CI gate | fails a PR that changes public behaviour with no docs change | needs a definition of "public behaviour" that a script can evaluate |
+| in-loop step | the SDLC loop drafts docs while the change is being made | no CI work, but nothing enforces it |
+| follow-up bot | opens a separate docs PR after the code PR merges | docs always lag by one merge |
+
+## The complication
+
+The documentation site is not in this monorepo. A gate here cannot require a change that has
+to land in another repository, so whichever mechanism wins has to answer the cross-repo
+question explicitly.
+
+## Expected contents
+
+- `spec.md`, which is mostly the mechanism decision
+- `plan.md`
+- the implementation, or a pointer to the PRs

--- a/public-docs/ome-898/05-release-docs-review/README.md
+++ b/public-docs/ome-898/05-release-docs-review/README.md
@@ -1,0 +1,28 @@
+# 05: release-time manual docs review by product
+
+Status: not started. No spec, no plan.
+
+## Scope, from the ticket
+
+When we do a big release, product reviews all documentation manually.
+
+## The deliverable
+
+A documented process, not code. It needs to answer three things:
+
+- **what** gets reviewed, and what "all docs" means at that moment
+- **who** owns the review and signs it off
+- **when** it happens in the release sequence, and what it blocks if it fails
+
+## Relationship to the other children
+
+Independent of 01 through 04, and needs no engineering. It is the human gate that catches
+what automation does not, so it is worth writing down even if the rest slips.
+
+Child 01's review procedure is a useful input here: the three passes and the nine-item
+scorecard give the reviewer something to work from rather than a blank page.
+
+## Expected contents
+
+- `spec.md`, or just the process document if a spec is overkill
+- `plan.md`, if it needs one

--- a/public-docs/ome-898/README.md
+++ b/public-docs/ome-898/README.md
@@ -1,0 +1,34 @@
+# OME-898: align SDLC with product and documentation flows
+
+The epic. This branch carries the epic-level map and the three children that have not
+started. Children 01 and 02 live on their own branches off this one, so each can be reviewed
+and landed without dragging the others along.
+
+| Child | Deliverable | Lands in | Where it is |
+|---|---|---|---|
+| 01 writing-docs | a product-agnostic documentation-writing and review skill | its own repository, not a product repo | branch `callis/ome-898-01-writing-docs` |
+| 02 product-context | a single source of truth for product and brand context | this monorepo | branch `callis/ome-898-02-product-context` |
+| [03 sdlc-flow-update](03-sdlc-flow-update/) | the `.claude/` flow, with folder-scoped routing to the new skills | this monorepo | not started |
+| [04 docs-in-every-pr](04-docs-in-every-pr/) | documentation generated as part of every PR | this monorepo, and the docs site | not started |
+| [05 release-docs-review](05-release-docs-review/) | the release-time manual docs review by product | process document | not started |
+
+The epic's own stated Done when is "SDLC flow updates", which is child 03. The epic cannot
+close before that lands.
+
+**Nothing in 03 through 05 should start before the drafts in 01 and 02 are reviewed.** They
+are consequences of that review, not queued work.
+
+## Numbering
+
+The numbers fix the order the children were derived in, which is the order of the scope
+bullets on the ticket. A number is not a priority and not a dependency, though 01 and 02 both
+feed 03.
+
+## Conventions
+
+- No em-dashes or en-dashes in anything written in this tree.
+- Nothing in child 01's deliverable names a product, an organisation, or a repository.
+  Everything project-specific reaches it through a context contract at runtime.
+- Specs and plans stay `status: draft` until the matching work item is filed.
+- Child 01 and child 02 are independent of each other and of any existing skill. Where a rule
+  is duplicated across them, that is accepted rather than factored out.


### PR DESCRIPTION
Epic branch for OME-898. Carries the epic map and the scope notes for the three children that have not started.

- the writing-docs skill draft
- the product-context skill draft

## What is here

`public-docs/ome-898/` with the epic map, plus 03 (SDLC flow update), 04 (docs in every PR), and 05 (release-time docs review), each scoped from the ticket's own bullets.

## What is not here

Nothing in 03 through 05 has started. They are consequences of the review on 01 and 02, not queued work. The epic's stated Done when is "SDLC flow updates", which is child 03, so the epic cannot close before that lands.

## Status

Draft. Nothing here should merge before the drafts in 01 and 02 have been reviewed.

Refs: OME-898