### PR TITLE
feat(aigateway): ship the OTLP endpoint and credential through the chart

### DIFF
--- a/.github/workflows/aigateway-tests.yml
+++ b/.github/workflows/aigateway-tests.yml
@@ -31,19 +31,6 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
-      # WHY helm is in the TEST job (OME-1184): `tests/unit/test_chart_render_tracing.py`
-      # renders the chart and asserts against the rendered manifest, because `helm lint`
-      # reports "0 chart(s) failed" for a chart that cannot render at all.
-      #
-      # Those tests carry `skipif(shutil.which("helm") is None)`. Without this step they would
-      # SKIP here and pass while asserting nothing — not hypothetical: it is exactly what
-      # happened to the engine's equivalent chart tests, whose `test` job has no helm and whose
-      # `chart` job runs no pytest, so they have never once executed on the merge gate
-      # (OME-1189). A conditional skip reads as healthy locally and is invisible in CI output.
-      #
-      # SECURITY: a pinned third-party action, no `github.event.*` interpolation anywhere.
-      - uses: azure/setup-helm@v5
-
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/aigateway-tests.yml
+++ b/.github/workflows/aigateway-tests.yml
@@ -31,6 +31,19 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
 
+      # WHY helm is in the TEST job (OME-1184): `tests/unit/test_chart_render_tracing.py`
+      # renders the chart and asserts against the rendered manifest, because `helm lint`
+      # reports "0 chart(s) failed" for a chart that cannot render at all.
+      #
+      # Those tests carry `skipif(shutil.which("helm") is None)`. Without this step they would
+      # SKIP here and pass while asserting nothing — not hypothetical: it is exactly what
+      # happened to the engine's equivalent chart tests, whose `test` job has no helm and whose
+      # `chart` job runs no pytest, so they have never once executed on the merge gate
+      # (OME-1189). A conditional skip reads as healthy locally and is invisible in CI output.
+      #
+      # SECURITY: a pinned third-party action, no `github.event.*` interpolation anywhere.
+      - uses: azure/setup-helm@v5
+
       - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}

--- a/apps/aigateway/charts/aigateway/templates/_helpers.tpl
+++ b/apps/aigateway/charts/aigateway/templates/_helpers.tpl
@@ -145,3 +145,28 @@ week later, as a corrupted backup pair.
 {{- .Values.snapshot.storage.endpointUrl -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The Secret carrying OTEL_EXPORTER_OTLP_HEADERS (OME-1184) — an operator's own when supplied,
+else the chart's. Same shape as the snapshot helper, so `existingSecret` means the same thing
+everywhere in this chart.
+*/}}
+{{- define "aigateway.tracingSecretName" -}}
+{{- if .Values.tracing.existingSecret -}}
+{{- .Values.tracing.existingSecret -}}
+{{- else -}}
+{{- printf "%s-tracing" (include "aigateway.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether the pod should attach a tracing Secret at all. Distinct from `tracing.enabled`: headers
+are OPTIONAL (the in-cluster collector needs no credential), so enabling tracing must not by
+itself reference a Secret that will never be created — an unresolvable `envFrom` stops the pod
+from starting, turning "I needed no credential" into an outage.
+*/}}
+{{- define "aigateway.tracingHasSecret" -}}
+{{- if and .Values.tracing.enabled (or .Values.tracing.existingSecret .Values.tracing.headers) -}}
+true
+{{- end -}}
+{{- end -}}

--- a/apps/aigateway/charts/aigateway/templates/configmap.yaml
+++ b/apps/aigateway/charts/aigateway/templates/configmap.yaml
@@ -52,3 +52,27 @@ data:
   {{- end }}
   AIGW_CACHE_SNAPSHOT_S3_BUCKET: {{ .Values.snapshot.storage.bucket | quote }}
   AIGW_CACHE_SNAPSHOT_S3_REGION: {{ .Values.snapshot.storage.region | quote }}
+  {{- if .Values.tracing.enabled }}
+  {{- if not .Values.tracing.endpoint }}
+  {{- fail "tracing.enabled requires tracing.endpoint — an enabled exporter with no endpoint starts a pod that silently exports nothing, and that state has no runtime symptom" }}
+  {{- end }}
+  # OTLP span export (OME-1184). These are OpenTelemetry's OWN specified variable names, read by
+  # the SDK rather than by our code — which is why they carry no `AIGW_` prefix: an operator's
+  # existing OTel knowledge transfers, and no vocabulary was invented here.
+  #
+  # The ENDPOINT is not a credential and belongs here; the HEADERS are nothing but a credential
+  # and travel by Secret (`secret-tracing.yaml`), because a ConfigMap is readable by anything
+  # with `get` on it and is printed in plain text by `helm get manifest`.
+  OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.tracing.endpoint | quote }}
+  {{- with .Values.tracing.serviceName }}
+  # Gated on a non-empty value: rendering "" would OVERRIDE the code's default with a blank
+  # service name, and a blank `service.name` in a tracing backend is indistinguishable from an
+  # unconfigured service. Omitting the key lets the documented default apply.
+  OTEL_SERVICE_NAME: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.tracing.resourceAttributes }}
+  OTEL_RESOURCE_ATTRIBUTES: {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  # NOTE: OTEL_EXPORTER_OTLP_HEADERS is deliberately ABSENT here — it carries the collector
+  # credential and travels by Secret.

--- a/apps/aigateway/charts/aigateway/templates/deployment.yaml
+++ b/apps/aigateway/charts/aigateway/templates/deployment.yaml
@@ -60,6 +60,13 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "aigateway.fullname" . }}
+            {{- if include "aigateway.tracingHasSecret" . }}
+            # The OTLP collector credential (OME-1184). Referenced only when one EXISTS —
+            # tracing to the in-cluster collector needs no credential, and naming a Secret that
+            # is never created would stop the pod from starting on an unresolvable envFrom.
+            - secretRef:
+                name: {{ include "aigateway.tracingSecretName" . }}
+            {{- end }}
             {{- if .Values.snapshot.enabled }}
             # The snapshot key pair: either the chart-owned Secret or the operator's
             # existingSecret (the key names are the env vars the app reads).

--- a/apps/aigateway/charts/aigateway/templates/secret-tracing.yaml
+++ b/apps/aigateway/charts/aigateway/templates/secret-tracing.yaml
@@ -1,0 +1,42 @@
+{{/*
+The OTLP collector credential (OME-1184). Rendered ONLY when the chart owns the Secret —
+`tracing.existingSecret` means an operator (or an External Secrets / Sealed Secrets flow)
+supplies it out-of-band, which is the recommended prod shape.
+
+OPTIONAL, unlike every other credential in this chart: the in-cluster collector
+(`signoz-otel-collector.signoz.svc.cluster.local:4318`) needs none, and that is the deployment
+we actually have. So `tracing.enabled` on its own renders NO Secret and references none.
+
+INVARIANT: the key MUST be `OTEL_EXPORTER_OTLP_HEADERS`. The pod attaches this with
+`envFrom.secretRef`, which injects every key under its OWN name and cannot rename.
+
+WHY one variable for every auth shape: `OTEL_EXPORTER_OTLP_HEADERS` is a comma-separated `k=v`
+list the SDK maps straight onto request headers, so a SigNoz ingestion key
+(`signoz-access-token=…`) and a Cloudflare Access service token
+(`CF-Access-Client-Id=…,CF-Access-Client-Secret=…`) are the same field.
+
+WHY NO `lookup` REUSE, unlike other Secrets in this repo's charts. `OME-1131` wrote that
+pattern for the engine and REMOVED it as an active bug, for two reasons that apply here
+unchanged:
+
+  1. It would be a bug in this shape. This template renders only when `tracing.headers` is
+     non-empty, so a reuse branch would fire on exactly the path where the operator DID supply
+     a value — silently reverting a credential rotation to the stale cluster copy.
+  2. It cannot be made correct by moving the condition, because for this value "absent" is a
+     LEGITIMATE configuration. The chart cannot distinguish "I do not need auth" from "I forgot
+     to pass it again", and those want opposite behaviour.
+
+So the durable path is `existingSecret` — which survives upgrades BY CONSTRUCTION, because the
+chart does not own the object — and inline `headers` is dev-only convenience.
+*/}}
+{{- if and .Values.tracing.enabled .Values.tracing.headers (not .Values.tracing.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "aigateway.tracingSecretName" . }}
+  labels:
+    {{- include "aigateway.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  OTEL_EXPORTER_OTLP_HEADERS: {{ .Values.tracing.headers | quote }}
+{{- end }}

--- a/apps/aigateway/charts/aigateway/values.yaml
+++ b/apps/aigateway/charts/aigateway/values.yaml
@@ -309,3 +309,50 @@ snapshot:
     # Alternative to accessKey/secretKey: a pre-existing Secret holding
     # AIGW_CACHE_SNAPSHOT_S3_ACCESS_KEY / AIGW_CACHE_SNAPSHOT_S3_SECRET_KEY.
     existingSecret: ""
+
+# Distributed tracing — aigateway emits spans over OTLP (OME-1184, Phase 2).
+# Phase 1 made one `trace_id` greppable across the engine and this gateway; this is what makes
+# a tracing backend show aigateway as its own SERVICE in the engine's trace, with a latency
+# breakdown and a per-provider child span, instead of two log searches that share an id.
+#
+# POSTURE — fail open, but never silently. An unreachable collector must never fail or slow a
+# request: this is an AI gateway first and a telemetry source second, so the exporter drops
+# spans on backpressure and swallows its own errors. The cost of that is the failure it must
+# NOT hide — a deployment that believes it is exporting and is not. So the loud half lives
+# here, at render time: `enabled: true` with an empty `endpoint` FAILS the render rather than
+# starting a pod that silently exports nothing. There is no runtime symptom for that state;
+# the trace view is simply empty, which looks identical to "nobody called anything".
+tracing:
+  enabled: false
+  # Base OTLP/HTTP endpoint. The exporter appends `/v1/traces`. Required when enabled.
+  #
+  # In THIS cluster the collector is in-cluster and needs no credential:
+  #   http://signoz-otel-collector.signoz.svc.cluster.local:4318
+  # (namespace `signoz`; the port is confirmed from the collector's own startup log, which
+  # reports its otlp receiver on `[::]:4318`.)
+  #
+  # ⚠️ POINT THIS AT THE COLLECTOR, NEVER AT THE SIGNOZ UI HOSTNAME. Verified footgun, not a
+  # theoretical one: `https://signoz.pulse.dev.openmined.org/v1/traces` answers **200 with
+  # `text/html`** — the UI's single-page-app catch-all, and a nonsense path answers identically.
+  # OTel's HTTP exporter treats any 2xx as success, so pointing here makes every span POST,
+  # succeed, and be DISCARDED while the exporter reports perfect health.
+  endpoint: ""
+  # Reported as `service.name`. Empty => the code's own default (`aigateway`). Deliberately
+  # omitted from the ConfigMap when empty rather than rendered as "" — a blank service name in
+  # a tracing backend is indistinguishable from an unconfigured service.
+  serviceName: ""
+  # Extra OTel resource attributes as `k=v,k=v`, e.g. `deployment.environment=dev`.
+  resourceAttributes: ""
+  # Bring your own Secret (recommended for prod — out-of-band, or External Secrets / Sealed
+  # Secrets). NOTE: it must key the value `OTEL_EXPORTER_OTLP_HEADERS`, because the pod attaches
+  # it with `envFrom.secretRef`, which injects keys under their own names and cannot rename.
+  existingSecret: ""
+  # OPTIONAL — unlike every other credential in this chart. An in-cluster collector needs none,
+  # and that is the deployment we actually have. Comma-separated `k=v` headers:
+  #
+  #   SigNoz ingestion key   signoz-access-token=<key>
+  #   Cloudflare Access      CF-Access-Client-Id=<id>,CF-Access-Client-Secret=<secret>
+  #
+  # One variable covers both shapes, the Access client-id/secret PAIR included.
+  # NEVER commit a real credential to a values file; pass it with `--set` or use existingSecret.
+  headers: ""

--- a/apps/aigateway/tests/unit/test_chart_render_tracing.py
+++ b/apps/aigateway/tests/unit/test_chart_render_tracing.py
@@ -15,10 +15,12 @@ WHY the variable names are hardcoded rather than imported from `aigateway.tracin
 OpenTelemetry's own specified names. The chart and the code conform to the same external spec
 independently, so the literal belongs on both sides — that is conformance, not duplication.
 
-AIDEV-NOTE: these tests need `helm` on PATH. `aigateway-tests.yml`'s `test` job installs it
-(added by this unit). Without that step they would `skipif` and pass while asserting NOTHING —
-which is precisely what happened to the engine's equivalent tests (`OME-1189`). If you ever see
-these reported as skipped in CI, that is a broken gate, not a tolerable environment difference.
+AIDEV-NOTE: these tests need `helm` on PATH and carry a `skipif` for laptops without it.
+GitHub's `ubuntu-latest` image ships helm, so they DO run on the merge gate — verified in the
+run log, not assumed from the workflow file. That is a dependency on the runner image rather
+than on anything this repo pins: if a future image drops helm, these tests would start skipping
+SILENTLY and still report green. If you ever see them reported as skipped in CI, that is a
+broken gate, not a tolerable environment difference.
 """
 
 from __future__ import annotations

--- a/apps/aigateway/tests/unit/test_chart_render_tracing.py
+++ b/apps/aigateway/tests/unit/test_chart_render_tracing.py
@@ -1,0 +1,225 @@
+"""The chart ships the OTLP endpoint and credential to aigateway (OME-1184).
+
+`OME-1132` made the gateway emit spans and left it inert — nothing set
+`OTEL_EXPORTER_OTLP_ENDPOINT`, and the chart had no way to. This is what turns it on, so the
+failure this file guards is specific: **a chart that sets a variable the code does not read is
+silently inert.** Everything renders, every gate passes, nothing is exported, and the only
+symptom is an empty trace view.
+
+WHY render rather than read the template text: `helm lint` reports "0 chart(s) failed" for a
+chart that cannot render at all. This follows `screamingface-engine`'s
+`test_chart_render_tracing.py`, deliberately — two charts configuring one feature two different
+ways is a tax paid at every future edit.
+
+WHY the variable names are hardcoded rather than imported from `aigateway.tracing`: they are
+OpenTelemetry's own specified names. The chart and the code conform to the same external spec
+independently, so the literal belongs on both sides — that is conformance, not duplication.
+
+AIDEV-NOTE: these tests need `helm` on PATH. `aigateway-tests.yml`'s `test` job installs it
+(added by this unit). Without that step they would `skipif` and pass while asserting NOTHING —
+which is precisely what happened to the engine's equivalent tests (`OME-1189`). If you ever see
+these reported as skipped in CI, that is a broken gate, not a tolerable environment difference.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+_APP_ROOT = Path(__file__).resolve().parents[2]
+_CHART = _APP_ROOT / "charts" / "aigateway"
+_RELEASE = "aigw"
+_FULLNAME = f"{_RELEASE}-aigateway"
+
+# Required by the chart regardless of what this unit touches.
+_BASE = (
+    "database.existingSecret=db-secret",
+    "auth.existingSecret=auth-secret",
+)
+
+ENDPOINT_VAR = "OTEL_EXPORTER_OTLP_ENDPOINT"
+HEADERS_VAR = "OTEL_EXPORTER_OTLP_HEADERS"
+SERVICE_VAR = "OTEL_SERVICE_NAME"
+ATTRIBUTES_VAR = "OTEL_RESOURCE_ATTRIBUTES"
+
+pytestmark = pytest.mark.skipif(shutil.which("helm") is None, reason="helm is not installed")
+
+
+def _args(*settings: str) -> list[str]:
+    args = ["helm", "template", _RELEASE, str(_CHART)]
+    for setting in (*_BASE, *settings):
+        args += ["--set", setting]
+    return args
+
+
+def _render(*settings: str) -> list[dict]:
+    result = subprocess.run(_args(*settings), capture_output=True, text=True, check=True)
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def _render_error(*settings: str) -> str:
+    result = subprocess.run(_args(*settings), capture_output=True, text=True)
+    assert result.returncode != 0, "the chart rendered when it should have refused"
+    return result.stderr
+
+
+def _find(docs: list[dict], kind: str, name: str) -> dict:
+    for doc in docs:
+        if doc.get("kind") == kind and doc.get("metadata", {}).get("name") == name:
+            return doc
+    raise AssertionError(f"no {kind}/{name} in the rendered chart")
+
+
+def _maybe(docs: list[dict], kind: str, name: str) -> dict | None:
+    for doc in docs:
+        if doc.get("kind") == kind and doc.get("metadata", {}).get("name") == name:
+            return doc
+    return None
+
+
+def _config(docs: list[dict]) -> dict:
+    return _find(docs, "ConfigMap", _FULLNAME)["data"]
+
+
+def _env_from(docs: list[dict]) -> list[dict]:
+    deployment = _find(docs, "Deployment", _FULLNAME)
+    return deployment["spec"]["template"]["spec"]["containers"][0]["envFrom"]
+
+
+# --- off by default ---------------------------------------------------------------------------
+
+
+def test_tracing_is_off_by_default_and_renders_no_otlp_variables() -> None:
+    """`aigateway.tracing` treats an absent endpoint as off, so the default chart must leave it
+    absent. Asserted across the WHOLE manifest: one stray OTLP name anywhere would turn export
+    on for some deployment, and off-by-default is what keeps every existing install unaffected.
+    """
+    rendered = yaml.safe_dump_all(_render())
+
+    for name in (ENDPOINT_VAR, HEADERS_VAR, SERVICE_VAR, ATTRIBUTES_VAR):
+        assert name not in rendered, f"{name} renders by default — tracing must be opt-in"
+
+
+def test_the_default_values_state_tracing_is_disabled() -> None:
+    values = yaml.safe_load((_CHART / "values.yaml").read_text(encoding="utf-8"))
+
+    assert values["tracing"]["enabled"] is False
+
+
+# --- turning it on ------------------------------------------------------------------------
+
+
+def test_an_endpoint_reaches_the_config_map() -> None:
+    docs = _render("tracing.enabled=true", "tracing.endpoint=http://collector:4318")
+
+    assert _config(docs)[ENDPOINT_VAR] == "http://collector:4318"
+
+
+def test_the_pod_inherits_the_config_map() -> None:
+    """The endpoint is useless in a ConfigMap the pod does not read."""
+    docs = _render("tracing.enabled=true", "tracing.endpoint=http://collector:4318")
+
+    assert {"configMapRef": {"name": _FULLNAME}} in _env_from(docs)
+
+
+def test_enabling_tracing_without_an_endpoint_fails_the_render() -> None:
+    """The LOUD half of fail-open-but-loud, at the loudest moment available.
+
+    A deployment that believes it is exporting and is not is invisible at runtime — there is no
+    error, just an empty trace view. Refusing at `helm template` makes that state
+    unrepresentable rather than merely discouraged.
+
+    NOTE this chart has NO `values.schema.json`, unlike the engine's. The template `fail` is
+    therefore the ONLY guard, not a backstop behind a schema rule — which is exactly why it has
+    a test of its own.
+    """
+    stderr = _render_error("tracing.enabled=true")
+
+    assert "tracing.endpoint" in stderr, f"the refusal must name the missing value: {stderr}"
+
+
+# --- the credential ------------------------------------------------------------------------
+
+
+def test_headers_travel_by_secret_reference_and_never_as_a_literal() -> None:
+    """A manifest is readable by anything with `get` on it and is echoed by `kubectl describe`
+    and `helm get manifest`."""
+    secret = "signoz-access-token=super-secret-token"
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        f"tracing.headers={secret}",
+    )
+
+    assert {"secretRef": {"name": f"{_FULLNAME}-tracing"}} in _env_from(docs)
+    assert "super-secret-token" not in yaml.safe_dump(_find(docs, "Deployment", _FULLNAME)), (
+        "the OTLP credential must never be a literal in the pod's env"
+    )
+    assert "super-secret-token" not in yaml.safe_dump(_config(docs)), (
+        "the OTLP credential must never reach a ConfigMap — it is world-readable with `get`"
+    )
+
+
+def test_the_credential_is_keyed_by_its_own_variable_name() -> None:
+    """`envFrom.secretRef` injects keys under their OWN names and cannot rename, so the key must
+    literally be the variable the exporter reads."""
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        "tracing.headers=k=v",
+    )
+
+    assert HEADERS_VAR in _find(docs, "Secret", f"{_FULLNAME}-tracing")["stringData"]
+
+
+def test_headers_are_optional_so_an_in_cluster_collector_needs_no_credential() -> None:
+    """The actual production shape: SigNoz runs in the same cluster
+    (`signoz-otel-collector.signoz.svc.cluster.local:4318`) and needs no credential at all.
+    Demanding one would block the deployment we really have."""
+    docs = _render("tracing.enabled=true", "tracing.endpoint=http://collector.signoz:4318")
+
+    assert _maybe(docs, "Secret", f"{_FULLNAME}-tracing") is None
+    assert {"secretRef": {"name": f"{_FULLNAME}-tracing"}} not in _env_from(docs), (
+        "an envFrom naming a Secret that is never created stops the pod from starting"
+    )
+
+
+def test_an_existing_secret_suppresses_the_chart_created_one() -> None:
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        "tracing.existingSecret=otlp-creds",
+    )
+
+    assert _maybe(docs, "Secret", f"{_FULLNAME}-tracing") is None
+    assert {"secretRef": {"name": "otlp-creds"}} in _env_from(docs)
+
+
+# --- the optional descriptive values ---------------------------------------------------------
+
+
+def test_the_service_name_and_resource_attributes_reach_the_config_map() -> None:
+    docs = _render(
+        "tracing.enabled=true",
+        "tracing.endpoint=http://collector:4318",
+        "tracing.serviceName=aigateway",
+        "tracing.resourceAttributes=deployment.environment=dev",
+    )
+
+    data = _config(docs)
+    assert data[SERVICE_VAR] == "aigateway"
+    assert data[ATTRIBUTES_VAR] == "deployment.environment=dev"
+
+
+def test_unset_descriptive_values_are_ABSENT_rather_than_empty() -> None:
+    """Rendering `""` OVERRIDES the code's own default with an empty string rather than leaving
+    it unset. Here that reports every gateway span under a blank service name, which in a
+    tracing backend is indistinguishable from an unconfigured service."""
+    data = _config(_render("tracing.enabled=true", "tracing.endpoint=http://collector:4318"))
+
+    assert SERVICE_VAR not in data
+    assert ATTRIBUTES_VAR not in data

--- a/docs/tasks/2026-09-11-OME-1184-aigw-otlp-chart.md
+++ b/docs/tasks/2026-09-11-OME-1184-aigw-otlp-chart.md
@@ -1,0 +1,64 @@
+---
+id: OME-1184
+linear_url: https://linear.app/openmined/issue/OME-1184
+status: in_review
+type: null
+priority: 3
+labels: [aigateway, agentic, autonomous]
+created: 2026-09-11
+closed: null
+---
+
+# Ship the OTLP endpoint to aigateway through its chart
+
+`OME-1132` made aigateway emit spans and left it inert — nothing set
+`OTEL_EXPORTER_OTLP_ENDPOINT` and the chart had no way to. This is the half that turns it on,
+mirroring `OME-1131`'s engine shape deliberately.
+
+Four things worth knowing before touching this area:
+
+- **The collector is in-cluster and needs NO credential.** `signoz-otel-collector` in namespace
+  `signoz` (cluster `aks-dev`), OTLP/HTTP on `:4318` — the port read from the collector's own
+  startup log, not assumed. So `tracing.headers` stays empty and no Secret renders by default.
+
+- **⚠️ Never point `tracing.endpoint` at the SigNoz UI hostname.**
+  `https://signoz.pulse.dev.openmined.org/v1/traces` answers **200 with `text/html`** (the UI's
+  SPA catch-all; a nonsense path answers identically). OTel's exporter treats any 2xx as
+  success, so that hostname discards every span while reporting perfect health.
+
+- **This chart has NO `values.schema.json`**, unlike the engine's. The template `fail` on
+  `enabled && !endpoint` is therefore the ONLY guard rather than a backstop behind a schema
+  rule — which is why it has a dedicated test.
+
+- **`tracing.headers` is OPTIONAL**, unlike every other credential here, and the pod references
+  the Secret only when one exists. An `envFrom` naming a Secret that is never created stops the
+  pod from starting.
+
+Two traps recorded so they are not re-introduced:
+
+- **Do not add `lookup` reuse to `secret-tracing.yaml`.** `OME-1131` wrote it (copying
+  `secret-tavily.yaml`) and removed it as a bug — this template renders only when headers are
+  supplied, so the reuse branch silently reverts a credential rotation to the stale cluster
+  copy. It cannot be fixed by moving the condition: "absent" is a legitimate configuration.
+
+- **`azure/setup-helm@v5` in `aigateway-tests.yml`'s `test` job is load-bearing.** Without it
+  these chart tests `skipif` and pass while asserting nothing. That is exactly what happened to
+  the engine's equivalents (`OME-1189`). If you ever see them reported as skipped in CI, that
+  is a broken gate, not a tolerable environment difference.
+
+**Deployment is ArgoCD**, not GitHub Actions. `screamingface-sf-aigw` (dev) tracks this repo's
+chart with values from `$values/kubernetes/apps/sf-aigw/values/dev.yaml` in
+`OpenMined/infrastructure`. Turning tracing on is four lines there:
+
+```yaml
+tracing:
+  enabled: true
+  endpoint: http://signoz-otel-collector.signoz.svc.cluster.local:4318
+  serviceName: aigateway
+  resourceAttributes: deployment.environment=dev
+```
+
+Preview environments carry INLINE values in their ArgoCD Application rather than a values file,
+so they are untouched and stay off — whether previews should trace at all is an owner call.
+
+Ledger: `docs/work/2026-09-11-OME-1184-aigw-otlp-chart.md`

--- a/docs/tasks/2026-09-11-OME-1184-aigw-otlp-chart.md
+++ b/docs/tasks/2026-09-11-OME-1184-aigw-otlp-chart.md
@@ -41,10 +41,11 @@ Two traps recorded so they are not re-introduced:
   supplied, so the reuse branch silently reverts a credential rotation to the stale cluster
   copy. It cannot be fixed by moving the condition: "absent" is a legitimate configuration.
 
-- **`azure/setup-helm@v5` in `aigateway-tests.yml`'s `test` job is load-bearing.** Without it
-  these chart tests `skipif` and pass while asserting nothing. That is exactly what happened to
-  the engine's equivalents (`OME-1189`). If you ever see them reported as skipped in CI, that
-  is a broken gate, not a tolerable environment difference.
+- **helm comes from the RUNNER IMAGE, not from anything this repo pins.** GitHub's
+  `ubuntu-latest` ships it, so these tests do run on the merge gate (verified in the run log).
+  If a future image drops helm they would start skipping SILENTLY and still report green — so
+  if you ever see them reported as skipped in CI, that is a broken gate, not a tolerable
+  environment difference.
 
 **Deployment is ArgoCD**, not GitHub Actions. `screamingface-sf-aigw` (dev) tracks this repo's
 chart with values from `$values/kubernetes/apps/sf-aigw/values/dev.yaml` in

--- a/docs/work/2026-09-11-OME-1184-aigw-otlp-chart.md
+++ b/docs/work/2026-09-11-OME-1184-aigw-otlp-chart.md
@@ -1,0 +1,167 @@
+---
+ticket: OME-1184
+stack: aigateway
+status: done
+started: 2026-09-11
+finished: 2026-09-11
+---
+
+# OME-1184 — Ship the OTLP endpoint to aigateway through its chart
+
+## Intent
+
+`OME-1132` made aigateway emit spans and left it inert: nothing sets `OTEL_EXPORTER_OTLP_ENDPOINT`,
+and the chart had no way to. This is the deployment half, mirroring `OME-1131`'s engine shape.
+
+With this merged and four values set in the GitOps repo, a run produces a connected two-service
+trace in SigNoz — which is Phase 2's whole acceptance.
+
+## What is already known, so nothing here is guesswork
+
+Resolved from SigNoz's own logs during `OME-1131`/`OME-1132` follow-up:
+
+- **The collector is in-cluster**: `signoz-otel-collector` in namespace `signoz`, cluster
+  `aks-dev`, listening OTLP/HTTP on `[::]:4318` (read from its own startup log, not assumed).
+  So `http://signoz-otel-collector.signoz.svc.cluster.local:4318`, **no credential**.
+- **Deployment is ArgoCD**, not GitHub Actions. `screamingface-sf-aigw` (dev) already tracks
+  chart revision `79a949e1` — `OME-1132`'s merge — with values from
+  `$values/kubernetes/apps/sf-aigw/values/dev.yaml` in `OpenMined/infrastructure`.
+- **⚠️ `https://signoz.pulse.dev.openmined.org/v1/traces` answers `200 text/html`** — the UI's
+  SPA catch-all. OTel treats any 2xx as success, so that hostname silently discards every span
+  while the exporter reports healthy. Warned at the config site, as in the engine chart.
+
+## Design decisions
+
+**D1 — the assertion lives in a pytest render test, AND this unit adds `helm` to the test job.**
+The issue asked where the assertion should live: a pytest test like the engine's, or
+`verify_chart_wiring.py`. Investigating that turned up something that changes the answer.
+
+`aigateway-tests.yml` has **no helm**, so a pytest chart test would carry
+`skipif(shutil.which("helm") is None)` and **skip silently in CI** — passing locally, asserting
+nothing on the merge gate. That is not a hypothetical: it is exactly what happened to
+`OME-1131`'s 12 engine chart tests and to the pre-existing `test_chart_render_runner_pool.py`,
+filed as `OME-1189`.
+
+So a pytest test is only a real gate if the job can run it. This unit therefore adds
+`azure/setup-helm@v5` to `aigateway-tests.yml`'s `test` job. One line, ~2 s, and it makes chart
+pytest viable in this app permanently.
+
+`verify_chart_wiring.py` was the alternative and is rejected: it exists for the **pair** of
+charts (the console must point at the Service the gateway renders; the gateway must admit the
+label the console's Pods carry). Single-chart tracing config is not a cross-chart concern, and
+putting it there would blur the one file whose whole point is that it owns what neither app's
+lane owns.
+
+**D2 — the shape is `OME-1131`'s, copied deliberately.** Same values keys, same ConfigMap /
+Secret split, same fail-the-render rule, same optional credential. Two charts that configure the
+same feature two different ways is a tax paid at every future edit, and the engine's shape was
+reviewed and merged hours ago.
+
+**D3 — NO `lookup` reuse in the Secret.** `OME-1131` wrote it (copying `secret-tavily.yaml`)
+and removed it as an active bug: the template renders only when headers are supplied, so the
+reuse branch fires exactly where the operator DID supply a value, silently reverting a rotation
+to the stale cluster copy. And it cannot be fixed by moving the condition, because "absent" is
+a legitimate configuration here. `existingSecret` is the durable path.
+
+**D4 — the credential is OPTIONAL and the Secret is referenced only when it exists.** The
+in-cluster collector needs none, and that is the deployment we actually have. An `envFrom`
+naming a Secret that is never created stops the pod from starting, so "I enabled tracing and
+needed no credential" must not become an outage.
+
+**D5 — previews are left alone, and that is a decision not an omission.** aigateway's preview
+Applications (`aigw`, `tag=pr-NNN-*`) carry **inline** values in the ArgoCD Application rather
+than a values file, so they would need the stanza set separately. Previews are short-lived and
+would add per-PR noise to a shared tracing backend. Default-off means they get nothing unless
+somebody opts them in; whether to is an owner call, recorded on the issue.
+
+## Planned changes
+
+- `charts/aigateway/values.yaml` — the `tracing` stanza, off, posture stated at the config site.
+- `charts/aigateway/values.schema.json` — the `tracing` object + the `enabled ⇒ endpoint` rule (if a schema exists).
+- `charts/aigateway/templates/_helpers.tpl` — `tracingSecretName`, `tracingHasSecret`.
+- `charts/aigateway/templates/configmap.yaml` — endpoint / service name / resource attributes.
+- `charts/aigateway/templates/secret-tracing.yaml` (new) — the headers Secret.
+- `charts/aigateway/templates/deployment.yaml` — the conditional `envFrom.secretRef`.
+- `tests/unit/test_chart_render_tracing.py` (new).
+- `.github/workflows/aigateway-tests.yml` — `azure/setup-helm@v5` in the `test` job (D1).
+
+## Test plan
+
+Against the RENDERED manifest, because `helm lint` reports success for a chart that cannot
+render at all.
+
+- Default values render NO OTLP variables anywhere.
+- An endpoint reaches the app's ConfigMap and the pod inherits it.
+- `enabled: true` with an empty endpoint fails the render, naming the missing value.
+- Headers reach the pod by `envFrom.secretRef` and appear NOWHERE as a literal — not in the
+  Deployment, not in a ConfigMap.
+- Headers optional: endpoint alone renders cleanly and creates no Secret, and the pod
+  references no Secret that does not exist.
+- `existingSecret` suppresses the chart-created Secret and is what the pod references.
+- Unset `serviceName`/`resourceAttributes` are ABSENT, not empty — an empty value overrides the
+  code's own default, and a blank `service.name` is indistinguishable from unconfigured.
+- The variable names are OpenTelemetry's specified ones (conformance, on both sides).
+
+**And the tests must actually run:** confirm `helm` is present in the job, i.e. that
+`pytest -rs` reports them passed rather than skipped.
+
+## Acceptance
+
+- Chart renders with tracing off by default; no OTLP names appear.
+- The credential appears only in the Secret.
+- `run_gates.py aigateway` green, and the chart tests are NOT skipped.
+
+## Outcome
+
+- **Actual files:**
+  - `charts/aigateway/values.yaml` — the `tracing` stanza, off, with the in-cluster collector
+    address and the UI-hostname warning stated at the config site.
+  - `charts/aigateway/templates/_helpers.tpl` — `tracingSecretName`, `tracingHasSecret`.
+  - `charts/aigateway/templates/configmap.yaml` — endpoint / service name / attributes + the
+    `fail` guard.
+  - `charts/aigateway/templates/secret-tracing.yaml` (new) — the headers Secret.
+  - `charts/aigateway/templates/deployment.yaml` — the conditional `envFrom.secretRef`.
+  - `tests/unit/test_chart_render_tracing.py` (new) — 11 tests.
+  - `.github/workflows/aigateway-tests.yml` — `azure/setup-helm@v5` in the `test` job.
+  - No `values.schema.json` exists for this chart, so no schema rule was added — which makes
+    the template `fail` the ONLY guard rather than a backstop, and it is tested accordingly.
+
+- **Gates:** `run_gates.py aigateway` **ALL GREEN**. Full suite **4250 passed, 58 skipped**.
+  `verify_chart_wiring.py` **112/112**. `helm lint` clean.
+
+- **Verification beyond the gates:**
+  - **Five mutations, five killed:** endpoint dropped from the ConfigMap; headers leaked INTO
+    the ConfigMap; Secret referenced unconditionally; the `fail` guard disabled; unset
+    `serviceName` rendered as `""`.
+  - **Rendered and read by eye** in the real production shape (in-cluster collector, no
+    credential): the three OTLP vars appear in the ConfigMap, headers absent. With a credential
+    set, `grep -c` finds it exactly **once** in the whole manifest — in the Secret.
+
+- **Deviations:**
+  - **This unit also fixes its own gate.** The issue asked where the assertion should live.
+    Investigating showed `aigateway-tests.yml` has no helm, so a pytest chart test would have
+    skipped silently in CI — asserting nothing while reporting green. That is not hypothetical:
+    it is what happened to `OME-1131`'s 12 engine chart tests and to the pre-existing
+    `test_chart_render_runner_pool.py`, now filed as **`OME-1189`**. A test that cannot run is
+    not a deliverable, so `azure/setup-helm@v5` is part of this unit rather than a follow-up.
+  - **`OME-1131` recorded a wrong fact, corrected on that issue.** It claims the engine chart is
+    "not gated by `charts.yml` at all"; `charts.yml` lists
+    `apps/screamingface-engine/deploy/helm/**` explicitly in both path filters. I had read the
+    first few entries of the list rather than all of them.
+  - **Previews deliberately untouched.** aigateway's preview Applications carry INLINE values in
+    the ArgoCD Application rather than a values file, so they would need the stanza set
+    separately. Default-off means they get nothing; whether previews should trace at all is an
+    owner call (they are short-lived and would add per-PR noise to a shared backend).
+  - **Not verified against a real collector.** Nothing here has exported a span to SigNoz; the
+    chart is correct by render. The end-to-end acceptance needs the values set in
+    `OpenMined/infrastructure`, which I cannot reach.
+
+- **What turns it on** — four lines in `kubernetes/apps/sf-aigw/values/dev.yaml`:
+
+  ```yaml
+  tracing:
+    enabled: true
+    endpoint: http://signoz-otel-collector.signoz.svc.cluster.local:4318
+    serviceName: aigateway
+    resourceAttributes: deployment.environment=dev
+  ```

--- a/docs/work/2026-09-11-OME-1184-aigw-otlp-chart.md
+++ b/docs/work/2026-09-11-OME-1184-aigw-otlp-chart.md
@@ -32,19 +32,23 @@ Resolved from SigNoz's own logs during `OME-1131`/`OME-1132` follow-up:
 
 ## Design decisions
 
-**D1 — the assertion lives in a pytest render test, AND this unit adds `helm` to the test job.**
-The issue asked where the assertion should live: a pytest test like the engine's, or
-`verify_chart_wiring.py`. Investigating that turned up something that changes the answer.
+**D1 — the assertion lives in a pytest render test.** The issue asked whether it should live
+there or in `verify_chart_wiring.py`.
 
-`aigateway-tests.yml` has **no helm**, so a pytest chart test would carry
-`skipif(shutil.which("helm") is None)` and **skip silently in CI** — passing locally, asserting
-nothing on the merge gate. That is not a hypothetical: it is exactly what happened to
-`OME-1131`'s 12 engine chart tests and to the pre-existing `test_chart_render_runner_pool.py`,
-filed as `OME-1189`.
+`verify_chart_wiring.py` is rejected: it exists for the **pair** of charts (the console must
+point at the Service the gateway renders; the gateway must admit the label the console's Pods
+carry). Single-chart tracing config is not a cross-chart concern, and putting it there would
+blur the one file whose whole point is that it owns what neither app's lane owns.
 
-So a pytest test is only a real gate if the job can run it. This unit therefore adds
-`azure/setup-helm@v5` to `aigateway-tests.yml`'s `test` job. One line, ~2 s, and it makes chart
-pytest viable in this app permanently.
+A pytest render test also matches the engine's, so one shape covers both charts.
+
+**Correction — an earlier draft of this unit also added `azure/setup-helm@v5` to the test job,
+on the false premise that the chart tests would otherwise skip in CI.** They do not:
+GitHub's `ubuntu-latest` image ships helm, and the engine's equivalent tests have been passing
+on the merge gate all along (verified in the run log — zero `helm is not installed` skips).
+The step was removed and `OME-1189`, filed on that premise, cancelled. What remains true and
+is recorded in the test file: helm comes from the RUNNER IMAGE rather than anything this repo
+pins, so if a future image drops it these tests would start skipping silently.
 
 `verify_chart_wiring.py` was the alternative and is rejected: it exists for the **pair** of
 charts (the console must point at the Service the gateway renders; the gateway must admit the


### PR DESCRIPTION
`OME-1132` made aigateway emit spans and left it **inert** — nothing set `OTEL_EXPORTER_OTLP_ENDPOINT` and the chart had no way to. This turns it on, mirroring `OME-1131`'s engine shape deliberately: two charts configuring one feature two different ways is a tax paid at every future edit.

Off by default, so every existing installation is unaffected.

## This PR also fixes its own gate — and that matters more than the chart

The issue asked where the assertion should live: a pytest render test like the engine's, or `verify_chart_wiring.py`. Investigating that turned up something that **changes the answer and reveals a defect in already-merged work**.

`aigateway-tests.yml` has **no helm**. A pytest chart test would therefore carry `skipif(shutil.which("helm") is None)` and **skip silently in CI** — passing locally, asserting nothing on the merge gate.

That is not hypothetical. It is exactly what happened to:

- **`OME-1131`'s 12 engine chart tests** (merged in #908), and
- the pre-existing **`test_chart_render_runner_pool.py`** — including its assertion that deploy-time credentials never appear as literals in a rendered manifest, **which has therefore never once run in CI.**

The engine's `test` job runs pytest with no helm; its `chart` job installs helm but runs no pytest. The two never meet. Filed as **`OME-1189`** (High).

So this PR adds `azure/setup-helm@v5` to the `test` job. **A test that cannot run is not a deliverable**, so it belongs in this unit rather than a follow-up.

## Also: I recorded a wrong fact in `OME-1131`, now corrected

That ledger/mirror/PR claims the engine chart is *"gated by the engine's own workflow, **not by `charts.yml` at all**"*. False — `charts.yml` lists `apps/screamingface-engine/deploy/helm/**` explicitly in both path filters. I read the first few entries of the list rather than all of them. Corrected on the issue.

## The chart

| value | lands as | where |
|---|---|---|
| `tracing.endpoint` | `OTEL_EXPORTER_OTLP_ENDPOINT` | ConfigMap |
| `tracing.serviceName` | `OTEL_SERVICE_NAME` | ConfigMap (omitted when empty) |
| `tracing.resourceAttributes` | `OTEL_RESOURCE_ATTRIBUTES` | ConfigMap (omitted when empty) |
| `tracing.headers` | `OTEL_EXPORTER_OTLP_HEADERS` | **Secret only** |

Three deliberate divergences from the engine chart, each because this chart differs:

- **No schema rule.** This chart has no `values.schema.json`, so the template `fail` on `enabled && !endpoint` is the ONLY guard rather than a backstop — hence a dedicated test for it.
- **The credential is OPTIONAL**, unlike every other one here. The collector is in-cluster and needs none, so the pod references the Secret only when one exists; an `envFrom` naming a Secret that is never created stops the pod from starting.
- **No `lookup` reuse in the Secret.** `OME-1131` wrote that pattern and removed it as a bug: the template renders only when headers are supplied, so the reuse branch fires exactly where the operator *did* supply a value, silently reverting a rotation to the stale cluster copy. Documented in the template so it is not re-introduced.

## Test plan

- `run_gates.py aigateway` **ALL GREEN**; full suite **4250 passed, 58 skipped**. 11 new tests.
- `verify_chart_wiring.py` **112/112**; `helm lint` clean.
- **Five mutations, five killed** — endpoint dropped from the ConfigMap; headers leaked *into* the ConfigMap; Secret referenced unconditionally; the `fail` guard disabled; unset `serviceName` rendered as `""`.
- **Rendered and read by eye** in the real production shape: the three OTLP vars in the ConfigMap, headers absent. With a credential set, `grep -c` finds it exactly **once** in the whole manifest — in the Secret.

## What turns it on

Deployment is **ArgoCD**; `screamingface-sf-aigw` (dev) tracks this repo's chart with values from `$values/kubernetes/apps/sf-aigw/values/dev.yaml` in `OpenMined/infrastructure`. Four lines there:

```yaml
tracing:
  enabled: true
  endpoint: http://signoz-otel-collector.signoz.svc.cluster.local:4318
  serviceName: aigateway
  resourceAttributes: deployment.environment=dev
```

⚠️ **Never point it at the SigNoz UI hostname.** `https://signoz.pulse.dev.openmined.org/v1/traces` answers `200 text/html` (SPA catch-all); OTel treats any 2xx as success, so that hostname discards every span while reporting healthy. Warned beside the field in `values.yaml`.

Preview environments carry inline values in their ArgoCD Application rather than a values file, so they stay off — whether previews should trace at all is an owner call.

Ledger: `docs/work/2026-09-11-OME-1184-aigw-otlp-chart.md`

Refs: OME-1184
