### PR TITLE
docs(tasks): close the OME-1167 mirror

### DIFF
--- a/docs/tasks/2026-09-10-OME-1167-keyless-model-parameters.md
+++ b/docs/tasks/2026-09-10-OME-1167-keyless-model-parameters.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1167
 linear_url: https://linear.app/openmined/issue/OME-1167/checking-a-models-parameter-limits-fails-unless-a-provider-is
-status: in_progress
+status: done
 type: bug
 priority: Medium
 labels: [aigateway, agentic, autonomous]
 created: 2026-09-10
-closed:
+closed: 2026-09-10
 ---
 
 # Checking a model's parameter limits fails unless a provider is connected


### PR DESCRIPTION
One-line: flip the OME-1167 docs mirror to done now that PR #887 is squash-merged and Linear OME-1167 is Done.

## Before / After

### Before
- Trigger: a dev checks docs/tasks for the state of the keyless model-parameters fix.
- Today: the mirror still says in_progress with an empty closed date, though the fix is on main and Linear says Done.
- Cost: the docs mirror and Linear disagree; the next agent session re-investigates a finished unit.

### After
- Same trigger.
- Now: mirror says done, closed 2026-09-10 — matching Linear and main.
- Win: both close-status sources agree, per the repo's close-in-both rule.

### Don't regress
- Ledger docs/work/2026-09-10-OME-1167-keyless-model-parameters.md already carries the outcome (landed with PR #887); untouched here.

## Review order
1. docs/tasks/2026-09-10-OME-1167-keyless-model-parameters.md — the mirror; verify only the two frontmatter lines changed (status, closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)