### PR TITLE
feat: add placement and service-link controls to the analytics chart

### DIFF
--- a/apps/analytics/charts/analytics/templates/deployment.yaml
+++ b/apps/analytics/charts/analytics/templates/deployment.yaml
@@ -13,6 +13,9 @@ spec:
         app: {{ .Release.Name }}-analytics
     spec:
       automountServiceAccountToken: false
+      # WHY: a Service named `analytics` injects ANALYTICS_* link variables that
+      # Settings rejects under extra="forbid", crash-looping on a sanitized message.
+      enableServiceLinks: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001
@@ -48,3 +51,11 @@ spec:
             httpGet: {path: /readyz, port: http}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/apps/analytics/charts/analytics/values.yaml
+++ b/apps/analytics/charts/analytics/values.yaml
@@ -17,6 +17,8 @@ service:
 resources:
   requests: {cpu: 100m, memory: 128Mi}
   limits: {cpu: "1", memory: 256Mi}
+nodeSelector: {}
+tolerations: []
 ingress:
   enabled: false
   className: ""

--- a/apps/analytics/scripts/check_chart.py
+++ b/apps/analytics/scripts/check_chart.py
@@ -36,6 +36,9 @@ for enabled in (False, True):
     assert container["ports"][0]["containerPort"] == 9110
     assert service["spec"]["ports"][0]["targetPort"] == "http"
     assert container["securityContext"]["readOnlyRootFilesystem"] is True
+    # INVARIANT: link variables never reach an ANALYTICS_-prefixed, extra-forbidding Settings.
+    assert pod["spec"]["enableServiceLinks"] is False
+    assert "nodeSelector" not in pod["spec"] and "tolerations" not in pod["spec"]
     env = {value["name"]: value for value in container["env"]}
     assert env["ANALYTICS_ENABLED"]["value"] == str(enabled).lower()
     if enabled:
@@ -46,4 +49,14 @@ for enabled in (False, True):
         assert route["backend"]["service"]["name"] == service["metadata"]["name"]
     else:
         assert "ANALYTICS_POSTHOG_PROJECT_TOKEN" not in env and "Ingress" not in objects
-print("PASS: disabled and enabled chart wiring, secret references and ingress route")
+placed = subprocess.check_output(
+    base + ["--set", "nodeSelector.pool=tenant", "--set", "tolerations[0].key=workload"], text=True
+)
+spec = next(
+    item["spec"]["template"]["spec"]
+    for item in yaml.safe_load_all(placed)
+    if item and item["kind"] == "Deployment"
+)
+assert spec["nodeSelector"] == {"pool": "tenant"}
+assert spec["tolerations"] == [{"key": "workload"}]
+print("PASS: chart wiring, secret references, ingress route, service links and placement")


### PR DESCRIPTION
## Summary

We are getting ready to deploy `apps/analytics` on our dev cluster, and the chart needs two things it does not yet express: pod placement, and a guard against Kubernetes' service-link environment variables. This adds both and extends `check_chart.py` to cover them. Targets the #873 branch rather than `main`, since the chart only exists there.

No behaviour change to the service itself.

**Asana:** none — tracked as OME-1157.

## Components touched

`apps/analytics` (chart templates, values, and `scripts/check_chart.py`). No source changes.

## What this adds

**`nodeSelector` and `tolerations`.** We run tenant apps on a node pool reserved for them, separate from the nodes running our own platform components. Placing a pod there needs those two fields. We supply the values; the chart just has to accept them. Both default to empty, so an install that does not set them renders exactly as before — verified by diffing `helm template` output before and after.

**`enableServiceLinks: false`.** This is the same guard you merged for scoreboard in #538, and it is sharper here.

Kubernetes injects an environment variable for every Service in the namespace, named after that Service. A Service named `analytics` produces `ANALYTICS_PORT`, `ANALYTICS_SERVICE_HOST` and `ANALYTICS_SERVICE_PORT`. `Settings` reads the `ANALYTICS_` prefix with `extra="forbid"`, so `ANALYTICS_SERVICE_HOST` matches no field and validation fails at startup.

What makes it worth preventing structurally rather than remembering: `main.py` deliberately discards the validation detail, because a formatted pydantic error can echo input values and one of those inputs is the PostHog token. That is the right call — but it means this failure surfaces as a crash-loop with `Invalid analytics configuration` and no indication of which variable caused it.

It is latent today, since nothing is named `analytics` yet. It stays latent only until someone adds an awkwardly named Service to that namespace. We are avoiding the name on our side too; the chart-level guard is the durable fix and costs one line.

## Test plan

- [x] `uv run .claude/scripts/run_gates.py analytics` — all gates green (lock, ruff, format, pyright, pytest at 95% floor, build)
- [x] `uv run apps/analytics/scripts/check_chart.py` — passes, now also asserting the link guard, the empty placement defaults, and placement rendering when set
- [x] `helm lint` clean
- [x] Rendered `helm template` with and without the change: the only default-render difference is the `enableServiceLinks` line
- [x] Rendered with our real placement values and confirmed the selector and toleration appear correctly

## Cross-service notes

One question on your side, not a blocker for this PR: `ANALYTICS_ENV` is `Literal["test", "production"]`, and we will be running **three** environments — dev, staging and production — so two of ours would have to be labelled `test`. Reading the code, nothing in `api.py`, `ingestion.py`, `contract.py` or `posthog.py` appears to consume the value, which matches your note that environment labels do not independently verify the destination project.

If it is only a label, that is fine and we will treat the project token as the sole routing control, checking the destination by hand before enabling each environment. Worth deciding whether it gains a third value, gets dropped, or gets a comment saying it is descriptive — mostly so nobody later reads it as a safety control.

@sergio-bershadsky @HupBaHa
