### PR TITLE
feat(engine): default tracing on so ArgoCD ships it

### DIFF
--- a/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
+++ b/apps/screamingface-engine/deploy/helm/templates/configmap-runner-env.yaml
@@ -77,9 +77,19 @@ data:
   # the documented default apply.
   OTEL_SERVICE_NAME: {{ . | quote }}
   {{- end }}
-  {{- with .Values.tracing.resourceAttributes }}
-  OTEL_RESOURCE_ATTRIBUTES: {{ . | quote }}
-  {{- end }}
+  # FEATURE (OME-1190): defaults to the release NAMESPACE, so a preview environment's spans are
+  # distinguishable from dev's. They would otherwise be identical — a direct OTLP export carries
+  # the app's OWN Resource, and the k8s collector's namespace enrichment applies to the LOGS it
+  # scrapes, not to spans an app posts itself.
+  #
+  # WHY here and not in `values.yaml`: Helm does not template values files, so
+  # `{{ `{{ .Release.Namespace }}` }}` written there renders as that literal string and every
+  # service reports the template source as its environment.
+  #
+  # Unlike OTEL_SERVICE_NAME above, this is NOT gated on a non-empty value: the chart knows
+  # something the code cannot — which namespace it is being installed into — so it has a
+  # meaningful default to supply rather than an empty one to avoid.
+  OTEL_RESOURCE_ATTRIBUTES: {{ .Values.tracing.resourceAttributes | default (printf "deployment.environment=%s" .Release.Namespace) | quote }}
   {{- end }}
   # NOTE: OTEL_EXPORTER_OTLP_HEADERS is deliberately ABSENT here, for the same reason as the S3
   # secret key below — it carries the collector credential.

--- a/apps/screamingface-engine/deploy/helm/values.yaml
+++ b/apps/screamingface-engine/deploy/helm/values.yaml
@@ -243,7 +243,18 @@ tavily:
 # mounted in the run mode), so configuring it there would wire up an exporter that does not
 # exist. aigateway is instrumented separately.
 tracing:
-  enabled: false
+  # ON by default (OME-1190) — deliberately, and conditionally.
+  #
+  # WHY the chart rather than the deployment's values file: ArgoCD merges chart defaults UNDER
+  # `$values/kubernetes/apps/sf-url4-cloud/values/dev.yaml` in `OpenMined/infrastructure`, so
+  # defaulting here turns tracing on with no change to that repo. An operator overrides it the
+  # normal way.
+  #
+  # ⚠️ THIS IS ONLY DEFENSIBLE WHILE THE CHART IS UNPUBLISHED, and that is a SUNSET condition.
+  # `release-screamingface-engine.yml` defers OCI Helm publishing until the NATS dependency is
+  # pinned and vendored (OME-567). The endpoint below is specific to `aks-dev`, so the day this
+  # chart ships to anyone else, BOTH lines must go back to being opt-in. Revisit with OME-567.
+  enabled: true
   # Base OTLP/HTTP endpoint, e.g. http://signoz-otel-collector.platform.svc.cluster.local:4318
   # The exporter appends `/v1/traces`. Required when enabled.
   #
@@ -254,15 +265,26 @@ tracing:
   # every span POST, succeed, and be DISCARDED, while the exporter reports perfect health and
   # the trace view stays empty. That is indistinguishable from "nobody ran anything".
   #
-  # Prefer the IN-CLUSTER Service address: it needs no credential, crosses no public network,
-  # and does not depend on an edge that can deny it. Find it with:
-  #   kubectl get svc -A | grep -i 'otel\|signoz'
-  endpoint: ""
+  # The IN-CLUSTER Service address below needs no credential, crosses no public network, and
+  # does not depend on an edge that can deny it. Confirmed from the collector's OWN startup log
+  # (`otelcol.component.id=otlp kind=receiver endpoint=[::]:4318`), not assumed from convention.
+  #
+  # CLUSTER-SPECIFIC: `aks-dev`, namespace `signoz`. See the sunset note on `enabled` above.
+  endpoint: "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
   # Reported as `service.name`. Empty => the code's own default (`screamingface-engine`).
   # Deliberately omitted from the ConfigMap when empty rather than rendered as "" — a blank
   # service name in a tracing backend is indistinguishable from an unconfigured service.
   serviceName: ""
-  # Extra OTel resource attributes as `k=v,k=v`, e.g. `deployment.environment=dev`.
+  # Extra OTel resource attributes as `k=v,k=v`.
+  #
+  # Empty does NOT mean absent here: the template defaults it to
+  # `deployment.environment=<release namespace>`, which is what keeps a preview environment's
+  # spans distinguishable from dev's. Without it they are identical — a direct OTLP export
+  # carries the app's OWN Resource, and the k8s collector's namespace enrichment applies to the
+  # LOGS it scrapes, not to spans an app posts itself.
+  #
+  # The default lives in the TEMPLATE, not here: Helm does not template values files, so
+  # `{{ .Release.Namespace }}` written at this line would render as that literal string.
   resourceAttributes: ""
   # Bring your own Secret (recommended for prod — created out-of-band or by an External Secrets
   # / Sealed Secrets flow). NOTE: it must key the value `OTEL_EXPORTER_OTLP_HEADERS`, because

--- a/apps/screamingface-engine/tests/unit/test_chart_render_tracing.py
+++ b/apps/screamingface-engine/tests/unit/test_chart_render_tracing.py
@@ -48,6 +48,15 @@ def _render(*settings: str) -> list[dict]:
     return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
 
 
+def _render_ns(namespace: str, *settings: str) -> list[dict]:
+    """Render into a specific namespace — `OME-1190`'s attribute default is derived from it."""
+    args = ["helm", "template", _RELEASE, str(_CHART), "-n", namespace, "--set-string", _NATS]
+    for setting in settings:
+        args += ["--set", setting]
+    result = subprocess.run(args, capture_output=True, text=True, check=True)
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
 def _render_error(*settings: str) -> str:
     """Render expecting REFUSAL, and return what helm said. Fails loudly if it succeeded."""
     args = ["helm", "template", _RELEASE, str(_CHART), "--set-string", _NATS]
@@ -83,23 +92,38 @@ def _pool(docs: list[dict]) -> dict:
 # --- off by default ---------------------------------------------------------------------------
 
 
-def test_tracing_is_off_by_default_and_renders_no_otlp_variables() -> None:
-    """`OME-1130` treats an absent endpoint as off, so the default chart must leave it absent.
+def test_tracing_is_ON_by_default_and_points_at_the_in_cluster_collector() -> None:
+    """INVERTED by `OME-1190`, deliberately. This used to assert off-by-default.
 
-    Asserted across the WHOLE manifest rather than one ConfigMap: a stray OTLP name anywhere
-    would turn export on for some deployment, and "off by default" is the property that keeps
-    every existing installation unaffected by this change.
+    ArgoCD merges chart defaults UNDER the deployment's values file, which lives in a repo this
+    project's agent cannot reach — so defaulting here is what actually ships tracing. Defensible
+    ONLY while the chart is unpublished; see the sunset note on `tracing.enabled` in values.yaml.
     """
-    rendered = yaml.safe_dump_all(_render())
+    data = _runner_env(_render())
 
-    for name in (ENDPOINT_VAR, HEADERS_VAR, SERVICE_VAR, ATTRIBUTES_VAR):
-        assert name not in rendered, f"{name} renders by default — tracing must be opt-in"
+    assert data[ENDPOINT_VAR] == "http://signoz-otel-collector.signoz.svc.cluster.local:4318"
 
 
-def test_the_default_values_state_tracing_is_disabled() -> None:
+def test_the_default_values_state_tracing_is_enabled() -> None:
     values = yaml.safe_load((_CHART / "values.yaml").read_text(encoding="utf-8"))
 
-    assert values["tracing"]["enabled"] is False
+    assert values["tracing"]["enabled"] is True
+
+
+def test_the_off_switch_still_works() -> None:
+    """Defaulting ON must not remove the ability to turn it OFF — an operator, or a cluster with
+    no collector, has to be able to render a chart that exports nothing."""
+    rendered = yaml.safe_dump_all(_render("tracing.enabled=false"))
+
+    for name in (ENDPOINT_VAR, HEADERS_VAR, SERVICE_VAR, ATTRIBUTES_VAR):
+        assert name not in rendered, f"{name} renders with tracing explicitly disabled"
+
+
+def test_the_default_endpoint_is_never_the_signoz_UI_hostname() -> None:
+    """The verified footgun, pinned now that the chart ships a default: the UI host answers
+    200 text/html for /v1/traces, OTel treats any 2xx as success, and every span would be
+    discarded while the exporter reported healthy."""
+    assert "signoz.pulse.dev.openmined.org" not in yaml.safe_dump_all(_render())
 
 
 # --- turning it on ------------------------------------------------------------------------
@@ -127,7 +151,7 @@ def test_enabling_tracing_without_an_endpoint_fails_the_render() -> None:
     to prevent, and it is invisible at runtime — there is no error, just an empty trace view.
     Refusing at `helm template` makes that state unrepresentable rather than merely discouraged.
     """
-    stderr = _render_error("tracing.enabled=true")
+    stderr = _render_error("tracing.enabled=true", "tracing.endpoint=")
 
     # helm renders the schema path as `/tracing/endpoint`; the property that matters is that
     # the refusal NAMES the missing value rather than saying "invalid values" and stopping.
@@ -151,6 +175,8 @@ def test_the_template_refuses_too_when_schema_validation_is_skipped() -> None:
             _NATS,
             "--set",
             "tracing.enabled=true",
+            "--set",
+            "tracing.endpoint=",
             "--skip-schema-validation",
         ],
         capture_output=True,
@@ -243,15 +269,50 @@ def test_the_service_name_and_resource_attributes_reach_the_configmap() -> None:
     assert data[ATTRIBUTES_VAR] == "deployment.environment=dev"
 
 
-def test_unset_descriptive_values_are_ABSENT_rather_than_empty() -> None:
+def test_an_unset_service_name_is_ABSENT_rather_than_empty() -> None:
     """Rendering `""` OVERRIDES the code's own default with an empty string rather than leaving
     it unset — the trap `URL4_CLOUD_ARTIFACTS_DIR` documents in this same ConfigMap, where an
     empty path silently became the working directory.
 
     Here it would report every engine span under a blank service name, which in a tracing
     backend is indistinguishable from an unconfigured service.
+
+    UNCHANGED by `OME-1190`. Its sibling assertion about `resourceAttributes` moved into the
+    tests below, because the chart gained a MEANINGFUL default for that one — it knows the
+    namespace, which the code cannot. There is no equivalent for the service name: the code
+    already has the right default, so the chart's job is to stay out of the way.
     """
     data = _runner_env(_render("tracing.enabled=true", "tracing.endpoint=http://collector:4318"))
 
     assert SERVICE_VAR not in data
-    assert ATTRIBUTES_VAR not in data
+
+
+def test_resource_attributes_default_to_the_release_NAMESPACE() -> None:
+    """OME-1190. Without this a preview environment's spans are indistinguishable from dev's:
+    a direct OTLP export carries the app's OWN Resource, and the k8s collector's namespace
+    enrichment applies to the LOGS it scrapes, not to spans an app posts itself."""
+    data = _runner_env(_render_ns("sf-fusion"))
+
+    assert data[ATTRIBUTES_VAR] == "deployment.environment=sf-fusion"
+
+
+def test_the_namespace_attribute_is_DERIVED_not_a_fixed_string() -> None:
+    """The assertion above would pass against a hardcoded `deployment.environment=sf-fusion`.
+    Two namespaces rendering differently is what proves it is computed.
+
+    It also pins the thing most likely to be got wrong: Helm does NOT template values files, so
+    `{{ .Release.Namespace }}` written in values.yaml renders as that literal string.
+    """
+    dev = _runner_env(_render_ns("sf-fusion"))[ATTRIBUTES_VAR]
+    preview = _runner_env(_render_ns("sf-preview-pr-999"))[ATTRIBUTES_VAR]
+
+    assert dev != preview
+    assert "{{" not in preview, "the values file was templated by hand and never evaluated"
+    assert preview == "deployment.environment=sf-preview-pr-999"
+
+
+def test_an_explicit_resource_attributes_value_still_wins() -> None:
+    """A default an operator cannot override is a hardcode wearing a default's clothes."""
+    data = _runner_env(_render_ns("sf-fusion", "tracing.resourceAttributes=team=platform"))
+
+    assert data[ATTRIBUTES_VAR] == "team=platform"

--- a/docs/tasks/2026-09-11-OME-1190-engine-tracing-default.md
+++ b/docs/tasks/2026-09-11-OME-1190-engine-tracing-default.md
@@ -1,0 +1,44 @@
+---
+id: OME-1190
+linear_url: https://linear.app/openmined/issue/OME-1190
+status: in_review
+type: null
+priority: 2
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-11
+closed: null
+---
+
+# Default engine tracing ON so ArgoCD ships it without an infra-repo change
+
+`OME-1131` shipped the `tracing` stanza off by default; turning it on needs four lines in a repo
+(`OpenMined/infrastructure`) the agent account cannot reach. Owner decision: default it ON in the
+chart, since ArgoCD merges chart defaults **under** the deployment's values file.
+
+Three things worth knowing before touching this area:
+
+- **⚠️ THIS HAS A SUNSET CONDITION.** Defaulting a *cluster-specific* endpoint is only
+  defensible because neither chart here is published — the engine's OCI publishing is deferred
+  (`OME-567`) and aigateway's `chart:` job only lints. **When `OME-567` lands, both
+  `tracing.enabled: true` and the hardcoded endpoint must go back to opt-in.**
+
+- **`{{ .Release.Namespace }}` must NOT go in `values.yaml`.** Helm does not template values
+  files — written there it renders as that literal string, and every service reports the
+  template source as its environment. The namespace default lives in the ConfigMap template,
+  and a test pins it (`assert "{{" not in preview`).
+
+- **`resourceAttributes` defaults but `serviceName` does not**, and the asymmetry is the point.
+  The chart knows something the code cannot — which namespace it is in — so it supplies a
+  meaningful default. For the service name the code already has the right default, so the chart
+  stays out of the way; rendering `""` there would report a blank `service.name`, which a
+  tracing backend cannot distinguish from unconfigured.
+
+**Modifies prior tests** (rule 5 Confidence-Gate, owner-approved, `--skip-append-only`): the
+off-by-default pair inverted, and the unset-descriptive-values test was SPLIT rather than
+weakened. Net assertions 12 → 17.
+
+Why previews are tagged rather than excluded: a direct OTLP export carries the app's own
+Resource, and the k8s collector's namespace enrichment applies to scraped LOGS, not to spans an
+app posts itself — so without the attribute a preview's spans are indistinguishable from dev's.
+
+Ledger: `docs/work/2026-09-11-OME-1190-engine-tracing-default.md`

--- a/docs/work/2026-09-11-OME-1190-engine-tracing-default.md
+++ b/docs/work/2026-09-11-OME-1190-engine-tracing-default.md
@@ -1,0 +1,133 @@
+---
+ticket: OME-1190
+stack: screamingface-engine
+status: done
+started: 2026-09-11
+finished: 2026-09-11
+---
+
+# OME-1190 — Default engine tracing ON so ArgoCD ships it without an infra-repo change
+
+## Intent
+
+`OME-1131` shipped the `tracing` stanza off by default, and turning it on needs four lines in
+`kubernetes/apps/sf-url4-cloud/values/dev.yaml` inside `git@github.com:OpenMined/infrastructure`
+— which this account cannot reach (full `repo` scope, but `OpenMined` is not among its orgs).
+
+Owner decision: default it ON in the chart. Helm merges chart defaults **under** the infra
+values file, so ArgoCD deploys it with no infra change, and an operator can still override.
+
+## Design decisions
+
+**D1 — this is only defensible because NEITHER chart in this repo is published, and that is a
+sunset condition, not a permanent state.** `release-screamingface-engine.yml` says OCI Helm
+publishing is DEFERRED until the NATS dependency is pinned and vendored (`OME-567`); aigateway's
+`chart:` job only lints and renders. So these charts are consumed solely by ArgoCD from this
+repo — our deployment config, not an artifact strangers install.
+
+A cluster-specific internal DNS name as a *published* chart default would be plainly wrong.
+The values file says so at the field, naming `OME-567` as the trigger to revisit.
+
+**D2 — the namespace tag lives in the TEMPLATE, not in `values.yaml`.** Helm does not template
+values files, so `{{ .Release.Namespace }}` written there renders as that literal string and the
+backend would show every service reporting `deployment.environment={{ .Release.Namespace }}`.
+The default is therefore applied where templating actually happens.
+
+**D3 — previews get tagged rather than excluded.** Defaulting on means `sf-preview-pr-*`
+namespaces export too. Their spans would otherwise be indistinguishable from dev's: a direct
+OTLP export carries the app's OWN Resource, and the k8s collector's namespace enrichment applies
+to the LOGS it scrapes, not to spans an app posts itself. So `OTEL_RESOURCE_ATTRIBUTES` defaults
+to `deployment.environment=<release namespace>`.
+
+Tagging beats excluding: a preview that exports under its own environment name is *useful*
+(you can watch a PR's traces), whereas a namespace-prefix check in a helper would put cleverness
+in the chart that nothing else there does.
+
+**D4 — `serviceName` keeps its absent-when-unset rule, and that asymmetry is deliberate.**
+An empty `OTEL_SERVICE_NAME` would override the code's own default with a blank `service.name`,
+which in a tracing backend is indistinguishable from an unconfigured service. There is no
+meaningful chart-level default for it — the code already has the right one. `resourceAttributes`
+differs precisely because the chart DOES know something the code cannot: which namespace it is
+being installed into.
+
+## ⚠️ Modifies a prior test — Confidence-Gate item, owner-approved
+
+`test_unset_descriptive_values_are_ABSENT_rather_than_empty` (merged in #908) asserts that an
+unset `resourceAttributes` renders no key. D3 makes that false on purpose.
+
+Handled by SPLITTING the test rather than weakening it:
+
+- the `serviceName` half keeps its original assertion verbatim (D4), and
+- the `resourceAttributes` half becomes a new test asserting the namespace default.
+
+Net assertions go UP, not down. Recorded here because rule 5 makes editing a prior test a
+decision to be named rather than a diff to be slipped through — the owner approved the
+behaviour change that forces it.
+
+## Planned changes
+
+- `deploy/helm/values.yaml` — `enabled: true`, the in-cluster endpoint, the sunset note.
+- `deploy/helm/templates/configmap-runner-env.yaml` — the namespace-derived attribute default.
+- `tests/unit/test_chart_render_tracing.py` — split per the note above, plus tests for the
+  new defaults and for the fact that an operator override still wins.
+
+## Test plan
+
+- The DEFAULT render (no `--set` at all) now emits `OTEL_EXPORTER_OTLP_ENDPOINT` pointed at the
+  in-cluster collector — the inverse of the old "off by default" test, which must be updated
+  rather than left asserting the opposite.
+- `OTEL_RESOURCE_ATTRIBUTES` defaults to `deployment.environment=<namespace>`, and differs
+  between two releases installed into different namespaces (proving it is derived, not fixed).
+- An explicit `resourceAttributes` still wins.
+- `serviceName` unset is still ABSENT (D4).
+- Still no Secret by default, and the pod still references none.
+- `tracing.enabled=false` still renders no OTLP names at all — the off switch must keep working.
+
+## Acceptance
+
+- `helm template` with no arguments produces a runner env pointed at the real collector.
+- `run_gates.py screamingface-engine` green.
+
+## Outcome
+
+- **Actual files:**
+  - `deploy/helm/values.yaml` — `enabled: true`, the in-cluster endpoint, the `OME-567` sunset
+    note, and a comment at `resourceAttributes` explaining why its default lives in the template.
+  - `deploy/helm/templates/configmap-runner-env.yaml` — the namespace-derived attribute default.
+  - `tests/unit/test_chart_render_tracing.py` — 12 tests → **17**.
+
+- **Gates:** `run_gates.py screamingface-engine --skip-append-only` **ALL GREEN** — ruff
+  check/format, pyright, `check_layering.py`, pytest+coverage.
+
+- **The append-only gate fired, and that is the point of it.** Rule 5 makes editing a prior
+  test a Confidence-Gate decision. The decision was named BEFORE the work (see the ⚠️ section
+  above and `OME-1190`'s description), the owner chose the behaviour that forces it, and the
+  override is the sanctioned `--skip-append-only` rather than a weakened assertion. Net
+  assertions went UP: 12 → 17.
+
+  What actually changed in prior tests:
+  - `test_tracing_is_off_by_default_…` → `…is_ON_by_default_…` (the behaviour inverted on
+    purpose), with a NEW `test_the_off_switch_still_works` preserving the old property under an
+    explicit `enabled=false`.
+  - `test_unset_descriptive_values_are_ABSENT_rather_than_empty` SPLIT: the `serviceName` half
+    kept verbatim, the `resourceAttributes` half replaced by three stronger tests.
+  - Two refusal tests now pass `tracing.endpoint=` explicitly, because the chart ships an
+    endpoint and `enabled=true` alone no longer produces the empty-endpoint state they test.
+
+- **Verification beyond the gates — four mutations, four killed:**
+  - namespace attribute hardcoded to `sf-fusion` instead of derived → killed
+  - the default made unconditional so an operator override is ignored → killed
+  - default endpoint swapped to the SigNoz **UI** hostname → killed
+  - the `enabled` guard forced true so the off switch stops working → killed
+
+- **Deviations:**
+  - **`{{ .Release.Namespace }}` cannot go in `values.yaml`.** Helm does not template values
+    files; written there it renders as that literal string and every service reports the
+    template source as its environment. A test pins this (`assert "{{" not in preview`).
+  - **The default render's namespace is `default`** when `helm template` is called with no
+    `-n`. Harmless — ArgoCD always supplies one — but it means the bare-render test asserts the
+    endpoint rather than the attribute, and the attribute has namespace-specific tests instead.
+  - **This change has a sunset condition, not an indefinite life.** It is defensible only while
+    the chart is unpublished (`OME-567`). Stated at the field, in the ticket, and here.
+  - **aigateway's equivalent is NOT in this PR** — it needs `OME-1184` (#919) merged first,
+    since that is what adds the stanza this would default. No stacked PRs in a squash repo.


### PR DESCRIPTION
**This is the PR that unblocks Phase 2 without infra-repo access.**

`OME-1131` shipped the engine's `tracing` stanza off by default. Turning it on needs four lines in `kubernetes/apps/sf-url4-cloud/values/dev.yaml` inside `git@github.com:OpenMined/infrastructure` — which this account cannot reach (full `repo` scope, but `OpenMined` is not among its orgs).

ArgoCD merges chart defaults **under** that values file. So defaulting here ships tracing with no infra change, and an operator still overrides it normally.

```yaml
tracing:
  enabled: true
  endpoint: http://signoz-otel-collector.signoz.svc.cluster.local:4318
```

Collector confirmed from its **own startup log** (`otelcol.component.id=otlp kind=receiver endpoint=[::]:4318`), namespace `signoz`, cluster `aks-dev`. No credential — no Secret renders.

## ⚠️ This has a sunset condition, not an indefinite life

Defaulting a **cluster-specific** endpoint is defensible only because neither chart in this repo is published: the engine's OCI publishing is deferred until the NATS dependency is pinned and vendored (`release-screamingface-engine.yml`, **`OME-567`**), and aigateway's `chart:` job only lints and renders. These charts are consumed solely by ArgoCD from this repo.

**When `OME-567` lands, both `enabled: true` and the hardcoded endpoint must go back to opt-in.** Stated at the field in `values.yaml`, in the ticket, and in the ledger.

## Previews are tagged, not excluded

Defaulting on means `sf-preview-pr-*` namespaces export too, and their spans would otherwise be **indistinguishable from dev's** — a direct OTLP export carries the app's own Resource, and the k8s collector's namespace enrichment applies to the LOGS it scrapes, not to spans an app posts itself.

So `OTEL_RESOURCE_ATTRIBUTES` defaults to `deployment.environment=<release namespace>`. Tagging beats excluding: a preview exporting under its own environment name is *useful*, and a namespace-prefix check would put cleverness in the chart that nothing else there does.

**The default lives in the TEMPLATE, not `values.yaml`** — Helm does not template values files, so `{{ .Release.Namespace }}` written there renders as that literal string and every service would report the template source as its environment. A test pins exactly that (`assert "{{" not in preview`).

## ⚠️ Modifies prior tests — rule 5 Confidence-Gate, owner-approved

The append-only gate fired, which is the point of it. The decision was named **before** the work (in `OME-1190`'s description and the ledger), the owner chose the behaviour that forces it, and the override is the sanctioned `--skip-append-only` — not a weakened assertion.

**Net assertions went UP: 12 → 17.**

| prior test | what happened |
|---|---|
| `test_tracing_is_off_by_default_…` | inverted to `…is_ON_by_default_…`; the old property preserved as a NEW `test_the_off_switch_still_works` under explicit `enabled=false` |
| `test_unset_descriptive_values_are_ABSENT_rather_than_empty` | **split** — `serviceName` half kept verbatim, `resourceAttributes` half replaced by three stronger tests |
| the two refusal tests | now pass `tracing.endpoint=` explicitly, since `enabled=true` alone no longer produces the empty-endpoint state they test |

`serviceName` deliberately keeps its absent-when-unset rule: the code already has the right default, and rendering `""` would report a blank `service.name` — indistinguishable from unconfigured. `resourceAttributes` differs because the chart knows something the code cannot: its namespace.

## Test plan

- `run_gates.py screamingface-engine --skip-append-only` **ALL GREEN**. 17 chart tests.
- **Four mutations, four killed** — namespace attribute hardcoded instead of derived; the default made unconditional so an override is ignored; default endpoint swapped to the SigNoz **UI** hostname; the `enabled` guard forced true so the off switch breaks.
- Rendered by eye: bare `helm template` emits the in-cluster endpoint; `-n sf-fusion` and `-n sf-preview-pr-999` produce different `deployment.environment` values.

## Note

aigateway's equivalent is **not** here — it needs #919 (`OME-1184`) merged first, since that is what adds the stanza this would default. No stacked PRs in a squash repo.

Ledger: `docs/work/2026-09-11-OME-1190-engine-tracing-default.md`

Refs: OME-1190
