### PR TITLE
fix(py-screamingface): refuse a foreign gateway database and print the effective config at up

### DIFF
--- a/docs/tasks/2026-09-10-OME-1169-local-stack-config-visibility.md
+++ b/docs/tasks/2026-09-10-OME-1169-local-stack-config-visibility.md
@@ -1,0 +1,19 @@
+---
+id: OME-1169
+linear_url: https://linear.app/openmined/issue/OME-1169/the-local-stack-silently-ignores-the-database-setting-and-never-shows
+status: in_progress
+type: bug
+priority: Medium
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-10
+closed:
+---
+
+# The local stack silently ignores the database setting and never shows what config it started with
+
+`AIGATEWAY_DATABASE_URL` is silently overridden by the runtime's hard-coded sqlite path, and
+`screamingface up` prints nothing about its effective config — both burned paid provider calls
+during the OME-1098 recordings. Fix: refuse a set `AIGATEWAY_DATABASE_URL` loudly at boot, and
+print the effective gateway config (db target + request-cache state, redacted) in the ready and
+adoption banners, sourced from the constructed gateway settings. Ledger:
+`docs/work/2026-09-10-OME-1169-local-stack-config-visibility.md`.

--- a/docs/work/2026-09-10-OME-1169-local-stack-config-visibility.md
+++ b/docs/work/2026-09-10-OME-1169-local-stack-config-visibility.md
@@ -1,0 +1,68 @@
+---
+ticket: OME-1169
+stack: screamingface
+status: done
+started: 2026-09-10
+finished: 2026-09-10
+---
+
+# OME-1169 — The local stack refuses a foreign database setting and prints its effective config
+
+## Intent
+
+Two silent failures burned money during the OME-1098 golden recordings: `AIGATEWAY_DATABASE_URL`
+is silently overridden by the local runtime's hard-coded sqlite path, and `screamingface up`
+prints nothing about the config the gateway actually booted with (so a cache flag that never
+reached the background child is invisible). This unit makes the mis-set environment fail loudly
+at boot and puts the effective gateway config (db target + request-cache state) in the ready
+banner, sourced from the settings object the gateway was constructed with.
+
+Design decision (per the ticket, silence being the only unacceptable option): the local stack
+keeps managing its own sqlite database; a set `AIGATEWAY_DATABASE_URL` is **refused at boot**
+with remediation, not honored.
+
+## Planned changes
+
+- `packages/screamingface/src/screamingface/_runtime/server.py` — compute a gateway config
+  summary (redacted db url + request_cache on/off) from the constructed `GatewaySettings`;
+  print it to the runtime log; publish it to the state file via a callback threaded from the
+  serving CLI.
+- `packages/screamingface/src/screamingface/_runtime/cli.py` — refuse `up`/`restart` when
+  `AIGATEWAY_DATABASE_URL` is set; print the published gateway config line in the ready banner
+  and in the adoption ("already running") banner; state-merge helper.
+- `packages/screamingface/tests/test_runtime_cli.py` — new tests (append-only).
+
+## Test plan
+
+- RED: `up` with `AIGATEWAY_DATABASE_URL` set raises with a message naming the variable and the
+  remediation (invariant: the local stack never silently records into a database other than the
+  one the operator configured).
+- RED: `up` with no such env does not refuse (default behavior unchanged — existing adoption
+  tests double as this guard).
+- RED: db-url redaction strips userinfo (`postgresql://u:p@h/db` → `postgresql://***@h/db`),
+  leaves sqlite paths untouched (invariant: the banner never prints secrets).
+- RED: gateway config summary reflects the settings values (cache on/off, db url).
+- RED: publishing the summary merges it into the state file without dropping owner fields.
+- RED: adoption banner prints the RUNNING stack's config from state; ready banner prints it
+  after a fresh boot.
+
+## Acceptance
+
+- `screamingface up` with `AIGATEWAY_DATABASE_URL` exported exits with the loud refusal.
+- The ready/adoption banner carries `gateway db=… · request_cache=on|off` sourced from the
+  child's constructed settings via the state file; userinfo redacted.
+- No env set → behavior byte-compatible except the added banner line.
+- All prior tests green, gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned — `_runtime/server.py` (redaction + summary + publish hook in
+  `run`/`_build_apps`), `_runtime/cli.py` (refusal, banner line, publish closure),
+  `tests/test_runtime_cli.py` (7 appended tests); plus this ledger + the `docs/tasks/` mirror.
+- **Commits:** `fix(py-screamingface): refuse a foreign gateway database and print the
+  effective config at up` (sha in the Linear close comment at merge).
+- **Gates:** `run_gates.py screamingface` ALL GREEN — ruff check, ruff format, pyright,
+  pytest (`--cov-fail-under=95`, 7 new tests, all prior tests unmodified), notebook check,
+  build, distribution check.
+- **Deviations:** none. Design fork resolved per the ticket's own framing: `AIGATEWAY_DATABASE_URL`
+  is refused at boot (also on adoption), not honored — the local stack keeps its own sqlite.

--- a/docs/work/2026-09-10-OME-1169-local-stack-config-visibility.md
+++ b/docs/work/2026-09-10-OME-1169-local-stack-config-visibility.md
@@ -66,3 +66,8 @@ with remediation, not honored.
   build, distribution check.
 - **Deviations:** none. Design fork resolved per the ticket's own framing: `AIGATEWAY_DATABASE_URL`
   is refused at boot (also on adoption), not honored — the local stack keeps its own sqlite.
+- **Review follow-up (`d48fa21c`):** two PR #891 findings fixed — (1) `restart` now refuses
+  BEFORE `down`, so a mis-set env can no longer stop a healthy stack and then raise; (2) the
+  suite's autouse fixture scrubs `AIGATEWAY_DATABASE_URL`, so the refusal cannot fail
+  pre-existing tests on a dev machine that exports it. One appended test; the fixture edit
+  was owner-directed (append-only gate green post-commit).

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -12,6 +12,7 @@ import sys
 import threading
 import time
 from collections import deque
+from collections.abc import Callable
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -173,6 +174,10 @@ def _environment_port(value: str | None, fallback: int) -> int:
 
 
 def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
+    # WHY first, before anything boots or is adopted (OME-1169): silence is the failure
+    # mode — the operator must learn at `up` time, for free, that the variable will not
+    # be honored, instead of after a paid run recorded into the wrong database.
+    _refuse_foreign_gateway_database()
     from screamingface._runtime.server import require_runtime_extra
 
     require_runtime_extra()
@@ -186,6 +191,9 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
         health = _health(_state_services(state))
         if all(health.values()):
             print("ScreamingFace is already running.")
+            # STORY: as an operator re-running `up` over a live stack, I see the RUNNING
+            # stack's effective config — exactly the case where a stale env bites hardest.
+            _print_gateway_config(state)
             _print_urls(_state_services(state), config.log_path)
             return
         raise RuntimeError(
@@ -236,7 +244,52 @@ def _up(config: RuntimeConfig, *, foreground: bool) -> None:  # noqa: PLR0915
             _request_shutdown(state)
         raise
     print("ScreamingFace is ready.")
+    # The child published its effective gateway config into the state record before its
+    # servers came up (server.run), so by ready time it is there to print.
+    _print_gateway_config(_read_state(config))
     _print_urls(config.services, config.log_path)
+
+
+def _refuse_foreign_gateway_database() -> None:
+    """Refuse to boot or adopt while AIGATEWAY_DATABASE_URL is set in the environment.
+
+    INVARIANT (OME-1169): the local stack must never silently record into a database
+    other than the one the operator configured. The runtime hard-wires the gateway to
+    its own sqlite file, so a set AIGATEWAY_DATABASE_URL would be overridden — the
+    2026-09-09 recording wrote paid rows into sqlite while the operator believed
+    Postgres was in use. Loud refusal is the ticket's decision; silence is the only
+    unacceptable option.
+    """
+    if os.getenv("AIGATEWAY_DATABASE_URL"):
+        raise RuntimeError(
+            "the local stack manages its own sqlite database; AIGATEWAY_DATABASE_URL "
+            "is ignored — unset it or use a deployed gateway"
+        )
+
+
+def _print_gateway_config(state: dict[str, object] | None) -> None:
+    """Print the running stack's effective gateway config line, if the child published one.
+
+    A state record written by an older build carries no `gateway_config`; the banner
+    must not invent one, so absence prints nothing.
+    """
+    value = state.get("gateway_config") if state else None
+    if not isinstance(value, dict):
+        return
+    print(f"  gateway db={value.get('database_url')} · request_cache={value.get('request_cache')}")
+
+
+def _publish_gateway_config(
+    config: RuntimeConfig, state: dict[str, object], summary: dict[str, str]
+) -> None:
+    """Merge the child's effective gateway config into the owned state record.
+
+    WHY a merge over the in-memory state (OME-1169): the serving child is the only
+    writer of its state file, and `state` is the exact document it wrote at boot — so
+    rewriting it with one added key preserves the ownership fields readers rely on.
+    """
+    state["gateway_config"] = summary
+    _write_state(config, state)
 
 
 def _ensure_adoptable(state: dict[str, object] | None) -> None:
@@ -300,8 +353,12 @@ def _serve_logged(config: RuntimeConfig, token: str) -> None:
     _write_state(config, state)
     control_thread = threading.Thread(target=control.serve_forever, daemon=True)
     control_thread.start()
+
+    def publish(summary: dict[str, str]) -> None:
+        _publish_gateway_config(config, state, summary)
+
     try:
-        _run_server(config, shutdown)
+        _run_server(config, shutdown, publish)
     finally:
         control.shutdown()
         control.server_close()
@@ -309,12 +366,16 @@ def _serve_logged(config: RuntimeConfig, token: str) -> None:
         _remove_owned_state(config, token)
 
 
-def _run_server(config: RuntimeConfig, shutdown: threading.Event) -> None:
+def _run_server(
+    config: RuntimeConfig,
+    shutdown: threading.Event,
+    publish_config: Callable[[dict[str, str]], None],
+) -> None:
     import asyncio
 
     from screamingface._runtime.server import run
 
-    asyncio.run(run(config, shutdown))
+    asyncio.run(run(config, shutdown, publish_config))
 
 
 def _down(config: RuntimeConfig) -> None:

--- a/packages/screamingface/src/screamingface/_runtime/cli.py
+++ b/packages/screamingface/src/screamingface/_runtime/cli.py
@@ -400,6 +400,10 @@ def _down(config: RuntimeConfig) -> None:
 
 
 def _restart(config: RuntimeConfig, args: argparse.Namespace, *, foreground: bool) -> None:
+    # WHY here too, not only inside `_up` (PR #891 review finding): restart is down THEN
+    # up — a refusal raised only by `_up` would land after `_down` already stopped a
+    # healthy stack, leaving the operator with a dead stack instead of a clean error.
+    _refuse_foreign_gateway_database()
     state = _read_state(config)
     # INVARIANT: restart = down + up, so it must refuse a foreign stack the same way
     # `up` does — otherwise it silently replaces another checkout's running services.

--- a/packages/screamingface/src/screamingface/_runtime/server.py
+++ b/packages/screamingface/src/screamingface/_runtime/server.py
@@ -35,6 +35,45 @@ class Server(Protocol):
     async def serve(self) -> None: ...
 
 
+class _SecretView(Protocol):
+    def get_secret_value(self) -> str: ...
+
+
+class _GatewayConfigView(Protocol):
+    """The two gateway settings an operator must see at boot (OME-1169)."""
+
+    # WHY properties, not attributes: a mutable protocol attribute is invariant, which
+    # would reject the concrete pydantic Settings class; the summary only reads.
+    @property
+    def database_url(self) -> _SecretView: ...
+    @property
+    def request_cache_enabled(self) -> bool: ...
+
+
+def _redact_database_url(url: str) -> str:
+    """Strip userinfo from a database URL so the banner can never print credentials."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(url)
+    if "@" not in parts.netloc:
+        return url
+    host: str = parts.netloc.rsplit("@", 1)[1]
+    return urlunsplit((parts.scheme, f"***@{host}", parts.path, parts.query, parts.fragment))
+
+
+def _gateway_config_summary(settings: _GatewayConfigView) -> dict[str, str]:
+    """Project the constructed gateway settings into the operator-facing banner fields.
+
+    WHY sourced from the settings object and not the shell (OME-1169): during the OME-1098
+    recordings a spawned child verifiably lacked the exported AIGW_REQUEST_CACHE_* flags —
+    only the object the gateway was actually constructed with tells the truth.
+    """
+    return {
+        "database_url": _redact_database_url(settings.database_url.get_secret_value()),
+        "request_cache": "on" if settings.request_cache_enabled else "off",
+    }
+
+
 # The modules ONLY the "runtime" extra provides AND the local boot path reaches before it
 # can serve: the gateway app (fastapi, litellm, pydantic_settings, tortoise, bcrypt,
 # cryptography), its sqlite database (aiosqlite), the Engine app (kubernetes — adapters.k8s
@@ -124,7 +163,11 @@ def require_runtime_extra() -> RuntimeSource:
     return source
 
 
-async def run(config: RuntimeConfig, shutdown_event: threading.Event | None = None) -> None:
+async def run(
+    config: RuntimeConfig,
+    shutdown_event: threading.Event | None = None,
+    publish_config: Callable[[dict[str, str]], None] | None = None,
+) -> None:
     source = require_runtime_extra()
     # WHY logged at boot: whether a stack serves the live checkout or the installed
     # package decides what a benchmark actually tests — it must be auditable in the
@@ -132,7 +175,17 @@ async def run(config: RuntimeConfig, shutdown_event: threading.Event | None = No
     print(f"runtime source: {source.describe()}", flush=True)
     config.data_dir.mkdir(parents=True, exist_ok=True)
     await _migrate(config)
-    gateway, engine = _build_apps(config)
+    gateway, engine, gateway_config = _build_apps(config)
+    # WHY printed AND published (OME-1169): the log line makes the effective config
+    # auditable next to the run it governed; publishing into the state record is what
+    # lets the parent `up` (and a later adopting `up`) print it in the ready banner.
+    print(
+        f"gateway config: db={gateway_config['database_url']} · "
+        f"request_cache={gateway_config['request_cache']}",
+        flush=True,
+    )
+    if publish_config is not None:
+        publish_config(gateway_config)
     servers = (
         _server(gateway, config.gateway_port, "AI Gateway"),
         _server(engine, config.engine_port, "Engine"),
@@ -190,7 +243,7 @@ async def _migrate(config: RuntimeConfig) -> None:
             await Tortoise.close_connections()
 
 
-def _build_apps(config: RuntimeConfig) -> tuple[object, object]:
+def _build_apps(config: RuntimeConfig) -> tuple[object, object, dict[str, str]]:
     from aigateway.config import Settings as GatewaySettings
     from aigateway.main import create_app as create_gateway_app
     from pydantic import SecretStr  # pyright: ignore[reportMissingImports]
@@ -198,14 +251,13 @@ def _build_apps(config: RuntimeConfig) -> tuple[object, object]:
     from screamingface_engine.config import Settings as EngineSettings
     from screamingface_engine.local import create_local_app
 
-    gateway = create_gateway_app(
-        GatewaySettings(
-            host="127.0.0.1",
-            port=config.gateway_port,
-            database_url=SecretStr(config.gateway_database_url),
-            auth_mode="disabled",
-        )
+    gateway_settings = GatewaySettings(
+        host="127.0.0.1",
+        port=config.gateway_port,
+        database_url=SecretStr(config.gateway_database_url),
+        auth_mode="disabled",
     )
+    gateway = create_gateway_app(gateway_settings)
     run_env: Mapping[str, str] = {
         **os.environ,
         job_env.RUNNER_CONFIG: str(config.runner_config),
@@ -216,7 +268,7 @@ def _build_apps(config: RuntimeConfig) -> tuple[object, object]:
         settings=EngineSettings(aigateway_base_url=config.services["gateway"]),
         env=run_env,
     )
-    return gateway, engine
+    return gateway, engine, _gateway_config_summary(gateway_settings)
 
 
 def run_scoreboard(config: RuntimeConfig) -> None:

--- a/packages/screamingface/tests/conftest.py
+++ b/packages/screamingface/tests/conftest.py
@@ -19,6 +19,12 @@ def _isolated_screamingface_data_dir(
         "SCREAMINGFACE_DATA_DIR",
         str(tmp_path_factory.mktemp("screamingface-data")),
     )
+    # INVARIANT (OME-1169): `up`/`restart` refuse to boot while AIGATEWAY_DATABASE_URL is
+    # set, reading live os.environ — on a dev machine that exports it (exactly the
+    # gateway-with-Postgres dev the refusal protects), every runtime test would fail with
+    # the refusal instead of exercising its own contract. Tests that need the variable
+    # set it themselves via monkeypatch.
+    monkeypatch.delenv("AIGATEWAY_DATABASE_URL", raising=False)
 
 
 __all__: list[str] = []

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -968,3 +968,28 @@ def test_gateway_config_line_is_omitted_for_pre_config_state(
     cli._print_gateway_config({"schema_version": 1})
 
     assert capsys.readouterr().out == ""
+
+
+def test_restart_refuses_a_foreign_gateway_database_url_before_stopping_anything(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # INVARIANT: the refusal must fire BEFORE `restart` tears the stack down — a
+    # refusal that lands after `_down` leaves the operator with a dead stack instead
+    # of a clean error (review finding on PR #891).
+    config = RuntimeConfig(data_dir=tmp_path)
+    _running_state(config, {"mode": "bundled", "root": None})
+    _healthy_owned_runtime(monkeypatch)
+    monkeypatch.setenv("SCREAMINGFACE_RUNTIME_SOURCE", "bundled")
+    monkeypatch.setenv("AIGATEWAY_DATABASE_URL", "postgresql://operator:pw@db.example/gw")
+    monkeypatch.setattr(
+        cli,
+        "_down",
+        lambda _config: pytest.fail("restart reached _down while the environment was refused"),
+    )
+    args = cli._parser().parse_args(["--data-dir", str(tmp_path), "restart"])
+
+    with pytest.raises(RuntimeError, match="AIGATEWAY_DATABASE_URL"):
+        cli._restart(config, args, foreground=False)
+
+    # Refusal means the running stack was left untouched.
+    assert config.state_path.exists()

--- a/packages/screamingface/tests/test_runtime_cli.py
+++ b/packages/screamingface/tests/test_runtime_cli.py
@@ -844,3 +844,127 @@ def test_the_local_projection_omits_an_absent_case_count() -> None:
         revision = "revision-from-engine"
 
     assert "case_count" not in json.loads(scoreboard_seed_json([Benchmark()]))[0]
+
+
+# FEATURE: OME-1169 — the local stack refuses a foreign database setting and prints the
+# effective gateway config in the ready banner.
+
+
+def test_up_refuses_a_foreign_gateway_database_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # INVARIANT: the local stack must never silently record into a database other than the
+    # one the operator configured — a set AIGATEWAY_DATABASE_URL is refused at boot, not
+    # overridden (the 2026-09-09 recording wrote paid rows into sqlite while the operator
+    # believed Postgres was in use).
+    config = RuntimeConfig(data_dir=tmp_path)
+    _stub_runtime_extra(monkeypatch)
+    monkeypatch.setenv("AIGATEWAY_DATABASE_URL", "postgresql://operator:pw@db.example/gw")
+
+    with pytest.raises(RuntimeError, match="AIGATEWAY_DATABASE_URL") as refusal:
+        cli._up(config, foreground=False)
+
+    # The refusal carries the remediation, not just the diagnosis.
+    assert "unset" in str(refusal.value)
+
+
+def test_up_refuses_a_foreign_gateway_database_url_even_when_adopting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # WHY: adoption is exactly where a stale exported URL bites hardest — the operator
+    # re-runs `up`, sees a healthy banner, and keeps believing the wrong database story.
+    config = RuntimeConfig(data_dir=tmp_path)
+    _running_state(config, {"mode": "bundled", "root": None})
+    _healthy_owned_runtime(monkeypatch)
+    monkeypatch.setenv("SCREAMINGFACE_RUNTIME_SOURCE", "bundled")
+    monkeypatch.setenv("AIGATEWAY_DATABASE_URL", "postgresql://operator:pw@db.example/gw")
+
+    with pytest.raises(RuntimeError, match="AIGATEWAY_DATABASE_URL"):
+        cli._up(config, foreground=False)
+
+
+def test_database_url_redaction_strips_userinfo_and_leaves_sqlite_alone() -> None:
+    # INVARIANT: the banner never prints secrets — userinfo is redacted before a database
+    # URL leaves the settings object.
+    assert (
+        server._redact_database_url("postgresql://operator:pw@db.example:5432/gw")
+        == "postgresql://***@db.example:5432/gw"
+    )
+    assert (
+        server._redact_database_url("sqlite:///home/dev/.screamingface/aigateway.sqlite3")
+        == "sqlite:///home/dev/.screamingface/aigateway.sqlite3"
+    )
+
+
+def test_gateway_config_summary_reflects_the_constructed_settings() -> None:
+    # WHY sourced from the settings object and not the shell: the OME-1098 flake was an env
+    # var that never reached the child — only the constructed settings tell the truth.
+    class Secret:
+        def get_secret_value(self) -> str:
+            return "postgresql://operator:pw@db.example/gw"
+
+    class Settings:
+        database_url = Secret()
+        request_cache_enabled = False
+
+    summary = server._gateway_config_summary(Settings())
+
+    assert summary == {
+        "database_url": "postgresql://***@db.example/gw",
+        "request_cache": "off",
+    }
+
+
+def test_publishing_the_gateway_config_merges_into_owned_state(tmp_path: Path) -> None:
+    config = RuntimeConfig(data_dir=tmp_path)
+    state: dict[str, object] = {
+        "schema_version": 1,
+        "pid": 42,
+        "owner_token": "secret",
+        "services": config.services,
+    }
+    cli._write_state(config, state)
+
+    cli._publish_gateway_config(
+        config, state, {"database_url": "sqlite://x", "request_cache": "on"}
+    )
+
+    stored = json.loads(config.state_path.read_text())
+    # The merge adds the config without dropping the ownership fields readers rely on.
+    assert stored["gateway_config"] == {"database_url": "sqlite://x", "request_cache": "on"}
+    assert stored["owner_token"] == "secret"
+    assert stored["services"] == config.services
+
+
+def test_adoption_banner_prints_the_running_stacks_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # STORY: as an operator re-running `up` over a live stack, I see the RUNNING stack's
+    # effective config — not what my current shell would produce.
+    config = RuntimeConfig(data_dir=tmp_path)
+    state: dict[str, object] = {
+        "schema_version": 1,
+        "pid": 42,
+        "owner_token": "secret",
+        "services": config.services,
+        "source": {"mode": "bundled", "root": None},
+        "gateway_config": {"database_url": "sqlite://adopted.sqlite3", "request_cache": "off"},
+    }
+    cli._write_state(config, state)
+    _healthy_owned_runtime(monkeypatch)
+    monkeypatch.setenv("SCREAMINGFACE_RUNTIME_SOURCE", "bundled")
+
+    cli._up(config, foreground=False)
+
+    output = capsys.readouterr().out
+    assert "gateway db=sqlite://adopted.sqlite3 · request_cache=off" in output
+
+
+def test_gateway_config_line_is_omitted_for_pre_config_state(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # WHY: a stack started by an older build carries no gateway_config record; the banner
+    # must not invent one.
+    cli._print_gateway_config({"schema_version": 1})
+
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
`screamingface up` now refuses a set `AIGATEWAY_DATABASE_URL` at boot and prints the gateway's effective config (database target + request-cache state) in the ready banner.

Refs: OME-1169

## Problem / Solution

**Problem.** The local stack quietly does its own thing: it ignores the database an operator asked for, and it never says what configuration it actually started with. Twice during golden recordings this burned real money — paid model calls ran with caching silently off, and results were recorded into a database nobody was looking at.

**Solution.** Make the environment impossible to mis-trust: a database override is loudly refused the moment `up` runs, and the ready banner reports the config the gateway was *actually* built with — read back from the running child, not from the shell.

## Before / After

### Before
- Trigger: a dev exports `AIGATEWAY_DATABASE_URL` and/or `AIGW_REQUEST_CACHE_*` and runs `screamingface up`.
- Today: the DB URL is silently overridden by the runtime's hard-coded sqlite path; nothing prints the effective config, so a cache flag that never reached the background child is invisible until the bill arrives.
- Cost: two paid incidents during the OME-1098 recordings (wrong database, uncached provider calls) — each would have been a 10-second catch with one printed line.

### After
- Same trigger.
- Now: `up` exits immediately with `the local stack manages its own sqlite database; AIGATEWAY_DATABASE_URL is ignored — unset it or use a deployed gateway`; with a clean environment, the banner gains one line: `gateway db=sqlite:///…/aigateway.sqlite3 · request_cache=off`, sourced from the settings object the gateway child constructed.
- Win: a mis-set environment fails at boot, in the operator's face, for free — no more recording into the wrong database, no more paid runs with caching silently off.

### Don't regress
- No env set → behavior unchanged except the added banner line (sqlite in the data dir, cache per gateway defaults).
- The banner never prints secrets: userinfo in a DB URL is redacted to `***` before it leaves the settings object.
- Adoption of an already-running healthy stack keeps working — and the adoption banner prints the RUNNING stack's stored config, exactly the case where a stale exported env bites hardest.
- A state record written by an older build carries no config record; the banner prints nothing rather than inventing one.

## How the config line travels

The gateway child is the only process that knows the truth (its constructed `GatewaySettings`), but the banner is printed by the parent `up`. The child projects its settings into a two-field summary (redacted db URL + `request_cache` on/off), prints it into the runtime log, and merges it into the `runtime.json` state record it owns — before its servers come up, so the parent's readiness wait guarantees the record is there when the banner prints. A later adopting `up` reads the same record.

## Review order

1. **`packages/screamingface/src/screamingface/_runtime/server.py`** — the source of truth. The new summary projection sits next to where `GatewaySettings` is constructed, so the banner can only ever describe the object the gateway really booted with. Verify: the summary is built from `gateway_settings`, not from `os.environ`, and the redaction helper strips userinfo before anything leaves the module.
2. **`packages/screamingface/src/screamingface/_runtime/cli.py`** — the operator surface. The refusal guard at the top of `_up` (fires before anything boots *or adopts*), the banner line in both the ready and adoption paths, and the publish closure that merges the child's summary into the state record it already owns. Verify: the refusal happens before the background child is spawned, and the state merge preserves the ownership fields (`owner_token`, `services`).
3. **`packages/screamingface/tests/test_runtime_cli.py`** — the contract, 7 appended tests (no prior test touched): refusal with remediation, refusal on adoption, redaction, summary-from-settings, state merge, adoption banner, and the older-state no-invention case.
4. **`docs/work/` + `docs/tasks/`** — ledger and mirror, mechanical skim.

Genuinely new runtime behavior (vs code motion): the boot-time refusal, and the child→state→banner config publication. Everything else is signature threading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
