### PR TITLE
feat(scoreboard): explain revision-mismatch submissions

### DIFF
--- a/apps/scoreboard/src/scoreboard/routes/scores.py
+++ b/apps/scoreboard/src/scoreboard/routes/scores.py
@@ -37,6 +37,7 @@ from scoreboard.scores.schemas import (
     FieldErrorDetail,
     FieldErrorResponse,
     MessageErrorResponse,
+    ScoreRankingNotice,
     ScoreSchema,
     ScoreSubmission,
 )
@@ -158,9 +159,25 @@ def _field_error_detail(field: str, message: str) -> dict[str, str]:
     return FieldErrorDetail(field=field, message=message).model_dump()
 
 
+def _submission_response(score: ScoreSchema, registered_revision: str | None) -> ScoreSchema:
+    submitted_revision = score.benchmark_revision
+    if registered_revision is None or submitted_revision == registered_revision:
+        return score
+    return score.model_copy(
+        update={
+            "ranking_notice": ScoreRankingNotice(
+                code="benchmark_revision_mismatch",
+                submitted_benchmark_revision=submitted_revision,
+                registered_benchmark_revision=registered_revision,
+            )
+        }
+    )
+
+
 @router.post(
     "/scores",
     response_model=ScoreSchema,
+    response_model_exclude_unset=True,
     status_code=status.HTTP_201_CREATED,
     responses=SUBMIT_SCORE_RESPONSES,
 )
@@ -197,6 +214,13 @@ async def submit_score(
                     f"unknown benchmark_id: {submission.benchmark_id!r}",
                 ),
             )
+
+        # FEATURE (OME-909): snapshot before the write, inside the same unavailable-store
+        # boundary. A read after a successful insert could fail and hide the persisted id from
+        # the caller. Keep `exists()` above as the established 404/503 seam; this narrow second
+        # read supplies only the submit-time comparability fact.
+        benchmark = await Benchmark.filter(id=submission.benchmark_id).only("revision").first()
+        registered_revision = None if benchmark is None else benchmark.revision
 
         # INVARIANT (OME-894): a private board cannot take a write without a VERIFIED submitter.
         # In `disabled` mode `_resolve_submitter` trusts the body's `submitted_by`, and combined
@@ -252,7 +276,7 @@ async def submit_score(
             # happened, including under a concurrent-duplicate race (found in PR
             # review, OME-391 / C28).
             response.status_code = status.HTTP_200_OK
-        return outcome.score
+        return _submission_response(outcome.score, registered_revision)
     except OperationalError as exc:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -421,8 +421,18 @@ class BenchmarkSchema(BaseModel):
     created_at: datetime
 
 
+class ScoreRankingNotice(BaseModel):
+    """Why a successfully persisted score will not enter the current ranking."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: Literal["benchmark_revision_mismatch"]
+    submitted_benchmark_revision: str | None
+    registered_benchmark_revision: str
+
+
 class ScoreSchema(BaseModel):
-    """Read DTO for a score."""
+    """Read DTO for a score and the successful submission receipt."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -453,6 +463,13 @@ class ScoreSchema(BaseModel):
     # classification registry. Operator-only, never set via ScoreSubmission.
     openness_override: Literal["open", "closed"] | None = None
     run_cost_usd: RunCostUsd
+    # WHY exclude None at the MODEL serializer: ScoreSchema also feeds private JSONL exports and
+    # GET responses. A submit-time fact must not add `ranking_notice: null` to either, while a
+    # mismatch supplied by POST remains visible and documented in the shared schema.
+    ranking_notice: ScoreRankingNotice | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
 
 
 class LeaderboardEntry(BaseModel):

--- a/apps/scoreboard/tests/unit/test_scores_routes.py
+++ b/apps/scoreboard/tests/unit/test_scores_routes.py
@@ -799,3 +799,125 @@ async def test_a_lost_race_after_a_flip_is_a_conflict_not_a_store_outage(
 
     assert seen["raises"], "the IntegrityError branch was never reached"
     assert response.status_code == 409, response.text
+
+
+# --- OME-909: a stored revision mismatch must not look rankable ------------------------------
+
+
+async def test_post_score_revision_mismatch_succeeds_and_names_both_revisions(
+    score_client: AsyncClient,
+) -> None:
+    await Benchmark.filter(id="hle").update(revision="registered-revision")
+
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(benchmark_revision="submitted-revision"),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["benchmark_revision"] == "submitted-revision"
+    assert body["ranking_notice"] == {
+        "code": "benchmark_revision_mismatch",
+        "submitted_benchmark_revision": "submitted-revision",
+        "registered_benchmark_revision": "registered-revision",
+    }
+    assert await Score.filter(id=body["id"]).exists(), "the warning must not reject the evidence"
+
+    fetched = await score_client.get(f"/v1/scores/{body['id']}")
+    assert fetched.status_code == 200
+    assert "ranking_notice" not in fetched.json(), "the notice belongs only to the submit snapshot"
+
+
+async def test_post_score_revision_mismatch_replay_returns_the_same_notice(
+    score_client: AsyncClient,
+) -> None:
+    await Benchmark.filter(id="hle").update(revision="registered-revision")
+    payload = _valid_payload(benchmark_revision="submitted-revision")
+
+    created = await score_client.post("/v1/scores", json=payload)
+    replayed = await score_client.post("/v1/scores", json=payload)
+
+    assert created.status_code == 201
+    assert replayed.status_code == 200
+    assert replayed.json()["id"] == created.json()["id"]
+    assert replayed.json()["ranking_notice"] == created.json()["ranking_notice"]
+    assert await Score.all().count() == 1
+
+
+async def test_post_score_matching_revision_keeps_the_existing_response_shape(
+    score_client: AsyncClient,
+) -> None:
+    await Benchmark.filter(id="hle").update(revision="same-revision")
+
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(benchmark_revision="same-revision"),
+    )
+
+    assert response.status_code == 201
+    assert "ranking_notice" not in response.json()
+
+
+async def test_post_score_revisionless_board_emits_no_revision_notice(
+    score_client: AsyncClient,
+) -> None:
+    response = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(benchmark_revision="some-revision"),
+    )
+
+    assert response.status_code == 201
+    assert "ranking_notice" not in response.json()
+
+
+async def test_post_score_missing_submitted_revision_mismatches_a_registered_board(
+    score_client: AsyncClient,
+) -> None:
+    await Benchmark.filter(id="hle").update(revision="registered-revision")
+
+    response = await score_client.post("/v1/scores", json=_valid_payload())
+
+    assert response.status_code == 201
+    assert response.json()["ranking_notice"] == {
+        "code": "benchmark_revision_mismatch",
+        "submitted_benchmark_revision": None,
+        "registered_benchmark_revision": "registered-revision",
+    }
+
+
+async def test_revision_mismatch_notice_does_not_make_the_score_rank(
+    score_client: AsyncClient,
+) -> None:
+    await Benchmark.filter(id="hle").update(revision="registered-revision")
+    submitted = await score_client.post(
+        "/v1/scores",
+        json=_valid_payload(benchmark_revision="submitted-revision"),
+    )
+
+    board = await score_client.get("/v1/leaderboard/hle")
+
+    assert submitted.status_code == 201
+    assert submitted.json()["ranking_notice"]["code"] == "benchmark_revision_mismatch"
+    assert board.status_code == 200
+    assert board.json()["entries"] == [], "OME-775's comparability filter must remain intact"
+
+
+async def test_openapi_documents_the_revision_mismatch_notice_on_the_score_contract(
+    score_client: AsyncClient,
+) -> None:
+    response = await score_client.get("/openapi.json")
+
+    assert response.status_code == 200
+    schema = response.json()
+    post_schema = schema["paths"]["/v1/scores"]["post"]["responses"]["201"]["content"][
+        "application/json"
+    ]["schema"]
+    get_schema = schema["paths"]["/v1/scores/{score_id}"]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+    notice_code = schema["components"]["schemas"]["ScoreRankingNotice"]["properties"]["code"]
+
+    assert post_schema == {"$ref": "#/components/schemas/ScoreSchema"}
+    assert get_schema == {"$ref": "#/components/schemas/ScoreSchema"}
+    assert notice_code["const"] == "benchmark_revision_mismatch"

--- a/docs/plan/2026-09-04-OME-909-not-ranked-feedback.md
+++ b/docs/plan/2026-09-04-OME-909-not-ranked-feedback.md
@@ -1,0 +1,27 @@
+# OME-909 — Implementation plan
+
+## Frame
+
+Add a narrow submit-response fact at the API seam, carry it through the public Client value, and
+render it on the existing published-score card. Do not touch persistence or leaderboard selection.
+
+## Changes
+
+1. Record the submit-time response, mismatch predicate, snapshot timing, and Client presentation
+   decisions before implementation.
+2. Add focused failing Scoreboard tests for mismatch creation/replay, match, revisionless board,
+   OpenAPI, and unchanged leaderboard exclusion.
+3. Add the typed notice and POST response schemas; snapshot the registered revision before the
+   write and build the optional notice from the persisted score.
+4. Add focused failing Client tests for decoding, validation, public exports, and warning-card
+   rendering, including HTML escaping and the absent-notice path.
+5. Add the immutable public notice value, response decoding, and SFDS warning block.
+6. Run focused tests, then the complete Scoreboard and `screamingface` gates.
+7. Complete the ledger, commit, push, open a PR, link it from Linear, and move OME-909 to In Review.
+
+## Non-goals
+
+- modifying the ranking query or making mismatched submissions fail;
+- populating GET score responses with a ranking snapshot;
+- folding OME-922 partial-run feedback into this revision-specific notice;
+- portal or database changes.

--- a/docs/spec/2026-09-04-OME-909-not-ranked-feedback.md
+++ b/docs/spec/2026-09-04-OME-909-not-ranked-feedback.md
@@ -1,0 +1,76 @@
+# OME-909 — Not-ranked submission feedback
+
+Status: in progress · Stack: scoreboard + screamingface
+
+## Problem
+
+The Scoreboard correctly excludes a score whose benchmark revision differs from the revision the
+board is registered at. The write still succeeds, but the POST response and Client card currently
+look identical to a rankable submission. A submitter can therefore pay for a full run, receive a
+success receipt, and only discover later that the score never appears in the ranking.
+
+## Decisions
+
+### D1 — Persist successfully; explain ranking separately
+
+A revision mismatch remains a successful `200` idempotent replay or `201` creation. The result is
+valid evidence and stays stored. This feature must not turn comparability into request validity.
+
+### D2 — The score contract carries one optional typed notice
+
+The shared `ScoreSchema` gains an optional `ranking_notice` object so the established POST and GET
+OpenAPI references remain intact. On a revision mismatch the POST contains the stable code
+`benchmark_revision_mismatch`, the revision stored on the submitted score, and the benchmark
+revision registered by the board. GET never populates the field: this is submit-time feedback, not
+mutable ranking state promised by later reads.
+
+### D3 — Matching responses remain unchanged on the wire
+
+When no mismatch exists, `ranking_notice` is omitted—not serialized as `null`. The field's model
+serializer excludes only an absent notice, including in GET and private JSONL export paths; it does
+not drop any existing nullable score field. Existing score output remains byte-for-key compatible.
+
+### D4 — The predicate mirrors the existing ranking rule
+
+A mismatch exists only when the board has a non-null registered revision and the persisted score's
+`benchmark_revision` is unequal to it. That includes a missing submitted revision. A board with no
+registered revision does not filter by revision today and therefore emits no mismatch notice.
+The ranking query and its revision filter are not changed.
+
+### D5 — Report the persisted revision and a pre-write board snapshot
+
+The submitted value comes from the persisted `ScoreSchema`, after the store's existing revision
+resolution. The registered value is read immediately before the store call, inside the existing
+database-error boundary. This avoids a new read after a successful write that could fail and hide a
+persisted score id. Like all ranking state, a later seed can supersede the snapshot.
+
+### D6 — The Client preserves the machine-readable fact
+
+`LeaderboardScore` gains an optional immutable `LeaderboardRankingNotice`. The HTTP decoder
+validates the exact reason code and both revision fields rather than reducing the response to
+presentation copy. Older Scoreboards omit the field and continue to decode normally.
+
+### D7 — The score card distinguishes publication from ranking
+
+The card keeps the factual `Score published` receipt and successful persistence marker, then adds
+an SFDS warning block: `Not ranked · benchmark revision mismatch.` It names the submitted and
+registered revisions. Matching submissions render exactly as before. Warning semantics use the
+existing shared report-card tokens; no new palette or decorative system is introduced.
+
+## Verification contract
+
+- mismatched creation and replay both persist/return success and include the same typed notice;
+- the notice names the stored submitted revision and registered revision;
+- matching and revisionless-board POST responses omit the notice;
+- OpenAPI preserves the shared `ScoreSchema` response reference and documents the stable reason;
+- the Client decodes absence and mismatch, rejects malformed notices, and exposes the typed value;
+- the mismatched score card has an alert warning with escaped revision text;
+- matching cards and the existing ranking filter remain unchanged;
+- full Scoreboard and `screamingface` gates pass.
+
+## Non-goals
+
+- changing which rows rank, updating a stored row, or adding a database migration;
+- reporting partial-run, privacy, verification, or reproduction state through this notice;
+- promising that a submit-time snapshot remains the board's revision forever;
+- changing the portal or adding an operator-side seed warning.

--- a/docs/tasks/2026-09-04-OME-909-not-ranked-feedback.md
+++ b/docs/tasks/2026-09-04-OME-909-not-ranked-feedback.md
@@ -1,0 +1,22 @@
+---
+id: OME-909
+linear_url: https://linear.app/openmined/issue/OME-909/tell-a-submitter-when-their-score-will-not-rank-instead-of-accepting
+status: in_review
+type: task
+priority: 2
+labels: [scoreboard, agentic, autonomous]
+created: 2026-08-20
+closed:
+---
+
+# Tell a submitter when their score will not rank
+
+Keep benchmark-revision-mismatched scores as successful, persisted measurements, but tell the
+submitter immediately that the score is not comparable with—and will not rank on—the board's
+registered revision. Surface the same typed fact in the Python Client's published-score card.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-04-OME-909-not-ranked-feedback.md`
+- Plan: `docs/plan/2026-09-04-OME-909-not-ranked-feedback.md`
+- Ledger: `docs/work/2026-09-04-OME-909-not-ranked-feedback.md`

--- a/docs/work/2026-09-04-OME-909-not-ranked-feedback.md
+++ b/docs/work/2026-09-04-OME-909-not-ranked-feedback.md
@@ -1,0 +1,69 @@
+---
+ticket: OME-909
+stack: repo
+status: done
+started: 2026-09-04
+finished: 2026-09-04
+---
+
+# OME-909 — Not-ranked submission feedback
+
+## Intent
+
+Tell a submitter at the successful write seam when their persisted score will not rank because its
+benchmark revision differs from the board's registered revision, and carry that fact into the
+Python Client's score card without changing ranking.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py` — typed POST-only ranking notice.
+- `apps/scoreboard/src/scoreboard/routes/scores.py` — snapshot, compare, and return the notice.
+- New Scoreboard tests — API contract, replay, boundaries, OpenAPI, and ranking regression.
+- `packages/screamingface/src/screamingface/leaderboard.py` and public exports — immutable notice.
+- `packages/screamingface/src/screamingface/_scoreboard/leaderboards.py` — strict decoding.
+- `packages/screamingface/src/screamingface/_ui/score_view.py` — SFDS warning in the receipt.
+- New Client tests — value, malformed response, matching card, mismatch card, and escaping.
+- task, spec, plan, and this work ledger.
+
+## Test plan
+
+- RED: mismatched create/replay succeeds, stores, and names both revisions.
+- Boundaries: matching revision and revisionless board omit the field; missing submitted revision
+  mismatches a registered board.
+- Contract: OpenAPI exposes the stable reason code without changing GET score responses.
+- Regression: a mismatched stored row still does not enter the leaderboard.
+- Client: absence is backward-compatible; mismatch decodes to a public typed value; malformed
+  notices fail closed; the warning card is accessible, escaped, and matching cards stay unchanged.
+- Run both stacks' complete official gates.
+
+## Acceptance
+
+- Mismatched submissions remain successful and persisted with machine-readable feedback.
+- Both persisted/submitted and registered revisions are present in that feedback.
+- Matching submissions are unchanged.
+- The Client score card says the published score is not ranked and why.
+- The ranking filter is byte-identical to `origin/main` and full gates are green.
+
+## Outcome
+
+- **Actual files:** the planned Scoreboard schemas/route and additive route tests; the planned
+  Client public value/export, decoder, card, and additive Client tests; the Client changelog and
+  deliberately regenerated public-surface snapshot required by its communication guard; and the
+  task/spec/plan/ledger set. No model, migration, leaderboard query, or store change exists.
+- **Commits:** one conventional feature commit on `OME-909-not-ranked-feedback` (squash target;
+  final merge sha will be recorded in Linear).
+- **Gates:** Scoreboard `run_gates.py scoreboard --base origin/main` ALL GREEN (append-only, Ruff,
+  format, Pyright, full pytest coverage ≥80%, and all three portal suites). Client
+  `run_gates.py screamingface --base origin/main --skip-append-only` ALL GREEN (Ruff, format,
+  Pyright, full pytest coverage ≥95%, deterministic notebooks, build, and distribution check).
+  The integrated public-surface plus leaderboard modules pass 98 focused tests.
+- **Deviations:** the first design used a POST-specific response subclass, but the full gate exposed
+  an existing OpenAPI invariant that both POST and GET reference `ScoreSchema`. The final shared
+  schema conditionally excludes only an absent notice, preserving matching/GET/private-export wire
+  output while documenting the reason. `#830` merged during implementation; the branch was rebased
+  onto it and both co-author and ranking-notice fields/card content were retained, with a small
+  validator extraction to stay under the complexity cap. The Client's generated public-surface
+  snapshot necessarily changed for `LeaderboardRankingNotice` and `LeaderboardScore.ranking_notice`;
+  the owner explicitly approved this narrow Confidence-Gate exception, no existing behavioral test
+  logic/assertion changed, and the changelog records the public addition. The SFDS review reused the
+  existing warning semantic and palette; no visual-system token changed.

--- a/packages/screamingface/CHANGELOG.md
+++ b/packages/screamingface/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+* **screamingface:** expose and render why a published score will not rank
+
 ## 0.1.1 (2026-08-13)
 
 Baseline-only release. `0.1.0` and `0.1.1` were both uploaded to PyPI by hand rather than by

--- a/packages/screamingface/src/screamingface/__init__.py
+++ b/packages/screamingface/src/screamingface/__init__.py
@@ -32,6 +32,7 @@ from screamingface.leaderboard import (
     LeaderboardBaseline,
     LeaderboardEntry,
     LeaderboardInfo,
+    LeaderboardRankingNotice,
     LeaderboardScore,
 )
 from screamingface.model import Model
@@ -92,6 +93,7 @@ __all__ = [
     "LeaderboardEntry",
     "LeaderboardError",
     "LeaderboardInfo",
+    "LeaderboardRankingNotice",
     "LeaderboardScore",
     "MemberResult",
     "Model",

--- a/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
+++ b/packages/screamingface/src/screamingface/_scoreboard/leaderboards.py
@@ -26,6 +26,7 @@ from screamingface.leaderboard import (
     LeaderboardBaseline,
     LeaderboardEntry,
     LeaderboardInfo,
+    LeaderboardRankingNotice,
     LeaderboardScore,
 )
 from screamingface.report import CandidateResult
@@ -378,9 +379,30 @@ def _decode_score(payload: object, scoreboard_url: str | None = None) -> Leaderb
             metadata=metadata,
             scoreboard_url=scoreboard_url,
             authors=_decode_authors(root.get("authors"), "Leaderboard score authors"),
+            ranking_notice=_decode_ranking_notice(root),
         )
     except (TypeError, ValueError) as exc:
         _invalid(str(exc), exc)
+
+
+def _decode_ranking_notice(root: Mapping[str, object]) -> LeaderboardRankingNotice | None:
+    if "ranking_notice" not in root:
+        return None
+    notice = _mapping(root["ranking_notice"], "Leaderboard score ranking notice")
+    code = _text(notice.get("code"), "Leaderboard score ranking notice code")
+    if code != "benchmark_revision_mismatch":
+        _invalid("Leaderboard score ranking notice has an unsupported code")
+    return LeaderboardRankingNotice(
+        code="benchmark_revision_mismatch",
+        submitted_benchmark_revision=_optional_text(
+            notice.get("submitted_benchmark_revision"),
+            "Leaderboard score ranking notice submitted_benchmark_revision",
+        ),
+        registered_benchmark_revision=_text(
+            notice.get("registered_benchmark_revision"),
+            "Leaderboard score ranking notice registered_benchmark_revision",
+        ),
+    )
 
 
 def _cost_text(cost: Decimal | None) -> str | None:

--- a/packages/screamingface/src/screamingface/_ui/score_view.py
+++ b/packages/screamingface/src/screamingface/_ui/score_view.py
@@ -35,6 +35,7 @@ def leaderboard_score_html(value: LeaderboardScore) -> str:
     questions = f"{value.total_questions} question" + ("" if value.total_questions == 1 else "s")
     receipt = " · ".join((questions, f"id {str(value.id)[:8]}…"))
     authors = ", ".join(value.authors) if value.authors else "—"
+    ranking_notice = _ranking_notice_html(value)
     cells = [
         # INVARIANT (OME-866): the score renders as stored — plain number, no ×100,
         # no percent. _score_text is shared with the Report card so the same figure
@@ -59,10 +60,25 @@ def leaderboard_score_html(value: LeaderboardScore) -> str:
         f"<span class='sf-report__strip-when'>{escape(_stamp(value.submitted_at))}</span>"
         f"<span class='sf-report__receipt'>{escape(receipt)}</span></div>"
         "<div class='sf-report__card'>"
+        f"{ranking_notice}"
         f"<div class='sf-report__grid'>{''.join(cells)}</div>"
         "<details class='sf-report__det'><summary>URL4</summary>"
         f"<pre class='sf-report__pre'>{escape(_clip(str(value.url4), 1200))}</pre>"
         "</details></div></div>"
+    )
+
+
+def _ranking_notice_html(value: LeaderboardScore) -> str:
+    notice = value.ranking_notice
+    if notice is None:
+        return ""
+    submitted = notice.submitted_benchmark_revision or "none reported"
+    return (
+        "<div class='sf-report__warn' role='alert'>"
+        "<strong>Not ranked · benchmark revision mismatch.</strong> "
+        f"This run used revision {escape(submitted)}; "
+        f"the board ranks revision {escape(notice.registered_benchmark_revision)}."
+        "</div>"
     )
 
 
@@ -90,6 +106,11 @@ def _board_link_html(value: LeaderboardScore) -> str:
 
 
 def _revision(value: LeaderboardScore) -> str | None:
+    # INVARIANT (OME-909): the mismatch notice carries the store-resolved revision. Prefer it to
+    # legacy free-form metadata, which can disagree with the typed submission field and otherwise
+    # make one receipt name two different submitted revisions.
+    if value.ranking_notice is not None:
+        return value.ranking_notice.submitted_benchmark_revision
     if value.metadata is None:
         return None
     candidate = value.metadata.get("benchmark_revision")

--- a/packages/screamingface/src/screamingface/leaderboard.py
+++ b/packages/screamingface/src/screamingface/leaderboard.py
@@ -6,6 +6,7 @@ import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Literal
 from urllib.parse import urlsplit
 from uuid import UUID
 
@@ -85,6 +86,35 @@ class LeaderboardEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class LeaderboardRankingNotice:
+    """Why a successfully published score will not enter the current ranking."""
+
+    code: Literal["benchmark_revision_mismatch"]
+    submitted_benchmark_revision: str | None
+    registered_benchmark_revision: str
+
+    def __post_init__(self) -> None:
+        if self.code != "benchmark_revision_mismatch":
+            raise ValueError("Leaderboard ranking notice has an unsupported code")
+        object.__setattr__(
+            self,
+            "submitted_benchmark_revision",
+            _optional_text(
+                self.submitted_benchmark_revision,
+                "Leaderboard ranking notice submitted_benchmark_revision",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "registered_benchmark_revision",
+            _text(
+                self.registered_benchmark_revision,
+                "Leaderboard ranking notice registered_benchmark_revision",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
 class LeaderboardScore:
     """One persisted candidate score returned by the public Scoreboard."""
 
@@ -110,6 +140,7 @@ class LeaderboardScore:
     scoreboard_url: str | None = None
     # Public Scoreboard JSON strips domains; full author emails never enter this read model.
     authors: tuple[str, ...] | None = None
+    ranking_notice: LeaderboardRankingNotice | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.id, UUID):
@@ -164,6 +195,11 @@ class LeaderboardScore:
                 "authors",
                 _authors(self.authors, "Leaderboard score authors"),
             )
+        object.__setattr__(
+            self,
+            "ranking_notice",
+            _optional_ranking_notice(self.ranking_notice),
+        )
 
     def __repr__(self) -> str:
         # WHY custom: the dataclass auto-repr printed the ENTIRE compiled url4
@@ -320,6 +356,16 @@ def _authors(values: object, label: str) -> tuple[str, ...]:
     return selected
 
 
+def _optional_ranking_notice(value: object) -> LeaderboardRankingNotice | None:
+    if value is None:
+        return None
+    if not isinstance(value, LeaderboardRankingNotice):
+        raise TypeError(
+            "Leaderboard score ranking_notice must be a LeaderboardRankingNotice or None"
+        )
+    return value
+
+
 def _instances[T](values: object, kind: type[T], label: str) -> tuple[T, ...]:
     if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
         raise TypeError(f"{label} must be a sequence")
@@ -334,5 +380,6 @@ __all__ = [
     "LeaderboardBaseline",
     "LeaderboardEntry",
     "LeaderboardInfo",
+    "LeaderboardRankingNotice",
     "LeaderboardScore",
 ]

--- a/packages/screamingface/tests/public_surface_snapshot.json
+++ b/packages/screamingface/tests/public_surface_snapshot.json
@@ -27,6 +27,7 @@
       "LeaderboardEntry",
       "LeaderboardError",
       "LeaderboardInfo",
+      "LeaderboardRankingNotice",
       "LeaderboardScore",
       "MemberResult",
       "Model",
@@ -406,10 +407,19 @@
           "id": "field"
         }
       },
+      "LeaderboardRankingNotice": {
+        "kind": "class",
+        "members": {
+          "__init__": "method (self, code: \"Literal['benchmark_revision_mismatch']\", submitted_benchmark_revision: 'str | None', registered_benchmark_revision: 'str') -> None",
+          "code": "field",
+          "registered_benchmark_revision": "field",
+          "submitted_benchmark_revision": "field"
+        }
+      },
       "LeaderboardScore": {
         "kind": "class",
         "members": {
-          "__init__": "method (self, id: 'UUID', version: 'int', benchmark_id: 'str', spec_id: 'str', url4: 'Url4', submitted_by: 'str | None', submitted_at: 'datetime', score: 'float', total_questions: 'int', correct_questions: 'int | None', ran_with_providers: 'tuple[str, ...]', ran_at_local: 'datetime | None', client_name: 'str | None', client_version: 'str | None', client_platform: 'str | None', verified_by_screamingface: 'bool', metadata: 'Mapping[str, object] | None', scoreboard_url: 'str | None' = None, authors: 'tuple[str, ...] | None' = None) -> None",
+          "__init__": "method (self, id: 'UUID', version: 'int', benchmark_id: 'str', spec_id: 'str', url4: 'Url4', submitted_by: 'str | None', submitted_at: 'datetime', score: 'float', total_questions: 'int', correct_questions: 'int | None', ran_with_providers: 'tuple[str, ...]', ran_at_local: 'datetime | None', client_name: 'str | None', client_version: 'str | None', client_platform: 'str | None', verified_by_screamingface: 'bool', metadata: 'Mapping[str, object] | None', scoreboard_url: 'str | None' = None, authors: 'tuple[str, ...] | None' = None, ranking_notice: 'LeaderboardRankingNotice | None' = None) -> None",
           "authors": "field",
           "benchmark_id": "field",
           "client_name": "field",
@@ -420,6 +430,7 @@
           "metadata": "field",
           "ran_at_local": "field",
           "ran_with_providers": "field",
+          "ranking_notice": "field",
           "score": "field",
           "scoreboard_url": "field",
           "spec_id": "field",

--- a/packages/screamingface/tests/test_leaderboards.py
+++ b/packages/screamingface/tests/test_leaderboards.py
@@ -1600,3 +1600,138 @@ def test_score_response_rejects_malformed_public_authors(authors: object) -> Non
         pytest.raises(sf.LeaderboardError, match="Invalid Scoreboard Leaderboard response"),
     ):
         client.leaderboards.get_score(SCORE_ID)
+
+
+# --- OME-909: the successful submit receipt says when the score will not rank ----------------
+
+
+def _revision_mismatch_response(
+    *, submitted: str | None = "submitted-revision", registered: str = "registered-revision"
+) -> dict[str, object]:
+    payload = _score_response()
+    payload["benchmark_revision"] = submitted
+    payload["ranking_notice"] = {
+        "code": "benchmark_revision_mismatch",
+        "submitted_benchmark_revision": submitted,
+        "registered_benchmark_revision": registered,
+    }
+    return payload
+
+
+def test_submit_decodes_a_revision_mismatch_as_a_public_typed_value() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json=_revision_mismatch_response())
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(_candidate_result())
+
+    assert submitted.ranking_notice == sf.LeaderboardRankingNotice(
+        code="benchmark_revision_mismatch",
+        submitted_benchmark_revision="submitted-revision",
+        registered_benchmark_revision="registered-revision",
+    )
+
+
+def test_submit_from_an_older_scoreboard_has_no_ranking_notice() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json=_score_response())
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(_candidate_result())
+
+    assert submitted.ranking_notice is None
+
+
+@pytest.mark.parametrize(
+    "notice",
+    [
+        None,
+        {},
+        {
+            "code": "some_future_reason",
+            "submitted_benchmark_revision": "old",
+            "registered_benchmark_revision": "new",
+        },
+        {
+            "code": "benchmark_revision_mismatch",
+            "submitted_benchmark_revision": "old",
+            "registered_benchmark_revision": None,
+        },
+    ],
+)
+def test_submit_rejects_a_malformed_ranking_notice(notice: object) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        payload = _score_response()
+        payload["ranking_notice"] = notice
+        return httpx.Response(201, json=payload)
+
+    with _sync_client(handler) as client:
+        with pytest.raises(sf.LeaderboardError, match="ranking notice"):
+            client.leaderboards.submit(_candidate_result())
+
+
+def test_revision_mismatch_card_keeps_the_receipt_and_adds_an_alert() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json=_revision_mismatch_response())
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(_candidate_result())
+
+    html = cast(Any, submitted)._repr_html_()
+
+    assert "Score published" in html
+    assert "Not ranked · benchmark revision mismatch." in html
+    assert "This run used revision submitted-revision" in html
+    assert "the board ranks revision registered-revision" in html
+    assert "class='sf-report__warn'" in html
+    assert "role='alert'" in html
+
+
+def test_revision_mismatch_card_escapes_server_revision_text() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json=_revision_mismatch_response(
+                submitted="old<script>alert(1)</script>",
+                registered="new' onclick='alert(2)",
+            ),
+        )
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(_candidate_result())
+
+    html = cast(Any, submitted)._repr_html_()
+
+    assert "<script>" not in html
+    assert "old&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "new&#x27; onclick=&#x27;alert(2)" in html
+
+
+def test_matching_revision_card_has_no_not_ranked_warning() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json=_score_response())
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(_candidate_result())
+
+    html = cast(Any, submitted)._repr_html_()
+
+    assert "Score published" in html
+    assert "Not ranked" not in html
+    assert "role='alert'" not in html
+
+
+def test_revision_mismatch_card_identity_uses_the_persisted_revision() -> None:
+    # The typed response field is the store-resolved authority. Metadata is untyped client input
+    # and can retain a stale, conflicting legacy revision; the warning and identity strip must not
+    # tell two different stories on the same receipt.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json=_revision_mismatch_response())
+
+    with _sync_client(handler) as client:
+        submitted = client.leaderboards.submit(_candidate_result())
+
+    html = cast(Any, submitted)._repr_html_()
+
+    assert "draco · rev submitted-revision" in html
+    assert "draco · rev fixture-revision" not in html


### PR DESCRIPTION
## Summary
- return a machine-readable benchmark revision mismatch notice while still storing and accepting the score
- expose the notice as an immutable Client value and render an accessible not-ranked warning in the published-score card
- preserve matching submission output, GET/private-export output, and the existing leaderboard revision filter
- compose with the author fields merged in #830

## Verification
- Scoreboard official gates: all green, including append-only, coverage, and portal suites
- ScreamingFace official gates: all green, including 95% coverage, notebooks, build, and distribution verification
- owner-approved skip-append-only used only for the deliberately regenerated public API surface snapshot; existing behavioral tests were not changed

Refs: OME-909