### PR TITLE
docs(screamingface): close the OME-1126 ledger and task mirror

### DIFF
--- a/docs/tasks/2026-09-05-OME-1126-medxpert-mcq.md
+++ b/docs/tasks/2026-09-05-OME-1126-medxpert-mcq.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1126
 linear_url: https://linear.app/openmined/issue/OME-1126/onboard-medxpertqa-text-as-an-exact-match-mcq-benchmark
-status: in_progress
+status: closed
 type: feature
 priority: medium
 labels: [url4-cloud, agentic, autonomous]
 created: 2026-09-05
-closed:
+closed: 2026-09-08
 ---
 
 # Onboard MedXpertQA (Text) as an exact-match MCQ benchmark

--- a/docs/work/2026-09-05-OME-1126-medxpert-mcq.md
+++ b/docs/work/2026-09-05-OME-1126-medxpert-mcq.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1126
 stack: screamingface-engine
-status: in_progress
+status: done
 started: 2026-09-05
-finished:
+finished: 2026-09-08
 ---
 
 # OME-1126 — MedXpertQA (Text) as an exact-match MCQ benchmark


### PR DESCRIPTION
MedXpertQA (OME-1126) merged in #846; this closes the work ledger and `docs/tasks/` mirror per the close discipline.

Refs: OME-1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)