### PR TITLE
refactor(screamingface-engine): read benchmark rows through one shared spine reader

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/gdpval/aggregate.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/gdpval/aggregate.py
@@ -22,11 +22,6 @@ from screamingface_engine.benchmarks.aggregation import (
     finalize_candidate_result,
     grading_failure_case_result,
 )
-from screamingface_engine.benchmarks.case_execution import (
-    CaseExecutionOutcome,
-    case_execution_matches,
-    case_execution_outcome,
-)
 from screamingface_engine.benchmarks.contract import CaseResult
 from screamingface_engine.benchmarks.gdpval.case_evaluation import decode_case_evaluation
 from screamingface_engine.benchmarks.gdpval.scoring import (
@@ -35,6 +30,7 @@ from screamingface_engine.benchmarks.gdpval.scoring import (
     verdict_coverage,
 )
 from screamingface_engine.benchmarks.spine.grading import CaseGrader
+from screamingface_engine.benchmarks.spine.rows import RowReader
 
 _FAILURE_MESSAGES = {
     "missing_rubric_asset": "the baked rubric asset for this Case is missing or invalid",
@@ -123,11 +119,11 @@ def aggregate(
     """
 
     selected_cases = _selected_cases(root, case_ids)
-    by_case, errors_by_case, grading_failures = _index_rows(_decode_rows(raw_rows), case_ids)
+    indexed = _ROWS.index(raw_rows, case_ids)
     case_results: list[CaseResult] = []
     for selected in selected_cases:
         case_id = int(selected.case_id)
-        grading_failure = grading_failures.get(case_id)
+        grading_failure = indexed.grading_failures.get(case_id)
         if grading_failure is not None:
             assert grading_failure.error is not None
             result = grading_failure_case_result(
@@ -141,7 +137,10 @@ def aggregate(
         else:
             points = load_rubric_points(root, case_id)
             result, _, _, _, _ = _GRADER.case_result(
-                selected, by_case.get(case_id), points, errors_by_case.get(case_id)
+                selected,
+                indexed.rows.get(case_id),
+                points,
+                indexed.collected_errors.get(case_id),
             )
         case_results.append(result)
     return finalize_candidate_result(
@@ -276,98 +275,6 @@ def _evidence(record: Mapping[str, Any]) -> dict[str, Any]:
     return value
 
 
-def _decode_rows(raw: str) -> list[Any]:
-    try:
-        decoded = json.loads(raw or "")
-    except ValueError as exc:
-        raise AggregateError(f"GDPval rows are not JSON: {exc}") from None
-    if not isinstance(decoded, list):
-        raise AggregateError("GDPval rows must be a JSON array")
-    return decoded
-
-
-def _index_rows(
-    rows: list[Any], case_ids: tuple[int, ...]
-) -> tuple[
-    dict[int, dict[str, Any]],
-    dict[int, list[dict[str, Any]]],
-    dict[int, CaseExecutionOutcome],
-]:
-    """Validate rows and split evaluations from positional collected errors."""
-
-    if len(rows) > len(case_ids):
-        raise AggregateError(
-            f"aggregate received {len(rows)} rows for {len(case_ids)} selected Cases"
-        )
-    indexed: dict[int, dict[str, Any]] = {}
-    errors_by_case: dict[int, list[dict[str, Any]]] = {}
-    grading_failures: dict[int, CaseExecutionOutcome] = {}
-    for index, entry in enumerate(rows):
-        _index_row(entry, index, case_ids[index], indexed, errors_by_case, grading_failures)
-    return indexed, errors_by_case, grading_failures
-
-
-def _index_row(
-    entry: object,
-    index: int,
-    expected_case_id: int,
-    indexed: dict[int, dict[str, Any]],
-    errors_by_case: dict[int, list[dict[str, Any]]],
-    grading_failures: dict[int, CaseExecutionOutcome],
-) -> None:
-    row = _row_value(entry, index)
-    if _index_outer_error(row, index, expected_case_id, indexed, errors_by_case):
-        return
-    try:
-        outcome = case_execution_outcome(row)
-        if not case_execution_matches(outcome, expected_case_id):
-            raise ValueError(
-                f"Case execution claims case_id {outcome.case_id!r}, "
-                f"but the selected Case is {expected_case_id!r}"
-            )
-        if outcome.error is not None:
-            grading_failures[expected_case_id] = outcome
-        else:
-            indexed[expected_case_id] = decode_case_evaluation(outcome.grading, expected_case_id)
-    except (TypeError, ValueError) as exc:
-        raise AggregateError(f"Case result at position {index} is invalid: {exc}") from None
-
-
-def _index_outer_error(
-    row: Mapping[str, Any],
-    index: int,
-    expected_case_id: int,
-    indexed: dict[int, dict[str, Any]],
-    errors_by_case: dict[int, list[dict[str, Any]]],
-) -> bool:
-    error = row.get("error")
-    if error is None:
-        return False
-    if not isinstance(error, Mapping):
-        raise AggregateError(f"Case result at position {index} has an invalid error")
-    claimed = row.get("case_id")
-    if claimed is not None and claimed != expected_case_id:
-        raise AggregateError(
-            f"Case result at position {index} claims case_id {claimed}, "
-            f"but the selected Case is {expected_case_id}"
-        )
-    if claimed is None:
-        errors_by_case.setdefault(expected_case_id, []).append(dict(row))
-    else:
-        indexed[expected_case_id] = dict(row)
-    return True
-
-
-def _row_value(entry: object, index: int) -> Mapping[str, Any]:
-    try:
-        row = json.loads(entry) if isinstance(entry, str) else entry
-    except ValueError as exc:
-        raise AggregateError(f"Case result at position {index} is not JSON: {exc}") from None
-    if not isinstance(row, Mapping):
-        raise AggregateError(f"Case result at position {index} must be an object")
-    return row
-
-
 def _verdicts(row: Mapping[str, Any]) -> tuple[dict[int, bool], int]:
     verdicts: dict[int, bool] = {}
     invalid = 0
@@ -398,6 +305,12 @@ def _verdicts(row: Mapping[str, Any]) -> tuple[dict[int, bool], int]:
 # WHY bound at module bottom: the grading steps live in the spine (OME-1039); the
 # hooks and the failure-message wording stay board-owned so per-case failure output
 # is byte-identical to the pre-extraction copies (the goldens pin every failure code).
+_ROWS = RowReader(
+    benchmark_label="GDPval",
+    error_type=AggregateError,
+    decode_case_evaluation=decode_case_evaluation,
+)
+
 _GRADER = CaseGrader(
     failure_messages=_FAILURE_MESSAGES,
     case_score=case_score,

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/aggregate.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/aggregate.py
@@ -42,11 +42,6 @@ from screamingface_engine.benchmarks.aggregation import (
     finalize_candidate_result,
     grading_failure_case_result,
 )
-from screamingface_engine.benchmarks.case_execution import (
-    CaseExecutionOutcome,
-    case_execution_matches,
-    case_execution_outcome,
-)
 from screamingface_engine.benchmarks.contract import CaseResult
 from screamingface_engine.benchmarks.healthbench.case_evaluation import decode_case_evaluation
 from screamingface_engine.benchmarks.healthbench.scoring import (
@@ -55,6 +50,7 @@ from screamingface_engine.benchmarks.healthbench.scoring import (
     verdict_coverage,
 )
 from screamingface_engine.benchmarks.spine.grading import CaseGrader
+from screamingface_engine.benchmarks.spine.rows import RowReader
 
 
 class AggregateError(ValueError):
@@ -153,11 +149,11 @@ def aggregate(
     """
 
     selected_cases = _selected_cases(root, case_ids)
-    by_case, errors_by_case, grading_failures = _index_rows(_decode_rows(raw_rows), case_ids)
+    indexed = _ROWS.index(raw_rows, case_ids)
     case_results: list[CaseResult] = []
     for selected in selected_cases:
         case_id = int(selected.case_id)
-        grading_failure = grading_failures.get(case_id)
+        grading_failure = indexed.grading_failures.get(case_id)
         if grading_failure is not None:
             assert grading_failure.error is not None
             result = grading_failure_case_result(
@@ -171,7 +167,10 @@ def aggregate(
         else:
             points = load_rubric_points(root, case_id)
             result, _, _, _, _ = _GRADER.case_result(
-                selected, by_case.get(case_id), points, errors_by_case.get(case_id)
+                selected,
+                indexed.rows.get(case_id),
+                points,
+                indexed.collected_errors.get(case_id),
             )
         case_results.append(result)
     return finalize_candidate_result(
@@ -325,119 +324,6 @@ _FAILURE_MESSAGES = {
 }
 
 
-def _decode_rows(raw: str) -> list[Any]:
-    try:
-        decoded = json.loads(raw or "")
-    except ValueError as exc:
-        raise AggregateError(f"HealthBench rows are not JSON: {exc}") from None
-    if not isinstance(decoded, list):
-        raise AggregateError("HealthBench rows must be a JSON array")
-    return decoded
-
-
-def _index_rows(
-    rows: list[Any], case_ids: tuple[int, ...]
-) -> tuple[
-    dict[int, dict[str, Any]],
-    dict[int, list[dict[str, Any]]],
-    dict[int, CaseExecutionOutcome],
-]:
-    """Validate rows and split evaluations from positional collected errors.
-
-    An ``on_error=collect`` row loses its Case identity, so it cannot be indexed;
-    it is RETAINED as an orphan and attached to whichever selected Case ends up
-    with no row (the missing_case_row failure) — the cause must never be dropped.
-    """
-
-    if len(rows) > len(case_ids):
-        raise AggregateError(
-            f"aggregate received {len(rows)} rows for {len(case_ids)} selected Cases"
-        )
-    indexed: dict[int, dict[str, Any]] = {}
-    errors_by_case: dict[int, list[dict[str, Any]]] = {}
-    grading_failures: dict[int, CaseExecutionOutcome] = {}
-    for index, entry in enumerate(rows):
-        _index_row(
-            entry,
-            index,
-            case_ids[index],
-            indexed,
-            errors_by_case,
-            grading_failures,
-        )
-    return indexed, errors_by_case, grading_failures
-
-
-def _index_row(
-    entry: object,
-    index: int,
-    expected_case_id: int,
-    indexed: dict[int, dict[str, Any]],
-    errors_by_case: dict[int, list[dict[str, Any]]],
-    grading_failures: dict[int, CaseExecutionOutcome],
-) -> None:
-    row = _row_value(entry, index)
-    if _index_outer_error(row, index, expected_case_id, indexed, errors_by_case):
-        return
-    try:
-        outcome = case_execution_outcome(row)
-        if not case_execution_matches(outcome, expected_case_id):
-            raise ValueError(
-                f"Case execution claims case_id {outcome.case_id!r}, "
-                f"but the selected Case is {expected_case_id!r}"
-            )
-        if outcome.error is not None:
-            grading_failures[expected_case_id] = outcome
-        else:
-            indexed[expected_case_id] = decode_case_evaluation(outcome.grading, expected_case_id)
-    except (TypeError, ValueError) as exc:
-        raise AggregateError(f"Case result at position {index} is invalid: {exc}") from None
-
-
-def _index_outer_error(
-    row: Mapping[str, Any],
-    index: int,
-    expected_case_id: int,
-    indexed: dict[int, dict[str, Any]],
-    errors_by_case: dict[int, list[dict[str, Any]]],
-) -> bool:
-    error = row.get("error")
-    if error is None:
-        return False
-    if not isinstance(error, Mapping):
-        raise AggregateError(f"Case result at position {index} has an invalid error")
-    claimed = row.get("case_id")
-    if claimed is not None and claimed != expected_case_id:
-        raise AggregateError(
-            f"Case result at position {index} claims case_id {claimed}, "
-            f"but the selected Case is {expected_case_id}"
-        )
-    if claimed is None:
-        _attach_collected_error(errors_by_case, expected_case_id, dict(row))
-    else:
-        indexed[expected_case_id] = dict(row)
-    return True
-
-
-def _row_value(entry: object, index: int) -> Mapping[str, Any]:
-    try:
-        row = json.loads(entry) if isinstance(entry, str) else entry
-    except ValueError as exc:
-        raise AggregateError(f"Case result at position {index} is not JSON: {exc}") from None
-    if not isinstance(row, Mapping):
-        raise AggregateError(f"Case result at position {index} must be an object")
-    return row
-
-
-def _attach_collected_error(
-    target: dict[int, list[dict[str, Any]]],
-    case_id: int | None,
-    error: dict[str, Any],
-) -> None:
-    if case_id is not None:
-        target.setdefault(case_id, []).append(error)
-
-
 def _verdicts(row: Mapping[str, Any]) -> tuple[dict[int, bool], int]:
     verdicts: dict[int, bool] = {}
     invalid = 0
@@ -468,6 +354,12 @@ def _verdicts(row: Mapping[str, Any]) -> tuple[dict[int, bool], int]:
 # WHY bound at module bottom: the grading steps live in the spine (OME-1039); the
 # hooks and the failure-message wording stay board-owned so per-case failure output
 # is byte-identical to the pre-extraction copies (the goldens pin every failure code).
+_ROWS = RowReader(
+    benchmark_label="HealthBench",
+    error_type=AggregateError,
+    decode_case_evaluation=decode_case_evaluation,
+)
+
 _GRADER = CaseGrader(
     failure_messages=_FAILURE_MESSAGES,
     case_score=case_score,

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/__init__.py
@@ -7,5 +7,6 @@ spine grows beside them as new modules only.
 """
 
 from screamingface_engine.benchmarks.spine.grading import CaseGrader
+from screamingface_engine.benchmarks.spine.rows import RowIndex, RowReader
 
-__all__ = ["CaseGrader"]
+__all__ = ["CaseGrader", "RowIndex", "RowReader"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/rows.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/rows.py
@@ -1,9 +1,30 @@
-"""Read a fan-out's collected rows back and file each one under its Case id.
+"""Read the per-Case fan-out's collected rows back and file each one under its Case id.
 
 Think of the exam hall at the end of a paper: the run fanned out over the selected Cases,
 one script came back per Case, and this is the invigilator collecting the pile and sorting
 it by student number. No marking happens here — a script is filed, or it is refused as
 unreadable. Marking is `spine.grading.CaseGrader`.
+
+WHAT "FAN-OUT" MEANS HERE — it is a url4 expression-graph word, not a scheduling one. A
+benchmark run is ONE url4 expression; a fan-out is a node in that expression producing N
+independent branches whose results collect back into an array. The branches are network
+calls to the AI Gateway, not CPU work, so the width is a property of the EXPRESSION and
+the bound on it is configured concurrency — never core count, never one Case per core.
+(`schemas/openapi.py` puts it plainly: "one url4 expression is many gateway calls".)
+
+WHICH fan-out — the repo has three, nested, and every other mention names its axis
+(`ensemble/policy.py` says "member fan-out"; `healthbench/exam.py` says "fan out one judge
+task per rubric item"). This module reads the OUTERMOST one and only that:
+
+    per-Case fan-out    one branch per selected Case          ← THIS MODULE reads it
+      member fan-out    an ensemble Candidate's member models — runs INSIDE one Candidate
+                        invocation and is collapsed into one answer before a row exists;
+                        its attribution rides opaquely in the row's `operations` field
+      judge fan-out     one judge call per rubric item        — already finished and nested
+                        inside the row as `rubric_evaluations`
+
+So by the time a row reaches this module the marking has happened and is stapled inside
+the script. `rubric_evaluations` is never read here; `CaseGrader`'s board hooks read it.
 
 FEATURE: one grading spine per benchmark (OME-1024); this module is the second extraction
 (OME-1039 took the failure ladder) — the row reader gdpval and healthbench duplicated
@@ -61,7 +82,7 @@ from screamingface_engine.benchmarks.case_execution import (
 
 @dataclass(frozen=True, slots=True)
 class RowIndex:
-    """One fan-out's rows, split by what each position turned out to be.
+    """One per-Case fan-out's rows, split by what each position turned out to be.
 
     Attributes:
         rows: Case id → the board-decoded evaluation envelope, opaque to the spine. Also
@@ -101,7 +122,7 @@ class RowReader:
     decode_case_evaluation: Callable[[object, int], dict[str, Any]]
 
     def index(self, raw_rows: str, case_ids: tuple[int, ...]) -> RowIndex:
-        """Sort one fan-out's collected rows into the three piles above.
+        """Sort one per-Case fan-out's collected rows into the three piles above.
 
         Args:
             raw_rows: the collected array as JSON text, in selected order.
@@ -114,8 +135,8 @@ class RowReader:
 
         Raises:
             `error_type`: the payload, a row, or a row's claimed identity is unusable. Every
-            such abort happens BEFORE any scoring, so a corrupt fan-out can never become a
-            quietly wrong score.
+            such abort happens BEFORE any scoring, so a corrupt per-Case fan-out can never
+            become a quietly wrong score.
         """
 
         # Stage 1-2 — decode the array and check it against the roll call.
@@ -189,7 +210,7 @@ class RowReader:
         expected_case_id: int,
         index: RowIndex,
     ) -> bool:
-        """Stage 4 — the whole fan-out branch failed; True when this row was filed here."""
+        """Stage 4 — this Case's whole branch failed; True when the row was filed here."""
 
         error = row.get("error")
         if error is None:

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/rows.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/rows.py
@@ -1,0 +1,215 @@
+"""Read a fan-out's collected rows back and file each one under its Case id.
+
+Think of the exam hall at the end of a paper: the run fanned out over the selected Cases,
+one script came back per Case, and this is the invigilator collecting the pile and sorting
+it by student number. No marking happens here — a script is filed, or it is refused as
+unreadable. Marking is `spine.grading.CaseGrader`.
+
+FEATURE: one grading spine per benchmark (OME-1024); this module is the second extraction
+(OME-1039 took the failure ladder) — the row reader gdpval and healthbench duplicated
+near byte-identically after the two-week-old fork.
+
+The stages, in execution order:
+
+    Stage 1  decode the collected array           → "rows are not JSON" / "must be an array"
+    Stage 2  guard the count against the roll call → more rows than Cases aborts
+    Stage 3  per position, unwrap the row value    → a row may arrive double-encoded
+    Stage 4  outer error?  identified → it IS that Case's row
+                           anonymous  → retained as an orphan against that position
+    Stage 5  otherwise decode the envelope         → grading error, or the board-decoded row
+
+Worked example — three Cases selected, `case_ids = (1, 2, 3)`:
+
+    rows[0] = a valid envelope for Case 1        → RowIndex.rows[1]
+    rows[1] = {"error": {...}}   (no case_id)    → RowIndex.collected_errors[2]
+    rows[2] = an envelope whose grading errored  → RowIndex.grading_failures[3]
+
+Case 2 ends with no row at all, so the grader reports it as `missing_case_row` — and the
+orphan error retained above it is what tells the reader *why*.
+
+INVARIANT: the row is an OPAQUE board-owned envelope. This module files it and never looks
+inside, so nothing here can freeze "a candidate's answer is text". The kind taxonomy is
+OME-1103's decision; the seam that opens the envelope is OME-1097's `grade_case`.
+
+INVARIANT: `case_ids` is the authoritative roll call and position is identity. A row that
+claims a Case other than the one selected at its position aborts the run — scoring the
+wrong Case is worse than reporting a failed one.
+
+INVARIANT: a collected error is never dropped. An `on_error=collect` row loses its Case
+identity, so it cannot be indexed; it is retained as an orphan and attached to the position
+it arrived at, so the report names the cause and not just the symptom (exactly what was
+missing in the first live smoke run).
+
+INVARIANT: failure wording stays board-owned. `benchmark_label` and `error_type` are
+injected so each board raises its own class with its own text — the extraction moves logic,
+never messages.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from screamingface_engine.benchmarks.case_execution import (
+    CaseExecutionOutcome,
+    case_execution_matches,
+    case_execution_outcome,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RowIndex:
+    """One fan-out's rows, split by what each position turned out to be.
+
+    Attributes:
+        rows: Case id → the board-decoded evaluation envelope, opaque to the spine. Also
+            holds an identified error row, which IS that Case's row.
+        collected_errors: Case id → the anonymous `on_error=collect` payloads that arrived
+            at that position, retained so a missing row can name its cause.
+        grading_failures: Case id → the preserved Candidate answer plus the grading error,
+            for a Case whose Candidate answered but whose grading step failed.
+    """
+
+    rows: dict[int, dict[str, Any]]
+    collected_errors: dict[int, list[dict[str, Any]]]
+    grading_failures: dict[int, CaseExecutionOutcome]
+
+
+@dataclass(frozen=True, slots=True)
+class RowReader:
+    """One board's row reader — the shared reading steps bound to the board's own names.
+
+    Each board constructs one module-level instance. Only three things differ between the
+    boards, and all three are here:
+
+    Attributes:
+        benchmark_label: the board's display name as it appears in this module's two
+            decode error messages ("GDPval rows are not JSON"). Display text, NOT an
+            identity — two Benchmarks (`healthbench-worst30`, `healthbench-professional`)
+            share the one label "HealthBench", so this is deliberately not `benchmark_id`.
+        error_type: the board's own `AggregateError`. Injected rather than shared so a
+            test asserting one board raised keeps failing when the other one does.
+        decode_case_evaluation: the board's envelope validator, the only authority on its
+            own schema. Called as `(grading, expected_case_id) -> decoded row`; it raises
+            `ValueError`/`TypeError`, which this module wraps with the row's position.
+    """
+
+    benchmark_label: str
+    error_type: type[Exception]
+    decode_case_evaluation: Callable[[object, int], dict[str, Any]]
+
+    def index(self, raw_rows: str, case_ids: tuple[int, ...]) -> RowIndex:
+        """Sort one fan-out's collected rows into the three piles above.
+
+        Args:
+            raw_rows: the collected array as JSON text, in selected order.
+            case_ids: the Cases this run selected — the authoritative roll call, and the
+                identity of each position.
+
+        Returns:
+            The `RowIndex`. A selected Case absent from all three piles simply had no row;
+            the grader reports that per Case, so nothing vanishes from the roll call.
+
+        Raises:
+            `error_type`: the payload, a row, or a row's claimed identity is unusable. Every
+            such abort happens BEFORE any scoring, so a corrupt fan-out can never become a
+            quietly wrong score.
+        """
+
+        # Stage 1-2 — decode the array and check it against the roll call.
+        rows = self._decoded_rows(raw_rows)
+        if len(rows) > len(case_ids):
+            raise self.error_type(
+                f"aggregate received {len(rows)} rows for {len(case_ids)} selected Cases"
+            )
+        index = RowIndex(rows={}, collected_errors={}, grading_failures={})
+        # Stage 3-5 — position IS identity: row i belongs to the Case selected at i.
+        for position, entry in enumerate(rows):
+            self._file_row(entry, position, case_ids[position], index)
+        return index
+
+    def _decoded_rows(self, raw: str) -> list[Any]:
+        """Stage 1 — the collected array, still opaque, one entry per Case that ran."""
+
+        try:
+            decoded = json.loads(raw or "")
+        except ValueError as exc:
+            raise self.error_type(f"{self.benchmark_label} rows are not JSON: {exc}") from None
+        if not isinstance(decoded, list):
+            raise self.error_type(f"{self.benchmark_label} rows must be a JSON array")
+        return decoded
+
+    def _file_row(
+        self,
+        entry: object,
+        position: int,
+        expected_case_id: int,
+        index: RowIndex,
+    ) -> None:
+        """Stages 3-5 — unwrap one row, then file it as an error, a failure, or a row."""
+
+        row = self._row_value(entry, position)
+        if self._filed_outer_error(row, position, expected_case_id, index):
+            return
+        try:
+            outcome = case_execution_outcome(row)
+            if not case_execution_matches(outcome, expected_case_id):
+                raise ValueError(
+                    f"Case execution claims case_id {outcome.case_id!r}, "
+                    f"but the selected Case is {expected_case_id!r}"
+                )
+            if outcome.error is not None:
+                index.grading_failures[expected_case_id] = outcome
+            else:
+                index.rows[expected_case_id] = self.decode_case_evaluation(
+                    outcome.grading, expected_case_id
+                )
+        except (TypeError, ValueError) as exc:
+            raise self.error_type(f"Case result at position {position} is invalid: {exc}") from None
+
+    def _row_value(self, entry: object, position: int) -> Mapping[str, Any]:
+        """Stage 3 — url4 hands some rows back as JSON text rather than as objects."""
+
+        try:
+            row = json.loads(entry) if isinstance(entry, str) else entry
+        except ValueError as exc:
+            raise self.error_type(
+                f"Case result at position {position} is not JSON: {exc}"
+            ) from None
+        if not isinstance(row, Mapping):
+            raise self.error_type(f"Case result at position {position} must be an object")
+        return row
+
+    def _filed_outer_error(
+        self,
+        row: Mapping[str, Any],
+        position: int,
+        expected_case_id: int,
+        index: RowIndex,
+    ) -> bool:
+        """Stage 4 — the whole fan-out branch failed; True when this row was filed here."""
+
+        error = row.get("error")
+        if error is None:
+            return False
+        if not isinstance(error, Mapping):
+            raise self.error_type(f"Case result at position {position} has an invalid error")
+        claimed = row.get("case_id")
+        if claimed is not None and claimed != expected_case_id:
+            raise self.error_type(
+                f"Case result at position {position} claims case_id {claimed}, "
+                f"but the selected Case is {expected_case_id}"
+            )
+        if claimed is None:
+            # WHY: an anonymous error cannot be indexed, so it is retained against the
+            # position it arrived at — the grader attaches it to the Case that ends up
+            # with no row, which is how the symptom keeps its cause.
+            index.collected_errors.setdefault(expected_case_id, []).append(dict(row))
+        else:
+            index.rows[expected_case_id] = dict(row)
+        return True
+
+
+__all__ = ["RowIndex", "RowReader"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/rows.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/rows.py
@@ -1,16 +1,12 @@
 """Read the per-Case fan-out's collected rows back and file each one under its Case id.
 
-Think of the exam hall at the end of a paper: the run fanned out over the selected Cases,
-one script came back per Case, and this is the invigilator collecting the pile and sorting
-it by student number. No marking happens here — a script is filed, or it is refused as
-unreadable. Marking is `spine.grading.CaseGrader`.
-
-WHAT "FAN-OUT" MEANS HERE — it is a url4 expression-graph word, not a scheduling one. A
-benchmark run is ONE url4 expression; a fan-out is a node in that expression producing N
-independent branches whose results collect back into an array. The branches are network
-calls to the AI Gateway, not CPU work, so the width is a property of the EXPRESSION and
-the bound on it is configured concurrency — never core count, never one Case per core.
-(`schemas/openapi.py` puts it plainly: "one url4 expression is many gateway calls".)
+A benchmark run is one url4 expression; every case in it produces one row. The engine fans
+out over the selected cases, and each case comes back as a row holding the candidate's answer
+plus the judge's verdicts, or an error where either step failed. The aggregate step is the part
+that reads all those rows back: decode the collected array, index rows by case id, notice
+an outer error (the whole fan-out branch failed), and pull the value out of each row.
+Think of it as collecting the exam scripts from the hall and sorting them by student
+number before any marking starts.
 
 WHICH fan-out — the repo has three, nested, and every other mention names its axis
 (`ensemble/policy.py` says "member fan-out"; `healthbench/exam.py` says "fan out one judge

--- a/apps/screamingface-engine/tests/unit/test_spine_row_reader.py
+++ b/apps/screamingface-engine/tests/unit/test_spine_row_reader.py
@@ -1,0 +1,232 @@
+"""OME-1096: the shared step that reads a fan-out's collected rows back.
+
+Think of it as the mailroom: the run fanned out over the selected Cases, one row came
+back per Case, and this step sorts the pile by student number before any marking starts.
+
+INVARIANT: the row is an OPAQUE board-owned envelope. The reader files it under its Case
+id and never looks inside, so nothing here can freeze "a candidate's answer is text" —
+the kind taxonomy is OME-1103's decision and the seam that opens the envelope is
+OME-1097's `grade_case`. The stub decoder below returns a bare marker dict precisely to
+prove the reader never inspects the contents.
+
+INVARIANT: an ``on_error=collect`` row loses its Case identity, so it cannot be indexed.
+It is RETAINED as an orphan and attached to whichever Case ends up with no row — dropping
+it would name the symptom (a missing row) and hide the cause.
+
+The board-varying bits are injected, so each board keeps its own error class and its own
+wording after the extraction.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from screamingface_engine.benchmarks.case_execution import case_execution_payload
+from screamingface_engine.benchmarks.contract import encode_candidate_invocation
+from screamingface_engine.benchmarks.spine.rows import RowReader
+
+
+class BoardError(ValueError):
+    """Stands in for a board's own ``AggregateError``."""
+
+
+class OtherBoardError(ValueError):
+    """A second board's error class — proves the reader raises the injected one."""
+
+
+def _decode(grading: object, expected_case_id: int) -> dict[str, Any]:
+    """Stub board decoder: marks the row without reading anything out of it."""
+
+    if grading == "reject-me":
+        raise ValueError("stub decoder rejected this envelope")
+    return {"decoded_for": expected_case_id, "grading": grading}
+
+
+def _reader(label: str = "TestBoard", error: type[Exception] = BoardError) -> RowReader:
+    return RowReader(
+        benchmark_label=label,
+        error_type=error,
+        decode_case_evaluation=_decode,
+    )
+
+
+def _envelope(case_id: int, grading: object = "graded") -> dict[str, object]:
+    """One valid Case-execution envelope carrying an opaque grading outcome."""
+
+    return case_execution_payload(
+        case_id,
+        encode_candidate_invocation(f"output-{case_id}", "stop", None),
+        [grading],
+    )
+
+
+def _collected_error(message: str, case_id: int | None = None) -> dict[str, object]:
+    """The shape an ``on_error=collect`` row has: an outer error, identity optional."""
+
+    row: dict[str, object] = {"error": {"kind": "transport", "message": message}}
+    if case_id is not None:
+        row["case_id"] = case_id
+    return row
+
+
+def test_rows_are_filed_under_their_selected_case_ids() -> None:
+    index = _reader().index(json.dumps([_envelope(1), _envelope(2)]), (1, 2))
+
+    assert sorted(index.rows) == [1, 2]
+    assert index.rows[1]["decoded_for"] == 1
+    assert index.rows[2]["decoded_for"] == 2
+    assert index.collected_errors == {}
+    assert index.grading_failures == {}
+
+
+def test_no_rows_indexes_nothing_rather_than_failing() -> None:
+    # WHY: an empty fan-out is not a protocol error — every selected Case simply ends up
+    # with no row, which the grader reports per Case as missing_case_row.
+    index = _reader().index("[]", (1, 2))
+
+    assert index.rows == {}
+    assert index.collected_errors == {}
+    assert index.grading_failures == {}
+
+
+def test_a_non_json_payload_names_the_benchmark() -> None:
+    with pytest.raises(BoardError, match="TestBoard rows are not JSON"):
+        _reader().index("not json", (1,))
+
+
+def test_an_empty_payload_names_the_benchmark() -> None:
+    with pytest.raises(BoardError, match="TestBoard rows are not JSON"):
+        _reader().index("", (1,))
+
+
+def test_a_json_object_payload_is_refused_as_not_an_array() -> None:
+    with pytest.raises(BoardError, match="TestBoard rows must be a JSON array"):
+        _reader().index("{}", (1,))
+
+
+def test_more_rows_than_selected_cases_abort_before_indexing() -> None:
+    # INVARIANT: case_ids is the authoritative roll call. More rows than Cases means the
+    # fan-out disagrees with the selection, so no row can be trusted to its position.
+    payload = json.dumps([_envelope(1), _envelope(2)])
+
+    with pytest.raises(BoardError, match="received 2 rows for 1 selected Cases"):
+        _reader().index(payload, (1,))
+
+
+def test_a_double_encoded_row_is_parsed() -> None:
+    # WHY: url4 hands some rows back as JSON text rather than as objects.
+    payload = json.dumps([json.dumps(_envelope(1))])
+
+    index = _reader().index(payload, (1,))
+
+    assert index.rows[1]["decoded_for"] == 1
+
+
+def test_a_row_that_is_not_an_object_aborts_with_its_position() -> None:
+    with pytest.raises(BoardError, match="Case result at position 0 must be an object"):
+        _reader().index(json.dumps([[1, 2, 3]]), (1,))
+
+
+def test_a_malformed_row_string_aborts_with_its_position() -> None:
+    with pytest.raises(BoardError, match="Case result at position 0 is not JSON"):
+        _reader().index(json.dumps(["{not json"]), (1,))
+
+
+def test_an_orphan_collected_error_is_retained_against_its_position() -> None:
+    # INVARIANT: the cause is never dropped. Without this the report would say
+    # "no row for Case 1" and hide the transport failure that caused it.
+    index = _reader().index(json.dumps([_collected_error("upstream 503")]), (1,))
+
+    assert index.rows == {}
+    assert index.grading_failures == {}
+    assert index.collected_errors[1][0]["error"]["message"] == "upstream 503"
+
+
+def test_two_orphan_errors_for_one_case_are_both_retained() -> None:
+    payload = json.dumps([_collected_error("first"), _collected_error("second")])
+
+    index = _reader().index(payload, (1, 1))
+
+    assert [row["error"]["message"] for row in index.collected_errors[1]] == [
+        "first",
+        "second",
+    ]
+
+
+def test_an_identified_error_row_is_filed_as_the_cases_row() -> None:
+    # WHY: an error row that kept its identity IS that Case's row — the grader reads the
+    # "error" key off it and reports case_error, rather than missing_case_row.
+    index = _reader().index(json.dumps([_collected_error("judge down", case_id=1)]), (1,))
+
+    assert index.rows[1]["error"]["message"] == "judge down"
+    assert index.collected_errors == {}
+
+
+def test_an_error_row_claiming_another_case_aborts() -> None:
+    # INVARIANT: a row whose claimed identity disagrees with the selection cannot be
+    # trusted to its position; scoring the wrong Case is worse than failing the run.
+    payload = json.dumps([_collected_error("wrong case", case_id=99)])
+
+    with pytest.raises(BoardError, match="claims case_id 99"):
+        _reader().index(payload, (1,))
+
+
+def test_an_error_that_is_not_an_object_aborts() -> None:
+    with pytest.raises(BoardError, match="position 0 has an invalid error"):
+        _reader().index(json.dumps([{"error": "boom"}]), (1,))
+
+
+def test_a_grading_error_lands_in_grading_failures_not_rows() -> None:
+    payload = json.dumps([_envelope(1, {"error": {"message": "grader crashed"}})])
+
+    index = _reader().index(payload, (1,))
+
+    assert index.rows == {}
+    assert index.grading_failures[1].error == {"message": "grader crashed"}
+
+
+def test_an_envelope_claiming_another_case_aborts() -> None:
+    payload = json.dumps([_envelope(99)])
+
+    with pytest.raises(BoardError, match="claims case_id"):
+        _reader().index(payload, (1,))
+
+
+def test_a_decoder_rejection_aborts_with_its_position() -> None:
+    # INVARIANT: the board's decoder is the only authority on its envelope shape; its
+    # rejection must surface as the board's own error, not leak a bare ValueError.
+    payload = json.dumps([_envelope(1, "reject-me")])
+
+    with pytest.raises(BoardError, match="position 0 is invalid: stub decoder rejected"):
+        _reader().index(payload, (1,))
+
+
+def test_a_malformed_envelope_aborts_with_its_position() -> None:
+    payload = json.dumps([{"schema": "wrong", "case_id": 1}])
+
+    with pytest.raises(BoardError, match="Case result at position 0 is invalid"):
+        _reader().index(payload, (1,))
+
+
+def test_each_reader_raises_its_own_error_class_with_its_own_wording() -> None:
+    # INVARIANT: extraction must not merge the boards' error identities — a test that
+    # asserts gdpval raised must keep failing when healthbench raises.
+    other = _reader(label="OtherBoard", error=OtherBoardError)
+
+    with pytest.raises(OtherBoardError, match="OtherBoard rows are not JSON"):
+        other.index("not json", (1,))
+    with pytest.raises(BoardError, match="TestBoard rows are not JSON"):
+        _reader().index("not json", (1,))
+
+
+def test_the_reader_never_reads_a_case_input_or_answer() -> None:
+    # INVARIANT (OME-1103): the row is an opaque payload. This reader files envelopes; it
+    # must not grow a `.answer: str`, or the agentic answer shape becomes a rewrite
+    # instead of a new kind. The stub decoder returns a marker with no text fields at
+    # all — if the reader ever inspects the answer, this stops working.
+    index = _reader().index(json.dumps([_envelope(1, {"opaque": ["anything", 42]})]), (1,))
+
+    assert index.rows[1]["grading"] == {"opaque": ["anything", 42]}

--- a/docs/tasks/2026-09-04-OME-1096-shared-row-decode.md
+++ b/docs/tasks/2026-09-04-OME-1096-shared-row-decode.md
@@ -1,0 +1,32 @@
+---
+id: OME-1096
+linear_url: https://linear.app/openmined/issue/OME-1096/share-the-row-decode-and-index-step-between-gdpval-and-healthbench
+status: in_progress
+type:
+priority: high
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+created: 2026-09-04
+closed:
+---
+
+# Share the row decode and index step between gdpval and healthbench
+
+Second code PR of the OME-1024 spine chain. The step that reads a fan-out's collected rows
+back — parse the array, guard the count against the roll call, notice an outer error, file
+each row under its Case id — existed twice, near byte-identically, because `gdpval/` was
+forked from `healthbench/` two weeks ago. It now lives once in
+`benchmarks/spine/rows.py` as `RowReader`, with the three board-varying bits injected at
+construction (`benchmark_label`, `error_type`, `decode_case_evaluation`), matching the
+`CaseGrader` precedent from OME-1039. Both copies deleted; every pre-existing test passes
+unmodified, which is the proof nothing observable moved.
+
+Design decision (owner-approved in session): the row stays an **opaque** board-owned
+mapping. The ticket's review note asked for kind-tagged payload types (`kind: "text"`);
+deferred deliberately because these functions never open the envelope, and inventing the
+kind vocabulary here would pre-empt `OME-1103`, the design session that exists to decide
+it. The invariant is recorded as an `INVARIANT:` anchor in the new module.
+
+Ledger: `docs/work/2026-09-04-OME-1096-shared-row-decode.md`

--- a/docs/work/2026-09-04-OME-1096-shared-row-decode.md
+++ b/docs/work/2026-09-04-OME-1096-shared-row-decode.md
@@ -1,0 +1,153 @@
+---
+ticket: OME-1096
+stack: screamingface-engine
+status: done
+started: 2026-09-04
+finished: 2026-09-04
+---
+
+# OME-1096 — Share the row decode and index step between gdpval and healthbench
+
+## Intent
+
+Third code PR of the OME-1024 spine chain (after OME-1094/1095 goldens work and OME-1039's
+declaration + failure ladder). The engine fans a benchmark run out over its selected cases and
+collects one row per case; the aggregate step reads that array back — parse the JSON, check the
+count, notice an outer error, file each row under its case id. That reader exists **twice**,
+near byte-identical, because `gdpval/` was forked from `healthbench/` two weeks ago
+(`_decode_rows`, `_index_rows`, `_index_row`, `_index_outer_error`, `_row_value`). Every fix
+lands in one copy and drifts from the other. This unit extracts the reader into the spine once.
+
+Purely mechanical: no grading, no scoring, no wording changes. The healthbench-worst30 golden
+(157 cases, per-case statuses and failure codes pinned by OME-1094) is the proof nothing
+observable moved.
+
+## Design decisions (owner-approved in session, 2026-09-04)
+
+**1. The row stays OPAQUE — no kind-tagged payload types in this unit.**
+
+The ticket's 2026-09-03 review note asks the decoded row to carry inputs and answers as
+kind-tagged payloads (`kind: "text"`). Deferred, deliberately, with owner approval:
+
+- These five functions never open the envelope. They file a sealed board-decoded mapping under
+  its case id; `case.input` / `case.output` are read one layer later by the board-owned
+  `_candidate_fields` hook, which is OME-1097's seam, not this ticket's.
+- The kind taxonomy is `OME-1103`'s decision (a design session, still Backlog, "No code in this
+  ticket"). Inventing `TextPayload` here would answer that question by accident — the exact
+  failure `OME-1103` warns about: *"Any decision made accidentally by the spine extraction (a
+  text-only row shape frozen into `grade_case`) becomes a contract break later."*
+- Keeping the row an opaque `Mapping` satisfies the note's actual requirement — nothing here
+  hard-codes `answer: str` — while leaving all three kinds open. A payload type with no
+  consumer would be dead scaffolding (YAGNI), and wiring one to a real consumer means editing
+  `CaseGrader`'s hook signature, which is OME-1097's file boundary and would blow the ~300-line
+  cap.
+
+The invariant is recorded as an `INVARIANT:` anchor in the new module so a later agent does not
+helpfully "improve" it into a typed row.
+
+**2. Board-varying bits are injected at construction** — the OME-1039 `CaseGrader` precedent.
+Exactly three things differ between the two copies:
+
+| Injected | gdpval | healthbench | Why it must vary |
+|---|---|---|---|
+| `benchmark_label` | `"GDPval"` | `"HealthBench"` | appears in two `_decode_rows` error messages; texts stay byte-identical |
+| `error_type` | `gdpval.AggregateError` | `healthbench.AggregateError` | keeps `pytest.raises(<board>.AggregateError)` meaning exactly what it means today |
+| `decode_case_evaluation` | gdpval's | healthbench's | each board validates its own envelope schema |
+
+Naming: `benchmark_label`, not `board_label` — "board" is prose-only vocabulary in this repo
+(104 occurrences, all docstrings/comments, zero identifiers); `benchmark_` is the code noun
+(`benchmark_id` ×61, `benchmark_revision` ×25). Not `benchmark_name` either: two Benchmarks
+(`healthbench-worst30`, `healthbench-professional`) share the one value `"HealthBench"`, so a
+`_name` beside the per-call `benchmark_id="healthbench-worst30"` would imply a 1:1 that does not
+exist. `_label` marks it as display text. `error_type` rather than `error` because the field
+holds a class, not an instance.
+
+## Planned changes
+
+- **new** `src/screamingface_engine/benchmarks/spine/rows.py` — `RowReader` frozen dataclass
+  (`benchmark_label`, `error_type`, `decode_case_evaluation`) with the five extracted steps
+  behind one public `index(raw_rows, case_ids) -> RowIndex` method; `RowIndex` is a small
+  frozen dataclass carrying `(rows, collected_errors, grading_failures)` so the call site stops
+  unpacking a bare 3-tuple.
+- `src/screamingface_engine/benchmarks/gdpval/aggregate.py` — bind `_ROWS` at module bottom
+  beside the existing `_GRADER`; delete the five copies.
+- `src/screamingface_engine/benchmarks/healthbench/aggregate.py` — same; also deletes
+  `_attach_collected_error` (a healthbench-only one-line wrapper whose `case_id is not None`
+  guard is dead at its single call site — gdpval's inline `setdefault().append()` is the
+  behaviour both keep).
+- **new** `tests/unit/test_spine_row_reader.py` — one test per decode branch through the shared
+  module.
+
+NOT touched (ticket's explicit boundary): `aggregation.py`, `contract.py`, `spine/grading.py`.
+No schema/model change, so stack rule S1 (migrations) does not apply.
+
+## Test plan (RED first)
+
+`tests/unit/test_spine_row_reader.py`, driving a `RowReader` built on a stub decoder so the
+spine's own branches are covered without either board's envelope schema:
+
+- happy path — two rows file under their selected case ids, in order
+- raw payload is not JSON → `error_type` raised, message carries `benchmark_label`
+- raw payload is a JSON object, not an array → `error_type`, label in message
+- more rows than selected cases → `error_type` (the count guard)
+- a row that is a JSON *string* is parsed (the `_row_value` double-encode path)
+- a row that is not an object → `error_type` "must be an object"
+- a row that is a malformed JSON string → `error_type` "is not JSON"
+- outer error row with no `case_id` → retained as an orphan collected error (INVARIANT: the
+  cause is never dropped — this is what made the first live smoke run debuggable)
+- outer error row with a matching `case_id` → filed as the case's row
+- outer error row claiming a different `case_id` → `error_type` (identity guard)
+- outer error that is not a mapping → `error_type`
+- a row whose decoder reports a grading error → lands in `grading_failures`, not `rows`
+- a row whose `case_id` disagrees with the selected case → `error_type`
+- decoder raising `ValueError`/`TypeError` → wrapped as `error_type` with the position
+- INVARIANT test: `benchmark_label` and `error_type` are honoured per instance — two readers
+  built with different values raise their own class with their own wording
+
+**Append-only:** every existing gdpval and healthbench test must pass **unmodified**. That is
+the real proof of this extraction — if a board test needs an edit, the extraction changed
+observable behaviour and that is a STOP.
+
+## Acceptance
+
+- The five decode/index functions exist once in the repo (`spine/rows.py`).
+- Both copies deleted; both aggregates call the shared reader.
+- Every pre-existing engine test green, unmodified.
+- `run_gates.py screamingface-engine` all green.
+- Diff under ~300 lines.
+- Free tests only — no paid model run. (healthbench-worst30 golden replay is a client-side
+  e2e lane, run separately by the owner.)
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus `benchmarks/spine/__init__.py` (re-export `RowReader` +
+  `RowIndex`, matching how OME-1039 re-exported `CaseGrader`) and the `docs/tasks/` mirror.
+  New tests: `test_spine_row_reader.py` (20).
+- **Commits:** single commit on `OME-1096-shared-row-decode` —
+  `refactor(screamingface-engine): read benchmark rows through one shared spine reader`.
+- **Gates:** `run_gates.py screamingface-engine` **ALL GREEN** — append-only test check,
+  ruff check, ruff format, pyright, layering, pytest **2340 passed / 5 skipped**, cov ≥80%.
+- **Diff:** modified files +28 / −222; new module 215 lines, new test 232. The extraction
+  itself is well under the ~300-line cap; the two new files are the shared module and its
+  tests, which the ticket asks for explicitly.
+- **Deviations:**
+  - **Kind-tagged payload types deferred to OME-1097/OME-1103, with owner approval in
+    session.** Reasoning recorded in "Design decisions" above. The row is opaque and a
+    test (`test_the_reader_never_reads_a_case_input_or_answer`) pins that as an invariant,
+    so a later agent cannot quietly turn it into a typed `answer: str` row.
+  - **`RowIndex` result type** rather than the bare 3-tuple both boards unpacked. Five
+    lines; the call sites now read `indexed.rows` / `indexed.collected_errors` /
+    `indexed.grading_failures` instead of positional unpacking. Declared in the plan.
+  - **healthbench's `_attach_collected_error` deleted, not extracted.** It was a
+    healthbench-only one-line wrapper whose `if case_id is not None` guard is dead at its
+    single call site (the caller has already established the id). gdpval's inline
+    `setdefault().append()` is the behaviour both boards now share — no behaviour change,
+    confirmed by healthbench's own orphan-error test passing unmodified.
+  - **Remote is `upstream`, not `origin`.** The repo `CLAUDE.md` worktree recipe says
+    `git fetch origin` / `origin/main`, but this clone has only `upstream`
+    (`github.com/ScreamingFace/screamingface`). Branched from `upstream/main`. Worth a
+    one-line fix to the recipe in `CLAUDE.md` — flagged, not changed (process tooling is
+    owner territory).
+  - **No existing test was modified** — `git status` shows only the two aggregate files as
+    modified, and the append-only gate passed. That is the extraction's real proof.
+- **Status:** DONE (pending review + merge).


### PR DESCRIPTION
The step that reads a benchmark run's collected rows back existed twice, near byte-identically, in `gdpval/aggregate.py` and `healthbench/aggregate.py`. It now lives once in the spine.

## Before / After

### Before
- **Trigger:** a dev fixes a bug in how a rubric benchmark reads its rows back — an outer error row, a row that never arrived, a row that isn't the object it claims to be.
- **Today:** they fix it in one of two near-identical copies. `_decode_rows`, `_index_rows`, `_index_row`, `_index_outer_error`, `_row_value` exist in both files; `gdpval/` was forked from `healthbench/` two weeks ago and each has been patched separately since (0.80 similar on normalized lines, 447 of 513 identical).
- **Cost:** the fix lands in one copy and the other silently drifts. Onboarding a new rubric board starts by copying ~500 lines a third time.

### After
- Same trigger.
- **Now:** one `RowReader` in `benchmarks/spine/rows.py`. Both boards bind an instance at module bottom, beside the `CaseGrader` from OME-1039, and call `_ROWS.index(raw_rows, case_ids)`. Both copies deleted.
- **Win:** one place to fix a row-reading bug. Modified files go **+28 / −222**. The next board inherits the reader instead of copying it.

### Don't regress
- **Every pre-existing test passes unmodified** — `git status` shows only the two aggregate files as modified, and the append-only gate is green. That is the extraction's proof, not a claim.
- Failure codes and message texts per case are byte-identical: `benchmark_label` and `error_type` are injected, so each board still raises its own class with its own wording.
- No REVISION moved; no rendered expression changed. Expression-SHA rung unaffected.
- `aggregation.py`, `contract.py` and `spine/grading.py` untouched, per the ticket's file boundary.

## What varies between the two boards

Exactly three things, all injected at construction — the `CaseGrader` precedent from OME-1039:

| Injected | gdpval | healthbench | Why it must vary |
|---|---|---|---|
| `benchmark_label` | `"GDPval"` | `"HealthBench"` | appears in two decode error messages; texts stay byte-identical |
| `error_type` | gdpval's `AggregateError` | healthbench's | keeps `pytest.raises(<board>.AggregateError)` meaning exactly what it means today |
| `decode_case_evaluation` | gdpval's | healthbench's | each board is the only authority on its own envelope schema |

**Naming note.** `benchmark_label`, not `board_label`: "board" is prose-only vocabulary in this repo (104 occurrences, all docstrings and comments, zero identifiers), while `benchmark_` is the code noun (`benchmark_id` ×61). Not `benchmark_name` either — `healthbench-worst30` and `healthbench-professional` are two Benchmarks sharing the one label `"HealthBench"`, so a `_name` sitting beside the per-call `benchmark_id="healthbench-worst30"` would imply a 1:1 that doesn't exist.

## The one non-mechanical decision: the row stays opaque

The ticket's 2026-09-03 review note asks the decoded row to carry inputs and answers as kind-tagged payloads (`kind: "text"`). **Deferred to OME-1097, deliberately, owner-approved in session.**

These five functions never open the envelope — they file a sealed board-decoded mapping under its Case id. `case.input` and `case.output` are read one layer later by the board-owned `_candidate_fields` hook, which is OME-1097's seam. Meanwhile the kind taxonomy is `OME-1103`'s decision, a design session still in Backlog whose own body warns about exactly this: *"Any decision made accidentally by the spine extraction (a text-only row shape frozen into `grade_case`) becomes a contract break later."*

Keeping the row an opaque `Mapping` satisfies what the note actually protects — nothing here hard-codes `answer: str` — while leaving `text`, `text+attachments` and `environment` all open. A payload type with no consumer would be dead scaffolding, and giving it a real consumer means editing `CaseGrader`'s hook signature, which is OME-1097's file boundary.

The invariant is pinned by a test (`test_the_reader_never_reads_a_case_input_or_answer`) and an `INVARIANT:` anchor in the module, so it can't quietly drift into a typed row.

## Test plan

- **New:** `tests/unit/test_spine_row_reader.py` — 20 tests, one per branch, driven through a stub decoder so the spine's own paths are covered without either board's envelope schema. Covers the happy path, the count guard, double-encoded rows, non-object rows, orphan collected errors (retained, never dropped), identified error rows, identity mismatches, grading failures, decoder rejections, and the per-instance label/error-class invariant.
- **Unchanged and green:** every existing gdpval and healthbench test.
- **Gates:** `run_gates.py screamingface-engine` **ALL GREEN** — append-only check, ruff check, ruff format, pyright, layering, pytest **2340 passed / 5 skipped**, coverage ≥80%.
- **Free tests only.** No paid model run. The healthbench-worst30 golden replay is a client-side e2e lane and is the owner's to run.

## Notes for the reviewer

- `RowIndex` replaces the bare 3-tuple both boards were unpacking, so call sites read `indexed.rows` / `indexed.collected_errors` / `indexed.grading_failures`.
- healthbench's `_attach_collected_error` is deleted rather than extracted: it was a one-line wrapper whose `if case_id is not None` guard is dead at its single call site. gdpval's inline `setdefault().append()` is what both boards now share — behaviour confirmed unchanged by healthbench's own orphan-error test passing unmodified.
- **Flagged, not changed:** the worktree recipe in `CLAUDE.md` says `git fetch origin` / `origin/main`, but this clone only has `upstream`. Worth a one-line fix; process tooling is owner territory.

Ledger: `docs/work/2026-09-04-OME-1096-shared-row-decode.md`

Refs: OME-1096
