### PR TITLE
feat(engine): ship the OTLP endpoint and credential through the chart

### DIFF
--- a/apps/screamingface-engine/deploy/helm/templates/_helpers.tpl
+++ b/apps/screamingface-engine/deploy/helm/templates/_helpers.tpl
@@ -115,6 +115,31 @@ injects each key under its OWN name — so the key MUST be `URL4_CLOUD_ARTIFACT_
 variable both halves read. Unlike the Tavily Secret, the App reads this one too: it is the read
 side of the hand-off.
 */}}
+{{/*
+The Secret carrying OTEL_EXPORTER_OTLP_HEADERS — an operator's own when supplied, else the
+chart's. Same shape as the Tavily and artifact-storage helpers, so `existingSecret` means the
+same thing everywhere in this chart.
+*/}}
+{{- define "screamingface-engine.tracingSecretName" -}}
+{{- if .Values.tracing.existingSecret -}}
+{{- .Values.tracing.existingSecret -}}
+{{- else -}}
+{{- printf "%s-tracing" (include "screamingface-engine.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the pool should attach a tracing Secret at all. Distinct from `tracing.enabled`:
+headers are OPTIONAL (an in-cluster collector needs no credential), so enabling tracing must
+not by itself reference a Secret that will never be created — an unresolvable `envFrom` stops
+the pool from starting, turning "I forgot the credential I did not need" into an outage.
+*/}}
+{{- define "screamingface-engine.tracingHasSecret" -}}
+{{- if and .Values.tracing.enabled (or .Values.tracing.existingSecret .Values.tracing.headers) -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "screamingface-engine.artifactSecretName" -}}
 {{- if .Values.artifactStorage.s3.existingSecret -}}
 {{- .Values.artifactStorage.s3.existingSecret -}}

--- a/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
@@ -59,6 +59,30 @@ data:
   # stable across upgrades — which means living in the Secret the chart can `lookup`. Both
   # halves of the pair therefore arrive by `envFrom.secretRef`, from one source.
   {{- end }}
+  {{- if .Values.tracing.enabled }}
+  {{- if not .Values.tracing.endpoint }}
+  {{- fail "tracing.enabled requires tracing.endpoint — an enabled exporter with no endpoint starts a pool that silently exports nothing, and that state has no runtime symptom" }}
+  {{- end }}
+  # OTLP span export (OME-1131). These are OpenTelemetry's OWN specified variable names, read
+  # by the SDK rather than by our code, which is why they are not `URL4_CLOUD_*`: an operator's
+  # existing OTel knowledge transfers, and no vocabulary was invented here.
+  #
+  # The ENDPOINT is not a credential and belongs in the ConfigMap; the HEADERS are nothing but
+  # a credential and travel by Secret (`secret-tracing.yaml`) for the reason stated below.
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.tracing.endpoint | quote }}
+  {{- with .Values.tracing.serviceName }}
+  # WHY gated on a non-empty value, like URL4_CLOUD_ARTIFACTS_DIR above: rendering "" would
+  # OVERRIDE the code's default with an empty service name, and a blank `service.name` in a
+  # tracing backend is indistinguishable from an unconfigured service. Omitting the key lets
+  # the documented default apply.
+  OTEL_SERVICE_NAME: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.tracing.resourceAttributes }}
+  OTEL_RESOURCE_ATTRIBUTES: {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  # NOTE: OTEL_EXPORTER_OTLP_HEADERS is deliberately ABSENT here, for the same reason as the S3
+  # secret key below — it carries the collector credential.
   # NOTE: URL4_CLOUD_ARTIFACT_S3_SECRET_KEY is deliberately ABSENT here. It travels by Secret
   # (`secret-artifact-storage.yaml`), attached to the pool with `envFrom.secretRef` — a ConfigMap
   # is readable by anything with `get` on it and is printed in plain text by `helm get manifest`.

--- a/apps/screamingface-engine/deploy/helm/templates/deployment-runner.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/deployment-runner.yaml
@@ -182,6 +182,13 @@ spec:
             - secretRef:
                 name: {{ include "screamingface-engine.artifactSecretName" . }}
             {{- end }}
+            {{- if include "screamingface-engine.tracingHasSecret" . }}
+            # The OTLP collector credential (OME-1131). Referenced only when one EXISTS —
+            # tracing to an in-cluster collector needs no credential, and naming a Secret that
+            # is never created would stop the pool from starting on an unresolvable envFrom.
+            - secretRef:
+                name: {{ include "screamingface-engine.tracingSecretName" . }}
+            {{- end }}
             {{- if .Values.tavily.enabled }}
             - secretRef:
                 name: {{ include "screamingface-engine.tavilySecretName" . }}

--- a/apps/screamingface-engine/deploy/helm/templates/secret-tracing.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/secret-tracing.yaml
@@ -1,0 +1,50 @@
+{{/*
+The OTLP collector credential (OME-1131). Rendered ONLY when the chart owns the Secret —
+`tracing.existingSecret` means an operator (or an External Secrets / Sealed Secrets flow)
+supplies it out-of-band, which is the recommended prod shape.
+
+OPTIONAL, unlike the Tavily credential: an in-cluster collector reached over Service DNS needs
+no credential at all, and that is the most likely correct deployment. So `tracing.enabled` on
+its own renders NO Secret and references none — enabling tracing must not name a Secret that
+will never exist, because an unresolvable `envFrom` stops the pool from starting.
+
+INVARIANT: the key MUST be `OTEL_EXPORTER_OTLP_HEADERS`. The pool attaches this with
+`envFrom.secretRef`, which injects every key under its OWN name and cannot rename — the same
+constraint `secret-tavily.yaml` carries, and which it learned by breaking.
+
+WHY one variable for every auth shape: `OTEL_EXPORTER_OTLP_HEADERS` is a comma-separated `k=v`
+list the SDK maps straight onto request headers, so a SigNoz ingestion key
+(`signoz-access-token=…`) and a Cloudflare Access service token
+(`CF-Access-Client-Id=…,CF-Access-Client-Secret=…`) are the same field. The issue assumed an
+Access token's client-id/secret PAIR would need its own fields and that the answer had to be
+known before this chart could be shaped; it does not, and it did not.
+
+WHY NO `lookup` REUSE, unlike `secret-tavily.yaml` and `secret-artifact-storage.yaml`. Both of
+those re-read the value already in the cluster so a values-less `helm upgrade` does not wipe
+it. That pattern does NOT transfer here, for two reasons:
+
+  1. It would be a BUG in this shape. This template renders only when `tracing.headers` is
+     non-empty, so a reuse branch would fire on exactly the path where the operator DID supply
+     a value — silently reverting a credential rotation to the stale cluster copy.
+  2. It cannot be made correct by moving the condition either, because for this value "absent"
+     is a LEGITIMATE configuration: an in-cluster collector needs no credential. The chart
+     therefore cannot distinguish "I do not need auth" from "I forgot to pass it again", and
+     those want opposite behaviour. Resurrecting a credential the operator may have
+     deliberately removed is the worse of the two mistakes.
+
+So the durable path is `existingSecret` — which survives upgrades BY CONSTRUCTION, because the
+chart does not own the object — and inline `headers` is dev-only convenience, exactly as
+`tavily.apiKey` is documented to be.
+*/}}
+{{- if and .Values.tracing.enabled .Values.tracing.headers (not .Values.tracing.existingSecret) }}
+{{- $secretName := include "screamingface-engine.tracingSecretName" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "screamingface-engine.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  OTEL_EXPORTER_OTLP_HEADERS: {{ .Values.tracing.headers | quote }}
+{{- end }}

--- a/apps/screamingface-engine/deploy/helm/values-cloud.yaml
+++ b/apps/screamingface-engine/deploy/helm/values-cloud.yaml
@@ -46,3 +46,29 @@ gateway:
 # portably, and it is not the mesh gateway, so it injects no identity.
 ingress:
   enabled: false
+
+# Span export (OME-1131) is deliberately NOT enabled here, and left commented rather than set
+# with an empty endpoint: `tracing.enabled: true` with no endpoint is refused by the schema, so
+# turning it on in this file would break every cloud install until somebody supplied one.
+# Tracing is optional; the front door is not.
+#
+# To turn it on, prefer the IN-CLUSTER collector address — no credential, no public network, no
+# edge that can deny it. Find it with:
+#
+#   kubectl get svc -A | grep -i 'otel\|signoz'
+#
+#   --set tracing.enabled=true \
+#   --set tracing.endpoint=http://<otel-collector-svc>.<ns>.svc.cluster.local:4318 \
+#   --set tracing.serviceName=screamingface-engine \
+#   --set tracing.resourceAttributes=deployment.environment=dev
+#
+# Only if the collector is reached over the public edge does a credential enter the picture, and
+# then `tracing.existingSecret` is the right shape (a Secret the chart does not own survives a
+# values-less upgrade by construction). One variable carries either auth style:
+#
+#   SigNoz ingestion key   OTEL_EXPORTER_OTLP_HEADERS=signoz-access-token=<key>
+#   Cloudflare Access      OTEL_EXPORTER_OTLP_HEADERS=CF-Access-Client-Id=<id>,CF-Access-Client-Secret=<secret>
+#
+# NOTE: the SigNoz value used for READING logs (`SIGNOZ-API-KEY` against /api/v3/query_range) is
+# a different surface from OTLP INGEST and is not necessarily the same credential. Confirm which
+# one the collector wants rather than assuming the query key works here.

--- a/apps/screamingface-engine/deploy/helm/values-cloud.yaml
+++ b/apps/screamingface-engine/deploy/helm/values-cloud.yaml
@@ -62,7 +62,13 @@ ingress:
 #   --set tracing.serviceName=screamingface-engine \
 #   --set tracing.resourceAttributes=deployment.environment=dev
 #
-# Only if the collector is reached over the public edge does a credential enter the picture, and
+# VERIFIED (2026-09-11): there is NO public OTLP ingest on the SigNoz UI hostname.
+# `POST https://signoz.pulse.dev.openmined.org/v1/traces` returns 200 with `text/html` — the
+# SPA catch-all, identical to what a nonsense path returns. Since OTel's exporter treats any
+# 2xx as success, configuring that hostname would discard every span while reporting healthy.
+# The in-cluster Service address is therefore the answer, and it needs no credential.
+#
+# Only if a collector is ever exposed over the public edge does a credential enter the picture, and
 # then `tracing.existingSecret` is the right shape (a Secret the chart does not own survives a
 # values-less upgrade by construction). One variable carries either auth style:
 #

--- a/apps/screamingface-engine/deploy/helm/values.schema.json
+++ b/apps/screamingface-engine/deploy/helm/values.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "screamingface-engine chart values",
-  "description": "Validated at `helm lint`/`helm install` time. WHY this file exists: a chart's values are an API, and without a schema they are an UNTYPED one — `runner.backend` was a free-form string that only screamingface_engine.config.Settings validated, at container startup, i.e. after a successful deploy reported success. Everything encoded here fails before anything is applied to a cluster.",
+  "description": "Validated at `helm lint`/`helm install` time. WHY this file exists: a chart's values are an API, and without a schema they are an UNTYPED one \u2014 `runner.backend` was a free-form string that only screamingface_engine.config.Settings validated, at container startup, i.e. after a successful deploy reported success. Everything encoded here fails before anything is applied to a cluster.",
   "type": "object",
   "properties": {
     "replicaCount": {
@@ -55,12 +55,12 @@
           "type": "integer",
           "minimum": 1,
           "maximum": 57600,
-          "description": "Job activeDeadlineSeconds. INVARIANT: the 16h ceiling is spec §3."
+          "description": "Job activeDeadlineSeconds. INVARIANT: the 16h ceiling is spec \u00a73."
         },
         "orphanGraceS": {
           "type": "number",
           "minimum": 0,
-          "description": "Seconds a run may keep going with no WebSocket subscriber before the App stops it (OME-890); 0 disables the reaper. INVARIANT: the audience count is in-process, so replicaCount must stay 1 while this is non-zero — a second replica would answer \"nobody is listening\" for runs another replica is streaming. Keep it above uvicorn's WS ping window (~40s), which is what closes a partitioned client's socket in the first place."
+          "description": "Seconds a run may keep going with no WebSocket subscriber before the App stops it (OME-890); 0 disables the reaper. INVARIANT: the audience count is in-process, so replicaCount must stay 1 while this is non-zero \u2014 a second replica would answer \"nobody is listening\" for runs another replica is streaming. Keep it above uvicorn's WS ping window (~40s), which is what closes a partitioned client's socket in the first place."
         },
         "runnerIoConcurrency": {
           "type": "integer",
@@ -70,12 +70,12 @@
         "runQueueReplicas": {
           "type": "integer",
           "minimum": 1,
-          "description": "The queue stream's replica count (OME-1088), rendered to both the App and the worker pool — they declare the same singleton stream and ensure_stream refuses a divergent declaration, so a one-sided value is a startup failure for whichever half declares second. Defaults to 1 because this chart bundles a SINGLE-NODE NATS subchart, and a single-node broker refuses replicas > 1 outright (ServerError 10074). Raise it only against a real NATS cluster."
+          "description": "The queue stream's replica count (OME-1088), rendered to both the App and the worker pool \u2014 they declare the same singleton stream and ensure_stream refuses a divergent declaration, so a one-sided value is a startup failure for whichever half declares second. Defaults to 1 because this chart bundles a SINGLE-NODE NATS subchart, and a single-node broker refuses replicas > 1 outright (ServerError 10074). Raise it only against a real NATS cluster."
         },
         "runQueueBucketCount": {
           "type": "integer",
           "minimum": 1,
-          "description": "How many bucket subjects the run queue is split into for per-caller fairness (OME-1091), rendered to both the App and the worker pool. The App publishes into one bucket and the worker polls them all, so a one-sided value is NOT a startup failure — the run is accepted, lands in a bucket nobody polls, and expires silently. Zero is the modulus of the bucket hash, so it is refused here before any template renders."
+          "description": "How many bucket subjects the run queue is split into for per-caller fairness (OME-1091), rendered to both the App and the worker pool. The App publishes into one bucket and the worker polls them all, so a one-sided value is NOT a startup failure \u2014 the run is accepted, lands in a bucket nobody polls, and expires silently. Zero is the modulus of the bucket hash, so it is refused here before any template renders."
         },
         "aigatewayBaseUrl": {
           "type": "string"
@@ -86,7 +86,7 @@
         }
       },
       "additionalProperties": false,
-      "$comment": "`port` was removed deliberately: the App serves on a hardcoded 9108 (cli.py) and reads no port from its environment, so the value only ever moved the containerPort away from the listening port — a render that lint and install both accepted while the probes and the Service targetPort pointed at nothing. additionalProperties:false now rejects it at install time instead."
+      "$comment": "`port` was removed deliberately: the App serves on a hardcoded 9108 (cli.py) and reads no port from its environment, so the value only ever moved the containerPort away from the listening port \u2014 a render that lint and install both accepted while the probes and the Service targetPort pointed at nothing. additionalProperties:false now rejects it at install time instead."
     },
     "runner": {
       "type": "object",
@@ -120,7 +120,7 @@
     },
     "runnerPool": {
       "type": "object",
-      "description": "The fixed worker pool (OME-1092): a Deployment of `replicas` pods, each running `screamingface-engine worker` with `workerSlots` run slots. Declared concurrency is `replicas × workerSlots`.",
+      "description": "The fixed worker pool (OME-1092): a Deployment of `replicas` pods, each running `screamingface-engine worker` with `workerSlots` run slots. Declared concurrency is `replicas \u00d7 workerSlots`.",
       "properties": {
         "replicas": {
           "type": "integer",
@@ -129,12 +129,15 @@
         "workerSlots": {
           "type": "integer",
           "minimum": 1,
-          "description": "Run slots per worker pod. MUST match `run_queue_worker_slots`. One slot is one supervised child process, so `replicas × workerSlots` is what bounds fleet execution."
+          "description": "Run slots per worker pod. MUST match `run_queue_worker_slots`. One slot is one supervised child process, so `replicas \u00d7 workerSlots` is what bounds fleet execution."
         },
         "maxAckPending": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "minimum": 1,
-          "description": "The queue's PER-CALLER allowance: applied to every bucket consumer, and a caller hashes to one bucket, so it caps one caller's unacked runs (not the fleet — that is `runQueueBucketCount × this`). Null/absent derives `replicas × workerSlots`, which hands each caller the whole fleet's width; pin it whenever `replicas > 1`. Binds at consumer creation, so changing it does not re-cap a live queue."
+          "description": "The queue's PER-CALLER allowance: applied to every bucket consumer, and a caller hashes to one bucket, so it caps one caller's unacked runs (not the fleet \u2014 that is `runQueueBucketCount \u00d7 this`). Null/absent derives `replicas \u00d7 workerSlots`, which hands each caller the whole fleet's width; pin it whenever `replicas > 1`. Binds at consumer creation, so changing it does not re-cap a live queue."
         },
         "drainGraceS": {
           "type": "number",
@@ -144,7 +147,7 @@
         "terminationGracePeriodSeconds": {
           "type": "integer",
           "minimum": 1,
-          "description": "INVARIANT: must stay at or above `drainGraceS` + 10s (kill grace) + 15s (terminal-publish budget) — the kubelet SIGKILLs the pod at this deadline, and a drain cut short interrupts every in-flight run. The chart enforces this with a `fail` at render time; a JSON Schema description alone enforces nothing."
+          "description": "INVARIANT: must stay at or above `drainGraceS` + 10s (kill grace) + 15s (terminal-publish budget) \u2014 the kubelet SIGKILLs the pod at this deadline, and a drain cut short interrupts every in-flight run. The chart enforces this with a `fail` at render time; a JSON Schema description alone enforces nothing."
         },
         "perRunCharge": {
           "type": "object",
@@ -303,7 +306,7 @@
             "required": [
               "existingSecret"
             ],
-            "description": "auth.create=false means the JWT signing secret must come from somewhere — without existingSecret the Deployment references a Secret that was never created."
+            "description": "auth.create=false means the JWT signing secret must come from somewhere \u2014 without existingSecret the Deployment references a Secret that was never created."
           }
         }
       ],
@@ -588,7 +591,7 @@
     },
     "garage": {
       "type": "object",
-      "description": "The bundled single-node S3-compatible store. Default-disabled: an existing endpoint can be named with artifactStorage.s3.endpointUrl instead. Needs a one-time bootstrap after install — see templates/garage.yaml.",
+      "description": "The bundled single-node S3-compatible store. Default-disabled: an existing endpoint can be named with artifactStorage.s3.endpointUrl instead. Needs a one-time bootstrap after install \u2014 see templates/garage.yaml.",
       "properties": {
         "enabled": {
           "type": "boolean"
@@ -631,6 +634,55 @@
         }
       },
       "additionalProperties": false
+    },
+    "tracing": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "serviceName": {
+          "type": "string"
+        },
+        "resourceAttributes": {
+          "type": "string"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            },
+            "required": [
+              "enabled"
+            ]
+          },
+          "then": {
+            "properties": {
+              "endpoint": {
+                "minLength": 1
+              }
+            },
+            "required": [
+              "endpoint"
+            ],
+            "description": "tracing.enabled requires tracing.endpoint. Enabled with an empty endpoint would start a runner pool that exports nothing, and that state has NO runtime symptom - the trace view is simply empty, which is indistinguishable from nobody having run anything. Refusing here is the only loud moment available. Note the credential (tracing.headers) is deliberately NOT required: an in-cluster collector needs none."
+          }
+        }
+      ],
+      "additionalProperties": false
     }
   },
   "required": [
@@ -639,5 +691,5 @@
     "runner"
   ],
   "additionalProperties": false,
-  "$comment": "additionalProperties:false is the point of this file — it turns a stale or misspelled key (a `podDisruptionBudget` block left behind after the template was deleted, a `runner.resource` typo) into an install-time error instead of a value that is silently ignored while the operator believes it took effect. `global` is allowed because Helm injects it for subcharts."
+  "$comment": "additionalProperties:false is the point of this file \u2014 it turns a stale or misspelled key (a `podDisruptionBudget` block left behind after the template was deleted, a `runner.resource` typo) into an install-time error instead of a value that is silently ignored while the operator believes it took effect. `global` is allowed because Helm injects it for subcharts."
 }

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -227,6 +227,50 @@ tavily:
   # pass it with `--set-file tavily.apiKey=<path>` or `--set`, or use `existingSecret`.
   apiKey: ""
 
+# Distributed tracing — the runner pool exports each run's spans over OTLP (OME-1131, Phase 2).
+# Phase 1 made one `trace_id` greppable across services; this is what makes a tracing backend's
+# TRACE VIEW show a waterfall instead of a log search.
+#
+# POSTURE — fail open, but never silently. An unreachable collector must never fail or slow a
+# run: the engine's job is executing runs, not shipping telemetry, so the exporter drops spans
+# on backpressure and swallows its own errors. The cost of that choice is the failure it CANNOT
+# be allowed to hide — a deployment that believes it is exporting and is not. So the loud half
+# lives HERE, at render time: `enabled: true` with an empty `endpoint` FAILS the render rather
+# than starting a pool that silently exports nothing. There is no runtime symptom for that
+# state; the trace view is simply empty, which looks identical to "nobody ran anything".
+#
+# Applies to the RUNNER POOL only. The control plane publishes no spans (the exporter is
+# mounted in the run mode), so configuring it there would wire up an exporter that does not
+# exist. aigateway is instrumented separately.
+tracing:
+  enabled: false
+  # Base OTLP/HTTP endpoint, e.g. http://signoz-otel-collector.platform.svc.cluster.local:4318
+  # The exporter appends `/v1/traces`. Required when enabled.
+  #
+  # Prefer the IN-CLUSTER Service address: it needs no credential, crosses no public network,
+  # and does not depend on an edge that can deny it.
+  endpoint: ""
+  # Reported as `service.name`. Empty => the code's own default (`screamingface-engine`).
+  # Deliberately omitted from the ConfigMap when empty rather than rendered as "" — a blank
+  # service name in a tracing backend is indistinguishable from an unconfigured service.
+  serviceName: ""
+  # Extra OTel resource attributes as `k=v,k=v`, e.g. `deployment.environment=dev`.
+  resourceAttributes: ""
+  # Bring your own Secret (recommended for prod — created out-of-band or by an External Secrets
+  # / Sealed Secrets flow). NOTE: it must key the value `OTEL_EXPORTER_OTLP_HEADERS`, because
+  # the pool attaches it with `envFrom.secretRef`, which injects keys under their own names and
+  # cannot rename.
+  existingSecret: ""
+  # OPTIONAL, unlike `tavily.apiKey` — an in-cluster collector needs no credential at all, and
+  # requiring one would block the most likely correct deployment. Comma-separated `k=v` headers:
+  #
+  #   SigNoz ingestion key        signoz-access-token=<key>
+  #   Cloudflare Access           CF-Access-Client-Id=<id>,CF-Access-Client-Secret=<secret>
+  #
+  # One variable covers both shapes, the Access client-id/secret PAIR included.
+  # NEVER commit a real credential to a values file; pass it with `--set` or use `existingSecret`.
+  headers: ""
+
 # JWT topic-capability signing secret (spec §4). HS256; never logged. When `create: true` the chart
 # generates a random 64-char secret (reused across upgrades via lookup), else supply `existingSecret`.
 auth:

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -247,8 +247,16 @@ tracing:
   # Base OTLP/HTTP endpoint, e.g. http://signoz-otel-collector.platform.svc.cluster.local:4318
   # The exporter appends `/v1/traces`. Required when enabled.
   #
+  # ⚠️ POINT THIS AT THE COLLECTOR, NEVER AT THE SIGNOZ UI HOSTNAME. This is a silent, verified
+  # footgun, not a theoretical one: `https://signoz.pulse.dev.openmined.org/v1/traces` answers
+  # **200 with `text/html`** — it is the UI's single-page-app catch-all, and a nonsense path
+  # answers identically. OTel's HTTP exporter treats any 2xx as success, so pointing here makes
+  # every span POST, succeed, and be DISCARDED, while the exporter reports perfect health and
+  # the trace view stays empty. That is indistinguishable from "nobody ran anything".
+  #
   # Prefer the IN-CLUSTER Service address: it needs no credential, crosses no public network,
-  # and does not depend on an edge that can deny it.
+  # and does not depend on an edge that can deny it. Find it with:
+  #   kubectl get svc -A | grep -i 'otel\|signoz'
   endpoint: ""
   # Reported as `service.name`. Empty => the code's own default (`screamingface-engine`).
   # Deliberately omitted from the ConfigMap when empty rather than rendered as "" — a blank

--- a/apps/screamingface-engine/tests/unit/test_chart_render_tracing.py
+++ b/apps/screamingface-engine/tests/unit/test_chart_render_tracing.py
@@ -1,0 +1,257 @@
+"""The chart ships the OTLP endpoint and credential to the runner pool (OME-1131).
+
+`OME-1130` built the exporter and deliberately left it inert — off unless an OTLP endpoint is
+configured. This is the half that can turn it on, so the failure mode this file guards is
+specific: **a chart that sets a variable the code does not read is silently inert.** Everything
+renders, every gate passes, nothing is exported, and the only symptom is an empty trace view.
+
+WHY render rather than read the template text: `helm lint` reports "0 chart(s) failed" for a
+chart that cannot render at all. Every chart test in this repo asserts against the RENDERED
+manifest for that reason, and this follows `test_chart_render_runner_pool.py`.
+
+WHY the variable names are hardcoded here rather than imported from the code: they are
+OpenTelemetry's own specified names, not ours. The chart and `screamingface_engine.tracing`
+conform to the same external spec independently, so the literal belongs on both sides — this
+is conformance, not a duplicated constant.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_APP_ROOT = Path(__file__).resolve().parents[2]
+_CHART = _APP_ROOT / "deploy" / "helm"
+_RELEASE = "url4-cloud"
+_FULLNAME = f"{_RELEASE}-{_RELEASE}"
+
+_NATS = "config.natsUrl=nats://nats.example:4222"
+
+ENDPOINT_VAR = "OTEL_EXPORTER_OTLP_ENDPOINT"
+HEADERS_VAR = "OTEL_EXPORTER_OTLP_HEADERS"
+SERVICE_VAR = "OTEL_SERVICE_NAME"
+ATTRIBUTES_VAR = "OTEL_RESOURCE_ATTRIBUTES"
+
+pytestmark = pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+
+
+def _render(*settings: str) -> list[dict]:
+    """Render the chart with extra `--set` pairs. Raises if helm refuses."""
+    args = ["helm", "template", _RELEASE, str(_CHART), "--set-string", _NATS]
+    for setting in settings:
+        args += ["--set", setting]
+    result = subprocess.run(args, capture_output=True, text=True, check=True)
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def _render_error(*settings: str) -> str:
+    """Render expecting REFUSAL, and return what helm said. Fails loudly if it succeeded."""
+    args = ["helm", "template", _RELEASE, str(_CHART), "--set-string", _NATS]
+    for setting in settings:
+        args += ["--set", setting]
+    result = subprocess.run(args, capture_output=True, text=True)
+    assert result.returncode != 0, "the chart rendered when it should have refused"
+    return result.stderr
+
+
+def _find(docs: list[dict], kind: str, name: str) -> dict:
+    for doc in docs:
+        if doc.get("kind") == kind and doc.get("metadata", {}).get("name") == name:
+            return doc
+    raise AssertionError(f"no {kind}/{name} in the rendered chart")
+
+
+def _maybe(docs: list[dict], kind: str, name: str) -> dict | None:
+    for doc in docs:
+        if doc.get("kind") == kind and doc.get("metadata", {}).get("name") == name:
+            return doc
+    return None
+
+
+def _runner_env(docs: list[dict]) -> dict:
+    return _find(docs, "ConfigMap", f"{_FULLNAME}-runner-env")["data"]
+
+
+def _pool(docs: list[dict]) -> dict:
+    return _find(docs, "Deployment", f"{_FULLNAME}-runner")
+
+
+# --- off by default ---------------------------------------------------------------------------
+
+
+def test_tracing_is_off_by_default_and_renders_no_otlp_variables() -> None:
+    """`OME-1130` treats an absent endpoint as off, so the default chart must leave it absent.
+
+    Asserted across the WHOLE manifest rather than one ConfigMap: a stray OTLP name anywhere
+    would turn export on for some deployment, and "off by default" is the property that keeps
+    every existing installation unaffected by this change.
+    """
+    rendered = yaml.safe_dump_all(_render())
+
+    for name in (ENDPOINT_VAR, HEADERS_VAR, SERVICE_VAR, ATTRIBUTES_VAR):
+        assert name not in rendered, f"{name} renders by default — tracing must be opt-in"
+
+
+def test_the_default_values_state_tracing_is_disabled() -> None:
+    values = yaml.safe_load((_CHART / "values.yaml").read_text(encoding="utf-8"))
+
+    assert values["tracing"]["enabled"] is False
+
+
+# --- turning it on ------------------------------------------------------------------------
+
+
+def test_an_endpoint_reaches_the_runner_env_configmap() -> None:
+    docs = _render("tracing.enabled=true", "tracing.endpoint=http://collector:4318")
+
+    assert _runner_env(docs)[ENDPOINT_VAR] == "http://collector:4318"
+
+
+def test_the_pool_inherits_the_tracing_configmap() -> None:
+    """The endpoint is useless in a ConfigMap the pool does not read — and the pool's children
+    inherit their env from the worker, so this one reference carries the whole chain."""
+    docs = _render("tracing.enabled=true", "tracing.endpoint=http://collector:4318")
+
+    env_from = _pool(docs)["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+    assert {"configMapRef": {"name": f"{_FULLNAME}-runner-env"}} in env_from
+
+
+def test_enabling_tracing_without_an_endpoint_fails_the_render() -> None:
+    """The LOUD half of fail-open-but-loud, at the loudest moment available.
+
+    A deployment that believes it is exporting and is not is the failure this whole unit exists
+    to prevent, and it is invisible at runtime — there is no error, just an empty trace view.
+    Refusing at `helm template` makes that state unrepresentable rather than merely discouraged.
+    """
+    stderr = _render_error("tracing.enabled=true")
+
+    # helm renders the schema path as `/tracing/endpoint`; the property that matters is that
+    # the refusal NAMES the missing value rather than saying "invalid values" and stopping.
+    assert "tracing" in stderr and "endpoint" in stderr, (
+        f"the refusal must name the missing value, got: {stderr}"
+    )
+
+
+def test_the_template_refuses_too_when_schema_validation_is_skipped() -> None:
+    """The schema rejects first, which would leave the template's own `fail` looking like dead
+    code. It is not: `--skip-schema-validation` is a real flag, and this is the guard that still
+    holds under it. Asserted rather than assumed, so the belt-and-braces is not decorative.
+    """
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            _RELEASE,
+            str(_CHART),
+            "--set-string",
+            _NATS,
+            "--set",
+            "tracing.enabled=true",
+            "--skip-schema-validation",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0, "the template rendered an enabled exporter with no endpoint"
+    assert "tracing.endpoint" in result.stderr
+
+
+# --- the credential ------------------------------------------------------------------------
+
+
+def test_headers_travel_by_secret_reference_and_never_as_a_literal() -> None:
+    """The same invariant `test_deploy_time_credentials_travel_by_secret_reference_never_as_
+    literals` holds for Tavily and object storage, extended to this credential.
+
+    A manifest is readable by anything with `get` on it and is echoed by `kubectl describe`
+    and `helm get manifest`.
+    """
+    secret = "signoz-access-token=super-secret-token"
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        f"tracing.headers={secret}",
+    )
+
+    env_from = _pool(docs)["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+    assert {"secretRef": {"name": f"{_FULLNAME}-tracing"}} in env_from
+    assert "super-secret-token" not in yaml.safe_dump(_pool(docs)), (
+        "the OTLP credential must never be a literal in the pool's env"
+    )
+    assert "super-secret-token" not in yaml.safe_dump(_runner_env(docs)), (
+        "the OTLP credential must never reach a ConfigMap — it is world-readable with `get`"
+    )
+
+
+def test_the_credential_is_keyed_by_its_own_variable_name() -> None:
+    """`envFrom.secretRef` injects keys under their OWN names and cannot rename, so the key
+    must literally be the variable the exporter reads. `secret-tavily.yaml` learned this the
+    breaking way; this follows the shape it ended at."""
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        "tracing.headers=k=v",
+    )
+
+    secret = _find(docs, "Secret", f"{_FULLNAME}-tracing")
+    assert HEADERS_VAR in secret["stringData"]
+
+
+def test_headers_are_optional_so_an_in_cluster_collector_needs_no_credential() -> None:
+    """The likely production shape: SigNoz in the same cluster, reached over internal DNS with
+    no credential and no Cloudflare Access at all. Demanding one — as `tavily.enabled` does —
+    would block the most probable correct deployment."""
+    docs = _render("tracing.enabled=true", "tracing.endpoint=http://collector.signoz:4318")
+
+    assert _maybe(docs, "Secret", f"{_FULLNAME}-tracing") is None
+    env_from = _pool(docs)["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+    assert {"secretRef": {"name": f"{_FULLNAME}-tracing"}} not in env_from
+
+
+def test_an_existing_secret_suppresses_the_chart_created_one() -> None:
+    """The recommended prod shape — supplied out-of-band or by External Secrets / Sealed
+    Secrets, exactly as `tavily.existingSecret` works."""
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        "tracing.existingSecret=otlp-creds",
+    )
+
+    assert _maybe(docs, "Secret", f"{_FULLNAME}-tracing") is None
+    env_from = _pool(docs)["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+    assert {"secretRef": {"name": "otlp-creds"}} in env_from
+
+
+# --- the optional descriptive values ---------------------------------------------------------
+
+
+def test_the_service_name_and_resource_attributes_reach_the_configmap() -> None:
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        "tracing.serviceName=sf-engine",
+        "tracing.resourceAttributes=deployment.environment=dev",
+    )
+
+    data = _runner_env(docs)
+    assert data[SERVICE_VAR] == "sf-engine"
+    assert data[ATTRIBUTES_VAR] == "deployment.environment=dev"
+
+
+def test_unset_descriptive_values_are_ABSENT_rather_than_empty() -> None:
+    """Rendering `""` OVERRIDES the code's own default with an empty string rather than leaving
+    it unset — the trap `URL4_CLOUD_ARTIFACTS_DIR` documents in this same ConfigMap, where an
+    empty path silently became the working directory.
+
+    Here it would report every engine span under a blank service name, which in a tracing
+    backend is indistinguishable from an unconfigured service.
+    """
+    data = _runner_env(_render("tracing.enabled=true", "tracing.endpoint=http://collector:4318"))
+
+    assert SERVICE_VAR not in data
+    assert ATTRIBUTES_VAR not in data

--- a/docs/tasks/2026-09-11-OME-1131-otlp-chart.md
+++ b/docs/tasks/2026-09-11-OME-1131-otlp-chart.md
@@ -1,0 +1,51 @@
+---
+id: OME-1131
+linear_url: https://linear.app/openmined/issue/OME-1131
+status: in_review
+type: null
+priority: 3
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-11
+closed: null
+---
+
+# Ship the OTLP endpoint and credentials through the engine chart
+
+`OME-1130` built the span exporter and deliberately left it inert — off unless an OTLP endpoint
+is configured, and nothing configured one. This is the half that can turn it on.
+
+Four things worth knowing before touching this area:
+
+- **One variable carries every auth shape.** `OTEL_EXPORTER_OTLP_HEADERS` is a comma-separated
+  `k=v` list mapped onto request headers, so a SigNoz ingestion key and a Cloudflare Access
+  service token — a client-id/secret **pair** — are the same field. The issue assumed the
+  answer had to be known before the chart could be shaped; it did not.
+
+- **This chart IS gated, but not by `charts.yml`.** `charts.yml` filters on
+  `apps/*/charts/**` and this chart lives at `deploy/helm/`, which reads as ungated. It is
+  actually covered by `screamingface-engine-tests.yml`'s `chart:` job ("Render the Helm
+  chart"). Reading `charts.yml` alone leads to the opposite and wrong conclusion.
+
+- **`tracing.enabled` with no endpoint FAILS the render**, by schema and again by template
+  `fail`. Fail-open is the exporter's job and is already done; the loud half belongs at deploy
+  time, because a pool that silently exports nothing has **no runtime symptom** — the trace
+  view is simply empty, which is indistinguishable from nobody having run anything.
+
+- **The credential is OPTIONAL, unlike every other Secret in this chart.** An in-cluster
+  collector reached over Service DNS needs none, and that is the likeliest correct deployment.
+  Consequently the pool references the tracing Secret only when one exists — an unresolvable
+  `envFrom` would stop the pool from starting.
+
+One trap recorded so it is not re-introduced: **do not add `lookup` reuse to
+`secret-tracing.yaml`.** It was written (copying `secret-tavily.yaml`) and removed as a bug —
+the template renders only when headers are supplied, so the reuse branch silently reverted a
+credential rotation to the stale cluster copy. It cannot be fixed by moving the condition
+either: "absent" is a legitimate configuration here, so the chart cannot tell "I need no auth"
+from "I forgot to pass it". `existingSecret` is the durable path.
+
+**Still open (owner):** where the engine actually sends spans. No cluster access from the
+agent's environment. `kubectl get svc -A | grep -i 'otel\|signoz'` settles it. Note the
+`SIGNOZ_TOKEN` confirmed earlier is for the **query** API, a different surface from OTLP
+**ingest**.
+
+Ledger: `docs/work/2026-09-11-OME-1131-otlp-chart.md`

--- a/docs/work/2026-09-11-OME-1131-otlp-chart.md
+++ b/docs/work/2026-09-11-OME-1131-otlp-chart.md
@@ -57,6 +57,20 @@ and is printed in plain text by `helm get manifest`.
 If SigNoz's endpoint turns out to be that shape, the endpoint stops being non-secret and this
 split is wrong for it. Not designed around today because SigNoz does not do that.
 
+**D2b — the endpoint has a SILENT failure mode, now documented at the config site.** Probed
+`POST https://signoz.pulse.dev.openmined.org/v1/traces` and got **200 with `text/html`** — the
+UI's single-page-app catch-all, byte-identical to what a nonsense path returns. OTel's HTTP
+exporter treats any 2xx as success, so pointing `tracing.endpoint` at the UI hostname would
+make every span POST, succeed, and be discarded, with the exporter reporting perfect health.
+
+That is the worst failure this feature can have — "tracing works" with an empty backend, which
+looks exactly like nobody having run anything. It is also the single most natural mistake to
+make, because the UI hostname is the one everybody knows. Warned about in `values.yaml` beside
+the field itself, where someone setting it will actually read it.
+
+It also settles the deployment question: **no public ingest exists, so the collector must be
+reached in-cluster, and therefore needs no credential.**
+
 **D3 — headers are OPTIONAL, and that is the likely production case.** If SigNoz runs in the
 same cluster, the engine reaches its collector over cluster-internal DNS with no credential and
 no Cloudflare Access at all. So unlike `tavily.enabled`, enabling tracing does NOT require a

--- a/docs/work/2026-09-11-OME-1131-otlp-chart.md
+++ b/docs/work/2026-09-11-OME-1131-otlp-chart.md
@@ -1,0 +1,182 @@
+---
+ticket: OME-1131
+stack: screamingface-engine
+status: done
+started: 2026-09-11
+finished: 2026-09-11
+---
+
+# OME-1131 — Ship the OTLP endpoint and credentials through the engine chart
+
+## Intent
+
+`OME-1130` built the exporter and left it inert: it is off unless an OTLP endpoint is
+configured, and nothing configures one. This is the half that turns it on — endpoint and
+credential into the runner pool's environment, off by default, credential by Secret only.
+
+## What the ticket got wrong, and what that changes
+
+**"Resolve whether `SIGNOZ_TOKEN` is a SigNoz API key or a Cloudflare Access service token
+before the chart shape is designed; it changes what fields exist."** It does not. Verified
+against the installed exporter (`opentelemetry-exporter-otlp-proto-http` 1.44.0) rather than
+assumed:
+
+```
+OTEL_EXPORTER_OTLP_HEADERS='signoz-access-token=abc,CF-Access-Client-Id=xyz'
+→ headers {'signoz-access-token': 'abc', 'cf-access-client-id': 'xyz'}
+```
+
+It is a comma-separated `k=v` list mapped onto request headers, so ONE variable expresses
+every candidate answer — including the Access client-id/secret **pair** the ticket thought a
+single value could not carry. The credential question becomes a `values-cloud.yaml` choice at
+deploy time instead of a code fork, so this unit is not blocked on it.
+
+**"`charts.yml` is path-filtered on `apps/*/charts/**`, so confirm the gate actually covers
+this chart."** Confirmed, and the answer is reassuring for an unobvious reason: the engine
+chart is gated by **`screamingface-engine-tests.yml`'s `chart:` job** ("Render the Helm
+chart"), not by `charts.yml` at all. Observed passing on PR #905. So the chart has a gate; it
+is simply a different one than the ticket assumed. Recorded here because the next person to
+read `charts.yml` will reach the ticket's conclusion and think this chart is ungated.
+
+## Design decisions
+
+**D1 — OFF is the default, and "on but unconfigured" FAILS THE RENDER.** The ticket asks for
+fail-open-but-loud. Fail-open is `OME-1130`'s job and is already done (a downed collector
+degrades telemetry alone). The LOUD half belongs here, and the loudest available moment is
+`helm template` — not a warning in a pod log nobody reads. `tracing.enabled=true` with an
+empty `endpoint` therefore `fail`s, exactly as `tavily.enabled` does without a credential
+source. A deployment that believes it is exporting and is not is the failure being designed
+out, so it is made unrepresentable rather than merely discouraged.
+
+**D2 — the endpoint goes in the ConfigMap, the headers go in a Secret.** An endpoint is not a
+credential; headers are nothing but. `configmap-runner-env.yaml`'s own note spells out the
+consequence of getting this backwards — a ConfigMap is readable by anything with `get` on it
+and is printed in plain text by `helm get manifest`.
+
+*Caveat worth stating rather than discovering:* some vendors embed a token IN the ingest URL.
+If SigNoz's endpoint turns out to be that shape, the endpoint stops being non-secret and this
+split is wrong for it. Not designed around today because SigNoz does not do that.
+
+**D3 — headers are OPTIONAL, and that is the likely production case.** If SigNoz runs in the
+same cluster, the engine reaches its collector over cluster-internal DNS with no credential and
+no Cloudflare Access at all. So unlike `tavily.enabled`, enabling tracing does NOT require a
+credential source — only an endpoint. Demanding one would block the most likely correct
+deployment.
+
+**D4 — the Secret key is literally `OTEL_EXPORTER_OTLP_HEADERS`.** The pool attaches it with
+`envFrom.secretRef`, which injects keys under their OWN names and cannot rename. `secret-tavily`
+carries the same constraint and learned it the breaking way (it used to be `tavily.secretKey`
+defaulting to `api-key`). Following the shape it ended at rather than repeating its history.
+
+**D5 — only the RUNNER pool gets this, not the control plane.** `OME-1130` mounted the exporter
+in `runner/main.py`; the serving half publishes no spans, so wiring OTLP into the App's own
+ConfigMap would configure an exporter that does not exist. `OME-1132` covers aigateway
+separately.
+
+**D6 — NO `lookup` reuse, unlike every other Secret in this chart.** Planned as a mirror of
+`secret-tavily.yaml`, which re-reads the value already in the cluster so a values-less
+`helm upgrade` does not wipe it. **Written, then removed — it was a bug.** The template renders
+only when `tracing.headers` is non-empty, so the reuse branch fired on exactly the path where
+the operator DID supply a value, silently reverting a credential rotation to the stale copy.
+
+Moving the condition would not have fixed it either, and that is the more interesting half:
+for this value, "absent" is a LEGITIMATE configuration (an in-cluster collector needs no
+credential). The chart cannot distinguish "I do not need auth" from "I forgot to pass it
+again", and those want opposite behaviour. Resurrecting a credential an operator may have
+deliberately removed is the worse mistake, so the durable path is `existingSecret` — which
+survives upgrades by construction, because the chart does not own the object — and inline
+`headers` is dev-only convenience, exactly as `tavily.apiKey` is documented to be.
+
+**D7 — the pool references the tracing Secret only when one EXISTS.** `tracing.enabled` alone
+must not add an `envFrom.secretRef`: an unresolvable reference stops the pool from starting, so
+"I enabled tracing to an in-cluster collector and needed no credential" would have been an
+outage. Hence the `tracingHasSecret` helper rather than reusing `tracing.enabled`.
+
+## Planned changes
+
+- `deploy/helm/values.yaml` — the `tracing` stanza, off, with the posture stated at the config site.
+- `deploy/helm/values.schema.json` — the `tracing` object.
+- `deploy/helm/templates/_helpers.tpl` — `screamingface-engine.tracingSecretName`.
+- `deploy/helm/templates/configmap-runner-env.yaml` — endpoint / service name / resource attributes.
+- `deploy/helm/templates/secret-tracing.yaml` (new) — the headers Secret.
+- `deploy/helm/templates/deployment-runner.yaml` — the `envFrom.secretRef`.
+- `tests/unit/test_chart_render_tracing.py` (new).
+
+## Test plan
+
+RED first, against the RENDERED manifest — `helm lint` reports success for a chart that cannot
+render, which is why every chart test in this repo renders.
+
+- Default values render NO OTLP variables anywhere (off by construction).
+- `tracing.enabled=true` + endpoint renders `OTEL_EXPORTER_OTLP_ENDPOINT` into the runner-env
+  ConfigMap, and the pool inherits it.
+- `tracing.enabled=true` with an EMPTY endpoint fails the render, naming the missing value.
+- Headers reach the pool by `envFrom.secretRef` and appear **nowhere** as a literal — the
+  `test_deploy_time_credentials_travel_by_secret_reference_never_as_literals` invariant,
+  extended to this credential.
+- Headers are OPTIONAL: endpoint alone renders cleanly and creates no Secret.
+- `existingSecret` suppresses the chart-created Secret and is what the pool references.
+- `serviceName` / `resourceAttributes` reach the ConfigMap when set, and are absent when not
+  (an empty value would override the code's default with "", which is worse than absent —
+  the same trap `URL4_CLOUD_ARTIFACTS_DIR` documents).
+- The variable NAMES match what `OME-1130`'s code actually reads — a chart that sets a
+  misspelled variable is silently inert, which is this unit's characteristic failure.
+
+## Acceptance
+
+- Chart renders with tracing off by default; no OTLP names appear.
+- The credential appears only in the Secret, never in the pool manifest or a ConfigMap.
+- `run_gates.py screamingface-engine` green, chart render job green.
+
+## Outcome
+
+- **Actual files:**
+  - `deploy/helm/values.yaml` — the `tracing` stanza, off, posture stated at the config site.
+  - `deploy/helm/values.schema.json` — the `tracing` object + the `enabled ⇒ endpoint` rule.
+  - `deploy/helm/values-cloud.yaml` — a commented stub showing where the deploy-time answer goes.
+  - `deploy/helm/templates/_helpers.tpl` — `tracingSecretName`, `tracingHasSecret`.
+  - `deploy/helm/templates/configmap-runner-env.yaml` — endpoint / service name / attributes.
+  - `deploy/helm/templates/secret-tracing.yaml` (new) — the headers Secret.
+  - `deploy/helm/templates/deployment-runner.yaml` — the conditional `envFrom.secretRef`.
+  - `tests/unit/test_chart_render_tracing.py` (new) — 12 tests.
+  - Mirror: `docs/tasks/2026-09-11-OME-1131-otlp-chart.md`.
+
+- **Gates:** `run_gates.py screamingface-engine` **ALL GREEN** — append-only, ruff check/format,
+  pyright, `check_layering.py`, pytest+coverage. The chart's own CI job is
+  `screamingface-engine-tests.yml`'s `chart:` ("Render the Helm chart").
+
+- **Verification beyond the gates:**
+  - **Four mutations, four killed:** dropping the endpoint from the ConfigMap; leaking the
+    headers INTO the ConfigMap; referencing the Secret unconditionally; rendering an unset
+    `serviceName` as `""`.
+  - **Rendered and read by eye**, not only asserted: with a credential set, `grep -c` finds it
+    exactly **once** in the whole manifest — in the Secret.
+  - **`values-cloud.yaml` still renders** with the full cloud posture after the edit.
+
+- **Deviations:**
+  - **The ticket's blocking premise was wrong, so this was not blocked.** "Resolve whether the
+    token is a SigNoz API key or a Cloudflare Access service token before the chart shape is
+    designed; it changes what fields exist." `OTEL_EXPORTER_OTLP_HEADERS` is a comma-separated
+    `k=v` list, so one field carries every candidate answer including the Access client-id/
+    secret **pair**. Verified against the installed exporter rather than assumed.
+  - **The gate question resolved the other way.** The ticket suspects this chart is ungated
+    because `charts.yml` filters on `apps/*/charts/**`. It IS gated — by the engine's own test
+    workflow. Worth keeping written down, because reading `charts.yml` alone leads to the
+    opposite and wrong conclusion.
+  - **The `lookup` reuse pattern was written and then removed** as an active bug. See D6.
+  - **The schema rejects before the template's `fail` runs**, which made that second guard look
+    like dead code. It is reachable under `--skip-schema-validation`, and now has a test that
+    proves it — rather than leaving belt-and-braces that nobody has checked is braces.
+  - **`tracing.headers` is optional where `tavily.apiKey` is mandatory.** A deliberate
+    divergence from the precedent being copied, because the likeliest correct deployment needs
+    no credential at all.
+  - **Not verified against a real collector.** Nothing here has exported a span to SigNoz,
+    because the endpoint is unknown (see below). The chart is correct by render; the end-to-end
+    acceptance needs the deployed answer.
+
+- **Open — needs the owner (no cluster access from here):** where does the engine send spans?
+  `kubectl config current-context` resolves to `k3s-ansible`, a context that does not exist
+  locally, so this could not be answered rather than guessed. Strong prior: SigNoz in the same
+  cluster, reached over Service DNS, needing no credential — which `kubectl get svc -A | grep
+  -i 'otel\|signoz'` settles in one line. Note the earlier `SIGNOZ_TOKEN` finding does NOT
+  settle it: that was the **query** API, a different surface from OTLP **ingest**.


### PR DESCRIPTION
`OME-1130` built the span exporter and deliberately left it inert — off unless an OTLP endpoint is configured, and nothing configured one. This is the half that can turn it on.

The endpoint reaches the runner pool through its env ConfigMap; the collector credential travels by Secret and appears nowhere else. **Off by default**, so every existing installation is unaffected.

## The issue held this blocked. It wasn't.

> *"Whether `SIGNOZ_TOKEN` is a SigNoz API key or an Access **service token** is unconfirmed — and an Access service token is a client-id/secret **pair**, so a single value cannot be one. Resolve that before the chart shape is designed; **it changes what fields exist**."*

It doesn't. Verified against the installed exporter rather than assumed:

```
OTEL_EXPORTER_OTLP_HEADERS='signoz-access-token=abc,CF-Access-Client-Id=xyz'
→ headers {'signoz-access-token': 'abc', 'cf-access-client-id': 'xyz'}
```

A comma-separated `k=v` list mapped onto request headers — so one field carries every candidate answer, the Access **pair** included:

| answer | endpoint | headers |
|---|---|---|
| in-cluster collector, no auth | `http://<svc>.<ns>.svc.cluster.local:4318` | *(none)* |
| external + SigNoz ingestion key | public endpoint | `signoz-access-token=…` |
| external behind CF Access | public endpoint | `CF-Access-Client-Id=…,CF-Access-Client-Secret=…` |

The credential becomes a deploy-time value, not a code fork.

## Enabling tracing with no endpoint fails the render

Fail-open belongs to the exporter and is already done — a downed collector degrades telemetry alone. The **loud** half belongs here, because a pool that silently exports nothing has *no runtime symptom*: the trace view is simply empty, which is indistinguishable from nobody having run anything. Refused by schema, and again by template `fail`.

The schema fires first, which made the template guard look like dead code. It's reachable under `--skip-schema-validation`, and now has a test proving it — rather than belt-and-braces nobody checked was braces.

## The credential is OPTIONAL — a deliberate divergence

Unlike every other Secret in this chart, `tracing.enabled` does **not** require a credential source. An in-cluster collector needs none, and that's the likeliest correct deployment. Consequently the pool references the tracing Secret only when one exists — an unresolvable `envFrom` would stop the pool from starting, turning "I needed no credential" into an outage.

## Also resolves the issue's gate question — the other way

> *"`charts.yml` is path-filtered on `apps/*/charts/**` — this chart is at `deploy/helm/`, so confirm the gate actually covers it."*

It **is** gated — by `screamingface-engine-tests.yml`'s `chart:` job ("Render the Helm chart"), not by `charts.yml`. Reading `charts.yml` alone leads to the opposite and wrong conclusion, so it's written down in both the ledger and the mirror.

## Test plan

- `run_gates.py screamingface-engine` **ALL GREEN**; 12 new chart tests.
- **Four mutations, four killed** — dropping the endpoint from the ConfigMap; leaking headers *into* the ConfigMap; referencing the Secret unconditionally; rendering an unset `serviceName` as `""`.
- **Rendered and read by eye**, not only asserted: with a credential set, `grep -c` finds it exactly **once** in the whole manifest — in the Secret.
- `values-cloud.yaml` still renders with the full cloud posture.

## Worth a reviewer's eye

- **I wrote the `lookup` reuse pattern from `secret-tavily.yaml`, then removed it as a bug.** This template renders only when `headers` is non-empty, so the reuse branch fired on exactly the path where the operator *did* supply a value — silently reverting a credential rotation to the stale cluster copy. It can't be fixed by moving the condition either: "absent" is a legitimate configuration here, so the chart can't tell "I need no auth" from "I forgot to pass it again". `existingSecret` is the durable path (a Secret the chart doesn't own survives upgrades by construction). Recorded in the template, the ledger and the mirror so it isn't re-introduced.
- **Nothing here has exported a span to a real collector.** The chart is correct by render; end-to-end acceptance needs the deployed endpoint.

## Still open — needs someone with cluster access

**Where does the engine send spans?** `kubectl config current-context` resolves to `k3s-ansible`, a context that doesn't exist in my environment, so I couldn't answer this rather than guess.

Strong prior: SigNoz in the same cluster, reached over Service DNS, needing no credential — `kubectl get svc -A | grep -i 'otel\|signoz'` settles it in one line. Note the `SIGNOZ_TOKEN` confirmed earlier is for the **query** API (`/api/v3/query_range`), a different surface from OTLP **ingest** (`:4318/v1/traces`); conflating them is the easy mistake here.

Ledger: `docs/work/2026-09-11-OME-1131-otlp-chart.md`

Refs: OME-1131