### PR TITLE
docs(tasks): close six done spine mirrors left in_progress

### DIFF
--- a/docs/tasks/2026-08-29-OME-1039-failure-policy-declaration.md
+++ b/docs/tasks/2026-08-29-OME-1039-failure-policy-declaration.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1039
 linear_url: https://linear.app/openmined/issue/OME-1039/declare-each-benchmarks-failure-policy-and-interaction-type-as-visible
-status: in_progress
+status: done
 type:
 priority: high
 labels:
@@ -9,7 +9,7 @@ labels:
   - agentic
   - autonomous
 created: 2026-08-29
-closed:
+closed: 2026-09-04
 ---
 
 # Declare each benchmark's failure policy and interaction type as visible parameters when the spine takes over grading

--- a/docs/tasks/2026-09-03-OME-1094-golden-failure-codes.md
+++ b/docs/tasks/2026-09-03-OME-1094-golden-failure-codes.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1094
 linear_url: https://linear.app/openmined/issue/OME-1094/pin-each-failed-cases-failure-code-in-the-e2e-goldens-so-a
-status: in_progress
+status: done
 type:
 priority: high
 labels:
@@ -9,7 +9,7 @@ labels:
   - agentic
   - autonomous
 created: 2026-09-03
-closed:
+closed: 2026-09-03
 ---
 
 # Pin each failed case's failure code in the e2e goldens so a reclassification can't pass as "failed"

--- a/docs/tasks/2026-09-03-OME-1095-registry-derived-board-tests.md
+++ b/docs/tasks/2026-09-03-OME-1095-registry-derived-board-tests.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1095
 linear_url: https://linear.app/openmined/issue/OME-1095/derive-the-hand-listed-benchmark-board-tuples-in-engine-tests-from-the
-status: in_progress
+status: done
 type:
 priority: high
 labels:
@@ -9,7 +9,7 @@ labels:
   - agentic
   - autonomous
 created: 2026-09-03
-closed:
+closed: 2026-09-03
 ---
 
 # Derive the hand-listed benchmark board tuples in engine tests from the registry

--- a/docs/tasks/2026-09-04-OME-1096-shared-row-decode.md
+++ b/docs/tasks/2026-09-04-OME-1096-shared-row-decode.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1096
 linear_url: https://linear.app/openmined/issue/OME-1096/share-the-row-decode-and-index-step-between-gdpval-and-healthbench
-status: in_progress
+status: done
 type:
 priority: high
 labels:
@@ -9,7 +9,7 @@ labels:
   - agentic
   - autonomous
 created: 2026-09-04
-closed:
+closed: 2026-09-04
 ---
 
 # Share the row decode and index step between gdpval and healthbench

--- a/docs/tasks/2026-09-07-OME-1097-shared-scored-path.md
+++ b/docs/tasks/2026-09-07-OME-1097-shared-scored-path.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1097
 linear_url: https://linear.app/openmined/issue/OME-1097/share-the-scored-path-and-scorer-for-rubric-benchmarks-behind-a-grade
-status: in_progress
+status: done
 type:
 priority: high
 labels:
@@ -9,7 +9,7 @@ labels:
   - agentic
   - autonomous
 created: 2026-09-07
-closed:
+closed: 2026-09-09
 ---
 
 # Share the scored path and scorer for rubric benchmarks behind a `grade_case` hook

--- a/docs/tasks/2026-09-09-spine-local-types.md
+++ b/docs/tasks/2026-09-09-spine-local-types.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1150
 linear_url: https://linear.app/openmined/issue/OME-1150/type-the-grading-spines-local-variables-and-land-the-rescued-candidate
-status: in_progress
+status: done
 type: task
 priority: medium
 labels: [screamingface-engine, agentic, autonomous, task]
 created: 2026-09-09
-closed:
+closed: 2026-09-11
 ---
 
 # Type the grading spine's local variables and land the rescued candidate-fields dataclass


### PR DESCRIPTION
Closes the docs/tasks mirrors for six OME-1024 sub-issues whose Linear tickets are Done and whose feature PRs merged, but whose mirrors were left at `in_progress`: OME-1039, OME-1094, OME-1095, OME-1096, OME-1097, OME-1150. Status flips + close dates only; ledgers already carry their outcomes.

Batched into one close-docs PR under the epic instead of six one-line PRs.

Refs: OME-1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)