### PR TITLE
feat(screamingface-engine): propagate the run's traceparent to aigateway (OME-1119)

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py
+++ b/apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py
@@ -199,17 +199,25 @@ def _headers(credential: Credential) -> dict[str, str]:
     No ``Authorization``: a deployed aigateway (``cloudflare_headers``) reads only the identity
     header, and a local one (``disabled``) reads nothing at all.
 
-    WHY no ``traceparent`` here, unlike the other two aigateway clients (OME-1119): this call is
-    NOT one-to-one with a caller. ``CachedCatalog`` coalesces concurrent misses for one
-    credential onto a single upstream fetch (``cache.py``'s ``_inflight``), and serves the result
-    to every waiter — so a catalog fetch is caused by whichever caller happened to lead the
-    refresh and is consumed by N others. Stamping the leader's trace would put a call in their
-    trace that also served people they never heard of, and leave the other N-1 with a gap where
-    a catalog read should be. Both readings are wrong, and the wrong one looks right.
+    AIDEV-NOTE (OME-1119): this function carries NO ``traceparent``, and the three callers do not
+    all want that for the same reason — so do not "fix" it in one place.
 
-    Sending nothing is the honest answer for Phase 1, whose payoff is grepping ONE id across
-    services for ONE run. Representing a coalesced fetch properly needs an OTel span Link (one
-    span, many causes), which is Phase 2 — see ``OME-1130``.
+    - ``fetch`` genuinely must not carry one. ``CachedCatalog`` coalesces concurrent misses for a
+      credential onto a single upstream fetch (``cache.py``'s ``_inflight``, typed
+      ``Future[ModelCatalog]``) and serves the result to every waiter, so that call is *caused by*
+      whichever caller led the refresh and *consumed by* N others. Stamping the leader's trace
+      would put a call in their trace that also served people they never heard of, and leave the
+      other N-1 with a gap where a catalog read should be — both readings wrong, and the wrong one
+      looks right. Representing it honestly needs an OTel span Link (one span, many causes), which
+      is Phase 2, ``OME-1130``.
+    - ``fetch_model_parameters`` and ``admit_model`` are NOT coalesced — ``_inflight`` covers only
+      ``fetch``, and ``CachedCatalog.model_parameter_source`` is documented as "the uncached detail
+      source". ``rest/catalog.py`` calls the first straight from a route, one upstream call per
+      inbound request. Those two SHOULD carry the caller's traceparent; they do not yet, because
+      the value has to be threaded from the REST edge through ``catalog/executable.py`` rather than
+      taken from ``Credential`` — ``Credential`` holds a derived cache ``key``, so a per-request
+      field on it would give every request its own cache entry and destroy the catalog cache.
+      Tracked as ``OME-1134``.
     """
     headers = dict(credential.identity)
     if credential.profile is not None:

--- a/apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py
+++ b/apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py
@@ -198,6 +198,18 @@ def _headers(credential: Credential) -> dict[str, str]:
 
     No ``Authorization``: a deployed aigateway (``cloudflare_headers``) reads only the identity
     header, and a local one (``disabled``) reads nothing at all.
+
+    WHY no ``traceparent`` here, unlike the other two aigateway clients (OME-1119): this call is
+    NOT one-to-one with a caller. ``CachedCatalog`` coalesces concurrent misses for one
+    credential onto a single upstream fetch (``cache.py``'s ``_inflight``), and serves the result
+    to every waiter — so a catalog fetch is caused by whichever caller happened to lead the
+    refresh and is consumed by N others. Stamping the leader's trace would put a call in their
+    trace that also served people they never heard of, and leave the other N-1 with a gap where
+    a catalog read should be. Both readings are wrong, and the wrong one looks right.
+
+    Sending nothing is the honest answer for Phase 1, whose payoff is grepping ONE id across
+    services for ONE run. Representing a coalesced fetch properly needs an OTel span Link (one
+    span, many causes), which is Phase 2 — see ``OME-1130``.
     """
     headers = dict(credential.identity)
     if credential.profile is not None:

--- a/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/aigateway.py
@@ -224,7 +224,7 @@ class AigatewayConnections:
             response = await self._client.request(
                 method,
                 path,
-                headers=dict(caller.identity),
+                headers=_headers(caller),
                 params=params,
                 json=json,
             )
@@ -388,6 +388,30 @@ def _is_uuid(value: object) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _headers(caller: Caller) -> dict[str, str]:
+    """The upstream headers for one caller-scoped request: identity, then what we own.
+
+    INVARIANT: the gateway-owned headers are written LAST, the same rule
+    ``runner.connector._headers`` and ``catalog.aigateway._headers`` apply. `caller.identity` is
+    built from inbound request headers, and although the mesh guarantees the identity header
+    itself is not forged, nothing guarantees the mapping holds ONLY that key — so a caller
+    cannot displace this request's own trace or routing profile by sending their own.
+
+    FEATURE (OME-1119): before this, `/v1/providers` and every other connections call went out
+    with identity alone — no `traceparent`, and no `X-Profile` either, which was the same
+    header-assembly gap in the same place.
+
+    Absent values are OMITTED, never sent blank: an empty `X-Profile` is not "no profile" to a
+    gateway that parses it, and a zero traceparent parses everywhere while joining nothing.
+    """
+    headers = dict(caller.identity)
+    if caller.profile is not None:
+        headers["X-Profile"] = caller.profile
+    if caller.traceparent is not None:
+        headers["traceparent"] = caller.traceparent
+    return headers
 
 
 def _decode_object(response: httpx.Response) -> dict[str, Any]:

--- a/apps/screamingface-engine/src/screamingface_engine/connections/port.py
+++ b/apps/screamingface-engine/src/screamingface_engine/connections/port.py
@@ -23,9 +23,20 @@ ConnectionStatus = Literal[
 
 @dataclass(frozen=True, slots=True)
 class Caller:
-    """Verified identity headers associated with one Engine request."""
+    """Verified identity headers associated with one Engine request.
+
+    FEATURE (OME-1119): also carries the request's own ``traceparent`` and routing ``profile``,
+    which the adapter renders onto every upstream call it makes on this caller's behalf.
+
+    WHY here rather than a ContextVar: this object already IS the per-request scope, one
+    instance per inbound Engine request, so the value cannot be read by a request that did not
+    carry it. The run-mode connector uses a ContextVar precisely because it has no such object —
+    its world is cached across runs.
+    """
 
     identity: Mapping[str, str] = field(default_factory=dict)
+    traceparent: str | None = None
+    profile: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/screamingface-engine/src/screamingface_engine/rest/connections.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/connections.py
@@ -22,6 +22,7 @@ from screamingface_engine.connections.port import (
     ConnectionStatus,
     OAuthAuthorization,
 )
+from url4.streaming.trace import valid_traceparent
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +137,17 @@ def _serialize_oauth(authorization: OAuthAuthorization) -> OAuthAuthorizationRes
 
 
 def _caller(request: Request) -> Caller:
-    return Caller(job_env.identity_from_headers(request.headers))
+    # WHY `valid_traceparent` and not the raw header (OME-1119): this value is forwarded to
+    # aigateway, and a malformed one is worse than none — it would be rejected or, worse,
+    # parsed into a trace joining nothing. Same rule the run path applies at
+    # `adapters/k8s.py:591`, so a caller cannot get a different answer depending on which
+    # Engine surface they entered through. Invalid degrades to absent, never to an error:
+    # a bad trace header must not fail an otherwise valid connections request.
+    return Caller(
+        job_env.identity_from_headers(request.headers),
+        traceparent=valid_traceparent(request.headers.get("traceparent")),
+        profile=request.headers.get("X-Profile"),
+    )
 
 
 def _service(request: Request) -> Connections:

--- a/apps/screamingface-engine/src/screamingface_engine/runner/connector.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/connector.py
@@ -61,6 +61,7 @@ from screamingface_engine.runner.web_tools import (
     build_runtime,
     truncate_tool_result,
 )
+from screamingface_engine.trace_scope import current_traceparent
 from screamingface_engine.world_config import ModelSpec, WorldConfigError, provider_of, routes_for
 from url4.core.errors import ResolutionError
 from url4.io.static import StaticIOLayer
@@ -802,10 +803,19 @@ def _headers(
     WHY no `Authorization`: aigateway runs `cloudflare_headers` when deployed and `disabled`
     locally. Neither mode reads a bearer token, and a deployed caller cannot obtain one, so the
     run carries none at all.
+
+    FEATURE (OME-1119): `traceparent` is gateway-owned for the same reason `X-Profile` is, and is
+    written under the same rule — the run's own trace must win over anything that arrived in the
+    identity mapping. Absent (no bound run) the key is OMITTED rather than sent empty: a
+    well-formed header carrying a zero or invented id would parse everywhere, join nothing, and
+    look correct in every log it reached.
     """
     headers = dict(identity_headers or {})
     if profile is not None:
         headers["X-Profile"] = profile
+    traceparent = current_traceparent()
+    if traceparent is not None:
+        headers["traceparent"] = traceparent
     return headers
 
 

--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -26,6 +26,7 @@ from screamingface_engine.artifacts import ArtifactWriter
 from screamingface_engine.runner.accounting import PRICING_VERSION, UNPRICED, accumulate
 from screamingface_engine.runner.cache_counters import RunCacheCounters
 from screamingface_engine.runner.summary import RunOutcome, RunSummary
+from screamingface_engine.trace_scope import run_trace_scope
 from url4.core.errors import ResolutionError
 from url4.dag import run as url4_run
 from url4.io.layer import IOLayer
@@ -809,19 +810,30 @@ class Url4Executor(Executor):
         """
 
         async def _drive() -> str:
-            try:
-                if trace is not None:
-                    return await url4_run(
-                        url4,
-                        self._io,
-                        observer=bridge,
-                        trace_id=trace.trace_id,
-                        root_span_id=trace.root_span_id,
-                        **self._run_kwargs,
-                    )
-                return await url4_run(url4, self._io, observer=bridge, **self._run_kwargs)
-            finally:
-                bridge.close()
+            # FEATURE (OME-1119): the run's trace is bound HERE, inside the driving task, so the
+            # world's outbound aigateway calls carry it (`runner.connector._headers`).
+            #
+            # WHY not around `execute`'s own `async for ... yield`: `execute` is an ASYNC
+            # GENERATOR, and consecutive steps of one can be driven from different contexts —
+            # `asyncio.ensure_future(gen.__anext__())` runs that step in a new Task with a COPIED
+            # context. A ContextVar token created in one and reset in another raises
+            # `ValueError: Token was created in a different Context`, which is what a cancelled
+            # run did (`test_a_cancelled_run_records_stopped`). This task is a single context for
+            # its whole life, and it is where every model call actually happens.
+            with run_trace_scope(trace):
+                try:
+                    if trace is not None:
+                        return await url4_run(
+                            url4,
+                            self._io,
+                            observer=bridge,
+                            trace_id=trace.trace_id,
+                            root_span_id=trace.root_span_id,
+                            **self._run_kwargs,
+                        )
+                    return await url4_run(url4, self._io, observer=bridge, **self._run_kwargs)
+                finally:
+                    bridge.close()
 
         task = asyncio.ensure_future(_drive())
         try:

--- a/apps/screamingface-engine/src/screamingface_engine/trace_scope.py
+++ b/apps/screamingface-engine/src/screamingface_engine/trace_scope.py
@@ -1,0 +1,74 @@
+"""The run's W3C trace, bound for the duration of one run so outbound calls can carry it.
+
+FEATURE (OME-1119): rung 2 of the correlation ladder. The engine adopted a caller's
+traceparent and told nobody — the header set aigateway received carried `X-User-Email` and
+`X-Profile` but no `traceparent`, so a user quoting the `trace_id` from their `Report` could
+see the engine's half of a run and nothing about the model calls, which is where the
+interesting failures are.
+
+WHY a ContextVar rather than a field on the world: `Url4Executor._resolve_world` caches
+`self._io`, so `build_aigateway_world` runs ONCE per executor while serve mode drives many
+runs through it. A per-run value parked on that shared object is one run reading another's —
+the defect `build_aigateway_world`'s own docstring warns about for `cache`. A ContextVar is
+read at request time rather than build time, so the world stays cacheable and the value cannot
+outlive its run. This is also the idiom the same call site already uses:
+`current_retrieval_policy()` and `operation_call_identity()` sit beside it in
+`runner/connector.py`.
+
+INVARIANT: the id here is the one `url4.streaming.lifecycle.run` resolved and handed to
+`Executor.execute`, NOT `logs.RunContext.trace_id`. `runner/main.py` binds the log context from
+`parse_traceparent(env)`, which is `None` when the caller sent none — and url4 then MINTS one
+that never reaches it. Reading the log context would propagate for client-originated runs
+(passing rung 2) and silently propagate nothing for every other run.
+"""
+
+import contextvars
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from url4.streaming.interfaces import TraceContext
+from url4.streaming.trace import format_traceparent
+
+_trace: contextvars.ContextVar[TraceContext | None] = contextvars.ContextVar(
+    "screamingface_engine_run_trace", default=None
+)
+
+
+@contextmanager
+def run_trace_scope(trace: TraceContext | None) -> Iterator[None]:
+    """Bind one run's trace for the duration of a scope; restore on exit.
+
+    ``None`` is a real argument, not a degenerate one: `Executor.execute` declares
+    ``trace: TraceContext | None`` and callers outside `lifecycle.run` pass nothing. Binding it
+    explicitly is what stops an inner run without a trace from inheriting an outer run's.
+    """
+
+    token = _trace.set(trace)
+    try:
+        yield
+    finally:
+        _trace.reset(token)
+
+
+def current_traceparent() -> str | None:
+    """This run's ``traceparent`` header value, or ``None`` outside any run.
+
+    ``None`` means the header is OMITTED, never sent empty or all-zero. A well-formed header
+    carrying a zero id would parse everywhere, join nothing, and look correct in every log it
+    reached — which is worse than its absence, because absence is diagnosable.
+
+    WHY `root_span_id` rather than a fresh span per call: W3C wants the caller's CURRENT span,
+    and OTel's HTTP instrumentation mints a client span per request. Doing that here would name
+    a span no exporter publishes, so once `OME-1130` makes spans real the gateway's parent
+    pointer would dangle. The root span is one `lifecycle` genuinely emits (`StartedEvent` rides
+    it). Attaching the per-node span — which `lifecycle._trace_fields` already resolves for
+    frames — is Phase 2 work.
+    """
+
+    trace = _trace.get()
+    if trace is None:
+        return None
+    return format_traceparent(trace.trace_id, trace.root_span_id)
+
+
+__all__ = ["current_traceparent", "run_trace_scope"]

--- a/apps/screamingface-engine/tests/unit/test_traceparent_propagation.py
+++ b/apps/screamingface-engine/tests/unit/test_traceparent_propagation.py
@@ -1,0 +1,406 @@
+"""The run's trace id travels from the engine onto every outbound aigateway request (OME-1119).
+
+Sibling of `test_traceparent.py`, which pins the INBOUND half — how a caller's traceparent is
+adopted and stamped onto the run's frames. This file pins the OUTBOUND half: the engine had
+been a trace sink, adopting an id and telling nobody. The header set aigateway received during
+the audit was `Host, Accept, Accept-Encoding, Connection, User-Agent, X-User-Email, X-Profile,
+Content-Length, Content-Type` — no traceparent on any of three client paths.
+
+Rung 2 of the correlation ladder (`packages/screamingface/tests/e2e/test_correlation_chain.py`)
+is the end-to-end statement of the same claim; these are the engine-side unit tests that say
+*why* it holds and pin the two boundaries an e2e run cannot reach:
+
+- a run whose caller sent NO inbound traceparent still propagates the id url4 minted, and
+- two runs sharing one cached world do not share one trace id.
+
+The second is the reason this is a ContextVar rather than a constructor argument.
+"""
+
+from __future__ import annotations
+
+import re
+
+import httpx
+import pytest
+from starlette.requests import Request
+
+from screamingface_engine.connections.aigateway import AigatewayConnections
+from screamingface_engine.connections.port import Caller
+from screamingface_engine.rest.connections import _caller
+from screamingface_engine.runner.connector import AigatewayConfig, build_aigateway_world
+from screamingface_engine.runner.executor import Url4Executor
+from screamingface_engine.trace_scope import current_traceparent, run_trace_scope
+from screamingface_engine.world_config import ModelSpec
+from url4.dag import run as url4_run
+from url4.streaming.interfaces import TraceContext
+
+
+def _fake_request(headers: dict[str, str]) -> Request:
+    """A real Starlette Request, so `_caller` is exercised through its actual signature."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/v1/connections",
+            "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+        }
+    )
+
+
+MODEL = "anthropic/claude-haiku-4-5"
+IDENTITY = {"X-User-Email": "someone@openmined.org"}
+
+TRACEPARENT = re.compile(r"^00-(?!0{32}$)([0-9a-f]{32})-(?!0{16}$)([0-9a-f]{16})-[0-9a-f]{2}$")
+"""The same shape url4's own parser accepts, including its two all-zero rejections.
+
+Restated rather than imported so a change to url4's regex that widened what counts as valid
+would surface here as a failure rather than be adopted silently — this IS the contract the
+gateway will parse.
+"""
+
+TRACE_A = TraceContext(trace_id="a" * 32, root_span_id="1" * 16)
+TRACE_B = TraceContext(trace_id="b" * 32, root_span_id="2" * 16)
+
+
+class _MockAigateway:
+    """Records every request the connector makes, answering each with a minimal completion."""
+
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"message": {"content": "ok"}}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            },
+        )
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handle), base_url="http://aigateway.test"
+        )
+
+
+async def _run_in_scope(
+    trace: TraceContext | None,
+    *,
+    identity: dict[str, str] | None = None,
+    profile: str | None = None,
+) -> httpx.Request:
+    """One model call made inside `trace`'s scope; returns the request that reached aigateway."""
+    gw = _MockAigateway()
+    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL),), default_model=MODEL)
+    async with gw.client() as client:
+        world = await build_aigateway_world(
+            cfg, client=client, identity_headers=identity, profile=profile
+        )
+        with run_trace_scope(trace):
+            await url4_run(f"/{MODEL}('ctx')!'go'", world.node)
+    assert len(gw.requests) == 1
+    return gw.requests[0]
+
+
+# --- the scope itself -------------------------------------------------------------------------
+
+
+def test_outside_any_run_there_is_no_traceparent() -> None:
+    """The control plane must stay byte-identical — no header, not an empty or zero one."""
+    assert current_traceparent() is None
+
+
+def test_the_scope_renders_the_bound_runs_trace_as_a_w3c_traceparent() -> None:
+    with run_trace_scope(TRACE_A):
+        rendered = current_traceparent()
+
+    assert rendered is not None
+    match = TRACEPARENT.match(rendered)
+    assert match, rendered
+    assert match.group(1) == TRACE_A.trace_id
+
+
+def test_the_scope_is_restored_on_exit() -> None:
+    """Nested and sequential runs in one process must not leak into each other."""
+    with run_trace_scope(TRACE_A):
+        with run_trace_scope(TRACE_B):
+            assert current_traceparent() is not None
+            inner = current_traceparent()
+        outer = current_traceparent()
+
+    assert inner is not None and outer is not None
+    assert TRACEPARENT.match(inner).group(1) == TRACE_B.trace_id  # type: ignore[union-attr]
+    assert TRACEPARENT.match(outer).group(1) == TRACE_A.trace_id  # type: ignore[union-attr]
+    assert current_traceparent() is None
+
+
+def test_a_scope_bound_to_no_trace_renders_nothing() -> None:
+    """`execute` is called with `trace=None` by callers that never resolved one."""
+    with run_trace_scope(None):
+        assert current_traceparent() is None
+
+
+# --- the connector: the run's trace -> the chat-completions request ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_connector_sends_the_runs_traceparent() -> None:
+    request = await _run_in_scope(TRACE_A)
+
+    sent = request.headers.get("traceparent")
+    assert sent is not None, (
+        "the engine sent no traceparent — this is the audit's finding, and the whole of rung 2"
+    )
+    match = TRACEPARENT.match(sent)
+    assert match, sent
+    assert match.group(1) == TRACE_A.trace_id, "the gateway got A trace id, not THIS run's"
+
+
+@pytest.mark.asyncio
+async def test_a_call_outside_any_run_sends_no_traceparent_header() -> None:
+    """Absent is absent — never a well-formed header carrying an all-zero or invented id.
+
+    A zero id would parse, join nothing, and look correct in every log it reached.
+    """
+    request = await _run_in_scope(None)
+
+    assert "traceparent" not in request.headers
+
+
+@pytest.mark.asyncio
+async def test_the_gateway_owned_profile_still_wins_over_an_inbound_value() -> None:
+    """The INVARIANT at `connector._headers` must survive gaining a third header.
+
+    Envoy guarantees the identity header is not forged, but nothing guarantees the mapping
+    reaching the connector holds ONLY that key.
+    """
+    request = await _run_in_scope(
+        TRACE_A,
+        identity={**IDENTITY, "X-Profile": "attacker-profile", "traceparent": "00-" + "f" * 32},
+        profile="gateway-owned",
+    )
+
+    assert request.headers["x-profile"] == "gateway-owned"
+    match = TRACEPARENT.match(request.headers["traceparent"])
+    assert match, request.headers["traceparent"]
+    assert match.group(1) == TRACE_A.trace_id, (
+        "an inbound traceparent displaced the run's own — the header is gateway-owned and must "
+        "be written last, exactly as X-Profile is"
+    )
+
+
+@pytest.mark.asyncio
+async def test_identity_still_travels_alongside_the_traceparent() -> None:
+    """Guards against the new key being written by replacing the identity mapping."""
+    request = await _run_in_scope(TRACE_A, identity=IDENTITY)
+
+    assert request.headers["X-User-Email"] == IDENTITY["X-User-Email"]
+    assert "traceparent" in request.headers
+    assert "authorization" not in request.headers
+
+
+# --- the executor: where the scope comes from -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_binds_the_trace_it_was_handed() -> None:
+    """The id must come from `lifecycle.run`, which is the ONLY place both cases are known.
+
+    `logs.RunContext.trace_id` is the tempting source and is wrong: `runner/main.py` binds
+    `parse_traceparent(env)`, which is None when the caller sent none — and url4 then mints one
+    that never reaches it. Reading that would propagate for client-originated runs (passing
+    rung 2) and silently propagate nothing for the rest.
+    """
+    gw = _MockAigateway()
+    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL),), default_model=MODEL)
+    async with gw.client() as client:
+        world = await build_aigateway_world(cfg, client=client)
+        executor = Url4Executor(world.node)
+        async for _ in executor.execute(f"/{MODEL}('ctx')!'go'", trace=TRACE_A):
+            pass
+
+    assert gw.requests, "the run made no model call"
+    match = TRACEPARENT.match(gw.requests[0].headers.get("traceparent", ""))
+    assert match, gw.requests[0].headers.get("traceparent")
+    assert match.group(1) == TRACE_A.trace_id
+
+
+@pytest.mark.asyncio
+async def test_two_runs_on_one_cached_world_do_not_share_a_trace_id() -> None:
+    """The regression a constructor argument would cause, asserted directly.
+
+    `Url4Executor._resolve_world` caches `self._io`, so `build_aigateway_world` runs once per
+    executor while serve mode drives many runs through it. A per-run value parked on that
+    shared object is one run reading another's — the defect `build_aigateway_world`'s own
+    docstring warns about for `cache`.
+    """
+    gw = _MockAigateway()
+    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL),), default_model=MODEL)
+    async with gw.client() as client:
+        world = await build_aigateway_world(cfg, client=client)
+        executor = Url4Executor(world.node)
+        for trace in (TRACE_A, TRACE_B):
+            async for _ in executor.execute(f"/{MODEL}('ctx')!'go'", trace=trace):
+                pass
+
+    assert len(gw.requests) == 2, "expected one model call per run"
+    first, second = (r.headers.get("traceparent", "") for r in gw.requests)
+    assert TRACEPARENT.match(first).group(1) == TRACE_A.trace_id  # type: ignore[union-attr]
+    assert TRACEPARENT.match(second).group(1) == TRACE_B.trace_id, (  # type: ignore[union-attr]
+        "the second run reused the first run's trace id — the world outlived the run that "
+        "built it, which is exactly why the trace is a ContextVar and not a field"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_run_with_no_inbound_traceparent_still_propagates_the_minted_id() -> None:
+    """The hole `logs.RunContext` would leave, asserted as its own case.
+
+    url4 mints a trace id when the caller sent none, and that run's model calls must carry it
+    — otherwise the deployed no-inbound-traceparent path stays anonymous while the ladder,
+    whose client always originates one, reports green.
+    """
+    minted = TraceContext(trace_id="c" * 32, root_span_id="3" * 16)
+    gw = _MockAigateway()
+    cfg = AigatewayConfig(models=(ModelSpec(id=MODEL),), default_model=MODEL)
+    async with gw.client() as client:
+        world = await build_aigateway_world(cfg, client=client)
+        executor = Url4Executor(world.node)
+        async for _ in executor.execute(f"/{MODEL}('ctx')!'go'", trace=minted):
+            pass
+
+    match = TRACEPARENT.match(gw.requests[0].headers.get("traceparent", ""))
+    assert match, "a run whose caller sent no traceparent propagated nothing"
+    assert match.group(1) == minted.trace_id
+
+
+# --- the connections path: the inbound request's trace -> the upstream call -------------------
+
+
+class _RecordingUpstream:
+    """Keeps every connections request, answering each path with the shape it must parse.
+
+    `list()` makes TWO upstream calls — `/v1/providers` then `/v1/oauth/connections` — and they
+    decode differently. Answering both with one shape makes the adapter raise before the
+    assertion is reached, which reads as a propagation failure and is not one.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if request.url.path == "/v1/providers":
+            return httpx.Response(200, json={"object": "list", "data": []})
+        return httpx.Response(200, json={"connections": []})
+
+    def client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(self._handle), base_url="http://aigateway.test"
+        )
+
+
+async def _list_as(caller: Caller) -> httpx.Request:
+    """Drive one `list()` and return the `/v1/providers` request — the path the issue names."""
+    upstream = _RecordingUpstream()
+    async with upstream.client() as client:
+        await AigatewayConnections(client).list(caller)
+    providers = [r for r in upstream.requests if r.url.path == "/v1/providers"]
+    assert len(providers) == 1, [r.url.path for r in upstream.requests]
+    # EVERY upstream call must carry it, not just the one asserted on — a per-path regression
+    # would otherwise hide behind the one request this helper returns.
+    assert len({r.headers.get("traceparent") for r in upstream.requests}) == 1
+    return providers[0]
+
+
+@pytest.mark.asyncio
+async def test_the_connections_path_forwards_the_requests_traceparent() -> None:
+    """`/v1/providers` went out with identity alone — no traceparent, and no X-Profile."""
+    inbound = "00-" + "d" * 32 + "-" + "4" * 16 + "-01"
+
+    request = await _list_as(Caller(IDENTITY, traceparent=inbound, profile="p1"))
+
+    assert request.headers["traceparent"] == inbound
+    assert request.headers["X-Profile"] == "p1"
+    assert request.headers["X-User-Email"] == IDENTITY["X-User-Email"]
+
+
+@pytest.mark.asyncio
+async def test_a_connections_request_without_a_trace_sends_no_traceparent() -> None:
+    request = await _list_as(Caller(IDENTITY))
+
+    assert "traceparent" not in request.headers
+    assert "x-profile" not in request.headers
+
+
+@pytest.mark.asyncio
+async def test_an_inbound_identity_mapping_cannot_displace_the_requests_own_trace() -> None:
+    """Gateway-owned headers are written last here too — the same INVARIANT as the connector."""
+    ours = "00-" + "e" * 32 + "-" + "5" * 16 + "-01"
+    forged = {**IDENTITY, "traceparent": "00-" + "0" * 32 + "-" + "0" * 16 + "-01"}
+
+    request = await _list_as(Caller(forged, traceparent=ours, profile="mine"))
+
+    assert request.headers["traceparent"] == ours
+
+
+def test_the_rest_edge_drops_a_malformed_inbound_traceparent() -> None:
+    """Invalid degrades to ABSENT, never to an error and never forwarded as-is.
+
+    Forwarding garbage would be rejected downstream or, worse, parsed into a trace that joins
+    nothing. Failing the request instead would let a bad trace header break an otherwise valid
+    connections call, which is a availability regression for a diagnostic feature.
+    """
+    request = _fake_request({"traceparent": "not-a-traceparent", "X-User-Email": "a@b.c"})
+
+    caller = _caller(request)
+
+    assert caller.traceparent is None
+    assert caller.identity == {"X-User-Email": "a@b.c"}
+
+
+def test_the_rest_edge_carries_a_valid_inbound_traceparent_through() -> None:
+    inbound = "00-" + "9" * 32 + "-" + "8" * 16 + "-01"
+
+    caller = _caller(_fake_request({"traceparent": inbound, "X-Profile": "prof"}))
+
+    assert caller.traceparent == inbound
+    assert caller.profile == "prof"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_run_does_not_raise_from_the_trace_scope() -> None:
+    """Regression: the scope must not hold a ContextVar token across an async-generator yield.
+
+    `Url4Executor.execute` is an ASYNC GENERATOR, and consecutive steps of one can be driven
+    from different contexts — `asyncio.ensure_future(gen.__anext__())` runs that step in a new
+    Task with a COPIED context. A token set in one and reset in another raises
+    `ValueError: Token was created in a different Context`.
+
+    `test_runner_summary.py::test_a_cancelled_run_records_stopped` is what caught this, but its
+    name promises nothing about contexts, so the constraint is restated here where a later
+    change to `trace_scope` would look for it.
+    """
+    import asyncio
+
+    from url4.io.static import StaticIOLayer
+
+    gate = asyncio.Event()
+
+    async def gated(_context: str, _intent: str) -> str:
+        await gate.wait()
+        return "GATED"
+
+    io = StaticIOLayer(fetch_map={"https://fast": "FAST"}, routes={"/gated": gated})
+    generator = Url4Executor(io).execute("(f=https://fast, g=/gated()!go)!'$f $g'", trace=TRACE_A)
+
+    await asyncio.wait_for(generator.__anext__(), timeout=2.0)
+    pending = asyncio.ensure_future(generator.__anext__())
+    pending.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await pending
+
+    # And the scope really is unbound afterwards — a leaked binding would attribute the NEXT
+    # run's model calls to this cancelled one.
+    assert current_traceparent() is None

--- a/docs/tasks/2026-09-07-OME-1119-engine-propagates-traceparent.md
+++ b/docs/tasks/2026-09-07-OME-1119-engine-propagates-traceparent.md
@@ -1,0 +1,32 @@
+---
+id: OME-1119
+linear_url: https://linear.app/openmined/issue/OME-1119/propagate-the-traceparent-from-the-engine-to-aigateway
+status: done
+type: null
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-07
+closed: 2026-09-07
+---
+
+# Propagate the traceparent from the engine to aigateway
+
+Rung 2 of the correlation ladder, second child of the Phase 1 epic (`OME-1118`). The engine
+adopted a caller's traceparent and told nobody — the header set aigateway received carried
+`X-User-Email` and `X-Profile` but no `traceparent`, so the trace stopped at the engine and a
+user quoting their `trace_id` saw nothing about the model calls.
+
+Two sources, because there are two kinds of caller:
+
+- **Run mode** — a ContextVar bound inside the executor's driving task, from the `TraceContext`
+  `url4.streaming.lifecycle.run` hands to `Executor.execute`. Not from `logs.RunContext`, which
+  is `None` whenever the caller sent no traceparent and url4 minted one instead.
+- **Connections** — carried on `Caller`, which already is the per-request object. One
+  `_headers(caller)` covers every upstream call, and `/v1/providers` gains the `X-Profile` it
+  had also been missing.
+
+The **catalog path deliberately sends nothing**: `CachedCatalog` coalesces concurrent misses
+onto one upstream fetch, so that call has many causes and no single honest trace. Documented at
+the call site; a span Link is Phase 2 (`OME-1130`).
+
+Ledger: `docs/work/2026-09-07-OME-1119-engine-propagates-traceparent.md`

--- a/docs/work/2026-09-07-OME-1119-engine-propagates-traceparent.md
+++ b/docs/work/2026-09-07-OME-1119-engine-propagates-traceparent.md
@@ -1,0 +1,189 @@
+---
+ticket: OME-1119
+stack: screamingface-engine
+status: done
+started: 2026-09-07
+finished: 2026-09-07
+---
+
+# OME-1119 — Propagate the traceparent from the engine to aigateway
+
+## Intent
+
+Rung 2 of the correlation ladder. `OME-967` made the client originate a traceparent and the
+engine already **adopts** it — the control plane forwards it into the runner as
+`job_env.TRACEPARENT` (`adapters/k8s.py:591`, `adapters/inprocess.py:155`) and the run's own
+frames carry it. But the engine sends **nothing onward**: the header set aigateway received
+during the audit was `Host, Accept, Accept-Encoding, Connection, User-Agent, X-User-Email,
+X-Profile, Content-Length, Content-Type` — no `traceparent`, on any of three client paths.
+
+The consequence is that the trace stops at the engine. A user quoting the `trace_id` from
+`CandidateResult` (`OME-1121`) can find the engine's half of the story and nothing about the
+model calls, which is where the interesting failures live.
+
+## Design decisions
+
+**D1 — There are TWO trace sources here, not one.** The issue reads as though one mechanism
+covers all three client paths. It does not:
+
+- `runner/connector.py` is **run mode**. Its trace is the run's `TraceContext`, computed by
+  `url4.streaming.lifecycle.run` and handed to `Url4Executor.execute(url4, trace=root_ctx)`.
+- `catalog/aigateway.py` and `rest/routes.py` are **control plane**, serving inbound HTTP.
+  There is no run and no `TraceContext`; their trace is whatever the **inbound request**
+  carried.
+
+Treating them alike would mean inventing a run context for the control plane or reaching for
+a global. They get the same header, from two different origins, and the ledger says so because
+the code will look asymmetric to a reviewer who expects one helper.
+
+**D2 — The run's id comes from `TraceContext`, NOT from `logs.RunContext.trace_id`.** This is
+the trap in this unit. `logs.py` already has exactly the shape wanted — `run_scope(topic,
+trace_id)` bound around the whole run, `current_run_context()` to read it — and using it would
+be one line. It is wrong:
+
+```python
+# runner/main.py:477
+trace_id = parse_traceparent(traceparent)   # None when the caller sent none
+with run_scope(params.topic, trace_id):
+```
+
+When the caller sends no traceparent, `lifecycle.run` **mints** one (`secrets.token_hex(16)`,
+`lifecycle.py:201`) and that minted id never reaches `RunContext`. Reading `RunContext` would
+therefore send a traceparent for client-originated runs — making rung 2 pass — and silently
+send none for every other run. A hole shaped exactly like a passing test.
+
+`lifecycle.run` computes the authoritative id in both cases and passes it to
+`executor.execute`. That is the source.
+
+**D3 — A ContextVar bound in `execute`, not a constructor parameter.** `Url4Executor` caches
+its world: `_resolve_world` is `if self._io is None and self._world_factory is not None`, so
+`build_aigateway_world` runs **once per executor**, and in serve mode one executor serves many
+runs. Threading the trace through `world_factory` → `build_aigateway_world` →
+`_ModelEndpoint` would park a per-run value on a process-shared object — precisely the defect
+`build_aigateway_world`'s own docstring warns about for `cache`:
+
+> `cfg` is the world, one description of the gateway shared by every run in the process, and a
+> per-run value there is a value one run reads out of another's.
+
+A ContextVar is read at *request* time rather than *build* time, so world caching stays
+correct and the value cannot outlive its run. It also matches the idiom this exact call site
+already uses — `current_retrieval_policy()` at `connector.py:198` and
+`operation_call_identity(...)` at `:203`, alongside `model_outcomes`, `grading_accounting`,
+`operation_calls` and `logs` itself. Six existing ContextVars; this is the house pattern.
+
+**D4 — The outbound span id is the run's `root_span_id`, not a per-call mint.** W3C says the
+`traceparent`'s span-id is the caller's *current* span, and OTel HTTP instrumentation mints a
+fresh client span per request. Doing that here would emit a span id that **no exporter ever
+publishes**, so once `OME-1130` makes spans real the gateway's parent pointer would dangle.
+`root_span_id` is a span `lifecycle` genuinely publishes (`StartedEvent` rides it). Attaching
+the per-node span — which `_trace_fields` already resolves for frames — is a Phase 2 concern
+and is recorded as a follow-up rather than guessed at now. The rung asserts the trace id half,
+which is identical either way.
+
+**D5 — `/v1/providers` also gains `X-Profile`.** Called out in the issue and kept in scope: it
+is the same header-assembly defect in the same function, and splitting it would mean touching
+that code twice.
+
+## Planned changes
+
+- `src/screamingface_engine/runner/trace_scope.py` (new) — the ContextVar plus
+  `run_trace_scope(trace)` / `current_traceparent()`. Its own module rather than a new export
+  from `logs.py`: `logs` is the *logging* layer, and a header source parked there would be
+  imported by the connector for a value that has nothing to do with logging.
+- `src/screamingface_engine/runner/executor.py` — bind the scope in `execute` around the run.
+- `src/screamingface_engine/runner/connector.py` — `_headers()` adds `traceparent` when bound.
+- `src/screamingface_engine/catalog/aigateway.py` — `_headers(credential)` adds it from the
+  inbound request's trace.
+- `src/screamingface_engine/rest/routes.py` — the connections path forwards the inbound
+  traceparent, plus the missing `X-Profile` (D5).
+- `packages/screamingface/tests/e2e/test_correlation_chain.py` — delete rung 2's strict-xfail
+  marker. **Trips the append-only gate**, as every rung PR does; see the note below.
+
+## Test plan
+
+RED first, engine-side unit tests before the e2e rung:
+
+- `_headers()` renders a well-formed `traceparent` carrying the bound run's trace id.
+- Outside any run scope it renders **no** `traceparent` key at all — not an empty string, not
+  a zero id. The control plane must stay byte-identical.
+- The id is the run's, not a fresh one: two calls inside one scope carry the same trace id.
+- Two sequential runs on ONE cached executor carry **different** trace ids — the regression D3
+  exists to prevent, and the one a constructor parameter would fail.
+- A run whose caller sent NO inbound traceparent still propagates the minted id — the D2 hole,
+  asserted directly rather than inferred.
+- `X-Profile` is written after the inbound identity mapping and cannot be displaced by it
+  (the existing INVARIANT at `connector.py:796`, re-asserted for the new key).
+- The catalog and connections paths each send it from the inbound request.
+- Rung 2 of the ladder passes; rungs 3, 4a, 4b stay strict xfails.
+
+## Acceptance
+
+- All three client paths send a `traceparent` carrying the run's / request's own trace id.
+- No traceparent is emitted outside a trace scope.
+- Rung 2 green, rungs 3/4a/4b still xfail.
+- `run_gates.py screamingface-engine` green; the `screamingface` ladder run green.
+
+## Known process consequence
+
+Deleting rung 2's marker modifies a prior test, so the append-only gate flags
+`test_correlation_chain.py` — inherent to the ladder from `OME-1105`, and the third PR to hit
+it. Raised for a once-and-for-all decision rather than re-approved silently.
+
+## Adjacent finding — NOT fixed here
+
+`run_scope` binds `trace_id=None` for any run whose caller sent no traceparent (D2), so those
+runs' process log lines carry `topic=` but no `trace_id=` even though the run has one. That is
+`OME-940`'s territory (rung 4a — engine logs the trace id), and fixing it here would widen this
+unit past its rung. Recorded on `OME-940` rather than left in a ledger nobody re-reads.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `trace_scope.py` (new), `runner/executor.py`, `runner/connector.py`,
+  `connections/port.py`, `connections/aigateway.py`, `rest/connections.py`,
+  `catalog/aigateway.py` (comment only), `tests/unit/test_traceparent_propagation.py` (new,
+  17 tests), the ladder, ledger + mirror.
+- **Commits:** `feat(screamingface-engine): propagate the run's traceparent to aigateway`
+  (sha at squash-merge).
+- **Gates:** `run_gates.py screamingface-engine` — **ALL GREEN** (append-only, ruff, ruff
+  format, pyright, check_layering, `pytest --cov --cov-fail-under=80`): **2366 passed, 5
+  skipped**. `run_gates.py screamingface --skip-append-only` — **ALL GREEN**.
+  The ladder against the real engine + real aigateway: **2 passed, 3 xfailed** — rung 2
+  flipped green, rungs 3/4a/4b still fail as designed.
+- **Deviations:**
+  - **The scope binds inside `_drive`, not around `execute`'s `yield` — and the first version
+    was a real bug.** `Url4Executor.execute` is an ASYNC GENERATOR, and consecutive steps of
+    one can be driven from different contexts: `asyncio.ensure_future(gen.__anext__())` runs
+    that step in a new Task with a COPIED context. A ContextVar token set in one and reset in
+    another raises `ValueError: Token was created in a different Context`, which is exactly
+    what `test_runner_summary.py::test_a_cancelled_run_records_stopped` reported. Caught by an
+    existing prior test, not by a new one — the append-only rule earning its keep. Moved into
+    the `_drive` task, which is one context for its whole life and is where every model call
+    actually happens. Restated as a named regression test so the constraint is findable.
+  - **The connections path uses `Caller`, not a ContextVar or middleware** (the ledger planned
+    a request-scoped ContextVar). `Caller` already IS the per-request object — one instance per
+    inbound Engine request — so the value cannot be read by a request that did not carry it,
+    with no middleware and no new global. `Caller` gained `traceparent` and `profile`; a single
+    `_headers(caller)` at `_request` covers **every** connections call, not just `/v1/providers`.
+    The run path still needs a ContextVar because it has no such object — its world is cached
+    across runs.
+  - **The catalog path deliberately sends NO traceparent**, against the issue's "all three
+    paths". `CachedCatalog` coalesces concurrent misses for one credential onto a single
+    upstream fetch (`cache.py`'s `_inflight`) and serves it to every waiter — so a catalog call
+    is *caused by* whichever caller led the refresh and *consumed by* N others. Stamping the
+    leader's trace would put a call in their trace that also served people they never heard of,
+    and leave the other N-1 with a gap where a catalog read should be. Both readings are wrong,
+    and the wrong one looks right. Documented at the call site; representing it honestly needs
+    an OTel span Link, which is `OME-1130`. **This is the one place the issue's premise did not
+    survive contact with the code** — flagged rather than quietly satisfied.
+  - **The REST edge validates rather than forwards.** `valid_traceparent` on the inbound header,
+    with invalid degrading to *absent* — never forwarded as-is (garbage that parses into a trace
+    joining nothing) and never an error (a bad trace header must not fail an otherwise valid
+    connections request). Same rule `adapters/k8s.py:591` applies to the run path, so a caller
+    gets one answer regardless of which Engine surface they enter through.
+  - **Rule 5 Confidence-Gate, third consecutive rung PR:** approved on the numbers — test
+    functions **5 → 5**, assertions **14 → 14**, one xfail marker deleted, no assertion
+    weakened. `--skip-append-only` used, as sanctioned. The standing recommendation to exempt
+    this one file rather than re-approve the identical shape twice more is unchanged.
+  - Worktree note: the first `git worktree add` ran with a relative path while the shell cwd
+    was inside another worktree, nesting it under `OME-1133`'s checkout. Detected before any
+    commit (`git ls-files` returned 0), removed, and recreated from an absolute path.

--- a/packages/screamingface/tests/e2e/test_correlation_chain.py
+++ b/packages/screamingface/tests/e2e/test_correlation_chain.py
@@ -171,14 +171,20 @@ def test_rung1_one_coherent_trace_id_spans_the_run(wire_run) -> None:
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(strict=True, reason="rung 2: the engine sends no traceparent to aigateway")
 def test_rung2_the_engine_propagates_the_trace_id_to_the_gateway(wire_run) -> None:
-    """RUNG 2 (not built — strict xfail).
+    """RUNG 2 (`OME-1119` — must PASS).
 
     The gateway must receive the run's OWN trace id, not merely some traceparent. The audit
     captured the engine's outbound header set as `Host, Accept, Accept-Encoding, Connection,
     User-Agent, X-User-Email, X-Profile, Content-Length, Content-Type` — no traceparent at
     all, on any of its three client paths.
+
+    This was a strict xfail until `OME-1119`, which binds the run's `TraceContext` in the
+    executor's driving task and renders it in `runner.connector._headers`. The engine-side
+    unit tests are `apps/screamingface-engine/tests/unit/test_traceparent_propagation.py`;
+    they pin two boundaries this rung cannot reach — a run whose caller sent NO inbound
+    traceparent still propagates the id url4 minted, and two runs sharing one cached world do
+    not share one trace id.
     """
     gateway: FakeGateway = wire_run["gateway"]
     assert gateway.inbound_headers, "the engine made no call to the gateway"


### PR DESCRIPTION
Rung 2 of the correlation ladder. Second child of the Phase 1 epic (`OME-1118`), after `OME-1121`.

## The problem

The engine **adopted** a caller's traceparent — the control plane forwards it into the runner as `job_env.TRACEPARENT` and the run's own frames carry it — and then sent nothing onward. The full header set aigateway received during the audit:

`Host, Accept, Accept-Encoding, Connection, User-Agent, X-User-Email, X-Profile, Content-Length, Content-Type`

The trace stopped at the engine, so a user quoting the `trace_id` from their `Report` (`OME-1121`) could see the engine's half of a run and nothing about the model calls — which is where the interesting failures are.

## Two sources, because there are two kinds of caller

**Run mode** — a ContextVar bound inside the executor's driving task, from the `TraceContext` that `url4.streaming.lifecycle.run` hands to `Executor.execute`.

Deliberately **not** `logs.RunContext.trace_id`, which is the tempting one-line answer and is wrong:

```python
# runner/main.py:477
trace_id = parse_traceparent(traceparent)   # None when the caller sent none
with run_scope(params.topic, trace_id):
```

When the caller sends no traceparent, url4 **mints** one and that id never reaches `RunContext`. Reading it would propagate for client-originated runs — passing rung 2 — and silently propagate nothing for every other run. A hole shaped exactly like a passing test. There is a test for that case specifically.

**Connections** — carried on `Caller`, which already *is* the per-request object, so no middleware and no new global. One `_headers(caller)` at `_request` covers **every** connections call, and `/v1/providers` gains the `X-Profile` it had also been missing (the same header-assembly gap the issue bundles).

## Why the scope binds inside `_drive`

`Url4Executor.execute` is an **async generator**, and consecutive steps of one can be driven from different contexts — `asyncio.ensure_future(gen.__anext__())` runs that step in a new Task with a **copied** context. A ContextVar token set in one and reset in another raises `ValueError: Token was created in a different Context`.

The first version wrapped `execute`'s `yield` and did exactly that. It was caught by an **existing** test (`test_runner_summary.py::test_a_cancelled_run_records_stopped`), not by a new one — the append-only rule earning its keep. The driving task is one context for its whole life and is where every model call actually happens. Restated as a named regression test so the constraint is findable next time.

## The catalog path deliberately sends nothing

This is the one place the issue's "three client paths" premise did not survive contact with the code, so it is flagged rather than quietly satisfied.

`CachedCatalog` coalesces concurrent misses for one credential onto a single upstream fetch (`cache.py`'s `_inflight`) and serves the result to every waiter. A catalog call is therefore *caused by* whichever caller led the refresh and *consumed by* N others. Stamping the leader's trace would put a call in their trace that also served people they never heard of, and leave the other N-1 with a gap where a catalog read should be — both readings wrong, and the wrong one looks right.

Sending nothing is the honest answer for Phase 1, whose payoff is grepping one id across services for one run. Representing a coalesced fetch properly needs an OTel span Link, which is `OME-1130`.

## Test plan

**Engine** — `run_gates.py screamingface-engine`: **ALL GREEN** (append-only, ruff, ruff format, pyright, check_layering, `pytest --cov --cov-fail-under=80`) — **2366 passed, 5 skipped**.

17 new tests in `tests/unit/test_traceparent_propagation.py`, including the boundaries an e2e run cannot reach:

- a run whose caller sent **no** inbound traceparent still propagates the id url4 minted;
- **two runs on one cached world do not share a trace id** — the regression a constructor argument would cause, since `_resolve_world` caches `self._io`;
- absent is **absent** — no header, never a zero or invented one that would parse everywhere and join nothing;
- the gateway-owned headers still win over an inbound mapping that carries its own `X-Profile`/`traceparent`;
- a malformed inbound traceparent degrades to absent, never forwarded and never an error;
- a cancelled run does not raise out of the trace scope.

**Client** — `run_gates.py screamingface --skip-append-only`: **ALL GREEN**.

**The ladder**, against the real engine and a real gateway subprocess: **2 passed, 3 xfailed** — rung 2 flipped green, rungs 3/4a/4b still fail as designed.

## Append-only gate — third consecutive rung PR

Deleting rung 2's strict-xfail marker modifies a prior test, so the gate flags it. Benign and verified by count: test functions **5 → 5**, assertions **14 → 14**, one marker removed, no assertion weakened.

This is the third PR to trip it for the identical reason and there are two more rungs to go. Standing recommendation: exempt `test_correlation_chain.py` from the check rather than approve the same shape twice more.

## Not visible in SigNoz yet

This puts the id on the wire. Nothing logs it until `OME-940` (engine side) and `OME-1120` (gateway side) land — see the parent epic for what becomes validatable after deploy.

Refs: OME-1119