### PR TITLE
docs(tasks): close the OME-1169 mirror

### DIFF
--- a/docs/tasks/2026-09-10-OME-1169-local-stack-config-visibility.md
+++ b/docs/tasks/2026-09-10-OME-1169-local-stack-config-visibility.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1169
 linear_url: https://linear.app/openmined/issue/OME-1169/the-local-stack-silently-ignores-the-database-setting-and-never-shows
-status: in_progress
+status: done
 type: bug
 priority: Medium
 labels: [py-screamingface, agentic, autonomous]
 created: 2026-09-10
-closed:
+closed: 2026-09-10
 ---
 
 # The local stack silently ignores the database setting and never shows what config it started with


### PR DESCRIPTION
Flips the `docs/tasks/` mirror for `OME-1169` to done/closed after PR #891 merged (squash `01d0c13c`). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)