### PR TITLE
feat(scoreboard): require run cost on direct submissions

### DIFF
--- a/apps/scoreboard/DEPLOYMENT.md
+++ b/apps/scoreboard/DEPLOYMENT.md
@@ -170,7 +170,7 @@ Submit a smoke score with an idempotency key. **`benchmark_id` must name a bench
 curl -fsS -X POST http://scoreboard.40.76.107.241.nip.io/v1/scores \
   -H "Content-Type: application/json" \
   -H "Idempotency-Key: score-007-smoke-1" \
-  -d '{"version":1,"benchmark_id":"smoke","spec_id":"score-007-smoke","url4_expression":"url4://smoke","submitted_by":"score-007","score":0.5,"total_questions":2,"ran_with_providers":["smoke"],"client":{"name":"curl","version":"0.1.0","platform":"k3s"}}'
+  -d '{"version":1,"benchmark_id":"smoke","spec_id":"score-007-smoke","url4_expression":"url4://smoke","submitted_by":"score-007","score":0.5,"total_questions":2,"ran_with_providers":["smoke"],"run_cost_usd":"0.000000","client":{"name":"curl","version":"0.1.0","platform":"k3s"}}'
 
 curl -fsS http://scoreboard.40.76.107.241.nip.io/v1/leaderboard/smoke
 ```

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -24,7 +24,7 @@ COST_CEILING = Decimal("999999.999999")
 _ZERO_COST = Decimal("0").quantize(COST_QUANTUM)
 
 
-def _validate_run_cost(value: Decimal | None) -> Decimal | None:
+def _validate_run_cost(value: Decimal) -> Decimal:
     """Reject a cost that cannot be stored; normalize every cost that can.
 
     Only two things are actually unstorable and therefore rejected: a negative or
@@ -45,8 +45,6 @@ def _validate_run_cost(value: Decimal | None) -> Decimal | None:
     Those constraints run BEFORE this validator, so they would reject the very
     values it exists to normalize.
     """
-    if value is None:
-        return None
     # ge=0 on the field already rejects negatives, and NaN fails that comparison,
     # but +Infinity passes it — and quantize() raises InvalidOperation rather than
     # returning a value, so non-finites have to go before any arithmetic.
@@ -324,17 +322,11 @@ class ScoreSubmission(BaseModel):
     # (D-SCORE-006). Persisted onto the flat client_* columns by the store.
     client: ClientInfo | None = None
     metadata: dict[str, Any] | None = None
-    # INVARIANT: absent (None) means "no cost was reported" and is NOT the same as
-    # 0. A fully cache-served run genuinely costing nothing is a legitimate 0, so
-    # OME-770's Pareto frontier must exclude None rather than rank it as the
-    # cheapest entry. Decimal, not float — this is money.
-    #
-    # AIDEV-NOTE: optional only because nothing emits a run cost yet (OME-303 is
-    # unmerged, the Engine does not roll per-call cost into a run total, and the
-    # Client has no field for it), and because the column lands on an already
-    # populated table. Once a client can send it, a direct submission arriving
-    # without one is a client bug and should be REJECTED — null then means
-    # "imported or legacy" only. Tracked on OME-770.
+    # INVARIANT (OME-822): every direct submission reports a cost. A fully
+    # cache-served run genuinely costing nothing is represented by 0; omission or
+    # null is a client bug and is rejected by this non-nullable required field.
+    # Database and read DTOs deliberately remain nullable because imported and
+    # legacy rows can still have no known cost. Decimal, not float — this is money.
     # INVARIANT: the request contract mirrors the column exactly — DECIMAL(12, 6).
     # `ge=0` alone let three failures through, each reproduced live:
     #   0.0000009 -> accepted (201) and silently stored as 0.000001, publishing a
@@ -350,11 +342,11 @@ class ScoreSubmission(BaseModel):
     # requires us to quantize and accept. `ge=0` stays here (it also rejects NaN,
     # which fails the comparison); allow_inf_nan=False stops +Infinity, which
     # would pass ge=0 and then raise inside quantize().
-    run_cost_usd: Decimal | None = Field(default=None, ge=0, allow_inf_nan=False)
+    run_cost_usd: Decimal = Field(ge=0, allow_inf_nan=False)
 
     @field_validator("run_cost_usd")
     @classmethod
-    def validate_run_cost(cls, value: Decimal | None) -> Decimal | None:
+    def validate_run_cost(cls, value: Decimal) -> Decimal:
         return _validate_run_cost(value)
 
     @field_validator("url4_expression")

--- a/apps/scoreboard/tests/unit/scores/test_idempotency_postgres.py
+++ b/apps/scoreboard/tests/unit/scores/test_idempotency_postgres.py
@@ -11,6 +11,7 @@ Runs only when SCOREBOARD_TEST_DATABASE_URL is set; skips otherwise.
 from __future__ import annotations
 
 import os
+from decimal import Decimal
 
 import pytest
 from tortoise import Tortoise
@@ -35,6 +36,7 @@ def _submission(submitted_by: str) -> ScoreSubmission:
         total_questions=100,
         correct_questions=75,
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
     )
 
 

--- a/apps/scoreboard/tests/unit/scores/test_leaderboard_coverage.py
+++ b/apps/scoreboard/tests/unit/scores/test_leaderboard_coverage.py
@@ -12,6 +12,8 @@ submission path works is a supported workflow, and the client already warns them
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 from scoreboard.scores.schemas import ScoreSubmission
@@ -33,6 +35,7 @@ def _submission(spec_id: str, score: float, total_questions: int) -> ScoreSubmis
         score=score,
         total_questions=total_questions,
         ran_with_providers=["openrouter"],
+        run_cost_usd=Decimal("1.000000"),
     )
 
 

--- a/apps/scoreboard/tests/unit/scores/test_schemas.py
+++ b/apps/scoreboard/tests/unit/scores/test_schemas.py
@@ -19,6 +19,7 @@ def _valid_payload() -> dict[str, object]:
         "total_questions": 4,
         "correct_questions": 3,
         "ran_with_providers": ["openai"],
+        "run_cost_usd": "1.25",
     }
 
 
@@ -468,12 +469,11 @@ def test_score_submission_rejects_a_client_supplied_verified_flag(claimed: bool)
         ScoreSubmission.model_validate(payload)
 
 
-# --- OME-770: run cost on a submission ------------------------------------
-# A cost is optional, and its ABSENCE is a distinct state from a zero cost:
-# absent means "we were never told", zero means "this run genuinely cost
-# nothing" (a fully cache-served run — the goal OME-767 is chasing). The
-# Pareto frontier in OME-770 would put an unknown-cost row at the cheapest
-# end if these two ever collapsed together, so the distinction is pinned here.
+# --- OME-770 / OME-822: run cost on a submission ---------------------------
+# Every direct submission reports a cost. Zero means "this run genuinely cost
+# nothing" (a fully cache-served run); omission and null are client errors.
+# Imported and legacy rows retain their distinct unknown-cost state in the
+# nullable database and read DTOs, outside ScoreSubmission.
 
 
 def test_score_submission_accepts_a_run_cost() -> None:
@@ -485,10 +485,16 @@ def test_score_submission_accepts_a_run_cost() -> None:
     assert submission.run_cost_usd == Decimal("12.50")
 
 
-def test_score_submission_without_a_run_cost_is_none_not_zero() -> None:
-    submission = ScoreSubmission.model_validate(_valid_payload())
+@pytest.mark.parametrize("missing", [True, False])
+def test_score_submission_requires_a_non_null_run_cost(missing: bool) -> None:
+    payload = _valid_payload()
+    if missing:
+        payload.pop("run_cost_usd")
+    else:
+        payload["run_cost_usd"] = None
 
-    assert submission.run_cost_usd is None
+    with pytest.raises(ValidationError):
+        ScoreSubmission.model_validate(payload)
 
 
 def test_score_submission_accepts_a_genuinely_zero_run_cost() -> None:

--- a/apps/scoreboard/tests/unit/scores/test_store.py
+++ b/apps/scoreboard/tests/unit/scores/test_store.py
@@ -40,6 +40,7 @@ def _submission(
         total_questions=100,
         correct_questions=correct_questions,
         ran_with_providers=providers or ["openai"],
+        run_cost_usd=Decimal("1.000000"),
         ran_at_local=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
         client=ClientInfo(name="scoreboard-test", version="0.1.0", platform="test"),
         metadata={"source": "unit"},
@@ -477,6 +478,7 @@ def _revision_submission(
         total_questions=100,
         correct_questions=75,
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
         benchmark_revision=benchmark_revision,
         metadata=metadata,
     )
@@ -653,6 +655,7 @@ async def test_leaderboard_still_collapses_within_one_revision(tortoise_db: None
             total_questions=100,
             correct_questions=60,
             ran_with_providers=["openai"],
+            run_cost_usd=Decimal("1.000000"),
             benchmark_revision="rev-same",
         )
     )
@@ -665,6 +668,7 @@ async def test_leaderboard_still_collapses_within_one_revision(tortoise_db: None
             total_questions=100,
             correct_questions=90,
             ran_with_providers=["openai"],
+            run_cost_usd=Decimal("1.000000"),
             benchmark_revision="rev-same",
         )
     )
@@ -905,7 +909,9 @@ async def test_run_cost_persists_and_reads_back_on_the_leaderboard(tortoise_db: 
     assert entries[0].run_cost_usd == Decimal("3.500000")
 
 
-async def test_a_submission_without_a_cost_reads_back_none_not_zero(tortoise_db: None) -> None:
+async def test_a_legacy_submission_without_a_cost_reads_back_none_not_zero(
+    tortoise_db: None,
+) -> None:
     """INVARIANT: unreported cost must stay distinguishable from a free run.
 
     OME-770's Pareto frontier would rank an unknown-cost entry as the cheapest
@@ -914,7 +920,8 @@ async def test_a_submission_without_a_cost_reads_back_none_not_zero(tortoise_db:
     await Benchmark.create(id="hle", display_name="HLE")
     store = ScoreStore()
 
-    await store.submit(_submission(spec_id="uncosted"))
+    legacy = _submission(spec_id="uncosted").model_copy(update={"run_cost_usd": None})
+    await store.submit(legacy)
     entries = await store.leaderboard("hle")
 
     assert entries[0].run_cost_usd is None
@@ -1124,6 +1131,7 @@ def _owned_submission(
         total_questions=100,
         correct_questions=int(score * 100),
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
         benchmark_revision=benchmark_revision,
     )
 
@@ -1181,6 +1189,7 @@ def _same_recipe(submitted_by: str) -> ScoreSubmission:
         total_questions=100,
         correct_questions=80,
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
     )
 
 
@@ -1354,6 +1363,7 @@ async def test_owned_rows_include_every_submission_for_one_spec(tortoise_db: Non
                 total_questions=100,
                 correct_questions=int(score * 100),
                 ran_with_providers=["openai"],
+                run_cost_usd=Decimal("1.000000"),
                 benchmark_revision="rev-1",
             ),
             identity_verified=True,

--- a/apps/scoreboard/tests/unit/test_benchmark_native_scores.py
+++ b/apps/scoreboard/tests/unit/test_benchmark_native_scores.py
@@ -49,6 +49,7 @@ def _native_payload(benchmark_id: str, score: float, **overrides: Any) -> dict[s
         "score": score,
         "total_questions": 10,
         "ran_with_providers": ["openrouter"],
+        "run_cost_usd": "2.500000",
         "ran_at_local": "2026-08-18T09:00:00+00:00",
         "client": {"name": "screamingface", "version": "0.3.0", "platform": "darwin"},
         "metadata": {"benchmark_revision": "rev-1", "run_id": "run-native"},

--- a/apps/scoreboard/tests/unit/test_check_rollback_safety.py
+++ b/apps/scoreboard/tests/unit/test_check_rollback_safety.py
@@ -14,6 +14,8 @@ keeps it honest (review of PR #719).
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 from scoreboard.check_rollback_safety import PrivateBoard, format_verdict, private_boards
@@ -33,6 +35,7 @@ def _submission(benchmark_id: str, spec_id: str) -> ScoreSubmission:
         total_questions=100,
         correct_questions=50,
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
     )
 
 

--- a/apps/scoreboard/tests/unit/test_export_private_submissions.py
+++ b/apps/scoreboard/tests/unit/test_export_private_submissions.py
@@ -9,6 +9,7 @@ expose. That also means this path must work when the API cannot help — it does
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 
 import pytest
 
@@ -33,6 +34,7 @@ def _submission(*, submitted_by: str, spec_id: str, score: float) -> ScoreSubmis
         total_questions=100,
         correct_questions=int(score * 100),
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
     )
 
 
@@ -96,6 +98,7 @@ async def test_a_public_benchmark_can_also_be_exported(tortoise_db: None) -> Non
             total_questions=100,
             correct_questions=50,
             ran_with_providers=["openai"],
+            run_cost_usd=Decimal("1.000000"),
         )
     )
 

--- a/apps/scoreboard/tests/unit/test_leaderboard_routes.py
+++ b/apps/scoreboard/tests/unit/test_leaderboard_routes.py
@@ -45,6 +45,7 @@ def _submission(
         total_questions=total_questions,
         correct_questions=correct_questions,
         ran_with_providers=providers or ["openai"],
+        run_cost_usd=Decimal("1.000000"),
         ran_at_local=datetime(2026, 5, 21, 12, 0, tzinfo=UTC),
         client=ClientInfo(name="scoreboard-test", version="0.1.0", platform="test"),
         metadata={"source": "unit"},
@@ -477,12 +478,12 @@ async def test_get_spec_history_includes_the_run_cost(
     assert Decimal(returned) == Decimal("7.25")
 
 
-async def test_get_spec_history_reports_an_absent_cost_as_null(
+async def test_get_spec_history_reports_a_legacy_absent_cost_as_null(
     async_client: httpx.AsyncClient,
 ) -> None:
     store = ScoreStore()
     await _register_benchmark(store)
-    await store.submit(_submission(spec_id="uncosted-history"))
+    await store.submit(_legacy_uncosted("uncosted-history"))
 
     response = await async_client.get("/v1/leaderboard/hle/uncosted-history/history")
 
@@ -538,6 +539,11 @@ def _costed(spec_id: str, cost: str) -> ScoreSubmission:
     return _submission(spec_id=spec_id).model_copy(update={"run_cost_usd": Decimal(cost)})
 
 
+def _legacy_uncosted(spec_id: str) -> ScoreSubmission:
+    """Model a row written before OME-822, bypassing the new request contract."""
+    return _submission(spec_id=spec_id).model_copy(update={"run_cost_usd": None})
+
+
 @pytest.mark.parametrize(
     ("submitted", "expected"),
     [
@@ -577,14 +583,14 @@ async def test_spec_history_serializes_the_cost_at_a_fixed_scale(
     assert response.json()["submissions"][0]["run_cost_usd"] == "1000.000000"
 
 
-async def test_an_absent_cost_serializes_as_null_not_a_string(
+async def test_a_legacy_absent_cost_serializes_as_null_not_a_string(
     async_client: httpx.AsyncClient,
 ) -> None:
     # INVARIANT (D5): absent must stay absent on the wire — not "0.000000", and
     # not the string "None".
     store = ScoreStore()
     await _register_benchmark(store)
-    await store.submit(_submission(spec_id="null-scale"))
+    await store.submit(_legacy_uncosted("null-scale"))
 
     response = await async_client.get("/v1/leaderboard/hle")
 
@@ -602,7 +608,7 @@ async def test_get_leaderboard_includes_the_run_cost(
     store = ScoreStore()
     await _register_benchmark(store)
     await store.submit(_costed("costed-board", "7.25"))
-    await store.submit(_submission(spec_id="uncosted-board"))
+    await store.submit(_legacy_uncosted("uncosted-board"))
 
     response = await async_client.get("/v1/leaderboard/hle")
 
@@ -836,6 +842,7 @@ def _private_submission(
         total_questions=100,
         correct_questions=int(score * 100),
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
         benchmark_revision=revision,
     )
 
@@ -1303,6 +1310,7 @@ async def test_the_frontier_route_passes_the_registered_case_count(
                 "score": score,
                 "total_questions": total,
                 "ran_with_providers": ["openrouter"],
+                "run_cost_usd": "1.000000",
             },
         )
         assert response.status_code == 201, response.text
@@ -1368,9 +1376,10 @@ async def _row(
     `submitted_at`.
     """
     created, _ = await store.submit(_submission(spec_id=spec_id, score=score))
-    updates: dict[str, object] = {"benchmark_revision": revision}
-    if cost is not None:
-        updates["run_cost_usd"] = Decimal(cost)
+    updates: dict[str, object] = {
+        "benchmark_revision": revision,
+        "run_cost_usd": Decimal(cost) if cost is not None else None,
+    }
     await Score.filter(id=created.id).update(**updates)
 
 
@@ -1405,8 +1414,7 @@ async def test_get_leaderboard_marks_the_pareto_frontier(
 async def test_get_leaderboard_marks_nothing_when_no_row_reports_a_cost(
     async_client: httpx.AsyncClient,
 ) -> None:
-    """Today's real board: OME-770 shipped the column, nothing has ever filled it. It must
-    render as an ordinary board, not error and not mark anything."""
+    """A legacy/imported board with no cost data renders without marks or errors."""
     store = ScoreStore()
     # WHY pinned: with an unregistered revision the D12 gate returns an empty frontier before
     # compute_pareto_frontier is ever called, so this test passed no matter how a null cost was

--- a/apps/scoreboard/tests/unit/test_multiple_authors.py
+++ b/apps/scoreboard/tests/unit/test_multiple_authors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,7 @@ def _submission(
         total_questions=100,
         correct_questions=75,
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
         metadata=metadata,
     )
 

--- a/apps/scoreboard/tests/unit/test_proxy_headers_integration.py
+++ b/apps/scoreboard/tests/unit/test_proxy_headers_integration.py
@@ -46,6 +46,7 @@ def _valid_payload(**overrides: Any) -> dict[str, Any]:
         "total_questions": 4,
         "correct_questions": 3,
         "ran_with_providers": ["openai"],
+        "run_cost_usd": "1.250000",
     }
     payload.update(overrides)
     return payload

--- a/apps/scoreboard/tests/unit/test_retire_benchmark.py
+++ b/apps/scoreboard/tests/unit/test_retire_benchmark.py
@@ -11,6 +11,8 @@ it rather than hand an operator an IntegrityError traceback.
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 from scoreboard.retire_benchmark import (
@@ -43,6 +45,7 @@ def _submission(benchmark_id: str = BENCHMARK) -> ScoreSubmission:
         total_questions=100,
         correct_questions=50,
         ran_with_providers=["openai"],
+        run_cost_usd=Decimal("1.000000"),
     )
 
 

--- a/apps/scoreboard/tests/unit/test_retire_benchmark_cli.py
+++ b/apps/scoreboard/tests/unit/test_retire_benchmark_cli.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Iterator
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,7 @@ def seeded_database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator
                 total_questions=100,
                 correct_questions=50,
                 ran_with_providers=["openai"],
+                run_cost_usd=Decimal("1.000000"),
             )
         )
         await close_db()

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -30,6 +30,7 @@ def _valid_payload(**overrides: Any) -> dict[str, Any]:
         "total_questions": 4,
         "correct_questions": 3,
         "ran_with_providers": ["openai"],
+        "run_cost_usd": "1.250000",
         "ran_at_local": "2026-05-21T12:00:00+00:00",
         "client": {"name": "scoreboard-test", "version": "0.1.0", "platform": "test"},
         "metadata": {"source": "unit"},
@@ -220,6 +221,21 @@ async def test_post_score_future_version_returns_422(score_client: AsyncClient) 
 
     assert response.status_code == 422
     assert response.json()["detail"][0]["loc"] == ["body", "version"]
+
+
+@pytest.mark.parametrize("run_cost_usd", [None, pytest.param("omitted", id="omitted")])
+async def test_post_score_requires_a_non_null_run_cost(
+    score_client: AsyncClient,
+    run_cost_usd: str | None,
+) -> None:
+    payload = _valid_payload(run_cost_usd=run_cost_usd)
+    if run_cost_usd == "omitted":
+        payload.pop("run_cost_usd")
+
+    response = await score_client.post("/v1/scores", json=payload)
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"] == ["body", "run_cost_usd"]
 
 
 async def test_post_score_url4_expression_too_long_returns_422(
@@ -417,6 +433,7 @@ async def test_openapi_schema_includes_new_endpoints(score_client: AsyncClient) 
     assert post_score["requestBody"]["content"]["application/json"]["schema"]["$ref"].endswith(
         "/ScoreSubmission",
     )
+    assert "run_cost_usd" in response.json()["components"]["schemas"]["ScoreSubmission"]["required"]
     assert post_score["responses"]["201"]["content"]["application/json"]["schema"]["$ref"].endswith(
         "/ScoreSchema",
     )

--- a/apps/scoreboard/tests/unit/test_sf_payload.py
+++ b/apps/scoreboard/tests/unit/test_sf_payload.py
@@ -38,6 +38,7 @@ def _sf_payload(**overrides: Any) -> dict[str, Any]:
         "total_questions": 1000,
         "correct_questions": 810,
         "ran_with_providers": ["claude", "codex", "gemini"],
+        "run_cost_usd": "4.250000",
         "submitted_by": None,
         "ran_at_local": "2026-05-04T11:55:00Z",
         "client": {"name": "screamingface-desktop", "version": "0.4.2", "platform": "darwin"},

--- a/docs/plan/2026-09-04-OME-822-require-run-cost.md
+++ b/docs/plan/2026-09-04-OME-822-require-run-cost.md
@@ -1,0 +1,25 @@
+# OME-822 — Implementation plan
+
+## Frame
+
+Tighten only the direct Scoreboard write DTO after the SDK producer has shipped. Preserve nullable
+storage and reads, including historical/imported behavior and the existing dedup decision.
+
+## Changes
+
+1. Record the now-satisfied upstream gate and binding null/zero decisions.
+2. Change `_validate_run_cost` and `ScoreSubmission.run_cost_usd` to non-null `Decimal` types.
+3. RED/GREEN the schema, HTTP `422`, and OpenAPI-required contracts.
+4. Add explicit costs to every existing direct-submission fixture under the owner-approved
+   Confidence-Gate exception; retain explicit legacy-null tests through controlled model copies.
+5. Update the deployment smoke payload and Client guide so shipped examples match the contract.
+6. Run focused tests, full Scoreboard gates, and the public-docs checks affected by the guide copy.
+7. Complete the ledger, commit, push, open the PR, link it from Linear, and move OME-822 to In
+   Review.
+
+## Non-goals
+
+- a database `NOT NULL` migration or historical backfill;
+- changing read DTO nullability or how the portal renders unknown cost;
+- adding cost to recipe identity or mutating a deduplicated legacy row;
+- fabricating a cost in the SDK when upstream accounting reports none.

--- a/docs/spec/2026-09-04-OME-822-require-run-cost.md
+++ b/docs/spec/2026-09-04-OME-822-require-run-cost.md
@@ -1,0 +1,61 @@
+# OME-822 — Require run cost on direct submissions
+
+Status: owner-approved · Stack: scoreboard
+
+## Problem
+
+`OME-770` deliberately made `run_cost_usd` optional while no producer existed. That gate is now
+satisfied: OME-303, OME-304, OME-306, and OME-1029 are Done, and the SDK publishes the run total.
+Leaving the request field optional now lets a new direct submission enter without the economic
+dimension required by the cost column and Pareto frontier.
+
+## Decisions
+
+### D1 — Required at the direct request boundary
+
+`ScoreSubmission.run_cost_usd` is a required, non-null `Decimal`. Omitting it or explicitly sending
+JSON `null` returns a `422` field error, and OpenAPI lists the field in the schema's `required` set.
+
+### D2 — Nullable storage and reads stay intact
+
+The `Score.run_cost_usd` database column and all read DTOs remain nullable. Imported and historical
+rows legitimately have unknown cost and continue to serialize as `null`. There is no migration or
+backfill.
+
+### D3 — Zero is real data, not an unknown fallback
+
+`0` remains valid and normalizes to `0.000000`; it means the run genuinely cost nothing. Neither an
+omitted nor a null direct cost is coerced to zero.
+
+### D4 — Existing money normalization is unchanged
+
+The OME-770 limits and normalization remain the only validator: finite, non-negative, at most
+`999999.999999`, six decimal places, positive sub-quantum values rounded away from zero, and
+negative zero normalized.
+
+### D5 — Dedup and historical rows do not mutate
+
+Cost remains excluded from recipe identity. A pre-existing null-cost row can still win dedup and
+remain null; this is the accepted OME-770 behavior and no fill-in or backfill is added here.
+
+### D6 — Unpriced direct runs are rejected deliberately
+
+OME-1029 preserves a possible `None` from upstream rather than inventing zero. After this contract
+lands, such a direct publish receives `422`. That is the enforcement requested by this ticket: a
+client must obtain a real total before publishing, while old/imported rows remain readable.
+
+## Verification contract
+
+- schema validation rejects omitted and explicit-null cost;
+- the real POST route returns `422` at `body.run_cost_usd` for both shapes;
+- OpenAPI marks the field required;
+- all existing direct-submission fixtures supply explicit realistic costs;
+- nullable read-path regressions remain green;
+- the deployment smoke request includes an explicit zero-cost value.
+
+## Confidence-Gate exception
+
+This contract change necessarily updates existing direct-submission fixtures and the prior test
+that asserted omission becomes `None`. The owner explicitly approved that append-only-test
+exception in the implementation session. Production behavior—not the tests—defines the new
+contract, and the full Scoreboard gate must remain green with the exception recorded.

--- a/docs/tasks/2026-09-04-OME-822-require-run-cost.md
+++ b/docs/tasks/2026-09-04-OME-822-require-run-cost.md
@@ -1,0 +1,22 @@
+---
+id: OME-822
+linear_url: https://linear.app/openmined/issue/OME-822/require-run-cost-usd-on-direct-leaderboard-submissions
+status: in_review
+type: task
+priority: 2
+labels: [scoreboard, agentic, deferred]
+created: 2026-08-13
+closed:
+---
+
+# Require run cost on direct leaderboard submissions
+
+Make `run_cost_usd` mandatory and non-null on the direct Scoreboard submission contract now that
+the accounting, run-total, persistence, and SDK-publish chain is shipped. Keep storage and every
+read DTO nullable for imported and historical rows; zero continues to mean a genuinely free run.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-04-OME-822-require-run-cost.md`
+- Plan: `docs/plan/2026-09-04-OME-822-require-run-cost.md`
+- Ledger: `docs/work/2026-09-04-OME-822-require-run-cost.md`

--- a/docs/work/2026-09-04-OME-822-require-run-cost.md
+++ b/docs/work/2026-09-04-OME-822-require-run-cost.md
@@ -1,0 +1,60 @@
+---
+ticket: OME-822
+stack: scoreboard
+status: done
+started: 2026-09-03
+finished: 2026-09-04
+---
+
+# OME-822 — Require run cost on direct submissions
+
+## Intent
+
+Reject new direct leaderboard submissions that omit or null the run total now that the producer
+chain is shipped, without changing the nullable historical/imported data contract.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py` — required non-null request field.
+- Scoreboard unit fixtures — explicit costs plus omission/null/OpenAPI route assertions.
+- `apps/scoreboard/DEPLOYMENT.md` — valid direct-submission smoke payload.
+- `public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue` — document the published cost and
+  null/zero boundary.
+- task, spec, plan, and this work ledger.
+
+## Test plan
+
+- Reject missing and null at schema and real HTTP boundaries.
+- Keep zero and the complete OME-770 normalization matrix green.
+- Keep imported/legacy null reads green.
+- Assert the OpenAPI request schema declares the field required.
+- Run the full Scoreboard and affected public-docs gates.
+
+## Acceptance
+
+- Direct omission/null returns a field-local `422`.
+- Every accepted direct submission stores a non-null normalized cost.
+- No database/read migration; old/imported null rows remain readable.
+- Docs and smoke commands match the request contract.
+- CI-equivalent gates are green and the PR is linked from Linear.
+
+## Outcome
+
+- **Actual files:** as planned. Tightened only the direct request DTO and validator typing; added
+  missing/null/OpenAPI assertions; supplied explicit costs in every direct-submission fixture;
+  retained controlled legacy-null read tests; corrected the deployment smoke payload and public
+  Client guide; added the task/spec/plan/ledger set.
+- **Commits:** one conventional feature commit on `OME-822-require-run-cost` (squash target; final
+  merge sha will be recorded in Linear).
+- **Gates:** Scoreboard `run_gates.py ... --base origin/main --skip-append-only` ALL GREEN (ruff,
+  format, pyright, pytest coverage ≥80, three explicit portal suites). Direct full run: 602 passed,
+  3 skipped, 3 deselected. Public docs: clean `npm ci`, bare oxlint, bare eslint, Vue typecheck, and
+  production Vite build all green.
+- **Deviations:** the spec/plan were recorded retroactively because the implementation commit had
+  already been prepared in the prior session. Existing test changes use the owner's explicit
+  Confidence-Gate exception; the database/read contract remains nullable and no migration exists.
+  The public-docs build succeeded locally, though Node 24.10 emitted an engine warning against the
+  repository's newer ≥24.12 floor; CI pins the repository version. The SFDS copy check kept the
+  guide change factual and evidence-led, with no visual-system changes. PR #840's independently
+  added direct-submission fixtures were also made cost-ready there, so the two PRs can merge in
+  either order without breaking `main`.

--- a/docs/work/2026-09-07-OME-822-refresh.md
+++ b/docs/work/2026-09-07-OME-822-refresh.md
@@ -1,0 +1,55 @@
+---
+ticket: OME-822
+stack: scoreboard
+status: done
+started: 2026-09-07
+finished: 2026-09-07
+---
+
+# OME-822 — Refresh required-cost PR
+
+## Intent
+
+Refresh PR #841 on current `origin/main` while preserving both the merged co-author documentation
+and OME-822's required run-cost contract. Resolve only the known guide conflict, then re-prove the
+Scoreboard and public-docs gates before updating the remote branch.
+
+## Planned changes
+
+- `public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue` — compose the co-author and
+  required-cost documentation in the single conflicting paragraph.
+- `docs/work/2026-09-07-OME-822-refresh.md` — record the rebase, resolution, and verification.
+
+## Test plan
+
+- Use the already reproduced three-way conflict against current `origin/main` as the red signal.
+- Confirm the rebased tree has no conflict markers and differs from `origin/main` only by the
+  intended OME-822 changes plus this ledger.
+- Run the full Scoreboard gate with the approved append-only exception.
+- Run clean-install public-docs lint, typecheck, and production build checks.
+
+## Acceptance
+
+- The guide names required `run_cost_usd`, optional authors, author correction, and the null/zero
+  cost boundary without losing either merged contract.
+- The branch is based on current `origin/main` and is cleanly mergeable.
+- Scoreboard and public-docs verification are green, and PR #841 points at the refreshed commit.
+
+## Outcome
+
+- **Actual files:** the planned guide conflict was composed in the rebased implementation commit,
+  retaining required cost, optional authors, author correction, idempotent replay, and the
+  historical-null versus genuine-zero boundary. This ledger records the refresh. No Python
+  behavior, schema decision, migration, or existing test assertion was manually changed during
+  the rebase.
+- **Commits:** rebased implementation `3f4af00d` (`feat(scoreboard): require run cost on direct
+  submissions`) plus `docs(work): record OME-822 refresh verification` for this ledger.
+- **Gates:** `run_gates.py scoreboard --base origin/main --skip-append-only` reported ALL GATES
+  GREEN: Ruff lint/format, Pyright, full Python coverage suite, and all three named portal suites.
+  Public docs passed clean `npm ci`, bare non-mutating `npx oxlint .`, bare `npx eslint .`, Vue
+  typecheck, and the production Vite build. The tree has no conflict markers or whitespace errors.
+- **Deviations:** local Node 24.10 remains below the repository's 24.12 floor and emitted the same
+  engine warning recorded in the original OME-822 ledger; all commands passed and CI uses the
+  repository-pinned version. The append-only gate remained skipped under the owner's existing
+  OME-822 Confidence-Gate approval because the feature intentionally updates direct-submission
+  fixtures and the prior optional-field assertion.

--- a/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
+++ b/public-docs/src/pages/sf-client/guides/LeaderboardsPage.vue
@@ -221,11 +221,13 @@ sf.evaluate(score.url4)        # fresh paid replay; omit benchmark= and limit=`
 
     <p>
       The Client posts <code>score</code>, <code>total_questions</code>, the compiled
-      <code>url4_expression</code>, provider names, optional authors, and client metadata. The
-      <code>Idempotency-Key</code> header is the candidate's <code>run_id</code>, so a retry of the
-      same run reuses the original score instead of inserting a duplicate. A resubmission by the
-      same submitter can correct its author list. If another correction wins the same race, the
-      Client reports a retryable conflict; retry the submission.
+      <code>url4_expression</code>, provider names, required <code>run_cost_usd</code>, optional
+      authors, and client metadata. Direct submissions require a non-null run cost; a genuine fully
+      cached run sends zero, while imported and historical rows may still display an unknown cost.
+      The <code>Idempotency-Key</code> header is the candidate's <code>run_id</code>, so a retry of
+      the same run reuses the original score instead of inserting a duplicate. A resubmission by
+      the same submitter can correct its author list. If another correction wins the same race,
+      the Client reports a retryable conflict; retry the submission.
     </p>
 
     <p>


### PR DESCRIPTION
## Summary

- require a non-null `run_cost_usd` on direct `ScoreSubmission` requests
- return a field-local `422` for both omission and explicit JSON `null`, and mark the field required in OpenAPI
- keep the database column and every read DTO nullable for imported and historical rows
- update the deployment smoke request and Client guide to match the tightened contract

## Why now

The producer gate is satisfied: OME-303, OME-304, OME-306, and OME-1029 are Done, and the SDK now publishes the run total. Zero remains a valid, distinct value for a genuinely free cached run; this change never coerces missing cost to zero.

## Deliberately unchanged

- no migration or backfill
- no change to the OME-770 normalization/limits
- no cost in recipe identity
- no mutation of legacy null-cost rows on dedup
- an upstream `None` now fails direct publish instead of inventing a cost

## Verification

- Scoreboard gates all green: ruff, format, pyright, coverage ≥80%, Python suite, and the three portal suites
- Python: 602 passed, 3 skipped, 3 deselected
- portal: 50 passed
- public docs: clean `npm ci`, oxlint, eslint, Vue typecheck, and production Vite build

The append-only check is skipped under the owner-approved Confidence-Gate exception: tightening a required request field necessarily updates existing direct-submission fixtures and replaces the prior test asserting omission becomes `None`. Legacy-null read behavior remains explicitly tested through controlled historical-row fixtures.

PR #840's newly added direct-submission fixtures have already been made cost-ready, so the two independent PRs can merge in either order without breaking `main`.

Refs: OME-822
