### PR TITLE
docs(tasks): close the OME-1170 mirror

### DIFF
--- a/docs/tasks/2026-09-10-OME-1170-catalog-timeout-retry.md
+++ b/docs/tasks/2026-09-10-OME-1170-catalog-timeout-retry.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1170
 linear_url: https://linear.app/openmined/issue/OME-1170/checking-a-models-parameters-fails-with-http-504-the-first-time-after
-status: in_progress
+status: done
 type: fix
 priority: Medium
 labels: [screamingface-engine, agentic, autonomous]
 created: 2026-09-10
-closed:
+closed: 2026-09-10
 ---
 
 # Checking a model's parameters fails with HTTP 504 the first time after a stack start


### PR DESCRIPTION
Marks the `docs/tasks/` mirror for `OME-1170` done/closed, matching the Linear issue after PR #890 merged.

Refs: OME-1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)