### PR TITLE
feat(url4): add safe node-scoped structured Log emission

### DIFF
--- a/docs/plan/2026-09-09-OME-934-log-seam.md
+++ b/docs/plan/2026-09-09-OME-934-log-seam.md
@@ -17,3 +17,7 @@ Owner approved [the revised spec](../spec/2026-09-09-OME-934-log-seam.md) and cr
 6. **Review and close.** Keep implementation PRs draft until the owner explicitly requests readiness. Review package and Engine changes separately; retain full gates and required approvals before squash merge. Close each implementation issue with its commits, gates, ledger and mirror. Merging these design documents alone closes none of the delivery work.
 
 The scratch probe establishes feasibility only. Its monkeypatches and private-context access must not be copied as production interfaces. Saved-error propagation is excluded from this plan.
+
+## PR 877 review fix iteration
+
+Under existing OME-1165 and its PR worktree: create a review ledger; add failing serialization and diagnostic regressions; replace the attribute proxy with a private immutable mapping whose detached deep copy is a dict and reconstruct Log through its constructor; instrument fixed drop reasons with bounded counters and publish immutable snapshots; document the API; run full URL4 gates, review the diff and push the fix to PR 877. Existing tests remain unchanged.

--- a/docs/spec/2026-09-09-OME-934-log-seam.md
+++ b/docs/spec/2026-09-09-OME-934-log-seam.md
@@ -92,3 +92,9 @@ Before delivery, formal tests must cover:
 ## Alternatives
 
 The Engine-only factory remains useful if a proven consumer requires explicit run-wide setup/teardown. It is not selected as the foundational emission path because URL4 already owns node observation and Logs. Closed PR 689's isolation/failure tests may inform the implementation; its Benchmark claim machinery and PR 692's dataset discovery/scoring do not belong in this change.
+
+## PR 877 review refinement (owner approved 2026-09-09)
+
+Preserve pickle, deepcopy and dataclasses.asdict compatibility for empty and populated Logs while keeping event attributes immutable. Detached asdict output contains ordinary dictionaries suitable for JSON.
+
+Expose log_sink_drop_counts() as an immutable snapshot of process-wide counts keyed only by expired, thread, body, severity, attributes and emit. Each rejected call increments its first failing reason; successful calls and propagated BaseException signals do not increment. Counters saturate at sys.maxsize and never reset, so diagnostic state has fixed cardinality and bounded storage. Synchronize short in-memory counter updates/snapshots across threads; never call observers, logging handlers or user code while holding that lock. No payload, exception object/text, span or producer identity is retained. These are aggregate integration diagnostics, not authoritative per-run accounting.

--- a/docs/tasks/2026-09-09-OME-1165-structured-log-sink.md
+++ b/docs/tasks/2026-09-09-OME-1165-structured-log-sink.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1165
 linear_url: https://linear.app/openmined/issue/OME-1165
-status: Backlog
+status: In Progress
 priority: High
 labels: [url4-python-sdk, agentic, autonomous]
 created: 2026-09-09
@@ -29,3 +29,5 @@ Extend packages/url4 observation Logs with optional immutable flat scalar attrib
 
 ## Delivery boundaries
 OME-934 owns Engine forwarding and safe bridge buffering and depends on this issue. OME-1161 owns production activity records and concrete serialized size/rate limits; OME-932 owns evaluation lifecycle, typed terminal observations and scoring. This package interface supplies emission only. No new wire event, URL grammar or identity change; saved failure diagnostics remain separate. Keep implementation PR draft until the owner requests readiness.
+
+Implementation started after PR 876 merged at 1a53690c. See [implementation ledger](../work/2026-09-09-OME-1165-structured-log-sink.md).

--- a/docs/tasks/2026-09-09-OME-1165-structured-log-sink.md
+++ b/docs/tasks/2026-09-09-OME-1165-structured-log-sink.md
@@ -31,3 +31,9 @@ Extend packages/url4 observation Logs with optional immutable flat scalar attrib
 OME-934 owns Engine forwarding and safe bridge buffering and depends on this issue. OME-1161 owns production activity records and concrete serialized size/rate limits; OME-932 owns evaluation lifecycle, typed terminal observations and scoring. This package interface supplies emission only. No new wire event, URL grammar or identity change; saved failure diagnostics remain separate. Keep implementation PR draft until the owner requests readiness.
 
 Implementation started after PR 876 merged at 1a53690c. See [implementation ledger](../work/2026-09-09-OME-1165-structured-log-sink.md).
+
+## PR 877 review fixes
+
+Owner requested both review fixes on 2026-09-09: preserve Log pickle/deepcopy/asdict
+compatibility and expose bounded, payload-free drop counters. See
+[review-fix ledger](../work/2026-09-09-OME-1165-log-review-fixes.md).

--- a/docs/work/2026-09-09-OME-1165-log-review-fixes.md
+++ b/docs/work/2026-09-09-OME-1165-log-review-fixes.md
@@ -1,0 +1,40 @@
+---
+ticket: OME-1165
+stack: url4
+status: done
+started: 2026-09-09
+finished: 2026-09-09
+---
+
+# OME-1165 — Address PR 877 Log review feedback
+
+## Intent
+
+Owner requested both review fixes on 2026-09-09: restore public Log serialization compatibility and make failed producer submissions diagnosable without exposing payloads.
+
+## Planned changes
+
+- packages/url4/src/url4/observe.py: reconstruction for Log and fixed-reason drop counters.
+- packages/url4/src/url4/_log_attributes.py: immutable mapping with copy/serialization support.
+- packages/url4/tests/unit/test_log_review_fixes.py: additive regressions.
+- packages/url4/README.md: serialization and diagnostics API.
+- Existing OME-934 spec/plan and OME-1165 task mirror: record approved review refinement.
+
+## Test plan
+
+Write and run failing regressions first. Cover pickle protocols, deepcopy, asdict/JSON, empty/populated scalar mappings, immutable round trips, every drop reason, repeated failures, concurrent off-thread calls, read-only counter snapshots, saturation, successful emission and process-control propagation. Preserve previous tests. Run full URL4 gates.
+
+## Acceptance
+
+Both review concerns fixed on PR 877; attributes stay immutable; counters contain only fixed reasons and bounded integers; callbacks, payloads and errors never enter diagnostics. Direct observation semantics remain unchanged.
+
+## Outcome
+
+- **Actual files:** As planned; one private attribute mapping module, observation changes, 27 new regression cases, README, spec/plan refinement, task mirror and this ledger.
+- **Commits:** fix(url4): preserve Log serialization and count dropped submissions; Refs: OME-1165.
+- **Gates:** Initial RED: 24 cases failed on mappingproxy serialization or absent counters. Additional immutability regression exposed deletion of wrapper storage, corrected before GREEN. Full `uv run .claude/scripts/run_gates.py url4` passed append-only, Ruff lint/format, Pyright and full pytest with the unchanged 95% coverage gate. New attribute wrapper: 100%; observe.py: 99%. Existing tests remain byte-for-byte unchanged.
+- **Deviations:** None. This review iteration is complete; OME-1165 remains open pending PR approval/merge. No review replies or merge performed.
+
+## Wisdom and confidence review
+
+The custom immutable mapping is necessary because dataclasses.asdict traverses fields without consulting Log's reducer. Its detached deepcopy deliberately becomes a plain dict; Log reconstruction re-wraps attributes for event immutability. No dependency or transport change. Drop counters retain only six fixed keys and saturated integers. Short locked updates make concurrent off-thread rejection count correctly; the lock never encloses user code. Successful submissions avoid diagnostics entirely. Existing silent-logging tests and process-control propagation continue to pass. Both review requirements are covered without changing previous tests or execution outcomes.

--- a/docs/work/2026-09-09-OME-1165-structured-log-sink.md
+++ b/docs/work/2026-09-09-OME-1165-structured-log-sink.md
@@ -1,0 +1,41 @@
+---
+ticket: OME-1165
+stack: url4
+status: done
+started: 2026-09-09
+finished: 2026-09-09
+---
+
+# OME-1165 — Generic node-scoped structured Log emission
+
+## Intent
+
+Implement the URL4 portion of the approved Log design, merged in PR 876 at 1a53690c. Generic adapters can emit structured observations within a node resolve without acquiring an ExecutionContext. Engine forwarding remains OME-934.
+
+## Planned changes
+
+- packages/url4/src/url4/observe.py: immutable Log attributes and safe scoped sink.
+- packages/url4/src/url4/dag/node.py: compatible attributes argument on direct logging.
+- packages/url4/src/url4/dag/executor.py: explicit sink binding around resolve.
+- packages/url4/tests/unit/test_log_sink.py and test_log_sink_lifecycle.py: new behavioral coverage.
+- packages/url4/docs/ observation documentation if the public interface needs an existing reference updated.
+- docs/tasks/2026-09-09-OME-1165-structured-log-sink.md.
+
+## Test plan
+
+Write failing tests before production edits. Exercise real DAG execution for attachment, nesting, concurrent scopes, inherited children, expiry and cancellation; verify direct logging compatibility, immutable snapshots, severity and whole-record validation, off-thread rejection, observer failure containment and process-signal propagation. Preserve all existing tests and run the full URL4 gates.
+
+## Acceptance
+
+The package requirements in [the approved spec](../spec/2026-09-09-OME-934-log-seam.md) and steps 2–3 of [the plan](../plan/2026-09-09-OME-934-log-seam.md) pass. No Engine, Client, domain-schema, identity or wire changes. Implementation PR stays draft.
+
+## Outcome
+
+- **Actual files:** Three planned production modules, two new test modules, package README, issue mirror and this ledger.
+- **Commits:** feat(url4): add safe node-scoped structured Log emission; Refs: OME-1165.
+- **Gates:** RED: both new modules initially failed importing the missing accessor. Additional terminal-ordering regression failed on the error path before the binding was moved inside the resolve try block. GREEN: 45 new tests passed. Full run_gates.py url4 passed append-only, Ruff lint/format, Pyright and the full pytest coverage gate (1,215 collected tests; 98% total coverage, 99% observe.py). No prior tests modified.
+- **Deviations:** Public usage documentation added to the existing package README (no package docs directory). No production diagnostics are emitted by the safe sink: silent dropping avoids payload leakage, recursion and throwing log handlers. This implements the approved optional-warning contract. Delivery remains open pending draft PR review and merge.
+
+## Wisdom and confidence review
+
+The interface extends the existing dependency-free observation module and explicit executor binding; no new queue, factory, registry, exporter or domain dependency. Revocation uses shared active state because ContextVar reset cannot revoke a copied child context. The safe path contains Exception only; direct observer failures and BaseException propagation stay intact. Attributes are copied before observation and immutable after publication. The hash excludes the mapping so existing hashable Log construction remains usable. Tests exercise real DAG execution, including nested subtree failure, rather than mocking scheduler internals. Node completion is emitted only after scope exit on both success and failure. Production-size/rate policy belongs to producer schemas, as approved.

--- a/packages/url4/README.md
+++ b/packages/url4/README.md
@@ -254,3 +254,30 @@ This interface defines emission, not delivery guarantees or content filtering. P
 schemas must specify privacy rules, maximum serialized record size, emission-rate/burst
 limits and heartbeat cleanup. Observers and producers must remain non-blocking; the sink
 creates no tasks, queue or I/O. Concrete exporters own forwarding and buffering.
+
+### Log serialization and drop diagnostics
+
+`Log` supports `pickle`, `copy.deepcopy` and `dataclasses.asdict`, with or without
+attributes. Reconstructed events retain immutable attribute snapshots; `asdict(log)`
+returns detached ordinary dictionaries suitable for JSON serialization.
+
+Use `url4.observe.log_sink_drop_counts()` to inspect optional emission failures:
+
+```python
+from url4.observe import log_sink_drop_counts
+
+before = log_sink_drop_counts()
+# Exercise the producer here.
+after = log_sink_drop_counts()
+severity_drops = after["severity"] - before["severity"]
+```
+
+Snapshots are immutable and process-wide. The six fixed keys are `expired`, `thread`
+(off-thread), `body`, `severity`, `attributes` and `emit` (observer/submission errors).
+Each dropped call counts its first failing reason. Counts never reset and saturate at
+`sys.maxsize`; deltas are meaningful below saturation and include other concurrent runs.
+Successful calls and propagated cancellation/process-control signals do not count.
+No messages, attribute keys/values, exception text or identities enter this diagnostic
+state. Updates use a short in-memory lock; no logging handlers, observers, tasks or I/O
+are invoked by diagnostics. These counters diagnose integrations, not authoritative
+run outcomes. `WARNING` remains invalid; use the documented severity `WARN`.

--- a/packages/url4/README.md
+++ b/packages/url4/README.md
@@ -220,3 +220,37 @@ uv run url4 eval "(/upper(hi)!'go')"
 ## License
 
 Apache-2.0, see [LICENSE](LICENSE).
+
+## Structured observations
+
+An adapter running inside an observed DAG node can emit optional structured Logs:
+
+```python
+from url4.observe import current_log_sink
+
+sink = current_log_sink()
+if sink is not None:
+    sink("Operation completed", {"duration_ms": 42, "cached": False})
+```
+
+Supply an `Observer` to `url4.dag.run` to receive these observations. The sink attaches
+records to the resolving node's span. Child tasks inherit the active binding; observed
+nested execution binds its own sink and restores the outer one. Unobserved nested execution
+inherits an active outer sink without creating a span. After the node exits, accessors
+return `None` and retained sinks silently drop submissions, including from child tasks.
+
+Emission is synchronous and confined to the node's event-loop thread. Invalid records,
+off-thread calls and ordinary observer errors silently drop; cancellation and process-control
+signals propagate. Existing `ExecutionContext.log` and direct observer failures still
+propagate. Direct logging also accepts `attributes=` without changing its severity behavior.
+
+Bodies must be nonempty built-in strings. Attributes have built-in string keys and flat
+`str`, `int`, finite `float`, `bool` or `None` values, copied into an immutable snapshot.
+The optional `severity=` defaults to `INFO`: whitespace is stripped and letters uppercased,
+then only `DEBUG`, `INFO`, `WARN` and `ERROR` are accepted (`WARNING` is not an alias).
+Malformed records are rejected whole, without coercion or partial emission.
+
+This interface defines emission, not delivery guarantees or content filtering. Producer
+schemas must specify privacy rules, maximum serialized record size, emission-rate/burst
+limits and heartbeat cleanup. Observers and producers must remain non-blocking; the sink
+creates no tasks, queue or I/O. Concrete exporters own forwarding and buffering.

--- a/packages/url4/src/url4/_log_attributes.py
+++ b/packages/url4/src/url4/_log_attributes.py
@@ -1,0 +1,40 @@
+"""Immutable observation snapshots with ordinary detached serialization."""
+
+from collections.abc import Iterator, Mapping
+from copy import deepcopy
+from types import MappingProxyType
+from typing import Any, Self
+
+
+class _LogAttributes[T](Mapping[str, T]):
+    __slots__ = ("_values",)
+    _values: Mapping[str, T]
+
+    def __init__(self, values: Mapping[str, T]) -> None:
+        object.__setattr__(self, "_values", MappingProxyType(dict(values)))
+
+    def __setattr__(self, name: str, value: object) -> None:
+        raise AttributeError("Log attributes are immutable")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("Log attributes are immutable")
+
+    def __getitem__(self, key: str) -> T:
+        return self._values[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __repr__(self) -> str:
+        return repr(dict(self._values))
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> dict[str, T]:
+        # WHY: asdict deep-copies non-dict mappings field-by-field, bypassing Log's
+        # reducer. Its detached result must be a normal dict for JSON consumers.
+        return deepcopy(dict(self._values), memo)
+
+    def __reduce__(self) -> tuple[type[Self], tuple[dict[str, T]]]:
+        return type(self), (dict(self._values),)

--- a/packages/url4/src/url4/dag/executor.py
+++ b/packages/url4/src/url4/dag/executor.py
@@ -192,23 +192,23 @@ class Executor:
             # re-attributing its code/permanent here would double-count it.
             obs.emit(NodeFinished(span_id, "cancelled", obs.next_seq()))
             raise
-        with _bind_node_sinks(node_ctx.report_usage, node_ctx.report_response):
-            try:
+        try:
+            with _bind_node_sinks(node_ctx.report_usage, node_ctx.report_response, node_ctx.log):
                 result = await node.resolve(dict(zip(roles, values, strict=True)), node_ctx)
-            except BaseException as exc:
-                status = "cancelled" if isinstance(exc, asyncio.CancelledError) else "error"
-                code = getattr(exc, "code", None)
-                permanent = getattr(exc, "permanent", None)
-                obs.emit(
-                    NodeFinished(
-                        span_id,
-                        status,
-                        obs.next_seq(),
-                        code if isinstance(code, str) else None,
-                        permanent if isinstance(permanent, bool) else None,
-                    )
+        except BaseException as exc:
+            status = "cancelled" if isinstance(exc, asyncio.CancelledError) else "error"
+            code = getattr(exc, "code", None)
+            permanent = getattr(exc, "permanent", None)
+            obs.emit(
+                NodeFinished(
+                    span_id,
+                    status,
+                    obs.next_seq(),
+                    code if isinstance(code, str) else None,
+                    permanent if isinstance(permanent, bool) else None,
                 )
-                raise
+            )
+            raise
         obs.emit(NodeFinished(span_id, "ok", obs.next_seq()))
         return result
 

--- a/packages/url4/src/url4/dag/node.py
+++ b/packages/url4/src/url4/dag/node.py
@@ -48,7 +48,7 @@ from url4.io.layer import (
     SupportsHoldings,
     SupportsProcessorRoutes,
 )
-from url4.observe import Log, ModelResponse, ObservationEvent, Observer, Usage
+from url4.observe import Log, LogScalar, ModelResponse, ObservationEvent, Observer, Usage
 
 
 @dataclass(frozen=True)
@@ -423,11 +423,17 @@ class ExecutionContext:
                 )
             )
 
-    def log(self, severity: str, body: str) -> None:
+    def log(
+        self, severity: str, body: str, *, attributes: Mapping[str, LogScalar] | None = None
+    ) -> None:
         """Emit a log line attributed to this node's current span. A no-op
-        when no ``observer`` was passed to :func:`~url4.dag.executor.run`."""
+        when no ``observer`` was passed to :func:`~url4.dag.executor.run`.
+
+        Attributes are snapshotted immutably. Observer failures still propagate;
+        use ``current_log_sink()`` for best-effort producer emission.
+        """
         if self._obs is not None:
-            self._obs.emit(Log(self._current_span_id, severity, body))
+            self._obs.emit(Log(self._current_span_id, severity, body, attributes or {}))
 
 
 async def _spawn_unset(text: str, scope: Context) -> str:

--- a/packages/url4/src/url4/observe.py
+++ b/packages/url4/src/url4/observe.py
@@ -11,18 +11,21 @@ downstream tracing product is deliberately kept out of this module.
 ``Observer.on_event`` is synchronous and non-blocking by contract — the
 executor calls it inline from its own coroutines, never behind a task or a
 queue, so a slow or blocking observer would slow the run itself. An observer
-that raises is not caught anywhere in the engine (an embedder bug should be
-loud, not swallowed): the exception propagates out of the run exactly like
-any other node failure.
+that raises propagates out of direct observation like any other node failure.
+The opt-in ``current_log_sink`` convenience alone contains ordinary submission
+failures; it never changes lifecycle or direct logging failure semantics.
 """
 
 from __future__ import annotations
 
 import contextlib
 import contextvars
-from collections.abc import Callable, Iterator
-from dataclasses import dataclass
+import math
+import threading
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass, field
 from decimal import Decimal
+from types import MappingProxyType
 from typing import Literal, Protocol, runtime_checkable
 
 
@@ -56,11 +59,19 @@ class NodeFinished:
     permanent: bool | None = None
 
 
+type LogScalar = str | int | float | bool | None
+
+
 @dataclass(frozen=True, slots=True)
 class Log:
     span_id: str | None
     severity: str
     body: str
+    attributes: Mapping[str, LogScalar] = field(default_factory=dict, hash=False)
+
+    def __post_init__(self) -> None:
+        # INVARIANT: observers and caller mutation cannot rewrite queued evidence.
+        object.__setattr__(self, "attributes", MappingProxyType(dict(self.attributes)))
 
 
 @dataclass(frozen=True, slots=True)
@@ -222,14 +233,102 @@ def current_response_sink() -> ResponseSink | None:
     return _response_sink.get()
 
 
+class LogSink(Protocol):
+    """Best-effort structured emission for the active node, on its loop thread.
+
+    No I/O or tasks are created. Invalid, expired and off-thread submissions
+    silently drop. Attributes are flat scalars; this is not content redaction.
+    Producer schemas must separately bound record size and emission rate.
+    """
+
+    def __call__(
+        self,
+        body: str,
+        attributes: Mapping[str, LogScalar] | None = None,
+        *,
+        severity: str = "INFO",
+    ) -> None: ...
+
+
+class _LogEmitter(Protocol):
+    def __call__(
+        self,
+        severity: str,
+        body: str,
+        *,
+        attributes: Mapping[str, LogScalar] | None = None,
+    ) -> None: ...
+
+
+def _log_attributes(attributes: Mapping[str, LogScalar] | None) -> dict[str, LogScalar]:
+    if attributes is None:
+        return {}
+    if not isinstance(attributes, Mapping):
+        raise ValueError("invalid attributes")
+    snapshot = dict(attributes)
+    for key, value in snapshot.items():
+        if type(key) is not str or type(value) not in (str, int, float, bool, type(None)):
+            raise ValueError("invalid scalar")
+        if type(value) is float and not math.isfinite(value):
+            raise ValueError("nonfinite scalar")
+    return snapshot
+
+
+class _NodeLogSink:
+    def __init__(self, emit: _LogEmitter) -> None:
+        self._emit = emit
+        self._thread = threading.get_ident()
+        self.active = True
+
+    def __call__(
+        self,
+        body: str,
+        attributes: Mapping[str, LogScalar] | None = None,
+        *,
+        severity: str = "INFO",
+    ) -> None:
+        if not self.active or threading.get_ident() != self._thread:
+            return
+        try:
+            if type(body) is not str or not body or type(severity) is not str:
+                return
+            normalized = severity.strip().upper()
+            if normalized not in ("DEBUG", "INFO", "WARN", "ERROR"):
+                return
+            self._emit(normalized, body, attributes=_log_attributes(attributes))
+        except Exception:
+            # WHY: only this opt-in emission path is fail-open. No diagnostic
+            # logging here: it could recurse, leak payload or fail through a handler.
+            # BaseException (cancellation/process control) deliberately propagates.
+            pass
+
+
+_log_sink: contextvars.ContextVar[_NodeLogSink | None] = contextvars.ContextVar(
+    "url4_log_sink", default=None
+)
+
+
+def current_log_sink() -> LogSink | None:
+    """Return the active node's sink, or None outside/after its resolve.
+
+    Child tasks inherit the binding. Observed nested runs bind their own;
+    unobserved nested runs inherit an active outer without creating a span.
+    Retained callables silently drop after expiry, including in copied contexts.
+    """
+    sink = _log_sink.get()
+    return sink if sink is not None and sink.active else None
+
+
 @contextlib.contextmanager
-def _bind_node_sinks(usage: UsageSink, response: ResponseSink) -> Iterator[None]:
-    """Bind both ctx-less sinks to the currently-resolving node, for the duration
+def _bind_node_sinks(
+    usage: UsageSink, response: ResponseSink, log: _LogEmitter | None = None
+) -> Iterator[None]:
+    """Bind ctx-less sinks to the currently-resolving node, for the duration
     of its own ``resolve`` only.
 
     Lives here rather than in the executor because the ContextVars are this
     module's private state — the executor should not have to reach into them to
-    scope a binding it does not own. Takes the two bound methods rather than an
+    scope a binding it does not own. Takes explicit bound callables rather than an
     ``ExecutionContext`` so this module stays the dependency-free leaf its
     docstring promises (``url4.dag.node`` imports *this*, never the reverse).
 
@@ -237,20 +336,28 @@ def _bind_node_sinks(usage: UsageSink, response: ResponseSink) -> Iterator[None]
     copied into each :class:`asyncio.Task`'s context at creation, so every
     sibling node sees its own binding, never another's.
 
-    INVARIANT: neither binding outlives the node's resolve — both are reset on
+    INVARIANT: bindings are restored when the node resolve exits on
     the success path and the failure path alike.
     """
+    sink = _NodeLogSink(log) if log is not None else None
+    log_token = _log_sink.set(sink)
     usage_token = _usage_sink.set(usage)
     response_token = _response_sink.set(response)
     try:
         yield
     finally:
+        # INVARIANT: resetting ContextVars alone cannot revoke copied child contexts.
+        if sink is not None:
+            sink.active = False
+        _log_sink.reset(log_token)
         _usage_sink.reset(usage_token)
         _response_sink.reset(response_token)
 
 
 __all__ = [
     "Log",
+    "LogScalar",
+    "LogSink",
     "ModelResponse",
     "NodeFinished",
     "NodeStarted",
@@ -262,6 +369,7 @@ __all__ = [
     "RunStarted",
     "Usage",
     "UsageSink",
+    "current_log_sink",
     "current_response_sink",
     "current_usage_sink",
 ]

--- a/packages/url4/src/url4/observe.py
+++ b/packages/url4/src/url4/observe.py
@@ -21,12 +21,15 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import math
+import sys
 import threading
 from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
 from types import MappingProxyType
-from typing import Literal, Protocol, runtime_checkable
+from typing import Literal, Protocol, Self, runtime_checkable
+
+from url4._log_attributes import _LogAttributes
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,7 +74,12 @@ class Log:
 
     def __post_init__(self) -> None:
         # INVARIANT: observers and caller mutation cannot rewrite queued evidence.
-        object.__setattr__(self, "attributes", MappingProxyType(dict(self.attributes)))
+        object.__setattr__(self, "attributes", _LogAttributes(self.attributes))
+
+    def __reduce__(self) -> tuple[type[Self], tuple[str | None, str, str, dict[str, LogScalar]]]:
+        # INVARIANT: pickle/deepcopy reconstruct through the constructor so event
+        # attributes remain immutable even though detached asdict output is mutable.
+        return type(self), (self.span_id, self.severity, self.body, dict(self.attributes))
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,7 +245,8 @@ class LogSink(Protocol):
     """Best-effort structured emission for the active node, on its loop thread.
 
     No I/O or tasks are created. Invalid, expired and off-thread submissions
-    silently drop. Attributes are flat scalars; this is not content redaction.
+    drop without logging; see log_sink_drop_counts(). Attributes are flat scalars;
+    this is not content redaction.
     Producer schemas must separately bound record size and emission rate.
     """
 
@@ -274,6 +283,29 @@ def _log_attributes(attributes: Mapping[str, LogScalar] | None) -> dict[str, Log
     return snapshot
 
 
+_log_drop_counts: dict[str, int] = dict.fromkeys(
+    ("expired", "thread", "body", "severity", "attributes", "emit"), 0
+)
+_log_drop_lock = threading.Lock()
+
+
+def _record_log_drop(reason: str) -> None:
+    # INVARIANT: fixed keys, bounded integers, no payload or callbacks under the lock.
+    with _log_drop_lock:
+        _log_drop_counts[reason] = min(_log_drop_counts[reason] + 1, sys.maxsize)
+
+
+def log_sink_drop_counts() -> Mapping[str, int]:
+    """Immutable snapshot of process-wide drops, saturating at sys.maxsize.
+
+    Keys are expired, thread, body, severity, attributes and emit. Each rejected
+    call counts its first failing phase; successful calls and propagated process
+    signals do not count. No reset, payload, exception text or per-run attribution.
+    """
+    with _log_drop_lock:
+        return MappingProxyType(dict(_log_drop_counts))
+
+
 class _NodeLogSink:
     def __init__(self, emit: _LogEmitter) -> None:
         self._emit = emit
@@ -287,20 +319,30 @@ class _NodeLogSink:
         *,
         severity: str = "INFO",
     ) -> None:
-        if not self.active or threading.get_ident() != self._thread:
+        if not self.active:
+            _record_log_drop("expired")
             return
+        if threading.get_ident() != self._thread:
+            _record_log_drop("thread")
+            return
+        phase = "body"
         try:
-            if type(body) is not str or not body or type(severity) is not str:
-                return
+            if type(body) is not str or not body:
+                raise ValueError("invalid body")
+            phase = "severity"
+            if type(severity) is not str:
+                raise ValueError("invalid severity")
             normalized = severity.strip().upper()
             if normalized not in ("DEBUG", "INFO", "WARN", "ERROR"):
-                return
-            self._emit(normalized, body, attributes=_log_attributes(attributes))
+                raise ValueError("invalid severity")
+            phase = "attributes"
+            snapshot = _log_attributes(attributes)
+            phase = "emit"
+            self._emit(normalized, body, attributes=snapshot)
         except Exception:
-            # WHY: only this opt-in emission path is fail-open. No diagnostic
-            # logging here: it could recurse, leak payload or fail through a handler.
-            # BaseException (cancellation/process control) deliberately propagates.
-            pass
+            # WHY: counter-only diagnostics cannot recurse through logging handlers
+            # or retain payload. BaseException (process control) still propagates.
+            _record_log_drop(phase)
 
 
 _log_sink: contextvars.ContextVar[_NodeLogSink | None] = contextvars.ContextVar(
@@ -372,4 +414,5 @@ __all__ = [
     "current_log_sink",
     "current_response_sink",
     "current_usage_sink",
+    "log_sink_drop_counts",
 ]

--- a/packages/url4/tests/unit/test_log_review_fixes.py
+++ b/packages/url4/tests/unit/test_log_review_fixes.py
@@ -1,0 +1,195 @@
+"""Public Log serialization and payload-free producer diagnostics regressions."""
+
+import copy
+import json
+import pickle
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict
+from operator import setitem
+from typing import Any, cast
+
+import pytest
+
+import url4.observe as observe
+from url4.observe import Log, _bind_node_sinks, current_log_sink
+
+
+@pytest.mark.parametrize("attributes", [{}, {"text": "v", "n": 2, "f": 1.5, "ok": True, "x": None}])
+@pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+def test_log_pickle_roundtrip_preserves_immutable_snapshot(attributes, protocol):
+    event = Log("span", "INFO", "body", attributes)
+    restored = pickle.loads(pickle.dumps(event, protocol=protocol))
+    assert restored == event
+    assert hash(restored) == hash(event)
+    with pytest.raises(TypeError):
+        setitem(cast(Any, restored.attributes), "new", 3)
+
+
+@pytest.mark.parametrize("attributes", [{}, {"attempt": 2}])
+def test_log_deepcopy_and_asdict_support_detached_json(attributes):
+    event = Log("span", "INFO", "body", attributes)
+    cloned = copy.deepcopy(event)
+    assert cloned == event
+    with pytest.raises(TypeError):
+        setitem(cast(Any, cloned.attributes), "attempt", 3)
+    serialized = asdict(event)
+    assert json.loads(json.dumps(serialized)) == {
+        "span_id": "span",
+        "severity": "INFO",
+        "body": "body",
+        "attributes": attributes,
+    }
+    serialized["attributes"]["attempt"] = 99
+    assert event.attributes == attributes
+    assert cloned.attributes == attributes
+
+
+def counts():
+    return observe.log_sink_drop_counts()
+
+
+def ignore(*args, **kwargs):
+    pass
+
+
+@pytest.mark.parametrize(
+    "body, attributes, severity, reason",
+    [
+        ("", None, "INFO", "body"),
+        (None, None, "INFO", "body"),
+        ("private", None, "WARNING", "severity"),
+        ("private", None, 3, "severity"),
+        ("private", {"secret": []}, "INFO", "attributes"),
+        ("private", {"secret": float("nan")}, "INFO", "attributes"),
+    ],
+)
+def test_rejected_records_count_only_first_reason(body, attributes, severity, reason, caplog):
+    before = counts()
+    emitted = []
+    with _bind_node_sinks(ignore, ignore, lambda *a, **kw: emitted.append((a, kw))):
+        sink = current_log_sink()
+        assert sink is not None
+        for _ in range(20):
+            sink(body, attributes, severity=severity)
+    after = counts()
+    assert {key: after[key] - before[key] for key in after} == {
+        key: 20 if key == reason else 0 for key in after
+    }
+    assert emitted == []
+    assert caplog.text == ""
+    assert "private" not in repr(after)
+    with pytest.raises(TypeError):
+        setitem(cast(Any, after), reason, 0)
+    assert before[reason] + 20 == after[reason]
+
+
+def test_observer_errors_count_without_payload_or_recursive_logging(caplog):
+    before = counts()
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("private exception body")
+
+    with _bind_node_sinks(ignore, ignore, fail):
+        sink = current_log_sink()
+        assert sink is not None
+        for _ in range(100):
+            sink("private message", {"secret": "value"})
+    after = counts()
+    assert after["emit"] - before["emit"] == 100
+    assert len(after) == 6
+    assert all(type(value) is int for value in after.values())
+    assert caplog.text == ""
+    assert "private" not in repr(after)
+
+
+def test_expired_and_concurrent_off_thread_calls_count_without_emission():
+    before = counts()
+    emitted = []
+    with _bind_node_sinks(ignore, ignore, lambda *a, **kw: emitted.append((a, kw))):
+        sink = current_log_sink()
+        assert sink is not None
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            list(pool.map(sink, ["private"] * 1000))
+    sink("expired")
+    after = counts()
+    assert after["thread"] - before["thread"] == 1000
+    assert after["expired"] - before["expired"] == 1
+    assert emitted == []
+
+
+def test_success_and_process_control_leave_counts_unchanged():
+    before = counts()
+    with _bind_node_sinks(ignore, ignore, ignore):
+        sink = current_log_sink()
+        assert sink is not None
+        sink("success")
+    for error in (KeyboardInterrupt(), SystemExit()):
+
+        def fail(*args, **kwargs):
+            raise error
+
+        with _bind_node_sinks(ignore, ignore, fail):
+            sink = current_log_sink()
+            assert sink is not None
+            with pytest.raises(type(error)):
+                sink("private")
+    assert counts() == before
+
+
+def test_drop_counters_saturate_without_growing_diagnostic_state(monkeypatch):
+    # INVARIANT: even permanently broken producers cannot grow counter storage forever.
+    monkeypatch.setitem(observe._log_drop_counts, "body", sys.maxsize - 1)
+    with _bind_node_sinks(ignore, ignore, ignore):
+        sink = current_log_sink()
+        assert sink is not None
+        for _ in range(3):
+            sink("")
+    assert counts()["body"] == sys.maxsize
+    assert set(counts()) == {"expired", "thread", "body", "severity", "attributes", "emit"}
+
+
+def test_legacy_three_argument_log_serialization():
+    event = Log("span", "custom", "body")
+    assert pickle.loads(pickle.dumps(event)) == event
+    assert copy.deepcopy(event) == event
+    assert asdict(event)["attributes"] == {}
+
+
+def test_attribute_mapping_copies_preserve_read_only_interface():
+    event = Log("span", "INFO", "body", {"attempt": 2})
+    assert len(event.attributes) == 1
+    assert "attempt" in repr(event.attributes)
+    for attributes in (
+        event.attributes,
+        copy.copy(event.attributes),
+        pickle.loads(pickle.dumps(event.attributes)),
+    ):
+        assert attributes == {"attempt": 2}
+        with pytest.raises(AttributeError):
+            setattr(attributes, "_values", {})
+        with pytest.raises(AttributeError):
+            delattr(attributes, "_values")
+        with pytest.raises(TypeError):
+            setitem(cast(Any, attributes), "attempt", 99)
+
+
+def test_broken_mapping_counts_attribute_failure_without_inspecting_exception():
+    from collections.abc import Mapping
+
+    class BrokenMapping(Mapping):
+        def __iter__(self):
+            raise RuntimeError("secret mapping")
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, key):
+            raise RuntimeError("secret mapping")
+
+    before = counts()
+    with _bind_node_sinks(ignore, ignore, ignore):
+        sink = current_log_sink()
+        assert sink is not None
+        sink("body", BrokenMapping())
+    assert counts()["attributes"] - before["attributes"] == 1

--- a/packages/url4/tests/unit/test_log_sink.py
+++ b/packages/url4/tests/unit/test_log_sink.py
@@ -1,0 +1,179 @@
+"""Structured emission is optional evidence with immutable flat snapshots."""
+
+from collections.abc import Mapping
+from operator import setitem
+from typing import Any, cast
+
+import pytest
+
+from url4.dag import run
+from url4.io.static import StaticIOLayer
+from url4.observe import Log, current_log_sink
+
+
+class Recorder:
+    def __init__(self):
+        self.events = []
+
+    def on_event(self, event):
+        self.events.append(event)
+
+    @property
+    def logs(self):
+        return [e for e in self.events if isinstance(e, Log)]
+
+
+class EmitNode:
+    deps: dict = {}
+
+    def __init__(self, action):
+        self.action = action
+
+    async def resolve(self, inputs, ctx):
+        self.action(ctx)
+        return "result"
+
+
+def emit(body: Any = "record", attributes: Any = None, severity: Any = "INFO") -> None:
+    sink = current_log_sink()
+    assert sink is not None
+    sink(body, attributes, severity=severity)
+
+
+def test_log_preserves_old_construction_and_immutable_attributes():
+    assert Log("span", "custom", "body").attributes == {}
+    attrs = {"count": 1}
+    record = Log("span", "INFO", "body", attrs)
+    attrs["count"] = 2
+    assert record.attributes == {"count": 1}
+    with pytest.raises(TypeError):
+        setitem(cast(Any, record.attributes), "count", 3)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("severity", ["DEBUG", "INFO", "WARN", "ERROR"])
+async def test_scalar_snapshot_and_severity_normalization(severity):
+    attrs = {"text": "v", "count": 1, "duration": 1.5, "ok": True, "unknown": None}
+    rec = Recorder()
+
+    def action(ctx):
+        emit(attributes=attrs, severity=f" {severity.lower()} ")
+        attrs["count"] = 99
+
+    assert await run(EmitNode(action), StaticIOLayer(), observer=rec) == "result"
+    assert len(rec.logs) == 1
+    assert rec.logs[0].severity == severity
+    assert rec.logs[0].attributes["count"] == 1
+    assert rec.logs[0].attributes["unknown"] is None
+
+
+class CustomString(str):
+    pass
+
+
+class CustomInt(int):
+    pass
+
+
+class BrokenMapping(Mapping):
+    def __iter__(self):
+        raise RuntimeError("private payload")
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, key):
+        raise RuntimeError("private payload")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body, attrs, severity",
+    [
+        ("", {}, "INFO"),
+        (None, {}, "INFO"),
+        (b"secret", {}, "INFO"),
+        (CustomString("secret"), {}, "INFO"),
+        ("body", {1: "bad key"}, "INFO"),
+        ("body", {CustomString("key"): 1}, "INFO"),
+        ("body", {"valid": 1, "invalid": []}, "INFO"),
+        ("body", {"invalid": {}}, "INFO"),
+        ("body", {"invalid": b"secret"}, "INFO"),
+        ("body", {"invalid": CustomInt(1)}, "INFO"),
+        ("body", {"invalid": float("nan")}, "INFO"),
+        ("body", {"invalid": float("inf")}, "INFO"),
+        ("body", {"invalid": float("-inf")}, "INFO"),
+        ("body", [("key", 1)], "INFO"),
+        ("body", BrokenMapping(), "INFO"),
+        ("body", {}, "WARNING"),
+        ("body", {}, "TRACE"),
+        ("body", {}, "FATAL"),
+        ("body", {}, ""),
+        ("body", {}, "unknown"),
+        ("body", {}, 9),
+        ("body", {}, None),
+        ("body", {}, CustomString("INFO")),
+    ],
+)
+async def test_invalid_record_drops_whole_without_affecting_result(body, attrs, severity, caplog):
+    rec = Recorder()
+    node = EmitNode(lambda ctx: emit(body, attrs, severity))
+    assert await run(node, StaticIOLayer(), observer=rec) == "result"
+    assert rec.logs == []
+    assert caplog.text == ""
+
+
+@pytest.mark.asyncio
+async def test_direct_log_preserves_custom_severity_and_copies_attributes():
+    rec = Recorder()
+    attrs = {"count": 1}
+
+    def action(ctx):
+        ctx.log("custom", "body", attributes=attrs)
+        attrs["count"] = 2
+
+    await run(EmitNode(action), StaticIOLayer(), observer=rec)
+    assert rec.logs[0].severity == "custom"
+    assert rec.logs[0].attributes == {"count": 1}
+
+
+class RaisingObserver:
+    def __init__(self, error):
+        self.error = error
+        self.attempts = 0
+
+    def on_event(self, event):
+        if isinstance(event, Log):
+            self.attempts += 1
+            raise self.error
+
+
+@pytest.mark.asyncio
+async def test_safe_sink_contains_observer_failures_without_diagnostics(caplog):
+    observer = RaisingObserver(RuntimeError("private payload"))
+    node = EmitNode(lambda ctx: [emit() for _ in range(20)])
+    assert await run(node, StaticIOLayer(), observer=observer) == "result"
+    assert observer.attempts == 20
+    assert caplog.text == ""
+
+
+@pytest.mark.asyncio
+async def test_direct_log_still_propagates_original_observer_error():
+    observer = RaisingObserver(RuntimeError("original"))
+    with pytest.raises(RuntimeError) as caught:
+        await run(EmitNode(lambda ctx: ctx.log("INFO", "body")), StaticIOLayer(), observer=observer)
+    assert caught.value is observer.error
+
+
+@pytest.mark.asyncio
+async def test_process_control_is_not_swallowed():
+    # WHY: catch inside resolve so SystemExit cannot escape the test's asyncio runner.
+    for error in (KeyboardInterrupt(), SystemExit()):
+        observer = RaisingObserver(error)
+
+        def action(ctx):
+            with pytest.raises(type(error)) as caught:
+                emit()
+            assert caught.value is error
+
+        await run(EmitNode(action), StaticIOLayer(), observer=observer)

--- a/packages/url4/tests/unit/test_log_sink_lifecycle.py
+++ b/packages/url4/tests/unit/test_log_sink_lifecycle.py
@@ -1,0 +1,266 @@
+"""The real DAG executor owns binding, inheritance and revocation."""
+
+import asyncio
+import subprocess
+import sys
+
+import pytest
+
+from url4.dag import run
+from url4.io.static import StaticIOLayer
+from url4.observe import Log, NodeFinished, NodeStarted, current_log_sink
+
+
+class Recorder:
+    def __init__(self):
+        self.events = []
+
+    def on_event(self, event):
+        self.events.append(event)
+
+    @property
+    def logs(self):
+        return [e for e in self.events if isinstance(e, Log)]
+
+
+class AsyncNode:
+    deps: dict = {}
+
+    def __init__(self, action):
+        self.action = action
+
+    async def resolve(self, inputs, ctx):
+        return await self.action(ctx)
+
+
+@pytest.mark.asyncio
+async def test_no_observer_has_no_sink():
+    async def action(ctx):
+        assert current_log_sink() is None
+        ctx.log("custom", "silent", attributes={"count": 1})
+        return "ok"
+
+    assert current_log_sink() is None
+    assert await run(AsyncNode(action), StaticIOLayer()) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_have_distinct_spans_and_expire_retained_sinks():
+    rec = Recorder()
+    retained = []
+    barrier = asyncio.Barrier(2)
+
+    async def action(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        retained.append(sink)
+        await barrier.wait()
+        sink("body", {"count": 1})
+        return "ok"
+
+    assert await asyncio.gather(
+        *(run(AsyncNode(action), StaticIOLayer(), observer=rec) for _ in range(2))
+    ) == ["ok", "ok"]
+    assert len({e.span_id for e in rec.logs}) == 2
+    starts = {e.span_id for e in rec.events if isinstance(e, NodeStarted)}
+    assert {e.span_id for e in rec.logs} == starts
+    for sink in retained:
+        sink("late")
+    assert len(rec.logs) == 2
+    assert current_log_sink() is None
+
+
+@pytest.mark.asyncio
+async def test_child_task_inherits_active_sink_but_cannot_use_expired_binding():
+    rec = Recorder()
+    release = asyncio.Event()
+    emitted = asyncio.Event()
+    children = []
+
+    async def child():
+        sink = current_log_sink()
+        assert sink is not None
+        sink("during")
+        emitted.set()
+        await release.wait()
+        assert current_log_sink() is None
+        sink("after")
+
+    async def action(ctx):
+        children.append(asyncio.create_task(child()))
+        await emitted.wait()
+        return "ok"
+
+    await run(AsyncNode(action), StaticIOLayer(), observer=rec)
+    release.set()
+    await asyncio.gather(*children)
+    assert [e.body for e in rec.logs] == ["during"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("observed", [False, True])
+async def test_nested_execution_binds_or_inherits_then_restores_outer(observed):
+    rec = Recorder()
+    retained = []
+
+    async def inner(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        retained.append(sink)
+        sink("inner")
+        return "inner"
+
+    async def outer(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        sink("before")
+        await run(AsyncNode(inner), StaticIOLayer(), observer=rec if observed else None)
+        assert current_log_sink() is sink
+        assert (retained[0] is sink) is (not observed)
+        sink("after")
+        return "outer"
+
+    await run(AsyncNode(outer), StaticIOLayer(), observer=rec)
+    before, inside, after = rec.logs
+    assert before.span_id == after.span_id
+    assert (inside.span_id == before.span_id) is (not observed)
+    assert len([e for e in rec.events if isinstance(e, NodeStarted)]) == (2 if observed else 1)
+    retained[0]("expired")
+    assert len(rec.logs) == 3
+
+
+@pytest.mark.asyncio
+async def test_off_thread_submission_is_dropped_even_with_copied_context():
+    rec = Recorder()
+
+    async def action(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        await asyncio.to_thread(sink, "off thread")
+        sink("on thread")
+        return "ok"
+
+    await run(AsyncNode(action), StaticIOLayer(), observer=rec)
+    assert [e.body for e in rec.logs] == ["on thread"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_failure_and_cancellation_revoke_sink_preserving_original_error(cancel):
+    rec = Recorder()
+    retained = []
+    entered = asyncio.Event()
+    error = RuntimeError("original node failure")
+
+    async def action(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        retained.append(sink)
+        entered.set()
+        if cancel:
+            await asyncio.Event().wait()
+        raise error
+
+    task = asyncio.create_task(run(AsyncNode(action), StaticIOLayer(), observer=rec))
+    await entered.wait()
+    if cancel:
+        task.cancel()
+    with pytest.raises(asyncio.CancelledError if cancel else RuntimeError) as caught:
+        await task
+    if not cancel:
+        assert caught.value is error
+    retained[0]("late")
+    assert rec.logs == []
+    finishes = [e for e in rec.events if isinstance(e, NodeFinished)]
+    assert finishes[0].status == ("cancelled" if cancel else "error")
+    assert current_log_sink() is None
+
+
+@pytest.mark.asyncio
+async def test_safe_sink_does_not_swallow_observer_cancellation():
+    class CancelObserver:
+        def on_event(self, event):
+            if isinstance(event, Log):
+                raise asyncio.CancelledError()
+
+    async def action(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        sink("body")
+        pytest.fail("cancellation swallowed")
+
+    with pytest.raises(asyncio.CancelledError):
+        await run(AsyncNode(action), StaticIOLayer(), observer=CancelObserver())
+
+
+def test_observation_import_stays_free_of_frameworks():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import url4.observe; "
+            "assert not any(n.split('.')[0] in {'pydantic', 'fastapi', 'opentelemetry', "
+            "'screamingface_engine'} for n in sys.modules)",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fails", [False, True])
+async def test_sink_is_expired_before_terminal_observation(fails):
+    retained = []
+
+    class TerminalObserver(Recorder):
+        def on_event(self, event):
+            super().on_event(event)
+            if isinstance(event, NodeFinished):
+                assert current_log_sink() is None
+                retained[0]("too late")
+
+    async def action(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        retained.append(sink)
+        if fails:
+            raise RuntimeError("node error")
+        return "ok"
+
+    rec = TerminalObserver()
+    if fails:
+        with pytest.raises(RuntimeError, match="node error"):
+            await run(AsyncNode(action), StaticIOLayer(), observer=rec)
+    else:
+        await run(AsyncNode(action), StaticIOLayer(), observer=rec)
+    assert rec.logs == []
+
+
+@pytest.mark.asyncio
+async def test_observed_subtree_restores_outer_sink_after_failure():
+    rec = Recorder()
+    retained = []
+
+    async def inner(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        retained.append(sink)
+        sink("inner")
+        raise RuntimeError("inner error")
+
+    async def outer(ctx):
+        sink = current_log_sink()
+        assert sink is not None
+        with pytest.raises(RuntimeError, match="inner error"):
+            await ctx.execute_node(AsyncNode(inner), ctx.scope)
+        assert current_log_sink() is sink
+        retained[0]("expired inner")
+        sink("outer")
+        return "ok"
+
+    await run(AsyncNode(outer), StaticIOLayer(), observer=rec)
+    assert [e.body for e in rec.logs] == ["inner", "outer"]
+    assert rec.logs[0].span_id != rec.logs[1].span_id
+    starts = [e for e in rec.events if isinstance(e, NodeStarted)]
+    assert starts[1].parent_span_id == starts[0].span_id


### PR DESCRIPTION
Long-running ensemble operations need to explain what is happening while the caller waits. This PR adds the URL4 reporting hook needed for structured activity such as completion timing or cache status to reach a future activity UI. Producers and client rendering remain separate work; this change does not generate or display that activity by itself.

## Example: reporting a retry inside a node

Illustrative instrumentation only; this change does not implement retry detection, a production activity schema or UI rendering.

While an observed URL4 node is resolving, adapter code that has detected a retry could call:

```python
from url4.observe import current_log_sink

sink = current_log_sink()
if sink is not None:
    sink("Retrying request", {"attempt": 2}, severity="WARN")
```

The executor binds the sink in the node's async execution context before calling resolve. The accessor retrieves that binding, so the adapter does not pass a node ID or register this message against a URL4 function. URL4 emits a Log containing the currently resolving node's span ID, the message and the attributes. The sink expires when resolution ends. Attribution is to that DAG node; distinguishing multiple model calls within one node requires separate application-defined fields.

The complete path is: adapter explicitly reports the retry → URL4 observer receives the node-attached Log → Engine forwarding from `OME-934` carries it to the existing Log stream → later client rendering can display it. URL4 does not discover retries automatically, and the attribute name `attempt` has no built-in meaning to URL4.

The earlier Engine-only proposal could carry the same information through a separate run-scoped input. This approach reuses URL4 observation and provides automatic node attachment; it does not make previously impossible information available. Evaluation-wide progress and scoring state remain Engine-owned under `OME-932`.

## Why this belongs in URL4

URL4 already owns node observation, Logs and task-local usage/response sinks. An adapter can now report a message with explicit fields, automatically attached to the currently resolving node, without receiving the whole ExecutionContext through its call chain. This keeps concurrent node activity distinguishable and lets consumers read fields instead of parsing prose. A node span identifies the observation context, not exact model-call or benchmark Case ownership.

OME-934 builds on this hook to forward attributes through the existing Engine Log stream and safely buffer optional activity around essential execution events. Reusing the existing observation path avoids a second Engine-specific logging input, factory or queue. Only three production modules change; no URL grammar, graph identity, scoring, external dependency or transport change is introduced.

## Why this is a generic URL4 capability

Adapters are an existing URL4 extension mechanism: the `IOLayer` protocol defines `fetch(...)`, with HTTP and in-memory implementations supplied in separate modules. Applications can supply their own implementations. Code implementing that interface can emit structured observations while it runs within an observed node's resolution on the event-loop thread. For example, an HTTP adapter could report bytes fetched or request duration; these illustrate possible instrumentation, not producers added by this PR. URL4 attaches the observation to the node without interpreting those fields or knowing the adapter's implementation.

This is architecturally consistent with URL4's existing separation of execution, I/O implementations and observers, and follows the existing task-local usage/response sink pattern. Validation, expiry and best-effort failure handling are new observation policies specified by the approved design in [PR #876](https://github.com/ScreamingFace/screamingface/pull/876); they are not requirements already imposed by URL4's grammar.

URL4 supplies the part it already owns: the active node's observation context and lifetime. It attaches a Log to that node, validates the generic record shape, snapshots attributes and expires the safe emitter when resolution ends. Centralizing this avoids each integration implementing its own task-local attribution and cleanup. Structured fields preserve machine-readable facts without requiring consumers to parse message prose.

The dependency direction stays outward: producer adapters use the URL4 interface, and a caller supplies an Observer implementing URL4's protocol. URL4 does not import the Engine, a producer or an exporter, and does not select a destination. An embedder can consume observations in-process without the ScreamingFace Engine, network transport or UI. The added observation code uses only the Python standard library.

Attribute names and meanings belong to producers and consumers. URL4 does not require or interpret model names, cache fields, benchmark Case IDs, scores or any other application vocabulary, and does not branch execution based on those attributes. Domain schemas, privacy filtering, payload/rate limits, delivery and rendering remain outside this interface.

“Agnostic” therefore means application- and exporter-agnostic, not policy-free or dependency-free for consumers. Producers choosing the accessor depend on URL4's observation API. URL4 deliberately specifies node scope, synchronous same-thread emission, flat scalar attributes, accepted severities and best-effort failure behavior. This is an additive library observation contract; it is not a change to URL grammar or a universal logging system outside URL4 execution.

## Implementation

Adapters inside a resolving URL4 node can now obtain `current_log_sink()` and emit structured Logs attached to that node's span. Attributes are immutable snapshots, and the sink drops invalid, expired, off-thread or ordinarily failing submissions without changing the node result. Existing direct logging and observer failure behavior remain intact.

Implements the package portion of the approved design in #876. Child-task bindings are revoked on scope exit; observed nesting binds/restores its own sink, while unobserved nesting inherits an active outer. Failure and cancellation expire the sink before terminal observation. Accepted severity names and flat scalar validation are documented in the package README.

## Scope and limitations

Logs are optional, best-effort activity. Invalid, expired or off-thread calls and ordinary observer failures may silently lose a message. A blocking observer can still slow execution. Reliable completion, accounting and saved failure diagnostics use separate authoritative paths.


URL4 observation and executor wiring only. OME-934 separately owns Engine forwarding and safe bridge buffering. Concrete activity schemas, Client rendering and benchmark progress remain their own issues. Keep this PR draft.

## Validation

- 45 new tests covering real DAG lifecycle, concurrent/nested scopes, child expiry, off-thread calls, immutable snapshots, validation, observer errors and process-control propagation.
- Full `uv run .claude/scripts/run_gates.py url4` passed: append-only, Ruff lint/format, Pyright and full pytest coverage gate. 1,215 tests collected; 98% overall coverage and 99% in observe.py.
- No existing tests modified; no live provider calls.

Asana: not applicable.

Refs: OME-1165
