### PR TITLE
fix(scoreboard): publish unambiguous author credits

### DIFF
--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -223,22 +223,50 @@ SubmittedBy = Annotated[
     PlainSerializer(_publish_submitter, return_type=str | None, when_used="json"),
 ]
 
+# INVARIANT: counting distinct people must not turn repeated author entries into
+# an unbounded public write. This matches the established metadata envelope.
+_AUTHORS_MAX_BYTES = 4096
+_AUTHORS_MAX_DISTINCT = 10
+
+
+def _author_identity(author: str) -> str:
+    """The one comparison identity for author validation and publication."""
+    return author.casefold()
+
 
 def _publish_authors(value: list[str] | None) -> list[str] | None:
-    """Apply the submitter privacy boundary to every credited author.
+    """Publish one unambiguous credit per distinct author.
 
-    INVARIANT: one trimming rule, delegated. `submitted_by` and `authors` must degrade
-    identically, or the same address is redacted on one field and published on the other.
+    INVARIANT: duplicate detection and the submission cap use the same full-address,
+    case-insensitive identity. The first submitted spelling and order win, while storage
+    remains untouched because this function runs only as a JSON serializer.
 
-    AIDEV-NOTE: `or author` below is a TYPE narrowing, not a fallback — read as a fallback it looks
-    like it publishes a raw address whenever the trimmer balks, which is the opposite of what this
-    function is for. It cannot: `_publish_submitter` returns None only for a None input, and these
-    elements are typed `str`. For anything that is not a dotted-domain address the trimmer already
-    returns the full value on purpose (see its docstring), so there is nothing here to rescue.
+    WHY domains appear only for collisions: OME-834's privacy rule remains the default,
+    but two distinct people with the same local part cannot both publish as the same name.
+    The domain is the minimum already-stored discriminator that makes that row truthful.
     """
     if value is None:
         return None
-    return [_publish_submitter(author) or author for author in value]
+
+    distinct: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for author in value:
+        identity = _author_identity(author)
+        if identity not in seen:
+            seen.add(identity)
+            published = _publish_submitter(author)
+            # `author` is non-null, so this is type narrowing rather than a raw-address fallback.
+            distinct.append((author, published if published is not None else author))
+
+    local_counts: dict[str, int] = {}
+    for _, published in distinct:
+        local = published.casefold()
+        local_counts[local] = local_counts.get(local, 0) + 1
+
+    return [
+        author if local_counts[published.casefold()] > 1 else published
+        for author, published in distinct
+    ]
 
 
 # INVARIANT: author addresses are full in Python mode (staff export) and local-part-only in
@@ -312,7 +340,7 @@ class ScoreSubmission(BaseModel):
     submitted_by: str | None = None
     # None means the client did not specify a credit line; reads then derive [submitted_by].
     # An explicit list is exact — the submitter is not auto-added (OME-1051 D1).
-    authors: Annotated[list[AuthorEmail], Field(min_length=1, max_length=10)] | None = None
+    authors: Annotated[list[AuthorEmail], Field(min_length=1)] | None = None
     # the exact primary score the Engine Benchmark produced — any
     # finite number, higher is better
     score: Annotated[float, Field(strict=True, allow_inf_nan=False)]
@@ -351,6 +379,20 @@ class ScoreSubmission(BaseModel):
     # which fails the comparison); allow_inf_nan=False stops +Infinity, which
     # would pass ge=0 and then raise inside quantize().
     run_cost_usd: Decimal | None = Field(default=None, ge=0, allow_inf_nan=False)
+
+    @field_validator("authors")
+    @classmethod
+    def validate_distinct_authors(cls, value: list[str] | None) -> list[str] | None:
+        # INVARIANT: the cap protects credit cardinality, not raw audit history. The
+        # serializer uses this exact key when it collapses repeated identities.
+        if value is None:
+            return value
+        if len({_author_identity(author) for author in value}) > _AUTHORS_MAX_DISTINCT:
+            raise ValueError(f"authors must credit at most {_AUTHORS_MAX_DISTINCT} distinct people")
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode()
+        if len(encoded) > _AUTHORS_MAX_BYTES:
+            raise ValueError(f"authors must serialize to at most {_AUTHORS_MAX_BYTES} bytes")
+        return value
 
     @field_validator("run_cost_usd")
     @classmethod

--- a/apps/scoreboard/tests/unit/test_multiple_authors.py
+++ b/apps/scoreboard/tests/unit/test_multiple_authors.py
@@ -264,3 +264,54 @@ def test_portal_leaderboard_table_has_no_submitter_column() -> None:
     assert "P.formatSubmitter(entry.submitted_by)" not in benchmark_js
     assert "P.formatAuthors(entry.authors)" in benchmark_js
     assert "P.formatSubmitter(s.submitted_by)" in (portal / "spec.js").read_text()
+
+
+def test_submission_author_cap_counts_case_insensitive_distinct_people() -> None:
+    authors = [f"author-{index}@example.test" for index in range(10)]
+    authors.append("AUTHOR-0@example.test")
+
+    submission = _submission(authors=authors)
+
+    # INVARIANT: validation counts people without rewriting audit data. The repeated
+    # spelling survives in the input DTO and is collapsed only at publication.
+    assert submission.authors == authors
+
+
+@pytest.mark.asyncio
+async def test_public_authors_collapse_duplicates_and_disambiguate_local_collisions(
+    tortoise_db: None,
+) -> None:
+    authors = [
+        "Irina@OpenMined.org",
+        "BOB@example.test",
+        "irina@openmined.org",
+        "irina@partner.com",
+    ]
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    score, _ = await store.submit(_submission(authors=authors))
+    stored = await Score.get(id=score.id)
+    leaderboard = await store.leaderboard("hle")
+    history = await store.list_for_spec("hle", "spec-1")
+    expected_public = ["Irina@OpenMined.org", "BOB", "irina@partner.com"]
+
+    # INVARIANT: every public DTO uses the same publication transform. A duplicate
+    # keeps its first spelling and position; only the colliding identities expose
+    # domains, while a unique local part retains OME-834's redacted form.
+    for public_row in (score, leaderboard[0], history[0]):
+        assert json.loads(public_row.model_dump_json())["authors"] == expected_public
+
+    # INVARIANT: publication cannot rewrite the audit trail. Staff see exactly what
+    # was submitted, including duplicate spelling, casing, and order.
+    assert stored.authors == authors
+    assert json.loads(format_jsonl([score]))["authors"] == authors
+
+
+def test_submission_rejects_an_unbounded_repeated_author_payload() -> None:
+    repeated = f"{'a' * 240}@example.test"
+
+    # One distinct person must not turn the public write path into an unbounded
+    # JSON field merely because duplicate entries do not consume the credit cap.
+    with pytest.raises(ValidationError, match="authors must serialize to at most 4096 bytes"):
+        _submission(authors=[repeated] * 20)

--- a/docs/plan/2026-09-08-OME-1109-author-credits.md
+++ b/docs/plan/2026-09-08-OME-1109-author-credits.md
@@ -1,0 +1,27 @@
+# OME-1109 — Implementation plan
+
+## Frame
+
+Change only the shared scoreboard author schema/publication seam. Preserve raw input and storage,
+and make every public DTO inherit one duplicate/collision rule through the existing `Authors`
+annotated serializer.
+
+## Changes
+
+1. Add failing schema tests for distinct-count validation, case-insensitive duplicate collapse,
+   collision disambiguation, stable order, and unchanged non-collision redaction.
+2. Add a failing persistence/export test proving raw author entries and casing survive while the
+   same DTO's public JSON is collapsed and disambiguated.
+3. Extract one case-folded full-address key and use it for both distinct-count validation and
+   publication deduplication; retain a separate 4 KiB serialized-list envelope so repeated
+   identities cannot create an unbounded public write.
+4. Group the first-seen distinct authors by case-folded local part; publish the full stored
+   address only for groups that collide.
+5. Run the focused multiple-author suite and then the complete scoreboard gate.
+6. Perform the wisdom/confidence review, finish the ledger, and commit with `Refs: OME-1109`.
+
+## Non-goals
+
+- modifying models, migrations, storage projections, portal code, or the Client package;
+- folding OME-840, OME-969, or any other public-write contract into this unit;
+- rebasing onto or copying changes from the unmerged OME-822/#841 branch.

--- a/docs/spec/2026-09-08-OME-1109-author-credits.md
+++ b/docs/spec/2026-09-08-OME-1109-author-credits.md
@@ -1,0 +1,63 @@
+# OME-1109 — Published author credits
+
+Status: approved for implementation on 2026-09-03 · Stack: scoreboard
+
+## Problem
+
+The multiple-author contract stores exact email addresses and publishes local parts. A repeated
+address is therefore credited twice, while two distinct people with the same local part publish
+as an indistinguishable pair such as `irina, irina`.
+
+## Decisions
+
+### D1 — One case-insensitive identity rule
+
+An author's comparison identity is the case-folded complete address. Publication collapses
+repeated identities in first-seen order and preserves the first submitted spelling. Comparison
+never normalizes or rewrites the stored list.
+
+### D2 — Domains appear only for actual local-part collisions
+
+After duplicates are removed, publication groups authors by case-folded local part. A local part
+that names one distinct identity stays local-part-only. Every identity in a group of two or more
+publishes its complete address so the credit line is unambiguous. No domain is exposed on a row
+without such a collision.
+
+### D3 — Publication is the only transforming boundary
+
+`ScoreSubmission.authors`, the database row, Python-mode DTO dumps, and the private staff JSONL
+export retain the submitted list byte-for-byte and in order, including repetitions and casing.
+The public JSON serializer alone collapses and disambiguates it.
+
+### D4 — The ten-author limit counts distinct people
+
+Validation applies the same complete-address comparison identity used by publication. Eleven list
+entries containing one repeated identity are accepted because they credit ten people; eleven
+distinct identities are rejected. The accepted value is not deduplicated on write. A separate
+4 KiB serialized-field cap keeps repeated identities from making this public write unbounded; it
+does not change which entries count as people.
+
+### D5 — Submitter identity and authorization do not change
+
+`submitted_by` remains a separate single identity and private-board authorization subject. This
+unit does not merge it into the author list, grant authors access, or change its publication rule.
+
+## Verification contract
+
+- exact and case-variant duplicates publish once, preserving the first spelling;
+- distinct addresses sharing a local part publish with domains, case-insensitively;
+- non-colliding author addresses still publish only local parts;
+- ten distinct people represented by eleven entries validate without rewriting the input;
+- eleven distinct people fail validation;
+- an oversized list of repeated identities fails the independent 4 KiB envelope;
+- database storage and staff JSONL preserve the exact submitted list;
+- leaderboard/history/score public JSON share the same serializer behavior;
+- existing dedup correction, private ownership, portal display, and recipe-identity tests remain
+  unchanged and green.
+
+## Non-goals
+
+- verifying co-author ownership or deliverability;
+- changing SDK input, portal layout, content hashing, idempotency, or database schema;
+- changing `submitted_by` validation or display (`OME-840` remains separate);
+- introducing usernames or a global identity directory.

--- a/docs/tasks/2026-09-08-OME-1109-author-credits.md
+++ b/docs/tasks/2026-09-08-OME-1109-author-credits.md
@@ -1,0 +1,21 @@
+---
+id: OME-1109
+linear_url: https://linear.app/openmined/issue/OME-1109/collapse-duplicate-authors-and-disambiguate-colliding-credit-names
+status: in_progress
+type: task
+priority: 3
+labels: [scoreboard, agentic, autonomous]
+created: 2026-09-03
+closed:
+---
+
+# Collapse duplicate authors and disambiguate colliding credit names
+
+Keep the exact submitted author list in storage and staff exports, while publishing each person
+once and adding domains only when distinct authors on the same row share a local part.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-08-OME-1109-author-credits.md`
+- Plan: `docs/plan/2026-09-08-OME-1109-author-credits.md`
+- Ledger: `docs/work/2026-09-08-OME-1109-author-credits.md`

--- a/docs/tasks/2026-09-08-OME-1139-client-author-limits.md
+++ b/docs/tasks/2026-09-08-OME-1139-client-author-limits.md
@@ -1,0 +1,18 @@
+---
+id: OME-1139
+linear_url: https://linear.app/openmined/issue/OME-1139/align-python-client-author-limits-with-distinct-person-semantics
+status: backlog
+type: task
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-08
+closed:
+---
+
+# Align Python client author limits with distinct-person semantics
+
+Make the Python client enforce the same author-list contract as the Scoreboard API: at most ten
+case-insensitive distinct email identities and at most 4 KiB of canonical serialized author data,
+without normalizing or reordering the values sent to the server.
+
+Discovered while implementing OME-1109; kept separate because it lands in `py-screamingface`.

--- a/docs/work/2026-09-08-OME-1109-author-credits.md
+++ b/docs/work/2026-09-08-OME-1109-author-credits.md
@@ -53,12 +53,11 @@ the privacy form of any non-colliding address.
   changed.
 - **Commits:** one conventional Scoreboard feature commit on `OME-1109-author-credits`; the
   immutable commit and eventual squash sha are recorded in the PR/Linear close record.
-- **Gates:** focused multiple-author suite 24 passed; full Scoreboard pytest 620 passed / 3
+- **Gates:** focused multiple-author suite 24 passed; full Scoreboard pytest 621 passed / 3
   skipped / 3 deselected; `run_gates.py scoreboard --base origin/main` ALL GREEN — append-only,
   Ruff check, Ruff format, Pyright, full pytest coverage ≥80%, and all three portal test files.
 - **Deviations:** the wisdom pass added a separate 4 KiB serialized author-list cap. Without it,
   changing the ten-entry limit to ten distinct people would make repeated entries an unbounded
   public write. The Client's `_submission_authors` still limits raw entries to ten, so it rejects
-  the accepted 11-entry/10-person boundary before HTTP; that belongs to a separate
-  `py-screamingface` work item under the repository's cross-landing rule and was not hidden inside
-  this Scoreboard change.
+  the accepted 11-entry/10-person boundary before HTTP; that is tracked separately as OME-1139
+  under the repository's cross-landing rule and was not hidden inside this Scoreboard change.

--- a/docs/work/2026-09-08-OME-1109-author-credits.md
+++ b/docs/work/2026-09-08-OME-1109-author-credits.md
@@ -1,0 +1,64 @@
+---
+ticket: OME-1109
+stack: scoreboard
+status: done
+started: 2026-09-08
+finished: 2026-09-08
+---
+
+# OME-1109 — Published author credits
+
+## Intent
+
+Publish a truthful multiple-author credit line: collapse repeated identities and disambiguate
+distinct people whose email addresses share a local part, without changing stored audit data or
+the privacy form of any non-colliding address.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py` — shared author identity, validation, and
+  public serialization behavior.
+- `apps/scoreboard/tests/unit/test_multiple_authors.py` — additive validation, publication,
+  persistence, export, order, and privacy regressions.
+- `docs/tasks/2026-09-08-OME-1109-author-credits.md` — task mirror.
+- `docs/spec/2026-09-08-OME-1109-author-credits.md` — approved behavior contract.
+- `docs/plan/2026-09-08-OME-1109-author-credits.md` — implementation sequence.
+- This ledger.
+
+## Test plan
+
+- RED: exact and case-variant repeated addresses publish once in first-seen order.
+- RED: distinct authors sharing a local part publish distinguishable domain-bearing values.
+- Boundary: non-colliding authors remain local-part-only; collision comparison ignores case.
+- Boundary: eleven entries representing ten identities validate unchanged; eleven distinct
+  identities fail.
+- Boundary: an oversized repeated-identity list fails the independent 4 KiB field envelope.
+- Persistence/privacy: the database and staff JSONL retain the exact submitted list while public
+  JSON applies the publication transform.
+- Regression: all existing multiple-author tests and the full scoreboard gate remain green.
+
+## Acceptance
+
+- Public credit lists contain one entry per case-insensitive complete address.
+- Domains are visible only for distinct identities colliding on a local part within that row.
+- Storage and staff export are byte-for-entry identical to the submitted author list.
+- The ten-author limit counts distinct people and all official scoreboard gates pass.
+- Repeated author entries cannot make the public write field unbounded.
+
+## Outcome
+
+- **Actual files:** the planned shared author validation/publication seam in
+  `scores/schemas.py`; three additive tests in `test_multiple_authors.py`; and the planned
+  task/spec/plan/ledger artifacts. No model, migration, store, portal, Client, or #841 file was
+  changed.
+- **Commits:** one conventional Scoreboard feature commit on `OME-1109-author-credits`; the
+  immutable commit and eventual squash sha are recorded in the PR/Linear close record.
+- **Gates:** focused multiple-author suite 24 passed; full Scoreboard pytest 620 passed / 3
+  skipped / 3 deselected; `run_gates.py scoreboard --base origin/main` ALL GREEN — append-only,
+  Ruff check, Ruff format, Pyright, full pytest coverage ≥80%, and all three portal test files.
+- **Deviations:** the wisdom pass added a separate 4 KiB serialized author-list cap. Without it,
+  changing the ten-entry limit to ten distinct people would make repeated entries an unbounded
+  public write. The Client's `_submission_authors` still limits raw entries to ten, so it rejects
+  the accepted 11-entry/10-person boundary before HTTP; that belongs to a separate
+  `py-screamingface` work item under the repository's cross-landing rule and was not hidden inside
+  this Scoreboard change.


### PR DESCRIPTION
## Summary

- collapse repeated author identities case-insensitively when publishing while preserving the exact submitted list in storage and staff exports
- show domains only when distinct authors on the same row share a local part
- enforce the ten-distinct-person cap plus a 4 KiB canonical serialized-field bound
- record the Python client contract alignment separately in OME-1139

**Asana:** N/A — tracked in Linear as OME-1109

## Components touched

- `apps/scoreboard`
- `docs/spec`, `docs/plan`, `docs/tasks`, and `docs/work`

## Test plan

- [x] `uv run .claude/scripts/run_gates.py scoreboard --base origin/main`
- [x] append-only guard, Ruff, formatting, Pyright, coverage, and all three portal suites green
- [x] full Scoreboard suite: 621 passed, 3 skipped, 3 deselected
- [ ] screenshots / recording attached — not applicable; serialization and validation only

## Cross-service notes

The Python client still rejects raw author lists longer than ten before HTTP. OME-1139 tracks aligning it with this distinct-person and 4 KiB contract; no client code is included here.

This is independent of the still-unmerged #841. Both touch the Scoreboard submission schema and tests, so whichever lands second may need a small mechanical rebase, but their contracts do not conflict.

Fixes OME-1109