### PR TITLE
docs(tasks): close the OME-1099 mirror and work ledger

### DIFF
--- a/docs/tasks/2026-09-03-OME-1099-shared-verdict-parser.md
+++ b/docs/tasks/2026-09-03-OME-1099-shared-verdict-parser.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1099
 linear_url: https://linear.app/openmined/issue/OME-1099/merge-the-three-drifted-judge-verdict-parsers-into-one-typed-shared
-status: in_progress
+status: done
 type: task
 priority: medium
 labels:
@@ -9,7 +9,7 @@ labels:
   - agentic
   - autonomous
 created: 2026-09-03
-closed:
+closed: 2026-09-11
 ---
 
 # Merge the three drifted judge-verdict parsers into one typed shared parser

--- a/docs/work/2026-09-09-OME-1099-shared-verdict-parser.md
+++ b/docs/work/2026-09-09-OME-1099-shared-verdict-parser.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1099
 stack: screamingface-engine
-status: in_progress
+status: done
 started: 2026-09-09
-finished:
+finished: 2026-09-11
 ---
 
 # OME-1099 — Merge the three drifted judge-verdict parsers into one typed shared parser
@@ -96,3 +96,5 @@ board-owned via shape declarations. Delivers OME-1025.
      primitive strips `line.strip().startswith`; old array copy used `line.startswith`).
   4. producer-id ValueError message unified to "producer_id must be non-empty text"
      (gdpval said "a non-empty string"; tests pin the raise, not the message).
+- **Merged:** PR #868 squash-merged to main as `138bf5ab` (2026-09-11); Linear `OME-1099`
+  closed with the close-template comment the same day.


### PR DESCRIPTION
One-line summary: record the finished state of `OME-1099` (verdict-parser merge, PR #868 / `138bf5ab`) on its docs/tasks mirror and docs/work ledger, which the feature PR left marked in progress.

## Problem / Solution

**Problem:** the verdict-parser work is merged and closed in Linear, but its paper trail in the repo still says the work is running — the next reader of the task mirror gets stale status.

**Solution:** flip both documents to done with the merge sha and close date, same pattern as the OME-1176 close-docs PR (#910).

## Review order

1. `docs/tasks/2026-09-03-OME-1099-shared-verdict-parser.md` — the status mirror; verify status/closed match Linear (Done, 2026-09-11).
2. `docs/work/2026-09-09-OME-1099-shared-verdict-parser.md` — the audit ledger; verify the appended merge line names PR #868 and `138bf5ab`.

Refs: OME-1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)