### PR TITLE
feat(e2e): add a setup validator for the traceability lanes (OME-1106)

### DIFF
--- a/docs/tasks/2026-09-03-OME-1106-setup-validator.md
+++ b/docs/tasks/2026-09-03-OME-1106-setup-validator.md
@@ -1,0 +1,30 @@
+---
+id: OME-1106
+linear_url: https://linear.app/openmined/issue/OME-1106/add-a-setup-validator-for-the-traceability-e2e-lanes
+status: in_progress
+type: task
+priority: 3
+labels: [repo, agentic, autonomous, task]
+created: 2026-09-03
+closed:
+---
+
+# Add a setup validator for the traceability e2e lanes
+
+`e2e/failor/check_setup.py` reports, per lane, whether this machine can run the traceability
+rungs — with the exact remedy for anything missing. Every prerequisite it checks was found
+the hard way during `OME-1105`.
+
+The dangerous one it guards: without prepared draco assets **every rung skips and `pytest`
+exits 0**, so an all-skipped run is indistinguishable from a passing one by exit code. The
+validator says so in as many words.
+
+Read-only and offline: it never SSHes, authenticates, or contacts a cluster. The firecall
+bastion (`firecall@172.190.209.255` → AKS `aks-dev-eastus`, namespaces `sf-aigw`,
+`sf-fusion`, `sf-scoreboard`) is recorded as constants and reported UNKNOWN rather than
+probed — opening a session to a jump host belongs to the operator.
+
+Only the local lane decides the exit code; the k8s lane depends on credentials nobody here
+controls, and a permanently red validator is an ignored one.
+
+Ledger: `docs/work/2026-09-03-OME-1106-setup-validator.md`.

--- a/docs/work/2026-09-03-OME-1106-setup-validator.md
+++ b/docs/work/2026-09-03-OME-1106-setup-validator.md
@@ -1,0 +1,85 @@
+---
+ticket: OME-1106
+stack: repo
+started: 2026-09-03
+status: in_progress
+finished:
+---
+
+# OME-1106 — Setup validator for the traceability e2e lanes
+
+## Intent
+
+Running the traceability rungs needs a chain of prerequisites that is only discoverable by
+hitting each one in turn. Every item below was found the hard way during `OME-1105`: the
+`[runtime]` extra, prepared draco assets, a Docker daemon, `SCREAMINGFACE_TEST_E2E=1`, a
+client build carrying `OME-967`, and — for the k8s lane — a kubectl context that currently
+does not resolve at all.
+
+The dangerous one is the assets: without them **every rung skips**, and `pytest` exits `0`.
+An all-skipped run looks exactly like a passing run to anyone reading the exit code, which is
+the single most likely way for someone to believe the chain was validated when nothing ran.
+
+## Design decisions
+
+**D1 — read-only and offline-safe.** The validator probes local state only. It does not SSH,
+authenticate, or contact a cluster. Bastion reachability is reported **unknown**, not tested:
+probing it is a credentialed action belonging to the operator, and an automated tool that
+silently opens sessions to a jump host is the wrong default.
+
+**D2 — `importlib.util.find_spec`, not imports, for the runtime extra.** Importing `litellm`
+to check presence is slow and has side effects (it installs logging handlers at import time —
+see `OME-1050`). `find_spec` answers the same question without executing the package.
+
+**D3 — exit code reflects the LOCAL lane only.** The local e2e lane is the one that can
+actually be made green on a laptop; the k8s lane depends on credentials nobody here controls.
+Failing the exit code on the k8s lane would make the validator permanently red and therefore
+ignored.
+
+## Planned changes
+
+- `e2e/failor/check_setup.py` — the validator.
+- `e2e/failor/notebooks/README.md` — point at it.
+- This ledger + the `docs/tasks/` mirror.
+
+## Test plan
+
+No stack gates apply (new file in a top-level directory outside every path filter) — but
+**ruff runs repo-wide via pre-commit**, which `OME-1074` established the hard way, so
+`ruff check` and `ruff format --check` must be clean. Verification:
+
+- the script runs on this machine and reports a truthful table (verified against the state
+  established during `OME-1105`: Docker up, runtime extra installed, draco assets present,
+  kubeconfig broken);
+- it exits non-zero when a local-lane prerequisite is missing and zero when they are all met;
+- it never performs a network or credentialed action.
+
+## Acceptance
+
+- One command reports per-lane readiness with an exact remedy for each missing item.
+- It states plainly that a skipped rung proves nothing.
+- Clean ruff; no network access.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `e2e/failor/check_setup.py`,
+  `e2e/failor/notebooks/README.md` (pointer), the ledger and the mirror.
+- **Commits:** `feat(e2e): add a setup validator for the traceability lanes` (sha at
+  squash-merge).
+- **Gates:** `ruff check` + `ruff format --check` clean (they run repo-wide via pre-commit —
+  `OME-1074` established that the hard way). No stack gate applies. **Both exit paths were
+  observed**, not reasoned about: `exit=1` with two prerequisites missing, then `exit=0` with
+  all five green after `uv sync --extra runtime` in this worktree.
+- **Deviations:**
+  - **The first version probed the wrong interpreter, and running it caught that.** It used
+    the in-process `importlib.util.find_spec`, but the script is invoked as
+    `python3 e2e/failor/check_setup.py` from the repo root — so it probed whatever python is
+    on PATH, not the client venv, and reported the `[runtime]` extra missing while it was
+    installed in the only environment that runs the lane. A validator that lies about
+    readiness is worse than no validator. It now probes
+    `packages/screamingface/.venv/bin/python` explicitly and labels which interpreter it
+    used, falling back with the fallback named in the output.
+  - The firecall bastion details (`firecall@172.190.209.255`, AKS `aks-dev-eastus` in
+    `rg-aks-platform-dev-eastus`, namespaces `sf-aigw` / `sf-fusion` / `sf-scoreboard`) are
+    recorded as constants so nobody has to SSH in to rediscover them. Reachability is
+    deliberately NOT probed — see D1.

--- a/docs/work/2026-09-03-OME-1106-setup-validator.md
+++ b/docs/work/2026-09-03-OME-1106-setup-validator.md
@@ -83,3 +83,64 @@ No stack gates apply (new file in a top-level directory outside every path filte
     `rg-aks-platform-dev-eastus`, namespaces `sf-aigw` / `sf-fusion` / `sf-scoreboard`) are
     recorded as constants so nobody has to SSH in to rediscover them. Reachability is
     deliberately NOT probed — see D1.
+
+## Round 2 — review fixes (2026-09-10, PR #832)
+
+@IonesioJunior reviewed and did not approve. Two bugs, both making the script print
+`LOCAL LANE READY` for a lane that is not ready — the exact failure it exists to prevent.
+Both were real and both reproduced.
+
+**R1 — the validator accepted an assets location the ladder never reads.** `_assets()` looked
+in three places; `test_correlation_chain.py::_assets_root` looked in two, and the home-directory
+default was not among them. So with assets where `screamingface prepare` actually writes, the
+script said `OK` and every rung still skipped — and an all-skipped run exits 0.
+
+**The fix went into the TEST, not the validator**, which is the reviewer's own suggestion and
+the right half. `test_boards.py:63-71` and `test_failures.py:365-372` both default to
+`default_data_dir() / "benchmark-assets"`, carrying an explicit `OME-1001` comment: *"it is
+where `screamingface prepare` writes, so the assets a dev prepares for the stack are the assets
+these tests find."* The ladder was the sole outlier, defaulting to `FIXTURES_DIR / "assets"` — a
+path `prepare` never writes and the repo does not ship. Aligning the validator instead would
+have codified the outlier and left the ladder needing a hand-set override forever.
+
+**This was already costing time and was misread as a local quirk.** During `OME-1119` the
+ladder had to be run as `SCREAMINGFACE_E2E_ASSETS=$PWD/tests/e2e/fixtures/assets/benchmark-assets`
+after `prepare --data-dir` wrote one level deeper than the test looked. That was this bug,
+diagnosed as an environment wrinkle and worked around instead of fixed.
+
+**R2 — `UNKNOWN` did not block.** `blocked = [c for c in local if c.state == MISSING]` asks
+"which failed" when three states demand "which did not succeed". `UNKNOWN` means *could not
+check* — an unsynced venv, a failed probe — and readiness cannot be concluded from a check that
+never ran. In that state the script printed READY and exited 0, while the run would die at
+import. Worse than the skip case: a skip is silent, this promises an outcome that cannot happen.
+Now `!= OK`, and the summary distinguishes "N missing, M unverifiable".
+
+**R3 (reviewer's smaller point) — `SCREAMINGFACE_DATA_DIR` was ignored.** The old code hardcoded
+`Path.home() / ".screamingface"`, but `default_data_dir()` honours that variable first
+(`_runtime/config.py:12-16`). Fixed structurally rather than by copying the rule: the validator
+now *asks the client* for its data dir via the venv interpreter it already probes, so the two
+cannot drift again.
+
+**R4 (reviewer's smaller point) — the printed ready command now echoes the override** when one
+is set, so the command shown is the command that was validated.
+
+**R5 (found here, not in review) — the printed expectation was stale.** It promised
+`5 xfailed, 0 failed`, which stopped being true when rungs 1 and 2 went green (`OME-1121`,
+`OME-1119`). A validator that states a wrong expected outcome trains the reader to ignore a real
+regression. Now `2 passed, 3 xfailed, 0 failed`, naming the two tickets.
+
+**Verified end to end, not reasoned about:** with the venv synced and no override set, the
+validator reported all five checks `OK`, and running the command it printed **verbatim** gave
+`2 passed, 3 xfailed` — the outcome it promised. Before the fix that same command skipped all
+five. The unsynced-venv path was exercised too: `exit=1`, "2 missing, 2 unverifiable".
+
+**Not addressed, and it is why these shipped:** `check_setup.py` has **no tests and no CI gate**
+— nothing under `.github/workflows/` matches `e2e/failor/**`. Both bugs are pure logic in an
+ungated file, so nothing could have caught them but a human reading it. Raised as a question for
+the owner rather than fixed here: the script is a standalone tool outside any uv project, so
+giving it a test home is a real decision, not a detail.
+
+**Gates:** `run_gates.py screamingface --skip-append-only` — **ALL GREEN**. Append-only flagged
+`test_correlation_chain.py` for the **fourth** consecutive time; benign by count — test functions
+5 → 5, assertions 14 → 14, xfail markers 10 → 10, the change confined to the `_assets_root`
+helper with no assertion touched.

--- a/e2e/failor/check_setup.py
+++ b/e2e/failor/check_setup.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Report whether this machine can run the traceability e2e lanes (OME-1106).
+
+    python3 e2e/failor/check_setup.py
+
+Two lanes are checked independently:
+
+- **local** — the correlation ladder (`packages/screamingface/tests/e2e/
+  test_correlation_chain.py`). Needs only Docker and a prepared board; it is the lane that
+  can actually be made green on a laptop, so it alone decides the exit code.
+- **k8s** — the live notebook (`e2e/failor/notebooks/`). Needs cluster credentials nobody
+  here controls, so it is reported but never fails the run; a permanently red validator is
+  an ignored one.
+
+INVARIANT: read-only and offline. This script never SSHes, authenticates, or contacts a
+cluster. Bastion reachability is reported UNKNOWN rather than probed — opening a session to a
+jump host is a credentialed action that belongs to the operator, not to a status command.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLIENT = REPO_ROOT / "packages" / "screamingface"
+
+# From `firecall-connect` on the bastion. Recorded so nobody has to SSH in to learn them.
+BASTION = "firecall@172.190.209.255"
+AKS_CLUSTER = "aks-dev-eastus"
+AKS_GROUP = "rg-aks-platform-dev-eastus"
+NAMESPACES = ("sf-aigw", "sf-fusion", "sf-scoreboard")
+
+# The modules the `[runtime]` extra provides that the local stack actually boots.
+RUNTIME_MODULES = (
+    "uvicorn",
+    "fastapi",
+    "tortoise",
+    "litellm",
+    "aiosqlite",
+    "pydantic_settings",
+)
+
+OK, MISSING, UNKNOWN = "OK", "MISSING", "UNKNOWN"
+
+
+def _client_python() -> tuple[str, str]:
+    """The interpreter to probe, and a label saying which one it is.
+
+    WHY not `sys.executable`: this script is run as `python3 e2e/failor/check_setup.py` from
+    the repo root, so `sys.executable` is whatever python is on PATH — usually NOT the client
+    venv. Probing that would report the `[runtime]` extra missing while it is installed in the
+    only environment that runs the lane, which is worse than not checking at all.
+    """
+    venv = CLIENT / ".venv" / "bin" / "python"
+    if venv.is_file():
+        return str(venv), "packages/screamingface/.venv"
+    return sys.executable, f"fallback: {sys.executable}"
+
+
+@dataclass(frozen=True, slots=True)
+class Check:
+    name: str
+    state: str
+    detail: str
+    remedy: str = ""
+
+
+def _docker() -> Check:
+    if shutil.which("docker") is None:
+        return Check(
+            "docker", MISSING, "not on PATH", "install Docker Desktop / colima"
+        )
+    probe = subprocess.run(["docker", "info"], capture_output=True, text=True)
+    if probe.returncode != 0:
+        return Check(
+            "docker", MISSING, "daemon unreachable", "start Docker, then re-run"
+        )
+    return Check("docker", OK, "daemon reachable")
+
+
+def _runtime_extra() -> Check:
+    # WHY find_spec and not import: importing litellm installs logging handlers at import
+    # time (OME-1050) and is slow. Presence is the question; execution is not needed.
+    python, label = _client_python()
+    probe = subprocess.run(
+        [
+            python,
+            "-c",
+            "import importlib.util,sys;"
+            f"mods={list(RUNTIME_MODULES)!r};"
+            "print(','.join(m for m in mods if importlib.util.find_spec(m) is None))",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0:
+        return Check(
+            "[runtime] extra",
+            UNKNOWN,
+            f"probe failed in {label}",
+            "cd packages/screamingface && uv sync --extra runtime",
+        )
+    absent = [m for m in probe.stdout.strip().split(",") if m]
+    if absent:
+        return Check(
+            "[runtime] extra",
+            MISSING,
+            f"absent in {label}: {', '.join(absent)}",
+            "cd packages/screamingface && uv sync --extra runtime",
+        )
+    return Check("[runtime] extra", OK, f"all local-stack modules present in {label}")
+
+
+def _assets() -> Check:
+    override = os.environ.get("SCREAMINGFACE_E2E_ASSETS")
+    roots = [Path(override)] if override else []
+    roots += [
+        Path.home() / ".screamingface" / "benchmark-assets",
+        CLIENT / "tests" / "e2e" / "fixtures" / "assets",
+    ]
+    for root in roots:
+        if (root / "draco").is_dir():
+            return Check("draco assets", OK, f"found at {root}")
+    return Check(
+        "draco assets",
+        MISSING,
+        "no prepared draco board found",
+        "screamingface prepare draco   # then export SCREAMINGFACE_E2E_ASSETS="
+        f"{Path.home() / '.screamingface' / 'benchmark-assets'}",
+    )
+
+
+def _e2e_env() -> Check:
+    if os.environ.get("SCREAMINGFACE_TEST_E2E") == "1":
+        return Check("SCREAMINGFACE_TEST_E2E", OK, "set to 1")
+    return Check(
+        "SCREAMINGFACE_TEST_E2E",
+        MISSING,
+        "unset — the lane is opt-in and will SKIP",
+        "export SCREAMINGFACE_TEST_E2E=1",
+    )
+
+
+def _client_has_trace_id() -> Check:
+    """Does the installed client carry OME-967 (`trace_id` on the error hierarchy)?"""
+    python, label = _client_python()
+    probe = subprocess.run(
+        [
+            python,
+            "-c",
+            "import inspect,screamingface as sf;"
+            "print('trace_id' in inspect.signature(sf.ScreamingFaceError).parameters)",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=CLIENT,
+    )
+    if probe.returncode != 0:
+        return Check(
+            "client has OME-967",
+            UNKNOWN,
+            f"screamingface not importable in {label}",
+            "cd packages/screamingface && uv sync --extra runtime",
+        )
+    if probe.stdout.strip() != "True":
+        return Check(
+            "client has OME-967",
+            MISSING,
+            "installed client predates OME-967",
+            "cd packages/screamingface && uv build && pip install -U dist/*.whl",
+        )
+    return Check("client has OME-967", OK, "ScreamingFaceError accepts trace_id")
+
+
+def _kubectl_context() -> Check:
+    if shutil.which("kubectl") is None:
+        return Check(
+            "kubectl context", MISSING, "kubectl not on PATH", "brew install kubectl"
+        )
+    probe = subprocess.run(
+        ["kubectl", "config", "view", "-o", "json"], capture_output=True, text=True
+    )
+    if probe.returncode != 0:
+        return Check(
+            "kubectl context",
+            MISSING,
+            "kubeconfig unreadable",
+            "restore ~/.kube/config",
+        )
+    config = json.loads(probe.stdout or "{}")
+    contexts = config.get("contexts") or []
+    current = config.get("current-context") or "<none>"
+    if not contexts:
+        clusters = [c.get("name") for c in (config.get("clusters") or [])]
+        return Check(
+            "kubectl context",
+            MISSING,
+            f"NO contexts defined (current-context names {current!r}; "
+            f"{len(clusters)} cluster(s) present but nothing binds them)",
+            f"ssh {BASTION} and run firecall-connect, then copy the kubeconfig back",
+        )
+    return Check(
+        "kubectl context", OK, f"{len(contexts)} context(s); current={current}"
+    )
+
+
+def _bastion() -> Check:
+    # Deliberately NOT probed — see the module docstring.
+    return Check(
+        "firecall bastion",
+        UNKNOWN,
+        f"{BASTION} -> AKS {AKS_CLUSTER} ({AKS_GROUP}); ns: {', '.join(NAMESPACES)}",
+        f"ssh {BASTION} 'firecall-connect'   # run it yourself; not probed from here",
+    )
+
+
+def _render(title: str, checks: list[Check]) -> None:
+    width = max(len(c.name) for c in checks)
+    print(f"\n{title}")
+    print("-" * (width + 42))
+    for c in checks:
+        print(f"  {c.state:<7}  {c.name:<{width}}  {c.detail}")
+        if c.remedy and c.state != OK:
+            print(f"  {'':<7}  {'':<{width}}  -> {c.remedy}")
+
+
+def main() -> int:
+    local = [_docker(), _runtime_extra(), _assets(), _e2e_env(), _client_has_trace_id()]
+    k8s = [_kubectl_context(), _bastion()]
+
+    _render("LOCAL LANE — the correlation ladder (decides the exit code)", local)
+    _render("K8S LANE — the live notebook (reported only, never fails this run)", k8s)
+
+    blocked = [c for c in local if c.state == MISSING]
+    print()
+    if blocked:
+        print(
+            f"LOCAL LANE NOT READY — {len(blocked)} prerequisite(s) missing (see -> lines)."
+        )
+        # WHY this warning is worth its own line: without assets every rung SKIPS and pytest
+        # exits 0. An all-skipped run is indistinguishable from a passing one by exit code,
+        # which is the most likely way to believe the chain was validated when nothing ran.
+        print(
+            "NOTE: a skipped rung proves NOTHING. `pytest` exits 0 on an all-skipped run."
+        )
+        return 1
+
+    print("LOCAL LANE READY. Run:")
+    print("  cd packages/screamingface && SCREAMINGFACE_TEST_E2E=1 \\")
+    print("    uv run pytest tests/e2e/test_correlation_chain.py -m e2e -q")
+    print(
+        "Expected today: 5 xfailed, 0 failed. A rung turning green means its change landed"
+    )
+    print("and its xfail marker must be deleted in that same PR.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/e2e/failor/check_setup.py
+++ b/e2e/failor/check_setup.py
@@ -117,22 +117,59 @@ def _runtime_extra() -> Check:
     return Check("[runtime] extra", OK, f"all local-stack modules present in {label}")
 
 
-def _assets() -> Check:
+def _assets_root() -> tuple[Path | None, str]:
+    """Where the ladder will look for boards, resolved the way the ladder resolves it.
+
+    INVARIANT: this must agree with `test_correlation_chain.py::_assets_root` EXACTLY. A
+    validator that accepts a location the test does not read reports `LOCAL LANE READY` for a
+    lane that then skips every rung — and an all-skipped run exits 0, which is the precise
+    failure this script exists to prevent. It happened: the first version also accepted
+    `packages/screamingface/tests/e2e/fixtures/assets`, which no test has ever read.
+
+    WHY the default is asked of the client rather than hardcoded: it is
+    `default_data_dir() / "benchmark-assets"`, and `default_data_dir()` honours
+    `SCREAMINGFACE_DATA_DIR` before falling back to `~/.screamingface`. Spelling the fallback
+    literally here gives a wrong answer to everyone who sets that variable.
+    """
     override = os.environ.get("SCREAMINGFACE_E2E_ASSETS")
-    roots = [Path(override)] if override else []
-    roots += [
-        Path.home() / ".screamingface" / "benchmark-assets",
-        CLIENT / "tests" / "e2e" / "fixtures" / "assets",
-    ]
-    for root in roots:
-        if (root / "draco").is_dir():
-            return Check("draco assets", OK, f"found at {root}")
+    if override:
+        return Path(override), "SCREAMINGFACE_E2E_ASSETS"
+    python, label = _client_python()
+    probe = subprocess.run(
+        [
+            python,
+            "-c",
+            "from screamingface._runtime.config import default_data_dir;"
+            "print(default_data_dir())",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0:
+        return None, label
+    data_dir = Path(probe.stdout.strip())
+    return data_dir / "benchmark-assets", "screamingface prepare default"
+
+
+def _assets() -> Check:
+    root, source = _assets_root()
+    if root is None:
+        # UNKNOWN, not MISSING: the client is not importable, so the default location cannot be
+        # resolved and the board may well be prepared. `main` blocks on anything that is not OK,
+        # so this still stops the lane — it just says the true reason.
+        return Check(
+            "draco assets",
+            UNKNOWN,
+            f"cannot resolve the assets root — screamingface not importable in {source}",
+            "cd packages/screamingface && uv sync --extra runtime",
+        )
+    if (root / "draco").is_dir():
+        return Check("draco assets", OK, f"found at {root} (via {source})")
     return Check(
         "draco assets",
         MISSING,
-        "no prepared draco board found",
-        "screamingface prepare draco   # then export SCREAMINGFACE_E2E_ASSETS="
-        f"{Path.home() / '.screamingface' / 'benchmark-assets'}",
+        f"no prepared draco board at {root} (via {source})",
+        f"screamingface prepare draco   # writes to {root}",
     )
 
 
@@ -237,12 +274,20 @@ def main() -> int:
     _render("LOCAL LANE — the correlation ladder (decides the exit code)", local)
     _render("K8S LANE — the live notebook (reported only, never fails this run)", k8s)
 
-    blocked = [c for c in local if c.state == MISSING]
+    # WHY `!= OK` and not `== MISSING`: with three states the question is "which checks did not
+    # SUCCEED", not "which failed". UNKNOWN means *could not check* — a probe that itself failed
+    # (`_runtime_extra`, `_assets`) or a client that is not importable — and readiness cannot be
+    # concluded from a check that never ran. Reading it as non-blocking printed LOCAL LANE READY
+    # and exited 0 for an unsynced venv, where the run then dies at import while the reader was
+    # told to expect a clean xfail line. That is worse than the skip case: a skip is silent, this
+    # promises an outcome that cannot happen.
+    blocked = [c for c in local if c.state != OK]
     print()
     if blocked:
-        print(
-            f"LOCAL LANE NOT READY — {len(blocked)} prerequisite(s) missing (see -> lines)."
-        )
+        missing = sum(1 for c in blocked if c.state == MISSING)
+        unknown = len(blocked) - missing
+        detail = f"{missing} missing" + (f", {unknown} unverifiable" if unknown else "")
+        print(f"LOCAL LANE NOT READY — {detail} (see -> lines).")
         # WHY this warning is worth its own line: without assets every rung SKIPS and pytest
         # exits 0. An all-skipped run is indistinguishable from a passing one by exit code,
         # which is the most likely way to believe the chain was validated when nothing ran.
@@ -251,13 +296,22 @@ def main() -> int:
         )
         return 1
 
+    root, source = _assets_root()
     print("LOCAL LANE READY. Run:")
     print("  cd packages/screamingface && SCREAMINGFACE_TEST_E2E=1 \\")
+    # WHY the override is echoed when one is set: the printed command must be the command that
+    # was actually validated. Printing a bare invocation while readiness was concluded from an
+    # override the next shell may not carry is how a READY report becomes an all-skipped run.
+    if source == "SCREAMINGFACE_E2E_ASSETS":
+        print(f"    SCREAMINGFACE_E2E_ASSETS={root} \\")
     print("    uv run pytest tests/e2e/test_correlation_chain.py -m e2e -q")
     print(
-        "Expected today: 5 xfailed, 0 failed. A rung turning green means its change landed"
+        "Expected today: 2 passed, 3 xfailed, 0 failed — rungs 1 (OME-1121) and 2 (OME-1119)"
     )
-    print("and its xfail marker must be deleted in that same PR.")
+    print(
+        "are green. A further rung turning green means its change landed and its xfail marker"
+    )
+    print("must be deleted in that same PR, or the suite fails on XPASS(strict).")
     return 0
 
 

--- a/e2e/failor/notebooks/README.md
+++ b/e2e/failor/notebooks/README.md
@@ -7,6 +7,16 @@ Hand-run notebooks that validate the correlation chain against the **deployed** 
 | `traceability_e2e_k8s.ipynb` | Walks the tracing ladder (`OME-935`), one rung per section, printing PASS/FAIL and a summary table |
 | `build_notebook.py` | Regenerates the notebook's authored cells — edit here, re-run, commit both |
 
+## Check your setup first
+
+```sh
+python3 e2e/failor/check_setup.py
+```
+
+Reports both lanes with the exact remedy for anything missing. Worth running before the
+notebook: without prepared assets every e2e rung **skips**, and `pytest` exits 0 — an
+all-skipped run is indistinguishable from a passing one by exit code alone.
+
 ## Run it
 
 ```sh

--- a/packages/screamingface/tests/e2e/test_correlation_chain.py
+++ b/packages/screamingface/tests/e2e/test_correlation_chain.py
@@ -34,7 +34,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
-from harness._gating import FIXTURES_DIR, SNAPSHOTS_DIR, require_e2e_stack
+from harness._gating import SNAPSHOTS_DIR, require_e2e_stack
 from harness.cache_seeded import CacheSeededGateway
 from harness.fake_gateway import FakeGateway
 from harness.stack import EngineProcess, replay_stack
@@ -63,8 +63,19 @@ asserted.
 
 
 def _assets_root() -> Path:
+    # WHY this default: it is where `screamingface prepare` writes, so the assets a dev
+    # prepares for the stack are the assets these tests find (OME-1001). `test_boards.py` and
+    # `test_failures.py` have resolved it this way all along; this file was the one outlier,
+    # defaulting to `FIXTURES_DIR / "assets"` — a path `prepare` never writes and the repo does
+    # not ship. The ladder was therefore unrunnable without setting the override by hand, and
+    # `check_setup.py` reported the lane ready from a location this function never read
+    # (OME-1106 review). `default_data_dir()` also honours SCREAMINGFACE_DATA_DIR.
+    from screamingface._runtime.config import default_data_dir
+
     override = os.environ.get(_ASSETS_ENV)
-    return Path(override) if override else FIXTURES_DIR / "assets"
+    if override:
+        return Path(override)
+    return default_data_dir() / "benchmark-assets"
 
 
 def _require_draco_assets() -> Path:


### PR DESCRIPTION
## Summary

`python3 e2e/failor/check_setup.py` — one command that says whether this machine can run the traceability rungs, and exactly what to type for anything missing.

Every prerequisite it checks was discovered the hard way during `OME-1105`: the `[runtime]` extra, prepared draco assets, Docker, `SCREAMINGFACE_TEST_E2E=1`, a client carrying `OME-967`, and a kubectl context.

**The failure mode it exists to prevent:** without prepared assets, *every* e2e rung skips and `pytest` exits `0`. An all-skipped run is indistinguishable from a passing one by exit code — the most likely way to believe the chain was validated when nothing ran. The validator states that outright.

## Output

```
LOCAL LANE — the correlation ladder (decides the exit code)
  OK       docker                  daemon reachable
  OK       [runtime] extra         all local-stack modules present in packages/screamingface/.venv
  OK       draco assets            found at ~/.screamingface/benchmark-assets
  OK       SCREAMINGFACE_TEST_E2E  set to 1
  OK       client has OME-967      ScreamingFaceError accepts trace_id

K8S LANE — the live notebook (reported only, never fails this run)
  MISSING  kubectl context   NO contexts defined (current-context names 'k3s-ansible';
                             2 cluster(s) present but nothing binds them)
  UNKNOWN  firecall bastion  firecall@172.190.209.255 -> AKS aks-dev-eastus; ns: sf-aigw, ...
```

## Three design points

**Read-only and offline.** It never SSHes, authenticates, or contacts a cluster. Bastion reachability is reported `UNKNOWN`, not probed — opening a session to a jump host is a credentialed action belonging to the operator, not to a status command. The bastion details are recorded as constants so nobody has to SSH in to rediscover them.

**Only the local lane decides the exit code.** The k8s lane needs credentials nobody here controls; failing on it would make the validator permanently red and therefore ignored.

**`find_spec` via subprocess, not import.** Importing `litellm` to test presence installs logging handlers at import time (see `OME-1050`) and is slow.

## It caught a defect in itself

The first version used **in-process** `importlib.util.find_spec` — but the script is invoked as `python3 e2e/failor/check_setup.py` from the repo root, so it probed whatever python was on `PATH` rather than the client venv. It reported the `[runtime]` extra **missing while it was installed in the only environment that runs the lane**.

A validator that lies about readiness is worse than no validator. It now probes `packages/screamingface/.venv/bin/python` explicitly and names which interpreter it used, so a fallback is visible rather than silent.

## Test plan

- `ruff check` + `ruff format --check` clean — they run repo-wide via pre-commit, including this path (`OME-1074` established that the hard way).
- **Both exit paths observed, not reasoned about:** `exit=1` with two prerequisites missing, then `exit=0` with all five green after `uv sync --extra runtime`.
- No stack gate applies (top-level directory outside every path filter).

Ledger: `docs/work/2026-09-03-OME-1106-setup-validator.md`
Mirror: `docs/tasks/2026-09-03-OME-1106-setup-validator.md`

Refs: OME-1106