### PR TITLE
feat(scoreboard): drop the Submitter column from the leaderboard table

### DIFF
--- a/apps/scoreboard/portal/benchmark.js
+++ b/apps/scoreboard/portal/benchmark.js
@@ -31,7 +31,6 @@
     // identities, and providers.length > 1 is not a valid fusion/solo test.
     // Keeping the honest label until a backend field exists.
     { key: "ran_with_providers", label: "Backends", sort: null },
-    { key: "submitted_by", label: "Submitter", sort: "string", dir: "asc" },
     { key: "authors", label: "Authors", sort: "string", dir: "asc" },
     { key: "score", label: "Score", sort: "number", dir: "desc", cls: "num" },
     // WHY Questions is gone: OME-769's column list is #, Name, Models, Author,
@@ -212,7 +211,6 @@
       tr.appendChild(specTd);
 
       tr.appendChild(P.el("td", null, P.formatProviders(entry.ran_with_providers)));
-      tr.appendChild(P.el("td", null, P.formatSubmitter(entry.submitted_by)));
       tr.appendChild(P.el("td", null, P.formatAuthors(entry.authors)));
       tr.appendChild(renderScoreCell(entry.score, barMin, barMax));
       // WHY the title: the cell rounds to cents, but the frontier compares the full stored

--- a/apps/scoreboard/tests/unit/test_multiple_authors.py
+++ b/apps/scoreboard/tests/unit/test_multiple_authors.py
@@ -194,8 +194,6 @@ async def test_another_submitter_cannot_rewrite_public_author_credit(tortoise_db
 def test_portal_renders_author_lists_in_leaderboard_and_history() -> None:
     portal = Path(__file__).resolve().parents[2] / "portal"
 
-    assert 'key: "submitted_by", label: "Submitter"' in (portal / "benchmark.js").read_text()
-    assert "P.formatSubmitter(entry.submitted_by)" in (portal / "benchmark.js").read_text()
     assert "P.formatAuthors(entry.authors)" in (portal / "benchmark.js").read_text()
     assert "P.formatSubmitter(s.submitted_by)" in (portal / "spec.js").read_text()
     assert "P.formatAuthors(s.authors)" in (portal / "spec.js").read_text()
@@ -248,3 +246,21 @@ async def test_owned_entries_carry_every_field_with_a_non_default_value(
                 "comparison above cannot tell a copied field from an omitted one. Give it a "
                 "distinctive value."
             )
+
+
+def test_portal_leaderboard_table_has_no_submitter_column() -> None:
+    """FEATURE (OME-1144): one identity column on the benchmark table, not two.
+
+    INVARIANT: the two absence assertions must stay paired with the two presence ones. `COLUMNS`
+    and `renderRows` are positional — a header removed without its cell (or the reverse) shifts
+    every column right of Backends — and the two survivors are what a bare absence check cannot
+    tell apart from the two wrong ways to satisfy it: deleting BOTH identity columns, or deleting
+    the shared `formatSubmitter` helper that `spec.js` still calls.
+    """
+    portal = Path(__file__).resolve().parents[2] / "portal"
+    benchmark_js = (portal / "benchmark.js").read_text()
+
+    assert 'label: "Submitter"' not in benchmark_js
+    assert "P.formatSubmitter(entry.submitted_by)" not in benchmark_js
+    assert "P.formatAuthors(entry.authors)" in benchmark_js
+    assert "P.formatSubmitter(s.submitted_by)" in (portal / "spec.js").read_text()

--- a/docs/plan/2026-09-08-OME-1144-remove-submitter-column.md
+++ b/docs/plan/2026-09-08-OME-1144-remove-submitter-column.md
@@ -1,0 +1,47 @@
+# OME-1144 — Plan
+
+Spec: `docs/spec/2026-09-08-OME-1144-remove-submitter-column.md`
+
+## Files
+
+| File | Change |
+|---|---|
+| `apps/scoreboard/portal/benchmark.js` | remove the `submitted_by` entry from `COLUMNS`; remove the matching `P.formatSubmitter(entry.submitted_by)` cell append |
+| `apps/scoreboard/tests/unit/test_multiple_authors.py` | drop the two assertions naming the removed column config and cell render (recorded exception); add `test_portal_leaderboard_table_has_no_submitter_column` |
+
+`apps/scoreboard/portal/main.js` is NOT modified — `formatSubmitter` still serves `spec.js`.
+
+## RED
+
+`test_portal_leaderboard_table_has_no_submitter_column` asserts, against `benchmark.js` source:
+
+- `'label: "Submitter"'` is absent;
+- `"P.formatSubmitter(entry.submitted_by)"` is absent;
+- `"P.formatAuthors(entry.authors)"` is still present — the removal must not take the sibling
+  identity column with it;
+- `"P.formatSubmitter(s.submitted_by)"` is still present in `spec.js` — the helper's other caller
+  survives, which is what keeps `main.js` untouched.
+
+The last two assertions are the ones that make this a real guard rather than a deletion echo: a
+change that removed both identity columns, or that removed the helper, would pass a bare
+absence check and fail this one.
+
+Run it first and confirm it fails on the two absence assertions.
+
+## GREEN
+
+Delete the two lines from `benchmark.js`. The column count drops from 9 to 8; no other column
+config references an index, so nothing else moves.
+
+## Gates
+
+`uv run .claude/scripts/run_gates.py scoreboard --base origin/main`
+
+The append-only check will flag `test_multiple_authors.py`. That is the exception recorded in the
+spec; re-run with `--skip-append-only` and record both results in the ledger.
+
+## Risks
+
+- `COLUMNS` drives both the header row and `renderRows`, and the two are positional. Removing the
+  config without the cell append (or the reverse) silently shifts every column right of Backends.
+  The existing portal suites plus the new assertions cover the pair.

--- a/docs/spec/2026-09-08-OME-1144-remove-submitter-column.md
+++ b/docs/spec/2026-09-08-OME-1144-remove-submitter-column.md
@@ -1,0 +1,68 @@
+# OME-1144 — Remove the Submitter column from the leaderboard table
+
+Status: owner-approved · Stack: scoreboard
+
+## Problem
+
+The benchmark leaderboard table renders two identity columns side by side: `Submitter` (OME-769)
+and `Authors` (OME-1052). `_resolved_authors` falls back to `[submitted_by]` whenever a submission
+carries no explicit author list, so for the common case the two cells render byte-identical text.
+Observed on `leaderboard.dev.screamingface.ai/benchmark.html?id=draco-3pass`.
+
+## Decisions
+
+### D1 — The leaderboard table drops the Submitter column
+
+The column config and its cell render come out of `portal/benchmark.js`. The table then shows one
+identity column, `Authors`.
+
+### D2 — Nothing behind the portal changes
+
+`submitted_by` stays on `Score`, on `LeaderboardEntry`, on `ScoreSchema`, and on every API
+response. This is a display change on one page. The private JSONL export and the staff surfaces
+keep the field untouched.
+
+### D3 — `formatSubmitter` stays
+
+OME-1144 says to drop it "if no other caller". There is another caller: `portal/spec.js:17`
+renders the submitter on each spec's history table, and `portal/spec.html` keeps its
+`<th>Submitter</th>`. So `portal/main.js` is not modified and the helper keeps its export.
+
+### D4 — The spec detail page is out of scope
+
+The ticket scopes the change to the benchmark leaderboard table. The spec page shows one row per
+submission rather than one row per spec, and its submitter column is not redundant with anything
+there today. It is left alone.
+
+### D5 — Accepted consequence: the surviving column is the unverified one
+
+`submitted_by` is resolved by `_resolve_submitter` from verified Cloudflare Access identity.
+`authors` is a client-supplied list on `ScoreSubmission` that nothing verifies. Removing Submitter
+therefore leaves the public table showing only a claim made by the submitter. The owner reviewed
+this trade and chose the removal as filed (2026-09-08); it is recorded here so the next reader does
+not rediscover it as a defect. The verified value remains available on the spec page and the API.
+
+## Verification contract
+
+- the rendered leaderboard table has no `Submitter` header and no submitter cell;
+- the `Authors` column still renders, including its em-dash empty state;
+- every remaining column keeps its position and its sort behaviour;
+- `portal/spec.js` and `portal/spec.html` still render the submitter;
+- `portal/main.js` still exports `formatSubmitter`;
+- full Scoreboard gates green.
+
+## Confidence-Gate exception
+
+`tests/unit/test_multiple_authors.py::test_portal_renders_author_lists_in_leaderboard_and_history`
+asserts the removed column config and cell render as source text (lines 196–197). Those two
+assertions describe the behaviour this unit deliberately removes, so they cannot survive it. The
+owner approved the removal as filed, which entails the edit. The test's other five assertions —
+`P.formatAuthors(entry.authors)`, both `spec.js` renders, and both `spec.html` headers — are kept
+unchanged, and a new test pins the absence, so coverage of this area does not shrink.
+
+## Non-goals
+
+- changing `submitted_by` anywhere behind the portal;
+- changing the spec detail page;
+- changing how authors are collapsed or disambiguated (OME-1109);
+- adding a conditional "hide when identical" behaviour.

--- a/docs/tasks/2026-09-08-OME-1144-remove-submitter-column.md
+++ b/docs/tasks/2026-09-08-OME-1144-remove-submitter-column.md
@@ -1,0 +1,27 @@
+---
+id: OME-1144
+linear_url: https://linear.app/openmined/issue/OME-1144/remove-the-submitter-column-from-the-leaderboard-table
+status: in_review
+type: task
+priority: 2
+labels: [scoreboard, agentic, autonomous, BUG]
+created: 2026-09-08
+closed:
+---
+
+# Remove the "Submitter" column from the leaderboard table
+
+Drop the `Submitter` column from the benchmark leaderboard table. It duplicates `Authors`
+(OME-1052) for every submission without an explicit author list, because `_resolved_authors` falls
+back to `[submitted_by]`.
+
+Portal display only. `submitted_by` stays on the model, the API, and the spec detail page.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-08-OME-1144-remove-submitter-column.md`
+- Plan: `docs/plan/2026-09-08-OME-1144-remove-submitter-column.md`
+- Ledger: `docs/work/2026-09-08-OME-1144-remove-submitter-column.md`
+
+Related: `OME-769` (added the columns), `OME-1052` (added Authors), `OME-1109` (author credit
+publication, in flight).

--- a/docs/work/2026-09-08-OME-1144-remove-submitter-column.md
+++ b/docs/work/2026-09-08-OME-1144-remove-submitter-column.md
@@ -1,0 +1,77 @@
+---
+ticket: OME-1144
+stack: scoreboard
+status: in_progress
+started: 2026-09-08
+finished:
+---
+
+# OME-1144 — Remove the Submitter column from the leaderboard table
+
+## Intent
+
+The benchmark leaderboard table shows `Submitter` and `Authors` next to each other, and
+`_resolved_authors` falls back to `[submitted_by]`, so for any submission without an explicit
+author list the two cells are byte-identical. Reported by the owner from the populated dev board.
+This unit removes the `Submitter` column from that one table and changes nothing behind the
+portal.
+
+## Planned changes
+
+- `apps/scoreboard/portal/benchmark.js` — drop the `submitted_by` `COLUMNS` entry and its cell
+  append.
+- `apps/scoreboard/tests/unit/test_multiple_authors.py` — remove the two assertions that name the
+  deleted column config and cell render; add `test_portal_leaderboard_table_has_no_submitter_column`.
+
+`apps/scoreboard/portal/main.js` is deliberately untouched: `formatSubmitter` still serves
+`portal/spec.js:17`, so the ticket's "drop it if no other caller" branch does not apply.
+
+## Test plan
+
+RED first, `test_portal_leaderboard_table_has_no_submitter_column`:
+
+- `'label: "Submitter"'` absent from `benchmark.js` (the header);
+- `"P.formatSubmitter(entry.submitted_by)"` absent from `benchmark.js` (the cell);
+- `"P.formatAuthors(entry.authors)"` still present — removing both identity columns must fail;
+- `"P.formatSubmitter(s.submitted_by)"` still present in `spec.js` — deleting the shared helper
+  must fail.
+
+The last two are the reason this is a guard and not a restatement of the diff.
+
+## Acceptance
+
+- the leaderboard table renders eight columns, none of them Submitter;
+- Authors still renders, em dash included;
+- the spec page and `main.js` are unchanged;
+- full Scoreboard gates green, with the append-only exception recorded.
+
+## Outcome
+
+- **Actual files:** as planned. `portal/benchmark.js` lost two lines (the `COLUMNS` entry and the
+  cell append); `tests/unit/test_multiple_authors.py` lost the two stale assertions and gained
+  `test_portal_leaderboard_table_has_no_submitter_column`. `portal/main.js`, `portal/spec.js` and
+  `portal/spec.html` untouched, as D3 and D4 require.
+- **Commits:** see the PR — one commit, `Refs: OME-1144`.
+- **Gates:**
+  - `run_gates.py scoreboard --base origin/main` → append-only check FAILS on
+    `tests/unit/test_multiple_authors.py` (removed old lines 197, 198). That is exactly the
+    recorded Confidence-Gate exception in the spec and nothing else was flagged.
+  - `run_gates.py scoreboard --base origin/main --skip-append-only` → ALL GATES GREEN: ruff check,
+    ruff format, pyright, pytest with `--cov-fail-under=80`, and all three portal suites.
+- **Mutation check:** the new guard was verified against three mutations of `benchmark.js`, each
+  restored afterwards and the file confirmed byte-identical to its backup:
+
+  | Mutation | Result |
+  |---|---|
+  | restore the header without its cell | CAUGHT |
+  | restore the cell without its header | CAUGHT |
+  | delete the Authors cell too (both identity columns gone) | CAUGHT |
+
+  The third is the one that matters: a bare "Submitter is absent" assertion would pass while the
+  board lost every identity column.
+- **Deviations:** two, both against the ticket text rather than the plan.
+  1. The ticket says `formatSubmitter` "becomes unused; drop it if no other caller". There is
+     another caller — `portal/spec.js:17` — so `portal/main.js` was left alone (spec D3).
+  2. The ticket says "update any portal tests asserting the Submitter header/column". No test
+     under `tests/portal/` asserts it; the assertions live in the Python suite at
+     `tests/unit/test_multiple_authors.py`, which is where the edit landed.


### PR DESCRIPTION
## Summary

- remove the `Submitter` column from the benchmark leaderboard table (`portal/benchmark.js`) — it duplicated `Authors` for every submission without an explicit author list, because `_resolved_authors` falls back to `[submitted_by]`
- portal display only: `submitted_by` is unchanged on the model, the API, the private JSONL export, and the spec detail page
- add a guard that pins the removal without pinning the two wrong ways to satisfy it

**Asana:** N/A — tracked in Linear as OME-1144

## Components touched

- `apps/scoreboard` (portal + one test file)
- `docs/spec`, `docs/plan`, `docs/tasks`, `docs/work`

## Two deviations from the ticket text

1. The ticket says `formatSubmitter` "becomes unused; drop it if no other caller". **There is another caller** — `portal/spec.js:17` renders the submitter on each spec's history table — so `portal/main.js` is untouched.
2. The ticket says to update "any portal tests asserting the Submitter header/column". Nothing under `tests/portal/` asserts it; the assertions live in `tests/unit/test_multiple_authors.py`, which is where the edit landed.

## Accepted trade-off, recorded in the spec

`submitted_by` is resolved from verified Cloudflare Access identity; `authors` is a client-supplied list that nothing verifies. Removing Submitter leaves the public table showing only the unverified claim. The owner reviewed this and chose the removal as filed (2026-09-08) — spec D5 records it so the next reader does not rediscover it as a defect. The verified value stays on the spec page and the API.

## Test plan

- [x] `uv run .claude/scripts/run_gates.py scoreboard --base origin/main --skip-append-only` → ALL GATES GREEN (ruff check, ruff format, pyright, pytest `--cov-fail-under=80`, all three portal suites)
- [x] new `test_portal_leaderboard_table_has_no_submitter_column` written first and confirmed RED for the right reason
- [x] mutation-checked, each mutation reverted and the file confirmed byte-identical afterwards:

| Mutation of `benchmark.js` | Result |
| --- | --- |
| restore the header without its cell | CAUGHT |
| restore the cell without its header | CAUGHT |
| delete the Authors cell too — both identity columns gone | CAUGHT |

The third is why the guard carries presence assertions as well as absence ones: `COLUMNS` and `renderRows` are positional, and a bare "Submitter is absent" check would pass on a board that lost every identity column.

- [ ] screenshots — not attached; the change is the removal of one column from an existing table

## Confidence-Gate exception (sdlc rule 5)

`test_portal_renders_author_lists_in_leaderboard_and_history` asserted the deleted column config and cell render as source text (old lines 197–198). Those two assertions describe the behaviour this PR deliberately removes, so they cannot survive it; the owner's decision to remove the column as filed entails the edit. Its other five assertions are unchanged, and the new guard covers the area, so coverage does not shrink.

`run_gates.py` without `--skip-append-only` flags exactly those two lines and nothing else.

## Cross-service notes

None. No API, schema, or client change.
