### PR TITLE
feat(screamingface-engine): make the runner pool's max_ack_pending an explicit per-caller allowance

### DIFF
--- a/apps/screamingface-engine/deploy/helm/templates/deployment-runner.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/deployment-runner.yaml
@@ -146,13 +146,17 @@ spec:
               value: {{ .Values.runnerPool.drainGraceS | quote }}
             - name: URL4_CLOUD_WORKER_METRICS_PORT
               value: {{ .Values.runnerPool.metricsPort | quote }}
-            # `max_ack_pending` is a WHOLE-CONSUMER bound — the fleet's total unacked runs —
-            # so the chart derives it from the fleet's own sizing: pods x slots. The code
-            # default is a generic fleet-sized constant; the chart's value is the truth for
-            # THIS deployment. (The value binds at consumer creation — resizing means a new
-            # consumer, which a cutover or bucket-count change already implies.)
+            # `max_ack_pending` is applied to EVERY bucket consumer (`runner_queue.py`:
+            # `_bound_subscription`), and a caller hashes to exactly one bucket, so it is a
+            # PER-CALLER allowance — NOT the fleet bound this comment used to claim. Deriving
+            # it from pods x slots therefore handed every caller the whole fleet's width, so
+            # one caller could saturate the pool at any replica count (OME-1142).
+            # `runnerPool.maxAckPending` pins it independently of pool sizing; empty keeps the
+            # historical derived product so an upgrade changes no running deployment.
+            # (The value binds at consumer creation — re-capping a live queue means deleting
+            # and rebuilding the durable consumers, which a cutover already implies.)
             - name: URL4_CLOUD_RUN_QUEUE_MAX_ACK_PENDING
-              value: {{ mul .Values.runnerPool.replicas .Values.runnerPool.workerSlots | quote }}
+              value: {{ .Values.runnerPool.maxAckPending | default (mul .Values.runnerPool.replicas .Values.runnerPool.workerSlots) | quote }}
           # Liveness on the metrics endpoint: the scrape server runs in its own thread, so
           # this catches process/pod-level death (the old Job-per-run design carried its own
           # per-run hard backstop; the pool needs a pod-level one). A wedged CLAIM loop with a

--- a/apps/screamingface-engine/deploy/helm/values.schema.json
+++ b/apps/screamingface-engine/deploy/helm/values.schema.json
@@ -129,7 +129,12 @@
         "workerSlots": {
           "type": "integer",
           "minimum": 1,
-          "description": "Run slots per worker pod. MUST match `run_queue_worker_slots` — the queue's `max_ack_pending` is `QUEUE_REPLICAS × this`."
+          "description": "Run slots per worker pod. MUST match `run_queue_worker_slots`. One slot is one supervised child process, so `replicas × workerSlots` is what bounds fleet execution."
+        },
+        "maxAckPending": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "The queue's PER-CALLER allowance: applied to every bucket consumer, and a caller hashes to one bucket, so it caps one caller's unacked runs (not the fleet — that is `runQueueBucketCount × this`). Null/absent derives `replicas × workerSlots`, which hands each caller the whole fleet's width; pin it whenever `replicas > 1`. Binds at consumer creation, so changing it does not re-cap a live queue."
         },
         "drainGraceS": {
           "type": "number",

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -381,10 +381,28 @@ readinessProbe:
 # assets the run mode needs. Private assets therefore still never reach the client-facing App.
 runnerPool:
   replicas: 1
-  # Run slots per worker pod — MUST match `run_queue_worker_slots`: the chart renders the
-  # fleet's `max_ack_pending` from `replicas × workerSlots`, so the pool and the queue
-  # cannot disagree about how many runs the fleet may hold in flight.
+  # Run slots per worker pod — MUST match `run_queue_worker_slots`. This is the pod's real
+  # execution width: one slot is one supervised child process, so `replicas × workerSlots` is
+  # what actually bounds how many runs the fleet executes at once.
   workerSlots: 4
+  # The queue's per-caller allowance, or empty to derive `replicas × workerSlots` (OME-1142).
+  #
+  # WHY per-caller and not a fleet bound: the queue is split into `config.runQueueBucketCount`
+  # bucket subjects, and `RunQueue._bound_subscription` creates one durable consumer PER BUCKET
+  # with this value. A caller hashes to exactly one bucket (`RunQueue.bucket_subject`), so this
+  # caps ONE caller's unacked runs. The emergent fleet ceiling is `bucketCount × this`; nothing
+  # enforces a single fleet total, and execution is bounded by the slots above.
+  #
+  # INVARIANT: raising `replicas` must increase how many CALLERS run at once, not how many runs
+  # one caller may hold. Leaving this empty breaks that — the derived product hands every caller
+  # the whole fleet's width, so a single caller can saturate the pool at any replica count. Pin
+  # it whenever the pool runs more than one replica.
+  #
+  # AIDEV-NOTE: the value binds when the consumer is CREATED — `pull_subscribe` is idempotent on
+  # existence, not on config — so changing it does NOT re-cap a live queue. The durable
+  # consumers must be deleted and rebuilt, and only while the queue is drained: deleting a
+  # consumer that holds in-flight acks redelivers those runs and re-spends provider calls.
+  maxAckPending:
   # Seconds a draining worker keeps its in-flight children alive after SIGTERM before
   # terminating them (`worker_drain_grace_s`). The preStop starts the drain by SIGTERMing the
   # worker, so the grace period below must exceed this or the kubelet SIGKILLs mid-drain.

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -68,14 +68,19 @@ DEFAULT_QUEUE_MAX_AGE_S = 86_400.0
 DEFAULT_ACK_WAIT_S = 60.0
 DEFAULT_MAX_DELIVER = 2
 DEFAULT_WORKER_SLOTS = 4
-# WHY fleet-sized and not `replicas × slots`: `max_ack_pending` is a WHOLE-CONSUMER bound —
-# the total unacked messages the one durable consumer may hand out across EVERY puller in the
-# fleet — not a per-worker limit. Deriving it from the stream's data-redundancy replica count
-# conflated two unrelated numbers and silently capped the whole fleet at 12 in-flight runs.
-# The default is sized for a fleet (32 pods × 8 slots, with headroom); deployments that size
-# differently must set `run_queue_max_ack_pending` to their fleet's true concurrency. NOTE:
-# the value binds when the consumer is CREATED — `pull_subscribe` is idempotent on existence,
-# not on config, so changing it on a running queue means deleting and recreating the consumer.
+# WHY not derived from `replicas × slots`: this is a PER-CONSUMER bound, and since the bucket
+# split (OME-1091) there is one durable consumer PER BUCKET SUBJECT — `_bound_subscription`
+# hands this same value to each. A caller hashes to exactly one bucket (`bucket_subject`), so
+# it caps ONE CALLER's unacked runs. The emergent fleet ceiling is `bucket_count × this`;
+# nothing enforces a single fleet total, and what actually bounds execution is the worker's
+# slot count. Deriving it from fleet sizing therefore hands every caller the whole fleet's
+# width, letting one caller saturate the pool at any replica count (OME-1142) — which is why
+# the chart exposes `runnerPool.maxAckPending` to pin it independently.
+# INVARIANT: growing the fleet must raise how many CALLERS run at once, never how many runs a
+# single caller may hold.
+# AIDEV-NOTE: the value binds when the consumer is CREATED — `pull_subscribe` is idempotent on
+# existence, not on config, so changing it on a running queue means deleting and recreating the
+# consumers, and only while drained: a consumer holding in-flight acks redelivers those runs.
 DEFAULT_MAX_ACK_PENDING = 256
 DEFAULT_DEPTH_CEILING = 10_000
 DEFAULT_IO_CONCURRENCY = 4

--- a/apps/screamingface-engine/tests/unit/test_chart_render_runner_pool.py
+++ b/apps/screamingface-engine/tests/unit/test_chart_render_runner_pool.py
@@ -159,9 +159,13 @@ def test_the_pool_renders_its_own_settings_into_the_worker_env() -> None:
     assert env["URL4_CLOUD_RUN_QUEUE_WORKER_SLOTS"] == "8"
     assert env["URL4_CLOUD_WORKER_DRAIN_GRACE_S"] == "17"
     assert env["URL4_CLOUD_WORKER_METRICS_PORT"] == "9199"
-    # The fleet's `max_ack_pending` is rendered from the pool's OWN sizing (replicas ×
-    # slots) — the whole-consumer bound the queue's durable consumer hands out across the
-    # fleet, which the code default can only approximate.
+    # With `runnerPool.maxAckPending` unset (this test does not set it), the chart still
+    # derives the value from the pool's own sizing — replicas × slots.
+    # AIDEV-NOTE (OME-1142): the derived product is a FALLBACK, not the contract. The value is
+    # applied to every bucket consumer and a caller hashes to one bucket, so it caps ONE
+    # CALLER's unacked runs — it is NOT the fleet-wide bound an earlier comment here claimed.
+    # A deployment running more than one replica should pin it; see
+    # `test_an_explicit_max_ack_pending_overrides_the_derived_product`.
     assert env["URL4_CLOUD_RUN_QUEUE_MAX_ACK_PENDING"] == "16"  # 2 replicas × 8 slots
     # The metrics port and the containerPort are the same knob — they must agree.
     port = next(p for p in container["ports"] if p["name"] == "metrics")
@@ -368,6 +372,66 @@ def test_the_default_termination_grace_covers_the_full_drain_with_headroom() -> 
     assert pool["terminationGracePeriodSeconds"] > pool["drainGraceS"] + kill_grace_s + (
         publish_budget_s
     ), "the default must leave real publish headroom PAST the enforced minimum"
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+def test_an_explicit_max_ack_pending_overrides_the_derived_product() -> None:
+    """OME-1142: `max_ack_pending` is applied to EVERY bucket consumer, and a caller hashes to
+    exactly one bucket, so it is a PER-CALLER allowance — not the fleet bound the old comment
+    claimed. Deriving it from `replicas × workerSlots` therefore set each caller's personal cap
+    to the whole fleet's slot count, letting one caller saturate the pool at any replica count.
+
+    INVARIANT: raising the pool's replica count increases how many CALLERS can run at once; it
+    must not increase how many runs any SINGLE caller may hold. An operator pins the per-caller
+    allowance here, independently of pool sizing.
+    """
+    docs = _render_with_overrides(
+        **{
+            "runnerPool.replicas": "2",
+            "runnerPool.workerSlots": "4",
+            "runnerPool.maxAckPending": "4",
+        }
+    )
+    pool = _find(docs, "Deployment", f"{_RELEASE}-{_RELEASE}-runner")
+    container = pool["spec"]["template"]["spec"]["containers"][0]
+    env = {entry["name"]: entry["value"] for entry in container["env"]}
+
+    # The derived product would be 8 (2 replicas × 4 slots); the explicit value wins.
+    assert env["URL4_CLOUD_RUN_QUEUE_MAX_ACK_PENDING"] == "4"
+    # The pool still SIZES for 2 pods — pinning the per-caller cap must not shrink the fleet.
+    assert pool["spec"]["replicas"] == 2
+    assert env["URL4_CLOUD_RUN_QUEUE_WORKER_SLOTS"] == "4"
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+def test_an_unset_max_ack_pending_still_derives_from_the_fleet() -> None:
+    """OME-1142 D3: the key is OPTIONAL — unset renders the historical derived product, so an
+    upgrade changes no running deployment and no operator is forced to pick a number.
+
+    AIDEV-NOTE: this guards the fallback against a future edit that drops the `default`. Helm's
+    `default` treats 0 as empty just like null, which is why the schema pins `minimum: 1` — a
+    meaningless 0 must fail the render rather than silently derive.
+    """
+    docs = _render_with_overrides(
+        **{
+            "runnerPool.replicas": "2",
+            "runnerPool.workerSlots": "4",
+        }
+    )
+    pool = _find(docs, "Deployment", f"{_RELEASE}-{_RELEASE}-runner")
+    container = pool["spec"]["template"]["spec"]["containers"][0]
+    env = {entry["name"]: entry["value"] for entry in container["env"]}
+
+    assert env["URL4_CLOUD_RUN_QUEUE_MAX_ACK_PENDING"] == "8"  # 2 replicas × 4 slots
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+def test_a_zero_max_ack_pending_fails_the_render_instead_of_deriving() -> None:
+    """The boundary the `minimum: 1` schema constraint exists for: `default` in Helm treats 0
+    as empty, so a `maxAckPending: 0` would silently fall back to the derived product instead
+    of failing — an operator asking for "no runs" would get the fleet's full allowance."""
+    with pytest.raises(subprocess.CalledProcessError):
+        _render_with_overrides(**{"runnerPool.maxAckPending": "0"})
 
 
 def test_the_charts_kill_grace_literal_matches_the_workers_constant() -> None:

--- a/docs/plan/2026-09-08-OME-1142-maxackpending-per-caller.md
+++ b/docs/plan/2026-09-08-OME-1142-maxackpending-per-caller.md
@@ -1,0 +1,54 @@
+# OME-1142 — Implementation plan
+
+## Frame
+
+Make the runner pool's `max_ack_pending` settable, keep the derived value as the fallback, and
+correct the comments that assert it is a fleet bound. Chart plus one code comment; no runtime
+logic changes.
+
+## Changes
+
+1. `deploy/helm/values.yaml` — add `runnerPool.maxAckPending: null` with a comment stating it
+   is a PER-CALLER allowance (one bucket consumer each), that unset derives
+   `replicas x workerSlots`, and that the value binds at consumer creation. Correct the
+   `workerSlots` comment above it, which currently calls it "the fleet's `max_ack_pending`".
+
+2. `deploy/helm/values.schema.json` — register `maxAckPending` under `runnerPool.properties` as
+   `type: ["integer", "null"], minimum: 1`. Leave it out of `required` so unset stays legal.
+   Mandatory because the object is `additionalProperties: false`.
+
+3. `deploy/helm/templates/deployment-runner.yaml` — render
+   `{{ .Values.runnerPool.maxAckPending | default (mul .Values.runnerPool.replicas .Values.runnerPool.workerSlots) | quote }}`
+   and rewrite the comment block above it per D1.
+
+4. `src/screamingface_engine/runner_queue.py` — correct the `DEFAULT_MAX_ACK_PENDING` comment
+   (currently "a WHOLE-CONSUMER bound ... across EVERY puller in the fleet"). State that it is
+   applied per bucket consumer, so the effective fleet ceiling is `bucket_count x` this value.
+   Constant value unchanged.
+
+5. `tests/unit/test_chart_render_runner_pool.py` — extend with two tests: an explicit
+   `maxAckPending` is rendered verbatim, and an unset one still renders `replicas x workerSlots`.
+
+## Test plan (RED first)
+
+- `test_an_explicit_max_ack_pending_overrides_the_derived_product` — set
+  `runnerPool.maxAckPending: 4` with `replicas: 2, workerSlots: 4`; assert the env var is `"4"`,
+  not `"8"`. Fails today: the template ignores the key, and the schema rejects it outright.
+- `test_an_unset_max_ack_pending_still_derives_from_the_fleet` — no key; assert `"8"` for
+  `replicas: 2, workerSlots: 4`. Guards D3 against a future edit that drops the fallback.
+
+## Gates
+
+`uv run python .claude/scripts/run_gates.py --stack screamingface-engine` (ruff, ruff format,
+pyright, pytest with the stack's coverage floor).
+
+## Wisdom check
+
+- The schema is the trap, not the template. `additionalProperties: false` means a values file
+  using the new key fails the render until the schema admits it — exactly how the stale `rbac`
+  key broke the infra render on 2026-09-08.
+- `default` in Helm treats `null` as empty, which is what makes the optional key work. It also
+  treats `0` as empty, so `minimum: 1` in the schema keeps a meaningless `0` from silently
+  falling back instead of failing.
+- This change does not alter any live deployment. Existing consumers keep the cap they were
+  created with until they are deleted and rebuilt.

--- a/docs/spec/2026-09-08-OME-1142-maxackpending-per-caller.md
+++ b/docs/spec/2026-09-08-OME-1142-maxackpending-per-caller.md
@@ -1,0 +1,73 @@
+# OME-1142 — `max_ack_pending` is a per-caller allowance
+
+## Problem
+
+The chart renders the worker's queue cap from fleet sizing
+(`deploy/helm/templates/deployment-runner.yaml:154-155`):
+
+```
+- name: URL4_CLOUD_RUN_QUEUE_MAX_ACK_PENDING
+  value: {{ mul .Values.runnerPool.replicas .Values.runnerPool.workerSlots | quote }}
+```
+
+The comment above it justifies the product by calling `max_ack_pending` "a WHOLE-CONSUMER
+bound — the fleet's total unacked runs". That was true before the bucket split (OME-1091),
+when the queue had one durable consumer. It is false now.
+
+`RunQueue._bound_subscription` (`src/screamingface_engine/runner_queue.py:651-659`) creates one
+durable consumer **per bucket subject** and hands each the same `max_ack_pending`.
+`bucket_subject` (`runner_queue.py:394-401`) hashes a caller's identity into exactly one
+bucket. So the value is applied once per bucket, and a caller occupies one bucket.
+
+Measured live on dev 2026-09-08: 16 consumers `url4-runners-00`..`0f` on `url4-runq`, each at
+`max_ack_pending=4`, with `ack_pending=4` concentrated on a single bucket while
+`worker_slots_busy=4` of `4`.
+
+## Decisions
+
+### D1 — The cap is per-caller, and the contract says so
+
+`max_ack_pending` bounds one bucket's unacked runs, therefore one caller's in-flight runs. The
+fleet-wide ceiling is an emergent `bucket_count x max_ack_pending`, which nothing enforces as a
+single number. Execution is bounded by the worker's slot count, not by this value. Every
+comment describing it as a fleet bound is wrong and gets corrected.
+
+### D2 — A per-caller allowance must not be derived from fleet size
+
+Deriving it from `replicas x workerSlots` makes each caller's personal allowance equal to the
+whole fleet's slot count. One caller can then saturate the pool at any replica count, which
+negates the fairness the bucket rotation exists to provide. Scaling the pool for *more callers*
+must not simultaneously widen *each* caller's share.
+
+### D3 — Unset keeps today's behaviour
+
+The key is optional. Unset renders the existing derived product, so an upgrade changes no
+running deployment and no operator is forced to pick a number. Choosing a value stays a
+deployment decision, made in the values file that owns the rest of the pool's sizing.
+
+### D4 — The schema must admit the key explicitly
+
+`runnerPool` is declared `additionalProperties: false`. A values file setting an unregistered
+key fails the render closed. The schema entry is therefore part of the change, not a follow-up.
+
+### D5 — Both render paths are pinned by tests
+
+A default-only test would pass while an explicit value silently did nothing, and an
+explicit-only test would let the fallback rot. The render test asserts the explicit value is
+honoured **and** that the derived product still appears when the key is unset.
+
+## Non-goals
+
+- Changing the default value, `DEFAULT_MAX_ACK_PENDING`, or the bucket count.
+- Introducing a real fleet-wide admission ceiling. That is a separate design question; this
+  change only makes the existing per-caller cap expressible.
+- Touching the App-side per-caller admission cap (`DEFAULT_CALLER_INFLIGHT_CAP`), which is a
+  different gate at a different layer.
+- Recreating live durable consumers. The value binds at consumer creation, so an existing
+  deployment keeps its current cap until its consumers are rebuilt — an operational step, not
+  a code change.
+
+## Invariant this protects
+
+Raising the pool's replica count increases how many callers can run concurrently. It must not
+increase how many runs any single caller may hold.

--- a/docs/tasks/2026-09-08-OME-1142-maxackpending-per-caller.md
+++ b/docs/tasks/2026-09-08-OME-1142-maxackpending-per-caller.md
@@ -1,0 +1,32 @@
+---
+id: OME-1142
+linear_url: https://linear.app/openmined/issue/OME-1142/make-the-runner-pools-max-ack-pending-an-explicit-per-caller-allowance
+status: in_progress
+type: task
+priority: high
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+created: 2026-09-08
+closed:
+---
+
+# Make the runner pool's max_ack_pending an explicit per-caller allowance
+
+The chart renders `URL4_CLOUD_RUN_QUEUE_MAX_ACK_PENDING` as `replicas x workerSlots`, claiming
+the value is a fleet-wide bound. Since the bucket split (OME-1091) the queue creates one
+durable consumer per bucket subject and a caller hashes to exactly one bucket, so the value is
+a per-caller allowance. Deriving it from fleet size therefore sets every caller's personal cap
+to the whole fleet's slot count, letting one caller saturate the pool at any replica count.
+
+Add an optional `runnerPool.maxAckPending` values key (unset keeps the derived product),
+register it in the chart schema (`runnerPool` is `additionalProperties: false`), and correct
+the comments in the template and in `runner_queue.py` that assert the fleet-bound premise.
+
+Blocks the infra-side change to run the pool at `replicas: 2` with the per-caller cap pinned
+at 4.
+
+Spec: `docs/spec/2026-09-08-OME-1142-maxackpending-per-caller.md`
+Plan: `docs/plan/2026-09-08-OME-1142-maxackpending-per-caller.md`
+Ledger: `docs/work/2026-09-08-OME-1142-maxackpending-per-caller.md`

--- a/docs/work/2026-09-08-OME-1142-maxackpending-per-caller.md
+++ b/docs/work/2026-09-08-OME-1142-maxackpending-per-caller.md
@@ -1,0 +1,87 @@
+---
+ticket: OME-1142
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-08
+finished:
+---
+
+# OME-1142 — `max_ack_pending` as an explicit per-caller allowance
+
+## Intent
+
+The chart derives the worker's `max_ack_pending` from `replicas x workerSlots` on the premise
+that it is a fleet-wide bound. Since the bucket split (OME-1091) the queue creates one durable
+consumer per bucket and a caller occupies exactly one bucket, so the value is a per-caller
+allowance. Deriving it from fleet size makes each caller's cap equal the whole pool, letting a
+single caller saturate it at any replica count. Make the value settable, keep the derived
+product as the fallback, and correct the comments that assert the old premise.
+
+## Planned changes
+
+- `apps/screamingface-engine/deploy/helm/values.yaml` — add `runnerPool.maxAckPending: null`;
+  fix the `workerSlots` comment that calls it "the fleet's max_ack_pending".
+- `apps/screamingface-engine/deploy/helm/values.schema.json` — register `maxAckPending`
+  (`type: ["integer","null"]`, `minimum: 1`, not required). Mandatory: `runnerPool` is
+  `additionalProperties: false`.
+- `apps/screamingface-engine/deploy/helm/templates/deployment-runner.yaml` — render the key
+  with `default (mul replicas workerSlots)`; rewrite the comment block.
+- `apps/screamingface-engine/src/screamingface_engine/runner_queue.py` — correct the
+  `DEFAULT_MAX_ACK_PENDING` comment. Value unchanged.
+- `apps/screamingface-engine/tests/unit/test_chart_render_runner_pool.py` — two new tests.
+
+## Test plan
+
+- `test_an_explicit_max_ack_pending_overrides_the_derived_product` — `maxAckPending: 4` with
+  `replicas: 2, workerSlots: 4` renders `"4"`. RED today twice over: the template ignores the
+  key and the schema rejects it.
+- `test_an_unset_max_ack_pending_still_derives_from_the_fleet` — no key, `replicas: 2,
+  workerSlots: 4` renders `"8"`. Protects the backwards-compatible fallback.
+
+## Acceptance
+
+- An operator can pin the per-caller cap independently of pool sizing.
+- Unset changes nothing about the rendered output for any existing values file.
+- No comment in the chart or `runner_queue.py` still describes the value as a fleet bound.
+- Stack gates green.
+
+## Outcome
+
+- **Actual files:** the five planned files, plus one unplanned comment repair. As planned:
+  `deploy/helm/values.yaml` (`maxAckPending` + corrected `workerSlots` comment),
+  `deploy/helm/values.schema.json` (key registered, `workerSlots` description corrected),
+  `deploy/helm/templates/deployment-runner.yaml` (`default` fallback + rewritten comment),
+  `src/screamingface_engine/runner_queue.py` (comment only; `DEFAULT_MAX_ACK_PENDING` value
+  unchanged), `tests/unit/test_chart_render_runner_pool.py` (+3 tests). Unplanned: the comment
+  inside the PRIOR test at lines 162-164 asserted the same false fleet-bound premise; corrected
+  under the owner's explicit instruction (see Deviations). No schema, migration, or public
+  Python contract changed — S1 does not apply.
+
+- **Commits:** `feat(screamingface-engine): make the runner pool's max_ack_pending an explicit
+  per-caller allowance` (the remote head is recorded by GitHub on the PR).
+
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` reported ALL GATES GREEN:
+  Ruff lint, Ruff format, Pyright, `check_layering.py`, and the full coverage suite
+  (`--cov=screamingface_engine --cov=url4.streaming --cov-fail-under=80`). 2636 tests collected
+  in the stack; the touched file is 17 passing (14 prior + 3 new). RED was confirmed first: the
+  explicit-value test failed because `runnerPool` is `additionalProperties: false` and the schema
+  rejected the unknown key. The zero-boundary test now fails for the intended reason —
+  `at '/runnerPool/maxAckPending': minimum: got 0, want 1` — where before the change it failed
+  only because the key was unknown.
+
+- **Deviations:** two.
+  1. The append-only check was skipped under the owner's explicit approval, to correct the
+     misleading comment inside the prior test `test_the_pool_renders_its_own_settings_into_the_worker_env`.
+     Its behavioural assertion (`== "16"`) is byte-identical and still passes; only the
+     explanatory comment changed, and it now carries an `AIDEV-NOTE` pointing at the new
+     explicit-value test. The gate correctly refused this as a silent change first, and the skip
+     is recorded here rather than passed over quietly.
+  2. The plan did not include the `workerSlots` description in `values.schema.json`. It asserted
+     "the queue's `max_ack_pending` is `QUEUE_REPLICAS × this`" — wrong twice over (the template
+     uses `runnerPool.replicas`, not the queue's stream-replica count, and the value is
+     per-bucket rather than fleet-wide), so it was corrected in the same pass.
+
+- **Follow-up (not this unit):** live deployments keep the cap their durable consumers were
+  created with. Re-capping `sf-fusion` means deleting the 16 `url4-runners-*` consumers while the
+  queue is drained, then the infra-side change to `replicas: 2` + `maxAckPending: 4` + the
+  `ns-ceiling` quota raise. Blocked on this chart reaching a release Kargo can pin.


### PR DESCRIPTION
## The premise the chart was built on is false

`deployment-runner.yaml` rendered the worker's queue cap from fleet sizing:

```yaml
- name: URL4_CLOUD_RUN_QUEUE_MAX_ACK_PENDING
  value: {{ mul .Values.runnerPool.replicas .Values.runnerPool.workerSlots | quote }}
```

justified by a comment calling it *"a WHOLE-CONSUMER bound — the fleet's total unacked runs"*.

That was true before the bucket split (OME-1091), when the queue had one durable consumer. It is not true now:

- `RunQueue._bound_subscription` (`runner_queue.py:651-659`) creates one durable consumer **per bucket subject**, handing each the same `max_ack_pending`.
- `RunQueue.bucket_subject` (`runner_queue.py:394-401`) hashes a caller's identity into exactly **one** bucket.

So the value caps **one caller's** unacked runs. The fleet ceiling is an emergent `bucket_count x` it — 16 x 4 = 64 on dev, not 4. What actually bounds execution is the worker's slot count.

### Why that matters

Deriving a per-caller allowance from fleet sizing set every caller's personal cap to the whole fleet's slot count. A single caller could therefore saturate the pool **at any replica count**, negating the fairness the bucket rotation exists to provide. Raising `replicas` to 2 would have raised each caller's cap to 8 and let one caller take all 8 slots.

Measured live on dev 2026-09-08: 16 consumers `url4-runners-00`..`0f` all at `max_ack_pending=4`, with `ack_pending=4` concentrated on a single bucket while `worker_slots_busy` was 4 of 4.

## The change

An optional `runnerPool.maxAckPending`, rendered through `default`:

```yaml
value: {{ .Values.runnerPool.maxAckPending | default (mul .Values.runnerPool.replicas .Values.runnerPool.workerSlots) | quote }}
```

- **Unset keeps today's behaviour** — the derived product — so an upgrade changes no running deployment and no operator is forced to pick a number.
- **The schema entry is part of the change, not a follow-up.** `runnerPool` is `additionalProperties: false`, so a values file using an unregistered key fails the render closed.
- **`minimum: 1` is load-bearing.** Helm's `default` treats `0` as empty exactly like `null`, so a `maxAckPending: 0` would silently derive the fleet's full width instead of failing. It now fails: `at '/runnerPool/maxAckPending': minimum: got 0, want 1`.

Also corrects every comment carrying the old premise — the template, the `workerSlots` entries in `values.yaml` and `values.schema.json` (the latter additionally said `QUEUE_REPLICAS x this`, naming the wrong replica count), and `DEFAULT_MAX_ACK_PENDING` in `runner_queue.py`. **No constant value, schema behaviour, or public Python contract changed.**

## Verification

RED first: the explicit-value test failed because the schema rejected the unknown key.

Gates: `run_gates.py screamingface-engine --skip-append-only` → **ALL GATES GREEN** (Ruff lint, Ruff format, Pyright, `check_layering.py`, full coverage suite at the 80% floor). 2636 tests collected in the stack; the touched file is 17 passing (14 prior + 3 new).

The target case renders as intended:

```
replicas: 2  +  maxAckPending: 4
  ->  replicas 2, WORKER_SLOTS 4, MAX_ACK_PENDING 4, BUCKET_COUNT 16
      requests 900m / 1152Mi per pod (unchanged)
```

Default render unchanged at `"4"`.

## Deviations — please read

1. **The append-only check was skipped, deliberately and with owner approval.** The comment inside the prior test `test_the_pool_renders_its_own_settings_into_the_worker_env` asserted the same false fleet-bound premise. Its behavioural assertion (`== "16"`) is byte-identical and still passes; only the explanatory comment changed, and it now carries an `AIDEV-NOTE` pointing at the new explicit-value test. The gate correctly refused this as a silent change on the first run — recording the skip here rather than letting it pass quietly.
2. The `workerSlots` description in `values.schema.json` was not in the plan; it carried the same wrong claim and was corrected in the same pass.

## This does not re-cap the live queue

`max_ack_pending` binds when the consumer is **created** — `pull_subscribe` is idempotent on existence, not on config. Existing deployments keep the cap their consumers were built with.

Follow-up chain, none of it in this PR:
1. This merges → engine release → Kargo pins the new chart.
2. Delete the 16 `url4-runners-*` consumers **while the queue is drained** so they rebuild at the new cap. Deleting a consumer holding in-flight acks redelivers those runs and re-spends provider calls.
3. Infra: `replicas: 2` + `maxAckPending: 4` + the `ns-ceiling` quota raise (4 pods during a rollout needs ~`requests.cpu: 5` / `memory: 6Gi` and a second tenant node — a capacity decision).

Spec: `docs/spec/2026-09-08-OME-1142-maxackpending-per-caller.md`
Plan: `docs/plan/2026-09-08-OME-1142-maxackpending-per-caller.md`
Ledger: `docs/work/2026-09-08-OME-1142-maxackpending-per-caller.md`

Refs: OME-1142