### PR TITLE
fix(aigateway): serve the model-parameters datasheet without a connected profile

### DIFF
--- a/apps/aigateway/src/aigateway/routes/chat_credentials.py
+++ b/apps/aigateway/src/aigateway/routes/chat_credentials.py
@@ -219,6 +219,7 @@ async def _credential_target_for_chat(
     provider: str,
     profile_name: str,
     plugin: Any,
+    missing_target_ok: bool = False,
 ) -> tuple[Profile | None, OAuthConnection | None, ProfileDefaults]:
     idx: ProfileIndexStore = request.app.state.profile_index
     profile = await idx.get(account_id, provider, profile_name)
@@ -237,6 +238,11 @@ async def _credential_target_for_chat(
             )
             return None, connection, ProfileDefaults()
         if not _allows_chatless_profile(plugin):
+            # WHY the escape (OME-1167): the model-parameters DATASHEET needs no
+            # stored credential target, so its route opts in to a target-less
+            # result here. Chat never sets the flag — dispatch keeps this 404.
+            if missing_target_ok:
+                return None, None, ProfileDefaults()
             raise HTTPException(
                 status_code=404,
                 detail={

--- a/apps/aigateway/src/aigateway/routes/model_parameters.py
+++ b/apps/aigateway/src/aigateway/routes/model_parameters.py
@@ -132,16 +132,20 @@ async def _contract_document(request: Request, *, account_id: str, model: str) -
             )
 
     profile_name = (request.headers.get("X-Profile") or "default").strip() or "default"
-    # Reuse the chat resolution verbatim (raises the same 404/409 on a missing/
-    # pending/errored profile) so summary, detail, and dispatch agree on context.
+    # Reuse the chat resolution (raises the same 409/401 on a pending/errored
+    # profile, and the same 404 on an explicitly NAMED missing profile) so
+    # summary, detail, and dispatch agree on context. The one divergence
+    # (OME-1167): the DEFAULT binding with no stored target answers instead of
+    # 404ing — the contract is a datasheet lookup, not a credentialed action.
     profile, connection, _defaults = await _credential_target_for_chat(
         request,
         account_id=account_id,
         provider=provider,
         profile_name=profile_name,
         plugin=plugin,
+        missing_target_ok=profile_name == "default",
     )
-    auth_mode = resolved_auth_mode(profile, connection, plugin=plugin)
+    auth_mode = _contract_auth_mode(plugin, profile, connection)
 
     # Observed LAST: a request that fails profile resolution must not have spent a
     # fetch on a contract it will never serve. (The lazy catalog consult above is
@@ -183,6 +187,33 @@ async def _contract_document(request: Request, *, account_id: str, model: str) -
         # contract_id is not silently handed evidence with a different provenance.
         source_revision=discovered.snapshot.source_revision if discovered.snapshot else None,
     )
+
+
+def _contract_auth_mode(
+    plugin: ProviderPluginBase,
+    profile: Profile | None,
+    connection: OAuthConnection | None,
+) -> AuthMode:
+    """The auth mode the published contract is bound to, keyless case included.
+
+    With any stored target — or a provider that permits a chatless profile —
+    this is exactly ``resolved_auth_mode``, unchanged. The added branch (OME-1167)
+    covers only the target-less answer that used to 404: the datasheet is
+    published under the provider's own declared preference — its profileless
+    mode when it names one, else its FIRST declared auth mode.
+
+    # WHY not ``resolved_auth_mode`` for that case: its target-less fallback is
+    # ``"oauth"``, which raises 400 for an api-key-only provider — correct for a
+    # dispatch target, wrong for a datasheet that merely needs A mode to be
+    # published under. The response's ``context.auth_mode`` names the binding,
+    # so the choice is visible, never a lie.
+    """
+    if profile is None and connection is None and not plugin.allows_chatless_profile():
+        keyless_mode: AuthMode | None = plugin.profileless_auth_mode()
+        if keyless_mode is not None:
+            return keyless_mode
+        return plugin.available_auth_modes()[0]
+    return resolved_auth_mode(profile, connection, plugin=plugin)
 
 
 async def _live_catalog_ids(request: Request, plugin: ProviderPluginBase[Any]) -> frozenset[str]:

--- a/apps/aigateway/tests/unit/test_model_parameters_route.py
+++ b/apps/aigateway/tests/unit/test_model_parameters_route.py
@@ -96,10 +96,54 @@ def test_unknown_model_under_known_provider_is_rejected_before_profile(authentic
     assert resp.json()["detail"]["code"] == "model_not_found"
 
 
-def test_missing_profile_reuses_chat_credential_resolution(authenticated_client):
-    # anthropic is not chatless, so with no profile the endpoint raises the SAME
-    # 404 the chat route raises — proving the resolution is reused, not reinvented.
+def test_missing_default_profile_answers_the_keyless_datasheet(authenticated_client):
+    # FEATURE: keyless parameter preflight (OME-1167). Reading the contract is a
+    # datasheet lookup, not a credentialed action — with no profile and no
+    # connection the DEFAULT binding answers 200 instead of chat's 404.
+    # (This flips the pre-OME-1167 pin that expected profile_not_found here;
+    # the flip is the ticket's mandated behavior change.)
+    # INVARIANT: the published auth mode is the provider's FIRST declared mode,
+    # so the binding is visible and deterministic — anthropic declares
+    # ("api_key", "oauth").
     resp = _get(authenticated_client)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["context"]["auth_mode"] == "api_key"
+    assert body["model"]["id"] == _MODEL
+    # The answer stays per-account on the wire even though its content is static.
+    _assert_private_cache_policy(resp)
+
+
+@pytest.mark.asyncio
+async def test_keyless_answer_equals_the_credentialed_static_contract(
+    credential_blobs, authenticated_client
+):
+    # INVARIANT (don't-regress, OME-1167): no credentialed data may leak into the
+    # uncredentialed answer — and none may be MISSING from it either. The keyless
+    # datasheet and an api_key-profile answer are the same static contract; only
+    # the context identity (and hence the opaque ids) may differ.
+    keyless = _get(authenticated_client)
+    assert keyless.status_code == 200, keyless.text
+
+    account_id = _account_id(authenticated_client)
+    await _seed_profile(credential_blobs, account_id, auth_type="api_key")
+    credentialed = _get(authenticated_client)
+    assert credentialed.status_code == 200, credentialed.text
+
+    keyless_body = keyless.json()
+    credentialed_body = credentialed.json()
+    for section in ("parameters", "tools", "transport", "model"):
+        assert keyless_body[section] == credentialed_body[section]
+    assert keyless_body["context"]["auth_mode"] == credentialed_body["context"]["auth_mode"]
+
+
+def test_missing_default_profile_on_chat_still_404s(authenticated_client):
+    # INVARIANT (don't-regress, OME-1167): only the datasheet went keyless —
+    # dispatch still refuses an account with no stored credential target.
+    resp = authenticated_client.post(
+        "/v1/chat/completions",
+        json={"model": _MODEL, "messages": [{"role": "user", "content": "hi"}]},
+    )
     assert resp.status_code == 404
     assert resp.json()["detail"]["code"] == "profile_not_found"
 

--- a/docs/tasks/2026-09-10-OME-1167-keyless-model-parameters.md
+++ b/docs/tasks/2026-09-10-OME-1167-keyless-model-parameters.md
@@ -1,0 +1,19 @@
+---
+id: OME-1167
+linear_url: https://linear.app/openmined/issue/OME-1167/checking-a-models-parameter-limits-fails-unless-a-provider-is
+status: in_progress
+type: bug
+priority: Medium
+labels: [aigateway, agentic, autonomous]
+created: 2026-09-10
+closed:
+---
+
+# Checking a model's parameter limits fails unless a provider is connected
+
+`GET /v1/model-parameters` reuses the chat credential resolution, so an account with no
+profile/connection for a provider gets 404 `profile_not_found` — even though the
+parameter contract is static datasheet content. Make the contract answerable keyless;
+dispatch and connection flows unchanged. Root cause lands in aigateway (relabelled from
+`screamingface-engine` after investigation). Ledger:
+`docs/work/2026-09-10-OME-1167-keyless-model-parameters.md`.

--- a/docs/work/2026-09-10-OME-1167-keyless-model-parameters.md
+++ b/docs/work/2026-09-10-OME-1167-keyless-model-parameters.md
@@ -1,0 +1,105 @@
+---
+ticket: OME-1167
+stack: aigateway
+status: done
+started: 2026-09-10
+finished: 2026-09-10
+---
+
+# OME-1167 — Checking a model's parameter limits fails unless a provider is connected
+
+## Intent
+
+Reading a model's parameter contract is a datasheet lookup, not a credentialed action —
+but today aigateway's `GET /v1/model-parameters` reuses the chat credential resolution,
+which raises 404 `profile_not_found` when the account has no profile and no connection
+for the provider. The Engine relays that verbatim and the SDK renders "profile is not
+connected", so a keyless stack cannot preflight a params-carrying candidate. This unit
+makes the contract answerable with no stored credential target, keeping dispatch and
+connection flows byte-identical.
+
+**Refusal origin (investigation result):** `apps/aigateway/src/aigateway/routes/chat_credentials.py`
+`_credential_target_for_chat` — the `profile_not_found` raise when profile and active
+connection are both absent and the plugin does not allow a chatless profile. The Engine
+route (`apps/screamingface-engine/.../rest/catalog.py`) and the SDK
+(`packages/screamingface/.../_engine/catalog.py`) only relay it. Landing relabeled
+`screamingface-engine` → `aigateway` per the ticket's note.
+
+**Escape-hatch note:** `SCREAMINGFACE_SKIP_PARAMETER_PREFLIGHT` does not exist on main
+or in PR #870 — the ticket pre-describes a hatch that has not shipped. Fixing the root
+cause here means it never ships; the "delete the hatch" closing step is vacuous and is
+recorded as a coordination comment on the ticket instead.
+
+## Design
+
+- Only the would-be `profile_not_found` case (no profile AND no active connection AND
+  plugin refuses chatless) becomes answerable. Pending (`409 profile_pending_auth`) and
+  errored (`401 auth_required`) profiles keep today's refusals — a stored-but-broken
+  target still points the human at the connect flow, and the SDK's retry semantics pin
+  those codes.
+- Keyless auth mode for the datasheet: `plugin.profileless_auth_mode()` if declared,
+  else the first entry of `plugin.available_auth_modes()`. The published document
+  already names its `auth_mode` in the context block, so the binding is visible, not a
+  lie. Providers that allow a chatless profile keep the existing
+  `resolved_auth_mode(None, None, plugin)` path unchanged.
+- `_context_identity` already renders the no-target case as `anon`; `scope` and the
+  `private, no-store` cache policy stay unchanged — the answer remains per-account on
+  the wire even though its content is static.
+- No credentialed data can leak: the document is composed from plugin-declared rules +
+  the PUBLIC discovery runtime; no credential is ever in scope on this route.
+
+## Planned changes
+
+- `apps/aigateway/src/aigateway/routes/chat_credentials.py` — teach
+  `_credential_target_for_chat` an opt-in `missing_target_ok` mode (default off; chat
+  path unchanged) that returns `(None, None, ProfileDefaults())` instead of raising
+  `profile_not_found`.
+- `apps/aigateway/src/aigateway/routes/model_parameters.py` — resolve with
+  `missing_target_ok=True`; when no target came back and the plugin refuses chatless,
+  bind the keyless datasheet auth mode instead of calling `resolved_auth_mode`.
+- Tests under `apps/aigateway/tests/` (extend the existing model-parameters route
+  suite).
+
+## Test plan
+
+- RED: no profile, no connection, chatless-refusing provider → 200 with a full
+  contract document; `context.auth_mode` = the plugin's first declared mode;
+  `Cache-Control: private, no-store` still present. (Invariant: the datasheet needs no
+  stored credential target.)
+- Pending profile still 409 `profile_pending_auth`; errored profile still 401
+  `auth_required`. (Invariant: a stored-but-broken target keeps pointing at the connect
+  flow.)
+- Connected profile answer unchanged (auth mode from the profile). (Invariant: the fix
+  widens, never rewrites, the credentialed answer.)
+- Chat dispatch with no profile still 404 `profile_not_found`. (Invariant: dispatch
+  stays credentialed; only the datasheet went keyless.)
+
+## Acceptance
+
+- `GET /v1/model-parameters?model=<seeded id>` answers 200 on a store with zero
+  profiles/connections for every seeded provider.
+- All existing aigateway gates green (`uv run pytest`, ruff, pyright).
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `routes/chat_credentials.py` (opt-in
+  `missing_target_ok` on `_credential_target_for_chat`; chat path untouched),
+  `routes/model_parameters.py` (`missing_target_ok=profile_name == "default"` +
+  `_contract_auth_mode` keyless binding), `tests/unit/test_model_parameters_route.py`
+  (flipped the pre-OME-1167 keyless-404 pin; added contract-equality and
+  dispatch-still-404s invariants).
+- **Commits:** see PR (single squash-merge commit).
+- **Gates:** `run_gates.py aigateway --skip-append-only` ALL GREEN (ruff check + format,
+  pyright, check_no_enterprise, pytest 17/17 in the route file, full suite green,
+  coverage ≥80%).
+- **Deviations:**
+  - Prior test `test_missing_profile_reuses_chat_credential_resolution` was rewritten
+    (append-only rule 5 exception): it pinned the exact "Before" behavior the ticket
+    orders removed. Acknowledged via the gate runner's own `--skip-append-only` flag;
+    every other prior test is untouched and green.
+  - The ticket's SDK closing step (delete `SCREAMINGFACE_SKIP_PARAMETER_PREFLIGHT`) is
+    vacuous: the hatch exists neither on main nor in PR #870 — the ticket pre-described
+    a hatch that never shipped. Recorded as a coordination comment on `OME-1167` so
+    OME-1098 does not ship it.
+  - No separate `docs/spec`/`docs/plan` artifact: the ticket's Before/After is the spec
+    and this ledger's Design section is the plan (bug-fix-sized unit).


### PR DESCRIPTION
Checking a model's parameter limits no longer requires a connected provider — the parameter contract is a datasheet lookup, and `GET /v1/model-parameters` now answers it keyless while everything that dispatches stays credentialed.

For example `GET /v1/model-parameters?model=anthropic/claude-opus-4-8` returns a JSON document like
```json
{
  "contract_id": "pc_…",
  "model": {"id": "anthropic/claude-opus-4-8", "gateway_provider": "anthropic"},
  "context": {"auth_mode": "api_key", "scope": "account_profile"},
  "parameters": {
    "max_tokens":  {"enabled": true, "schema": {"type": "integer", "max": 32000}},
    "temperature": {"enabled": true, "schema": {"type": "number", "min": 0, "max": 1}},
    "reasoning_effort": {"enabled": false, "gateway_reason": "…"}
  },
  "tools": {...}, "transport": {"stream": ...}
}
```
## Before / After

### Before
- Trigger: any caller asks what parameters a model supports — the SDK's free pre-spend check does this for every candidate that sets `max_tokens` / `temperature` / etc.
- Today: on a stack with zero connected providers the answer is 404 "profile is not connected", because the route reuses chat's credential resolution — even though the contract is static content composed from the deployment's own seeds and public discovery, and answering costs nothing.
- Cost: the keyless e2e replay lane structurally cannot evaluate a params-carrying candidate; OME-1098 was about to ship a replay-only escape hatch (`SCREAMINGFACE_SKIP_PARAMETER_PREFLIGHT`) to work around it.

### After
- Same trigger.
- Now: the **default** profile binding with no stored target answers the full contract, published under the provider's profileless auth mode or its first declared auth mode (`context.auth_mode` names the binding, so it is visible, never a lie).
- Win: a keyless stack preflights like a notebook does; the escape hatch never needs to exist (it had not shipped anywhere — nothing to delete).

### Don't regress
- No credentialed data leaks into the keyless answer: a new test pins that `parameters` / `tools` / `transport` / `model` are byte-identical to the api-key-profile answer — nothing extra, nothing missing.
- Chat dispatch with no profile still 404s `profile_not_found` (pinned by a new test).
- Explicitly named missing profiles keep their 404, pending profiles their 409, errored profiles their 401 — the connect-flow diagnostics are untouched (existing tests unchanged).
- `Cache-Control: private, no-store` + `Vary: Authorization, X-Profile` hold on the keyless answer too.

## Root cause

The refusal originated in aigateway, not the Engine (the ticket's first investigation step): `_credential_target_for_chat` in `routes/chat_credentials.py` raises 404 `profile_not_found` when profile and active connection are both absent and the provider refuses chatless profiles. The Engine's `/v1/model-parameters` relay and the SDK's error decoding just carry it through. Hence the landing relabel `screamingface-engine` → `aigateway` on OME-1167.

## Implementation

- `_credential_target_for_chat` gains an opt-in `missing_target_ok` flag (default off — chat's behavior is byte-identical). When set, the would-be `profile_not_found` raise becomes a target-less return.
- The model-parameters route sets the flag only for the **default** profile name, and binds the keyless answer's auth mode via a new route-local `_contract_auth_mode`: any stored target (or chatless-allowed provider) takes the existing `resolved_auth_mode` path unchanged; only the previously-404ing case gets the new binding (profileless mode, else first declared mode — `resolved_auth_mode`'s "oauth" fallback would 400 an api-key-only provider, correct for dispatch, wrong for a datasheet).

**Genuinely new runtime behavior:** one — the keyless default-binding 200. Everything else is code motion around it. Note a keyless caller can now reach the public-catalog discovery observe (same read any credentialed caller triggers; its config gating, caching, and limits are unchanged).

**Append-only-tests exception:** `test_missing_profile_reuses_chat_credential_resolution` pinned the exact "Before" behavior this ticket orders removed, and was rewritten into the keyless-200 pin. Acknowledged through the gate runner's own `--skip-append-only`; every other prior test is untouched and green.

## Test plan

- New: keyless default binding answers 200 with the private cache policy; keyless answer equals the credentialed static contract; chat dispatch still 404s.
- Unchanged and green: named-missing-profile 404, pending 409, errored 401, cache-policy-on-error suite, contract-id determinism.
- Gates: `run_gates.py aigateway` — ruff check + format, pyright, check_no_enterprise, full pytest with coverage ≥80%: ALL GREEN.

## Review order

1. `apps/aigateway/tests/unit/test_model_parameters_route.py` — the spec of the change. Verify the flipped test (the keyless-200 pin replacing the old keyless-404 pin) and that the equality test compares every content section against the credentialed answer.
2. `apps/aigateway/src/aigateway/routes/model_parameters.py` — the seam: the flag is passed only for the default profile name, and `_contract_auth_mode` only diverges on the previously-404ing branch. Verify the credentialed path still calls `resolved_auth_mode` untouched.
3. `apps/aigateway/src/aigateway/routes/chat_credentials.py` — the shared resolution. One concrete check: the flag defaults off and no chat call site passes it, so dispatch is byte-identical.
4. `docs/work/` + `docs/tasks/` — the ledger and mirror (mechanical skim).

Refs: OME-1167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
