### PR TITLE
fix(screamingface): restore recovery budget for late disconnects

### DIFF
--- a/docs/plan/2026-09-09-OME-1141-reconnect-budget.md
+++ b/docs/plan/2026-09-09-OME-1141-reconnect-budget.md
@@ -1,0 +1,12 @@
+# OME-1141 — Implementation plan
+
+1. Add deterministic tests driving both real reconnect loops with scripted socket
+   outcomes and a local fake monotonic clock. Assert late-close recovery, cursor and
+   capability reuse, exhausted outages, stable recovery, and no retry after abort.
+2. Run new tests against unchanged production code and capture failures.
+3. Add a private recovery-window object shared by both transports. Record successful
+   attachment time; initialize/reset deadline and attempts only on a new outage.
+4. Run new and existing reconnect tests, then the complete screamingface quality gates.
+5. Review scope and invariants, update the ledger, commit, push, and open the PR.
+
+Design: docs/spec/2026-09-09-OME-1141-reconnect-budget.md.

--- a/docs/spec/2026-09-09-OME-1141-reconnect-budget.md
+++ b/docs/spec/2026-09-09-OME-1141-reconnect-budget.md
@@ -1,0 +1,24 @@
+# OME-1141 — Recovery budgets measure outages
+
+Approved by the user in this session: implement the diagnosed recovery-budget fix and
+open a PR. The current deadline begins at run start; a first failure at 1085 seconds
+therefore immediately stops active runs rather than resuming them.
+
+## Contract
+
+- Start the 90-second recovery deadline on the first observed connection failure.
+- Preserve that deadline across failed attempts and short-lived reattachments.
+- Once a successfully attached connection lasts at least the configured recovery budget,
+  treat a subsequent failure as a new outage: reset the deadline and backoff attempt.
+  This uses the existing budget as the stability threshold, avoiding a new setting and
+  preventing a repeatedly restarting Engine from retrying forever.
+- Reuse the Run capability and lifecycle cursor; never restart the Run on recovery.
+- Preserve abort, terminal protocol errors, exhaustion cleanup, and error diagnostics.
+- Apply identical policy to synchronous and asynchronous transports.
+
+## Scope
+
+Heartbeat tuning and the runtime cause of delayed Pongs are separate investigations.
+This change makes the existing reconnect mechanism usable for long Evaluations.
+It retains existing handshake timeouts and retry pacing; the deadline governs retry
+eligibility, not cancellation of in-flight network calls.

--- a/docs/tasks/2026-09-09-OME-1141-reconnect-budget.md
+++ b/docs/tasks/2026-09-09-OME-1141-reconnect-budget.md
@@ -1,0 +1,15 @@
+---
+id: OME-1141
+linear_url: https://linear.app/openmined/issue/OME-1141
+status: in_review
+type: bug
+priority: 3
+labels: [py-screamingface, agentic, autonomous, BUG]
+created: 2026-09-08
+closed:
+---
+
+# Restore reconnect attempts after long healthy Evaluations
+
+Implement the recovery-budget portion of OME-1141 in both SDK transports. See the
+matching spec, plan, and work ledger. Keep delayed-Pong diagnosis outside this PR.

--- a/docs/work/2026-09-09-OME-1141-reconnect-budget.md
+++ b/docs/work/2026-09-09-OME-1141-reconnect-budget.md
@@ -1,0 +1,53 @@
+---
+ticket: OME-1141
+stack: screamingface
+status: done
+started: 2026-09-09
+finished: 2026-09-09
+---
+
+# OME-1141 — Give late disconnects their recovery budget
+
+## Intent
+
+Fix the SDK recovery deadline so healthy Evaluation runtime cannot exhaust reconnect
+attempts before a connection fails. User approved implementation and opening a PR.
+
+## Planned changes
+
+- SDK transport and a private recovery-window helper shared by sync/async loops.
+- New deterministic transport regression tests; preserve all existing tests.
+- Spec, plan, task mirror, and this ledger.
+
+## Test plan
+
+Simulate the actual reconnect loops with a controllable clock and scripted sockets:
+late keepalive close, cursor/token reuse, first-failure budget, repeated connection
+failures, flapping sockets, a stable recovered connection, zero budget, and cancellation.
+Run the full screamingface gate runner including 95% coverage and packaging checks.
+
+## Acceptance
+
+A disconnect after 1085 seconds gets retries and resumes. Repeated failed attempts
+remain bounded. A stable connection restores a fresh budget and backoff. Both clients
+behave identically. No heartbeat, Engine, or public API changes.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** transport.py; new _engine/reconnect.py and test_reconnect_recovery_window.py; matching spec, plan, task mirror, and ledger.
+- **Commits:** planned `fix(screamingface): give disconnects a fresh recovery budget` (Refs: OME-1141).
+- **Gates:** final regression harness against original transport: 14 failed / 4 passed; fixed transport: 18 passed in 0.27s. Existing reconnect suite: 6 passed. `uv run .claude/scripts/run_gates.py screamingface`: ALL GATES GREEN (append-only, lint, format, pyright, full pytest with 95% minimum coverage, notebooks, build, distribution). Pre-commit hooks all passed.
+- **Deviations:** none
+
+## Wisdom and confidence review
+
+- A 26-line private state object shares the policy between both clients; no dependency,
+  public interface, schema, or Engine change. Existing transport file is already over
+  450 lines; unrelated extraction is outside this focused fix.
+- Tests retain the real lifecycle and stream parser, scripting only I/O and time. They
+  assert saved cursor/capability reuse, no duplicate start, bounded retries, cleanup,
+  stable reset at the threshold, and abort. Existing tests remain unchanged.
+- Resetting on every handshake would allow infinite flapping. A connection must last
+  the existing recovery-window duration before its next failure starts a fresh outage.
+- No credentials are exposed and no authentication or terminal-error behavior changes.
+- Runtime cause of the missed Pong remains unconfirmed; this PR fixes recovery only.

--- a/packages/screamingface/src/screamingface/_engine/reconnect.py
+++ b/packages/screamingface/src/screamingface/_engine/reconnect.py
@@ -1,0 +1,26 @@
+"""Per-outage recovery accounting shared by both WebSocket transports."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class _RecoveryWindow:
+    budget_s: float
+    attempts: int = 0
+    _deadline: float | None = None
+    _connected_at: float | None = None
+
+    def connected(self, now: float) -> None:
+        self._connected_at = now
+
+    def failed(self, now: float) -> float:
+        """Return the current outage deadline, refreshing only after stable recovery."""
+        stable = self._connected_at is not None and now - self._connected_at >= self.budget_s
+        # FEATURE: OME-1141 — healthy Evaluation runtime never spends its recovery budget.
+        # WHY: a handshake alone isn't recovery. Keep one deadline across flapping sockets;
+        # a connection lasting a full recovery window earns a new budget and backoff.
+        if self._deadline is None or stable:
+            self._deadline = now + self.budget_s
+            self.attempts = 0
+        self._connected_at = None
+        return self._deadline

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -29,6 +29,7 @@ from screamingface._access.base import _TransportAuth
 from screamingface._access.contract import _challenge_audience
 from screamingface._core.ports import _ResultArtifact, _RunOutcome
 from screamingface._core.wire import _REPLAY_SAFE
+from screamingface._engine.reconnect import _RecoveryWindow
 from screamingface._engine.run_lifecycle import _Lifecycle
 from screamingface._engine.trace import TraceContext, new_trace_context
 from screamingface._evaluation.model import Candidate
@@ -165,12 +166,11 @@ class Url4CloudTransport:
         resumes from the last accepted stream sequence with the SAME capability (valid for
         the Run's whole life after OME-1018). A handshake 401/403 that is not an Access
         challenge is FATAL — dead credentials, no probe on a single-engine fleet (D5). A
-        connect/OS/timeout failure backs off with full jitter; when the cumulative budget
+        connect/OS/timeout failure backs off with full jitter; when the outage recovery budget
         is spent, everything this client owns is stopped and the Run surfaces as
         `websocket_disconnected`.
         """
-        budget_deadline = time.monotonic() + self._reconnect_budget_s
-        attempts = 0
+        recovery = _RecoveryWindow(self._reconnect_budget_s)
         run_started = False
         while True:
             try:
@@ -193,6 +193,7 @@ class Url4CloudTransport:
                         run_started = True
                     else:
                         websocket.send(lifecycle.resume_attach())
+                    recovery.connected(time.monotonic())
                     outcome = self._run_connected(websocket, lifecycle, on_event)
                 # FEATURE OME-892: redeem the claim ticket OUTSIDE the socket scope.
                 # By now the run is over and the WS is closed — a fetch failure here
@@ -201,10 +202,13 @@ class Url4CloudTransport:
                 return _materialize_sync(self._http, outcome)
             except InvalidStatus as exc:
                 self._on_handshake_rejection(exc, minted, run_started, trace)
-                attempts += 1
+                recovery.attempts += 1
                 continue
             except (WebSocketException, OSError, TimeoutError) as exc:
-                attempts = self._on_stream_failure(exc, attempts, budget_deadline, started)
+                deadline = recovery.failed(time.monotonic())
+                recovery.attempts = self._on_stream_failure(
+                    exc, recovery.attempts, deadline, started
+                )
                 continue
 
     def _on_handshake_rejection(
@@ -432,8 +436,7 @@ class AsyncUrl4CloudTransport:
         trace: TraceContext,
     ) -> _RunOutcome:
         """Async twin of the sync reconnecting loop — see its docstring (spec §6 S3)."""
-        budget_deadline = time.monotonic() + self._reconnect_budget_s
-        attempts = 0
+        recovery = _RecoveryWindow(self._reconnect_budget_s)
         run_started = False
         while True:
             try:
@@ -456,15 +459,19 @@ class AsyncUrl4CloudTransport:
                         run_started = True
                     else:
                         await websocket.send(lifecycle.resume_attach())
+                    recovery.connected(time.monotonic())
                     outcome = await self._run_connected(websocket, lifecycle, on_event)
                 # FEATURE OME-892: redeem outside the socket scope — see the sync twin.
                 return await _materialize_async(self._http, outcome)
             except InvalidStatus as exc:
                 await self._on_handshake_rejection(exc, minted, run_started, trace)
-                attempts += 1
+                recovery.attempts += 1
                 continue
             except (WebSocketException, OSError, TimeoutError) as exc:
-                attempts = await self._on_stream_failure(exc, attempts, budget_deadline, started)
+                deadline = recovery.failed(time.monotonic())
+                recovery.attempts = await self._on_stream_failure(
+                    exc, recovery.attempts, deadline, started
+                )
                 continue
 
     async def _on_handshake_rejection(

--- a/packages/screamingface/tests/test_reconnect_recovery_window.py
+++ b/packages/screamingface/tests/test_reconnect_recovery_window.py
@@ -1,0 +1,237 @@
+"""OME-1141: recovery time starts at failure, not at Evaluation start."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from websockets.exceptions import ConnectionClosedError
+from websockets.frames import Close
+
+from screamingface._access.base import _TransportAuth
+from screamingface._engine import transport as module
+from screamingface._engine.run_lifecycle import _Lifecycle
+from screamingface._engine.trace import new_trace_context
+from screamingface._evaluation.model import _compiled_candidate, _compiled_operation
+from screamingface.errors import ExecutionError
+
+
+@dataclass
+class Clock:
+    now: float = 0.0
+    sleeps: list[float] = field(default_factory=list)
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, delay: float) -> None:
+        self.sleeps.append(delay)
+        self.now += delay
+
+    async def asleep(self, delay: float) -> None:
+        self.sleep(delay)
+
+
+def _frame(kind: str, data: dict[str, object], sequence: int) -> str:
+    return json.dumps(
+        {
+            "specversion": "1.0",
+            "id": str(sequence),
+            "source": "/trace/test/node/root",
+            "time": "2026-09-09T12:00:00Z",
+            "subject": "test",
+            "type": kind,
+            "datacontenttype": "application/json",
+            "sequence": str(sequence),
+            "sequencetype": "Integer",
+            "data": data,
+        }
+    )
+
+
+class Script:
+    """Fake only I/O and time; retain real lifecycle, cursor and reconnect decisions."""
+
+    def __init__(self, clock: Clock, steps: list[tuple[float, str]], asynchronous: bool):
+        self.clock = clock
+        self.steps = iter(steps)
+        self.asynchronous = asynchronous
+        self.urls: list[str] = []
+        self.attaches: list[dict[str, object]] = []
+        self.sequence = 0
+
+    def connect(self, url: str, **kwargs: object) -> MagicMock:
+        self.urls.append(url)
+        duration, action = next(self.steps)
+        if action == "refused":
+            self.clock.now += duration
+            raise OSError("connection refused")
+        socket = MagicMock(subprotocol="cloudevents.json")
+        receiver = self.receive(duration, action)
+        socket.recv.side_effect = lambda **kw: next(receiver)
+        socket.send.side_effect = self.send
+        if self.asynchronous:
+            socket.recv = AsyncMock(side_effect=lambda: next(receiver))
+            socket.send = AsyncMock(side_effect=self.send)
+        context = MagicMock()
+        context.__enter__.return_value = socket
+        context.__aenter__.return_value = socket
+        return context
+
+    def send(self, message: str) -> None:
+        event = json.loads(message)
+        if event["type"] == "ai.url4.attach":
+            self.attaches.append(event["data"])
+
+    def receive(self, duration: float, action: str):
+        self.sequence += 1
+        if self.sequence == 1:
+            yield _frame("ai.url4.started", {"url4": "(@)!'hi'"}, self.sequence)
+        else:
+            yield _frame(
+                "ai.url4.log",
+                {"severity_text": "INFO", "severity_number": 9, "body": "working"},
+                self.sequence,
+            )
+        self.clock.now += duration
+        if action == "close":
+            raise ConnectionClosedError(None, Close(1011, "keepalive ping timeout"))
+        self.sequence += 1
+        yield _frame(
+            "ai.url4.result", {"body": "complete", "media_type": "text/plain"}, self.sequence
+        )
+        self.sequence += 1
+        yield _frame("ai.url4.terminated", {"status": "succeeded", "error": None}, self.sequence)
+
+
+@pytest.fixture(params=[False, True], ids=["sync", "async"])
+def harness(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    asynchronous = request.param
+    clock = Clock()
+    monkeypatch.setattr(module, "time", clock)
+    monkeypatch.setattr(
+        module, "asyncio", SimpleNamespace(sleep=clock.asleep, wait_for=asyncio.wait_for)
+    )
+    monkeypatch.setattr(module.random, "random", lambda: 1.0)
+    auth = Mock(spec=_TransportAuth)
+    auth.websocket_headers.return_value = {}
+    auth.websocket_headers_async = AsyncMock(return_value={})
+    cls = module.AsyncUrl4CloudTransport if asynchronous else module.Url4CloudTransport
+    client = cls("http://example.invalid", caller_auth=auth)
+    sweep = AsyncMock() if asynchronous else Mock()
+    monkeypatch.setattr(client, "_sweep_after_disconnect", sweep)
+    start = AsyncMock() if asynchronous else Mock()
+    monkeypatch.setattr(module, "_start_async" if asynchronous else "_start_sync", start)
+    return SimpleNamespace(
+        client=client, clock=clock, asynchronous=asynchronous, sweep=sweep, start=start
+    )
+
+
+async def _run(harness, monkeypatch: pytest.MonkeyPatch, steps: list[tuple[float, str]]):
+    script = Script(harness.clock, steps, harness.asynchronous)
+    harness.script = script
+    ws_module = module.async_ws if harness.asynchronous else module.sync_ws
+    monkeypatch.setattr(ws_module, "connect", script.connect)
+    candidate = _compiled_candidate(
+        name="model",
+        kind="model",
+        models=("provider/model",),
+        url4="(@)!'hi'",
+        operations=(_compiled_operation(id="model", kind="model", label="answer", depends_on=()),),
+    )
+    args = (_Lifecycle(candidate), ["same-token"], candidate, None, 0.0, new_trace_context())
+    try:
+        if harness.asynchronous:
+            return await harness.client._run_reconnecting(*args)
+        return harness.client._run_reconnecting(*args)
+    finally:
+        if harness.asynchronous:
+            await harness.client.close()
+        else:
+            harness.client.close()
+
+
+@pytest.mark.asyncio
+async def test_late_keepalive_failure_resumes_same_run(harness, monkeypatch):
+    outcome = await _run(harness, monkeypatch, [(1085, "close"), (0, "complete")])
+    assert outcome.result_body == "complete"
+    assert len(harness.script.urls) == 2
+    assert len(set(harness.script.urls)) == 1
+    assert harness.script.attaches == [{"from_sequence": None}, {"from_sequence": 2}]
+    harness.start.assert_called_once()
+    harness.sweep.assert_not_called()
+    assert harness.clock.sleeps == [0.5]
+
+
+@pytest.mark.asyncio
+async def test_late_failure_retains_one_budget_across_failed_attempts(harness, monkeypatch):
+    with pytest.raises(ExecutionError, match="websocket|WebSocket") as caught:
+        await _run(harness, monkeypatch, [(1085, "close"), (45, "refused"), (45, "refused")])
+    assert caught.value.code == "websocket_disconnected"
+    assert len(harness.script.urls) == 3
+    assert harness.clock.sleeps == [0.5, 1.0]
+    harness.sweep.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_flapping_attachments_do_not_restart_budget(harness, monkeypatch):
+    with pytest.raises(ExecutionError):
+        await _run(harness, monkeypatch, [(1085, "close"), (45, "close"), (45, "close")])
+    assert len(harness.script.attaches) == 3
+    assert harness.clock.sleeps == [0.5, 1.0]
+    harness.sweep.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stable_seconds", [90, 1085])
+async def test_stable_recovery_restores_budget_and_backoff(harness, monkeypatch, stable_seconds):
+    outcome = await _run(
+        harness, monkeypatch, [(10, "close"), (stable_seconds, "close"), (0, "complete")]
+    )
+    assert outcome.result_body == "complete"
+    assert harness.clock.sleeps == [0.5, 0.5]
+    harness.sweep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_first_connection_failure_starts_budget_when_observed(harness, monkeypatch):
+    outcome = await _run(harness, monkeypatch, [(100, "refused"), (0, "complete")])
+    assert outcome.result_body == "complete"
+    assert harness.script.attaches == [{"from_sequence": None}]
+    harness.start.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_zero_budget_does_not_retry(harness, monkeypatch):
+    harness.client._reconnect_budget_s = 0
+    with pytest.raises(ExecutionError, match="keepalive ping timeout"):
+        await _run(harness, monkeypatch, [(1085, "close")])
+    assert len(harness.script.urls) == 1
+    assert harness.clock.sleeps == []
+    harness.sweep.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_owner_abort_does_not_retry_or_sweep_again(harness, monkeypatch):
+    harness.client._aborted = True
+    with pytest.raises(ExecutionError):
+        await _run(harness, monkeypatch, [(1085, "close")])
+    assert len(harness.script.urls) == 1
+    assert harness.clock.sleeps == []
+    harness.sweep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_short_reconnection_exhausts_at_exact_deadline(harness, monkeypatch):
+    # INVARIANT: the 0.5s backoff plus 89.5s connection uses the original 90s window;
+    # that socket has not stayed healthy long enough to earn another recovery budget.
+    with pytest.raises(ExecutionError, match="keepalive ping timeout") as caught:
+        await _run(harness, monkeypatch, [(1085, "close"), (89.5, "close")])
+    assert caught.value.code == "websocket_disconnected"
+    assert len(harness.script.urls) == 2
+    assert harness.clock.now == 1175
+    harness.sweep.assert_called_once()


### PR DESCRIPTION
## Summary

A keepalive disconnect after 1,085 seconds previously exhausted the SDK's 90-second reconnect budget before any retry, because the deadline began at Run start. Both sync and async clients now start that budget on the first connection failure and resume the same Run from its saved cursor.

Failed attempts and short-lived reattachments share one deadline. A connection that stays attached for a full recovery window restores the budget and backoff for a subsequent outage, preventing both premature failure and endless retries against a flapping Engine.

Refs: OME-1141

**Asana:** Not applicable; Linear bug [OME-1141](https://linear.app/openmined/issue/OME-1141).

## Components touched

`packages/screamingface` only, plus the required spec, plan, task mirror, and work ledger.

## Test plan

- 18 deterministic regression cases exercise the real reconnect loops and lifecycle in both sync and async clients: late keepalive closes, cursor/capability reuse, no duplicate start, exhausted outages, flapping connections, stable recovery, the exact deadline, zero budget, and owner abort.
- The final regression suite fails against the original transport (14 failed, 4 passed) and passes with the fix (18 passed).
- All 6 existing reconnect tests pass unchanged.
- Full SDK gates: lint, format, typecheck, complete test suite with 95% minimum coverage, notebook validation, build, and distribution validation.

## Cross-service notes

No Engine or protocol changes. Heartbeat settings are unchanged; determining why a Pong was delayed remains a separate investigation. Existing in-flight connection timeouts and retry pacing are preserved.
