### PR TITLE
docs(tasks): close the OME-1109 mirror and ledger

### DIFF
--- a/docs/tasks/2026-09-08-OME-1109-author-credits.md
+++ b/docs/tasks/2026-09-08-OME-1109-author-credits.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1109
 linear_url: https://linear.app/openmined/issue/OME-1109/collapse-duplicate-authors-and-disambiguate-colliding-credit-names
-status: in_progress
+status: Done
 type: task
 priority: 3
 labels: [scoreboard, agentic, autonomous]
 created: 2026-09-03
-closed:
+closed: 2026-09-11
 ---
 
 # Collapse duplicate authors and disambiguate colliding credit names

--- a/docs/work/2026-09-08-OME-1109-author-credits.md
+++ b/docs/work/2026-09-08-OME-1109-author-credits.md
@@ -51,8 +51,14 @@ the privacy form of any non-colliding address.
   `scores/schemas.py`; three additive tests in `test_multiple_authors.py`; and the planned
   task/spec/plan/ledger artifacts. No model, migration, store, portal, Client, or #841 file was
   changed.
-- **Commits:** one conventional Scoreboard feature commit on `OME-1109-author-credits`; the
-  immutable commit and eventual squash sha are recorded in the PR/Linear close record.
+- **Commits:** `76713851` — `fix(scoreboard): publish unambiguous author credits`, alongside
+  `7822bd80` — `docs(tasks): track client author-limit alignment` (the OME-1139 mirror). Landed
+  on `main` via PR #853 on 2026-09-11 as merge commit `8c62bfba`.
+
+  AIDEV-NOTE: #853 was merged with a merge commit, not squash-merged. The repository rule
+  (`CLAUDE.md` §6) is squash-merge only, so the two commits above are both on `main` history
+  rather than collapsed into one. Recorded rather than corrected — rewriting `main` is worse
+  than the inconsistency.
 - **Gates:** focused multiple-author suite 24 passed; full Scoreboard pytest 621 passed / 3
   skipped / 3 deselected; `run_gates.py scoreboard --base origin/main` ALL GREEN — append-only,
   Ruff check, Ruff format, Pyright, full pytest coverage ≥80%, and all three portal test files.


### PR DESCRIPTION
## Summary

`OME-1109` landed this morning via PR #853, but the SDLC records were left open:

- `docs/tasks/…-OME-1109-….md` still read `status: in_progress`
- `docs/work/…-OME-1109-….md` had `Commits:` as a placeholder — "the eventual squash sha are recorded in the PR/Linear close record"

This closes the mirror and records the real commits: `76713851` (the fix) and `7822bd80` (the OME-1139 mirror), landed as merge commit `8c62bfba`.

## One note

#853 was **merged**, not squash-merged. `CLAUDE.md` §6 says squash-merge only, so both commits sit on `main` history rather than collapsed into one. The ledger records this rather than correcting it — rewriting `main` is worse than the inconsistency.

## Test plan

Documentation only — no source, test, or portal files touched. Nothing under `docs/**` triggers a stack lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
