### PR TITLE
feat(aigateway): emit spans so the gateway appears as an OTel service

### DIFF
--- a/apps/aigateway/pyproject.toml
+++ b/apps/aigateway/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "aiosqlite==0.22.1",
     "cryptography==50.0.0",
     "python-multipart>=0.0.20",
+    "opentelemetry-sdk>=1.30.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0",
 ]
 
 [project.scripts]

--- a/apps/aigateway/src/aigateway/main.py
+++ b/apps/aigateway/src/aigateway/main.py
@@ -66,6 +66,7 @@ from .routes import (
     tavily_retrieval_cache,
 )
 from .routes.chat_accounting import accounting_error_response
+from .tracing import install as install_tracing
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,10 @@ def _attach_log_filter() -> None:
     # `tests/unit/test_call_context.py` pins both. Ordered this way only because redaction is
     # the security-critical one and reads better installed first.
     install_call_context_injection()
+    # FEATURE (OME-1132): aigateway as an OTel service. No-op unless an OTLP endpoint is
+    # configured, which is the default everywhere, and it never raises — an AI gateway that
+    # refuses to boot because a collector address was wrong is a worse outage than no spans.
+    install_tracing(os.environ)
     for name in ("", "uvicorn.access", "uvicorn.error", "aigateway"):
         target = logging.getLogger(name)
         if not any(isinstance(f, RedactProvisioningTokenFilter) for f in target.filters):

--- a/apps/aigateway/src/aigateway/middleware/call_id.py
+++ b/apps/aigateway/src/aigateway/middleware/call_id.py
@@ -29,7 +29,8 @@ from __future__ import annotations
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from aigateway.call_context import call_scope, new_gateway_call_id
-from aigateway.w3c_trace import adopt_or_mint_trace_id
+from aigateway.tracing import server_span
+from aigateway.w3c_trace import adopt_or_mint_trace_id, parse_traceparent
 
 TRACE_RESPONSE_HEADER = b"x-aigw-trace-id"
 """Echoed on every response so a STREAMING caller can read the id.
@@ -52,6 +53,18 @@ def _inbound_traceparent(scope: Scope) -> str | None:
     return None
 
 
+def _route_name(scope: Scope) -> str:
+    """The span's name: `<METHOD> <path>`.
+
+    The RAW path, deliberately not a templated route — this runs before routing has happened,
+    which is the same reason the ids are bound here. Path parameters in aigateway's surface are
+    ids, not secrets, so the cardinality cost is bounded and the alternative (naming every span
+    after the method alone) makes the trace view useless.
+    """
+    method = scope.get("method", "HTTP")
+    return f"{method} {scope.get('path', '')}".strip()
+
+
 class CallIdMiddleware:
     """Give every HTTP request its correlation ids, bound for the whole request."""
 
@@ -66,8 +79,15 @@ class CallIdMiddleware:
             await self._app(scope, receive, send)
             return
 
+        inbound = _inbound_traceparent(scope)
+        trace_id = adopt_or_mint_trace_id(inbound)
         call_id = new_gateway_call_id()
-        trace_id = adopt_or_mint_trace_id(_inbound_traceparent(scope))
+        # The caller's SPAN id, when it sent a usable one — the edge that attaches this
+        # gateway's span to the engine node that called it. `adopt_or_mint_trace_id` above
+        # keeps only the trace id, which is all a log line needs and not enough for a span.
+        # Re-parsing rather than threading it through: one validated read, same rejections.
+        parsed = parse_traceparent(inbound)
+        parent_span_id = parsed[1] if parsed is not None else None
 
         async def send_with_trace(message: Message) -> None:
             # INVARIANT: appended, never replacing the header list. A response that already
@@ -78,7 +98,14 @@ class CallIdMiddleware:
                 message = {**message, "headers": headers}
             await send(message)
 
-        with call_scope(call_id, trace_id=trace_id):
+        # INVARIANT: the span opens INSIDE `call_scope`. `tracing`'s id generator reads the
+        # bound trace id from that scope, so opening the span outside it would mint a
+        # different one and produce the two-ids-for-one-call state this middleware exists to
+        # prevent (OME-1132). A no-op when tracing is not configured, which is the default.
+        with (
+            call_scope(call_id, trace_id=trace_id),
+            server_span(_route_name(scope), parent_span_id=parent_span_id),
+        ):
             # Published on the scope so downstream consumers (the taxonomy session, the
             # exception handlers) read the SAME ids rather than minting a second set for the
             # same request — two ids for one call is worse than none, because both look right.

--- a/apps/aigateway/src/aigateway/routes/chat_dispatch.py
+++ b/apps/aigateway/src/aigateway/routes/chat_dispatch.py
@@ -26,6 +26,7 @@ from ..core.http_status import valid_http_error_status
 from ..core.oauth.models import OAuthConnection
 from ..core.profile_models import AuthType, Profile
 from ..core.retry import RetryPolicy, parse_retry_after_seconds, with_overload_retry
+from ..tracing import provider_span
 from .chat_accounting import note_conversion_failure
 from .chat_credentials import (
     _invalidate_profile_session,
@@ -169,11 +170,24 @@ async def _dispatch_with_backpressure(
             on_dispatch()
         return plugin.chat_completion(body)
 
-    async with provider_slot(request.app, provider, effective_provider_limit(settings, provider)):
-        return await with_overload_retry(
-            _attempt,
-            policy=RetryPolicy.from_settings(settings),
-        )
+    # FEATURE (OME-1132): the provider call as a CHILD span — "which provider was slow",
+    # answerable at last. Deliberately wraps the WHOLE block, slot wait and retries included,
+    # because that is the wall-clock the caller experienced; per-attempt detail already lives
+    # in the accounting record.
+    #
+    # WHY here and not in `plugins/taxonomy/collector.py`, which already measures this latency:
+    # that plugin is gated by `AIGW_TAXONOMY_ENABLED`, so reusing its measurement would make an
+    # accounting kill-switch silently delete the gateway's spans — the same coupling
+    # `middleware/call_id.py` was written to undo for the correlation ids. One extra clock read
+    # is the cheaper of the two costs.
+    with provider_span(provider):
+        async with provider_slot(
+            request.app, provider, effective_provider_limit(settings, provider)
+        ):
+            return await with_overload_retry(
+                _attempt,
+                policy=RetryPolicy.from_settings(settings),
+            )
 
 
 # WHY (FINDING B): the client-facing message is gateway-authored per machine

--- a/apps/aigateway/src/aigateway/tracing.py
+++ b/apps/aigateway/src/aigateway/tracing.py
@@ -1,0 +1,243 @@
+"""aigateway as an OTel service — spans, not just correlated log lines (OME-1132).
+
+Phase 1 made one `trace_id` greppable across the engine and `sf-aigw`. That is not enough for a
+trace view: a shared id in two log lines draws no edge in a service map, produces no latency
+breakdown, and cannot answer "which provider call was slow". This emits real spans so aigateway
+appears as its own service in the tree the engine's exporter (`OME-1130`) starts.
+
+THE SUBTLE REQUIREMENT — the span's trace id must be the id the middleware ALREADY BOUND.
+OTel ships `TraceContextTextMapPropagator` to extract a parent from headers, and using it here
+would be a bug. `CallIdMiddleware` computes `adopt_or_mint_trace_id(inbound)`; the propagator
+would agree with it on a well-formed traceparent and DIVERGE on a malformed or absent one,
+because each mints its own replacement. One request would then carry two different ids — the
+failure `middleware/call_id.py` names exactly: *"two ids for one call is worse than none,
+because both look right."* So the propagator is not used, and :class:`_BoundIdGenerator` hands
+OTel the id already in the call context, which makes the agreement structural.
+
+NOT GATED BY `AIGW_TAXONOMY_ENABLED`. That flag is an observability kill-switch: flipping it
+removes `call_` from logs, body and headers at once. `middleware/call_id.py` exists BECAUSE the
+correlation ids used to live inside that plugin, so disabling usage accounting silently deleted
+the gateway's only correlation mechanism. Spans are correlation. Gating them on an accounting
+flag would re-commit the mistake that middleware was written to undo.
+
+SECURITY — span attributes NEVER carry provider text. `routes/chat_dispatch.py` refuses
+`str(exc)` because it serializes raw LiteLLM/provider text, and any secret embedded in it, into
+places it must not reach. A span attribute is the same exposure with a different name, and it
+travels to a third system searched by people who never saw the response. Failures are recorded
+as the exception CLASS NAME only.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+
+from aigateway.call_context import current_trace_id
+from aigateway.w3c_trace import new_trace_id
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SERVICE_NAME = "aigateway"
+"""Used when the deployment sets no `OTEL_SERVICE_NAME`. A service reporting itself as OTel's
+default `unknown_service` is indistinguishable from every other unconfigured service, which
+defeats the point of emitting the spans."""
+
+OTLP_ENDPOINT_VARS = ("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT")
+"""Both halves of OTel's endpoint contract. Reading only the generic one would leave a
+deployment that set just the signal-specific variable silently un-traced."""
+
+PROVIDER_ATTRIBUTE = "gen_ai.provider.name"
+ERROR_TYPE_ATTRIBUTE = "error.type"
+"""OTel's conventional name for a failure's CLASS. Conventional precisely because it is the
+half that is safe to record — `error.message` is the half this gateway must never fill."""
+
+_TRACER_NAME = "aigateway.tracing"
+
+
+def otlp_configured(env: Mapping[str, str]) -> bool:
+    """Whether this deployment asked for span export at all.
+
+    A blank value counts as unset: a chart rendering `OTEL_EXPORTER_OTLP_ENDPOINT: ""` for an
+    unconfigured environment must read as "off", not as "export to the empty string".
+
+    AIDEV-NOTE: unlike the engine's equivalent, this module imports the OTel SDK at module
+    level. The engine defers it because its exporter is mounted in a SHORT-LIVED run process
+    where ~62 ms of import is paid per run; aigateway is a long-running server that boots once,
+    so the same deferral would buy nothing and cost the ability to subclass `RandomIdGenerator`
+    properly. Different cost profile, different answer — not an inconsistency.
+    """
+    return any(env.get(name, "").strip() for name in OTLP_ENDPOINT_VARS)
+
+
+def install(env: Mapping[str, str]) -> bool:
+    """Install the global tracer provider. Returns whether tracing is now on.
+
+    INVARIANT: never raises. A misconfigured exporter must not stop the gateway from serving —
+    it is an AI gateway first and a telemetry source second, and a process that refuses to boot
+    because a collector address was wrong is a far worse outage than missing spans.
+    """
+    if not otlp_configured(env):
+        return False
+    try:
+        resource = Resource.create(
+            {"service.name": env.get("OTEL_SERVICE_NAME") or DEFAULT_SERVICE_NAME}
+        )
+        provider = TracerProvider(resource=resource, id_generator=_BoundIdGenerator())
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+        trace.set_tracer_provider(provider)
+    except Exception:
+        logger.warning("span export is configured but could not be started", exc_info=True)
+        return False
+    logger.info(
+        "otlp span export enabled service=%s",
+        env.get("OTEL_SERVICE_NAME") or DEFAULT_SERVICE_NAME,
+    )
+    return True
+
+
+@contextmanager
+def server_span(name: str, *, parent_span_id: str | None) -> Iterator[None]:
+    """The span for one inbound HTTP request.
+
+    `parent_span_id` is the id off the caller's traceparent, already validated by
+    `w3c_trace.parse_traceparent`, or None when the caller sent nothing usable. None yields a
+    ROOT span rather than a child of a fabricated parent — a span pointing at an id nobody
+    emitted renders as a gap in the waterfall and is worse than an honest root.
+    """
+    with _span(name, kind="server", parent_span_id=parent_span_id):
+        yield
+
+
+@contextmanager
+def provider_span(provider: str) -> Iterator[None]:
+    """The span for one dispatch to a provider — the answer to "which call was slow".
+
+    It covers the WHOLE dispatch: waiting for the per-provider concurrency slot, every overload
+    retry, and the provider's own time. That is deliberate. `_dispatch_with_backpressure` holds
+    the slot across retries, so the wall-clock the caller actually experienced includes queueing
+    and backoff; timing only the final attempt would show a fast span for a call somebody waited
+    seconds on. The per-attempt breakdown already exists in the accounting record.
+
+    INVARIANT: a failure records the exception CLASS NAME and nothing else. See the module
+    SECURITY note — `str(exc)` here would leak raw provider text into the tracing backend.
+    """
+    with _span(
+        f"chat.completions {provider}",
+        kind="client",
+        attributes={PROVIDER_ATTRIBUTE: provider},
+    ):
+        yield
+
+
+@contextmanager
+def _span(
+    name: str,
+    *,
+    kind: str,
+    parent_span_id: str | None = None,
+    attributes: Mapping[str, str] | None = None,
+) -> Iterator[None]:
+    """One span, or nothing at all when tracing is off.
+
+    INVARIANT: never raises and never alters control flow. Everything here is a side effect on
+    a request that must succeed or fail on its own merits; an exception escaping this would
+    turn a telemetry fault into a failed API call.
+    """
+    if isinstance(trace.get_tracer_provider(), trace.NoOpTracerProvider):
+        # Not installed: do not pay for span objects that go nowhere. Every request passes
+        # through here, so the off path must be as close to free as a function call gets.
+        yield
+        return
+
+    tracer = trace.get_tracer(_TRACER_NAME)
+    context = _parent_context(parent_span_id)
+    span_kind = trace.SpanKind.SERVER if kind == "server" else trace.SpanKind.CLIENT
+    # SECURITY — `record_exception=False` is LOAD-BEARING, not tidiness. OTel defaults it to
+    # TRUE, which attaches the exception's `str()` AND its traceback to the span as an event.
+    # For this gateway that is raw LiteLLM/provider text — the exact payload
+    # `routes/chat_dispatch.py` refuses to put in a response — shipped to a tracing backend
+    # searched by people who never saw the request. A test asserts a secret in a provider
+    # exception does not reach the span; it FAILED before this argument existed.
+    #
+    # `set_status_on_exception=False` for the same reason: it records the message as the
+    # status DESCRIPTION. The status is set explicitly below, with no description.
+    with tracer.start_as_current_span(
+        name,
+        context=context,
+        kind=span_kind,
+        attributes=dict(attributes or {}),
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        try:
+            yield
+        except Exception as exc:
+            # CLASS NAME ONLY. Never `str(exc)`, never `record_exception` (which attaches the
+            # message AND the traceback) — both would carry raw provider text.
+            span.set_attribute(ERROR_TYPE_ATTRIBUTE, type(exc).__name__)
+            span.set_status(trace.Status(trace.StatusCode.ERROR))
+            raise
+
+
+def _parent_context(parent_span_id: str | None) -> Context | None:
+    """The remote parent to hang this span off, or None for a root.
+
+    Built from the ids the middleware already validated rather than by running OTel's
+    propagator over the headers again — see the module docstring for why that distinction is
+    load-bearing rather than stylistic.
+    """
+    if parent_span_id is None:
+        return None
+    trace_id = current_trace_id()
+    if trace_id is None:
+        return None
+    parent = trace.SpanContext(
+        trace_id=int(trace_id, 16),
+        span_id=int(parent_span_id, 16),
+        is_remote=True,
+        trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+    )
+    return trace.set_span_in_context(trace.NonRecordingSpan(parent))
+
+
+class _BoundIdGenerator(RandomIdGenerator):
+    """Hands OTel the trace id the request is ALREADY bound to.
+
+    WHY this exists rather than letting the SDK mint: the id in every log line comes from
+    `call_context`, and an independently minted span trace id would mean an operator who greps
+    a `trace_id=` out of the logs finds no matching trace, and vice versa. That is not a
+    cosmetic mismatch — it silently breaks the join between the two halves of the observability
+    story this phase exists to connect.
+
+    Falls back to a fresh id outside a request (a background task, a boot-time span), because
+    returning a null id would produce a span the backend rejects.
+
+    Subclasses `RandomIdGenerator` rather than duck-typing the interface: the SDK also calls
+    `is_trace_id_random()`, and a hand-rolled generator missing it raises at span creation —
+    inside a request, at runtime, which is the worst place to find an interface mismatch. It
+    did exactly that here before this line existed.
+    """
+
+    def generate_trace_id(self) -> int:
+        return int(current_trace_id() or new_trace_id(), 16)
+
+
+__all__ = [
+    "DEFAULT_SERVICE_NAME",
+    "ERROR_TYPE_ATTRIBUTE",
+    "OTLP_ENDPOINT_VARS",
+    "PROVIDER_ATTRIBUTE",
+    "install",
+    "otlp_configured",
+    "provider_span",
+    "server_span",
+]

--- a/apps/aigateway/src/aigateway/w3c_trace.py
+++ b/apps/aigateway/src/aigateway/w3c_trace.py
@@ -44,13 +44,35 @@ def parse_trace_id(value: str | None) -> str | None:
     The two all-zero rejections are not pedantry: the spec defines them as invalid precisely
     because they are what a broken or lazy implementation emits, and an all-zero id would
     happily group every such request together under one meaningless key.
+
+    Delegates to :func:`parse_traceparent` so there is ONE parse and one rejection table. Two
+    copies of this rule inside a module whose own docstring warns that three copies across
+    services is already the cost being managed would be the worst of both.
+    """
+    parsed = parse_traceparent(value)
+    return parsed[0] if parsed is not None else None
+
+
+def parse_traceparent(value: str | None) -> tuple[str, str] | None:
+    """BOTH ids a well-formed traceparent states — `(trace_id, parent_span_id)` — or None.
+
+    `parse_trace_id` validates the span id and then throws it away, which is right for its
+    callers: they group log lines, and a log line has no parent. A SPAN does. Without the
+    second id aigateway's server span can share the engine's trace but cannot attach to
+    anything inside it, so the waterfall shows two unconnected roots under one trace.
+
+    Added alongside rather than widening `parse_trace_id`, whose callers want exactly what it
+    already returns.
+
+    SECURITY: same rule, same rejections. The value is caller-controlled, so a malformed one
+    yields None and the caller starts its own trace — never a repaired version of the input.
     """
     if not value:
         return None
     match = _TRACEPARENT_RE.match(value)
     if match is None or match.group(1) == _ALL_ZERO_TRACE or match.group(2) == _ALL_ZERO_SPAN:
         return None
-    return match.group(1)
+    return match.group(1), match.group(2)
 
 
 def new_trace_id() -> str:
@@ -75,4 +97,5 @@ __all__ = [
     "adopt_or_mint_trace_id",
     "new_trace_id",
     "parse_trace_id",
+    "parse_traceparent",
 ]

--- a/apps/aigateway/tests/unit/test_tracing.py
+++ b/apps/aigateway/tests/unit/test_tracing.py
@@ -1,0 +1,309 @@
+"""aigateway emits spans, and they join the caller's trace (OME-1132).
+
+Phase 2's last unit. The engine's exporter (`OME-1130`) turns its frames into spans; aigateway
+is a separate service, so without this a trace stops at the engine.
+
+THE PROPERTY MOST OF THIS FILE DEFENDS: **the span's trace id is the same id the middleware
+bound and every log line carries.** OTel's own `TraceContextTextMapPropagator` would agree with
+`adopt_or_mint_trace_id` on a well-formed traceparent and diverge on a malformed or absent one,
+because each mints its own replacement — and an operator who greps `trace_id=` out of the logs
+would then find no matching trace. `middleware/call_id.py` names that failure exactly: "two ids
+for one call is worse than none, because both look right." So the divergent cases get tests,
+not just the agreeing one.
+
+No collector and no network: OTel's own `InMemorySpanExporter` with a `SimpleSpanProcessor`,
+which is the real SDK path a live exporter sits behind.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanContext
+
+from aigateway import tracing
+from aigateway.call_context import call_scope
+from aigateway.w3c_trace import parse_traceparent
+
+TRACE = "4bf92f3577b34da6a3ce929d0e0e4736"
+PARENT = "00f067aa0ba902b7"
+
+
+@pytest.fixture
+def exporter(monkeypatch) -> InMemorySpanExporter:
+    """A real SDK provider with the module's own id generator, exporting in memory.
+
+    `_BoundIdGenerator` is the piece under test in half these cases, so it is wired exactly as
+    `install` wires it rather than stubbed.
+    """
+    memory = InMemorySpanExporter()
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": "aigateway"}),
+        id_generator=tracing._BoundIdGenerator(),
+    )
+    provider.add_span_processor(SimpleSpanProcessor(memory))
+    monkeypatch.setattr(trace, "_TRACER_PROVIDER", provider, raising=False)
+    monkeypatch.setattr(trace, "_TRACER_PROVIDER_SET_ONCE", _AlreadySet(), raising=False)
+    return memory
+
+
+class _AlreadySet:
+    """Lets the test swap the global provider, which OTel otherwise allows only once."""
+
+    def do_once(self, _func) -> bool:  # noqa: ANN001 - matches OTel's Once surface
+        return False
+
+
+def only(exporter: InMemorySpanExporter) -> ReadableSpan:
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, f"expected exactly one span, got {[s.name for s in spans]}"
+    return spans[0]
+
+
+def hexid(value: int, width: int) -> str:
+    return format(value, f"0{width}x")
+
+
+def context_of(span: ReadableSpan) -> SpanContext:
+    """The span's context, narrowed. `ReadableSpan.context` is Optional for spans that were
+    never started; every span these tests read has been."""
+    assert span.context is not None
+    return span.context
+
+
+def attributes_of(span: ReadableSpan) -> Mapping[str, Any]:
+    assert span.attributes is not None
+    return span.attributes
+
+
+# --- the trace id agreement (the load-bearing property) ----------------------------------------
+
+
+def test_the_span_joins_the_bound_trace_id(exporter) -> None:
+    with call_scope("call-1", trace_id=TRACE), tracing.server_span("POST /x", parent_span_id=None):
+        pass
+
+    assert hexid(context_of(only(exporter)).trace_id, 32) == TRACE
+
+
+def test_the_span_joins_the_bound_id_even_when_the_caller_sent_NOTHING(exporter) -> None:
+    """The divergence case. With no inbound traceparent the middleware MINTS an id; OTel's
+    propagator would have minted a different one, and the logs and the trace would name the
+    same request by two ids."""
+    minted = "1" * 32
+
+    with call_scope("call-1", trace_id=minted), tracing.server_span("POST /x", parent_span_id=None):
+        pass
+
+    assert hexid(context_of(only(exporter)).trace_id, 32) == minted
+
+
+def test_the_span_joins_the_bound_id_when_the_caller_sent_GARBAGE(exporter) -> None:
+    """`adopt_or_mint_trace_id` REPLACES an unparseable value rather than repairing it, so the
+    bound id is one the caller never chose. The span must follow the middleware, not the
+    header."""
+    assert parse_traceparent("not-a-traceparent") is None
+    replaced = "2" * 32
+
+    with call_scope("c", trace_id=replaced), tracing.server_span("POST /x", parent_span_id=None):
+        pass
+
+    assert hexid(context_of(only(exporter)).trace_id, 32) == replaced
+
+
+# --- the parent edge ---------------------------------------------------------------------------
+
+
+def test_a_well_formed_caller_span_id_becomes_the_parent(exporter) -> None:
+    """What actually attaches aigateway to the engine node that called it — without this the
+    waterfall shows two unconnected roots under one trace."""
+    with call_scope("c", trace_id=TRACE), tracing.server_span("POST /x", parent_span_id=PARENT):
+        pass
+
+    span = only(exporter)
+    assert span.parent is not None
+    assert hexid(span.parent.span_id, 16) == PARENT
+    assert span.parent.trace_id == context_of(span).trace_id
+
+
+def test_no_caller_span_id_yields_a_ROOT_not_a_fabricated_parent(exporter) -> None:
+    """A span pointing at an id nobody emitted renders as a gap in the waterfall. An honest
+    root is better than an invented edge — the same refusal the engine's mapper makes."""
+    with call_scope("c", trace_id=TRACE), tracing.server_span("POST /x", parent_span_id=None):
+        pass
+
+    assert only(exporter).parent is None
+
+
+def test_the_server_span_is_kind_SERVER(exporter) -> None:
+    with call_scope("c", trace_id=TRACE), tracing.server_span("POST /x", parent_span_id=None):
+        pass
+
+    assert only(exporter).kind is trace.SpanKind.SERVER
+
+
+# --- the provider span -------------------------------------------------------------------
+
+
+def test_the_provider_call_is_a_child_of_the_server_span(exporter) -> None:
+    """ "Which provider was slow" is only answerable if the provider span sits UNDER the
+    request span rather than beside it."""
+    with call_scope("c", trace_id=TRACE), tracing.server_span("POST /x", parent_span_id=None):
+        with tracing.provider_span("openrouter"):
+            pass
+
+    spans = {s.name: s for s in exporter.get_finished_spans()}
+    provider = spans["chat.completions openrouter"]
+    server = spans["POST /x"]
+    assert provider.parent is not None
+    assert provider.parent.span_id == context_of(server).span_id
+    assert provider.kind is trace.SpanKind.CLIENT
+
+
+def test_the_provider_span_names_the_provider_conventionally(exporter) -> None:
+    with call_scope("c", trace_id=TRACE), tracing.provider_span("anthropic"):
+        pass
+
+    assert attributes_of(only(exporter))[tracing.PROVIDER_ATTRIBUTE] == "anthropic"
+
+
+# --- what a failure may say ---------------------------------------------------------------
+
+
+def test_a_failed_provider_call_records_the_exception_CLASS_and_nothing_else(exporter) -> None:
+    """SECURITY. `routes/chat_dispatch.py` refuses `str(exc)` because it serializes raw
+    LiteLLM/provider text — and any secret inside it. A span attribute is the same exposure
+    with a different name, and it travels to a backend searched by people who never saw the
+    response.
+    """
+    secret = "sk-live-DO-NOT-LEAK"
+
+    with pytest.raises(RuntimeError):
+        with call_scope("c", trace_id=TRACE), tracing.provider_span("openrouter"):
+            raise RuntimeError(f"provider said: {secret}")
+
+    span = only(exporter)
+    assert attributes_of(span)[tracing.ERROR_TYPE_ATTRIBUTE] == "RuntimeError"
+    assert span.status.status_code is trace.StatusCode.ERROR
+
+    # WHY the events are walked field by field rather than `repr`'d: `Event.__repr__` is the
+    # default `<... object at 0x...>`, so a `repr(span.events)` check reads as thorough and
+    # detects NOTHING. This test passed against `record_exception=True` — the very leak it
+    # exists to catch — until a mutation run exposed it.
+    rendered = [repr(dict(span.attributes or {})), repr(span.status.description)]
+    for event in span.events:
+        rendered.append(event.name)
+        rendered.append(repr(dict(event.attributes or {})))
+    haystack = " ".join(rendered)
+
+    assert secret not in haystack, f"provider text reached the span: {haystack}"
+    assert "provider said" not in haystack, f"provider text reached the span: {haystack}"
+
+
+def test_the_exception_still_propagates(exporter) -> None:
+    """The span must observe, never swallow — a caller that stopped seeing provider failures
+    because tracing was enabled would be a catastrophic regression."""
+    with pytest.raises(ValueError):
+        with call_scope("c", trace_id=TRACE), tracing.provider_span("p"):
+            raise ValueError("boom")
+
+
+# --- off by default ---------------------------------------------------------------------------
+
+
+def test_no_endpoint_configured_means_tracing_is_not_installed() -> None:
+    assert tracing.install({}) is False
+
+
+def test_a_blank_endpoint_reads_as_off() -> None:
+    assert tracing.install({"OTEL_EXPORTER_OTLP_ENDPOINT": "   "}) is False
+
+
+def test_either_endpoint_variable_turns_it_on() -> None:
+    """OTel's contract lets a deployment set only the signal-specific variable; reading just
+    the generic one would leave such a deployment silently un-traced."""
+    assert tracing.otlp_configured({"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://c:4318"})
+    assert tracing.otlp_configured({"OTEL_EXPORTER_OTLP_ENDPOINT": "http://c:4318"})
+
+
+def test_the_span_helpers_are_no_ops_when_tracing_is_off() -> None:
+    """Every request goes through `server_span`, so with tracing off it must cost nothing and
+    — far more importantly — must not raise."""
+    with call_scope("c", trace_id=TRACE), tracing.server_span("POST /x", parent_span_id=PARENT):
+        pass
+    with tracing.provider_span("openrouter"):
+        pass
+
+
+# --- spans are NOT gated by the taxonomy kill-switch (D1) -------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_middleware_emits_a_span_with_no_taxonomy_plugin_involved(exporter) -> None:
+    """`AIGW_TAXONOMY_ENABLED` must NOT gate spans, and this is what proves it: the span comes
+    out of the middleware, driven with a bare ASGI app and no plugin anywhere in the call.
+
+    The ticket asks for this decision to be made explicitly. It is the same call the codebase
+    already made for the ids — `middleware/call_id.py` exists BECAUSE they used to live in
+    `plugins/taxonomy/session.py`, so turning off usage accounting silently deleted the
+    gateway's only correlation mechanism. Spans are correlation.
+    """
+    from aigateway.middleware.call_id import CallIdMiddleware
+
+    async def app(scope, receive, send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "headers": [(b"traceparent", f"00-{TRACE}-{PARENT}-01".encode())],
+    }
+    sent: list = []
+
+    async def receive():  # pragma: no cover - never awaited by this app
+        return {"type": "http.request"}
+
+    async def send(message) -> None:
+        sent.append(message)
+
+    await CallIdMiddleware(app)(scope, receive, send)
+
+    span = only(exporter)
+    assert span.name == "POST /v1/chat/completions"
+    assert hexid(context_of(span).trace_id, 32) == TRACE
+    assert span.parent is not None and hexid(span.parent.span_id, 16) == PARENT
+
+
+def test_the_tracing_module_does_not_consult_the_taxonomy_settings() -> None:
+    """The structural half of D1: a future edit that gates spans on the accounting flag has to
+    introduce the reference here, and this fails when it does."""
+    from pathlib import Path
+
+    source = Path(tracing.__file__).read_text(encoding="utf-8")
+
+    # The docstring MENTIONS the flag to explain why it is ignored, so this checks for the
+    # ways it could be READ, not for the word.
+    assert "TaxonomyPluginSettings" not in source
+    assert "taxonomy_enabled" not in source
+    assert "from aigateway.plugins" not in source
+
+
+def test_a_broken_exporter_config_does_not_stop_the_gateway(monkeypatch) -> None:
+    """An AI gateway that refuses to boot because a collector address was wrong is a far worse
+    outage than missing spans."""
+    import aigateway.tracing as module
+
+    monkeypatch.setattr(module, "DEFAULT_SERVICE_NAME", property(lambda _: 1 / 0), raising=False)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "://not-a-url")
+
+    # Whatever happens inside, it must not escape.
+    tracing.install({"OTEL_EXPORTER_OTLP_ENDPOINT": "://not-a-url"})

--- a/apps/aigateway/uv.lock
+++ b/apps/aigateway/uv.lock
@@ -14,6 +14,8 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "litellm" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -42,6 +44,8 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "litellm", specifier = ">=1.55" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyjwt", specifier = "==2.13.0" },
@@ -821,6 +825,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1304,6 +1320,87 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1413,6 +1510,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/73/f66c748df06e7fe24e658eddd600d19c4b40bad836c97ce2d0ad9851fb6b/protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524", size = 512499, upload-time = "2026-08-31T22:40:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6c/3a54a58f2948b0f485df9ecdd06590f15d0a7abf46a89d50c3de709ff4ff/protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca", size = 456046, upload-time = "2026-08-31T22:39:56.865Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/9f9548793c771095245c0eeaf0c84b76b16a5ef26158043d456f551344a0/protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969", size = 344226, upload-time = "2026-08-31T22:39:58.263Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/51/1bdbd612fa3c51e42ea6f45d05e84dc748ddcd2663e1aa1e89a00a33facd/protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44", size = 357229, upload-time = "2026-08-31T22:39:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa", size = 343228, upload-time = "2026-08-31T22:40:00.179Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/d4724ec5d86d496fe4108e220618aa0837ad3423a7af7ccdd9684ccc77c8/protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00", size = 443002, upload-time = "2026-08-31T22:40:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/db/37/155788a0d8daded960375af604202805308169f9b859419ea0aa370946e2/protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363", size = 456518, upload-time = "2026-08-31T22:40:02.494Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/c47f91d3cab175b01fd8c4f0d80fdf8613be876cc616e66ad281a59c5ddf/protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c", size = 179813, upload-time = "2026-08-31T22:40:03.54Z" },
 ]
 
 [[package]]

--- a/docs/tasks/2026-09-11-OME-1132-aigw-otel.md
+++ b/docs/tasks/2026-09-11-OME-1132-aigw-otel.md
@@ -1,0 +1,49 @@
+---
+id: OME-1132
+linear_url: https://linear.app/openmined/issue/OME-1132
+status: in_review
+type: null
+priority: 3
+labels: [aigateway, agentic, autonomous]
+created: 2026-09-11
+closed: null
+---
+
+# Instrument aigateway as an OTel service so it appears as spans
+
+Phase 2's last code unit. The engine's exporter (`OME-1130`) turns its frames into spans;
+aigateway is a separate service, so without this a trace stops at the engine. Log correlation
+is not a span — a shared id in two log lines draws no edge in a service map.
+
+Four things worth knowing before touching this area:
+
+- **OTel defaults `record_exception=True`, and for this gateway that is a LEAK.** It attaches
+  the exception's `str()` and traceback to the span — raw LiteLLM/provider text, exactly what
+  `routes/chat_dispatch.py` refuses to put in a response — and ships it to a backend searched
+  by people who never saw the request. `record_exception=False,
+  set_status_on_exception=False` are load-bearing. Failures record the exception CLASS only.
+
+- **Do NOT use `TraceContextTextMapPropagator` here.** It would agree with
+  `adopt_or_mint_trace_id` on a well-formed traceparent and diverge on a malformed or absent
+  one, because each mints its own replacement — one request would carry two ids, and an
+  operator grepping `trace_id=` from the logs would find no matching trace.
+  `_BoundIdGenerator` hands OTel the id already in the call context instead.
+
+- **`AIGW_TAXONOMY_ENABLED` does NOT gate spans**, decided explicitly and tested. The provider
+  span therefore takes its own timing at the dispatch seam rather than reusing the accounting
+  handler's, which lives behind that flag. Reusing it would repeat the bug
+  `middleware/call_id.py` was written to undo — an accounting switch deleting the gateway's
+  correlation.
+
+- **Module-level OTel import here, lazy in the engine.** Different cost profiles: a
+  short-lived run process pays ~62 ms per run, a server boots once. Not an inconsistency.
+
+**Known limitation:** aigateway's span attaches to the engine's ROOT span, not the node that
+made the call, because `screamingface_engine/trace_scope.py` binds `root_span_id`. That choice
+predates `OME-1130` emitting a root span and would now be better as the current node's span id
+— an engine-side change, worth its own issue.
+
+**Ships inert** until the aigateway chart carries an OTLP endpoint (sibling issue), the same
+accepted state `OME-1130` shipped in before `OME-1131`.
+
+Ledger: `docs/work/2026-09-11-OME-1132-aigw-otel.md`

--- a/docs/work/2026-09-11-OME-1132-aigw-otel.md
+++ b/docs/work/2026-09-11-OME-1132-aigw-otel.md
@@ -1,0 +1,171 @@
+---
+ticket: OME-1132
+stack: aigateway
+status: done
+started: 2026-09-11
+finished: 2026-09-11
+---
+
+# OME-1132 — Instrument aigateway as an OTel service so it appears as spans
+
+## Intent
+
+The last Phase 2 unit. `OME-1130` turns the engine's frames into spans; aigateway is a
+**separate service**, so without this a trace stops at the engine. Log correlation is not a
+span: a shared id in two log lines draws no edge in a service map, produces no latency
+breakdown, and cannot answer "which provider call was slow".
+
+Depends on `OME-1120` (aigateway joins the inbound traceparent) — confirmed merged and on
+`main` (`w3c_trace.py`, `call_context.py`, `middleware/call_id.py` all present).
+
+## Design decisions
+
+**D1 — spans are NOT gated by `AIGW_TAXONOMY_ENABLED`.** The ticket asks for this to be
+decided explicitly. The answer is no, and the codebase already made the identical call for
+the identical reason: `middleware/call_id.py` exists BECAUSE the correlation ids used to live
+in `plugins/taxonomy/session.py`, so turning off a *usage-accounting* feature silently deleted
+the gateway's only correlation mechanism. Spans are correlation. Gating them on an accounting
+flag would re-commit the exact mistake that middleware was written to undo.
+
+**Consequence, and it contradicts the ticket:** the ticket says the provider span should reuse
+the accounting handler's existing latency measurement ("that measurement is the span duration
+rather than a second one"). That measurement lives in `plugins/taxonomy/collector.py`, which
+IS gated. Reusing it would couple spans to the kill-switch. So the provider span takes its own
+timing at the un-gated dispatch seam, and the duplicate `time.monotonic()` is accepted
+deliberately: one extra clock read is cheap, and the two measure slightly different boundaries
+anyway. The coupling was the real cost.
+
+**D2 — span attributes carry NO provider text, ever.** `routes/chat_dispatch.py` refuses
+`str(exc)` because it serializes raw LiteLLM/provider text — and any secret embedded in it —
+into responses and logs. A span attribute is the same exposure with a different name, and
+spans travel to a third system that is searched by people who were never shown the response.
+Failures are recorded as **exception class name only**, matching the dispatch path's existing
+posture. The review spec's traceback amendment (§5) does NOT extend to spans.
+
+**D3 — the span's trace id MUST equal the one the middleware already bound.** This is the
+subtle correctness requirement of the whole unit. `CallIdMiddleware` computes
+`adopt_or_mint_trace_id(inbound)`; if the span layer independently ran OTel's standard
+`TraceContextTextMapPropagator.extract`, the two would agree on a WELL-FORMED traceparent and
+diverge on a malformed or absent one — the middleware mints its id, OTel mints a different
+one, and one request carries two ids. `call_id.py` names that failure precisely: *"two ids for
+one call is worse than none, because both look right."*
+
+So the propagator is NOT used. A custom `IdGenerator` returns the already-bound `trace_id` from
+the call-context ContextVar, which makes agreement structural rather than coincidental.
+
+**D4 — the SERVER span is parented to the inbound span id when there is one.** Requires
+`parse_traceparent`, because today's `parse_trace_id` throws the parent span id away
+(`match.group(2)` is validated and discarded). Added alongside rather than changing the
+existing function, whose callers want exactly what it returns.
+
+**D5 — the provider span covers slot wait + retries + provider time, and says so.**
+`_dispatch_with_backpressure` holds a per-provider concurrency slot ACROSS retries, so the
+wall-clock a caller experienced includes queueing and backoff. Reporting only the final
+attempt's provider time would show a fast span for a call the caller waited seconds on. The
+span is the honest number; the attempt breakdown already exists in the accounting record.
+
+**D6 — off unless an OTLP endpoint is configured, same contract as the engine.** OTel's own
+env variables (`OTEL_EXPORTER_OTLP_*`, `OTEL_SERVICE_NAME`), no vocabulary invented here, and
+a blank endpoint reads as off. Every existing deployment and every test is unaffected by
+construction.
+
+## Known limitation, recorded not fixed
+
+**aigateway's server span attaches to the engine's ROOT span, not to the node that made the
+call.** `screamingface_engine/trace_scope.py` (OME-1119) deliberately binds `root_span_id`
+rather than a per-call span id, because at the time nothing emitted a root span and a per-node
+parent would have dangled. `OME-1130` now emits that root, so sending the current node's span
+id would be strictly better and would make the waterfall show which *node* called the provider.
+
+That is an ENGINE-side change, outside this ticket's stack. Flagged rather than silently
+accepted, because the trace will look correct and simply be coarser than it could be.
+
+## Planned changes
+
+- `src/aigateway/w3c_trace.py` — `parse_traceparent` returning `(trace_id, span_id)`.
+- `src/aigateway/tracing.py` (new) — the OTel setup, the bound-id generator, the span helpers.
+- `src/aigateway/middleware/call_id.py` — open the server span inside the bound scope.
+- `src/aigateway/routes/chat_dispatch.py` — the provider child span.
+- `src/aigateway/main.py` — start the provider at boot when configured.
+- ~~`charts/`~~ — **split into a sibling issue.** The engine's own Phase 2 work is deliberately
+  two units, code (`OME-1130`) then chart (`OME-1131`); mirroring that for aigateway keeps the
+  same separation, and CLAUDE.md rule 8 pushes the same way. Concretely: aigateway's chart has
+  no pytest render-test precedent (it is gated by `charts.yml` / `verify_chart_wiring.py`, not
+  by its own suite), so wiring it here would introduce a new test pattern inside an already
+  large instrumentation PR. This unit therefore ships INERT until that lands — the same
+  accepted state `OME-1130` shipped in.
+
+## Test plan
+
+RED first, with an in-memory exporter — no collector, no network:
+
+- With no endpoint configured, nothing is installed and no span is produced.
+- A request produces ONE server span, kind SERVER.
+- **The span's trace id equals the `trace_id` the middleware bound** — asserted for a
+  well-formed inbound traceparent AND for a malformed one, which is where an independent
+  propagator would diverge.
+- A well-formed inbound traceparent makes the server span a CHILD of the inbound span id.
+- A malformed/absent traceparent yields a root span, never a child of a fabricated parent.
+- The provider call is a CHILD span of the server span, carrying `gen_ai.provider.name`.
+- A failed provider call records the exception CLASS NAME and no provider text.
+- `AIGW_TAXONOMY_ENABLED=false` still produces spans (D1).
+
+## Acceptance
+
+- A trace from the engine through aigateway to a provider call renders as one connected tree,
+  with aigateway a distinct service.
+- `run_gates.py aigateway` green.
+
+## Outcome
+
+- **Actual files:**
+  - `src/aigateway/tracing.py` (new) — setup, `_BoundIdGenerator`, `server_span`,
+    `provider_span`.
+  - `src/aigateway/w3c_trace.py` — `parse_traceparent`; `parse_trace_id` now delegates to it,
+    so there is ONE parse and one rejection table in a module whose own docstring warns that
+    three copies across services is already the cost being managed.
+  - `src/aigateway/middleware/call_id.py` — the server span, opened INSIDE `call_scope`.
+  - `src/aigateway/routes/chat_dispatch.py` — the provider child span.
+  - `src/aigateway/main.py` — `install_tracing(os.environ)` at boot.
+  - `pyproject.toml` / `uv.lock` — OTel SDK + OTLP HTTP exporter.
+  - `tests/unit/test_tracing.py` (new) — 17 tests.
+
+- **Gates:** `run_gates.py aigateway` **ALL GREEN** — append-only, ruff check/format, pyright,
+  `check_no_enterprise.py`, pytest+coverage. Full suite **4239 passed, 58 skipped**.
+
+- **Verification beyond the gates — and it found a real security bug:**
+
+  **Five mutations run; four killed and ONE SURVIVED**, which was the point of running them.
+  Flipping `record_exception=True` did NOT fail the security test, because the test asserted
+  over `repr(span.events)` and `Event.__repr__` is the default `<... object at 0x...>` — it
+  rendered nothing and detected nothing. The test now walks each event's `name` and
+  `attributes` explicitly, and the mutation is killed.
+
+  That matters beyond the test: **OTel defaults `record_exception=True`**, which attaches the
+  exception's `str()` and traceback to the span. For this gateway that is raw LiteLLM/provider
+  text — precisely what `routes/chat_dispatch.py` refuses to put in a response — shipped to a
+  tracing backend searched by people who never saw the request. The first working version of
+  this module leaked it. `record_exception=False, set_status_on_exception=False` are load-
+  bearing arguments, commented as such.
+
+- **Deviations:**
+  - **The ticket's suggestion to reuse the accounting handler's latency was NOT followed.**
+    That measurement lives in `plugins/taxonomy/collector.py`, which `AIGW_TAXONOMY_ENABLED`
+    gates. Reusing it would make an accounting kill-switch silently delete the gateway's spans
+    — the coupling `middleware/call_id.py` exists to undo. The provider span takes its own
+    timing at the un-gated dispatch seam; one extra `time.monotonic()` is the cheaper cost.
+    This answers the ticket's "decide explicitly whether it also gates spans, and say so": it
+    does not, and there is a test.
+  - **OTel's `TraceContextTextMapPropagator` is deliberately unused.** It would agree with
+    `adopt_or_mint_trace_id` on a well-formed traceparent and diverge on a malformed or absent
+    one, giving one request two ids. `_BoundIdGenerator` makes the agreement structural. The
+    two divergent cases have their own tests, because the agreeing case passes either way.
+  - **Module-level OTel import here, lazy in the engine.** Not an inconsistency: the engine's
+    exporter runs in a short-lived process that pays ~62 ms per run, aigateway is a server that
+    boots once. Deferring here would buy nothing and cost the ability to subclass
+    `RandomIdGenerator` — which the first version duck-typed, and which failed at span creation
+    because the SDK also calls `is_trace_id_random()`.
+  - **The chart wiring is a sibling issue** — see Planned changes. This ships inert until then.
+  - **Known limitation, recorded above:** aigateway's span attaches to the engine's ROOT span
+    rather than the node that made the call, because `trace_scope.py` binds `root_span_id`.
+    Engine-side, outside this stack. The trace will look correct and simply be coarser.


### PR DESCRIPTION
Phase 2's last code unit (epic `OME-1129`). The engine's exporter (`OME-1130`) turns its frames into spans; aigateway is a **separate service**, so without this a trace stops at the engine. Log correlation is not a span — a shared id in two log lines draws no edge in a service map, produces no latency breakdown, and can't answer "which provider was slow".

A **server span** per request, parented to the caller's traceparent, plus the **provider dispatch as a child span**. Off unless an OTLP endpoint is configured.

## This found a real security bug — please read this bit

**OTel defaults `record_exception=True`**, which attaches the exception's `str()` *and traceback* to the span. For this gateway that is raw LiteLLM/provider text — exactly what `routes/chat_dispatch.py` refuses to put in a response, because it can carry a secret — shipped to a tracing backend searched by people who never saw the request.

The first working version of this module leaked it. Worse: **the test written to catch that leak didn't.** It asserted over `repr(span.events)`, and `Event.__repr__` is the default `<... object at 0x...>` — it rendered nothing and detected nothing. A mutation run exposed it: flipping `record_exception=True` left the suite green.

Now: `record_exception=False, set_status_on_exception=False` (commented as load-bearing), failures record the exception **class name** only, and the test walks each event's `name` and `attributes` explicitly. The mutation is killed.

## Design calls worth your eye

**`TraceContextTextMapPropagator` is deliberately unused.** It would agree with `adopt_or_mint_trace_id` on a well-formed traceparent and **diverge** on a malformed or absent one, because each mints its own replacement. One request would carry two ids, and an operator grepping `trace_id=` from the logs would find no matching trace — the failure `middleware/call_id.py` names as *"two ids for one call is worse than none, because both look right."* A bound id generator hands OTel the id already in the call context, making the agreement structural. Both divergent cases have their own tests, since the agreeing case passes either way.

**`AIGW_TAXONOMY_ENABLED` does NOT gate spans** — the ticket asked for this to be decided explicitly. It is the same call the codebase already made for the ids: `middleware/call_id.py` exists *because* they used to live in `plugins/taxonomy/session.py`, so disabling usage accounting silently deleted the gateway's only correlation mechanism. Spans are correlation.

**Consequence — this contradicts the ticket.** It suggests reusing the accounting handler's latency ("that measurement is the span duration rather than a second one"). That handler is behind the gated plugin, so reusing it couples spans to the kill-switch. The provider span takes its own timing at the un-gated dispatch seam; one extra `time.monotonic()` is the cheaper of the two costs.

**Module-level OTel import here, lazy in the engine.** Not an inconsistency: a short-lived run process pays ~62 ms per run, a server boots once. Deferring here would buy nothing and cost the ability to subclass `RandomIdGenerator` — which the first version duck-typed, and which failed at span creation because the SDK also calls `is_trace_id_random()`.

## Test plan

- `run_gates.py aigateway` **ALL GREEN**; full suite **4239 passed, 58 skipped**. 17 new tests.
- **Five mutations run, one survived** — see the security section. All five killed now: provider text out of spans; exception message out of span status; span trace id == the middleware's bound id; no parent id means an honest root; middleware passes the caller's span id through.

## Scope

**Ships inert** — the aigateway chart does not carry an OTLP endpoint yet. That is a **sibling issue**, mirroring the engine's own deliberate split (`OME-1130` code then `OME-1131` chart), and CLAUDE.md rule 8 pushes the same way. Concretely, aigateway's chart has no pytest render-test precedent (it is gated by `charts.yml`/`verify_chart_wiring.py`), so wiring it here would add a new test pattern inside an already large instrumentation PR.

**Known limitation:** aigateway's span attaches to the engine's **root** span, not the node that made the call, because `screamingface_engine/trace_scope.py` binds `root_span_id`. That predates `OME-1130` emitting a root span; sending the current node's span id would now be strictly better. Engine-side, so flagged rather than done here — the trace looks correct, just coarser.

Ledger: `docs/work/2026-09-11-OME-1132-aigw-otel.md`

Refs: OME-1132
