### PR TITLE
docs(work): record the OME-1145 openness-metric review

### DIFF
--- a/docs/work/2026-09-10-OME-1145-openness-metric-review-feedback.md
+++ b/docs/work/2026-09-10-OME-1145-openness-metric-review-feedback.md
@@ -1,0 +1,340 @@
+---
+ticket: OME-1145
+stack: scoreboard
+status: done
+started: 2026-09-10
+finished: 2026-09-10
+---
+
+# OME-1145 — feedback on the openness-metric review
+
+## Intent
+
+Verify the claims and proposed Linear edits in
+`docs/work/2026-09-10-OME-1145-openness-metric-review.md` against `origin/main`, the live
+development Scoreboard API, and the current Linear issues. This is review evidence only: it
+does not change source code or Linear.
+
+## Verdict
+
+The review found the right architectural problem: the existing openness statistic and the
+cost/score Pareto marks are separate implementations, the SDK throws away structured model
+identities before submission, and the current classifier cannot classify mixed-owner model
+families correctly.
+
+The pending Linear edits should **not** be applied exactly as written yet. Five material
+issues remain:
+
+1. revision mixing is already visible in live data, not merely a hypothetical unpinned-board
+   concern;
+2. the row-level operator override still needs an explicit compatibility decision;
+3. “open” has no sufficiently precise licence/weights definition for the proposed exceptions;
+4. the proposed second query is not bounded; and
+5. the API and legacy-row migration behavior is unspecified.
+
+## Evidence checked
+
+- `origin/main` at `17048f5d`.
+- Anonymous live reads on 2026-09-10:
+  - `GET https://leaderboard.dev.screamingface.ai/v1/benchmarks`
+  - `GET https://leaderboard.dev.screamingface.ai/v1/leaderboard/draco-3pass`
+  - `GET https://leaderboard.dev.screamingface.ai/v1/leaderboard/draco-3pass/frontier`
+  - public per-spec history routes for every visible `draco-3pass` spec.
+- Current Linear descriptions, relations, and comments for `OME-1145`, `OME-1179`,
+  `OME-1180`, `OME-1181`, `OME-772`, `OME-428`, `OME-394`, and `OME-831`.
+- Official model sources for the disputed classification examples:
+  - [Google Gemma 2 model card](https://ai.google.dev/gemma/docs/core/model_card_2)
+  - [Google Gemma terms](https://ai.google.dev/gemma/terms)
+  - [OpenAI gpt-oss documentation](https://developers.openai.com/api/docs/models/gpt-oss-120b)
+  - [Mistral Large 2411 model card](https://huggingface.co/mistralai/Mistral-Large-Instruct-2411)
+  - [Moonshot Kimi K2.6 model card](https://huggingface.co/moonshotai/Kimi-K2.6)
+
+## Claims confirmed
+
+The following parts of the review are supported by both code and live behavior:
+
+- `draco-3pass` currently returns seven ranked entries, no baselines, and one marked Pareto
+  entry. All seven visible entries report `ran_with_providers=["openrouter"]` and
+  `run_cost_usd="0.000000"`.
+- The separate frontier-stat endpoint reports `open_count=0`, `closed_count=10`, and
+  `open_share=0.0`.
+- The current ranked-board Pareto calculation uses `leaderboard_pareto_inputs()` and
+  `compute_pareto_frontier_ids()`. It applies the registered revision, best-per-spec collapse,
+  case-count rule, and the `pinned` gate.
+- The openness endpoint instead uses `list_all_for_benchmark()` and `compute_frontier()`. It
+  reads every Score row, has no revision filter, does not use cost, includes Baselines in the
+  current split, and returns 404 for a private board.
+- `_current_split()` implements the earlier `OME-323` specification faithfully. In particular,
+  the old spec deliberately includes Baselines in the current split while excluding them from
+  the trend. Replacing that meaning requires an explicit Confidence-Gate exception; it is not
+  an accidental one-line bug.
+- `_submission()` sends provider prefixes derived from `CandidateResult.models`; `_providers`
+  is at line 502 and its call site is line 443 on this revision.
+- A live `url4_expression` contains the declared candidate routes literally and also contains
+  the DRACO grader route three times. The seven candidate-model lists in the review match the
+  live expressions.
+- Scoreboard has no URL4 parser dependency. Adding a structured `models` field is preferable to
+  parsing a harness-dependent expression.
+- `CandidateResult.models` is required, ordered, non-empty, unique, and derived from the
+  compiled recipe. It represents **declared candidate models**, not models observed from usage
+  events.
+- `ScoreSubmission` uses `extra="forbid"`, so Scoreboard support must deploy before the SDK
+  starts sending a new top-level field.
+- `openness_override` has no HTTP, CLI, or import-DTO write path. It is intentionally
+  operator-only and can currently be changed only outside the normal application write path.
+- OpenRouter is the only production AIGateway adapter currently calling
+  `DirectCost.reported(...)`.
+- `OME-772` does already record that the board has provider names and an opaque expression but
+  no clean model list. It remains assigned to Irina in Pick Immediately, and its `focus` claim
+  is stale.
+
+## Corrections required
+
+### 1. The live statistic already mixes revisions
+
+The review says revision mixing is “not currently visible because every live board has one
+revision.” That confuses a benchmark's one **registered** revision with the revisions stored on
+its Score rows.
+
+The live `draco-3pass` history contains seven scores at the registered revision
+`2634cec91fd0f19a` and three older scores at `b8c8afd8f9dddca0`:
+
+- old `pareto_cross`;
+- old `claude-fable-5`; and
+- old-only `claude-opus-5`.
+
+The ranked leaderboard filters those old rows. The openness endpoint includes them. Its trend
+currently exposes the old `claude-opus-5` score as its first point. Therefore the 10-versus-7
+gap is not described fully by “all rows versus best-per-spec”; on today's data it is also the
+direct result of missing revision filtering.
+
+This changes the framing of `OME-1145`: changing the denominator from entries to Pareto models
+supersedes an earlier product decision, but mixing incomparable benchmark revisions is a real
+integration defect introduced by later revision semantics.
+
+### 2. Empty-board API values are `0.0`, not a dash
+
+For example, `/v1/leaderboard/draco/frontier` currently returns `open_share: 0.0`,
+`current: null`, and an empty trend. The portal may suppress the card when there are no rows,
+but a table described as API evidence should record `0.0` or explicitly label the dash as
+portal presentation.
+
+### 3. Use “declared models,” never “models actually behind the rows”
+
+The URL4 evidence recovers what the submitted recipe declares. It does not prove the exact
+provider response selected at runtime, and it does not turn `url4_expression` into a structured
+model field. Recommended wording:
+
+> The Scoreboard stores enough public recipe text to recover candidate model routes with
+> harness-aware parsing, but it has no structured, unambiguous candidate-model field.
+
+That is more accurate than either “the Scoreboard cannot tell at all” or “the Scoreboard can
+tell which model produced the result.”
+
+### 4. Public URL4 data does not resolve the API-shape decision
+
+It is true that the model names already appear in a public field. A separate `models` array
+does not disclose a new category of data. It does, however, make that data directly enumerable
+and creates a new supported wire contract.
+
+`D6` should therefore not be marked resolved merely because URL4 is public. The implementation
+must still choose whether `models` is:
+
+- stored and used internally only; or
+- returned as a first-class public `LeaderboardEntry` field.
+
+The privacy concern is largely resolved; the API compatibility and product-display decision is
+not.
+
+### 5. “Open” needs a precise definition before adding exceptions
+
+The classifier counterexamples are valuable, but the table's `weights` column overstates the
+certainty of the judgements:
+
+- Gemma 2 has downloadable weights under Google's Gemma terms, which contain use restrictions.
+- `gpt-oss-120b` has downloadable weights under Apache 2.0 plus the gpt-oss usage policy.
+- Kimi K2.6 publishes code and weights under a Modified MIT licence.
+- Mistral Large 2411 publishes downloadable weights under the Mistral Research License, which
+  permits research/non-commercial use. Calling it “closed weights” is factually inaccurate;
+  calling it unsuitable for a permissively licensed open category may still be a valid product
+  decision.
+
+The contract must say whether `open` means:
+
+1. weights are downloadable and locally runnable;
+2. weights are available under a permissive commercial licence; or
+3. the complete stack meets a stricter open-source/reproducibility standard.
+
+The earlier `OME-323` policy was routing-based and does not settle this licence boundary. Until
+that definition is explicit, “tighten Mistral” is not an implementation-ready instruction.
+
+### 6. A per-model classifier function is still needed
+
+The existing `classify_providers(Sequence[str])` returns one row-level `open|closed` verdict and
+implements any-closed-wins. The new statistic counts individual models. Even if the same marker
+data is retained, the code needs a separate API such as `classify_model(route)` and explicit
+precedence for exceptions such as:
+
+- `openrouter/openai/gpt-oss-*` before the `openai` closed-owner rule;
+- `openrouter/google/gemma-*` before the `google` closed-owner rule; and
+- specific open Mistral families rather than the substring `mistral`.
+
+Calling this “no new classifier” hides a real semantic change. Reusing the registry is fine;
+reusing the aggregate function unchanged is not.
+
+### 7. Do not drop the override decision
+
+The heading “the manual override cannot be set” is too strong. It has no supported application
+write path, but the model column exists precisely for an operator database correction. Current
+values cannot be checked anonymously, and future values remain possible.
+
+Consequently `D-H` is not safe. Absence of a normal write endpoint does not define what an
+existing row-level override means in a per-model metric.
+
+Recommended resolution:
+
+> `openness_override` remains effective for the legacy row-level classifier and historical
+> score trend. It does not affect the new per-model Pareto share because a row-level value cannot
+> identify which constituent models it overrides. Model classification exceptions belong in
+> the model registry.
+
+That is an explicit compatibility decision and removes the blocker without pretending the
+field does not exist.
+
+### 8. A Pareto frontier is not bounded
+
+`OME-1179` and `OME-1181` say the second model query is safe because the frontier is “small and
+bounded.” It is neither guaranteed. Every best-per-spec point can be non-dominated, and the
+number of submitted spec IDs is client-controlled. A large `WHERE id IN (...)` can also exceed
+database parameter limits.
+
+The second projection is still the right shape, but it must be implemented as a compact,
+chunked/streamed query over `id, models`, with explicit bounds on:
+
+- number of model routes per submission;
+- length of each route; and
+- total serialized model-field size.
+
+It must never fetch URL4 expressions or display metadata for the whole board.
+
+### 9. The public API migration is missing
+
+The current `/frontier` response combines:
+
+- `open_count`, `closed_count`, and `open_share` from all rows; with
+- `current` and `trend` from the running best **score**.
+
+Changing the counts to models on the **cost/score Pareto frontier** while leaving the trend as a
+row-level score history makes one response contain two unrelated definitions. It also changes
+the meaning and unit of existing public fields.
+
+Prefer either:
+
+- a new `pareto_openness` object/endpoint with explicit model-count field names; or
+- a versioned replacement of the old response.
+
+Do not silently reuse `open_count` for “number of open models” while `current.openness` still
+means “row-level classification of the running best score.”
+
+### 10. Legacy and deduplicated rows need a policy
+
+Adding a nullable `models` column leaves every existing Score row without structured identities.
+The current dedup replay path updates `authors` and `metadata`, but not cost or any future
+`models` field. Re-submitting the same result from the new SDK would therefore return the old
+row and discard the new model identities unless the implementation changes that behavior.
+
+Before implementation, decide among:
+
+- leave legacy rows unknown and accept that the live metric initially has no classified
+  frontier entries;
+- allow a same-owner dedup replay to enrich a null `models` field, with the same anti-hijack and
+  visibility locking used for author/metadata updates; or
+- perform a controlled one-time backfill/purge and resubmission.
+
+Models should not be added to `content_hash`: doing so would split one recipe/result identity
+only because a newer client sent a richer projection of data already present in the recipe.
+
+### 11. Qualify the OpenRouter cost claim
+
+OpenRouter is the only production Gateway adapter currently emitting
+`DirectCost.reported(...)`. It does not follow that every priced Score must use OpenRouter:
+`ScoreSubmission` accepts a caller-provided cost, and future adapters can add reporting.
+
+Recommended wording:
+
+> OpenRouter is currently the only implemented Gateway path that emits provider-reported direct
+> USD cost, so it dominates the SDK-generated priced rows available today.
+
+### 12. `OME-831` is not a successor openness-classification issue
+
+`OME-831` is about Hugging Face `hosted_shared` credentials. Its scope does not define model
+openness or reconcile registries. It is a successor to the hosted-credentials portion of
+`OME-394`, not to the missing gateway openness signal. The recommendation not to comment there
+is sound, but the review should remove “Successor is OME-831” from the classification discussion.
+
+### 13. Small internal inconsistencies
+
+- The introduction says four Linear claims are wrong; its table lists six. Use “several” or
+  state the final count.
+- With all costs equal, the Pareto frontier does not always contain exactly one row. It contains
+  every row tied for the highest score at that cost. The live board has one because
+  `fable_plus_gpt` is the unique highest-scoring zero-cost entry.
+
+## Assessment of the proposed owner decisions
+
+| decision | assessment |
+| -- | -- |
+| D-A — keep the epic and relate `OME-772` | Good. The two-package delivery still requires the epic and two landing issues. |
+| D-B — correct the `pinned` premise | Good, but also record that stale revisions are already included in the live statistic. |
+| D-C — rewrite the problem and reject URL4 parsing | Good. Use “declared candidate routes” throughout. |
+| D-D — retain and widen the marker list | Viable only after defining `open`; implement model-specific precedence and a per-model classifier. |
+| D-E — rewrite `OME-1145` and move it to Blocked | Good. Describe both the product-definition change and the live revision-mixing defect. |
+| D-F — leave the dev card until the real fix | Reasonable for a team-only dev board. |
+| D-G — record the Baseline consequence | Good. Baselines have no comparable cost and therefore cannot join the cost/score Pareto set. |
+| D-H — drop the override question | Reject. Replace it with the explicit legacy-only override rule proposed above. |
+| D-I — do not comment on `OME-831` | Good. Also stop describing `OME-831` as the successor classification work. |
+| D-J — hold Linear edits until review | Good. |
+
+The file calls these “owner decisions,” but the current Linear threads do not record them. If
+they came from a separate owner conversation, link or summarize that source before treating
+them as durable product decisions. Otherwise label them “proposed decisions.”
+
+## Recommended delivery sequence
+
+1. **Correct the Linear design first.** Add the definition of `open`, the API shape, the
+   override compatibility rule, model-field bounds, and legacy/dedup policy.
+2. **Scoreboard ships first (`OME-1181`).** Accept and validate optional declared model routes;
+   store them with a migration; add a per-model classifier; expose or internally aggregate them
+   according to the chosen API shape; query the frontier projection safely.
+3. **Deploy Scoreboard.** Confirm an old client still submits successfully.
+4. **SDK ships second (`OME-1180`).** Send `CandidateResult.models` verbatim and retain
+   `ran_with_providers` for the existing Backends surface.
+5. **Repair `OME-1145`.** Use the same registered-revision filtering, case-count rule, pinned
+   gate, and full-board Pareto membership as the row marks. Do not derive membership from the
+   displayed page.
+6. **Close only after cost semantics are real.** `OME-1143`/`OME-1156` still determine whether
+   the resulting live Pareto set is economically meaningful.
+
+## Recommended changes to the pending Linear edits
+
+In addition to the corrections already listed in the original review:
+
+- `OME-1179`: add the exact live stale-revision evidence; keep D5 as a resolved compatibility
+  rule rather than deleting it; define `open`; leave D6 open until the public DTO shape is
+  chosen; remove the bounded-frontier claim; add legacy-row behavior.
+- `OME-1180`: keep the server-first rollout and full declared routes; state that its release is
+  blocked until the deployed Scoreboard accepts the field.
+- `OME-1181`: specify field bounds, route normalization and classifier precedence, chunked
+  frontier-model reads, public response shape, and same-owner dedup enrichment or an explicit
+  no-enrichment decision.
+- `OME-1145`: distinguish the specified-but-superseded all-row/Baseline denominator from the
+  genuine stale-revision integration defect. Preserve or version the legacy trend instead of
+  quietly combining it with model-level Pareto counts.
+- `OME-772`: add only the `relatedTo` relation and leave its separate design decisions alone.
+
+## Outcome
+
+- **Actual files:** this feedback document only.
+- **Commits:** not committed in this review turn.
+- **Gates:** not run; documentation-only review with no application source changes.
+- **Deviations:** none.

--- a/docs/work/2026-09-10-OME-1145-openness-metric-review.md
+++ b/docs/work/2026-09-10-OME-1145-openness-metric-review.md
@@ -1,0 +1,347 @@
+---
+ticket: OME-1145
+stack: scoreboard
+status: blocked
+started: 2026-09-10
+finished:
+---
+
+# OME-1145 — pre-work review of the "open frontier share" metric
+
+## Intent
+
+No code changes. This is the audit record for a twelve-round review of OME-1145 and the
+epic filed against it (OME-1179 / OME-1180 / OME-1181), plus the owner decisions taken on
+2026-09-10. It exists because four of the claims already written into those tickets are
+wrong, and the corrections have not yet been applied to Linear. Read this before editing
+any of the five tickets.
+
+Nothing has been written to Linear. The pending edits are listed at the bottom.
+
+---
+
+## 1. What the board actually shows
+
+Fetched anonymously from `https://leaderboard.dev.screamingface.ai/v1/...` on 2026-09-10.
+
+| board | entries | baselines | on Pareto frontier | rows in the statistic | open_share |
+| -- | -- | -- | -- | -- | -- |
+| `draco-3pass` | 7 | 0 | **1** | **10** | 0.0 |
+| `draco` | 0 | 0 | 0 | 0 | — |
+| `gdpval-text` | 0 | 0 | 0 | 0 | — |
+| `ifeval` | 0 | 0 | 0 | 0 | — |
+| `medxpert` | 0 | 0 | 0 | 0 | — |
+| `healthbench-professional` | 0 | 0 | 0 | 0 | — |
+
+`draco-3pass` is the only populated board. All seven entries store
+`ran_with_providers = ['openrouter']`. Every `run_cost_usd` is `0.000000`. The board is
+pinned (`revision = 2634cec91fd0f19a`, `case_count = 100`).
+
+The 10-vs-7 gap is the two code paths: the statistic counts every Score row, the table
+counts best-per-spec.
+
+### The models actually behind those rows
+
+Recovered from each entry's stored `url4_expression`, splitting the `candidate:` binding
+from the rest of the harness:
+
+| spec | candidate models | harness |
+| -- | -- | -- |
+| `fable_plus_gpt` | claude-fable-5, claude-opus-4.8, gpt-5.5 | gemini-3.1-pro-preview |
+| `opus_plus_gpt` | claude-opus-4.8, gpt-5.5 | gemini-3.1-pro-preview |
+| `pareto_cross` | deepseek-v4-pro, kimi-k2.6, gpt-5.5 | gemini-3.1-pro-preview |
+| `budget_trio` | claude-opus-4.8, deepseek-v4-pro, gemini-3-flash-preview, kimi-k2.6 | gemini-3.1-pro-preview |
+| `best_open_source` | deepseek-v4-pro, kimi-k2.6, qwen3.6-plus | gemini-3.1-pro-preview |
+| `pareto_lean` | deepseek-v4-pro, kimi-k2.6 | gemini-3.1-pro-preview |
+| `claude-fable-5` | claude-fable-5 | gemini-3.1-pro-preview |
+
+All routes are `openrouter/`-prefixed. `gemini-3.1-pro-preview` appears three times per
+expression in every entry and is never a candidate model — it is the DRACO grader.
+
+---
+
+## 2. Two separate code paths, not one
+
+The single most consequential finding. The openness percentage and the Pareto row marks
+share a word and nothing else.
+
+| | openness statistic | Pareto row marks |
+| -- | -- | -- |
+| route | `GET /v1/leaderboard/{id}/frontier` (`routes/leaderboard.py:400`) | `GET /v1/leaderboard/{id}` (`routes/leaderboard.py:235`) |
+| function | `compute_frontier` (`scores/frontier.py:72`) | `compute_pareto_frontier_ids` (`scores/pareto.py:79`) |
+| query | `list_all_for_benchmark` — **every** Score row (`store.py:1217`) | `leaderboard_pareto_inputs` — best-per-spec (`store.py:1135`) |
+| revision filter | **none** | `registered_revision` (`store.py:545`) |
+| `pinned` gate | **none** | yes (`leaderboard.py:276`, D12) |
+| cost | not used | the whole basis |
+| baselines | included | **excluded** — the query reads Score only |
+| private board | 404 | returns empty entries |
+
+Each function has exactly one production caller. There is no shared code.
+
+Consequences:
+
+- The statistic **mixes benchmark revisions**. `_comparable` (`frontier.py:51`) applies only
+  the OME-1056 case-count rule. Nothing filters on revision. Not currently visible because
+  every live board has one revision.
+- Implementing Irina's metric is a route migration, not a change to `_current_split`.
+- Adding the `pinned` gate or a revision filter to the statistic changes what a live public
+  endpoint returns for an unpinned board. Moot today — all seven boards are pinned.
+
+---
+
+## 3. `_current_split` is not a defect
+
+`docs/spec/2026-07-16-open-vs-closed-frontier-stats-spec.md` resolved this on 2026-08-06:
+
+> **Baseline timing, resolved (2026-08-06):** … Baselines still count toward the *current*
+> open/closed split (§5), but are **excluded from the time-series trend**.
+
+and pinned it as an acceptance criterion in §8:
+
+> Baselines are included in the current open/closed split but excluded from the
+> time-series trend (§6).
+
+§6 also defines "the frontier" as *the single best score across all specs within a
+benchmark* — score only. Cost arrived later, via OME-770 and OME-923. So the repo now has
+two different concepts sharing the word "frontier", and `frontier.py`'s self-contradicting
+docstring traces straight back to the spec, not to a coding error.
+
+**OME-1145 is therefore a request to supersede an owner-resolved decision and its
+acceptance criterion, not a bug report against the implementation.** Irina's own framing —
+"Needs: A decision on the correct definition" — was right.
+
+### Rule-5 cost
+
+`apps/scoreboard/tests/unit/scores/test_frontier.py:92`,
+`test_baseline_counts_in_split_but_never_becomes_trend_holder`, asserts
+`open_count == 1`, `closed_count == 1`, `open_share == 0.5` with a Baseline in the
+denominator. Its entire purpose is to pin that baselines count. Changing the metric changes
+that test, which is a Confidence-Gate decision requiring owner approval.
+
+`test_openness_override_changes_the_holders_reported_openness` (line 163) may also move.
+
+---
+
+## 4. Why the number is 0%
+
+`packages/screamingface/src/screamingface/_scoreboard/leaderboards.py:502`:
+
+```python
+def _providers(models: Sequence[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(model.split("/", 1)[0] for model in models))
+```
+
+Called at line 443. `openrouter/meta-llama/Llama-3.1-70B-Instruct` is submitted as
+`"openrouter"`. `classify_score` reads `ran_with_providers`, matches `openrouter` on
+`_CLOSED_PROVIDER_MARKERS`, and files an open-weights run as closed.
+
+OpenRouter is the only provider that reports a cost — `DirectCost.reported(...)` has exactly
+one caller, `apps/aigateway/src/aigateway/plugins/openrouter_provider/usage_accounting.py:115` —
+so it dominates any board with cost data.
+
+Live effect: an entry named `best_open_source`, running deepseek + kimi + qwen, is counted
+closed.
+
+---
+
+## 5. The identities are already stored, and already public
+
+Verified against the live payload, not a synthetic object. A real submitted
+`url4_expression` is 21,105 characters and begins:
+
+```
+(candidate:0.0:'(model_1:0.0:/openrouter/anthropic/claude-fable-5?max_tokens=32768&q=($input)!'…
+```
+
+Every model route is literal. `url4_expression` is returned on the public
+`LeaderboardEntry` payload (confirmed in the live entry keys), so the model identities are
+already published on the board today.
+
+**This resolves D6.** Sending a `models` field publishes nothing that is not already public.
+
+### Why parsing `url4_expression` is still not the answer
+
+Two reasons, both verified:
+
+1. **The expression mixes the system under test with the harness grading it.** The DRACO
+   grader `openrouter/google/gemini-3.1-pro-preview` appears three times in every
+   expression, outside the `candidate:` binding. A naive extraction counts the judge as
+   part of the candidate. Separating them means locating the candidate binding boundary and
+   depending on the harness expression shape staying stable.
+2. **The Scoreboard has no URL4 parser.** No `url4` entry in `apps/scoreboard/pyproject.toml`
+   and no import anywhere in `src/`. Option C means adding `packages/url4` as a runtime
+   dependency of the scoreboard image.
+
+`CandidateResult.models` has neither problem: it is exactly the candidate's declared routes.
+That is the real justification for OME-1180, and it is stronger than the one currently in
+the ticket.
+
+For the record, every model in every recipe kind reaches the expression through one of two
+call sites — `_model_route(route)` at `_evaluation/candidate.py:215` (every `Model` node)
+and `_model_route(synthesizer)` at line 267 — so route recovery *would* be complete if the
+grader problem did not exist.
+
+---
+
+## 6. The keyword list does not hold the right answers
+
+After stripping the routing prefix, `classify_providers` on realistic routes:
+
+| route | weights | classifier | |
+| -- | -- | -- | -- |
+| `meta-llama/Llama-3.1-70B-Instruct` | open | open | ok |
+| `qwen/Qwen2.5-72B-Instruct` | open | open | ok |
+| `deepseek/deepseek-v3` | open | open | ok |
+| `mistralai/Mistral-7B-Instruct-v0.3` | open | open | ok |
+| `openai/gpt-5.5` | closed | closed | ok |
+| `anthropic/claude-opus-4.8` | closed | closed | ok |
+| `google/gemini-3-pro` | closed | closed | ok |
+| `google/gemma-2-27b-it` | open | **closed** | **wrong** |
+| `openai/gpt-oss-120b` | open | **closed** | **wrong** |
+| `mistralai/mistral-large-2411` | closed | **open** | **wrong** |
+
+Three of ten. Two of the three understate the open share — the exact complaint on OME-1145.
+The cause is structural: `_OPEN_PROVIDER_MARKERS` and `_CLOSED_PROVIDER_MARKERS` conflate
+model *owner* with openness, and Google, OpenAI and Mistral all now ship both.
+
+On live data, `moonshotai/kimi-k2.6` matches nothing in either list and fails closed. So
+`best_open_source` would read 2/3 open after the epic's fix, not 3/3.
+
+> The open/closed judgements in the table above are my assessment of the models, not
+> anything the repository asserts.
+
+---
+
+## 7. What the metric would actually read
+
+Applying the epic's fix (candidate models, prefix stripped, current marker list) to live
+`draco-3pass` data:
+
+| definition | entries | models counted | open | share |
+| -- | -- | -- | -- | -- |
+| all 7 leaderboard entries | 7 | 18 | 5 | **28%** |
+| Pareto frontier (today) | **1** | 3 | 0 | **0%** |
+
+With every cost at `0.000000` the frontier degenerates to a single entry — `fable_plus_gpt`,
+whose three models are all closed. **Irina's metric, correctly implemented, still reads 0%
+on the only board with data.** OME-1143 is a hard blocker, not a nicety.
+
+---
+
+## 8. The manual override cannot be set
+
+`openness_override` exists on both `Score` and `Baseline` and wins outright in
+`classify_score` / `classify_baseline`. It has no write path anywhere in the application:
+absent from `ScoreSubmission` and `BaselineImportRow` (both `extra="forbid"`),
+`_submission_to_kwargs` lists every kwarg explicitly, and no route, CLI or script sets it.
+
+`docs/work/2026-08-06-OME-323-implement-frontier-stats.md:70` records this as intended —
+"The override is genuinely operator-only, as designed" — meaning a direct database edit.
+
+Not verifiable from outside: whether any row currently has one set. The field is on
+`ScoreSchema` but not on the public `LeaderboardEntry` payload.
+
+Consequence: with the keyword list retained as the classification mechanism and no usable
+override, correcting a misclassified model requires a code release.
+
+---
+
+## 9. Prior art that was missed
+
+**OME-772** ("Feedback on leaderboard-mvp design gaps", filed 2026-08-11, assigned Irina,
+status Pick Immediately) already catalogues this gap, and describes it more accurately than
+the epic filed yesterday:
+
+> | Models | partial | Only provider names + the opaque `url4_expression`, no clean list |
+
+and:
+
+> Models needs small work, not new architecture.
+
+`apps/scoreboard/portal/benchmark.js:30` carries the same observation in a code comment:
+"`ran_with_providers` is provider names, not model identities … Keeping the honest label
+until a backend field exists."
+
+One row of OME-772's gap table is now stale: the benchmark DTO does expose `focus`.
+
+### Checked and not duplicates
+
+- **OME-665** "Display models as provider/model handles" — Canceled the same day it was
+  filed, legacy desktop UI.
+- **OME-701** "Define provider grouping and classification in the API" — Studio presentation
+  metadata, not open/closed weights. Does not supply an openness signal.
+- **OME-428 / OME-394** — both Done. The OME-323 spec §4 required a cross-reference note on
+  each pointing at the scoreboard's registry, so gateway-side classification would not
+  silently diverge. **That note was never added.** Successor is OME-831 (Backlog, Dmitry).
+
+---
+
+## 10. Corrections to claims already written into Linear
+
+| # | Where | Claim | Reality |
+| -- | -- | -- | -- |
+| 1 | OME-1179 c2, OME-1181 | "The frontier is gated by `pinned`, so the statistic reports `n/a`" | That gate is on the ranked leaderboard route. The statistic's route has no gate and no revision filter. Inheriting it means adding it, changing a live endpoint. |
+| 2 | OME-1179 Problem | "`url4_expression` holds the compiled dataflow with `$candidate` placeholders" | It holds every model route literally, plus the harness grader's routes. |
+| 3 | OME-1179 Problem | "The Scoreboard cannot tell which model produced a result" | It can, ambiguously — and the field is already public. |
+| 4 | OME-1179, OME-1181 | "No new classifier is needed — it already holds the right answers" | Misses gemma and gpt-oss (open marked closed), mistral-large (closed marked open), and kimi (unknown → closed). |
+| 5 | OME-1179, OME-1180 | `leaderboards.py:430` | `_providers` is at line 502; the call site is 443. |
+| 6 | OME-1179 Not-in-scope | "`_current_split` … is a separate defect" | It is the specified behaviour, resolved 2026-08-06 and pinned by an acceptance criterion. |
+
+Two further corrections to statements made in conversation, not written to Linear: "OME-775
+exists to prevent revision mixing" was overstated (OME-775 is a catalogue-registration
+ticket whose acceptance concerns *ranking*), and `benchmark.js:279` hides the card only when
+there are zero rows, not at 0%.
+
+**Process note.** Rounds 1–8 kept producing new contradictions because they reasoned from
+synthetically compiled objects. Round 11 pulled the live payload and the picture settled in
+one pass — including reversing two conclusions from rounds 6 and 7. Verify against the
+deployed payload before asserting anything about what the board stores.
+
+---
+
+## 11. Decisions taken 2026-09-10 (owner)
+
+| # | Decision |
+| -- | -- |
+| D-A | OME-1179 stays the implementation epic. Add a `relatedTo` link to OME-772; do not reparent. |
+| D-B | Correct the `pinned` premise in both tickets, naming the two routes, and record separately that the statistic applies no revision filter. |
+| D-C | Rewrite OME-1179's Problem section, and record "parse `url4_expression`" as a rejected option with its two reasons. |
+| D-D | Keep the substring keyword list. Widen it inside OME-1181: add `moonshotai`/`kimi`, carve `gemma` and `gpt-oss` out of the owner-level closed markers, tighten `mistral`. Keep fail-closed logging. |
+| D-E | Rewrite OME-1145's body; move Triage → Blocked. |
+| D-F | Leave the live "0% open" card as it is — dev board, team audience. Record the exposure on OME-1145. |
+| D-G | Record the baseline consequence in **both** OME-1145 (as part of the definition call) and OME-1179 (as a pointer for the implementer). |
+| D-H | **Drop D5 entirely** from OME-1179. The override cannot be set, so there is nothing to decide. This removes the epic's only stated owner blocker, so OME-1181 is no longer gated on a decision. |
+| D-I | Do not comment on OME-831. Record in OME-1179 that the scoreboard keeps its own list and that gateway-side classification would need reconciling. |
+| D-J | Apply none of this to Linear yet. Write it here first. |
+
+---
+
+## 12. Pending Linear edits (not applied)
+
+**OME-1179** — rewrite Problem (§5 above); add the rejected-option note; fix `:430` →
+`:502`/`:443`; correct constraint 2 per D-B; correct the classifier claim per §6; drop D5;
+record D6 as resolved; fix the "separate defect" wording; add the baseline pointer; add the
+gateway-divergence note; add the live numbers from §7; add `relatedTo` OME-772.
+
+**OME-1180** — fix the `:430` citation; replace the justification with the grader-ambiguity
+argument from §5.
+
+**OME-1181** — same constraint-2 correction; bring marker widening into scope per D-D;
+remove the "Blocked on D5" section; add the baseline pointer.
+
+**OME-1145** — rewrite the body per §3, §2, §7 and the rule-5 cost; note the live card
+exposure; Triage → Blocked. The three `blockedBy` relations (OME-1179, OME-1143, OME-1156)
+are already correct.
+
+**OME-772** — picks up the relation from the OME-1179 side. No comment, no status change.
+
+---
+
+## Outcome
+
+- **Actual files:** this ledger only. No source changes.
+- **Commits:** see branch `OME-1145-openness-review`.
+- **Gates:** not run — documentation-only change, no stack touched.
+- **Deviations:** this ledger records pre-work analysis rather than an implemented unit, so
+  the Planned changes / Test plan / Acceptance sections of `TEMPLATE.md` do not apply. The
+  unit it describes is blocked and has not started.

--- a/docs/work/2026-09-10-OME-1145-openness-metric-review.md
+++ b/docs/work/2026-09-10-OME-1145-openness-metric-review.md
@@ -409,7 +409,7 @@ asserting what the board stores.
 | D-G | Record the Baseline consequence in **both** OME-1145 and OME-1179. |
 | D-H | *(revised — was "drop D5")* Do not silently drop it. Record that under D-L the override loses its only consumer, and raise Q4. |
 | D-I | Do not comment on OME-831. Record in OME-1179 that the Scoreboard keeps its own registry and that Gateway-side classification would need reconciling. Stop calling OME-831 a successor. |
-| D-J | Hold all Linear edits until this document is reviewed. |
+| D-J | Hold all Linear edits until this document is reviewed. **Satisfied** — reviewed, then applied 2026-09-10; see §13. |
 | D-K | Assume OME-1143 lands and costs become real. The one-row frontier is a **sequencing** fact — it blocks demonstrating the fix, not designing it. |
 | D-L | **API shape: option (a).** Move the entire `/frontier` response to the frontier and per-model basis. The holder-based trend is **replaced** by an open-share-over-time series, not adapted. Justified because the board is in testing and nothing depends on the August history. |
 | D-M | Leave the existing pre-OME-1143 rows in place. They will likely be deleted later. Trend points computed before real costs are meaningless and unrecoverable. |
@@ -446,7 +446,19 @@ anti-hijack and visibility locking the author/metadata path uses.
 
 ---
 
-## 13. Pending Linear edits (not yet applied)
+## 13. Linear edits — APPLIED 2026-09-10
+
+All five tickets updated via MCP after this document was reviewed. No comments were posted
+on anyone's ticket; OME-772 received only the relation.
+
+One scope change was made during application, beyond the corrections listed here: the
+boundary between OME-1181 and OME-1145 was redrawn. OME-1181 now provides the **inputs**
+(accept, store, derive, `classify_model()`, bounded frontier read) and OME-1145 owns the
+**metric and the public response**. The first version had OME-1181 doing the counting, which
+would have made it undeployable ahead of the Client — the opposite of what the one-directional
+rollout requires.
+
+What each ticket received:
 
 **OME-1179** — rewrite Problem per §5; add the rejected-option note; fix `:430` → `:502`/`:443`
 and `:293` → `:276`; correct constraint 2 per D-B with the live stale-revision evidence; correct

--- a/docs/work/2026-09-10-OME-1145-openness-metric-review.md
+++ b/docs/work/2026-09-10-OME-1145-openness-metric-review.md
@@ -10,42 +10,64 @@ finished:
 
 ## Intent
 
-No code changes. This is the audit record for a twelve-round review of OME-1145 and the
-epic filed against it (OME-1179 / OME-1180 / OME-1181), plus the owner decisions taken on
-2026-09-10. It exists because four of the claims already written into those tickets are
-wrong, and the corrections have not yet been applied to Linear. Read this before editing
-any of the five tickets.
+No source changes. This is the audit record for a review of OME-1145 and the epic filed
+against it (OME-1179 / OME-1180 / OME-1181), plus the decisions taken with the Scoreboard
+owner on 2026-09-10.
 
-Nothing has been written to Linear. The pending edits are listed at the bottom.
+It exists because several claims already written into those tickets are wrong. Read this
+before editing any of the five tickets.
+
+**Companion document.** `2026-09-10-OME-1145-openness-metric-review-feedback.md` is an
+independent verification of an earlier revision of this file. Its corrections are absorbed
+here; read it for the underlying evidence and licence citations.
+
+**Provenance of the decisions in §11.** They were taken in a working session with Filip
+Boltuzic, the Scoreboard owner and the assignee of OME-1145, on 2026-09-10. They are not
+yet recorded in Linear.
 
 ---
 
 ## 1. What the board actually shows
 
 Fetched anonymously from `https://leaderboard.dev.screamingface.ai/v1/...` on 2026-09-10.
+Code references are against `origin/main` at `17048f5d`.
 
-| board | entries | baselines | on Pareto frontier | rows in the statistic | open_share |
+| board | ranked entries | baselines | on Pareto frontier | rows in the statistic | `open_share` |
 | -- | -- | -- | -- | -- | -- |
-| `draco-3pass` | 7 | 0 | **1** | **10** | 0.0 |
-| `draco` | 0 | 0 | 0 | 0 | — |
-| `gdpval-text` | 0 | 0 | 0 | 0 | — |
-| `ifeval` | 0 | 0 | 0 | 0 | — |
-| `medxpert` | 0 | 0 | 0 | 0 | — |
-| `healthbench-professional` | 0 | 0 | 0 | 0 | — |
+| `draco-3pass` | 7 | 0 | **1** | **10** | `0.0` |
+| `draco` | 0 | 0 | 0 | 0 | `0.0` |
+| `gdpval-text` | 0 | 0 | 0 | 0 | `0.0` |
+| `ifeval` | 0 | 0 | 0 | 0 | `0.0` |
+| `medxpert` | 0 | 0 | 0 | 0 | `0.0` |
+| `healthbench-professional` | 0 | 0 | 0 | 0 | `0.0` |
 
-`draco-3pass` is the only populated board. All seven entries store
-`ran_with_providers = ['openrouter']`. Every `run_cost_usd` is `0.000000`. The board is
-pinned (`revision = 2634cec91fd0f19a`, `case_count = 100`).
+An empty board returns `open_share: 0.0`, `current: null`, empty `trend` — **not** a null or
+a dash. The portal suppresses the card at `total === 0`, so nothing renders; that suppression
+is presentation, not an API value.
 
-The 10-vs-7 gap is the two code paths: the statistic counts every Score row, the table
-counts best-per-spec.
+`draco-3pass` is the only populated board. All seven ranked entries report
+`ran_with_providers = ["openrouter"]` and `run_cost_usd = "0.000000"`. The board is pinned
+(`revision = 2634cec91fd0f19a`, `case_count = 100`).
 
-### The models actually behind those rows
+### The 10-vs-7 gap has two causes, not one
 
-Recovered from each entry's stored `url4_expression`, splitting the `candidate:` binding
-from the rest of the harness:
+| revision | rows | specs |
+| -- | -- | -- |
+| `2634cec91fd0f19a` (registered) | 7 | the seven on the ranked table |
+| `b8c8afd8f9dddca0` (superseded) | **3** | `claude-fable-5`, `pareto_cross`, **`claude-opus-5`** |
 
-| spec | candidate models | harness |
+Best-per-spec collapse explains part of it. **Missing revision filtering explains the rest.**
+`claude-opus-5` exists only at the old revision, so it never appears on the ranked table — yet
+it is in the statistic's denominator and it holds the **first published point of the trend**
+(2026-08-24T20:01:07, score 0.6527).
+
+### Declared candidate models behind those rows
+
+Recovered from each entry's stored `url4_expression` by separating the `candidate:` binding
+from the rest of the harness. These are the routes the submitted **recipe declares**. They are
+not proof of which provider response was selected at runtime.
+
+| spec | declared candidate routes | harness |
 | -- | -- | -- |
 | `fable_plus_gpt` | claude-fable-5, claude-opus-4.8, gpt-5.5 | gemini-3.1-pro-preview |
 | `opus_plus_gpt` | claude-opus-4.8, gpt-5.5 | gemini-3.1-pro-preview |
@@ -55,15 +77,14 @@ from the rest of the harness:
 | `pareto_lean` | deepseek-v4-pro, kimi-k2.6 | gemini-3.1-pro-preview |
 | `claude-fable-5` | claude-fable-5 | gemini-3.1-pro-preview |
 
-All routes are `openrouter/`-prefixed. `gemini-3.1-pro-preview` appears three times per
+All routes carry an `openrouter/` prefix. `gemini-3.1-pro-preview` appears three times per
 expression in every entry and is never a candidate model — it is the DRACO grader.
 
 ---
 
 ## 2. Two separate code paths, not one
 
-The single most consequential finding. The openness percentage and the Pareto row marks
-share a word and nothing else.
+The openness percentage and the Pareto row marks share a word and nothing else.
 
 | | openness statistic | Pareto row marks |
 | -- | -- | -- |
@@ -76,16 +97,17 @@ share a word and nothing else.
 | baselines | included | **excluded** — the query reads Score only |
 | private board | 404 | returns empty entries |
 
-Each function has exactly one production caller. There is no shared code.
+Each function has exactly one production caller. No shared code.
 
 Consequences:
 
-- The statistic **mixes benchmark revisions**. `_comparable` (`frontier.py:51`) applies only
-  the OME-1056 case-count rule. Nothing filters on revision. Not currently visible because
-  every live board has one revision.
+- **The statistic mixes benchmark revisions, live, today.** `_comparable` (`frontier.py:51`)
+  applies only the OME-1056 case-count rule. Nothing filters on revision. See §1 for the
+  three stale rows and the stale trend point. This is a real integration defect introduced
+  when revision semantics arrived (OME-775), not a hypothetical about unpinned boards.
 - Implementing Irina's metric is a route migration, not a change to `_current_split`.
-- Adding the `pinned` gate or a revision filter to the statistic changes what a live public
-  endpoint returns for an unpinned board. Moot today — all seven boards are pinned.
+- **The migration fixes the revision defect for free**, because the frontier path already
+  filters. It is an argument for the move rather than separate work.
 
 ---
 
@@ -102,155 +124,219 @@ and pinned it as an acceptance criterion in §8:
 > time-series trend (§6).
 
 §6 also defines "the frontier" as *the single best score across all specs within a
-benchmark* — score only. Cost arrived later, via OME-770 and OME-923. So the repo now has
+benchmark* — score only. Cost arrived later, via OME-770 and OME-923. The repo therefore has
 two different concepts sharing the word "frontier", and `frontier.py`'s self-contradicting
-docstring traces straight back to the spec, not to a coding error.
+docstring traces to the spec, not to a coding error.
 
-**OME-1145 is therefore a request to supersede an owner-resolved decision and its
-acceptance criterion, not a bug report against the implementation.** Irina's own framing —
-"Needs: A decision on the correct definition" — was right.
+**OME-1145 is a request to supersede an owner-resolved decision and its acceptance criterion,
+not a bug report against the implementation.** Irina's own framing — "Needs: A decision on the
+correct definition" — was right.
 
 ### Rule-5 cost
 
 `apps/scoreboard/tests/unit/scores/test_frontier.py:92`,
-`test_baseline_counts_in_split_but_never_becomes_trend_holder`, asserts
-`open_count == 1`, `closed_count == 1`, `open_share == 0.5` with a Baseline in the
-denominator. Its entire purpose is to pin that baselines count. Changing the metric changes
-that test, which is a Confidence-Gate decision requiring owner approval.
+`test_baseline_counts_in_split_but_never_becomes_trend_holder`, asserts `open_count == 1`,
+`closed_count == 1`, `open_share == 0.5` with a Baseline in the denominator. Its purpose is to
+pin that baselines count. Changing the metric changes that test — a Confidence-Gate decision
+requiring owner approval. Granted, see D-N.
 
-`test_openness_override_changes_the_holders_reported_openness` (line 163) may also move.
+`test_openness_override_changes_the_holders_reported_openness` (line 163) also moves under D-L.
 
 ---
 
 ## 4. Why the number is 0%
 
-`packages/screamingface/src/screamingface/_scoreboard/leaderboards.py:502`:
+`packages/screamingface/src/screamingface/_scoreboard/leaderboards.py:502`, called at 443:
 
 ```python
 def _providers(models: Sequence[str]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(model.split("/", 1)[0] for model in models))
 ```
 
-Called at line 443. `openrouter/meta-llama/Llama-3.1-70B-Instruct` is submitted as
-`"openrouter"`. `classify_score` reads `ran_with_providers`, matches `openrouter` on
-`_CLOSED_PROVIDER_MARKERS`, and files an open-weights run as closed.
+`openrouter/meta-llama/Llama-3.1-70B-Instruct` is submitted as `"openrouter"`. `classify_score`
+reads `ran_with_providers`, matches `openrouter` on `_CLOSED_PROVIDER_MARKERS`, and files an
+open-weights run as closed.
 
-OpenRouter is the only provider that reports a cost — `DirectCost.reported(...)` has exactly
-one caller, `apps/aigateway/src/aigateway/plugins/openrouter_provider/usage_accounting.py:115` —
-so it dominates any board with cost data.
+Live effect: `best_open_source`, running deepseek + kimi + qwen, is counted closed.
 
-Live effect: an entry named `best_open_source`, running deepseek + kimi + qwen, is counted
-closed.
+### It was nobody's decision
+
+The spec (2026-07-16) recorded what it expected the field to hold:
+
+> `ran_with_providers: list[str]` (provider name strings, e.g. `["openai", "anthropic"]`)
+
+On that assumption, provider is a sound proxy for openness. Then routing changed under it:
+
+| date | event |
+| -- | -- |
+| 2026-07-16 | spec assumes the field holds `["openai", "anthropic"]` |
+| 2026-08-07 | OpenRouter lands in the Gateway (OME-428) |
+| 2026-08-09 | the truncation is written in `f757921c`, a 4,317-line feature commit, no ticket ref, no comment |
+| 2026-08-17 | the openness classifier ships with `openrouter` on the closed list (#519) |
+| 2026-08-19 | "run any OpenRouter model" (#633) — OpenRouter becomes the default path |
+
+The field is named *providers*, so the SDK supplied a provider. The classifier trusted the
+spec's example. Nobody connected the two.
+
+### Cost reporting, stated precisely
+
+OpenRouter is currently the only implemented Gateway path emitting provider-reported direct USD
+cost — `DirectCost.reported(...)` has one caller,
+`apps/aigateway/src/aigateway/plugins/openrouter_provider/usage_accounting.py:115`. It does not
+follow that a priced Score must be an OpenRouter row: `ScoreSubmission` accepts a
+caller-provided cost, and future adapters can report. OpenRouter dominates the SDK-generated
+priced rows available today.
 
 ---
 
-## 5. The identities are already stored, and already public
+## 5. The identities are stored and public, but not structured
 
-Verified against the live payload, not a synthetic object. A real submitted
-`url4_expression` is 21,105 characters and begins:
+A real submitted `url4_expression` is 21,105 characters and begins:
 
 ```
 (candidate:0.0:'(model_1:0.0:/openrouter/anthropic/claude-fable-5?max_tokens=32768&q=($input)!'…
 ```
 
-Every model route is literal. `url4_expression` is returned on the public
-`LeaderboardEntry` payload (confirmed in the live entry keys), so the model identities are
-already published on the board today.
+Every declared route is literal, and `url4_expression` is returned on the public
+`LeaderboardEntry` payload.
 
-**This resolves D6.** Sending a `models` field publishes nothing that is not already public.
+Accurate statement of the gap:
 
-### Why parsing `url4_expression` is still not the answer
+> The Scoreboard stores enough public recipe text to recover candidate model routes with
+> harness-aware parsing, but it has no structured, unambiguous candidate-model field.
 
-Two reasons, both verified:
+That is more accurate than either "the Scoreboard cannot tell" or "the Scoreboard can tell
+which model produced the result".
 
-1. **The expression mixes the system under test with the harness grading it.** The DRACO
-   grader `openrouter/google/gemini-3.1-pro-preview` appears three times in every
-   expression, outside the `candidate:` binding. A naive extraction counts the judge as
-   part of the candidate. Separating them means locating the candidate binding boundary and
-   depending on the harness expression shape staying stable.
-2. **The Scoreboard has no URL4 parser.** No `url4` entry in `apps/scoreboard/pyproject.toml`
-   and no import anywhere in `src/`. Option C means adding `packages/url4` as a runtime
-   dependency of the scoreboard image.
+### Why parsing `url4_expression` is rejected
 
-`CandidateResult.models` has neither problem: it is exactly the candidate's declared routes.
-That is the real justification for OME-1180, and it is stronger than the one currently in
-the ticket.
+1. **The expression mixes the system under test with the harness grading it.** The DRACO grader
+   `openrouter/google/gemini-3.1-pro-preview` appears three times in every expression, outside
+   the `candidate:` binding. Naive extraction counts the judge. Separating them requires
+   locating the candidate binding boundary and depending on the harness expression shape.
+2. **The Scoreboard has no URL4 parser.** No `url4` entry in `apps/scoreboard/pyproject.toml`,
+   no import in `src/`. This would add `packages/url4` as a runtime dependency of the image.
 
-For the record, every model in every recipe kind reaches the expression through one of two
-call sites — `_model_route(route)` at `_evaluation/candidate.py:215` (every `Model` node)
-and `_model_route(synthesizer)` at line 267 — so route recovery *would* be complete if the
-grader problem did not exist.
+`CandidateResult.models` has neither problem: required, ordered, unique, non-empty, and exactly
+the candidate's **declared** routes. That is the justification for OME-1180, and it is stronger
+than the one currently in the ticket.
+
+For the record, every model in every recipe kind reaches the expression through
+`_model_route()` at `_evaluation/candidate.py:215` (every `Model` node) or `:267` (a Fusion
+synthesizer), so route recovery would be complete if the grader problem did not exist.
+
+### D6 is only partly resolved
+
+Public `url4_expression` settles the **disclosure** question: a `models` array exposes no new
+category of data. It does not settle whether `models` becomes a first-class public
+`LeaderboardEntry` field or stays internal to classification. That is an API-surface and
+product-display commitment, and it remains **open** (Q2).
 
 ---
 
-## 6. The keyword list does not hold the right answers
+## 6. The classifier needs work, and "open" needs a definition
+
+### The registry data is wrong in both directions
 
 After stripping the routing prefix, `classify_providers` on realistic routes:
 
-| route | weights | classifier | |
+| route | licence reality | classifier | |
 | -- | -- | -- | -- |
-| `meta-llama/Llama-3.1-70B-Instruct` | open | open | ok |
-| `qwen/Qwen2.5-72B-Instruct` | open | open | ok |
-| `deepseek/deepseek-v3` | open | open | ok |
-| `mistralai/Mistral-7B-Instruct-v0.3` | open | open | ok |
-| `openai/gpt-5.5` | closed | closed | ok |
-| `anthropic/claude-opus-4.8` | closed | closed | ok |
-| `google/gemini-3-pro` | closed | closed | ok |
-| `google/gemma-2-27b-it` | open | **closed** | **wrong** |
-| `openai/gpt-oss-120b` | open | **closed** | **wrong** |
-| `mistralai/mistral-large-2411` | closed | **open** | **wrong** |
+| `meta-llama/Llama-3.1-70B-Instruct` | open weights | open | ok |
+| `qwen/Qwen2.5-72B-Instruct` | open weights | open | ok |
+| `deepseek/deepseek-v3` | open weights | open | ok |
+| `openai/gpt-5.5` | API only | closed | ok |
+| `anthropic/claude-opus-4.8` | API only | closed | ok |
+| `google/gemini-3-pro` | API only | closed | ok |
+| `google/gemma-2-27b-it` | downloadable, Gemma terms with use restrictions | **closed** | **wrong** |
+| `openai/gpt-oss-120b` | downloadable, Apache 2.0 + usage policy | **closed** | **wrong** |
+| `mistralai/mistral-large-2411` | downloadable, Mistral Research License (non-commercial) | open | **arguable** |
+| `moonshotai/kimi-k2.6` | downloadable, Modified MIT | **closed** (unmatched) | **wrong** |
 
-Three of ten. Two of the three understate the open share — the exact complaint on OME-1145.
-The cause is structural: `_OPEN_PROVIDER_MARKERS` and `_CLOSED_PROVIDER_MARKERS` conflate
-model *owner* with openness, and Google, OpenAI and Mistral all now ship both.
+Two of these understate the open share — the exact OME-1145 complaint. The cause is structural:
+the marker lists conflate model **owner** with openness, and Google, OpenAI and Mistral all now
+ship both kinds.
 
-On live data, `moonshotai/kimi-k2.6` matches nothing in either list and fails closed. So
-`best_open_source` would read 2/3 open after the epic's fix, not 3/3.
+Correction to an earlier revision of this file: Mistral Large 2411 was described as "closed
+weights". That is inaccurate — the weights are downloadable under the Mistral Research License.
+Excluding it from a permissive-commercial open category may still be the right product call,
+but that is a definition, not a fact about the weights.
 
-> The open/closed judgements in the table above are my assessment of the models, not
-> anything the repository asserts.
+### Q1 — what does "open" mean?
+
+Not answerable from the code. The contract must choose one:
+
+1. weights are downloadable and locally runnable;
+2. weights are available under a permissive **commercial** licence;
+3. the whole stack meets a stricter open-source / reproducibility standard.
+
+OME-323's policy was routing-based and does not settle this. Until it is chosen, "tighten
+mistral" is not an implementation-ready instruction. **Open question.**
+
+### A new classifier function IS needed
+
+`classify_providers(Sequence[str]) -> open|closed` returns one row-level verdict under
+any-closed-wins. A per-model count needs a different shape:
+`classify_model(route) -> open|closed|unknown`, plus explicit precedence so specific model
+rules beat owner rules:
+
+- `openrouter/openai/gpt-oss-*` before the `openai` closed-owner rule
+- `openrouter/google/gemma-*` before the `google` closed-owner rule
+- specific open Mistral families rather than the bare substring `mistral`
+
+Reusing the registry **data** is fine. Reusing the aggregate **function** is not. "No new
+classifier is needed" was wrong and hides a real semantic change.
 
 ---
 
-## 7. What the metric would actually read
+## 7. What the metric would read
 
-Applying the epic's fix (candidate models, prefix stripped, current marker list) to live
-`draco-3pass` data:
+Applying declared candidate models with the current marker list to live `draco-3pass`:
 
 | definition | entries | models counted | open | share |
 | -- | -- | -- | -- | -- |
-| all 7 leaderboard entries | 7 | 18 | 5 | **28%** |
+| all 7 ranked entries | 7 | 18 | 5 | **28%** |
 | Pareto frontier (today) | **1** | 3 | 0 | **0%** |
 
-With every cost at `0.000000` the frontier degenerates to a single entry — `fable_plus_gpt`,
-whose three models are all closed. **Irina's metric, correctly implemented, still reads 0%
-on the only board with data.** OME-1143 is a hard blocker, not a nicety.
+With every cost at `0.000000`, cost drops out of the domination test and the frontier reduces
+to the highest-scoring rows. `fable_plus_gpt` is the unique highest scorer here, so the frontier
+is one row — with ties it would be all the tied rows, not necessarily one.
+
+So the metric, correctly implemented, still reads 0% until OME-1143 lands. That is a
+**sequencing** constraint, not a design problem (D-K).
 
 ---
 
-## 8. The manual override cannot be set
+## 8. The manual override
 
-`openness_override` exists on both `Score` and `Baseline` and wins outright in
-`classify_score` / `classify_baseline`. It has no write path anywhere in the application:
-absent from `ScoreSubmission` and `BaselineImportRow` (both `extra="forbid"`),
-`_submission_to_kwargs` lists every kwarg explicitly, and no route, CLI or script sets it.
-
+`openness_override` exists on `Score` and `Baseline` and wins outright in `classify_score` /
+`classify_baseline`. It has **no supported application write path**: absent from
+`ScoreSubmission` and `BaselineImportRow` (both `extra="forbid"`), `_submission_to_kwargs` lists
+every kwarg explicitly, and no route, CLI or script sets it.
 `docs/work/2026-08-06-OME-323-implement-frontier-stats.md:70` records this as intended —
-"The override is genuinely operator-only, as designed" — meaning a direct database edit.
+"genuinely operator-only, as designed" — meaning a direct database correction.
 
-Not verifiable from outside: whether any row currently has one set. The field is on
-`ScoreSchema` but not on the public `LeaderboardEntry` payload.
+It is operator-only, **not nonexistent**. Current values are not observable anonymously (the
+field is on `ScoreSchema` but not on the public `LeaderboardEntry`), and future values remain
+possible.
 
-Consequence: with the keyword list retained as the classification mechanism and no usable
-override, correcting a misclassified model requires a code release.
+### What D-L does to it
+
+The external review recommended keeping the override effective for the legacy row-level trend
+and ignoring it for the new per-model statistic. That compromise assumes the legacy trend
+survives. Under **D-L it does not** — the whole `/frontier` response moves to the frontier and
+per-model basis, and the holder-based trend is replaced.
+
+`classify_score` has exactly two callers, both in `frontier.py`: `_current_split` and
+`_compute_trend`. D-L replaces both. The override therefore loses its only consumer, and the
+question becomes whether the column is removed or left dormant. **Open question (Q4).**
 
 ---
 
-## 9. Prior art that was missed
+## 9. Prior art
 
-**OME-772** ("Feedback on leaderboard-mvp design gaps", filed 2026-08-11, assigned Irina,
-status Pick Immediately) already catalogues this gap, and describes it more accurately than
-the epic filed yesterday:
+**OME-772** ("Feedback on leaderboard-mvp design gaps", filed 2026-08-11, assigned Irina, Pick
+Immediately) already records this, more accurately than the epic filed on 2026-09-09:
 
 > | Models | partial | Only provider names + the opaque `url4_expression`, no clean list |
 
@@ -258,80 +344,127 @@ and:
 
 > Models needs small work, not new architecture.
 
-`apps/scoreboard/portal/benchmark.js:30` carries the same observation in a code comment:
-"`ran_with_providers` is provider names, not model identities … Keeping the honest label
-until a backend field exists."
-
-One row of OME-772's gap table is now stale: the benchmark DTO does expose `focus`.
+`apps/scoreboard/portal/benchmark.js:30` carries the same observation as a code comment. Both
+framed it as a **display** gap; neither connected it to the openness percentage, which the same
+field feeds. One row of OME-772's gap table is stale — the benchmark DTO does expose `focus`.
 
 ### Checked and not duplicates
 
-- **OME-665** "Display models as provider/model handles" — Canceled the same day it was
-  filed, legacy desktop UI.
+- **OME-665** "Display models as provider/model handles" — Canceled the day it was filed,
+  legacy desktop UI.
 - **OME-701** "Define provider grouping and classification in the API" — Studio presentation
-  metadata, not open/closed weights. Does not supply an openness signal.
-- **OME-428 / OME-394** — both Done. The OME-323 spec §4 required a cross-reference note on
-  each pointing at the scoreboard's registry, so gateway-side classification would not
-  silently diverge. **That note was never added.** Successor is OME-831 (Backlog, Dmitry).
+  metadata, not weights openness.
+- **OME-428 / OME-394** — both Done. OME-323 §4 required a cross-reference note on each pointing
+  at the Scoreboard registry so Gateway-side classification would not diverge. **Never added.**
+- **OME-831** is Hugging Face `hosted_shared` **credentials**. It succeeds the credentials half
+  of OME-394. It is **not** a successor for Gateway openness classification — no such ticket
+  exists.
 
 ---
 
-## 10. Corrections to claims already written into Linear
+## 10. Corrections to claims written into Linear
 
 | # | Where | Claim | Reality |
 | -- | -- | -- | -- |
-| 1 | OME-1179 c2, OME-1181 | "The frontier is gated by `pinned`, so the statistic reports `n/a`" | That gate is on the ranked leaderboard route. The statistic's route has no gate and no revision filter. Inheriting it means adding it, changing a live endpoint. |
-| 2 | OME-1179 Problem | "`url4_expression` holds the compiled dataflow with `$candidate` placeholders" | It holds every model route literally, plus the harness grader's routes. |
-| 3 | OME-1179 Problem | "The Scoreboard cannot tell which model produced a result" | It can, ambiguously — and the field is already public. |
-| 4 | OME-1179, OME-1181 | "No new classifier is needed — it already holds the right answers" | Misses gemma and gpt-oss (open marked closed), mistral-large (closed marked open), and kimi (unknown → closed). |
-| 5 | OME-1179, OME-1180 | `leaderboards.py:430` | `_providers` is at line 502; the call site is 443. |
-| 6 | OME-1179 Not-in-scope | "`_current_split` … is a separate defect" | It is the specified behaviour, resolved 2026-08-06 and pinned by an acceptance criterion. |
+| 1 | OME-1179 c2, OME-1181 | "gated by `pinned`, so the statistic reports `n/a`" | That gate is on the ranked route. The statistic has no gate and no revision filter, and is mixing revisions live. |
+| 2 | OME-1179 Problem | "`url4_expression` holds … `$candidate` placeholders" | It holds every declared route literally, plus the harness grader's routes. |
+| 3 | OME-1179 Problem | "The Scoreboard cannot tell which model produced a result" | It stores recoverable recipe text, already public. What it lacks is a structured field. |
+| 4 | OME-1179, OME-1181 | "No new classifier is needed — it already holds the right answers" | Wrong on gemma, gpt-oss and kimi; arguable on mistral-large. A per-model function is also required. |
+| 5 | OME-1179, OME-1180 | `leaderboards.py:430` | `_providers` is at 502; the call site is 443. |
+| 6 | OME-1179 Not-in-scope | "`_current_split` … is a separate defect" | It is specified behaviour, resolved 2026-08-06 and pinned by an acceptance criterion. |
+| 7 | OME-1179, OME-1181 | the frontier set is "small and bounded" | Neither is guaranteed. Every best-per-spec point can be non-dominated and spec ids are client-controlled. |
+| 8 | OME-1179 c2 | `leaderboard.py:293` | `pinned` is at line 276 on `origin/main`. |
 
-Two further corrections to statements made in conversation, not written to Linear: "OME-775
-exists to prevent revision mixing" was overstated (OME-775 is a catalogue-registration
-ticket whose acceptance concerns *ranking*), and `benchmark.js:279` hides the card only when
-there are zero rows, not at 0%.
+Corrections to earlier revisions of **this document**:
 
-**Process note.** Rounds 1–8 kept producing new contradictions because they reasoned from
-synthetically compiled objects. Round 11 pulled the live payload and the picture settled in
-one pass — including reversing two conclusions from rounds 6 and 7. Verify against the
-deployed payload before asserting anything about what the board stores.
+- "Not currently visible because every live board has one revision" — wrong. Three of ten rows
+  on `draco-3pass` are at a superseded revision, and one is the first trend point.
+- Empty boards were shown as "—". They return `0.0`.
+- Mistral Large 2411 was called "closed weights". It has downloadable research-licensed weights.
+- "A historical frontier needs cost data we didn't have then" — wrong. Rows are immutable and
+  carry their own cost and timestamp, so the series is a straightforward replay. The real
+  obstacle is that pre-OME-1143 costs are `0.000000` and unrecoverable.
+- "The frontier degenerates to exactly one row at uniform cost" — it degenerates to every row
+  tied for the top score. One here only because `fable_plus_gpt` is the unique top scorer.
+- OME-831 was described as the successor classification ticket. It is credentials.
+- The intro said four Linear claims were wrong. The count is eight.
+
+**Process note.** Repeated rounds of self-review kept producing new contradictions while
+reasoning from synthetically compiled objects. The picture settled once the live payload was
+pulled — which also reversed two conclusions. Verify against the deployed payload before
+asserting what the board stores.
 
 ---
 
-## 11. Decisions taken 2026-09-10 (owner)
+## 11. Decisions taken 2026-09-10 with the Scoreboard owner
 
 | # | Decision |
 | -- | -- |
-| D-A | OME-1179 stays the implementation epic. Add a `relatedTo` link to OME-772; do not reparent. |
-| D-B | Correct the `pinned` premise in both tickets, naming the two routes, and record separately that the statistic applies no revision filter. |
-| D-C | Rewrite OME-1179's Problem section, and record "parse `url4_expression`" as a rejected option with its two reasons. |
-| D-D | Keep the substring keyword list. Widen it inside OME-1181: add `moonshotai`/`kimi`, carve `gemma` and `gpt-oss` out of the owner-level closed markers, tighten `mistral`. Keep fail-closed logging. |
-| D-E | Rewrite OME-1145's body; move Triage → Blocked. |
+| D-A | OME-1179 stays the implementation epic. Add `relatedTo` OME-772; do not reparent. |
+| D-B | Correct the `pinned` premise in both tickets, name the two routes, and record the live stale-revision evidence. |
+| D-C | Rewrite OME-1179's Problem section; record "parse `url4_expression`" as a rejected option with its two reasons; use "declared candidate routes" throughout. |
+| D-D | *(revised)* Keep the substring registry as the **data** source and widen it. A per-model `classify_model` function with model-before-owner precedence is still required. Blocked on Q1. |
+| D-E | Rewrite OME-1145's body; Triage → Blocked. Describe both the product-definition change and the live revision-mixing defect. |
 | D-F | Leave the live "0% open" card as it is — dev board, team audience. Record the exposure on OME-1145. |
-| D-G | Record the baseline consequence in **both** OME-1145 (as part of the definition call) and OME-1179 (as a pointer for the implementer). |
-| D-H | **Drop D5 entirely** from OME-1179. The override cannot be set, so there is nothing to decide. This removes the epic's only stated owner blocker, so OME-1181 is no longer gated on a decision. |
-| D-I | Do not comment on OME-831. Record in OME-1179 that the scoreboard keeps its own list and that gateway-side classification would need reconciling. |
-| D-J | Apply none of this to Linear yet. Write it here first. |
+| D-G | Record the Baseline consequence in **both** OME-1145 and OME-1179. |
+| D-H | *(revised — was "drop D5")* Do not silently drop it. Record that under D-L the override loses its only consumer, and raise Q4. |
+| D-I | Do not comment on OME-831. Record in OME-1179 that the Scoreboard keeps its own registry and that Gateway-side classification would need reconciling. Stop calling OME-831 a successor. |
+| D-J | Hold all Linear edits until this document is reviewed. |
+| D-K | Assume OME-1143 lands and costs become real. The one-row frontier is a **sequencing** fact — it blocks demonstrating the fix, not designing it. |
+| D-L | **API shape: option (a).** Move the entire `/frontier` response to the frontier and per-model basis. The holder-based trend is **replaced** by an open-share-over-time series, not adapted. Justified because the board is in testing and nothing depends on the August history. |
+| D-M | Leave the existing pre-OME-1143 rows in place. They will likely be deleted later. Trend points computed before real costs are meaningless and unrecoverable. |
+| D-N | Accept the consequences of the move: a small and volatile numerator, baselines leaving the statistic, superseding the 2026-08-06 spec resolution, and the rule-5 change to `test_frontier.py:92`. Owner approval granted. |
+
+### Open questions
+
+| # | Question |
+| -- | -- |
+| Q1 | What does "open" mean — downloadable weights, permissive **commercial** licence, or a stricter reproducibility standard? Blocks D-D's registry work. |
+| Q2 | Is `models` a first-class public `LeaderboardEntry` field, or internal to classification only? (D6, reopened.) |
+| Q3 | Legacy and deduplicated rows: leave `models` null, allow same-owner dedup replay to enrich a null field, or do a controlled backfill? `models` must **not** enter `content_hash`. |
+| Q4 | After D-L removes its only consumer, is the `openness_override` column removed or left dormant? |
 
 ---
 
-## 12. Pending Linear edits (not applied)
+## 12. Implementation constraints for OME-1181
 
-**OME-1179** — rewrite Problem (§5 above); add the rejected-option note; fix `:430` →
-`:502`/`:443`; correct constraint 2 per D-B; correct the classifier claim per §6; drop D5;
-record D6 as resolved; fix the "separate defect" wording; add the baseline pointer; add the
-gateway-divergence note; add the live numbers from §7; add `relatedTo` OME-772.
+Beyond the corrections, three things must be specified before code:
+
+**Bounded model reads.** The second projection over frontier ids must be chunked or streamed
+over `id, models` only, with explicit bounds on routes per submission, length per route, and
+total serialized field size. A large `WHERE id IN (…)` can exceed database parameter limits. It
+must never fetch URL4 expressions or display metadata for the whole board.
+
+**Rollout order is one-directional.** `ScoreSubmission` is `extra="forbid"` (`schemas.py:302`),
+so an older Scoreboard returns 422 for an unknown top-level field. Scoreboard (OME-1181) must
+deploy before the SDK (OME-1180) is released.
+
+**Dedup enrichment.** `store.py:835-849` builds the replay `updates` dict from exactly two
+fields, `authors` and `metadata`. A resubmission carrying `models` against an existing row is
+silently discarded today. Q3 decides whether that changes; if it does, it needs the same
+anti-hijack and visibility locking the author/metadata path uses.
+
+---
+
+## 13. Pending Linear edits (not yet applied)
+
+**OME-1179** — rewrite Problem per §5; add the rejected-option note; fix `:430` → `:502`/`:443`
+and `:293` → `:276`; correct constraint 2 per D-B with the live stale-revision evidence; correct
+the classifier claim per §6 and add the per-model function requirement; remove the "small and
+bounded" claim and replace with the bounding requirements; replace D5 per D-H; reopen D6 as Q2;
+add Q1, Q3, Q4; fix the "separate defect" wording; add the baseline pointer; add the
+Gateway-divergence note; add the live numbers from §7; add `relatedTo` OME-772.
 
 **OME-1180** — fix the `:430` citation; replace the justification with the grader-ambiguity
-argument from §5.
+argument from §5; state that release is blocked until the deployed Scoreboard accepts the field.
 
-**OME-1181** — same constraint-2 correction; bring marker widening into scope per D-D;
-remove the "Blocked on D5" section; add the baseline pointer.
+**OME-1181** — same constraint corrections; per-model classifier with precedence; registry
+widening blocked on Q1; field bounds and chunked frontier reads per §12; the D-L response shape;
+the Q3 dedup decision; remove the "Blocked on D5" section.
 
-**OME-1145** — rewrite the body per §3, §2, §7 and the rule-5 cost; note the live card
-exposure; Triage → Blocked. The three `blockedBy` relations (OME-1179, OME-1143, OME-1156)
-are already correct.
+**OME-1145** — rewrite per §3, §2, §7 and the rule-5 cost; separate the superseded all-rows
+denominator from the genuine stale-revision defect; note the live card exposure; Triage →
+Blocked. The three `blockedBy` relations (OME-1179, OME-1143, OME-1156) are already correct.
 
 **OME-772** — picks up the relation from the OME-1179 side. No comment, no status change.
 
@@ -339,9 +472,9 @@ are already correct.
 
 ## Outcome
 
-- **Actual files:** this ledger only. No source changes.
-- **Commits:** see branch `OME-1145-openness-review`.
-- **Gates:** not run — documentation-only change, no stack touched.
+- **Actual files:** this ledger and its companion feedback document. No source changes.
+- **Commits:** branch `OME-1145-openness-review`.
+- **Gates:** not run — documentation only, no stack touched.
 - **Deviations:** this ledger records pre-work analysis rather than an implemented unit, so
-  the Planned changes / Test plan / Acceptance sections of `TEMPLATE.md` do not apply. The
-  unit it describes is blocked and has not started.
+  `TEMPLATE.md`'s Planned changes / Test plan / Acceptance sections do not apply. The unit it
+  describes is blocked and has not started.


### PR DESCRIPTION
## Summary

Pre-work investigation of `OME-1145` ("Open frontier share" percentage is inaccurate) and the epic filed against it. Two documents, no source changes:

- `docs/work/2026-09-10-OME-1145-openness-metric-review.md` — the audit record
- `docs/work/2026-09-10-OME-1145-openness-metric-review-feedback.md` — an independent verification of an earlier revision of it

## Why it exists

Several claims written into `OME-1179` / `OME-1180` / `OME-1181` were wrong. The corrections have since been applied to those tickets; this is the evidence behind them.

The substantive findings:

- **The openness statistic and the Pareto row marks are separate programs.** Different endpoints, different queries, different rules, no shared code. Implementing the requested metric is a route migration, not a one-function edit.
- **The statistic is mixing benchmark revisions live.** Three of the ten rows counted on `draco-3pass` are at a superseded revision, and one of them is the first published point of the trend. Not previously filed anywhere.
- **`_current_split` is not a defect.** The all-rows denominator is what the `OME-323` spec resolved on 2026-08-06 and pinned as an acceptance criterion. `OME-1145` supersedes an owner decision rather than fixing a bug.
- **Model identities are already stored and public** inside `url4_expression` — but the expression also carries the benchmark harness's grader routes, which is why an explicit `models` field is still the right answer.

It also records the owner decisions taken on 2026-09-10 and four open questions that block implementation.

## Test plan

Documentation only — no source, test, or portal files touched. No gates apply; nothing under `docs/**` triggers a stack lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)