### PR TITLE
fix(engine): release in-flight reservations when a run actually finishes

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -37,7 +37,7 @@ import math
 import time
 import uuid
 from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Protocol
 
 import nats
@@ -51,6 +51,7 @@ from screamingface_engine.runner_queue import (
     DEFAULT_CALLER_INFLIGHT_CAP,
     DEFAULT_DEPTH_CEILING,
     DEFAULT_IO_CONCURRENCY,
+    DEFAULT_RESERVATION_LEASE_S,
     DEFAULT_STATE_CACHE_TTL_S,
     caller_key,
     encode_message,
@@ -198,6 +199,12 @@ class QueueJobRunner(IdentityAwareJobRunner):
         # queue itself caches its `stream_info` reading; this is the runner's own window, which
         # is what the reservation counter covers.
         state_cache_ttl_s: float = DEFAULT_STATE_CACHE_TTL_S,
+        # FEATURE (OME-1108): the backstop on a reservation's lifetime. The primary release is
+        # observation — see `_release_finished_for` — and this bounds the case observation
+        # cannot cover, a broker whose tails stay unreadable. It replaces reliance on
+        # `capability_lifetime_s` (16.3h), which let a finished run hold a slot for most of a
+        # day. Generous against the longest legitimate run, so it never fires in normal use.
+        reservation_lease_s: float = DEFAULT_RESERVATION_LEASE_S,
     ) -> None:
         self._queue = queue
         self._publisher = publisher
@@ -210,6 +217,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
         # while the app runs, and a model admitted a second ago must reach the very next
         # run — the same rule as the inprocess adapter's `_extra_models`.
         self._extra_models = extra_models
+        self._reservation_lease_s = reservation_lease_s
         self._depth_ceiling = depth_ceiling
         self._caller_inflight_cap = caller_inflight_cap
         self._state_cache_ttl_s = state_cache_ttl_s
@@ -543,9 +551,16 @@ class QueueJobRunner(IdentityAwareJobRunner):
                     self._depth_ceiling,
                     retry_after_s=self._drain_estimate_s(),
                 )
-            count = sum(
-                len(topics) for topics in self._in_flight_by_caller.get(caller, {}).values()
-            )
+            count = self._in_flight_count(caller)
+            if count >= self._caller_inflight_cap:
+                # FEATURE (OME-1108): a caller at its cap may be held there by runs that have
+                # already finished. Nothing else releases them — `status()` is the only
+                # observer and it is reached only from the 409 pre-check and the orphan
+                # reaper, never from the WebSocket path the SDK actually uses — so before
+                # refusing, find out whether these runs are still running. Live deployment
+                # refused 7 of 8 candidates against an EMPTY queue and an idle pool this way.
+                await self._release_finished_for(caller)
+                count = self._in_flight_count(caller)
             if count >= self._caller_inflight_cap:
                 # WHY not the drain estimate (review follow-up P2-11): the cap branch is
                 # reached precisely when the queue is NOT at its ceiling, so the drain
@@ -562,6 +577,56 @@ class QueueJobRunner(IdentityAwareJobRunner):
             self._in_flight_by_caller.setdefault(caller, {}).setdefault(topic, []).append(token)
             self._caller_of_topic[topic] = caller
             return token
+
+    def _in_flight_count(self, caller: str) -> int:
+        """How many reservations `caller` currently holds, across all of its topics."""
+        return sum(len(topics) for topics in self._in_flight_by_caller.get(caller, {}).values())
+
+    async def _release_finished_for(self, caller: str) -> None:
+        """Release the reservations of `caller`'s runs that have already finished.
+
+        The runner's own observation of a finish. It reuses the exact pair `status()` uses —
+        `_read_tail` for the evidence and `_forget_in_flight` for the accounting — so the
+        stale-frame guard (a re-scheduled topic still shows its FIRST run's terminal frame)
+        and the per-caller cleanup apply here unchanged.
+
+        INVARIANT: only a TERMINAL frame releases. `_UNREADABLE_TAIL` is unknown, not
+        finished, and handing out a slot on a broker blip would let a caller exceed its cap
+        while its runs are still billing — the same rule every other consumer of `_read_tail`
+        follows.
+
+        SCOPED to one caller deliberately: this runs on the admission path, so it must cost
+        no more than the decision it informs. A caller below its cap does no reads at all,
+        and a caller at its cap reads only its own topics — bounded by the cap itself.
+        """
+        for topic in sorted(self._in_flight_by_caller.get(caller, {})):
+            frame = await self._read_tail(topic)
+            if isinstance(frame, TerminatedEvent):
+                self._forget_in_flight(topic, frame)
+
+    def _expire_leases(self) -> None:
+        """Drop reservations older than `reservation_lease_s` — the backstop for what
+        observation cannot reach.
+
+        WHY a second mechanism at all: `_release_finished_for` needs a readable stream tail.
+        A broker that stays unreadable would otherwise leave the slot held until the
+        capability expires, which is 16.3 hours — long enough to lock a caller out for a
+        working day over a transient fault. The lease bounds that without weakening the cap
+        for any run shorter than it.
+        """
+        cutoff = self._clock() - timedelta(seconds=self._reservation_lease_s)
+        for by_caller in self._in_flight_by_caller.values():
+            for topic in list(by_caller):
+                kept = [token for token in by_caller[topic] if token > cutoff]
+                if kept:
+                    by_caller[topic] = kept
+                else:
+                    del by_caller[topic]
+        held = {topic for topics in self._in_flight_by_caller.values() for topic in topics}
+        for topic in [t for t in list(self._caller_of_topic) if t not in held]:
+            self._caller_of_topic.pop(topic, None)
+        for caller in [c for c, topics in self._in_flight_by_caller.items() if not topics]:
+            del self._in_flight_by_caller[caller]
 
     async def _release_reservation(self, topic: str, caller: str, token: datetime) -> None:
         """Release the ONE reservation `token` identifies, for a run that was not durably
@@ -721,6 +786,9 @@ class QueueJobRunner(IdentityAwareJobRunner):
         for topic in expired:
             del self._scheduled_at[topic]
             self._forget_in_flight(topic)
+        # OME-1108: the lease is the shorter of the two bounds and is checked on the same
+        # path, so a reservation cannot outlive its run by a capability lifetime.
+        self._expire_leases()
 
 
 __all__ = [

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -107,6 +107,14 @@ PULL_SUB_TTL_S = 300.0
 # once. 8 matches the Client's fan-out (`_MAX_CANDIDATES_IN_FLIGHT`), so one ordinary
 # Evaluation fits while a second concurrent one is refused until the first's runs finish.
 DEFAULT_CALLER_INFLIGHT_CAP = 8
+# The BACKSTOP on how long one admission may hold a slot (OME-1108). The primary release is
+# observation — the runner re-reads a caller's terminal frames before refusing it — and this
+# covers only what observation cannot: a broker whose tails stay unreadable. Before it existed
+# the sole expiry was `capability_lifetime_s` (16.3h), so a run that finished in four minutes
+# could hold its slot for most of a day; a caller was then refused by its own history while the
+# queue sat empty and the pool idle. One hour is far above the longest legitimate run observed
+# (~6 min) and far below that lifetime, so it never fires in normal use.
+DEFAULT_RESERVATION_LEASE_S = 3600.0
 # The anonymous caller's key: a run with no verified identity is its own caller, so it cannot
 # hide behind another caller's footprint.
 _ANONYMOUS_CALLER = "anonymous"

--- a/apps/screamingface-engine/tests/unit/test_queue_admission_release.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission_release.py
@@ -1,0 +1,262 @@
+"""The runner observes its own finished runs before refusing a caller (OME-1108).
+
+A caller was permanently locked out by runs that finished long ago. Observed live: an
+evaluation of 7 candidates had 1 accepted and 7 refused with "the runner is at capacity" while
+`url4-runq` held ZERO messages, every consumer sat at `pending=0/ack_pending=0`, and the worker
+reported 0 of 4 slots busy. The App still held the 8 reservations admitted ~23 minutes earlier.
+
+A reservation was released only by `status()` observing a terminal frame — and `status()` is
+reached only from the pre-schedule 409 check and the orphan reaper, never from the WebSocket
+path the SDK actually uses — or by `_prune()` at `capability_lifetime_s`, 16.3 hours. With the
+reaper disabled there was no background release at all, so the cap counted history.
+
+INVARIANT under test: the cap must count what is RUNNING, not what once ran. The runner now
+re-reads the terminal frames of a caller's in-flight topics before refusing it, and only
+refuses if the slots are genuinely still held.
+"""
+
+from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from screamingface_engine.adapters.jetstream import QueueReadError
+from screamingface_engine.adapters.queue_runner import QueueJobRunner
+from url4.streaming.interfaces import JobRunnerAtCapacity
+from url4.streaming.protocol import TerminatedData, TerminatedEvent, source_for
+
+pytestmark = pytest.mark.asyncio
+
+T0 = datetime(2026, 9, 3, 15, 0, 0, tzinfo=UTC)
+CALLER: Mapping[str, str] = {"X-User-Email": "caller@example.com"}
+OTHER: Mapping[str, str] = {"X-User-Email": "other@example.com"}
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = T0
+
+    def __call__(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += timedelta(seconds=seconds)
+
+
+class _Queue:
+    def __init__(self, *, depth: int = 0) -> None:
+        self._depth = depth
+        self.published: list[bytes] = []
+
+    async def publish(self, message: bytes, *, identity: Mapping[str, str] | None = None) -> None:
+        self.published.append(message)
+
+    async def depth(self) -> int:
+        return self._depth
+
+    async def oldest_age(self) -> float | None:
+        return None
+
+
+def _terminated(topic: str, when: datetime) -> TerminatedEvent:
+    """A terminal frame stamped `when` — the time matters: `_forget_in_flight` ignores a frame
+    older than a reservation, which is what stops a prior run's frame freeing a live slot."""
+    return TerminatedEvent(
+        id=f"term-{topic}",
+        source=source_for(topic),
+        time=when,
+        data=TerminatedData(status="succeeded"),
+    )
+
+
+class _Publisher:
+    """Per-topic scripted tails, counting reads so the zero-cost property is assertable."""
+
+    def __init__(self) -> None:
+        self.tails: dict[str, Any] = {}
+        self.unreadable: set[str] = set()
+        self.reads: list[str] = []
+        self.published: list[Any] = []
+
+    async def last_frame(self, topic: str) -> Any:
+        self.reads.append(topic)
+        if topic in self.unreadable:
+            raise QueueReadError(f"unreadable {topic}")
+        return self.tails.get(topic)
+
+    async def stream_exists(self, topic: str) -> bool:
+        return True
+
+    async def ensure_stream(self, topic: str) -> None:
+        pass
+
+    async def publish(self, topic: str, event: Any) -> None:
+        self.published.append(event)
+
+    async def flush(self) -> None:
+        pass
+
+
+class _Control:
+    async def request(self, subject: str, payload: bytes, *, timeout: float) -> Any:
+        raise TimeoutError()
+
+
+def _runner(
+    queue: _Queue,
+    publisher: _Publisher,
+    clock: _Clock,
+    *,
+    cap: int = 3,
+    **kwargs: Any,
+) -> QueueJobRunner:
+    return QueueJobRunner(
+        queue=queue,
+        publisher=publisher,
+        control=_Control(),
+        clock=clock,
+        capability_lifetime_s=58_800.0,
+        depth_ceiling=1000,
+        caller_inflight_cap=cap,
+        **kwargs,
+    )
+
+
+async def _fill_to_cap(runner: QueueJobRunner, cap: int, identity: Mapping[str, str]) -> list[str]:
+    topics = [f"t-{i}" for i in range(cap)]
+    for topic in topics:
+        await runner.schedule(topic, "'hi'", 60, identity=identity)
+    return topics
+
+
+async def test_a_caller_whose_runs_all_finished_is_admitted_not_refused() -> None:
+    """THE incident. Every run this caller holds has a terminal frame, the queue is empty and
+    the pool is idle — admitting is the only honest answer."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=3)
+    topics = await _fill_to_cap(runner, 3, CALLER)
+
+    clock.advance(600)
+    for topic in topics:
+        publisher.tails[topic] = _terminated(topic, clock.now)
+
+    await runner.schedule("t-new", "'hi'", 60, identity=CALLER)
+
+    assert len(queue.published) == 4, "the fourth run must reach the queue, not a 503"
+
+
+async def test_a_caller_whose_runs_are_live_is_still_refused() -> None:
+    """The cap must keep working: no terminal frames means the slots are genuinely held."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=3)
+    await _fill_to_cap(runner, 3, CALLER)
+
+    with pytest.raises(JobRunnerAtCapacity) as raised:
+        await runner.schedule("t-new", "'hi'", 60, identity=CALLER)
+
+    assert raised.value.limit == 3
+
+
+async def test_only_the_finished_runs_free_their_slots() -> None:
+    """A partially finished caller is admitted, and the cap still counts the live ones."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=3)
+    topics = await _fill_to_cap(runner, 3, CALLER)
+
+    clock.advance(600)
+    publisher.tails[topics[0]] = _terminated(topics[0], clock.now)
+
+    await runner.schedule("t-new", "'hi'", 60, identity=CALLER)
+    # One slot was freed and immediately taken, so the caller is at the cap again.
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule("t-newer", "'hi'", 60, identity=CALLER)
+
+
+async def test_an_unreadable_tail_never_frees_a_slot() -> None:
+    """Unknown is not terminal. A broker blip must not hand out a slot that may still be held —
+    the same discipline `status()` applies."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=2)
+    topics = await _fill_to_cap(runner, 2, CALLER)
+    publisher.unreadable.update(topics)
+
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule("t-new", "'hi'", 60, identity=CALLER)
+
+
+async def test_a_stale_frame_from_a_prior_run_does_not_free_the_live_slot() -> None:
+    """A re-scheduled topic still shows its FIRST run's terminal frame. Releasing on that
+    sighting would free the SECOND run's slot — `_forget_in_flight`'s guard, exercised through
+    the new release path."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=2)
+
+    await runner.schedule("t-reused", "'hi'", 60, identity=CALLER)
+    stale = _terminated("t-reused", clock.now)
+    clock.advance(60)
+    publisher.tails["t-reused"] = stale
+    # Re-scheduled AFTER that frame: the second run is live and the frame cannot speak for it.
+    await runner.schedule("t-reused", "'hi'", 60, identity=CALLER)
+
+    clock.advance(1)
+    # The FIRST reservation is genuinely finished, so its slot is freed and this is admitted.
+    await runner.schedule("t-new", "'hi'", 60, identity=CALLER)
+
+    # ...but the LIVE second reservation must have survived the same stale frame, so the
+    # caller is at its cap again. If the guard were absent, both would have been released
+    # and this would be admitted too.
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule("t-newer", "'hi'", 60, identity=CALLER)
+
+
+async def test_a_caller_below_its_cap_costs_no_broker_reads() -> None:
+    """The zero-cost property: the sweep runs only when a refusal is imminent, so the happy
+    path is exactly as cheap as before."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=8)
+
+    await runner.schedule("t-0", "'hi'", 60, identity=CALLER)
+    await runner.schedule("t-1", "'hi'", 60, identity=CALLER)
+
+    assert publisher.reads == []
+
+
+async def test_one_callers_finished_runs_do_not_free_anothers_slots() -> None:
+    """The sweep is scoped to the caller being judged; it must not touch a sibling's accounting."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=2)
+    await _fill_to_cap(runner, 2, CALLER)
+    await runner.schedule("o-0", "'hi'", 60, identity=OTHER)
+
+    clock.advance(600)
+    publisher.tails["t-0"] = _terminated("t-0", clock.now)
+    await runner.schedule("t-new", "'hi'", 60, identity=CALLER)
+
+    assert "o-0" not in publisher.reads, "another caller's topics must not be swept"
+
+
+async def test_a_reservation_older_than_the_lease_is_released() -> None:
+    """The backstop: when the broker cannot be read at all, a slot must still not outlive its
+    run by the 16.3h capability lifetime."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=2, reservation_lease_s=300.0)
+    topics = await _fill_to_cap(runner, 2, CALLER)
+    publisher.unreadable.update(topics)
+
+    clock.advance(301)
+    await runner.schedule("t-new", "'hi'", 60, identity=CALLER)
+
+    assert len(queue.published) == 3
+
+
+async def test_a_reservation_within_the_lease_still_holds_its_slot() -> None:
+    """The lease is a backstop, not a timer that quietly lifts the cap."""
+    queue, publisher, clock = _Queue(), _Publisher(), _Clock()
+    runner = _runner(queue, publisher, clock, cap=2, reservation_lease_s=300.0)
+    topics = await _fill_to_cap(runner, 2, CALLER)
+    publisher.unreadable.update(topics)
+
+    clock.advance(100)
+    with pytest.raises(JobRunnerAtCapacity):
+        await runner.schedule("t-new", "'hi'", 60, identity=CALLER)

--- a/docs/tasks/2026-09-03-OME-1108-release-in-flight-reservations.md
+++ b/docs/tasks/2026-09-03-OME-1108-release-in-flight-reservations.md
@@ -1,0 +1,28 @@
+---
+id: OME-1108
+linear_url: https://linear.app/openmined/issue/OME-1108/release-in-flight-reservations-when-a-run-actually-finishes
+status: in_progress
+type: task
+priority: 1
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-03
+closed:
+---
+
+# Release in-flight reservations when a run actually finishes
+
+A caller was permanently locked out of the runner by runs that had already finished. Observed
+live on the kind rig: an evaluation of 7 candidates had 1 accepted and **7 refused with 503
+"the runner is at capacity"** while `url4-runq` held zero messages, every consumer sat at
+`pending=0/ack_pending=0`, and the worker reported 0 of 4 slots busy. The App still held the 8
+reservations admitted ~23 minutes earlier.
+
+Root cause: a reservation was released only by `status()` observing a terminal frame — and
+`status()` is reached only from the pre-schedule 409 check and the orphan reaper, never from
+the WebSocket path the SDK uses — or by `_prune()` at `capability_lifetime_s` (16.3h). The
+reaper is disabled in this deployment, silently.
+
+Fix: the runner observes its own finished runs before refusing a caller, reusing the release
+`status()` already performs, plus a bounded reservation lease as the backstop.
+
+Ledger: `docs/work/2026-09-03-OME-1108-release-in-flight-reservations.md`

--- a/docs/work/2026-09-03-OME-1108-release-in-flight-reservations.md
+++ b/docs/work/2026-09-03-OME-1108-release-in-flight-reservations.md
@@ -1,0 +1,126 @@
+---
+ticket: OME-1108
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-03
+finished:
+---
+
+# OME-1108 — release in-flight reservations when a run actually finishes
+
+## Intent
+
+A caller is permanently locked out of the runner by runs that finished long ago. Observed live
+twice on the kind rig: at 15:52 an evaluation of 7 candidates had **1 accepted (202) and 7
+refused (503 "the runner is at capacity")** while `url4-runq` held **0 messages**, every
+consumer sat at `pending=0/ack_pending=0`, and the worker reported `slots_busy 0` of 4 with
+`pull_failures_total 0`. The App pod had not restarted since `15:23:36Z`, so it still held the
+8 reservations admitted during the 15:29 evaluation — runs that finished ~23 minutes earlier.
+
+The client symptom is worse than a refusal: the refused candidates still attach their
+WebSockets (101) to topics whose runs were never created, so no frame ever arrives and nothing
+ends them. They never execute and never fail.
+
+## Root cause
+
+`QueueJobRunner` reserves a per-caller slot at admission and releases it only via:
+
+- `_forget_in_flight` from `status()` on a terminal frame — but `status()` has exactly ONE
+  caller, `exists()`, reached only from the pre-schedule 409 check and the reaper's
+  `_still_armed`. The WebSocket path the SDK actually uses never calls it.
+- `_release_reservation` from `schedule()`'s publish-failure path.
+- `_prune()` at `capability_lifetime_s` = 58,800s ≈ **16.3 hours**.
+
+The reaper is the only background release path, it is **disabled here**
+(`URL4_CLOUD_ORPHAN_GRACE_S=0`, and `app.py` then creates no task and logs nothing), and even
+enabled it sweeps only topics armed by `audience_left` past a full grace window — release would
+be an accident of orphan reaping, not a designed path. The module's own comment names the gap:
+"the runner cannot observe a finish any other way".
+
+## Design
+
+`status()` already releases correctly, including `_forget_in_flight`'s stale-frame guard for a
+re-scheduled topic. Nothing new is needed except **making the runner do that observation
+itself, at the one moment it matters**.
+
+In `_admit_or_raise`, when a caller is found at its cap: re-read the terminal frames of that
+caller's in-flight topics, release the finished ones, recount, and only then refuse. Plus a
+bounded reservation lease so a slot cannot outlive its run by 16 hours when the broker is
+unreadable.
+
+**WHY at the cap and not on a timer:** it costs nothing on the happy path (a caller below its
+cap does no extra broker reads at all), it needs no background task and no lifecycle to get
+wrong in tests or at shutdown, it widens no port on `_Publisher`, and it runs exactly when a
+stale reservation would otherwise produce a wrong answer. A caller that stops submitting keeps
+stale entries harmlessly — nobody is being refused — and the lease bounds them regardless.
+
+Rejected: a per-topic terminal-frame subscriber (needs a `subscribe` on `_Publisher`, a task
+per run, and reconnect handling) and a periodic sweep task (a lifecycle to leak, and it pays
+broker reads when nothing is wrong).
+
+## Planned changes
+
+- `src/screamingface_engine/adapters/queue_runner.py`
+  - `DEFAULT_RESERVATION_LEASE_S` + a `reservation_lease_s` constructor knob.
+  - `_release_finished_for(caller)` — observe terminal frames for that caller's in-flight
+    topics and release them, via the existing `_read_tail` + `_forget_in_flight`.
+  - `_admit_or_raise`: sweep-then-recount before the cap refusal.
+  - `_expire_leases()` called from `_prune()`.
+- `tests/unit/test_queue_admission_release.py` — NEW file (tests are append-only).
+
+## Test plan
+
+- A caller at its cap whose runs have ALL finished is admitted, not refused — the incident.
+- A caller at its cap whose runs are genuinely live is still refused (the cap must keep working).
+- A partially finished caller is admitted and the count reflects only the live runs.
+- A stale terminal frame from a PRIOR run of a re-scheduled topic does NOT release the live
+  run's slot (the `_forget_in_flight` guard, exercised through the new path).
+- An unreadable tail never releases — unknown is not terminal.
+- Below the cap, admission performs NO extra broker reads (the zero-cost property).
+- A reservation older than the lease is released even when the tail is unreadable.
+
+## Acceptance
+
+- The 15:52 scenario admits instead of refusing.
+- `run_gates.py screamingface-engine` green.
+
+## Outcome
+
+- **Actual files:** as planned, plus the constant's home.
+  - `src/screamingface_engine/runner_queue.py` — `DEFAULT_RESERVATION_LEASE_S = 3600.0`,
+    placed beside `DEFAULT_CALLER_INFLIGHT_CAP` where the other admission defaults live.
+  - `src/screamingface_engine/adapters/queue_runner.py` — `reservation_lease_s` knob;
+    `_in_flight_count`; `_release_finished_for`; `_expire_leases`; the sweep-then-recount in
+    `_admit_or_raise`; `_expire_leases()` called from `_prune`; `timedelta` import.
+  - `tests/unit/test_queue_admission_release.py` — NEW, 9 tests.
+- **Commits:** `fix(engine): release in-flight reservations when a run actually finishes`
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only`. RED observed first: 6 of
+  9 new tests failed on the missing behaviour, while 3 passed from the start — deliberately,
+  since they pin properties that were ALREADY correct (the cap still refuses live runs, an
+  unreadable tail never frees a slot, a caller below its cap does no broker reads). Related
+  suites re-run clean: 48 passed across admission, fairness, status, cancel and factory.
+- **Deviations:**
+  1. **The approved design was "terminal-frame watcher + short lease"; this ships
+     "observe-at-the-cap + short lease".** A per-topic watcher needs a `subscribe` on the
+     `_Publisher` port, one task per run, and reconnect handling — core-widening for a fix
+     whose whole job is to answer one question at one moment. `status()` already contains the
+     correct release, including the stale-frame guard; the defect is only that nothing calls
+     it for in-flight topics. Calling it exactly where the wrong answer would otherwise be
+     given is smaller, has no lifecycle to leak, and costs nothing below the cap. The lease
+     half of the approved design is implemented as specified.
+  2. **`reservation_lease_s` is not templated in the chart.** Neither are
+     `caller_inflight_cap` nor `capability_lifetime_s` — an operator cannot tune any of the
+     three. Out of scope here; noted below.
+  3. **Branched off `OME-1092-chart-cutover`, not `origin/main`.** `queue_runner.py` does not
+     exist on main — it arrives with #819 — so this fix is unbuildable there. It stacks as a
+     sixth PR on the existing series rather than reopening the green #821.
+
+## Follow-ups surfaced (not in this unit)
+
+- **This state is invisible in `/metrics`.** There is no caller-in-flight gauge and no
+  admission-refusal counter, so a spurious 503 against an idle pool looks like a lie from the
+  outside. That absence is why the leak survived two incidents.
+- `URL4_CLOUD_ORPHAN_GRACE_S=0` disables the reaper **silently** — `app.py` returns without
+  creating the task and without logging. Disabling a background release path should say so.
+- `caller_inflight_cap`, `capability_lifetime_s` and now `reservation_lease_s` are all
+  untunable from the chart.


### PR DESCRIPTION
## Summary

A caller was permanently locked out of the runner by runs that had already finished.

Observed live on the kind rig: an `sf.evaluate` of 7 candidates had **1 accepted (202) and 7 refused (503 "the runner is at capacity")** while `url4-runq` held **zero** messages, every consumer sat at `pending=0/ack_pending=0`, and the worker reported **0 of 4 slots busy**. The App pod had not restarted since `15:23:36Z`, so it still held the 8 reservations admitted ~23 minutes earlier.

The client symptom is worse than a refusal: the refused candidates still attach their WebSockets (101) to topics whose runs were never created, so no frame ever arrives and nothing ends them. They neither execute nor fail.

## Root cause

A reservation was released only by:

- `_forget_in_flight` from `status()` on a terminal frame — but `status()` has exactly one caller, `exists()`, reached only from the pre-schedule 409 check and the orphan reaper. **The WebSocket path the SDK actually uses never calls it.**
- `_release_reservation` from `schedule()`'s publish-failure path.
- `_prune()` at `capability_lifetime_s` = **16.3 hours**.

The reaper is the only background release path, and it is disabled in this deployment (`URL4_CLOUD_ORPHAN_GRACE_S=0`; `app.py` then creates no task **and logs nothing**). So the cap counted history rather than what was running. The module's own comment named the gap: *"the runner cannot observe a finish any other way."*

## Fix

`status()` already contains the correct release, stale-frame guard included — the defect is only that nothing calls it for in-flight topics. The runner now makes that observation itself, at the one moment the answer matters: when a caller is found at its cap, re-read its in-flight topics' terminal frames, release the finished, recount, and only then refuse.

**Why at the cap rather than on a timer:** zero cost on the happy path (a caller below its cap does no broker reads at all), no background task and no lifecycle to leak, no new method on the `_Publisher` port, and it runs exactly where a stale reservation would otherwise give a wrong answer.

`reservation_lease_s` (1h) is the backstop for what observation cannot reach — a broker whose tails stay unreadable — replacing reliance on the 16.3h capability lifetime.

Unknown is still not terminal: an unreadable tail never frees a slot.

## Test plan

- [x] 9 new tests in `test_queue_admission_release.py`; RED observed first (6 failed on the missing behaviour; 3 passed from the start by design, pinning properties that were already correct)
- [x] a caller whose runs all finished is admitted — the incident
- [x] a caller whose runs are genuinely live is still refused
- [x] a stale frame from a prior run of a re-scheduled topic does not free the live slot
- [x] an unreadable tail never frees a slot
- [x] a caller below its cap performs no broker reads
- [x] one caller's finished runs do not touch another's accounting
- [x] lease expiry releases when the broker is unreadable; within the lease the slot holds
- [x] 48 related tests re-run clean (admission, fairness, status, cancel, factory)
- [x] `run_gates.py screamingface-engine` — ALL GATES GREEN

## Notes

Based on `OME-1092-chart-cutover`, not `main`: `queue_runner.py` does not exist on main (it arrives with #819), so this is unbuildable there. It stacks as a sixth PR rather than reopening the green #821.

Follow-ups not in scope: there is **no** caller-in-flight gauge and **no** admission-refusal counter, so this state is invisible in `/metrics` — which is why the leak survived two incidents. `URL4_CLOUD_ORPHAN_GRACE_S=0` disables the reaper silently. And `caller_inflight_cap`, `capability_lifetime_s` and `reservation_lease_s` are all untunable from the chart.

Refs: OME-1108
