### PR TITLE
fix(engine): forward structured Logs with safe buffer admission

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/executor.py
@@ -89,7 +89,7 @@ class _Bridge:
     """A bounded async event queue between the engine's synchronous `url4.observe` callback
     and the async streaming loop draining it.
 
-    Buffers up to `maxsize` events; beyond that, an incoming `Log` is dropped outright, while
+    At either capacity limit, an incoming `Log` is dropped outright, while
     an incoming non-Log event instead evicts the oldest buffered `Log` to make room (or, if no
     `Log` is buffered, evicts nothing and the buffer grows toward the hard cap) — since a `Log`
     is the only event kind safe to lose without corrupting the run's span/cost accounting.
@@ -157,19 +157,16 @@ class _Bridge:
     def on_event(self, event: ObservationEvent) -> None:
         """Called synchronously by the engine for every observation event.
 
-        Policy at the soft cap (`maxsize`): a `Log` is dropped outright (counted in
+        Policy at either the soft or hard cap: a `Log` is dropped outright (counted in
         `dropped`); anything else evicts the oldest buffered `Log` to make room, since a
         `Log` is the only event kind safe to lose without corrupting the run's span/cost
         accounting. Only once the backlog still exceeds the hard cap after that eviction does
         this raise `BridgeOverflowError`.
         """
-        # INVARIANT: with the default budget the hard cap sits far above `_max`, giving the
-        # buffer headroom past the soft cap before the budget binds — NOT a guarantee that a
-        # Log is available to evict. A backlog with no buffered Log at all is exactly the
-        # state that runs out that headroom and raises BridgeOverflowError. A budget below
-        # `_max` events' worth makes the hard cap bind first; the policy stays correct, the
-        # soft cap simply never gets to help.
-        if len(self._buf) >= self._max:
+        # INVARIANT: optional activity cannot consume the last slot needed by an
+        # authoritative event, even when the hard cap is below the soft cap.
+        # The buffer never exceeds the hard cap, so one eviction admits one event.
+        if len(self._buf) >= min(self._max, self._hard_cap):
             if isinstance(event, Log):
                 self._dropped += 1
                 return
@@ -676,7 +673,9 @@ def _closing_logs(bridge: _Bridge, counters: RunCacheCounters) -> list[Traced]:
 def _log_frame(event: Log) -> LogData:
     # The engine's severity is a free string; anything the protocol does not name maps to INFO.
     severity = cast(Severity, event.severity.upper())
-    return LogData.at(severity if severity in SEVERITY_NUMBER else "INFO", event.body)
+    return LogData.at(
+        severity if severity in SEVERITY_NUMBER else "INFO", event.body, dict(event.attributes)
+    )
 
 
 World = tuple[IOLayer, Callable[[], Awaitable[None]] | None]

--- a/apps/screamingface-engine/tests/unit/test_structured_log_forwarding.py
+++ b/apps/screamingface-engine/tests/unit/test_structured_log_forwarding.py
@@ -1,0 +1,183 @@
+"""Generic endpoint activity survives real Engine execution and wire publication."""
+
+import asyncio
+
+import pytest
+
+from screamingface_engine.runner.executor import Url4Executor, _log_frame
+from screamingface_engine.testing import InMemoryEventStream
+from url4.io.static import StaticIOLayer
+from url4.observe import Log, current_log_sink
+from url4.streaming.interfaces import Completed, Traced
+from url4.streaming.lifecycle import run as publish_run
+from url4.streaming.protocol import LogData, LogEvent, SpanEvent, TerminatedEvent
+
+
+@pytest.mark.parametrize("severity", ["DEBUG", "INFO", "WARN", "ERROR", "custom"])
+def test_conversion_preserves_attributes_and_existing_severity_fallback(severity):
+    attributes = {"count": 2, "duration": 1.25, "ok": True, "unknown": None, "text": "x"}
+    frame = _log_frame(Log("a" * 16, severity, "activity", attributes))
+    assert frame.attributes == attributes
+    assert frame.severity_text == (severity if severity != "custom" else "INFO")
+    assert _log_frame(Log(None, severity, "old style")).attributes == {}
+
+
+async def _published_activity(marker):
+    attrs = {"marker": marker, "count": 2, "ok": True, "unknown": None}
+
+    async def endpoint(context, intent):
+        sink = current_log_sink()
+        assert sink is not None
+        sink("operation activity", attrs, severity="WARN")
+        attrs["count"] = 99
+        return "finished"
+
+    stream = InMemoryEventStream()
+    await publish_run(
+        stream,
+        Url4Executor(StaticIOLayer(routes={"/operation": endpoint})),
+        marker,
+        "/operation()!go",
+    )
+    frames = []
+    async for frame in stream.subscribe(marker, from_sequence=1):
+        frames.append(frame)
+        if isinstance(frame, TerminatedEvent):
+            break
+    return frames
+
+
+@pytest.mark.asyncio
+async def test_concurrent_endpoint_logs_keep_attributes_node_attachment_and_wire_order():
+    runs = await asyncio.gather(_published_activity("one"), _published_activity("two"))
+    traceparents = []
+    for marker, frames in zip(("one", "two"), runs, strict=True):
+        logs = [
+            f for f in frames if isinstance(f, LogEvent) and f.data.body == "operation activity"
+        ]
+        assert len(logs) == 1
+        log = logs[0]
+        assert log.data.attributes == {"marker": marker, "count": 2, "ok": True, "unknown": None}
+        assert log.data.severity_text == "WARN"
+        assert LogEvent.model_validate_json(log.model_dump_json()) == log
+        assert any(isinstance(f, SpanEvent) and f.traceparent == log.traceparent for f in frames)
+        assert [int(f.sequence) for f in frames] == list(range(1, len(frames) + 1))
+        assert frames[-1].data.status == "succeeded"
+        traceparents.append(log.traceparent)
+    assert traceparents[0] != traceparents[1]
+
+
+@pytest.mark.asyncio
+async def test_activity_streams_before_endpoint_completion():
+    release = asyncio.Event()
+
+    async def endpoint(context, intent):
+        sink = current_log_sink()
+        assert sink is not None
+        sink("waiting", {"elapsed_seconds": 30})
+        await release.wait()
+        return "finished"
+
+    executor = Url4Executor(StaticIOLayer(routes={"/operation": endpoint}))
+    steps = executor.execute("/operation()!go")
+    first = None
+    try:
+        async with asyncio.timeout(2):
+            async for first in steps:
+                if isinstance(first, Traced) and isinstance(first.payload, LogData):
+                    break
+        assert isinstance(first, Traced) and isinstance(first.payload, LogData)
+        assert first.payload.body == "waiting"
+        assert first.payload.attributes == {"elapsed_seconds": 30}
+        assert first.span is not None
+        assert not release.is_set()
+    finally:
+        release.set()
+        rest = [step async for step in steps]
+    assert isinstance(rest[-1], Completed)
+    assert rest[-1].result.body == "finished"
+
+
+@pytest.mark.asyncio
+async def test_existing_client_decodes_real_serialized_engine_lifecycle():
+    # WHY: protocol model round-trips alone cannot prove the independent Client accepts it.
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    frames = await _published_activity("client")
+    client_src = Path(__file__).resolve().parents[4] / "packages/screamingface/src"
+    script = """
+import sys
+from screamingface._engine.contract import _RunState
+from screamingface.events import Log
+state = _RunState("/operation()!go")
+logs = []
+for line in sys.stdin:
+    accepted = state.accept(line)
+    if isinstance(accepted.event, Log) and accepted.event.body == "operation activity":
+        logs.append(accepted.event)
+assert len(logs) == 1
+assert logs[0].attributes == {"marker": "client", "count": 2, "ok": True, "unknown": None}
+assert logs[0].traceparent
+assert accepted.outcome is not None
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        input="\n".join(frame.model_dump_json(by_alias=True) for frame in frames),
+        text=True,
+        capture_output=True,
+        timeout=15,
+        env={**os.environ, "PYTHONPATH": str(client_src)},
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("soft,hard", [(2, 8), (8, 8), (100, 8)])
+@pytest.mark.parametrize("fails", [False, True])
+@pytest.mark.asyncio
+async def test_real_endpoint_lifecycle_is_unchanged_by_log_pressure(soft, hard, fails):
+    from screamingface_engine.runner.executor import EVENT_SIZE_ESTIMATE_BYTES
+    from url4.core.errors import ResolutionError
+    from url4.streaming.protocol import ResultEvent
+
+    outcomes = []
+    for noisy in (False, True):
+
+        async def endpoint(context, intent):
+            sink = current_log_sink()
+            assert sink is not None
+            if noisy:
+                for i in range(40):
+                    sink("optional burst", {"index": i})
+            if fails:
+                raise ResolutionError("original endpoint error")
+            return "finished"
+
+        executor = Url4Executor(
+            StaticIOLayer(routes={"/operation": endpoint}),
+            queue_cap=soft,
+            memory_budget=hard * EVENT_SIZE_ESTIMATE_BYTES,
+        )
+        stream = InMemoryEventStream()
+        await publish_run(stream, executor, "pressure", "/operation()!go")
+        frames = []
+        async for frame in stream.subscribe("pressure", from_sequence=1):
+            frames.append(frame)
+            if isinstance(frame, TerminatedEvent):
+                break
+        delivered = sum(isinstance(f, LogEvent) and f.data.body == "optional burst" for f in frames)
+        summary = executor.last_summary()
+        assert summary is not None
+        assert summary.dropped_logs == (40 if noisy else 0) - delivered
+        assert summary.high_water <= hard
+        outcomes.append(
+            (
+                frames[-1].data.model_dump(),
+                [f.data.model_dump() for f in frames if isinstance(f, ResultEvent)],
+                [(f.data.name, f.data.status) for f in frames if isinstance(f, SpanEvent)],
+            )
+        )
+    assert outcomes[0] == outcomes[1]
+    assert outcomes[0][0]["status"] == ("failed" if fails else "succeeded")

--- a/apps/screamingface-engine/tests/unit/test_structured_log_pressure.py
+++ b/apps/screamingface-engine/tests/unit/test_structured_log_pressure.py
@@ -1,0 +1,70 @@
+"""Optional activity never prevents an otherwise admissible lifecycle sequence."""
+
+import pytest
+
+from screamingface_engine.runner.executor import (
+    EVENT_SIZE_ESTIMATE_BYTES,
+    BridgeOverflowError,
+    _Bridge,
+)
+from url4.observe import Log, NodeFinished, NodeStarted, RunFinished, RunStarted, Usage
+
+
+def _bridge(soft, hard):
+    return _Bridge(maxsize=soft, memory_budget=hard * EVENT_SIZE_ESTIMATE_BYTES)
+
+
+@pytest.mark.parametrize("soft,hard", [(2, 5), (5, 5), (20, 5)])
+@pytest.mark.parametrize("status", ["ok", "error", "cancelled"])
+@pytest.mark.asyncio
+async def test_optional_logs_preserve_identical_authoritative_lifecycle(soft, hard, status):
+    lifecycle = [
+        RunStarted("a" * 32, "b" * 16, "expression"),
+        NodeStarted("c" * 16, "b" * 16, "RelUrlNode", "/operation"),
+        Usage("c" * 16, "provider", "model", 2, 1),
+        NodeFinished("c" * 16, status, 1),
+        RunFinished(status, 2),
+    ]
+    outputs = []
+    for noisy in (False, True):
+        bridge = _bridge(soft, hard)
+        emitted = 0
+        for event in lifecycle:
+            if noisy:
+                for _ in range(7):
+                    bridge.on_event(Log("c" * 16, "INFO", "optional", {"attempt": 2}))
+                    emitted += 1
+            bridge.on_event(event)
+        bridge.close()
+        drained = [event async for event in bridge.drain()]
+        outputs.append([event for event in drained if not isinstance(event, Log)])
+        # INVARIANT: every submitted Log is either delivered or counted exactly once as lost.
+        delivered = sum(isinstance(event, Log) for event in drained)
+        assert bridge.dropped == emitted - delivered
+        assert bridge.high_water <= hard
+    assert outputs == [lifecycle, lifecycle]
+
+
+@pytest.mark.parametrize("soft,hard", [(2, 4), (4, 4), (8, 4)])
+def test_authoritative_only_hard_cap_still_fails_and_incoming_log_drops(soft, hard):
+    bridge = _bridge(soft, hard)
+    for i in range(hard):
+        bridge.on_event(NodeStarted(str(i), None, "TextNode", ""))
+    bridge.on_event(Log(None, "INFO", "optional"))
+    assert bridge.dropped == 1
+    assert len(bridge._buf) == hard
+    with pytest.raises(BridgeOverflowError):
+        bridge.on_event(NodeFinished("0", "ok", 1))
+
+
+@pytest.mark.asyncio
+async def test_eviction_preserves_surviving_log_order_and_counts_loss():
+    bridge = _bridge(4, 4)
+    logs = [Log(None, "INFO", str(i)) for i in range(4)]
+    for log in logs:
+        bridge.on_event(log)
+    terminal = RunFinished("ok", 1)
+    bridge.on_event(terminal)
+    bridge.close()
+    assert [event async for event in bridge.drain()] == [*logs[1:], terminal]
+    assert bridge.dropped == 1

--- a/docs/tasks/2026-09-09-OME-934-log-seam.md
+++ b/docs/tasks/2026-09-09-OME-934-log-seam.md
@@ -23,3 +23,7 @@ Owner approved the revised design on 2026-09-09. OME-1165 owns the generic URL4 
 Existing downstream tickets: OME-1161 activity producer, OME-1135 Client Logs tab and OME-932 evaluation lifecycle/provisional progress. OME-699 owns semantic attribution. Saved failure diagnostics remain separate.
 
 Implementation follows the docs merge in separate worktrees and draft PRs, URL4 first. No production implementation is delivered by draft PR 876. The spec and plan enumerate acceptance, including paired lifecycle pressure regressions and authoritative-only overflow preservation.
+
+## Engine implementation
+
+Started after PR 877 merged at cfd3eb38, from a fresh origin/main worktree. [Implementation ledger](../work/2026-09-09-OME-934-structured-log-forwarding.md) records forwarding, buffer-pressure and Client wire compatibility verification. Delivery remains open pending draft PR review and merge.

--- a/docs/work/2026-09-09-OME-934-structured-log-forwarding.md
+++ b/docs/work/2026-09-09-OME-934-structured-log-forwarding.md
@@ -1,0 +1,41 @@
+---
+ticket: OME-934
+stack: screamingface-engine
+status: done
+started: 2026-09-09
+finished: 2026-09-09
+---
+
+# OME-934 — Forward structured Logs without disrupting execution
+
+## Intent
+
+Carry URL4 Log attributes through the Engine and ensure optional activity cannot displace otherwise admissible authoritative events. Implements the Engine portion of the approved September 9 spec/plan after PR 877 merged at cfd3eb38; user authorized implementation in this session.
+
+## Planned changes
+
+- apps/screamingface-engine/src/screamingface_engine/runner/executor.py: Log conversion and targeted soft/hard bridge admission.
+- apps/screamingface-engine/tests/unit/test_structured_log_forwarding.py: real endpoint emission, sequencing, wire conversion and lifecycle compatibility.
+- apps/screamingface-engine/tests/unit/test_structured_log_pressure.py: paired lifecycle sequences, exact loss counts and authoritative-only overflow.
+- docs/tasks/2026-09-09-OME-934-log-seam.md: implementation delivery link/status.
+
+## Test plan
+
+Write new failing tests first for lost attributes and hard-cap-before-soft-cap Log pressure. Preserve all existing tests. Exercise soft/hard boundary combinations, eviction and incoming drops, original failure behavior, concurrent run attribution, live emission before completion, and serialized events decoded by the existing Client. Run the full Engine gate runner.
+
+## Acceptance
+
+Approved docs/spec/2026-09-09-OME-934-log-seam.md Engine requirements and plan steps 4–6 pass. No second event type/queue, producer schema, Client code change or scoring behavior. Draft PR only; no merge or ticket closure before delivery review.
+
+## Outcome
+
+- **Actual files:** one production module, two new test modules, issue mirror and this ledger, as planned.
+- **Commits:** fix(engine): forward structured Logs with safe buffer admission; Refs: OME-934. Commit SHA is recorded with the draft PR.
+- **Gates:** full `uv run .claude/scripts/run_gates.py screamingface-engine` green: append-only, Ruff lint/format, Pyright, layering and full pytest coverage gate. 2,682 tests collected; 93% aggregate coverage. All 27 added cases pass; no existing tests changed.
+- **RED evidence:** attributes converted to empty mappings; hard-cap-before-soft-cap Logs raised BridgeOverflowError. A live streaming test was corrected to allow preceding node spans; it then failed on the intended lost-attributes assertion. New test sequence comparison uses the protocol's numeric string sequence. Client probe uses actual wire aliases.
+- **Deviations:** none in production scope. A new Engine-side subprocess compatibility test imports the unchanged Client source and feeds real serialized lifecycle frames through its independent decoder. No SDK dependency or source change is needed.
+- **Delivery:** implementation complete; issue remains open pending draft PR review/merge. No production model-activity producer or Client rendering is included.
+
+## Wisdom and confidence review
+
+The buffer is always at or below its hard cap before admission, so one eviction is sufficient to admit one incoming authoritative event. Applying the existing policy at the lower limit preserves soft-cap behavior and corrects inverted-cap behavior without another queue or event type. Attributes are copied into the existing LogData representation and old severity fallback remains intact. Paired synthetic and actual endpoint runs verify lifecycle outcomes and exact loss accounting. Existing Client decoding passes with node trace attachment and structured fields. Independent standards and spec reviews found no actionable issues. The implementation adds no domain schema, I/O, privacy policy, scoring logic or cross-package production dependency.


### PR DESCRIPTION
URL4's structured Logs from #877 currently lose their attributes when the Engine converts them for the wire. Optional Logs can also trigger overflow when the bridge's hard capacity is below its soft capacity. This change forwards the attributes and applies the existing drop/eviction policy at whichever limit is reached first.

For example, an instrumented endpoint can emit `"Retrying request"` with `{"attempt": 2}` during node resolution. The fields and node trace attachment now survive Engine publication and existing Client decoding. This PR supplies forwarding only: OME-1161 owns actual model-call activity producers, and OME-1135 owns the Logs tab.

## Implementation

- Forward a detached copy of Log attributes into existing LogData, preserving severity fallback, sequencing and span attachment.
- Drop incoming optional Logs or evict the oldest buffered Log at either limit; count each loss. Authoritative-only hard-cap exhaustion still fails.
- Keep the production change in the existing executor module, with no new queue, event type, domain schema or SDK change.

## Validation

- 27 new cases cover scalar fields, concurrent attribution, live emission before completion, real wire/Client decoding, exact loss counts and paired lifecycle outcomes with/without Log pressure.
- Full `uv run .claude/scripts/run_gates.py screamingface-engine` passed: append-only, Ruff lint/format, Pyright, layering and full pytest coverage gate; 2,682 tests collected and 93% aggregate coverage.
- No existing tests changed; no live provider calls.
- Standards and spec reviews found no actionable issues.

Implements the Engine portion of the approved design in #876, after #877 merged. Keep draft pending owner review.

Ledger: `docs/work/2026-09-09-OME-934-structured-log-forwarding.md`

Asana: not applicable.

Refs: OME-934
