### PR TITLE
refactor(screamingface-engine): merge the drifted judge-verdict parsers into one typed shared parser

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/verdict.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/draco/verdict.py
@@ -1,19 +1,40 @@
-"""DRACO's deterministic binding of a Judge reply to an Engine-known criterion.
+"""DRACO's verdict dialect — a shape declaration over the shared spine parser.
 
-INVARIANT: Case, criterion, sequence, and producer identity come from Engine-owned URL4 bindings;
-the Judge supplies only the verdict payload and cannot relabel its Evidence.
+INVARIANT: Case, criterion, sequence, and producer identity come from Engine-owned URL4
+bindings; the Judge supplies only the verdict payload and cannot relabel its Evidence.
+
+The parsing work lives once in ``spine.verdict`` (OME-1099); this module keeps what is
+DRACO's to own: its ``MET``/``UNMET`` enum dialect with a required explanation, its
+reason vocabulary, and its own ``call``/``binding_key`` — DRACO's binding carries a
+``sequence`` and an opaque criterion id, unlike the rubric boards' integer pair.
 """
 
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping
-from typing import Any
-
 from screamingface_engine.benchmarks.draco.validation import require_text
+from screamingface_engine.benchmarks.spine.verdict import (
+    VerdictShape,
+    parse_verdict,
+    require_positive_int,
+)
 from url4 import Node, RelExpr, Text, render
 
 SCHEMA = "screamingface.criterion-verdict.v1"
+
+SHAPE = VerdictShape(
+    schema=SCHEMA,
+    status_field="criterion_status",
+    statuses=("MET", "UNMET"),
+    explanation_required=True,
+    reasons={
+        "empty": "empty",
+        "not_json": "invalid_json",
+        "not_object": "invalid_shape",
+        "bad_explanation": "invalid_shape",
+        "missing_status": "invalid_shape",
+        "bad_status": "invalid_status",
+    },
+)
 
 
 def call(
@@ -74,106 +95,16 @@ def bind(
 ) -> dict[str, object]:
     """Validate ``raw`` and attach Engine-known case and criterion identifiers."""
 
-    if isinstance(case_id, bool) or not isinstance(case_id, int) or case_id < 1:
-        raise ValueError("case_id must be a positive integer")
-    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
-        raise ValueError("sequence must be a positive integer")
+    require_positive_int(case_id, "case_id")
+    require_positive_int(sequence, "sequence")
     selected_id = require_text(criterion_id, "criterion_id")
     selected_producer = require_text(producer_id, "producer_id")
-    decoded = _decode_object(raw)
-    reason = _invalid_reason(raw, decoded)
-    if reason is not None:
-        return _invalid(
-            raw,
-            case_id=case_id,
-            criterion_id=selected_id,
-            sequence=sequence,
-            producer_id=selected_producer,
-            reason=reason,
-        )
-    assert isinstance(decoded, Mapping)
-    explanation = decoded.get("explanation")
-    status = decoded.get("criterion_status")
-    assert isinstance(explanation, str) and status in ("MET", "UNMET")
-    return {
-        "schema": SCHEMA,
-        "case_id": case_id,
-        "criterion_id": selected_id,
-        "sequence": sequence,
-        "producer_type": "model",
-        "producer_id": selected_producer,
-        "valid": True,
-        "explanation": explanation,
-        "criterion_status": status,
-        "raw_output": raw,
-    }
-
-
-def _invalid_reason(raw: object, decoded: object) -> str | None:
-    if not isinstance(raw, str) or not raw.strip():
-        reason = "empty"
-    elif decoded is None:
-        reason = "invalid_json"
-    elif not isinstance(decoded, Mapping):
-        reason = "invalid_shape"
-    elif not isinstance(decoded.get("explanation"), str) or "criterion_status" not in decoded:
-        reason = "invalid_shape"
-    elif decoded.get("criterion_status") not in ("MET", "UNMET"):
-        reason = "invalid_status"
-    else:
-        reason = None
-    return reason
-
-
-def _decode_object(raw: object) -> Any:
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-    text = _without_fences(raw.strip())
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return _first_json_value(text)
-
-
-def _without_fences(text: str) -> str:
-    if "```" not in text:
-        return text
-    return "\n".join(
-        line for line in text.splitlines() if not line.strip().startswith("```")
-    ).strip()
-
-
-def _first_json_value(text: str) -> Any:
-    start = text.find("{")
-    if start < 0:
-        return None
-    try:
-        value, _ = json.JSONDecoder().raw_decode(text[start:])
-    except json.JSONDecodeError:
-        return None
-    return value
-
-
-def _invalid(
-    raw: str,
-    *,
-    case_id: int,
-    criterion_id: str,
-    sequence: int,
-    producer_id: str,
-    reason: str,
-) -> dict[str, object]:
-    return {
-        "schema": SCHEMA,
-        "case_id": case_id,
-        "criterion_id": criterion_id,
-        "sequence": sequence,
-        "producer_type": "model",
-        "producer_id": producer_id,
-        "valid": False,
-        "reason": reason,
-        "raw_output": raw,
-    }
+    return parse_verdict(
+        raw,
+        shape=SHAPE,
+        identity=(("case_id", case_id), ("criterion_id", selected_id), ("sequence", sequence)),
+        producer_id=selected_producer,
+    ).record()
 
 
 __all__ = ["SCHEMA", "bind", "binding_key", "call"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/gdpval/verdict.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/gdpval/verdict.py
@@ -1,195 +1,56 @@
-"""Parse one judge reply into a verdict record, or a documented failure. No model calls here.
+"""GDPval's verdict dialect — a shape declaration over the shared spine parser.
 
-The judge is asked for ``{"explanation": ..., "criteria_met": true/false}``. Models sometimes
-answer with something else, and a judge can never be trusted to say WHICH criterion it was
-grading. This module handles both problems deterministically:
-
-- ``binding_key`` decodes the ``case_id:rubric_id`` intent the Engine threads through the route.
-- ``bind`` parses one reply, stamping the Engine-known ids onto it, or returns a ``valid: false``
-  record. Either way the raw reply is kept for audit (OME-1023).
-
-INVARIANT: only a REAL JSON boolean counts. A string ``"true"`` or a ``1`` is an invalid reply,
-never a lenient yes — a judge that cannot follow the reply format has not demonstrably followed
-the grading instruction either, and a lenient cast would silently convert that confusion into a
-scored answer.
-
-INVARIANT: ``bind`` RETURNS failures instead of raising. The caller decides what a failure means
-— retry first (the expression re-resolves the nested judge call for a fresh sample), then fail
-the Case loudly with this record as the evidence.
+The parsing work (JSON recovery, strict-boolean gate, identity stamping, mandatory audit
+trail — OME-1023's raw-reply rule included) lives once in ``spine.verdict`` (OME-1099);
+this module keeps only what is GDPval's to own: its schema string and its prose reason
+vocabulary, which reaches the wire on rejected verdicts and must stay byte-identical.
 """
 
 from __future__ import annotations
 
-import json
-from typing import Any
+from screamingface_engine.benchmarks.spine.verdict import (
+    VerdictShape,
+    parse_verdict,
+    require_positive_int,
+)
+from screamingface_engine.benchmarks.spine.verdict import (
+    rubric_binding_key as binding_key,
+)
+from screamingface_engine.benchmarks.spine.verdict import (
+    rubric_verdict_call as call,
+)
 
 SCHEMA = "screamingface.gdpval-rubric-verdict.v1"
 
-
-def call(judge: object, *, case_id: str, rubric_id: str, route: str, retry: int):
-    """Wrap a judge call so a parse retry redraws a FRESH judge sample.
-
-    The problem: a judge sometimes answers with something that is not the JSON we asked for.
-    That is still a SUCCESSFUL model call, so ``;retry=`` on the judge itself would never fire —
-    there is no error to retry.
-
-    The trick: nest the judge INSIDE the verdict call as its context, and put ``;retry=`` on the
-    verdict. The flow becomes:
-
-        judge answers -> verdict route parses -> garbage? -> verdict RAISES ->
-        ``;retry=`` re-resolves the whole nested expression -> the judge is asked AGAIN ->
-        a fresh sample (temperature 0.2) that may parse this time.
-
-    INVARIANT: the judge never sees ``case_id`` or ``rubric_id``. The Engine writes both into
-    the verdict route's intent, so identity is stamped rather than echoed.
-    """
-
-    from url4 import Node, RelExpr, Text, render, src
-
-    if not isinstance(judge, Node):
-        raise ValueError("verdict call needs a URL4 judge node")
-    if not isinstance(route, str) or not route.startswith("/"):
-        raise ValueError("rubric verdict route must be an absolute URL4 path")
-    if isinstance(retry, bool) or not isinstance(retry, int) or retry < 0:
-        raise ValueError("retry must be a non-negative integer")
-    return src(
-        RelExpr(
-            path=route,
-            context=render(judge, check=False),
-            intent=Text(f"{case_id}:{rubric_id}"),
-        ),
-        name="verdict",
-        weight=0.0,
-        retry=retry,
-    )
-
-
-def binding_key(value: str) -> tuple[int, int]:
-    """Decode ``case_id:rubric_id`` — both Engine-assigned positive integers."""
-
-    case_text, separator, rubric_text = value.partition(":")
-    if not separator:
-        raise ValueError("rubric verdict binding must contain case_id:rubric_id")
-    try:
-        case_id = int(case_text)
-        rubric_id = int(rubric_text)
-    except ValueError as exc:
-        raise ValueError("rubric verdict case_id and rubric_id must be positive integers") from exc
-    if case_id < 1 or rubric_id < 1:
-        raise ValueError("rubric verdict case_id and rubric_id must be positive integers")
-    return case_id, rubric_id
+# INVARIANT: only a REAL JSON boolean counts (statuses=None) — a judge that cannot follow
+# the reply format has not demonstrably followed the grading instruction either, and a
+# lenient cast would silently convert that confusion into a scored answer.
+SHAPE = VerdictShape(
+    schema=SCHEMA,
+    status_field="criteria_met",
+    statuses=None,
+    explanation_required=False,
+    reasons={
+        "empty": "empty judge reply",
+        "not_json": "judge reply is not a JSON object",
+        "not_object": "judge reply is not a JSON object",
+        "missing_status": "judge reply lacks criteria_met",
+        "bad_status": "judge reply criteria_met is not a JSON boolean",
+    },
+)
 
 
 def bind(raw: str, *, case_id: int, rubric_id: int, producer_id: str) -> dict[str, object]:
-    """Turn one raw judge reply into a verdict record, or a documented failure.
+    """Turn one raw judge reply into GDPval's verdict record, or a documented failure."""
 
-    AIDEV-NOTE: identity is stamped by the ENGINE, not read from the reply. The judge never saw
-    ``case_id`` or ``rubric_id``; if a reply contains them they are ignored, because a model that
-    invented an id would otherwise be able to redirect a verdict onto another criterion.
-    """
-
-    _require_positive(case_id, "case_id")
-    _require_positive(rubric_id, "rubric_id")
-    if not isinstance(producer_id, str) or not producer_id.strip():
-        raise ValueError("producer_id must be a non-empty string")
-
-    record: dict[str, object] = {
-        "schema": SCHEMA,
-        "case_id": case_id,
-        "rubric_id": rubric_id,
-        "producer_type": "model",
-        "producer_id": producer_id.strip(),
-        # WHY keep the raw text on EVERY verdict, not only rejected ones (OME-1023): a disputed
-        # verdict on a paid run is unfalsifiable unless the reply that produced it can be
-        # re-read — and the original bytes, not the fence-stripped parse, are what expose a
-        # lossy parse. HealthBench and DRACO persist it the same way.
-        "raw_output": raw,
-    }
-    decoded = _decode_object(raw)
-    reason = _invalid_reason(raw, decoded)
-    if reason is not None:
-        return {**record, "valid": False, "reason": reason}
-    assert decoded is not None  # narrowed by _invalid_reason returning None
-    return {
-        **record,
-        "valid": True,
-        "criteria_met": decoded["criteria_met"],
-        "explanation": str(decoded.get("explanation", "")),
-    }
-
-
-def _require_positive(value: object, label: str) -> None:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
-        raise ValueError(f"{label} must be a positive integer")
-
-
-def _decode_object(raw: object) -> dict[str, Any] | None:
-    """Recover the judge's JSON object from however it chose to present it.
-
-    AIDEV-NOTE: the pinned judge (gemini-3.1-pro-preview) wraps its JSON in a ```json fence —
-    measured 2026-08-25, and it failed every Case at rubric 1 until this was handled. DRACO hit
-    the same behaviour with the same model and strips fences for the same reason.
-
-    INVARIANT: recovering the object is NOT the same as relaxing what counts as a verdict.
-    `_invalid_reason` still demands a real JSON boolean, so a fenced reply carrying
-    `"criteria_met": "true"` remains invalid.
-    """
-
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-    text = _without_fences(raw.strip())
-    try:
-        decoded = json.loads(text)
-    except json.JSONDecodeError:
-        decoded = _first_json_value(text)
-    return decoded if isinstance(decoded, dict) else None
-
-
-def _without_fences(text: str) -> str:
-    if "```" not in text:
-        return text
-    return "\n".join(
-        line for line in text.splitlines() if not line.strip().startswith("```")
-    ).strip()
-
-
-def _first_json_value(text: str) -> Any:
-    """The first JSON object embedded in prose, or None.
-
-    WHY a fallback rather than strictness: the alternative is spending two retries and failing
-    the Case on a reply that plainly contains the verdict.
-    """
-
-    start = text.find("{")
-    if start < 0:
-        return None
-    try:
-        value, _ = json.JSONDecoder().raw_decode(text[start:])
-    except json.JSONDecodeError:
-        return None
-    return value
-
-
-def _invalid_reason(raw: object, decoded: dict[str, Any] | None) -> str | None:
-    """The first reason this reply is not a verdict, or ``None`` when it is one.
-
-    INVARIANT: order matters — each check assumes the previous ones passed. The bool check must
-    come last AND be an ``isinstance(..., bool)``: ``isinstance(True, int)`` is True in Python,
-    so a truthiness test would accept a ``1`` as a verdict.
-    """
-
-    checks = (
-        (not isinstance(raw, str) or not raw.strip(), "empty judge reply"),
-        (decoded is None, "judge reply is not a JSON object"),
-        (decoded is not None and "criteria_met" not in decoded, "judge reply lacks criteria_met"),
-        (
-            decoded is not None
-            and "criteria_met" in decoded
-            and not isinstance(decoded["criteria_met"], bool),
-            "judge reply criteria_met is not a JSON boolean",
-        ),
-    )
-    return next((reason for failed, reason in checks if failed), None)
+    require_positive_int(case_id, "case_id")
+    require_positive_int(rubric_id, "rubric_id")
+    return parse_verdict(
+        raw,
+        shape=SHAPE,
+        identity=(("case_id", case_id), ("rubric_id", rubric_id)),
+        producer_id=producer_id,
+    ).record()
 
 
 __all__ = ["SCHEMA", "bind", "binding_key", "call"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/verdict.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/healthbench/verdict.py
@@ -1,194 +1,57 @@
-"""Turn raw judge replies into trustworthy verdicts, tied to the right rubric item.
+"""HealthBench's verdict dialect — a shape declaration over the shared spine parser.
 
-The judge model returns free text that *should* be ``{"explanation": ...,
-"criteria_met": true/false}`` — but models produce garbage sometimes, and a judge
-can never be trusted to say which Case/rubric item it was grading. This module
-handles both problems deterministically:
-
-- ``call``  — wires the judge call into the expression so a garbage reply can be
-  retried with a fresh sample (see its docstring for the nesting trick).
-- ``bind``  — parses one reply into a verdict record, stamping on the
-  Engine-known ``case_id``/``rubric_id`` (the judge never sees them), or returns
-  a documented ``valid: false`` failure with the raw reply kept for audit.
-- ``binding_key`` — decodes the ``case_id:rubric_id`` intent the Engine threads
-  through the verdict route.
-
-No model calls happen here — everything is pure parsing and validation.
+The parsing work (JSON recovery, strict-boolean gate, identity stamping, mandatory audit
+trail) lives once in ``spine.verdict`` (OME-1099); this module keeps only what is
+HealthBench's to own: its schema string, its reason vocabulary, and the strict-bool
+``criteria_met`` dialect that mirrors the reference ``grade_sample`` loop
+(https://github.com/openai/simple-evals/blob/main/healthbench_eval.py).
 """
 
 from __future__ import annotations
 
-import json
-from collections.abc import Mapping
-from typing import Any
+from screamingface_engine.benchmarks.spine.verdict import (
+    VerdictShape,
+    parse_verdict,
+    require_positive_int,
+)
+from screamingface_engine.benchmarks.spine.verdict import (
+    rubric_binding_key as binding_key,
+)
+from screamingface_engine.benchmarks.spine.verdict import (
+    rubric_verdict_call as call,
+)
 
 SCHEMA = "screamingface.healthbench-rubric-verdict.v1"
 
-
-def call(judge: object, *, case_id: str, rubric_id: str, route: str, retry: int):
-    """Wrap a judge call so parse retries redraw a FRESH judge sample.
-
-    The problem this solves: the judge sometimes answers with garbage (not the
-    JSON we asked for). Garbage is still a *successful* model call — so putting
-    ``;retry=`` on the judge itself would never fire; there is no error to retry.
-
-    The trick: nest the judge INSIDE the verdict call (as its context), and put
-    ``;retry=`` on the verdict. Now the flow is:
-
-        judge answers → verdict route parses → garbage? → verdict RAISES →
-        ``;retry=`` re-resolves the whole nested expression → the judge is
-        asked AGAIN → a fresh sample (provider-default temperature) that may
-        parse this time.
-
-    This is exactly the reference's own recovery loop — ``grade_sample`` re-asks
-    on bad JSON (https://github.com/openai/simple-evals/blob/main/healthbench_eval.py)
-    — except bounded at ``retry`` attempts instead of forever.
-    Shape follows draco's ``verdict.call``.
-    """
-
-    from url4 import Node, RelExpr, Text, render, src
-
-    if not isinstance(judge, Node):
-        raise ValueError("verdict call needs a URL4 judge node")
-    if not isinstance(route, str) or not route.startswith("/"):
-        raise ValueError("rubric verdict route must be an absolute URL4 path")
-    if isinstance(retry, bool) or not isinstance(retry, int) or retry < 0:
-        raise ValueError("retry must be a non-negative integer")
-    return src(
-        RelExpr(
-            path=route,
-            context=render(judge, check=False),
-            # The Engine writes both ids into the intent — the judge never sees them.
-            intent=Text(f"{case_id}:{rubric_id}"),
-        ),
-        name="verdict",
-        weight=0.0,
-        retry=retry,
-    )
+# INVARIANT: only a REAL JSON boolean counts (statuses=None) — a string "true" or a 1 is
+# an invalid reply, never a lenient yes; the reference loops until `label is True or
+# label is False`, so anything else must trigger a retry, not a verdict.
+SHAPE = VerdictShape(
+    schema=SCHEMA,
+    status_field="criteria_met",
+    statuses=None,
+    explanation_required=False,
+    reasons={
+        "empty": "empty",
+        "not_json": "invalid_json",
+        "not_object": "invalid_shape",
+        "missing_status": "invalid_criteria_met",
+        "bad_status": "invalid_criteria_met",
+    },
+)
 
 
-def binding_key(value: str) -> tuple[int, int]:
-    """Decode ``case_id:rubric_id`` — both Engine-assigned positive integers."""
+def bind(raw: str, *, case_id: int, rubric_id: int, producer_id: str) -> dict[str, object]:
+    """Turn one raw judge reply into HealthBench's verdict record, or a documented failure."""
 
-    case_text, separator, rubric_text = value.partition(":")
-    if not separator:
-        raise ValueError("rubric verdict binding must contain case_id:rubric_id")
-    try:
-        case_id = int(case_text)
-        rubric_id = int(rubric_text)
-    except ValueError as exc:
-        raise ValueError("rubric verdict case_id and rubric_id must be positive integers") from exc
-    if case_id < 1 or rubric_id < 1:
-        raise ValueError("rubric verdict case_id and rubric_id must be positive integers")
-    return case_id, rubric_id
+    require_positive_int(case_id, "case_id")
+    require_positive_int(rubric_id, "rubric_id")
+    return parse_verdict(
+        raw,
+        shape=SHAPE,
+        identity=(("case_id", case_id), ("rubric_id", rubric_id)),
+        producer_id=producer_id,
+    ).record()
 
 
-def bind(
-    raw: str,
-    *,
-    case_id: int,
-    rubric_id: int,
-    producer_id: str,
-) -> dict[str, object]:
-    """Turn one raw judge reply into a verdict record, or a documented failure.
-
-    The judge was asked for ``{"explanation": ..., "criteria_met": true/false}``.
-    This function decides whether what came back counts as a verdict:
-
-    - Parseable with a REAL JSON boolean ``criteria_met`` → ``valid: true`` plus
-      the verdict. A string ``"true"`` or a ``1`` does NOT count — the reference
-      ``grade_sample`` loops until ``label is True or label is False``
-      (https://github.com/openai/simple-evals/blob/main/healthbench_eval.py),
-      so anything else is an invalid reply, never a lenient yes.
-    - Anything else (empty, bad JSON, wrong shape, non-bool) → ``valid: false``
-      with a ``reason`` and the raw output kept for audit.
-
-    Note it RETURNS the failure instead of raising: the caller (runtime's verdict
-    route) decides what a failure means — retry first, then fail the Case loudly
-    with this record as the evidence.
-
-    The Engine stamps ``case_id``/``rubric_id`` on here itself; the judge never
-    saw those ids and cannot be trusted to echo them.
-    """
-
-    if isinstance(case_id, bool) or not isinstance(case_id, int) or case_id < 1:
-        raise ValueError("case_id must be a positive integer")
-    if isinstance(rubric_id, bool) or not isinstance(rubric_id, int) or rubric_id < 1:
-        raise ValueError("rubric_id must be a positive integer")
-    selected_producer = _text(producer_id, "producer_id")
-    decoded = _decode_object(raw)
-    reason = _invalid_reason(raw, decoded)
-    common: dict[str, object] = {
-        "schema": SCHEMA,
-        "case_id": case_id,
-        "rubric_id": rubric_id,
-        "producer_type": "model",
-        "producer_id": selected_producer,
-        "raw_output": raw,
-    }
-    if reason is not None:
-        return {**common, "valid": False, "reason": reason}
-    assert isinstance(decoded, Mapping)
-    criteria_met = decoded.get("criteria_met")
-    assert criteria_met is True or criteria_met is False
-    explanation = decoded.get("explanation")
-    return {
-        **common,
-        "valid": True,
-        "criteria_met": criteria_met,
-        "explanation": explanation if isinstance(explanation, str) else "",
-    }
-
-
-def _invalid_reason(raw: object, decoded: object) -> str | None:
-    if not isinstance(raw, str) or not raw.strip():
-        reason = "empty"
-    elif decoded is None:
-        reason = "invalid_json"
-    elif not isinstance(decoded, Mapping):
-        reason = "invalid_shape"
-    # WHY: `is True / is False`, not truthiness — mirrors the reference's strict-bool
-    # gate and the July port's StrictBool; "true"/1 must trigger a retry, not a verdict.
-    elif not (decoded.get("criteria_met") is True or decoded.get("criteria_met") is False):
-        reason = "invalid_criteria_met"
-    else:
-        reason = None
-    return reason
-
-
-def _decode_object(raw: object) -> Any:
-    if not isinstance(raw, str) or not raw.strip():
-        return None
-    text = _without_fences(raw.strip())
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return _first_json_value(text)
-
-
-def _without_fences(text: str) -> str:
-    if "```" not in text:
-        return text
-    return "\n".join(
-        line for line in text.splitlines() if not line.strip().startswith("```")
-    ).strip()
-
-
-def _first_json_value(text: str) -> Any:
-    start = text.find("{")
-    if start < 0:
-        return None
-    try:
-        value, _ = json.JSONDecoder().raw_decode(text[start:])
-    except json.JSONDecodeError:
-        return None
-    return value
-
-
-def _text(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value.strip():
-        raise ValueError(f"{label} must be non-empty text")
-    return value
-
-
-__all__ = ["SCHEMA", "bind", "binding_key"]
+__all__ = ["SCHEMA", "bind", "binding_key", "call"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/rubric_check.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/rubric_check.py
@@ -52,6 +52,7 @@ from screamingface_engine.benchmarks.contract import CANDIDATE_INPUT_SCHEMA
 from screamingface_engine.benchmarks.ensemble.policy import CHECK_SURFACE_SCHEMA
 from screamingface_engine.benchmarks.evaluation import benchmark_unavailable as _unavailable
 from screamingface_engine.benchmarks.evaluation import candidate_answer, compact_json, json_object
+from screamingface_engine.benchmarks.spine.verdict import recovered_array
 from url4 import RelExpr, Text, expr, render, src
 from url4.core.errors import ResolutionError
 from url4.peer.server import Request, Url4Node
@@ -442,15 +443,9 @@ def _verdict_row(row: object, count: int) -> tuple[int, bool] | None:
 
 
 def _decoded_array(reply: str) -> list[object] | None:
-    text = "\n".join(line for line in (reply or "").splitlines() if not line.startswith("```"))
-    start = text.find("[")
-    if start < 0:
-        return None
-    try:
-        decoded, _ = json.JSONDecoder().raw_decode(text[start:])
-    except ValueError:
-        return None
-    return decoded if isinstance(decoded, list) else None
+    # The shared JSON-recovery primitive (spine.verdict, OME-1099) — same fence
+    # stripping and first-value scan as the per-item verdict parsers.
+    return recovered_array(reply or "")
 
 
 # --- scoring + sanitization -------------------------------------------------------

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/__init__.py
@@ -16,6 +16,7 @@ from screamingface_engine.benchmarks.spine.scored import (
     GradeRequest,
     ScoredPath,
 )
+from screamingface_engine.benchmarks.spine.verdict import Verdict, VerdictShape, parse_verdict
 
 __all__ = [
     "CaseGradeOutcome",
@@ -27,6 +28,9 @@ __all__ = [
     "RowReader",
     "ScoredPath",
     "TextPayload",
+    "Verdict",
+    "VerdictShape",
+    "parse_verdict",
     "read_selected_cases",
     "rubric_grade_case",
 ]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/verdict.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/verdict.py
@@ -1,0 +1,341 @@
+"""The one judge-verdict parser every rubric board configures. No model calls here.
+
+FEATURE: one grading spine per benchmark (OME-1024; this module lands OME-1099 and
+delivers the typed record OME-1025 asked for).
+STORY: as the next rubric board, I declare my verdict dialect and get parsing for free —
+I cannot drift a copy, and I cannot drop an audit field.
+
+Mental model: a judge replies in text that *should* be JSON, and can never be trusted to
+say WHICH criterion it was grading. Turning that reply into evidence is the same work on
+every board — recover the JSON from however the judge presented it, demand the board's
+verdict field, stamp the Engine-known identity on, keep the raw reply for audit. Only the
+paperwork differs per board, so the work lives here once and each board supplies a
+``VerdictShape``: its schema string, its verdict field (an enum status or a strict JSON
+boolean), and its reason vocabulary — merged parsers, unchanged wire records.
+
+Worked example (the bool dialect): raw ``'```json\\n{"criteria_met": true}\\n```'`` →
+fences stripped → JSON recovered → ``criteria_met`` is a real boolean → a valid
+``Verdict`` whose ``raw_output`` still holds the ORIGINAL fenced bytes. The same reply
+with ``"criteria_met": "true"`` is invalid (``bad_status``) — recovery never softens what
+counts as a verdict.
+
+INVARIANT (OME-1023): every audit field on ``Verdict`` is a required constructor
+argument — no defaults — so a caller omitting ``raw_output`` fails typecheck and runtime
+construction. ``raw_output: ""`` was type-valid with the wrong meaning; absence is not.
+
+INVARIANT: identity is stamped by the ENGINE, never read from the reply. A model that
+invented an id could otherwise redirect a verdict onto another criterion.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+# Canonical failure codes, in detection order. Each board's shape maps every code it can
+# hit onto its own wire ``reason`` string, so merging the parsers changed no records.
+_FAILURE_CODES = (
+    "empty",
+    "not_json",
+    "not_object",
+    "bad_explanation",
+    "missing_status",
+    "bad_status",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class VerdictShape:
+    """One board's verdict dialect — arguments, not code.
+
+    Args (as fields):
+        schema: the board's wire schema string, stamped on every record.
+        status_field: the reply field carrying the verdict (``criterion_status``,
+            ``criteria_met``).
+        statuses: the accepted enum values (``("MET", "UNMET")``), or ``None`` for a
+            strict JSON boolean — ``"true"``/``1`` never count (simple-evals parity).
+        explanation_required: whether a reply without a text ``explanation`` is invalid
+            (draco) or tolerated as empty text (the rubric boards).
+        reasons: canonical failure code → this board's wire ``reason`` string.
+    """
+
+    schema: str
+    status_field: str
+    statuses: tuple[str, ...] | None
+    explanation_required: bool
+    reasons: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        required = {code for code in _FAILURE_CODES if code != "bad_explanation"}
+        if self.explanation_required:
+            required.add("bad_explanation")
+        missing = required - set(self.reasons)
+        if missing:
+            raise ValueError(f"verdict shape must name a reason for {sorted(missing)}")
+
+
+@dataclass(frozen=True, slots=True)
+class Verdict:
+    """One judge reply bound to Engine identity — the audit trail is mandatory.
+
+    INVARIANT: NO field has a default (pinned by test). Every call site must hand over
+    the full audit trail, so a parser cannot silently drop ``raw_output`` again.
+    """
+
+    schema: str
+    #: Engine-stamped identity fields in wire order, e.g. ``(("case_id", 1), ("rubric_id", 2))``.
+    identity: tuple[tuple[str, int | str], ...]
+    producer_id: str
+    #: The judge's ORIGINAL bytes — never the fence-stripped parse; a lossy parse is
+    #: exactly what the audit trail exists to expose.
+    raw_output: str
+    valid: bool
+    #: The board-dialect verdict fields when valid (status + explanation); empty otherwise.
+    payload: tuple[tuple[str, object], ...]
+    reason: str | None
+
+    def __post_init__(self) -> None:
+        if self.valid is (self.reason is not None):
+            raise ValueError("a verdict is either valid or carries a reason, never both")
+
+    def record(self) -> dict[str, object]:
+        """Project into the wire dict the runtimes persist — byte-identical to the old copies."""
+
+        value: dict[str, object] = {
+            "schema": self.schema,
+            **dict(self.identity),
+            "producer_type": "model",
+            "producer_id": self.producer_id,
+            "valid": self.valid,
+            "raw_output": self.raw_output,
+        }
+        if self.valid:
+            value.update(self.payload)
+        else:
+            value["reason"] = self.reason
+        return value
+
+
+def parse_verdict(
+    raw: str,
+    *,
+    shape: VerdictShape,
+    identity: tuple[tuple[str, int | str], ...],
+    producer_id: str,
+) -> Verdict:
+    """Turn one raw judge reply into a ``Verdict``, or a documented failure.
+
+    Stages, in execution order:
+
+    1. Recover the JSON from however the judge presented it (fenced, prose-prefixed, bare).
+    2. Walk the failure checks in canonical order; the first hit becomes the board's
+       ``reason`` string via the shape's vocabulary.
+    3. A clean reply yields the board-dialect payload; either way the ORIGINAL bytes ride
+       along as ``raw_output``.
+
+    INVARIANT: this RETURNS failures instead of raising. The caller (a runtime's verdict
+    route) decides what a failure means — retry first, then fail the Case loudly with
+    this record as the evidence.
+    """
+
+    require_text(producer_id, "producer_id")
+    decoded = recovered_object(raw)
+    code = _failure_code(shape, raw, decoded)
+    if code is not None:
+        return Verdict(
+            schema=shape.schema,
+            identity=identity,
+            producer_id=producer_id,
+            raw_output=raw,
+            valid=False,
+            payload=(),
+            reason=shape.reasons[code],
+        )
+    assert isinstance(decoded, Mapping)  # narrowed by _failure_code returning None
+    return Verdict(
+        schema=shape.schema,
+        identity=identity,
+        producer_id=producer_id,
+        raw_output=raw,
+        valid=True,
+        payload=_payload(shape, decoded),
+        reason=None,
+    )
+
+
+def _failure_code(shape: VerdictShape, raw: object, decoded: object) -> str | None:
+    """The first canonical reason this reply is not a verdict, or None when it is one.
+
+    INVARIANT: order matters — each check assumes the previous ones passed, and the
+    boolean check must be identity (`is True / is False`), never truthiness:
+    ``isinstance(True, int)`` is True in Python, so a ``1`` would otherwise pass.
+    """
+
+    def accepted_status(value: object) -> bool:
+        if shape.statuses is None:
+            return value is True or value is False
+        return value in shape.statuses
+
+    is_object = isinstance(decoded, Mapping)
+    reply: Mapping[str, Any] = decoded if isinstance(decoded, Mapping) else {}
+    checks = (
+        (not isinstance(raw, str) or not raw.strip(), "empty"),
+        (decoded is None, "not_json"),
+        (not is_object, "not_object"),
+        (
+            shape.explanation_required and not isinstance(reply.get("explanation"), str),
+            "bad_explanation",
+        ),
+        (shape.status_field not in reply, "missing_status"),
+        (not accepted_status(reply.get(shape.status_field)), "bad_status"),
+    )
+    return next((code for failed, code in checks if failed), None)
+
+
+def _payload(shape: VerdictShape, decoded: Mapping[str, Any]) -> tuple[tuple[str, object], ...]:
+    """The board-dialect verdict fields off a reply `_failure_code` already accepted."""
+
+    status: object = decoded[shape.status_field]
+    explanation = decoded.get("explanation")
+    if shape.statuses is None:
+        # Bool dialect tolerates a missing/non-text explanation as empty text; the enum
+        # dialect already required it (`bad_explanation`), so it is a str here.
+        text = explanation if isinstance(explanation, str) else ""
+        return ((shape.status_field, status), ("explanation", text))
+    return (("explanation", explanation), (shape.status_field, status))
+
+
+# --- JSON recovery — shared by every dialect and the check surface -----------------------
+
+
+def recovered_object(raw: object) -> Any:
+    """The judge's JSON value from however it chose to present it, or None.
+
+    AIDEV-NOTE: the pinned rubric judge (gemini-3.1-pro-preview) wraps its JSON in a
+    ```json fence — measured 2026-08-25; unhandled, it failed every Case at rubric 1.
+    WHY the prose fallback rather than strictness: the alternative is burning retries and
+    failing the Case on a reply that plainly contains the verdict.
+    """
+
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    text = _without_fences(raw.strip())
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return _first_json_value(text, "{")
+
+
+def recovered_array(reply: str) -> list[object] | None:
+    """The first JSON array embedded in a judge reply, or None — the check surface's shape."""
+
+    if not isinstance(reply, str):
+        return None
+    decoded = _first_json_value(_without_fences(reply), "[")
+    return decoded if isinstance(decoded, list) else None
+
+
+def _without_fences(text: str) -> str:
+    if "```" not in text:
+        return text
+    return "\n".join(
+        line for line in text.splitlines() if not line.strip().startswith("```")
+    ).strip()
+
+
+def _first_json_value(text: str, opener: str) -> Any:
+    start = text.find(opener)
+    if start < 0:
+        return None
+    try:
+        value, _ = json.JSONDecoder().raw_decode(text[start:])
+    except json.JSONDecodeError:
+        return None
+    return value
+
+
+# --- shared scalar validation ------------------------------------------------------------
+
+
+def require_positive_int(value: object, label: str) -> int:
+    """One Engine-assigned positive integer id, or the field-specific ValueError."""
+
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def require_text(value: object, label: str) -> str:
+    """One non-empty text field, unnormalized — evidence needs an attributable producer."""
+
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be non-empty text")
+    return value
+
+
+# --- shared rubric wiring (healthbench and gdpval were byte-identical copies) ------------
+
+
+def rubric_binding_key(value: str) -> tuple[int, int]:
+    """Decode ``case_id:rubric_id`` — both Engine-assigned positive integers."""
+
+    case_text, separator, rubric_text = value.partition(":")
+    if not separator:
+        raise ValueError("rubric verdict binding must contain case_id:rubric_id")
+    try:
+        case_id = int(case_text)
+        rubric_id = int(rubric_text)
+    except ValueError as exc:
+        raise ValueError("rubric verdict case_id and rubric_id must be positive integers") from exc
+    if case_id < 1 or rubric_id < 1:
+        raise ValueError("rubric verdict case_id and rubric_id must be positive integers")
+    return case_id, rubric_id
+
+
+def rubric_verdict_call(judge: object, *, case_id: str, rubric_id: str, route: str, retry: int):
+    """Wrap a judge call so a parse retry redraws a FRESH judge sample.
+
+    The problem: a garbage reply is still a SUCCESSFUL model call, so ``;retry=`` on the
+    judge itself would never fire — there is no error to retry. The trick: nest the judge
+    INSIDE the verdict call as its context and put ``;retry=`` on the verdict, so a parse
+    failure re-resolves the whole nested expression and re-asks the judge. This is the
+    reference's own recovery loop (simple-evals ``grade_sample`` re-asks on bad JSON),
+    bounded at ``retry`` attempts instead of forever.
+
+    INVARIANT: the judge never sees ``case_id`` or ``rubric_id`` — the Engine writes both
+    into the verdict route's intent, so identity is stamped rather than echoed.
+    """
+
+    from url4 import Node, RelExpr, Text, render, src
+
+    if not isinstance(judge, Node):
+        raise ValueError("verdict call needs a URL4 judge node")
+    if not isinstance(route, str) or not route.startswith("/"):
+        raise ValueError("rubric verdict route must be an absolute URL4 path")
+    if isinstance(retry, bool) or not isinstance(retry, int) or retry < 0:
+        raise ValueError("retry must be a non-negative integer")
+    return src(
+        RelExpr(
+            path=route,
+            context=render(judge, check=False),
+            intent=Text(f"{case_id}:{rubric_id}"),
+        ),
+        name="verdict",
+        weight=0.0,
+        retry=retry,
+    )
+
+
+__all__ = [
+    "Verdict",
+    "VerdictShape",
+    "parse_verdict",
+    "recovered_array",
+    "recovered_object",
+    "require_positive_int",
+    "require_text",
+    "rubric_binding_key",
+    "rubric_verdict_call",
+]

--- a/apps/screamingface-engine/tests/unit/test_spine_verdict.py
+++ b/apps/screamingface-engine/tests/unit/test_spine_verdict.py
@@ -1,0 +1,262 @@
+"""The one shared verdict parser — and the typed record that cannot drop its audit trail.
+
+INVARIANT under test (OME-1099, born from OME-1023): every audit field on a verdict record
+is a REQUIRED constructor argument. The regression this prevents: a new board's parser
+silently omitting ``raw_output`` on valid verdicts, leaving a scored criterion with nothing
+to re-read when a grade is disputed.
+
+INVARIANT under test: merging the parsers changed no board's wire records. Each board's
+schema string, reason vocabulary, and payload fields are byte-identical to the drifted
+copies this module replaced — the shape declaration carries the differences, the parser
+carries the work.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import MISSING, fields
+from typing import Any, cast
+
+import pytest
+
+from screamingface_engine.benchmarks.spine.verdict import (
+    Verdict,
+    VerdictShape,
+    parse_verdict,
+    recovered_array,
+    rubric_binding_key,
+)
+
+# The two real payload dialects, spelled the way the boards declare them.
+ENUM_SHAPE = VerdictShape(
+    schema="test.enum-verdict.v1",
+    status_field="criterion_status",
+    statuses=("MET", "UNMET"),
+    explanation_required=True,
+    reasons={
+        "empty": "empty",
+        "not_json": "invalid_json",
+        "not_object": "invalid_shape",
+        "bad_explanation": "invalid_shape",
+        "missing_status": "invalid_shape",
+        "bad_status": "invalid_status",
+    },
+)
+BOOL_SHAPE = VerdictShape(
+    schema="test.bool-verdict.v1",
+    status_field="criteria_met",
+    statuses=None,
+    explanation_required=False,
+    reasons={
+        "empty": "empty judge reply",
+        "not_json": "judge reply is not a JSON object",
+        "not_object": "judge reply is not a JSON object",
+        "missing_status": "judge reply lacks criteria_met",
+        "bad_status": "judge reply criteria_met is not a JSON boolean",
+    },
+)
+
+
+def _bool_bind(raw: str) -> dict[str, object]:
+    return parse_verdict(
+        raw,
+        shape=BOOL_SHAPE,
+        identity=(("case_id", 1), ("rubric_id", 2)),
+        producer_id="judge-x",
+    ).record()
+
+
+# --- the typed record refuses to lose its audit trail ------------------------------------
+
+
+def test_every_audit_field_is_a_required_constructor_argument() -> None:
+    # INVARIANT: no field of the verdict record carries a default. A default on
+    # `raw_output` is exactly the OME-1023 bug re-armed: `raw_output=""` is type-valid
+    # with the wrong meaning, so the only safe default is none at all — omitting the
+    # field must fail pyright at every call site (and TypeError at runtime).
+    for field in fields(Verdict):
+        assert field.default is MISSING and field.default_factory is MISSING, (
+            f"Verdict.{field.name} has a default — an audit field a caller can silently drop"
+        )
+
+
+def test_constructing_a_verdict_without_the_raw_reply_fails() -> None:
+    # The runtime floor of the type-level rule: pyright rejects the omission statically
+    # (no default on the field), and the dataclass rejects it at runtime too.
+    with pytest.raises(TypeError):
+        cast(Any, Verdict)(
+            schema="test.enum-verdict.v1",
+            identity=(("case_id", 1),),
+            producer_id="judge-x",
+            valid=False,
+            payload=(),
+            reason="empty",
+        )
+
+
+def test_a_verdict_is_either_valid_or_carries_a_reason_never_both() -> None:
+    with pytest.raises(ValueError):
+        Verdict(
+            schema="s",
+            identity=(("case_id", 1),),
+            producer_id="j",
+            raw_output="raw",
+            valid=True,
+            payload=(("criteria_met", True),),
+            reason="empty",
+        )
+    with pytest.raises(ValueError):
+        Verdict(
+            schema="s",
+            identity=(("case_id", 1),),
+            producer_id="j",
+            raw_output="raw",
+            valid=False,
+            payload=(),
+            reason=None,
+        )
+
+
+# --- one parser, each board's exact wire record ------------------------------------------
+
+
+def test_the_enum_dialect_produces_dracos_exact_valid_record() -> None:
+    raw = json.dumps({"explanation": "The requirement is present.", "criterion_status": "MET"})
+    record = parse_verdict(
+        raw,
+        shape=ENUM_SHAPE,
+        identity=(("case_id", 7), ("criterion_id", "actual-id"), ("sequence", 1)),
+        producer_id="fixture-judge",
+    ).record()
+    assert record == {
+        "schema": "test.enum-verdict.v1",
+        "case_id": 7,
+        "criterion_id": "actual-id",
+        "sequence": 1,
+        "producer_type": "model",
+        "producer_id": "fixture-judge",
+        "valid": True,
+        "explanation": "The requirement is present.",
+        "criterion_status": "MET",
+        "raw_output": raw,
+    }
+
+
+def test_the_bool_dialect_produces_the_rubric_boards_exact_valid_record() -> None:
+    raw = json.dumps({"explanation": "because", "criteria_met": False})
+    assert _bool_bind(raw) == {
+        "schema": "test.bool-verdict.v1",
+        "case_id": 1,
+        "rubric_id": 2,
+        "producer_type": "model",
+        "producer_id": "judge-x",
+        "valid": True,
+        "criteria_met": False,
+        "explanation": "because",
+        "raw_output": raw,
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason"),
+    [
+        ("", "empty"),
+        ("   ", "empty"),
+        ("not json", "invalid_json"),
+        ("[1, 2]", "invalid_shape"),
+        ('{"criterion_status": "MET"}', "invalid_shape"),  # explanation missing
+        ('{"explanation": 5, "criterion_status": "MET"}', "invalid_shape"),
+        ('{"explanation": "x"}', "invalid_shape"),  # status missing
+        ('{"explanation": "x", "criterion_status": "MAYBE"}', "invalid_status"),
+    ],
+)
+def test_the_enum_dialect_keeps_dracos_reason_vocabulary(raw: str, reason: str) -> None:
+    record = parse_verdict(
+        raw, shape=ENUM_SHAPE, identity=(("case_id", 1),), producer_id="j"
+    ).record()
+    assert record["valid"] is False
+    assert record["reason"] == reason
+    # WHY: the reply is kept even when rejected — the rejection is only auditable
+    # against what the judge actually said.
+    assert record["raw_output"] == raw
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason"),
+    [
+        ("", "empty judge reply"),
+        ("prose only", "judge reply is not a JSON object"),
+        ("[1, 2]", "judge reply is not a JSON object"),
+        ('{"explanation": "x"}', "judge reply lacks criteria_met"),
+        (
+            '{"explanation": "x", "criteria_met": "true"}',
+            "judge reply criteria_met is not a JSON boolean",
+        ),
+        (
+            '{"explanation": "x", "criteria_met": 1}',
+            "judge reply criteria_met is not a JSON boolean",
+        ),
+    ],
+)
+def test_the_bool_dialect_keeps_gdpvals_reason_vocabulary(raw: str, reason: str) -> None:
+    # INVARIANT: only a REAL JSON boolean counts — "true" and 1 stay invalid replies,
+    # exactly as the reference grade_sample loops on `label is True or label is False`.
+    record = _bool_bind(raw)
+    assert record["valid"] is False
+    assert record["reason"] == reason
+
+
+def test_fenced_and_prose_wrapped_json_is_recovered_with_original_bytes_kept() -> None:
+    raw = 'Here is my verdict:\n```json\n{"explanation": "ok", "criteria_met": true}\n```'
+    record = _bool_bind(raw)
+    assert record["valid"] is True
+    assert record["criteria_met"] is True
+    # INVARIANT: the ORIGINAL bytes are the audit trail — persisting the fence-stripped
+    # parse would hide exactly the lossy-parse case the trail exists to expose.
+    assert record["raw_output"] == raw
+
+
+def test_a_non_string_explanation_on_a_valid_bool_verdict_becomes_empty_text() -> None:
+    record = _bool_bind('{"explanation": 5, "criteria_met": true}')
+    assert record["valid"] is True
+    assert record["explanation"] == ""
+
+
+def test_the_parser_never_trusts_identity_the_judge_claims() -> None:
+    raw = json.dumps({"explanation": "x", "criteria_met": True, "case_id": 999, "rubric_id": 888})
+    record = _bool_bind(raw)
+    assert record["case_id"] == 1
+    assert record["rubric_id"] == 2
+
+
+def test_a_blank_producer_id_is_refused() -> None:
+    # WHY: the verdict record is evidence; evidence with no attributable producer
+    # cannot be audited after the fact.
+    with pytest.raises(ValueError):
+        parse_verdict("{}", shape=BOOL_SHAPE, identity=(("case_id", 1),), producer_id="  ")
+
+
+# --- shared rubric wiring (healthbench and gdpval were byte-identical) -------------------
+
+
+def test_rubric_binding_key_decodes_case_and_rubric_ids() -> None:
+    assert rubric_binding_key("12:34") == (12, 34)
+
+
+@pytest.mark.parametrize("value", ["", "12", "12:", ":34", "a:b", "0:1", "1:0", "-1:2"])
+def test_rubric_binding_key_rejects_malformed_or_non_positive(value: str) -> None:
+    with pytest.raises(ValueError):
+        rubric_binding_key(value)
+
+
+# --- the check surface's array recovery shares the same JSON-recovery primitive ----------
+
+
+def test_recovered_array_reads_a_fenced_ordinal_reply() -> None:
+    reply = '```json\n[{"id": 1, "status": "MET"}]\n```'
+    assert recovered_array(reply) == [{"id": 1, "status": "MET"}]
+
+
+def test_recovered_array_refuses_replies_with_no_array() -> None:
+    assert recovered_array("no verdicts here") is None
+    assert recovered_array("") is None

--- a/docs/tasks/2026-09-03-OME-1099-shared-verdict-parser.md
+++ b/docs/tasks/2026-09-03-OME-1099-shared-verdict-parser.md
@@ -1,0 +1,28 @@
+---
+id: OME-1099
+linear_url: https://linear.app/openmined/issue/OME-1099/merge-the-three-drifted-judge-verdict-parsers-into-one-typed-shared
+status: in_progress
+type: task
+priority: medium
+labels:
+  - screamingface-engine
+  - agentic
+  - autonomous
+created: 2026-09-03
+closed:
+---
+
+# Merge the three drifted judge-verdict parsers into one typed shared parser
+
+Verdict parsing (judge reply → record with mandatory audit fields) exists four times —
+the check surface in `rubric_check.py` and per-board copies in `draco/verdict.py`,
+`healthbench/verdict.py`, `gdpval/verdict.py` — and the copies have drifted (OME-1023:
+the newest copy silently dropped the raw reply on valid verdicts, and nothing caught it).
+
+Merge the parsing into one spine module with a typed record whose audit fields (raw
+reply among them) are required constructor arguments, so omitting one fails typecheck.
+Boards keep their own verdict semantics by declaring their shape (schema, status field,
+enum vs strict boolean, reason vocabulary). Delivers OME-1025. Wire records stay
+byte-identical; draco-3pass and healthbench-worst30 goldens stay green.
+
+Ledger: `docs/work/2026-09-09-OME-1099-shared-verdict-parser.md`

--- a/docs/work/2026-09-09-OME-1099-shared-verdict-parser.md
+++ b/docs/work/2026-09-09-OME-1099-shared-verdict-parser.md
@@ -1,0 +1,98 @@
+---
+ticket: OME-1099
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-09
+finished:
+---
+
+# OME-1099 — Merge the three drifted judge-verdict parsers into one typed shared parser
+
+## Intent
+
+Verdict parsing (judge reply → typed record with mandatory audit fields) exists four
+times: `rubric_check.py`'s verdict section and the three per-board `verdict.py` files
+(draco, healthbench, gdpval). The copies have drifted (0.45 similarity between the two
+that share a docstring), and the drift already cost us OME-1023 (a copy silently
+dropped `raw_output` on valid verdicts). This unit merges the *parsing* into one spine
+module with a typed record whose audit fields are required constructor arguments, so a
+new rubric board cannot drop an audit field. Per-board verdict *semantics* stay
+board-owned via shape declarations. Delivers OME-1025.
+
+## Planned changes
+
+- **Create** `src/screamingface_engine/benchmarks/spine/verdict.py` — the one parser:
+  - `Verdict` frozen dataclass: `schema`, `identity` (engine-stamped ids), `producer_id`,
+    `raw_output`, `valid`, `payload`, `reason` — **no defaults on audit fields**, so
+    omitting `raw_output` fails both pyright and runtime construction. `.record()`
+    projects to the wire dict the runtimes persist today (byte-identical keys/values).
+  - `VerdictShape` frozen dataclass — per-board declaration: `schema`, status field
+    name + accepted values (enum `("MET","UNMET")` vs strict JSON bool), whether
+    `explanation` is required, and the board's reason-string vocabulary (canonical
+    failure code → board wire string), so each board's `reason` values stay
+    byte-identical.
+  - Shared JSON recovery: fence stripping + first-JSON-value fallback (today
+    byte-identical in all three `verdict.py`), exposed for both `{`-objects and
+    `[`-arrays.
+  - Shared `rubric_binding_key` (healthbench/gdpval byte-identical today) and shared
+    rubric `call()` retry wrapper (healthbench/gdpval byte-identical today).
+- **Reduce** `benchmarks/draco/verdict.py`, `benchmarks/healthbench/verdict.py`,
+  `benchmarks/gdpval/verdict.py` to shape declarations + board-specific wiring
+  (draco keeps its own `call`/`binding_key` — different intent format); public API
+  (`SCHEMA`, `bind`, `binding_key`, `call`) unchanged so runtimes/exams/case_results
+  keep importing from the board modules.
+- **Rewire** `benchmarks/rubric_check.py` `_decoded_array` onto the shared JSON
+  recovery (the check surface's ordinal-array parsing stays local — different shape,
+  same recovery primitive).
+- **Export** the new names from `benchmarks/spine/__init__.py`.
+- Spine collision note honored: no edits to `benchmarks/contract.py` or
+  `benchmarks/aggregation.py`.
+
+## Test plan
+
+- New `tests/unit/test_spine_verdict.py` written FIRST:
+  - typed-record invariant: constructing `Verdict` without `raw_output` raises
+    `TypeError` at runtime and fails pyright (`# type: ignore` + pyright's
+    reportUnnecessaryTypeIgnoreComment behavior verified; runtime TypeError is the
+    floor);
+  - one parse produces the exact wire dicts each board produces today (golden dicts
+    lifted from the current implementations for all three shapes: valid, fenced,
+    prose-prefixed, empty, non-JSON, wrong-shape, wrong-status/non-bool);
+  - reason strings per board byte-identical to today's.
+- All existing tests stay green and unmodified: `test_draco_verdict.py`,
+  `test_gdpval_verdict.py`, `test_healthbench_runtime.py`, check-surface tests —
+  they now exercise the shared parser through the board modules.
+
+## Acceptance
+
+- One parser module; the three `verdict.py` files reduced to shape declarations.
+- Type-level test: a verdict record without the raw reply does not typecheck.
+- Full engine gate green (`run_gates.py screamingface-engine`); prior tests untouched.
+- Diff under ~700 lines.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — new `benchmarks/spine/verdict.py` (341 lines) +
+  `tests/unit/test_spine_verdict.py` (34 tests); `draco/verdict.py` 179→110,
+  `healthbench/verdict.py` 194→57, `gdpval/verdict.py` 195→56 (shape declarations +
+  board-owned wiring); `rubric_check.py` `_decoded_array` → shared `recovered_array`;
+  spine `__init__` exports. `contract.py`/`aggregation.py` untouched (collision note).
+- **Commits:** this branch's single squash-bound commit —
+  `refactor(screamingface-engine): merge the drifted judge-verdict parsers into one
+  typed spine parser` (`Refs: OME-1099`).
+- **Gates:** ruff check ✓ · ruff format ✓ · pyright 0 errors ✓ · check_layering ✓ ·
+  pytest 2680 passed, 8 skipped, coverage 93.08% (≥80) — 1 pre-existing failure
+  unrelated to this unit: `test_worker_child_memory_cap` (OME-1089, merged 2026-09-08)
+  fails on macOS because Darwin refuses the exec wrapper's `RLIMIT_AS` lowering
+  ("current limit exceeds maximum limit"); fails identically on unmodified `main`,
+  passes in Linux CI. Surfaced for its own ticket, not touched here.
+- **Deviations:** four micro-behaviors on degenerate inputs, all wire-invisible on real
+  runs and unpinned by any prior test:
+  1. gdpval `bind` no longer strips whitespace from `producer_id` (draco/healthbench
+     majority behavior; runtimes pass clean ids).
+  2. gdpval valid-verdict `explanation`: non-string values now become `""` (healthbench
+     behavior) instead of `str()` coercion (which turned `None` into `"None"`).
+  3. check-surface fence stripping now tolerates indented ``` fences (the shared
+     primitive strips `line.strip().startswith`; old array copy used `line.startswith`).
+  4. producer-id ValueError message unified to "producer_id must be non-empty text"
+     (gdpval said "a non-empty string"; tests pin the raise, not the message).


### PR DESCRIPTION
**Problem**: We have repeated logic to parse judge verdict (turning a judge's free-text reply into an auditable MET/UNMET record). It existed four times (the check surface plus a drifted copy per rubric board). 

**Solution**: This PR make it exist only once, behind a typed record that cannot drop its audit trail. Closes OME-1099, delivers OME-1025.

## Before / After

### Before
- Trigger: a dev adds a rubric board, or a judge replies in a shape one board tolerates and another rejects (fenced JSON, prose-wrapped JSON, a non-boolean verdict).
- Today: four hand-maintained parser copies (`rubric_check.py` + `draco`/`healthbench`/`gdpval` `verdict.py`); the healthbench and gdpval copies drifted to 0.45 similarity while describing the same problems. OME-1023 was the bill: the newest copy silently dropped the judge's raw reply on valid verdicts, and nothing — no type, no test — caught it, because `raw_output: ""` is type-valid with the wrong meaning.
- Cost: the same judge reply can grade differently per board, and audit evidence goes missing silently on paid runs.

### After
- Same trigger.
- Now: one spine parser does the work; each board declares only its dialect (schema string, `criterion_status` enum vs strict-boolean `criteria_met`, reason vocabulary). The typed `Verdict` record makes every audit field a **required constructor argument** — omitting `raw_output` fails pyright and runtime construction.
- Win: a new rubric board gets parsing for free and *cannot* re-introduce the OME-1023 bug; the three board files shrink from ~190 lines each to ~55-line shape declarations.

### Don't regress
- Wire records are byte-identical per board: schema strings, reason strings, payload fields, and the original (never fence-stripped) raw reply are all pinned by tests.
- Per-board verdict semantics unchanged — this merges parsing, not judging. The strict-boolean gate (a string `"true"` or a `1` is never a lenient yes) stays exactly as the simple-evals reference demands.
- Board modules keep their public API (`SCHEMA`, `bind`, `binding_key`, `call`), so runtimes, exams, and case_results kept their imports.
- `benchmarks/contract.py` and `aggregation.py` untouched (spine collision note).

## What genuinely changes at runtime

Almost nothing — four micro-behaviors on degenerate inputs, none pinned by prior tests, all listed in the ledger (`docs/work/2026-09-09-OME-1099-shared-verdict-parser.md`): gdpval no longer whitespace-strips `producer_id`, gdpval renders a non-string explanation as `""` instead of `str()`-coercing it (so `None` no longer becomes `"None"`), the check surface now also tolerates *indented* code fences, and one ValueError message is unified.

## Review order

1. **`apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/verdict.py`** — the whole idea. The parser that recovers JSON from however the judge presented it, walks the failure checks in canonical order, and builds the typed `Verdict`. Verify: no field of `Verdict` has a default, and `record()` emits exactly the wire keys the old copies emitted.
2. **The three shape declarations** — `draco/verdict.py`, `healthbench/verdict.py`, `gdpval/verdict.py`. Each is now paperwork: a schema string, a dialect, a reason vocabulary, a thin `bind`. Verify: each board's reason strings match its deleted copy byte-for-byte (the diff shows the old strings on the removed lines).
3. **`benchmarks/rubric_check.py`** — the check surface hands its ordinal-array recovery to the same shared primitive. Verify: `_decoded_array` behavior is unchanged for unfenced and fenced replies.
4. **`tests/unit/test_spine_verdict.py`** — the contract. Two tests carry the ticket's acceptance: every `Verdict` field is default-less (the type-level rule), and each dialect reproduces the boards' exact wire records including reason vocabularies. The pre-existing board tests (`test_draco_verdict.py`, `test_gdpval_verdict.py`) are untouched and now exercise the shared parser through the board modules — they are the drift net.
5. **Mechanical skims** — `spine/__init__.py` exports, the work ledger, the task mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
