### PR TITLE
feat(screamingface): support leaderboard co-authors

### DIFF
--- a/docs/plan/2026-09-03-OME-1053-client-authors.md
+++ b/docs/plan/2026-09-03-OME-1053-client-authors.md
@@ -1,0 +1,13 @@
+# OME-1053 — Client authorship implementation plan
+
+1. Add failing tests for the three public submission entry points, omission semantics, exact-list
+   preservation, local validation boundaries, response decoding, and immutable returned values.
+2. Thread the keyword-only `authors` parameter through lazy, sync, and async submission methods
+   into the one shared payload builder.
+3. Validate author arguments once beside the payload builder and conditionally add the JSON field.
+4. Add optional immutable `authors` fields to `LeaderboardScore` and `LeaderboardEntry`, then
+   decode non-null Scoreboard arrays into tuples.
+5. Refresh the public API snapshot, run focused and full tests, then run the complete
+   `screamingface` gate set.
+6. Complete the ledger, commit with `Refs: OME-1053`, push, and open a draft PR that names the
+   unmerged/deployment dependency on the Scoreboard implementation.

--- a/docs/spec/2026-09-03-OME-1053-client-authors.md
+++ b/docs/spec/2026-09-03-OME-1053-client-authors.md
@@ -1,0 +1,65 @@
+# OME-1053 — Client authorship contract
+
+Status: approved for implementation on 2026-09-03.
+Parent contract: `docs/spec/2026-09-01-OME-1051-multiple-authors.md` on the Scoreboard feature
+branch.
+
+## User contract
+
+All submission surfaces accept the same keyword-only parameter:
+
+```python
+authors: Sequence[str] | None = None
+```
+
+The supported calls are the lazy `sf.leaderboards.submit`, bound synchronous
+`Client.leaderboards.submit`, and bound asynchronous `AsyncClient.leaderboards.submit` APIs.
+
+- `None` preserves today's request shape by omitting `authors`.
+- A supplied sequence is the exact credit list. The submitter is never added implicitly.
+- A supplied sequence contains 1–10 syntactically valid email addresses of at most 255
+  characters each.
+- Order and duplicates are preserved; the client performs no normalization or ownership check.
+
+## Wire contract
+
+The shared submission builder adds the top-level field only when specified:
+
+```json
+{"authors": ["alice@example.com", "bob@example.com"]}
+```
+
+The Scoreboard remains the authoritative validator and persistence owner. Local validation exists
+to reject invalid Python API arguments before network I/O and mirrors the approved Scoreboard
+syntax contract exactly.
+
+## Read contract
+
+`LeaderboardScore` and `LeaderboardEntry` expose:
+
+```python
+authors: tuple[str, ...] | None
+```
+
+This is deliberately not named `author_emails`. Public Scoreboard JSON privacy-trims email domains,
+so a write containing `alice@example.com` can read back as `("alice",)`. The client
+preserves that public response exactly as an immutable tuple.
+
+`None` is allowed because the Scoreboard contract permits a submission without a resolved
+submitter. A non-null response must be a non-empty JSON array of non-blank strings. This client is
+released only after the Scoreboard feature deploys; compatibility with a pre-feature Scoreboard is
+not a release requirement. Existing decoder fixtures that omit the new optional value continue to
+decode as `None` without a special legacy fallback.
+
+## Deployment constraint
+
+The current Scoreboard rejects unknown submission fields. The Scoreboard implementation must be
+merged and deployed before a client containing `authors=` is released. The client PR may be opened
+as a draft and developed independently against the approved wire contract.
+
+## Out of scope
+
+- Co-author identity, allowlist, ownership, or deliverability verification.
+- Granting authors access to private submissions.
+- Automatically including the submitter.
+- Scoreboard storage, migration, deduplication, and portal display.

--- a/docs/tasks/2026-09-03-OME-1053-add-co-author-emails-to-client-submissions.md
+++ b/docs/tasks/2026-09-03-OME-1053-add-co-author-emails-to-client-submissions.md
@@ -1,0 +1,19 @@
+---
+id: OME-1053
+linear_url: https://linear.app/openmined/issue/OME-1053/add-co-author-emails-to-client-submissions
+status: in_progress
+type: feature
+priority: high
+labels:
+  - py-screamingface
+  - agentic
+  - autonomous
+created: 2026-08-31
+closed:
+---
+
+# Add co-author emails to client submissions
+
+The Python client accepts an exact co-author email list when publishing a result and exposes the
+Scoreboard's public author list on immutable returned values. Implementation and validation details
+live in the linked spec and work ledger; Linear remains the status authority.

--- a/docs/tasks/2026-09-04-OME-1123-preserve-created-versus-deduplicated-submission-outcome.md
+++ b/docs/tasks/2026-09-04-OME-1123-preserve-created-versus-deduplicated-submission-outcome.md
@@ -1,0 +1,20 @@
+---
+id: OME-1123
+linear_url: https://linear.app/openmined/issue/OME-1123/preserve-the-created-versus-deduplicated-leaderboard-submission
+status: backlog
+type: null
+priority: 3
+labels: [py-screamingface, agentic, design-session]
+created: 2026-09-04
+closed: null
+---
+
+# Preserve the created-versus-deduplicated leaderboard submission outcome
+
+The Scoreboard returns HTTP 201 when it creates a row and HTTP 200 when a submission deduplicates
+onto an existing row, but the Python client currently returns only the decoded score body. Decide
+on a backward-compatible public API that preserves this outcome and distinguishes creation,
+same-submitter correction or replay, and deduplication onto another submitter's public row.
+
+This is related to `OME-970`, which covers the Scoreboard returning another run's identity. The
+transport signal already exists; this issue owns only the Python client's public representation.

--- a/docs/work/2026-09-03-OME-1053-client-authors.md
+++ b/docs/work/2026-09-03-OME-1053-client-authors.md
@@ -123,3 +123,43 @@ the server promises.
   precheck was skipped for this authorized correction; all other package gates ran unchanged.
 - **Scope:** diagnostics findings raised during the follow-up were verified as absent from PR #830
   and were not mixed into this unit of work.
+
+## Lazy delegation cleanup — 2026-09-04
+
+### Intent
+
+Remove the behaviorally redundant `authors is None` branch from the lazy leaderboard facade so
+delegation has one explicit, maintainable path.
+
+### Planned changes
+
+- Update the lazy-client test double and assertions to require forwarding both omitted and explicit
+  author values.
+- Replace the conditional delegation and its compatibility comment with one call.
+
+### Test plan
+
+- RED: make the lazy-delegation test require `authors=None` to be forwarded and confirm the old
+  branch fails that assertion.
+- GREEN: run the focused lazy delegation test and the complete ScreamingFace gate runner.
+
+### Acceptance
+
+- The lazy facade always delegates exactly once with `authors=authors`.
+- Omitted authors still produce no `authors` field in the Scoreboard request body.
+- Existing and explicit-author delegation remain covered.
+
+### Outcome
+
+- **Actual files:** simplified `leaderboards.py`, strengthened its existing lazy-delegation test,
+  and recorded this follow-up in the OME-1053 ledger.
+- **RED/GREEN:** the strengthened test first failed because the old branch omitted the keyword;
+  after the one-call implementation, 22 focused author, conflict, and delegation tests passed.
+- **Gates:** the complete ScreamingFace gate runner passed ruff check and format, pyright, pytest
+  with the 95% coverage floor, notebook validation, wheel build, and distribution checks.
+- **Deviation:** the owner explicitly approved updating the prior fake-client test as part of
+  removing the branch. The append-only precheck was skipped for that authorized test correction;
+  every substantive package gate ran unchanged.
+- **Wisdom review:** this removes speculative compatibility logic without changing the public or
+  wire contract; `authors=None` is still omitted by the submission serializer. No schema,
+  dependency, security, or UI behavior changed.

--- a/docs/work/2026-09-03-OME-1053-client-authors.md
+++ b/docs/work/2026-09-03-OME-1053-client-authors.md
@@ -1,0 +1,71 @@
+---
+ticket: OME-1053
+stack: screamingface
+status: done
+started: 2026-09-03
+finished: 2026-09-03
+---
+
+# OME-1053 — Add co-author emails to client submissions
+
+## Intent
+
+Allow Python users to credit every collaborator on a leaderboard submission while keeping
+submission ownership separate from authorship. The client sends the exact author email list to
+the Scoreboard and exposes the Scoreboard's privacy-trimmed author identifiers on returned score
+and leaderboard values.
+
+## Planned changes
+
+- Add the approved client contract in `docs/spec/2026-09-03-OME-1053-client-authors.md` and its
+  implementation plan in `docs/plan/2026-09-03-OME-1053-client-authors.md`.
+- Add the required issue mirror in
+  `docs/tasks/2026-09-03-OME-1053-add-co-author-emails-to-client-submissions.md`.
+- Extend the lazy, synchronous, and asynchronous leaderboard submission APIs in
+  `packages/screamingface/src/screamingface/leaderboards.py` and
+  `packages/screamingface/src/screamingface/_scoreboard/leaderboards.py`.
+- Add immutable author data to `packages/screamingface/src/screamingface/leaderboard.py` and
+  decode it from Scoreboard score and leaderboard responses.
+- Document the public call and read behavior in `packages/screamingface/README.md`.
+- Add append-only behavior and contract coverage in
+  `packages/screamingface/tests/test_leaderboards.py`, refresh the public API snapshot, and record
+  the public feature in `packages/screamingface/CHANGELOG.md`.
+
+## Test plan
+
+- RED: prove lazy, sync, and async APIs forward the exact author list and never auto-add the
+  submitter.
+- RED: prove omitted authors stay omitted and invalid local author inputs fail before HTTP.
+- RED: prove score and leaderboard responses expose immutable privacy-trimmed authors and reject
+  malformed author arrays.
+- GREEN: run the focused tests, full package suite, coverage, lint, format, typecheck, notebook,
+  build, and distribution gates.
+
+## Acceptance
+
+- `sf.leaderboards.submit(result, authors=[...])`, sync Client, and AsyncClient all send the same
+  top-level `authors` array.
+- `authors=None` sends no field; an explicit list is exact and never expanded with the submitter.
+- Author input is a non-empty collection of at most ten syntactically valid email strings, each
+  at most 255 characters.
+- `LeaderboardScore.authors` and `LeaderboardEntry.authors` expose immutable values decoded from
+  the new Scoreboard contract.
+- All ScreamingFace package quality gates pass and a draft PR identifies the Scoreboard rollout
+  dependency.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** all planned implementation, test, snapshot, changelog, README, spec, plan,
+  task-mirror, and ledger files.
+- **Commits:** `feat(screamingface): support leaderboard co-authors` (one squash-ready commit on
+  `OME-1053-client-authors`; sha recorded in the draft PR).
+- **Gates:** 16 author-focused tests passed; the complete
+  `python3 .claude/scripts/run_gates.py screamingface --skip-append-only` suite passed twice:
+  ruff check, ruff format check, pyright (0 errors), pytest with at least 95% coverage,
+  deterministic notebook validation, wheel build, and distribution validation.
+- **Deviations:** The public-surface snapshot is an existing test artifact and changed because the
+  owner explicitly approved the new public `authors=` signature and returned `authors` fields.
+  The snapshot's own regeneration workflow passed; the gate runner's append-only precheck was
+  skipped only for that authorized mechanical snapshot update. All test behavior was added
+  append-only. Read support was included in this unit by owner decision so the SDK does not
+  silently discard the Scoreboard's new response field.

--- a/docs/work/2026-09-03-OME-1053-client-authors.md
+++ b/docs/work/2026-09-03-OME-1053-client-authors.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1053
 stack: screamingface
-status: done
+status: in_review
 started: 2026-09-03
-finished: 2026-09-03
+finished: 2026-09-04
 ---
 
 # OME-1053 — Add co-author emails to client submissions
@@ -69,3 +69,57 @@ and leaderboard values.
   skipped only for that authorized mechanical snapshot update. All test behavior was added
   append-only. Read support was included in this unit by owner decision so the SDK does not
   silently discard the Scoreboard's new response field.
+
+## Review follow-up — 2026-09-04
+
+### Intent
+
+Close the validated PR review findings before marking the client authorship change ready: keep
+write validation aligned with Scoreboard while making reads forward-compatible, present authorship
+honestly in the receipt and public docs, and classify Scoreboard conflicts with the retry remedy
+the server promises.
+
+### Planned changes
+
+- Add regression tests for accepted write boundaries, uncapped and exact read values, retryable
+  submission conflicts, and separate submitter/authors receipt fields.
+- Remove the write-only author cap and normalization from read models while retaining structural
+  response validation.
+- Render separate submitter and authors values in the notebook receipt.
+- Treat Scoreboard submission conflicts as retryable with a stable client error code and hint.
+- Remove the manual release-please changelog entry and update both public leaderboard docs pages.
+
+### Test plan
+
+- RED: run the new focused ScreamingFace tests and confirm each review regression fails for its
+  intended reason.
+- GREEN: run the full ScreamingFace gate runner.
+- Run the public-docs lint, typecheck, and production build gates.
+
+### Acceptance
+
+- Exactly ten authors and a 255-character address are accepted on writes; the existing rejected
+  boundaries remain rejected.
+- Reads accept more than ten nonblank authors and preserve each string byte-for-byte.
+- The receipt labels and displays both submitter and authors without changing SFDS styling.
+- Submission HTTP 409 raises a retryable `LeaderboardError` with a conflict-specific remedy.
+- Release automation owns the changelog entry and deployed public docs describe the new API.
+
+### Outcome
+
+- **Actual files:** updated the Scoreboard adapter, public leaderboard models, notebook receipt,
+  leaderboard tests, and both public-docs leaderboard pages; removed the hand-written changelog
+  entry so release-please remains the sole owner of release notes.
+- **RED/GREEN:** the focused review suite first failed in the four intended areas (conflict
+  classification, read cap, exact read text, and receipt fields), then passed with 21 tests.
+  The complete package suite passed with 1,334 tests and 22 skips.
+- **Package gates:** the canonical ScreamingFace gate runner passed ruff check and format, pyright,
+  pytest with the 95% coverage floor, notebook validation, wheel build, and distribution checks.
+- **Public-docs gates:** Prettier, oxlint, ESLint, Vue typechecking, and the production Vite build
+  passed.
+- **Deviation:** one test added by the original OME-1053 commit treated eleven returned authors as
+  malformed. The approved review correction removed that write-only limit from the read contract,
+  so that parameter was replaced with positive forward-compatibility coverage. The append-only
+  precheck was skipped for this authorized correction; all other package gates ran unchanged.
+- **Scope:** diagnostics findings raised during the follow-up were verified as absent from PR #830
+  and were not mixed into this unit of work.

--- a/docs/work/2026-09-03-OME-1053-client-authors.md
+++ b/docs/work/2026-09-03-OME-1053-client-authors.md
@@ -163,3 +163,54 @@ delegation has one explicit, maintainable path.
 - **Wisdom review:** this removes speculative compatibility logic without changing the public or
   wire contract; `authors=None` is still omitted by the submission serializer. No schema,
   dependency, security, or UI behavior changed.
+
+## Deduplicated-response review follow-up — 2026-09-04
+
+### Intent
+
+Pin the client side of the Scoreboard resubmission-correction contract: a successful score POST
+may return HTTP 200 when it deduplicates onto an existing row, and the returned corrected author
+list must still decode as the immutable public value.
+
+### Planned changes
+
+- Add one append-only fake-transport test covering a score submission that returns HTTP 200 with
+  corrected public authors.
+- File the separate public-API design question about preserving the Scoreboard's 201-versus-200
+  outcome signal, and add its required task mirror without implementing it in this PR.
+- Add visual evidence of the changed notebook receipt to PR #830.
+
+### Test plan
+
+- CHARACTERIZATION: run the new focused test and prove it exercises the POST/200 response seam.
+  The behavior already exists because `_response_json` accepts every successful status, so an
+  honest production-code RED is not expected and no artificial failure will be manufactured.
+- GREEN: run the complete ScreamingFace gate runner with all prior tests unchanged.
+
+### Acceptance
+
+- A POST returning HTTP 200 decodes its returned authors into an immutable tuple.
+- No production behavior or public API changes in this follow-up.
+- The created-versus-deduplicated outcome question is captured outside OME-1053.
+- PR #830 includes visual evidence for its notebook receipt UI change.
+
+### Outcome
+
+- **Actual files:** added one append-only fake-transport regression in
+  `packages/screamingface/tests/test_leaderboards.py`, this ledger entry, and the required
+  `docs/tasks/` mirror for follow-up `OME-1123`.
+- **Characterization:** the focused POST/200 test passed immediately (`1 passed, 79 deselected`),
+  confirming the client behavior already existed and the review finding was a coverage gap rather
+  than a production defect.
+- **Gates:** `python3 .claude/scripts/run_gates.py screamingface` passed the append-only check,
+  ruff check and format, pyright, pytest with the 95% coverage floor, deterministic notebooks,
+  wheel build, and distribution validation.
+- **Follow-up:** filed `OME-1123` in Backlog at medium priority with `py-screamingface`, `agentic`,
+  and `design-session`, related to `OME-970`. No created-versus-deduplicated API was designed or
+  implemented in this PR.
+- **Deviation:** no failing production RED was possible because the requested behavior already
+  worked; an artificial failure was not manufactured. The browser surface was unavailable, so the
+  PR's receipt screenshot remains an explicit owner-verification item.
+- **Wisdom review:** the direct test is simpler than introducing a helper, asserts the meaningful
+  POST/status/decode seam, and changes no public contract, runtime path, dependency, schema, or
+  security behavior. All prior tests remain unchanged.

--- a/packages/screamingface/CHANGELOG.md
+++ b/packages/screamingface/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Features
-
-* **screamingface:** submit and read leaderboard co-authors
-
 ## 0.1.1 (2026-08-13)
 
 Baseline-only release. `0.1.0` and `0.1.1` were both uploaded to PyPI by hand rather than by

--- a/packages/screamingface/CHANGELOG.md
+++ b/packages/screamingface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **screamingface:** submit and read leaderboard co-authors
+
 ## 0.1.1 (2026-08-13)
 
 Baseline-only release. `0.1.0` and `0.1.1` were both uploaded to PyPI by hand rather than by

--- a/packages/screamingface/README.md
+++ b/packages/screamingface/README.md
@@ -452,7 +452,10 @@ boards = sf.leaderboards.list()
 draco_board = sf.leaderboards.get("draco", top=50)
 
 # After evaluating a Benchmark whose Scoreboard accepts submissions:
-submission = sf.leaderboards.submit(report.candidates.only)
+submission = sf.leaderboards.submit(
+    report.candidates.only,
+    authors=["alice@example.com", "bob@example.org"],
+)
 same_submission = sf.leaderboards.get_score(submission.id)
 editable_python = same_submission.url4.to_python()
 replayed_report = sf.evaluate(same_submission.url4)
@@ -470,7 +473,10 @@ best-per-spec entries and imported single-Model baselines. `submit(candidate_res
 already-evaluated result — the Benchmark-native score exactly as the Engine graded it, fractional
 or negative included — without asking the caller to repeat its Benchmark, URL4,
 models, or run identity; `get_score(id)` retrieves the resulting immutable
-`LeaderboardScore`. Its `.url4` property is a string-compatible `Url4` value:
+`LeaderboardScore`. Omit `authors` to credit the authenticated submitter by default. When supplied,
+the list is the exact credit line—the submitter is not added automatically—and the public
+`LeaderboardScore.authors` and `LeaderboardEntry.authors` values contain the Scoreboard's
+privacy-trimmed author identifiers. A score's `.url4` property is a string-compatible `Url4` value:
 `.to_python()` produces an editable fork, while passing the value to `sf.evaluate(...)` replays it
 through the configured Engine. Submitting a limited or incompletely graded Candidate surfaces a
 `Partial submission` advisory because its score is not directly comparable with a full run. In a

--- a/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
+++ b/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
@@ -259,13 +259,19 @@ def _response_json(
     if not response.is_success:
         details = _error_details(response)
         suffix = f" ({details})" if isinstance(details, str) and details else ""
+        submission_conflict = response.status_code == 409 and operation == "submit a score to"
         raise LeaderboardError(
             f"Could not {operation} the Scoreboard: HTTP {response.status_code}{suffix}",
             scoreboard_url=scoreboard_url,
             code=_status_code(response.status_code, operation),
             status=response.status_code,
-            permanent=response.status_code < 500 and response.status_code != 429,
+            permanent=(
+                response.status_code < 500
+                and response.status_code != 429
+                and not submission_conflict
+            ),
             details=details,
+            hint="Retry the submission." if submission_conflict else None,
         )
     try:
         return response.json()
@@ -290,6 +296,7 @@ def _status_code(status: int, operation: str) -> str:
         400: "invalid_score_submission",
         401: "scoreboard_authentication_required",
         403: "score_submission_forbidden",
+        409: "score_submission_conflict",
         422: "invalid_score_submission",
     }.get(status, "scoreboard_contract_error")
 
@@ -563,11 +570,16 @@ def _decode_authors(value: object, label: str) -> tuple[str, ...] | None:
     selected = _array(value, label)
     if not selected:
         _invalid(f"{label} must not be empty")
-    if len(selected) > _MAX_AUTHORS:
-        _invalid(f"{label} must contain at most {_MAX_AUTHORS} values")
     # WHY no email validation: public Scoreboard JSON strips email domains before returning
-    # authors. These are public credit identifiers, while full email syntax belongs only to writes.
-    return tuple(_text(author, f"{label} item") for author in selected)
+    # authors. These are public credit identifiers, while full email syntax and the write-side cap
+    # belong only to submissions. Preserve every nonblank value exactly as the read contract says.
+    return tuple(_public_author(author, f"{label} item") for author in selected)
+
+
+def _public_author(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        _invalid(f"{label} must be non-blank text")
+    return value
 
 
 def _text(value: object, label: str) -> str:

--- a/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
+++ b/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import platform
+import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime
 from decimal import Decimal
@@ -33,6 +34,9 @@ from screamingface.url4 import Url4
 _BENCHMARKS_PATH = "/v1/benchmarks"
 _LEADERBOARD_PATH = "/v1/leaderboard"
 _SCORES_PATH = "/v1/scores"
+_AUTHOR_EMAIL = re.compile(r"^[^@\s]+@[^@\s.]+(?:\.[^@\s.]+)+$")
+_MAX_AUTHORS = 10
+_MAX_AUTHOR_LENGTH = 255
 
 
 class Leaderboards:
@@ -68,8 +72,13 @@ class Leaderboards:
             )
         )
 
-    def submit(self, candidate_result: CandidateResult) -> LeaderboardScore:
-        payload = _submission(candidate_result)
+    def submit(
+        self,
+        candidate_result: CandidateResult,
+        *,
+        authors: Sequence[str] | None = None,
+    ) -> LeaderboardScore:
+        payload = _submission(candidate_result, authors=authors)
         notebook_notice = prepare_submission_notice(candidate_result)
         score = _decode_score(
             scoreboard_url=self._scoreboard_url,
@@ -139,8 +148,13 @@ class AsyncLeaderboards:
             )
         )
 
-    async def submit(self, candidate_result: CandidateResult) -> LeaderboardScore:
-        payload = _submission(candidate_result)
+    async def submit(
+        self,
+        candidate_result: CandidateResult,
+        *,
+        authors: Sequence[str] | None = None,
+    ) -> LeaderboardScore:
+        payload = _submission(candidate_result, authors=authors)
         notebook_notice = prepare_submission_notice(candidate_result)
         score = _decode_score(
             scoreboard_url=self._scoreboard_url,
@@ -356,6 +370,7 @@ def _decode_score(payload: object, scoreboard_url: str | None = None) -> Leaderb
             ),
             metadata=metadata,
             scoreboard_url=scoreboard_url,
+            authors=_decode_authors(root.get("authors"), "Leaderboard score authors"),
         )
     except (TypeError, ValueError) as exc:
         _invalid(str(exc), exc)
@@ -381,10 +396,15 @@ def _cost_text(cost: Decimal | None) -> str | None:
     return None if cost is None else str(cost)
 
 
-def _submission(candidate_result: CandidateResult) -> dict[str, object]:
+def _submission(
+    candidate_result: CandidateResult,
+    *,
+    authors: Sequence[str] | None = None,
+) -> dict[str, object]:
     if not isinstance(candidate_result, CandidateResult):
         raise TypeError("candidate_result must be an sf.CandidateResult")
-    return {
+    selected_authors = _submission_authors(authors)
+    payload: dict[str, object] = {
         "version": 1,
         "benchmark_id": candidate_result.benchmark.id,
         "spec_id": candidate_result.name,
@@ -405,6 +425,29 @@ def _submission(candidate_result: CandidateResult) -> dict[str, object]:
             "run_id": candidate_result.run_id,
         },
     }
+    # INVARIANT (OME-1053): absence means "use the authenticated submitter" while a supplied
+    # list is exact. Never send null or auto-add an identity the caller did not name.
+    if selected_authors is not None:
+        payload["authors"] = list(selected_authors)
+    return payload
+
+
+def _submission_authors(authors: Sequence[str] | None) -> tuple[str, ...] | None:
+    if authors is None:
+        return None
+    if isinstance(authors, (str, bytes)) or not isinstance(authors, Sequence):
+        raise TypeError("authors must be a sequence of email addresses")
+    selected = tuple(authors)
+    if not selected:
+        raise ValueError("authors must contain at least one email address")
+    if len(selected) > _MAX_AUTHORS:
+        raise ValueError(f"authors must contain at most {_MAX_AUTHORS} email addresses")
+    for author in selected:
+        if not isinstance(author, str):
+            raise TypeError("each author must be an email address string")
+        if len(author) > _MAX_AUTHOR_LENGTH or _AUTHOR_EMAIL.fullmatch(author) is None:
+            raise ValueError("each author must be a valid email address of at most 255 characters")
+    return selected
 
 
 def _score_value(candidate_result: CandidateResult) -> float:
@@ -476,6 +519,7 @@ def _decode_entry(value: object) -> LeaderboardEntry:
                 root.get("verified_by_screamingface"), "Leaderboard entry verified_by_screamingface"
             ),
             url4=Url4(_text(root.get("url4_expression"), "Leaderboard entry url4_expression")),
+            authors=_decode_authors(root.get("authors"), "Leaderboard entry authors"),
         )
     except (TypeError, ValueError) as exc:
         _invalid(str(exc), exc)
@@ -511,6 +555,19 @@ def _array(value: object, label: str) -> list[object]:
     if not isinstance(value, list):
         _invalid(f"{label} must be an array")
     return value
+
+
+def _decode_authors(value: object, label: str) -> tuple[str, ...] | None:
+    if value is None:
+        return None
+    selected = _array(value, label)
+    if not selected:
+        _invalid(f"{label} must not be empty")
+    if len(selected) > _MAX_AUTHORS:
+        _invalid(f"{label} must contain at most {_MAX_AUTHORS} values")
+    # WHY no email validation: public Scoreboard JSON strips email domains before returning
+    # authors. These are public credit identifiers, while full email syntax belongs only to writes.
+    return tuple(_text(author, f"{label} item") for author in selected)
 
 
 def _text(value: object, label: str) -> str:

--- a/packages/screamingface/src/screamingface/_ui/score_view.py
+++ b/packages/screamingface/src/screamingface/_ui/score_view.py
@@ -34,15 +34,17 @@ def leaderboard_score_html(value: LeaderboardScore) -> str:
     identity = str(value.benchmark_id) + (f" · rev {revision}" if revision else "")
     questions = f"{value.total_questions} question" + ("" if value.total_questions == 1 else "s")
     receipt = " · ".join((questions, f"id {str(value.id)[:8]}…"))
+    authors = ", ".join(value.authors) if value.authors else "—"
     cells = [
         # INVARIANT (OME-866): the score renders as stored — plain number, no ×100,
         # no percent. _score_text is shared with the Report card so the same figure
         # never renders two ways in one notebook.
         _cell("score", _score_text(value.score), score=True),
         _cell("spec", str(value.spec_id)),
-        # "—" here is honest: the SDK never claims an author; identity is attached
-        # by the Scoreboard's auth layer (or stays empty on a local stack).
-        _cell("author", value.submitted_by or "—"),
+        # INVARIANT (OME-1053): ownership and credit are distinct. Keep both visible so the
+        # receipt never calls the authenticated submitter an author the caller did not credit.
+        _cell("submitter", value.submitted_by or "—"),
+        _cell("authors", authors, title=authors),
         _cell("submitted", _stamp(value.submitted_at)),
     ]
     return (

--- a/packages/screamingface/src/screamingface/leaderboard.py
+++ b/packages/screamingface/src/screamingface/leaderboard.py
@@ -50,6 +50,8 @@ class LeaderboardEntry:
     submitted_by: str | None
     verified_by_screamingface: bool
     url4: Url4
+    # Public Scoreboard JSON strips domains; these are immutable display identifiers.
+    authors: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         _positive_int(self.rank, "Leaderboard rank")
@@ -74,6 +76,12 @@ class LeaderboardEntry:
             "url4",
             Url4(_text(self.url4, "Leaderboard url4")),
         )
+        if self.authors is not None:
+            object.__setattr__(
+                self,
+                "authors",
+                _authors(self.authors, "Leaderboard authors"),
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,6 +108,8 @@ class LeaderboardScore:
     verified_by_screamingface: bool
     metadata: Mapping[str, object] | None
     scoreboard_url: str | None = None
+    # Public Scoreboard JSON strips domains; full author emails never enter this read model.
+    authors: tuple[str, ...] | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.id, UUID):
@@ -147,6 +157,12 @@ class LeaderboardScore:
                 self,
                 "metadata",
                 freeze_mapping(self.metadata, "Leaderboard score metadata"),
+            )
+        if self.authors is not None:
+            object.__setattr__(
+                self,
+                "authors",
+                _authors(self.authors, "Leaderboard score authors"),
             )
 
     def __repr__(self) -> str:
@@ -285,6 +301,19 @@ def _names(values: object, label: str) -> tuple[str, ...]:
     selected = tuple(_text(value, label) for value in values)
     if len(set(selected)) != len(selected):
         raise ValueError(f"{label} must not contain duplicates")
+    return selected
+
+
+def _authors(values: object, label: str) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise TypeError(f"{label} must be a sequence")
+    selected = tuple(_text(value, label) for value in values)
+    if not selected:
+        raise ValueError(f"{label} must not be empty")
+    if len(selected) > 10:
+        raise ValueError(f"{label} must contain at most 10 values")
+    # INVARIANT (OME-1053): authorship is an ordered credit line. Unlike provider names,
+    # duplicates are preserved because the client must not rewrite the Scoreboard's public value.
     return selected
 
 

--- a/packages/screamingface/src/screamingface/leaderboard.py
+++ b/packages/screamingface/src/screamingface/leaderboard.py
@@ -307,13 +307,16 @@ def _names(values: object, label: str) -> tuple[str, ...]:
 def _authors(values: object, label: str) -> tuple[str, ...]:
     if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
         raise TypeError(f"{label} must be a sequence")
-    selected = tuple(_text(value, label) for value in values)
+    selected = tuple(values)
     if not selected:
         raise ValueError(f"{label} must not be empty")
-    if len(selected) > 10:
-        raise ValueError(f"{label} must contain at most 10 values")
+    if any(not isinstance(value, str) for value in selected):
+        raise TypeError(f"{label} values must be strings")
+    if any(not value.strip() for value in selected):
+        raise ValueError(f"{label} values must be non-blank")
     # INVARIANT (OME-1053): authorship is an ordered credit line. Unlike provider names,
-    # duplicates are preserved because the client must not rewrite the Scoreboard's public value.
+    # duplicates and surrounding whitespace are preserved because the client must not rewrite the
+    # Scoreboard's public value. The ten-address bound belongs only to the submission write seam.
     return selected
 
 

--- a/packages/screamingface/src/screamingface/leaderboards.py
+++ b/packages/screamingface/src/screamingface/leaderboards.py
@@ -29,12 +29,7 @@ def submit(
 ) -> LeaderboardScore:
     """Publish one evaluated Candidate Result to its registered Leaderboard."""
 
-    leaderboards = default_client().leaderboards
-    # INVARIANT (OME-1053): the no-authors lazy call remains the exact delegation it was before
-    # this keyword existed. Only an explicit credit line adds the new argument and wire field.
-    if authors is None:
-        return leaderboards.submit(candidate_result)
-    return leaderboards.submit(candidate_result, authors=authors)
+    return default_client().leaderboards.submit(candidate_result, authors=authors)
 
 
 def get_score(score_id: UUID | str) -> LeaderboardScore:

--- a/packages/screamingface/src/screamingface/leaderboards.py
+++ b/packages/screamingface/src/screamingface/leaderboards.py
@@ -22,10 +22,19 @@ def get(benchmark_id: str, *, top: int = 50) -> Leaderboard:
     return default_client().leaderboards.get(benchmark_id, top=top)
 
 
-def submit(candidate_result: CandidateResult) -> LeaderboardScore:
+def submit(
+    candidate_result: CandidateResult,
+    *,
+    authors: Sequence[str] | None = None,
+) -> LeaderboardScore:
     """Publish one evaluated Candidate Result to its registered Leaderboard."""
 
-    return default_client().leaderboards.submit(candidate_result)
+    leaderboards = default_client().leaderboards
+    # INVARIANT (OME-1053): the no-authors lazy call remains the exact delegation it was before
+    # this keyword existed. Only an explicit credit line adds the new argument and wire field.
+    if authors is None:
+        return leaderboards.submit(candidate_result)
+    return leaderboards.submit(candidate_result, authors=authors)
 
 
 def get_score(score_id: UUID | str) -> LeaderboardScore:

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -370,7 +370,8 @@
       "LeaderboardEntry": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, rank: 'int', spec_id: 'str', score: 'float', total_questions: 'int', ran_with_providers: 'tuple[str, ...]', submitted_at: 'datetime', submitted_by: 'str | None', verified_by_screamingface: 'bool', url4: 'Url4') -> None",
+          "__init__": "method (self, rank: 'int', spec_id: 'str', score: 'float', total_questions: 'int', ran_with_providers: 'tuple[str, ...]', submitted_at: 'datetime', submitted_by: 'str | None', verified_by_screamingface: 'bool', url4: 'Url4', authors: 'tuple[str, ...] | None' = None) -> None",
+          "authors": "field",
           "ran_with_providers": "field",
           "rank": "field",
           "score": "field",
@@ -408,7 +409,8 @@
       "LeaderboardScore": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, id: 'UUID', version: 'int', benchmark_id: 'str', spec_id: 'str', url4: 'Url4', submitted_by: 'str | None', submitted_at: 'datetime', score: 'float', total_questions: 'int', correct_questions: 'int | None', ran_with_providers: 'tuple[str, ...]', ran_at_local: 'datetime | None', client_name: 'str | None', client_version: 'str | None', client_platform: 'str | None', verified_by_screamingface: 'bool', metadata: 'Mapping[str, object] | None', scoreboard_url: 'str | None' = None) -> None",
+          "__init__": "method (self, id: 'UUID', version: 'int', benchmark_id: 'str', spec_id: 'str', url4: 'Url4', submitted_by: 'str | None', submitted_at: 'datetime', score: 'float', total_questions: 'int', correct_questions: 'int | None', ran_with_providers: 'tuple[str, ...]', ran_at_local: 'datetime | None', client_name: 'str | None', client_version: 'str | None', client_platform: 'str | None', verified_by_screamingface: 'bool', metadata: 'Mapping[str, object] | None', scoreboard_url: 'str | None' = None, authors: 'tuple[str, ...] | None' = None) -> None",
+          "authors": "field",
           "benchmark_id": "field",
           "client_name": "field",
           "client_platform": "field",
@@ -951,7 +953,7 @@
       },
       "submit": {
         "kind": "function",
-        "signature": "(candidate_result: 'CandidateResult') -> 'LeaderboardScore'"
+        "signature": "(candidate_result: 'CandidateResult', *, authors: 'Sequence[str] | None' = None) -> 'LeaderboardScore'"
       }
     }
   },

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -1475,6 +1475,26 @@ def test_sync_submit_sends_exact_authors_and_decodes_public_authors() -> None:
     assert isinstance(submitted.authors, tuple)
 
 
+def test_submit_decodes_corrected_authors_from_a_deduplicated_response() -> None:
+    response = _score_response()
+    response["authors"] = ["alice", "bob"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # INVARIANT: Scoreboard answers a deduplicated correction with 200, not the 201 used for a
+        # newly created row. Both successful POST outcomes carry the same score response contract.
+        assert request.method == "POST"
+        return httpx.Response(200, json=response)
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(
+            _candidate_result(),
+            authors=["alice@example.com", "bob@example.org"],
+        )
+
+    assert submitted.authors == ("alice", "bob")
+    assert isinstance(submitted.authors, tuple)
+
+
 @pytest.mark.asyncio
 async def test_async_submit_uses_the_same_authors_contract() -> None:
     seen: list[httpx.Request] = []

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -469,6 +469,23 @@ def test_submit_surfaces_the_live_closed_write_contract() -> None:
     assert exc_info.value.details == "score submission is not open yet"
 
 
+def test_submit_surfaces_a_scoreboard_conflict_as_retryable() -> None:
+    client = _sync_client(
+        lambda _: httpx.Response(
+            409,
+            json={"detail": "another request changed this submission; retry"},
+        )
+    )
+
+    with client, pytest.raises(sf.LeaderboardError) as exc_info:
+        client.leaderboards.submit(_candidate_result())
+
+    assert exc_info.value.code == "score_submission_conflict"
+    assert exc_info.value.status == 409
+    assert exc_info.value.retryable is True
+    assert exc_info.value.hint == "Retry the submission."
+
+
 def test_leaderboard_rich_display_uses_the_brand_board_with_only_real_fields() -> None:
     with _sync_client(lambda _: httpx.Response(200, json=_get_response())) as client:
         board = client.leaderboards.get("draco")
@@ -1394,6 +1411,14 @@ def test_submission_omits_unspecified_authors_and_preserves_an_explicit_list() -
     )["authors"] == ["alice@example.com", "bob@example.org", "alice@example.com"]
 
 
+def test_submission_accepts_the_author_count_and_length_boundaries() -> None:
+    boundary_address = "a" * 243 + "@example.com"
+    authors = (boundary_address,) * 10
+
+    assert len(boundary_address) == 255
+    assert _submission(_candidate_result(), authors=authors)["authors"] == list(authors)
+
+
 @pytest.mark.parametrize(
     ("authors", "error"),
     [
@@ -1496,7 +1521,44 @@ def test_leaderboard_entries_decode_public_authors_as_an_immutable_tuple() -> No
     assert isinstance(board.entries[0].authors, tuple)
 
 
-@pytest.mark.parametrize("authors", [[], "alice", [""], ["alice"] * 11])
+def test_score_response_does_not_apply_the_write_cap_to_public_authors() -> None:
+    response = _score_response()
+    response["authors"] = [f"author-{index}" for index in range(11)]
+
+    with _sync_client(lambda _request: httpx.Response(200, json=response)) as client:
+        score = client.leaderboards.get_score(SCORE_ID)
+
+    assert score.authors == tuple(f"author-{index}" for index in range(11))
+
+
+def test_score_response_preserves_nonblank_public_author_text_exactly() -> None:
+    response = _score_response()
+    response["authors"] = [" alice "]
+
+    with _sync_client(lambda _request: httpx.Response(200, json=response)) as client:
+        score = client.leaderboards.get_score(SCORE_ID)
+
+    assert score.authors == (" alice ",)
+
+
+def test_score_receipt_distinguishes_submitter_from_authors_and_escapes_them() -> None:
+    response = _score_response()
+    response["authors"] = ["alice<admin>", "bob"]
+
+    with _sync_client(lambda _request: httpx.Response(200, json=response)) as client:
+        score = client.leaderboards.get_score(SCORE_ID)
+
+    html = cast(Any, score)._repr_html_()
+
+    assert ">submitter<" in html
+    assert ">authors<" in html
+    assert ">author<" not in html
+    assert "researcher@example.com" in html
+    assert "alice&lt;admin&gt;, bob" in html
+    assert "alice<admin>" not in html
+
+
+@pytest.mark.parametrize("authors", [[], "alice", [""]])
 def test_score_response_rejects_malformed_public_authors(authors: object) -> None:
     response = _score_response()
     response["authors"] = authors

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -579,6 +579,8 @@ async def test_async_client_submits_and_gets_scores() -> None:
 
 
 def test_module_leaderboards_delegate_to_the_lazy_default_client(monkeypatch: Any) -> None:
+    omitted = object()
+
     class Leaderboards:
         def list(self) -> tuple[str, ...]:
             return ("draco",)
@@ -586,8 +588,13 @@ def test_module_leaderboards_delegate_to_the_lazy_default_client(monkeypatch: An
         def get(self, benchmark_id: str, *, top: int = 50) -> str:
             return f"{benchmark_id}:{top}"
 
-        def submit(self, candidate_result: object) -> tuple[str, object]:
-            return ("submitted", candidate_result)
+        def submit(
+            self,
+            candidate_result: object,
+            *,
+            authors: object = omitted,
+        ) -> tuple[str, object, object]:
+            return ("submitted", candidate_result, authors)
 
         def get_score(self, score_id: object) -> tuple[str, object]:
             return ("score", score_id)
@@ -600,7 +607,12 @@ def test_module_leaderboards_delegate_to_the_lazy_default_client(monkeypatch: An
     assert sf.leaderboards.list() == ("draco",)
     assert sf.leaderboards.get("draco", top=20) == "draco:20"
     candidate = _candidate_result()
-    assert sf.leaderboards.submit(candidate) == ("submitted", candidate)
+    assert sf.leaderboards.submit(candidate) == ("submitted", candidate, None)
+    assert sf.leaderboards.submit(candidate, authors=("alice@example.com",)) == (
+        "submitted",
+        candidate,
+        ("alice@example.com",),
+    )
     assert sf.leaderboards.get_score(SCORE_ID) == ("score", SCORE_ID)
 
     monkeypatch.setattr(_default_client, "_client", None)

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import replace
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -1379,3 +1379,130 @@ def test_the_wire_string_parses_back_to_the_same_decimal(cost: str) -> None:
 def test_no_cost_is_absent_rather_than_an_empty_string() -> None:
     # An empty string would parse as neither a Decimal nor null and would 422 the submission.
     assert _submission(_result_costing(None))["run_cost_usd"] is None
+
+
+# --- OME-1053: explicit authorship is distinct from the authenticated submitter ----------------
+
+
+def test_submission_omits_unspecified_authors_and_preserves_an_explicit_list() -> None:
+    candidate = _candidate_result()
+
+    assert "authors" not in _submission(candidate)
+    assert _submission(
+        candidate,
+        authors=("alice@example.com", "bob@example.org", "alice@example.com"),
+    )["authors"] == ["alice@example.com", "bob@example.org", "alice@example.com"]
+
+
+@pytest.mark.parametrize(
+    ("authors", "error"),
+    [
+        ("alice@example.com", TypeError),
+        (("alice@example.com", 7), TypeError),
+        ((), ValueError),
+        (("alice@example.com",) * 11, ValueError),
+        (("not-an-email",), ValueError),
+        (("alice@localhost",), ValueError),
+        ((" alice@example.com",), ValueError),
+        (("a" * 244 + "@example.com",), ValueError),
+    ],
+)
+def test_submission_rejects_invalid_author_arguments_before_http(
+    authors: object,
+    error: type[Exception],
+) -> None:
+    with pytest.raises(error):
+        _submission(_candidate_result(), authors=cast(Any, authors))
+
+
+def test_sync_submit_sends_exact_authors_and_decodes_public_authors() -> None:
+    seen: list[httpx.Request] = []
+    response = _score_response()
+    response["authors"] = ["alice", "bob"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(201, json=response)
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(
+            _candidate_result(),
+            authors=["alice@example.com", "bob@example.org"],
+        )
+
+    assert json.loads(seen[-1].content)["authors"] == [
+        "alice@example.com",
+        "bob@example.org",
+    ]
+    assert submitted.authors == ("alice", "bob")
+    assert isinstance(submitted.authors, tuple)
+
+
+@pytest.mark.asyncio
+async def test_async_submit_uses_the_same_authors_contract() -> None:
+    seen: list[httpx.Request] = []
+    response = _score_response()
+    response["authors"] = ["alice"]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(201, json=response)
+
+    async with _async_client(handler) as client:
+        submitted = await client.leaderboards.submit(
+            _candidate_result(), authors=["alice@example.com"]
+        )
+
+    assert json.loads(seen[-1].content)["authors"] == ["alice@example.com"]
+    assert submitted.authors == ("alice",)
+
+
+def test_lazy_submit_forwards_authors_to_the_default_client(monkeypatch: Any) -> None:
+    seen: list[object] = []
+
+    class Leaderboards:
+        def submit(
+            self,
+            candidate_result: object,
+            *,
+            authors: Sequence[str] | None = None,
+        ) -> tuple[object, Sequence[str] | None]:
+            seen.extend((candidate_result, authors))
+            return candidate_result, authors
+
+    class FakeClient:
+        leaderboards = Leaderboards()
+
+    fake = FakeClient()
+    monkeypatch.setattr(_default_client, "_client", fake)
+    candidate = _candidate_result()
+
+    assert sf.leaderboards.submit(candidate, authors=["alice@example.com"]) == (
+        candidate,
+        ["alice@example.com"],
+    )
+    assert seen == [candidate, ["alice@example.com"]]
+
+
+def test_leaderboard_entries_decode_public_authors_as_an_immutable_tuple() -> None:
+    response = _get_response()
+    entries = cast(list[dict[str, object]], response["entries"])
+    entries[0]["authors"] = ["alice", "bob"]
+
+    with _sync_client(lambda _request: httpx.Response(200, json=response)) as client:
+        board = client.leaderboards.get("draco")
+
+    assert board.entries[0].authors == ("alice", "bob")
+    assert isinstance(board.entries[0].authors, tuple)
+
+
+@pytest.mark.parametrize("authors", [[], "alice", [""], ["alice"] * 11])
+def test_score_response_rejects_malformed_public_authors(authors: object) -> None:
+    response = _score_response()
+    response["authors"] = authors
+
+    with (
+        _sync_client(lambda _request: httpx.Response(200, json=response)) as client,
+        pytest.raises(sf.LeaderboardError, match="Invalid Scoreboard Leaderboard response"),
+    ):
+        client.leaderboards.get_score(SCORE_ID)

--- a/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/api/LeaderboardsPage.vue
@@ -16,7 +16,10 @@ client = sf.Client()
 const listRunOut = `[('draco/smoke', 'DRACO Smoke')]`
 
 const submit = `report = client.evaluate(recipe, benchmark="ifeval", limit=1)
-client.leaderboards.submit(report.candidates.only)`
+client.leaderboards.submit(
+    report.candidates.only,
+    authors=["alice@example.com", "bob@example.org"],
+)`
 </script>
 
 <template>
@@ -178,6 +181,11 @@ client.leaderboards.submit(report.candidates.only)`
           <td>When it was published, and by whom where that is recorded.</td>
         </tr>
         <tr>
+          <td><code>authors</code></td>
+          <td><code>tuple[str, ...]&nbsp;|&nbsp;None</code></td>
+          <td>The ordered credit line, with email domains removed by the public leaderboard.</td>
+        </tr>
+        <tr>
           <td><code>verified_by_screamingface</code></td>
           <td><code>bool</code></td>
           <td>Whether ScreamingFace re-ran the entry and confirmed the score.</td>
@@ -241,6 +249,12 @@ client.leaderboards.submit(report.candidates.only)`
       <NbCell :count="2" :code="submit" />
     </div>
 
+    <p>
+      <code>submit(candidate_result, *, authors=None)</code> accepts one to ten email addresses. A
+      supplied list is exact: order and duplicates are preserved, and the authenticated submitter is
+      not added automatically. Omit it to use the leaderboard's default credit line.
+    </p>
+
     <table>
       <thead>
         <tr>
@@ -298,6 +312,14 @@ client.leaderboards.submit(report.candidates.only)`
           <td><code>submitted_at</code> · <code>submitted_by</code></td>
           <td><code>datetime</code> / <code>str&nbsp;|&nbsp;None</code></td>
           <td>When it was published, and by whom.</td>
+        </tr>
+        <tr>
+          <td><code>authors</code></td>
+          <td><code>tuple[str, ...]&nbsp;|&nbsp;None</code></td>
+          <td>
+            The ordered, privacy-trimmed credit line. This is separate from
+            <code>submitted_by</code>, which records who sent the result.
+          </td>
         </tr>
         <tr>
           <td><code>verified_by_screamingface</code></td>

--- a/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
@@ -31,14 +31,17 @@ const configure = `sf.configure(
 const publish = `report = sf.evaluate(candidate, benchmark="ifeval", limit=3)
 
 # publish one candidate
-sf.leaderboards.submit(report.candidates.only)
+sf.leaderboards.submit(
+    report.candidates.only,
+    authors=["alice@example.com", "bob@example.org"],
+)
 
 # or publish every candidate in the report
 [sf.leaderboards.submit(c) for c in report.candidates]`
 
 const fetchScore = `score = sf.leaderboards.get_score("57cc25d7-00bf-44ec-bf9d-55d66cd1e003")
-score.score, score.total_questions, score.verified_by_screamingface`
-const fetchScoreOut = `(1.0, 1, False)`
+score.score, score.authors, score.verified_by_screamingface`
+const fetchScoreOut = `(1.0, ('alice', 'bob'), False)`
 
 const remix = `plan = score.url4.to_python()   # Model / Fusion / Pipeline, free
 sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
@@ -110,11 +113,11 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
           </td>
         </tr>
         <tr>
-          <td><code>sf.leaderboards.submit(candidate_result)</code></td>
+          <td><code>sf.leaderboards.submit(candidate_result, *, authors=None)</code></td>
           <td>
             Publishes one evaluated <code>CandidateResult</code>. The Client derives benchmark id,
-            spec id, url4, the benchmark-native score, providers, and the idempotency key from
-            that result.
+            spec id, url4, the benchmark-native score, providers, and the idempotency key from that
+            result. An optional author list supplies the exact credit line.
           </td>
         </tr>
         <tr>
@@ -136,9 +139,9 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
 
     <p>
       Ranking is best-per-spec: for each <code>spec_id</code> the leaderboard keeps the highest
-      score, and breaks ties by newest <code>submitted_at</code>. The table is then ordered by
-      score descending. Baselines are imported separately and sit beside community entries; they
-      are not the same as a submitted score.
+      score, and breaks ties by newest <code>submitted_at</code>. The table is then ordered by score
+      descending. Baselines are imported separately and sit beside community entries; they are not
+      the same as a submitted score.
     </p>
 
     <h2>How to</h2>
@@ -166,10 +169,11 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
     </div>
 
     <p>
-      Each entry carries <code>score</code>, <code>total_questions</code>, the providers used,
-      who submitted it when that is known, the <code>verified_by_screamingface</code> flag, and the
-      <code>url4</code> expression. Notebook displays render the board as an interactive widget; the
-      fields above are what each entry holds.
+      Each entry carries <code>score</code>, <code>total_questions</code>, the providers used, who
+      submitted it when that is known, its separate <code>authors</code> credit line, the
+      <code>verified_by_screamingface</code> flag, and the <code>url4</code> expression. Public
+      author values omit email domains. Notebook displays render the board as an interactive widget;
+      the fields above are what each entry holds.
     </p>
 
     <p>
@@ -204,23 +208,32 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
       candidate, or iterate <code>report.candidates</code> to publish every candidate in the report.
     </p>
 
+    <p>
+      Pass <code>authors=[...]</code> to set the exact ordered credit line. It accepts one to ten
+      email addresses, preserves duplicates, and never adds the authenticated submitter for you.
+      Omit the argument to use the leaderboard's default credit line. Authorship grants credit, not
+      ownership or access to a private submission.
+    </p>
+
     <div class="not-prose">
       <NbCell :count="5" :code="publish" />
     </div>
 
     <p>
       The Client posts <code>score</code>, <code>total_questions</code>, the compiled
-      <code>url4_expression</code>, provider names, and client metadata. The
-      <code>Idempotency-Key</code> header is the candidate's <code>run_id</code>, so a retry of
-      the same run replays the original score instead of inserting a duplicate.
+      <code>url4_expression</code>, provider names, optional authors, and client metadata. The
+      <code>Idempotency-Key</code> header is the candidate's <code>run_id</code>, so a retry of the
+      same run reuses the original score instead of inserting a duplicate. A resubmission by the
+      same submitter can correct its author list. If another correction wins the same race, the
+      Client reports a retryable conflict; retry the submission.
     </p>
 
     <p>
       The score is benchmark-native: the Client submits <code>CandidateResult.score</code> exactly
-      as the benchmark's own grading produced it — fractional for DRACO's weighted rubrics,
-      negative for HealthBench worst-30 — and never derives a replacement from case grades,
-      normalizes, or bounds it. The only universal requirements are that a score exists and is a
-      finite number; unscored or non-finite results are rejected before HTTP.
+      as the benchmark's own grading produced it — fractional for DRACO's weighted rubrics, negative
+      for HealthBench worst-30 — and never derives a replacement from case grades, normalizes, or
+      bounds it. The only universal requirements are that a score exists and is a finite number;
+      unscored or non-finite results are rejected before HTTP.
     </p>
 
     <h3>5 · Fetch a published score</h3>


### PR DESCRIPTION
## Summary
- add an exact co-author email list to lazy, synchronous, and asynchronous leaderboard submissions
- expose privacy-trimmed authors on immutable LeaderboardScore and LeaderboardEntry values
- validate the approved 1–10 author write contract and document the public API

## Dependency
Draft until the Scoreboard implementation for OME-1052 / OME-1054 is merged and deployed. The currently deployed Scoreboard rejects the new authors field.

Scoreboard branch: https://github.com/ScreamingFace/screamingface/compare/OME-1051-scoreboard-authors
Linear: https://linear.app/openmined/issue/OME-1053/add-co-author-emails-to-client-submissions

## Test plan
- 16 author-focused tests pass
- full ScreamingFace SDK gate suite passes: ruff check and format, pyright, pytest with 95%+ coverage, deterministic notebooks, wheel build, and distribution validation
- public API snapshot regenerated and verified

## Process note
The append-only precheck was skipped only for the owner-approved public-surface snapshot regeneration. Test behavior was added append-only.

Refs: OME-1053

Asana: none