### PR TITLE
feat: publish analytics dev images on merge to main

### DIFF
--- a/.github/scripts/verify_chart_wiring.py
+++ b/.github/scripts/verify_chart_wiring.py
@@ -1380,6 +1380,36 @@ check(
     "the benchmark image is published only under immutable version tags",
 )
 
+# analytics publishes from ONE lane — the dev lane on every merge to main. There is no release
+# lane yet, so unlike the pairs above there is no second publisher to agree with: the chart default
+# and this lane are the whole agreement, which is why it is asserted here rather than left to a
+# release lane that does not exist. A chart naming an image nobody pushes is installable and
+# permanently ImagePullBackOff.
+analytics_chart_values = yaml.safe_load(
+    (REPO / "apps/analytics/charts/analytics/values.yaml").read_text()
+)
+analytics_dev_lane = yaml.safe_load(
+    (REPO / ".github/workflows/dev-build-analytics.yml").read_text()
+)
+analytics_dev_tags = [
+    tag.strip()
+    for tag in analytics_dev_lane["jobs"]["image"]["steps"][-1]["with"]["tags"].split("\n")
+    if tag.strip()
+]
+check(
+    any(
+        tag.rsplit(":", 1)[0] == analytics_chart_values["image"]["repository"]
+        for tag in analytics_dev_tags
+    ),
+    f"analytics's dev lane pushes the SAME image repository the chart names "
+    f"({analytics_chart_values['image']['repository']})",
+)
+check(
+    all(":main-" in tag for tag in analytics_dev_tags)
+    and not any(tag.endswith(":latest") for tag in analytics_dev_tags),
+    "analytics's dev lane publishes only immutable main-<sha> tags — never :latest",
+)
+
 # A shared GHA cache scope between images with disjoint layer sets (uv/Python vs node/Next.js) is
 # not incorrect, but it is pure eviction pressure with no hits. Cheap to assert, easy to get wrong
 # by copying a sibling lane.

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -22,6 +22,7 @@ on:
       # a renamed field has to re-run it. Without this line the rename lands green here and the
       # pod runs on the field's default — which for AUTH_MODE is authentication disabled.
       - "apps/report-intake/src/report_intake/config.py"
+      - "apps/analytics/charts/**"
       - "apps/screamingface-engine/deploy/helm/**"
       - ".github/scripts/verify_chart_wiring.py"
       - ".github/workflows/charts.yml"
@@ -47,6 +48,7 @@ on:
       # a renamed field has to re-run it. Without this line the rename lands green here and the
       # pod runs on the field's default — which for AUTH_MODE is authentication disabled.
       - "apps/report-intake/src/report_intake/config.py"
+      - "apps/analytics/charts/**"
       - "apps/screamingface-engine/deploy/helm/**"
       - ".github/scripts/verify_chart_wiring.py"
       - ".github/workflows/charts.yml"

--- a/.github/workflows/dev-build-analytics.yml
+++ b/.github/workflows/dev-build-analytics.yml
@@ -1,0 +1,86 @@
+# Dev image on every merge to main (path-filtered): immutable main-<shortsha> tags
+# so a dev environment can track main automatically. Mirrors
+# dev-build-report-intake.yml. Single-arch (amd64) for speed; dev clusters are amd64.
+#
+# There is no release lane for analytics yet, so this is currently the ONLY
+# publisher of this image. The chart's `image.repository` default names the same
+# repository these tags do — verify_chart_wiring.py asserts it, because a chart
+# naming an image nobody pushes is installable and permanently ImagePullBackOff.
+#
+# THE IMAGE IS NOT WHAT MAKES THE SERVICE SAFE TO RUN. It ships disabled: without
+# ANALYTICS_ENABLED, an allowlisted HTTPS destination and a project token, the
+# settings validator refuses to start, /readyz answers 503 and no event is
+# forwarded. analytics-tests.yml asserts exactly that on the built image.
+#
+# SECURITY: no `run:` block interpolates a `${{ }}` expression carrying free text.
+# The two that interpolate at all read `github.sha` and the checkout's own git log;
+# no `github.event.*` value is referenced anywhere in this file.
+name: Dev build analytics
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/analytics/**"
+      - ".github/workflows/dev-build-analytics.yml"
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+  id-token: write # OIDC → Azure; no stored credentials
+concurrency:
+  group: dev-build-analytics-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # Pin the image's embedded build timestamp to the commit's own timestamp.
+      # WHY: with a warm layer cache, two builds from different commits can
+      # reproduce an IDENTICAL config `created` time, and any consumer that
+      # orders these tags by build time — the deployment automation that
+      # promotes them does exactly that — treats a tie as not-newer and never
+      # ships the new build. Commit time is unique per merge and monotonic on
+      # main. Same reasoning as dev-build-report-intake.yml.
+      - id: epoch
+        run: echo "epoch=$(git show -s --format=%ct HEAD)" >> "$GITHUB_OUTPUT"
+      - id: sha
+        run: echo "short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Platform registry (ACR) — the dev cluster pulls from here. OIDC only:
+      # sp-screamingface-ci is federated to this repo's main branch and holds
+      # AcrPush on acropenmined and nothing else. No secrets are stored here;
+      # the three vars below are non-secret identifiers.
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - run: az acr login --name acropenmined
+      - uses: docker/build-push-action@v7
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.epoch }}
+        with:
+          # Context is the repo root — the Dockerfile COPYs apps/analytics paths
+          # from outside its own directory, matching the sibling lanes.
+          context: .
+          file: apps/analytics/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ghcr.io/screamingface/screamingface-analytics:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-analytics:main-${{ steps.sha.outputs.short }}
+            acropenmined.azurecr.io/screamingface-analytics:main-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          # Its OWN scope. Sharing one with a sibling lane whose layer set is disjoint
+          # is pure eviction pressure with no hits, and is the easy mistake when a lane
+          # is copied — verify_chart_wiring.py asserts every dev lane's scope is distinct.
+          cache-from: type=gha,scope=dev-analytics
+          cache-to: type=gha,scope=dev-analytics,mode=max

--- a/apps/analytics/charts/analytics/values.yaml
+++ b/apps/analytics/charts/analytics/values.yaml
@@ -1,6 +1,6 @@
 replicaCount: 1
 image:
-  repository: ghcr.io/screamingface/analytics
+  repository: ghcr.io/screamingface/screamingface-analytics
   tag: ""
   pullPolicy: IfNotPresent
 analytics:


### PR DESCRIPTION
## Summary

`apps/analytics` has test, container and chart gates, but nothing publishes an image — so there is no build to deploy. This adds the dev lane, mirroring `dev-build-report-intake.yml`, and makes the chart's default image name agree with what it publishes. Targets the #873 branch rather than `main`, since `apps/analytics` only exists there.

**Asana:** none — tracked as OME-1157.

## Components touched

`apps/analytics` (chart values only), `.github/workflows`, `.github/scripts`. No source changes.

## What this adds

**`dev-build-analytics.yml`** — on merge to `main`, path-filtered to `apps/analytics/**`. Immutable `main-<sha>` tags to GHCR and ACR, OIDC to Azure with no stored credentials, single-arch amd64, its own cache scope `dev-analytics`, and the build epoch pinned to the commit's own timestamp. That last one is copied deliberately: your report-intake lane records that a warm layer cache can give two commits an identical `created` time, and anything ordering tags by build time then treats the newer build as not-newer.

**The chart's default image repository** moves from `ghcr.io/screamingface/analytics` to `ghcr.io/screamingface/screamingface-analytics`.

This is the part worth a second look. Your other charts default to `screamingface-<app>`:

| app | chart default |
|---|---|
| report-intake | `ghcr.io/screamingface/screamingface-report-intake` |
| scoreboard | `ghcr.io/screamingface/screamingface-scoreboard` |
| analytics (before) | `ghcr.io/screamingface/analytics` |

`dev-build-report-intake.yml`'s own header states the invariant: a dev image published under a different name than the chart defaults to "is one the chart can never be pointed at without editing values." Since analytics has no release lane yet, this lane and the chart default are the entire agreement — there is no third party to reconcile against. I moved the chart rather than the lane so the naming matches its siblings and the registry the deployment automation already watches. Say the word if you'd rather the lane publish bare `analytics` and I'll flip it.

**`verify_chart_wiring.py`** gains two analytics checks — that the lane pushes the repository the chart names, and that it publishes only immutable `main-<sha>` tags, never `:latest`. Same shape as the report-intake pair.

**`charts.yml`** gains `apps/analytics/charts/**` in both path lists, so a chart edit re-runs the comparison. `dev-build-*.yml` was already a glob there, so the lane itself already triggers it.

## Test plan

- [x] `uv run .github/scripts/verify_chart_wiring.py` — **112/112**, including the two new checks and the cache-scope check now reporting 6 lanes, 6 distinct scopes
- [x] **Negative test**: reverted the chart default alone and confirmed the new check FAILS (111/112, naming the mismatch), then restored it. An assertion that cannot fail is not worth adding
- [x] `uv run .claude/scripts/run_gates.py analytics` — all gates green
- [x] `uv run apps/analytics/scripts/check_chart.py` — passes
- [x] `helm lint` clean
- [x] Workflow parses as YAML

Not exercised: the lane itself, which cannot run until it is on `main`. Its Azure step is byte-identical to the report-intake lane's, using the same `sp-screamingface-ci` identity and the same three repository variables, and that identity already holds `AcrPush` registry-wide, so a new repository name needs no grant on our side.

## Cross-service notes

The lane will not fire until #873 merges — it triggers on pushes to `main`, and `apps/analytics` is not there yet. Once it does, the first merge publishes a build we can pin and deploy.

@sergio-bershadsky @HupBaHa
