### PR TITLE
fix(screamingface-engine): survive a cold gateway when fetching model parameters

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/catalog/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/catalog/__init__.py
@@ -39,7 +39,12 @@ from screamingface_engine.world_config import WorldConfigError, declared_model_i
 
 logger = logging.getLogger(__name__)
 
-_UPSTREAM_TIMEOUT_S = 10.0
+# WHY 30s (OME-1170): a COLD gateway composes a model's parameter datasheet in 3–11.8s per
+# model (measured 2026-09-10 across six models; warm repeats ~0.002s). The previous 10.0s
+# budget sat inside that range, so the first fetch after a stack start deterministically
+# timed out for the slower models and surfaced as HTTP 504. Do not lower this below the
+# measured cold ceiling; the warm path never comes near it.
+_UPSTREAM_TIMEOUT_S = 30.0
 
 
 def _default_client(base_url: str) -> httpx.AsyncClient:

--- a/apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py
+++ b/apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py
@@ -37,6 +37,10 @@ _CALLER_CORRECTABLE_STATUSES = frozenset({400, 401, 403, 404, 409})
 # a bad credential (CatalogRejected, always surfaced as 401) rather than CatalogBadResponse.
 _REJECTION_STATUSES = frozenset({401, 403})
 
+# INVARIANT: two attempts total — one retry after a timeout, never a loop — so a genuinely
+# down gateway still fails within a bounded wall time (see `_request`, OME-1170).
+_TIMEOUT_ATTEMPTS = 2
+
 
 class AigatewayCatalogSource:
     """Fetch and minimally validate AI Gateway model discovery for one caller."""
@@ -125,16 +129,28 @@ class AigatewayCatalogSource:
         bad_response: type[CatalogBadResponse],
         params: dict[str, str] | None = None,
     ) -> httpx.Response:
-        """Issue one upstream GET and translate transport failures at the adapter boundary."""
+        """Issue one upstream GET and translate transport failures at the adapter boundary.
 
-        try:
-            return await self._client.get(path, params=params, headers=_headers(credential))
-        except httpx.TimeoutException as exc:
-            logger.warning("aigateway %s request timed out", label)
-            raise CatalogUnavailable(CatalogUnavailable.detail) from exc
-        except httpx.HTTPError as exc:
-            logger.warning("aigateway %s request failed at the transport layer", label)
-            raise bad_response(bad_response.detail) from exc
+        WHY one retry on timeout only (OME-1170): a cold gateway composes a parameter
+        datasheet slowly, and that failed slow attempt fills the gateway's cache — so an
+        immediate second attempt answers in milliseconds. Other transport failures (refused
+        connection, reset) gain nothing from an instant repeat, so they are not retried.
+        The retry is bounded: two attempts total, then ``CatalogUnavailable``.
+        """
+
+        for attempt in range(_TIMEOUT_ATTEMPTS):
+            try:
+                return await self._client.get(path, params=params, headers=_headers(credential))
+            except httpx.TimeoutException as exc:
+                if attempt + 1 < _TIMEOUT_ATTEMPTS:
+                    logger.warning("aigateway %s request timed out; retrying once", label)
+                    continue
+                logger.warning("aigateway %s request timed out", label)
+                raise CatalogUnavailable(CatalogUnavailable.detail) from exc
+            except httpx.HTTPError as exc:
+                logger.warning("aigateway %s request failed at the transport layer", label)
+                raise bad_response(bad_response.detail) from exc
+        raise AssertionError("unreachable: the final attempt returns or raises")
 
     def _decode_json(
         self,

--- a/apps/screamingface-engine/tests/unit/test_catalog_aigateway.py
+++ b/apps/screamingface-engine/tests/unit/test_catalog_aigateway.py
@@ -179,3 +179,77 @@ async def test_the_callers_email_is_never_logged_on_a_failure_path(
         await adapter.fetch(Credential.derive(None, IDENTITY))
     assert IDENTITY["X-User-Email"] not in caplog.text
     assert IDENTITY["X-User-Email"] not in str(excinfo.value)
+
+
+# OME-1170 — a cold gateway composes a datasheet slowly; the failed slow attempt warms its
+# cache, so one retry after a timeout turns a deterministic 504 into a success.
+MODEL_PARAMETERS = {
+    "schema_version": 1,
+    "model": {"id": "claude-haiku-4-5"},
+    "parameters": {},
+    "tools": {},
+    "transport": {},
+}
+
+
+def timeout_then(handler: object) -> object:
+    calls = {"n": 0}
+
+    def route(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ReadTimeout("cold composition too slow", request=request)
+        return handler(request)  # type: ignore[operator]
+
+    return route
+
+
+async def test_a_single_timeout_is_retried_and_the_catalog_is_returned() -> None:
+    adapter, seen = source_for(timeout_then(ok(CATALOG)))
+    catalog = await adapter.fetch(Credential.derive(None, IDENTITY))
+    assert catalog.body == CATALOG
+    assert len(seen) == 2
+
+
+async def test_a_single_timeout_is_retried_for_model_parameters() -> None:
+    # INVARIANT: the parameter datasheet route — the one the cold-start bug actually hits —
+    # answers after one timeout instead of surfacing 504 to the SDK's pre-spend check.
+    adapter, seen = source_for(timeout_then(ok(MODEL_PARAMETERS)))
+    answer = await adapter.fetch_model_parameters(
+        Credential.derive(None, IDENTITY), "claude-haiku-4-5"
+    )
+    assert answer.status == 200
+    assert len(seen) == 2
+
+
+async def test_a_persistent_timeout_stops_after_exactly_one_retry() -> None:
+    # INVARIANT: a genuinely down/hung gateway fails bounded — two attempts, never a loop —
+    # and keeps the CatalogUnavailable classification.
+    def always_timeout(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("still too slow", request=request)
+
+    adapter, seen = source_for(always_timeout)
+    with pytest.raises(CatalogUnavailable):
+        await adapter.fetch(Credential.derive(None, IDENTITY))
+    assert len(seen) == 2
+
+
+async def test_a_non_timeout_transport_failure_is_not_retried() -> None:
+    # WHY timeout-only: only a timeout implies "the slow attempt just warmed the gateway's
+    # cache"; a refused connection gains nothing from an immediate second attempt.
+    def refused(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused", request=request)
+
+    adapter, seen = source_for(refused)
+    with pytest.raises(CatalogBadResponse):
+        await adapter.fetch(Credential.derive(None, IDENTITY))
+    assert len(seen) == 1
+
+
+async def test_the_upstream_timeout_covers_the_measured_cold_composition_ceiling() -> None:
+    # INVARIANT: cold datasheet composition measured 3–11.8s per model (2026-09-10, OME-1170);
+    # the budget must stay well above that ceiling so nobody "optimizes" it back down.
+    from screamingface_engine.catalog import _UPSTREAM_TIMEOUT_S, _default_client
+
+    assert _UPSTREAM_TIMEOUT_S == 30.0
+    assert _default_client("http://aigateway.test").timeout == httpx.Timeout(30.0)

--- a/docs/tasks/2026-09-10-OME-1170-catalog-timeout-retry.md
+++ b/docs/tasks/2026-09-10-OME-1170-catalog-timeout-retry.md
@@ -1,0 +1,22 @@
+---
+id: OME-1170
+linear_url: https://linear.app/openmined/issue/OME-1170/checking-a-models-parameters-fails-with-http-504-the-first-time-after
+status: in_progress
+type: fix
+priority: Medium
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-10
+closed:
+---
+
+# Checking a model's parameters fails with HTTP 504 the first time after a stack start
+
+On a fresh stack, the engine gives the gateway 10s per catalog/datasheet fetch,
+but a cold gateway composes a model's parameter datasheet in 3–11.8s — the
+timeout loses, the engine answers 504, and the SDK's free pre-spend check dies
+with a hard PlanningError even though the failed attempt just warmed the
+gateway's cache. Fix: raise the upstream timeout to 30s (above the measured
+cold ceiling) and retry once on a timeout only — the retry is nearly free. A
+down gateway still fails bounded (two attempts) as CatalogUnavailable; the
+warm ~2ms path is untouched. Details + evidence: Linear issue; how: ledger
+`docs/work/2026-09-10-OME-1170-catalog-timeout-retry.md`.

--- a/docs/work/2026-09-10-OME-1170-catalog-timeout-retry.md
+++ b/docs/work/2026-09-10-OME-1170-catalog-timeout-retry.md
@@ -1,0 +1,57 @@
+---
+ticket: OME-1170
+stack: screamingface-engine
+status: done
+started: 2026-09-10
+finished: 2026-09-10
+---
+
+# OME-1170 — Catalog upstream timeout survives a cold gateway (30s + one retry)
+
+## Intent
+
+On a freshly started stack, the engine's catalog fetch gives the gateway 10s, but a cold
+datasheet composition measures 3–11.8s per model — so the first parameter check after boot
+deterministically 504s for the slower models and the SDK surfaces a hard `PlanningError`.
+Raise the upstream timeout to 30s (above the measured cold ceiling) and retry once on a
+timeout (nearly free: the failed attempt warmed the gateway's cache), so a
+first-evaluate-after-boot succeeds instead of failing.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/catalog/__init__.py` — raise
+  `_UPSTREAM_TIMEOUT_S` 10.0 → 30.0 with a WHY comment carrying the measured cold-path numbers.
+- `apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py` — `_request`
+  retries once on `httpx.TimeoutException` before raising `CatalogUnavailable`.
+
+## Test plan
+
+- RED (in `tests/unit/test_catalog_aigateway.py`):
+  - timeout then success → `fetch` returns the catalog; exactly 2 upstream requests.
+  - timeout then success → `fetch_model_parameters` returns the datasheet (the route the bug
+    actually hits); exactly 2 upstream requests.
+  - persistent timeout → `CatalogUnavailable`; exactly 2 upstream requests (bounded — a down
+    gateway fails within 2×timeout, never loops).
+  - non-timeout transport error → no retry (1 request) — retry is timeout-only, because only
+    a timeout implies "the slow attempt warmed the cache".
+  - `_default_client` timeout is 30s, above the 11.8s measured cold maximum (guards the
+    "don't optimize it back down" invariant).
+- Prior tests untouched; `test_a_timeout_raises_catalog_unavailable` stays green (persistent
+  timeout still classifies as `CatalogUnavailable`).
+
+## Acceptance
+
+- First fetch after a cold gateway (≤30s composition, or 10–12s + warm retry) succeeds.
+- A down/hung gateway still fails as `CatalogUnavailable` within ~2×30s, never unbounded.
+- Warm path untouched; all prior tests green; engine gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus `docs/tasks/2026-09-10-OME-1170-catalog-timeout-retry.md`
+  (issue mirror) and this ledger. Retry bound expressed as `_TIMEOUT_ATTEMPTS = 2` constant in
+  `aigateway.py` (INVARIANT-commented) rather than a bare literal.
+- **Commits:** (filled at PR) `fix(screamingface-engine): survive a cold gateway when fetching model parameters`
+- **Gates:** run_gates.py screamingface-engine — ALL GATES GREEN (ruff check, format, pyright,
+  check_layering, pytest 2678 passed / 9 skipped, coverage ≥80%). 5 new tests; prior tests
+  untouched (append-only check green).
+- **Deviations:** none.


### PR DESCRIPTION
Raises the engine's upstream catalog timeout to 30s and retries once on a timeout, so the first model-parameter check after a stack start no longer dies with HTTP 504.

## Before / After

### Before
- Trigger: on a freshly started stack, a notebook user evaluates any candidate with explicit params (`max_tokens`, `temperature`, …) — the SDK's free pre-spend check fetches each model's parameter datasheet through the engine.
- Today: the engine gives the gateway 10s per fetch, but a **cold** gateway composes a datasheet in **3–11.8s per model** (measured 2026-09-10). The timeout loses, the engine answers 504, and the SDK surfaces a hard `PlanningError: Could not load the SF Engine Model details: HTTP 504` — even though the failed slow attempt just warmed the gateway's cache and an immediate retry would answer in ~2 ms.
- Cost: hit the owner three times in one day; the workaround was hand-warming routes with `curl` and re-running the cell. Every fresh-stack notebook user with a params-carrying candidate hits this.

### After
- Same trigger.
- Now: the engine waits out a cold composition (timeout **30s**, above the measured ceiling) and retries once on a timeout — the retry is nearly free because the first attempt filled the cache. A first-evaluate-after-boot succeeds, just visibly slower.
- Win: no more 504s on a fresh stack; no curl warm-up folklore.

### Don't regress
- A genuinely down/hung gateway still fails bounded — two attempts, ~2×30s max — with the same `CatalogUnavailable` classification (test: exactly-one-retry).
- Non-timeout transport failures (refused connection) are **not** retried — an instant repeat gains nothing there.
- Warm-path latency unchanged (~2 ms answers untouched).
- The timeout stays a named constant with the measured cold-path numbers in its WHY comment.

## Test plan

- 5 new unit tests in `tests/unit/test_catalog_aigateway.py`: timeout-then-success for both the catalog and the model-parameters route (the one the bug hits), persistent-timeout bounded to exactly two attempts, connect-failure not retried, and the 30s constant guarded against being optimized back down.
- Full engine suite: 2678 passed / 9 skipped; all gates (ruff, format, pyright, layering, coverage) green. Prior tests unmodified.

## Review order

1. `apps/screamingface-engine/src/screamingface_engine/catalog/aigateway.py` — the gateway adapter, where every upstream GET funnels through one `_request` helper. This carries the genuinely new runtime behavior: a bounded two-attempt loop that retries only on a timeout. Verify the non-timeout branch (`httpx.HTTPError`) still raises immediately with no second attempt.
2. `apps/screamingface-engine/src/screamingface_engine/catalog/__init__.py` — the composition root that builds the shared HTTP client. One constant changed, 10s → 30s. Verify the WHY comment carries the measured numbers so the value can't be silently "tidied" down later.
3. `apps/screamingface-engine/tests/unit/test_catalog_aigateway.py` — the contract tests. All additions are appended; verify the pre-existing `test_a_timeout_raises_catalog_unavailable` is byte-identical (a persistent timeout still classifies the same way).
4. `docs/work/…` + `docs/tasks/…` — mechanical skims: the work ledger and the issue mirror.

Refs: OME-1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)