### PR TITLE
fix(screamingface-engine): skip the Linux-only memory-cap test off-Linux

### DIFF
--- a/apps/screamingface-engine/tests/unit/test_worker_child_memory_cap.py
+++ b/apps/screamingface-engine/tests/unit/test_worker_child_memory_cap.py
@@ -10,6 +10,7 @@ sets the limit and execs the fake in place, exactly as it would exec the real en
 import asyncio
 import json
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -21,6 +22,19 @@ from screamingface_engine.worker.loop import Worker
 from screamingface_engine.worker.supervisor import CHILD_EXITED
 
 pytestmark = pytest.mark.asyncio
+
+# WHY: the cap under test is Linux-only behavior. Linux lets a process LOWER its own
+# RLIMIT_AS ceiling; macOS refuses ("current limit exceeds maximum limit") and the
+# wrapper's setrlimit raises, so the child dies for the wrong reason and the assertion
+# fails on any Mac dev box. The worker only deploys in Linux containers, so skipping
+# off-Linux loses no real coverage — Linux CI still runs this unskipped (OME-1151).
+pytestmark = [
+    pytestmark,
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="RLIMIT_AS self-lowering is Linux-only; macOS setrlimit refuses it",
+    ),
+]
 
 # 128 MiB of address space: enough for the interpreter to start, far too little for the
 # fake runner's 512 MiB allocation. (RLIMIT_AS bounds VIRTUAL address space, which is

--- a/docs/tasks/2026-09-09-OME-1151-skip-memory-cap-test-on-macos.md
+++ b/docs/tasks/2026-09-09-OME-1151-skip-memory-cap-test-on-macos.md
@@ -1,0 +1,21 @@
+---
+id: OME-1151
+linear_url: https://linear.app/openmined/issue/OME-1151/engine-test-suite-goes-red-on-a-mac-so-the-pre-push-hook-rejects-every
+status: in_progress
+type: fix
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-09
+closed:
+---
+
+# Engine test suite goes red on a Mac, so the pre-push hook rejects every push
+
+`test_worker_child_memory_cap` (OME-1089) caps a child's memory via
+`resource.setrlimit(RLIMIT_AS, ...)`. Linux lets a process lower its own ceiling; macOS
+refuses (`ValueError: current limit exceeds maximum limit`), so the child dies for the
+wrong reason and the test fails even on clean `main` — and the pre-push hook's red gate
+then rejects every push from a Mac. The worker only deploys in Linux containers, so the
+fix is a non-Linux `skipif` guard on the test; Linux CI keeps running it unskipped.
+
+Ledger: `docs/work/2026-09-09-OME-1151-skip-memory-cap-test-on-macos.md`

--- a/docs/work/2026-09-09-OME-1151-skip-memory-cap-test-on-macos.md
+++ b/docs/work/2026-09-09-OME-1151-skip-memory-cap-test-on-macos.md
@@ -1,0 +1,50 @@
+---
+ticket: OME-1151
+stack: screamingface-engine
+status: done
+started: 2026-09-09
+finished: 2026-09-09
+---
+
+# OME-1151 — Engine test suite goes red on a Mac, so the pre-push hook rejects every push
+
+## Intent
+
+`test_worker_child_memory_cap` (OME-1089) fails on macOS: the exec wrapper's child calls
+`resource.setrlimit(RLIMIT_AS, ...)`, which Linux permits (a process may lower its own
+ceiling) but macOS refuses with `ValueError: current limit exceeds maximum limit`. The
+child dies for the wrong reason, the assertion fails, and the pre-push hook's red gate
+rejects every push from a Mac — even on clean `main`. The worker only deploys in Linux
+containers, so the behavior under test is Linux-only; the test needs a platform guard.
+
+## Planned changes
+
+- `apps/screamingface-engine/tests/unit/test_worker_child_memory_cap.py` — add a
+  module-level `skipif` for non-Linux platforms, with a reason naming the macOS
+  `setrlimit` refusal.
+
+## Test plan
+
+- Test-only change. RED evidence: the test fails on macOS on clean `main`
+  (`AssertionError: assert 2 == 1`, both children dead of the `setrlimit` `ValueError`).
+- GREEN: after the guard, the test reports `skipped` on macOS; full suite green.
+- Linux CI keeps running it unskipped — the memory-cap invariant stays guarded where it
+  deploys.
+
+## Acceptance
+
+- `uv run pytest` in `apps/screamingface-engine` is green on macOS (test skipped, not
+  failed); no other test touched.
+- The skip condition is `sys.platform != "linux"` (guards any non-Linux dev box, not just
+  darwin), with a reason naming the platform difference.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus this ledger and the `docs/tasks/` mirror.
+- **Commits:** `fix(screamingface-engine): skip the Linux-only memory-cap test off-Linux` (sha in PR)
+- **Gates:** `run_gates.py screamingface-engine` ALL GREEN (append-only check, ruff check,
+  ruff format, pyright, layering, pytest with coverage ≥80; the memory-cap test reports
+  `skipped` on macOS with the platform reason).
+- **Deviations:** the first guard attempt rewrote the existing `pytestmark` line and the
+  append-only test gate rejected it; restructured as a purely additive second
+  `pytestmark` assignment wrapping the original, so no prior line changed.


### PR DESCRIPTION
Guards the per-child memory-cap test (from OME-1089) with a non-Linux skip, so the full-suite pre-push gate is green again on Mac dev machines while Linux CI keeps the real coverage. Refs: OME-1151.

## Before / After

### Before
- Trigger: a dev on a Mac pushes any branch; the pre-push hook runs the full engine test gate.
- Today: `test_worker_child_memory_cap` fails on macOS even on clean `main`, so the gate is red and the hook rejects every push — including pushes that touch nothing near the worker.
- Cost: no dev on a Mac can push at all, and the failure looks like their own change broke something.

### After
- Same trigger.
- Now: the test reports `skipped` on non-Linux platforms, with a reason naming the platform difference; the gate is green on a Mac.
- Win: pushes from a Mac work again (this PR's own push went through the previously-red hook).

### Don't regress
- Linux CI still runs the test unskipped — the memory-cap invariant stays guarded on the platform the worker actually deploys to.

## Root cause

The test spawns a real child through the worker's exec wrapper, and the wrapper caps the child with `resource.setrlimit(RLIMIT_AS, ...)`. Linux lets a process lower its own address-space ceiling; macOS refuses (`ValueError: current limit exceeds maximum limit`), so the child dies of the setrlimit error instead of the MemoryError under test and the assertion fails. The worker only ever runs in Linux containers, so the behavior under test is Linux-only by nature — the test just lacked the platform guard.

## Review order

1. `apps/screamingface-engine/tests/unit/test_worker_child_memory_cap.py` — the whole change: a second, purely additive `pytestmark` assignment that wraps the existing asyncio marker with a `skipif` for non-Linux platforms. Verify the original marker line is untouched (the repo's append-only-test gate enforced that) and that the skip condition is platform-based, not a blanket skip.
2. `docs/work/2026-09-09-OME-1151-*.md` and `docs/tasks/2026-09-09-OME-1151-*.md` — the unit's ledger and issue mirror; mechanical skim.

No runtime behavior changes — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
