### PR TITLE
docs(repo): triage the Dependabot backlog by CODEOWNER

### DIFF
--- a/docs/plan/2026-09-10-dependabot-backlog-triage.md
+++ b/docs/plan/2026-09-10-dependabot-backlog-triage.md
@@ -1,0 +1,159 @@
+# Dependabot backlog triage — 2026-09-10
+
+**Work item:** OME-1171 · **Ledger:** `docs/work/2026-09-10-OME-1171-dependabot-backlog.md`
+
+18 Dependabot PRs were open, the oldest from 2026-09-01. Ten have been merged. **Eight remain, and
+each one needs a decision from its CODEOWNER.** Find your section below; you only need to read
+yours.
+
+Two of the remaining PRs carry unauthenticated-RCE advisories and are marked **URGENT**.
+
+## How the split was made
+
+| Bucket | Count | Rule |
+|---|---|---|
+| Merged | 10 | Lockfile-only transitive bump, no manifest edit, green CI |
+| Awaiting owner | 7 | Edits a manifest, moves a framework version, or ships a native binary |
+| Needs a replacement PR | 1 | `#803` is red against a deliberate runtime guard |
+
+Nothing platform-side enforces this split. `reviewDecision` is empty and no ruleset or branch
+protection requires review, so **`.github/CODEOWNERS` is advisory in this repo** — any of us can
+squash any of these today. The split is a choice, not a constraint.
+
+## Why the remaining eight were not simply closed
+
+Closing does not stick. Dependabot recreates a closed PR on its next weekly run unless
+`.github/dependabot.yml` gains a matching `ignore:`, and every ignore needs a 1:1 rationale entry
+in `.github/dependabot-ignores.yml` whose `blocker.kind` is one of exactly two machine-checkable
+kinds — `npm_peer` or `ci_matrix` — audited by the "Dependabot ignore audit" job in
+`.github/workflows/repo-checks.yml`.
+
+None of these eight has a blocker that fits that schema. They are not blocked on upstream; they are
+waiting on a human. So the options are merge or replace, and there is no third door.
+
+---
+
+## @HupBaHa — aigateway, aigateway-ui, scoreboard, co-owner of `/.github/`
+
+| PR | Change | Why it needs you |
+|---|---|---|
+| **#862** | **URGENT.** `next` 16.3.2 → 16.3.3, plus js-yaml, fast-uri, nanoid. Edits `package.json` | Fixes two unauthenticated-RCE advisories: GHSA-p293-qw3h-jr36 (Windows-hosted servers) and GHSA-2xp9-vwfh-vxw4 (Image Optimization API, AVIF) |
+| #857 | `next` 16.3.2 → 16.3.4, `@testing-library/react`, `@vitejs/plugin-react`, `stylelint`. Edits `package.json` | Moves the build and test toolchain, not just the lock. **Merge after #862** — it supersedes #862's `next` bump |
+| #881 | `azure/setup-helm` 4.3.1 → 5.0.1 across 8 workflows | See the note below — lower risk than "major" suggests |
+
+**On #881.** `main` already runs the floating `@v5` in 7 of 8 workflows; only
+`analytics-tests.yml:57` is still on `@v4.3.1`. The PR converts all of them to an exact `@v5.0.1`,
+so it is mostly a *tightening*. v5's sole breaking change is the node20 → node24 runtime, and
+`Render the Helm chart`, `Lint and verify chart wiring` and `chart` all pass on the PR — v5 is
+already exercised green.
+
+**Also yours:** OME-1172, the replacement for `#803` (see the `#803` section below). It touches
+security logic, so it needs your review specifically.
+
+**Already merged, for your awareness:** `#798` (scoreboard: pydantic 2.13.4 → 2.13.5,
+ruff 0.16.4 → 0.16.6, `uv.lock` only).
+
+## @itstauq — screamingface-studio
+
+| PR | Change | Why it needs you |
+|---|---|---|
+| **#861** | **URGENT.** `next` 16.3.0 → 16.3.3. Edits `package.json` | Same two RCE advisories as #862. Studio sits two patches further behind than aigateway-ui did |
+| #863 | `sharp` 0.35.3 → 0.35.4 | Native binary in the image pipeline, with platform-specific optional dependencies — not a pure lock bump in practice |
+
+**Worth knowing about your tree.** Studio's `frontend` (npm) and `src-tauri` (cargo) are
+deliberately absent from `.github/dependabot.yml`, pending OME-739. The PRs above reached studio
+anyway because Dependabot *security* updates ignore the `directory:` scoping (noted in the
+dependabot.yml header under OME-733). Net effect until OME-739 lands: studio receives security PRs
+but no routine version PRs, so routine drift accumulates silently.
+
+**Already merged, for your awareness:** `#809` (nltk 3.10.2 → 3.10.3), `#864` (js-yaml 4.3.1 →
+4.3.2), `#807` (browserslist 4.28.6 → 4.28.8). All security patches, all lockfile-only.
+
+## @IonesioJunior @keelancj — packages/screamingface
+
+| PR | Change | Why it needs you |
+|---|---|---|
+| #858 | `litellm` 1.98.0 → 1.100.0, plus cryptography, pydantic, ruff, websockets. Edits `pyproject.toml` | **Highest-risk merge in the backlog** — it changes a hard `==` pin on the *distributed* package |
+
+The pin at `pyproject.toml:51` is `litellm==1.98.0`, inside the `runtime` optional-dependency group.
+Moving it changes what every consumer of the published package resolves.
+
+See also **OME-1173**: `apps/aigateway` guards its litellm version explicitly, while this tree pins
+a different one with no guard, so the packaged runtime can ship a litellm that aigateway's
+hardening was never verified against. Merging #858 helps by coincidence; OME-1173 proposes making
+the agreement checkable.
+
+**Already merged, for your awareness:** `#810` (tornado 6.5.7 → 6.5.8 security patch,
+`uv.lock` only).
+
+## @IrinaMBejan — public-docs
+
+| PR | Change | Why it needs you |
+|---|---|---|
+| #879 | `vue-router` 5.2.0 → 5.3.1, `markdown-it` 15.0.0 → 15.0.1, `eslint` 10.9.1 → 10.10.0, `eslint-plugin-vue`, `eslint-plugin-oxlint`, `oxlint` 1.80 → 1.81, `@types/node`, `vue` 3.5.41 → 3.5.42. Edits `package.json` | A router minor plus a linter bump on the public docs site — 8 updates in one group |
+
+**Already merged, for your awareness:** `#860` (nanoid 3.3.17 → 3.3.18 security patch,
+`package-lock.json` only).
+
+---
+
+## #803 — do not merge this one; it is being replaced
+
+`#803` bumps `litellm` 1.97.0 → 1.100.0 in `apps/aigateway`. It is the only red PR in the backlog,
+and it is red for a good reason: it trips three deliberate tripwires. **The guard is working as
+designed.**
+
+**1. The version pin lives in the tests, not the manifest.**
+`tests/unit/openai/test_openai_runtime_guard.py:256` and `:342` each assert
+`importlib.metadata.version("litellm") == "1.97.0"`. `apps/aigateway/pyproject.toml:12` declares
+only `litellm>=1.55`, so the resolver is otherwise free to move — those two asserts are what stops
+it. Their failure message says it outright: "re-verify the tuple against the new release before
+moving this pin."
+
+**2. Three new callback parameters appeared upstream.**
+`tests/unit/core/test_request_hardening.py:210`
+`test_litellm_dynamic_callback_parameter_set_is_covered` reads litellm's private
+`_supported_callback_params` and found `newrelic_region`, `newrelic_api_key` and
+`langfuse_environment` missing from our allowlist.
+
+That allowlist is security logic, not a dependency list. From `request_hardening.py:55-58`:
+
+> every name in litellm's `_supported_callback_params` must appear here, so a client can never turn
+> a chat request into a telemetry redirect.
+
+There is **no live vulnerability today** — those three parameters do not exist on the pinned
+1.97.0. The guard is precisely what prevents the upgrade from introducing one silently.
+
+Moving the pin properly requires re-verifying 12 guarded globals against 1.100.0 and hand-mirroring
+the result into a second list that is deliberately maintained separately (the two sides must be
+able to disagree, or the comparison proves nothing), then running the full local gates including
+live tests, which CI skips. That is a unit of work, not a rubber stamp — filed as **OME-1172**,
+owner @HupBaHa. `#803` closes as superseded once OME-1172 lands.
+
+## Follow-ups filed
+
+| Issue | Owner | What |
+|---|---|---|
+| OME-1172 | @HupBaHa | Re-verify the LiteLLM runtime guard against 1.100.0, replacing `#803` |
+| OME-1173 | @IonesioJunior @keelancj | Make the packaged litellm pin and aigateway's guarded version checkably equal |
+| OME-1174 | @sergio-bershadsky @HupBaHa | Pin the helm version in CI — chart rendering currently resolves `latest`, which is already helm v4.2.4 |
+
+## Merged in OME-1171
+
+Ten PRs, all lockfile-only with no manifest edit and green CI at merge time.
+
+| PR | Change | Path |
+|---|---|---|
+| #811 | tornado 6.5.7 → 6.5.8 (security) | `apps/screamingface-engine/uv.lock` |
+| #804 | pydantic, ruff, websockets | `apps/screamingface-engine/uv.lock` |
+| #802 | pydantic, ruff | `apps/report-intake/uv.lock` |
+| #799 | pydantic, ruff | `packages/url4/uv.lock` |
+| #798 | pydantic, ruff | `apps/scoreboard/uv.lock` |
+| #810 | tornado 6.5.7 → 6.5.8 (security) | `packages/screamingface/uv.lock` |
+| #809 | nltk 3.10.2 → 3.10.3 (security) | `apps/screamingface-studio/runtime/uv.lock` |
+| #864 | js-yaml 4.3.1 → 4.3.2 (security) | `apps/screamingface-studio/frontend/package-lock.json` |
+| #807 | browserslist 4.28.6 → 4.28.8 (security) | `apps/screamingface-studio/frontend/package-lock.json` |
+| #860 | nanoid 3.3.17 → 3.3.18 (security) | `public-docs/package-lock.json` |
+
+Six of those ten sit in trees owned by someone other than the merger. They are listed under each
+owner's section above so nobody discovers a merge after the fact.

--- a/docs/tasks/2026-09-10-OME-1171-dependabot-backlog.md
+++ b/docs/tasks/2026-09-10-OME-1171-dependabot-backlog.md
@@ -1,0 +1,21 @@
+---
+id: OME-1171
+linear_url: https://linear.app/openmined/issue/OME-1171/merge-the-safe-dependabot-backlog-and-publish-an-owner-triage
+status: in_progress
+type: task
+priority: High
+labels: [repo, agentic, autonomous, task]
+created: 2026-09-10
+closed:
+---
+
+# Merge the safe Dependabot backlog and publish an owner triage
+
+18 open Dependabot PRs, oldest 2026-09-01, nine of them security updates including two
+unauthenticated-RCE advisories for Next.js. Merge the 10 that are lockfile-only transitive bumps
+with green CI; hand the 7 that edit a manifest or move a framework version to their CODEOWNER; and
+replace #803 rather than merge it, since it trips a deliberate LiteLLM runtime guard covering
+security logic. Zero open PRs is not the target — CODEOWNERS is advisory here, and closing without
+a schema-valid `ignore:` would just have Dependabot recreate them. Details: Linear issue; how:
+ledger `docs/work/2026-09-10-OME-1171-dependabot-backlog.md`; triage for owners:
+`docs/plan/2026-09-10-dependabot-backlog-triage.md`.

--- a/docs/tasks/2026-09-10-OME-1171-dependabot-backlog.md
+++ b/docs/tasks/2026-09-10-OME-1171-dependabot-backlog.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1171
 linear_url: https://linear.app/openmined/issue/OME-1171/merge-the-safe-dependabot-backlog-and-publish-an-owner-triage
-status: in_progress
+status: done
 type: task
 priority: High
 labels: [repo, agentic, autonomous, task]
 created: 2026-09-10
-closed:
+closed: 2026-09-10
 ---
 
 # Merge the safe Dependabot backlog and publish an owner triage

--- a/docs/work/2026-09-10-OME-1171-dependabot-backlog.md
+++ b/docs/work/2026-09-10-OME-1171-dependabot-backlog.md
@@ -1,0 +1,63 @@
+---
+ticket: OME-1171
+stack: repo
+status: in_progress
+started: 2026-09-10
+finished:
+---
+
+# OME-1171 — Merge the safe Dependabot backlog and publish an owner triage
+
+## Intent
+
+18 Dependabot PRs sit open, the oldest from 2026-09-01, nine of them security updates and two
+carrying unauthenticated-RCE advisories for Next.js. The backlog is not uniformly safe: seven PRs
+edit a manifest, move a framework version, or ship a native binary in a tree owned by another
+maintainer per `.github/CODEOWNERS`, and one (#803) is red because it trips a deliberate LiteLLM
+runtime guard. This unit merges only the unambiguously safe tail and turns the rest into a written,
+per-owner triage so the remaining decisions land with the people who own them.
+
+Zero open PRs is deliberately NOT the goal. `reviewDecision` is empty and no ruleset blocks merge,
+so CODEOWNERS is advisory — nothing platform-side would stop us squashing another team's framework
+bump. Closing them instead does not stick: Dependabot recreates a closed PR unless
+`.github/dependabot.yml` gains an `ignore:` with a 1:1 rationale in `.github/dependabot-ignores.yml`
+whose `blocker.kind` is `npm_peer` or `ci_matrix` (audited by `repo-checks.yml`), and nothing in
+this backlog fits that schema.
+
+## Planned changes
+
+No application code. Repo writes are confined to this branch:
+
+- `docs/plan/2026-09-10-dependabot-backlog-triage.md` — the triage document, organised by CODEOWNER
+- `docs/work/2026-09-10-OME-1171-dependabot-backlog.md` — this ledger
+- `docs/tasks/2026-09-10-OME-1171-dependabot-backlog.md` — the Linear mirror
+
+Merged directly on GitHub (10 PRs, lockfile-only, no manifest edit, green CI):
+#811, #804, #802, #799, #798, #810, #809, #864, #807, #860.
+
+## Test plan
+
+No new tests — this unit ships no executable code. The safety argument rests on each merged PR's
+own CI, which must be green at merge time, and on the diff shape: `uv.lock` / `package-lock.json`
+only, verified per PR with `gh pr view <n> --json files`.
+
+Two clusters share a lockfile and must be merged in order, re-checking `mergeStateStatus` between
+merges and issuing `@dependabot rebase` on DIRTY/BEHIND:
+
+- `apps/screamingface-engine/uv.lock`: #811 -> #804
+- `apps/screamingface-studio/frontend/package-lock.json`: #864 -> #807
+
+## Acceptance
+
+- The 10 PRs above are squash-merged, each on green CI; never `--admin`.
+- `gh pr list --author "app/dependabot" --state open` returns 8 (7 owner-gated + #803), down from 18.
+- The triage doc names, for every one of those 8, the owner, the ask, and the specific risk.
+- Three follow-up issues exist and are referenced from the triage doc: the LiteLLM 1.100 guard
+  re-verification (supersedes #803), the packaged-litellm pin split, and the unpinned helm renderer.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">

--- a/docs/work/2026-09-10-OME-1171-dependabot-backlog.md
+++ b/docs/work/2026-09-10-OME-1171-dependabot-backlog.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1171
 stack: repo
-status: in_progress
+status: done
 started: 2026-09-10
-finished:
+finished: 2026-09-10
 ---
 
 # OME-1171 — Merge the safe Dependabot backlog and publish an owner triage
@@ -55,9 +55,34 @@ merges and issuing `@dependabot rebase` on DIRTY/BEHIND:
 - Three follow-up issues exist and are referenced from the triage doc: the LiteLLM 1.100 guard
   re-verification (supersedes #803), the packaged-litellm pin split, and the unpinned helm renderer.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files:** as planned — `docs/plan/2026-09-10-dependabot-backlog-triage.md`,
+  this ledger, and `docs/tasks/2026-09-10-OME-1171-dependabot-backlog.md`. No application code.
+- **Commits:** `0c3a9b69` — docs(repo): triage the Dependabot backlog by CODEOWNER (PR #895)
+- **Merged PRs (10):** #811, #802, #799, #798, #810, #809, #864, #860, then the two cluster
+  siblings #804 and #807. Each `mergeStateStatus: CLEAN` and green at merge time; squash, no
+  `--admin`.
+- **Gates:** no `run_gates.py` — this unit ships no executable code. Verification was CI instead:
+  - PR #895: all checks pass (`CodeQL`, `Analyze` × 4, `plan`), `mergeStateStatus: CLEAN`.
+  - `main` after the sweep: no failing repo workflow. `screamingface-engine-tests`,
+    `ScreamingFace E2E Replay`, `Dev build screamingface-engine` and `Release Please` all green.
+  - Confirmed the bumps actually landed: `apps/screamingface-engine/uv.lock` on `origin/main` now
+    shows tornado 6.5.8, pydantic 2.13.5, ruff 0.16.6.
+- **Deviations:**
+  1. **No `@dependabot rebase` was needed.** Both lockfile clusters (#811 -> #804,
+     #864 -> #807) re-reported `CLEAN` after the head merged, because the grouped bumps touch
+     disjoint lock entries. The rebase step in the plan went unused.
+  2. **Two cancelled runs on #811's merge commit** (`screamingface-engine-tests`,
+     `Dev build screamingface-engine`) — concurrency-cancelled when #804 merged into the same
+     tree 54s later. Not a gap: #804's runs cover a commit containing both bumps and are green.
+  3. **Two red `Dependabot Updates` runs on `main`**, for nanoid and js-yaml. These are
+     Dependabot's own post-merge security-refresh jobs, triggered by the very merges that fixed
+     the advisories — the logs read "Checking if js-yaml 4.3.2 needs updating" and "Found no
+     dependencies to update", then exit `unknown_error`. Dependabot-side race, not our CI and not
+     a regression on `main`.
+  4. **The unit did not reach zero open Dependabot PRs**, by design — see the Intent section.
+     18 -> 8. The remaining 8 are owner-gated and handed over in the triage doc.
+- **Follow-ups filed:** OME-1172 (LiteLLM 1.100 guard re-verification, supersedes #803),
+  OME-1173 (packaged litellm pin drift, blocked by OME-1172), OME-1174 (helm renderer unpinned
+  in CI — `version: latest` currently resolves v4.2.4).


### PR DESCRIPTION
Closes OME-1171.

## What happened

The Dependabot backlog was 18 open PRs, oldest from 2026-09-01. **Ten are now merged, eight remain.**

| Bucket | Count | Rule |
|---|---|---|
| Merged | 10 | Lockfile-only transitive bump, no manifest edit, green CI |
| Awaiting owner | 7 | Edits a manifest, moves a framework version, or ships a native binary |
| Needs a replacement PR | 1 | `#803` is red against a deliberate runtime guard |

This PR adds the triage document that hands those eight to their CODEOWNERs, organised so each person reads only their own section.

## Why not zero open PRs

`reviewDecision` is empty and no ruleset requires review, so `.github/CODEOWNERS` is **advisory** in this repo — nothing platform-side stops any of us squashing another team's framework bump. Getting to zero today would have meant doing exactly that, seven times, including a hard `==` pin change on the distributed `packages/screamingface`.

Closing them instead does not stick either. Dependabot recreates a closed PR unless `.github/dependabot.yml` gains a matching `ignore:`, and every ignore needs a 1:1 rationale in `.github/dependabot-ignores.yml` whose `blocker.kind` is `npm_peer` or `ci_matrix` (audited by `repo-checks.yml`). None of these eight is blocked on upstream — they are blocked on a human — so none fits that schema.

## Two urgent items in there

`#862` (aigateway-ui) and `#861` (studio) both carry GHSA-p293-qw3h-jr36 and GHSA-2xp9-vwfh-vxw4 — unauthenticated RCE in Next.js. They are flagged urgent in their owners' sections.

## Follow-ups filed

- **OME-1172** (@HupBaHa) — re-verify the LiteLLM runtime guard against 1.100.0, replacing `#803`. The guard protects `_CALLBACK_DYNAMIC_FIELDS`, which stops a client turning a chat request into a telemetry redirect; three new upstream callback params need reviewing into the allowlist by hand.
- **OME-1173** (@IonesioJunior @keelancj) — `apps/aigateway` guards its litellm version while `packages/screamingface` hard-pins a different one unguarded, so the packaged runtime can ship a litellm our hardening never saw.
- **OME-1174** (@sergio-bershadsky @HupBaHa) — all 7 `azure/setup-helm` usages are unpinned; CI's chart renderer resolves `latest`, which is already helm v4.2.4.

## Verification

- Docs-only change; no application code touched.
- `gh pr list --author "app/dependabot" --state open` → 8, down from 18.
- Every merged PR was `mergeStateStatus: CLEAN` with green CI at merge time, squash-merged, no `--admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WRRtLE4MN8DXeHqNyofoE