### PR TITLE
docs(tasks): close the OME-1144 mirror and ledger

### DIFF
--- a/docs/tasks/2026-09-08-OME-1144-remove-submitter-column.md
+++ b/docs/tasks/2026-09-08-OME-1144-remove-submitter-column.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1144
 linear_url: https://linear.app/openmined/issue/OME-1144/remove-the-submitter-column-from-the-leaderboard-table
-status: in_review
+status: Done
 type: task
 priority: 2
 labels: [scoreboard, agentic, autonomous, BUG]
 created: 2026-09-08
-closed:
+closed: 2026-09-09
 ---
 
 # Remove the "Submitter" column from the leaderboard table

--- a/docs/work/2026-09-08-OME-1144-remove-submitter-column.md
+++ b/docs/work/2026-09-08-OME-1144-remove-submitter-column.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1144
 stack: scoreboard
-status: in_progress
+status: done
 started: 2026-09-08
-finished:
+finished: 2026-09-09
 ---
 
 # OME-1144 — Remove the Submitter column from the leaderboard table
@@ -51,7 +51,8 @@ The last two are the reason this is a guard and not a restatement of the diff.
   cell append); `tests/unit/test_multiple_authors.py` lost the two stale assertions and gained
   `test_portal_leaderboard_table_has_no_submitter_column`. `portal/main.js`, `portal/spec.js` and
   `portal/spec.html` untouched, as D3 and D4 require.
-- **Commits:** see the PR — one commit, `Refs: OME-1144`.
+- **Commits:** `f887d88d` — `feat(scoreboard): drop the Submitter column from the leaderboard table`
+  (`Refs: OME-1144`). Landed on `main` as PR #859, squash-merged 2026-09-09 (`4744cf07`).
 - **Gates:**
   - `run_gates.py scoreboard --base origin/main` → append-only check FAILS on
     `tests/unit/test_multiple_authors.py` (removed old lines 197, 198). That is exactly the


### PR DESCRIPTION
## Summary

`OME-1144` shipped on 2026-09-09 — PR #859, squash-merged as `4744cf07` — but both SDLC records were left open:

- `docs/tasks/…-OME-1144-….md` still read `status: in_review`
- `docs/work/…-OME-1144-….md` still read `status: in_progress`, with `Commits: see the PR` as a placeholder

This closes both and substitutes the real commit (`f887d88d`).

## Test plan

Documentation only — no source, test, or portal files touched. No gates apply; `run_gates.py scoreboard` is not triggered by `docs/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)