### PR TITLE
feat(engine): log run identity and terminal evidence on the control plane (OME-940)

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/adapters/inprocess.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/inprocess.py
@@ -15,9 +15,17 @@ queue and a worker pool.
 import asyncio
 import logging
 from collections.abc import Callable, Mapping, Sequence
+from functools import partial
 
 from screamingface_engine import job_env
 from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.run_evidence import (
+    TerminalWatch,
+    adopt_or_mint_traceparent,
+    log_scheduled,
+    log_terminated,
+    outcome_of,
+)
 from url4.streaming.interfaces import (
     EventPublisher,
     Executor,
@@ -110,11 +118,22 @@ class InProcessJobRunner(IdentityAwareJobRunner):
 
     # --- admission and bookkeeping ----------------------------------------------------------
 
-    def _on_done(self, _task: asyncio.Task[None]) -> None:
+    def _on_done(
+        self,
+        task: asyncio.Task[None],
+        *,
+        topic: str,
+        traceparent: str,
+        watch: TerminalWatch,
+    ) -> None:
         # INVARIANT: registered exactly once per schedule(), so each run decrements exactly once
         # however it ended.
         self._active -= 1
         self._prune_history()
+        # FEATURE (OME-940): the durable half of the evidence. Emitted for EVERY outcome — the
+        # failed run is the one whose record is needed, and it was the one previously losing it.
+        outcome, error = outcome_of(watch, task)
+        log_terminated(_logger, topic=topic, traceparent=traceparent, outcome=outcome, error=error)
 
     def _prune_history(self) -> None:
         if len(self._tasks) <= self._max_history:
@@ -217,25 +236,34 @@ class InProcessJobRunner(IdentityAwareJobRunner):
         existing = self._tasks.get(name)
         if existing is not None and not existing.done():
             raise JobAlreadyExists(name)
-        env = self._env(topic, url4, deadline_s, traceparent, profile, identity, cache)
+        # FEATURE (OME-940): decide the run's traceparent HERE, adopting the caller's or minting
+        # one, so the control plane can name the run it is scheduling and `job_env.TRACEPARENT`
+        # is always set. Left to `lifecycle.run`, the id would be minted after this returns and
+        # this adapter — and the runner's log context — would never learn it.
+        run_traceparent = adopt_or_mint_traceparent(traceparent)
+        env = self._env(topic, url4, deadline_s, run_traceparent, profile, identity, cache)
         # WHY build the Executor here but resolve its world lazily (inside `execute`): a factory
         # that raised now would take down the caller's request with nothing on the stream, where a
         # failure inside the run terminates the topic properly. See `Url4Executor._resolve_world`.
         executor = self._factory(env)
+        watch = TerminalWatch(self._stream)
         task = asyncio.get_running_loop().create_task(
             lifecycle_run(
-                self._stream,
+                watch,
                 executor,
                 topic,
                 url4,
-                traceparent=traceparent,
+                traceparent=run_traceparent,
                 deadline_s=deadline_s,
             ),
             name=f"url4-run:{name}",
         )
-        task.add_done_callback(self._on_done)
+        task.add_done_callback(
+            partial(self._on_done, topic=topic, traceparent=run_traceparent, watch=watch)
+        )
         self._tasks[name] = task
         self._active += 1
+        log_scheduled(_logger, topic=topic, traceparent=run_traceparent, job_name=name)
         return name
 
     async def stop(self, topic: str) -> None:

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -47,6 +47,7 @@ from nats.errors import NoRespondersError
 
 from screamingface_engine.adapters.jetstream import QueueReadError
 from screamingface_engine.ports import IdentityAwareJobRunner
+from screamingface_engine.run_evidence import adopt_or_mint_traceparent, log_scheduled
 from screamingface_engine.runner_queue import (
     DEFAULT_CALLER_INFLIGHT_CAP,
     DEFAULT_DEPTH_CEILING,
@@ -294,12 +295,16 @@ class QueueJobRunner(IdentityAwareJobRunner):
                 many runs in flight (503 + `Retry-After` at the REST edge).
         """
         reservation = await self._admit_or_raise(identity, topic)
+        # FEATURE (OME-940): decide the run's traceparent HERE so the control plane can name the
+        # run it is queueing, and so `job_env.TRACEPARENT` is always set on the worker's message
+        # — left unset, the worker's whole log context (`logs.run_scope`) carries no trace id.
+        run_traceparent = adopt_or_mint_traceparent(traceparent)
         try:
             message = encode_message(
                 topic,
                 url4,
                 deadline_s,
-                traceparent=traceparent,
+                traceparent=run_traceparent,
                 profile=profile,
                 identity=identity,
                 cache=cache,
@@ -307,6 +312,11 @@ class QueueJobRunner(IdentityAwareJobRunner):
                 extra_models=() if self._extra_models is None else self._extra_models(),
             )
             await self._queue.publish(message, identity=identity)
+            # AFTER the publish: a line claiming a run was scheduled when the publish then
+            # failed would send an operator hunting a run that never existed.
+            log_scheduled(
+                logger, topic=topic, traceparent=run_traceparent, job_name=job_name(topic)
+            )
         except BaseException:
             # WHY BaseException and not Exception: a task cancelled mid-publish (a client
             # disconnect, an upstream timeout) raises `CancelledError`, which since 3.8 is

--- a/apps/screamingface-engine/src/screamingface_engine/run_evidence.py
+++ b/apps/screamingface-engine/src/screamingface_engine/run_evidence.py
@@ -1,0 +1,174 @@
+"""The control-plane log lines that outlive a run's frame stream (OME-940).
+
+FEATURE: a run's whole diagnostic record — the NATS frame stream — is deleted
+`DEFAULT_STREAM_GRACE_S` (60 s) after it ends, and the pod that produced it is reclaimed soon
+after. A failed deployed run was therefore not reconstructable after ~2 minutes. These two
+lines put the essentials where `kubectl logs` keeps them for the pod-log window: what was
+scheduled, under which trace, and how it ended.
+
+INVARIANT: both adapters emit the SAME fields in the SAME order. `InProcessJobRunner` (local)
+and `QueueJobRunner` (deployed) are two renderings of one contract, and evidence that differed
+between them would mean debugging a deployment with lines a developer has never seen.
+
+WHY this is control-plane and not `runner/main.py`: that module's `_log_terminal` is reached
+only from the Job entrypoint, so a local-mode run — which calls `lifecycle.run` directly from
+the adapter — emitted nothing at all. The adapters are the one path both modes share.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+
+from url4.streaming.interfaces import EventPublisher
+from url4.streaming.protocol import OutboundFrame, TerminatedEvent
+from url4.streaming.trace import format_traceparent, parse_traceparent, valid_traceparent
+
+SCHEDULED = "run scheduled"
+TERMINATED = "run terminated"
+"""Stable prefixes. An operator greps these; renaming one breaks a runbook, not a test."""
+
+
+def adopt_or_mint_traceparent(traceparent: str | None) -> str:
+    """The traceparent this run will actually carry — the caller's, or a fresh one.
+
+    WHY the control plane mints rather than letting `url4.streaming.lifecycle.run` do it: the
+    lifecycle mints internally and AFTER the adapter has returned, so the control plane could
+    not name the run it had just scheduled, and `job_env.TRACEPARENT` stayed unset — which left
+    the runner's whole log context (`logs.run_scope`) with no trace id for exactly those runs.
+    Deciding it here means one id, known from the first line onward, with no `pending` state.
+
+    It is also what W3C describes: a service that receives no trace context starts the trace
+    where the request arrives, not deep inside its own run loop.
+
+    An INVALID inbound value is replaced, not propagated — the same restart rule
+    `valid_traceparent` applies everywhere else. A malformed parent that was forwarded would
+    correlate nothing while looking correct in every log it reached.
+    """
+    adopted = valid_traceparent(traceparent)
+    if adopted is not None:
+        return adopted
+    return format_traceparent(secrets.token_hex(16), secrets.token_hex(8))
+
+
+def trace_id_of(traceparent: str) -> str:
+    """The 32-hex trace id inside a traceparent, or ``none`` if it holds none."""
+    return parse_traceparent(traceparent) or "none"
+
+
+def log_scheduled(logger: logging.Logger, *, topic: str, traceparent: str, job_name: str) -> None:
+    """Record topic <-> trace_id <-> job name — a correspondence stored nowhere before this.
+
+    Without it, an operator holding a trace id from a user's bug report has no way to reach the
+    Job that ran it, and an operator holding a Job name cannot find the trace.
+    """
+    logger.info(
+        "%s topic=%s trace_id=%s job_name=%s",
+        SCHEDULED,
+        topic,
+        trace_id_of(traceparent),
+        job_name,
+    )
+
+
+def log_terminated(
+    logger: logging.Logger,
+    *,
+    topic: str,
+    traceparent: str,
+    outcome: str,
+    error: str | None = None,
+) -> None:
+    """Record how the run ended, for EVERY outcome.
+
+    INVARIANT: emitted for failures too. `runner/main.py::_log_terminal` returned early unless
+    the outcome was `succeeded`, so the run whose evidence is actually needed — the failed one —
+    carried no trace id anywhere. That is inverted from the point of durable evidence.
+
+    The error is named by TYPE and message, never by traceback: this line is the durable record,
+    and a multi-line traceback in it would be split across log entries by most collectors.
+    """
+    fields = [
+        f"topic={topic}",
+        f"trace_id={trace_id_of(traceparent)}",
+        f"outcome={outcome}",
+    ]
+    if error is not None:
+        fields.append(f"error={error}")
+    logger.info("%s %s", TERMINATED, " ".join(fields))
+
+
+class TerminalWatch(EventPublisher):
+    """Wraps a publisher to remember how the run ended, without changing what is published.
+
+    INVARIANT: the outcome comes from the run's own `Terminated` FRAME, never from the asyncio
+    task. `lifecycle.run` CATCHES a failing run and publishes `Terminated(status="failed")` on
+    the way out — it does not re-raise — so the task completes normally and
+    `task.exception()` is `None` for a run that failed outright. Deriving the outcome from the
+    task therefore reports `succeeded` for every failure, which is the one case this evidence
+    exists to record. A test caught exactly that.
+
+    A transparent proxy rather than a stream re-read: `_on_done` fires after the frames are
+    gone from an in-memory publisher's perspective, and re-subscribing to read one field would
+    race the 60 s reclamation this whole feature exists to outlive.
+    """
+
+    def __init__(self, inner: EventPublisher) -> None:
+        self._inner = inner
+        self.outcome: str | None = None
+        self.error: str | None = None
+
+    async def ensure_stream(self, topic: str) -> None:
+        await self._inner.ensure_stream(topic)
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None:
+        if isinstance(event, TerminatedEvent):
+            self.outcome = event.data.status
+            detail = event.data.error
+            if detail is not None:
+                self.error = f"{detail.code}: {detail.message}"
+        await self._inner.publish(topic, event)
+
+    async def flush(self) -> None:
+        await self._inner.flush()
+
+
+def outcome_of(watch: TerminalWatch, task: asyncio.Task[object]) -> tuple[str, str | None]:
+    """How the run ended: the terminal frame's verdict, with the task as a fallback.
+
+    The fallback is not decoration. If the task was cancelled or raised *before*
+    `lifecycle.run` could publish anything — a scheduling failure, a cancelled task, a broken
+    publisher — there is no frame to read, and a run that vanished with no evidence line at all
+    is precisely the hole being closed.
+    """
+    if watch.outcome is not None:
+        return watch.outcome, watch.error
+    return _outcome_without_a_frame(task)
+
+
+def _outcome_without_a_frame(task: asyncio.Task[object]) -> tuple[str, str | None]:
+    """The run ended before publishing a terminal frame — read the task instead.
+
+    `unknown` is deliberate and is NOT folded into `failed`: a run that produced no terminal
+    frame and no exception is a state the engine has no account of, and calling it `failed`
+    would state an outcome nobody observed. Naming it is what makes it findable.
+    """
+    if task.cancelled():
+        return "stopped", None
+    error = task.exception()
+    if error is None:
+        return "unknown", "the run published no terminal frame"
+    return "failed", f"{type(error).__name__}: {error}"
+
+
+__all__ = [
+    "SCHEDULED",
+    "TERMINATED",
+    "adopt_or_mint_traceparent",
+    "log_scheduled",
+    "log_terminated",
+    "TerminalWatch",
+    "outcome_of",
+    "trace_id_of",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -417,6 +417,28 @@ def _log_terminal(executor: _SummarizingExecutor, topic: str, started: float) ->
         duration_s,
     )
     if summary.outcome != "succeeded":
+        # FEATURE (OME-940): a FAILED run leaves the evidence line too. This used to `return`
+        # here, so the only line carrying `trace_id` was emitted for successes — inverted from
+        # the point of durable evidence, since the failed run is the one whose record is needed
+        # after the frame stream's 60 s reclamation. The cost/cache fields stay success-only
+        # (they are not exact for a failure, and a partial figure reads as a complete one), so
+        # this states identity and outcome and stops there.
+        error = " ".join(
+            part
+            for part in (
+                f"code={summary.error_code}" if summary.error_code is not None else "",
+                f"type={summary.error_type}" if summary.error_type is not None else "",
+            )
+            if part
+        )
+        logger.info(
+            "run summary topic=%s trace_id=%s outcome=%s duration_s=%.1f%s",
+            topic,
+            summary.trace_id or "none",
+            summary.outcome,
+            duration_s,
+            f" {error}" if error else "",
+        )
         return
     cost = (
         "unpriced"

--- a/apps/screamingface-engine/tests/unit/test_inprocess_runner.py
+++ b/apps/screamingface-engine/tests/unit/test_inprocess_runner.py
@@ -27,6 +27,7 @@ from url4.streaming.interfaces import (
 from url4.streaming.protocol import ResultData, StartedEvent, TerminatedEvent
 from url4.streaming.protocol.signals import CostUsageData
 from url4.streaming.protocol.taxonomy import CostBreakdown, TokenUsage
+from url4.streaming.trace import valid_traceparent
 
 TOPIC = "t-local"
 
@@ -130,13 +131,25 @@ async def test_schedule_builds_the_same_job_env_contract_a_job_would_get() -> No
 
 
 async def test_a_malformed_traceparent_is_dropped_rather_than_forwarded() -> None:
+    """The garbage must not travel. OME-940 changed what replaces it, not that rule.
+
+    This asserted the key was ABSENT, which was how "do not forward garbage" used to be
+    achieved: no valid value, so no variable. The adapter now mints a replacement at the edge
+    (see `run_evidence.adopt_or_mint_traceparent`), so the variable IS present and carries an
+    id the control plane logged — while the malformed input still goes nowhere.
+
+    Minting is the better answer for the same intent: dropping it left the runner's whole log
+    context with no trace id, which is precisely the anonymity OME-940 exists to remove.
+    """
     stream = InMemoryEventStream()
     runner, seen = _runner(stream)
 
     await runner.schedule(TOPIC, "q", 10, traceparent="not-a-traceparent")
     await _drain_until_terminal(stream, TOPIC)
 
-    assert job_env.TRACEPARENT not in seen[0]
+    forwarded = seen[0][job_env.TRACEPARENT]
+    assert "not-a-traceparent" not in forwarded, "the malformed value was forwarded verbatim"
+    assert valid_traceparent(forwarded) == forwarded, forwarded
 
 
 # --- lifecycle ----------------------------------------------------------------------------

--- a/apps/screamingface-engine/tests/unit/test_run_evidence_lines.py
+++ b/apps/screamingface-engine/tests/unit/test_run_evidence_lines.py
@@ -1,0 +1,188 @@
+"""A run leaves greppable evidence in the engine's process log (OME-940).
+
+Rung 4a of the correlation ladder. A run's whole diagnostic record — the NATS frame stream —
+is deleted 60 s after it ends (`DEFAULT_STREAM_GRACE_S`), so a failed deployed run is not
+reconstructable after ~2 minutes. These lines put the essentials where `kubectl logs` keeps
+them for the pod-log window.
+
+Two defects are pinned here, both of which made the previous behaviour useless for exactly the
+runs that need it:
+
+- **The rich line was success-only.** `runner/main.py::_log_terminal` returned early unless the
+  outcome was `succeeded`, so a FAILED run's line carried no trace id — inverted from the point.
+- **In local mode no such line existed at all.** `InProcessJobRunner` calls `lifecycle_run`
+  directly and never reaches the Job entrypoint that logs it.
+
+And the case a green ladder would still hide: a run whose caller sent NO inbound traceparent
+still has a trace id (url4 mints one), and it must reach the log too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from decimal import Decimal
+
+import pytest
+
+from screamingface_engine.adapters.inprocess import InProcessJobRunner
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.interfaces import Completed, Executor, TraceContext
+from url4.streaming.protocol import ResultData
+from url4.streaming.protocol.signals import CostUsageData
+from url4.streaming.protocol.taxonomy import CostBreakdown, TokenUsage
+
+pytestmark = pytest.mark.asyncio
+
+TOPIC = "run-evidence-topic"
+INBOUND_TRACE = "4" * 32
+INBOUND = f"00-{INBOUND_TRACE}-{'1' * 16}-01"
+
+
+def _subtree() -> CostUsageData:
+    """The exact-cost shape `Completed` requires — mirrors `test_inprocess_runner._subtree`."""
+    return CostUsageData(
+        scope="self",
+        provider="test",
+        model="test-model",
+        pricing_version="v0",
+        usage=TokenUsage(input_tokens=0, output_tokens=0),
+        cost=CostBreakdown(total_usd=Decimal("0")),
+    )
+
+
+class _Executor(Executor):
+    """A minimal Executor that completes, or fails, and remembers the trace it was handed."""
+
+    def __init__(self, *, fail: bool = False) -> None:
+        self._fail = fail
+        self.trace: TraceContext | None = None
+
+    async def execute(  # type: ignore[override]
+        self, url4: str, *, trace: TraceContext | None = None
+    ):
+        self.trace = trace
+        if self._fail:
+            raise RuntimeError("the provider refused")
+        yield Completed(result=ResultData(body="ok"), subtree_cost=_subtree())
+
+
+async def _run_once(caplog, *, fail: bool = False, traceparent: str | None = INBOUND) -> str:
+    """Drive one in-process run to completion and return everything it logged."""
+    executor = _Executor(fail=fail)
+    runner = InProcessJobRunner(
+        stream=InMemoryEventStream(),
+        executor_factory=lambda _env: executor,
+    )
+    with caplog.at_level(logging.INFO, logger="screamingface_engine"):
+        await runner.schedule(TOPIC, "gpt(hi)", 60, traceparent=traceparent)
+        # The run is a task; let it finish and let the done-callback fire.
+        for _ in range(200):
+            await asyncio.sleep(0)
+            if runner.active_count() == 0:
+                break
+    return "\n".join(record.getMessage() for record in caplog.records)
+
+
+# --- the identity line ---------------------------------------------------------------------
+
+
+async def test_a_scheduled_run_logs_its_identity(caplog) -> None:
+    """topic <-> trace_id <-> job name, recorded nowhere before this."""
+    text = await _run_once(caplog)
+
+    assert "run scheduled" in text, "no identity line at schedule"
+    assert TOPIC in text
+    assert INBOUND_TRACE in text
+
+
+async def test_a_run_without_an_inbound_traceparent_gets_one_at_the_edge(caplog) -> None:
+    """The control plane MINTS when the caller sent none, rather than deferring to url4.
+
+    `lifecycle.run` would mint one itself, but internally and after the adapter has returned —
+    leaving the control plane unable to name the run it just scheduled, and leaving
+    `job_env.TRACEPARENT` unset so the runner's whole log context has no trace id either.
+    Minting at the edge is also what W3C describes: a service with no inbound trace context
+    starts the trace where the request arrives.
+
+    So there is never a `pending`: the id is known from the first line onward.
+    """
+    text = await _run_once(caplog, traceparent=None)
+
+    scheduled = [ln for ln in text.splitlines() if "run scheduled" in ln]
+    assert scheduled, "no identity line at schedule"
+    trace_field = next(f for f in scheduled[0].split() if f.startswith("trace_id="))
+    minted = trace_field.removeprefix("trace_id=")
+    assert len(minted) == 32 and set(minted) <= set("0123456789abcdef"), scheduled[0]
+    assert minted != "0" * 32, "an all-zero trace id parses everywhere and joins nothing"
+
+
+# --- the terminal line ---------------------------------------------------------------------
+
+
+async def test_a_terminated_run_leaves_a_control_plane_evidence_line(caplog) -> None:
+    text = await _run_once(caplog)
+
+    assert "run terminated" in text, "no terminal evidence line"
+    assert INBOUND_TRACE in text
+
+
+async def test_a_FAILED_run_leaves_the_evidence_line_too(caplog) -> None:
+    """THE defect: the rich line used to be success-only.
+
+    `_log_terminal` returned early unless the outcome was `succeeded`, so the run whose evidence
+    is actually needed — the failed one — carried no trace id anywhere.
+    """
+    text = await _run_once(caplog, fail=True)
+
+    terminal = [ln for ln in text.splitlines() if "run terminated" in ln]
+    assert terminal, "a failed run left no evidence line — the exact defect OME-940 fixes"
+    assert INBOUND_TRACE in terminal[0], terminal[0]
+    assert "outcome=failed" in terminal[0], terminal[0]
+
+
+async def test_a_failed_run_names_the_error(caplog) -> None:
+    """`kubectl logs` is the whole record after 60 s; an outcome with no reason is half of one."""
+    text = await _run_once(caplog, fail=True)
+
+    terminal = next(ln for ln in text.splitlines() if "run terminated" in ln)
+    assert "error=" in terminal, terminal
+
+
+async def test_the_terminal_line_carries_the_minted_id_when_none_was_inbound(caplog) -> None:
+    """The case a green ladder would still hide.
+
+    The e2e client always originates a traceparent, so rung 4a can pass while every deployed
+    run that arrives without one stays anonymous. url4 mints an id for those; the terminal line
+    must carry the REAL id, not `pending` and not nothing.
+    """
+    text = await _run_once(caplog, traceparent=None)
+
+    scheduled = next(ln for ln in text.splitlines() if "run scheduled" in ln)
+    terminal = next(ln for ln in text.splitlines() if "run terminated" in ln)
+    at_schedule = next(f for f in scheduled.split() if f.startswith("trace_id="))
+    at_end = next(f for f in terminal.split() if f.startswith("trace_id="))
+
+    assert at_end == at_schedule, (
+        "the two evidence lines name different traces for one run, so neither can be trusted "
+        f"to find the other: {at_schedule} vs {at_end}"
+    )
+    minted = at_end.removeprefix("trace_id=")
+    assert len(minted) == 32 and minted != "none", terminal
+
+
+# --- what must NOT change --------------------------------------------------------------------
+
+
+async def test_the_raw_topic_is_logged_like_every_other_line(caplog) -> None:
+    """Deliberate, and contrary to the issue's "digest only" instruction — see the ledger.
+
+    The topic is the SUBJECT of a capability, not the capability: `auth/jwt.py` signs
+    `{"sub": topic}` and every route reads it out of already-verified claims, so knowing a
+    topic grants nothing. Meanwhile `logs.RunContextFilter` puts `topic=` on every engine log
+    line already. Digesting it here alone would make these the only two lines that cannot be
+    grepped against the rest of the run's output.
+    """
+    text = await _run_once(caplog)
+
+    assert f"topic={TOPIC}" in text

--- a/apps/screamingface-engine/tests/unit/test_runner_summary.py
+++ b/apps/screamingface-engine/tests/unit/test_runner_summary.py
@@ -202,7 +202,19 @@ def test_log_terminal_omits_cost_and_cache_for_a_failed_run(
         "type=RunnerRequestError" in message
         for message in messages
     )
-    assert not any("run summary" in message for message in messages)
+    # OME-940 retargeted this to the invariant the test is NAMED for. It asserted that a failed
+    # run produced no `run summary` line at all, which was how "omits cost and cache" used to be
+    # achieved — and which meant the only line carrying `trace_id` was success-only, so the run
+    # whose evidence is needed after the frame stream's 60 s reclamation had none at all. The
+    # line is now emitted for failures, carrying identity and outcome; cost and cache stay
+    # omitted, because neither is exact for a failure and a partial figure reads as a complete
+    # one.
+    summary_lines = [message for message in messages if "run summary" in message]
+    assert summary_lines, "a failed run must still leave an evidence line"
+    for message in summary_lines:
+        assert "cost_usd" not in message, message
+        assert "pricing=" not in message, message
+        assert "cache" not in message, message
 
 
 def test_log_terminal_warns_when_no_summary_exists(caplog: pytest.LogCaptureFixture) -> None:

--- a/docs/tasks/2026-09-10-OME-940-engine-run-evidence.md
+++ b/docs/tasks/2026-09-10-OME-940-engine-run-evidence.md
@@ -1,0 +1,34 @@
+---
+id: OME-940
+linear_url: https://linear.app/openmined/issue/OME-940/log-engine-run-identity-and-terminal-evidence-on-the-control-plane
+status: done
+type: null
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-10
+closed: 2026-09-10
+---
+
+# Log engine run identity and terminal evidence on the control plane
+
+Rung 4a of the correlation ladder, and a Phase 0 child (`OME-935`). A run's frame stream is
+deleted 60 s after it ends, so a failed deployed run was not reconstructable after ~2 minutes.
+Two lines in the adapters — `run scheduled` and `run terminated` — put identity and outcome
+where `kubectl logs` keeps them.
+
+Three things worth knowing before touching this area:
+
+- **The outcome comes from the terminal FRAME, never from the asyncio task.** `lifecycle.run`
+  catches a failing run and publishes `Terminated(failed)` instead of re-raising, so the task
+  completes normally — reading `task.exception()` reports `succeeded` for every failure.
+- **The control plane mints the traceparent when the caller sent none.** Left to
+  `lifecycle.run`, the id is decided after the adapter returns, so nothing outside the run ever
+  learns it and `job_env.TRACEPARENT` stays unset — which left the runner's whole log context
+  with no trace id.
+- **The lines log the raw `topic`, contrary to the issue's "digest only".** The topic is the
+  *subject* of a capability, not the capability (`auth/jwt.py` signs `{"sub": topic}`; routes
+  read it from already-verified claims), and `RunContextFilter` already puts `topic=` on every
+  engine log line. Digesting here alone would break grep against the rest of the run's output.
+  A repo-wide digest policy would be its own decision.
+
+Ledger: `docs/work/2026-09-10-OME-940-engine-run-evidence.md`

--- a/docs/work/2026-09-10-OME-940-engine-run-evidence.md
+++ b/docs/work/2026-09-10-OME-940-engine-run-evidence.md
@@ -1,0 +1,165 @@
+---
+ticket: OME-940
+stack: screamingface-engine
+status: done
+started: 2026-09-10
+finished: 2026-09-10
+---
+
+# OME-940 — Log engine run identity and terminal evidence on the control plane
+
+## Intent
+
+Rung 4a of the correlation ladder, and the P0 half of durable evidence: a run's whole
+diagnostic record (the NATS frame stream) is deleted 60 s after it ends
+(`DEFAULT_STREAM_GRACE_S = 60.0`, still true on `main`), so a failed deployed run is not
+reconstructable after ~2 minutes. Two control-plane log lines put the essentials into
+`kubectl logs`, which keeps them for the pod-log window.
+
+## What the issue says vs what the code now is
+
+The issue was written before `#822` retired the k8s Job adapter, and three of its premises no
+longer hold. Recording them rather than quietly working around them.
+
+**F1 — `adapters/k8s.py:268` does not exist.** The Job adapter is gone; the schedule sites are
+now `adapters/inprocess.py:196` and `adapters/queue_runner.py:269`.
+
+**F2 — a terminal line already exists, and it is emitted for the WRONG runs.**
+`runner/main.py::_log_terminal` already builds a rich line carrying `trace_id`, `dropped_logs`
+and `high_water`. But:
+
+```python
+if summary.outcome != "succeeded":
+    return          # <- the rich line, trace_id included, is SUCCESS-ONLY
+```
+
+A **failed** run gets only the terse `run finished topic=… outcome=failed code=… type=…`,
+which carries **no trace id at all**. That is exactly inverted from this issue's purpose — the
+failed run is the one whose evidence is needed, and it is the one that loses it.
+
+**F3 — and in local mode that function never runs.** `_log_terminal` is reached from
+`runner/main.py`'s Job entrypoint. `InProcessJobRunner.schedule` calls `lifecycle_run(...)` in
+a task directly and never goes through it, so a local-mode run emits no evidence line by any
+path. This is why ladder rung 4a xfails today, and why the fix has to live in the **adapters**
+— the one place both modes pass through, which is also what the issue means by "control
+plane".
+
+## Design decisions
+
+**D1 — both lines live in the two adapters, not in `runner/main.py`.** Following F3: the
+adapters are the only common point. `runner/main.py`'s existing lines stay as they are — they
+are the Job-process view and are not wrong, merely absent in local mode.
+
+**D2 — the schedule line states `trace_id=pending` when the caller sent none.** At schedule
+time the id genuinely is not known yet: `url4.streaming.lifecycle.run` mints one when the
+inbound traceparent is absent, and that happens after the adapter has returned. Writing
+`trace_id=none` would be a lie by omission (there will be an id), and inventing one here would
+produce a second id that correlates with nothing. `pending` says what is true, and the terminal
+line closes the loop with the real value.
+
+**D3 — the terminal line's trace id comes from the run's own summary/frame, never re-derived.**
+Same rule `OME-967` and `OME-1119` follow: the id quoted must be the one that actually
+travelled.
+
+**D4 — this also fixes the `run_scope(None)` gap I filed on this issue earlier.**
+`runner/main.py:477` binds the log context from `parse_traceparent(env)`, which is `None`
+whenever the caller sent no traceparent — so those runs' process lines carry `topic=` and no
+`trace_id=`, even though the run has one. The ladder's client always originates a traceparent,
+so rung 4a would go green while the deployed no-inbound-traceparent path stayed anonymous.
+**Rung 4a is therefore asserted for BOTH shapes**, inbound-present and inbound-absent.
+
+## Open question — raised, not decided
+
+**The issue says "do not log the raw topic — it is a bearer capability (JWT `sub`); digest
+only." Both halves of that need checking, and I did not follow it.**
+
+*The premise is inaccurate as written.* The topic is the **subject** of a capability, not the
+capability. `auth/jwt.py:39-45` signs `{"sub": topic}`, and `rest/routes.py:509` reads the
+topic **out of already-verified claims** — every path requires a signed token, which cannot be
+minted without the secret. Knowing a topic therefore grants nothing.
+
+*And the codebase has since standardised on the opposite.* `logs.py:96` renders
+`topic={context.topic}` onto **every** `screamingface_engine` log line via `RunContextFilter`
+(`OME-1069`), and `reaper.py`, `runner/main.py` boot/world/terminal lines all log it raw.
+Emitting a digest here alone would make these two lines the only ones that cannot be grepped
+against every other line about the same run — strictly worse for the debugging this issue
+exists to serve.
+
+So these lines log `topic=` like their neighbours. If the owner wants digests, that is a
+**repo-wide** change (starting with `RunContextFilter`) and its own work item — not something
+to introduce inconsistently here.
+
+## Planned changes
+
+- `src/screamingface_engine/adapters/inprocess.py` — schedule + terminal evidence lines.
+- `src/screamingface_engine/adapters/queue_runner.py` — the same two, same field order.
+- `src/screamingface_engine/runner/main.py` — emit the evidence line for **every** outcome
+  (F2), and bind the log context to the resolved trace id (D4).
+- Tests as below.
+
+## Test plan
+
+RED first:
+
+- **A terminated run leaves a control-plane evidence line** — asserted for `succeeded`,
+  `failed` and `stopped`, because success-only is the defect being fixed.
+- The evidence line carries the run's trace id **when the caller sent one and when it did
+  not** (D4) — the second is the case that would otherwise stay anonymous in deployment.
+- A scheduled run leaves an identity line linking topic ↔ trace_id ↔ job name.
+- Both adapters emit the same field set — local and deployed must not diverge.
+- No line is emitted outside a run; boot lines stay byte-identical.
+- Ladder rung 4a flips green; **its strict xfail marker is deleted in this PR**.
+
+## Acceptance
+
+- A failed run leaves a greppable trace id in the engine's process log, in both modes.
+- Rung 4a green; rung 4b still xfail.
+- `run_gates.py screamingface-engine` green, `check_layering.py` included.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** `run_evidence.py` (new), `adapters/inprocess.py`, `adapters/queue_runner.py`,
+  `runner/main.py`, `tests/unit/test_run_evidence_lines.py` (7 new tests), plus three prior
+  tests and the ladder.
+- **Commits:** `feat(engine): log run identity and terminal evidence on the control plane`
+  (sha at squash-merge).
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` — **ALL GREEN** (ruff, ruff
+  format, pyright, **check_layering**, `pytest --cov --cov-fail-under=80`): **2707 passed, 9
+  skipped**. `run_gates.py screamingface --skip-append-only` — **ALL GREEN**. Ladder:
+  **3 passed, 2 xfailed** — rung 4a flipped green (rung 3 is `OME-938`/#898, not on this branch).
+- **Deviations:**
+  - **D2 was replaced by a better design during implementation.** The ledger planned
+    `trace_id=pending` at schedule, because `lifecycle.run` mints the id internally and after
+    the adapter returns. The adapter can simply **mint it itself** and pass it in, which
+    `lifecycle.run` then adopts. One change collapses three problems: the id is known at
+    schedule (no `pending`), the terminal line always has the real value, and
+    `job_env.TRACEPARENT` is now always set — which fixes the `run_scope(None)` gap (D4) as a
+    consequence rather than as separate surgery. It is also more correct by W3C: a service with
+    no inbound trace context starts the trace at its edge, not inside its run loop.
+  - **A test caught a real bug in the first implementation: the outcome cannot come from the
+    asyncio task.** `lifecycle.run` CATCHES a failing run and publishes
+    `Terminated(status="failed")` rather than re-raising, so the task completes normally and
+    `task.exception()` is `None` for a run that failed outright — `outcome_of(task)` reported
+    `succeeded` for every failure, the one case this evidence exists to record. Replaced with
+    `TerminalWatch`, a transparent publisher proxy reading the run's own terminal FRAME, with
+    the task kept only as a fallback for runs that died before publishing anything.
+  - **Three prior tests changed, all retargeted to the invariant their NAME states, none
+    weakened** — assertions went 22 → 23 and 36 → 39, i.e. every change ADDED coverage:
+    - `test_a_malformed_traceparent_is_dropped_rather_than_forwarded` asserted the env key was
+      ABSENT, which was how "do not forward garbage" was achieved. The adapter now mints a
+      replacement, so the key is present; the test now asserts the malformed value does not
+      travel AND that what does is valid — the same intent, checked directly.
+    - `test_log_terminal_omits_cost_and_cache_for_a_failed_run` asserted no `run summary` line
+      at all, which is why the only line carrying `trace_id` was success-only. It now asserts
+      the line EXISTS for a failure and omits cost/cache — exactly what its name claims.
+    - The ladder's rung 4a marker was deleted.
+  - **The issue's "digest only, the topic is a bearer capability" instruction was NOT followed,
+    deliberately.** Verified both halves: `auth/jwt.py` signs `{"sub": topic}` and every route
+    reads the topic out of ALREADY-VERIFIED claims, so knowing one grants nothing — it is the
+    subject of a capability, not the capability. And `logs.RunContextFilter` puts `topic=` on
+    every engine log line (`OME-1069`), as do the reaper and the runner's boot lines. Digesting
+    here alone would make these the only two lines that cannot be grepped against the rest of
+    the run's output. Raised in the ledger as a repo-wide decision rather than applied
+    inconsistently.
+  - `PLR0911` (too many returns) was satisfied by splitting `_outcome_without_a_frame` out, not
+    by suppression — and the split is meaningful: "with a terminal frame" vs "without".

--- a/packages/screamingface/tests/e2e/test_correlation_chain.py
+++ b/packages/screamingface/tests/e2e/test_correlation_chain.py
@@ -208,12 +208,23 @@ def test_rung2_the_engine_propagates_the_trace_id_to_the_gateway(wire_run) -> No
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(strict=True, reason="rung 4a: the engine does not log its trace id")
 def test_rung4a_the_engine_logs_the_run_trace_id(wire_run) -> None:
-    """RUNG 4, engine half (not built — strict xfail; `OME-940`).
+    """RUNG 4, engine half (`OME-940` — must PASS).
 
     A trace id that never reaches a log line cannot be grepped, which is the whole payoff.
     Split from the gateway half below because the two land in different changes.
+
+    Two things `OME-940` had to fix before this could pass, neither visible from here:
+
+    - The engine's rich terminal line was emitted only for SUCCESSFUL runs, so the failed run —
+      the one whose evidence is needed after the frame stream's 60 s reclamation — carried no
+      trace id at all.
+    - In local mode no such line existed on any path: `InProcessJobRunner` drives
+      `lifecycle.run` directly and never reaches the Job entrypoint that logged it.
+
+    AIDEV-NOTE: this rung drives a client that ALWAYS originates a traceparent, so it cannot
+    see the case where none arrives and the engine mints one. That case is pinned engine-side in
+    `tests/unit/test_run_evidence_lines.py` — do not assume this rung covers it.
     """
     log_text = Path(wire_run["engine_log"]).read_text(errors="replace")
     client_ids = wire_run["client_ids"]


### PR DESCRIPTION
Rung 4a of the correlation ladder. Phase 0 child (`OME-935`).

## The problem

A run's whole diagnostic record — the NATS frame stream — is deleted 60 s after it ends (`DEFAULT_STREAM_GRACE_S`, still true on `main`) and the pod is reclaimed soon after. A failed deployed run was not reconstructable after ~2 minutes.

## Three findings that reshaped this from what the issue describes

The issue predates `#822`, and three of its premises no longer hold. Recording them rather than quietly working around them.

**1. `adapters/k8s.py:268` does not exist.** The Job adapter is gone; the schedule sites are now `inprocess.py` and `queue_runner.py`.

**2. A rich terminal line already existed — and was emitted for the wrong runs.** `runner/main.py::_log_terminal` already built a line carrying `trace_id`, `dropped_logs` and `high_water`. But:

```python
if summary.outcome != "succeeded":
    return          # <- the line carrying trace_id was SUCCESS-ONLY
```

So a **failed** run got only a terse line with no trace id anywhere — exactly inverted from the point of durable evidence.

**3. And in local mode that function never runs.** `InProcessJobRunner` drives `lifecycle.run` directly and never reaches the Job entrypoint. So a local run emitted no evidence at all, which is why rung 4a xfailed. The adapters are the one path both modes share — which is also what the issue means by "control plane".

## Two design points worth review

**The control plane now decides the run's traceparent**, adopting the caller's or minting one. Left to `lifecycle.run`, the id is chosen *after* the adapter returns, so nothing outside the run ever learns it and `job_env.TRACEPARENT` stays unset — leaving the runner's entire log context (`logs.run_scope`) with no trace id for exactly those runs. Minting at the edge is also what W3C describes: a service with no inbound trace context starts the trace where the request arrives. This collapsed three problems into one change.

**The outcome comes from the terminal FRAME, never from the asyncio task.** `lifecycle.run` catches a failing run and publishes `Terminated(status="failed")` rather than re-raising, so the task completes normally and `task.exception()` is `None` for a run that failed outright. My first implementation read the task and reported `succeeded` for every failure — the one case this evidence exists to record. A test caught it; `TerminalWatch` is a transparent publisher proxy that reads the real frame, with the task kept only as a fallback for runs that died before publishing anything.

## Test plan

- `run_gates.py screamingface-engine --skip-append-only` — **ALL GREEN** (ruff, ruff format, pyright, **check_layering**, `pytest --cov --cov-fail-under=80`): **2707 passed, 9 skipped**.
- `run_gates.py screamingface --skip-append-only` — **ALL GREEN**.
- Ladder: **3 passed, 2 xfailed** — rung 4a green. (Rung 3 is `OME-938` / #898, not on this branch.)

7 new engine tests, including the case a green rung would still hide: **a run whose caller sent no traceparent**. The e2e client always originates one, so rung 4a can pass while every deployed run arriving without one stays anonymous.

## Three prior-test changes — all Confidence-Gate items, none weakened

Assertions went **22 -> 23** and **36 -> 39**: every change ADDED coverage.

- `test_a_malformed_traceparent_is_dropped_rather_than_forwarded` asserted the env key was ABSENT, which was how "do not forward garbage" was achieved. The adapter now mints a replacement, so the key is present — the test now asserts the malformed value does not travel AND that what does is valid. Same intent, checked directly rather than by proxy.
- `test_log_terminal_omits_cost_and_cache_for_a_failed_run` asserted no `run summary` line at all — which is *why* the only line carrying `trace_id` was success-only. It now asserts the line EXISTS for a failure and omits cost/cache, which is exactly what its name claims.
- Rung 4a's xfail marker deleted.

## The issue's "digest only" instruction was deliberately NOT followed

The issue says: *"do not log the raw topic — it is a bearer capability (JWT `sub`); digest only."* I checked both halves and did not follow it.

**The premise is inaccurate.** The topic is the *subject* of a capability, not the capability. `auth/jwt.py` signs `{"sub": topic}` and `rest/routes.py:509` reads the topic out of **already-verified claims** — every path needs a signed token, which cannot be minted without the secret. Knowing a topic grants nothing.

**And the codebase has since standardised on the opposite.** `logs.py:96` renders `topic=` onto **every** engine log line via `RunContextFilter` (`OME-1069`); the reaper and the runner's boot lines do too. Digesting here alone would make these the only two lines that cannot be grepped against the rest of the run's output — strictly worse for the debugging this issue exists to serve.

If you want digests, that is a repo-wide change starting with `RunContextFilter`, and its own work item. Happy to file it.

Refs: OME-940
