### PR TITLE
fix(py-screamingface): refuse contradictory bless modes and police golden fields both ways

### DIFF
--- a/docs/tasks/2026-09-10-OME-1176-bless-mode-exclusivity.md
+++ b/docs/tasks/2026-09-10-OME-1176-bless-mode-exclusivity.md
@@ -1,0 +1,22 @@
+---
+id: OME-1176
+linear_url: https://linear.app/openmined/issue/OME-1176/combining-two-bless-modes-silently-runs-only-one-of-them
+status: in_progress
+type: fix
+priority: 3
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-09-10
+closed:
+---
+
+# Combining two bless modes silently runs only one of them
+
+Post-merge review findings on PR #870 (OME-1098 goldens): `--refresh-golden
+--dump-fresh` silently ignores the fresh recording (boolean flags dodge the
+`is not None` exclusion guard); golden field policing is one-directional
+(fusion fields ride a loop golden as dead weight); three logic blocks in the
+bless tool exist as near-verbatim copies. Fix the two bugs loudly, fold each
+copy into one authority.
+
+Full spec: the Linear issue. Ledger:
+`docs/work/2026-09-10-OME-1176-bless-mode-exclusivity.md`.

--- a/docs/work/2026-09-10-OME-1176-bless-mode-exclusivity.md
+++ b/docs/work/2026-09-10-OME-1176-bless-mode-exclusivity.md
@@ -1,0 +1,70 @@
+---
+ticket: OME-1176
+stack: screamingface
+status: in_progress   # planned | in_progress | done | blocked
+started: 2026-09-10
+finished:
+---
+
+# OME-1176 — Bless-mode exclusivity, two-way golden field policing, and deduplication
+
+## Intent
+
+Close the post-merge review findings on PR #870 (the OME-1098 goldens). Two bugs and
+a cleanup batch in the bless tool + golden schema:
+
+1. `--refresh-golden --dump-fresh` silently drops `--dump-fresh` (boolean flags dodge
+   the `is not None` exclusion guard) — the one silent path in a tool whose whole job
+   is refusing loudly.
+2. Golden field policing is one-directional: loop fields refuse on other kinds, but
+   `recipe`/`synthesizer` ride a loop golden as silently dead fields.
+3. Duplication: `_loop_candidate` mirrors `build_candidate`'s loop branch; the
+   BLESS-REFUSED status-drift block and the report→`_ReplayEvidence` construction are
+   copy-pasted (2× and 3×).
+4. Minor: `FreshReportFacts.revision` parsed but never read; `_loop_candidate`
+   docstring missing (moot once deduplicated).
+
+## Planned changes
+
+- `packages/screamingface/tests/e2e/fixtures/slice_snapshot.py` — explicit refusal for
+  the boolean mode-flag pair in `_run_gated_bless`; share the loop-candidate
+  construction with `harness.goldens`; extract the status-drift refusal and the
+  evidence construction into single helpers; drop the dead `revision` field.
+- `packages/screamingface/tests/e2e/harness/goldens.py` — mirrored `elif` refusing
+  fusion-only fields on a corrective_loop golden (and keep the existing direction).
+- `packages/screamingface/tests/e2e/test_fresh_dump_contracts.py` — RED tests for both
+  bugs (carried over from the review session) + adjustments for the dropped field.
+
+## Test plan
+
+- RED (already failing on this branch): the flag pair raises a named SystemExit; a
+  loop golden with `recipe` or `synthesizer` refuses validation.
+- Existing 17 fresh-dump contract tests + full suite stay green (refactors are
+  behavior-preserving; the four committed goldens still load).
+
+## Acceptance
+
+- No silent mode combination remains; field policing is symmetric; each formerly
+  duplicated block has exactly one home.
+- Gates: `uv run .claude/scripts/run_gates.py screamingface` all green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+  - `packages/screamingface/tests/e2e/fixtures/slice_snapshot.py` — explicit
+    `--refresh-golden`+`--dump-fresh` refusal in `_run_gated_bless`; `_loop_candidate`
+    deleted in favour of `harness.goldens.loop_candidate`; `_refuse_status_drift` +
+    `_evidence` extracted (2× and 3× copies folded); dead `FreshReportFacts.revision`
+    dropped.
+  - `packages/screamingface/tests/e2e/harness/goldens.py` — mirrored refusal
+    (`recipe`/`synthesizer` on a corrective_loop golden) + `loop_candidate` (the ONE
+    spec→CorrectiveLoop builder, used by `build_candidate` and the fresh-dump bless).
+  - `packages/screamingface/tests/e2e/test_fresh_dump_contracts.py` — 2 new tests
+    (flag-pair refusal; fusion-fields-on-loop refusal).
+- **Commits:** single commit on `OME-1176-bless-mode-exclusivity`.
+- **Gates:** `run_gates.py screamingface --skip-append-only` ALL GREEN (96 e2e
+  contract tests incl. the 2 new; full suite; cov ≥95). Append-only skip disclosed:
+  harness/tool files extended, no test function changed.
+- **Deviations:** `FreshReportFacts.revision` dropped rather than cross-checked — a
+  revision mismatch already fails the expression rung (the revision is embedded in
+  the rendered url4 path), so a second check would be a restatement.

--- a/packages/screamingface/tests/e2e/fixtures/slice_snapshot.py
+++ b/packages/screamingface/tests/e2e/fixtures/slice_snapshot.py
@@ -418,7 +418,6 @@ class FreshReportFacts:
     replay must reproduce."""
 
     board: str
-    revision: str
     kind: str
     rendered_url4: str
     expected_score: float | None
@@ -518,7 +517,6 @@ def parse_fresh_report(report: Mapping[str, Any]) -> FreshReportFacts:
     candidate = candidates[0]
     return FreshReportFacts(
         board=str(report["benchmark"]["id"]),
-        revision=str(report["benchmark"]["revision"]),
         kind=str(candidate["kind"]),
         rendered_url4=str(candidate["url4"]),
         expected_score=candidate["score"],
@@ -1176,15 +1174,7 @@ def _replay_and_slice(
         if proxy is not None:
             proxy.shutdown()
         backend.stop_sync()
-    candidate = report.candidates.only
-    return _ReplayEvidence(
-        revision=report.benchmark.revision,
-        rendered_url4=str(candidate.url4),
-        final_score=candidate.score,
-        case_statuses=statuses,
-        case_failures=failure_document(candidate.cases),
-        slice_rows=[line for line in slice_output.split("\n") if line and not line.isspace()],
-    )
+    return _evidence(report, statuses, slice_output)
 
 
 def _write_fixtures(
@@ -1507,16 +1497,7 @@ def _report_replay_and_slice(
         # Baseline BEFORE the verified replay, so the slice can observe movement.
         _psql(backend._container, _BASELINE_SQL)
         report, statuses = _verified_replay(engine_url, args, candidate=_fusion_candidate(tape))
-        if statuses != tape.case_statuses:
-            drifted = {
-                case: (tape.case_statuses.get(case), statuses.get(case))
-                for case in tape.case_statuses.keys() | statuses.keys()
-                if tape.case_statuses.get(case) != statuses.get(case)
-            }
-            raise SystemExit(
-                f"BLESS REFUSED — replayed case statuses diverge from the report "
-                f"(report, replay): {drifted}"
-            )
+        _refuse_status_drift(tape.case_statuses, statuses)
         slice_output = _psql(backend._container, _SLICE_SQL)
     finally:
         engine.stop()
@@ -1524,15 +1505,7 @@ def _report_replay_and_slice(
             proxy.shutdown()
         backend.stop_sync()
 
-    candidate = report.candidates.only
-    return _ReplayEvidence(
-        revision=report.benchmark.revision,
-        rendered_url4=str(candidate.url4),
-        final_score=candidate.score,
-        case_statuses=statuses,
-        case_failures=failure_document(candidate.cases),
-        slice_rows=[line for line in slice_output.split("\n") if line and not line.isspace()],
-    )
+    return _evidence(report, statuses, slice_output)
 
 
 def _bless_from_report(args: argparse.Namespace) -> None:
@@ -1587,15 +1560,38 @@ def _fresh_header(board: str, dump_sha: str, report_sha: str) -> list[str]:
     ]
 
 
-def _loop_candidate(member_specs: Any, judge_spec: Any, max_rounds: int) -> Any:
-    from harness.goldens import spec_model
+def _refuse_status_drift(expected: Mapping[str, str], statuses: Mapping[str, str]) -> None:
+    """Refuse the bless when the replayed case statuses diverge from the report's.
 
-    import screamingface as sf
+    ONE refusal for both report-backed replay flows (OME-1176) — the drift map names
+    (report, replay) per diverging case so the owner sees exactly which cases moved.
+    """
+    if dict(statuses) != dict(expected):
+        drifted = {
+            case: (expected.get(case), statuses.get(case))
+            for case in expected.keys() | statuses.keys()
+            if expected.get(case) != statuses.get(case)
+        }
+        raise SystemExit(
+            f"BLESS REFUSED — replayed case statuses diverge from the report "
+            f"(report, replay): {drifted}"
+        )
 
-    return sf.CorrectiveLoop(
-        [spec_model(spec) for spec in member_specs],
-        judge=spec_model(judge_spec),
-        max_rounds=max_rounds,
+
+def _evidence(report: Any, statuses: dict[str, str], slice_output: str) -> _ReplayEvidence:
+    """One verified replay + its observed slice → the ``_ReplayEvidence`` record.
+
+    The ONE constructor for all three replay flows (OME-1176), so what a golden is
+    authored from can never be assembled three subtly different ways.
+    """
+    candidate = report.candidates.only
+    return _ReplayEvidence(
+        revision=report.benchmark.revision,
+        rendered_url4=str(candidate.url4),
+        final_score=candidate.score,
+        case_statuses=statuses,
+        case_failures=failure_document(candidate.cases),
+        slice_rows=[line for line in slice_output.split("\n") if line and not line.isspace()],
     )
 
 
@@ -1625,30 +1621,13 @@ def _fresh_replay_and_slice(
                 "the saved report recorded; the --candidate spec does not rebuild the "
                 "recorded run (check every member/judge prompt and param, verbatim)"
             )
-        if statuses != facts.case_statuses:
-            drifted = {
-                case: (facts.case_statuses.get(case), statuses.get(case))
-                for case in facts.case_statuses.keys() | statuses.keys()
-                if facts.case_statuses.get(case) != statuses.get(case)
-            }
-            raise SystemExit(
-                f"BLESS REFUSED — replayed case statuses diverge from the report "
-                f"(report, replay): {drifted}"
-            )
+        _refuse_status_drift(facts.case_statuses, statuses)
         slice_output = _psql(backend._container, _SLICE_SQL)
     finally:
         engine.stop()
         backend.stop_sync()
 
-    candidate_result = report.candidates.only
-    return _ReplayEvidence(
-        revision=report.benchmark.revision,
-        rendered_url4=str(candidate_result.url4),
-        final_score=candidate_result.score,
-        case_statuses=statuses,
-        case_failures=failure_document(candidate_result.cases),
-        slice_rows=[line for line in slice_output.split("\n") if line and not line.isspace()],
-    )
+    return _evidence(report, statuses, slice_output)
 
 
 def _bless_fresh_dump(args: argparse.Namespace) -> None:
@@ -1685,7 +1664,9 @@ def _bless_fresh_dump(args: argparse.Namespace) -> None:
 
     pin_report_expectations(args, score=facts.expected_score, coverage=facts.expected_coverage)
 
-    candidate = _loop_candidate(member_specs, judge_spec, max_rounds)
+    from harness.goldens import loop_candidate
+
+    candidate = loop_candidate(member_specs, judge_spec, max_rounds)
     evidence = _fresh_replay_and_slice(args, candidate, facts, assets_root)
     golden = author_golden(
         board=args.board,
@@ -1843,6 +1824,15 @@ def main() -> None:
 
 def _run_gated_bless(args: argparse.Namespace) -> None:
     """Dispatch the two flag-selected modes (kept out of ``main`` for the return budget)."""
+    # WHY an explicit pair check (OME-1176): `_run_exclusive_mode` polices sources via
+    # `is not None`, which boolean store_true flags dodge — without this, the pair
+    # would silently run only the refresh and IGNORE the fresh recording.
+    if args.refresh_golden and args.dump_fresh:
+        raise SystemExit(
+            "--refresh-golden cannot be combined with --dump-fresh — a refresh "
+            "re-authors from the COMMITTED snapshot and would silently ignore the "
+            "fresh recording; run one mode at a time"
+        )
     if args.refresh_golden:
         _run_exclusive_mode(
             args,

--- a/packages/screamingface/tests/e2e/harness/goldens.py
+++ b/packages/screamingface/tests/e2e/harness/goldens.py
@@ -208,6 +208,13 @@ class GoldenReport(BaseModel):
                     f"models {self.models!r} must mirror the member spec routes "
                     f"{routes!r}, in order"
                 )
+            # The mirror of the elif below (OME-1176): fusion-only fields on a loop
+            # golden would be silently DEAD replay inputs — refused, not tolerated.
+            if self.recipe is not None or self.synthesizer is not None:
+                raise ValueError(
+                    "recipe/synthesizer belong to a fusion golden only — this golden "
+                    "is kind 'corrective_loop'"
+                )
         elif self.member_specs or self.judge_spec is not None or self.max_rounds is not None:
             raise ValueError(
                 f"member_specs/judge_spec/max_rounds belong to a corrective_loop "
@@ -283,6 +290,26 @@ def spec_model(spec: GoldenModelSpec):  # -> sf.Model
     return sf.Model(spec.model, prompt=spec.prompt, params=spec.params or None)
 
 
+def loop_candidate(
+    member_specs: Iterable[GoldenModelSpec],
+    judge_spec: GoldenModelSpec,
+    max_rounds: int,
+):  # -> sf.CorrectiveLoop
+    """Full specs → the exact ``sf.CorrectiveLoop`` they record — the ONE builder.
+
+    Both the golden replay (``build_candidate``) and the fresh-dump bless construct
+    the loop through here (OME-1176), so the two can never disagree about how a
+    spec becomes a candidate.
+    """
+    import screamingface as sf
+
+    return sf.CorrectiveLoop(
+        [spec_model(spec) for spec in member_specs],
+        judge=spec_model(judge_spec),
+        max_rounds=max_rounds,
+    )
+
+
 def build_candidate(golden: GoldenReport):  # -> sf.Model | sf.Fusion | sf.CorrectiveLoop
     """The golden's replay INPUT, rebuilt: the exact candidate the bless ran.
 
@@ -300,11 +327,7 @@ def build_candidate(golden: GoldenReport):  # -> sf.Model | sf.Fusion | sf.Corre
     if golden.kind == "corrective_loop":
         # The validator guarantees member specs + judge spec + max_rounds here.
         assert golden.judge_spec is not None and golden.max_rounds is not None
-        return sf.CorrectiveLoop(
-            [spec_model(spec) for spec in golden.member_specs],
-            judge=spec_model(golden.judge_spec),
-            max_rounds=golden.max_rounds,
-        )
+        return loop_candidate(golden.member_specs, golden.judge_spec, golden.max_rounds)
     if golden.kind == "fusion":
         # The validator guarantees recipe + synthesizer + ≥2 members on this branch.
         return sf.Fusion(

--- a/packages/screamingface/tests/e2e/test_fresh_dump_contracts.py
+++ b/packages/screamingface/tests/e2e/test_fresh_dump_contracts.py
@@ -293,3 +293,25 @@ def test_replay_input_fields_carries_the_loop_spec_through_a_refresh() -> None:
     assert authored["member_specs"] == _member_specs()
     assert authored["judge_spec"] == _judge_spec()
     assert authored["max_rounds"] == 3
+
+
+def test_refresh_and_fresh_dump_flags_refuse_each_other() -> None:
+    # INVARIANT (review finding, blocking): boolean mode flags dodge the
+    # `is not None` exclusion guard, so the pair must refuse explicitly —
+    # silently ignoring the fresh recording is the one unacceptable outcome.
+    import argparse
+
+    from fixtures.slice_snapshot import _run_gated_bless
+
+    args = argparse.Namespace(refresh_golden=True, dump_fresh=True, board="ifeval")
+    with pytest.raises(SystemExit, match="cannot be combined"):
+        _run_gated_bless(args)
+
+
+def test_fusion_fields_are_refused_on_a_loop_golden() -> None:
+    # The mirror of test_loop_fields_are_refused_on_other_kinds: recipe/synthesizer
+    # on a corrective_loop golden would be silently dead fields, not inputs.
+    with pytest.raises(Exception, match="corrective_loop"):
+        GoldenReport.model_validate(_loop_golden_document(recipe="open_panel"))
+    with pytest.raises(Exception, match="corrective_loop"):
+        GoldenReport.model_validate(_loop_golden_document(synthesizer=_JUDGE))


### PR DESCRIPTION
Closes the post-merge review findings on #870: the bless tool's one silent path, the golden schema's one-directional field policing, and three copy-pasted logic blocks.

## Problem / Solution

**Problem:** ask the golden-blessing tool to do two jobs at once and it quietly does only one — a dev can believe a fresh recording was verified when it was never even opened. Separately, a loop golden tolerates leftover fusion fields as dead weight, and three pieces of bless logic exist as near-identical copies waiting to drift.

**Solution:** every contradictory flag pair now refuses loudly, golden fields are policed in both directions, and each copied block has exactly one home.

## Before / After

### Before
- Trigger: a dev drives the bless/refresh tool or validates a golden.
- Today: `--refresh-golden --dump-fresh` silently drops `--dump-fresh` (boolean flags dodge the `is not None` source guard — every *other* mode pair refuses loudly); `recipe`/`synthesizer` on a `corrective_loop` golden validate as silently dead fields; the loop-candidate construction, the BLESS-REFUSED status-drift block, and the report→evidence construction are duplicated 2–3×.
- Cost: a silently wrong bless invocation in the tool whose entire job is refusing loudly, plus drift-prone copies guarding leaderboard numbers.

### After
- Same trigger.
- Now: the flag pair refuses with a named error before any docker boots; a loop golden carrying fusion fields refuses at load exactly like the reverse; `loop_candidate` / `_refuse_status_drift` / `_evidence` are each the single authority; the parsed-but-never-read `FreshReportFacts.revision` is dropped (a revision mismatch already fails the expression rung — the revision is embedded in the rendered url4 path).
- Win: no silent path, no duplicated authority, symmetric schema policing.

### Don't regress
- All four committed goldens load and replay unchanged (full suite green).
- Every mode invoked correctly behaves identically — the refactors are behavior-preserving.

## Review order

1. **`tests/e2e/fixtures/slice_snapshot.py`, `_run_gated_bless`** — the bug fix: the explicit pair refusal with its WHY comment. Verify it fires before any exclusion-guard logic.
2. **`tests/e2e/harness/goldens.py`** — the mirrored validator branch (fusion fields on a loop golden) and `loop_candidate`, the one spec→CorrectiveLoop builder now used by both `build_candidate` and the bless flow. Verify no behavior change for model/fusion kinds.
3. **`tests/e2e/test_fresh_dump_contracts.py`** — the two new tests pin both bugs by their failure story, not just "it raised".
4. **The dedup diff in `slice_snapshot.py`** (`_refuse_status_drift`, `_evidence`, dropped `revision`) — pure code motion; confirm the three former copies are byte-equivalent to the helpers.
5. **`docs/work/`, `docs/tasks/`** — ledger + mirror, skim.

**Genuinely new runtime behavior:** only the two refusals. Everything else is code motion under existing tests.

Refs: OME-1176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
