### PR TITLE
docs(tasks): close the five stale observability mirrors and ledgers (OME-1133)

### DIFF
--- a/docs/tasks/2026-08-24-OME-967-client-originates-traceparent.md
+++ b/docs/tasks/2026-08-24-OME-967-client-originates-traceparent.md
@@ -1,12 +1,12 @@
 ---
 id: OME-967
 linear_url: https://linear.app/openmined/issue/OME-967/originate-the-traceparent-in-the-client-and-surface-trace-id-to-the
-status: in_progress
+status: done
 type: null
 priority: 2
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-08-24
-closed:
+closed: 2026-09-02
 ---
 
 # Originate the traceparent in the client and surface `trace_id` to the user

--- a/docs/tasks/2026-08-25-OME-990-runtime-log-prompts.md
+++ b/docs/tasks/2026-08-25-OME-990-runtime-log-prompts.md
@@ -1,12 +1,12 @@
 ---
 id: OME-990
 linear_url: https://linear.app/openmined/issue/OME-990/runtimelog-records-user-prompts-in-cleartext
-status: in_progress
+status: done
 type: null
 priority: 2
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-08-25
-closed:
+closed: 2026-09-02
 ---
 
 # runtime.log records user prompts in cleartext

--- a/docs/tasks/2026-09-02-OME-1074-e2e-traceability-notebook.md
+++ b/docs/tasks/2026-09-02-OME-1074-e2e-traceability-notebook.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1074
 linear_url: https://linear.app/openmined/issue/OME-1074/commit-the-live-k8s-traceability-e2e-notebook
-status: in_progress
+status: done
 type: task
 priority: 3
 labels: [repo, agentic, autonomous, task]
 created: 2026-09-02
-closed:
+closed: 2026-09-02
 ---
 
 # Commit the live-k8s traceability e2e notebook

--- a/docs/tasks/2026-09-03-OME-1105-correlation-chain-e2e.md
+++ b/docs/tasks/2026-09-03-OME-1105-correlation-chain-e2e.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1105
 linear_url: https://linear.app/openmined/issue/OME-1105/add-the-correlation-chain-ladder-to-the-local-e2e-harness
-status: in_progress
+status: done
 type: null
 priority: 2
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-09-03
-closed:
+closed: 2026-09-03
 ---
 
 # Add the correlation-chain ladder to the local e2e harness

--- a/docs/tasks/2026-09-04-OME-1121-report-trace-id.md
+++ b/docs/tasks/2026-09-04-OME-1121-report-trace-id.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1121
 linear_url: https://linear.app/openmined/issue/OME-1121/expose-trace-id-on-report-so-a-completed-run-can-be-quoted
-status: in_progress
+status: done
 type: null
 priority: 2
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-09-04
-closed:
+closed: 2026-09-07
 ---
 
 # Expose trace_id on the public result so a completed run can be quoted

--- a/docs/tasks/2026-09-07-OME-1133-close-stale-mirrors.md
+++ b/docs/tasks/2026-09-07-OME-1133-close-stale-mirrors.md
@@ -1,0 +1,28 @@
+---
+id: OME-1133
+linear_url: https://linear.app/openmined/issue/OME-1133/close-the-five-stale-docstasks-mirrors-and-work-ledgers-from-the
+status: done
+type: task
+priority: 3
+labels: [repo, agentic, autonomous, task]
+created: 2026-09-07
+closed: 2026-09-07
+---
+
+# Close the five stale docs/tasks mirrors and work ledgers
+
+`OME-967`, `OME-990`, `OME-1074`, `OME-1105` and `OME-1121` all shipped and are Done in
+Linear, but their mirrors and ledgers still read `status: in_progress`. Linear is the status
+authority and the mirror is its repo-side reflection — so a reader with only the checkout saw
+five observability items apparently still in flight while Phase 1 was being built on top of
+them.
+
+Frontmatter only: `status: done` plus the PR's merge date in `finished:`/`closed:`. Prose and
+ledger Outcome sections are untouched.
+
+The underlying process defect — the mirror close belongs in the shipping PR and was missed
+five consecutive times — is recorded in the Linear issue. Enforcing it mechanically is
+deliberately **not** in scope: `run_gates.py` cannot see Linear state, so where that check
+lives is its own decision.
+
+Ledger: `docs/work/2026-09-07-OME-1133-close-stale-mirrors.md`

--- a/docs/work/2026-08-31-OME-990-runtime-access-log-off.md
+++ b/docs/work/2026-08-31-OME-990-runtime-access-log-off.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-990
 stack: screamingface
-status: in_progress
+status: done
 started: 2026-08-31
-finished:
+finished: 2026-09-02
 ---
 
 # OME-990 — Stop writing prompt-bearing query strings into `runtime.log`

--- a/docs/work/2026-09-01-OME-967-client-originates-traceparent.md
+++ b/docs/work/2026-09-01-OME-967-client-originates-traceparent.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-967
 stack: screamingface
-status: in_progress
+status: done
 started: 2026-09-01
-finished:
+finished: 2026-09-02
 ---
 
 # OME-967 — Originate the traceparent in the client and surface `trace_id`

--- a/docs/work/2026-09-02-OME-1074-e2e-traceability-notebook.md
+++ b/docs/work/2026-09-02-OME-1074-e2e-traceability-notebook.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1074
 stack: repo
-status: in_progress
+status: done
 started: 2026-09-02
-finished:
+finished: 2026-09-02
 ---
 
 # OME-1074 — Commit the live-k8s traceability e2e notebook

--- a/docs/work/2026-09-03-OME-1105-correlation-chain-e2e.md
+++ b/docs/work/2026-09-03-OME-1105-correlation-chain-e2e.md
@@ -2,8 +2,8 @@
 ticket: OME-1105
 stack: screamingface
 started: 2026-09-03
-status: in_progress
-finished:
+status: done
+finished: 2026-09-03
 ---
 
 # OME-1105 — Correlation-chain ladder in the local e2e harness

--- a/docs/work/2026-09-04-OME-1121-report-trace-id.md
+++ b/docs/work/2026-09-04-OME-1121-report-trace-id.md
@@ -2,8 +2,8 @@
 ticket: OME-1121
 stack: screamingface
 started: 2026-09-04
-status: in_progress
-finished:
+status: done
+finished: 2026-09-07
 ---
 
 # OME-1121 — Surface the run's `trace_id` on the public result

--- a/docs/work/2026-09-07-OME-1133-close-stale-mirrors.md
+++ b/docs/work/2026-09-07-OME-1133-close-stale-mirrors.md
@@ -1,0 +1,73 @@
+---
+ticket: OME-1133
+stack: repo
+status: done
+started: 2026-09-07
+finished: 2026-09-07
+---
+
+# OME-1133 — Close the five stale docs/tasks mirrors and work ledgers
+
+## Intent
+
+Five observability work items shipped and are **Done** in Linear, but their repo-side mirrors
+and ledgers on `main` still read `status: in_progress` with an empty `finished:`. The card
+makes Linear the status authority and the mirror its repo-side reflection; a reader working
+from the checkout alone — the normal case for anyone reading the repo cold — currently sees
+five items apparently still in flight while Phase 1 is actively being built on top of them.
+That is how a duplicate ticket gets filed for merged work.
+
+Stated plainly: each of those PRs closed its Linear issue but not its mirror. Five in a row is
+a process defect, not five slips. Recorded rather than quietly fixed.
+
+## Planned changes
+
+Frontmatter only — `status: in_progress` → `done`, and `finished:` → the PR's merge date. No
+prose is rewritten and no ledger Outcome section is touched; those are already filled.
+
+| Item | Merged | Files |
+|---|---|---|
+| `OME-967` | 2026-09-02 (#789) | `docs/tasks/2026-08-24-OME-967-client-originates-traceparent.md` · `docs/work/2026-09-01-OME-967-client-originates-traceparent.md` |
+| `OME-990` | 2026-09-02 (#780) | `docs/tasks/2026-08-25-OME-990-runtime-log-prompts.md` · `docs/work/2026-08-31-OME-990-runtime-access-log-off.md` |
+| `OME-1074` | 2026-09-02 (#812) | `docs/tasks/2026-09-02-OME-1074-e2e-traceability-notebook.md` · `docs/work/2026-09-02-OME-1074-e2e-traceability-notebook.md` |
+| `OME-1105` | 2026-09-03 (#831) | `docs/tasks/2026-09-03-OME-1105-correlation-chain-e2e.md` · `docs/work/2026-09-03-OME-1105-correlation-chain-e2e.md` |
+| `OME-1121` | 2026-09-07 (#842) | `docs/tasks/2026-09-04-OME-1121-report-trace-id.md` · `docs/work/2026-09-04-OME-1121-report-trace-id.md` |
+
+Plus this ledger and the `OME-1133` mirror, both closed in the same change — the defect this
+unit fixes is exactly "the mirror close was deferred", so deferring it here would be absurd.
+
+## Test plan
+
+There is no code under change, so there is no failing test to write first. The verifiable
+claim is a state one, and it is checked mechanically rather than by eye: no file under
+`docs/tasks/` or `docs/work/` naming a Linear-Done item may carry `status: in_progress`. The
+check is run before and after — it must list ten files before and none after.
+
+## Acceptance
+
+- All ten files read `status: done` with a `finished:` date matching their PR's merge date.
+- No prose or Outcome content changed — the diff is frontmatter lines only.
+- `OME-1133`'s own mirror and this ledger are closed in the same commit.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — ten frontmatter edits across `docs/tasks/` and `docs/work/`,
+  plus this ledger and `docs/tasks/2026-09-07-OME-1133-close-stale-mirrors.md`.
+- **Commits:** `docs(tasks): close the five stale observability mirrors and ledgers` (sha at
+  squash-merge).
+- **Gates:** no stack gate applies — the change touches `docs/` only, so no
+  `run_gates.py <stack>` lane is triggered and CI's path filters run nothing. The verifiable
+  claim was checked mechanically instead: the scratchpad checker listed **10 stale files
+  before and 0 after**, and `git diff -U0` confirms **20 changed lines, every one a
+  `status:`/`finished:`/`closed:` field** — no prose or Outcome content altered.
+- **Deviations:**
+  - **The checker had a bug that would have let this unit pass falsely.**
+    `finished:[ \t]*(\S*)` was first written with `\s*`, which crosses the newline on an empty
+    field and captures the `---` fence below it — so a file marked `done` with **no date**
+    would have reported `ok`. Caught on the baseline run (`finished=---` for every stale
+    file), fixed to `[ \t]*`, and the baseline re-run before any edit. Worth recording: a
+    check that cannot fail is the same defect class as a mirror that is never closed.
+  - **No enforcement gate was added**, deliberately. `run_gates.py` cannot see Linear state,
+    so a mechanical "mirror closed at merge" check needs a decision about where it lives
+    (PR template · CI job reading the Linear API · close-time step in the SDLC skill). Left
+    to its own item rather than guessed at here.


### PR DESCRIPTION
Closes the repo-side status for five observability items that shipped but whose mirrors and ledgers were never closed.

## Why

Linear is the status authority and `docs/tasks/` is its repo-side reflection. On `main` today, `OME-967`, `OME-990`, `OME-1074`, `OME-1105` and `OME-1121` are all **Done** in Linear but all ten of their mirror and ledger files still read `status: in_progress` with an empty `finished:`. Anyone reading the checkout without Linear access — the normal case — sees five observability items apparently still in flight, while Phase 1 (`OME-1118`) is actively being built on top of them. That is how a duplicate ticket gets filed for merged work.

The root cause is worth naming rather than quietly fixing: the mirror close belongs in each shipping PR and was missed five consecutive times. That makes it a process defect, not five slips.

## What changed

Frontmatter only — `status: in_progress` → `done`, and `finished:`/`closed:` → the PR's merge date.

| Item | Merged | PR |
|---|---|---|
| `OME-967` | 2026-09-02 | #789 |
| `OME-990` | 2026-09-02 | #780 |
| `OME-1074` | 2026-09-02 | #812 |
| `OME-1105` | 2026-09-03 | #831 |
| `OME-1121` | 2026-09-07 | #842 |

Plus this unit's own ledger and mirror, closed in the same commit — deferring them would reproduce the exact defect being fixed.

## Test plan

No code changes, so no stack gate applies and CI's path filters run nothing. The claim is a state one and was checked mechanically rather than by eye:

- A checker listing every `docs/tasks` + `docs/work` file for a Linear-Done item that still reads `in_progress`: **10 stale before, 0 after.**
- `git diff -U0` confirms **20 changed lines, every one a `status:`/`finished:`/`closed:` field** — no prose or ledger Outcome content altered.

One thing worth flagging: the checker's first version used `finished:\s*(\S*)`, where `\s*` crosses the newline on an empty field and captures the `---` fence below it — so a file marked `done` with **no date** would have reported clean. Caught on the baseline run, fixed to `[ \t]*`, baseline re-run before any edit.

## Not in scope

Adding a gate that enforces mirror closure at merge. It is worth doing, but `run_gates.py` cannot see Linear state, so where the check lives (PR template · CI job against the Linear API · a close-time step in the SDLC skill) is a decision rather than a detail. Left to its own item.

Refs: OME-1133