### PR TITLE
feat(scoreboard): make private rollback fail closed

### DIFF
--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -272,10 +272,34 @@ revision's hooks (`execHook(targetRelease, release.HookPreRollback, ...)` in Hel
 stored manifest has no such hook, so nothing added to this chart can run in the dangerous
 direction.
 
-Before **any** `helm rollback`, run the preflight in a pod on the current release:
+Package version is not a release identity here: both the privacy-blind base and the
+privacy-aware release package `scoreboard 0.1.1`. For every known-safe deployment, record the Helm
+revision, rendered image reference, and runtime `imageID` digest together in the deployment record:
 
 ```bash
-kubectl -n scoreboard exec deploy/scoreboard-scoreboard -- \
+NAMESPACE=scoreboard
+RELEASE=scoreboard
+DEPLOYMENT=scoreboard-scoreboard
+SELECTOR='app.kubernetes.io/instance=scoreboard,app.kubernetes.io/name=scoreboard'
+
+helm list --namespace "$NAMESPACE" --filter "^${RELEASE}$"
+helm history "$RELEASE" --namespace "$NAMESPACE"
+kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="scoreboard")].image}{"\n"}'
+kubectl -n "$NAMESPACE" get pods -l "$SELECTOR" \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[?(@.name=="scoreboard")].imageID}{"\n"}{end}'
+```
+
+Every serving pod must report the same immutable digest. Record it while the known-safe release is
+live; a mutable image tag in old Helm values cannot reconstruct this evidence later. Before **any**
+rollback, compare the requested target revision and image with that deployment record, then run the
+database preflight in a pod on the current release:
+
+```bash
+TARGET_REVISION=<revision-from-helm-history>
+helm get manifest "$RELEASE" --namespace "$NAMESPACE" --revision "$TARGET_REVISION" \
+  | grep 'image:'
+kubectl -n "$NAMESPACE" exec "deploy/$DEPLOYMENT" -- \
   python -m scoreboard.check_rollback_safety
 ```
 
@@ -283,17 +307,72 @@ It exits `0` when no benchmark is private, and non-zero — listing each private
 submission count — when one is. It is read-only and has no override flag: clearing the refusal by
 flipping a board to public *is* the leak, performed deliberately.
 
-If it refuses and you still must roll back below the floor it names, use the fail-closed
-procedure:
+If the target has recorded evidence that it is privacy-aware, a refusal is expected and the normal
+rollback is safe. If that evidence is absent, treat the target as privacy-blind. Postpone the
+rollback, or use this destructive fallback for **each** board listed by the preflight.
 
-1. `kubectl -n scoreboard scale deploy/scoreboard-scoreboard --replicas=0` — stop serving before
-   anything else. Every later step is safe only while nothing answers requests.
-2. `python -m scoreboard.export_private_submissions --benchmark <id>` for each board the preflight
-   listed, keeping the output somewhere staff-only. This is the participants' data and the next
-   step destroys it.
-3. Delete the exported rows and the private benchmarks, so the restored code has nothing private
-   left to serve.
-4. `helm rollback`, then scale back up.
+First, export through the still-privacy-aware pod to a staff-only file on the operator's machine.
+The local shell performs the redirection; the file is not left in the pod:
+
+```bash
+BENCHMARK=healthbench-worst30
+BACKUP_DIR=<absolute-path-to-staff-only-storage>
+umask 077
+kubectl -n "$NAMESPACE" exec "deploy/$DEPLOYMENT" -- \
+  python -m scoreboard.export_private_submissions --benchmark "$BENCHMARK" \
+  > "$BACKUP_DIR/$BENCHMARK.jsonl"
+shasum -a 256 "$BACKUP_DIR/$BENCHMARK.jsonl"
+EXPORT_SHA256=<64-hex-digest-printed-above>
+```
+
+Then make the application compare the database's current canonical export with that exact digest.
+The first command is a dry run. Read its benchmark id, row count, and digest before repeating with
+`--yes`:
+
+```bash
+kubectl -n "$NAMESPACE" exec "deploy/$DEPLOYMENT" -- \
+  python -m scoreboard.purge_private_benchmark \
+    --benchmark "$BENCHMARK" \
+    --expected-export-sha256 "$EXPORT_SHA256"
+
+kubectl -n "$NAMESPACE" exec "deploy/$DEPLOYMENT" -- \
+  python -m scoreboard.purge_private_benchmark \
+    --benchmark "$BENCHMARK" \
+    --expected-export-sha256 "$EXPORT_SHA256" \
+    --yes
+```
+
+The purge locks that exact benchmark, re-reads every submission, and deletes its scores,
+idempotency mappings, and benchmark in one transaction. A new submission changes the digest and
+refuses the purge without deleting anything. It also refuses an unknown/public board or one with a
+baseline. Preserve the export; it contains participant identities and there is no automatic
+re-import.
+
+Repeat export and purge for every private board, then require the preflight to say `SAFE`. Only now
+remove all serving endpoints and start the rollback:
+
+```bash
+kubectl -n "$NAMESPACE" exec "deploy/$DEPLOYMENT" -- \
+  python -m scoreboard.check_rollback_safety
+
+REPLICAS=$(kubectl -n "$NAMESPACE" get deploy "$DEPLOYMENT" \
+  -o jsonpath='{.spec.replicas}')
+kubectl -n "$NAMESPACE" scale deploy "$DEPLOYMENT" --replicas=0
+kubectl -n "$NAMESPACE" wait --for=delete pod -l "$SELECTOR" --timeout=5m
+
+SERVICE=scoreboard-scoreboard
+test -z "$(kubectl -n "$NAMESPACE" get endpoints "$SERVICE" \
+  -o jsonpath='{.subsets[*].addresses[*].ip}')"
+
+helm rollback "$RELEASE" "$TARGET_REVISION" --namespace "$NAMESPACE" --wait
+kubectl -n "$NAMESPACE" scale deploy "$DEPLOYMENT" --replicas="$REPLICAS"
+kubectl -n "$NAMESPACE" rollout status deploy "$DEPLOYMENT" --timeout=5m
+```
+
+Do not continue unless the preflight exits `0`, the pod wait succeeds, and the endpoint assertion
+is empty. `helm rollback` applies the target's stored replica count, so its pods can begin starting
+during that command; the private rows must already be gone before it runs. The explicit final scale
+restores the replica count recorded from the current release.
 
 Re-importing after rolling forward again is manual; there is no tooling for it. That asymmetry is
 deliberate — it should be easier to postpone a rollback than to destroy a challenge in progress.

--- a/apps/scoreboard/src/scoreboard/check_rollback_safety.py
+++ b/apps/scoreboard/src/scoreboard/check_rollback_safety.py
@@ -42,11 +42,11 @@ class PrivateBoard:
 
 
 def running_version() -> str:
-    """The version doing the reporting — which is exactly the rollback floor.
+    """The package version doing the reporting, for diagnostics only.
 
-    WHY this is not a constant: the privacy-aware release did not exist when this was written, so
-    a hardcoded floor would have been a guess that then rotted. This code demonstrably reads
-    ``visibility``, therefore any release below the one shipping it demonstrably does not.
+    INVARIANT (OME-1027): this value is NOT a rollback floor. Both the base image that ignores
+    ``Benchmark.visibility`` and the privacy-aware release package scoreboard 0.1.1. Only the
+    recorded Helm revision plus the immutable runtime image digest identify a safe target.
     """
     try:
         return version("scoreboard")
@@ -76,8 +76,8 @@ def format_verdict(boards: Sequence[PrivateBoard], *, running_version: str) -> s
 
     noun = "benchmark" if len(boards) == 1 else "benchmarks"
     lines = [
-        f"REFUSED: {len(boards)} private {noun} would be published by rolling back below "
-        f"scoreboard {running_version}.",
+        f"REFUSED: {len(boards)} private {noun} would be published by a rollback to "
+        "privacy-blind code.",
         "",
     ]
     width = max(len(board.benchmark_id) for board in boards)
@@ -88,9 +88,12 @@ def format_verdict(boards: Sequence[PrivateBoard], *, running_version: str) -> s
         )
     lines += [
         "",
-        f"This code reads `Benchmark.visibility`; releases below {running_version} do not. A "
-        "rollback leaves `visibility=private` in the database and restores code that serves "
-        "every row unscoped.",
+        f"Package version: {running_version} (diagnostic only; not a rollback floor).",
+        "This code reads `Benchmark.visibility`, but package semver does not identify the release "
+        "that introduced that behavior. A rollback leaves `visibility=private` in the database "
+        "and may restore code that serves every row unscoped.",
+        "",
+        "Record and compare the Helm revision and immutable image digest before rollback.",
         "",
         f"Run the fail-closed procedure in {DEPLOYMENT_DOC} first.",
     ]

--- a/apps/scoreboard/src/scoreboard/export_private_submissions.py
+++ b/apps/scoreboard/src/scoreboard/export_private_submissions.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import sys
 from collections.abc import Sequence
 from typing import Any
 
@@ -56,6 +57,13 @@ def format_jsonl(rows: Sequence[ScoreSchema]) -> str:
     return "\n".join(lines)
 
 
+def format_jsonl_bytes(rows: Sequence[ScoreSchema]) -> bytes:
+    """The exact bytes written by the export CLI and certified by the purge command."""
+    output = format_jsonl(rows)
+    # INVARIANT: every non-empty JSONL export ends in one newline; an empty export is zero bytes.
+    return f"{output}\n".encode() if output else b""
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Export every submission on a benchmark, including private boards.",
@@ -68,11 +76,11 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-async def _run(benchmark_id: str) -> str:
+async def _run(benchmark_id: str) -> bytes:
     settings = Settings()
     await init_db(settings.database_url)
     try:
-        return format_jsonl(await collect_submissions(benchmark_id))
+        return format_jsonl_bytes(await collect_submissions(benchmark_id))
     finally:
         await close_db()
 
@@ -85,8 +93,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     except LookupError as exc:
         parser.error(str(exc))
     else:
-        if output:
-            print(output)
+        sys.stdout.buffer.write(output)
 
 
 if __name__ == "__main__":

--- a/apps/scoreboard/src/scoreboard/purge_private_benchmark.py
+++ b/apps/scoreboard/src/scoreboard/purge_private_benchmark.py
@@ -1,0 +1,181 @@
+"""Export-verified deletion for the exceptional private-board rollback path (OME-1027).
+
+This is intentionally a database-only operator command, not an HTTP endpoint. It removes one
+exact private benchmark only after the rows still in the database hash to the operator's saved
+JSONL export. The lock, comparison, and deletes share one transaction, so a mismatch or failure
+leaves every row intact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import hmac
+import re
+from collections.abc import Sequence
+
+from tortoise import BaseDBAsyncClient
+from tortoise.transactions import in_transaction
+
+from .config import Settings
+from .db import close_db, init_db
+from .export_private_submissions import format_jsonl
+from .scores.models import Baseline, Benchmark, Score
+from .scores.schemas import ScoreSchema
+from .scores.store import ScoreStore
+
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+
+
+class PurgeRefused(RuntimeError):
+    """The requested purge did not satisfy every fail-closed precondition."""
+
+
+def export_sha256(rows: Sequence[ScoreSchema]) -> str:
+    """SHA-256 of the exact bytes emitted by ``export_private_submissions``.
+
+    The exporter uses ``print`` for a non-empty result, which adds one trailing newline. An empty
+    export prints nothing and therefore hashes as zero bytes.
+    """
+    output = format_jsonl(rows)
+    payload = f"{output}\n".encode() if output else b""
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _validated_digest(value: str) -> str:
+    digest = value.strip().lower()
+    if _SHA256.fullmatch(digest) is None:
+        raise PurgeRefused("expected export sha256 must be exactly 64 hexadecimal characters")
+    return digest
+
+
+async def _delete_benchmark(connection: BaseDBAsyncClient, benchmark_id: str) -> None:
+    """Delete and verify the one locked benchmark; split out for rollback-path testing."""
+    deleted = await Benchmark.filter(id=benchmark_id).using_db(connection).delete()
+    if deleted != 1:
+        raise PurgeRefused(
+            f"expected to delete exactly one private benchmark {benchmark_id!r}; deleted {deleted}"
+        )
+    if await Benchmark.filter(id=benchmark_id).using_db(connection).exists():
+        raise PurgeRefused(f"benchmark {benchmark_id!r} still exists after deletion")
+
+
+async def _revalidate_visibility_for_purge(
+    connection: BaseDBAsyncClient,
+    benchmark_id: str,
+) -> None:
+    """Lock the named board and prove it is private immediately before digesting it."""
+    benchmark = await (
+        Benchmark.filter(id=benchmark_id).using_db(connection).select_for_update().first()
+    )
+    if benchmark is None:
+        raise LookupError(f"unknown benchmark_id: {benchmark_id!r}")
+    if benchmark.visibility != "private":
+        raise PurgeRefused(f"benchmark {benchmark_id!r} is not private")
+
+
+async def purge_private_benchmark(
+    benchmark_id: str,
+    expected_export_sha256: str,
+    *,
+    confirmed: bool,
+) -> str:
+    """Verify one private board against its export, and optionally delete it atomically."""
+    expected_digest = _validated_digest(expected_export_sha256)
+
+    async with in_transaction() as connection:
+        # ScoreStore.submit() takes the same row lock before inserting. Once this lock is held,
+        # the digest cannot become stale between comparison and deletion on PostgreSQL.
+        await _revalidate_visibility_for_purge(connection, benchmark_id)
+
+        baseline_count = await (
+            Baseline.filter(benchmark_id=benchmark_id).using_db(connection).count()
+        )
+        if baseline_count:
+            noun = "baseline" if baseline_count == 1 else "baselines"
+            raise PurgeRefused(
+                f"benchmark {benchmark_id!r} has {baseline_count} {noun}; nothing was purged"
+            )
+
+        rows = await ScoreStore().list_all_for_benchmark(benchmark_id, using_db=connection)
+        actual_digest = export_sha256(rows)
+        if not hmac.compare_digest(actual_digest, expected_digest):
+            raise PurgeRefused(
+                f"database sha256 {actual_digest} does not match saved export sha256 "
+                f"{expected_digest}; nothing was purged"
+            )
+
+        submission_count = len(rows)
+        if not confirmed:
+            return (
+                f"would purge {benchmark_id!r}: {submission_count} submissions match export "
+                f"sha256 {actual_digest}; re-run with --yes to delete"
+            )
+
+        # Tortoise's delete count includes database-cascaded IdempotencyKey rows on SQLite, so it
+        # cannot be compared to the Score count. Verify the exact filtered set is empty instead.
+        await Score.filter(benchmark_id=benchmark_id).using_db(connection).delete()
+        if await Score.filter(benchmark_id=benchmark_id).using_db(connection).exists():
+            raise PurgeRefused(f"submissions remain on benchmark {benchmark_id!r} after deletion")
+
+        await _delete_benchmark(connection, benchmark_id)
+
+    return (
+        f"purged {benchmark_id!r}: {submission_count} submissions matched export sha256 "
+        f"{actual_digest}"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify one private benchmark against a saved JSONL export, then optionally purge it."
+        ),
+    )
+    parser.add_argument("--benchmark", required=True, help="Exact private benchmark id to purge.")
+    parser.add_argument(
+        "--expected-export-sha256",
+        required=True,
+        help="SHA-256 of the file emitted by export_private_submissions.",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Delete after verification. Without this flag the command is a dry run.",
+    )
+    return parser
+
+
+async def _run(benchmark_id: str, expected_export_sha256: str, *, confirmed: bool) -> str:
+    settings = Settings()
+    await init_db(settings.database_url)
+    try:
+        return await purge_private_benchmark(
+            benchmark_id,
+            expected_export_sha256,
+            confirmed=confirmed,
+        )
+    finally:
+        await close_db()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        outcome = asyncio.run(
+            _run(
+                args.benchmark,
+                args.expected_export_sha256,
+                confirmed=args.yes,
+            )
+        )
+    except (LookupError, PurgeRefused) as exc:
+        parser.error(str(exc))
+    else:
+        print(outcome)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/scoreboard/src/scoreboard/purge_private_benchmark.py
+++ b/apps/scoreboard/src/scoreboard/purge_private_benchmark.py
@@ -16,11 +16,12 @@ import re
 from collections.abc import Sequence
 
 from tortoise import BaseDBAsyncClient
+from tortoise.queryset import QuerySet
 from tortoise.transactions import in_transaction
 
 from .config import Settings
 from .db import close_db, init_db
-from .export_private_submissions import format_jsonl
+from .export_private_submissions import format_jsonl_bytes
 from .scores.models import Baseline, Benchmark, Score
 from .scores.schemas import ScoreSchema
 from .scores.store import ScoreStore
@@ -33,14 +34,8 @@ class PurgeRefused(RuntimeError):
 
 
 def export_sha256(rows: Sequence[ScoreSchema]) -> str:
-    """SHA-256 of the exact bytes emitted by ``export_private_submissions``.
-
-    The exporter uses ``print`` for a non-empty result, which adds one trailing newline. An empty
-    export prints nothing and therefore hashes as zero bytes.
-    """
-    output = format_jsonl(rows)
-    payload = f"{output}\n".encode() if output else b""
-    return hashlib.sha256(payload).hexdigest()
+    """SHA-256 of the exact bytes emitted by ``export_private_submissions``."""
+    return hashlib.sha256(format_jsonl_bytes(rows)).hexdigest()
 
 
 def _validated_digest(value: str) -> str:
@@ -61,14 +56,21 @@ async def _delete_benchmark(connection: BaseDBAsyncClient, benchmark_id: str) ->
         raise PurgeRefused(f"benchmark {benchmark_id!r} still exists after deletion")
 
 
+def _purge_visibility_query(
+    connection: BaseDBAsyncClient,
+    benchmark_id: str,
+) -> QuerySet[Benchmark]:
+    """The exact locking query used by the purge, exposed for asyncpg SQL rendering."""
+    # INVARIANT: share the already-guarded model projection; a values projection drops FOR UPDATE.
+    return ScoreStore().visibility_query(benchmark_id, connection=connection, lock=True)
+
+
 async def _revalidate_visibility_for_purge(
     connection: BaseDBAsyncClient,
     benchmark_id: str,
 ) -> None:
     """Lock the named board and prove it is private immediately before digesting it."""
-    benchmark = await (
-        Benchmark.filter(id=benchmark_id).using_db(connection).select_for_update().first()
-    )
+    benchmark = await _purge_visibility_query(connection, benchmark_id).first()
     if benchmark is None:
         raise LookupError(f"unknown benchmark_id: {benchmark_id!r}")
     if benchmark.visibility != "private":

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from pypika_tortoise.analytics import RowNumber
 from pypika_tortoise.enums import Order
 from pypika_tortoise.queries import Query, QueryBuilder
-from tortoise import Tortoise
+from tortoise import BaseDBAsyncClient, Tortoise
 from tortoise.exceptions import FieldError, IntegrityError
 from tortoise.expressions import Q
 from tortoise.query_api import execute_pypika
@@ -1214,13 +1214,20 @@ class ScoreStore:
             for row in rows
         ]
 
-    async def list_all_for_benchmark(self, benchmark_id: str) -> list[ScoreSchema]:
+    async def list_all_for_benchmark(
+        self,
+        benchmark_id: str,
+        *,
+        using_db: BaseDBAsyncClient | None = None,
+    ) -> list[ScoreSchema]:
         """Every Score row for a benchmark, chronologically — unlike `leaderboard()`
         (best-per-spec only), this is what OME-323's frontier trend needs: the full
         submission history across all specs, deliberately benchmark-wide (spec §6's
         frontier-scope resolution).
         """
-        rows = await Score.filter(benchmark_id=benchmark_id).order_by("submitted_at")
+        rows = await (
+            Score.filter(benchmark_id=benchmark_id).using_db(using_db).order_by("submitted_at")
+        )
         return [_score_to_schema(score) for score in rows]
 
     async def mark_verified(self, score_id: UUID | str) -> None:

--- a/apps/scoreboard/tests/unit/guards/test_visibility_exit_guard.py
+++ b/apps/scoreboard/tests/unit/guards/test_visibility_exit_guard.py
@@ -59,6 +59,11 @@ pytestmark = pytest.mark.anyio
 # authorise, and a board flipped a second after it runs is caught by the next run. Revalidating
 # would only narrow a window that has nothing on the other side of it.
 #   check_rollback_safety.private_boards / format_verdict / running_version
+#
+# QUERY BUILDER — returns an unevaluated locking query, not visibility data or a decision. Its
+# caller awaits the query and refuses immediately unless the freshly locked row is private; the
+# PostgreSQL SQL assertion below separately proves that this exact query retains `FOR UPDATE`.
+#   purge_private_benchmark._purge_visibility_query
 EXPECTED_UNGUARDED: dict[tuple[str, str], int] = {
     ("leaderboard.py::_private_leaderboard", "Return"): 1,
     ("leaderboard.py::get_leaderboard", "Return"): 1,
@@ -82,6 +87,7 @@ EXPECTED_UNGUARDED: dict[tuple[str, str], int] = {
     ("check_rollback_safety.py::private_boards", "Return"): 1,
     ("check_rollback_safety.py::format_verdict", "Return"): 2,
     ("check_rollback_safety.py::running_version", "Return"): 2,
+    ("purge_private_benchmark.py::_purge_visibility_query", "Return"): 1,
 }
 
 
@@ -277,15 +283,15 @@ def test_a_baseline_publishes_nothing_participant_derived() -> None:
         )
 
 
-# --- the persist path really takes the PostgreSQL row lock ------------------------------------
+# --- the persist and purge paths really take the PostgreSQL row lock ---------------------------
 
 
-async def test_the_persist_path_really_locks_the_row() -> None:
-    """`_revalidate_visibility(lock=True)` must emit `FOR UPDATE` on PostgreSQL.
+async def test_the_persist_and_purge_paths_really_lock_the_row() -> None:
+    """Both production visibility-lock paths must emit `FOR UPDATE` on PostgreSQL.
 
-    INVARIANT: the lock is the only thing that CLOSES the flip window on the persist path —
-    revalidation alone narrows it to the commit interval. SQLite does not implement the lock, so no
-    behavioural test can hold this; rendering the SQL can, and does.
+    INVARIANT: the lock is the only thing that CLOSES the flip window on the persist and purge paths
+    — revalidation alone narrows it to the commit interval. SQLite does not implement the lock, so
+    no behavioural test can hold this; rendering the SQL can, and does.
 
     WHY this test exists at all: the first version of that code called `select_for_update()` and
     then `values_list()`. The former sets lock state on the QuerySet; the latter builds a fresh
@@ -295,6 +301,7 @@ async def test_the_persist_path_really_locks_the_row() -> None:
     """
     from tortoise import Tortoise
 
+    from scoreboard.purge_private_benchmark import _purge_visibility_query
     from scoreboard.scores.models import Benchmark
     from scoreboard.scores.store import ScoreStore
 
@@ -312,6 +319,9 @@ async def test_the_persist_path_really_locks_the_row() -> None:
         # strip the lock — `.select_for_update().only(...)` and `.first()` both preserve it, while
         # `.values()` and `.values_list()` are the two that drop it.
         locked = store.visibility_query("any-benchmark", lock=True).sql()
+        purge_locked = _purge_visibility_query(
+            Tortoise.get_connection("default"), "any-benchmark"
+        ).sql()
         unlocked = store.visibility_query("any-benchmark").sql()
         projected = (
             Benchmark.filter(id="any-benchmark")
@@ -323,6 +333,9 @@ async def test_the_persist_path_really_locks_the_row() -> None:
         await Tortoise.close_connections()
 
     assert "FOR UPDATE" in locked.upper(), f"the locking revalidation query lost its lock: {locked}"
+    assert "FOR UPDATE" in purge_locked.upper(), (
+        f"the private-board purge query lost its lock: {purge_locked}"
+    )
     assert "FOR UPDATE" not in unlocked.upper(), (
         "the read-only revalidation must NOT lock — it runs on every dedup hit"
     )

--- a/apps/scoreboard/tests/unit/test_check_rollback_safety.py
+++ b/apps/scoreboard/tests/unit/test_check_rollback_safety.py
@@ -96,16 +96,18 @@ async def test_an_empty_private_board_is_still_refused(tortoise_db: None) -> Non
     assert "0 submissions" in format_verdict(boards, running_version="0.1.1")
 
 
-def test_the_verdict_names_the_version_that_must_not_be_rolled_below() -> None:
-    # The floor is not a constant this module can hardcode: the privacy-aware release did not
-    # exist when it was written. What IS knowable at runtime is the version doing the reporting,
-    # and that is exactly the floor — this code reads `visibility`, so anything below it may not.
+def test_the_verdict_does_not_treat_package_version_as_the_rollback_floor() -> None:
+    # INVARIANT (OME-1027): privacy-aware and privacy-blind images both package version 0.1.1.
+    # Package semver is useful diagnostics but cannot identify the safe Helm revision or immutable
+    # image digest, so presenting it as the floor gives an operator false confidence.
     verdict = format_verdict(
         [PrivateBoard(benchmark_id="secret", display_name="Secret", submissions=3)],
         running_version="9.9.9",
     )
 
-    assert "9.9.9" in verdict
+    assert "Package version: 9.9.9 (diagnostic only; not a rollback floor)." in verdict
+    assert "Helm revision and immutable image digest" in verdict
+    assert "releases below 9.9.9" not in verdict
     assert "secret" in verdict
 
 

--- a/apps/scoreboard/tests/unit/test_check_rollback_safety.py
+++ b/apps/scoreboard/tests/unit/test_check_rollback_safety.py
@@ -33,6 +33,7 @@ def _submission(benchmark_id: str, spec_id: str) -> ScoreSubmission:
         total_questions=100,
         correct_questions=50,
         ran_with_providers=["openai"],
+        run_cost_usd="1.000000",
     )
 
 

--- a/apps/scoreboard/tests/unit/test_check_rollback_safety.py
+++ b/apps/scoreboard/tests/unit/test_check_rollback_safety.py
@@ -14,6 +14,8 @@ keeps it honest (review of PR #719).
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 from scoreboard.check_rollback_safety import PrivateBoard, format_verdict, private_boards
@@ -33,7 +35,7 @@ def _submission(benchmark_id: str, spec_id: str) -> ScoreSubmission:
         total_questions=100,
         correct_questions=50,
         ran_with_providers=["openai"],
-        run_cost_usd="1.000000",
+        run_cost_usd=Decimal("1.000000"),
     )
 
 

--- a/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
@@ -38,6 +38,7 @@ def _submission(spec_id: str) -> ScoreSubmission:
         total_questions=100,
         correct_questions=80,
         ran_with_providers=["openai"],
+        run_cost_usd="1.000000",
     )
 
 

--- a/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
@@ -1,0 +1,209 @@
+"""Fail-closed proof for the exceptional private-board purge (OME-1027).
+
+The rollback procedure may destroy private submissions only when the operator proves that the
+exact rows being deleted already exist in a staff-only export. Any ambiguity or concurrent change
+must leave the benchmark and every dependent row untouched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from scoreboard import purge_private_benchmark as purge_module
+from scoreboard.export_private_submissions import collect_submissions, format_jsonl
+from scoreboard.purge_private_benchmark import (
+    PurgeRefused,
+    export_sha256,
+    purge_private_benchmark,
+)
+from scoreboard.scores.baseline_store import BaselineStore
+from scoreboard.scores.models import Benchmark, IdempotencyKey, Score
+from scoreboard.scores.schemas import BaselineImportRow, ScoreSubmission
+from scoreboard.scores.store import ScoreStore
+
+pytestmark = pytest.mark.asyncio
+
+BENCHMARK = "healthbench-worst30"
+
+
+def _submission(spec_id: str) -> ScoreSubmission:
+    return ScoreSubmission(
+        benchmark_id=BENCHMARK,
+        spec_id=spec_id,
+        url4_expression=f"url4://{BENCHMARK}/{spec_id}",
+        submitted_by="reviewer@example.test",
+        score=0.8,
+        total_questions=100,
+        correct_questions=80,
+        ran_with_providers=["openai"],
+    )
+
+
+async def _seed_private(*, submissions: int = 2) -> None:
+    store = ScoreStore()
+    await store.register_benchmark(
+        benchmark_id=BENCHMARK,
+        display_name="HealthBench Worst 30",
+        visibility="private",
+    )
+    for index in range(submissions):
+        await store.submit(
+            _submission(f"spec-{index}"),
+            idempotency_key=f"purge-test-{index}",
+            identity_verified=True,
+        )
+
+
+async def _current_digest() -> str:
+    return export_sha256(await collect_submissions(BENCHMARK))
+
+
+async def test_export_digest_matches_the_exact_cli_bytes(tortoise_db: None) -> None:
+    await _seed_private(submissions=1)
+    rows = await collect_submissions(BENCHMARK)
+
+    cli_bytes = f"{format_jsonl(rows)}\n".encode()
+
+    assert export_sha256(rows) == hashlib.sha256(cli_bytes).hexdigest()
+
+
+async def test_dry_run_preserves_a_matching_private_export(tortoise_db: None) -> None:
+    await _seed_private()
+    digest = await _current_digest()
+
+    outcome = await purge_private_benchmark(BENCHMARK, digest, confirmed=False)
+
+    assert outcome == (
+        f"would purge {BENCHMARK!r}: 2 submissions match export sha256 {digest}; "
+        "re-run with --yes to delete"
+    )
+    assert await Benchmark.exists(id=BENCHMARK)
+    assert await Score.filter(benchmark_id=BENCHMARK).count() == 2
+
+
+async def test_a_malformed_digest_refuses_before_deleting_anything(tortoise_db: None) -> None:
+    await _seed_private(submissions=1)
+
+    with pytest.raises(PurgeRefused, match="exactly 64 hexadecimal"):
+        await purge_private_benchmark(BENCHMARK, "not-a-sha256", confirmed=True)
+
+    assert await Benchmark.exists(id=BENCHMARK)
+    assert await Score.filter(benchmark_id=BENCHMARK).count() == 1
+
+
+async def test_a_stale_export_refuses_without_deleting_anything(tortoise_db: None) -> None:
+    await _seed_private(submissions=1)
+    stale_digest = await _current_digest()
+    await ScoreStore().submit(
+        _submission("arrived-later"),
+        idempotency_key="arrived-later",
+        identity_verified=True,
+    )
+
+    with pytest.raises(PurgeRefused, match="does not match"):
+        await purge_private_benchmark(BENCHMARK, stale_digest, confirmed=True)
+
+    assert await Benchmark.exists(id=BENCHMARK)
+    assert await Score.filter(benchmark_id=BENCHMARK).count() == 2
+
+
+async def test_a_public_benchmark_is_never_purged(tortoise_db: None) -> None:
+    await ScoreStore().register_benchmark(
+        benchmark_id=BENCHMARK,
+        display_name="Public",
+        visibility="public",
+    )
+
+    with pytest.raises(PurgeRefused, match="not private"):
+        await purge_private_benchmark(BENCHMARK, hashlib.sha256(b"").hexdigest(), confirmed=True)
+
+    assert await Benchmark.exists(id=BENCHMARK)
+
+
+async def test_an_unknown_benchmark_is_not_an_empty_private_board(tortoise_db: None) -> None:
+    with pytest.raises(LookupError, match="unknown benchmark_id"):
+        await purge_private_benchmark(BENCHMARK, hashlib.sha256(b"").hexdigest(), confirmed=True)
+
+
+async def test_a_private_benchmark_with_a_baseline_is_never_purged(tortoise_db: None) -> None:
+    await _seed_private(submissions=0)
+    await BaselineStore().import_baseline(
+        BaselineImportRow(
+            benchmark_id=BENCHMARK,
+            model_name="reference-model",
+            score=0.7,
+            source="operator",
+        )
+    )
+
+    with pytest.raises(PurgeRefused, match="1 baseline"):
+        await purge_private_benchmark(
+            BENCHMARK,
+            hashlib.sha256(b"").hexdigest(),
+            confirmed=True,
+        )
+
+    assert await Benchmark.exists(id=BENCHMARK)
+
+
+async def test_confirmed_matching_export_deletes_scores_and_idempotency_keys(
+    tortoise_db: None,
+) -> None:
+    await _seed_private()
+    digest = await _current_digest()
+
+    outcome = await purge_private_benchmark(BENCHMARK, digest, confirmed=True)
+
+    assert outcome == f"purged {BENCHMARK!r}: 2 submissions matched export sha256 {digest}"
+    assert not await Benchmark.exists(id=BENCHMARK)
+    assert await Score.filter(benchmark_id=BENCHMARK).count() == 0
+    assert await IdempotencyKey.all().count() == 0
+
+
+async def test_an_empty_private_benchmark_can_clear_the_preflight(tortoise_db: None) -> None:
+    await _seed_private(submissions=0)
+
+    outcome = await purge_private_benchmark(
+        BENCHMARK,
+        hashlib.sha256(b"").hexdigest(),
+        confirmed=True,
+    )
+
+    assert "0 submissions" in outcome
+    assert not await Benchmark.exists(id=BENCHMARK)
+
+
+async def test_only_the_exact_named_private_benchmark_is_purged(tortoise_db: None) -> None:
+    await _seed_private(submissions=1)
+    await ScoreStore().register_benchmark(
+        benchmark_id=f"{BENCHMARK}-copy",
+        display_name="Copy",
+        visibility="private",
+    )
+
+    await purge_private_benchmark(BENCHMARK, await _current_digest(), confirmed=True)
+
+    assert not await Benchmark.exists(id=BENCHMARK)
+    assert await Benchmark.exists(id=f"{BENCHMARK}-copy")
+
+
+async def test_a_final_delete_failure_rolls_the_transaction_back(
+    tortoise_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _seed_private()
+    digest = await _current_digest()
+
+    async def _fail_to_delete_benchmark(*args: object, **kwargs: object) -> None:
+        raise PurgeRefused("simulated final delete failure")
+
+    monkeypatch.setattr(purge_module, "_delete_benchmark", _fail_to_delete_benchmark)
+
+    with pytest.raises(PurgeRefused, match="simulated final delete failure"):
+        await purge_private_benchmark(BENCHMARK, digest, confirmed=True)
+
+    assert await Benchmark.exists(id=BENCHMARK)
+    assert await Score.filter(benchmark_id=BENCHMARK).count() == 2
+    assert await IdempotencyKey.all().count() == 2

--- a/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 import pytest
 
 from scoreboard import purge_private_benchmark as purge_module
-from scoreboard.export_private_submissions import collect_submissions, format_jsonl
+from scoreboard.export_private_submissions import collect_submissions, format_jsonl_bytes
 from scoreboard.purge_private_benchmark import (
     PurgeRefused,
     export_sha256,
@@ -66,9 +66,17 @@ async def test_export_digest_matches_the_exact_cli_bytes(tortoise_db: None) -> N
     await _seed_private(submissions=1)
     rows = await collect_submissions(BENCHMARK)
 
-    cli_bytes = f"{format_jsonl(rows)}\n".encode()
+    cli_bytes = format_jsonl_bytes(rows)
 
+    assert cli_bytes.endswith(b"\n")
     assert export_sha256(rows) == hashlib.sha256(cli_bytes).hexdigest()
+
+
+async def test_an_empty_export_digest_matches_empty_cli_output() -> None:
+    cli_bytes = format_jsonl_bytes([])
+
+    assert cli_bytes == b""
+    assert export_sha256([]) == hashlib.sha256(cli_bytes).hexdigest()
 
 
 async def test_dry_run_preserves_a_matching_private_export(tortoise_db: None) -> None:

--- a/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_purge_private_benchmark.py
@@ -8,6 +8,7 @@ must leave the benchmark and every dependent row untouched.
 from __future__ import annotations
 
 import hashlib
+from decimal import Decimal
 
 import pytest
 
@@ -38,7 +39,7 @@ def _submission(spec_id: str) -> ScoreSubmission:
         total_questions=100,
         correct_questions=80,
         ran_with_providers=["openai"],
-        run_cost_usd="1.000000",
+        run_cost_usd=Decimal("1.000000"),
     )
 
 

--- a/docs/plan/2026-09-04-OME-1027-rollback-floor.md
+++ b/docs/plan/2026-09-04-OME-1027-rollback-floor.md
@@ -1,0 +1,33 @@
+# OME-1027 — Implementation plan
+
+## Frame
+
+Replace the misleading semver floor, provide an export-certified private-board purge, and turn the
+fallback runbook into an exact sequence that verifies both data removal and zero serving endpoints.
+
+## Changes
+
+1. Add task, spec, plan, and work-ledger artifacts.
+2. RED: add a new purge test module covering dry-run, confirmation, exact digest, public/unknown
+   refusal, baseline refusal, exact targeting, and rollback-on-failure behavior.
+3. RED: update the existing verdict test that asserts the now-rejected semver-floor claim. This is
+   the one prior-test exception explicitly approved by the owner on 2026-09-04 when approving the
+   switch from semver to immutable release identity.
+4. GREEN: add `scoreboard.purge_private_benchmark`, sharing the existing export serialization and
+   using one Tortoise transaction with a locked benchmark row.
+5. Allow the existing full-history score reader to use an explicit transaction connection; no
+   model or schema change is involved.
+6. Rewrite `DEPLOYMENT.md` with exact Helm/image evidence, export/digest/purge commands, the `SAFE`
+   check, pod termination wait, endpoint assertion, rollback, and replica restoration.
+7. Run focused tests, the full Scoreboard suite, and `run_gates.py scoreboard` with the documented
+   append-only exception.
+8. Complete the ledger, commit with `Refs: OME-1027`, push, and open a PR. Leave Linear In Progress
+   until production evidence satisfies the operational closure gate.
+
+## Wisdom check
+
+- A generic database shell or pasted SQL would be smaller in lines but not safer: it cannot prove
+  which exported bytes correspond to the rows being destroyed.
+- A Helm hook cannot guard a rollback to an old manifest.
+- A bulk purge increases blast radius without helping the one-board emergency procedure.
+- No migration is needed because the database schema is unchanged.

--- a/docs/spec/2026-09-04-OME-1027-rollback-floor.md
+++ b/docs/spec/2026-09-04-OME-1027-rollback-floor.md
@@ -1,0 +1,88 @@
+# OME-1027 — Privacy-aware rollback floor
+
+## Problem
+
+Private-board privacy is enforced by application code while the database retains the private rows.
+Rolling back to privacy-blind code publishes them. The current preflight correctly detects private
+boards, but incorrectly describes package semver as the floor; both privacy-aware and privacy-blind
+images package version `0.1.1`. Its fallback runbook also names deletion without providing an
+executable, export-verified path.
+
+The development catalogue already marks `healthbench-worst30` private. Current anonymous reads
+fail closed, but the rollback/recovery hazard is active now.
+
+## Decisions
+
+### D1 — Release identity is external and immutable
+
+The safe floor is recorded as all three of:
+
+1. the Helm release revision;
+2. the deployed image reference;
+3. the runtime `imageID` digest reported by Kubernetes.
+
+Package semver remains diagnostic output only. The database preflight cannot inspect Helm history
+and must not imply that it can identify a safe target.
+
+### D2 — No Helm hook pretends to guard the rollback
+
+Helm executes the target revision's rollback hooks. A privacy-blind target has no new hook, so the
+gate remains an explicit operator procedure.
+
+### D3 — Destruction requires proof of the exact export
+
+Add `python -m scoreboard.purge_private_benchmark` for the exceptional rollback path. It:
+
+- accepts one exact benchmark id, never a pattern;
+- refuses a public or unknown benchmark;
+- refuses while a baseline references the benchmark;
+- computes the same canonical JSONL bytes as `export_private_submissions`;
+- requires the operator-provided SHA-256 of the saved export;
+- is dry-run by default and deletes only with `--yes`;
+- locks the benchmark and verifies the digest before deleting scores and the benchmark in one
+  transaction;
+- reports exact deletion counts and verifies that the named benchmark is gone.
+
+An export/digest mismatch refuses without deleting anything. The operator re-exports and retries;
+this handles submissions arriving between the first export and the purge.
+
+### D4 — Stop serving only after the private data is safely removed
+
+Export and purge run through the still-privacy-aware pod. Purge locks and re-verifies the exported
+snapshot, so it is safe while that code serves; after the benchmark is deleted, new submissions to
+it cannot persist. The operator then:
+
+1. re-runs the preflight and requires `SAFE`;
+2. scales the deployment to zero;
+3. waits for every selected pod to disappear;
+4. verifies the Service has zero ready endpoint addresses;
+5. rolls back;
+6. restores the recorded replica count.
+
+This ordering avoids the current impossible instruction to `kubectl exec` export/deletion commands
+after all application pods have been removed.
+
+### D5 — Operational evidence cannot be manufactured in code review
+
+The issue is not Done when the PR merges. Closure additionally requires production evidence:
+
+- a privacy-aware release is deployed;
+- `helm history scoreboard` identifies the exact rollback target;
+- every serving pod reports the expected immutable image digest;
+- the preflight has run successfully inside a production pod;
+- the operator records the evidence in Linear.
+
+## Security invariants
+
+- Never make a private board public to clear the preflight.
+- Never delete a row absent a matching export digest.
+- Never roll privacy-blind code into service while any private benchmark remains.
+- Never call a mutable tag or package semver the rollback floor.
+- The destructive command is unavailable through HTTP and has no bulk mode.
+
+## Non-goals
+
+- Automating `helm rollback`.
+- Re-importing purged submissions.
+- Changing benchmark visibility, authentication, or database schema.
+- Executing destructive steps from tests or CI.

--- a/docs/tasks/2026-09-04-OME-1027-rollback-floor.md
+++ b/docs/tasks/2026-09-04-OME-1027-rollback-floor.md
@@ -1,0 +1,25 @@
+---
+id: OME-1027
+linear_url: https://linear.app/openmined/issue/OME-1027/gate-a-privacy-aware-release-must-be-the-rollback-floor-before-any
+status: in_progress
+type: task
+priority: 2
+labels: [scoreboard, human, deferred, task]
+created: 2026-08-27
+closed:
+---
+
+# Gate private-board activation on a privacy-aware rollback floor
+
+Make the emergency rollback procedure executable and fail-closed: identify the rollback floor by
+Helm revision plus immutable image digest, prove an export before deleting private submissions,
+and verify that no private data remains before old code may serve.
+
+The code and runbook can land independently. This issue remains open until an operator records the
+production release evidence and runs the preflight inside that release's pod.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-04-OME-1027-rollback-floor.md`
+- Plan: `docs/plan/2026-09-04-OME-1027-rollback-floor.md`
+- Ledger: `docs/work/2026-09-04-OME-1027-rollback-floor.md`

--- a/docs/work/2026-09-04-OME-1027-rollback-floor.md
+++ b/docs/work/2026-09-04-OME-1027-rollback-floor.md
@@ -1,0 +1,64 @@
+---
+ticket: OME-1027
+stack: scoreboard
+status: done
+started: 2026-09-04
+finished: 2026-09-04
+---
+
+# OME-1027 — Make the private-board rollback floor operational
+
+## Intent
+
+Prevent an emergency rollback from either publishing private submissions or destroying them
+without a verified export. Replace mutable/ambiguous release identity with Helm revision plus image
+digest evidence and provide the exact destructive operation the existing runbook only gestures at.
+
+## Planned changes
+
+- `docs/tasks/2026-09-04-OME-1027-rollback-floor.md` — Linear mirror and closure boundary.
+- `docs/spec/2026-09-04-OME-1027-rollback-floor.md` — threat model and binding decisions.
+- `docs/plan/2026-09-04-OME-1027-rollback-floor.md` — implementation sequence.
+- `apps/scoreboard/src/scoreboard/check_rollback_safety.py` — semver becomes diagnostic only.
+- `apps/scoreboard/src/scoreboard/purge_private_benchmark.py` — export-certified destructive CLI.
+- `apps/scoreboard/src/scoreboard/scores/store.py` — explicit connection for transactional export.
+- `apps/scoreboard/DEPLOYMENT.md` — executable release-floor and fallback procedure.
+- `apps/scoreboard/tests/unit/test_check_rollback_safety.py` — corrected release identity contract.
+- `apps/scoreboard/tests/unit/test_purge_private_benchmark.py` — new destructive-path coverage.
+
+## Test plan
+
+- Prove semver is labelled diagnostic and never described as the floor.
+- Prove a matching export digest is necessary but insufficient without explicit confirmation.
+- Prove mismatch, public board, unknown board, and baseline references refuse without mutation.
+- Prove confirmation deletes exactly the exported private scores, their idempotency mappings, and
+  the named benchmark while preserving neighbours.
+- Prove any failed final deletion rolls the score deletion back.
+- Run full Scoreboard gates including portal tests.
+
+## Acceptance
+
+- The runbook records and compares Helm revision, deployed image, and runtime image digest.
+- Every destructive fallback command is executable and ordered fail-closed.
+- No private data is deleted without a matching saved-export digest and explicit confirmation.
+- The procedure requires `SAFE`, zero pods, and zero endpoint addresses before rollback.
+- Full gates are green; operational production evidence remains an explicit closure requirement.
+
+## Outcome
+
+- **Actual files:** as planned. Added the export-verified purge CLI and its new unit suite; made
+  the full-history reader transaction-aware; corrected the preflight's release-identity language;
+  replaced the incomplete fallback with exact evidence, export, purge, quiescence, endpoint, and
+  restoration commands; committed the task/spec/plan/ledger set.
+- **Commits:** one conventional feature commit on `OME-1027-rollback-floor` (squash target; final
+  merge sha will be recorded in Linear).
+- **Gates:** `run_gates.py scoreboard --base origin/main --skip-append-only` ALL GREEN: ruff lint,
+  ruff format, pyright, Python suite with coverage ≥80, and all three explicitly named Node portal
+  suites. Direct full-suite run: 608 passed before the final two added purge cases; focused final
+  safety run: 26 passed. The final gate includes all 610 Python tests.
+- **Deviations:** the prior test asserting package semver was the rollback floor was corrected
+  under the owner's explicit 2026-09-04 Confidence-Gate approval, so the append-only check was
+  skipped and documented. No database model or migration changed. Production Helm revision/image
+  evidence is intentionally not claimed: this machine has no Scoreboard cluster context, so
+  Linear remains In Progress after the code PR until an operator records that evidence and runs
+  the preflight in a production pod.

--- a/docs/work/2026-09-04-OME-1027-rollback-floor.md
+++ b/docs/work/2026-09-04-OME-1027-rollback-floor.md
@@ -58,7 +58,9 @@ digest evidence and provide the exact destructive operation the existing runbook
   safety run: 26 passed. The final gate includes all 610 Python tests.
 - **Deviations:** the prior test asserting package semver was the rollback floor was corrected
   under the owner's explicit 2026-09-04 Confidence-Gate approval, so the append-only check was
-  skipped and documented. No database model or migration changed. Production Helm revision/image
-  evidence is intentionally not claimed: this machine has no Scoreboard cluster context, so
-  Linear remains In Progress after the code PR until an operator records that evidence and runs
-  the preflight in a production pod.
+  skipped and documented. The two direct-submission fixtures added here include a cost even though
+  it is optional on this branch, so the independently published OME-822 contract PR is safe to
+  merge before or after this one. No database model or migration changed. Production Helm
+  revision/image evidence is intentionally not claimed: this machine has no Scoreboard cluster
+  context, so Linear remains In Progress after the code PR until an operator records that evidence
+  and runs the preflight in a production pod.

--- a/docs/work/2026-09-07-OME-1027-ci-repair.md
+++ b/docs/work/2026-09-07-OME-1027-ci-repair.md
@@ -1,0 +1,53 @@
+---
+ticket: OME-1027
+stack: scoreboard
+status: done
+started: 2026-09-07
+finished: 2026-09-07
+---
+
+# OME-1027 — Repair and refresh PR #840
+
+## Intent
+
+Restore the published rollback-safety PR to a merge-ready state after its compatibility follow-up
+passed a decimal value as a string in two typed `ScoreSubmission` fixtures. Refresh the branch on
+current `origin/main` without changing the rollback contract or claiming the outstanding production
+verification.
+
+## Planned changes
+
+- `apps/scoreboard/tests/unit/test_check_rollback_safety.py` — construct the fixture cost as a
+  `Decimal`.
+- `apps/scoreboard/tests/unit/test_purge_private_benchmark.py` — construct the fixture cost as a
+  `Decimal`.
+- `docs/work/2026-09-07-OME-1027-ci-repair.md` — record the repair, refresh, and verification.
+
+## Test plan
+
+- Reproduce the current Pyright failure for both string-valued fixtures.
+- Run the two affected unit modules after the typed fixture correction.
+- Rebase on current `origin/main` and run the full Scoreboard quality gate.
+
+## Acceptance
+
+- Both fixtures use the public schema's declared `Decimal | None` type.
+- The rollback and purge behavior tests remain unchanged and green.
+- The branch is based on current `origin/main`, all Scoreboard gates pass, and PR #840 is updated.
+- OME-1027 remains operationally open until production release-floor evidence is recorded.
+
+## Outcome
+
+- **Actual files:** the two planned fixture modules now pass `Decimal("1.000000")`; this ledger
+  records the repair. No production source, schema, migration, or public contract changed.
+- **Commits:** `fix(scoreboard): repair rollback cost fixtures` (the remote head is recorded by
+  GitHub when this same ledger-bearing commit updates PR #840).
+- **Gates:** reproduced Pyright's two `reportArgumentType` failures; after the repair, Pyright
+  reported zero errors and the two affected modules passed all 22 tests. After rebasing cleanly on
+  `origin/main` at `cbb85f07`, `run_gates.py scoreboard --base origin/main --skip-append-only`
+  reported ALL GATES GREEN: Ruff lint/format, Pyright, the full Python coverage suite, and all three
+  named portal suites.
+- **Deviations:** the append-only check was skipped under the owner's explicit approval to repair
+  these two existing fixtures. Their behavioral assertions are unchanged. Production Helm
+  revision/image evidence remains outside this workstation and is still required before Linear
+  OME-1027 can close.

--- a/docs/work/2026-09-07-OME-1027-review-followups.md
+++ b/docs/work/2026-09-07-OME-1027-review-followups.md
@@ -1,0 +1,58 @@
+---
+ticket: OME-1027
+stack: scoreboard
+status: done
+started: 2026-09-07
+finished: 2026-09-07
+---
+
+# OME-1027 — Close the rollback purge review follow-ups
+
+## Intent
+
+Make the approved private-board purge easier to trust and harder to regress: render its production
+row-lock query in the existing PostgreSQL guard, and give the private export a single canonical byte
+representation shared by CLI output and purge hashing.
+
+## Planned changes
+
+- `apps/scoreboard/tests/unit/guards/test_visibility_exit_guard.py` — extend the existing asyncpg
+  SQL guard to cover the purge query.
+- `apps/scoreboard/tests/unit/test_purge_private_benchmark.py` — require the digest to consume the
+  exporter's canonical bytes.
+- `apps/scoreboard/src/scoreboard/purge_private_benchmark.py` — expose the exact purge visibility
+  query for guard rendering and hash canonical export bytes.
+- `apps/scoreboard/src/scoreboard/export_private_submissions.py` — define and emit canonical JSONL
+  bytes, including the trailing newline.
+
+## Test plan
+
+- RED: the existing PostgreSQL visibility guard cannot import/render the purge query yet.
+- RED: the exporter does not expose canonical bytes for the digest test yet.
+- GREEN: run the two changed safety modules and the private-export module.
+- Run the complete Scoreboard gate runner against `origin/main`.
+
+## Acceptance
+
+- The exact purge query emits `FOR UPDATE` on the installed asyncpg/Tortoise dialect.
+- The CLI and purge digest consume one shared byte representation, including empty-output behavior.
+- Existing purge refusal, transaction rollback, and export privacy behavior remains green.
+- The full Scoreboard gate passes before commit.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned. The purge now builds its locked benchmark read through a named
+  production query that delegates to `ScoreStore.visibility_query`; the existing asyncpg guard
+  renders that exact query and proves it contains `FOR UPDATE`. The exporter now owns the canonical
+  JSONL bytes, writes those bytes directly, and supplies the same bytes to purge hashing. One empty
+  export boundary test was added.
+- **Commits:** `fix(scoreboard): harden rollback purge invariants` (the remote SHA is recorded by
+  GitHub when this ledger-bearing commit updates PR #840).
+- **Gates:** focused RED checks failed on the two missing seams, then 20 affected safety/export tests
+  passed. `run_gates.py scoreboard --base origin/main --skip-append-only` reported ALL GATES GREEN:
+  Ruff lint/format, Pyright, Python coverage, and all three portal modules. Direct counts: 611 Python
+  tests passed, 3 skipped, 3 deselected; 50 Node portal tests passed.
+- **Deviations:** the append-only precheck was skipped under the owner's explicit 2026-09-07
+  Confidence-Gate approval to extend the existing PostgreSQL lock invariant test. The first full
+  gate run found one Ruff `UP012` spelling issue; removing the redundant UTF-8 argument made the
+  second run green. No public API, dependency, database schema, or migration changed.


### PR DESCRIPTION
## Summary

- replace the misleading package-semver rollback floor with Helm revision, rendered image, and immutable runtime image-digest evidence
- add a dry-run-by-default `purge_private_benchmark` operator CLI that requires a matching canonical export SHA-256 and deletes one exact private board atomically
- make the rollback runbook executable through export, checksum, purge, `SAFE` preflight, zero pods/endpoints, rollback, and replica restoration

## Safety properties

- unknown or public benchmarks refuse
- benchmarks with baselines refuse
- an export mismatch or any failed final delete rolls the whole transaction back
- score ingestion and purge lock the same benchmark row, preventing a new submission between digest verification and deletion on PostgreSQL
- the command is database-only, has no HTTP surface or bulk mode, and requires `--yes` after a successful dry run

## Verification

- `run_gates.py scoreboard --base origin/main --skip-append-only` — all gates green
- Python: 610 passed, 3 skipped, 3 deselected; coverage gate ≥80%
- portal: 50 passed across the three explicit Node suites
- ruff lint/format and pyright clean

The append-only check is skipped under the owner's explicit Confidence-Gate approval because the prior test asserting package semver was the rollback floor had to be corrected; both safe and unsafe images package version `0.1.1`.

## Operational closure

This PR completes the code and runbook portion of OME-1027. The Linear issue should remain In Progress until an operator records the production Helm revision/image digest and runs the preflight inside the production Scoreboard pod. This workstation has no Scoreboard cluster context, so this PR does not claim that evidence.

Refs: OME-1027
