### PR TITLE
feat(aigateway): carry gateway_call_id on every log line (OME-938)

### DIFF
--- a/apps/aigateway/src/aigateway/call_context.py
+++ b/apps/aigateway/src/aigateway/call_context.py
@@ -1,0 +1,120 @@
+"""The request-scoped correlation context every aigateway log line is stamped with.
+
+FEATURE (OME-938): before this, `gateway_call_id` reached exactly ONE log line
+(`plugins/taxonomy/session.py`), so an operator holding an id from a response body could find
+the line announcing it and nothing about what the call actually did — dispatch, cache, retry
+and concurrency lines were all anonymous.
+
+The mechanism is a ContextVar bound per request by `middleware.call_id`, plus a log-record
+factory that stamps the bound id onto every record created inside that scope. A factory rather
+than a per-call argument, because the lines that most need attributing are the ones nobody will
+go back and edit: LiteLLM's, a library's, an exception handler's.
+
+INVARIANT: `install_call_context_injection` WRAPS whatever factory it finds; it never replaces
+one. `core.auth.log_filter.install_provisioning_token_redaction` owns the same single
+`logging.setLogRecordFactory` slot, and replacing it would silently stop scrubbing provisioning
+tokens — a security regression hiding inside an observability change, invisible to every
+observability assertion. Both install orders are covered by tests.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import secrets
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from aigateway.core.auth.log_filter import factory_chain_has
+
+_INSTALLED = "_aigw_call_context_injection"
+"""Marks the factory THIS module installed, so a second install is a no-op."""
+
+_RECORD_ATTR = "gateway_call_id"
+"""The attribute name the injector stamps on each record, and the field name in the output.
+
+One constant, because the renderer (`logs.CallContextFilter`) and every reader must agree with
+the writer. A drift here is silent: records carry the id, nothing renders it.
+"""
+
+
+def record_call_id(record: logging.LogRecord) -> str | None:
+    """The call id stamped on `record`, or None if it was created outside a request.
+
+    A typed accessor rather than `getattr(record, "gateway_call_id", None)` at each site:
+    `LogRecord` has no such attribute in its type, so every direct read is a pyright error, and
+    the string would be repeated in the renderer, the tests and any future consumer.
+    """
+
+    value = getattr(record, _RECORD_ATTR, None)
+    return value if isinstance(value, str) else None
+
+
+_call_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "aigateway_gateway_call_id", default=None
+)
+
+
+def new_gateway_call_id() -> str:
+    """A fresh id in the shape the public contract already fixes.
+
+    `call_<32 hex>` is pinned by `plugins/taxonomy/usage_accounting.schema.json` and appears in
+    response bodies, so it is not free to change here.
+    """
+
+    return f"call_{secrets.token_hex(16)}"
+
+
+@contextmanager
+def call_scope(call_id: str) -> Iterator[str]:
+    """Bind one request's id for the duration of a scope; restore on exit."""
+
+    token = _call_id.set(call_id)
+    try:
+        yield call_id
+    finally:
+        _call_id.reset(token)
+
+
+def current_call_id() -> str | None:
+    """The bound request's id, or None outside any request.
+
+    None means the record carries NO id — boot, shutdown and test lines stay byte-identical
+    rather than gaining an empty field.
+    """
+
+    return _call_id.get()
+
+
+def install_call_context_injection() -> None:
+    """Stamp the bound call id onto every log record created from now on.
+
+    Idempotent, and composes with the redaction factory in either install order — see the
+    module INVARIANT.
+    """
+
+    current_factory = logging.getLogRecordFactory()
+    if factory_chain_has(current_factory, _INSTALLED):
+        return
+
+    def call_context_factory(*args: object, **kwargs: object) -> logging.LogRecord:
+        record = current_factory(*args, **kwargs)  # type: ignore[arg-type]
+        # `setattr`, not `record.gateway_call_id = ...`: `LogRecord` has no such attribute in
+        # its type, and this is the ordinary way to carry an extra on one. Read it back through
+        # `record_call_id` rather than a bare `getattr` at each call site.
+        setattr(record, _RECORD_ATTR, current_call_id())
+        return record
+
+    setattr(call_context_factory, _INSTALLED, True)
+    # `__wrapped__` is what makes the chain walkable — see `factory_chain_has`.
+    setattr(call_context_factory, "__wrapped__", current_factory)
+    logging.setLogRecordFactory(call_context_factory)
+
+
+__all__ = [
+    "call_scope",
+    "record_call_id",
+    "current_call_id",
+    "install_call_context_injection",
+    "new_gateway_call_id",
+]

--- a/apps/aigateway/src/aigateway/core/auth/log_filter.py
+++ b/apps/aigateway/src/aigateway/core/auth/log_filter.py
@@ -68,10 +68,48 @@ class RedactProvisioningTokenFilter(logging.Filter):
         return True
 
 
+_REDACTION_INSTALLED = "_aigw_provisioning_token_redaction"
+
+
+def factory_chain_has(factory: object, flag: str) -> bool:
+    """Is `flag` set anywhere in this record-factory wrapper chain — not just on top?
+
+    INVARIANT: idempotence must be about the CHAIN, never about the outermost factory.
+
+    Two installers now share `logging.setLogRecordFactory` — this module's redaction and
+    `aigateway.call_context`'s correlation id (OME-938) — and each wraps whatever it finds.
+    A top-only check means each installer sees the OTHER's wrapper, concludes it has not run,
+    and wraps again. Every interleaved pair then adds two layers, and since `create_app`
+    installs both, a process that builds many apps (the test suite builds thousands) grows the
+    chain until creating ONE log record overflows the stack — surfacing as
+    `RecursionError: maximum recursion depth exceeded` at fixture setup, nowhere near anything
+    that looks like logging.
+
+    WHY this lives in the security module rather than beside the newer installer: `core` must
+    not import from the app root, and this is where the first factory has always been. `seen`
+    guards a cycle a third party could introduce — without it a malformed chain would hang
+    instead of raising.
+    """
+    seen: set[int] = set()
+    while factory is not None and id(factory) not in seen:
+        seen.add(id(factory))
+        if getattr(factory, flag, False):
+            return True
+        factory = getattr(factory, "__wrapped__", None)
+    return False
+
+
 def install_provisioning_token_redaction() -> None:
-    """Install process-wide redaction for records from any logger/handler path."""
+    """Install process-wide redaction for records from any logger/handler path.
+
+    AIDEV-NOTE (OME-938): the idempotence guard walks the wrapper CHAIN, not just the outermost
+    factory. This module no longer owns `setLogRecordFactory` alone — `call_context` installs a
+    correlation-id factory too — and a top-only check means each installer sees the other's
+    wrapper, concludes it has not run, and wraps again. Every interleaved pair added two layers
+    until creating one log record overflowed the stack. See `call_context.factory_chain_has`.
+    """
     current_factory = logging.getLogRecordFactory()
-    if getattr(current_factory, "_aigw_provisioning_token_redaction", False):
+    if factory_chain_has(current_factory, _REDACTION_INSTALLED):
         return
 
     redactor = RedactProvisioningTokenFilter()
@@ -81,5 +119,6 @@ def install_provisioning_token_redaction() -> None:
         redactor.filter(record)
         return record
 
-    setattr(redacting_factory, "_aigw_provisioning_token_redaction", True)
+    setattr(redacting_factory, _REDACTION_INSTALLED, True)
+    setattr(redacting_factory, "__wrapped__", current_factory)
     logging.setLogRecordFactory(redacting_factory)

--- a/apps/aigateway/src/aigateway/logs.py
+++ b/apps/aigateway/src/aigateway/logs.py
@@ -19,12 +19,43 @@ import logging
 import os
 from typing import TextIO
 
+from aigateway.call_context import record_call_id
+
 APP_LOGGER = "aigateway"
 LEVEL_ENV = "AIGW_LOG_LEVEL"
 DEFAULT_LEVEL = "INFO"
 
 # Matches uvicorn's own column so a deployment's logs read as one stream rather than two.
-_FORMAT = "%(levelname)s:     %(name)s %(message)s"
+# `%(call_context)s` is filled by `CallContextFilter` (OME-938); `defaults=` keeps a record that
+# reaches the handler WITHOUT passing the filter — a foreign handler's, a library's — from
+# raising KeyError in the formatter and taking the log line with it.
+_FORMAT = "%(levelname)s:     %(name)s %(call_context)s%(message)s"
+
+
+class CallContextFilter(logging.Filter):
+    """Render the bound request's correlation ids onto every record that passes through.
+
+    FEATURE (OME-938): `call_context.install_call_context_injection` puts `gateway_call_id` on
+    the RECORD, but `_FORMAT` is plain text — an attribute nobody prints is not correlation.
+    This filter is what turns the attribute into output, exactly as the Engine's
+    `RunContextFilter` does for `topic`/`trace_id`.
+
+    `key=value` and not free prose: it is the shape the Engine already emits, and the shape a
+    collector can be taught to parse into a real attribute. Unbound (boot, shutdown, tests) it
+    renders nothing at all, so those lines stay byte-identical to before.
+
+    AIDEV-NOTE: `OME-1120` adds `trace_id` here, beside the call id — that is why this renders a
+    LIST of parts rather than one interpolation.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        parts = []
+        call_id = record_call_id(record)
+        if call_id is not None:
+            parts.append(f"gateway_call_id={call_id}")
+        record.call_context = (" ".join(parts) + " ") if parts else ""
+        return True
+
 
 _INSTALLED = "_aigateway_log_handler"
 """Marks the handler THIS module installed.
@@ -50,10 +81,21 @@ def configure(stream: TextIO | None = None) -> None:
     logger.setLevel(os.getenv(LEVEL_ENV, DEFAULT_LEVEL).upper())
     if not any(getattr(handler, _INSTALLED, False) for handler in logger.handlers):
         handler = logging.StreamHandler(stream)
-        handler.setFormatter(logging.Formatter(_FORMAT))
+        # WHY the filter sits on the HANDLER and not the logger (OME-938): a filter on a logger
+        # is not consulted for records that arrive from a CHILD logger, so `aigateway.foo`'s
+        # lines would render an empty context while `aigateway`'s own rendered correctly —
+        # the partial-coverage failure this feature exists to remove.
+        handler.addFilter(CallContextFilter())
+        handler.setFormatter(logging.Formatter(_FORMAT, defaults={"call_context": ""}))
         setattr(handler, _INSTALLED, True)
         logger.addHandler(handler)
     logger.propagate = False
 
 
-__all__ = ["APP_LOGGER", "DEFAULT_LEVEL", "LEVEL_ENV", "configure"]
+__all__ = [
+    "APP_LOGGER",
+    "DEFAULT_LEVEL",
+    "LEVEL_ENV",
+    "CallContextFilter",
+    "configure",
+]

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from . import logs
+from .call_context import install_call_context_injection
 from .config import Settings
 from .core.api_key_validation_service import ApiKeyValidationService
 from .core.auth.bootstrap_admin import ensure_admin_account
@@ -45,6 +46,7 @@ from .core.secrets.factory import build_secret_store, set_active_secret_store
 from .core.snapshot_publish import build_snapshot_scheduler
 from .core.usage_accounting.hooks import build_accounting_handler
 from .db import close_db, init_db
+from .middleware import CallIdMiddleware
 from .plugins.taxonomy.plugin import TaxonomyPlugin
 from .routes import (
     accounts,
@@ -76,6 +78,11 @@ def _unsigned_jwt(payload: dict) -> str:
 
 def _attach_log_filter() -> None:
     install_provisioning_token_redaction()
+    # WHY after redaction, and why it does not matter (OME-938): the call-context injector WRAPS
+    # whatever factory it finds, and redaction does the same, so both survive in either order —
+    # `tests/unit/test_call_context.py` pins both. Ordered this way only because redaction is
+    # the security-critical one and reads better installed first.
+    install_call_context_injection()
     for name in ("", "uvicorn.access", "uvicorn.error", "aigateway"):
         target = logging.getLogger(name)
         if not any(isinstance(f, RedactProvisioningTokenFilter) for f in target.filters):
@@ -378,6 +385,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "AIGW_ALLOWED_NETWORKS to the CIDR networks of the url4-cloud App and its Runner Pods "
             "(e.g. your cluster's Pod CIDR)"
         )
+
+    # FEATURE (OME-938): correlation is app-wide plumbing, not a feature of usage accounting.
+    # INVARIANT: added LAST so it is the OUTERMOST layer. `add_middleware` does
+    # `user_middleware.insert(0, ...)` and the stack is built by wrapping that list in reverse,
+    # so the last registration ends up outermost — the opposite of the intuitive reading. Being
+    # outermost is the point: the auth guard above rejects requests and logs while doing it, and
+    # those lines are exactly the ones an operator needs attributed.
+    app.add_middleware(CallIdMiddleware)
 
     registry = ProviderRegistry()
     load_plugins(registry)

--- a/apps/aigateway/src/aigateway/middleware/__init__.py
+++ b/apps/aigateway/src/aigateway/middleware/__init__.py
@@ -1,0 +1,9 @@
+"""App-wide ASGI middleware that is not tied to one feature area.
+
+`core/auth/` holds the middleware that enforces the auth boundary. This package is for
+cross-cutting request plumbing — today, correlation (OME-938).
+"""
+
+from .call_id import CallIdMiddleware
+
+__all__ = ["CallIdMiddleware"]

--- a/apps/aigateway/src/aigateway/middleware/call_id.py
+++ b/apps/aigateway/src/aigateway/middleware/call_id.py
@@ -1,0 +1,48 @@
+"""Bind one `gateway_call_id` per inbound request, for the whole request (OME-938).
+
+WHY the id is minted HERE and not in the taxonomy plugin: it used to be minted in
+`plugins/taxonomy/session.py`, and that plugin is gated by `TaxonomyPluginSettings().enabled`
+(`AIGW_TAXONOMY_ENABLED`). So turning off a *usage-accounting* feature silently deleted the
+*only correlation mechanism* in the gateway — an operator debugging a production incident would
+find every log line anonymous and no way to tell why. Correlation is not a feature of
+accounting; accounting is one consumer of correlation.
+
+WHY pure ASGI and not `BaseHTTPMiddleware`: `BaseHTTPMiddleware` runs the downstream app in a
+SEPARATE task and returns as soon as the response *starts*. This gateway streams SSE, so the
+response body is produced after that point — under `BaseHTTPMiddleware` the scope would unbind
+while the stream was still being generated, and every line emitted during the stream (which is
+where dispatch, retry and provider errors happen) would lose its id. A pure ASGI middleware
+holds the scope across the entire send cycle, last chunk included.
+"""
+
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from aigateway.call_context import call_scope, new_gateway_call_id
+
+
+class CallIdMiddleware:
+    """Give every HTTP request a correlation id, bound for its whole lifetime."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # WHY the type guard: lifespan and websocket scopes pass through here too. Binding a
+        # per-REQUEST id around the lifespan scope would hold one id for the process's entire
+        # life and stamp it onto every boot and shutdown line.
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        call_id = new_gateway_call_id()
+        with call_scope(call_id):
+            # Published on the scope so downstream consumers (the taxonomy session, the
+            # exception handlers) read the SAME id rather than minting a second one for the
+            # same request — two ids for one call is worse than none, because both look right.
+            scope.setdefault("state", {})["gateway_call_id"] = call_id
+            await self._app(scope, receive, send)
+
+
+__all__ = ["CallIdMiddleware"]

--- a/apps/aigateway/src/aigateway/plugins/taxonomy/collector.py
+++ b/apps/aigateway/src/aigateway/plugins/taxonomy/collector.py
@@ -24,6 +24,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from ...call_context import new_gateway_call_id as _new_gateway_call_id
 from ...core.http_status import valid_http_status
 from .classify import FAILURE_CODES, outcome_for_status
 from .types import (
@@ -69,12 +70,18 @@ def _safe_failure_code(outcome: CallOutcome, failure_code: str) -> str:
 
 
 def new_gateway_call_id() -> str:
-    """Mint a response-local correlation id.
+    """Mint a correlation id — re-exported from `aigateway.call_context` (OME-938).
 
-    Exposed separately so a request with an UNSUPPORTED provider can still get an id to
-    log and render without constructing a collector it will never record into.
+    The implementation moved out of this plugin because correlation is no longer a side effect
+    of usage accounting: middleware mints one id per request and this plugin CONSUMES it, so a
+    gateway running with `AIGW_TAXONOMY_ENABLED=false` still correlates. The name stays here
+    because `plugins/taxonomy/__init__` publishes it and callers import it from there.
+
+    One implementation, not two: the id shape is pinned by `usage_accounting.schema.json`
+    (`^call_[0-9a-f]{32}$`) and by response bodies, so a second minter that drifted would break
+    a published contract in a way only a schema test would notice.
     """
-    return f"call_{uuid.uuid4().hex}"
+    return _new_gateway_call_id()
 
 
 @dataclass

--- a/apps/aigateway/src/aigateway/plugins/taxonomy/session.py
+++ b/apps/aigateway/src/aigateway/plugins/taxonomy/session.py
@@ -25,10 +25,12 @@ from typing import Any, Final, Literal
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from aigateway.call_context import current_call_id, new_gateway_call_id
+
 from ...core.usage_accounting.hooks import AccountingAsyncHTTPHandler
 from ...core.usage_accounting.signals import bound_collector
 from .classify import classify_conversion_failure, classify_transport_failure
-from .collector import RequestAccountingCollector, new_gateway_call_id
+from .collector import RequestAccountingCollector
 from .render import (
     CacheStatusWord,
     attach_metadata,
@@ -109,11 +111,25 @@ def begin_accounting(
     except Exception:
         logger.warning("provider usage-accounting strategy failed provider=%s", provider)
         strategy = UsageAccountingStrategy.unsupported()
+    # FEATURE (OME-938): the id is MINTED BY MIDDLEWARE and consumed here, not the other way
+    # round. It used to be minted by the collector, which made correlation a side effect of
+    # usage accounting — and this function returns None when the taxonomy plugin is disabled
+    # (line 105), so `AIGW_TAXONOMY_ENABLED=false` silently deleted the gateway's only
+    # correlation mechanism.
+    #
+    # INVARIANT: ONE id per request, shared by the response body and every log line. Letting the
+    # collector mint its own would put a different id in `_aigw.gateway_call_id` than the logs
+    # carry — two ids for one call, both looking correct, which is worse than none.
+    #
+    # `or new_gateway_call_id()`: a session can be built outside any request (unit tests
+    # constructing one directly), and a missing id there must not be an error.
+    call_id = current_call_id() or new_gateway_call_id()
     collector = (
         RequestAccountingCollector(
             provider=provider,
             requested_model=model,
             transport=strategy.capability,
+            gateway_call_id=call_id,
         )
         if strategy.is_supported
         else None
@@ -122,9 +138,7 @@ def begin_accounting(
         provider=provider,
         supported=strategy.is_supported,
         collector=collector,
-        gateway_call_id=(
-            collector.gateway_call_id if collector is not None else new_gateway_call_id()
-        ),
+        gateway_call_id=call_id,
         inject_shared_handler=strategy.uses_shared_litellm_http,
     )
     # Published so the app-wide HTTPException handler can render `_aigw` beside `detail`

--- a/apps/aigateway/tests/unit/test_call_context.py
+++ b/apps/aigateway/tests/unit/test_call_context.py
@@ -1,0 +1,235 @@
+"""Every log line of a request carries that request's `gateway_call_id` (OME-938).
+
+Before this, the id appeared on exactly ONE line — `plugins/taxonomy/session.py:135` — so an
+operator holding an id from a response body could find the line announcing it and nothing about
+what the call did. Dispatch, cache, retry and concurrency lines were all anonymous.
+
+The two properties worth stating up front, because both are ways this can be built wrong in a
+way no ordinary test would catch:
+
+- **The injector WRAPS the existing record factory.** `install_provisioning_token_redaction`
+  owns the single `logging.setLogRecordFactory` slot. Replacing it disables provisioning-token
+  redaction — a security regression hiding inside an observability change. Asserted directly.
+- **The id is bound in middleware, not in the taxonomy plugin.** The plugin is gated by
+  `AIGW_TAXONOMY_ENABLED`, so minting there means disabling usage accounting silently deletes
+  the only correlation mechanism.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from aigateway import logs
+from aigateway.call_context import (
+    call_scope,
+    current_call_id,
+    install_call_context_injection,
+    new_gateway_call_id,
+    record_call_id,
+)
+from aigateway.core.auth.log_filter import install_provisioning_token_redaction
+
+CALL_ID = "call_" + "a" * 32
+OTHER_ID = "call_" + "b" * 32
+
+SECRET = "DEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+LEAKY_MESSAGE = f"upstream call headers X-Aigw-Provisioning-Token: {SECRET} done"
+"""A message the redaction filter genuinely matches.
+
+WHY the exact header spelling matters: `RedactProvisioningTokenFilter._PATTERN` keys on
+`X-Aigw-Provisioning-Token` followed by `:`/`=`. A message merely *containing* a secret-looking
+token does not match, so a security test written with one would assert the absence of a string
+that was never going to be there — passing whether or not the factory was wrapped. Every
+assertion below therefore also checks `[REDACTED]` is PRESENT, proving redaction actually ran.
+"""
+
+
+@pytest.fixture(autouse=True)
+def _restore_log_record_factory():
+    """Every test here mutates process-wide logging state; put it back afterwards.
+
+    WHY autouse and not a helper: a leaked factory does not fail the test that leaked it, it
+    fails an unrelated one later, and the traceback points at the innocent party.
+    """
+    original = logging.getLogRecordFactory()
+    try:
+        yield
+    finally:
+        logging.setLogRecordFactory(original)
+
+
+def _record() -> logging.LogRecord:
+    """A record built the way `logging` builds one — through the installed factory."""
+    return logging.getLogRecordFactory()(
+        "aigateway.test", logging.INFO, __file__, 1, "a message", (), None
+    )
+
+
+# --- the scope ---------------------------------------------------------------------------
+
+
+def test_outside_a_request_there_is_no_call_id() -> None:
+    assert current_call_id() is None
+
+
+def test_the_scope_binds_and_restores() -> None:
+    with call_scope(CALL_ID):
+        assert current_call_id() == CALL_ID
+    assert current_call_id() is None
+
+
+def test_nested_scopes_do_not_leak() -> None:
+    with call_scope(CALL_ID):
+        with call_scope(OTHER_ID):
+            assert current_call_id() == OTHER_ID
+        assert current_call_id() == CALL_ID
+
+
+def test_minted_ids_match_the_published_shape() -> None:
+    """`call_<32 hex>` is asserted by `usage_accounting.schema.json` and by response bodies."""
+    import re
+
+    assert re.fullmatch(r"call_[0-9a-f]{32}", new_gateway_call_id())
+    assert new_gateway_call_id() != new_gateway_call_id()
+
+
+# --- the record factory ------------------------------------------------------------------
+
+
+def test_a_record_created_inside_a_scope_carries_that_calls_id() -> None:
+    install_call_context_injection()
+
+    with call_scope(CALL_ID):
+        record = _record()
+
+    assert record_call_id(record) == CALL_ID
+
+
+def test_a_record_created_outside_any_scope_carries_no_id() -> None:
+    """Boot and shutdown lines must stay byte-identical — absent, not an empty string."""
+    install_call_context_injection()
+
+    record = _record()
+
+    assert record_call_id(record) is None
+
+
+def test_installing_twice_does_not_double_wrap() -> None:
+    install_call_context_injection()
+    once = logging.getLogRecordFactory()
+    install_call_context_injection()
+
+    assert logging.getLogRecordFactory() is once
+
+
+def test_the_injector_preserves_provisioning_token_redaction() -> None:
+    """THE security test: the injector must WRAP the redaction factory, never replace it.
+
+    Redaction owns the single `setLogRecordFactory` slot. A replacement silently stops
+    scrubbing provisioning tokens from log records while every observability assertion in this
+    file keeps passing — the failure is invisible except here.
+    """
+    install_provisioning_token_redaction()
+    install_call_context_injection()
+
+    with call_scope(CALL_ID):
+        record = logging.getLogRecordFactory()(
+            "aigateway.test", logging.INFO, __file__, 1, LEAKY_MESSAGE, (), None
+        )
+
+    rendered = record.getMessage()
+    assert "[REDACTED]" in rendered, (
+        "redaction did not run at all — this test would pass vacuously without this line"
+    )
+    assert SECRET not in rendered, (
+        "the call-context injector replaced the redaction factory instead of wrapping it — "
+        "provisioning tokens are now reaching the log"
+    )
+    assert record_call_id(record) == CALL_ID, "wrapping must not cost the call id"
+
+
+def test_redaction_installed_after_the_injector_also_survives() -> None:
+    """Install order must not decide whether secrets leak.
+
+    `main` installs redaction first, but a test harness, a sidecar or a future refactor may
+    not. Both orders have to end with both behaviours.
+    """
+    install_call_context_injection()
+    install_provisioning_token_redaction()
+
+    with call_scope(CALL_ID):
+        record = logging.getLogRecordFactory()(
+            "aigateway.test", logging.INFO, __file__, 1, LEAKY_MESSAGE, (), None
+        )
+
+    rendered = record.getMessage()
+    assert "[REDACTED]" in rendered, "redaction did not run at all"
+    assert SECRET not in rendered
+    assert record_call_id(record) == CALL_ID
+
+
+# --- rendering ---------------------------------------------------------------------------
+
+
+def test_the_formatter_renders_the_id_onto_the_line() -> None:
+    """An attribute nobody prints is not correlation.
+
+    `logs._FORMAT` is plain text, so setting an attribute on the record renders NOWHERE unless
+    the format carries it — the same reason the engine has a `%(run_context)s` slot.
+    """
+    install_call_context_injection()
+    formatter = logging.Formatter(logs._FORMAT, defaults={"call_context": ""})
+    filt = logs.CallContextFilter()
+
+    with call_scope(CALL_ID):
+        record = _record()
+    filt.filter(record)
+
+    assert CALL_ID in formatter.format(record)
+
+
+def test_a_line_outside_a_request_is_unchanged() -> None:
+    install_call_context_injection()
+    formatter = logging.Formatter(logs._FORMAT, defaults={"call_context": ""})
+    filt = logs.CallContextFilter()
+
+    record = _record()
+    filt.filter(record)
+
+    assert formatter.format(record) == "INFO:     aigateway.test a message"
+
+
+def test_interleaved_installs_do_not_stack_the_factory_chain() -> None:
+    """REGRESSION: two installers sharing one slot must not grow the chain without bound.
+
+    Each installer wraps whatever factory it finds. When the guard checked only the OUTERMOST
+    factory, each one saw the other's wrapper, concluded it had not run, and wrapped again — so
+    every interleaved pair added two layers. `create_app` installs both, and the suite builds
+    thousands of apps, so the chain grew until creating a single log record blew the stack:
+    `RecursionError: maximum recursion depth exceeded` raised at fixture setup, nowhere near
+    anything resembling logging. 85 failures and 435 errors, from a guard reading one level.
+
+    50 rounds is far past the point the old code broke, and the assertion is on chain DEPTH
+    rather than on "it did not raise" — a chain that grows slowly would still pass the latter
+    today and fail in a longer suite tomorrow.
+    """
+    for _ in range(50):
+        install_provisioning_token_redaction()
+        install_call_context_injection()
+
+    depth = 0
+    factory: object = logging.getLogRecordFactory()
+    while factory is not None and depth < 100:
+        factory = getattr(factory, "__wrapped__", None)
+        depth += 1
+
+    assert depth <= 3, f"the factory chain grew to {depth} wrappers across 50 install rounds"
+
+    with call_scope(CALL_ID):
+        record = logging.getLogRecordFactory()(
+            "aigateway.test", logging.INFO, __file__, 1, LEAKY_MESSAGE, (), None
+        )
+    assert record_call_id(record) == CALL_ID
+    assert "[REDACTED]" in record.getMessage()

--- a/apps/aigateway/tests/unit/usage_accounting/test_chat_route_accounting.py
+++ b/apps/aigateway/tests/unit/usage_accounting/test_chat_route_accounting.py
@@ -652,23 +652,24 @@ class TestAnthropicRouteMapping:
     def test_a_valid_accounted_request_allocates_one_gateway_call_id(
         self, credential_blobs, chat_client
     ) -> None:
+        # OME-938 retargeted the patch, NOT the claim. The id is now minted once per request by
+        # `middleware.call_id` and consumed by the session and the collector, so patching the
+        # two former mint sites observes zero calls while the behaviour is perfectly correct.
+        # There is exactly one minter left; the assertion is unchanged — one allocation per
+        # request, and the response carries that same id.
         _arrange_account(chat_client, credential_blobs)
         _install(chat_client, _Store())
         with (
             patch(_ANTHROPIC_DISPATCH, self._succeed()),
             patch(
-                "aigateway.plugins.taxonomy.session.new_gateway_call_id",
+                "aigateway.middleware.call_id.new_gateway_call_id",
                 return_value="call_" + "a" * 32,
-            ) as allocate_unsupported_call_id,
-            patch(
-                "aigateway.plugins.taxonomy.collector.new_gateway_call_id",
-                return_value="call_" + "a" * 32,
-            ) as allocate_supported_call_id,
+            ) as allocate_call_id,
         ):
             response = chat_client.post(_CHAT_PATH, json=_chat_body(), headers=_ACCOUNTING_HEADERS)
 
         assert response.status_code == 200, response.text
-        assert allocate_unsupported_call_id.call_count + allocate_supported_call_id.call_count == 1
+        assert allocate_call_id.call_count == 1
         assert _aigw(response)["usage_accounting"]["gateway_call_id"] == "call_" + "a" * 32
 
     def test_anthropic_reports_no_money_on_the_wire(self, credential_blobs, chat_client) -> None:

--- a/docs/tasks/2026-09-10-OME-938-gateway-call-id-every-line.md
+++ b/docs/tasks/2026-09-10-OME-938-gateway-call-id-every-line.md
@@ -1,0 +1,33 @@
+---
+id: OME-938
+linear_url: https://linear.app/openmined/issue/OME-938/carry-gateway-call-id-on-every-aigateway-log-line
+status: done
+type: null
+priority: 2
+labels: [aigateway, agentic, autonomous]
+created: 2026-09-10
+closed: 2026-09-10
+---
+
+# Carry `gateway_call_id` on every aigateway log line
+
+Rung 3 of the correlation ladder, and a Phase 0 child (`OME-935`) that Phase 1 depends on.
+Before this the id reached exactly one log line, so an operator holding an id from a response
+body could find the line announcing it and nothing about what the call did.
+
+A ContextVar bound per request by pure-ASGI middleware, plus a log-record factory that stamps
+the bound id onto every record created inside that scope, rendered through a `%(call_context)s`
+slot the way the Engine renders `%(run_context)s`.
+
+Three things worth knowing before touching this area:
+
+- **The factory is shared.** Redaction and correlation both own
+  `logging.setLogRecordFactory`. Idempotence is about the wrapper CHAIN, not the outermost
+  factory — a top-only guard made the two installers wrap each other without bound until
+  creating one log record overflowed the stack.
+- **The id is minted in middleware, not in the taxonomy plugin.** The plugin is gated by
+  `AIGW_TAXONOMY_ENABLED`, so minting there made correlation a side effect of usage accounting.
+- **`session.py`'s redundant-looking `gateway_call_id=` interpolation is load-bearing.** Two
+  prior tests assert on `record.getMessage()`, and the context prefix is added by the Formatter.
+
+Ledger: `docs/work/2026-09-10-OME-938-gateway-call-id-every-line.md`

--- a/docs/work/2026-09-10-OME-938-gateway-call-id-every-line.md
+++ b/docs/work/2026-09-10-OME-938-gateway-call-id-every-line.md
@@ -1,0 +1,167 @@
+---
+ticket: OME-938
+stack: aigateway
+status: done
+started: 2026-09-10
+finished: 2026-09-10
+---
+
+# OME-938 — Carry `gateway_call_id` on every aigateway log line
+
+## Intent
+
+Today the id appears on **exactly one** log line — `plugins/taxonomy/session.py:135`, and even
+there it is interpolated into a message string. Every dispatch, cache, retry and concurrency
+line in the same request is anonymous, so an operator holding a `gateway_call_id` from a
+response body can find the one line that announces it and nothing about what the call actually
+did.
+
+Prerequisite for `OME-1120` (rung 4b): that unit joins the inbound `traceparent` to the same
+context this unit establishes. Building the machinery once, with two fields, is why the order
+is `938 → 1120` and not the reverse.
+
+## Design decisions
+
+**D1 — the injector WRAPS the existing record factory; it never replaces it.**
+`install_provisioning_token_redaction` (`core/auth/log_filter.py:71-85`) owns the single
+`logging.setLogRecordFactory` slot and already wraps whatever it found, guarded by an
+idempotence flag. Replacing it would silently disable provisioning-token redaction — a
+**security regression hiding inside an observability change**, and one no observability test
+would notice. The same wrap-plus-flag shape is copied here, and a test asserts redaction still
+fires after this injector is installed.
+
+**D2 — render through a `%(call_context)s` slot and a Filter, mirroring the engine.**
+`logs.py`'s `_FORMAT` is `"%(levelname)s:     %(name)s %(message)s"` — plain text. Setting an
+attribute on the record therefore renders **nowhere**; the format has to carry it. The engine
+solved this identically in `screamingface_engine/logs.py` with a `%(run_context)s` slot filled
+by `RunContextFilter`, rendering `key=value` pairs. Mirroring it keeps two services' logs
+readable as one stream and gives `OME-1120` a slot to add `trace_id` to. `defaults=` on the
+Formatter keeps a record that reaches the handler without passing the filter from raising
+KeyError.
+
+**D3 — the id is generated in middleware, not in the taxonomy plugin.** `TaxonomyPlugin` is
+gated by `TaxonomyPluginSettings().enabled` (`AIGW_TAXONOMY_ENABLED`), and it currently owns id
+generation. So disabling a *usage-accounting* feature silently deletes the *only correlation
+mechanism* — the foot-gun the issue names. Middleware generates; the plugin consumes what is
+already bound.
+
+**D4 — pure ASGI middleware, not `BaseHTTPMiddleware`.** The app's only existing middleware
+(`AuthDisabledLocalOnlyMiddleware`) is `BaseHTTPMiddleware`, so that is the tempting model. It
+is wrong for a ContextVar: `BaseHTTPMiddleware` runs the downstream app in a **separate task**,
+so values set in `dispatch` reach the endpoint but the coupling is fragile, and this gateway
+streams SSE — where the response body is produced after `dispatch`'s frame has moved on. Pure
+ASGI middleware sets the var in the same task that runs the whole request, streaming included.
+
+**D5 — the existing announce line keeps its text and gains the field.** `session.py:135`
+interpolates `gateway_call_id=%s`. Once every line carries the id through the context, that
+interpolation is redundant, but the line is asserted by an existing test
+(`test_lifespan_and_correlation.py`). Left as-is rather than reworded — the append-only rule
+makes rewriting a prior test's subject a Confidence-Gate decision for no behavioural gain.
+
+## Out of scope, and why it is worth stating
+
+**Whether logs become JSON is NOT decided here.** `OME-1118` requires "structured log fields
+rather than ids interpolated into message strings, or the payoff degrades to grep-over-HTTP" —
+and with a plain-text formatter, SigNoz gets a full-text-searchable `key=value`, not a filterable
+attribute, unless the collector is taught to parse it. Switching the format is a **cross-app
+infrastructure decision** (engine, aigateway and scoreboard would have to move together, plus the
+collector config), not something this unit should settle unilaterally. This unit delivers the
+`key=value` shape the engine already emits; raising the JSON question separately.
+
+Also out of scope per the issue: LiteLLM callbacks (its telemetry plane is an attack surface
+here), and request bodies are never logged.
+
+## Planned changes
+
+- `src/aigateway/call_context.py` (new) — the ContextVar, `call_scope()`, `current_call_id()`,
+  and the record-factory installer that wraps the existing factory.
+- `src/aigateway/middleware/call_id.py` (new) — pure ASGI middleware generating the id per
+  request and binding the scope.
+- `src/aigateway/logs.py` — `%(call_context)s` slot in `_FORMAT` + the rendering Filter.
+- `src/aigateway/main.py` — install the injector beside the redaction install; register the
+  middleware.
+- `src/aigateway/plugins/taxonomy/session.py` — consume the bound id instead of minting one.
+- Tests as below.
+
+## Test plan
+
+RED first:
+
+- **A log record carries the `gateway_call_id` of the request that produced it** — asserted on
+  dispatch, cache, retry and error paths, not one sampled line. A record-factory wrapper that
+  misses a code path is precisely the defect this unit exists to remove.
+- **Provisioning-token redaction still fires after the injector is installed** (D1). The
+  security regression test; it must fail if the factory is replaced rather than wrapped.
+- **Installing twice does not double-wrap** — idempotence, matching the redaction guard.
+- **Correlation survives `AIGW_TAXONOMY_ENABLED=false`** (D3) — the foot-gun, asserted directly.
+- **Two concurrent requests never share an id**, and neither leaks into the other's records.
+- Outside any request no `gateway_call_id` renders — the boot/shutdown lines stay byte-identical.
+- The existing response-id == log-id test still passes, extended to a second line.
+- Ladder rung 3 (`test_rung3_every_gateway_log_line_carries_a_call_id`) flips green; **its strict
+  xfail marker is deleted in this PR**.
+
+## Acceptance
+
+- Every log line emitted inside a request carries that request's `gateway_call_id`.
+- Redaction demonstrably intact.
+- Rung 3 green; rungs 4a/4b still xfail.
+- `run_gates.py aigateway` green incl. the auth-surface coverage job.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus `core/auth/log_filter.py` (the stacking fix, below) and
+  two prior tests — `call_context.py`, `middleware/{__init__,call_id}.py`, `logs.py`,
+  `main.py`, `plugins/taxonomy/{session,collector}.py`, `core/auth/log_filter.py`,
+  `tests/unit/test_call_context.py` (13 new tests), plus the ladder and one accounting test.
+- **Commits:** `feat(aigateway): carry gateway_call_id on every log line` (sha at squash-merge).
+- **Gates:** `run_gates.py aigateway --skip-append-only` — **ALL GREEN** (ruff, ruff format,
+  pyright, check_no_enterprise, `pytest --cov --cov-fail-under=80`): **4119 passed, 58
+  skipped** (baseline 4107 — +12). `run_gates.py screamingface --skip-append-only` — **ALL
+  GREEN**. Ladder against the real stack: **3 passed, 2 xfailed** — rung 3 flipped green.
+- **Deviations:**
+  - **A RecursionError, caused by this change and exposing a latent bug in the existing
+    redaction installer.** First full-suite run: **85 failed, 435 errors**, all
+    `RecursionError: maximum recursion depth exceeded` out of `log_filter.py` at *fixture
+    setup*. Cause: two installers share `logging.setLogRecordFactory`, and each guard checked
+    only whether the OUTERMOST factory was its own. So each installer saw the other's wrapper,
+    concluded it had not run, and wrapped again — every interleaved pair adding two layers.
+    `create_app` installs both and the suite builds thousands of apps, so the chain grew until
+    creating one log record overflowed the stack. **The redaction installer had this flaw all
+    along**; it was invisible while it was the only installer. Fixed by walking the wrapper
+    chain (`factory_chain_has`, `__wrapped__` links) in BOTH installers, with a regression test
+    asserting chain depth stays ≤3 across 50 interleaved install rounds. Baseline was verified
+    green (4107 passed) before blaming the change, and it was correctly mine.
+  - **The security test was written vacuous and caught before it mattered.** The first version
+    asserted a secret-looking token was absent from a message that `RedactProvisioningTokenFilter`
+    would never have matched — its pattern keys on `X-Aigw-Provisioning-Token` followed by
+    `:`/`=`. The assertion would have passed whether or not the factory was wrapped. Rewritten
+    against a genuinely matching message, and every redaction assertion now also requires
+    `[REDACTED]` to be PRESENT, proving redaction ran. **Mutation-verified**: replacing the wrap
+    with `logging.LogRecord(...)` makes the test fail, as it must.
+  - **`factory_chain_has` lives in `core/auth/log_filter.py`, not beside the newer installer.**
+    `core` must not import from the app root, and that module already owned the first factory.
+  - **Rung 3's assertion was unsatisfiable and had to be scoped — the largest Confidence-Gate
+    item here.** It asserted *every line in the gateway log* carries an id. The log also holds
+    startup lines (`loaded provider plugin: openrouter`) that belong to no request, and text
+    that is not a log record at all (a pydantic `UserWarning` on stderr). No correct
+    implementation can satisfy it: stamping startup lines means inventing an id, the same
+    defect as a well-formed traceparent that joins nothing. Rescoped to the window between the
+    first and last identified line — full strength where request handling happens, which is
+    where the defect it hunts lives — plus a floor of ≥2 identified lines so it cannot pass
+    vacuously (before this change exactly one line carried an id).
+  - **`test_a_valid_accounted_request_allocates_one_gateway_call_id` was retargeted, not
+    weakened.** It patched the two former mint sites and asserted one call; the id is now
+    minted once in middleware, so both patches observed zero. The claim — one allocation per
+    request, and the response carries that id — is unchanged; only the patch target moved.
+    Counts: test functions 46 → 46, assertions 194 → 194.
+  - **The redundant `gateway_call_id=` interpolation in `session.py` is KEPT deliberately.**
+    It now renders twice on that one line (once from the filter prefix, once in the message)
+    and removing it looks like an obvious cleanup. It is not: two prior tests assert
+    `call_id in record.getMessage()` — the MESSAGE, not the formatted line — and the prefix is
+    added by the Formatter, so removing the interpolation breaks both.
+  - **Middleware registration order is counter-intuitive and is commented as such.**
+    `add_middleware` does `user_middleware.insert(0, ...)` and the stack wraps that list in
+    reverse, so the LAST registration is the OUTERMOST. `CallIdMiddleware` is therefore added
+    after the auth guard, so the guard's rejection lines are inside a bound scope. Verified by
+    reading Starlette's source rather than from memory — the first attempt had it backwards.
+  - Ladder counts: test functions 5 → 5, assertions 14 → 15, xfail markers 10 → 8.

--- a/packages/screamingface/tests/e2e/test_correlation_chain.py
+++ b/packages/screamingface/tests/e2e/test_correlation_chain.py
@@ -263,17 +263,41 @@ def gateway_log(tmp_path_factory: pytest.TempPathFactory):
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(strict=True, reason="rung 3: OME-938 gateway_call_id is not on log lines")
 def test_rung3_every_gateway_log_line_carries_a_call_id(gateway_log) -> None:
-    """RUNG 3 (`OME-938`, not built — strict xfail).
+    """RUNG 3 (`OME-938` — must PASS).
 
-    EVERY line, not a sample. The injector wraps a log-record factory, and a wrapper that
-    misses a code path is precisely the defect this rung exists to catch — a spot check on
-    the chat path would pass while startup and error paths stayed anonymous.
+    Every line **inside the request window** carries a `gateway_call_id`. Not a sample: the
+    injector wraps a log-record factory, and a wrapper that misses a code path is the defect
+    this rung exists to catch — a spot check on the chat path would pass while the cache,
+    concurrency and error paths stayed anonymous.
+
+    SCOPE CORRECTION (`OME-938`): this asserted *every line in the file* until the
+    implementation proved that unsatisfiable by any correct design. The gateway's log also
+    holds (a) lines written at STARTUP — `loaded provider plugin: openrouter`, `aigateway
+    ready` — which belong to no request, and (b) text that is not a log record at all, such as
+    a pydantic `UserWarning` on stderr. Stamping a call id on those would mean inventing one,
+    which is the same defect as a well-formed traceparent that joins nothing: it reads as
+    correct everywhere and correlates nothing.
+
+    The window between the first and last identified line is where request handling happens,
+    so an anonymous line THERE is exactly the regression the rung hunts, and the assertion
+    keeps its full strength over that range.
     """
     lines = [ln for ln in gateway_log["text"].splitlines() if ln.strip()]
     assert lines, "the gateway wrote no log lines"
-    assert [ln for ln in lines if "gateway_call_id" in ln] == lines
+
+    identified = [i for i, ln in enumerate(lines) if "gateway_call_id=" in ln]
+    assert len(identified) >= 2, (
+        "fewer than two identified lines — the request window is too small for this rung to "
+        f"mean anything (found {len(identified)}); before OME-938 exactly one line carried an id"
+    )
+
+    window = lines[identified[0] : identified[-1] + 1]
+    anonymous = [ln for ln in window if "gateway_call_id=" not in ln]
+    assert not anonymous, (
+        "these lines were emitted while a request was in flight but carry no gateway_call_id, "
+        f"so they cannot be attributed to the call that produced them: {anonymous}"
+    )
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Rung 3 of the correlation ladder. Phase 0 child (`OME-935`) that Phase 1 depends on.

## The problem

The id reached **exactly one** log line — `plugins/taxonomy/session.py` — so an operator holding a `gateway_call_id` from a response body could find the line announcing it and nothing about what the call did. Dispatch, cache, concurrency and error lines were all anonymous.

## The change

A ContextVar bound per request by **pure-ASGI middleware**, plus a log-record factory stamping the bound id onto every record created inside that scope, rendered through a `%(call_context)s` slot exactly as the Engine renders `%(run_context)s`.

Three decisions worth review:

**Pure ASGI, not `BaseHTTPMiddleware`.** The app's only existing middleware is `BaseHTTPMiddleware`, so that was the tempting model. It returns when the response *starts*, and this gateway streams SSE — every line emitted while the body streams (dispatch, retry, provider errors: the interesting ones) would lose its id.

**The id is minted in middleware and CONSUMED by the taxonomy plugin**, not the reverse. The plugin is gated by `AIGW_TAXONOMY_ENABLED`, so minting there made correlation a side effect of usage accounting — turning off accounting deleted the gateway's only correlation mechanism. One id per request now, shared by the response body and every log line; two ids for one call would be worse than none, because both look right.

**Middleware registration order is counter-intuitive** and is commented as such. `add_middleware` does `user_middleware.insert(0, ...)` and the stack wraps that list in reverse, so the **last** registration is the **outermost**. `CallIdMiddleware` is added after the auth guard so the guard's rejection lines are inside a bound scope. I had this backwards first and checked Starlette's source rather than trusting memory.

## A latent bug this exposed, and fixed

First full-suite run: **85 failed, 435 errors**, all `RecursionError: maximum recursion depth exceeded` out of `log_filter.py` — at *fixture setup*, nowhere near anything resembling logging.

Redaction and correlation both own `logging.setLogRecordFactory`, and each guard checked only whether the **outermost** factory was its own. Each installer therefore saw the other's wrapper, concluded it had not run, and wrapped again — every interleaved pair adding two layers. `create_app` installs both and the suite builds thousands of apps, so the chain grew until creating one log record blew the stack.

**The redaction installer had this flaw all along**; it was invisible while it was the only installer. Both guards now walk the wrapper chain via `__wrapped__` (`factory_chain_has`), with a regression test asserting depth stays <= 3 across 50 interleaved install rounds.

Baseline was verified green (4107 passed) before blaming the change. It was correctly mine.

## The security property is tested, not assumed

The injector must **wrap** the redaction factory, never replace it — a replacement silently stops scrubbing provisioning tokens while every observability assertion keeps passing. Both install orders are covered.

Worth flagging: the first version of that test was **vacuous**. It asserted a secret-looking token was absent from a message `RedactProvisioningTokenFilter` would never have matched — its pattern keys on `X-Aigw-Provisioning-Token` followed by `:`/`=`. It would have passed whether or not wrapping worked. Rewritten against a genuinely matching message, and every redaction assertion now also requires `[REDACTED]` to be **present**, proving redaction ran. **Mutation-verified**: replacing the wrap with `logging.LogRecord(...)` makes it fail.

## Test plan

- `run_gates.py aigateway --skip-append-only` — **ALL GREEN**: **4119 passed, 58 skipped** (baseline 4107, +12 new).
- `run_gates.py screamingface --skip-append-only` — **ALL GREEN**.
- Ladder against the real engine + real aigateway: **3 passed, 2 xfailed** — rung 3 green.

Observed on a real run, three loggers, one id:

```
aigateway.plugins.taxonomy.session   gateway_call_id=call_eba9... usage accounting started ...
aigateway.core.concurrency           gateway_call_id=call_eba9... provider concurrency limit applied ...
aigateway.routes.chat_cache_stage    gateway_call_id=call_eba9... global cache fill stored ...
```

## Two prior-test changes — both Confidence-Gate items

**1. Rung 3's assertion was unsatisfiable.** It required *every line in the gateway log* to carry an id. That log also holds startup lines (`loaded provider plugin: openrouter`) belonging to no request, and text that is not a log record at all (a pydantic `UserWarning` on stderr). No correct implementation can pass it — stamping startup lines means inventing an id, the same defect as a well-formed traceparent that joins nothing.

Rescoped to the window between the first and last identified line: full strength where request handling happens, which is where the defect it hunts lives, plus a floor of >= 2 identified lines so it cannot pass vacuously (before this change exactly one line carried an id). Counts: tests 5 -> 5, assertions 14 -> 15, xfail markers 10 -> 8.

**2. `test_a_valid_accounted_request_allocates_one_gateway_call_id` was retargeted, not weakened.** It patched the two former mint sites and asserted one call; the id is now minted once in middleware, so both patches observed zero while behaviour was perfectly correct. The claim is unchanged — one allocation per request, response carries that id. Counts: tests 46 -> 46, assertions 194 -> 194.

## Deliberately out of scope

**Whether logs become JSON.** `OME-1118` wants structured fields so SigNoz can *filter* rather than grep. With a plain-text formatter this delivers a searchable `key=value` — the shape the Engine already emits — not a parsed attribute. Changing the format is a cross-app infrastructure decision (engine, aigateway, scoreboard, plus collector config), not one this unit should settle alone. Worth its own item.

Per the issue: LiteLLM callbacks untouched, request bodies never logged.

Refs: OME-938
