### PR TITLE
feat(engine): export a run's span frames to OTLP

### DIFF
--- a/apps/screamingface-engine/pyproject.toml
+++ b/apps/screamingface-engine/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "immutabledict>=4.2.0",
     "langdetect>=1.0.9",
     "nltk>=3.9.1",
+    "opentelemetry-sdk>=1.30.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0",
 ]
 
 [project.scripts]

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -34,7 +34,9 @@ from screamingface_engine.runner.executor import Url4Executor, World, deny_by_de
 from screamingface_engine.runner.fair_share import FairShareGate, FairShareIOLayer
 from screamingface_engine.runner.operation_capture import OperationCapturingExecutor
 from screamingface_engine.runner.summary import RunSummary
+from screamingface_engine.tracing.relay import SpanRelay, SpanSink, otlp_configured
 from screamingface_engine.world_config import WorldConfig, WorldConfigError, load_config
+from url4.streaming.interfaces import EventPublisher
 from url4.streaming.lifecycle import run
 from url4.streaming.protocol import CachePolicy
 from url4.streaming.trace import parse_traceparent
@@ -351,6 +353,31 @@ def build_executor(
     )
 
 
+def span_sink(env: Mapping[str, str]) -> SpanSink | None:
+    """The run's span sink, or ``None`` when this deployment configured no OTLP endpoint.
+
+    WHY the import is LAZY. `tracing.otlp` pulls the OTel SDK, protobuf and `requests` —
+    measured at ~62 ms of this module's ~227 ms import time, which every Job would otherwise
+    pay whether or not it exports anything. `check_layering.py` protects a Job's cold start
+    from the engine's OWN modules; nothing protects it from a third-party dependency, so this
+    is the same discipline applied by hand. `cli.py` and `worker_composition` import their
+    heavy halves the same way, for the same reason.
+
+    INVARIANT: never raises. A broken exporter config must not stop a run from happening — the
+    whole point of the relay is that telemetry degrades alone. An unreachable collector is
+    already handled downstream (the exporter drops); this covers the boot-time half.
+    """
+    if not otlp_configured(env):
+        return None
+    try:
+        from screamingface_engine.tracing.otlp import sink_from_env
+
+        return sink_from_env(env)
+    except Exception:
+        logger.warning("span export is configured but could not be started", exc_info=True)
+        return None
+
+
 def _cache_stated(policy: CachePolicy) -> str:
     """Whether a run's cache policy stated anything — 'stated' or 'not-stated'.
 
@@ -461,7 +488,7 @@ def _log_terminal(executor: _SummarizingExecutor, topic: str, started: float) ->
 
 async def _run_and_log(
     executor: OperationCapturingExecutor,
-    publisher: JetStreamPublisher,
+    publisher: EventPublisher,
     params: RunnerParams,
     traceparent: str | None,
 ) -> None:
@@ -497,11 +524,24 @@ def main() -> None:  # pragma: no cover - real NATS + event loop (INFRA rule)
         # the executor records and the summary line reports). Bound for the whole run so
         # every process log line inside it carries topic and trace id.
         trace_id = parse_traceparent(traceparent)
-        with run_scope(params.topic, trace_id):
+        # FEATURE (OME-1130): the run's spans, exported to a tracing backend so SigNoz shows a
+        # WATERFALL instead of a log search. The relay wraps the run's own publisher — the one
+        # path every frame of every run travels, attached client or not — and is a pure
+        # passthrough when no OTLP endpoint is configured, which is the default everywhere.
+        #
+        # `with`, not a hand-written `finally`: this process is short-lived, and an unflushed
+        # batch loses the tail of every trace including its root span. See `tracing.relay`.
+        #
+        # `run_and_reclaim` keeps the RAW publisher: it needs `delete_stream`, which is
+        # JetStream's, not the wire port's — the relay only stands where frames are published.
+        with (
+            run_scope(params.topic, trace_id),
+            SpanRelay(publisher, span_sink(os.environ)) as relay,
+        ):
             await run_and_reclaim(
                 publisher,
                 params.topic,
-                lambda: _run_and_log(executor, publisher, params, traceparent),
+                lambda: _run_and_log(executor, relay, params, traceparent),
                 grace_s=stream_grace_s(os.environ),
             )
 

--- a/apps/screamingface-engine/src/screamingface_engine/tracing/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/tracing/__init__.py
@@ -1,0 +1,12 @@
+"""Turning a run's frame stream into spans (OME-1130, Phase 2).
+
+INVARIANT: `span_tree` is PURE — standard library only, no OTel, no network. The OTel
+dependency lives in the sink beside it and nowhere else, because
+`packages/url4/tests/unit/test_import_isolation.py` forbids `opentelemetry` anywhere reachable
+from `import url4` and checks it in a clean subprocess. Keeping the semantics separate from the
+transport is also what lets the risky half change without re-testing the meaning.
+"""
+
+from .span_tree import Span, SpanTree, build_span_tree
+
+__all__ = ["Span", "SpanTree", "build_span_tree"]

--- a/apps/screamingface-engine/src/screamingface_engine/tracing/__init__.py
+++ b/apps/screamingface-engine/src/screamingface_engine/tracing/__init__.py
@@ -5,8 +5,23 @@ dependency lives in the sink beside it and nowhere else, because
 `packages/url4/tests/unit/test_import_isolation.py` forbids `opentelemetry` anywhere reachable
 from `import url4` and checks it in a clean subprocess. Keeping the semantics separate from the
 transport is also what lets the risky half change without re-testing the meaning.
+
+AIDEV-NOTE — DO NOT re-export from `.otlp` here. This package is imported by
+`runner/main.py`, and `otlp` pulls the OTel SDK, protobuf and `requests` (~62 ms of a Job's
+~227 ms import budget). Importing it from this `__init__` would re-introduce that cost on every
+run while looking like tidy-up, and would silently undo the lazy import in `main.span_sink`.
+`tests/unit/test_span_export_wiring.py` fails if it happens.
 """
 
-from .span_tree import Span, SpanTree, build_span_tree
+from .relay import SpanRelay, SpanSink, otlp_configured
+from .span_tree import Span, SpanTree, build_span_tree, span_from_frame
 
-__all__ = ["Span", "SpanTree", "build_span_tree"]
+__all__ = [
+    "Span",
+    "SpanRelay",
+    "SpanSink",
+    "SpanTree",
+    "build_span_tree",
+    "otlp_configured",
+    "span_from_frame",
+]

--- a/apps/screamingface-engine/src/screamingface_engine/tracing/otlp.py
+++ b/apps/screamingface-engine/src/screamingface_engine/tracing/otlp.py
@@ -1,0 +1,159 @@
+"""The OTLP adapter: a mapped :class:`Span` becomes a real OTel span (OME-1130).
+
+THE ONLY MODULE IN THE ENGINE THAT IMPORTS `opentelemetry`. The port is
+:class:`screamingface_engine.tracing.relay.SpanSink`; keeping the import here is what lets the
+relay's whole behaviour be tested with no OTel, no collector and no network, and what keeps a
+transport change from re-opening the semantics (ledger D1, D8).
+
+WHY spans are built by hand rather than through `tracer.start_span`. The normal SDK path MINTS
+ids and takes the parent from the ambient context. Here both are already decided: the run
+minted them, the wire published them, the aigateway logged them in Phase 1, and a client is
+holding the trace id from its report. Re-minting would produce a technically valid trace that
+correlates with nothing anybody has. `ReadableSpan` + `SpanProcessor.on_end` is the documented
+seam for exactly this — a bridge from another tracing system — and it is what the OTLP encoder
+consumes.
+
+WHY `BatchSpanProcessor` and not a direct `exporter.export(...)`. Export must never fail or slow
+a run (ledger D4). The batch processor already owns the hard parts: a background thread, a
+bounded queue that DROPS rather than blocks when the collector is slow, and a `force_flush`
+/`shutdown` pair. Reimplementing that here would be strictly worse code with the same bugs.
+
+CONFIGURED THE STANDARD WAY (ledger D9). The endpoint, headers and resource all come from
+OTel's own env contract — `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
+`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES` — rather than a vocabulary invented here. That
+is deliberate: it makes `OME-1131` a matter of setting standard variables in the chart, with no
+new credential scheme to design, and it means an operator's existing OTel knowledge transfers.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from datetime import datetime
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+from opentelemetry.trace import SpanContext, SpanKind, TraceFlags
+from opentelemetry.trace.status import Status, StatusCode
+
+from screamingface_engine.tracing.relay import otlp_configured
+from screamingface_engine.tracing.span_tree import Span
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SERVICE_NAME = "screamingface-engine"
+"""Used only when the deployment sets no `OTEL_SERVICE_NAME`. A service that reports itself as
+OTel's default `unknown_service` is indistinguishable from every other unconfigured service in
+the backend, which defeats the point of shipping the spans at all."""
+
+_OK_STATUSES = frozenset({"ok", "succeeded"})
+"""The non-error vocabulary from BOTH wire types: `SpanData.status` says `ok`,
+`TerminatedData.status` says `succeeded`, and this adapter receives spans carrying either
+(see :class:`Span`)."""
+
+_KINDS = {"client": SpanKind.CLIENT, "internal": SpanKind.INTERNAL, "server": SpanKind.SERVER}
+
+_SCOPE = InstrumentationScope("screamingface_engine.tracing", "1")
+
+
+class OtlpSpanSink:
+    """Feeds mapped spans to an OTel `SpanProcessor`.
+
+    The processor is injected rather than built here so tests can drive the REAL SDK path with
+    an in-memory exporter; :func:`sink_from_env` is the production constructor.
+    """
+
+    def __init__(self, processor: SpanProcessor, resource: Resource | None = None) -> None:
+        self._processor = processor
+        self._resource = resource if resource is not None else Resource.create()
+
+    def emit(self, span: Span) -> None:
+        self._processor.on_end(_readable(span, self._resource))
+
+    def close(self) -> None:
+        """Flush what is queued, then stop the exporter's thread.
+
+        `force_flush` before `shutdown` is the load-bearing order: the run process exits
+        immediately after this, and whatever is still queued would otherwise be dropped —
+        starting with the root span, which is emitted last (ledger D10).
+        """
+        self._processor.force_flush()
+        self._processor.shutdown()
+
+
+def sink_from_env(env: Mapping[str, str]) -> OtlpSpanSink | None:
+    """The run's span sink, or ``None`` when no OTLP endpoint is configured.
+
+    ``None`` is the default state everywhere — local runs, tests, and any deployment
+    `OME-1131` has not reached — so the feature is off by construction rather than by a flag
+    someone has to remember to unset (ledger D9).
+
+    The "is it configured" predicate lives in the PORT module, not here, because the
+    composition root must answer it without importing this one — see :func:`otlp_configured`.
+    """
+    if not otlp_configured(env):
+        return None
+    resource = Resource.create(
+        {"service.name": env.get("OTEL_SERVICE_NAME") or DEFAULT_SERVICE_NAME}
+    )
+    logger.info("otlp span export enabled service=%s", resource.attributes.get("service.name"))
+    return OtlpSpanSink(BatchSpanProcessor(OTLPSpanExporter()), resource)
+
+
+def _readable(span: Span, resource: Resource) -> ReadableSpan:
+    """One domain span -> one `ReadableSpan` the OTLP encoder accepts."""
+    context = _context(span.trace_id, span.span_id)
+    parent = _context(span.trace_id, span.parent_span_id) if span.parent_span_id else None
+    return ReadableSpan(
+        name=span.name,
+        context=context,
+        parent=parent,
+        resource=resource,
+        attributes={"gen_ai.operation.name": span.operation, **span.attributes},
+        kind=_KINDS.get(span.kind, SpanKind.INTERNAL),
+        status=_status(span.status),
+        start_time=_nanos(span.start_time),
+        end_time=_nanos(span.end_time) if span.end_time is not None else None,
+        instrumentation_scope=_SCOPE,
+    )
+
+
+def _context(trace_id: str, span_id: str) -> SpanContext:
+    """A span context from the WIRE's hex ids.
+
+    INVARIANT: `TraceFlags.SAMPLED` must be set. `BatchSpanProcessor.on_end` opens with
+    `if not (span.context and span.context.trace_flags.sampled): return` — an unsampled span is
+    dropped by the SDK silently, with no error raised and nothing logged, which presents as
+    "the exporter runs and the backend stays empty". `url4.streaming.trace` hardcodes
+    `_SAMPLED = "01"`, so every run is nominally sampled and this is faithful, not a shortcut.
+    """
+    return SpanContext(
+        trace_id=int(trace_id, 16),
+        span_id=int(span_id, 16),
+        is_remote=False,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+
+
+def _status(status: str) -> Status:
+    """Wire status -> OTel status, keeping the VERBATIM reason on the way through.
+
+    OTel has one non-OK code and the wire has three non-OK run outcomes (`failed`, `stopped`,
+    `timed_out`). Flattening them would erase the only place a stopped run is still
+    distinguishable from a failed one — `cancelled` is collapsed to `error` before a node span
+    is ever published, so the root's description is where that survives (ledger D7).
+    """
+    if status in _OK_STATUSES:
+        return Status(StatusCode.OK)
+    return Status(StatusCode.ERROR, description=status)
+
+
+def _nanos(when: datetime) -> int:
+    """OTel timestamps are integer nanoseconds since the epoch."""
+    return int(when.timestamp() * 1_000_000_000)
+
+
+__all__ = ["DEFAULT_SERVICE_NAME", "OtlpSpanSink", "sink_from_env"]

--- a/apps/screamingface-engine/src/screamingface_engine/tracing/relay.py
+++ b/apps/screamingface-engine/src/screamingface_engine/tracing/relay.py
@@ -1,0 +1,234 @@
+"""The publisher proxy that ships a run's spans to a tracing backend (OME-1130).
+
+MOUNT POINT. `OME-1130` specifies "the engine control-plane relay, never the runner". That
+subscription does not exist: `stream_for(topic)` creates ONE JetStream stream per run, so
+nothing in the control plane sees all runs — only `ws/bridge.py` subscribes, and only for runs
+somebody is watching. Exporting from there would reproduce the "absent because not exercised"
+ambiguity that cost a real diagnosis in `OME-940`. The owner resolved the fork in favour of a
+PUBLISHER PROXY: the run's own publisher, wrapped, which sees every frame of every run whether
+or not a client is attached.
+
+INVARIANT — THE RELAY MAY NEVER FAIL OR ALTER A RUN. It sits on the one path every frame
+travels, so a downed collector, an unmapped frame, or a bug in this module must degrade
+telemetry and nothing else. Every call into the sink is therefore wrapped, and the frame
+reaches the inner publisher whatever happened. `Exception` is caught deliberately broadly here:
+the specific-exceptions rule exists so failures surface, and this is the one place where a
+surfaced failure is strictly worse than a swallowed one — the alternative to swallowing is
+turning a telemetry outage into a fleet of failed runs.
+
+LAYERING: this module defines the PORT (:class:`SpanSink`) and imports no transport. The OTel
+adapter lives in :mod:`screamingface_engine.tracing.otlp` and is wired by the composition root,
+so the engine's `opentelemetry` import stays confined to one module and the relay's whole
+behaviour is testable with a fake.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Protocol
+
+from screamingface_engine.tracing.span_tree import Span, identity_of, span_from_frame
+from url4.streaming.interfaces import EventPublisher
+from url4.streaming.protocol import OutboundFrame, SpanEvent, StartedEvent, TerminatedEvent
+
+logger = logging.getLogger(__name__)
+
+ROOT_SPAN_NAME = "url4.run"
+"""The synthetic root's span name — what an operator sees at the top of the waterfall."""
+
+OTLP_ENDPOINT_VARS = ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT")
+"""Both halves of OTel's endpoint contract. Reading only the generic one would leave a
+deployment that configured just the signal-specific variable silently un-traced — a failure
+that produces no error anywhere."""
+
+
+def otlp_configured(env: Mapping[str, str]) -> bool:
+    """Whether a deployment has asked for span export at all.
+
+    Lives HERE, in the port module, rather than in the adapter — because the composition root
+    must answer it WITHOUT importing the adapter. `tracing.otlp` pulls the OTel SDK, protobuf
+    and `requests`: measured at ~62 ms of a Job's ~227 ms import budget, paid on every run
+    including the overwhelming majority that export nothing. `check_layering.py` exists to keep
+    a Job's cold start at "the engine + httpx + nats-py"; it checks engine submodules and would
+    not have caught a third-party regression of the same shape.
+
+    A blank value counts as unset: a chart rendering `OTEL_EXPORTER_OTLP_ENDPOINT: ""` for an
+    unconfigured environment must read as "off", not as "export to the empty string".
+    """
+    return any(env.get(name, "").strip() for name in OTLP_ENDPOINT_VARS)
+
+
+class SpanSink(Protocol):
+    """Where mapped spans go. The port; :mod:`.otlp` is the only adapter that exists."""
+
+    def emit(self, span: Span) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class SpanRelay(EventPublisher):
+    """Wraps a publisher to export the run's spans, without changing what is published.
+
+    A transparent proxy in the same sense as `run_evidence.TerminalWatch`: every method
+    forwards, and the observation is a side effect that cannot be observed by the run.
+
+    `sink` is ``None`` when no OTLP endpoint is configured, which is the default everywhere
+    (local runs, tests, any deployment `OME-1131` has not reached). In that state the relay is
+    a pure passthrough — the feature is off by construction rather than by a flag someone must
+    remember to unset.
+    """
+
+    def __init__(self, inner: EventPublisher, sink: SpanSink | None) -> None:
+        self._inner = inner
+        self._sink = sink
+        self._trace_id: str | None = None
+        self._root_span_id: str | None = None
+        self._started_at: datetime | None = None
+        self._closed = False
+        self.undecodable = 0
+        """Frames whose `traceparent` stated no usable identity — counted, never invented."""
+        self.unfinished = 0
+        """Spans with no end. OTLP has no way to say "still running" (ledger D11)."""
+
+    def __enter__(self) -> SpanRelay:
+        """Use the relay as a context manager so :meth:`close` cannot be forgotten.
+
+        D10's flush is mandatory and its absence is SILENT — every trace simply loses its
+        ending. A hand-written `finally` at the composition root would work exactly as well
+        right up until somebody edits that function; `with` is the version the language
+        enforces.
+        """
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.shutdown()
+
+    async def ensure_stream(self, topic: str) -> None:
+        await self._inner.ensure_stream(topic)
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None:
+        if self._sink is not None:
+            self._observe(topic, event)
+        await self._inner.publish(topic, event)
+
+    async def flush(self) -> None:
+        await self._inner.flush()
+
+    async def close(self) -> None:
+        """The WIRE port's close — forwarded, like every other method on the proxy.
+
+        Distinct from :meth:`shutdown`, which is the sink's. They are deliberately not merged:
+        this one is `async` and belongs to `EventPublisher`, and a transparent proxy that
+        quietly stopped forwarding it would leave the inner publisher's transport open.
+
+        AIDEV-NOTE: the base declares this NON-abstract and `async`, so a sync override
+        type-checks in Python and only fails at the `await` — at teardown, in production, on a
+        path that runs when something is already going wrong. Pyright caught exactly that here.
+        """
+        await self._inner.close()
+
+    def shutdown(self) -> None:
+        """Flush and shut the SINK down. Idempotent, and safe to call from a ``finally``.
+
+        MANDATORY, not a nicety (ledger D10): the run process is short-lived, and a batching
+        exporter drops whatever is still queued at exit — which is the tail of every trace,
+        including the root span, since the root is by definition emitted last. Losing it looks
+        like "tracing works" while every run is missing its ending.
+        """
+        if self._closed or self._sink is None:
+            return
+        self._closed = True
+        try:
+            self._sink.close()
+        except Exception:
+            logger.warning("the span sink did not shut down cleanly", exc_info=True)
+
+    # --- observation ---------------------------------------------------------------------
+
+    def _observe(self, topic: str, event: OutboundFrame) -> None:
+        """Map one frame and offer it to the sink. INVARIANT: never raises."""
+        try:
+            if isinstance(event, StartedEvent):
+                self._open_root(event)
+            elif isinstance(event, SpanEvent):
+                self._node(event)
+            elif isinstance(event, TerminatedEvent):
+                self._close_root(topic, event)
+        except Exception:
+            # The run is worth more than its telemetry. See the module INVARIANT.
+            logger.warning("could not export a span for topic %s", topic, exc_info=True)
+
+    def _open_root(self, event: StartedEvent) -> None:
+        """Learn the run's identity from the frame that states it.
+
+        `lifecycle._trace_fields` publishes run-level frames under
+        `format_traceparent(trace_id, root_span_id)`, so the `Started` envelope carries the
+        root's span id — the id every `url4.parent=` and every Phase 1 gateway `traceparent`
+        already references, and which no `SpanEvent` ever carries.
+        """
+        identity = identity_of(event.traceparent)
+        if identity is None:
+            self.undecodable += 1
+            return
+        self._trace_id, self._root_span_id = identity
+        self._started_at = event.time
+
+    def _node(self, event: SpanEvent) -> None:
+        span = span_from_frame(event)
+        if span is None:
+            self.undecodable += 1
+            return
+        if span.end_time is None:
+            self.unfinished += 1
+            return
+        self._emit(span)
+
+    def _close_root(self, topic: str, event: TerminatedEvent) -> None:
+        """Materialise the run's own span, now that its end is known.
+
+        Emitted LAST because that is when its end time exists. A run killed hard enough to
+        publish no terminal frame therefore contributes no root — the same refusal D11 applies
+        to a node, for the same reason: an unbounded span renders as a 56-year one.
+        """
+        if self._trace_id is None or self._root_span_id is None or self._started_at is None:
+            return
+        end = event.time
+        if end is None:
+            self.unfinished += 1
+            return
+        self._emit(
+            Span(
+                trace_id=self._trace_id,
+                span_id=self._root_span_id,
+                parent_span_id=None,
+                name=ROOT_SPAN_NAME,
+                operation="run",
+                start_time=self._started_at,
+                end_time=end,
+                status=event.data.status,
+                attributes={"url4.topic": topic, "url4.run.status": event.data.status},
+            )
+        )
+
+    def _emit(self, span: Span) -> None:
+        """Hand one span to the sink, resolving an implicit parent to the run's root.
+
+        A node with no `url4.parent` on the wire is a CHILD OF THE ROOT, not a root itself
+        (`_trace_fields` omits the tracestate in exactly that case). Leaving it parentless
+        would render one run as N disconnected traces.
+        """
+        assert self._sink is not None  # guarded by the caller; keeps the type narrow
+        adopts_root = (
+            span.is_root_child
+            and self._root_span_id is not None
+            and span.span_id != self._root_span_id
+        )
+        if adopts_root:
+            span = dataclasses.replace(span, parent_span_id=self._root_span_id)
+        self._sink.emit(span)
+
+
+__all__ = ["OTLP_ENDPOINT_VARS", "ROOT_SPAN_NAME", "SpanRelay", "SpanSink", "otlp_configured"]

--- a/apps/screamingface-engine/src/screamingface_engine/tracing/span_tree.py
+++ b/apps/screamingface-engine/src/screamingface_engine/tracing/span_tree.py
@@ -1,0 +1,140 @@
+"""Wire span frames -> a span tree. Pure, total, and it never fabricates (OME-1130).
+
+INPUT IS THE WIRE, NOT THE OBSERVER SEAM. `OME-1130`'s description points at
+`url4/observe.py`'s `NodeStarted`/`NodeFinished`, and that is the RUNNER's in-process
+observation seam — the control-plane relay never sees those objects. It sees published
+CloudEvents: `SpanEvent` carrying `SpanData`. Building on `url4.observe` here also fails
+`test_only_engine_extensions_import_url4`, which confines the url4 ENGINE to Runner adapters and
+Benchmark extensions while exempting `url4.streaming` as the shared wire contract. The guard
+caught it; this module is built on the wire.
+
+Three consequences of that, all load-bearing:
+
+* **No started/finished pairing.** The runner emits ONE `SpanEvent` per completed span
+  (`executor.py::_RunState._finish`), so a span arrives whole.
+* **Identity lives on the ENVELOPE, not the payload.** `traceparent` carries
+  `00-<trace_id>-<span_id>-01`; the parent edge rides `tracestate` as `url4.parent=<span_id>`.
+* **A missing `tracestate` MEANS the root is the parent** — `lifecycle._trace_fields` omits it
+  when `parent is None or parent == root_span_id`. Absent is information here, not a gap.
+
+WHY the timing is better than `OME-1130` assumed: the ticket says durations must come from
+envelope publish times and warns they carry publish latency. They do not. `SpanData` carries its
+own `start`/`end`, captured in the runner when the observation event arrives
+(`executor.py:358`, `datetime.now(UTC)`), so a duration is the node's own, not a publish
+artifact. It is still observation time rather than exact `resolve` boundaries — but the
+publish-latency caveat the ticket asks to be written down does not apply.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from url4.streaming.protocol import SpanEvent
+
+_TRACEPARENT_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$")
+_PARENT_RE = re.compile(r"(?:^|,)\s*url4\.parent=([0-9a-f]{16})\s*(?:,|$)")
+_ALL_ZERO_TRACE = "0" * 32
+_ALL_ZERO_SPAN = "0" * 16
+
+
+@dataclass(frozen=True, slots=True)
+class Span:
+    """One node evaluation, as the wire stated it."""
+
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None
+    name: str
+    operation: str
+    start_time: datetime
+    end_time: datetime | None
+    status: str
+    provider: str | None = None
+    request_model: str | None = None
+    response_model: str | None = None
+
+    @property
+    def is_root_child(self) -> bool:
+        """No `url4.parent` on the wire means the run's root span is the parent."""
+        return self.parent_span_id is None
+
+
+@dataclass(frozen=True, slots=True)
+class SpanTree:
+    """Everything the frames said, including what they could not say.
+
+    `undecodable` is part of the RESULT rather than a logged warning: a consumer deciding
+    whether a trace is complete needs to know frames were skipped, and an exporter that
+    silently dropped them would ship a tree that looks whole.
+    """
+
+    trace_id: str | None
+    spans: tuple[Span, ...]
+    undecodable: int
+
+
+def _identity(traceparent: str | None) -> tuple[str, str] | None:
+    """The (trace_id, span_id) a traceparent states, or None if it states none usably.
+
+    The all-zero rejections are the same two Phase 1 applies (`aigateway.w3c_trace`,
+    `url4.streaming.trace`): an all-zero id is valid hex, parses cleanly, and correlates
+    nothing. Admitting one would put a span in the UI under an id that can never join anything.
+    """
+    match = _TRACEPARENT_RE.match(traceparent) if traceparent else None
+    if match is None:
+        return None
+    trace_id, span_id = match.group(1), match.group(2)
+    if trace_id == _ALL_ZERO_TRACE or span_id == _ALL_ZERO_SPAN:
+        return None
+    return trace_id, span_id
+
+
+def _parent(tracestate: str | None) -> str | None:
+    if not tracestate:
+        return None
+    match = _PARENT_RE.search(tracestate)
+    return match.group(1) if match else None
+
+
+def build_span_tree(frames: Sequence[SpanEvent]) -> SpanTree:
+    """Fold published span frames into the tree they describe.
+
+    INVARIANT — never fabricate. A frame whose `traceparent` will not parse is COUNTED and
+    skipped, never given a synthesised id: a span under an invented trace id would appear in
+    the UI as a real run that never happened, which is worse than a visibly short trace.
+    """
+    spans: list[Span] = []
+    undecodable = 0
+    trace_id: str | None = None
+
+    for frame in frames:
+        identity = _identity(frame.traceparent)
+        if identity is None:
+            undecodable += 1
+            continue
+        frame_trace, span_id = identity
+        trace_id = trace_id or frame_trace
+        data = frame.data
+        spans.append(
+            Span(
+                trace_id=frame_trace,
+                span_id=span_id,
+                parent_span_id=_parent(frame.tracestate),
+                name=data.name,
+                operation=data.operation,
+                start_time=data.start,
+                end_time=data.end,
+                status=data.status,
+                provider=data.provider,
+                request_model=data.request_model,
+                response_model=data.response_model,
+            )
+        )
+
+    return SpanTree(trace_id=trace_id, spans=tuple(spans), undecodable=undecodable)
+
+
+__all__ = ["Span", "SpanTree", "build_span_tree"]

--- a/apps/screamingface-engine/src/screamingface_engine/tracing/span_tree.py
+++ b/apps/screamingface-engine/src/screamingface_engine/tracing/span_tree.py
@@ -28,21 +28,38 @@ publish-latency caveat the ticket asks to be written down does not apply.
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import datetime
 
-from url4.streaming.protocol import SpanEvent
+from url4.streaming.protocol import SpanData, SpanEvent
 
 _TRACEPARENT_RE = re.compile(r"^00-([0-9a-f]{32})-([0-9a-f]{16})-[0-9a-f]{2}$")
 _PARENT_RE = re.compile(r"(?:^|,)\s*url4\.parent=([0-9a-f]{16})\s*(?:,|$)")
 _ALL_ZERO_TRACE = "0" * 32
 _ALL_ZERO_SPAN = "0" * 16
 
+AttributeValue = str | int | float | bool | Sequence[str]
+"""What a span attribute may hold — OTel's scalar set, narrowed to the shapes `SpanData`
+actually produces (`finish_reasons` is the only sequence)."""
+
+_STRUCTURE = frozenset({"name", "kind", "start", "end", "status"})
+"""`SpanData` fields that are span STRUCTURE, not attributes — they become dedicated fields on
+:class:`Span` and must not be duplicated into the attribute bag. Everything else on the payload
+is an attribute, which is why :func:`_attributes` subtracts rather than enumerates: a new
+`gen_ai.*` field on the protocol then flows through with no edit here."""
+
 
 @dataclass(frozen=True, slots=True)
 class Span:
-    """One node evaluation, as the wire stated it."""
+    """One evaluation, as the wire stated it — a node's, or the run's own (the synthetic root).
+
+    `status` deliberately carries TWO vocabularies: `SpanData.status` (`ok` | `error`) for a
+    node, and `TerminatedData.status` (`succeeded` | `failed` | `stopped` | `timed_out`) for the
+    root. Normalising them here would throw away the run-level distinction at the only point it
+    still exists — `cancelled` is already collapsed to `error` before a node span is published,
+    so the root is where "stopped" survives at all. The adapter understands both.
+    """
 
     trace_id: str
     span_id: str
@@ -52,14 +69,34 @@ class Span:
     start_time: datetime
     end_time: datetime | None
     status: str
-    provider: str | None = None
-    request_model: str | None = None
-    response_model: str | None = None
+    kind: str = "internal"
+    attributes: Mapping[str, AttributeValue] = field(default_factory=dict)
 
     @property
     def is_root_child(self) -> bool:
         """No `url4.parent` on the wire means the run's root span is the parent."""
         return self.parent_span_id is None
+
+
+def _attributes(data: SpanData) -> Mapping[str, AttributeValue]:
+    """Every non-structural payload field, under the name the PROTOCOL gives it.
+
+    `SpanData` already declares OTel serialization aliases — `gen_ai.request.model`,
+    `gen_ai.usage.input_tokens`, and so on — so the conventional attribute names are the
+    protocol's own and are not re-decided here. Its deliberate NON-aliases (`refusal`,
+    `cache_status`, `cache_reason`) are local extensions whose docstrings say so explicitly;
+    they get a `url4.` prefix rather than a bare name, so nothing reads as a standard attribute
+    that is not one.
+
+    `exclude_none` follows OTel's absent-or-populated convention: an attribute present with a
+    null value says something different from an absent one, and the wire means absent.
+    """
+    dumped = data.model_dump(by_alias=True, exclude_none=True)
+    return {
+        (key if "." in key else f"url4.{key}"): value
+        for key, value in dumped.items()
+        if key not in _STRUCTURE
+    }
 
 
 @dataclass(frozen=True, slots=True)
@@ -76,7 +113,7 @@ class SpanTree:
     undecodable: int
 
 
-def _identity(traceparent: str | None) -> tuple[str, str] | None:
+def identity_of(traceparent: str | None) -> tuple[str, str] | None:
     """The (trace_id, span_id) a traceparent states, or None if it states none usably.
 
     The all-zero rejections are the same two Phase 1 applies (`aigateway.w3c_trace`,
@@ -99,42 +136,62 @@ def _parent(tracestate: str | None) -> str | None:
     return match.group(1) if match else None
 
 
+def span_from_frame(frame: SpanEvent) -> Span | None:
+    """One published frame -> one span, or ``None`` when the frame states no usable identity.
+
+    INVARIANT — never fabricate. A frame whose `traceparent` will not parse gets no span at
+    all, never a synthesised id: a span under an invented trace id would appear in the UI as a
+    real run that never happened, which is worse than a visibly short trace. The CALLER decides
+    what to do with the refusal (count it, log it); this function only refuses.
+
+    Split out of :func:`build_span_tree` for the relay, which sees frames one at a time as they
+    are published and cannot wait for a complete sequence.
+    """
+    identity = identity_of(frame.traceparent)
+    if identity is None:
+        return None
+    trace_id, span_id = identity
+    data = frame.data
+    return Span(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=_parent(frame.tracestate),
+        name=data.name,
+        operation=data.operation,
+        start_time=data.start,
+        end_time=data.end,
+        status=data.status,
+        kind=data.kind,
+        attributes=_attributes(data),
+    )
+
+
 def build_span_tree(frames: Sequence[SpanEvent]) -> SpanTree:
     """Fold published span frames into the tree they describe.
 
-    INVARIANT — never fabricate. A frame whose `traceparent` will not parse is COUNTED and
-    skipped, never given a synthesised id: a span under an invented trace id would appear in
-    the UI as a real run that never happened, which is worse than a visibly short trace.
+    A batch view over :func:`span_from_frame`, for anything holding a whole run's frames at
+    once; the streaming relay uses the per-frame function directly.
     """
     spans: list[Span] = []
     undecodable = 0
     trace_id: str | None = None
 
     for frame in frames:
-        identity = _identity(frame.traceparent)
-        if identity is None:
+        span = span_from_frame(frame)
+        if span is None:
             undecodable += 1
             continue
-        frame_trace, span_id = identity
-        trace_id = trace_id or frame_trace
-        data = frame.data
-        spans.append(
-            Span(
-                trace_id=frame_trace,
-                span_id=span_id,
-                parent_span_id=_parent(frame.tracestate),
-                name=data.name,
-                operation=data.operation,
-                start_time=data.start,
-                end_time=data.end,
-                status=data.status,
-                provider=data.provider,
-                request_model=data.request_model,
-                response_model=data.response_model,
-            )
-        )
+        trace_id = trace_id or span.trace_id
+        spans.append(span)
 
     return SpanTree(trace_id=trace_id, spans=tuple(spans), undecodable=undecodable)
 
 
-__all__ = ["Span", "SpanTree", "build_span_tree"]
+__all__ = [
+    "AttributeValue",
+    "Span",
+    "SpanTree",
+    "build_span_tree",
+    "identity_of",
+    "span_from_frame",
+]

--- a/apps/screamingface-engine/tests/unit/test_otlp_sink.py
+++ b/apps/screamingface-engine/tests/unit/test_otlp_sink.py
@@ -1,0 +1,211 @@
+"""The OTLP adapter: a mapped `Span` becomes a real OTel span (OME-1130).
+
+This is the ONE module in the engine that imports `opentelemetry` (ledger D8), so it is the one
+test file that does. It uses OTel's own `InMemorySpanExporter`, which means the conversion is
+exercised through the REAL SDK path — the same `SpanProcessor.on_end` a live collector sits
+behind — with no network.
+
+WHY that matters more than it looks: `BatchSpanProcessor.on_end` opens with
+`if not (span.context and span.context.trace_flags.sampled): return`. A span built without the
+sampled flag is dropped SILENTLY, by the SDK, with no error anywhere. Exporting nothing while
+every log line says the exporter is running is precisely the failure this ticket exists to
+avoid, so the flag has a test of its own below.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from screamingface_engine.tracing.otlp import OtlpSpanSink, sink_from_env
+from screamingface_engine.tracing.span_tree import Span
+
+TRACE = "4bf92f3577b34da6a3ce929d0e0e4736"
+ROOT = "00f067aa0ba902b7"
+CHILD = "a" * 16
+T0 = datetime(2026, 9, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def at(seconds: float) -> datetime:
+    return T0 + timedelta(seconds=seconds)
+
+
+def a_span(
+    *,
+    span_id: str = CHILD,
+    parent: str | None = ROOT,
+    status: str = "ok",
+    end: datetime | None = None,
+    attributes: dict[str, str | int | float | bool] | None = None,
+) -> Span:
+    return Span(
+        trace_id=TRACE,
+        span_id=span_id,
+        parent_span_id=parent,
+        name="gpt",
+        operation="chat",
+        start_time=at(1),
+        end_time=end if end is not None else at(3),
+        status=status,
+        attributes=attributes or {},
+    )
+
+
+def exported(*spans: Span) -> list[ReadableSpan]:
+    """Drive spans through the real SDK processor path and read back what a collector would."""
+    exporter = InMemorySpanExporter()
+    sink = OtlpSpanSink(SimpleSpanProcessor(exporter))
+    for span in spans:
+        sink.emit(span)
+    sink.close()
+    return list(exporter.get_finished_spans())
+
+
+# --- identity survives the conversion ----------------------------------------------------------
+
+
+def test_the_wire_s_hex_ids_become_the_otel_ids() -> None:
+    (out,) = exported(a_span())
+
+    assert out.context is not None
+    assert format(out.context.trace_id, "032x") == TRACE
+    assert format(out.context.span_id, "016x") == CHILD
+
+
+def test_the_parent_edge_becomes_a_parent_context_in_the_same_trace() -> None:
+    (out,) = exported(a_span(parent=ROOT))
+
+    assert out.parent is not None
+    assert format(out.parent.span_id, "016x") == ROOT
+    assert out.parent.trace_id == out.context.trace_id if out.context else False
+
+
+def test_a_span_with_no_parent_is_a_root() -> None:
+    (out,) = exported(a_span(span_id=ROOT, parent=None))
+
+    assert out.parent is None
+
+
+def test_the_sampled_flag_is_set_or_the_sdk_drops_the_span_silently() -> None:
+    """`url4.streaming.trace` hardcodes `_SAMPLED = "01"` — every run is nominally sampled
+    (ledger D5), and the SDK's processors enforce that flag rather than trusting the caller."""
+    (out,) = exported(a_span())
+
+    assert out.context is not None
+    assert out.context.trace_flags.sampled
+
+
+# --- timing ---------------------------------------------------------------------------------
+
+
+def test_timestamps_become_nanoseconds_since_epoch() -> None:
+    (out,) = exported(a_span())
+
+    assert out.start_time == int(at(1).timestamp() * 1_000_000_000)
+    assert out.end_time == int(at(3).timestamp() * 1_000_000_000)
+
+
+def test_the_duration_is_preserved_exactly() -> None:
+    (out,) = exported(a_span(end=at(4)))
+
+    assert out.end_time is not None and out.start_time is not None
+    assert out.end_time - out.start_time == 3 * 1_000_000_000
+
+
+# --- status ------------------------------------------------------------------------------------
+
+
+def test_an_ok_span_is_ok() -> None:
+    (out,) = exported(a_span(status="ok"))
+
+    assert out.status.status_code is StatusCode.OK
+
+
+def test_an_error_span_is_an_error() -> None:
+    (out,) = exported(a_span(status="error"))
+
+    assert out.status.status_code is StatusCode.ERROR
+
+
+def test_a_succeeded_run_root_is_ok() -> None:
+    """The ROOT carries `TerminatedData.status` vocabulary (`succeeded`), not `SpanData`'s
+    (`ok`). Both reach this mapper, so both must be understood."""
+    (out,) = exported(a_span(status="succeeded"))
+
+    assert out.status.status_code is StatusCode.OK
+
+
+def test_a_stopped_run_keeps_its_verbatim_reason_rather_than_being_flattened_to_error() -> None:
+    """`stopped` and `failed` are both non-OK, and OTel has one non-OK code. Losing which of
+    the two it was would erase the only place that distinction still survives (ledger D7)."""
+    (stopped,) = exported(a_span(status="stopped"))
+    (failed,) = exported(a_span(status="failed"))
+
+    assert stopped.status.status_code is StatusCode.ERROR
+    assert stopped.status.description == "stopped"
+    assert failed.status.description == "failed"
+
+
+# --- attributes ----------------------------------------------------------------------------
+
+
+def test_gen_ai_attributes_survive_under_their_conventional_names() -> None:
+    """`SpanData` already declares OTel serialization aliases (`gen_ai.request.model`, …), so
+    the conventional names are the protocol's own — not a mapping invented here."""
+    (out,) = exported(
+        a_span(attributes={"gen_ai.request.model": "gpt-5.5", "gen_ai.usage.input_tokens": 124})
+    )
+
+    assert out.attributes is not None
+    assert out.attributes["gen_ai.request.model"] == "gpt-5.5"
+    assert out.attributes["gen_ai.usage.input_tokens"] == 124
+
+
+def test_the_operation_is_recorded_as_the_conventional_attribute() -> None:
+    (out,) = exported(a_span())
+
+    assert out.attributes is not None
+    assert out.attributes["gen_ai.operation.name"] == "chat"
+
+
+def test_the_span_name_comes_from_the_wire() -> None:
+    (out,) = exported(a_span())
+
+    assert out.name == "gpt"
+
+
+# --- off by default (ledger D9) ----------------------------------------------------------------
+
+
+def test_no_endpoint_configured_means_no_sink() -> None:
+    """Every existing run, every local run and every test must be unaffected by construction —
+    not by a flag someone remembered to set."""
+    assert sink_from_env({}) is None
+
+
+def test_an_empty_endpoint_is_treated_as_unset() -> None:
+    """A chart that renders `OTEL_EXPORTER_OTLP_ENDPOINT: ""` for an unconfigured environment
+    must read as "off", not as "export to the empty string"."""
+    assert sink_from_env({"OTEL_EXPORTER_OTLP_ENDPOINT": "   "}) is None
+
+
+def test_a_configured_endpoint_builds_a_sink() -> None:
+    sink = sink_from_env({"OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector.invalid:4318"})
+
+    assert sink is not None
+    sink.close()
+
+
+def test_the_traces_specific_endpoint_also_turns_it_on() -> None:
+    """OTel's env contract lets a deployment set only the signal-specific variable; reading
+    just the generic one would leave such a deployment silently un-traced."""
+    sink = sink_from_env(
+        {"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://collector.invalid:4318/v1/traces"}
+    )
+
+    assert sink is not None
+    sink.close()

--- a/apps/screamingface-engine/tests/unit/test_span_export_wiring.py
+++ b/apps/screamingface-engine/tests/unit/test_span_export_wiring.py
@@ -1,0 +1,93 @@
+"""The composition root's half of span export (OME-1130): what a Job pays, and when.
+
+Two properties, both of which fail SILENTLY if broken — which is why they are tests and not
+comments:
+
+* export is OFF unless configured, so no existing run changes behaviour;
+* the OTel SDK is not imported when it is off, so no Job pays ~62 ms of cold start for a
+  feature it does not use.
+
+The second is the same discipline `check_layering.py` applies to the engine's own modules.
+That gate protects a Job's import graph from `screamingface_engine` submodules and cannot see
+a third-party dependency, so this covers the direction it structurally cannot.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from screamingface_engine.runner.main import span_sink
+
+ENDPOINT = "http://collector.invalid:4318"
+
+
+# --- off unless configured --------------------------------------------------------------------
+
+
+def test_a_clean_environment_gets_no_sink() -> None:
+    assert span_sink({}) is None
+
+
+def test_a_configured_endpoint_gets_a_sink() -> None:
+    sink = span_sink({"OTEL_EXPORTER_OTLP_ENDPOINT": ENDPOINT})
+
+    assert sink is not None
+    sink.close()
+
+
+def test_a_blank_endpoint_is_off_not_broken() -> None:
+    """A chart renders `""` for an environment nobody has configured yet. That must read as
+    "off" — not as an endpoint, and not as a crash on boot."""
+    assert span_sink({"OTEL_EXPORTER_OTLP_ENDPOINT": ""}) is None
+
+
+def test_a_broken_exporter_config_does_not_stop_the_run(monkeypatch) -> None:
+    """INVARIANT: telemetry degrades ALONE. A misconfigured collector must not become the
+    reason a benchmark run never happens — the run is worth more than its trace."""
+    import screamingface_engine.tracing.otlp as otlp
+
+    def explode(_env: object) -> None:
+        raise RuntimeError("bad OTLP config")
+
+    monkeypatch.setattr(otlp, "sink_from_env", explode)
+
+    assert span_sink({"OTEL_EXPORTER_OTLP_ENDPOINT": ENDPOINT}) is None
+
+
+# --- what the import costs ----------------------------------------------------------------
+
+
+def test_importing_the_run_entrypoint_does_not_load_opentelemetry() -> None:
+    """A CLEAN SUBPROCESS, so the claim has teeth: in-process, another test having imported
+    `tracing.otlp` would leave `opentelemetry` in `sys.modules` and this would pass vacuously.
+
+    `packages/url4/tests/unit/test_import_isolation.py` makes the same claim the same way, for
+    the same reason.
+    """
+    probe = (
+        "import sys; import screamingface_engine.runner.main; "
+        "print(len([m for m in sys.modules if m.startswith('opentelemetry')]))"
+    )
+    loaded = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert loaded.stdout.strip() == "0", (
+        "importing the run entrypoint pulled in the OTel SDK — every Job now pays ~62ms of "
+        "cold start for a feature most of them do not use. Keep the import inside `span_sink`."
+    )
+
+
+def test_the_probe_can_actually_detect_a_loaded_sdk() -> None:
+    """The guard above asserts a ZERO count, so it would also pass if the probe were simply
+    broken and always printed 0. This proves the probe sees the SDK when it IS there."""
+    probe = (
+        "import sys; import screamingface_engine.tracing.otlp; "
+        "print(len([m for m in sys.modules if m.startswith('opentelemetry')]))"
+    )
+    loaded = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert int(loaded.stdout.strip()) > 0

--- a/apps/screamingface-engine/tests/unit/test_span_relay.py
+++ b/apps/screamingface-engine/tests/unit/test_span_relay.py
@@ -1,0 +1,382 @@
+"""The publisher proxy that ships a run's spans to a sink (OME-1130).
+
+MOUNT: the run's own publisher, wrapped. The ticket said "the control-plane relay, never the
+runner" — but there is no control-plane subscription that sees all runs (`stream_for(topic)`
+creates ONE JetStream stream per run), so that mount point does not exist. The owner resolved
+the fork in favour of a publisher proxy, which sees every frame of every run by construction,
+attached client or not.
+
+THE INVARIANT THIS FILE EXISTS FOR: **the relay may never fail or alter a run.** It sits on the
+one path every frame of every run travels. A sink that raises, a mapper that trips, a collector
+that is down — none of them may turn a working run into a failed one. Half the tests below are
+that single property approached from different directions.
+
+No OTel here: the sink is a PORT, and these tests hand in a fake. That is the whole point of
+the port/adapter split (ledger D8) — the semantics are testable without the transport.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from screamingface_engine.tracing.relay import SpanRelay
+from screamingface_engine.tracing.span_tree import Span
+from url4.streaming.interfaces import EventPublisher
+from url4.streaming.protocol import (
+    OutboundFrame,
+    SpanData,
+    SpanEvent,
+    StartedData,
+    StartedEvent,
+    TerminatedData,
+    TerminatedEvent,
+)
+from url4.streaming.protocol.envelope import source_for
+
+TRACE = "4bf92f3577b34da6a3ce929d0e0e4736"
+ROOT = "00f067aa0ba902b7"
+TOPIC = "t"
+T0 = datetime(2026, 9, 10, 12, 0, 0, tzinfo=UTC)
+
+
+def at(seconds: float) -> datetime:
+    return T0 + timedelta(seconds=seconds)
+
+
+class Recorder(EventPublisher):
+    """The inner publisher — remembers what reached the transport, in order."""
+
+    def __init__(self) -> None:
+        self.frames: list[OutboundFrame] = []
+        self.streams: list[str] = []
+        self.flushes = 0
+        self.closes = 0
+
+    async def ensure_stream(self, topic: str) -> None:
+        self.streams.append(topic)
+
+    async def publish(self, topic: str, event: OutboundFrame) -> None:
+        self.frames.append(event)
+
+    async def flush(self) -> None:
+        self.flushes += 1
+
+    async def close(self) -> None:
+        self.closes += 1
+
+
+class FakeSink:
+    """The `SpanSink` port, recorded. `closed` counts rather than flags — the relay must
+    close exactly once, and a double `shutdown()` on the real OTel processor is not a no-op."""
+
+    def __init__(self, *, explode: bool = False) -> None:
+        self.spans: list[Span] = []
+        self.closed = 0
+        self._explode = explode
+
+    def emit(self, span: Span) -> None:
+        if self._explode:
+            raise RuntimeError("the collector is on fire")
+        self.spans.append(span)
+
+    def close(self) -> None:
+        self.closed += 1
+        if self._explode:
+            raise RuntimeError("the collector is still on fire")
+
+
+def _envelope(traceparent: str, tracestate: str | None = None, *, time: datetime | None = None):
+    return {
+        "id": "evt",
+        "source": source_for(TOPIC, "root"),
+        "subject": TOPIC,
+        "sequence": "1",
+        "time": time if time is not None else at(0),
+        "traceparent": traceparent,
+        "tracestate": tracestate,
+    }
+
+
+def started(*, time: datetime | None = None) -> StartedEvent:
+    """A run-level frame: `_trace_fields` publishes it under the ROOT traceparent, which is
+    how the relay learns an identity no `SpanEvent` ever carries."""
+    return StartedEvent(**_envelope(f"00-{TRACE}-{ROOT}-01", time=time), data=StartedData(url4="x"))
+
+
+def terminated(status: str = "succeeded", *, time: datetime | None = None) -> TerminatedEvent:
+    return TerminatedEvent(
+        **_envelope(f"00-{TRACE}-{ROOT}-01", time=time),
+        data=TerminatedData(status=status),  # type: ignore[arg-type]
+    )
+
+
+def span(
+    span_id: str = "a" * 16,
+    *,
+    parent: str | None = None,
+    traceparent: str | None = None,
+    end: datetime | None = None,
+) -> SpanEvent:
+    return SpanEvent(
+        **_envelope(
+            traceparent if traceparent is not None else f"00-{TRACE}-{span_id}-01",
+            f"url4.parent={parent}" if parent else None,
+        ),
+        data=SpanData(
+            name="gpt",
+            operation="chat",
+            start=at(1),
+            end=end if end is not None else at(2),
+            status="ok",
+        ),
+    )
+
+
+async def drive(relay: SpanRelay, *frames: OutboundFrame) -> None:
+    await relay.ensure_stream(TOPIC)
+    for frame in frames:
+        await relay.publish(TOPIC, frame)
+
+
+# --- transparency: the relay must be invisible to the run -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_frame_reaches_the_inner_publisher_unchanged() -> None:
+    """The property that makes it safe to mount this on the run's ONLY publisher."""
+    inner, sink = Recorder(), FakeSink()
+    frames = (started(), span(), terminated())
+
+    await drive(SpanRelay(inner, sink), *frames)
+
+    assert inner.frames == list(frames)
+    assert inner.streams == [TOPIC]
+
+
+@pytest.mark.asyncio
+async def test_flush_is_forwarded() -> None:
+    inner, sink = Recorder(), FakeSink()
+
+    await SpanRelay(inner, sink).flush()
+
+    assert inner.flushes == 1
+
+
+@pytest.mark.asyncio
+async def test_the_wire_ports_close_is_forwarded_and_is_not_the_sinks() -> None:
+    """`EventPublisher.close` is a non-abstract ASYNC no-op, so a sync override type-checks in
+    Python and only fails at the `await` — at teardown, on the path that runs when something
+    has already gone wrong. Pyright caught that here; this keeps it caught.
+
+    The two are separate methods on purpose: this one closes the TRANSPORT, `shutdown()`
+    closes the sink. A proxy that stopped forwarding this would leak the inner connection.
+    """
+    inner, sink = Recorder(), FakeSink()
+    relay = SpanRelay(inner, sink)
+
+    await relay.close()
+
+    assert inner.closes == 1
+    assert sink.closed == 0, "closing the wire must not shut down the exporter"
+
+
+@pytest.mark.asyncio
+async def test_a_sink_that_raises_does_not_fail_the_run() -> None:
+    """INVARIANT (ledger D4). A collector outage must degrade telemetry, never the run.
+
+    This is the single most important test in the file: the relay sits on the path every
+    frame travels, so an exception escaping here converts a downed collector into a fleet of
+    failed runs.
+    """
+    inner, sink = Recorder(), FakeSink(explode=True)
+
+    await drive(SpanRelay(inner, sink), started(), span(), terminated())
+
+    assert [type(f) for f in inner.frames] == [StartedEvent, SpanEvent, TerminatedEvent]
+
+
+@pytest.mark.asyncio
+async def test_a_sink_that_raises_on_close_does_not_fail_the_run() -> None:
+    relay = SpanRelay(Recorder(), FakeSink(explode=True))
+
+    relay.shutdown()  # must not raise
+
+
+# --- what reaches the sink --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_span_frame_becomes_a_span() -> None:
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(), span("b" * 16), terminated())
+
+    emitted = [s for s in sink.spans if s.span_id == "b" * 16]
+    assert len(emitted) == 1
+    assert emitted[0].trace_id == TRACE
+
+
+@pytest.mark.asyncio
+async def test_run_level_frames_are_not_mistaken_for_spans() -> None:
+    """`Started`/`Terminated` ride the ROOT traceparent. Mapping them as node spans would
+    emit a duplicate of the root under the root's own id."""
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(), terminated())
+
+    assert [s.span_id for s in sink.spans] == [ROOT], "only the synthetic root should appear"
+
+
+@pytest.mark.asyncio
+async def test_an_undecodable_traceparent_is_counted_not_invented() -> None:
+    inner, sink = Recorder(), FakeSink()
+    relay = SpanRelay(inner, sink)
+
+    await drive(relay, started(), span(traceparent="not-a-traceparent"), terminated())
+
+    assert [s.span_id for s in sink.spans] == [ROOT]
+    assert relay.undecodable == 1
+
+
+@pytest.mark.asyncio
+async def test_an_unfinished_span_is_counted_not_given_a_fabricated_end() -> None:
+    """Ledger D11: OTLP cannot say "still running". `end=None` encodes as epoch 0 and renders
+    as a 56-year span; `end == start` states a 0 ms duration that is a lie. Absent is better."""
+    inner, sink = Recorder(), FakeSink()
+    relay = SpanRelay(inner, sink)
+
+    frame = span().model_copy(update={"data": span().data.model_copy(update={"end": None})})
+    await drive(relay, started(), frame, terminated())
+
+    assert [s.span_id for s in sink.spans] == [ROOT]
+    assert relay.unfinished == 1
+
+
+# --- the synthetic root (ledger D7) ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_run_gets_a_root_span_carrying_the_wire_s_own_root_id() -> None:
+    """Not fabrication: `lifecycle._trace_fields` publishes run-level frames under
+    `format_traceparent(trace_id, root_span_id)`, so the `Started` envelope STATES this id.
+    Every `url4.parent=` and every Phase 1 gateway `traceparent` already references it."""
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(time=at(0)), span(), terminated(time=at(30)))
+
+    root = next(s for s in sink.spans if s.span_id == ROOT)
+    assert root.trace_id == TRACE
+    assert root.parent_span_id is None
+    assert (root.start_time, root.end_time) == (at(0), at(30))
+
+
+@pytest.mark.asyncio
+async def test_a_top_level_node_is_reparented_onto_the_run_s_root() -> None:
+    """The PAYOFF of synthesising the root. `_trace_fields` omits `tracestate` when the parent
+    IS the root, so a top-level node arrives claiming no parent. Emitting it that way renders
+    one run as N disconnected traces in the UI — the waterfall never forms."""
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(), span("b" * 16), terminated())
+
+    node = next(s for s in sink.spans if s.span_id == "b" * 16)
+    assert node.parent_span_id == ROOT
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_parent_is_left_alone() -> None:
+    """Reparenting must apply ONLY to the implicit case; overwriting a stated `url4.parent`
+    would flatten every nested run into a single level."""
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(), span("c" * 16, parent="b" * 16), terminated())
+
+    node = next(s for s in sink.spans if s.span_id == "c" * 16)
+    assert node.parent_span_id == "b" * 16
+
+
+@pytest.mark.asyncio
+async def test_the_root_itself_is_not_reparented_onto_itself() -> None:
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(), terminated())
+
+    assert sink.spans[-1].parent_span_id is None, "the root must not be its own parent"
+
+
+@pytest.mark.asyncio
+async def test_the_root_is_emitted_last_so_it_bounds_its_children() -> None:
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(), span(), terminated())
+
+    assert sink.spans[-1].span_id == ROOT
+
+
+@pytest.mark.asyncio
+async def test_a_stopped_run_is_distinguishable_from_a_failed_one_on_the_root() -> None:
+    """`SpanData.status` is only ok|error — `cancelled` is collapsed before publication, so a
+    stopped run looks failed in the child spans. `TerminatedData.status` keeps all four, so the
+    ROOT is where that distinction survives."""
+    stopped, failed = FakeSink(), FakeSink()
+
+    await drive(SpanRelay(Recorder(), stopped), started(), terminated("stopped"))
+    await drive(SpanRelay(Recorder(), failed), started(), terminated("failed"))
+
+    assert stopped.spans[-1].status != failed.spans[-1].status
+
+
+@pytest.mark.asyncio
+async def test_a_run_that_never_terminated_emits_no_root_rather_than_an_open_one() -> None:
+    """A hard-killed run (OOM, eviction) publishes no terminal frame. Its root has no end, and
+    D11's rule applies to the root exactly as to a node."""
+    inner, sink = Recorder(), FakeSink()
+
+    await drive(SpanRelay(inner, sink), started(), span())
+
+    assert [s.span_id for s in sink.spans] == ["a" * 16]
+
+
+# --- lifecycle ----------------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_shuts_the_sink_down_exactly_once() -> None:
+    """Ledger D10: the run process is short-lived, so an unflushed batch loses the tail of
+    EVERY trace — including the root, which is by definition emitted last."""
+    relay = SpanRelay(Recorder(), (sink := FakeSink()))
+
+    await drive(relay, started(), span(), terminated())
+    relay.shutdown()
+    relay.shutdown()
+
+    assert sink.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_leaving_the_context_closes_the_sink_even_when_the_run_raised() -> None:
+    """The composition root drives this with `with`, so a run that dies mid-flight still
+    flushes. A run that RAISED is exactly the one whose trace someone will go looking for."""
+    sink = FakeSink()
+
+    with pytest.raises(RuntimeError):
+        with SpanRelay(Recorder(), sink) as relay:
+            await drive(relay, started(), span())
+            raise RuntimeError("the run blew up")
+
+    assert sink.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_no_sink_means_the_relay_is_a_plain_passthrough() -> None:
+    """Ledger D9: with no endpoint configured there is no sink, and the relay must cost
+    nothing — this is what keeps every existing run and every test unaffected."""
+    inner = Recorder()
+    relay = SpanRelay(inner, None)
+
+    await drive(relay, started(), span(), terminated())
+    relay.shutdown()
+
+    assert len(inner.frames) == 3

--- a/apps/screamingface-engine/tests/unit/test_span_tree.py
+++ b/apps/screamingface-engine/tests/unit/test_span_tree.py
@@ -1,0 +1,167 @@
+"""Published span frames become a span tree, faithfully (OME-1130) — Phase 2's semantics.
+
+Phase 1 made one `trace_id` greppable. This is what makes SigNoz's trace VIEW stop being empty.
+
+The input is the WIRE, not `url4.observe`: the relay sees `SpanEvent`/`SpanData`, and identity
+travels on the ENVELOPE — `traceparent` carries trace+span, `tracestate` carries the parent as
+`url4.parent=`. See the module docstring for why (a layering guard enforces it).
+
+INVARIANT under test: **the mapper never fabricates.** A frame it cannot decode is counted and
+skipped, never given a synthesised id — a span under an invented trace id shows up in the UI as
+a run that never happened, which is worse than a visibly short trace.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from screamingface_engine.tracing.span_tree import build_span_tree
+from url4.streaming.protocol import SpanData, SpanEvent
+from url4.streaming.protocol.envelope import source_for
+
+WireStatus = Literal["ok", "error"]
+"""Mirrors `SpanData.status`. NOTE the wire has only two states — `url4.observe` also has
+`cancelled`, and it is collapsed before publication. A stopped run is not distinguishable
+from a failed one in the trace view; that is a wire-level limitation, not a mapper one."""
+
+TRACE = "4bf92f3577b34da6a3ce929d0e0e4736"
+ROOT = "00f067aa0ba902b7"
+T0 = datetime(2026, 9, 10, 12, 0, 0, tzinfo=UTC)
+
+_UNSET = object()
+"""Distinguishes "caller said nothing" from "caller said None".
+
+A plain `end or at(2)` default silently swallowed an explicit `end=None`, so the
+unfinished-span test asserted against a fabricated end and failed for the wrong reason."""
+
+
+def at(seconds: float) -> datetime:
+    return T0 + timedelta(seconds=seconds)
+
+
+def span_event(
+    span_id: str,
+    *,
+    parent: str | None = None,
+    trace: str = TRACE,
+    status: WireStatus = "ok",
+    start: datetime | None = None,
+    end: Any = _UNSET,
+    traceparent: str | None = None,
+) -> SpanEvent:
+    return SpanEvent(
+        id=f"evt-{span_id[:8]}",
+        # `topic`/`node` are NOT envelope fields — they are inputs to `source_for`, which
+        # builds the CloudEvents `source` URI-ref. Pydantic tolerated them as extras at
+        # runtime; pyright did not, which is the better signal.
+        source=source_for("t", "root"),
+        sequence="1",
+        time=at(0),
+        traceparent=(traceparent if traceparent is not None else f"00-{trace}-{span_id}-01"),
+        tracestate=f"url4.parent={parent}" if parent else None,
+        data=SpanData(
+            name="gpt",
+            operation="chat",
+            start=start or at(1),
+            end=at(2) if end is _UNSET else end,
+            status=status,
+        ),
+    )
+
+
+# --- identity comes off the envelope ---------------------------------------------------------
+
+
+def test_trace_and_span_ids_are_read_from_the_traceparent() -> None:
+    tree = build_span_tree([span_event("a" * 16)])
+
+    only = tree.spans[0]
+    assert only.trace_id == TRACE
+    assert only.span_id == "a" * 16
+
+
+def test_the_parent_edge_is_read_from_tracestate() -> None:
+    tree = build_span_tree([span_event("b" * 16, parent="a" * 16)])
+
+    assert tree.spans[0].parent_span_id == "a" * 16
+
+
+def test_no_tracestate_MEANS_the_root_is_the_parent() -> None:
+    """`lifecycle._trace_fields` omits tracestate when the parent IS the root span.
+
+    Absent is information here, not a gap — treating it as "unknown parent" would orphan
+    every top-level node in the waterfall.
+    """
+    tree = build_span_tree([span_event("a" * 16)])
+
+    assert tree.spans[0].parent_span_id is None
+    assert tree.spans[0].is_root_child
+
+
+def test_a_deep_chain_keeps_every_edge() -> None:
+    a, b, c = "a" * 16, "b" * 16, "c" * 16
+    tree = build_span_tree([span_event(a), span_event(b, parent=a), span_event(c, parent=b)])
+
+    assert {s.span_id: s.parent_span_id for s in tree.spans} == {a: None, b: a, c: b}
+
+
+# --- timing and status -----------------------------------------------------------------------
+
+
+def test_timing_comes_from_the_payload_not_the_envelope() -> None:
+    """OME-1130 assumed publish times; SpanData carries its own start/end.
+
+    They are captured in the runner when the observation event arrives
+    (`executor.py:358`), so a duration is the node's own rather than a publish artifact.
+    """
+    tree = build_span_tree([span_event("a" * 16, start=at(5), end=at(9))])
+
+    assert (tree.spans[0].start_time, tree.spans[0].end_time) == (at(5), at(9))
+
+
+def test_an_unfinished_span_keeps_a_null_end() -> None:
+    """`SpanData.end` is optional; a run cut short must not get a fabricated end."""
+    tree = build_span_tree([span_event("a" * 16, end=None)])
+
+    assert tree.spans[0].end_time is None
+
+
+def test_error_status_is_carried() -> None:
+    tree = build_span_tree([span_event("a" * 16, status="error")])
+
+    assert tree.spans[0].status == "error"
+
+
+# --- what it refuses to invent ----------------------------------------------------------------
+
+
+def test_a_frame_with_an_unparseable_traceparent_is_counted_not_invented() -> None:
+    tree = build_span_tree([span_event("a" * 16, traceparent="not-a-traceparent")])
+
+    assert tree.spans == ()
+    assert tree.undecodable == 1
+
+
+def test_an_all_zero_span_id_is_refused() -> None:
+    """A zero id parses as hex and correlates nothing — the same trap Phase 1 rejects."""
+    tree = build_span_tree([span_event("a" * 16, traceparent=f"00-{TRACE}-{'0' * 16}-01")])
+
+    assert tree.spans == (), "an all-zero span id was admitted"
+    assert tree.undecodable == 1
+
+
+def test_a_garbage_tracestate_yields_no_parent_rather_than_a_wrong_one() -> None:
+    frame = span_event("a" * 16)
+    frame = frame.model_copy(update={"tracestate": "vendor=something-else"})
+
+    tree = build_span_tree([frame])
+
+    assert tree.spans[0].parent_span_id is None
+
+
+def test_an_empty_stream_yields_no_spans_and_no_trace() -> None:
+    tree = build_span_tree([])
+
+    assert tree.spans == ()
+    assert tree.trace_id is None

--- a/apps/screamingface-engine/uv.lock
+++ b/apps/screamingface-engine/uv.lock
@@ -505,6 +505,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1145,6 +1157,87 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1220,6 +1313,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/73/f66c748df06e7fe24e658eddd600d19c4b40bad836c97ce2d0ad9851fb6b/protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524", size = 512499, upload-time = "2026-08-31T22:40:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6c/3a54a58f2948b0f485df9ecdd06590f15d0a7abf46a89d50c3de709ff4ff/protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca", size = 456046, upload-time = "2026-08-31T22:39:56.865Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/9f9548793c771095245c0eeaf0c84b76b16a5ef26158043d456f551344a0/protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969", size = 344226, upload-time = "2026-08-31T22:39:58.263Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/51/1bdbd612fa3c51e42ea6f45d05e84dc748ddcd2663e1aa1e89a00a33facd/protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44", size = 357229, upload-time = "2026-08-31T22:39:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa", size = 343228, upload-time = "2026-08-31T22:40:00.179Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/d4724ec5d86d496fe4108e220618aa0837ad3423a7af7ccdd9684ccc77c8/protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00", size = 443002, upload-time = "2026-08-31T22:40:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/db/37/155788a0d8daded960375af604202805308169f9b859419ea0aa370946e2/protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363", size = 456518, upload-time = "2026-08-31T22:40:02.494Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/c47f91d3cab175b01fd8c4f0d80fdf8613be876cc616e66ad281a59c5ddf/protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c", size = 179813, upload-time = "2026-08-31T22:40:03.54Z" },
 ]
 
 [[package]]
@@ -1874,6 +1982,8 @@ dependencies = [
     { name = "langdetect" },
     { name = "nats-py" },
     { name = "nltk" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1907,6 +2017,8 @@ requires-dist = [
     { name = "langdetect", specifier = ">=1.0.9" },
     { name = "nats-py", specifier = ">=2.9.0" },
     { name = "nltk", specifier = ">=3.9.1" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },

--- a/docs/tasks/2026-09-10-OME-1130-frame-otlp-exporter.md
+++ b/docs/tasks/2026-09-10-OME-1130-frame-otlp-exporter.md
@@ -1,0 +1,52 @@
+---
+id: OME-1130
+linear_url: https://linear.app/openmined/issue/OME-1130
+status: in_review
+type: null
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-10
+closed: null
+---
+
+# Export a run's span frames to OTLP
+
+The core of Phase 2 (`OME-1129`). Phase 1 made one `trace_id` greppable across services; this
+is what makes SigNoz's **trace view** stop being empty — a waterfall with per-span timing
+instead of a log search.
+
+Four things worth knowing before touching this area:
+
+- **The input is the WIRE, not `url4.observe`.** The issue points at `NodeStarted`/
+  `NodeFinished`, which are the runner's in-process observation seam and are never published.
+  What a relay sees is `SpanEvent` carrying `SpanData`. Building on `url4.observe` also fails
+  `test_only_engine_extensions_import_url4`, which confines the url4 ENGINE to Runner adapters
+  while exempting `url4.streaming` as the shared wire contract.
+
+- **The mount point in the issue does not exist.** "The engine control-plane relay, never the
+  runner" presumes a subscription that sees all runs; `stream_for(topic)` creates ONE
+  JetStream stream per run, and only `ws/bridge.py` subscribes — per attached client. Owner
+  decision: a **publisher proxy in the worker**, which sees every frame of every run whether
+  or not anyone is watching. This deliberately overrides the issue's "never the runner".
+
+- **Timing is better than the issue assumed.** It warns that durations must come from envelope
+  publish times and carry publish latency. `SpanData` carries its own `start`/`end`, captured
+  in the runner when the observation event arrives (`runner/executor.py:358`), so a duration is
+  the node's own. Only the synthetic root uses envelope times, where it is exact.
+
+- **A stopped run is indistinguishable from a failed one in the CHILD spans.** `SpanData.status`
+  is only `ok | error`; `cancelled` is collapsed before publication. `TerminatedData.status`
+  keeps all four states, so the synthetic root is the only place that distinction survives.
+
+Two costs recorded rather than discovered later:
+
+- **Export is off unless an OTLP endpoint is configured**, and configured through OTel's own
+  env contract (`OTEL_EXPORTER_OTLP_*`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`)
+  rather than a vocabulary invented here. That makes `OME-1131` a chart-values job with no new
+  credential scheme to design.
+- **The OTel SDK is imported lazily.** It costs ~62 ms of a Job's ~227 ms import budget, which
+  every run would otherwise pay for a feature most do not use. `check_layering.py` guards a
+  Job's cold start against the engine's own modules and structurally cannot see a third-party
+  dependency, so a subprocess test covers that direction.
+
+Ledger: `docs/work/2026-09-10-OME-1130-frame-otlp-exporter.md`

--- a/docs/work/2026-09-10-OME-1130-frame-otlp-exporter.md
+++ b/docs/work/2026-09-10-OME-1130-frame-otlp-exporter.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1130
 stack: screamingface-engine
-status: in_progress
+status: done
 started: 2026-09-10
-finished:
+finished: 2026-09-10
 ---
 
 # OME-1130 — Frame-to-OTLP exporter at the engine control-plane relay
@@ -13,9 +13,11 @@ finished:
 The core of Phase 2. Phase 1 made one `trace_id` greppable across services; this makes SigNoz's
 **trace view** stop being empty — a waterfall with per-span timing instead of log search.
 
-This is an adapter, not a rewrite. The frames already ARE a span tree: `NodeStarted` carries
-`span_id` and `parent_span_id`, so the parent edge is **given, not inferred**, and pairing with
-`NodeFinished` by `span_id` yields duration and status.
+This is an adapter, not a rewrite. The frames already ARE a span tree — though NOT in the shape
+the ticket describes (see D2/D6). One published `SpanEvent` carries a whole completed span, and
+identity rides the ENVELOPE: `traceparent` carries trace+span, `tracestate` carries the parent as
+`url4.parent=`. So the parent edge is **given, not inferred**, and duration and status come off
+the payload.
 
 ## Design decisions
 
@@ -25,19 +27,26 @@ OTLP exporter is a thin sink behind it. This is not tidiness: it is what lets th
 (transport, backpressure, credentials) change without re-testing the semantics, and it keeps
 the OTel import confined to one module.
 
-**D2 — span timing is PUBLISH time, and that is an approximation that must be written down.**
-`_Sequencer.next()` stamps `time=datetime.now(UTC)` on every published envelope
-(`url4/streaming/lifecycle.py:62`), so a span's start/end are its `NodeStarted`/`NodeFinished`
-FRAME times, not true resolve boundaries. Durations therefore include publish latency.
+**D2 — ~~span timing is PUBLISH time~~ — WRONG, corrected after reading the wire.** The ticket
+says durations must come from envelope publish times and warns they carry publish latency. They
+do not. `SpanData` carries its own `start`/`end`, captured in the runner when the observation
+event arrives (`runner/executor.py:358`), so a duration is the node's own, not a publish
+artifact. It is still *observation* time rather than exact `resolve` boundaries — but the
+publish-latency caveat the ticket asks to be written down does not apply, and writing it down
+anyway would have taught every future reader something false.
 
-Acceptable for a trace UI; **not** a basis for SLOs. Recording it here rather than leaving it
-to be discovered by whoever first measures against it and finds their numbers slightly wrong.
+Publish time IS used for exactly one span: the synthetic root (D7), whose start/end come from
+the `Started`/`Terminated` envelopes. For the run as a whole that is not an approximation —
+the run really did begin when it published `Started`.
 
-**D3 — the OTel dependency lives in the engine's serve-mode adapter ONLY.**
-`packages/url4/tests/unit/test_import_isolation.py` forbids `opentelemetry` anywhere reachable
-from `import url4`, checked in a **clean subprocess** so the claim has teeth, and CI runs it
-with and without the `url4[server]` extra. `check_layering.py` gates the engine additionally.
-An exporter that imports OTel from url4 core or the runner fails CI by design.
+**D3 — the OTel dependency is confined to `tracing/otlp.py`, and the mount is the RUN mode,
+not serve mode.** D3 originally said "serve-mode adapter ONLY"; that was written before the
+mount point was resolved (D6 → D9) and is now wrong about the half. What survives is the part
+that matters: `packages/url4/tests/unit/test_import_isolation.py` forbids `opentelemetry`
+anywhere reachable from `import url4`, checked in a **clean subprocess** so the claim has
+teeth. The exporter lives in `screamingface_engine`, never in `url4`, so that holds by
+construction. Within the engine the OTel import is confined to ONE module by the port/adapter
+split in D8.
 
 **D4 — export must never fail or slow a run.** The observation seam is explicitly synchronous
 and non-blocking by contract (`observe.py`'s module docstring: the executor calls it inline from
@@ -53,8 +62,63 @@ so it is recorded rather than silently deferred.
 **D6 — the mount point is NOT the WS bridge.** `ws/bridge.py` subscribes per attached client, so
 mounting there would export spans only for runs somebody happened to be watching — the exact
 "absent because not exercised" ambiguity that cost a real diagnosis in `OME-940`. The exporter
-needs a subscription that exists whether or not a client is attached. Resolving exactly where
-that lives is the first task of the transport half.
+needs a subscription that exists whether or not a client is attached.
+
+Investigating that turned up a harder fact: **there is no control-plane subscription that sees
+all runs.** `stream_for(topic)` creates ONE JetStream stream per run, so the ticket's stated
+mount point does not exist to be mounted on. Raised as a fork; the owner chose a **publisher
+proxy in the worker**, which deliberately overrides the ticket's "never the runner". D9 records
+what that costs.
+
+**D7 — the exporter emits a SYNTHETIC ROOT SPAN, and that is not fabrication.** The runner emits
+one `SpanEvent` per *node*; there is no frame for the run itself. Without a root, every
+top-level node becomes its own root and one run renders as N disconnected traces — and worse,
+every `url4.parent=` reference and every gateway `traceparent` from Phase 1 points at a span id
+that exists nowhere.
+
+That id is not invented: `lifecycle._trace_fields` publishes run-level frames under
+`format_traceparent(trace_id, root_span_id)`, so **the `Started` envelope states the root's
+identity** and the `Terminated` envelope states when it ended. The exporter materialises a span
+that the wire already asserts. This is the distinction the mapper's own invariant draws — never
+mint an id, always honour one.
+
+Bonus recovered: `TerminatedData.status` is `succeeded | failed | stopped | timed_out`, four
+states, where `SpanData.status` is only `ok | error`. So the ROOT span can distinguish a
+stopped run from a failed one even though its children cannot — which partially repairs the
+`cancelled`-collapse limitation recorded on the ticket.
+
+**D8 — port/adapter split, so OTel is importable from exactly one module.** `tracing/relay.py`
+defines the `SpanSink` port and the transparent `EventPublisher` proxy; `tracing/otlp.py` is the
+only module that imports `opentelemetry`. The composition root wires them. This is the repo's
+mandated hexagonal shape, and concretely it is what lets the relay's whole behaviour — mapping,
+root synthesis, never-fail-the-run — be tested with a fake sink and no OTel, no collector, no
+network.
+
+**D9 — the sink is OFF unless an endpoint is configured, and configured the STANDARD way.**
+`sink_from_env` returns `None` when no OTLP endpoint env var is set, so every existing run,
+every local run, and every test is unaffected by construction. When one IS set, the exporter and
+the resource are built from OTel's own env contract (`OTEL_EXPORTER_OTLP_*`,
+`OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`) rather than a config vocabulary invented here.
+
+That is a deliberate gift to `OME-1131`: its job becomes "set standard env vars in the chart",
+with **no new credential scheme to design**, and the owner decision it must stop for shrinks to
+"which endpoint, which auth header".
+
+**D10 — flush on shutdown is MANDATORY, not a nicety.** The run process is short-lived (D9's
+mount is the Job entrypoint). A `BatchSpanProcessor` with default behaviour drops whatever is
+still queued when the process exits — which is the tail of *every* trace, including the root
+span, which is by definition the last thing emitted. That failure mode looks like "tracing
+works" while every run is missing its ending. The sink's shutdown therefore calls
+`force_flush()` before `shutdown()`, and `SpanRelay` is a CONTEXT MANAGER so the composition
+root drives it with `with` — a hand-written `finally` works exactly as well right up until
+somebody edits that function, and this failure is silent.
+
+**D11 — an UNFINISHED span is not exported, and is counted.** OTLP has no representation for
+"still running": `end_time=None` encodes as epoch 0 and renders as a 56-year span, while
+`end == start` states a 0 ms duration that is simply a lie. Both are worse than an absent span,
+so an unfinished span is skipped and surfaced in the relay's counters. (In practice unreachable
+— `_RunState._finish` emits one frame per *completed* span — but `SpanData.end` is `Optional`
+on the wire, so the mapper must answer for it.)
 
 **Supersedes:** emit-time export makes the tracing backend the durable evidence store, which
 retires the design-only "Enclave" trace store the spec sketches (§6, F2). Stated here so that
@@ -63,32 +127,98 @@ design is not resurrected.
 ## Planned changes
 
 - `src/screamingface_engine/tracing/span_tree.py` (new) — the pure mapper.
-- `src/screamingface_engine/tracing/otlp.py` (new) — the OTel sink (transport half).
+- `src/screamingface_engine/tracing/relay.py` (new) — the `SpanSink` port + publisher proxy.
+- `src/screamingface_engine/tracing/otlp.py` (new) — the OTel adapter (transport half).
+- `src/screamingface_engine/runner/main.py` — wire the relay into the run's publisher.
 - `pyproject.toml` — OTel SDK + OTLP exporter, engine only.
-- Tests over recorded frame fixtures.
 
 ## Test plan
 
-RED first, over the pure mapper:
+RED first. The mapper's own tests are already green; these are the new halves.
 
-- Parent edges are preserved exactly — a nested run yields the same tree the frames describe.
-- One trace per run; every span carries the run's `trace_id`.
-- `NodeFinished.status` maps to span status: `ok`, `error`, `cancelled` distinctly.
-- A `NodeStarted` with no matching `NodeFinished` (a run cut short) does not crash the mapper
-  and is reported as unfinished rather than silently dropped.
-- A `NodeFinished` with no `NodeStarted` is reported, not guessed at.
-- Duration is derived from envelope times, and a span whose frames carry no time is not
-  assigned a fabricated one.
+**The relay (no OTel, fake sink):**
+- Every frame passes through to the inner publisher unchanged — transparency is the property
+  that makes this safe to mount on the run's only publisher.
+- A `SpanEvent` reaches the sink as a mapped `Span`; a non-span frame does not.
+- `Started` + `Terminated` produce the synthetic root, with the run's own root span id.
+- An undecodable `traceparent` is counted and NOT sent (never fabricate).
+- An unfinished span is counted and NOT sent (D11).
+- **A sink that RAISES does not fail the publish** — D4, the invariant the whole design exists
+  to protect.
+- `close()` is driven even when the run raised.
+
+**The OTLP adapter (OTel, no network):**
+- `sink_from_env` returns `None` with no endpoint set — off by default (D9).
+- A `Span` becomes a `ReadableSpan` whose ids are the hex parsed to ints, whose timestamps are
+  ns, and whose parent context is the run's root when `is_root_child`.
+- The sampled flag is set — `BatchSpanProcessor.on_end` silently DROPS an unsampled span, so
+  this is the difference between working and silently exporting nothing.
+- The `gen_ai.*` attributes survive as their OTel-conventional names.
 
 ## Acceptance
 
-- The mapper is total over recorded fixtures and preserves the tree.
+- The mapper is total over the wire types and preserves the tree.
 - No OTel import is reachable from `import url4` (existing test still green).
+- No OTel import outside `tracing/otlp.py` within the engine.
+- A run with no endpoint configured behaves exactly as before.
 - `run_gates.py screamingface-engine` green, `check_layering.py` included.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
 - **Actual files:**
-- **Commits:**
-- **Gates:**
+  - `src/screamingface_engine/tracing/span_tree.py` — the pure mapper; gained `span_from_frame`
+    (the streaming relay sees frames one at a time), `identity_of`, and an `attributes` bag.
+  - `src/screamingface_engine/tracing/relay.py` (new) — the `SpanSink` port, `otlp_configured`,
+    and `SpanRelay`, a transparent `EventPublisher` proxy.
+  - `src/screamingface_engine/tracing/otlp.py` (new) — the OTel adapter; the ONLY module in the
+    engine importing `opentelemetry`.
+  - `src/screamingface_engine/tracing/__init__.py` — re-exports the port half only, with an
+    AIDEV-NOTE against re-exporting the adapter (it would undo the lazy import).
+  - `src/screamingface_engine/runner/main.py` — `span_sink()` + the `with SpanRelay(...)` wiring.
+  - `pyproject.toml` / `uv.lock` — `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`.
+  - Tests: `test_span_relay.py`, `test_otlp_sink.py`, `test_span_export_wiring.py` (new);
+    `test_span_tree.py` unchanged — the mapper's contract held under the refactor.
+  - Mirror: `docs/tasks/2026-09-10-OME-1130-frame-otlp-exporter.md`.
+
+- **Gates:** `run_gates.py screamingface-engine` **ALL GREEN** — append-only check, ruff
+  check/format, pyright, `check_layering.py`, and pytest with coverage. Full engine suite
+  **2760 passed, 9 skipped**. `packages/url4` `test_import_isolation.py` still green (7 passed),
+  which is what D3 rests on.
+
+- **Verification beyond the gates:**
+  - **Six mutations, six killed.** Each critical invariant was broken on purpose to confirm the
+    test that guards it actually fails: the relay swallowing sink errors; the `SAMPLED` flag;
+    reparenting a top-level node onto the root; refusing an unfinished span; the verbatim
+    status reason; blank-endpoint-means-off. A green test that cannot fail is the defect this
+    project keeps re-learning, so this is now routine rather than optional.
+  - **The OTLP encoding was PROVED, not assumed.** A hand-built `ReadableSpan` was pushed
+    through `encode_spans` before any of this was written, because "construct SDK spans by hand
+    from foreign ids" is the one part of the design with no precedent in the repo.
+  - **Cold start measured, not estimated:** 227 ms with the eager import, 201 ms without, and
+    `import screamingface_engine.runner.main` now loads **0** `opentelemetry` modules.
+
 - **Deviations:**
+  - **`EventPublisher.close` already exists, is `async`, and is NOT abstract — pyright caught a
+    real bug.** The relay's sink-shutdown method was called `close`, which silently overrode it
+    with an incompatible sync signature. Nothing would have failed until someone did
+    `await publisher.close()` on a wrapped publisher — at teardown, in production, on the path
+    that only runs when something is already going wrong. Split into an async `close` that
+    forwards to the transport and a sync `shutdown` that closes the sink, with a test for the
+    distinction. Worth recording because `run_evidence.TerminalWatch` proxies the same port and
+    does not forward `close` either — the same latent gap, not introduced here, not fixed here.
+  - **The mount point overrides the ticket, by owner decision.** See D6.
+  - **Three of the ticket's stated premises were wrong** (the observation seam, publish-time
+    durations, the mount point) and one of its warnings did not apply. Corrected on the issue
+    rather than implemented as written.
+  - **Flush-on-shutdown is enforced by `with`, not by a `finally`.** D10's failure mode is
+    silent — every trace merely loses its ending — so the context manager makes it structural.
+  - **`SpanRelay` exposes `undecodable`/`unfinished` counters that nothing reads yet.** Kept
+    because the relay must be able to say a trace is incomplete, and flagged rather than
+    silently left. A future line in `_log_terminal` is the natural consumer.
+  - **Local (`--local`) runs export nothing**, because they call `lifecycle.run` from the
+    in-process adapter rather than through `runner/main`. That is the same split `run_evidence`
+    hit and documented. In scope terms it is correct — Phase 2 targets the deployed trace view,
+    and a local run has no collector — but it is a real asymmetry, not an oversight.
+  - **Not covered by this unit:** `OME-1131` supplies the endpoint and credentials, without
+    which every one of these paths is inert in production. Nothing here has yet exported a span
+    to a real collector; the acceptance for that lives in `OME-1131`.

--- a/docs/work/2026-09-10-OME-1130-frame-otlp-exporter.md
+++ b/docs/work/2026-09-10-OME-1130-frame-otlp-exporter.md
@@ -1,0 +1,94 @@
+---
+ticket: OME-1130
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-10
+finished:
+---
+
+# OME-1130 — Frame-to-OTLP exporter at the engine control-plane relay
+
+## Intent
+
+The core of Phase 2. Phase 1 made one `trace_id` greppable across services; this makes SigNoz's
+**trace view** stop being empty — a waterfall with per-span timing instead of log search.
+
+This is an adapter, not a rewrite. The frames already ARE a span tree: `NodeStarted` carries
+`span_id` and `parent_span_id`, so the parent edge is **given, not inferred**, and pairing with
+`NodeFinished` by `span_id` yields duration and status.
+
+## Design decisions
+
+**D1 — the mapper is PURE and separate from the transport.** `frames -> span tree` is a total
+function over recorded fixtures, unit-testable with no OTel, no network and no engine boot. The
+OTLP exporter is a thin sink behind it. This is not tidiness: it is what lets the risky half
+(transport, backpressure, credentials) change without re-testing the semantics, and it keeps
+the OTel import confined to one module.
+
+**D2 — span timing is PUBLISH time, and that is an approximation that must be written down.**
+`_Sequencer.next()` stamps `time=datetime.now(UTC)` on every published envelope
+(`url4/streaming/lifecycle.py:62`), so a span's start/end are its `NodeStarted`/`NodeFinished`
+FRAME times, not true resolve boundaries. Durations therefore include publish latency.
+
+Acceptable for a trace UI; **not** a basis for SLOs. Recording it here rather than leaving it
+to be discovered by whoever first measures against it and finds their numbers slightly wrong.
+
+**D3 — the OTel dependency lives in the engine's serve-mode adapter ONLY.**
+`packages/url4/tests/unit/test_import_isolation.py` forbids `opentelemetry` anywhere reachable
+from `import url4`, checked in a **clean subprocess** so the claim has teeth, and CI runs it
+with and without the `url4[server]` extra. `check_layering.py` gates the engine additionally.
+An exporter that imports OTel from url4 core or the runner fails CI by design.
+
+**D4 — export must never fail or slow a run.** The observation seam is explicitly synchronous
+and non-blocking by contract (`observe.py`'s module docstring: the executor calls it inline from
+its own coroutines). So the sink is fire-and-forget behind a bounded queue, and **drops on
+backpressure rather than blocking**. A collector outage must degrade telemetry, never the run.
+
+**D5 — export every span for now, and say so.** `url4/streaming/trace.py` hardcodes
+`_SAMPLED = "01"`, so every run is nominally sampled and there is no sampling decision to
+honour. Head sampling would need a policy nobody has set. Exporting everything is correct at
+current volume and wrong at some larger one; the point at which it becomes wrong is a decision,
+so it is recorded rather than silently deferred.
+
+**D6 — the mount point is NOT the WS bridge.** `ws/bridge.py` subscribes per attached client, so
+mounting there would export spans only for runs somebody happened to be watching — the exact
+"absent because not exercised" ambiguity that cost a real diagnosis in `OME-940`. The exporter
+needs a subscription that exists whether or not a client is attached. Resolving exactly where
+that lives is the first task of the transport half.
+
+**Supersedes:** emit-time export makes the tracing backend the durable evidence store, which
+retires the design-only "Enclave" trace store the spec sketches (§6, F2). Stated here so that
+design is not resurrected.
+
+## Planned changes
+
+- `src/screamingface_engine/tracing/span_tree.py` (new) — the pure mapper.
+- `src/screamingface_engine/tracing/otlp.py` (new) — the OTel sink (transport half).
+- `pyproject.toml` — OTel SDK + OTLP exporter, engine only.
+- Tests over recorded frame fixtures.
+
+## Test plan
+
+RED first, over the pure mapper:
+
+- Parent edges are preserved exactly — a nested run yields the same tree the frames describe.
+- One trace per run; every span carries the run's `trace_id`.
+- `NodeFinished.status` maps to span status: `ok`, `error`, `cancelled` distinctly.
+- A `NodeStarted` with no matching `NodeFinished` (a run cut short) does not crash the mapper
+  and is reported as unfinished rather than silently dropped.
+- A `NodeFinished` with no `NodeStarted` is reported, not guessed at.
+- Duration is derived from envelope times, and a span whose frames carry no time is not
+  assigned a fabricated one.
+
+## Acceptance
+
+- The mapper is total over recorded fixtures and preserves the tree.
+- No OTel import is reachable from `import url4` (existing test still green).
+- `run_gates.py screamingface-engine` green, `check_layering.py` included.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**


### PR DESCRIPTION
Phase 2's core (epic `OME-1129`). Phase 1 made one `trace_id` greppable across services; this makes SigNoz's **trace view** stop being empty — a waterfall with per-span timing instead of a log search.

## What it does

A transparent `EventPublisher` proxy wraps the run's own publisher, maps each published `SpanEvent` to an OTel span, and ships it via OTLP. Every frame still reaches the transport unchanged.

## Three of the ticket's premises were wrong

Found by reading the wire, corrected on the issue rather than implemented as written:

| Ticket says | Actually |
|---|---|
| Map `url4.observe`'s `NodeStarted`/`NodeFinished` | Those are the runner's **in-process** seam and are never published. The wire is `SpanEvent`/`SpanData`, and `test_only_engine_extensions_import_url4` forbids reaching the url4 engine from here anyway. |
| Durations come from envelope publish times; write down the latency caveat | `SpanData` carries its own `start`/`end`, captured in the runner (`runner/executor.py:358`). The caveat does not apply — writing it down would have taught every future reader something false. |
| Mount on "the control-plane relay, never the runner" | **That subscription does not exist.** `stream_for(topic)` creates one JetStream stream per run; only `ws/bridge.py` subscribes, per attached client. Mounting there exports spans only for runs somebody happened to be watching — the "absent because not exercised" ambiguity that cost a real diagnosis in `OME-940`. |

The mount point went to the owner as a fork. Decision: **publisher proxy in the worker**, deliberately overriding "never the runner".

## The synthetic root span

The runner emits one `SpanEvent` per *node* — there is no frame for the run itself. Without a root, one run renders as N disconnected traces, and every `url4.parent=` plus every Phase 1 gateway `traceparent` points at a span id that exists nowhere.

That id is not invented: `lifecycle._trace_fields` publishes run-level frames under `format_traceparent(trace_id, root_span_id)`, so the `Started` envelope **states** the root's identity and `Terminated` states when it ended. The relay materialises a span the wire already asserts.

Bonus: `TerminatedData.status` has four states (`succeeded|failed|stopped|timed_out`) where `SpanData.status` has two (`ok|error`). The root is the only place a stopped run stays distinguishable from a failed one.

## Cost and safety

- **Off unless configured**, via OTel's own env contract (`OTEL_EXPORTER_OTLP_*`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`) rather than a vocabulary invented here — so `OME-1131` becomes a chart-values change with **no new credential scheme to design**.
- **Lazy SDK import.** OTel costs ~62 ms of a Job's ~227 ms import budget. `check_layering.py` guards a Job's cold start against the engine's own modules and structurally cannot see a third-party dependency, so a subprocess test covers that direction. Measured: `import runner.main` loads **0** `opentelemetry` modules.
- **The relay may never fail a run.** It sits on the path every frame travels; a downed collector must degrade telemetry alone.

## Test plan

- `run_gates.py screamingface-engine` **ALL GREEN** — append-only, ruff, pyright, `check_layering.py`, pytest+coverage. Full suite **2760 passed, 9 skipped**.
- `packages/url4` `test_import_isolation.py` still green (7 passed) — no `opentelemetry` reachable from `import url4`.
- **Six mutations, six killed** — each critical invariant broken on purpose to confirm its test actually fails (error-swallowing, the `SAMPLED` flag, root reparenting, unfinished-span refusal, verbatim status, blank-endpoint-is-off).
- OTLP encoding proved with `encode_spans` before the design was committed to — building SDK spans by hand from foreign ids has no precedent in this repo.

## Worth a reviewer's eye

- **pyright caught a real bug:** `EventPublisher.close` already exists, is `async`, and is *not* abstract — the sink-shutdown method named `close` silently overrode it. Nothing would have failed until `await publisher.close()` on a wrapped publisher, at teardown. Split into async `close` (forwards to transport) and sync `shutdown` (closes the sink). **`run_evidence.TerminalWatch` proxies the same port and does not forward `close` either** — same latent gap, not introduced here, not fixed here.
- **Local (`--local`) runs export nothing** — they call `lifecycle.run` from the in-process adapter, not through `runner/main`. Same split `run_evidence` hit. Correct for Phase 2's scope (a local run has no collector) but a real asymmetry.
- **Nothing here has exported a span to a real collector yet.** `OME-1131` supplies the endpoint; that acceptance lives there.

Ledger: `docs/work/2026-09-10-OME-1130-frame-otlp-exporter.md`

Refs: OME-1130