### PR TITLE
fix(py-screamingface): render only answer and feedback into the loop coach prompt

### DIFF
--- a/docs/tasks/2026-09-10-judge-prompt-minimal.md
+++ b/docs/tasks/2026-09-10-judge-prompt-minimal.md
@@ -1,0 +1,21 @@
+---
+id: OME-1168
+linear_url: https://linear.app/openmined/issue/OME-1168/the-loops-judge-sees-internal-accounting-metadata-in-its-prompt-so-a
+status: in_progress
+type: fix
+priority: High
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-10
+closed:
+---
+
+# The loop's judge sees internal accounting metadata in its prompt, so a recorded run can't be replayed
+
+The CorrectiveLoop coach prompt embeds the full round object, dragging each
+member's Candidate Invocation envelope (accounting/usage, provider/model ids)
+into the judge's paid prompt. Live vs replay accounting values differ, so
+multi-round recorded runs never replay. Fix: client-side only — the coach's
+`verdicts` becomes a per-member {answer, feedback} projection; the round object
+(needed verbatim by gate/select/answer/result) is untouched. Tie path already
+clean. Details + evidence: Linear issue; how: ledger
+`docs/work/2026-09-10-OME-1168-judge-prompt-minimal.md`.

--- a/docs/work/2026-09-10-OME-1168-judge-prompt-minimal.md
+++ b/docs/work/2026-09-10-OME-1168-judge-prompt-minimal.md
@@ -1,0 +1,69 @@
+---
+ticket: OME-1168
+stack: screamingface
+status: in_progress
+started: 2026-09-10
+finished:
+---
+
+# OME-1168 — Stop pasting the runtime envelope into the loop's judge prompt
+
+## Intent
+
+The CorrectiveLoop's coach prompt embeds the whole round object (`$loop_round_k`),
+which drags each member's full Candidate Invocation envelope — accounting/usage
+token counts, provider/model identifiers, request ids — into a paid model prompt.
+Live token counts differ from replay's cache-hit zeros, so multi-round recorded
+runs can never replay (all 9 multi-round OME-1098 ifeval cases miss). The fix is
+client-side prompt rendering only: the coach's `verdicts` payload becomes a
+per-member projection of {answer, feedback} built from dotted refs, leaving
+`$loop_round_k` (which gate/select/answer/result legitimately consume, including
+the envelope for verbatim selection) untouched. Tie-picker is already clean
+(engine `_gate` emits only {key, answer}).
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_evaluation/corrective.py` —
+  `_coach` panel branch: replace `"verdicts": $loop_round_{attempt}` with a
+  per-label struct of `$loop_check_{attempt}_{label}.answer` /
+  `.feedback`; fold the verdict shape into the material hashed by
+  `CORRECTIVE_PROTOCOL_REVISION` so the revision moves with the prompt shape.
+- `packages/screamingface/tests/` — pin the new coach context shape; assert no
+  accounting/provider/envelope text appears in any rendered judge-role body.
+
+## Test plan
+
+- RED: rendered-expression test that compiles a CorrectiveLoop candidate and
+  asserts the coach role context references `.answer`/`.feedback` projections
+  and does NOT reference the bare round object; assert the strings
+  `accounting`/`candidate-invocation` cannot flow into the coach context
+  (structural: the coach context contains no `$loop_round_` reference).
+- Invariant kept: gate/select/answer contexts still reference
+  `$loop_round_{k}` (verbatim-selection path untouched).
+- `CORRECTIVE_PROTOCOL_REVISION` changes vs the previous constant value.
+- All prior corrective tests stay green unmodified (append-only).
+
+## Acceptance
+
+- Coach prompt context = {request, task, verdicts: per-member {answer, feedback}}.
+- No envelope fields reachable from any judge-role rendered context.
+- Round object untouched for gate/select/answer/result.
+- Protocol revision hash covers the verdict shape.
+- Full `screamingface` stack gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned —
+  `packages/screamingface/src/screamingface/_evaluation/corrective.py`
+  (`_coach` panel branch renders per-member `{answer, feedback}` projection;
+  new `COACH_VERDICT_FIELDS` constant folded into
+  `CORRECTIVE_PROTOCOL_REVISION`, now `f8fcb8eada80aa7d`, was
+  `284c47e50ca0ba4f`) +
+  `packages/screamingface/tests/test_corrective_compilation.py` (3 new tests).
+- **Commits:** single commit on `OME-1168-judge-prompt-minimal`
+  (`fix(py-screamingface): render only answer and feedback into the loop coach prompt`).
+- **Gates:** `run_gates.py screamingface` ALL GREEN — append-only check, ruff
+  check/format, pyright, pytest 1420 passed / 22 skipped (cov ≥95),
+  notebooks, build, distribution.
+- **Deviations:** none. Follow-up owned by `OME-1098`: fresh ifeval
+  CorrectiveLoop recording (rendered keys changed), then `just e2e-bless-fresh`.

--- a/docs/work/2026-09-10-OME-1168-judge-prompt-minimal.md
+++ b/docs/work/2026-09-10-OME-1168-judge-prompt-minimal.md
@@ -56,7 +56,7 @@ the envelope for verbatim selection) untouched. Tie-picker is already clean
 - **Actual files:** as planned —
   `packages/screamingface/src/screamingface/_evaluation/corrective.py`
   (`_coach` panel branch renders per-member `{answer, feedback}` projection;
-  new `COACH_VERDICT_FIELDS` constant folded into
+  new `_COACH_VERDICT_FIELDS` constant generates the projection AND is folded into
   `CORRECTIVE_PROTOCOL_REVISION`, now `f8fcb8eada80aa7d`, was
   `284c47e50ca0ba4f`) +
   `packages/screamingface/tests/test_corrective_compilation.py` (3 new tests).
@@ -65,5 +65,7 @@ the envelope for verbatim selection) untouched. Tie-picker is already clean
 - **Gates:** `run_gates.py screamingface` ALL GREEN — append-only check, ruff
   check/format, pyright, pytest 1420 passed / 22 skipped (cov ≥95),
   notebooks, build, distribution.
-- **Deviations:** none. Follow-up owned by `OME-1098`: fresh ifeval
+- **Deviations:** review findings applied pre-commit — the verdict-fields constant
+  is underscore-private and the coach projection is generated from it, so reshaping
+  the prompt shape necessarily moves the protocol revision. Follow-up owned by `OME-1098`: fresh ifeval
   CorrectiveLoop recording (rendered keys changed), then `just e2e-bless-fresh`.

--- a/packages/screamingface/src/screamingface/_evaluation/corrective.py
+++ b/packages/screamingface/src/screamingface/_evaluation/corrective.py
@@ -85,7 +85,7 @@ TIE_BREAK_INSTRUCTION = (
 )
 # INVARIANT (OME-1168): the coach's per-member verdict projection carries ONLY
 # these check-surface fields — never the record's Candidate Invocation envelope.
-COACH_VERDICT_FIELDS = ("answer", "feedback")
+_COACH_VERDICT_FIELDS = ("answer", "feedback")
 
 CORRECTIVE_FLOW = (
     "at most max_rounds attempts; every member answers each executed attempt; an "
@@ -109,7 +109,7 @@ CORRECTIVE_PROTOCOL_REVISION = hashlib.sha256(
             MEMBER_LABEL_SCHEME,
             # WHY hashed: the coach prompt's verdict shape is Client-rendered
             # behavior — reshaping it (OME-1168) must move the revision.
-            ",".join(COACH_VERDICT_FIELDS),
+            ",".join(_COACH_VERDICT_FIELDS),
             RETRY_INSTRUCTION,
             SELF_FEEDBACK_INSTRUCTION,
             JUDGE_FEEDBACK_INSTRUCTION,
@@ -444,8 +444,8 @@ class _LoopRenderer:
                     "task": JUDGE_FEEDBACK_INSTRUCTION,
                     "verdicts": {
                         label: {
-                            "answer": f"$loop_check_{attempt}_{label}.answer",
-                            "feedback": f"$loop_check_{attempt}_{label}.feedback",
+                            field: f"$loop_check_{attempt}_{label}.{field}"
+                            for field in _COACH_VERDICT_FIELDS
                         }
                         for label in self._labels
                     },

--- a/packages/screamingface/src/screamingface/_evaluation/corrective.py
+++ b/packages/screamingface/src/screamingface/_evaluation/corrective.py
@@ -83,6 +83,9 @@ TIE_BREAK_INSTRUCTION = (
     "Every candidate answer already satisfies the requirements. Pick the best-written "
     "one. Reply with exactly one candidate label and nothing else."
 )
+# INVARIANT (OME-1168): the coach's per-member verdict projection carries ONLY
+# these check-surface fields — never the record's Candidate Invocation envelope.
+COACH_VERDICT_FIELDS = ("answer", "feedback")
 
 CORRECTIVE_FLOW = (
     "at most max_rounds attempts; every member answers each executed attempt; an "
@@ -104,6 +107,9 @@ CORRECTIVE_PROTOCOL_REVISION = hashlib.sha256(
             CHECK_SURFACE_SCHEMA,
             str(_MIN_MEMBERS),
             MEMBER_LABEL_SCHEME,
+            # WHY hashed: the coach prompt's verdict shape is Client-rendered
+            # behavior — reshaping it (OME-1168) must move the revision.
+            ",".join(COACH_VERDICT_FIELDS),
             RETRY_INSTRUCTION,
             SELF_FEEDBACK_INSTRUCTION,
             JUDGE_FEEDBACK_INSTRUCTION,
@@ -424,11 +430,25 @@ class _LoopRenderer:
                 f" | {SELF_FEEDBACK_INSTRUCTION}"
             )
         else:
+            # WHY a projection, not the round object (OME-1168): the round's
+            # records carry each member's full Candidate Invocation envelope
+            # (accounting/usage token counts, provider/model identity) for the
+            # SELECT endpoint's verbatim-selection invariant. Pasting that into
+            # the coach prompt makes a recorded run unreplayable (live token
+            # counts vs replay's cache-hit zeros re-key the request) and leaks
+            # member identity the judge's role design withholds. The coach
+            # consumes exactly answer + check feedback per member.
             context = _structured_context(
                 {
                     "request": "$input",
                     "task": JUDGE_FEEDBACK_INSTRUCTION,
-                    "verdicts": f"$loop_round_{attempt}",
+                    "verdicts": {
+                        label: {
+                            "answer": f"$loop_check_{attempt}_{label}.answer",
+                            "feedback": f"$loop_check_{attempt}_{label}.feedback",
+                        }
+                        for label in self._labels
+                    },
                 }
             )
         resolved, captured = self._captured(

--- a/packages/screamingface/tests/test_corrective_compilation.py
+++ b/packages/screamingface/tests/test_corrective_compilation.py
@@ -226,3 +226,36 @@ def test_retry_prompts_thread_own_previous_answer_and_coaching() -> None:
     # Each member retries ITS OWN draft, not a teammate's.
     assert "$loop_check_1_a.answer" in compiled.url4
     assert "$loop_check_1_b.answer" in compiled.url4
+
+
+def test_coach_verdicts_carry_only_answer_and_feedback_per_member() -> None:
+    # INVARIANT (OME-1168 — replayability + role isolation): the coach prompt is
+    # a pure function of case input + member answer/feedback texts. The round's
+    # Candidate Invocation envelopes (accounting/usage token counts, provider and
+    # model identity) must never render into a judge-role body — live token
+    # counts differ from replay's cache-hit zeros, so an envelope in the prompt
+    # makes a recorded run unreplayable.
+    compiled = compile_candidate(_loop(max_rounds=2), check_surface=_SURFACE)
+    assert (
+        "verdicts: {a: {answer: '$loop_check_1_a.answer', "
+        "feedback: '$loop_check_1_a.feedback'}, "
+        "b: {answer: '$loop_check_1_b.answer', "
+        "feedback: '$loop_check_1_b.feedback'}}"
+    ) in compiled.url4
+    assert "verdicts: '$loop_round_1'" not in compiled.url4
+
+
+def test_the_round_object_still_feeds_gate_and_select_verbatim() -> None:
+    # INVARIANT: the verbatim-selection path is untouched — tie gate, continue
+    # gate, and select still consume the FULL round object (whose records carry
+    # the envelope the SELECT endpoint returns verbatim). Exactly those three
+    # consumers reference round 1; the coach is no longer one of them.
+    compiled = compile_candidate(_loop(max_rounds=2), check_surface=_SURFACE)
+    assert compiled.url4.count("$loop_round_1") == 3
+
+
+def test_protocol_revision_moved_with_the_coach_verdict_shape() -> None:
+    # WHY pin the retired hash: the revision must move whenever the Client-
+    # rendered prompt shape changes; OME-1168 reshaped the coach verdicts, so
+    # the pre-change revision is retired for good.
+    assert CORRECTIVE_PROTOCOL_REVISION != "284c47e50ca0ba4f"


### PR DESCRIPTION
Stops the CorrectiveLoop from pasting each member's internal invocation envelope (accounting/usage token counts, provider/model identity) into the judge's coach prompt, which made every multi-round recorded run unreplayable.

Linear: [OME-1168](https://linear.app/openmined/issue/OME-1168/the-loops-judge-sees-internal-accounting-metadata-in-its-prompt-so-a)

## Before / After

### Before
- Trigger: a CorrectiveLoop case fails a round, so the loop asks the judge model for corrective feedback.
- Today: that prompt embeds the whole round object as JSON, and each member record inside it drags the full internal invocation envelope along — token counts, provider name, model id, request ids.
- Cost: an on-call dev replaying a recorded golden watches every multi-round case miss its cache (live token counts vs replay zeros re-key the request — 9/9 multi-round ifeval cases fail); every paid coach call carries hundreds of tokens of accounting JSON; and the judge sees which provider wrote which answer, which the loop's role design deliberately withholds.

### After
- Same trigger.
- Now: the coach receives exactly what its task consumes — the original request, its instruction, and per member the answer text plus the check's failed-requirement feedback. Rendering is a pure function of case input + member answer texts.
- Win: loop runs are byte-replayable (unblocks the ifeval golden in OME-1098 and every future loop golden), coach calls get cheaper, and judge role isolation holds.

### Don't regress
- The round object (which legitimately carries the envelope) still feeds gate / select / answer verbatim — the selected outcome keeps refusal identity and finish_reason exactly.
- Tie-break path was audited: the engine's gate already emits only `{key, answer}` pairs — no envelope there, no change needed.
- Cost accounting everywhere it belongs (report `usage`, `cost.usage` events, totals) is untouched — this PR only stops pasting it into another model's prompt.
- The self-corrective (solo) prompt already had the minimal shape; it is unchanged.

## Root cause

The coach context reused `$loop_round_k` — the same object the loop's control-flow endpoints consume. That object must carry each member's full Candidate Invocation envelope, because the SELECT endpoint returns the winning member's outcome verbatim (refusal identity, finish_reason). Reusing it for the prompt leaked the envelope into paid, cache-keyed request bytes.

## Implementation

Client-side only (`packages/screamingface`), no engine change:

- The coach's `verdicts` payload becomes a per-member `{answer, feedback}` struct built from check-surface dotted refs (`$loop_check_k_a.answer`, `.feedback`) — the same refs the retry prompts already use.
- The verdict field list (`COACH_VERDICT_FIELDS`) is folded into `CORRECTIVE_PROTOCOL_REVISION` (now `f8fcb8eada80aa7d`), so run records self-identify the new prompt shape and any future reshape moves the revision.

**New runtime behavior** (vs pure code motion): the rendered coach request bytes shrink and change — existing loop recordings will not replay against this branch. That is the point; OME-1098 re-records its ifeval golden after this lands (draco / healthbench goldens embed no verdict JSON and are unaffected).

## Review order

1. `packages/screamingface/src/screamingface/_evaluation/corrective.py` — the seam. The coaching call builder (the room where the judge's prompt is written) now projects each member's answer + check feedback instead of handing over the whole round object. Verify: the round object reference survives everywhere except the coach context, and the revision hash material gained exactly the verdict field list.
2. `packages/screamingface/tests/test_corrective_compilation.py` — the spec. Three appended tests: the coach context's exact rendered shape, the count of remaining round-object consumers (tie gate, continue gate, select — and no longer the coach), and the retirement of the old revision hash. Verify: no pre-existing test was modified.

## Test plan

- `run_gates.py screamingface` ALL GREEN: ruff check/format, pyright, pytest **1420 passed / 22 skipped** (coverage ≥95%), notebook determinism, build, distribution check.
- Real-world verification is owned by OME-1098: one fresh owner recording, then `just e2e-bless-fresh` must replay all 50 cases byte-identically, multi-round included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
