### PR TITLE
feat(engine): define optional execution observation ports

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/observations.py
+++ b/apps/screamingface-engine/src/screamingface_engine/observations.py
@@ -1,0 +1,234 @@
+"""Execution-owned observation ports and fault-isolated lifecycle dispatch.
+
+Observers receive facts; they never control requests, results or retry decisions.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import sys
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import AbstractContextManager, ExitStack, contextmanager
+from contextvars import ContextVar, Token
+from types import TracebackType
+from typing import Protocol
+
+Scalar = str | int | float | bool | None
+logger = logging.getLogger(__name__)
+
+
+class LogEmitter(Protocol):
+    """A caller-supplied structured sink; transport and node binding stay with its owner."""
+
+    def __call__(
+        self, body: str, attributes: Mapping[str, Scalar] | None = None, *, severity: str = "INFO"
+    ) -> None: ...
+
+
+class ModelObservation(Protocol):
+    """Observe one call without controlling its requests, retries or result.
+
+    The dispatcher starts the observation, reports facts, then closes it with the
+    original scope-exit information. Close must tolerate partially failed startup.
+    Adapters own their resources; ordinary callback failures are contained, while
+    cancellation and other process-control exceptions retain their semantics.
+    """
+
+    async def start(self) -> None: ...
+    async def close(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
+    def completed(self, finish_reason: str | None) -> None: ...
+    def failed(self, code: str) -> None: ...
+    def retry(self, *, attempt: int, delay_seconds: float) -> None: ...
+
+
+class RunObserver(Protocol):
+    """One factory-created observer per execution, reused across its inner steps.
+
+    Each bind returns a fresh context manager that restores context on exit. Binding
+    cleanup is separate from operation outcomes; model close receives those errors.
+    aclose releases run-owned resources. Callbacks must not perform execution work.
+    """
+
+    def bind(self) -> AbstractContextManager[None]: ...
+    async def aclose(self) -> None: ...
+    def model_call(self, model_id: str, emit: LogEmitter | None) -> ModelObservation: ...
+    def bridge_loss(self, dropped: int) -> Mapping[str, Scalar]: ...
+
+
+ObserverFactory = Callable[[], RunObserver]
+_CURRENT: ContextVar[RunObservations | None] = ContextVar("run_observations", default=None)
+_CALL: ContextVar[ModelCall | None] = ContextVar("model_observation", default=None)
+
+
+def _fault(run: RunObservations | None = None) -> None:
+    # INVARIANT: one best-effort warning per run, with no exception text or payload.
+    run = run if run is not None else _CURRENT.get()
+    if run is not None:
+        if run.fault_reported:
+            return
+        run.fault_reported = True
+    try:
+        logger.warning("execution observer failed; execution continues")
+    except Exception:
+        # WHY: failure of the last-resort diagnostic must not break original work either.
+        return
+
+
+@contextmanager
+def _bind(observer: RunObserver) -> Iterator[None]:
+    try:
+        context = observer.bind()
+        context.__enter__()
+    except Exception:
+        _fault()
+        yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            context.__exit__(None, None, None)
+        except Exception:
+            _fault()
+
+
+class RunObservations:
+    """Own observer instances and isolate dispatch; no activity schema or policy.
+
+    Bind around inner execution steps, never across an outward generator yield:
+    another task may advance or close that generator. Final cleanup revokes dispatch.
+    """
+
+    def __init__(self, factories: tuple[ObserverFactory, ...]) -> None:
+        self.observers: list[RunObserver] = []
+        self.active = True
+        self.fault_reported = False
+        for factory in factories:
+            try:
+                self.observers.append(factory())
+            except Exception:
+                _fault(self)
+
+    @contextmanager
+    def bind(self) -> Iterator[None]:
+        # INVARIANT: even an empty registration masks inherited execution observers.
+        token = _CURRENT.set(self)
+        try:
+            with ExitStack() as stack:
+                for observer in self.observers:
+                    stack.enter_context(_bind(observer))
+                yield
+        finally:
+            _CURRENT.reset(token)
+
+    async def aclose(self) -> None:
+        self.active = False
+        for observer in reversed(self.observers):
+            try:
+                await observer.aclose()
+            except Exception:
+                _fault(self)
+
+
+class ModelCall:
+    """Scope observer callbacks to one call and its owning execution.
+
+    Retry lookup checks both contexts so nested executions cannot update a parent
+    call. Observer scope exit cannot suppress the execution exception.
+    """
+
+    def __init__(self, model_id: str, emit: LogEmitter | None) -> None:
+        self._run = _CURRENT.get()
+        self._observers: list[ModelObservation] = []
+        self._token: Token[ModelCall | None] | None = None
+        self._closed = False
+        if self._run is not None and self._run.active:
+            for observer in self._run.observers:
+                try:
+                    self._observers.append(observer.model_call(model_id, emit))
+                except Exception:
+                    _fault()
+
+    async def __aenter__(self) -> ModelCall:
+        self._token = _CALL.set(self)
+        try:
+            for observer in self._observers:
+                try:
+                    await observer.start()
+                except Exception:
+                    _fault()
+        except BaseException:
+            await self.__aexit__(*sys.exc_info())
+            raise
+        return self
+
+    def _notify(self, callback: Callable[[ModelObservation], None]) -> None:
+        if self._closed or self._run is None or not self._run.active:
+            return
+        for observer in self._observers:
+            try:
+                callback(observer)
+            except Exception:
+                _fault()
+
+    def completed(self, finish_reason: str | None) -> None:
+        self._notify(lambda observer: observer.completed(finish_reason))
+
+    def failed(self, code: str) -> None:
+        self._notify(lambda observer: observer.failed(code))
+
+    def retry(self, *, attempt: int, delay_seconds: float) -> None:
+        self._notify(lambda observer: observer.retry(attempt=attempt, delay_seconds=delay_seconds))
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        try:
+            for observer in reversed(self._observers):
+                try:
+                    await observer.close(exc_type, exc, tb)
+                except Exception:
+                    _fault()
+        finally:
+            self._closed = True
+            if self._token is not None:
+                _CALL.reset(self._token)
+
+
+def current_model_call() -> ModelCall | None:
+    call = _CALL.get()
+    run = _CURRENT.get()
+    return call if call and not call._closed and run and run.active and call._run is run else None
+
+
+def bridge_loss_attributes(dropped: int) -> dict[str, Scalar]:
+    attributes: dict[str, Scalar] = {}
+    run = _CURRENT.get()
+    if run is not None and run.active:
+        for observer in run.observers:
+            try:
+                snapshot = dict(observer.bridge_loss(dropped))
+                if not all(_valid_attribute(k, v) for k, v in snapshot.items()):
+                    raise ValueError("invalid observer attributes")
+                attributes.update(snapshot)
+            except Exception:
+                _fault()
+    return attributes
+
+
+def _valid_attribute(key: str, value: Scalar) -> bool:
+    return isinstance(key, str) and (
+        value is None
+        or isinstance(value, (str, int, bool))
+        or isinstance(value, float)
+        and math.isfinite(value)
+    )

--- a/apps/screamingface-engine/src/screamingface_engine/observations.py
+++ b/apps/screamingface-engine/src/screamingface_engine/observations.py
@@ -27,12 +27,10 @@ class LogEmitter(Protocol):
 
 
 class ModelObservation(Protocol):
-    """Observe one call without controlling its requests, retries or result.
+    """Observe facts without controlling requests, retries or results.
 
-    The dispatcher starts the observation, reports facts, then closes it with the
-    original scope-exit information. Close must tolerate partially failed startup.
-    Adapters own their resources; ordinary callback failures are contained, while
-    cancellation and other process-control exceptions retain their semantics.
+    Close receives the original exit information and must tolerate partial startup.
+    Adapters own resources; ordinary failures are contained, process control propagates.
     """
 
     async def start(self) -> None: ...
@@ -51,7 +49,8 @@ class RunObserver(Protocol):
     """One factory-created observer per execution, reused across its inner steps.
 
     Each bind returns a fresh context manager that restores context on exit. Binding
-    cleanup is separate from operation outcomes; model close receives those errors.
+    teardown receives the current step exception, but cannot suppress it or declare
+    the whole run outcome; model close receives the call outcome separately.
     aclose releases run-owned resources. Callbacks must not perform execution work.
     """
 
@@ -66,13 +65,11 @@ _CURRENT: ContextVar[RunObservations | None] = ContextVar("run_observations", de
 _CALL: ContextVar[ModelCall | None] = ContextVar("model_observation", default=None)
 
 
-def _fault(run: RunObservations | None = None) -> None:
+def _fault(run: RunObservations | None) -> None:
     # INVARIANT: one best-effort warning per run, with no exception text or payload.
-    run = run if run is not None else _CURRENT.get()
-    if run is not None:
-        if run.fault_reported:
-            return
-        run.fault_reported = True
+    if run is None or run.fault_reported:
+        return
+    run.fault_reported = True
     try:
         logger.warning("execution observer failed; execution continues")
     except Exception:
@@ -81,28 +78,42 @@ def _fault(run: RunObservations | None = None) -> None:
 
 
 @contextmanager
-def _bind(observer: RunObserver) -> Iterator[None]:
+def _guard(run: RunObservations | None) -> Iterator[None]:
+    # WHY: the same guard covers synchronous callbacks and awaited callbacks.
     try:
-        context = observer.bind()
-        context.__enter__()
+        yield
     except Exception:
-        _fault()
-        yield
-        return
+        _fault(run)
+
+
+@contextmanager
+def _bind(run: RunObservations, observer: RunObserver) -> Iterator[None]:
+    context = None
+    with _guard(run):
+        candidate = observer.bind()
+        candidate.__enter__()
+        context = candidate
+    error: BaseException | None = None
     try:
         yield
+    except BaseException as exc:
+        error = exc
+        raise
     finally:
-        try:
-            context.__exit__(None, None, None)
-        except Exception:
-            _fault()
+        if context is not None:
+            with _guard(run):
+                context.__exit__(
+                    type(error) if error is not None else None,
+                    error,
+                    error.__traceback__ if error is not None else None,
+                )
 
 
 class RunObservations:
-    """Own observer instances and isolate dispatch; no activity schema or policy.
+    """Own observers and isolated dispatch without activity policy.
 
-    Bind around inner execution steps, never across an outward generator yield:
-    another task may advance or close that generator. Final cleanup revokes dispatch.
+    Bind inner steps, never outward yields: generator consumers may change tasks.
+    Final cleanup revokes dispatch.
     """
 
     def __init__(self, factories: tuple[ObserverFactory, ...]) -> None:
@@ -110,10 +121,8 @@ class RunObservations:
         self.active = True
         self.fault_reported = False
         for factory in factories:
-            try:
+            with _guard(self):
                 self.observers.append(factory())
-            except Exception:
-                _fault(self)
 
     @contextmanager
     def bind(self) -> Iterator[None]:
@@ -122,7 +131,7 @@ class RunObservations:
         try:
             with ExitStack() as stack:
                 for observer in self.observers:
-                    stack.enter_context(_bind(observer))
+                    stack.enter_context(_bind(self, observer))
                 yield
         finally:
             _CURRENT.reset(token)
@@ -130,17 +139,14 @@ class RunObservations:
     async def aclose(self) -> None:
         self.active = False
         for observer in reversed(self.observers):
-            try:
+            with _guard(self):
                 await observer.aclose()
-            except Exception:
-                _fault(self)
 
 
 class ModelCall:
-    """Scope observer callbacks to one call and its owning execution.
+    """Bind callbacks to a call and its run; nested runs cannot target its retry.
 
-    Retry lookup checks both contexts so nested executions cannot update a parent
-    call. Observer scope exit cannot suppress the execution exception.
+    Observer scope exit cannot suppress the execution exception.
     """
 
     def __init__(self, model_id: str, emit: LogEmitter | None) -> None:
@@ -150,19 +156,15 @@ class ModelCall:
         self._closed = False
         if self._run is not None and self._run.active:
             for observer in self._run.observers:
-                try:
+                with _guard(self._run):
                     self._observers.append(observer.model_call(model_id, emit))
-                except Exception:
-                    _fault()
 
     async def __aenter__(self) -> ModelCall:
         self._token = _CALL.set(self)
         try:
             for observer in self._observers:
-                try:
+                with _guard(self._run):
                     await observer.start()
-                except Exception:
-                    _fault()
         except BaseException:
             await self.__aexit__(*sys.exc_info())
             raise
@@ -172,10 +174,8 @@ class ModelCall:
         if self._closed or self._run is None or not self._run.active:
             return
         for observer in self._observers:
-            try:
+            with _guard(self._run):
                 callback(observer)
-            except Exception:
-                _fault()
 
     def completed(self, finish_reason: str | None) -> None:
         self._notify(lambda observer: observer.completed(finish_reason))
@@ -194,10 +194,8 @@ class ModelCall:
     ) -> None:
         try:
             for observer in reversed(self._observers):
-                try:
+                with _guard(self._run):
                     await observer.close(exc_type, exc, tb)
-                except Exception:
-                    _fault()
         finally:
             self._closed = True
             if self._token is not None:
@@ -215,20 +213,15 @@ def bridge_loss_attributes(dropped: int) -> dict[str, Scalar]:
     run = _CURRENT.get()
     if run is not None and run.active:
         for observer in run.observers:
-            try:
+            with _guard(run):
                 snapshot = dict(observer.bridge_loss(dropped))
                 if not all(_valid_attribute(k, v) for k, v in snapshot.items()):
                     raise ValueError("invalid observer attributes")
                 attributes.update(snapshot)
-            except Exception:
-                _fault()
     return attributes
 
 
 def _valid_attribute(key: str, value: Scalar) -> bool:
-    return isinstance(key, str) and (
-        value is None
-        or isinstance(value, (str, int, bool))
-        or isinstance(value, float)
-        and math.isfinite(value)
-    )
+    if isinstance(value, float):
+        return isinstance(key, str) and math.isfinite(value)
+    return isinstance(key, str) and (value is None or isinstance(value, (str, int)))

--- a/apps/screamingface-engine/tests/unit/test_observation_seam.py
+++ b/apps/screamingface-engine/tests/unit/test_observation_seam.py
@@ -200,3 +200,54 @@ def test_failed_factory_is_inert_and_diagnostic_excludes_exception_text(caplog):
     run = RunObservations((broken,))
     assert run.observers == [] and run.active
     assert "execution observer failed" in caplog.text and "PRIVATE" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fault", ["start", "retry", "close"])
+async def test_call_fault_budget_belongs_to_captured_run(fault, caplog):
+    from screamingface_engine.observations import ModelCall, RunObservations
+
+    owner = RunObservations((lambda: ObservingRun([], fault),))
+    nested = RunObservations(())
+    with owner.bind():
+        call = ModelCall("model", None)
+        with nested.bind():
+            async with call:
+                call.retry(attempt=2, delay_seconds=0)
+        assert owner.fault_reported and not nested.fault_reported
+        async with ModelCall("model", None) as again:
+            again.retry(attempt=2, delay_seconds=0)
+    assert caplog.text.count("execution observer failed") == 1
+
+
+@pytest.mark.parametrize("outcome", ["success", "error", "cancel"])
+def test_bind_receives_step_exception_but_cannot_suppress_it(outcome, monkeypatch):
+    import asyncio
+
+    from screamingface_engine.observations import RunObservations
+
+    error = {"success": None, "error": ValueError("work"), "cancel": asyncio.CancelledError()}[
+        outcome
+    ]
+    seen = []
+
+    class Binding:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, kind, value, tb):
+            seen.append((kind, value, tb))
+            return True
+
+    observer = ObservingRun([], "")
+    monkeypatch.setattr(observer, "bind", Binding)
+    try:
+        with RunObservations((lambda: observer,)).bind():
+            if error is not None:
+                raise error
+    except BaseException as raised:
+        assert raised is error
+    else:
+        assert error is None
+    assert seen[0][:2] == (type(error) if error is not None else None, error)
+    assert (seen[0][2] is None) == (error is None)

--- a/apps/screamingface-engine/tests/unit/test_observation_seam.py
+++ b/apps/screamingface-engine/tests/unit/test_observation_seam.py
@@ -1,0 +1,202 @@
+"""Optional observation dispatch preserves execution outcomes and context isolation."""
+
+import pytest
+
+
+class ObservingCall:
+    def __init__(self, events, fault):
+        self.events, self.fault = events, fault
+
+    def note(self, phase):
+        self.events.append(phase)
+        if self.fault == phase:
+            raise RuntimeError("PRIVATE observer detail")
+
+    async def start(self):
+        self.note("start")
+
+    async def close(self, exc_type, exc, tb):
+        self.note("close")
+
+    def completed(self, finish_reason):
+        self.note("completed")
+
+    def failed(self, code):
+        self.note("failed")
+
+    def retry(self, *, attempt, delay_seconds):
+        self.note("retry")
+
+
+class ObservingRun:
+    def __init__(self, events, fault):
+        self.call = ObservingCall(events, fault)
+
+    def bind(self):
+        from contextlib import contextmanager
+
+        @contextmanager
+        def context():
+            self.call.note("bind")
+            try:
+                yield
+            finally:
+                self.call.note("unbind")
+
+        return context()
+
+    async def aclose(self):
+        self.call.note("aclose")
+
+    def model_call(self, model_id, emit):
+        self.call.note("model_call")
+        return self.call
+
+    def bridge_loss(self, dropped):
+        self.call.note("bridge_loss")
+        return {"test.loss": dropped}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "bind",
+        "unbind",
+        "aclose",
+        "model_call",
+        "start",
+        "close",
+        "completed",
+        "failed",
+        "retry",
+        "bridge_loss",
+    ],
+)
+async def test_observer_faults_preserve_original_work_and_cleanup(fault, caplog):
+    from screamingface_engine.observations import (
+        ModelCall,
+        RunObservations,
+        bridge_loss_attributes,
+        current_model_call,
+    )
+
+    events = []
+    run = RunObservations((lambda: ObservingRun(events, fault),))
+    error = ValueError("original execution error")
+    with pytest.raises(ValueError) as raised:
+        try:
+            with run.bind():
+                async with ModelCall("model", None) as call:
+                    assert current_model_call() is call
+                    call.retry(attempt=2, delay_seconds=0.1)
+                    call.completed("stop")
+                    call.failed("provider_timeout")
+                    bridge_loss_attributes(10)
+                    raise error
+        finally:
+            await run.aclose()
+    assert raised.value is error
+    assert current_model_call() is None
+    assert "aclose" in events
+    if fault != "model_call":
+        assert "close" in events
+    assert "PRIVATE" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unregistered_nested_run_cannot_report_retry_on_parent_call():
+    from screamingface_engine.observations import ModelCall, RunObservations, current_model_call
+
+    events = []
+    outer = RunObservations((lambda: ObservingRun(events, ""),))
+    inner = RunObservations(())
+    with outer.bind():
+        async with ModelCall("model", None) as call:
+            with inner.bind():
+                assert current_model_call() is None
+            assert current_model_call() is call
+    assert "retry" not in events
+    await inner.aclose()
+    await outer.aclose()
+
+
+@pytest.mark.asyncio
+async def test_broken_fault_diagnostic_cannot_replace_execution_error(monkeypatch):
+    from screamingface_engine import observations
+
+    def broken_diagnostic(*args, **kwargs):
+        raise RuntimeError("broken log handler")
+
+    monkeypatch.setattr(observations.logger, "warning", broken_diagnostic)
+    run = observations.RunObservations((lambda: ObservingRun([], "retry"),))
+    error = ValueError("original work failure")
+    with pytest.raises(ValueError) as raised:
+        with run.bind():
+            async with observations.ModelCall("model", None) as call:
+                call.retry(attempt=2, delay_seconds=0.1)
+                raise error
+    assert raised.value is error
+    await run.aclose()
+
+
+@pytest.mark.asyncio
+async def test_repeated_observer_failures_emit_one_safe_warning_per_run(caplog):
+    from screamingface_engine.observations import ModelCall, RunObservations
+
+    run = RunObservations((lambda: ObservingRun([], "retry"),))
+    with run.bind():
+        async with ModelCall("model", None) as call:
+            for _ in range(1000):
+                call.retry(attempt=2, delay_seconds=0.1)
+    await run.aclose()
+    assert caplog.text.count("execution observer failed") == 1
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_observer_start_unwinds_call_and_resources():
+    import asyncio
+
+    from screamingface_engine.observations import ModelCall, RunObservations, current_model_call
+
+    events = []
+
+    class CancelledCall(ObservingCall):
+        async def start(self):
+            raise asyncio.CancelledError()
+
+    observer = ObservingRun(events, "")
+    observer.call = CancelledCall(events, "")
+    run = RunObservations((lambda: observer,))
+    with run.bind():
+        with pytest.raises(asyncio.CancelledError):
+            async with ModelCall("model", None):
+                pytest.fail("work must not start after cancellation")
+        assert current_model_call() is None
+    await run.aclose()
+    assert events == ["bind", "model_call", "close", "unbind", "aclose"]
+
+
+@pytest.mark.asyncio
+async def test_bad_loss_attributes_do_not_break_transport_diagnostic():
+    from screamingface_engine.observations import RunObservations, bridge_loss_attributes
+
+    class BadLoss(ObservingRun):
+        def bridge_loss(self, dropped):
+            return {"bad": float("nan")}
+
+    run = RunObservations((lambda: BadLoss([], ""),))
+    with run.bind():
+        assert bridge_loss_attributes(3) == {}
+    await run.aclose()
+
+
+def test_failed_factory_is_inert_and_diagnostic_excludes_exception_text(caplog):
+    from screamingface_engine.observations import RunObservations
+
+    def broken():
+        raise ValueError("PRIVATE factory detail")
+
+    run = RunObservations((broken,))
+    assert run.observers == [] and run.active
+    assert "execution observer failed" in caplog.text and "PRIVATE" not in caplog.text

--- a/docs/tasks/2026-09-10-OME-1161-model-activity.md
+++ b/docs/tasks/2026-09-10-OME-1161-model-activity.md
@@ -9,8 +9,9 @@ closed:
 
 # Stream safe model-call activity
 
-PR 897 is documentation-only: design, rationale and delivery plan. Code follows in sequential
-main-based PRs, each at most 500 added plus deleted lines including tests/docs. No stacked PRs.
+Docs PR 897 merged at af58b5c1. The first code unit adds observation interfaces/dispatch
+and unit tests; execution integration follows after its merge. Each main-based PR changes
+at most 500 added plus deleted lines including tests/docs. No stacked PRs.
 The first code PR supplies observation interfaces; later units integrate execution, activity
 and deployment policy. Keep this overall feature open until delivery is complete.
 Client rendering, benchmark-stage producers and provisional scores remain separate.

--- a/docs/work/2026-09-10-OME-1161-observation-split.md
+++ b/docs/work/2026-09-10-OME-1161-observation-split.md
@@ -31,3 +31,17 @@ Verified: docs-only diff, relative links, one file per folder and 177 changed li
 After docs merge, extract each code unit from updated main and repeat gates/review. Existing
 pre-PR tests remain intact; deferred tests stay with their preserved implementation.
 OME-1161 remains open. Append subsequent delivery outcomes to this same ledger.
+
+
+## Code unit 1 — observation ports (2026-09-10)
+
+Docs PR 897 merged at af58b5c1. Extract only observations.py and its unit tests from
+f9aa283f onto a fresh origin/main worktree. Explain adapter lifecycle obligations in
+interface docstrings. No execution integration or activity implementation in this unit.
+RED first on the absent module, then full Engine gates and independent review. Keep
+all changes, including shared-doc updates, below 500 added plus deleted lines.
+
+Outcome: 16 focused tests pass; full Engine gates pass (append-only, Ruff lint/format,
+Pyright, layering and full tests/coverage). Independent Standards/Spec reviews found
+no remaining issues. No execution hooks or activity policy ship in this unit. Reused
+shared docs only; final line-budget check passed before commit. Feature remains open.

--- a/docs/work/2026-09-10-OME-1161-observation-split.md
+++ b/docs/work/2026-09-10-OME-1161-observation-split.md
@@ -35,13 +35,10 @@ OME-1161 remains open. Append subsequent delivery outcomes to this same ledger.
 
 ## Code unit 1 — observation ports (2026-09-10)
 
-Docs PR 897 merged at af58b5c1. Extract only observations.py and its unit tests from
-f9aa283f onto a fresh origin/main worktree. Explain adapter lifecycle obligations in
-interface docstrings. No execution integration or activity implementation in this unit.
-RED first on the absent module, then full Engine gates and independent review. Keep
-all changes, including shared-doc updates, below 500 added plus deleted lines.
-
-Outcome: 16 focused tests pass; full Engine gates pass (append-only, Ruff lint/format,
-Pyright, layering and full tests/coverage). Independent Standards/Spec reviews found
-no remaining issues. No execution hooks or activity policy ship in this unit. Reused
-shared docs only; final line-budget check passed before commit. Feature remains open.
+Extracted ports/tests from f9aa283f after docs merge af58b5c1, on a fresh main worktree.
+Interface docstrings explain lifecycle obligations; no execution hooks or activity ship.
+RED reproduced the absent module, then wrong-run fault attribution and lost bind errors.
+Owner-approved revision uses explicit fault ownership, faithful step-exception teardown
+and one guard for synchronous/awaited callbacks. Nested execution isolation is unchanged.
+All 22 focused tests and full Engine gates pass; both reviews found no remaining issues.
+Full PR: 496 changed lines, including shared artifacts. The overall feature remains open.


### PR DESCRIPTION
This PR defines a safe way for optional logging code to observe what the Engine is doing. For example, when the Engine retries a model request, a future activity adapter can turn that fact into “Model request retrying in 2 seconds” for the researcher’s logs.

This PR adds and tests the observation interfaces. Follow-up PRs connect them to execution and implement the activity adapter; the Client then displays the records. This PR alone does not produce new researcher logs. Ordinary logging failures are contained so they cannot interrupt evaluation.

The separation lets the Engine keep ownership of requests, retries and results while an optional adapter owns how activity is described. The activity adapter can be removed without changing core execution. This follows the design merged in [PR 897](https://github.com/ScreamingFace/screamingface/pull/897).

This is the first code unit for [OME-1161](https://linear.app/openmined/issue/OME-1161), branched from main after the docs merge. Its final diff is **496 changed lines (494 additions, 2 deletions) across four files**, including tests and shared-doc updates. It adds one production module and its unit tests. Execution integration comes in the next main-based PR; this unit alone does not emit researcher activity or alter requests.

### What the interfaces provide, and why

- **Run observer factories and context binding.** Each execution can create fresh observer state. An empty observer set masks inherited dispatch, preventing nested execution from accidentally updating its parent’s telemetry.
- **Model-call observations.** Adapters receive start, actual retry facts, completion/failure and scope exit. They can translate those facts into their own schema while request and retry decisions stay with the Engine.
- **Cleanup responsibilities.** Interface docstrings specify fresh context bindings, partial-startup cleanup and process-control semantics. Binding teardown receives the actual step exception and traceback, including cancellation. Its return value cannot suppress execution errors. Binding is scoped to inner execution steps so context tokens will not cross generator yields when the integration is added.
- **Bridge-loss decoration.** Optional validated scalar attributes let an adapter describe transport loss without parsing a message or creating a new event stream.
- **Fault isolation.** One shared context-manager guard protects both synchronous and awaited callbacks. Every guard receives its explicit owning run, so a call created under A cannot charge its warning budget to a currently bound B. Ordinary failures cannot replace work errors; the diagnostic warning is itself best-effort and attempted at most once per owning run.

The module uses only the standard library and imports no activity implementation or URL4 internals. It has a concrete planned consumer: the preserved activity adapter owns the researcher schema, privacy policy, rate limits, occurrence IDs and heartbeat resources. Those choices do not belong in these interfaces.

### Review scope and follow-up

No connector, executor, configuration, Helm or Client changes are included. The next PR connects these interfaces to existing execution facts and verifies real requests/retries, accounting, cancellation and operator diagnostics. Activity behavior follows in later units.

Each PR starts from updated main after its predecessor merges: no stack, and a hard maximum of 500 added plus deleted lines including tests/docs. This PR updates the existing shared work ledger and task mirror rather than adding another set of documents. OME-1161 remains open until the feature is delivered.

### Validation

- RED first: the initial 16 cases failed with the missing module. Six additional regression cases cover captured-run fault ownership and successful/error/cancelled binding teardown; the failing cases reproduced both review bugs before the fixes. All 22 focused cases pass.
- Callback/factory faults, original-error preservation, nested-run isolation, broken diagnostic handler, one-warning budget, startup cancellation and malformed loss attributes.
- Independent Standards and Spec reviews found no remaining confirmed findings.
- Full local Engine gates passed: append-only, Ruff lint/format, Pyright, layering and full suite/coverage (2,731 collected, 93% coverage). Final diff: 496 changed lines, below the 500-line maximum.

Refs: OME-1161
