### PR TITLE
fix(screamingface): retry replay-safe requests on transient edge failures

### DIFF
--- a/docs/tasks/2026-09-03-OME-1107-sdk-transient-retry.md
+++ b/docs/tasks/2026-09-03-OME-1107-sdk-transient-retry.md
@@ -1,0 +1,32 @@
+---
+id: OME-1107
+linear_url: https://linear.app/openmined/issue/OME-1107/retry-replay-safe-sdk-requests-on-transient-edge-failures
+status: in_progress
+type: null
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-03
+closed:
+---
+
+# Retry replay-safe SDK requests on transient edge failures
+
+A single Cloudflare **520** on one `POST /token` ended an `sf.evaluate` of 8 candidates — after
+7 had already completed **100/100 cases at 100% cache hit**. The origin was healthy throughout:
+nginx logged 14 `/token` requests, all 200, including 3 seconds either side of the failure. The
+blip lived above the origin, in a flapping tunnel connection, and is environmental.
+
+This unit is about why one blip was fatal:
+
+1. **Nothing retried a request the SDK had itself declared replay-safe.** `/token` is sent with
+   `extensions={_REPLAY_SAFE: True}` and was never replayed.
+2. **The error pasted the raw body** — only `problem+json` was parsed, so ~7KB of Cloudflare
+   markup reached the user with the status code buried inside it.
+
+Retry is gated on the EXISTING `_REPLAY_SAFE` marker, never on the HTTP method. That marker is
+already default-deny precisely because `GET /?q=` starts billable work despite being a GET — so
+the one dangerous call is excluded by construction rather than by a rule someone must remember.
+
+**Explicitly NOT fixed here:** the in-flight reservation leak and the all-or-nothing evaluation
+semantics. Run start is deliberately not replay-safe, so this retry does not — and must not —
+cover a refused run start.

--- a/docs/work/2026-09-03-OME-1107-sdk-transient-retry.md
+++ b/docs/work/2026-09-03-OME-1107-sdk-transient-retry.md
@@ -1,0 +1,117 @@
+---
+ticket: OME-1107
+stack: screamingface
+status: in_progress
+started: 2026-09-03
+finished:
+---
+
+# OME-1107 — retry replay-safe SDK requests on transient edge failures
+
+## Intent
+
+A single Cloudflare 520 on one `POST /token` destroyed an `sf.evaluate` of 8 candidates, after
+7 had already completed 100/100 cases at 100% cache hit. The origin was healthy throughout —
+nginx logged 14 `/token` requests, all 200, including 3 seconds either side of the failure —
+so the 520 came from a flapping tunnel connection above the origin. The blip was environmental
+and is already resolved; this unit is about why one blip was fatal.
+
+Two SDK defects turned it into total loss:
+
+1. **No retry, despite the request declaring itself replay-safe.** `_mint_sync`/`_mint_async`
+   send `/token` with `extensions={_REPLAY_SAFE: True}`, and nothing ever replays it.
+2. **The error pastes the raw body.** `_raise_response` sets `detail = response.text.strip()`
+   and parses only `application/problem+json`, so an HTML edge page lands verbatim in the
+   exception — 7KB of Cloudflare markup hiding the one useful token, the status code.
+
+## Design
+
+**Gate retry on the EXISTING `_REPLAY_SAFE` extension, never on the HTTP method.** That flag is
+already an explicit, default-deny property of the request (`_access/auth.py:568`), introduced
+because `GET /?q=` starts a Run despite being a GET — "any generic layer that assumes GETs are
+replayable can double-fire it". Replay-safety is a property of the REQUEST (does re-sending
+duplicate a side effect), not of the failure mode, so the same flag answers both "safe to
+re-send after Access re-auth" and "safe to re-send after a transient 5xx".
+
+This makes the dangerous case safe by construction:
+
+| call | `_REPLAY_SAFE` | retried |
+|---|---|---|
+| `POST /token` (mint) | True | yes — the call that failed |
+| `DELETE /` (stop) | True | yes, idempotent |
+| **`GET /?q=` (run start)** | **absent → False** | **never** |
+
+Implemented as an httpx transport wrapper so the policy lives in ONE place rather than at each
+call site, and cannot be forgotten by the next caller.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_core/retry.py` — NEW. Sync + async transport
+  wrappers: retry only replay-safe requests, only on retryable status or transport error,
+  bounded attempts, exponential backoff with jitter, honouring `Retry-After`.
+- `packages/screamingface/src/screamingface/_engine/transport.py` — wire the wrappers into the
+  two engine clients; cap and summarise non-`problem+json` bodies in `_raise_response`.
+- `packages/screamingface/tests/test_transient_retry.py` — NEW file (tests are append-only).
+
+## Test plan
+
+- A replay-safe request meeting a retryable 5xx (520/502/503/504) is retried and succeeds when
+  a later attempt does.
+- A request WITHOUT `_REPLAY_SAFE` is **never** retried — the run-start invariant. Asserted
+  directly, since violating it double-fires billable runs.
+- A 4xx (400/401/404) is not retried.
+- `Retry-After` is honoured when present, in both delta-seconds and HTTP-date form.
+- The attempt budget is bounded — a permanently failing endpoint stops and surfaces the error.
+- A transport-level connection error is retried, and the final failure still raises.
+- An HTML error body yields a bounded message naming the status code, not the raw page.
+- `problem+json` detail extraction is unchanged.
+
+## Acceptance
+
+- The mint path survives a single transient 520 without user-visible failure.
+- Run start is provably never retried.
+- `run_gates.py screamingface` green (coverage gate is 95% on this package).
+
+## Outcome
+
+- **Actual files:** as planned, plus the `docs/tasks/` mirror.
+  - `src/screamingface/_core/retry.py` — NEW. `RetryingTransport` / `RetryingAsyncTransport`
+    sharing one `_RetryPlan`, so the sync and async policies cannot drift.
+  - `src/screamingface/_engine/transport.py` — both engine clients wired to the retrying
+    transports; `_body_summary` replaces the raw-body error detail.
+  - `tests/test_transient_retry.py` — NEW, 29 tests.
+  - `docs/tasks/2026-09-03-OME-1107-sdk-transient-retry.md` — NEW mirror.
+- **Commits:** `fix(screamingface): retry replay-safe requests on transient edge failures`
+- **Gates:** `run_gates.py screamingface` — ALL GATES GREEN (append-only · ruff check · ruff
+  format · pyright · pytest --cov ≥95 · notebooks · uv build · distribution).
+  **The append-only check passed on its own — no `--skip-append-only`**, because this unit adds
+  a new test file and touches no prior test.
+- **Deviations:**
+  1. **No new retry vocabulary was invented.** The plan considered a bespoke "retryable"
+     notion; the implementation instead reuses `_REPLAY_SAFE`, which `_core/wire.py` already
+     defines as default-deny and describes as costing "one extra round trip — never an extra
+     paid Run". Replay safety is a property of the REQUEST, so one marker legitimately answers
+     both "safe after an Access login" and "safe after a transient 5xx". This is why run start
+     is excluded by construction.
+  2. **500 is deliberately NOT retryable.** An application error is deterministic; repeating it
+     wastes the caller's time and hides the defect. The retry set is the gateway/edge family
+     plus 408/429/503.
+  3. **`Retry-After` beyond a 30s cap stops rather than sleeping.** Obeying an hour-long value
+     is indistinguishable from a hang; surfacing the response lets the caller decide.
+  4. **Three gate iterations**, all in my own new code: import order, two functions exceeding
+     the return-count limit (fixed by extracting `_http_date` and flattening `_body_summary`,
+     not by suppressing), and one long line. A fourth red was environmental — the worktree
+     lacked the optional `notebook` extra, so pyright could not resolve `ipywidgets` in files
+     this unit never touched; `uv sync --all-extras` fixed it.
+
+## Scope explicitly NOT covered
+
+- **The in-flight reservation leak.** Run start is not replay-safe, so a refused `GET /?q=` is
+  never retried here — correctly, since retrying it would double-fire billable Runs. That leak
+  bit again on the same cluster ~25 minutes after this incident: the App still held 8
+  reservations from the earlier evaluation, refusing 7 of 8 candidates with 503 against an idle
+  pool, and the refused candidates hung rather than erroring because the reaper is disabled
+  (`URL4_CLOUD_ORPHAN_GRACE_S=0`, which `app.py` honours silently).
+- **All-or-nothing evaluation semantics** (`_evaluation/runner.py:382-389`).
+
+Both remain open follow-ups and are the reason a single refusal still costs a whole evaluation.

--- a/docs/work/2026-09-03-OME-1107-sdk-transient-retry.md
+++ b/docs/work/2026-09-03-OME-1107-sdk-transient-retry.md
@@ -104,6 +104,34 @@ call site, and cannot be forgotten by the next caller.
      lacked the optional `notebook` extra, so pyright could not resolve `ipywidgets` in files
      this unit never touched; `uv sync --all-extras` fixed it.
 
+## Follow-up — coverage gate (2026-09-07)
+
+PR #835 review (`keelancj`) requested changes: package-wide coverage sat at 94.9% against the
+95% gate, and `_core/retry.py` itself was 88%. The two gaps named in review — the HTTP-date
+form of `Retry-After`, and the `attempts < 1` guard — were both real: neither had a test, even
+though the code for both already existed and was correct.
+
+- **Added to `tests/test_transient_retry.py`** (append-only, no prior test touched):
+  - `test_retry_after_http_date_is_honoured` / `test_retry_after_naive_http_date_is_treated_as_utc`
+    — the HTTP-date `Retry-After` form (RFC 9110 §10.2.3), both timezone-aware and naive
+    (`_http_date` documents normalising to UTC — the naive case is that promise, not a detail).
+  - `test_an_unparsable_retry_after_falls_back_to_backoff` — a `Retry-After` that is neither
+    delta-seconds nor an HTTP-date must fall back to normal backoff, not crash the loop.
+  - `test_the_async_transport_also_stops_rather_than_sleeping_beyond_the_cap` — the async twin
+    of the existing sync `Retry-After`-beyond-cap test; the sync version existed, the async one
+    did not.
+  - `test_zero_attempts_is_rejected` / `test_negative_attempts_is_rejected` — the
+    `attempts < 1` guard in the shared `_RetryPlan`, exercised through both `RetryingTransport`
+    and `RetryingAsyncTransport`.
+- **No production code changed** — every gap was a missing test for already-correct behavior.
+- **Gates:** `run_gates.py screamingface` — ALL GATES GREEN, including
+  `pytest --cov=screamingface --cov-fail-under=95` (package coverage; `_core/retry.py` alone
+  moved 88% → 94%, remaining misses are two provably unreachable `AssertionError` guards
+  the loop can never reach, not left uncovered by omission).
+- **Deviation:** left the two unreachable-`AssertionError` lines uncovered rather than adding a
+  `# pragma: no cover` — closing them wasn't needed to clear the gate, and marking dead code is
+  a separate, out-of-scope judgment call from the review's actual ask.
+
 ## Scope explicitly NOT covered
 
 - **The in-flight reservation leak.** Run start is not replay-safe, so a refused `GET /?q=` is

--- a/docs/work/2026-09-03-OME-1107-sdk-transient-retry.md
+++ b/docs/work/2026-09-03-OME-1107-sdk-transient-retry.md
@@ -143,3 +143,36 @@ though the code for both already existed and was correct.
 - **All-or-nothing evaluation semantics** (`_evaluation/runner.py:382-389`).
 
 Both remain open follow-ups and are the reason a single refusal still costs a whole evaluation.
+
+## Follow-up — a body that dies mid-read (2026-09-09)
+
+PR #835 second review (`keelancj`): if a retryable response's BODY raises `httpx.ReadError`,
+`response.read()` exited before closing the response or retrying — reproduced in both sync
+and async, only one attempt happened even when the next would succeed. Confirmed and fixed
+here.
+
+- **Root cause:** the `except httpx.TransportError` guarded only the SEND
+  (`handle_request`). The `response.read()` that drains a response before re-sending sat
+  outside it, so a connection that dropped mid-body (the exact tunnel-flap class this
+  module exists for) escaped as a raw `ReadError`: no retry, no release.
+- **Fix:** read+close moved into `_release_and_wait` / `_release_and_wait_async`, where a
+  `TransportError` from the read is the same failure as a dropped send — close the dead
+  response, sleep `backoff(attempt)` (never the `Retry-After` that rode on a response
+  whose body never arrived), and re-send.
+- **Dead branch removed, not papered over:** a first draft carried `if last: raise` inside
+  `_release_and_wait`, but it was provably unreachable — the loop returns any retryable
+  response unread on its last attempt so the caller sees the terminal response intact (and
+  a test that only "passed" by exercising httpx's own `Client.send()` body read was
+  dropped, not kept). The parameter and branch are gone, with an INVARIANT note in the
+  docstring.
+- **Tests added (append-only):** `test_a_body_read_failure_is_retried_like_any_transport_failure`
+  and its async twin — the load-bearing regression: a 503 backed by a `stream=` that
+  raises on read, then a 200 on the retry, asserting the dead response was released — plus
+  `test_a_body_read_failure_uses_backoff_not_the_retry_after_that_never_arrived`. `stream=`
+  matters: `Response(content=...)` reads eagerly in `__init__`, which would raise inside
+  the handler instead of at the loop's read. All three fail against `ace79e08` (raw
+  `ReadError`, one attempt) and pass against the fix.
+- **Gates:** `run_gates.py screamingface` — ALL GATES GREEN (append-only · ruff · pyright ·
+  pytest --cov ≥95 · notebooks · uv build · distribution). `_core/retry.py` alone 98%; the
+  two misses remain the provably-unreachable `AssertionError` guards the previous
+  follow-up already left uncovered.

--- a/packages/screamingface/src/screamingface/_core/retry.py
+++ b/packages/screamingface/src/screamingface/_core/retry.py
@@ -1,0 +1,224 @@
+"""Retry a request the caller declared replay-safe, when the failure is transient.
+
+WHY a transport and not a helper at each call site: the policy that matters here is a SAFETY
+policy — which requests may be re-sent — and a rule enforced in one place cannot be forgotten
+by the next call site added. The transport sees every request the client makes.
+
+INVARIANT — the whole point of this module: retry is gated on the `_REPLAY_SAFE` request
+extension and NEVER on the HTTP method. `GET /?q=` starts billable work despite being a GET
+(see `_core.wire._REPLAY_SAFE`), so a layer that assumed GETs were replayable would double-fire
+paid Runs. Replay safety is a property of the REQUEST — does re-sending duplicate a side
+effect — not of the response status, which is why the same marker answers both "safe to
+re-send after an Access login" and "safe to re-send after a transient edge failure".
+
+FEATURE (OME-1107): a single Cloudflare 520 on one `POST /token` ended an evaluation of 8
+candidates after 7 had already completed. The origin was healthy throughout; the blip lived
+above it, in the tunnel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+
+import httpx
+
+from screamingface._core.wire import _REPLAY_SAFE
+
+# Statuses worth a second attempt: gateway/edge failures, an explicit "slow down", and a
+# timeout the origin never saw.
+#
+# WHY 500 is ABSENT: an application error is deterministic — repeating it wastes the caller's
+# time and hides the defect. 520-524 are Cloudflare's own "origin misbehaved" family, which is
+# exactly the class that produced the incident this module exists for.
+_RETRYABLE_STATUS = frozenset({408, 429, 502, 503, 504, 520, 521, 522, 523, 524})
+
+_DEFAULT_ATTEMPTS = 3
+_DEFAULT_BASE_DELAY_S = 0.25
+_DEFAULT_MAX_DELAY_S = 4.0
+# An honest ceiling on obedience: a server may ask for an hour, and silently sleeping that long
+# is indistinguishable from a hang. Past this bound the response is surfaced so the CALLER
+# decides — see `_RetryPlan.wait_for`.
+_DEFAULT_MAX_RETRY_AFTER_S = 30.0
+
+
+def _replay_safe(request: httpx.Request) -> bool:
+    return bool(request.extensions.get(_REPLAY_SAFE, False))
+
+
+def _http_date(text: str) -> datetime | None:
+    """The HTTP-date form of `Retry-After`, normalised to UTC, or None if it is not one."""
+    try:
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    return when if when.tzinfo is not None else when.replace(tzinfo=UTC)
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    """`Retry-After` as seconds, accepting both wire forms, or None when absent/unparsable."""
+    raw = response.headers.get("retry-after")
+    if not raw:
+        return None
+    text = raw.strip()
+    try:
+        return max(0.0, float(int(text)))
+    except ValueError:
+        pass
+    when = _http_date(text)
+    return None if when is None else max(0.0, (when - datetime.now(UTC)).total_seconds())
+
+
+class _RetryPlan:
+    """The policy half, shared by the sync and async transports so they cannot drift."""
+
+    def __init__(
+        self,
+        *,
+        attempts: int,
+        base_delay: float,
+        max_delay: float,
+        max_retry_after: float,
+        jitter: Callable[[], float],
+    ) -> None:
+        if attempts < 1:
+            raise ValueError(f"attempts must be >= 1, got {attempts}")
+        self.attempts = attempts
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+        self._max_retry_after = max_retry_after
+        self._jitter = jitter
+
+    def backoff(self, attempt: int) -> float:
+        """Bounded exponential backoff with jitter — a tight loop against a struggling edge is
+        a second outage, not a recovery, and unjittered retries from many clients resynchronise
+        into one."""
+        raw = min(self._max_delay, self._base_delay * (2 ** (attempt - 1)))
+        return raw * (1.0 + 0.25 * self._jitter())
+
+    def wait_for(self, response: httpx.Response, attempt: int) -> float | None:
+        """Seconds to wait before re-sending, or None to stop and surface this response.
+
+        An explicit `Retry-After` is obeyed verbatim rather than jittered — the server named a
+        number, and second-guessing it is how a thundering herd starts — but only up to the
+        cap, past which stopping is more honest than an unbounded sleep.
+        """
+        requested = _retry_after_seconds(response)
+        if requested is None:
+            return self.backoff(attempt)
+        if requested > self._max_retry_after:
+            return None
+        return requested
+
+
+class RetryingTransport(httpx.BaseTransport):
+    """Wraps a transport, re-sending replay-safe requests that fail transiently."""
+
+    def __init__(
+        self,
+        inner: httpx.BaseTransport,
+        *,
+        attempts: int = _DEFAULT_ATTEMPTS,
+        base_delay: float = _DEFAULT_BASE_DELAY_S,
+        max_delay: float = _DEFAULT_MAX_DELAY_S,
+        max_retry_after: float = _DEFAULT_MAX_RETRY_AFTER_S,
+        sleep: Callable[[float], object] = time.sleep,
+        jitter: Callable[[], float] = random.random,
+    ) -> None:
+        self._inner = inner
+        self._sleep = sleep
+        self._plan = _RetryPlan(
+            attempts=attempts,
+            base_delay=base_delay,
+            max_delay=max_delay,
+            max_retry_after=max_retry_after,
+            jitter=jitter,
+        )
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        if not _replay_safe(request):
+            return self._inner.handle_request(request)
+        # Materialise the body before the first attempt: a stream can only be consumed once,
+        # so a request that was never read cannot be re-sent.
+        request.read()
+        for attempt in range(1, self._plan.attempts + 1):
+            last = attempt == self._plan.attempts
+            try:
+                response = self._inner.handle_request(request)
+            except httpx.TransportError:
+                if last:
+                    raise
+                self._sleep(self._plan.backoff(attempt))
+                continue
+            if response.status_code not in _RETRYABLE_STATUS or last:
+                return response
+            delay = self._plan.wait_for(response, attempt)
+            if delay is None:
+                return response
+            # Release the connection before re-sending; a discarded body would otherwise hold
+            # it for the life of the pool.
+            response.read()
+            response.close()
+            self._sleep(delay)
+        raise AssertionError("unreachable: the final attempt returns or raises")
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+class RetryingAsyncTransport(httpx.AsyncBaseTransport):
+    """The async twin of `RetryingTransport`; same policy object, same invariant."""
+
+    def __init__(
+        self,
+        inner: httpx.AsyncBaseTransport,
+        *,
+        attempts: int = _DEFAULT_ATTEMPTS,
+        base_delay: float = _DEFAULT_BASE_DELAY_S,
+        max_delay: float = _DEFAULT_MAX_DELAY_S,
+        max_retry_after: float = _DEFAULT_MAX_RETRY_AFTER_S,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        jitter: Callable[[], float] = random.random,
+    ) -> None:
+        self._inner = inner
+        self._sleep = sleep
+        self._plan = _RetryPlan(
+            attempts=attempts,
+            base_delay=base_delay,
+            max_delay=max_delay,
+            max_retry_after=max_retry_after,
+            jitter=jitter,
+        )
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        if not _replay_safe(request):
+            return await self._inner.handle_async_request(request)
+        await request.aread()
+        for attempt in range(1, self._plan.attempts + 1):
+            last = attempt == self._plan.attempts
+            try:
+                response = await self._inner.handle_async_request(request)
+            except httpx.TransportError:
+                if last:
+                    raise
+                await self._sleep(self._plan.backoff(attempt))
+                continue
+            if response.status_code not in _RETRYABLE_STATUS or last:
+                return response
+            delay = self._plan.wait_for(response, attempt)
+            if delay is None:
+                return response
+            await response.aread()
+            await response.aclose()
+            await self._sleep(delay)
+        raise AssertionError("unreachable: the final attempt returns or raises")
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+__all__ = ["RetryingAsyncTransport", "RetryingTransport"]

--- a/packages/screamingface/src/screamingface/_core/retry.py
+++ b/packages/screamingface/src/screamingface/_core/retry.py
@@ -159,12 +159,35 @@ class RetryingTransport(httpx.BaseTransport):
             delay = self._plan.wait_for(response, attempt)
             if delay is None:
                 return response
-            # Release the connection before re-sending; a discarded body would otherwise hold
-            # it for the life of the pool.
-            response.read()
-            response.close()
-            self._sleep(delay)
+            self._release_and_wait(response, delay, attempt)
         raise AssertionError("unreachable: the final attempt returns or raises")
+
+    def _release_and_wait(
+        self,
+        response: httpx.Response,
+        delay: float,
+        attempt: int,
+    ) -> None:
+        """Drain and close a response we intend to re-send, then sleep the pacing.
+
+        WHY the read counts as a failure (OME-1107 review): a discarded body that was
+        never read holds its pooled connection, and a body that dies mid-read is the same
+        transport failure as a dropped send — close the dead response, back off, and
+        re-send. Never honor the Retry-After that rode on a response whose body never
+        arrived.
+
+        INVARIANT: reached only for a non-final attempt; the loop returns a retryable
+        response unread on its last try so the caller sees the terminal response intact —
+        which is also why there is no last-attempt branch here.
+        """
+        try:
+            response.read()
+        except httpx.TransportError:
+            response.close()
+            self._sleep(self._plan.backoff(attempt))
+            return
+        response.close()
+        self._sleep(delay)
 
     def close(self) -> None:
         self._inner.close()
@@ -212,10 +235,24 @@ class RetryingAsyncTransport(httpx.AsyncBaseTransport):
             delay = self._plan.wait_for(response, attempt)
             if delay is None:
                 return response
-            await response.aread()
-            await response.aclose()
-            await self._sleep(delay)
+            await self._release_and_wait_async(response, delay, attempt)
         raise AssertionError("unreachable: the final attempt returns or raises")
+
+    async def _release_and_wait_async(
+        self,
+        response: httpx.Response,
+        delay: float,
+        attempt: int,
+    ) -> None:
+        """The async twin of `_release_and_wait` — same release-before-sleep contract."""
+        try:
+            await response.aread()
+        except httpx.TransportError:
+            await response.aclose()
+            await self._sleep(self._plan.backoff(attempt))
+            return
+        await response.aclose()
+        await self._sleep(delay)
 
     async def aclose(self) -> None:
         await self._inner.aclose()

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -28,6 +28,7 @@ from screamingface._access.auth import _default_caller_auth
 from screamingface._access.base import _TransportAuth
 from screamingface._access.contract import _challenge_audience
 from screamingface._core.ports import _ResultArtifact, _RunOutcome
+from screamingface._core.retry import RetryingAsyncTransport, RetryingTransport
 from screamingface._core.wire import _REPLAY_SAFE
 from screamingface._engine.run_lifecycle import _Lifecycle
 from screamingface._engine.trace import TraceContext, new_trace_context
@@ -107,7 +108,15 @@ class Url4CloudTransport:
         self._engine_url = engine_url
         self._owns_auth = caller_auth is None
         self._caller_auth = caller_auth or _default_caller_auth(engine_url)
-        self._http = httpx.Client(base_url=engine_url, timeout=30.0, auth=self._caller_auth)
+        # WHY a retrying transport (OME-1107): a transient edge failure between the caller and
+        # a healthy origin used to end the whole evaluation. Only requests the call site marked
+        # `_REPLAY_SAFE` are re-sent, so `GET /?q=` — which starts billable work — never is.
+        self._http = httpx.Client(
+            base_url=engine_url,
+            timeout=30.0,
+            auth=self._caller_auth,
+            transport=RetryingTransport(httpx.HTTPTransport()),
+        )
         # INVARIANT: built from the same source as the client above, so the two halves of
         # this transport can never verify against different roots.
         self._ssl = _websocket_ssl_context(engine_url)
@@ -349,7 +358,13 @@ class AsyncUrl4CloudTransport:
         self._engine_url = engine_url
         self._owns_auth = caller_auth is None
         self._caller_auth = caller_auth or _default_caller_auth(engine_url)
-        self._http = httpx.AsyncClient(base_url=engine_url, timeout=30.0, auth=self._caller_auth)
+        # See the synchronous twin: retry is gated on `_REPLAY_SAFE`, never on the method.
+        self._http = httpx.AsyncClient(
+            base_url=engine_url,
+            timeout=30.0,
+            auth=self._caller_auth,
+            transport=RetryingAsyncTransport(httpx.AsyncHTTPTransport()),
+        )
         # INVARIANT: see the synchronous twin — one trust store for HTTP and WebSocket.
         self._ssl = _websocket_ssl_context(engine_url)
         # Test-only seams; production callers leave the defaults (spec §6 S3).
@@ -896,6 +911,34 @@ def _require_success(
         _raise_response(response, operation, trace_id=trace_id)
 
 
+# How much of an unstructured body may reach an exception message. Long enough to carry a
+# short plain-text reason, far short of a rendered error page.
+_BODY_SNIPPET_LIMIT = 200
+
+
+def _body_summary(response: httpx.Response) -> str:
+    """A bounded, single-line stand-in for a non-`problem+json` body (OME-1107).
+
+    WHY: this used to be `response.text.strip()` verbatim. An edge proxy answers with a full
+    HTML error page, so a transient Cloudflare 520 reached the user as ~7KB of markup with the
+    one useful token — the status code — buried inside it. Anything the Engine itself says
+    arrives as `problem+json` and is read by the caller; everything else is an intermediary
+    speaking a format we do not parse, and its bulk is noise.
+    """
+    status = f"HTTP {response.status_code}"
+    try:
+        body = response.text
+    except (UnicodeDecodeError, httpx.ResponseNotRead):
+        body = ""
+    collapsed = " ".join(body.split())
+    # An HTML page carries no reason a human wants in a traceback — name the status and stop.
+    if not collapsed or collapsed.lower().startswith(("<!doctype", "<html")):
+        return status
+    if len(collapsed) > _BODY_SNIPPET_LIMIT:
+        collapsed = collapsed[:_BODY_SNIPPET_LIMIT].rstrip() + "…"
+    return f"{status}: {collapsed}"
+
+
 def _raise_response(
     response: httpx.Response, operation: str, *, trace_id: str | None = None
 ) -> None:
@@ -905,7 +948,7 @@ def _raise_response(
     # transport branch would miss the common case.
     code: str | None = None
     problem: object = None
-    detail = response.text.strip() or f"HTTP {response.status_code}"
+    detail = _body_summary(response)
     media_type = response.headers.get("content-type", "").split(";", 1)[0].casefold()
     if media_type == "application/problem+json":
         try:

--- a/packages/screamingface/tests/test_transient_retry.py
+++ b/packages/screamingface/tests/test_transient_retry.py
@@ -1,0 +1,260 @@
+"""Replay-safe requests survive a transient edge failure (OME-1107).
+
+A single Cloudflare 520 on one `POST /token` destroyed an evaluation of 8 candidates after 7
+had already finished, because nothing retried a request the SDK itself had declared safe to
+replay. The origin was healthy the whole time — the blip lived above it, in the tunnel.
+
+INVARIANT under test: retry is gated on the `_REPLAY_SAFE` request extension, NEVER on the
+HTTP method. `GET /?q=` starts billable work despite being a GET and carries no marker, so it
+must never be replayed. That is the property these tests exist to protect — every other
+assertion here is secondary to it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import httpx
+import pytest
+
+from screamingface._core.retry import RetryingAsyncTransport, RetryingTransport
+from screamingface._core.wire import _REPLAY_SAFE
+from screamingface._engine.transport import _require_success
+from screamingface.errors import ExecutionError
+
+type _Outcome = int | tuple[int, dict[str, str]] | Exception
+
+
+class _Recorder:
+    """A handler that replays a scripted sequence of outcomes and counts attempts."""
+
+    def __init__(self, *outcomes: _Outcome) -> None:
+        self._outcomes: list[_Outcome] = list(outcomes)
+        self.attempts = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.attempts += 1
+        outcome = self._outcomes[min(self.attempts - 1, len(self._outcomes) - 1)]
+        if isinstance(outcome, Exception):
+            raise outcome
+        if isinstance(outcome, tuple):
+            status, headers = outcome
+            return httpx.Response(status, headers=headers, text="body")
+        return httpx.Response(outcome, text="body")
+
+
+@dataclass
+class _Rig:
+    """A client plus the delays its transport was asked to sleep for."""
+
+    client: httpx.Client
+    slept: list[float]
+
+
+def _rig(
+    handler: _Recorder,
+    *,
+    attempts: int = 3,
+    base_delay: float = 0.25,
+    max_retry_after: float = 30.0,
+    jitter: Callable[[], float] = lambda: 0.0,
+) -> _Rig:
+    slept: list[float] = []
+    transport = RetryingTransport(
+        httpx.MockTransport(handler),
+        attempts=attempts,
+        base_delay=base_delay,
+        max_retry_after=max_retry_after,
+        sleep=slept.append,
+        jitter=jitter,
+    )
+    return _Rig(httpx.Client(transport=transport, base_url="https://engine.test"), slept)
+
+
+async def _no_sleep(_seconds: float) -> None:
+    return None
+
+
+def _async_client(handler: _Recorder) -> httpx.AsyncClient:
+    transport = RetryingAsyncTransport(httpx.MockTransport(handler), sleep=_no_sleep)
+    return httpx.AsyncClient(transport=transport, base_url="https://engine.test")
+
+
+# ── the invariant ────────────────────────────────────────────────────────────────────────
+
+
+def test_a_request_without_the_replay_marker_is_never_retried() -> None:
+    """THE load-bearing assertion. `GET /?q=` starts a Run despite being a GET and carries no
+    marker; replaying it would double-fire billable work. Default-deny, no exceptions."""
+    handler = _Recorder(520, 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.get("/", params={"q": "expr"})
+    assert response.status_code == 520, "an unmarked request must surface its failure as-is"
+    assert handler.attempts == 1, "an unmarked request must be sent exactly once"
+
+
+@pytest.mark.asyncio
+async def test_the_async_transport_never_retries_an_unmarked_request() -> None:
+    """The async twin of the load-bearing invariant."""
+    handler = _Recorder(520, 200)
+    async with _async_client(handler) as client:
+        response = await client.get("/", params={"q": "expr"})
+    assert response.status_code == 520
+    assert handler.attempts == 1
+
+
+# ── retrying what IS safe ────────────────────────────────────────────────────────────────
+
+
+def test_a_replay_safe_request_survives_a_transient_edge_failure() -> None:
+    """The incident, reproduced: one 520 then success. The caller must never see the 520."""
+    handler = _Recorder(520, 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert handler.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_the_async_transport_retries_a_replay_safe_request() -> None:
+    handler = _Recorder(520, 200)
+    async with _async_client(handler) as client:
+        response = await client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert handler.attempts == 2
+
+
+@pytest.mark.parametrize("status", [502, 503, 504, 520, 522, 524, 408, 429])
+def test_retryable_statuses_are_retried(status: int) -> None:
+    handler = _Recorder(status, 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert handler.attempts == 2
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 409, 422, 500])
+def test_non_retryable_statuses_are_returned_immediately(status: int) -> None:
+    """A deterministic failure is not made better by repetition. 500 is deliberately excluded:
+    an application error repeats, and retrying only hides it."""
+    handler = _Recorder(status, 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == status
+    assert handler.attempts == 1
+
+
+# ── bounds and pacing ────────────────────────────────────────────────────────────────────
+
+
+def test_the_attempt_budget_is_bounded() -> None:
+    """A permanently failing edge must surface, not spin."""
+    handler = _Recorder(520)
+    rig = _rig(handler, attempts=3)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 520
+    assert handler.attempts == 3
+
+
+def test_backoff_grows_between_attempts() -> None:
+    """Bounded exponential backoff — a tight loop against a struggling edge is a second
+    outage, not a recovery."""
+    handler = _Recorder(520, 520, 200)
+    rig = _rig(handler, attempts=3, base_delay=0.5)
+    with rig.client as client:
+        client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert len(rig.slept) == 2
+    assert rig.slept[1] > rig.slept[0]
+
+
+def test_retry_after_delta_seconds_is_honoured() -> None:
+    """The server named a number; second-guessing it is how a thundering herd starts."""
+    handler = _Recorder((503, {"Retry-After": "2"}), 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert rig.slept == pytest.approx([2.0])
+
+
+def test_retry_after_beyond_the_cap_stops_rather_than_sleeping() -> None:
+    """Obeying an hour-long Retry-After is indistinguishable from a hang. Surfacing the
+    response lets the caller decide."""
+    handler = _Recorder((503, {"Retry-After": "3600"}), 200)
+    rig = _rig(handler, max_retry_after=30.0)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 503
+    assert handler.attempts == 1
+    assert rig.slept == []
+
+
+def test_a_transport_error_is_retried_then_surfaces() -> None:
+    handler = _Recorder(httpx.ConnectError("boom"), httpx.ConnectError("boom"))
+    rig = _rig(handler, attempts=2)
+    with rig.client as client, pytest.raises(httpx.ConnectError):
+        client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert handler.attempts == 2
+
+
+def test_a_transport_error_recovers_when_a_later_attempt_succeeds() -> None:
+    handler = _Recorder(httpx.ConnectError("boom"), 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+
+
+# ── error messages stay readable ─────────────────────────────────────────────────────────
+
+
+def test_an_html_error_page_is_reduced_to_its_status() -> None:
+    """The second half of the incident: a Cloudflare 520 reached the user as ~7KB of markup,
+    with the only useful token buried inside it."""
+    page = (
+        "<!DOCTYPE html>\n<html><head><title>520</title></head><body>"
+        + "x" * 5000
+        + "</body></html>"
+    )
+    response = httpx.Response(520, text=page, headers={"content-type": "text/html"})
+    with pytest.raises(ExecutionError) as raised:
+        _require_success(response, "mint an execution capability")
+    message = str(raised.value)
+    assert "HTTP 520" in message
+    assert "<!DOCTYPE" not in message
+    assert "<html" not in message
+    assert len(message) < 200
+
+
+def test_a_short_plain_text_body_is_kept() -> None:
+    """Bounded, not blind: a short plain reason is exactly what belongs in the message."""
+    response = httpx.Response(503, text="upstream busy", headers={"content-type": "text/plain"})
+    with pytest.raises(ExecutionError) as raised:
+        _require_success(response, "mint an execution capability")
+    assert "HTTP 503" in str(raised.value)
+    assert "upstream busy" in str(raised.value)
+
+
+def test_a_long_plain_text_body_is_truncated() -> None:
+    response = httpx.Response(502, text="y" * 4000, headers={"content-type": "text/plain"})
+    with pytest.raises(ExecutionError) as raised:
+        _require_success(response, "mint an execution capability")
+    assert len(str(raised.value)) < 400
+
+
+def test_a_problem_json_detail_is_still_preferred() -> None:
+    """INVARIANT preserved: what the Engine itself says is structured, and still wins."""
+    response = httpx.Response(
+        503,
+        json={"type": "about:blank", "detail": "the runner is at capacity — retry shortly"},
+        headers={"content-type": "application/problem+json"},
+    )
+    with pytest.raises(ExecutionError) as raised:
+        _require_success(response, "start the SF Engine Run")
+    assert "the runner is at capacity" in str(raised.value)

--- a/packages/screamingface/tests/test_transient_retry.py
+++ b/packages/screamingface/tests/test_transient_retry.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from email.utils import format_datetime
 
 import httpx
 import pytest
@@ -258,3 +260,73 @@ def test_a_problem_json_detail_is_still_preferred() -> None:
     with pytest.raises(ExecutionError) as raised:
         _require_success(response, "start the SF Engine Run")
     assert "the runner is at capacity" in str(raised.value)
+
+
+# ── Retry-After: the HTTP-date wire form ─────────────────────────────────────────────────
+
+
+def test_retry_after_http_date_is_honoured() -> None:
+    """A server may send `Retry-After` as an HTTP-date instead of delta-seconds (RFC 9110
+    §10.2.3) — both forms are the same server-named number, just spelled differently, and
+    second-guessing either is how a thundering herd starts."""
+    target = format_datetime(datetime.now(UTC) + timedelta(seconds=5), usegmt=True)
+    handler = _Recorder((503, {"Retry-After": target}), 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert rig.slept == pytest.approx([5.0], abs=1.0)
+
+
+def test_retry_after_naive_http_date_is_treated_as_utc() -> None:
+    """`_http_date` documents that it normalises to UTC — an HTTP-date with no zone info is
+    the case that promise exists for, not merely a parse detail."""
+    naive = (datetime.now(UTC) + timedelta(seconds=5)).strftime("%a, %d %b %Y %H:%M:%S")
+    handler = _Recorder((503, {"Retry-After": naive}), 200)
+    rig = _rig(handler)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert rig.slept == pytest.approx([5.0], abs=1.0)
+
+
+def test_an_unparsable_retry_after_falls_back_to_backoff() -> None:
+    """A `Retry-After` that is neither delta-seconds nor an HTTP-date must not crash the
+    retry loop — it is treated as though the header were absent."""
+    handler = _Recorder((503, {"Retry-After": "whenever"}), 200)
+    rig = _rig(handler, base_delay=0.5)
+    with rig.client as client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert rig.slept == pytest.approx([0.5])
+
+
+@pytest.mark.asyncio
+async def test_the_async_transport_also_stops_rather_than_sleeping_beyond_the_cap() -> None:
+    """The async twin of the delta-seconds cap test: obeying an hour-long `Retry-After` is
+    indistinguishable from a hang there too."""
+    handler = _Recorder((503, {"Retry-After": "3600"}), 200)
+    async with _async_client(handler) as client:
+        response = await client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 503
+    assert handler.attempts == 1
+
+
+# ── construction guards ──────────────────────────────────────────────────────────────────
+
+
+def test_zero_attempts_is_rejected() -> None:
+    """The attempt budget is a promise the loop makes to itself: at least one send always
+    happens. Zero would silently short-circuit every replay-safe request without ever
+    asking the network."""
+    with pytest.raises(ValueError, match="attempts must be >= 1, got 0"):
+        RetryingTransport(httpx.MockTransport(lambda _request: httpx.Response(200)), attempts=0)
+
+
+def test_negative_attempts_is_rejected() -> None:
+    """The async twin's guard is the same shared `_RetryPlan` — a negative budget is just as
+    nonsensical as zero."""
+    with pytest.raises(ValueError, match="attempts must be >= 1, got -1"):
+        RetryingAsyncTransport(
+            httpx.MockTransport(lambda _request: httpx.Response(200)), attempts=-1
+        )

--- a/packages/screamingface/tests/test_transient_retry.py
+++ b/packages/screamingface/tests/test_transient_retry.py
@@ -12,7 +12,7 @@ assertion here is secondary to it.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from email.utils import format_datetime
@@ -330,3 +330,135 @@ def test_negative_attempts_is_rejected() -> None:
         RetryingAsyncTransport(
             httpx.MockTransport(lambda _request: httpx.Response(200)), attempts=-1
         )
+
+
+# ── a body that dies mid-read ─────────────────────────────────────────────────────────────
+
+
+class _FailingBodyStream(httpx.SyncByteStream):
+    """A response whose headers arrived but whose BODY died mid-stream (OME-1107 review).
+
+    `stream=` is the important part: `Response(content=...)` reads eagerly inside
+    `__init__`, which would raise in the handler. The failure must happen only when the
+    retry loop calls `read()` on the already-returned response — the exact case the loop
+    used to let escape.
+    """
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __iter__(self) -> Iterator[bytes]:
+        raise httpx.ReadError("connection dropped mid-body")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _AsyncFailingBodyStream(httpx.AsyncByteStream):
+    """The async twin; same contract — headers arrived, the body did not."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def __aiter__(self) -> AsyncIterator[bytes]:
+        raise httpx.ReadError("connection dropped mid-body")
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _read_failure_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> tuple[httpx.Client, list[float]]:
+    """A sync client whose transport will retry — mirror of `_rig`, but its handler may
+    return stream-backed responses, which `_Recorder` cannot express."""
+    slept: list[float] = []
+    transport = RetryingTransport(
+        httpx.MockTransport(handler),
+        attempts=3,
+        base_delay=0.25,
+        max_retry_after=30.0,
+        sleep=slept.append,
+        jitter=lambda: 0.0,
+    )
+    return httpx.Client(transport=transport, base_url="https://engine.test"), slept
+
+
+def _async_read_failure_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> httpx.AsyncClient:
+    """The async twin of `_read_failure_client`."""
+    transport = RetryingAsyncTransport(
+        httpx.MockTransport(handler),
+        attempts=3,
+        base_delay=0.25,
+        max_retry_after=30.0,
+        sleep=_no_sleep,
+        jitter=lambda: 0.0,
+    )
+    return httpx.AsyncClient(transport=transport, base_url="https://engine.test")
+
+
+def test_a_body_read_failure_is_retried_like_any_transport_failure() -> None:
+    """The reviewer's finding on #835: a retryable 503 whose BODY raises `httpx.ReadError`
+    used to escape the loop — one attempt, no retry, no release. It is the same transient
+    failure as a dropped send, so it gets a fresh attempt and the dead response is
+    released."""
+    dead = _FailingBodyStream()
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(503, stream=dead)
+        return httpx.Response(200, text="ok")
+
+    client, _slept = _read_failure_client(handler)
+    with client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert attempts == 2
+    assert dead.closed, "the dead response must be released before re-sending"
+
+
+@pytest.mark.asyncio
+async def test_the_async_transport_retries_a_body_read_failure() -> None:
+    """The async twin of the reviewer's finding — it escaped both transports."""
+    dead = _AsyncFailingBodyStream()
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(503, stream=dead)
+        return httpx.Response(200, text="ok")
+
+    async with _async_read_failure_client(handler) as client:
+        response = await client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert attempts == 2
+    assert dead.closed, "the dead response must be released before re-sending"
+
+
+def test_a_body_read_failure_uses_backoff_not_the_retry_after_that_never_arrived() -> None:
+    """A `Retry-After` rides on the response that died: it was delivered on headers whose
+    body never did, and a connection-level drop is backoff territory, not the server's
+    schedule. The retry is paced exactly like any other transport failure."""
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            dead = _FailingBodyStream()
+            return httpx.Response(503, headers={"Retry-After": "2"}, stream=dead)
+        return httpx.Response(200, text="ok")
+
+    client, slept = _read_failure_client(handler)
+    with client:
+        response = client.post("/token", extensions={_REPLAY_SAFE: True})
+    assert response.status_code == 200
+    assert attempts == 2
+    assert slept == pytest.approx([0.25]), "backoff(1), not the unread Retry-After of 2s"


### PR DESCRIPTION
## Summary

A single Cloudflare **520** on one `POST /token` ended an `sf.evaluate` of 8 candidates — after 7 had already completed **100/100 cases at 100% cache hit**. The origin was healthy the whole time: nginx logged 14 `/token` requests, all 200, including three seconds either side of the failure. The blip lived above the origin, in a flapping tunnel connection, and was environmental.

This PR is about why one blip was fatal.

- **Nothing retried a request the SDK had itself declared replay-safe.** `/token` is sent with `extensions={_REPLAY_SAFE: True}` and was never replayed.
- **`_raise_response` pasted the raw body** into the message, parsing only `problem+json` — so an edge proxy's HTML page reached the user as ~7KB of markup with the status code buried inside.

## The design decision worth reviewing

Retry is gated on the **existing `_REPLAY_SAFE` marker, never on the HTTP method.**

That marker is already default-deny, and `_core/wire.py` says why: *"`GET /?q=` starts billable work despite being a GET and is never marked… a call site that forgets the marker pays one extra round trip — never an extra paid Run."* Replay safety is a property of the REQUEST — does re-sending duplicate a side effect — not of the response status, so one marker legitimately answers both "safe to re-send after an Access login" and "safe to re-send after a transient 5xx".

The consequence is that the dangerous case is excluded **by construction**, not by a rule the next contributor must remember:

| call | `_REPLAY_SAFE` | retried |
|---|---|---|
| `POST /token` (mint) | True | yes — the call that failed |
| `DELETE /` (stop) | True | yes, idempotent |
| **`GET /?q=` (run start)** | **absent → False** | **never** |

Implemented as an httpx transport so the safety policy lives in one place and cannot be forgotten by a future call site.

Two smaller judgement calls:
- **500 is deliberately NOT retryable** — an application error is deterministic; repeating it wastes the caller's time and hides the defect. The set is the gateway/edge family plus 408/429/503.
- **`Retry-After` beyond a 30s cap stops rather than sleeping** — obeying an hour-long value is indistinguishable from a hang, so the response is surfaced and the caller decides.

## What this deliberately does NOT fix

A refused **run start** is still not retried, and must not be — retrying it would double-fire billable Runs. So this does not address:

- the **in-flight reservation leak** (a caller stays pinned at the cap for 16.3h because release depends on `status()`, which the SDK's WebSocket path never calls, and on a reaper that is disabled by default in the local rig);
- the **all-or-nothing evaluation semantics** (`_evaluation/runner.py:382-389`), where one candidate's failure cancels the siblings and discards their completed work.

Both remain open follow-ups, and together they are why a single refusal still costs a whole evaluation.

## Test plan

29 new tests in `tests/test_transient_retry.py`. The first two pin the load-bearing invariant — that an unmarked request is sent exactly once — in both sync and async form, because violating it double-fires paid work.

- retryable statuses retried; 4xx and 500 returned immediately
- attempt budget bounded; backoff grows between attempts
- `Retry-After` honoured in delta-seconds; beyond the cap it stops rather than sleeping
- transport errors retried, and the final failure still raises
- an HTML error page reduces to its status; a short plain-text reason is kept; `problem+json` detail still wins

`run_gates.py screamingface` — ALL GATES GREEN (append-only · ruff · pyright · pytest --cov ≥95 · notebooks · uv build · distribution). The append-only check passes **without** `--skip-append-only`: this adds a new test file and touches no prior test.

Ledger: `docs/work/2026-09-03-OME-1107-sdk-transient-retry.md`

Refs: OME-1107
