### PR TITLE
docs(screamingface): consolidate notebook Copy and Report design

### DIFF
--- a/docs/plan/2026-09-07-OME-1013-notebook-error-reporting.md
+++ b/docs/plan/2026-09-07-OME-1013-notebook-error-reporting.md
@@ -1,0 +1,44 @@
+# OME-1013 — Implement one notebook reporting flow
+
+Spec: [Notebook error reporting](../spec/2026-09-07-OME-1013-notebook-error-reporting.md).
+Owner direction: combine OME-1014 into OME-1013 and replace the public receipt-management
+interface with compact Copy/Report actions. This plan records the combined work; it does not
+claim PR #756 already implements it.
+
+1. Reconcile #756 with current main (including merged #842). Preserve the owner's modified
+   quickstart and exported diagnostic file in its existing worktree. Use an isolated checkout
+   for implementation/gates. Update the older branch spec/plan to point to this superseding spec.
+2. Before implementing transport/UI, inspect report-audience credential reuse and demonstrate
+   browser Turnstile/clipboard support in the supported notebook hosts. Confirm endpoint/site-key
+   configuration and the dev sink through read-only deployment access. Record missing access
+   explicitly; do not bypass Access/Turnstile or weaken service settings to make a demo pass.
+3. Write failing tests for the private snapshot lifecycle, before-frame trace retention and
+   sanitized diagnostic failure logs. Replace public lookup/receipt exports with private values,
+   remove the global ring if unnecessary, and preserve bounded ownership/disposal.
+4. Define a private projection into the existing service schema, including safe error.message,
+   attributable primary candidate/correlation and capped extra context. Test its serialized bytes
+   against the real service contract in integration tests without importing app internals into
+   Client runtime code. No new public serialization contract or service schema is introduced.
+5. Implement one private submission state machine for prepared/sending/received/recoverable
+   failure. Freeze the exact preview payload and idempotency key, resolve authentication safely,
+   submit from the kernel, parse report ref/delivery/ticket, and preserve draft on failure.
+6. Build the compact SFDS toolbar and inline form, optional note/reply address, exact preview,
+   identity disclosure and explicit Send. Add real frontend support for browser-owned clipboard
+   and Turnstile where available, plus usable static/selectable/save fallbacks. Never add a global
+   exception hook or expose credentials in widget serialization.
+7. Run the Client SDLC gates and focused service-contract tests, then real notebook UX checks.
+   Perform the two labelled dev submissions and idempotent replays from the spec. Inspect their
+   stored identity/payload and actual delivery results. Record refs, revision, test counts and
+   delivery evidence without recording tokens or unrelated reports.
+8. Update #756's title/body around the complete final implementation and validation. Close
+   OME-1013 and its mirrors only after the implementation lands and required verification is
+   complete; close OME-1003 when its overall acceptance is met.
+
+## Consolidation ledger
+
+- OME-1013: surviving implementation ticket; PR #756 remains open.
+- OME-1014: Duplicate of OME-1013, closed because scope moved, not because sending shipped.
+- OME-1003: parent retained; completed OME-967 no longer blocks it.
+- OME-416: retain version provenance; reporting acceptance moves to OME-1013 under OME-1003.
+- Service closeout (OME-1005–1012), OME-976's deployment decision, OME-1072's evaluation semantics,
+  OME-979's failure attribution and OME-1124's analytics remain separate; no automatic closure.

--- a/docs/plan/2026-09-07-OME-1013-notebook-error-reporting.md
+++ b/docs/plan/2026-09-07-OME-1013-notebook-error-reporting.md
@@ -42,3 +42,15 @@ claim PR #756 already implements it.
 - OME-416: retain version provenance; reporting acceptance moves to OME-1013 under OME-1003.
 - Service closeout (OME-1005–1012), OME-976's deployment decision, OME-1072's evaluation semantics,
   OME-979's failure attribution and OME-1124's analytics remain separate; no automatic closure.
+
+## Integration evidence — 2026-09-07
+
+The live Engine and internal reporting route advertise the same Access audience. All 79 existing
+Client authentication tests pass, including sharing one login for matching audiences. Report
+authentication should use the existing per-Client token store; no separate global token store is
+needed. This is feasibility evidence, not an accepted live report.
+
+Real notebook verification awaits a working browser connection, the reporting Turnstile public
+site key/allowed origin and notebook selection. Backend verification also needs deployment access
+(no kubectl context is configured). Full evidence and the browser bootstrap failure are recorded
+in [the integration ledger](../work/2026-09-07-OME-1013-report-auth-integration.md).

--- a/docs/spec/2026-09-07-OME-1013-notebook-error-reporting.md
+++ b/docs/spec/2026-09-07-OME-1013-notebook-error-reporting.md
@@ -1,0 +1,143 @@
+# OME-1013 — Notebook error reporting
+
+Status: owner-directed consolidation, 2026-09-07. This supersedes the split between local
+receipts in OME-1013 and notebook sending in OME-1014, including conflicting public-interface
+requirements in the 2026-08-26 OME-1013 spec on PR #756. Implementation is not yet complete.
+
+## Outcome and ownership
+
+An evaluation error keeps its original Python exception and gains a compact Copy/Report
+interaction. Users need no diagnostic-management interface. OME-1013 owns the complete Client
+flow; OME-1014 closes as superseded, with its requirements carried here. OME-1003 remains the
+parent. OME-416 owns only Client/notebook version provenance. The existing report-intake service,
+operational tracing and opt-in product analytics remain separate work.
+
+## Interaction
+
+- Keep the original error presentation. Add one compact row: **Copy diagnostics** and
+  **Report issue**. No full diagnostic panel opens automatically.
+- Copy is a local action. Use a supported frontend mechanism; if clipboard access is unavailable,
+  reveal selectable text with honest copy guidance rather than a dead button.
+- Report expands inline with an optional note, optional reply address for follow-up, a clear
+  anonymous/account-associated submission label, a collapsed exact-payload preview, Send and
+  Cancel. Opening the form never submits it or automatically writes a file.
+- Changes to the note, reply address or browser facts update the payload preview. Send freezes
+  that payload; previews/copy/save of a prepared submission use those same bytes.
+- Disable repeat submission while sending. Retrying the same logical submission reuses its
+  idempotency key and payload. Authentication tokens are headers, never preview content.
+- Render **Report received: <ref>** when accepted. Show a ticket link only if the response
+  actually carries one. A pending delivery is not a failure to receive the report.
+- On failure, retain the draft and offer Retry, Copy and explicit Save. No automatic write.
+- A missing widget manager or reopened notebook must have a useful static fallback (selectable
+  sanitized diagnostics and an explicit save/download action where supported). Do not publish
+  inline event handlers or fake working controls. Never serialize credentials into notebook
+  output. A stored preview is allowed only after the user explicitly reveals/copies it.
+- Use SFDS's app register: neutral compact layout, blue interactions, square edges, Plex Sans
+  controls and Mono diagnostic values. Keyboard focus, accessible labels/status changes, light
+  and dark themes, and no focus stealing are acceptance criteria.
+
+## Private diagnostic capture
+
+Keep the allowlisted capture policy from PR #756: error type and safe structured fields,
+sanitized stack frames, version/environment facts, Engine host, benchmark/candidate identity,
+compiled topology, validated effective parameters and bounded lifecycle evidence when observable.
+Prompts, responses, cell source, raw traceback text, locals, paths, credentials, full URLs,
+URL4 expressions and internal stream topics are excluded. A freeform user note is explicit input
+and is previewed; do not silently add other content sources to it.
+
+Attach a bounded immutable snapshot privately to the relevant exception/view. Retain separate
+candidate execution identities without copying the internal topic as run_id. Capture available
+client-minted trace IDs from transport failures before frames, as well as observable events.
+Do not retain an extra traceback/frame graph for reporting.
+
+No public `sf.diagnostics`, `DiagnosticReceipt`, `last()`, `get()`, or `sf.report(ref)` is required.
+Remove the process-global receipt registry unless an observed lifecycle requirement establishes
+a need; a view can own its snapshot. Private serialization and explicit UI save remain useful.
+Bound both each snapshot and retained view state; dispose widgets/callbacks on teardown. Removing
+the ring must not silently replace it with unbounded retained widget snapshots.
+
+Capture remains fail-open and preserves the original exception/cause chain. Diagnostic failures
+must not log that original chain, sensitive values, or source lines. KeyboardInterrupt and async
+cancellation retain their original semantics. SystemExit and GeneratorExit bypass capture.
+Successful and partial returned Reports do not create error cards; OME-1072's proposed change to
+raising behavior is outside this work. Do not install a global notebook exception hook.
+
+## Service contract and routing
+
+The development endpoints supplied by the owner are:
+
+- Anonymous: `https://reports.dev.screamingface.ai/v1/reports`.
+- Internal: `https://reports-internal.dev.screamingface.ai/v1/reports`.
+
+Both accept the same `screamingface.error-report/v1` JSON contract. Development endpoint values
+must not become unconditional production defaults. The notebook kernel submits via HTTP; do not
+put a report or credential into a URL, HTML form, browser fetch or notebook-saved token state.
+
+Use the internal route when a usable report-service Access credential is available. An Engine
+login flag or browser session alone is insufficient: the current Access token store shares tokens
+only across matching audiences. Resolve the report audience and reuse only credentials valid
+for it, without triggering a login just to submit a report. Otherwise prepare anonymous submission
+with a fresh browser-produced Turnstile response in `CF-Turnstile-Response`. Show the selected
+identity mode before Send. If it changes after a failed attempt, require another explicit Send;
+do not silently resubmit under a different identity. Never forward internal credentials to the
+anonymous hostname or across redirects.
+
+Private projection is mandatory: PR #756's `screamingface.diagnostic/v1` document is not the intake
+document. The service requires `occurred_at`, `client`, and `error.type`/`error.message`; it has one
+primary candidate and one nullable correlation. It forbids unknown top-level fields. Carry a
+known failing candidate/trace into that primary context; never pick an arbitrary candidate from a
+multi-candidate operation. Any additional safe execution context must fit the existing extensible
+context, depth/size limits and classifier. Required error.message must come from reviewed safe
+error facts, with a non-content fallback for arbitrary exceptions; do not serialize str(exc)
+wholesale merely to satisfy a required field. Pin this choice in projection contract tests.
+
+The total body limit is 64 KiB. The backend bounds fields, rejects content, and stores only accepted
+reports. Client preview/send equality refers to outgoing bytes; the backend may truncate accepted
+fields according to its documented caps. No service schema changes are assumed by this ticket.
+
+## Backend behavior
+
+POST authenticates/admit-checks the caller, checks content type and JSON/schema/size, applies
+content classification, persists and deduplicates, renders safe ticket content, then attempts
+delivery. Persistence precedes delivery. A new accepted submission returns 202 and a server-minted
+ref; an idempotent replay returns 200 and the original record without a new delivery attempt.
+
+QueueSink is the code default: the report table itself is the queue, and an operator/agent later
+files it. The stored state `queued` is returned as delivery.state `pending`, ticket null. If the
+deployment selects LinearSink, successful delivery supplies a ticket; retryable failures remain
+pending for the worker, and permanent failures become failed. Verify the actual dev configuration
+rather than inferring the sink from its hostname or the existence of LinearSink code.
+
+Missing/rejected Turnstile is 403; rate limiting is 429; invalid schema/content is 422; oversized
+body is 413; pre-persistence storage failure or unevaluable bot gate is 503. An Access challenge
+must be handled as authentication, not parsed as a JSON success. After an ambiguous timeout,
+reuse the original submission key and bytes; do not assume nothing was stored.
+
+## Verification required before calling the flow complete
+
+1. Deterministic Client tests cover capture/privacy, sync/async and multi-candidate failure
+   attribution, before-frame trace IDs, original exception preservation, capture logging, exact
+   projection/preview/send bytes, bounds, copy/save fallback, and one submission per click.
+2. Route-selection tests cover matching/mismatched/expired/missing Access credentials, anonymous
+   token acquisition, no credential leakage and no silent identity change. Never stub a token
+   as valid in the deployed acceptance test.
+3. Service contract tests cover authentication, schema, classification, persistence, idempotency,
+   queue/Linear success and delivery failure/retry without changing deployed service settings.
+4. In a real supported notebook, test the full UI in light/dark, keyboard-only, missing-widget
+   and reopened-output cases. Verify frontend support for clipboard and Turnstile token transfer;
+   a Python callback test cannot establish either.
+5. Submit one clearly labelled synthetic test report through each dev route using a real fresh
+   Turnstile token and real report-service Access authentication respectively. Confirm 202/ref,
+   persisted rows, anonymous caller_email absent versus internal verified caller_email present,
+   and the actual configured delivery outcome. Never put a user's failure content into smoke data.
+6. Replay each payload with the same idempotency key (and fresh Turnstile token where needed):
+   expect 200, the same ref, one row and no additional immediate ticket delivery. Exercise bad
+   schema/content and rejected authentication safely; simulate outages in isolated tests.
+7. Use operator queue/DB inspection to verify persistence/delivery. There is no GET-by-ref API;
+   do not add one merely for tests. For LinearSink, verify the linked test ticket. For QueueSink,
+   verify queued content and distinguish that from completed Linear filing.
+
+Observed on 2026-09-07: public GET returned 405; empty unauthenticated public POST returned 403
+and explicitly said nothing was stored; internal unauthenticated GET/POST redirected to Access.
+These establish admission behavior only. Successful live submissions, persistence, sink
+configuration and delivery are not yet verified.

--- a/docs/tasks/2026-09-07-OME-1003-client-reporting.md
+++ b/docs/tasks/2026-09-07-OME-1003-client-reporting.md
@@ -1,0 +1,19 @@
+---
+id: OME-1003
+linear_url: https://linear.app/openmined/issue/OME-1003
+status: in_progress
+type: null
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-26
+updated: 2026-09-07
+closed:
+---
+
+# Deliver the notebook Copy and Report error flow
+
+Parent of OME-1013. OME-1014 consolidated into that child. Completed OME-967 no longer blocks this work. OME-416 retains distinct version provenance.
+
+Spec: [Notebook error reporting](../spec/2026-09-07-OME-1013-notebook-error-reporting.md).
+Plan: [Implementation plan](../plan/2026-09-07-OME-1013-notebook-error-reporting.md).
+Ledger: [Consolidation](../work/2026-09-07-OME-1013-reporting-consolidation.md).

--- a/docs/tasks/2026-09-07-OME-1013-notebook-error-reporting.md
+++ b/docs/tasks/2026-09-07-OME-1013-notebook-error-reporting.md
@@ -1,0 +1,19 @@
+---
+id: OME-1013
+linear_url: https://linear.app/openmined/issue/OME-1013
+status: in_progress
+type: null
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-26
+updated: 2026-09-07
+closed:
+---
+
+# Add Copy and Report actions to notebook evaluation errors
+
+Owns the combined private capture, compact Copy/Report UI, note/preview, authentication routing and intake submission. PR #756 remains open. OME-1014 is superseded. Successful live anonymous/internal submissions and backend delivery remain required.
+
+Spec: [Notebook error reporting](../spec/2026-09-07-OME-1013-notebook-error-reporting.md).
+Plan: [Implementation plan](../plan/2026-09-07-OME-1013-notebook-error-reporting.md).
+Ledger: [Consolidation](../work/2026-09-07-OME-1013-reporting-consolidation.md).

--- a/docs/tasks/2026-09-07-OME-1014-reporting-consolidation.md
+++ b/docs/tasks/2026-09-07-OME-1014-reporting-consolidation.md
@@ -1,0 +1,20 @@
+---
+id: OME-1014
+linear_url: https://linear.app/openmined/issue/OME-1014
+status: duplicate
+type: null
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-08-26
+updated: 2026-09-07
+closed: 2026-09-07
+duplicate_of: OME-1013
+---
+
+# Render the report card and send it on click
+
+Superseded by OME-1013 at the owner's request on 2026-09-07. Scope moved; functionality has not shipped. Original Linear description retained as historical evidence. No files or issue history deleted.
+
+Spec: [Notebook error reporting](../spec/2026-09-07-OME-1013-notebook-error-reporting.md).
+Plan: [Implementation plan](../plan/2026-09-07-OME-1013-notebook-error-reporting.md).
+Ledger: [Consolidation](../work/2026-09-07-OME-1013-reporting-consolidation.md).

--- a/docs/tasks/2026-09-07-OME-416-version-provenance.md
+++ b/docs/tasks/2026-09-07-OME-416-version-provenance.md
@@ -1,0 +1,19 @@
+---
+id: OME-416
+linear_url: https://linear.app/openmined/issue/OME-416
+status: backlog
+type: null
+priority: 3
+labels: [py-screamingface, human, design-session]
+created: 2026-07-13
+updated: 2026-09-07
+closed:
+---
+
+# Add Client and generated-notebook version provenance
+
+Retains request metadata, generated notebook version stamps and typed returned provenance. Error-reporting scope moved to OME-1003 / OME-1013; it was not canceled. Existing assignee, priority and milestone retained.
+
+Spec: [Notebook error reporting](../spec/2026-09-07-OME-1013-notebook-error-reporting.md).
+Plan: [Implementation plan](../plan/2026-09-07-OME-1013-notebook-error-reporting.md).
+Ledger: [Consolidation](../work/2026-09-07-OME-1013-reporting-consolidation.md).

--- a/docs/work/2026-09-07-OME-1013-report-auth-integration.md
+++ b/docs/work/2026-09-07-OME-1013-report-auth-integration.md
@@ -1,0 +1,55 @@
+---
+ticket: OME-1013
+stack: repo
+status: blocked
+started: 2026-09-07
+finished:
+---
+
+# OME-1013 — Check real notebook reporting prerequisites
+
+## Intent
+
+Verify report-service authentication reuse and anonymous Turnstile integration before building
+the combined notebook UI. Separate admission evidence from successful persistence and delivery.
+
+## Planned changes
+
+- This evidence ledger only; no application changes or deployment configuration changes.
+
+## Test plan
+
+- Discover available notebook/browser access using the installed browser skill.
+- Compare public Access challenges for the configured Engine and internal report service.
+- Run existing Client authentication tests without modifying user files.
+- Perform real notebook submissions only with valid report credentials/Turnstile and inspect
+  backend evidence when deployment access is available.
+
+## Acceptance
+
+- Authentication reuse is demonstrated or its actual prerequisite identified.
+- Real browser and backend-access limitations are recorded without claiming end-to-end success.
+
+## Outcome
+
+- **Actual files:** this ledger and the integration-evidence note in the consolidated plan.
+- **Commits:** this iteration's `docs(screamingface): record reporting auth integration evidence`.
+- **Gates:** 79 existing Client authentication tests passed at PR #756 head `4a9abe64`,
+  including matching-audience login reuse and distinct-audience isolation. Initial sandbox
+  run had 75 passes and four local-server bind permission failures; full rerun with socket
+  access passed. No application files changed.
+- **Live evidence:** unauthenticated GET requests to the configured Engine
+  `https://fusion.dev.screamingface.ai/v1/models` and internal reporting endpoint both returned
+  Access 302 and the same audience (`f9d2d35a2db5c5d89fb2493b2e26c8343c9b3d83a11b9345b40097c6de6f47bf`).
+  Only public challenge metadata was inspected. Existing Client auth owns a token store per Client,
+  shared by Engine/Scoreboard auth objects; report auth must be wired to that same store.
+- **Blockers:** no running local notebook was found; browser bootstrap failed because its trusted
+  worker imports the missing `browser/26.814.41407/scripts/browser-service.mjs`, while the installed
+  plugin is `26.825.32147`. No browser cookies, tokens or profile stores were inspected. Public
+  report Turnstile site key/allowed notebook origin was not found in scoped configuration;
+  requested the public key/configuration location and intended notebook from the owner.
+  kubectl still has no current context, so deployed sink and stored rows cannot be verified.
+- **Deviations:** real notebook flow, valid Turnstile issuance, accepted internal/anonymous POSTs
+  and backend delivery remain unverified. No valid live report was submitted, no auth gate
+  bypassed and no application/deployment configuration changed. Matching public audiences plus
+  passing mocked/local auth tests establish feasibility, not successful live reporting.

--- a/docs/work/2026-09-07-OME-1013-reporting-consolidation.md
+++ b/docs/work/2026-09-07-OME-1013-reporting-consolidation.md
@@ -1,0 +1,57 @@
+---
+ticket: OME-1013
+stack: repo
+status: done
+started: 2026-09-07
+finished: 2026-09-07
+---
+
+# OME-1013 — Consolidate notebook error reporting
+
+## Intent
+
+Record the owner's direction to deliver private capture and the complete Copy/Report flow in
+OME-1013, superseding OME-1014. Narrow OME-416 to version provenance and align the design with
+the existing intake contract and two development hostnames. This iteration changes planning
+and issue ownership; application implementation remains open in PR #756.
+
+## Planned changes
+
+- docs/spec/2026-09-07-OME-1013-notebook-error-reporting.md
+- docs/plan/2026-09-07-OME-1013-notebook-error-reporting.md
+- docs/tasks/2026-09-07-OME-1013-notebook-error-reporting.md
+- docs/tasks/2026-09-07-OME-1014-reporting-consolidation.md
+- docs/tasks/2026-09-07-OME-1003-client-reporting.md
+- docs/tasks/2026-09-07-OME-416-version-provenance.md
+- Linear OME-1013, OME-1014, OME-1003 and OME-416.
+
+## Test plan
+
+- Read current issues, relations, source contract, authentication and delivery implementations.
+- Verify public/internal admission rejection with empty JSON (cannot create a valid report).
+- Check document links and diff whitespace; reread changed Linear issues after updating.
+- Specify successful live submissions and persistence/delivery checks as implementation gates.
+
+## Acceptance
+
+- One implementation ticket owns capture, copy, preview, note, routing and submission.
+- OME-1014 remains as a superseded historical record, not a claim of shipped functionality.
+- OME-416 retains its distinct version-provenance work.
+- No public diagnostic registry is required; authentication is scoped to the report audience.
+- Live admission checks are distinguished from unperformed successful end-to-end checks.
+
+## Outcome
+
+- **Actual files:** the seven planned spec/plan/task-mirror files plus this ledger (seven
+  files total: one spec, one plan, four mirrors, one ledger). Updated all four Linear issues;
+  reread their states and relations. OME-1014 is Duplicate of OME-1013, its blocker removed;
+  OME-1003's completed prerequisite removed; OME-416 narrowed with existing metadata retained.
+- **Commits:** this iteration's `docs(screamingface): consolidate notebook reporting scope` commit.
+- **Gates:** current service schema/auth/persistence/delivery implementations inspected;
+  public empty POST returned 403 with no storage; internal empty POST returned Access 302.
+  Issue readback verified. Documentation links and staged whitespace checked before commit.
+  No application test suite required for this documentation/issue-only iteration.
+- **Deviations:** no application code, deployment configuration or valid test reports changed.
+  kubectl has no current context configured in this session, so actual deployment sink/rows
+  could not be inspected. Real Turnstile and internal Access successful submissions remain
+  unverified. OME-1013 remains In Progress; this ledger marks only consolidation complete.


### PR DESCRIPTION
Consolidates notebook diagnostic capture and the Copy/Report interaction into OME-1013. OME-1014 is now superseded, OME-416 retains version provenance, and OME-1003 no longer waits on completed trace-origin work.

The revised spec removes the public diagnostic-management interface requirement and defines one private snapshot, compact note/preview/send UI, report-audience authentication routing, exact intake projection and explicit recovery. It requires accepted anonymous/internal dev submissions plus persisted identity and actual queue/Linear delivery verification.

This PR contains planning and ticket mirrors only. Application implementation remains open in #756; it does not claim the combined UI is implemented or end-to-end delivery is verified.

Validation: checked the current service schema, authentication and delivery code; reread all four updated Linear issues and their relations; staged diff whitespace and local artifact links checked. Public empty POST returned 403 with nothing stored; internal unauthenticated POST redirected to Access. No Kubernetes context is configured in this session, so deployment sink/row inspection and successful authenticated submissions remain outstanding.

Refs: OME-1013
Related: OME-1014, OME-1003, OME-416
