### PR TITLE
refactor(screamingface-engine): split provider refusal from graded refusal in case status

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/aggregation.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/aggregation.py
@@ -278,7 +278,7 @@ def failed_case_result(
     )
 
 
-def refused_case_result(
+def refusal_case_result(
     *,
     selected_case: SelectedCase,
     refusal: str | None,
@@ -289,7 +289,25 @@ def refused_case_result(
     execution: CorrectiveExecution | Mapping[str, Any] | None = None,
     operations: Sequence[OperationOutput | Mapping[str, Any]] | None = None,
 ) -> CaseResult:
-    """Construct a refused Case after normal Benchmark grading."""
+    """Classify one refused Candidate Invocation into its case-level outcome.
+
+    Mental model (OME-1037): the invocation layer says only "the Candidate did not
+    answer"; THIS is the one place that decides what that means for the Case. A
+    refusal the Benchmark graded (DRACO scoring a decline 1.0, another benchmark
+    0.0) is an ordinary scored Case carrying the `refusal` text; a refusal the
+    Benchmark could not grade is a failed Case led by a `provider_refusal` failure,
+    followed by the grading failures, with the refusal text kept as evidence.
+
+    Worked example: refusal="I won't help", grade.score=0.8, no failures → scored,
+    refusal carried. refusal="I won't help", grade.score=None, one
+    incomplete_verdicts failure → failed, failures=[provider_refusal,
+    incomplete_verdicts]. refusal=None, grade.score=0.0 → failed with the score
+    DROPPED: a textless refusal is exactly a content_filter provider decline
+    (`runner/model_response.py` fires on content_filter OR non-null refusal, and
+    content_filter turns normally carry null text), so the model never answered and
+    a judge score over the empty answer would publish an infrastructure failure as
+    a plausible grade. The grade's checks/metrics stay as audit evidence.
+    """
 
     typed_grade = grade if isinstance(grade, CaseGrade) else CaseGrade.model_validate(grade)
     typed_failures = [
@@ -297,9 +315,41 @@ def refused_case_result(
         for failure in failures
     ]
     stop_reason, rounds_executed = _execution_fields(execution)
-
+    if typed_grade.score is not None and refusal is not None and not typed_failures:
+        return CaseResult(
+            status="scored",
+            case_id=selected_case.case_id,
+            input=selected_case.input,
+            output=None,
+            finish_reason=finish_reason,
+            refusal=refusal,
+            stop_reason=stop_reason,
+            rounds_executed=rounds_executed,
+            grade=typed_grade,
+            failures=[],
+            metadata=_case_metadata(selected_case, metadata),
+            operations=_operation_outputs(operations),
+        )
+    if typed_grade.score is not None:
+        # WHY: a failed Case cannot publish a numeric grade — the score over an
+        # answer that never existed is dropped, the audit material retained.
+        typed_grade = CaseGrade(
+            method=typed_grade.method,
+            score=None,
+            metrics=typed_grade.metrics,
+            checks=typed_grade.checks,
+        )
+    provider_refusal = Failure(
+        stage="candidate",
+        code="provider_refusal",
+        # The runner's own classification message (`runner/model_response.py`).
+        message="provider refused the request",
+        retryable=False,
+        case_id=selected_case.case_id,
+        metadata={},
+    )
     return CaseResult(
-        status="refused",
+        status="failed",
         case_id=selected_case.case_id,
         input=selected_case.input,
         output=None,
@@ -308,7 +358,7 @@ def refused_case_result(
         stop_reason=stop_reason,
         rounds_executed=rounds_executed,
         grade=typed_grade,
-        failures=typed_failures,
+        failures=[provider_refusal, *typed_failures],
         metadata=_case_metadata(selected_case, metadata),
         operations=_operation_outputs(operations),
     )
@@ -343,7 +393,7 @@ def grading_failure_case_result(
     )
     grade = CaseGrade(method=method, score=None, metrics={}, checks=[])
     if candidate.status == "refused":
-        return refused_case_result(
+        return refusal_case_result(
             selected_case=selected_case,
             refusal=candidate.refusal,
             finish_reason=candidate.finish_reason,
@@ -405,6 +455,6 @@ __all__ = [
     "finalize_candidate_result",
     "grading_failure_case_result",
     "public_error",
-    "refused_case_result",
+    "refusal_case_result",
     "scored_case_result",
 ]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/contract.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/contract.py
@@ -34,7 +34,12 @@ CANDIDATE_MESSAGE_ROLES = frozenset({"system", "developer", "user", "assistant"}
 CaseId = StrictInt | StrictStr
 Outcome = Literal["MET", "UNMET", "PASS", "FAIL"]
 FailureStage = Literal["candidate", "grading", "aggregation"]
-CaseStatus = Literal["scored", "refused", "failed"]
+# WHY only two values (OME-1037): `refused` meant "provider declined" in most
+# benchmarks and "correct answer" in DRACO — a graded refusal is an ordinary scored
+# Case carrying `refusal` text, and an ungradeable one is a failed Case whose
+# failures include the `provider_refusal` code. The invocation-layer `refused`
+# (CandidateInvocationStatus) stays: there it unambiguously means "did not answer".
+CaseStatus = Literal["scored", "failed"]
 CandidateInvocationStatus = Literal["completed", "refused"]
 
 
@@ -133,7 +138,7 @@ class Failure(_StrictWireModel):
 
 
 class CaseResult(_StrictWireModel):
-    """One selected Case with an explicit scored, refused, or failed outcome."""
+    """One selected Case with an explicit scored or failed outcome."""
 
     status: CaseStatus
     case_id: CaseId
@@ -179,8 +184,6 @@ class CaseResult(_StrictWireModel):
             raise ValueError("every Case Failure must reference its own case_id")
         if self.status == "scored":
             _require_scored_case(self)
-        elif self.status == "refused":
-            _require_refused_case(self)
         else:
             _require_failed_case(self)
         return self
@@ -278,42 +281,29 @@ def validate_corrective_execution(value: object) -> CorrectiveExecution:
 
 
 def _require_scored_case(case: CaseResult) -> None:
+    # INVARIANT (OME-1037): a scored Case is either an answer that was graded or a
+    # refusal that was graded — exactly one of output/refusal, never both or neither.
     if (
         case.grade is None
         or case.grade.score is None
-        or case.output is None
-        or case.refusal is not None
+        or (case.output is None) == (case.refusal is None)
         or case.failures
     ):
         raise ValueError(
-            "a scored Case requires output and a numeric grade and cannot carry refusal or failures"
+            "a scored Case requires a numeric grade and exactly one of output and refusal, "
+            "and cannot carry failures"
         )
 
 
-def _require_refused_case(case: CaseResult) -> None:
-    if case.output is not None or case.grade is None:
-        raise ValueError("a refused Case requires no output and a Benchmark grade")
-    if case.grade.score is not None and case.failures:
-        raise ValueError("a graded refused Case cannot carry failures")
-    if case.grade.score is None and (
-        not case.failures or any(failure.stage != "grading" for failure in case.failures)
-    ):
-        raise ValueError("an ungraded refused Case requires one or more grading failures")
-
-
 def _require_failed_case(case: CaseResult) -> None:
-    # WHY no provider_refusal Failure-code check: no producer can emit one. The Candidate
-    # adapter converts the runner's provider_refusal error into an ordinary refused
-    # invocation before it can become a Failure, and url4's on_error=collect envelope
-    # carries only kind+message — collected error codes always fall back to the
-    # aggregate defaults. Refusals reach this contract only through `case.refusal`.
-    if (
-        not case.failures
-        or case.refusal is not None
-        or case.grade is not None
-        and case.grade.score is not None
+    if not case.failures or case.grade is not None and case.grade.score is not None:
+        raise ValueError("a failed Case requires failures and no numeric grade")
+    # INVARIANT (OME-1037): refusal text on a failed Case is evidence for its
+    # provider_refusal failure; every other failed Case stays refusal-free.
+    if case.refusal is not None and all(
+        failure.code != "provider_refusal" for failure in case.failures
     ):
-        raise ValueError("a failed Case requires failures, no refusal, and no numeric grade")
+        raise ValueError("a failed Case carries refusal text only with a provider_refusal failure")
 
 
 class CandidateResult(_StrictWireModel):

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/case_results.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/case_results.py
@@ -12,7 +12,7 @@ from screamingface_engine.benchmarks.aggregation import (
     failed_case_result as build_failed_case_result,
 )
 from screamingface_engine.benchmarks.aggregation import (
-    refused_case_result as build_refused_case_result,
+    refusal_case_result as build_refusal_case_result,
 )
 from screamingface_engine.benchmarks.aggregation import (
     scored_case_result as build_scored_case_result,
@@ -162,7 +162,7 @@ def ungraded_case_result(case_record: Mapping[str, Any], failure: Mapping[str, A
     selected = _selected_case(case_record, id_key="case_id")
     refusal = case_record.get("refusal")
     if case_record.get("status") == "refused":
-        return build_refused_case_result(
+        return build_refusal_case_result(
             selected_case=selected,
             refusal=refusal if isinstance(refusal, str) else None,
             finish_reason=_finish_reason(case_record.get("finish_reason")),
@@ -210,7 +210,7 @@ def _case_result(
         "checks": [dict(check) for check in checks],
     }
     if case_record.get("status") == "refused":
-        return build_refused_case_result(
+        return build_refusal_case_result(
             selected_case=selected,
             refusal=refusal if isinstance(refusal, str) else None,
             finish_reason=finish_reason,

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/aggregate.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/aggregate.py
@@ -25,7 +25,7 @@ from screamingface_engine.benchmarks.aggregation import (
     finalize_candidate_result,
     grading_failure_case_result,
     public_error,
-    refused_case_result,
+    refusal_case_result,
     scored_case_result,
 )
 from screamingface_engine.benchmarks.case_execution import (
@@ -358,7 +358,7 @@ def _case_result(selected_case: SelectedCase, record: Mapping[str, Any]) -> Case
     }
     refusal = record.get("refusal")
     if record.get("status") == "refused":
-        return refused_case_result(
+        return refusal_case_result(
             selected_case=selected_case,
             refusal=refusal if isinstance(refusal, str) else None,
             finish_reason=record["finish_reason"],

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/grading.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/grading.py
@@ -38,7 +38,7 @@ from screamingface_engine.benchmarks.aggregation import (
     SelectedCase,
     failed_case_result,
     public_error,
-    refused_case_result,
+    refusal_case_result,
     scored_case_result,
 )
 from screamingface_engine.benchmarks.contract import CaseResult
@@ -162,7 +162,9 @@ class CaseGrader:
             "operations": fields.get("operations"),
         }
         if fields["status"] == "refused":
-            scored = refused_case_result(refusal=fields["refusal"], **common)
+            # WHY (OME-1037): the builder decides scored-vs-failed — a graded
+            # refusal with text is scored; a textless provider decline is failed.
+            scored = refusal_case_result(refusal=fields["refusal"], **common)
         else:
             scored = scored_case_result(output=fields["output"], **common)
         return scored, score, len(verdicts), sum(verdicts.values()), invalid
@@ -202,7 +204,7 @@ class CaseGrader:
             "operations": fields.get("operations"),
         }
         if fields["status"] == "refused":
-            return refused_case_result(refusal=fields["refusal"], **common)
+            return refusal_case_result(refusal=fields["refusal"], **common)
         return failed_case_result(output=fields["output"], **common)
 
     def _failure(self, case_id: int, stage: str, code: str, **metadata: Any) -> dict[str, Any]:

--- a/apps/screamingface-engine/tests/unit/test_benchmark_aggregation.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_aggregation.py
@@ -12,7 +12,7 @@ from screamingface_engine.benchmarks.aggregation import (
     failed_case_result,
     finalize_candidate_result,
     public_error,
-    refused_case_result,
+    refusal_case_result,
     scored_case_result,
 )
 from screamingface_engine.benchmarks.contract import CaseGrade, CaseResult, Failure
@@ -230,16 +230,18 @@ def test_finalizer_does_not_coerce_a_string_score() -> None:
         )
 
 
-def test_refused_case_constructor_preserves_exact_text_and_normal_grade() -> None:
+def test_refusal_case_constructor_preserves_exact_text_and_normal_grade() -> None:
+    # INVARIANT (OME-1037): a refusal the Benchmark graded is an ordinary SCORED
+    # Case carrying the exact refusal text — no more `refused` case status.
     exact = "I can’t provide that dosage."
-    case = refused_case_result(
+    case = refusal_case_result(
         selected_case=SelectedCase(case_id="health-7", input="Recommend a dosage.", metadata={}),
         refusal=exact,
         finish_reason="content_filter",
         grade=CaseGrade(method="test", score=0.0, metrics={}, checks=[]),
     )
 
-    assert case.status == "refused"
+    assert case.status == "scored"
     assert case.refusal == exact
     assert case.output is None
     assert case.grade is not None and case.grade.score == 0.0

--- a/apps/screamingface-engine/tests/unit/test_benchmark_failure_policy.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_failure_policy.py
@@ -11,7 +11,7 @@ from screamingface_engine.benchmarks.aggregation import (
     CandidateScore,
     SelectedCase,
     finalize_candidate_result,
-    refused_case_result,
+    refusal_case_result,
 )
 from screamingface_engine.benchmarks.contract import (
     CandidateResult,
@@ -74,7 +74,7 @@ def test_refusal_is_normal_benchmark_input_and_can_carry_a_numeric_grade() -> No
     exact = "I cannot provide those instructions."
     answer = candidate_answer(encode_candidate_invocation("", "content_filter", exact))
     assert answer.refusal is not None
-    case = refused_case_result(
+    case = refusal_case_result(
         selected_case=SelectedCase(case_id=1, input="question", metadata={}),
         refusal=answer.refusal,
         finish_reason=answer.finish_reason,
@@ -84,7 +84,8 @@ def test_refusal_is_normal_benchmark_input_and_can_carry_a_numeric_grade() -> No
     assert answer.text == exact
     assert answer.output is None
     assert answer.refusal == exact
-    assert case.status == "refused"
+    # INVARIANT (OME-1037): a graded refusal is an ordinary scored Case.
+    assert case.status == "scored"
     assert case.refusal == exact
     assert case.output is None
     assert case.grade is not None and case.grade.score == 0.0
@@ -100,16 +101,19 @@ def test_refusal_retains_a_missing_grade_when_later_grading_fails() -> None:
         case_id=1,
         metadata={},
     )
-    case = refused_case_result(
+    case = refusal_case_result(
         selected_case=SelectedCase(case_id=1, input="question", metadata={}),
         refusal="I cannot answer.",
         grade=_grade(None),
         failures=[failure],
     )
 
-    assert case.status == "refused"
+    # INVARIANT (OME-1037): an ungradeable refusal is a FAILED Case led by the
+    # provider_refusal failure, with the grading failure retained after it.
+    assert case.status == "failed"
+    assert case.refusal == "I cannot answer."
     assert case.grade is not None and case.grade.score is None
-    assert case.failures == [failure]
+    assert [item.code for item in case.failures] == ["provider_refusal", "judge_unavailable"]
 
 
 def test_partial_candidate_scores_only_gradeable_cases_and_declares_coverage() -> None:

--- a/apps/screamingface-engine/tests/unit/test_benchmark_outcome_conformance.py
+++ b/apps/screamingface-engine/tests/unit/test_benchmark_outcome_conformance.py
@@ -88,12 +88,17 @@ def test_refusal_survives_a_later_grading_failure_across_benchmarks(
     assert result["coverage"] == 0.0
     assert result["metrics"] == {}
     case = result["cases"][0]
-    assert case["status"] == "refused"
+    # INVARIANT (OME-1037): an ungradeable refusal is a FAILED Case led by a
+    # provider_refusal failure, the grading failure retained after it, and the
+    # refusal text preserved verbatim as evidence (None stays None).
+    assert case["status"] == "failed"
     assert case["output"] is None
     assert case["refusal"] == refusal
     assert case["grade"]["score"] is None
-    assert case["failures"][0]["stage"] == "grading"
-    assert case["failures"][0]["code"] == "judge_unavailable"
+    assert [(item["stage"], item["code"]) for item in case["failures"]] == [
+        ("candidate", "provider_refusal"),
+        ("grading", "judge_unavailable"),
+    ]
 
 
 @pytest.mark.parametrize("aggregate", (_ifeval, _draco, _healthbench))

--- a/apps/screamingface-engine/tests/unit/test_candidate_result_contract.py
+++ b/apps/screamingface-engine/tests/unit/test_candidate_result_contract.py
@@ -271,10 +271,12 @@ def test_open_wire_fields_accept_only_json_values() -> None:
             build()
 
 
-def test_refused_case_preserves_exact_refusal_and_normal_grade() -> None:
+def test_a_graded_refusal_is_a_scored_case_with_exact_refusal_text() -> None:
+    # INVARIANT (OME-1037): a refusal the Benchmark graded is an ordinary scored
+    # Case carrying exactly one of output/refusal — the `refused` status is gone.
     refusal = "I can’t provide that dosage."
     case = CaseResult(
-        status="refused",
+        status="scored",
         case_id=7,
         input="Recommend a dosage.",
         output=None,
@@ -285,12 +287,12 @@ def test_refused_case_preserves_exact_refusal_and_normal_grade() -> None:
         metadata={},
     )
 
+    assert case.status == "scored"
     assert case.refusal == refusal
     assert case.grade is not None and case.grade.score == 0.0
     assert case.failures == []
-    no_text = CaseResult(**{**case.model_dump(), "refusal": None})
-    assert no_text.status == "refused"
-    assert no_text.refusal is None
+    with pytest.raises(ValidationError, match="exactly one"):
+        CaseResult(**{**case.model_dump(), "refusal": None})
 
 
 def test_failed_case_requires_a_typed_failure_and_cannot_carry_a_score() -> None:

--- a/apps/screamingface-engine/tests/unit/test_corrective_loop_e2e.py
+++ b/apps/screamingface-engine/tests/unit/test_corrective_loop_e2e.py
@@ -206,7 +206,8 @@ async def test_a_selected_provider_refusal_is_graded_and_published_verbatim(
     )
     assert result["score"] == 1.0
     case = _first_case(result)
-    assert case["status"] == "refused"
+    # INVARIANT (OME-1037): a graded refusal publishes as an ordinary scored Case.
+    assert case["status"] == "scored"
     assert case["output"] is None
     assert case["refusal"] == _PASS_ANSWER
     assert case["finish_reason"] == "content_filter"

--- a/apps/screamingface-engine/tests/unit/test_draco_failure_integrity.py
+++ b/apps/screamingface-engine/tests/unit/test_draco_failure_integrity.py
@@ -174,7 +174,7 @@ def test_provider_refusal_is_retained_exactly_and_graded_normally() -> None:
     case = result["cases"][0]
     assert result["score"] == 1.0
     assert result["coverage"] == 1.0
-    assert case["status"] == "refused"
+    assert case["status"] == "scored"  # OME-1037: a graded refusal is scored
     assert case["refusal"] == exact
     assert case["finish_reason"] == "content_filter"
     assert case["grade"]["score"] == 1.0

--- a/apps/screamingface-engine/tests/unit/test_healthbench_aggregate.py
+++ b/apps/screamingface-engine/tests/unit/test_healthbench_aggregate.py
@@ -409,7 +409,7 @@ def test_provider_refusals_are_mapped_by_case_and_preserved_exactly(tmp_path: Pa
 
     assert result["score"] == 0.5
     assert result["coverage"] == 1.0
-    assert [case["status"] for case in result["cases"]] == ["refused", "refused"]
+    assert [case["status"] for case in result["cases"]] == ["scored", "scored"]  # OME-1037
     assert [case["refusal"] for case in result["cases"]] == [first, second]
     assert [case["finish_reason"] for case in result["cases"]] == [
         "content_filter",

--- a/apps/screamingface-engine/tests/unit/test_ifeval_unscored_results.py
+++ b/apps/screamingface-engine/tests/unit/test_ifeval_unscored_results.py
@@ -130,7 +130,7 @@ def test_provider_refusal_is_retained_exactly_and_graded_normally() -> None:
     case = result["cases"][0]
     assert result["score"] == 0.0
     assert result["coverage"] == 1.0
-    assert case["status"] == "refused"
+    assert case["status"] == "scored"  # OME-1037: a graded refusal is scored
     assert case["refusal"] == exact
     assert case["finish_reason"] == "content_filter"
     assert case["grade"]["score"] == 0.0

--- a/apps/screamingface-engine/tests/unit/test_refusal_status_split.py
+++ b/apps/screamingface-engine/tests/unit/test_refusal_status_split.py
@@ -1,0 +1,193 @@
+"""The case-status space carries one meaning per value (OME-1037).
+
+INVARIANT defended: `refused` is no longer a case status — the word meant "provider
+declined" in most benchmarks and "correct answer" in DRACO (refusing a deceptive
+prompt is graded as success). A refusal the benchmark graded is an ordinary `scored`
+case carrying `refusal` text; a refusal the benchmark could not grade is a `failed`
+case carrying a `provider_refusal` failure plus the grading failures. The invocation
+layer's `refused` (`CandidateInvocationStatus`) is untouched — there it unambiguously
+means "the candidate did not answer".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from screamingface_engine.benchmarks.aggregation import (
+    SelectedCase,
+    refusal_case_result,
+)
+from screamingface_engine.benchmarks.contract import CaseResult
+
+
+def _grade(**overrides: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "method": "rubric",
+        "score": 1.0,
+        "metrics": {"judged": 3},
+        "checks": [],
+    }
+    values.update(overrides)
+    return values
+
+
+def _case(**overrides: Any) -> CaseResult:
+    values: dict[str, Any] = {
+        "status": "scored",
+        "case_id": 7,
+        "input": "A deceptive prompt.",
+        "output": None,
+        "finish_reason": "stop",
+        "refusal": "I will not help with that.",
+        "grade": _grade(),
+        "failures": [],
+        "metadata": {},
+    }
+    values.update(overrides)
+    return CaseResult.model_validate(values)
+
+
+def _grading_failure(**overrides: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "stage": "grading",
+        "code": "incomplete_verdicts",
+        "message": "the Judge did not return a usable verdict",
+        "retryable": True,
+        "case_id": 7,
+        "metadata": {},
+    }
+    values.update(overrides)
+    return values
+
+
+def _selected_case() -> SelectedCase:
+    return SelectedCase(case_id=7, input="A deceptive prompt.", metadata={"axis": "deception"})
+
+
+def test_refused_is_no_longer_a_case_status() -> None:
+    # WHY: the one word carried two opposite meanings across benchmarks; after
+    # OME-1037 the wire vocabulary has no `refused` case status at all.
+    with pytest.raises(ValidationError):
+        _case(status="refused")
+
+
+def test_a_graded_refusal_is_an_ordinary_scored_case_carrying_refusal_text() -> None:
+    # STORY: DRACO grades a model's decline of a deceptive prompt as success — a
+    # graded refusal is a normal scored outcome, not failure vocabulary.
+    case = _case()
+
+    assert case.status == "scored"
+    assert case.output is None
+    assert case.refusal == "I will not help with that."
+    assert case.grade is not None and case.grade.score == 1.0
+
+
+@pytest.mark.parametrize(
+    ("output", "refusal"),
+    [
+        pytest.param("An answer.", "I refuse.", id="both-answer-and-refusal"),
+        pytest.param(None, None, id="neither-answer-nor-refusal"),
+    ],
+)
+def test_a_scored_case_carries_exactly_one_of_output_and_refusal(
+    output: str | None, refusal: str | None
+) -> None:
+    # INVARIANT: a scored case is either an answer that was graded or a refusal
+    # that was graded — never both, never neither.
+    with pytest.raises(ValidationError, match="exactly one"):
+        _case(output=output, refusal=refusal)
+
+
+def test_an_ungradeable_refusal_is_a_failed_case_with_a_provider_refusal_failure() -> None:
+    case = _case(
+        status="failed",
+        grade=_grade(score=None, metrics={}),
+        failures=[
+            _grading_failure(
+                stage="candidate", code="provider_refusal", message="provider refused the request"
+            ),
+            _grading_failure(),
+        ],
+    )
+
+    assert case.status == "failed"
+    assert case.refusal == "I will not help with that."
+
+
+def test_a_failed_case_carries_refusal_text_only_as_provider_refusal_evidence() -> None:
+    # INVARIANT: refusal text on a failed case is evidence for a provider_refusal
+    # failure; any other failed case stays refusal-free.
+    with pytest.raises(ValidationError, match="provider_refusal"):
+        _case(status="failed", grade=_grade(score=None, metrics={}), failures=[_grading_failure()])
+
+
+def test_builder_classifies_a_graded_refusal_as_scored() -> None:
+    case = refusal_case_result(
+        selected_case=_selected_case(),
+        refusal="I will not help with that.",
+        finish_reason="stop",
+        grade=_grade(score=0.8),
+    )
+
+    assert case.status == "scored"
+    assert case.refusal == "I will not help with that."
+    assert case.output is None
+    assert case.grade is not None and case.grade.score == 0.8
+    assert case.failures == []
+
+
+def test_builder_classifies_an_ungraded_refusal_as_failed_with_provider_refusal() -> None:
+    case = refusal_case_result(
+        selected_case=_selected_case(),
+        refusal="I will not help with that.",
+        finish_reason="stop",
+        grade=_grade(score=None, metrics={}),
+        failures=[_grading_failure()],
+    )
+
+    assert case.status == "failed"
+    # WHY the ordering: the provider refusal explains WHY grading failed, so it
+    # leads; the grading failures follow as the downstream evidence.
+    assert [failure.code for failure in case.failures] == [
+        "provider_refusal",
+        "incomplete_verdicts",
+    ]
+    assert case.refusal == "I will not help with that."
+    assert case.grade is not None and case.grade.score is None
+
+
+def test_builder_demotes_a_textless_provider_decline_even_when_a_score_came_back() -> None:
+    # WHY: a textless refusal is exactly a content_filter provider decline
+    # (`raise_if_unusable` fires on content_filter OR non-null refusal, and
+    # content_filter turns normally carry null text). The model never answered, so
+    # a judge score over the empty answer would be an infrastructure failure
+    # published as a plausible grade — the score is dropped, the checks stay as
+    # audit evidence, and the case is a visible provider failure.
+    case = refusal_case_result(
+        selected_case=_selected_case(),
+        refusal=None,
+        finish_reason="content_filter",
+        grade=_grade(score=0.0, metrics={"judged": 3}),
+    )
+
+    assert case.status == "failed"
+    assert case.refusal is None
+    assert [failure.code for failure in case.failures] == ["provider_refusal"]
+    assert case.grade is not None and case.grade.score is None
+    assert case.grade.metrics == {"judged": 3}
+
+
+def test_builder_keeps_selected_case_metadata_and_finish_reason() -> None:
+    case = refusal_case_result(
+        selected_case=_selected_case(),
+        refusal="I will not help with that.",
+        finish_reason="content_filter",
+        grade=_grade(score=1.0),
+    )
+
+    assert case.metadata == {"axis": "deception"}
+    assert case.finish_reason == "content_filter"
+    assert case.case_id == 7

--- a/apps/screamingface-engine/tests/unit/test_spine_case_grader.py
+++ b/apps/screamingface-engine/tests/unit/test_spine_case_grader.py
@@ -155,7 +155,8 @@ def test_a_fully_judged_case_scores_without_failures() -> None:
     assert (judged, met, invalid) == (2, 1, 0)
 
 
-def test_a_refused_case_still_carries_its_numeric_grade() -> None:
+def test_a_graded_refusal_is_scored_and_still_carries_its_numeric_grade() -> None:
+    # INVARIANT (OME-1037): a refusal the board graded is an ordinary scored Case.
     row = {
         "verdicts": {1: False, 2: False},
         "status": "refused",
@@ -163,6 +164,6 @@ def test_a_refused_case_still_carries_its_numeric_grade() -> None:
         "finish_reason": "content_filter",
     }
     result, score, *_ = GRADER.case_result(CASE, row, [4, 4])
-    assert result.status == "refused"
+    assert result.status == "scored"
     assert result.refusal == "I cannot help with that."
     assert score == 0.0

--- a/docs/tasks/2026-09-06-OME-1037-refused-status-split.md
+++ b/docs/tasks/2026-09-06-OME-1037-refused-status-split.md
@@ -1,0 +1,25 @@
+---
+id: OME-1037
+linear_url: https://linear.app/openmined/issue/OME-1037/refused-means-a-provider-failure-in-one-benchmark-and-correct-behavior
+status: in_progress
+type:
+priority: medium
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+created: 2026-09-06
+closed:
+---
+
+# "Refused" means a provider failure in one benchmark and correct behavior in another
+
+Re-partition the case-status space: `CaseStatus` drops `refused`. A refusal the
+benchmark can grade becomes an ordinary `scored` case carrying `refusal` text
+(exactly one of `output`/`refusal` set); a refusal the benchmark cannot grade becomes
+a `failed` case carrying a `provider_refusal` failure plus the grading failures.
+`CandidateInvocationStatus` (`completed`/`refused`) is untouched — at the invocation
+layer "refused" is unambiguous.
+
+Full issue body: see linear_url. Work ledger:
+`docs/work/2026-09-06-OME-1037-refused-status-split.md`.

--- a/docs/work/2026-09-06-OME-1037-refused-status-split.md
+++ b/docs/work/2026-09-06-OME-1037-refused-status-split.md
@@ -1,0 +1,152 @@
+---
+ticket: OME-1037
+stack: screamingface-engine + screamingface
+status: in_progress
+started: 2026-09-06
+finished:
+---
+
+# OME-1037 — split provider refusal from graded refusal in the case status
+
+## Intent
+
+The case status `refused` means "provider declined" in most benchmarks but "correct
+answer" in DRACO (refusing a deceptive prompt is graded as success). This unit
+re-partitions the case-status space so no single status value carries both meanings:
+`CaseStatus = "scored" | "failed"`. A refusal the benchmark graded is an ordinary
+`scored` case carrying `refusal` text; a refusal the benchmark could not grade is a
+`failed` case carrying a `provider_refusal` failure plus the grading failures.
+`CandidateInvocationStatus = "completed" | "refused"` is untouched — at the
+invocation layer "refused" is unambiguous (the candidate did not answer).
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/contract.py`
+  - `CaseStatus = Literal["scored", "failed"]` (delete `refused`).
+  - Scored invariant: exactly one of `output`/`refusal` set + numeric grade + no failures.
+  - Failed invariant: failures required, no numeric grade; `refusal` allowed iff
+    failures include code `provider_refusal`.
+  - Delete `_require_refused_case` and the now-false "no producer can emit one" WHY
+    comment (~line 305) — the spine now emits `provider_refusal` failures.
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/aggregation.py`
+  - Rework/rename `refused_case_result` → `refusal_case_result`: given the grade the
+    benchmark produced, classify — grade came back AND refusal text exists → scored
+    case with `refusal`; otherwise → failed case with a `provider_refusal` failure
+    (stage `candidate`, message "provider refused the request", retryable False)
+    prepended to the grading failures, refusal text preserved as evidence, and the
+    grade retained with `score=None`.
+  - `grading_failure_case_result` follows the rename.
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/grading.py`
+  - Both `refused_case_result` call sites (~164, ~204) follow the rename; the
+    scored/failed classification now lives in the builder.
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/case_results.py`,
+  `.../ifeval/aggregate.py` — call sites follow the rename (3 sites).
+- `packages/screamingface/src/screamingface/case_result.py`
+  - `CaseStatus` drops `refused`; `_validate_refused_case` deleted;
+    scored/failed validators mirror the engine invariants (failed now ACCEPTS
+    `provider_refusal` + refusal-with-provider_refusal); status derivation for
+    directly-built values follows (`refusal is not None` no longer implies refused).
+  - `refusal_kind` re-homed: derived for any case that represents a refusal
+    (scored-with-refusal, or failed-with-`provider_refusal`), same OME-745 signal
+    table (content_filter first), never serialized.
+- `packages/screamingface/src/screamingface/_evaluation/results.py` — `_case_status`
+  decode drops `refused`.
+- `packages/screamingface/src/screamingface/_ui/report_view.py` — `refused` display
+  state removed; scored-with-refusal renders as a graded case, ungradeable refusals
+  land in the failed/unscored buckets.
+- Detection layers UNTOUCHED: `runner/model_response.py`, `runner/connector.py`,
+  `benchmarks/invocation.py`, `benchmarks/ensemble/runtime.py`.
+- No schema/model (ORM) change — S1 not applicable.
+
+## Decision (95% gate, resolved from OME-745 semantics)
+
+A graded refusal WITHOUT refusal text cannot satisfy "exactly one of
+output/refusal". Textless refusals are exactly the `content_filter` provider
+declines (`raise_if_unusable` triggers on `content_filter` OR non-null refusal;
+`content_filter` turns normally carry null text). A provider decline is not a model
+answer, so a judge score over the empty answer is an infrastructure failure
+masquerading as a graded outcome ("infrastructure failure never becomes a plausible
+zero"). The builder therefore demotes it: failed case, `provider_refusal` failure,
+grade retained with `score=None` (checks kept as audit evidence).
+
+## Test plan (RED first)
+
+- Engine contract: `refused` status rejected by `CaseResult`; scored-with-refusal
+  accepted; scored with both/neither of output/refusal rejected;
+  failed-with-provider_refusal (+ refusal text) accepted; failed with refusal but no
+  provider_refusal code rejected; failed with numeric grade still rejected.
+- Engine builder: `refusal_case_result` with graded refusal text → scored case
+  carrying refusal; with score-None grade + grading failure → failed case with
+  provider_refusal + the grading failure, refusal preserved; with score but no
+  refusal text (content_filter decline) → failed with score demoted to None.
+- SDK: decode of status `refused` raises; scored-with-refusal and
+  failed-with-provider_refusal decode; `refusal_kind` truth table re-homed.
+- Prior tests/goldens asserting the old `refused` case status are the contract this
+  ticket deliberately changes — each one updated is listed under Deviations.
+- e2e replay goldens re-blessed via the replay harness; no live calls (fixtures
+  contain no refused case, so goldens are expected byte-identical).
+
+## Acceptance
+
+- No status value means both provider-decline and graded model refusal.
+- A benchmark grades a model refusal as success without overloading failure vocabulary.
+- Gates green: `run_gates.py screamingface-engine` and `run_gates.py screamingface`.
+- All e2e replays green against (re-)blessed goldens; zero live model calls.
+
+## Outcome (fill at the end — required before COMMIT)
+
+Status note: implementation complete, gates green, draft PR open — **awaiting
+review**; ledger stays `in_progress` until the PR merges and OME-1037 closes.
+
+- **Actual files:** exactly as planned, plus the consumer sweep found three more
+  surfaces (all updated in this unit):
+  - Engine src: `benchmarks/contract.py`, `benchmarks/aggregation.py`,
+    `benchmarks/spine/grading.py`, `benchmarks/draco/case_results.py`,
+    `benchmarks/ifeval/aggregate.py` (the last two are call-site renames the plan
+    grouped under "spine callers").
+  - SDK src: `case_result.py`, `_evaluation/results.py`, `_ui/report_view.py`.
+  - e2e harness: `tests/e2e/harness/goldens.py` (docstring only — the schema
+    imports the SDK `CaseStatus`, so its vocabulary shrank automatically).
+  - New tests: `apps/screamingface-engine/tests/unit/test_refusal_status_split.py`
+    (10), `packages/screamingface/tests/test_refusal_status_split.py` (10).
+  - Scoreboard/portal/report-intake: swept — zero consumers of the `refused` case
+    status (all grep hits were unrelated prose or the invocation-layer vocabulary).
+- **Commits:** single implementation commit on `OME-1037-refused-status-split`
+  (sha recorded in the follow-up ledger commit and the PR).
+- **Gates:**
+  - `run_gates.py screamingface-engine --skip-append-only`: ALL GATES GREEN
+    (ruff check, ruff format, pyright, check_layering, pytest with coverage ≥80 —
+    2350 passed, 5 skipped).
+  - `run_gates.py screamingface --skip-append-only`: ALL GATES GREEN (ruff check,
+    ruff format, pyright, pytest with coverage ≥95 — 1368 tests incl. the e2e
+    replay suite, notebooks check, uv build, distribution check). Zero live model
+    calls; committed goldens unchanged (no refusal case recorded in them).
+- **Deviations:** (prior tests/goldens changed — owner-approved for this unit, they
+  assert the exact contract this ticket re-partitions)
+  - Engine prior tests updated (assertion flips `refused` → `scored`/`failed`,
+    builder rename `refused_case_result` → `refusal_case_result`):
+    `tests/unit/test_benchmark_aggregation.py`,
+    `tests/unit/test_benchmark_failure_policy.py` (2 tests),
+    `tests/unit/test_benchmark_outcome_conformance.py`,
+    `tests/unit/test_candidate_result_contract.py`,
+    `tests/unit/test_corrective_loop_e2e.py`,
+    `tests/unit/test_draco_failure_integrity.py`,
+    `tests/unit/test_healthbench_aggregate.py`,
+    `tests/unit/test_ifeval_unscored_results.py`,
+    `tests/unit/test_spine_case_grader.py`.
+  - SDK prior tests updated: `tests/test_case_outcome_decoding.py`,
+    `tests/test_case_refusal_kind.py` (rewritten to the two new refusal homes),
+    `tests/test_candidate_result_coverage.py`, `tests/test_report.py`,
+    `tests/test_report_panel.py`, `tests/test_draco_vertical_slice.py`,
+    `tests/e2e/test_harness_contracts.py` (synthetic golden vocabulary),
+    `tests/e2e/test_bless_contracts.py` (author_golden fixture).
+  - `run_gates.py` run with `--skip-append-only` (the runner's own flag) because
+    the mechanical append-only check cannot see the owner approval; every touched
+    prior test is listed above.
+  - Committed e2e goldens NOT re-blessed: neither committed golden
+    (`draco-3pass`, `healthbench-worst30`) contains a refusal case, so replay
+    outcomes are byte-identical under the new partition — verified by the e2e
+    suite, zero live calls.
+  - Report panel copy: the pane label `provider refusal` → `refusal` (the text may
+    now be a scored model decline); a graded refusal renders a real verdict
+    (correct/incorrect), no longer a warning state.

--- a/docs/work/2026-09-06-OME-1037-refused-status-split.md
+++ b/docs/work/2026-09-06-OME-1037-refused-status-split.md
@@ -111,8 +111,9 @@ review**; ledger stays `in_progress` until the PR merges and OME-1037 closes.
     (10), `packages/screamingface/tests/test_refusal_status_split.py` (10).
   - Scoreboard/portal/report-intake: swept — zero consumers of the `refused` case
     status (all grep hits were unrelated prose or the invocation-layer vocabulary).
-- **Commits:** single implementation commit on `OME-1037-refused-status-split`
-  (sha recorded in the follow-up ledger commit and the PR).
+- **Commits:**
+  - `fe1a8cff` — refactor(screamingface-engine): split provider refusal from
+    graded refusal in case status
 - **Gates:**
   - `run_gates.py screamingface-engine --skip-append-only`: ALL GATES GREEN
     (ruff check, ruff format, pyright, check_layering, pytest with coverage ≥80 —

--- a/packages/screamingface/src/screamingface/_evaluation/results.py
+++ b/packages/screamingface/src/screamingface/_evaluation/results.py
@@ -502,10 +502,11 @@ def _evidence_outcome(
 
 
 def _case_status(value: object) -> CaseStatus:
+    # WHY no `refused` branch (OME-1037): the value no longer exists on the wire —
+    # a graded refusal is `scored` with refusal text, an ungradeable one `failed`
+    # with a provider_refusal failure. An Engine still emitting it fails loudly.
     if value == "scored":
         return "scored"
-    if value == "refused":
-        return "refused"
     if value == "failed":
         return "failed"
     raise ExecutionError("Case Result status is unsupported")

--- a/packages/screamingface/src/screamingface/_ui/report_view.py
+++ b/packages/screamingface/src/screamingface/_ui/report_view.py
@@ -334,13 +334,13 @@ def _coverage_notice_html(candidate: CandidateResult) -> str:
     else:
         heading = "score unavailable"
         states = tuple(_case_state(case) for case in candidate.cases)
-        incomplete = tuple(state for state in states if state in {"refused", "failed", "unscored"})
+        incomplete = tuple(state for state in states if state in {"failed", "unscored"})
         message = ""
         if incomplete:
             total = len(candidate.cases)
             parts = tuple(
                 f"{incomplete.count(state)} {state}"
-                for state in ("refused", "failed", "unscored")
+                for state in ("failed", "unscored")
                 if state in incomplete
             )
             message = (
@@ -630,7 +630,6 @@ def _rail_item(item: str, candidate: CandidateResult, case: CaseResult, show_who
         + {
             "passed": "",
             "incorrect": " sf-mark--bad",
-            "refused": " sf-mark--warn",
             "failed": " sf-mark--warn",
             "unscored": " sf-mark--warn",
         }[state]
@@ -638,7 +637,6 @@ def _rail_item(item: str, candidate: CandidateResult, case: CaseResult, show_who
     glyph = {
         "passed": "&check;",
         "incorrect": "&times;",
-        "refused": "!",
         "failed": "!",
         "unscored": "?",
     }[state]
@@ -656,7 +654,7 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
     state = _case_state(case)
     # WHY (OME-793): tri-state verdict — "failed" (warning) is neither correct nor
     # incorrect; the case was never graded, and the badge must say so.
-    if state in {"refused", "failed", "unscored"}:
+    if state in {"failed", "unscored"}:
         verdict = _badge(state, good=False, warn=True)
     else:
         verdict = _badge("correct" if state == "passed" else "incorrect", good=state == "passed")
@@ -673,8 +671,10 @@ def _pane_html(candidate: CandidateResult, case: CaseResult) -> str:
         if answer
         else ""
     )
+    # WHY the neutral label (OME-1037): the text may be the model's own graded
+    # decline (a scored Case) or provider-refusal evidence on a failed Case.
     refusal_html = (
-        "<div class='sf-detail__k'>provider refusal</div>"
+        "<div class='sf-detail__k'>refusal</div>"
         f"<pre class='sf-report__pre'>{escape(case.refusal)}</pre>"
         if case.refusal is not None
         else ""
@@ -756,10 +756,13 @@ def _case_passed(case: CaseResult) -> bool:
 
 
 def _case_state(case: CaseResult) -> str:
-    """Present the Engine outcome without re-deriving it from Benchmark semantics."""
+    """Present the Engine outcome without re-deriving it from Benchmark semantics.
 
-    if case.status == "refused":
-        return "refused"
+    WHY no `refused` state (OME-1037): a refusal the benchmark graded is a scored
+    Case (its verdict is real — DRACO grades a decline as passed), and an
+    ungradeable one is a failed Case carrying a provider_refusal failure.
+    """
+
     if case.status == "failed":
         return "unscored" if case.grade is not None else "failed"
     return "passed" if _case_passed(case) else "incorrect"

--- a/packages/screamingface/src/screamingface/case_result.py
+++ b/packages/screamingface/src/screamingface/case_result.py
@@ -25,12 +25,15 @@ type EvidenceOutcome = Literal["MET", "UNMET", "PASS", "FAIL"]
 type CheckOutcome = Literal["MET", "UNMET"]
 
 # The Engine's explicit per-Case outcome; kept in lock-step with url4-cloud's
-# `benchmarks/contract.py` CaseStatus.
-type CaseStatus = Literal["scored", "refused", "failed"]
+# `benchmarks/contract.py` CaseStatus. WHY only two values (OME-1037): `refused`
+# meant "provider declined" in most benchmarks and "correct answer" in DRACO — a
+# graded refusal is now an ordinary scored Case carrying `refusal` text, and an
+# ungradeable one a failed Case whose failures include the `provider_refusal` code.
+type CaseStatus = Literal["scored", "failed"]
 type StopReason = Literal["passed", "max_rounds"]
-# Which side refused a refused Case — derived from the two provider-verbatim signals
-# the Engine's runner classifies a refusal from (OME-745, `runner/model_response.py`);
-# never carried on the wire.
+# Which side refused a Case that represents a refusal — derived from the two
+# provider-verbatim signals the Engine's runner classifies a refusal from (OME-745,
+# `runner/model_response.py`); never carried on the wire.
 type RefusalKind = Literal["provider_declined", "model_refusal"]
 
 
@@ -388,12 +391,18 @@ class CaseResult:
         model's own refusal message. This property is the client's ONE reading of
         that split, checked in the Engine classifier's own order — ``content_filter``
         first, so a filtered turn that also carries refusal text still reads as the
-        provider declining. ``None`` for any non-refused Case, and for a refused Case
-        whose payload carries neither signal (older Engines) — unknown, never a
-        guess. Derived, never serialized: ``to_dict`` stays byte-identical.
+        provider declining. Since OME-1037 there is no ``refused`` status: a Case
+        represents a refusal when it is scored-with-refusal (the benchmark graded
+        the decline) or failed with a ``provider_refusal`` failure (it could not).
+        ``None`` for every other Case, and for a refusal payload carrying neither
+        signal — unknown, never a guess. Derived, never serialized: ``to_dict``
+        stays byte-identical.
         """
 
-        if self.status != "refused":
+        represents_refusal = self.refusal is not None or any(
+            failure.code == "provider_refusal" for failure in self.failures
+        )
+        if not represents_refusal:
             return None
         if self.finish_reason == "content_filter":
             return "provider_declined"
@@ -550,13 +559,11 @@ def _validate_case_outcome(
     repeat a status already unambiguously determined by the complete Case shape.
     """
 
-    selected_status = _case_status(status, refusal, grade)
+    selected_status = _case_status(status, grade)
     if any(failure.case_id != case_id for failure in failures):
         raise ValueError("every Case Result Failure must reference its own case_id")
     if selected_status == "scored":
         _validate_scored_case(refusal, grade, output, failures)
-    elif selected_status == "refused":
-        _validate_refused_case(refusal, grade, output, failures)
     else:
         _validate_failed_case(refusal, grade, failures)
     return selected_status
@@ -564,15 +571,12 @@ def _validate_case_outcome(
 
 def _case_status(
     status: CaseStatus | None,
-    refusal: str | None,
     grade: CaseGrade | None,
 ) -> CaseStatus:
     if status is not None:
-        if status not in {"scored", "refused", "failed"}:
-            raise ValueError("Case Result status must be 'scored', 'refused', or 'failed'")
+        if status not in {"scored", "failed"}:
+            raise ValueError("Case Result status must be 'scored' or 'failed'")
         return status
-    if refusal is not None:
-        return "refused"
     return "scored" if grade is not None and grade.score is not None else "failed"
 
 
@@ -582,27 +586,13 @@ def _validate_scored_case(
     output: object,
     failures: Sequence[Failure],
 ) -> None:
-    if grade is None or grade.score is None or output is None or refusal is not None or failures:
+    # INVARIANT (OME-1037): a scored Case is either an answer that was graded or a
+    # refusal that was graded — exactly one of output/refusal, never both/neither.
+    if grade is None or grade.score is None or (output is None) == (refusal is None) or failures:
         raise ValueError(
-            "Case Result status 'scored' requires output and a numeric grade and cannot "
-            "carry refusal or failures"
+            "Case Result status 'scored' requires a numeric grade and exactly one of "
+            "output and refusal, and cannot carry failures"
         )
-
-
-def _validate_refused_case(
-    refusal: str | None,
-    grade: CaseGrade | None,
-    output: object,
-    failures: Sequence[Failure],
-) -> None:
-    if output is not None or grade is None:
-        raise ValueError("Case Result status 'refused' requires no output and a grade")
-    if grade.score is not None and failures:
-        raise ValueError("a graded refused Case Result cannot contain failures")
-    if grade.score is None and (
-        not failures or any(failure.stage != "grading" for failure in failures)
-    ):
-        raise ValueError("an ungraded refused Case Result requires only grading failures")
 
 
 def _validate_failed_case(
@@ -610,15 +600,13 @@ def _validate_failed_case(
     grade: CaseGrade | None,
     failures: Sequence[Failure],
 ) -> None:
-    if (
-        not failures
-        or refusal is not None
-        or any(failure.code == "provider_refusal" for failure in failures)
-        or grade is not None
-        and grade.score is not None
-    ):
+    if not failures or grade is not None and grade.score is not None:
+        raise ValueError("Case Result status 'failed' requires failures and no numeric grade")
+    # INVARIANT (OME-1037): refusal text on a failed Case is evidence for its
+    # provider_refusal failure; every other failed Case stays refusal-free.
+    if refusal is not None and all(failure.code != "provider_refusal" for failure in failures):
         raise ValueError(
-            "Case Result status 'failed' requires failures, no refusal, and no numeric grade"
+            "Case Result status 'failed' carries refusal text only with a provider_refusal failure"
         )
 
 

--- a/packages/screamingface/tests/e2e/harness/goldens.py
+++ b/packages/screamingface/tests/e2e/harness/goldens.py
@@ -8,7 +8,7 @@ STAGED walk, and THE ORDER IS THE CONTRACT:
    recorded ``expression_sha``. A mismatch means the experiment itself changed, so every
    downstream number measures something else; the failure says "expression changed,
    goldens stale" and deliberately says nothing about scores.
-2. **cases** — the per-case status map (``scored`` / ``refused`` / ``failed``) must
+2. **cases** — the per-case status map (``scored`` / ``failed``, OME-1037) must
    match. Statuses drifting with the expression intact means the replay itself broke.
 3. **codes** — the per-case failure map (``stage`` + ``code`` for every case that
    carries a failure) must match (OME-1094). Five rubric failure reasons all spell

--- a/packages/screamingface/tests/e2e/test_bless_contracts.py
+++ b/packages/screamingface/tests/e2e/test_bless_contracts.py
@@ -186,8 +186,10 @@ def test_author_golden_conforms_and_derives_counters() -> None:
         limit=None,
         rendered_url4="url4://example/expression",
         final_score=0.5,
-        case_statuses={"1": "scored", "2": "refused"},
-        case_failures={},
+        case_statuses={"1": "scored", "2": "failed"},
+        # OME-1037: `refused` is no longer a case status; the failed case names
+        # its reason — here an ungradeable provider refusal.
+        case_failures={"2": [{"stage": "candidate", "code": "provider_refusal"}]},
     )
     # ``load_golden`` must accept every blessed file — validate through the SAME
     # model the test lane loads with, counters derived, score canonicalized.

--- a/packages/screamingface/tests/e2e/test_harness_contracts.py
+++ b/packages/screamingface/tests/e2e/test_harness_contracts.py
@@ -79,7 +79,10 @@ def _golden_document(**overrides: object) -> dict[str, object]:
         "final_score": "0.5",
         "case_count": 2,
         "gradeable_count": 1,
-        "case_statuses": {"case_1": "scored", "case_2": "refused"},
+        # OME-1037: `refused` is no longer a case status — the default synthetic
+        # golden pins one scored case and one failed case with its named reason.
+        "case_statuses": {"case_1": "scored", "case_2": "failed"},
+        "case_failures": {"case_2": [{"stage": "grading", "code": "incomplete_verdicts"}]},
     }
     document.update(overrides)
     return document
@@ -200,7 +203,8 @@ def test_matching_outcome_passes() -> None:
     actual = ActualOutcome(
         rendered_url4="rendered expression",
         final_score=0.5,
-        case_statuses={"case_1": "scored", "case_2": "refused"},
+        case_statuses={"case_1": "scored", "case_2": "failed"},
+        case_failures={"case_2": (GoldenFailure(stage="grading", code="incomplete_verdicts"),)},
         coverage=0.5,
     )
 
@@ -212,7 +216,7 @@ def test_case_statuses_are_checked_before_the_score() -> None:
     actual = ActualOutcome(
         rendered_url4="rendered expression",
         final_score=0.0,  # wrong, but the status drift must be named first
-        case_statuses={"case_1": "failed", "case_2": "refused"},
+        case_statuses={"case_1": "failed", "case_2": "failed"},
         coverage=0.0,
     )
 
@@ -230,7 +234,8 @@ def test_a_coverage_figure_that_contradicts_the_statuses_is_caught() -> None:
     actual = ActualOutcome(
         rendered_url4="rendered expression",
         final_score=0.5,
-        case_statuses={"case_1": "scored", "case_2": "refused"},
+        case_statuses={"case_1": "scored", "case_2": "failed"},
+        case_failures={"case_2": (GoldenFailure(stage="grading", code="incomplete_verdicts"),)},
         coverage=1.0,  # the report claims full coverage; its statuses say half
     )
 
@@ -245,7 +250,8 @@ def test_a_score_drift_is_reported_as_decimal_strings() -> None:
     actual = ActualOutcome(
         rendered_url4="rendered expression",
         final_score=0.75,
-        case_statuses={"case_1": "scored", "case_2": "refused"},
+        case_statuses={"case_1": "scored", "case_2": "failed"},
+        case_failures={"case_2": (GoldenFailure(stage="grading", code="incomplete_verdicts"),)},
         coverage=0.5,
     )
 
@@ -287,10 +293,19 @@ def test_counters_must_agree_with_the_statuses(tmp_path) -> None:
         load_golden(path)
 
 
-def test_an_unknown_case_status_is_refused(tmp_path) -> None:
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param("maybe", id="a-made-up-word"),
+        # OME-1037: the pre-split vocabulary — a golden still pinning `refused`
+        # must be re-blessed, never silently reinterpreted.
+        pytest.param("refused", id="the-retired-refused-status"),
+    ],
+)
+def test_an_unknown_case_status_is_refused(tmp_path, status: str) -> None:
     path = tmp_path / "synthetic.golden.json"
     path.write_text(
-        json.dumps(_golden_document(case_statuses={"case_1": "scored", "case_2": "maybe"}))
+        json.dumps(_golden_document(case_statuses={"case_1": "scored", "case_2": status}))
     )
 
     with pytest.raises(ValueError):
@@ -394,7 +409,9 @@ def test_a_scored_case_with_a_failure_entry_is_refused_at_load() -> None:
 def test_a_failed_case_without_a_failure_entry_is_refused_at_load() -> None:
     # The pre-OME-1094 golden shape: a failed case pinned by status alone. Refusing
     # it at load is what forces the re-bless instead of leaving the hole open.
-    document = _golden_document(case_statuses={"case_1": "scored", "case_2": "failed"})
+    document = _golden_document(
+        case_statuses={"case_1": "scored", "case_2": "failed"}, case_failures={}
+    )
 
     with pytest.raises(Exception, match="case_2"):
         GoldenReport.model_validate(document)
@@ -409,22 +426,34 @@ def test_a_failure_entry_for_an_unknown_case_is_refused_at_load() -> None:
         GoldenReport.model_validate(document)
 
 
-def test_an_ungraded_refused_case_may_carry_grading_failures() -> None:
-    # The SDK contract: an ungraded refused Case carries only grading failures, so
-    # the golden must be able to pin them — refused is neither scored nor failed.
+def test_a_failed_refusal_pins_its_provider_refusal_and_grading_codes() -> None:
+    # The SDK contract (OME-1037): an ungradeable refusal is a failed Case whose
+    # failures lead with provider_refusal — the golden pins both codes in order.
     document = _golden_document(
-        case_failures={"case_2": [{"stage": "grading", "code": "incomplete_verdicts"}]},
+        case_failures={
+            "case_2": [
+                {"stage": "candidate", "code": "provider_refusal"},
+                {"stage": "grading", "code": "incomplete_verdicts"},
+            ]
+        },
     )
 
     report = GoldenReport.model_validate(document)
 
-    assert report.case_failures == {"case_2": (_INCOMPLETE,)}
+    assert report.case_failures == {
+        "case_2": (GoldenFailure(stage="candidate", code="provider_refusal"), _INCOMPLETE)
+    }
 
 
 def test_goldens_blessed_before_the_codes_rung_still_load_when_nothing_failed() -> None:
     # draco-3pass shape: no ``case_failures`` key and no failed case — loads as an
     # empty map, so an all-scored golden never needs a replay to be re-blessed.
-    report = GoldenReport.model_validate(_golden_document())
+    document = _golden_document(
+        case_statuses={"case_1": "scored", "case_2": "scored"}, gradeable_count=2
+    )
+    del document["case_failures"]
+
+    report = GoldenReport.model_validate(document)
 
     assert report.case_failures == {}
 

--- a/packages/screamingface/tests/test_candidate_result_coverage.py
+++ b/packages/screamingface/tests/test_candidate_result_coverage.py
@@ -104,8 +104,9 @@ def test_a_scored_candidate_can_retain_a_safe_candidate_failure() -> None:
 
 
 def test_a_refusal_is_normally_graded_without_a_synthetic_failure() -> None:
+    # OME-1037: a graded refusal is an ordinary scored Case carrying refusal text.
     payload = {
-        "status": "refused",
+        "status": "scored",
         "case_id": 1,
         "input": "A clinical question",
         "output": None,
@@ -125,16 +126,19 @@ def test_a_refusal_is_normally_graded_without_a_synthetic_failure() -> None:
 
     case = _case_result(payload)
 
-    assert case.status == "refused"
+    assert case.status == "scored"
     assert case.grade is not None
     assert case.grade.score == 0.0
     assert case.failures == ()
     assert case.to_dict() == payload
 
 
-def test_a_refusal_whose_grading_failed_retains_only_grading_failures() -> None:
+def test_a_refusal_whose_grading_failed_is_failed_with_provider_refusal_evidence() -> None:
+    # INVARIANT (OME-1037): an ungradeable refusal is a failed Case led by the
+    # provider_refusal failure, the grading failures retained after it and the
+    # refusal text preserved as evidence.
     payload = {
-        "status": "refused",
+        "status": "failed",
         "case_id": 1,
         "input": "A clinical question",
         "output": None,
@@ -150,21 +154,30 @@ def test_a_refusal_whose_grading_failed_retains_only_grading_failures() -> None:
         },
         "failures": [
             {
+                "stage": "candidate",
+                "code": "provider_refusal",
+                "message": "provider refused the request",
+                "retryable": False,
+                "case_id": 1,
+                "metadata": {},
+            },
+            {
                 "stage": "grading",
                 "code": "checker_failed",
                 "message": "the checker failed",
                 "retryable": False,
                 "case_id": 1,
                 "metadata": {},
-            }
+            },
         ],
         "metadata": {},
     }
 
     case = _case_result(payload)
 
-    assert case.status == "refused"
+    assert case.status == "failed"
+    assert case.refusal == "I cannot answer that request."
     assert case.grade is not None
     assert case.grade.score is None
-    assert tuple(failure.stage for failure in case.failures) == ("grading",)
+    assert tuple(failure.stage for failure in case.failures) == ("candidate", "grading")
     assert case.to_dict() == payload

--- a/packages/screamingface/tests/test_case_outcome_decoding.py
+++ b/packages/screamingface/tests/test_case_outcome_decoding.py
@@ -1,9 +1,9 @@
 """The client decodes the explicit Case outcome the OME-802 Engine publishes.
 
 INVARIANT defended: the `screamingface.candidate-result.v1` Case Result carries
-`status` (scored | refused | failed) and `refusal` on every Case — the client
-decodes them strictly (unknown keys and unknown statuses still fail loudly) and
-exposes them unmodified, never recalculating Benchmark semantics client-side.
+`status` (scored | failed, since OME-1037) and `refusal` on every Case — the
+client decodes them strictly (unknown keys and unknown statuses still fail loudly)
+and exposes them unmodified, never recalculating Benchmark semantics client-side.
 """
 
 from __future__ import annotations
@@ -32,9 +32,11 @@ def _scored_payload() -> dict[str, Any]:
     }
 
 
-def _refused_payload() -> dict[str, Any]:
+def _refusal_payload() -> dict[str, Any]:
+    # OME-1037: a refusal the benchmark graded is an ordinary scored Case
+    # carrying the refusal text instead of an output.
     return {
-        "status": "refused",
+        "status": "scored",
         "case_id": 1,
         "input": "A clinical question",
         "output": None,
@@ -108,7 +110,7 @@ def _healthbench_payload() -> dict[str, Any]:
     ("payload", "status", "refusal"),
     [
         (_scored_payload(), "scored", None),
-        (_refused_payload(), "refused", "I can't help with that request."),
+        (_refusal_payload(), "scored", "I can't help with that request."),
         (_failed_payload(), "failed", None),
     ],
 )
@@ -122,9 +124,9 @@ def test_every_wire_status_decodes_and_is_exposed_unmodified(
 
 
 def test_decoded_outcome_survives_export() -> None:
-    exported = _case_result(_refused_payload()).to_dict()
+    exported = _case_result(_refusal_payload()).to_dict()
 
-    assert exported["status"] == "refused"
+    assert exported["status"] == "scored"
     assert exported["refusal"] == "I can't help with that request."
 
 
@@ -154,7 +156,7 @@ def test_malformed_corrective_execution_telemetry_fails_closed(
 
 
 def test_wire_text_and_string_identity_survive_without_normalization() -> None:
-    payload = _refused_payload()
+    payload = _refusal_payload()
     payload.update(
         {
             "case_id": " case-1 ",
@@ -287,7 +289,7 @@ def test_an_unsupported_status_is_rejected() -> None:
 
 def test_blank_refusal_text_is_rejected() -> None:
     with pytest.raises(sf.ExecutionError, match="refusal"):
-        _case_result({**_refused_payload(), "refusal": "   "})
+        _case_result({**_refusal_payload(), "refusal": "   "})
 
 
 def test_a_status_contradicting_the_grade_shape_is_rejected() -> None:
@@ -304,13 +306,16 @@ def test_a_status_contradicting_the_grade_shape_is_rejected() -> None:
         )
 
 
-def test_a_scored_case_cannot_carry_refusal_text() -> None:
-    with pytest.raises(ValueError, match="refusal"):
+def test_a_scored_case_cannot_carry_output_and_refusal_together() -> None:
+    # INVARIANT (OME-1037): mirrors contract.py _require_scored_case — a scored
+    # Case carries exactly one of output/refusal, so a locally built value can
+    # never round-trip into a contract-invalid payload.
+    with pytest.raises(ValueError, match="exactly one"):
         sf.CaseResult(
             status="scored",
             case_id=1,
             input="question",
-            output=None,
+            output="an answer the engine would reject",
             finish_reason="stop",
             refusal="I refuse.",
             grade=sf.CaseGrade(method="rubric", score=1.0, metrics={}, checks=()),
@@ -319,24 +324,10 @@ def test_a_scored_case_cannot_carry_refusal_text() -> None:
         )
 
 
-def test_a_refused_case_cannot_carry_output() -> None:
-    # INVARIANT: mirrors contract.py _enforce_status — a refused Case has no output,
-    # so a locally built value can never round-trip into a contract-invalid payload.
-    with pytest.raises(ValueError, match="refused"):
-        sf.CaseResult(
-            case_id=1,
-            input="question",
-            output="an answer the engine would reject",
-            finish_reason="stop",
-            refusal="I can't help with that request.",
-            grade=sf.CaseGrade(method="rubric", score=0.0, metrics={}, checks=()),
-            failures=(),
-            metadata={},
-        )
-
-
-def test_a_refused_case_requires_a_grade() -> None:
-    with pytest.raises(ValueError, match="refused"):
+def test_an_ungraded_refusal_requires_its_failures() -> None:
+    # OME-1037: a refusal with no grade derives `failed`, and a failed Case must
+    # name its failures — a bare ungraded refusal cannot be built.
+    with pytest.raises(ValueError, match="failures"):
         sf.CaseResult(
             case_id=1,
             input="question",
@@ -350,7 +341,9 @@ def test_a_refused_case_requires_a_grade() -> None:
 
 
 def test_a_locally_built_case_derives_status_without_weakening_wire_decoding() -> None:
-    refused = sf.CaseResult(
+    # OME-1037: a graded refusal derives `scored` — the refusal text is the
+    # answer-side of the Case, and the numeric grade is what classifies it.
+    graded_refusal = sf.CaseResult(
         case_id=1,
         input="question",
         output=None,
@@ -361,7 +354,7 @@ def test_a_locally_built_case_derives_status_without_weakening_wire_decoding() -
         metadata={},
     )
 
-    assert refused.status == "refused"
+    assert graded_refusal.status == "scored"
 
 
 # FEATURE: OME-843 member-output capture — the optional `operations` case key carries

--- a/packages/screamingface/tests/test_case_refusal_kind.py
+++ b/packages/screamingface/tests/test_case_refusal_kind.py
@@ -1,4 +1,4 @@
-"""A refused Case states which side refused: the provider declined, or the model.
+"""A Case that represents a refusal states which side refused: provider or model.
 
 INVARIANT defended: the Engine's runner classifies a refused turn from two
 provider-verbatim signals it already publishes on every Case (OME-745,
@@ -6,7 +6,9 @@ provider-verbatim signals it already publishes on every Case (OME-745,
 filter terminated the call; a non-null `refusal` field carries the model's own
 refusal message. The client derives `refusal_kind` from exactly those wire fields —
 never from answer text, never serialized, and never guessed when neither signal is
-present (older payloads stay loadable with kind `None`).
+present. Since OME-1037 there is no `refused` case status: the kind is read off a
+scored Case carrying refusal text (the benchmark graded the decline) or a failed
+Case carrying a `provider_refusal` failure (it could not be graded).
 """
 
 from __future__ import annotations
@@ -19,9 +21,9 @@ import screamingface as sf
 from screamingface._evaluation.results import _case_result
 
 
-def _refused_payload(finish_reason: str | None, refusal: str | None) -> dict[str, Any]:
+def _graded_refusal_payload(finish_reason: str | None, refusal: str) -> dict[str, Any]:
     return {
-        "status": "refused",
+        "status": "scored",
         "case_id": 1,
         "input": "A clinical question",
         "output": None,
@@ -35,61 +37,78 @@ def _refused_payload(finish_reason: str | None, refusal: str | None) -> dict[str
     }
 
 
+def _ungradeable_refusal_payload(finish_reason: str | None, refusal: str | None) -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "case_id": 1,
+        "input": "A clinical question",
+        "output": None,
+        "finish_reason": finish_reason,
+        "refusal": refusal,
+        "stop_reason": None,
+        "rounds_executed": None,
+        "grade": {"method": "rubric", "score": None, "metrics": {}, "checks": []},
+        "failures": [
+            {
+                "stage": "candidate",
+                "code": "provider_refusal",
+                "message": "provider refused the request",
+                "retryable": False,
+                "case_id": 1,
+                "metadata": {},
+            }
+        ],
+        "metadata": {},
+    }
+
+
 @pytest.mark.parametrize(
-    ("finish_reason", "refusal", "kind"),
+    ("payload", "kind"),
     [
         pytest.param(
-            "content_filter",
-            None,
+            _ungradeable_refusal_payload("content_filter", None),
             "provider_declined",
             id="content-filter-is-the-provider-declining",
         ),
         pytest.param(
-            "stop",
-            "I can't help with that request.",
+            _graded_refusal_payload("stop", "I can't help with that request."),
             "model_refusal",
             id="a-refusal-message-is-the-model-refusing",
         ),
         pytest.param(
-            None,
-            "I can't help with that request.",
+            _graded_refusal_payload(None, "I can't help with that request."),
             "model_refusal",
             id="the-message-alone-decides-without-a-finish-reason",
         ),
         pytest.param(
-            "content_filter",
-            "exact refusal",
+            _graded_refusal_payload("content_filter", "exact refusal"),
             "provider_declined",
             id="both-signals-present-the-provider-wins",
         ),
         pytest.param(
+            _ungradeable_refusal_payload(None, None),
             None,
-            None,
-            None,
-            id="a-pre-OME-745-payload-loads-with-unknown-kind",
+            id="a-refusal-with-neither-signal-loads-with-unknown-kind",
         ),
     ],
 )
 def test_the_kind_follows_the_engine_classifiers_signal_table(
-    finish_reason: str | None, refusal: str | None, kind: str | None
+    payload: dict[str, Any], kind: str | None
 ) -> None:
     # WHY: one row per line of the Engine classifier's own truth table
     # (`runner/model_response.py`, OME-745): `content_filter` means the provider's
     # filter terminated the call and is checked FIRST (so a filtered turn with
     # refusal text tagging along still reads as the provider declining); a
     # non-null `refusal` — the model's own refusal message — alone decides even
-    # without a finish reason (OME-745 captured the two independently); and a
-    # pre-OME-745 payload carrying neither signal still loads, with the kind
-    # unknown — never a crash and never a guess.
-    case = _case_result(_refused_payload(finish_reason, refusal))
-
-    assert case.status == "refused"
-    assert case.refusal_kind == kind
+    # without a finish reason; and a refusal payload carrying neither signal
+    # still loads, with the kind unknown — never a crash and never a guess.
+    assert _case_result(payload).refusal_kind == kind
 
 
 def test_a_provider_402_failure_is_no_kind_of_refusal() -> None:
-    # WHY: a provider that errors (e.g. a 402) produces a FAILED Case — it must not
-    # read as a model refusal, or as any refusal at all.
+    # WHY: a provider that errors (e.g. a 402) produces a FAILED Case without a
+    # provider_refusal failure — it must not read as a model refusal, or as any
+    # refusal at all.
     payload: dict[str, Any] = {
         "status": "failed",
         "case_id": 1,
@@ -116,11 +135,11 @@ def test_a_provider_402_failure_is_no_kind_of_refusal() -> None:
     assert _case_result(payload).refusal_kind is None
 
 
-def test_a_scored_case_has_no_refusal_kind() -> None:
-    # WHY: `content_filter` never reaches a scored Case in practice, but the kind
-    # is a reading of REFUSED Cases only — status semantics stay untouched.
-    payload = _refused_payload("stop", None)
-    payload.update(status="scored", output="Four.")
+def test_an_answered_scored_case_has_no_refusal_kind() -> None:
+    # WHY: the kind is a reading of Cases that REPRESENT a refusal only — an
+    # ordinary graded answer carries none, whatever its finish reason.
+    payload = _graded_refusal_payload("stop", "unused")
+    payload.update(output="Four.", refusal=None)
     payload["grade"] = {"method": "rubric", "score": 1.0, "metrics": {}, "checks": []}
 
     assert _case_result(payload).refusal_kind is None
@@ -129,7 +148,7 @@ def test_a_scored_case_has_no_refusal_kind() -> None:
 def test_the_derived_kind_is_never_serialized() -> None:
     # WHY: no wire change — `to_dict()` stays byte-identical to the payload, so
     # saved reports round-trip unchanged and old readers see nothing new.
-    payload = _refused_payload("content_filter", None)
+    payload = _ungradeable_refusal_payload("content_filter", None)
 
     exported = _case_result(payload).to_dict()
 
@@ -137,15 +156,16 @@ def test_the_derived_kind_is_never_serialized() -> None:
     assert "refusal_kind" not in exported
 
 
-def test_a_locally_built_refused_case_derives_the_same_kind() -> None:
+def test_a_locally_built_refusal_case_derives_the_same_kind() -> None:
     # WHY: the kind is a pure function of the Case fields, so a directly
     # constructed value and a wire-decoded one can never disagree.
     case = sf.CaseResult(
-        status="refused",
+        status="scored",
         case_id=1,
         input="A clinical question",
         output=None,
         finish_reason="content_filter",
+        refusal="I can't help with that request.",
         grade=sf.CaseGrade(method="rubric", score=0.0, metrics={}, checks=()),
         failures=(),
         metadata={},
@@ -155,20 +175,19 @@ def test_a_locally_built_refused_case_derives_the_same_kind() -> None:
 
 
 @pytest.mark.parametrize(
-    ("finish_reason", "refusal", "kind"),
+    ("payload", "kind"),
     [
-        ("content_filter", None, "provider_declined"),
-        ("stop", "I can't help with that request.", "model_refusal"),
+        (_ungradeable_refusal_payload("content_filter", None), "provider_declined"),
+        (
+            _graded_refusal_payload("stop", "I can't help with that request."),
+            "model_refusal",
+        ),
     ],
 )
-def test_the_kind_survives_a_save_and_reload_round_trip(
-    finish_reason: str | None, refusal: str | None, kind: str
-) -> None:
-    # WHY: the acceptance path — a refused Case round-tripping from the real
+def test_the_kind_survives_a_save_and_reload_round_trip(payload: dict[str, Any], kind: str) -> None:
+    # WHY: the acceptance path — a refusal Case round-tripping from the real
     # engine payload shape states which of the two kinds it was, on both sides
     # of a save/reload.
-    payload = _refused_payload(finish_reason, refusal)
-
     reloaded = _case_result(_case_result(payload).to_dict())
 
     assert reloaded.refusal_kind == kind

--- a/packages/screamingface/tests/test_draco_vertical_slice.py
+++ b/packages/screamingface/tests/test_draco_vertical_slice.py
@@ -826,7 +826,7 @@ def test_candidate_result_decoder_retains_a_normally_graded_refusal() -> None:
                 "metrics": {},
                 "cases": [
                     {
-                        "status": "refused",
+                        "status": "scored",  # OME-1037: a graded refusal is scored
                         "case_id": 1,
                         "input": "Fixture question",
                         "output": None,
@@ -858,7 +858,7 @@ def test_candidate_result_decoder_retains_a_normally_graded_refusal() -> None:
     assert result.metrics == {}
     assert result.cases[0].grade is not None
     assert result.cases[0].grade.score == 0.0
-    assert result.cases[0].status == "refused"
+    assert result.cases[0].status == "scored"  # OME-1037
     assert result.cases[0].refusal == "provider refused the request"
     assert result.cases[0].failures == ()
 

--- a/packages/screamingface/tests/test_refusal_status_split.py
+++ b/packages/screamingface/tests/test_refusal_status_split.py
@@ -1,0 +1,156 @@
+"""The client mirrors the OME-1037 case-status split: no `refused` status.
+
+INVARIANT defended: the wire vocabulary carries one meaning per status value. A
+refusal the benchmark graded decodes as an ordinary `scored` case carrying
+`refusal` text (exactly one of `output`/`refusal` set); a refusal the benchmark
+could not grade decodes as a `failed` case whose failures include the
+`provider_refusal` code — the only failed shape allowed to keep refusal text as
+evidence. The pre-split `refused` status is rejected loudly, never reinterpreted.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import screamingface as sf
+from screamingface._evaluation.results import _case_result
+
+
+def _scored_refusal_payload(**overrides: Any) -> dict[str, Any]:
+    values: dict[str, Any] = {
+        "status": "scored",
+        "case_id": 1,
+        "input": "A deceptive prompt.",
+        "output": None,
+        "finish_reason": "stop",
+        "refusal": "I will not help with that.",
+        "stop_reason": None,
+        "rounds_executed": None,
+        "grade": {"method": "rubric", "score": 1.0, "metrics": {}, "checks": []},
+        "failures": [],
+        "metadata": {},
+    }
+    values.update(overrides)
+    return values
+
+
+def _provider_refusal_failure(code: str = "provider_refusal") -> dict[str, Any]:
+    return {
+        "stage": "candidate",
+        "code": code,
+        "message": "provider refused the request",
+        "retryable": False,
+        "case_id": 1,
+        "metadata": {},
+    }
+
+
+def _failed_refusal_payload(**overrides: Any) -> dict[str, Any]:
+    values = _scored_refusal_payload(
+        status="failed",
+        finish_reason="content_filter",
+        grade={"method": "rubric", "score": None, "metrics": {}, "checks": []},
+        failures=[_provider_refusal_failure()],
+    )
+    values.update(overrides)
+    return values
+
+
+def test_the_refused_status_is_rejected_by_the_decoder() -> None:
+    # WHY: `refused` meant "provider declined" in most benchmarks and "correct
+    # answer" in DRACO — after OME-1037 the value no longer exists on the wire,
+    # and an Engine still emitting it must fail loudly, never load ambiguously.
+    with pytest.raises(sf.ExecutionError, match="status"):
+        _case_result(_scored_refusal_payload(status="refused"))
+
+
+def test_a_graded_refusal_decodes_as_a_scored_case_with_refusal_text() -> None:
+    case = _case_result(_scored_refusal_payload())
+
+    assert case.status == "scored"
+    assert case.output is None
+    assert case.refusal == "I will not help with that."
+    assert case.grade is not None and case.grade.score == 1.0
+
+
+@pytest.mark.parametrize(
+    ("output", "refusal"),
+    [
+        pytest.param("An answer.", "I refuse.", id="both"),
+        pytest.param(None, None, id="neither"),
+    ],
+)
+def test_a_scored_case_carries_exactly_one_of_output_and_refusal(
+    output: str | None, refusal: str | None
+) -> None:
+    with pytest.raises(sf.ExecutionError):
+        _case_result(_scored_refusal_payload(output=output, refusal=refusal))
+
+
+def test_an_ungradeable_refusal_decodes_as_failed_with_provider_refusal() -> None:
+    case = _case_result(_failed_refusal_payload())
+
+    assert case.status == "failed"
+    assert case.refusal == "I will not help with that."
+    assert [failure.code for failure in case.failures] == ["provider_refusal"]
+
+
+def test_a_failed_case_without_provider_refusal_stays_refusal_free() -> None:
+    # INVARIANT: refusal text on a failed case is provider_refusal evidence only.
+    with pytest.raises(sf.ExecutionError, match="provider_refusal"):
+        _case_result(_failed_refusal_payload(failures=[_provider_refusal_failure("case_error")]))
+
+
+def test_a_directly_built_value_enforces_the_same_split() -> None:
+    # WHY: the SDK's directly constructed values and its wire decode share one
+    # validator, so a test fixture cannot build a shape the Engine cannot emit.
+    legacy_fields: dict[str, Any] = {
+        "status": "refused",  # the rejected legacy value, typed loosely on purpose
+        "case_id": 1,
+        "input": "A deceptive prompt.",
+        "output": None,
+        "finish_reason": "stop",
+        "grade": None,
+        "failures": (),
+        "metadata": {},
+    }
+
+    with pytest.raises(ValueError, match="scored|failed"):
+        sf.CaseResult(**legacy_fields)
+
+
+@pytest.mark.parametrize(
+    ("payload", "kind"),
+    [
+        pytest.param(_scored_refusal_payload(), "model_refusal", id="graded-model-refusal"),
+        pytest.param(
+            _scored_refusal_payload(finish_reason="content_filter"),
+            "provider_declined",
+            id="filtered-turn-with-text-still-reads-provider",
+        ),
+        pytest.param(_failed_refusal_payload(), "provider_declined", id="textless-decline"),
+    ],
+)
+def test_refusal_kind_reads_the_same_signals_across_both_new_homes(
+    payload: dict[str, Any], kind: str
+) -> None:
+    # WHY: OME-745's signal table survives the status split — `content_filter`
+    # first (the provider's filter terminated the call), else refusal text (the
+    # model's own decline). The gate moves from `status == "refused"` to "this
+    # case represents a refusal": scored-with-refusal or failed-with-
+    # provider_refusal.
+    assert _case_result(payload).refusal_kind == kind
+
+
+def test_refusal_kind_stays_none_for_ordinary_outcomes() -> None:
+    answered = _scored_refusal_payload(output="Four.", refusal=None)
+    plain_failure = _failed_refusal_payload(
+        refusal=None,
+        finish_reason=None,
+        failures=[_provider_refusal_failure("case_error")],
+    )
+
+    assert _case_result(answered).refusal_kind is None
+    assert _case_result(plain_failure).refusal_kind is None

--- a/packages/screamingface/tests/test_report.py
+++ b/packages/screamingface/tests/test_report.py
@@ -178,8 +178,9 @@ def test_candidate_cases_keep_order_and_use_explicit_identity_lookup() -> None:
 
 
 def test_report_json_and_export_preserve_refusal_and_failure_fields(tmp_path: Path) -> None:
+    # OME-1037: a graded refusal is an ordinary scored Case carrying refusal text.
     refused = sf.CaseResult(
-        status="refused",
+        status="scored",
         case_id="refusal-case",
         input="A request",
         output=None,
@@ -218,7 +219,7 @@ def test_report_json_and_export_preserve_refusal_and_failure_fields(tmp_path: Pa
     selected = value.export(tmp_path / "report.json")
     payload = json.loads(selected.read_text(encoding="utf-8"))
     exported_cases = payload["candidates"][0]["cases"]
-    assert exported_cases[0]["status"] == "refused"
+    assert exported_cases[0]["status"] == "scored"
     assert exported_cases[0]["refusal"] == "I cannot comply."
     assert exported_cases[0]["grade"]["score"] == 0.0
     assert exported_cases[0]["failures"] == []

--- a/packages/screamingface/tests/test_report_panel.py
+++ b/packages/screamingface/tests/test_report_panel.py
@@ -398,8 +398,8 @@ def test_existing_report_warnings_use_the_current_sfds_warning_palette() -> None
     assert "--sf-warning-bg:#130e0c" in html
 
 
-def refused_case(case_id: int = 154) -> CaseResult:
-    """A provider refusal is a scored zero outcome, not missing infrastructure."""
+def refusal_case(case_id: int = 154) -> CaseResult:
+    """A graded refusal is a scored zero outcome, not missing infrastructure (OME-1037)."""
 
     refusal = "I cannot provide an answer to that request."
     return CaseResult(
@@ -410,7 +410,7 @@ def refused_case(case_id: int = 154) -> CaseResult:
         grade=CaseGrade(method="rubric", score=0.0, metrics={}, checks=[]),
         failures=[],
         metadata={},
-        status="refused",
+        status="scored",
         refusal=refusal,
     )
 
@@ -459,14 +459,16 @@ def test_a_failed_case_pane_shows_the_failure_chain_not_nothing() -> None:
     assert "input unavailable" in html
 
 
-def test_a_refused_case_is_named_and_shows_the_exact_provider_refusal() -> None:
-    html = body(report_html(report(candidate("m", 0.0, cases=(refused_case(),)))))
+def test_a_graded_refusal_is_a_real_verdict_and_shows_the_exact_refusal() -> None:
+    # INVARIANT (OME-1037): a refusal the benchmark graded is a scored Case — its
+    # zero here is a real "incorrect" verdict, not a warning state, and the exact
+    # refusal text stays visible in the pane as the Case's answer-side evidence.
+    html = body(report_html(report(candidate("m", 0.0, cases=(refusal_case(),)))))
 
-    assert "refused" in html
-    assert "provider refusal" in html
+    assert "refusal" in html
     assert "I cannot provide an answer to that request." in html
-    assert "incorrect" not in html
-    assert "sf-badge--warn" in html
+    assert "incorrect" in html
+    assert "sf-badge--warn" not in html
 
 
 def test_a_corrective_case_names_why_and_when_the_loop_stopped() -> None:


### PR DESCRIPTION
When the model refuses to answer a question (we mark it `refused`), it means that "the provider declined the call" in most benchmarks. However, for some benchmarks (e.g. DRACO), it means that "the model gave the correct answer" by refusing to answer a bad question; this change re-partitions the case-status space so every saved report and leaderboard row carries one meaning per status value.

## Before / After

### Before
- Trigger: someone reads a saved report or a leaderboard row and sees a case marked `refused`.
- Today: `refused` on the wire means *the provider declined* — a failure — however, in DRACO, declining a deceptive prompt is the *correct* answer, graded as success. Same word, same wire format, opposite meanings. This is actually quite common in AI safety benchmarks
- Cost: a signed or published scorecard is the worst place to discover the ambiguity; once the value appears in cited leaderboard results, the fix becomes a data migration instead of a rename.

### After
- Same trigger.
- Now: there is no `refused` case status. A refusal the benchmark **graded** is an ordinary `scored` case carrying the `refusal` text (DRACO scores a decline 1.0; another benchmark can score it 0.0). A refusal the benchmark **could not grade** is a `failed` case whose failures lead with the `provider_refusal` code, the grading failures retained after it and the refusal text kept as evidence.
- Win: a report is unambiguous without reading the engine source; a downstream grader can score a model refusal as success without overloading the failure vocabulary.

### Don't regress
- OME-745 / OME-924 semantics stay intact: which side refused is still read off the same two provider-verbatim signals (`content_filter` finish reason first, then `refusal` text); the SDK's `refusal_kind` keeps the exact truth table, now gated on "this case represents a refusal" instead of the retired status.
- The invocation layer is untouched: `CandidateInvocationStatus = "completed" | "refused"` still means "the candidate did not answer" — detection in `runner/model_response.py`, `runner/connector.py`, `benchmarks/invocation.py` and the ensemble runtime is unchanged.
- Committed e2e goldens (`draco-3pass`, `healthbench-worst30`) contain no refusal case, so replay outcomes are byte-identical — verified by the replay suite with zero live model calls.
- A golden or payload still spelling `refused` fails loudly at load — never silently reinterpreted.

## Root cause

The case status conflated two layers. At the **invocation** layer "refused" is unambiguous (the candidate did not answer). At the **case** layer the same word had to carry the *benchmark's judgment* of that non-answer — and DRACO's judgment is "correct". One value cannot mean both "infrastructure failure" and "graded outcome".

## Implementation

- `benchmarks/contract.py` (engine): `CaseStatus = "scored" | "failed"`. Scored invariant: numeric grade + **exactly one** of `output`/`refusal`, no failures. Failed invariant: failures + no numeric grade; refusal text allowed iff the failures include `provider_refusal`. `_require_refused_case` and its now-false "no producer can emit one" comment are gone — the spine now emits that failure code.
- `benchmarks/aggregation.py`: `refused_case_result` reworked into `refusal_case_result`, the ONE place that classifies an invocation-level refusal into its case-level outcome (all callers — spine grading, DRACO, IFEval, `grading_failure_case_result` — inherit it). Edge case: a **textless** refusal is exactly a `content_filter` provider decline (the runner fires on `content_filter` OR non-null refusal, and content-filter turns normally carry null text); the model never answered, so any judge score over the empty answer is dropped (`score=None`, checks kept as audit evidence) and the case is a visible provider failure — infrastructure failure never becomes a plausible grade.
- SDK mirror (`packages/screamingface`): `case_result.py` validators and the `_evaluation/results.py` decode mirror the new invariants; `refusal_kind` re-homed to scored-with-refusal / failed-with-`provider_refusal`; the report view drops the `refused` display state (a graded refusal renders a real correct/incorrect verdict; ungradeable ones land in the failed/unscored warning buckets), and the pane's refusal label is now neutral ("refusal") since the text may be the model's own graded decline.
- e2e harness: the golden schema imports the SDK's `CaseStatus`, so its vocabulary shrank automatically; the synthetic-golden fixtures moved off `refused`, and a golden still pinning it is refused at load by name.

## Test plan

- New invariant tests first (TDD red): `apps/screamingface-engine/tests/unit/test_refusal_status_split.py` (10 tests: status rejection, exactly-one, provider_refusal evidence rule, builder classification incl. the textless-decline demotion) and `packages/screamingface/tests/test_refusal_status_split.py` (10 tests: decode/build invariants + the re-homed `refusal_kind` table).
- Prior tests asserting the old `refused` status were updated to the new partition (the deliberate contract change of this ticket) — 9 engine test files and 8 SDK test files; each is listed in the work ledger's Deviations (`docs/work/2026-09-06-OME-1037-refused-status-split.md`).
- Gates: `run_gates.py screamingface-engine` ALL GREEN (ruff, format, pyright, layering, pytest 2350 passed / 5 skipped, cov ≥80). `run_gates.py screamingface` ALL GREEN (ruff, format, pyright, pytest incl. e2e replays, cov ≥95, notebooks, build, distribution). The runner's `--skip-append-only` flag was used because the mechanical append-only check cannot see this ticket's sanctioned prior-test updates.

Linear: https://linear.app/openmined/issue/OME-1037/refused-means-a-provider-failure-in-one-benchmark-and-correct-behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
