### PR TITLE
feat(scoreboard): list only established boards on the portal index

### DIFF
--- a/apps/scoreboard/portal/leaderboard-logic.js
+++ b/apps/scoreboard/portal/leaderboard-logic.js
@@ -1,13 +1,15 @@
-/* Pure ranking / SOTA decisions for the leaderboard board (OME-769).
+/* Pure decisions the leaderboard portal makes about what it publishes (OME-769).
  *
  * FEATURE: the per-benchmark submissions board — ranked rows, score bars, and
- * the SOTA medal on the best reproducible result.
+ * the SOTA medal on the best reproducible result — and, since OME-1147, which
+ * boards the index catalogue lists at all.
  *
- * WHY this file exists separately from benchmark.js: these three functions decide
- * what the public board *claims* — which row (if any) is presented as
- * state-of-the-art, and how long each score bar reads. Keeping them free of
- * the DOM makes them assertable in `tests/portal/leaderboard-logic.test.js`
- * without a browser, which the rest of the portal's rendering is not.
+ * WHY this file exists separately from benchmark.js and main.js: these functions
+ * decide what the public portal *claims* — which row (if any) is presented as
+ * state-of-the-art, how long each score bar reads, and which benchmarks a
+ * visitor is shown. Keeping them free of the DOM makes them assertable in
+ * `tests/portal/leaderboard-logic.test.js` without a browser, which the rest of
+ * the portal's rendering is not.
  *
  * Loaded as a plain <script> in the browser (exposing window.SFLeaderboardLogic)
  * and via require() in tests. No build step, matching the rest of the portal.
@@ -191,6 +193,28 @@
     return best;
   }
 
+  // FEATURE (OME-1147): the index catalogue lists established boards only. A private board's
+  // card is empty for every anonymous visitor — the server refuses its rankings — so it reads as
+  // broken rather than as a challenge.
+  //
+  // INVARIANT: this is cosmetic, NOT an access control. `get_leaderboard` already refuses
+  // private rankings server-side and is untouched by this. So the rule fails OPEN: only the
+  // exact string "private" removes a card, and an absent or unrecognised value keeps one.
+  // Guessing "hide it" would buy no privacy and could empty the public catalogue on a
+  // serialisation change.
+  //
+  // AIDEV-NOTE: `visibility` stands in for PROVENANCE here. The owner's rule is "established
+  // benchmarks only" — ours versus academic — and the two coincide today because
+  // healthbench-worst30 is both the only board we assembled and the only private one. They part
+  // company the first time we run a challenge on an academic benchmark, or publish one of our
+  // own. OME-1112 records where each benchmark came from; move this predicate there when it lands.
+  function listedBenchmarks(benchmarks) {
+    if (!Array.isArray(benchmarks)) return [];
+    return benchmarks.filter(function (benchmark) {
+      return !benchmark || benchmark.visibility !== "private";
+    });
+  }
+
   return {
     isReproducible: isReproducible,
     isParetoMarked: isParetoMarked,
@@ -202,5 +226,6 @@
     isSota: isSota,
     orderRows: orderRows,
     barWidth: barWidth,
+    listedBenchmarks: listedBenchmarks,
   };
 });

--- a/apps/scoreboard/portal/main.js
+++ b/apps/scoreboard/portal/main.js
@@ -327,9 +327,13 @@ window.ScorePortal = (function () {
 
     fetchJson("/v1/benchmarks").then(
       function (data) {
-        var benchmarks = (data && data.benchmarks) || [];
+        // OME-1147: filter BEFORE the per-board fetches below, so the page does not request a
+        // board it will never draw. `/v1/benchmarks` deliberately keeps returning every board —
+        // `sf.leaderboards` needs the private ones so challenge participants can submit against
+        // them — so the catalogue is trimmed here rather than at the API.
+        var benchmarks = SFLeaderboardLogic.listedBenchmarks((data && data.benchmarks) || []);
         if (benchmarks.length === 0) {
-          showEmpty(statusNode, "No public benchmarks yet. The API is live; rows will appear here as soon as benchmark specs are registered.");
+          showEmpty(statusNode, "No listed benchmarks yet. The API is live; rows will appear here as soon as benchmark specs are registered.");
           return;
         }
         return Promise.all(benchmarks.map(function (b) { return fetchBoard(b.id); })).then(

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -187,9 +187,15 @@ async def list_benchmarks(request: Request) -> BenchmarksResponse:
     """List EVERY registered benchmark, private ones included. Public, no auth.
 
     WHY private boards are listed here: a challenge participant has to discover the board before
-    they can submit to it, and `sf.leaderboards` reads this endpoint. Listing a board is not
-    disclosing it — `get_leaderboard` still refuses its rankings to anyone but the submitter
-    (OME-894), so the catalogue entry carries a name and no results.
+    they can submit to it, and `sf.leaderboards` reads this endpoint. Listing exposes benchmark
+    METADATA, never participant results — the catalogue entry carries a name and nothing else.
+
+    INVARIANT (OME-894): a private board has no ranking at all, so `get_leaderboard` returns
+    `entries: []` to EVERYONE, the submitter included. An authenticated participant receives only
+    their own rows, unranked, in `my_submissions`. Do not paraphrase this as "rankings are
+    refused to anyone but the submitter": that reads as though a participant sees a ranking, and
+    would justify populating `entries` or adding a rank to `my_submissions` for them. Neither has
+    a rank to show.
 
     AIDEV-NOTE (OME-1147): the portal index does NOT render everything this returns. It drops
     private boards client-side in `portal/leaderboard-logic.js::listedBenchmarks`. That is a

--- a/apps/scoreboard/src/scoreboard/routes/leaderboard.py
+++ b/apps/scoreboard/src/scoreboard/routes/leaderboard.py
@@ -184,7 +184,18 @@ def _history_submission(score: ScoreSchema) -> HistorySubmission:
 
 @router.get("/benchmarks", response_model=BenchmarksResponse, tags=["benchmarks"])
 async def list_benchmarks(request: Request) -> BenchmarksResponse:
-    """List registered public benchmarks. This endpoint is public and has no auth."""
+    """List EVERY registered benchmark, private ones included. Public, no auth.
+
+    WHY private boards are listed here: a challenge participant has to discover the board before
+    they can submit to it, and `sf.leaderboards` reads this endpoint. Listing a board is not
+    disclosing it — `get_leaderboard` still refuses its rankings to anyone but the submitter
+    (OME-894), so the catalogue entry carries a name and no results.
+
+    AIDEV-NOTE (OME-1147): the portal index does NOT render everything this returns. It drops
+    private boards client-side in `portal/leaderboard-logic.js::listedBenchmarks`. That is a
+    cosmetic catalogue rule, not an access rule; do not "fix" the apparent inconsistency by
+    filtering here, or challenge participants lose the ability to find their board.
+    """
     benchmarks = await _score_store(request).list_benchmarks()
     return BenchmarksResponse(benchmarks=benchmarks)
 

--- a/apps/scoreboard/tests/portal/leaderboard-logic.test.js
+++ b/apps/scoreboard/tests/portal/leaderboard-logic.test.js
@@ -319,3 +319,47 @@ test("formatCost does not render one cent in two different formats", () => {
   // Genuinely sub-cent values still keep their four places.
   assert.equal(L.formatCost({ run_cost_usd: "0.009000" }), "$0.0090");
 });
+
+// --- OME-1147: the portal index lists only established boards -------------------------------
+// The card for a private board is empty for every anonymous visitor, because the server refuses
+// its rankings. Dropping it from the index is cosmetic — the access rule is enforced server-side
+// and is not touched here — so the filter is deliberately FAIL-OPEN: only the exact string
+// "private" removes a card. Anything else, including a field the API stops sending, stays listed
+// rather than silently vanishing from the public catalogue.
+
+test("listedBenchmarks drops a private board and keeps a public one", () => {
+  const listed = L.listedBenchmarks([
+    { id: "draco-3pass", visibility: "public" },
+    { id: "healthbench-worst30", visibility: "private" },
+  ]);
+
+  assert.deepEqual(
+    listed.map((b) => b.id),
+    ["draco-3pass"],
+  );
+});
+
+test("listedBenchmarks keeps a board whose visibility it cannot read", () => {
+  // Fail-open (spec D3). An absent, null or unrecognised value must not erase a board: this
+  // filter buys no privacy, so guessing "hide it" only risks emptying the public catalogue on a
+  // serialisation change.
+  const listed = L.listedBenchmarks([
+    { id: "absent" },
+    { id: "null-valued", visibility: null },
+    { id: "unrecognised", visibility: "unlisted" },
+  ]);
+
+  assert.deepEqual(
+    listed.map((b) => b.id),
+    ["absent", "null-valued", "unrecognised"],
+  );
+});
+
+test("listedBenchmarks tolerates a non-array and leaves its input alone", () => {
+  assert.deepEqual(L.listedBenchmarks(undefined), []);
+  assert.deepEqual(L.listedBenchmarks(null), []);
+
+  const input = [{ id: "a", visibility: "public" }, { id: "b", visibility: "private" }];
+  L.listedBenchmarks(input);
+  assert.equal(input.length, 2, "the caller's array must not be filtered in place");
+});

--- a/apps/scoreboard/tests/unit/test_portal_static.py
+++ b/apps/scoreboard/tests/unit/test_portal_static.py
@@ -211,3 +211,25 @@ def test_pareto_chart_dark_theme_uses_the_right_paint_property_for_each_element(
     assert "fill: var(--info-solid)" in point.group(1)
     assert key is not None
     assert "background: var(--info-solid)" in key.group(1)
+
+
+def test_portal_index_filters_private_boards_through_the_shared_logic_module() -> None:
+    """FEATURE (OME-1147): the index lists established boards only.
+
+    INVARIANT: the rule living in `leaderboard-logic.js` is not the same as the rule being
+    applied. `tests/portal/leaderboard-logic.test.js` proves the helper behaves; it cannot see
+    `main.js`, so a correct helper that nothing calls passes every behavioural test. This asserts
+    the call, and the script order that makes the call resolvable — the two ways the wiring
+    breaks silently while the logic stays perfect.
+    """
+    portal = Path(__file__).resolve().parents[2] / "portal"
+    logic = (portal / "leaderboard-logic.js").read_text(encoding="utf-8")
+    main = (portal / "main.js").read_text(encoding="utf-8")
+    index = (portal / "index.html").read_text(encoding="utf-8")
+
+    assert "listedBenchmarks: listedBenchmarks," in logic
+    assert "listedBenchmarks(" in main
+
+    logic_at = index.index('<script src="leaderboard-logic.js"')
+    caller_at = index.index('<script src="main.js"')
+    assert logic_at < caller_at

--- a/docs/plan/2026-09-10-OME-1147-unlist-private-boards.md
+++ b/docs/plan/2026-09-10-OME-1147-unlist-private-boards.md
@@ -1,0 +1,64 @@
+# OME-1147 — Plan
+
+Spec: `docs/spec/2026-09-10-OME-1147-unlist-private-boards.md`
+
+## Files
+
+| File | Change |
+|---|---|
+| `portal/leaderboard-logic.js` | add `listedBenchmarks(benchmarks)`; widen the header comment |
+| `portal/main.js` | `initIndex()` filters before `Promise.all(...fetchBoard)`; fix the empty-state copy |
+| `src/scoreboard/routes/leaderboard.py` | correct the `list_benchmarks` docstring |
+| `tests/portal/leaderboard-logic.test.js` | behaviour of the new helper |
+| `tests/unit/test_portal_static.py` | the wiring assertion |
+
+No new test file, so the gate list and `scoreboard-tests.yml` are untouched.
+
+## RED — two layers
+
+**Node, `tests/portal/leaderboard-logic.test.js`** — the rule:
+
+- a `"private"` benchmark is dropped;
+- a `"public"` one is kept;
+- absent, `null`, and `"unrecognised"` are all kept (D3);
+- a non-array input yields an empty array rather than throwing;
+- the input array is not mutated.
+
+**Python, `tests/unit/test_portal_static.py`** — the wiring:
+
+- `main.js` calls `L.listedBenchmarks(` inside `initIndex`;
+- `leaderboard-logic.js` exports it;
+- `index.html` still loads `leaderboard-logic.js` before `main.js`.
+
+The second layer is the one that matters. The node suite cannot see `main.js`, so a correct helper
+that nothing calls would pass every behavioural test. The script-order assertion guards the other
+half of the same failure: the helper is called, but the module that defines it has not loaded yet.
+
+## GREEN
+
+```js
+function listedBenchmarks(benchmarks) {
+  if (!Array.isArray(benchmarks)) return [];
+  return benchmarks.filter(function (b) {
+    return !b || b.visibility !== "private";
+  });
+}
+```
+
+In `initIndex`, immediately after `var benchmarks = (data && data.benchmarks) || [];`.
+
+## Gates
+
+`uv run .claude/scripts/run_gates.py scoreboard --base origin/main`
+
+Expected fully green including append-only: every test change is an addition. If append-only does
+flag something, stop — that means an existing assertion was disturbed, which this plan does not
+intend.
+
+## Risks
+
+- **The helper exists but nothing calls it.** Covered by the wiring assertion.
+- **Script order regresses**, so `L` is undefined at call time. Covered by the load-order assertion;
+  `test_portal_static.py` already uses the same technique for `benchmark.js`.
+- **Over-filtering.** D3's fail-open keeps a board visible whenever the field is anything but the
+  exact string `"private"`; three of the five node cases pin that.

--- a/docs/spec/2026-09-10-OME-1147-unlist-private-boards.md
+++ b/docs/spec/2026-09-10-OME-1147-unlist-private-boards.md
@@ -1,0 +1,78 @@
+# OME-1147 — Unlist private boards from the portal index
+
+Status: owner-approved · Stack: scoreboard
+
+## Problem
+
+`healthbench-worst30` is the Fusion Monsters entry challenge, assembled by us rather than proposed
+by academics. It appears on the public portal index as a card with no entries, because
+`initIndex()` renders every benchmark `/v1/benchmarks` returns and a private board yields no rows
+to an anonymous visitor.
+
+The owner's requirements (2026-09-09): the index shows only established benchmarks; `sf.leaderboards`
+still lists everything so participants can submit against the challenge; nobody outside the
+OpenMined product team sees its rankings.
+
+Two of the three already hold. `get_leaderboard` routes private boards to `_private_leaderboard`,
+and `ScoreStore.list_benchmarks()` returns every board unfiltered. Only the index is wrong.
+
+## Decisions
+
+### D1 — The index filters on `visibility`, client-side
+
+`BenchmarkSchema` already exposes `visibility`, so `/v1/benchmarks` already carries what the portal
+needs. No API change, no schema change, no migration, no seed change.
+
+### D2 — Filtering happens before the boards are fetched
+
+`initIndex()` currently issues one `fetchBoard()` per benchmark and then renders. Filtering first
+also stops the page requesting a board it will never draw. That is incidental to the ask and is
+the obviously correct ordering, so it is stated rather than left to chance.
+
+### D3 — The rule is FAIL-OPEN
+
+A benchmark whose `visibility` is absent, null, or an unrecognised string stays listed. This is a
+cosmetic filter, not an access control: the server already refuses private rankings to anyone who
+should not see them. A stricter client-side rule buys no privacy and risks silently erasing a
+board from the public catalogue on a serialisation change.
+
+INVARIANT: only the exact string `"private"` removes a card.
+
+### D4 — The logic lives in `leaderboard-logic.js`
+
+`index.html` already loads that module before `main.js`, it is already exercised by
+`tests/portal/leaderboard-logic.test.js`, and that file is already named in the scoreboard gate
+list. A helper in `main.js` would be untestable, and a new test file would mean editing the gate
+list by name (`OME-798`) for one function. Its header is widened to say it holds the portal's pure
+decisions rather than only the board's.
+
+### D5 — Visibility stands in for provenance, and says so
+
+The owner's rule is *established versus ours*. Filtering on `visibility` produces exactly that
+result today, because `healthbench-worst30` is both the only board we assembled and the only
+private one. They diverge the moment we run a challenge on an academic benchmark or publish one of
+our own. `OME-1112` — "Benchmark catalogue records where each benchmark came from" — is where the
+provenance rule belongs, and the code says so at the filter.
+
+### D6 — Two docstrings are corrected
+
+`routes/leaderboard.py` documents `list_benchmarks` as "List registered public benchmarks" while
+the store returns private boards as well. That behaviour is what requirement 2 depends on, so the
+docstring must state it. The index's empty-state copy carries the same slip.
+
+## Verification contract
+
+- a private benchmark is dropped from the index;
+- a public one is kept;
+- absent, null and unrecognised visibility values are kept (D3);
+- `initIndex` actually calls the helper — the rule existing is not the rule being used;
+- `/v1/benchmarks` still returns private boards, unchanged;
+- full Scoreboard gates green.
+
+## Non-goals
+
+- any change to who can read rankings — `OME-894`'s behaviour is untouched;
+- a `listed_in_portal` field, a migration, or a seed change;
+- the direct `benchmark.html?id=healthbench-worst30` URL, which still resolves and still shows
+  nothing to anyone unauthorised;
+- the provenance rule itself (`OME-1112`).

--- a/docs/tasks/2026-09-10-OME-1147-unlist-private-boards.md
+++ b/docs/tasks/2026-09-10-OME-1147-unlist-private-boards.md
@@ -1,0 +1,31 @@
+---
+id: OME-1147
+linear_url: https://linear.app/openmined/issue/OME-1147/unlist-the-healthbench-worst-30percent-challenge-from-the-portal-index
+status: in_review
+type: task
+priority: 2
+labels: [BUG, scoreboard, agentic, autonomous]
+created: 2026-09-08
+closed:
+---
+
+# Unlist the HealthBench Worst-30% challenge from the portal index
+
+Filter private boards out of the portal index so the Fusion Monsters entry challenge stops
+appearing as an empty card. `sf.leaderboards` keeps listing every benchmark so participants can
+submit, and rankings stay private.
+
+Web-only. No API, schema, migration or seed change — `BenchmarkSchema` already exposes
+`visibility`.
+
+Visibility stands in for provenance here; the owner's rule is "established versus ours", which
+`OME-1112` will make expressible.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-10-OME-1147-unlist-private-boards.md`
+- Plan: `docs/plan/2026-09-10-OME-1147-unlist-private-boards.md`
+- Ledger: `docs/work/2026-09-10-OME-1147-unlist-private-boards.md`
+
+Related: `OME-894` (private boards), `OME-1112` (benchmark provenance), `OME-798` (portal JS tests
+are named in the gate list, never globbed).

--- a/docs/work/2026-09-10-OME-1147-unlist-private-boards.md
+++ b/docs/work/2026-09-10-OME-1147-unlist-private-boards.md
@@ -1,0 +1,88 @@
+---
+ticket: OME-1147
+stack: scoreboard
+status: in_progress
+started: 2026-09-10
+finished:
+---
+
+# OME-1147 — Unlist private boards from the portal index
+
+## Intent
+
+The public portal index renders a card for `healthbench-worst30`, the Fusion Monsters entry
+challenge, and that card is empty for every anonymous visitor because the board is private. The
+owner wants the index to show established benchmarks only, while `sf.leaderboards` keeps listing
+everything so participants can still submit, and rankings stay private.
+
+Two of those three already hold. This unit closes the third with a client-side filter on a field
+the API already returns.
+
+## Planned changes
+
+- `portal/leaderboard-logic.js` — `listedBenchmarks(benchmarks)`, plus a widened header.
+- `portal/main.js` — filter in `initIndex()` before the per-board fetches; fix the empty-state copy.
+- `src/scoreboard/routes/leaderboard.py` — correct the `list_benchmarks` docstring, which claims
+  the endpoint lists public benchmarks while the store returns every board.
+- `tests/portal/leaderboard-logic.test.js` and `tests/unit/test_portal_static.py` — see below.
+
+No new test file, so the gate list and `scoreboard-tests.yml` stay untouched.
+
+## Test plan
+
+Two layers, because neither alone is sufficient.
+
+**Node** — the rule: private dropped, public kept, absent/null/unrecognised kept, non-array yields
+`[]`, input not mutated.
+
+**Python** — the wiring: `initIndex` calls the helper, the module exports it, and `index.html`
+still loads `leaderboard-logic.js` before `main.js`. The node suite cannot see `main.js`, so a
+perfect helper that nothing calls would pass every behavioural test.
+
+## Acceptance
+
+- the index drops private boards and keeps everything else;
+- `/v1/benchmarks` is unchanged and still returns private boards;
+- no change to who can read rankings;
+- full Scoreboard gates green, append-only included — every test change is an addition.
+
+## Outcome
+
+- **Actual files:** as planned — `portal/leaderboard-logic.js` (+32/−7, the helper plus a widened
+  header), `portal/main.js` (+6/−2), `routes/leaderboard.py` (+12/−1, docstring),
+  `tests/portal/leaderboard-logic.test.js` (+44/−0), `tests/unit/test_portal_static.py` (+22/−0).
+- **Commits:** see the PR — one commit, `Refs: OME-1147`.
+- **Gates:**
+  - `run_gates.py scoreboard --base origin/main --skip-append-only` → ALL GATES GREEN: ruff check,
+    ruff format, pyright, pytest with `--cov-fail-under=80`, all three portal suites.
+    `leaderboard-logic.test.js` alone: 43 passed.
+  - `run_gates.py scoreboard --base origin/main` → append-only flags
+    `tests/portal/leaderboard-logic.test.js` with *"existing test artifact is unsupported or
+    unparseable"*. **This is not a rule-5 violation.** The change is +44/−0 and `git diff | grep
+    '^-[^-]'` returns zero removed lines. The checker has no JavaScript parser, so it reports any
+    modification to a `.js` test file rather than reading it. No prior assertion was touched and
+    no owner decision is required. See Deviations.
+- **Mutation check:** four mutations across three files, each reverted in a `finally` and all
+  three files confirmed byte-identical to their backups afterwards:
+
+  | Mutation | Layer | Result |
+  |---|---|---|
+  | filter made fail-closed | node | CAUGHT |
+  | predicate inverted | node | CAUGHT |
+  | helper defined but never called from `main.js` | python | CAUGHT |
+  | `index.html` script order reversed | python | CAUGHT |
+
+  The last two are the reason the Python layer exists: the node suite cannot see `main.js`, so a
+  perfect helper that nothing calls, or one whose module loads too late, passes every behavioural
+  test.
+
+- **Deviations:**
+  1. **The append-only checker cannot parse JS.** Its message is "unsupported or unparseable", not
+     a diff of changed lines, and it fires on a purely additive change. Worth a follow-up ticket:
+     as it stands, every future portal JS test addition will need `--skip-append-only`, which
+     trains the team to skip the check that also guards the Python suites.
+  2. **The first mutation harness aborted mid-run and left `main.js` mutated**, because its
+     "did the runner execute?" marker looked for `"passed"` — absent from a failing pytest run,
+     which is exactly what a caught mutation produces. Rewritten with the restore in a `finally`
+     and a marker that matches either outcome. The mutated line was restored by hand and the
+     final state verified byte-identical.


### PR DESCRIPTION
## Summary

- the portal index drops private boards, so the Fusion Monsters entry challenge stops rendering as an empty card
- `/v1/benchmarks` is unchanged and still returns every board — `sf.leaderboards` needs the private ones so participants can submit
- rankings are untouched; `OME-894`'s access rule is exactly as it was

**Asana:** N/A — tracked in Linear as OME-1147

## Scope came from the owner's clarification

The original ticket asked for the full rankings to stay public over the API. The owner's comment of 2026-09-09 reverses that — *"none to see the rankings … outside of the product team"* — and asks for a web-only unlisting. The ticket description has been rewritten to match; this PR implements that version.

Two of the three requirements already held:

| Requirement | Mechanism | Status |
| --- | --- | --- |
| rankings stay private | `get_leaderboard` → `_private_leaderboard` | already correct (`OME-894`) |
| `sf.leaderboards` lists everything | `ScoreStore.list_benchmarks()` returns all boards | already correct |
| the index hides it | `initIndex()` rendered everything | **fixed here** |

No API, schema, migration or seed change: `BenchmarkSchema` already exposes `visibility`.

## The filter fails open, deliberately

Only the exact string `"private"` removes a card. Absent, null and unrecognised values keep one. This is a **cosmetic catalogue rule, not an access control** — the server already refuses private rankings — so guessing "hide it" buys no privacy and risks emptying the public catalogue on a serialisation change.

## Why the logic went into `leaderboard-logic.js`

`index.html` already loads it before `main.js`, it is already exercised by `tests/portal/leaderboard-logic.test.js`, and that file is already named in the scoreboard gate list. A helper in `main.js` would be untestable, and a new test file would mean editing the gate list by name (`OME-798`) for one function.

## Test plan

- [x] `uv run .claude/scripts/run_gates.py scoreboard --base origin/main --skip-append-only` → ALL GATES GREEN. `leaderboard-logic.test.js` alone: 43 passed.
- [x] both layers written first and confirmed RED
- [x] mutation-checked, every mutation reverted in a `finally` and all three files confirmed byte-identical afterwards:

| Mutation | Layer | Result |
| --- | --- | --- |
| filter made fail-closed | node | CAUGHT |
| predicate inverted | node | CAUGHT |
| helper defined but never called from `main.js` | python | CAUGHT |
| `index.html` script order reversed | python | CAUGHT |

The last two are why the Python layer exists. The node suite cannot see `main.js`, so a perfect helper that nothing calls — or one whose module loads too late — passes every behavioural test.

- [ ] screenshots — not attached; the visible change is one card no longer appearing

## ⚠️ The append-only gate reports a false positive here

`run_gates.py` without `--skip-append-only` flags `tests/portal/leaderboard-logic.test.js` with *"existing test artifact is unsupported or unparseable"*.

**This is not a rule-5 violation.** The change is `+44/−0`, and a diff filtered for removed lines returns nothing. The checker has no JavaScript parser, so it reports any modification to a `.js` test file rather than reading it. No prior assertion was touched.

Worth a follow-up: as it stands, every future portal JS test addition needs `--skip-append-only`, which trains us to skip the check that also guards the Python suites.

## Note for whoever picks up OME-1112

An `AIDEV-NOTE` at the filter records that `visibility` stands in for **provenance**. The owner's rule is "established versus ours", and the two coincide only while `healthbench-worst30` is both the only board we assembled and the only private one. They part company the first time we run a challenge on an academic benchmark, or publish one of our own.

## Cross-service notes

None. No API, schema, or client change.
