### PR TITLE
feat(scoreboard): name the Pareto chart after what it plots

### DIFF
--- a/apps/scoreboard/portal/benchmark.html
+++ b/apps/scoreboard/portal/benchmark.html
@@ -64,7 +64,7 @@
     </div>
 
     <section id="pareto-chart-section" class="pareto-chart-section" hidden>
-      <h2>Score for cost</h2>
+      <h2>Pareto Frontier (cost/score)</h2>
       <figure class="pareto-chart-figure">
         <!-- The table below is the accessible data source. This SVG is a visual summary with
              native hover tooltips, so hiding it prevents dozens of duplicate data announcements. -->
@@ -72,7 +72,7 @@
           class="pareto-chart-scroll"
           tabindex="0"
           role="region"
-          aria-label="Score for cost chart, horizontally scrollable"
+          aria-label="Pareto Frontier (cost/score) chart, horizontally scrollable"
         >
           <div id="pareto-chart" aria-hidden="true"></div>
         </div>

--- a/apps/scoreboard/tests/unit/test_portal_static.py
+++ b/apps/scoreboard/tests/unit/test_portal_static.py
@@ -186,7 +186,7 @@ def test_pareto_chart_shell_is_bounded_provenanced_and_loaded_before_its_caller(
 
     assert re.search(r'<section[^>]*id="pareto-chart-section"[^>]*hidden', html)
     assert re.search(r'<div[^>]*class="pareto-chart-scroll"[^>]*tabindex="0"', html)
-    assert 'aria-label="Score for cost chart, horizontally scrollable"' in html
+    assert 'aria-label="Pareto Frontier (cost/score) chart, horizontally scrollable"' in html
     assert 'id="pareto-chart"' in html
     assert 'aria-hidden="true"' in html
     assert "Costs are self-reported, not verified by re-running." in html
@@ -211,3 +211,23 @@ def test_pareto_chart_dark_theme_uses_the_right_paint_property_for_each_element(
     assert "fill: var(--info-solid)" in point.group(1)
     assert key is not None
     assert "background: var(--info-solid)" in key.group(1)
+
+
+def test_pareto_chart_heading_and_label_name_the_pareto_frontier() -> None:
+    """FEATURE (OME-1146 part 1): the chart carries the name the rest of the page uses.
+
+    INVARIANT: heading and `aria-label` are renamed as one. Only the label was previously
+    asserted, so a rename that touched the heading alone — or the label alone — would leave the
+    page describing itself two ways, silently, to two different audiences.
+
+    INVARIANT: the disclaimer assertion below is not incidental. OME-1146 also asks to delete it,
+    and this unit deliberately does not. Nothing else in the suite pins "renamed but still
+    disclaimed", which is exactly the state this unit ships.
+    """
+    portal = Path(__file__).resolve().parents[2] / "portal"
+    html = (portal / "benchmark.html").read_text(encoding="utf-8")
+
+    assert "<h2>Pareto Frontier (cost/score)</h2>" in html
+    assert 'aria-label="Pareto Frontier (cost/score) chart, horizontally scrollable"' in html
+    assert "Score for cost" not in html
+    assert "Costs are self-reported, not verified by re-running." in html

--- a/docs/plan/2026-09-10-OME-1146-pareto-chart-title.md
+++ b/docs/plan/2026-09-10-OME-1146-pareto-chart-title.md
@@ -1,0 +1,55 @@
+# OME-1146 (part 1) — Plan
+
+Spec: `docs/spec/2026-09-10-OME-1146-pareto-chart-title.md`
+
+## Discovery
+
+`grep -rn "Score for cost" apps/scoreboard/` returns exactly three hits:
+
+| File | Line | What |
+|---|---|---|
+| `portal/benchmark.html` | 67 | `<h2>Score for cost</h2>` |
+| `portal/benchmark.html` | 75 | `aria-label="Score for cost chart, horizontally scrollable"` |
+| `tests/unit/test_portal_static.py` | 189 | asserts the aria-label |
+
+No hits in `pareto-chart.js` or under `tests/portal/`, so the ticket's "check for strays" step is
+satisfied and no JS changes.
+
+## Files
+
+| File | Change |
+|---|---|
+| `portal/benchmark.html` | rename the `h2` and the `aria-label` |
+| `tests/unit/test_portal_static.py` | retarget the line-189 assertion (recorded exception); add `test_pareto_chart_heading_and_label_name_the_pareto_frontier` |
+
+## RED
+
+The new test asserts four things:
+
+- `<h2>Pareto Frontier (cost/score)</h2>` is present — the heading is currently asserted **nowhere**,
+  so without this the rename would ship unguarded;
+- the new `aria-label` is present;
+- `"Score for cost"` appears nowhere in the file — catches a partial rename;
+- the disclaimer `"Costs are self-reported, not verified by re-running."` is still present.
+
+The last assertion is the one that makes this a guard rather than an echo of the diff. This unit's
+whole point is that the rename ships and the disclaimer does not, and nothing else in the suite
+pins that pairing.
+
+Run it first and confirm it fails on the heading and label assertions.
+
+## GREEN
+
+Two string edits in `benchmark.html`.
+
+## Gates
+
+`uv run .claude/scripts/run_gates.py scoreboard --base origin/main`
+
+Append-only will flag the one retargeted assertion in `test_portal_static.py`. That is the
+exception recorded in the spec; re-run with `--skip-append-only` and record both results.
+
+## Risks
+
+- The heading and the `aria-label` can drift apart, since only the label was previously asserted.
+  The new test pins both, which is why it asserts them separately rather than grepping once.

--- a/docs/spec/2026-09-10-OME-1146-pareto-chart-title.md
+++ b/docs/spec/2026-09-10-OME-1146-pareto-chart-title.md
@@ -1,0 +1,67 @@
+# OME-1146 (part 1) — Rename the Pareto chart
+
+Status: owner-approved · Stack: scoreboard
+
+## Problem
+
+The benchmark page's Pareto chart is headed "Score for cost". OME-923 part B introduced the term
+"Pareto frontier" in the same page's legend and mark labels, so the chart and the thing it plots
+now have two different names. "Pareto Frontier (cost/score)" is the name used everywhere else.
+
+## Scope — the rename only
+
+OME-1146 asks for two changes. This unit delivers one of them.
+
+### D1 — The heading and its accessible label are renamed together
+
+`<h2>Score for cost</h2>` becomes `<h2>Pareto Frontier (cost/score)</h2>`, and the scroll region's
+`aria-label` becomes `Pareto Frontier (cost/score) chart, horizontally scrollable`. They are one
+change: a screen-reader user navigating by region hears the label, and a sighted user reads the
+heading. Renaming one without the other makes the page describe itself two ways.
+
+### D2 — The self-reported-costs disclaimer is NOT touched
+
+OME-1146 also asks to delete the disclaimer at `benchmark.html:85` and `:123`, on the grounds that
+submissions are verified by default. That half is **deliberately excluded from this unit** and the
+ticket stays open for it. Two reasons, both recorded in the codebase:
+
+- `scores/models/score.py`, above `verified_by_screamingface = True`: *"the public portal must not
+  claim more than this … Change the default and that copy together, or the board lies."* The
+  default is a placeholder from `OME-820`; `OME-821`, which would give it a real signal, is in
+  Backlog.
+- `scores/schemas.py`, on `LeaderboardEntry.run_cost_usd`: *"Self-reported and unverifiable:
+  re-running a submission tells us what *we* paid, not what the submitter paid … never as a
+  verified figure."* Cost verification is not score verification, so the disclaimer stays true
+  even after `OME-821`.
+
+`OME-1143` — filed the same afternoon — additionally reports that the costs on this chart are
+currently wrong for cache-served runs. Removing the line that says they are unverified while that
+is open is the wrong direction.
+
+Dropping the disclaimer also reverses `OME-770` D11. A reversal of a recorded decision is an owner
+call, and the question is posted on the ticket awaiting an answer.
+
+### D3 — No behaviour changes
+
+No JS, no data, no API. `pareto-chart.js` never referenced the old string, confirmed by grep over
+`apps/scoreboard/`.
+
+## Verification contract
+
+- the rendered page has no "Score for cost" anywhere;
+- the heading and the scroll region's `aria-label` carry the same new name;
+- the disclaimer, the provenance comment, and every other caption line are unchanged;
+- full Scoreboard gates green.
+
+## Confidence-Gate exception
+
+`test_portal_static.py::test_pareto_chart_shell_is_bounded_provenanced_and_loaded_before_its_caller`
+asserts the old `aria-label` string at line 189. That assertion names the exact text this unit
+renames, so it cannot survive it. Its seven other assertions — including the disclaimer at line
+192, which this unit deliberately preserves — are unchanged.
+
+## Non-goals
+
+- the disclaimer at `:85` and `:123`, and the `OME-770` D11 provenance comment at `:113–116`;
+- any change to what the chart plots or how the frontier is computed;
+- `OME-1145`'s open-share figure, which sits on the same page.

--- a/docs/tasks/2026-09-10-OME-1146-pareto-chart-title.md
+++ b/docs/tasks/2026-09-10-OME-1146-pareto-chart-title.md
@@ -1,0 +1,28 @@
+---
+id: OME-1146
+linear_url: https://linear.app/openmined/issue/OME-1146/rename-the-score-for-cost-chart-to-pareto-frontier-costscore-and-drop
+status: in_review
+type: task
+priority: 2
+labels: [BUG, scoreboard, agentic, autonomous]
+created: 2026-09-08
+closed:
+---
+
+# Rename the "Score for cost" chart to "Pareto Frontier (cost/score)"
+
+Part 1 of OME-1146: the rename only. The heading and the scroll region's `aria-label` on
+`portal/benchmark.html` take the name used everywhere else on the page.
+
+**The ticket stays open.** Its second half — deleting the self-reported-costs disclaimer —
+reverses `OME-770` D11 and contradicts recorded invariants in `scores/models/score.py` and
+`scores/schemas.py`. The question is posted on the ticket and awaits the owner.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-10-OME-1146-pareto-chart-title.md`
+- Plan: `docs/plan/2026-09-10-OME-1146-pareto-chart-title.md`
+- Ledger: `docs/work/2026-09-10-OME-1146-pareto-chart-title.md`
+
+Related: `OME-923` (introduced the Pareto frontier naming), `OME-770` (D11, the disclaimer),
+`OME-1143` (costs on this chart are currently wrong for cached runs).

--- a/docs/work/2026-09-10-OME-1146-pareto-chart-title.md
+++ b/docs/work/2026-09-10-OME-1146-pareto-chart-title.md
@@ -1,0 +1,73 @@
+---
+ticket: OME-1146
+stack: scoreboard
+status: in_progress
+started: 2026-09-10
+finished:
+---
+
+# OME-1146 (part 1) — Rename the Pareto chart
+
+## Intent
+
+The benchmark page heads its Pareto chart "Score for cost" while the legend, the row marks and
+every other surface call the same thing the Pareto frontier. Rename the heading and its accessible
+label to "Pareto Frontier (cost/score)".
+
+This is **half** of OME-1146. The ticket also asks to delete the self-reported-costs disclaimer;
+that half reverses OME-770 D11 and contradicts two recorded invariants, so it stays open pending
+the owner's answer on the ticket. Spec D2 records why.
+
+## Planned changes
+
+- `apps/scoreboard/portal/benchmark.html` — the `h2` at :67 and the `aria-label` at :75.
+- `apps/scoreboard/tests/unit/test_portal_static.py` — retarget the aria-label assertion at :189;
+  add `test_pareto_chart_heading_and_label_name_the_pareto_frontier`.
+
+No JS. `grep -rn "Score for cost" apps/scoreboard/` returns three hits and none is in
+`pareto-chart.js` or under `tests/portal/`.
+
+## Test plan
+
+RED first, four assertions:
+
+- the new `<h2>` is present — the heading was asserted nowhere before, so the rename would
+  otherwise ship unguarded;
+- the new `aria-label` is present;
+- `"Score for cost"` is absent from the file — catches a half-done rename;
+- the disclaimer is still present — pins the deliberate scope boundary of this unit.
+
+## Acceptance
+
+- no "Score for cost" anywhere in the portal;
+- heading and `aria-label` agree;
+- disclaimer, provenance comment and every other caption line untouched;
+- full Scoreboard gates green with the append-only exception recorded.
+
+## Outcome
+
+- **Actual files:** as planned. Two string edits in `portal/benchmark.html`; one retargeted
+  assertion plus one new test in `tests/unit/test_portal_static.py`. No JS touched.
+- **Commits:** see the PR — one commit, `Refs: OME-1146`.
+- **Gates:**
+  - `run_gates.py scoreboard --base origin/main` → append-only FAILS on
+    `tests/unit/test_portal_static.py` (old line 189) and nothing else. That is the recorded
+    Confidence-Gate exception in the spec.
+  - `run_gates.py scoreboard --base origin/main --skip-append-only` → ALL GATES GREEN: ruff check,
+    ruff format, pyright, pytest with `--cov-fail-under=80`, and all three portal suites.
+    `test_portal_static.py` alone: 16 passed.
+- **Mutation check:** three mutations of `benchmark.html`, each reverted and the file confirmed
+  byte-identical to its backup afterwards:
+
+  | Mutation | Result |
+  |---|---|
+  | heading renamed, `aria-label` left behind | CAUGHT |
+  | `aria-label` renamed, heading left behind | CAUGHT |
+  | disclaimer deleted as well (the out-of-scope half) | CAUGHT |
+
+  The third is the one that matters. It is the only thing in the suite that pins this unit's
+  actual scope: renamed, and still disclaimed.
+- **Deviations:** none. The ticket's step 6 asked for a stray grep before starting;
+  `grep -rn "Score for cost" apps/scoreboard/` returned exactly the three known hits, so steps 3,
+  4 (second assertion) and 5 of the ticket are untouched by design — they belong to the disclaimer
+  half, which stays open.


### PR DESCRIPTION
## Summary

- rename the benchmark page's chart heading from **"Score for cost"** to **"Pareto Frontier (cost/score)"**, and the scroll region's `aria-label` with it
- add a guard pinning both names, the absence of the old one, and the scope boundary of this change

**Asana:** N/A — tracked in Linear as OME-1146

## This is half of OME-1146, and the ticket stays open

OME-1146 asks for two things. This PR does the rename. It deliberately does **not** delete the self-reported-costs disclaimer, because that half reverses `OME-770` D11 and contradicts two comments already in the code:

`scores/models/score.py`, directly above `verified_by_screamingface = True`:

> INVARIANT: the public portal must not claim more than this… **Change the default and that copy together, or the board lies.**

That default is a placeholder from `OME-820`; `OME-821`, which would give the flag a real signal, is still Backlog.

`scores/schemas.py`, on `LeaderboardEntry.run_cost_usd`:

> Self-reported and unverifiable: re-running a submission tells us what *we* paid, not what the submitter paid… never as a verified figure.

Cost verification is not score verification, so the disclaimer stays true even after `OME-821`. And `OME-1143` — filed the same afternoon, also High — reports that the costs on this exact chart are currently wrong for cache-served runs.

The question is posted on the ticket and awaits the owner. Spec D2 records the reasoning so it does not have to be rediscovered.

## Components touched

- `apps/scoreboard/portal/benchmark.html` — two strings
- `apps/scoreboard/tests/unit/test_portal_static.py`
- `docs/spec`, `docs/plan`, `docs/tasks`, `docs/work`

No JS. The ticket's stray-check step was run first: `grep -rn "Score for cost" apps/scoreboard/` returns exactly three hits, none in `pareto-chart.js` or under `tests/portal/`.

## Test plan

- [x] `uv run .claude/scripts/run_gates.py scoreboard --base origin/main --skip-append-only` → ALL GATES GREEN (ruff check, ruff format, pyright, pytest `--cov-fail-under=80`, all three portal suites). `test_portal_static.py` alone: 16 passed.
- [x] new test written first and confirmed RED on the heading assertion
- [x] mutation-checked, each mutation reverted and the file confirmed byte-identical afterwards:

| Mutation of `benchmark.html` | Result |
| --- | --- |
| heading renamed, `aria-label` left behind | CAUGHT |
| `aria-label` renamed, heading left behind | CAUGHT |
| disclaimer deleted as well — the out-of-scope half | CAUGHT |

The third matters most. It is the only assertion anywhere that pins what this unit actually ships: renamed, and still disclaimed. Without it a future change could strip the provenance line and no test would object.

- [ ] screenshots — not attached; the change is two strings of copy

## Confidence-Gate exception (sdlc rule 5)

`test_pareto_chart_shell_is_bounded_provenanced_and_loaded_before_its_caller` asserted the old `aria-label` at line 189. That assertion names the exact text being renamed, so it cannot survive. Its seven other assertions are unchanged — including the disclaimer at line 192, which this PR preserves on purpose.

`run_gates.py` without `--skip-append-only` flags that one line and nothing else.

## Cross-service notes

None. Copy only; no API, schema, or client change.
