### PR TITLE
fix: accept PostHog Cloud's acknowledgement so delivery can succeed

### DIFF
--- a/apps/analytics/src/analytics_service/adapters/posthog.py
+++ b/apps/analytics/src/analytics_service/adapters/posthog.py
@@ -47,13 +47,29 @@ def retry_delay(value: str | None) -> float:
     return delay
 
 
+# The acknowledgements /batch/ is known to answer with. PostHog Cloud returns
+# {"status":"Ok"}, verified live against us.i.posthog.com on 2026-09-09; the
+# integer form is the older acknowledgement and stays accepted so a self-hosted
+# or pinned deployment does not regress. Neither shape is documented, so this
+# tuple is the whole contract and any addition belongs here.
+ACKNOWLEDGEMENTS = ({"status": "Ok"}, {"status": 1})
+
+
 def accepted(body: bytes) -> bool:
     # WHY: malformed/partial responses cannot acknowledge the whole batch.
     try:
         value = json.loads(body)
     except (ValueError, UnicodeDecodeError):
         return False
-    return type(value) is dict and value == {"status": 1} and type(value["status"]) is int
+    if type(value) is not dict:
+        return False
+    # INVARIANT: exact match, so a response carrying extra keys is still
+    # refused. The status type check is load-bearing on the integer form —
+    # JSON true equals 1 in Python, so equality alone would accept
+    # {"status": true}.
+    return any(
+        value == ack and type(value["status"]) is type(ack["status"]) for ack in ACKNOWLEDGEMENTS
+    )
 
 
 class PostHogDelivery:

--- a/apps/analytics/tests/test_delivery.py
+++ b/apps/analytics/tests/test_delivery.py
@@ -118,3 +118,24 @@ def test_retry_dates_and_session_mapping(envelope):
     mapped = map_event(batch.events[0], batch)
     assert isinstance(mapped["properties"], dict)
     assert mapped["properties"]["distinct_id"] == "sf:session:" + event["session_id"]
+
+
+def test_posthog_cloud_acknowledgement_shape():
+    """PostHog Cloud answers {"status":"Ok"}, not the integer form.
+
+    Verified live against us.i.posthog.com/batch/ on 2026-09-09: a 200 with
+    body {"status":"Ok"}. The previous exact-match on {"status": 1} rejected
+    it, so every delivery retried once and then raised DeliveryUnavailable —
+    the event reached PostHog twice and the caller still saw 503.
+    """
+    from analytics_service.adapters.posthog import accepted
+
+    assert accepted(b'{"status":"Ok"}')
+    assert accepted(b'{"status":1}')
+    # Still refused: partial acknowledgements, wrong types, wrong shapes.
+    assert not accepted(b'{"status":"Ok","errors":["partial"]}')
+    assert not accepted(b'{"status":"ok"}')
+    assert not accepted(b'{"status":true}')
+    assert not accepted(b'{"status":"1"}')
+    assert not accepted(b'"Ok"')
+    assert not accepted(b"not json")


### PR DESCRIPTION
## Summary

We deployed `apps/analytics` to our dev cluster today. Every request answered **503** — while the events themselves were arriving in PostHog perfectly well.

PostHog Cloud's `/batch/` returns **`{"status":"Ok"}`** — a string. `accepted()` matched only `{"status": 1}`, so no delivery was ever acknowledged.

**Asana:** none — tracked as OME-1157.

## Components touched

`apps/analytics` (`adapters/posthog.py`, `tests/test_delivery.py`). No chart or packaging changes.

## How it was found

Live, from inside the running pod, with the real dev project token:

```
POST https://us.i.posthog.com/batch/  ->  200  b'{"status":"Ok"}'
accepted() would return: False
```

Before that: `/healthz` 200, `/readyz` `{"ready":true}`, DNS + TLS + a full HTTPS round trip to PostHog in 0.05s. So it was neither configuration, nor the network, nor the 1.5s budget.

## Why this is worse than a wrong status code

`send()` reported not-accepted, so `attempts()` **retried and delivered the same batch a second time** before raising `DeliveryUnavailable`. Your deduplication design saved the data — the retry reuses each event `uuid` — but the effect in production would have been:

- every event delivered **twice**
- every caller told **503** for events that had in fact landed
- **no health signal showing any of it**: pod Running, liveness green, `/healthz` 200, `/readyz` ready

That last point is why I would not have caught this without sending a real event.

## The fix

Both known acknowledgements are accepted. Deliberately narrow:

- The integer form stays, so a self-hosted or pinned deployment does not regress.
- The match is still **exact**, so a partial acknowledgement carrying extra keys is refused exactly as before — your `(200, {"status": 1, "errors": ["partial"]}, DeliveryUnavailable, 2)` case still passes unchanged.
- The status **type** check is kept, because JSON `true` equals `1` in Python and equality alone would accept `{"status": true}`.

Neither shape appears in PostHog's docs, so `ACKNOWLEDGEMENTS` is commented as the whole contract and the single place to extend.

## Test plan

- [x] `uv run .claude/scripts/run_gates.py analytics` — **all gates green** (append-only check, lock, ruff, format, pyright, pytest at the 95% floor, build)
- [x] New test appended rather than editing an existing body, per the append-only gate
- [x] Covers both accepted shapes and five refusals: partial acknowledgement, wrong case, `true`, the string `"1"`, a bare scalar, and non-JSON

## One thing worth your judgement, not fixed here

Coupling acceptance to an **undocumented response body** is fragile — this is the second shape it has had, and a third would fail exactly the same silent way. You may prefer a contract like "2xx and no `quota_limited`". That is a design call about your delivery guarantee, so I have not made it; this change only restores the intent you already had.

@sergio-bershadsky @HupBaHa