### PR TITLE
feat(aigateway): join the inbound traceparent to the log context (OME-1120)

### DIFF
--- a/apps/aigateway/src/aigateway/call_context.py
+++ b/apps/aigateway/src/aigateway/call_context.py
@@ -30,12 +30,26 @@ from aigateway.core.auth.log_filter import factory_chain_has
 _INSTALLED = "_aigw_call_context_injection"
 """Marks the factory THIS module installed, so a second install is a no-op."""
 
+_TRACE_RECORD_ATTR = "trace_id"
+"""The attribute the injector stamps for the caller's trace, and the field name in output.
+
+Same name the Engine uses in its own `run_context` (`screamingface_engine/logs.py`), so one
+grep finds the id in both services' logs — which is the whole of Phase 1.
+"""
+
 _RECORD_ATTR = "gateway_call_id"
 """The attribute name the injector stamps on each record, and the field name in the output.
 
 One constant, because the renderer (`logs.CallContextFilter`) and every reader must agree with
 the writer. A drift here is silent: records carry the id, nothing renders it.
 """
+
+
+def record_trace_id(record: logging.LogRecord) -> str | None:
+    """The caller's trace id stamped on `record`, or None outside a request."""
+
+    value = getattr(record, _TRACE_RECORD_ATTR, None)
+    return value if isinstance(value, str) else None
 
 
 def record_call_id(record: logging.LogRecord) -> str | None:
@@ -54,6 +68,17 @@ _call_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "aigateway_gateway_call_id", default=None
 )
 
+_trace_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "aigateway_trace_id", default=None
+)
+"""FEATURE (OME-1120): the CALLER's trace id, joined from the inbound `traceparent`.
+
+Separate from `_call_id` and not merged into one dataclass: they have different origins and
+different trust. The call id is ours and always exists; the trace id comes from a header a
+caller controls and may be absent. Binding them separately keeps "we could not read a trace"
+distinguishable from "this request has no id at all".
+"""
+
 
 def new_gateway_call_id() -> str:
     """A fresh id in the shape the public contract already fixes.
@@ -66,14 +91,26 @@ def new_gateway_call_id() -> str:
 
 
 @contextmanager
-def call_scope(call_id: str) -> Iterator[str]:
-    """Bind one request's id for the duration of a scope; restore on exit."""
+def call_scope(call_id: str, *, trace_id: str | None = None) -> Iterator[str]:
+    """Bind one request's correlation ids for the duration of a scope; restore on exit.
 
-    token = _call_id.set(call_id)
+    `trace_id` is keyword-only and optional so every existing caller and test keeps working
+    unchanged (OME-1120): a scope with no trace is a legitimate state, not a degenerate one.
+    """
+
+    call_token = _call_id.set(call_id)
+    trace_token = _trace_id.set(trace_id)
     try:
         yield call_id
     finally:
-        _call_id.reset(token)
+        _trace_id.reset(trace_token)
+        _call_id.reset(call_token)
+
+
+def current_trace_id() -> str | None:
+    """The caller's bound trace id, or None outside a request or when none was readable."""
+
+    return _trace_id.get()
 
 
 def current_call_id() -> str | None:
@@ -103,6 +140,7 @@ def install_call_context_injection() -> None:
         # its type, and this is the ordinary way to carry an extra on one. Read it back through
         # `record_call_id` rather than a bare `getattr` at each call site.
         setattr(record, _RECORD_ATTR, current_call_id())
+        setattr(record, _TRACE_RECORD_ATTR, current_trace_id())
         return record
 
     setattr(call_context_factory, _INSTALLED, True)
@@ -114,6 +152,8 @@ def install_call_context_injection() -> None:
 __all__ = [
     "call_scope",
     "record_call_id",
+    "current_trace_id",
+    "record_trace_id",
     "current_call_id",
     "install_call_context_injection",
     "new_gateway_call_id",

--- a/apps/aigateway/src/aigateway/logs.py
+++ b/apps/aigateway/src/aigateway/logs.py
@@ -19,7 +19,7 @@ import logging
 import os
 from typing import TextIO
 
-from aigateway.call_context import record_call_id
+from aigateway.call_context import record_call_id, record_trace_id
 
 APP_LOGGER = "aigateway"
 LEVEL_ENV = "AIGW_LOG_LEVEL"
@@ -30,6 +30,18 @@ DEFAULT_LEVEL = "INFO"
 # reaches the handler WITHOUT passing the filter — a foreign handler's, a library's — from
 # raising KeyError in the formatter and taking the log line with it.
 _FORMAT = "%(levelname)s:     %(name)s %(call_context)s%(message)s"
+
+
+def rendered_context(record: logging.LogRecord) -> str:
+    """What `CallContextFilter` rendered onto `record`, or "" if it never passed one.
+
+    A typed accessor for the same reason `record_call_id` is one: `LogRecord` has no
+    `call_context` in its type, so every direct read is a pyright error and the attribute name
+    would be repeated at each site.
+    """
+
+    value = getattr(record, "call_context", "")
+    return value if isinstance(value, str) else ""
 
 
 class CallContextFilter(logging.Filter):
@@ -44,8 +56,8 @@ class CallContextFilter(logging.Filter):
     collector can be taught to parse into a real attribute. Unbound (boot, shutdown, tests) it
     renders nothing at all, so those lines stay byte-identical to before.
 
-    AIDEV-NOTE: `OME-1120` adds `trace_id` here, beside the call id — that is why this renders a
-    LIST of parts rather than one interpolation.
+    `OME-1120` added `trace_id` beside the call id — which is why this renders a LIST of parts
+    rather than one interpolation. Further ids belong in the same list, same shape.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:
@@ -53,6 +65,12 @@ class CallContextFilter(logging.Filter):
         call_id = record_call_id(record)
         if call_id is not None:
             parts.append(f"gateway_call_id={call_id}")
+        # FEATURE (OME-1120): the CALLER's trace id, so one grep spans this service and the
+        # engine. Omitted entirely when absent — never rendered empty or all-zero, both of
+        # which parse downstream as a value and correlate nothing.
+        trace_id = record_trace_id(record)
+        if trace_id is not None:
+            parts.append(f"trace_id={trace_id}")
         record.call_context = (" ".join(parts) + " ") if parts else ""
         return True
 
@@ -97,5 +115,6 @@ __all__ = [
     "DEFAULT_LEVEL",
     "LEVEL_ENV",
     "CallContextFilter",
+    "rendered_context",
     "configure",
 ]

--- a/apps/aigateway/src/aigateway/middleware/call_id.py
+++ b/apps/aigateway/src/aigateway/middleware/call_id.py
@@ -1,29 +1,59 @@
-"""Bind one `gateway_call_id` per inbound request, for the whole request (OME-938).
+"""Bind one request's correlation ids for its whole lifetime (OME-938, OME-1120).
 
-WHY the id is minted HERE and not in the taxonomy plugin: it used to be minted in
+Two ids, one scope:
+
+- `gateway_call_id` — ours, minted here, always present.
+- `trace_id` — the CALLER's, joined from the inbound `traceparent` when it is well-formed,
+  minted here when it is not. This is what makes one id greppable across the engine's
+  namespace and `sf-aigw`, which is Phase 1's whole payoff.
+
+WHY the ids are minted HERE and not in the taxonomy plugin: they used to be minted in
 `plugins/taxonomy/session.py`, and that plugin is gated by `TaxonomyPluginSettings().enabled`
 (`AIGW_TAXONOMY_ENABLED`). So turning off a *usage-accounting* feature silently deleted the
-*only correlation mechanism* in the gateway — an operator debugging a production incident would
-find every log line anonymous and no way to tell why. Correlation is not a feature of
-accounting; accounting is one consumer of correlation.
+*only correlation mechanism* in the gateway. Correlation is not a feature of accounting;
+accounting is one consumer of correlation.
 
 WHY pure ASGI and not `BaseHTTPMiddleware`: `BaseHTTPMiddleware` runs the downstream app in a
 SEPARATE task and returns as soon as the response *starts*. This gateway streams SSE, so the
 response body is produced after that point — under `BaseHTTPMiddleware` the scope would unbind
 while the stream was still being generated, and every line emitted during the stream (which is
-where dispatch, retry and provider errors happen) would lose its id. A pure ASGI middleware
-holds the scope across the entire send cycle, last chunk included.
+where dispatch, retry and provider errors happen) would lose its ids.
+
+SECURITY: `traceparent` is caller-controlled. Adopting a malformed or attacker-chosen value
+would let a caller pick the key other requests are grouped under, so anything that does not
+parse is REPLACED, never cleaned up. See `aigateway.w3c_trace`.
 """
 
 from __future__ import annotations
 
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from aigateway.call_context import call_scope, new_gateway_call_id
+from aigateway.w3c_trace import adopt_or_mint_trace_id
+
+TRACE_RESPONSE_HEADER = b"x-aigw-trace-id"
+"""Echoed on every response so a STREAMING caller can read the id.
+
+An SSE consumer never sees a response body object, so `_aigw.trace_id` in the JSON is not
+reachable for the very calls this gateway mostly serves. A header is the only channel both a
+JSON and a streaming caller can read.
+"""
+
+
+def _inbound_traceparent(scope: Scope) -> str | None:
+    """The raw `traceparent` header, read off the ASGI scope.
+
+    WHY the scope and not a Starlette `Request`: this runs before any framework object exists,
+    which is the point — the ids must be bound before the first line any layer can log.
+    """
+    for name, value in scope.get("headers", ()):
+        if name == b"traceparent":
+            return value.decode("latin-1")
+    return None
 
 
 class CallIdMiddleware:
-    """Give every HTTP request a correlation id, bound for its whole lifetime."""
+    """Give every HTTP request its correlation ids, bound for the whole request."""
 
     def __init__(self, app: ASGIApp) -> None:
         self._app = app
@@ -37,12 +67,25 @@ class CallIdMiddleware:
             return
 
         call_id = new_gateway_call_id()
-        with call_scope(call_id):
+        trace_id = adopt_or_mint_trace_id(_inbound_traceparent(scope))
+
+        async def send_with_trace(message: Message) -> None:
+            # INVARIANT: appended, never replacing the header list. A response that already
+            # sets headers (content-type, the SSE stream's own) must keep them.
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers.append((TRACE_RESPONSE_HEADER, trace_id.encode("latin-1")))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        with call_scope(call_id, trace_id=trace_id):
             # Published on the scope so downstream consumers (the taxonomy session, the
-            # exception handlers) read the SAME id rather than minting a second one for the
+            # exception handlers) read the SAME ids rather than minting a second set for the
             # same request — two ids for one call is worse than none, because both look right.
-            scope.setdefault("state", {})["gateway_call_id"] = call_id
-            await self._app(scope, receive, send)
+            state = scope.setdefault("state", {})
+            state["gateway_call_id"] = call_id
+            state["trace_id"] = trace_id
+            await self._app(scope, receive, send_with_trace)
 
 
-__all__ = ["CallIdMiddleware"]
+__all__ = ["TRACE_RESPONSE_HEADER", "CallIdMiddleware"]

--- a/apps/aigateway/src/aigateway/plugins/taxonomy/render.py
+++ b/apps/aigateway/src/aigateway/plugins/taxonomy/render.py
@@ -141,6 +141,7 @@ def render_aigw_metadata(
     supported: bool,
     cache_status: CacheStatusWord,
     gateway_call_id: str,
+    trace_id: str | None = None,
     cache_reference: CacheReference | None = None,
 ) -> dict[str, Any]:
     """Build bounded metadata from authoritative observed attempts."""
@@ -164,7 +165,15 @@ def render_aigw_metadata(
     for attempt in attempts_json:
         attempt["provider_extensions_truncated"] = False
     _bound_response_extensions(attempts_json)
-    metadata: dict[str, Any] = {
+    metadata: dict[str, Any] = {}
+    # FEATURE (OME-1120): the caller's trace id, echoed so a JSON caller can quote it.
+    # WHY at the `_aigw` TOP level and not inside `usage_accounting`: the trace is not an
+    # accounting fact, and `usage_accounting.schema.json` fixes that object's required keys —
+    # putting it there would change a published schema for a field that has nothing to do with
+    # usage. Streaming callers read the same value from the response header instead.
+    if trace_id is not None:
+        metadata["trace_id"] = trace_id
+    metadata |= {
         "usage_accounting": {
             "schema": SCHEMA_USAGE_ACCOUNTING,
             "capture_status": capture_status,

--- a/apps/aigateway/src/aigateway/plugins/taxonomy/session.py
+++ b/apps/aigateway/src/aigateway/plugins/taxonomy/session.py
@@ -25,7 +25,7 @@ from typing import Any, Final, Literal
 from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from aigateway.call_context import current_call_id, new_gateway_call_id
+from aigateway.call_context import current_call_id, current_trace_id, new_gateway_call_id
 
 from ...core.usage_accounting.hooks import AccountingAsyncHTTPHandler
 from ...core.usage_accounting.signals import bound_collector
@@ -320,6 +320,7 @@ def _metadata(
     cache_reference: CacheReference | None = None,
 ) -> dict[str, Any]:
     return render_aigw_metadata(
+        trace_id=current_trace_id(),
         collector=session.collector,
         supported=session.supported,
         cache_status=cache_status,

--- a/apps/aigateway/src/aigateway/plugins/taxonomy/usage_accounting.schema.json
+++ b/apps/aigateway/src/aigateway/plugins/taxonomy/usage_accounting.schema.json
@@ -7,7 +7,8 @@
   "required": ["usage_accounting", "request_economics"],
   "properties": {
     "usage_accounting": {"$ref": "#/$defs/usage_accounting"},
-    "request_economics": {"$ref": "#/$defs/request_economics"}
+    "request_economics": {"$ref": "#/$defs/request_economics"},
+    "trace_id": {"type": "string", "pattern": "^[0-9a-f]{32}$"}
   },
   "$defs": {
     "count": {

--- a/apps/aigateway/src/aigateway/w3c_trace.py
+++ b/apps/aigateway/src/aigateway/w3c_trace.py
@@ -1,0 +1,78 @@
+"""The W3C trace-context shape, as aigateway enforces it (OME-1120).
+
+INVARIANT: this rule must stay identical to `url4.streaming.trace` and to the regex
+`packages/screamingface` restates in `tests/e2e/test_correlation_chain.py`. All three services
+have to agree on what a valid traceparent is, or an id one accepts is dropped by the next hop
+and the correlation silently ends there.
+
+WHY it is copied rather than imported: `apps/aigateway` does not depend on `url4`, and a
+distribution dependency for a six-line regex would be the tail wagging the dog. The client made
+the same call in `OME-967`. The cost is a rule in three places; the mitigation is that each
+copy's rejection table is asserted, so a divergence fails a test rather than being adopted
+silently.
+
+SECURITY: the inbound header is CALLER-CONTROLLED. Adopting a malformed or attacker-chosen
+value would let a caller pick the correlation key that other requests are grouped under, so
+`adopt_or_mint_trace_id` replaces anything that does not parse. Never "clean up" a bad value
+into a usable one — mint instead.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+
+TRACE_ID_LEN = 32
+SPAN_ID_LEN = 16
+
+_TRACEPARENT_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$")
+"""Version `00` only, lowercase hex only — both deliberate.
+
+A future version prefix is not forward-compatible-by-guessing: `01` may carry different
+fields, and treating it as `00` would parse a value whose meaning we do not know. Uppercase is
+rejected because the W3C spec fixes lowercase, and accepting both would make two spellings of
+one id that never match as strings.
+"""
+
+_ALL_ZERO_TRACE = "0" * TRACE_ID_LEN
+_ALL_ZERO_SPAN = "0" * SPAN_ID_LEN
+
+
+def parse_trace_id(value: str | None) -> str | None:
+    """The 32-hex trace id inside a well-formed traceparent, or None.
+
+    The two all-zero rejections are not pedantry: the spec defines them as invalid precisely
+    because they are what a broken or lazy implementation emits, and an all-zero id would
+    happily group every such request together under one meaningless key.
+    """
+    if not value:
+        return None
+    match = _TRACEPARENT_RE.match(value)
+    if match is None or match.group(1) == _ALL_ZERO_TRACE or match.group(2) == _ALL_ZERO_SPAN:
+        return None
+    return match.group(1)
+
+
+def new_trace_id() -> str:
+    """A fresh 128-bit trace id."""
+    return secrets.token_hex(TRACE_ID_LEN // 2)
+
+
+def adopt_or_mint_trace_id(value: str | None) -> str:
+    """Join the caller's trace when it is well-formed; otherwise start our own.
+
+    INVARIANT: never returns the input when the input did not parse, and never returns None.
+    Returning the input would let a caller choose the key; returning None would leave the
+    request anonymous — and an anonymous request in the gateway is exactly the state this
+    phase exists to remove.
+    """
+    return parse_trace_id(value) or new_trace_id()
+
+
+__all__ = [
+    "SPAN_ID_LEN",
+    "TRACE_ID_LEN",
+    "adopt_or_mint_trace_id",
+    "new_trace_id",
+    "parse_trace_id",
+]

--- a/apps/aigateway/tests/unit/test_trace_context.py
+++ b/apps/aigateway/tests/unit/test_trace_context.py
@@ -1,0 +1,239 @@
+"""The caller's trace id joins aigateway's log context (OME-1120) — rung 4b, the payoff rung.
+
+`OME-1119` put the client's trace id on the wire to this gateway; `OME-938` gave it a
+per-request log context and a render slot. This joins them, so one id is greppable across the
+engine's namespace and `sf-aigw` — which IS Phase 1's acceptance.
+
+The property that matters most here is not the happy path. **The header is caller-controlled.**
+Adopting a malformed or attacker-chosen value would hand a caller the correlation key for other
+people's requests, so the nine-case rejection table below is the real subject of this file.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from aigateway import logs
+from aigateway.call_context import (
+    call_scope,
+    current_trace_id,
+    install_call_context_injection,
+    record_trace_id,
+)
+from aigateway.w3c_trace import TRACE_ID_LEN, adopt_or_mint_trace_id, parse_trace_id
+
+CALL_ID = "call_" + "a" * 32
+INBOUND_TRACE = "4bf92f3577b34da6a3ce929d0e0e4736"
+INBOUND = f"00-{INBOUND_TRACE}-00f067aa0ba902b7-01"
+
+
+@pytest.fixture(autouse=True)
+def _restore_log_record_factory():
+    original = logging.getLogRecordFactory()
+    try:
+        yield
+    finally:
+        logging.setLogRecordFactory(original)
+
+
+def _record() -> logging.LogRecord:
+    return logging.getLogRecordFactory()(
+        "aigateway.test", logging.INFO, __file__, 1, "a message", (), None
+    )
+
+
+# --- the rejection table — the security surface ---------------------------------------------
+
+REJECTED = [
+    pytest.param("00-" + "0" * 32 + "-00f067aa0ba902b7-01", id="all-zero-trace"),
+    pytest.param(f"00-{INBOUND_TRACE}-" + "0" * 16 + "-01", id="all-zero-span"),
+    pytest.param(f"01-{INBOUND_TRACE}-00f067aa0ba902b7-01", id="version-01"),
+    pytest.param(f"00-{INBOUND_TRACE.upper()}-00f067aa0ba902b7-01", id="uppercase-hex"),
+    pytest.param("", id="empty"),
+    pytest.param("not-a-traceparent", id="garbage"),
+    pytest.param(f"00-{INBOUND_TRACE}-00f067aa0ba902b7", id="missing-flags"),
+    pytest.param("00-abc-00f067aa0ba902b7-01", id="short-trace-id"),
+    pytest.param(f"00-{INBOUND_TRACE}-00f067-01", id="short-span-id"),
+]
+"""The nine shapes the engine rejects, restated rather than imported.
+
+`apps/aigateway` does not depend on `url4`, so this table IS the contract between the two
+services. Restating it means a change to url4's rule that widened what counts as valid would
+surface here as a failure rather than be adopted silently.
+"""
+
+
+@pytest.mark.parametrize("value", REJECTED)
+def test_a_malformed_traceparent_is_never_adopted(value: str) -> None:
+    assert parse_trace_id(value) is None
+
+
+@pytest.mark.parametrize("value", REJECTED)
+def test_a_malformed_traceparent_yields_a_fresh_id_not_the_input(value: str) -> None:
+    """Rejecting is half of it. The request still needs an id, and it must not be the caller's.
+
+    Returning None here would leave the request anonymous; returning the input would let a
+    caller pick the correlation key. Neither is acceptable, so the rule is adopt-or-MINT.
+    """
+    minted = adopt_or_mint_trace_id(value)
+
+    assert len(minted) == TRACE_ID_LEN
+    assert set(minted) <= set("0123456789abcdef")
+    assert minted != "0" * TRACE_ID_LEN
+    assert minted not in value
+
+
+def test_a_valid_traceparent_is_adopted_verbatim() -> None:
+    """The whole point: the gateway must join the CALLER's trace, not start its own."""
+    assert parse_trace_id(INBOUND) == INBOUND_TRACE
+    assert adopt_or_mint_trace_id(INBOUND) == INBOUND_TRACE
+
+
+def test_an_absent_header_yields_a_minted_id() -> None:
+    minted = adopt_or_mint_trace_id(None)
+
+    assert len(minted) == TRACE_ID_LEN
+    assert minted != "0" * TRACE_ID_LEN
+
+
+def test_two_mints_never_collide() -> None:
+    assert adopt_or_mint_trace_id(None) != adopt_or_mint_trace_id(None)
+
+
+# --- the scope and the record ----------------------------------------------------------------
+
+
+def test_outside_a_request_there_is_no_trace_id() -> None:
+    assert current_trace_id() is None
+
+
+def test_the_scope_carries_both_ids_together() -> None:
+    with call_scope(CALL_ID, trace_id=INBOUND_TRACE):
+        assert current_trace_id() == INBOUND_TRACE
+    assert current_trace_id() is None
+
+
+def test_a_record_created_in_scope_carries_the_trace_id() -> None:
+    install_call_context_injection()
+
+    with call_scope(CALL_ID, trace_id=INBOUND_TRACE):
+        record = _record()
+
+    assert record_trace_id(record) == INBOUND_TRACE
+
+
+def test_a_record_outside_any_request_carries_no_trace_id() -> None:
+    install_call_context_injection()
+
+    assert record_trace_id(_record()) is None
+
+
+# --- rendering --------------------------------------------------------------------------------
+
+
+def test_the_line_carries_both_ids() -> None:
+    install_call_context_injection()
+    formatter = logging.Formatter(logs._FORMAT, defaults={"call_context": ""})
+    filt = logs.CallContextFilter()
+
+    with call_scope(CALL_ID, trace_id=INBOUND_TRACE):
+        record = _record()
+    filt.filter(record)
+    rendered = formatter.format(record)
+
+    assert f"gateway_call_id={CALL_ID}" in rendered
+    assert f"trace_id={INBOUND_TRACE}" in rendered
+
+
+def test_a_call_without_a_trace_renders_only_the_call_id() -> None:
+    """A request that somehow has no trace must not render `trace_id=` empty or zero.
+
+    An empty field parses as a value downstream; an all-zero id correlates nothing while
+    looking correct in every log it reaches.
+    """
+    install_call_context_injection()
+    filt = logs.CallContextFilter()
+
+    with call_scope(CALL_ID):
+        record = _record()
+    filt.filter(record)
+
+    assert "gateway_call_id=" in logs.rendered_context(record)
+    assert "trace_id=" not in logs.rendered_context(record)
+
+
+def test_a_line_outside_a_request_is_unchanged() -> None:
+    install_call_context_injection()
+    formatter = logging.Formatter(logs._FORMAT, defaults={"call_context": ""})
+    filt = logs.CallContextFilter()
+
+    record = _record()
+    filt.filter(record)
+
+    assert formatter.format(record) == "INFO:     aigateway.test a message"
+
+
+# --- through the real app: the wire, not the unit ---------------------------------------------
+
+
+def _app_client():
+    """A minimal real app, so the middleware is exercised where it actually runs."""
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
+
+    from aigateway.call_context import current_call_id, current_trace_id
+    from aigateway.middleware import CallIdMiddleware
+
+    app = FastAPI()
+    app.add_middleware(CallIdMiddleware)
+
+    @app.get("/probe")
+    def probe() -> dict[str, str | None]:
+        return {"trace_id": current_trace_id(), "gateway_call_id": current_call_id()}
+
+    return TestClient(app)
+
+
+def test_a_wellformed_inbound_trace_is_joined_end_to_end() -> None:
+    body = _app_client().get("/probe", headers={"traceparent": INBOUND}).json()
+
+    assert body["trace_id"] == INBOUND_TRACE, "the gateway started its own trace instead of joining"
+
+
+@pytest.mark.parametrize("value", REJECTED)
+def test_a_malformed_inbound_trace_never_reaches_the_request(value: str) -> None:
+    """The security property, asserted on the wire rather than on the helper."""
+    body = _app_client().get("/probe", headers={"traceparent": value}).json()
+
+    assert body["trace_id"] != value
+    assert len(body["trace_id"]) == TRACE_ID_LEN
+
+
+def test_every_response_echoes_the_trace_id_as_a_header() -> None:
+    """A STREAMING caller never sees a response body object — the header is its only channel."""
+    from aigateway.middleware.call_id import TRACE_RESPONSE_HEADER
+
+    response = _app_client().get("/probe", headers={"traceparent": INBOUND})
+
+    header = TRACE_RESPONSE_HEADER.decode()
+    assert response.headers[header] == INBOUND_TRACE
+    assert response.json()["trace_id"] == response.headers[header]
+
+
+def test_the_echo_does_not_drop_the_responses_own_headers() -> None:
+    """The header list is APPENDED to, never replaced — content-type must survive."""
+    response = _app_client().get("/probe", headers={"traceparent": INBOUND})
+
+    assert response.headers["content-type"].startswith("application/json")
+
+
+def test_two_requests_do_not_share_a_trace() -> None:
+    client = _app_client()
+
+    first = client.get("/probe", headers={"traceparent": INBOUND}).json()
+    second = client.get("/probe").json()
+
+    assert first["trace_id"] == INBOUND_TRACE
+    assert second["trace_id"] != first["trace_id"], "one caller's trace leaked into another's"

--- a/apps/aigateway/tests/unit/usage_accounting/test_chat_route_accounting.py
+++ b/apps/aigateway/tests/unit/usage_accounting/test_chat_route_accounting.py
@@ -191,7 +191,12 @@ class TestActivation:
             response = chat_client.post(_CHAT_PATH, json=_chat_body(), headers=_ACCOUNTING_HEADERS)
         assert response.status_code == 200, response.text
         metadata = _aigw(response)
-        assert set(metadata) == {"usage_accounting", "request_economics"}
+        # OME-1120 added `_aigw.trace_id` — the caller's W3C trace id, echoed so a JSON
+        # caller can quote it in a bug report. This assertion pins the EXACT key set on
+        # purpose, so a new key has to be a deliberate act; it is, and the published schema
+        # gained it too (optional, not required, so a payload from an older gateway still
+        # validates).
+        assert set(metadata) == {"usage_accounting", "request_economics", "trace_id"}
         assert metadata["usage_accounting"]["schema"] == "aigw.chat_usage_accounting"
         assert metadata["request_economics"]["schema"] == "aigw.request_economics"
 

--- a/docs/tasks/2026-09-10-OME-1120-gateway-joins-trace.md
+++ b/docs/tasks/2026-09-10-OME-1120-gateway-joins-trace.md
@@ -1,0 +1,30 @@
+---
+id: OME-1120
+linear_url: https://linear.app/openmined/issue/OME-1120/join-the-inbound-traceparent-to-aigateways-log-context-and-echo-it
+status: done
+type: null
+priority: 2
+labels: [aigateway, agentic, autonomous]
+created: 2026-09-10
+closed: 2026-09-10
+---
+
+# Join the inbound traceparent to aigateway's log context and echo it
+
+Rung 4b — the payoff rung, and the last one. With this, **all five ladder rungs pass**: one
+`trace_id` spans client → engine → gateway logs, which is Phase 1's local acceptance in full.
+
+Three things worth knowing before touching this area:
+
+- **The `traceparent` header is caller-controlled.** Adopting a malformed or attacker-chosen
+  value would let a caller pick the key other requests are grouped under, so anything that
+  does not parse is REPLACED, never cleaned up. Nine rejection cases are pinned in
+  `tests/unit/test_trace_context.py` — that table is the security half of this unit, and the
+  e2e rung does not cover it (the client always sends a well-formed header).
+- **The W3C rule is mirrored, not imported** — `apps/aigateway` has no `url4` dependency, so
+  the rule lives in three places. Each copy asserts its own rejection table so a divergence
+  fails a test.
+- **`_aigw.trace_id` is a published response-contract change.** The schema declares
+  `additionalProperties: false`; the field was added optional so older payloads still validate.
+
+Ledger: `docs/work/2026-09-10-OME-1120-gateway-joins-trace.md`

--- a/docs/work/2026-09-10-OME-1120-gateway-joins-trace.md
+++ b/docs/work/2026-09-10-OME-1120-gateway-joins-trace.md
@@ -1,0 +1,119 @@
+---
+ticket: OME-1120
+stack: aigateway
+status: done
+started: 2026-09-10
+finished: 2026-09-10
+---
+
+# OME-1120 — Join the inbound traceparent to aigateway's log context and echo it
+
+## Intent
+
+Rung 4b — the payoff rung, and the last one. `OME-1119` put the client's trace id on the wire
+to aigateway; `OME-938` gave aigateway a per-request log context and a `%(call_context)s`
+render slot. This joins the two: the inbound `traceparent` becomes a field on every aigateway
+log line, so one id is greppable across the engine's namespace and `sf-aigw`.
+
+That join IS Phase 1's acceptance (`docs/plan/2026-09-04-OME-1118-*` row 5). Nothing else is
+outstanding for the goal.
+
+## Design decisions
+
+**D1 — the W3C rule is mirrored locally, not imported.** `apps/aigateway` does not depend on
+`url4` and must not gain a distribution dependency for a 6-line regex. `packages/screamingface`
+made the same call in `OME-967`. The rule copied is url4's `_TRACEPARENT_RE` plus its two
+all-zero rejections, so all three services agree on what a valid traceparent is; the tests
+restate the rejection table rather than importing it, which is what makes a future divergence
+show up as a failure instead of being adopted silently.
+
+**D2 — the inbound header is UNTRUSTED input.** A caller controls it. Adopting a malformed or
+attacker-chosen value would hand the caller the correlation key for other people's requests.
+Invalid → mint a fresh id, the same restart rule the engine applies at its own edge. Nine
+rejection cases are pinned: all-zero trace, all-zero span, version `01`, uppercase hex, empty,
+absent, wrong field count, short trace id, short span id.
+
+**D3 — the id is bound in the SAME middleware that mints `gateway_call_id`.** One scope, one
+place, one lifetime. A second middleware would double the ordering questions
+(`add_middleware` inserts at 0, so the last registration is outermost — already a footgun
+commented in `main.py`) for no gain.
+
+**D4 — rendered through the existing `parts` list in `CallContextFilter`.** `OME-938` left that
+as a list with an AIDEV-NOTE saying this unit adds `trace_id` beside the call id. No new
+mechanism.
+
+**D5 — echoed in the response body under `_aigw`, and as a response header.** The body is how a
+JSON caller learns the id; the header is how a STREAMING caller learns it, since an SSE
+consumer never sees a body object. Both matter: the engine's model calls are streaming.
+
+## Out of scope, restated because the issue asks for it
+
+The issue says "emit it as a **field**, not inside a message string… this distinction decides
+whether the phase delivers a filter or a grep." With aigateway's plain-text formatter, a field
+on the record renders as `trace_id=<id>` inside the line — **full-text searchable in SigNoz,
+not a filterable attribute**. Making it a real attribute means JSON logs, which is a cross-app
+migration (engine + aigateway + scoreboard + collector config) deliberately excluded from
+`OME-938` for the same reason. This unit delivers the phase's stated payoff — "one trace_id
+greppable across every pod's logs" — and the ceiling stays a recorded decision.
+
+## Planned changes
+
+- `src/aigateway/w3c_trace.py` (new) — the shape rule, mirrored from url4.
+- `src/aigateway/call_context.py` — a `trace_id` alongside the call id in the same scope.
+- `src/aigateway/logs.py` — render `trace_id=` in `CallContextFilter`'s parts.
+- `src/aigateway/middleware/call_id.py` — read, validate, adopt-or-mint, bind; echo the header.
+- `src/aigateway/plugins/taxonomy/render.py` — `trace_id` in the `_aigw` subtree.
+- Tests as below.
+
+## Test plan
+
+RED first:
+
+- The inbound trace id appears on **every** log line of that request, beside the call id.
+- **The nine-case rejection table**: each malformed value is replaced by a freshly minted id,
+  never adopted and never propagated verbatim.
+- A caller cannot displace another request's id — two concurrent requests keep their own.
+- Absent header → a minted id, not a missing field and not an all-zero one.
+- The response body's `_aigw.trace_id` equals the id on the log lines.
+- A streaming response carries the id as a header.
+- Rung 4b flips green; **its strict xfail marker is deleted in this PR**.
+
+## Acceptance
+
+- One id spans client → engine → gateway logs; all five ladder rungs green.
+- `run_gates.py aigateway` green incl. the auth-surface coverage job.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** as planned, plus the published schema — `w3c_trace.py` (new),
+  `call_context.py`, `logs.py`, `middleware/call_id.py`, `plugins/taxonomy/render.py`,
+  `plugins/taxonomy/session.py`, `usage_accounting.schema.json`,
+  `tests/unit/test_trace_context.py` (41 tests), one prior test, and the ladder.
+- **Commits:** `feat(aigateway): join the inbound traceparent to the log context` (sha at
+  squash-merge).
+- **Gates:** `run_gates.py aigateway --skip-append-only` — **ALL GREEN**: **4208 passed**.
+  `run_gates.py screamingface --skip-append-only` — **ALL GREEN**.
+  **The ladder: 5 passed, 0 xfailed — every rung green, Phase 1's local acceptance in full.**
+- **Deviations:**
+  - **A published JSON schema changed, which is more than a test edit.**
+    `usage_accounting.schema.json` (`$id: https://screamingface.ai/schemas/aigw-usage-accounting.json`)
+    declares `"additionalProperties": false`, so echoing `_aigw.trace_id` — which the issue
+    asks for explicitly — is a **public response-contract change**. Added to `properties` but
+    deliberately NOT to `required`, so a payload from an older gateway still validates.
+    `test_the_legacy_header_does_not_change_accounting` pins the exact top-level key set on
+    purpose, precisely so a new key has to be deliberate; it was updated to match.
+  - **`trace_id` sits at the `_aigw` TOP level, not inside `usage_accounting`.** The trace is
+    not an accounting fact, and that object's schema fixes its required keys — putting it there
+    would change a published sub-schema for a field unrelated to usage.
+  - **A response HEADER was added alongside the body field** (`x-aigw-trace-id`). The issue
+    asks for it and the reason is load-bearing: an SSE consumer never sees a response body
+    object, and streaming is most of what this gateway serves — so the body field alone would
+    leave the majority of callers unable to read their own trace id.
+  - **The rejection table is restated, not imported.** `apps/aigateway` has no `url4`
+    dependency, so the W3C rule now lives in three places (url4, the client's ladder regex,
+    here). Each copy asserts its own rejection table, which is what makes a future divergence
+    fail a test rather than be adopted silently.
+  - `logs.rendered_context()` was added as a typed accessor for the same reason `OME-938` added
+    `record_call_id` — `LogRecord` has no such attribute in its type, so a direct read is a
+    pyright error at every site. No `type: ignore` was used.
+  - Ladder counts: tests 5 → 5, assertions 15 → 15, xfail markers 6 → 4 (the last two).

--- a/packages/screamingface/tests/e2e/test_correlation_chain.py
+++ b/packages/screamingface/tests/e2e/test_correlation_chain.py
@@ -312,15 +312,20 @@ def test_rung3_every_gateway_log_line_carries_a_call_id(gateway_log) -> None:
 
 
 @pytest.mark.e2e
-@pytest.mark.xfail(strict=True, reason="rung 4b: aigateway does not join the inbound trace")
 def test_rung4b_the_gateway_logs_this_runs_trace_id(gateway_log) -> None:
-    """RUNG 4, gateway half (not built — strict xfail).
+    """RUNG 4, gateway half (`OME-1120` — must PASS). THE PAYOFF RUNG.
 
-    The payoff rung: once this and its engine twin pass, one id is greppable across both
-    services and a bug report's `trace_id` finally points at something.
+    With this and its engine twin (`OME-940`) green, one id is greppable across both services
+    and a bug report's `trace_id` finally points at something. All five rungs now pass, which
+    is Phase 1's local acceptance in full.
 
     It asserts THIS run's id, not merely that some 32-hex token appears — a log full of
     unrelated hex would satisfy the weaker check while joining nothing.
+
+    AIDEV-NOTE: this rung proves the id ARRIVES and is logged. It cannot prove the gateway
+    rejects a hostile one, because the client always sends a well-formed traceparent. The
+    nine-case rejection table lives in `apps/aigateway/tests/unit/test_trace_context.py` —
+    that is the security half, and it is not covered here.
     """
     trace_ids = gateway_log["trace_ids"]
     assert trace_ids, "the run emitted no trace id to look for"


### PR DESCRIPTION
Rung 4b — **the payoff rung, and the last one.**

## The ladder is now fully green

```
rung 1  trace id reachable from the public API   GREEN   OME-1121
rung 2  engine -> gateway header                 GREEN   OME-1119
rung 3  gateway_call_id on every line            GREEN   OME-938
rung 4a engine logs the trace id                 GREEN   OME-940
rung 4b gateway logs THIS run's trace id         GREEN   OME-1120  <- this PR
```

**`5 passed, 0 xfailed`** against the real engine and a real aigateway subprocess. That is Phase 1's local acceptance in full: one `trace_id` spans client → engine → gateway logs.

## The change

The inbound `traceparent` is read, validated, and joined to the per-request log context `OME-938` established — rendered through the `parts` list that PR deliberately left open for it. No new mechanism.

## The part that actually matters: the header is caller-controlled

Adopting a malformed or attacker-chosen value would let a caller pick the correlation key that **other people's requests** are grouped under. So anything that does not parse is **replaced**, never cleaned up.

Nine rejection cases are pinned, twice — once against the helper and once **on the wire through the real app**:

`all-zero-trace` · `all-zero-span` · `version-01` · `uppercase-hex` · `empty` · `garbage` · `missing-flags` · `short-trace-id` · `short-span-id`

Worth stating plainly: **the e2e rung does not cover this.** The client always sends a well-formed traceparent, so rung 4b proves the id arrives and is logged, and proves nothing about hostile input. The table in `tests/unit/test_trace_context.py` is the security half.

## A published schema changed — flagging it explicitly

`usage_accounting.schema.json` (`$id: https://screamingface.ai/schemas/aigw-usage-accounting.json`) declares `"additionalProperties": false`. Echoing `_aigw.trace_id` — which the issue asks for by name — is therefore a **public response-contract change**, not just a test edit.

- Added to `properties`, deliberately **not** to `required`, so a payload from an older gateway still validates.
- Placed at the `_aigw` **top level**, not inside `usage_accounting`: the trace is not an accounting fact, and that object's schema fixes its required keys.
- `test_the_legacy_header_does_not_change_accounting` pins the exact top-level key set on purpose — precisely so a new key must be deliberate. Updated to match.

## A response header too, and why it is not redundant

`x-aigw-trace-id` on every response. An **SSE consumer never sees a response body object**, and streaming is most of what this gateway serves — the body field alone would leave the majority of callers unable to read their own trace id. The header list is appended to, never replaced, and a test pins that `content-type` survives.

## Test plan

- `run_gates.py aigateway --skip-append-only` — **ALL GREEN**: **4208 passed**.
- `run_gates.py screamingface --skip-append-only` — **ALL GREEN**.
- The ladder: **5 passed, 0 xfailed**.

41 new tests, including both ends of every rejection case, cross-request isolation, and the `_aigw` / header / log-line agreement.

## One prior test changed

`test_the_legacy_header_does_not_change_accounting` — the exact-key-set assertion above. Ladder counts: tests 5 -> 5, assertions 15 -> 15, xfail markers 6 -> 4 (the last two).

## The ceiling, restated

The issue asks for a **field, not a message string**, because "this distinction decides whether the phase delivers a filter or a grep." With aigateway's plain-text formatter, the field renders as `trace_id=<id>` **inside the line** — full-text searchable in SigNoz, not a filterable attribute. Making it a real attribute means JSON logs: a cross-app migration (engine + aigateway + scoreboard + collector config), excluded from `OME-938` for the same reason.

This delivers the phase's stated payoff — *"one trace_id greppable across every pod's logs with zero new infrastructure"* — and the ceiling stays a recorded decision rather than a surprise.

Refs: OME-1120
