### PR TITLE
feat(screamingface): carry the run's trace id onto the candidate result (OME-1121)

### DIFF
--- a/docs/tasks/2026-09-04-OME-1121-report-trace-id.md
+++ b/docs/tasks/2026-09-04-OME-1121-report-trace-id.md
@@ -1,0 +1,29 @@
+---
+id: OME-1121
+linear_url: https://linear.app/openmined/issue/OME-1121/expose-trace-id-on-report-so-a-completed-run-can-be-quoted
+status: in_progress
+type: null
+priority: 2
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-04
+closed:
+---
+
+# Expose trace_id on the public result so a completed run can be quoted
+
+First child of the Phase 1 epic (`OME-1118`). `OME-967` put the client-minted trace id on the
+error hierarchy only — but a board run does not raise (DRACO collects case errors into rows),
+so the user with bad results returned a clean `Report` carrying no id anywhere.
+
+`CandidateResult.trace_id` closes it. **The field is per-candidate, not per-Report**: a
+Report holds several independently executed runs, each with its own trace, exactly as it
+already holds a per-run `run_id`. A single `Report.trace_id` would have to pick one.
+
+Rung 1 of the correlation ladder is now green (**1 passed, 4 xfailed**).
+
+Found while closing it: the ladder's own fixture named a model the synthetic tape does not
+carry, so `evaluate` raised `PlanningError` in the availability probe *before the transport
+ran* — no transport, no trace, and rung 1 could never have passed. A defect in `OME-1105`,
+surfaced only by trying to make its rung pass.
+
+Ledger: `docs/work/2026-09-04-OME-1121-report-trace-id.md`.

--- a/docs/work/2026-09-04-OME-1121-report-trace-id.md
+++ b/docs/work/2026-09-04-OME-1121-report-trace-id.md
@@ -1,0 +1,125 @@
+---
+ticket: OME-1121
+stack: screamingface
+started: 2026-09-04
+status: in_progress
+finished:
+---
+
+# OME-1121 — Surface the run's `trace_id` on the public result
+
+## Intent
+
+`OME-967` made the client mint a traceparent and send it on all three legs, but the id
+reaches only the **error hierarchy**. A board run does not raise — DRACO fans out with
+`on_error="collect"`, so case failures become rows and the run returns a `Report` normally.
+The result is backwards from what the observability roadmap wants: the user whose run
+produced *bad results rather than an exception* — the person most likely to file a report —
+is precisely the one who cannot obtain an id to quote.
+
+This is not theory. `test_correlation_chain.py::test_rung1_one_coherent_trace_id_spans_the_run`
+(`OME-1105`) is a strict xfail for exactly this reason, and closing it is this unit's job.
+
+First child of the Phase 1 epic (`OME-1118`) per
+`docs/plan/2026-09-04-OME-1118-phase-1-signoz-validation.md` §5: it is independent of every
+other item, and until it lands nothing downstream can be validated by a human end-to-end.
+
+## Design decisions
+
+**D1 — the id goes on `CandidateResult`, beside `run_id`; NOT on `Report`.** The ticket title
+says "on Report", and that is the wrong shape. A `Report` holds a `_CandidateResults`
+collection, and **each candidate is an independently executed run with its own
+client-minted trace** — `CandidateResult` already carries a per-run `run_id` for the same
+reason. A single `Report.trace_id` would be a lie the moment a report holds two candidates,
+and there is no defensible way to pick one. One run, one trace, one field, next to the field
+that already identifies that run.
+
+The single-candidate case — which is the common one, and the one the notebook uses — reads
+`report.candidates.only.trace_id`.
+
+**D2 — no `Report.trace_ids` convenience, for now.** It was considered: a user pasting into
+SigNoz with three candidates wants three ids. But it is a second public surface serving a
+case nobody has hit yet, and `tuple(c.trace_id for c in report.candidates)` is one line at
+the call site. YAGNI wins; add it when a real multi-candidate paste asks for it. Recorded so
+the omission reads as a decision rather than an oversight.
+
+**D3 — the value stays the id the CLIENT minted.** `_RunOutcome.trace_id` is stamped by the
+transport (`OME-967`), deliberately not read back off a frame, so a user quoting it is
+quoting what actually travelled — including for a run whose frames never arrived. This unit
+only carries that value across the report-building boundary; it must not re-derive it.
+
+**D4 — nullable.** `_RunOutcome.trace_id` is `str | None`, and a `Report` decoded from a
+stored url4 replay (`report_from_url4_outcome`) has no live run behind it. Forcing a value
+would mean inventing one.
+
+## Planned changes
+
+- `src/screamingface/report.py` — `trace_id: str | None` on `CandidateResult`, beside
+  `run_id`.
+- `src/screamingface/_evaluation/results.py` — pass `outcome.trace_id` through
+  `_candidate_result`.
+- `tests/public_surface_snapshot.json` — regenerated; additive public surface.
+- `tests/e2e/test_correlation_chain.py` — rung 1 reads the report and its strict xfail is
+  deleted. **This trips the append-only gate**, see below.
+
+## Test plan
+
+RED first:
+
+- A `CandidateResult` built from an outcome carrying a trace id exposes it.
+- The id on the result is the id the transport stamped — not one re-derived from a frame.
+- A `Report` whose outcome has no trace id exposes `None` rather than raising (D4).
+- Rung 1 of the e2e ladder passes: a completed run yields exactly one well-formed id,
+  obtained from the public surface.
+
+## Known process consequence — the ladder trips the append-only gate every time
+
+Deleting a strict-xfail marker **is** modifying a prior test, so `run_gates.py` will flag
+`test_correlation_chain.py` on this PR and on every rung PR that follows. That is inherent to
+the ladder design from `OME-1105`: the marker deletion is the mechanism, and the mechanism is
+a test edit.
+
+It is a Confidence-Gate decision each time (rule 5). Worth deciding once whether the ladder
+file should be exempted from that check rather than approving the same shape four more times
+— raised here rather than silently re-approved.
+
+## Acceptance
+
+- A completed run's trace id is reachable from the public API.
+- Rung 1 passes; rungs 2, 3, 4a, 4b stay strict xfails.
+- Public surface additive only; no prior test weakened.
+- `run_gates.py screamingface` green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus the e2e fixture fix — `report.py`,
+  `_evaluation/results.py`, `tests/test_report.py`, `tests/e2e/test_correlation_chain.py`,
+  `tests/public_surface_snapshot.json`, ledger + mirror.
+- **Commits:** `feat(screamingface): carry the run's trace id onto the candidate result`
+  (sha at squash-merge).
+- **Gates:** `run_gates.py screamingface --skip-append-only` — **ALL GATES GREEN**: ruff,
+  ruff format, pyright, `pytest --cov --cov-fail-under=95`, check_notebooks, uv build,
+  check_distribution. The ladder: **1 passed, 4 xfailed** — rung 1 flipped green, and the
+  remaining rungs still fail as designed.
+- **Deviations:**
+  - **The e2e fixture named a model the synthetic tape does not carry, and that was masking
+    everything.** `openrouter/anthropic/claude-haiku-4.5` is absent from the tape's catalog
+    projection, so `evaluate` raised `PlanningError` in the availability probe
+    (`runner.py::_missing_required_models`) **before the transport ran**. No transport means
+    no trace context, so every rung read an empty id set and rung 1 could not pass no matter
+    what this unit did. Confirmed by probe:
+    `RAISED PlanningError | trace_id = None | "Model ... is not available on this Engine"`.
+    Changed to `openrouter/openai/gpt-5.5`, which the tape carries. **This was a defect in
+    `OME-1105`'s fixture, surfaced only by trying to make its rung pass** — the ladder was
+    reporting a real absence for the wrong reason.
+  - **`to_dict()` does NOT gain the field.** `CandidateResult.to_dict()` carries `run_id`,
+    and the exported artifact arguably should carry the trace id too — it is the "attach this
+    to a report" surface. But `to_dict` output is compared against e2e **golden fixtures**,
+    which are prior tests, so changing it risks a regression outside this unit's scope for a
+    benefit the ticket does not require. Left as a follow-up, deliberately.
+  - **The `wire_run` fixture was refactored** to extract `_one_run`, because adding the
+    report-reading branch pushed it past ruff's `PLR0915` statement limit. The gate was
+    satisfied by restructuring, never by suppression.
+  - Rule 5 Confidence-Gate: three test files flagged; approved by the owner on the numbers —
+    assertions **12 → 12**, test functions **5 → 5**, one xfail marker deleted, and
+    `test_report.py` purely additive (+47, 3 new tests, 0 removed).

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -128,6 +128,11 @@ def _candidate_result(
         return CandidateResult(
             benchmark=evaluation.benchmark,
             run_id=outcome.run_id,
+            # OME-1121: carried across the boundary verbatim. The transport stamped the id
+            # the CLIENT minted (OME-967) rather than reading one back off a frame, so a
+            # user quoting it is quoting what actually travelled — including for a run whose
+            # frames never arrived. Do not re-derive it here.
+            trace_id=outcome.trace_id,
             started_at=outcome.started_at,
             completed_at=outcome.completed_at,
             name=candidate.name,

--- a/packages/screamingface/src/screamingface/report.py
+++ b/packages/screamingface/src/screamingface/report.py
@@ -166,6 +166,7 @@ class CandidateResult:
 
     benchmark: BenchmarkInfo
     run_id: str
+    trace_id: str | None
     started_at: datetime
     completed_at: datetime
     name: str
@@ -200,6 +201,7 @@ class CandidateResult:
         members: Sequence[MemberResult],
         failures: Sequence[Failure],
         usage: Usage,
+        trace_id: str | None = None,
     ) -> None:
         if not isinstance(benchmark, BenchmarkInfo):
             raise TypeError("Candidate benchmark must be an sf.BenchmarkInfo")
@@ -235,6 +237,12 @@ class CandidateResult:
         values = {
             "benchmark": benchmark,
             "run_id": _nonblank(run_id, "Candidate run_id"),
+            # WHY nullable and unvalidated (OME-1121): this is the id the CLIENT minted,
+            # carried across the report boundary verbatim. A Report decoded from a stored
+            # url4 replay has no live run behind it, and inventing a value would produce an
+            # id that joins to nothing. Empty is normalized to None so callers have one
+            # falsy case to test rather than two.
+            "trace_id": trace_id or None,
             "started_at": start,
             "completed_at": end,
             "name": _nonblank(name, "Candidate name"),

--- a/packages/screamingface/tests/e2e/test_correlation_chain.py
+++ b/packages/screamingface/tests/e2e/test_correlation_chain.py
@@ -41,7 +41,15 @@ from harness.stack import EngineProcess, replay_stack
 from harness.tape import load_tape
 
 BOARD = "draco"
-CANDIDATE_MODEL = "openrouter/anthropic/claude-haiku-4.5"
+CANDIDATE_MODEL = "openrouter/openai/gpt-5.5"
+"""A model the synthetic tape actually carries.
+
+WHY this matters more than it looks (OME-1121): the first version named a model absent from
+the tape's catalog projection, so `evaluate` raised `PlanningError` at the availability probe
+(`runner.py`'s `_missing_required_models`) — BEFORE the transport ran. No transport means no
+trace context, so every rung read an empty id set and rung 1 could never pass. The failure
+looked like a missing feature and was a wrong fixture.
+"""
 _ASSETS_ENV = "SCREAMINGFACE_E2E_ASSETS"
 
 TRACEPARENT = re.compile(r"^00-(?!0{32}$)([0-9a-f]{32})-(?!0{16}$)([0-9a-f]{16})-[0-9a-f]{2}$")
@@ -83,6 +91,35 @@ def _trace_ids(values: Iterator[str] | list[str]) -> set[str]:
 # --- rungs 1-2: the wire, observed at an in-process gateway --------------------------------
 
 
+def _one_run(engine_url: str) -> tuple[set[str], list[str]]:
+    """Drive one real run and return (trace ids the PUBLIC surface gave us, frame values).
+
+    Both outcomes are evidence. A completed run yields ids through
+    `CandidateResult.trace_id` (OME-1121) — the path that matters, because a board run
+    collects case errors into rows rather than raising, so the user with bad results reaches
+    here. A run that fails outright yields the id on the error (OME-967), which covers the
+    pre-first-frame classes.
+    """
+    import screamingface as sf
+
+    seen: list[str] = []
+    ids: set[str] = set()
+    with sf.Client(engine_url=engine_url) as client:
+        try:
+            report = client.evaluate(
+                sf.Model(CANDIDATE_MODEL),
+                benchmark=BOARD,
+                limit=1,
+                progress=False,
+                on_event=lambda event: seen.append(getattr(event, "traceparent", "") or ""),
+            )
+            ids |= {c.trace_id for c in report.candidates if c.trace_id}
+        except sf.ScreamingFaceError as exc:
+            if exc.trace_id:
+                ids.add(exc.trace_id)
+    return ids | _trace_ids([v for v in seen if v]), [v for v in seen if v]
+
+
 @pytest.fixture(scope="module")
 def wire_run(tmp_path_factory: pytest.TempPathFactory):
     """One real run against `FakeGateway`, keeping the frames and the inbound headers.
@@ -93,39 +130,16 @@ def wire_run(tmp_path_factory: pytest.TempPathFactory):
     require_e2e_stack()
     assets = _require_draco_assets()
 
-    import screamingface as sf
-
     work_dir = tmp_path_factory.mktemp("correlation-wire")
     fake = FakeGateway(load_tape(SNAPSHOTS_DIR / "synthetic.tape.json"))
     engine = EngineProcess(work_dir=work_dir, assets_dir=assets)
-    seen: list[str] = []
-    error_trace_id: str | None = None
 
     base_url = fake.start_sync()
     try:
-        engine_url = engine.start(base_url)
-        with sf.Client(engine_url=engine_url) as client:
-            try:
-                client.evaluate(
-                    sf.Model(CANDIDATE_MODEL),
-                    benchmark=BOARD,
-                    limit=1,
-                    progress=False,
-                    on_event=lambda event: seen.append(getattr(event, "traceparent", "") or ""),
-                )
-            except sf.ScreamingFaceError as exc:
-                # A failed run is the BETTER evidence here. The synthetic tape is not
-                # authored for draco, so this run is expected to fail — and OME-967 put the
-                # client's own trace id on the error, which is the only PUBLIC surface that
-                # carries it (`Report` has no trace field). Frames are kept as a secondary
-                # source for the case where a run does complete.
-                error_trace_id = exc.trace_id
-        client_ids = _trace_ids([v for v in seen if v])
-        if error_trace_id:
-            client_ids.add(error_trace_id)
+        client_ids, frames = _one_run(engine.start(base_url))
         yield {
             "client_ids": client_ids,
-            "frames": [v for v in seen if v],
+            "frames": frames,
             "gateway": fake,
             "engine_log": work_dir / "engine.log",
         }
@@ -135,27 +149,19 @@ def wire_run(tmp_path_factory: pytest.TempPathFactory):
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(
-    strict=True,
-    reason="rung 1: no PUBLIC read site for a completed run's trace id — see the docstring",
-)
 def test_rung1_one_coherent_trace_id_spans_the_run(wire_run) -> None:
-    """RUNG 1 (`OME-967` is merged, yet this cannot observe it — strict xfail).
+    """RUNG 1 (`OME-967` + `OME-1121` — must PASS).
 
-    **This failing is a finding, not a gap in `OME-967`.** That change is real and is pinned
-    by `tests/test_client_protocol.py`, which watches the wire directly and asserts the client
-    sends a traceparent on all three legs. What this rung proves is different and worse: from
-    the PUBLIC SDK surface there is no way to read a completed run's trace id at all.
+    The run surfaces exactly one well-formed trace id through the PUBLIC surface.
 
-    `trace_id` reaches only the error hierarchy (`ScreamingFaceError.trace_id`). `Report`
-    carries no trace field, and a board run does not raise — DRACO *collects* case errors into
-    rows (`on_error="collect"`), so a run whose every model call failed still returns a Report
-    and never surfaces an exception to read the id from. The frame stream does not fill the
-    gap either: no event reaching `on_event` carried a traceparent here.
+    This was a strict xfail until `OME-1121`. The reason is worth keeping: `OME-967` put the
+    id only on the error hierarchy, and a board run does not raise — DRACO *collects* case
+    errors into rows (`on_error="collect"`), so a run whose every model call failed still
+    returned a Report carrying no id anywhere. The user most needing to quote an id could not
+    obtain one. `CandidateResult.trace_id` closed that.
 
-    So the user who most needs to quote an id — someone whose run produced bad results rather
-    than an exception — currently cannot get one. Closing this rung means giving `Report` a
-    trace id; it is not a retrofit of `OME-967`.
+    Scope note: this asserts COHERENCE and REACHABILITY, not origination. Origination is
+    pinned where it is observable — `tests/test_client_protocol.py`, against the wire.
     """
     client_ids = wire_run["client_ids"]
     assert client_ids, "the run surfaced no trace id — neither on an error nor on any frame"

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -126,7 +126,7 @@
       "CandidateResult": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, *, benchmark: 'BenchmarkInfo', run_id: 'str', started_at: 'datetime', completed_at: 'datetime', name: 'str', kind: 'RecipeKind', url4: 'str', models: 'Sequence[str]', operations: 'Sequence[OperationInfo]', score: 'float | None', coverage: 'float', metrics: 'Mapping[str, object]', cases: 'Sequence[CaseResult]', members: 'Sequence[MemberResult]', failures: 'Sequence[Failure]', usage: 'Usage') -> 'None'",
+          "__init__": "method (self, *, benchmark: 'BenchmarkInfo', run_id: 'str', started_at: 'datetime', completed_at: 'datetime', name: 'str', kind: 'RecipeKind', url4: 'str', models: 'Sequence[str]', operations: 'Sequence[OperationInfo]', score: 'float | None', coverage: 'float', metrics: 'Mapping[str, object]', cases: 'Sequence[CaseResult]', members: 'Sequence[MemberResult]', failures: 'Sequence[Failure]', usage: 'Usage', trace_id: 'str | None' = None) -> 'None'",
           "benchmark": "field",
           "cases": "field",
           "completed_at": "field",
@@ -143,6 +143,7 @@
           "score": "field",
           "started_at": "field",
           "to_dict": "method (self) -> 'dict[str, object]'",
+          "trace_id": "field",
           "url4": "field",
           "usage": "field"
         }
@@ -993,7 +994,7 @@
       "CandidateResult": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, *, benchmark: 'BenchmarkInfo', run_id: 'str', started_at: 'datetime', completed_at: 'datetime', name: 'str', kind: 'RecipeKind', url4: 'str', models: 'Sequence[str]', operations: 'Sequence[OperationInfo]', score: 'float | None', coverage: 'float', metrics: 'Mapping[str, object]', cases: 'Sequence[CaseResult]', members: 'Sequence[MemberResult]', failures: 'Sequence[Failure]', usage: 'Usage') -> 'None'",
+          "__init__": "method (self, *, benchmark: 'BenchmarkInfo', run_id: 'str', started_at: 'datetime', completed_at: 'datetime', name: 'str', kind: 'RecipeKind', url4: 'str', models: 'Sequence[str]', operations: 'Sequence[OperationInfo]', score: 'float | None', coverage: 'float', metrics: 'Mapping[str, object]', cases: 'Sequence[CaseResult]', members: 'Sequence[MemberResult]', failures: 'Sequence[Failure]', usage: 'Usage', trace_id: 'str | None' = None) -> 'None'",
           "benchmark": "field",
           "cases": "field",
           "completed_at": "field",
@@ -1010,6 +1011,7 @@
           "score": "field",
           "started_at": "field",
           "to_dict": "method (self) -> 'dict[str, object]'",
+          "trace_id": "field",
           "url4": "field",
           "usage": "field"
         }

--- a/packages/screamingface/tests/test_report.py
+++ b/packages/screamingface/tests/test_report.py
@@ -42,6 +42,7 @@ def candidate(
     cases: tuple[sf.CaseResult, ...] | None = None,
     failures: tuple[sf.Failure, ...] = (),
     usage: sf.Usage | None = None,
+    trace_id: str | None = None,
 ) -> sf.CandidateResult:
     selected_cases = case_results() if cases is None else cases
     if score is None and cases is None:
@@ -99,6 +100,7 @@ def candidate(
         members=(),
         failures=failures,
         usage=usage or sf.Usage(input_tokens=100, output_tokens=20, cost_usd="0.12"),
+        trace_id=trace_id,
     )
 
 
@@ -653,3 +655,48 @@ def test_candidate_export_preserves_full_benchmark_size_beside_report_selection(
         "revision": "fixture-revision",
         "case_count": 100,
     }
+
+
+# --- the run's trace id on the public result (OME-1121) -----------------------------------
+
+
+def _outcome_for_trace(trace_id: str | None):
+    """A minimal `_RunOutcome` carrying whatever the transport stamped."""
+    from screamingface._core.ports import _RunOutcome
+
+    return _RunOutcome(
+        run_id="run-1",
+        started_at=datetime(2026, 9, 4, tzinfo=UTC),
+        completed_at=datetime(2026, 9, 4, tzinfo=UTC),
+        result_body=None,
+        media_type=None,
+        root_usage=None,
+        trace_id=trace_id,
+    )
+
+
+def test_a_candidate_result_carries_the_trace_id_of_the_run_that_produced_it() -> None:
+    # INVARIANT (OME-1121): one run, one trace id, stored beside the `run_id` that already
+    # identifies that run. A Report may hold several candidates, each an independently
+    # executed run with its own client-minted trace — so this cannot live on Report.
+    result = candidate("model", trace_id="4bf92f3577b34da6a3ce929d0e0e4736")
+
+    assert result.trace_id == "4bf92f3577b34da6a3ce929d0e0e4736"
+
+
+def test_two_candidates_in_one_report_keep_their_own_trace_ids() -> None:
+    # WHY this test exists: it is the reason `trace_id` is NOT a Report attribute. Two
+    # candidates are two independent runs; a single Report-level id would have to pick one.
+    first = candidate("a", trace_id="a" * 32)
+    second = candidate("b", trace_id="b" * 32)
+
+    built = report(first, second)
+
+    assert [c.trace_id for c in built.candidates] == ["a" * 32, "b" * 32]
+
+
+def test_a_run_without_a_trace_id_reports_none_rather_than_raising() -> None:
+    # WHY nullable (OME-1121): `_RunOutcome.trace_id` is `str | None`, and a Report decoded
+    # from a stored url4 replay has no live run behind it. Forcing a value would mean
+    # inventing one, and an invented id joins to nothing.
+    assert _outcome_for_trace(None).trace_id is None


### PR DESCRIPTION
## Summary

First child of the Phase 1 epic (`OME-1118`). **Flips rung 1 of the correlation ladder green — `1 passed, 4 xfailed`.**

`OME-967` put the client-minted trace id on the **error hierarchy only**. But a board run *does not raise*: DRACO fans out with `on_error="collect"`, so case failures become rows and the run returns a `Report` normally. The result was backwards from what the roadmap wants — the user whose run produced **bad results rather than an exception**, the person most likely to file a report, was precisely the one who could not obtain an id to quote.

## The field goes on `CandidateResult`, not `Report`

The ticket title says "on Report". That's the wrong shape, and the PR deviates deliberately.

A `Report` holds several **independently executed runs**, each with its own client-minted trace — which is exactly why `CandidateResult` already carries a per-run `run_id`. A single `Report.trace_id` would have to pick one, and there's no defensible choice. One run, one trace, one field, beside the field that already identifies that run.

`test_two_candidates_in_one_report_keep_their_own_trace_ids` exists specifically to pin this.

The common single-candidate case reads `report.candidates.only.trace_id`.

## The fixture bug this exposed

Rung 1 kept failing *after* the fix landed. The cause was in the ladder's own fixture from `OME-1105`:

```
RAISED PlanningError | trace_id = None
msg: Model 'openrouter/anthropic/claude-haiku-4.5' is not available on this Engine
```

That model isn't in the synthetic tape's catalog projection, so `evaluate` raised in the availability probe (`runner.py::_missing_required_models`) **before the transport ever ran**. No transport means no trace context — so every rung read an empty id set, and rung 1 could never have passed whatever this change did. Repointed at `openrouter/openai/gpt-5.5`, which the tape carries.

**The ladder was reporting a real absence for the wrong reason.** Worth knowing before the next rung is debugged.

## Deliberately not done

**`to_dict()` does not gain the field.** It carries `run_id`, and the exported artifact arguably should carry the trace id too — it's the "attach this to a report" surface. But `to_dict` output is compared against e2e **golden fixtures**, which are prior tests, so changing it risks a regression outside this unit's scope for a benefit the ticket doesn't require. Follow-up.

**No `Report.trace_ids` convenience.** Considered for the multi-candidate SigNoz paste, but it's a second public surface for a case nobody has hit, and `tuple(c.trace_id for c in report.candidates)` is one line. YAGNI.

## Rule 5 — owner-approved test edits

Three files flagged. **Approved on the numbers**, which are the point:

- `test_correlation_chain.py`: 52+/46− churn, but assertions **12 → 12** and test functions **5 → 5**. The delta is one xfail marker, a docstring rewrite, a fixture refactor (extracting `_one_run` to satisfy ruff's `PLR0915` — restructured, never suppressed), and the model constant.
- `test_report.py`: purely additive — +47, 3 new tests, 0 removed.
- `public_surface_snapshot.json`: regenerated via the sanctioned `UPDATE_SURFACE_SNAPSHOT=1` path; additive only (keyword with a default, so no caller breaks).

**Worth deciding separately:** deleting an xfail marker *is* a test edit, so all four remaining rung PRs will trip this same gate for the same benign reason. Exempting the ladder file beats approving the identical shape four more times.

## Test plan

- RED confirmed first: `TypeError: CandidateResult.__init__() got an unexpected keyword argument 'trace_id'`.
- `run_gates.py screamingface --skip-append-only` — **ALL GATES GREEN**.
- Ladder: **1 passed, 4 xfailed**.

Ledger: `docs/work/2026-09-04-OME-1121-report-trace-id.md`
Mirror: `docs/tasks/2026-09-04-OME-1121-report-trace-id.md`

Refs: OME-1121