### PR TITLE
fix(screamingface): include bundled runtime tracing dependencies

### DIFF
--- a/docs/plan/2026-09-11-OME-1188-client-runtime-otel.md
+++ b/docs/plan/2026-09-11-OME-1188-client-runtime-otel.md
@@ -1,0 +1,6 @@
+# OME-1188 — Implementation plan
+
+1. Reproduce the existing runtime dependency-parity failure before editing dependencies.
+2. Add the two approved requirements to the runtime extra and refresh the lockfile.
+3. Run the existing regression and full screamingface gate runner; inspect dependency churn.
+4. Record validation, commit, push, and open a draft PR. Keep the issue open for review.

--- a/docs/spec/2026-09-11-OME-1188-client-runtime-otel.md
+++ b/docs/spec/2026-09-11-OME-1188-client-runtime-otel.md
@@ -1,0 +1,13 @@
+# OME-1188 — Runtime dependency parity
+
+The optional Client runtime extra must provide `opentelemetry-sdk>=1.30.0` and
+`opentelemetry-exporter-otlp-proto-http>=1.30.0`, matching the bundled Engine and
+Gateway requirements introduced by PRs 905 and 909. Base Client requirements,
+application code, and export configuration remain unchanged.
+
+Refresh the Client lockfile without upgrading unrelated packages. The existing
+runtime dependency-parity regression test must pass, along with all Client gates.
+Deliver a draft PR; do not merge or close the issue.
+
+The user explicitly approved implementing this scoped fix and creating a draft PR
+on 11 September 2026.

--- a/docs/tasks/2026-09-11-OME-1188-client-runtime-otel.md
+++ b/docs/tasks/2026-09-11-OME-1188-client-runtime-otel.md
@@ -1,0 +1,22 @@
+---
+id: OME-1188
+linear_url: https://linear.app/openmined/issue/OME-1188
+status: In Progress
+type: task
+priority: High
+labels: [py-screamingface, agentic, autonomous, task]
+created: 2026-09-11
+closed:
+---
+
+# Add bundled apps’ OpenTelemetry dependencies to the Client runtime extra
+
+Mirror `opentelemetry-sdk>=1.30.0` and
+`opentelemetry-exporter-otlp-proto-http>=1.30.0` into the Client runtime extra,
+refresh its lockfile, and pass the existing dependency-parity test and Client gates.
+Base Client requirements and telemetry behavior stay unchanged.
+
+Introduced by Engine PR 905 and Gateway PR 909; exposed by CI on Client PR 918.
+Deliver a separate Client packaging fix PR. Linear holds full evidence and acceptance criteria.
+
+Implementation and draft PR authorized on 11 September 2026.

--- a/docs/work/2026-09-11-OME-1188-client-runtime-otel.md
+++ b/docs/work/2026-09-11-OME-1188-client-runtime-otel.md
@@ -1,0 +1,50 @@
+---
+ticket: OME-1188
+stack: screamingface
+status: in_progress
+started: 2026-09-11
+finished:
+---
+
+# OME-1188 — Client runtime OpenTelemetry dependency parity
+
+## Intent
+
+Record the user-authorized packaging ticket for the dependency mismatch introduced
+by PRs 905 and 909 and caught by Client CI on PR 918. The user has now authorized
+implementation and a draft PR.
+
+## Planned changes
+
+- Add the two missing requirements to the Client runtime extra and refresh its lockfile.
+- Maintain the task mirror and this ledger through the separate fix PR.
+
+## Test plan
+
+- Reproduce the existing runtime dependency-parity failure before implementation.
+- Run full screamingface gates after the packaging fix.
+
+## Acceptance
+
+- Runtime extra matches bundled apps' requirements and required CI passes.
+- Base Client dependencies and tracing behavior are unchanged.
+
+## Outcome
+
+- Actual files: Client pyproject and lockfile, spec, plan, task mirror, and this ledger.
+- RED: the unchanged runtime dependency-parity test failed on both missing OTel requirements.
+- GREEN: that same test passes after adding the requirements; no tests were modified.
+- Lockfile: eight new OTel/protobuf dependencies; no existing package version changes.
+- Gates: `run_gates.py screamingface` reports ALL GATES GREEN, including full pytest
+  with >=95% coverage, lint, formatting, pyright, notebook checks, build and distribution checks.
+- Additional checks: `uv lock --check`; built wheel metadata restricts both new requirements
+  to the runtime extra; `git diff --check`.
+- Environment: the first gate attempt lacked the notebook extra; installed it with
+  `uv sync --extra notebook`, matching CI, and reran all gates successfully.
+- Wisdom: this is the minimal packaging repair; reuses existing regression coverage,
+  adds no application code, changes no base requirements or telemetry configuration,
+  and introduces no secrets, schema changes, or public API changes. Confidence >=95%.
+- Commit: `fix(screamingface): include bundled runtime tracing dependencies`, Refs: OME-1188.
+- Deviations: used the existing failing regression rather than duplicating its assertions.
+- Gate log: `.docs/OME-1188-gates.log` (local).
+- Draft PR delivery only; issue remains open until review and merge.

--- a/packages/screamingface/pyproject.toml
+++ b/packages/screamingface/pyproject.toml
@@ -51,6 +51,9 @@ runtime = [
     "litellm==1.98.0",
     "nats-py>=2.9.0",
     "nltk>=3.9.1",
+    # WHY: pip resolves this extra, not the bundled Engine/Gateway tracing requirements.
+    "opentelemetry-exporter-otlp-proto-http>=1.30.0",
+    "opentelemetry-sdk>=1.30.0",
     # WHY pinned exactly, like `datasets`: these flatten GDPval's reference PDFs and Word
     # documents to text at BUILD time, and that text is baked into the answer key. A version
     # whose extraction differs would silently change what every candidate is asked, without

--- a/packages/screamingface/uv.lock
+++ b/packages/screamingface/uv.lock
@@ -1043,6 +1043,18 @@ http = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2229,6 +2241,87 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2333,7 +2426,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2542,6 +2635,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/73/f66c748df06e7fe24e658eddd600d19c4b40bad836c97ce2d0ad9851fb6b/protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524", size = 512499, upload-time = "2026-08-31T22:40:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6c/3a54a58f2948b0f485df9ecdd06590f15d0a7abf46a89d50c3de709ff4ff/protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca", size = 456046, upload-time = "2026-08-31T22:39:56.865Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/9f9548793c771095245c0eeaf0c84b76b16a5ef26158043d456f551344a0/protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969", size = 344226, upload-time = "2026-08-31T22:39:58.263Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/51/1bdbd612fa3c51e42ea6f45d05e84dc748ddcd2663e1aa1e89a00a33facd/protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44", size = 357229, upload-time = "2026-08-31T22:39:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa", size = 343228, upload-time = "2026-08-31T22:40:00.179Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/d4724ec5d86d496fe4108e220618aa0837ad3423a7af7ccdd9684ccc77c8/protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00", size = 443002, upload-time = "2026-08-31T22:40:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/db/37/155788a0d8daded960375af604202805308169f9b859419ea0aa370946e2/protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363", size = 456518, upload-time = "2026-08-31T22:40:02.494Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/c47f91d3cab175b01fd8c4f0d80fdf8613be876cc616e66ad281a59c5ddf/protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c", size = 179813, upload-time = "2026-08-31T22:40:03.54Z" },
 ]
 
 [[package]]
@@ -3387,6 +3495,8 @@ runtime = [
     { name = "litellm" },
     { name = "nats-py" },
     { name = "nltk" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
     { name = "pdfplumber" },
     { name = "prometheus-client" },
     { name = "pydantic-settings" },
@@ -3427,6 +3537,8 @@ requires-dist = [
     { name = "litellm", marker = "extra == 'runtime'", specifier = "==1.98.0" },
     { name = "nats-py", marker = "extra == 'runtime'", specifier = ">=2.9.0" },
     { name = "nltk", marker = "extra == 'runtime'", specifier = ">=3.9.1" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'runtime'", specifier = ">=1.30.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'runtime'", specifier = ">=1.30.0" },
     { name = "pdfplumber", marker = "extra == 'runtime'", specifier = "==0.11.10" },
     { name = "prometheus-client", marker = "extra == 'runtime'", specifier = ">=0.26.0" },
     { name = "pydantic-settings", marker = "extra == 'runtime'", specifier = ">=2.14.2" },


### PR DESCRIPTION
The bundled Engine and AI Gateway gained OpenTelemetry dependencies in PRs #905 and #909, but the Client's optional runtime extra did not declare them. This breaks the runtime dependency-parity gate, including on PR #918.

Add `opentelemetry-sdk>=1.30.0` and `opentelemetry-exporter-otlp-proto-http>=1.30.0` to the runtime extra and refresh the lockfile. The lockfile adds eight packages without changing existing package versions. Base Client dependencies and telemetry export configuration remain unchanged.

Validation:
- Reproduced the existing dependency-parity test failure before the change; the unchanged test now passes.
- Full `run_gates.py screamingface`: ALL GATES GREEN, including full pytest with >=95% coverage, lint, formatting, pyright, notebook checks, build and distribution checks.
- `uv lock --check` passes; inspected built wheel metadata to confirm both requirements are conditional on the runtime extra.

Refs: OME-1188
