### PR TITLE
feat(screamingface): identify Client requests and generated notebooks

### DIFF
--- a/docs/plan/2026-09-11-OME-416-client-version-provenance.md
+++ b/docs/plan/2026-09-11-OME-416-client-version-provenance.md
@@ -1,0 +1,9 @@
+# OME-416 — Client implementation plan
+
+1. Add failing tests for exact Engine request headers and deterministic notebook stamps.
+2. Add a small shared header helper using the installed-version resolver; wire all four Engine
+   HTTP client constructors. Keep existing auth, tracing, retries and request semantics.
+3. Add source-project version metadata to the notebook builder and regenerate examples.
+4. Run the new tests, full Client gates, and inspect notebook diffs for metadata-only changes.
+5. Commit, push and create a draft PR. Update Linear description directly without comments;
+   retain open status for Engine retention/returned provenance work.

--- a/docs/spec/2026-09-11-OME-416-client-version-provenance.md
+++ b/docs/spec/2026-09-11-OME-416-client-version-provenance.md
@@ -1,0 +1,26 @@
+# OME-416 — Client provenance, first delivery
+
+## Notebook origin
+
+The generator adds `metadata.screamingface.generated_by_version` from the generating checkout's
+`packages/screamingface/pyproject.toml` project version. Use Jupyter's custom metadata namespace.
+No timestamps or absolute paths. This identifies generation, not the package later executing the
+notebook. A package release does not retroactively change an already-generated notebook's stamp.
+
+## Request identity
+
+Set `User-Agent: screamingface/<version>` on Engine HTTP clients, covering sync/async catalogue and
+evaluation transport. Reuse `_version.resolve_version()` including `0.0.0+source` fallback.
+Per-request capability, trace and other headers still merge normally. No request-body changes.
+WebSocket handshake identification and Scoreboard/Access clients are outside this first delivery.
+
+## Remaining work
+
+Current Engine code does not retain Client versions with runs. No published Client-version
+metadata field was found. Engine storage and any returned typed provenance require a separate
+Engine-owned design/unit; this Client-only PR must not close OME-416.
+
+## Standards
+
+- Jupyter custom metadata: https://nbformat.readthedocs.io/en/5.2.0/format_description.html
+- HTTP User-Agent product/version: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.1.5

--- a/docs/tasks/2026-09-11-OME-416-client-version-provenance.md
+++ b/docs/tasks/2026-09-11-OME-416-client-version-provenance.md
@@ -1,0 +1,18 @@
+---
+id: OME-416
+linear_url: https://linear.app/openmined/issue/OME-416
+status: In Progress
+type: task
+priority: Medium
+labels: [py-screamingface, agentic, autonomous]
+created: 2026-07-13
+closed:
+---
+
+# Add Client and generated-notebook version provenance
+
+First delivery: deterministic namespaced notebook-generation version and standard User-Agent on
+Engine HTTP clients. Engine run-associated retention and returned typed provenance remain open.
+
+Spec: `docs/spec/2026-09-11-OME-416-client-version-provenance.md`
+Plan: `docs/plan/2026-09-11-OME-416-client-version-provenance.md`

--- a/docs/work/2026-09-11-OME-416-client-version-provenance.md
+++ b/docs/work/2026-09-11-OME-416-client-version-provenance.md
@@ -1,0 +1,52 @@
+---
+ticket: OME-416
+stack: screamingface
+status: in_progress
+started: 2026-09-11
+finished:
+---
+
+# OME-416 — Client version provenance, first delivery
+
+## Intent
+
+Identify the Client software making Engine HTTP requests and the source version generating
+public notebooks. User authorized starting OME-416 and creating a draft PR after discussing
+standard notebook metadata and User-Agent. Engine retention remains separate unresolved scope.
+
+## Planned changes
+
+- Shared private User-Agent helper using the existing installed-version resolver.
+- Engine HTTP clients in `client.py` and `_engine/transport.py`, sync and async.
+- `scripts/build_notebooks.py` and regenerated `examples/*.ipynb` metadata.
+- New regression tests; spec, plan and task mirror.
+
+## Test plan
+
+RED first: request construction proves exact User-Agent and preserved per-request headers for
+sync/async catalogue and run transports, including source-tree fallback. Notebook builder tests
+prove deterministic namespaced metadata matches its source pyproject, never a different installed
+package. Existing output-free/generated notebook checks and complete Client gates remain required.
+
+## Acceptance
+
+Version metadata has no machine/user details; notebook source and output behavior remain unchanged.
+Sending the header does not claim Engine storage or returned version provenance. Draft PR only.
+
+## Outcome
+
+- Implemented shared Engine User-Agent on all four HTTP client constructors.
+- Added deterministic source-version metadata to the builder and regenerated nine notebooks.
+- RED: all 18 new regression cases failed on the original missing header/stamp behavior.
+- GREEN: all 18 pass; all prior tests remain unchanged.
+- `run_gates.py screamingface`: ALL GATES GREEN (append-only, lint, formatting, pyright,
+  full pytest with >=95% coverage, notebook checks, build and distribution checks).
+- Parsed-JSON comparison confirms only the new metadata changed in all nine notebooks.
+- Wisdom review: shared helper prevents sync/async drift; existing version resolver reused;
+  no public API, body schema, auth, retry, visible UI or dependency changes. Source stamping
+  avoids silently recording another installed package's version. No telemetry introduced.
+- Commit: `feat(screamingface): identify Client requests and generated notebooks` (Refs: OME-416).
+- Deviations: none within the stated first-delivery scope. Engine retention/returned provenance
+  remain unresolved, and OME-416 stays open. Ticket updates are direct edits, with no comments.
+- Logs: `.docs/OME-416-red.log`, `.docs/OME-416-header-red.log`, `.docs/OME-416-gates.log`.
+- Draft PR follows validation; not merged.

--- a/packages/screamingface/examples/00_quickstart.ipynb
+++ b/packages/screamingface/examples/00_quickstart.ipynb
@@ -273,6 +273,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/01_client_tour.ipynb
+++ b/packages/screamingface/examples/01_client_tour.ipynb
@@ -497,6 +497,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/02_connection.ipynb
+++ b/packages/screamingface/examples/02_connection.ipynb
@@ -221,6 +221,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/06_draco.ipynb
+++ b/packages/screamingface/examples/06_draco.ipynb
@@ -240,6 +240,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/07_ifeval.ipynb
+++ b/packages/screamingface/examples/07_ifeval.ipynb
@@ -268,6 +268,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/08_healthbench.ipynb
+++ b/packages/screamingface/examples/08_healthbench.ipynb
@@ -252,6 +252,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/09_corrective_loops.ipynb
+++ b/packages/screamingface/examples/09_corrective_loops.ipynb
@@ -224,6 +224,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/10_gdpval.ipynb
+++ b/packages/screamingface/examples/10_gdpval.ipynb
@@ -225,6 +225,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/examples/11_medxpert.ipynb
+++ b/packages/screamingface/examples/11_medxpert.ipynb
@@ -228,6 +228,9 @@
   "language_info": {
    "name": "python",
    "version": "3.12"
+  },
+  "screamingface": {
+   "generated_by_version": "0.1.1.post8"
   }
  },
  "nbformat": 4,

--- a/packages/screamingface/scripts/build_notebooks.py
+++ b/packages/screamingface/scripts/build_notebooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
 
 import nbformat
@@ -56,11 +57,14 @@ def notebooks() -> dict[str, NotebookNode]:
 
 
 def _notebook(*cells: NotebookNode) -> NotebookNode:
+    # WHY: record the generating checkout, not an unrelated package installed in the builder.
+    project = tomllib.loads((Path(__file__).parents[1] / "pyproject.toml").read_text())
     for index, cell in enumerate(cells, 1):
         cell["id"] = f"cell-{index:02d}"
     return nbformat.v4.new_notebook(
         cells=list(cells),
         metadata={
+            "screamingface": {"generated_by_version": project["project"]["version"]},
             "kernelspec": {
                 "display_name": "Python 3",
                 "language": "python",

--- a/packages/screamingface/src/screamingface/_engine/identity.py
+++ b/packages/screamingface/src/screamingface/_engine/identity.py
@@ -1,0 +1,8 @@
+"""HTTP software identity shared by catalogue and evaluation clients."""
+
+from screamingface._version import resolve_version
+
+
+def engine_headers() -> dict[str, str]:
+    # WHY: identify the installed Client, without leaking machine or user details.
+    return {"User-Agent": f"screamingface/{resolve_version()}"}

--- a/packages/screamingface/src/screamingface/_engine/transport.py
+++ b/packages/screamingface/src/screamingface/_engine/transport.py
@@ -30,6 +30,7 @@ from screamingface._access.contract import _challenge_audience
 from screamingface._core.ports import _ResultArtifact, _RunOutcome
 from screamingface._core.retry import RetryingAsyncTransport, RetryingTransport
 from screamingface._core.wire import _REPLAY_SAFE
+from screamingface._engine.identity import engine_headers
 from screamingface._engine.reconnect import _RecoveryWindow
 from screamingface._engine.run_lifecycle import _Lifecycle
 from screamingface._engine.trace import TraceContext, new_trace_context
@@ -114,6 +115,7 @@ class Url4CloudTransport:
         # `_REPLAY_SAFE` are re-sent, so `GET /?q=` — which starts billable work — never is.
         self._http = httpx.Client(
             base_url=engine_url,
+            headers=engine_headers(),
             timeout=30.0,
             auth=self._caller_auth,
             transport=RetryingTransport(httpx.HTTPTransport()),
@@ -365,6 +367,7 @@ class AsyncUrl4CloudTransport:
         # See the synchronous twin: retry is gated on `_REPLAY_SAFE`, never on the method.
         self._http = httpx.AsyncClient(
             base_url=engine_url,
+            headers=engine_headers(),
             timeout=30.0,
             auth=self._caller_auth,
             transport=RetryingAsyncTransport(httpx.AsyncHTTPTransport()),

--- a/packages/screamingface/src/screamingface/client.py
+++ b/packages/screamingface/src/screamingface/client.py
@@ -16,6 +16,7 @@ from screamingface._client_connections import (
     _scoreboard_origin,
 )
 from screamingface._core.wire import _REPLAY_SAFE
+from screamingface._engine.identity import engine_headers
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -76,6 +77,7 @@ class Client:
         )
         self._http = httpx.Client(
             base_url=self._engine_url,
+            headers=engine_headers(),
             timeout=30.0,
             auth=self._engine_auth,
             transport=http_transport,
@@ -400,6 +402,7 @@ class AsyncClient:
         )
         self._http = httpx.AsyncClient(
             base_url=self._engine_url,
+            headers=engine_headers(),
             timeout=30.0,
             auth=self._engine_auth,
             transport=http_transport,

--- a/packages/screamingface/tests/test_client_version_provenance.py
+++ b/packages/screamingface/tests/test_client_version_provenance.py
@@ -1,0 +1,68 @@
+"""Engine HTTP identity uses the installed Client version on every transport path."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+
+import screamingface as sf
+from screamingface import _version
+from screamingface._engine.transport import AsyncUrl4CloudTransport, Url4CloudTransport
+
+
+def _installed_version(monkeypatch: pytest.MonkeyPatch, version: str | None) -> str:
+    def lookup(name: str) -> str:
+        assert name == "screamingface"
+        if version is None:
+            raise PackageNotFoundError(name)
+        return version
+
+    monkeypatch.setattr(_version, "distribution_version", lookup)
+    return version or _version.SOURCE_TREE_VERSION
+
+
+@pytest.mark.parametrize("version", ["9.8.7+local", None])
+@pytest.mark.parametrize("factory", [sf.Client, Url4CloudTransport])
+def test_sync_engine_request_identifies_client_and_preserves_request_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    version: str | None,
+    factory: type[sf.Client] | type[Url4CloudTransport],
+) -> None:
+    expected = _installed_version(monkeypatch, version)
+    client = factory(engine_url="http://127.0.0.1:9108")
+    try:
+        request = client._http.build_request(
+            "GET", "/", params={"q": "test"}, headers={"URL4-Capability": "capability"}
+        )
+        assert request.headers["User-Agent"] == f"screamingface/{expected}"
+        assert request.headers["URL4-Capability"] == "capability"
+        assert request.url.params["q"] == "test"
+        assert request.content == b""
+    finally:
+        client.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", ["9.8.7+local", None])
+@pytest.mark.parametrize("factory", [sf.AsyncClient, AsyncUrl4CloudTransport])
+async def test_async_engine_request_identifies_client_and_preserves_request_headers(
+    monkeypatch: pytest.MonkeyPatch,
+    version: str | None,
+    factory: type[sf.AsyncClient] | type[AsyncUrl4CloudTransport],
+) -> None:
+    expected = _installed_version(monkeypatch, version)
+    client = factory(engine_url="http://127.0.0.1:9108")
+    try:
+        request = client._http.build_request(
+            "GET", "/", params={"q": "test"}, headers={"URL4-Capability": "capability"}
+        )
+        assert request.headers["User-Agent"] == f"screamingface/{expected}"
+        assert request.headers["URL4-Capability"] == "capability"
+        assert request.url.params["q"] == "test"
+        assert request.content == b""
+    finally:
+        if isinstance(client, sf.AsyncClient):
+            await client.aclose()
+        else:
+            await client.close()

--- a/packages/screamingface/tests/test_notebook_version_provenance.py
+++ b/packages/screamingface/tests/test_notebook_version_provenance.py
@@ -1,0 +1,41 @@
+"""Generated notebook identity survives sharing without machine-dependent metadata."""
+
+from __future__ import annotations
+
+import json
+import runpy
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from screamingface import _version
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_builder_stamps_source_version_deterministically_not_an_unrelated_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(_version, "distribution_version", lambda _: "999.0.0")
+    builder = runpy.run_path(str(_ROOT / "scripts/build_notebooks.py"))["notebooks"]
+    expected = tomllib.loads((_ROOT / "pyproject.toml").read_text())["project"]["version"]
+    first = builder()
+    second = builder()
+
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    for notebook in first.values():
+        assert notebook.metadata["screamingface"] == {"generated_by_version": expected}
+        for cell in notebook.cells:
+            if cell.cell_type == "code":
+                assert cell.execution_count is None
+                assert cell.outputs == []
+
+
+@pytest.mark.parametrize("path", sorted((_ROOT / "examples").glob("*.ipynb")), ids=lambda p: p.name)
+def test_distributed_notebooks_keep_their_generation_stamp(path: Path) -> None:
+    # WHY: a later package release must not rewrite the historical generation version.
+    metadata = json.loads(path.read_text())["metadata"]["screamingface"]
+    assert set(metadata) == {"generated_by_version"}
+    assert isinstance(metadata["generated_by_version"], str)
+    assert metadata["generated_by_version"].strip()


### PR DESCRIPTION
## Problem and result

Generated example notebooks currently carry no ScreamingFace generation version, and Engine HTTP requests identify the HTTP library rather than the ScreamingFace Client.

The notebook builder now writes `metadata.screamingface.generated_by_version` from its source package version. Regenerating the nine examples changes only that metadata. The stamp stays with the file even if someone later runs it with a newer installed package.

The Client now sends `User-Agent: screamingface/<installed version>` automatically on Engine HTTP requests, covering synchronous and asynchronous catalogue and evaluation transports. It reuses the existing source-tree fallback and preserves request-specific headers. No notebook setup or request-body changes are required.

## Remaining OME-416 work

This PR sends the version; it does not make the Engine retain it against a run or return typed version provenance. Those contracts still need an Engine-owned design. OME-416 remains open after this first delivery. Scoreboard submission provenance and opt-in error reporting are outside this change.

## Validation

- 18 new regression cases pass: four Engine HTTP clients with installed/source-tree identity, header merging, deterministic builder metadata, output-free cells, and all nine distributed notebook stamps.
- Compared parsed notebook JSON before and after: only the namespaced generation metadata changed.
- `run_gates.py screamingface`: all gates green (append-only checks, lint, formatting, pyright, full pytest with >=95% coverage, notebook checks, build and distribution checks).

Refs: OME-416
