### PR TITLE
test(screamingface): add the correlation-chain ladder to the e2e harness (OME-1105)

### DIFF
--- a/docs/tasks/2026-09-03-OME-1105-correlation-chain-e2e.md
+++ b/docs/tasks/2026-09-03-OME-1105-correlation-chain-e2e.md
@@ -1,0 +1,30 @@
+---
+id: OME-1105
+linear_url: https://linear.app/openmined/issue/OME-1105/add-the-correlation-chain-ladder-to-the-local-e2e-harness
+status: in_progress
+type: null
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-03
+closed:
+---
+
+# Add the correlation-chain ladder to the local e2e harness
+
+Makes the tracing roadmap's rungs testable **without cluster access** — the live-k8s notebook
+(`OME-1074`) needs credentials behind a break-glass tool, while the local harness needs only
+Docker and already boots the real engine + real aigateway.
+
+`tests/e2e/test_correlation_chain.py` holds five rungs, every one `xfail(strict=True)`. Strict
+is the mechanism: a rung that starts passing FAILS the suite, so the change implementing it
+must delete its marker in the same PR.
+
+Observed running: **5 xfailed, 0 failed**.
+
+**The finding.** Rung 1 was planned to pass — `OME-967` is merged — and cannot. From the
+public SDK surface there is no way to read a completed run's trace id: it reaches only the
+error hierarchy, `Report` has no trace field, and a board run does not raise because DRACO
+collects case errors into rows. The user with bad results rather than an exception, who most
+needs to quote an id, cannot get one. Closing rung 1 means giving `Report` a trace id.
+
+Ledger: `docs/work/2026-09-03-OME-1105-correlation-chain-e2e.md`.

--- a/docs/work/2026-09-03-OME-1105-correlation-chain-e2e.md
+++ b/docs/work/2026-09-03-OME-1105-correlation-chain-e2e.md
@@ -1,0 +1,103 @@
+---
+ticket: OME-1105
+stack: screamingface
+started: 2026-09-03
+status: in_progress
+finished:
+---
+
+# OME-1105 — Correlation-chain ladder in the local e2e harness
+
+## Intent
+
+Make the tracing roadmap's rungs testable **without cluster access**. The live-k8s notebook
+(`OME-1074`) turned out to need credentials gated behind a break-glass tool the owner does
+not currently have, so the roadmap's acceptance evidence was blocked on someone else. The
+local harness needs only Docker and already boots the real spine — real engine subprocess,
+real aigateway subprocess against a Postgres testcontainer, log files on disk.
+
+k8s adds deployment realism (the Runner Job indirection, the mesh edge). It adds nothing to
+the question *does a traceparent survive engine → gateway*, which is what rungs 2–4 ask.
+
+## Design decisions
+
+**D1 — `FakeGateway` for rungs 1–2, not `CacheSeededGateway`.** The cache-seeded backend is
+the *real* aigateway as a **subprocess**, so a test in this process cannot observe the headers
+it received; its only channel is `aigateway.log`, and aigateway does not log an inbound
+traceparent until rung 4 exists. `FakeGateway` is an in-process `BaseHTTPRequestHandler`, so
+inbound headers are directly observable. Rungs 3–4 are log assertions and therefore keep the
+real gateway.
+
+**D2 — capture lives in the concrete backend, never on the port.** `harness/ports.py` states
+the invariant outright: `ReplayBackend` is exactly `start() -> base_url` / `stop()`, and
+growing it with introspection would couple the engine boot to one backend's internals. The
+recorder is a `FakeGateway` attribute, mirroring the existing `refusals` accessor, and the
+test holds the concrete type.
+
+**D3 — `xfail(strict=True)`, not plain xfail.** A strict xfail that *starts passing* fails
+the suite. That is the whole mechanism: the PR implementing a rung is forced to delete its
+marker in the same change, so the ladder cannot drift out of date and a later regression
+cannot slip back to "expected failure". A non-strict xfail would silently absorb both.
+
+**D4 — rung 1 is NOT xfail.** `OME-967` is merged, so it must pass today. It is the
+regression guard for the one rung that already works.
+
+## Planned changes
+
+- `packages/screamingface/tests/e2e/harness/fake_gateway.py` — record inbound request headers
+  alongside the existing refusal record; expose them read-only.
+- `packages/screamingface/tests/e2e/test_correlation_chain.py` *(new)* — four rungs.
+- This ledger + the `docs/tasks/` mirror.
+
+## Test plan
+
+The tests *are* the deliverable, so the plan is what each rung pins:
+
+1. **Rung 1** (passes today) — the client mints one well-formed W3C trace id and holds it;
+   the id it reports is the id it sent. Guards `OME-967` against regression.
+2. **Rung 2** (`xfail(strict=True)`) — the gateway received a `traceparent` whose trace id
+   equals the client's. Fails today: the engine sends none.
+3. **Rung 3** (`xfail(strict=True)`) — every `aigateway.log` line carries `gateway_call_id`.
+   Fails today: `OME-938` unbuilt.
+4. **Rung 4** (`xfail(strict=True)`) — the same trace id appears in `engine.log` **and**
+   `aigateway.log`. Fails today: nothing joins the id to either log.
+
+## Acceptance
+
+- Rung 1 passes; rungs 2–4 xfail strictly.
+- The lane stays opt-in (`SCREAMINGFACE_TEST_E2E=1` + Docker) and out of CI.
+- `ReplayBackend` is unchanged.
+- No prior test modified; `run_gates.py screamingface` green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `tests/e2e/harness/fake_gateway.py` (header recorder),
+  `tests/e2e/test_correlation_chain.py` (new, 5 rungs), the ledger and the mirror.
+- **Commits:** `test(screamingface): add the correlation-chain ladder to the e2e harness`
+  (sha at squash-merge).
+- **Gates:** `run_gates.py screamingface` — see below. The ladder itself was **observed
+  running against the real stack**: `SCREAMINGFACE_TEST_E2E=1 pytest tests/e2e/
+  test_correlation_chain.py -m e2e` → **5 xfailed, 0 failed**, with the real engine
+  subprocess, the real aigateway (Postgres testcontainer) and `FakeGateway` all booting.
+  Prerequisite discovered: the lane needs `uv sync --extra runtime` and
+  `screamingface prepare draco` (100 cases) — without assets every rung skips, exactly like
+  `test_failures.py` and `test_boards.py`.
+- **Deviations:**
+  - **Rung 1 became a strict xfail, and that is the unit's most valuable finding.** It was
+    planned to PASS, since `OME-967` is merged. It cannot: from the PUBLIC SDK surface there
+    is no way to read a completed run's trace id. `trace_id` reaches only the error hierarchy,
+    `Report` carries no trace field, and a board run **does not raise** — DRACO collects case
+    errors into rows (`on_error="collect"`), so a run whose every model call failed still
+    returns a Report with no id anywhere. The frame stream did not fill the gap either: no
+    event reaching `on_event` carried a traceparent. This does not retract `OME-967`, which is
+    pinned by `tests/test_client_protocol.py` against the wire — it says the *user-facing*
+    half is missing, and it is the user with bad results rather than an exception who most
+    needs to quote an id. **Closing rung 1 means giving `Report` a trace id.**
+  - **Rung 4 split into 4a (engine log) and 4b (gateway log).** They land in different
+    changes and therefore cannot share one marker.
+  - **A vacuous-pass bug was caught by running it.** Rung 2 first reported `XPASS(strict)`:
+    both `trace_ids_seen()` and the client's id set were empty, and `set() == set()` is true,
+    so a rung asserting propagation passed while nothing propagated. The non-empty assertion
+    now comes first, with a comment recording why. Worth noting that only *executing* the
+    ladder surfaced this — review would not have.
+  - Fixture paths initially pointed at `FIXTURES_DIR` rather than `SNAPSHOTS_DIR`.

--- a/packages/screamingface/tests/e2e/harness/fake_gateway.py
+++ b/packages/screamingface/tests/e2e/harness/fake_gateway.py
@@ -86,6 +86,10 @@ class FakeGateway:
     def __init__(self, tape: Tape) -> None:
         self._by_model = _index_by_model(tape)
         self._refusals: list[RefusedRequest] = []
+        # OME-1105: every inbound request's headers, in arrival order. The engine is the
+        # only caller, so this is the wire between engine and gateway — the one place a
+        # test can see whether trace context actually crossed it.
+        self._inbound_headers: list[dict[str, str]] = []
         self._lock = threading.Lock()
         self._server: ThreadingHTTPServer | None = None
         self._thread: threading.Thread | None = None
@@ -138,12 +142,40 @@ class FakeGateway:
         with self._lock:
             self._by_model = by_model
             self._refusals.clear()
+            self._inbound_headers.clear()
 
     @property
     def refusals(self) -> tuple[RefusedRequest, ...]:
         """Every off-script request served the loud error, in arrival order."""
         with self._lock:
             return tuple(self._refusals)
+
+    @property
+    def inbound_headers(self) -> tuple[dict[str, str], ...]:
+        """Headers of every request the engine made to this gateway, in arrival order.
+
+        INVARIANT (OME-1105): this lives on the CONCRETE backend, never on
+        ``ports.ReplayBackend``. That protocol is exactly ``start()``/``stop()`` and its
+        docstring forbids growing it with introspection — a header hook there would couple
+        the engine boot to one backend's internals.
+        """
+        with self._lock:
+            return tuple(dict(h) for h in self._inbound_headers)
+
+    def trace_ids_seen(self) -> set[str]:
+        """Distinct W3C trace ids observed on inbound ``traceparent`` headers."""
+        found = set()
+        for headers in self.inbound_headers:
+            value = headers.get("traceparent")
+            if value:
+                parts = value.split("-")
+                if len(parts) == 4 and len(parts[1]) == 32:
+                    found.add(parts[1])
+        return found
+
+    def _record_headers(self, headers: dict[str, str]) -> None:
+        with self._lock:
+            self._inbound_headers.append(headers)
 
     # -- handler callbacks (each request runs on its own server thread) ---------------
     def _lookup_model(self, model: str | None) -> RecordedExchange | None:
@@ -206,6 +238,7 @@ class _Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib handler naming
+        self.gateway._record_headers(dict(self.headers))
         if self.path == _HEALTH_PATH:
             self._reply(200, b'{"status":"ok"}', "application/json")
             return
@@ -215,6 +248,7 @@ class _Handler(BaseHTTPRequestHandler):
         self._refuse_unroutable()
 
     def do_POST(self) -> None:  # noqa: N802 - stdlib handler naming
+        self.gateway._record_headers(dict(self.headers))
         if self.path != _COMPLETIONS_PATH:
             self._refuse_unroutable()
             return

--- a/packages/screamingface/tests/e2e/test_correlation_chain.py
+++ b/packages/screamingface/tests/e2e/test_correlation_chain.py
@@ -1,0 +1,269 @@
+"""The correlation-chain ladder — one rung per change in the tracing roadmap (OME-1105).
+
+Mental model: this file is the acceptance test for `OME-935`, runnable on a laptop. The
+live-k8s notebook (`e2e/failor/notebooks/`) validates the same chain against the deployed
+stack, but it needs cluster credentials; this needs only Docker. k8s adds deployment realism
+— the Runner Job indirection, the mesh edge — and adds nothing to the question each rung
+asks, which is whether a trace id survives one hop.
+
+**`xfail(strict=True)` is the mechanism, not decoration.** A strict xfail that starts passing
+FAILS the suite, so the change that implements a rung is forced to delete its marker in the
+same PR. Without `strict`, an implemented rung would sit here quietly marked "expected
+failure" forever, and a later regression would look identical to the status quo.
+
+Which backend, and why it is not a free choice:
+
+- **Rungs 1–2 use `FakeGateway`** — an in-process ``BaseHTTPRequestHandler``, so the headers
+  the engine sent are directly observable. This is the only way to see the engine→gateway
+  wire from the test process.
+- **Rungs 3–4 use `CacheSeededGateway`** — the REAL aigateway as a subprocess. Nothing
+  in-process can see its request handling, so its only channel is ``aigateway.log``, which is
+  exactly what those two rungs assert on.
+
+INVARIANT (OME-1105): the header recorder lives on `FakeGateway`, never on
+``ports.ReplayBackend``. That protocol is exactly ``start()``/``stop()`` and its own docstring
+forbids growing it with introspection — a hook there would couple the engine boot to one
+backend's internals.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from harness._gating import FIXTURES_DIR, SNAPSHOTS_DIR, require_e2e_stack
+from harness.cache_seeded import CacheSeededGateway
+from harness.fake_gateway import FakeGateway
+from harness.stack import EngineProcess, replay_stack
+from harness.tape import load_tape
+
+BOARD = "draco"
+CANDIDATE_MODEL = "openrouter/anthropic/claude-haiku-4.5"
+_ASSETS_ENV = "SCREAMINGFACE_E2E_ASSETS"
+
+TRACEPARENT = re.compile(r"^00-(?!0{32}$)([0-9a-f]{32})-(?!0{16}$)([0-9a-f]{16})-[0-9a-f]{2}$")
+"""The shape url4's own ``_TRACEPARENT_RE`` accepts, plus its two all-zero rejections.
+
+WHY restated rather than imported: `packages/screamingface` does not depend on `url4`, and
+`OME-967` mints locally rather than adding a distribution dependency for four lines of string
+formatting. This regex IS the contract between the two packages, so it is written where it is
+asserted.
+"""
+
+
+def _assets_root() -> Path:
+    override = os.environ.get(_ASSETS_ENV)
+    return Path(override) if override else FIXTURES_DIR / "assets"
+
+
+def _require_draco_assets() -> Path:
+    assets = _assets_root()
+    if not (assets / BOARD).is_dir():
+        pytest.skip(
+            f"the correlation ladder drives the {BOARD} board and needs prepared assets at "
+            f"{assets / BOARD} (run `screamingface prepare {BOARD}`, or point {_ASSETS_ENV} "
+            f"at them)"
+        )
+    return assets
+
+
+def _trace_ids(values: Iterator[str] | list[str]) -> set[str]:
+    """The distinct trace ids inside a collection of raw ``traceparent`` values."""
+    found = set()
+    for value in values:
+        match = TRACEPARENT.match(value or "")
+        if match:
+            found.add(match.group(1))
+    return found
+
+
+# --- rungs 1-2: the wire, observed at an in-process gateway --------------------------------
+
+
+@pytest.fixture(scope="module")
+def wire_run(tmp_path_factory: pytest.TempPathFactory):
+    """One real run against `FakeGateway`, keeping the frames and the inbound headers.
+
+    Booted once: the engine subprocess is the slow part, and both wire rungs read the same
+    single run rather than paying for it twice.
+    """
+    require_e2e_stack()
+    assets = _require_draco_assets()
+
+    import screamingface as sf
+
+    work_dir = tmp_path_factory.mktemp("correlation-wire")
+    fake = FakeGateway(load_tape(SNAPSHOTS_DIR / "synthetic.tape.json"))
+    engine = EngineProcess(work_dir=work_dir, assets_dir=assets)
+    seen: list[str] = []
+    error_trace_id: str | None = None
+
+    base_url = fake.start_sync()
+    try:
+        engine_url = engine.start(base_url)
+        with sf.Client(engine_url=engine_url) as client:
+            try:
+                client.evaluate(
+                    sf.Model(CANDIDATE_MODEL),
+                    benchmark=BOARD,
+                    limit=1,
+                    progress=False,
+                    on_event=lambda event: seen.append(getattr(event, "traceparent", "") or ""),
+                )
+            except sf.ScreamingFaceError as exc:
+                # A failed run is the BETTER evidence here. The synthetic tape is not
+                # authored for draco, so this run is expected to fail — and OME-967 put the
+                # client's own trace id on the error, which is the only PUBLIC surface that
+                # carries it (`Report` has no trace field). Frames are kept as a secondary
+                # source for the case where a run does complete.
+                error_trace_id = exc.trace_id
+        client_ids = _trace_ids([v for v in seen if v])
+        if error_trace_id:
+            client_ids.add(error_trace_id)
+        yield {
+            "client_ids": client_ids,
+            "frames": [v for v in seen if v],
+            "gateway": fake,
+            "engine_log": work_dir / "engine.log",
+        }
+    finally:
+        engine.stop()
+        fake.stop_sync()
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(
+    strict=True,
+    reason="rung 1: no PUBLIC read site for a completed run's trace id — see the docstring",
+)
+def test_rung1_one_coherent_trace_id_spans_the_run(wire_run) -> None:
+    """RUNG 1 (`OME-967` is merged, yet this cannot observe it — strict xfail).
+
+    **This failing is a finding, not a gap in `OME-967`.** That change is real and is pinned
+    by `tests/test_client_protocol.py`, which watches the wire directly and asserts the client
+    sends a traceparent on all three legs. What this rung proves is different and worse: from
+    the PUBLIC SDK surface there is no way to read a completed run's trace id at all.
+
+    `trace_id` reaches only the error hierarchy (`ScreamingFaceError.trace_id`). `Report`
+    carries no trace field, and a board run does not raise — DRACO *collects* case errors into
+    rows (`on_error="collect"`), so a run whose every model call failed still returns a Report
+    and never surfaces an exception to read the id from. The frame stream does not fill the
+    gap either: no event reaching `on_event` carried a traceparent here.
+
+    So the user who most needs to quote an id — someone whose run produced bad results rather
+    than an exception — currently cannot get one. Closing this rung means giving `Report` a
+    trace id; it is not a retrofit of `OME-967`.
+    """
+    client_ids = wire_run["client_ids"]
+    assert client_ids, "the run surfaced no trace id — neither on an error nor on any frame"
+    assert len(client_ids) == 1, f"the run split across {len(client_ids)} trace ids"
+    (trace_id,) = client_ids
+    assert TRACEPARENT.match(f"00-{trace_id}-0000000000000001-01"), trace_id
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(strict=True, reason="rung 2: the engine sends no traceparent to aigateway")
+def test_rung2_the_engine_propagates_the_trace_id_to_the_gateway(wire_run) -> None:
+    """RUNG 2 (not built — strict xfail).
+
+    The gateway must receive the run's OWN trace id, not merely some traceparent. The audit
+    captured the engine's outbound header set as `Host, Accept, Accept-Encoding, Connection,
+    User-Agent, X-User-Email, X-Profile, Content-Length, Content-Type` — no traceparent at
+    all, on any of its three client paths.
+    """
+    gateway: FakeGateway = wire_run["gateway"]
+    assert gateway.inbound_headers, "the engine made no call to the gateway"
+    seen_ids = gateway.trace_ids_seen()
+    # WHY the non-empty assertion comes FIRST: without it this rung passes vacuously the
+    # moment both sides are empty, because `set() == set()`. That is exactly what happened
+    # on the first run of this file — a strict xfail reported XPASS while nothing propagated.
+    assert seen_ids, "the gateway received no traceparent on any inbound request"
+    assert seen_ids == wire_run["client_ids"]
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(strict=True, reason="rung 4a: the engine does not log its trace id")
+def test_rung4a_the_engine_logs_the_run_trace_id(wire_run) -> None:
+    """RUNG 4, engine half (not built — strict xfail; `OME-940`).
+
+    A trace id that never reaches a log line cannot be grepped, which is the whole payoff.
+    Split from the gateway half below because the two land in different changes.
+    """
+    log_text = Path(wire_run["engine_log"]).read_text(errors="replace")
+    client_ids = wire_run["client_ids"]
+    assert client_ids, "no trace id to look for"
+    assert any(t in log_text for t in client_ids)
+
+
+# --- rungs 3-4b: the logs, from the real aigateway -----------------------------------------
+
+
+@pytest.fixture(scope="module")
+def gateway_log(tmp_path_factory: pytest.TempPathFactory):
+    """One real run against the REAL aigateway, yielding its log text AND the run's trace id.
+
+    WHY a second stack rather than reusing the one above: `FakeGateway` writes no log, and
+    these two rungs assert on aigateway's own log lines. Nothing in-process can observe a
+    subprocess's request handling, so the log IS the interface.
+    """
+    require_e2e_stack()
+    assets = _require_draco_assets()
+    snapshot = SNAPSHOTS_DIR / "draco-3pass.snapshot.gz"
+    manifest = SNAPSHOTS_DIR / "draco-3pass.manifest.json"
+    if not snapshot.is_file():
+        pytest.skip(f"missing cache snapshot {snapshot}")
+
+    import screamingface as sf
+
+    work_dir = tmp_path_factory.mktemp("correlation-logs")
+    backend = CacheSeededGateway(snapshot=snapshot, manifest=manifest, work_dir=work_dir)
+    seen: list[str] = []
+    with replay_stack(backend, work_dir=work_dir, assets_dir=assets) as stack:
+        with sf.Client(engine_url=stack.engine_url) as client:
+            try:
+                client.evaluate(
+                    sf.Model(CANDIDATE_MODEL),
+                    benchmark=BOARD,
+                    limit=1,
+                    progress=False,
+                    on_event=lambda event: seen.append(getattr(event, "traceparent", "") or ""),
+                )
+            except sf.ScreamingFaceError:
+                pass  # the log is the evidence either way — see the wire fixture's note
+    yield {
+        "text": (work_dir / "aigateway.log").read_text(errors="replace"),
+        "trace_ids": _trace_ids([v for v in seen if v]),
+    }
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(strict=True, reason="rung 3: OME-938 gateway_call_id is not on log lines")
+def test_rung3_every_gateway_log_line_carries_a_call_id(gateway_log) -> None:
+    """RUNG 3 (`OME-938`, not built — strict xfail).
+
+    EVERY line, not a sample. The injector wraps a log-record factory, and a wrapper that
+    misses a code path is precisely the defect this rung exists to catch — a spot check on
+    the chat path would pass while startup and error paths stayed anonymous.
+    """
+    lines = [ln for ln in gateway_log["text"].splitlines() if ln.strip()]
+    assert lines, "the gateway wrote no log lines"
+    assert [ln for ln in lines if "gateway_call_id" in ln] == lines
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(strict=True, reason="rung 4b: aigateway does not join the inbound trace")
+def test_rung4b_the_gateway_logs_this_runs_trace_id(gateway_log) -> None:
+    """RUNG 4, gateway half (not built — strict xfail).
+
+    The payoff rung: once this and its engine twin pass, one id is greppable across both
+    services and a bug report's `trace_id` finally points at something.
+
+    It asserts THIS run's id, not merely that some 32-hex token appears — a log full of
+    unrelated hex would satisfy the weaker check while joining nothing.
+    """
+    trace_ids = gateway_log["trace_ids"]
+    assert trace_ids, "the run emitted no trace id to look for"
+    assert any(t in gateway_log["text"] for t in trace_ids)


### PR DESCRIPTION
## Summary

Makes the tracing roadmap's rungs testable **without cluster access**. The live-k8s notebook (`OME-1074`) needs credentials behind a break-glass tool; this needs only Docker, and the harness already boots the real spine — real engine subprocess, real aigateway on a Postgres testcontainer, log files on disk.

k8s adds deployment realism. It adds nothing to the question each rung asks: *does a trace id survive this hop*.

**Observed running against the real stack: `5 xfailed, 0 failed`.**

```sh
uv sync --extra runtime
screamingface prepare draco
SCREAMINGFACE_TEST_E2E=1 SCREAMINGFACE_E2E_ASSETS=~/.screamingface/benchmark-assets \
  uv run pytest tests/e2e/test_correlation_chain.py -m e2e
```

## Rung 1 is the finding

It was planned to **pass** — `OME-967` is merged. It cannot, and that is worth more than the ladder itself:

**From the public SDK surface there is no way to read a completed run's trace id.** It reaches only the error hierarchy (`ScreamingFaceError.trace_id`); `Report` carries no trace field; and a board run *does not raise*, because DRACO collects case errors into rows (`on_error="collect"`). So a run whose every model call failed still returns a `Report` with no id anywhere. The frame stream doesn't fill the gap either — no event reaching `on_event` carried a traceparent.

This does **not** retract `OME-967`, which is pinned against the wire in `test_client_protocol.py`. It says the *user-facing* half is missing — and it's the user with bad results rather than an exception who most needs to quote an id in a report.

**Closing rung 1 means giving `Report` a trace id.** Worth its own ticket.

## Why `strict=True` is load-bearing

A strict xfail that starts passing **fails the suite**, so the change implementing a rung must delete its marker in the same PR. A plain xfail would let an implemented rung sit here marked "expected failure" forever, and a later regression would look identical to the status quo.

It earned that immediately: **rung 2 first reported `XPASS(strict)`** because both sides of `gateway.trace_ids_seen() == client_ids` were empty sets — a rung asserting propagation passed while nothing propagated. The non-empty assertion now comes first, with a comment recording why. Only *executing* the ladder surfaced that; review would not have.

## Backend choice is forced, not stylistic

- **Rungs 1–2 → `FakeGateway`**: in-process `BaseHTTPRequestHandler`, so the headers the engine sent are directly observable. The only way to see the engine→gateway wire from the test process.
- **Rungs 3–4 → `CacheSeededGateway`**: the real aigateway as a *subprocess*, so its only channel is `aigateway.log` — which is exactly what those rungs assert on.

The header recorder lives on `FakeGateway`, **not** on `ports.ReplayBackend`, whose docstring forbids growing that protocol with introspection ("would couple the engine boot to one backend's internals").

## Rule 5 — owner-approved fixture edit

The append-only gate flagged `tests/e2e/harness/fake_gateway.py`. **Approved with the numbers: 34 insertions, 0 deletions, 0 assertions removed or changed** — an inbound-header recorder mirroring the existing `refusals` accessor, plus one capture call in each of `do_GET`/`do_POST`. The alternative (a second HTTP stand-in existing only to observe headers) was rejected as duplication that would drift.

## Test plan

- `run_gates.py screamingface --skip-append-only` — **ALL GATES GREEN**: ruff, ruff format, pyright, `pytest --cov=screamingface --cov-fail-under=95`, check_notebooks, uv build, check_distribution.
- Ladder observed: 5 xfailed, 0 failed. Prerequisite: `--extra runtime` + prepared draco assets, else every rung skips (same convention as `test_failures.py` / `test_boards.py`).
- Lane stays opt-in and out of CI.

Ledger: `docs/work/2026-09-03-OME-1105-correlation-chain-e2e.md`
Mirror: `docs/tasks/2026-09-03-OME-1105-correlation-chain-e2e.md`

Refs: OME-1105