### PR TITLE
feat(scoreboard): accept and classify declared model identities

### DIFF
--- a/apps/scoreboard/src/scoreboard/classification/openness.py
+++ b/apps/scoreboard/src/scoreboard/classification/openness.py
@@ -46,37 +46,51 @@ _OPEN_BASELINE_MARKERS: tuple[str, ...] = ("llama", "mistral", "qwen", "deepseek
 # describe PROVIDERS and keep serving `classify_providers` unchanged.
 ModelOpenness = Literal["open", "closed", "unknown"]
 
-# WHY a separate list rather than more entries in _OPEN_PROVIDER_MARKERS: these are the
-# vendors that ship BOTH. Every marker here names a model family whose OWNER is on the closed
-# list, so it must be consulted before the owner rule or the owner wins and an open-weights
-# model is published as closed. That is the OME-1145 defect, and on the live draco-3pass board
-# `moonshotai`/`kimi` alone is the difference between 0% and 29%.
+# INVARIANT: model routes are CLIENT-SUBMITTED, so this is an adversarial surface and the rules
+# below are STRUCTURAL, never substring. An earlier version matched any open marker anywhere in
+# the route, which let a submitter name a proprietary model `not-gemma-proprietary` and be
+# published as open — the fail-closed contract inverted by choosing a string (review of PR #922).
 #
-# INVARIANT (OME-1179 Q1): membership here means "weights are downloadable and locally
-# runnable", NOT "permissively licensed". Gemma carries use restrictions and gpt-oss a usage
-# policy; both are still open under the chosen definition, because the board's claim is
-# reproducibility — can someone else run this and get your number.
-_OPEN_MODEL_MARKERS: tuple[str, ...] = (
-    "gpt-oss",
-    "gemma",
-    "moonshotai",
-    "kimi",
+# A route is `owner/model`. The OWNER segment decides, matched exactly.
+_OPEN_OWNERS: frozenset[str] = frozenset(
+    {
+        "meta-llama",
+        "mistralai",
+        "qwen",
+        "deepseek",
+        "moonshotai",
+        "huggingface",
+        # A locally-run model is the definition of downloadable-and-runnable under Q1.
+        "ollama",
+    }
 )
+_CLOSED_OWNERS: frozenset[str] = frozenset(
+    {
+        "openai",
+        "anthropic",
+        "google",
+        "gemini",
+        "cohere",
+        "xai",
+    }
+)
+
+# The vendors that ship BOTH. A family exception is SCOPED TO ITS OWNER and matched as a prefix
+# of the model segment, so `google/gemma-*` is open while `openai/gemma-anything` is not —
+# Google ships Gemma's weights, OpenAI does not.
+#
+# INVARIANT (OME-1179 Q1): membership means "weights are downloadable and locally runnable", NOT
+# "permissively licensed". Gemma carries use restrictions and gpt-oss a usage policy; both are
+# still open under the chosen definition, because the board's claim is reproducibility.
+_OPEN_FAMILIES_BY_OWNER: dict[str, tuple[str, ...]] = {
+    "openai": ("gpt-oss",),
+    "google": ("gemma",),
+}
 
 # WHY: a routing prefix says who carried the request, not what ran. Every live draco-3pass
-# route is `openrouter/`-prefixed and `openrouter` is a closed PROVIDER marker, so without
-# stripping this every model on the board classifies closed however open its weights are.
-_ROUTING_PREFIXES: tuple[str, ...] = ("openrouter",)
-
-# INVARIANT: ORDER IS THE RULE. `classify_model` returns on the first match, so the specific
-# model markers must sit above the owner markers — `gpt-oss` before `openai`, `gemma` before
-# `google`. Reordering these three entries silently reintroduces OME-1145. Expressed as data
-# rather than an if-chain so the precedence is visible in one place and testable.
-_MODEL_RULES: tuple[tuple[tuple[str, ...], ModelOpenness], ...] = (
-    (_OPEN_MODEL_MARKERS, "open"),
-    (_OPEN_PROVIDER_MARKERS, "open"),
-    (_CLOSED_PROVIDER_MARKERS, "closed"),
-)
+# route is `openrouter/`-prefixed, so without stripping this the owner segment would always
+# read `openrouter` and no model could ever be classified at all.
+_ROUTING_PREFIXES: frozenset[str] = frozenset({"openrouter"})
 
 
 def _matches_any(name: str, markers: tuple[str, ...]) -> bool:
@@ -113,11 +127,18 @@ def classify_providers(providers: Sequence[str]) -> Openness:
     return "closed" if saw_closed else "open"
 
 
-def _strip_routing_prefix(route: str) -> str:
-    head, separator, tail = route.partition("/")
-    if separator and head.lower() in _ROUTING_PREFIXES:
-        return tail
-    return route
+def _split_route(route: str) -> tuple[str, str] | None:
+    """`owner/model` for a route, after dropping any routing prefix. None if it has no owner.
+
+    A bare `claude-opus-4.8` carries no owner to reason about, and guessing from the string is
+    exactly the hole this parsing closes, so the caller fails closed on None.
+    """
+    segments = [segment for segment in route.lower().split("/") if segment]
+    if segments and segments[0] in _ROUTING_PREFIXES:
+        segments = segments[1:]
+    if len(segments) < 2:
+        return None
+    return segments[0], "/".join(segments[1:])
 
 
 def classify_model(route: str) -> ModelOpenness:
@@ -127,20 +148,36 @@ def classify_model(route: str) -> ModelOpenness:
     its provider prefixes. OME-1179 D1 keeps that any-closed-wins aggregation; this only
     changes what gets fed to it.
 
+    INVARIANT: STRUCTURAL, never substring. Routes are client-submitted, so any rule that reads
+    the whole string lets a submitter buy a verdict by naming their model after an open family
+    — `openai/not-gemma-proprietary` classified open under the first version of this function
+    (review of PR #922). The owner segment decides, matched exactly; a family exception must
+    belong to that owner.
+
     INVARIANT: `unknown` is a THIRD value, not a synonym for `closed`. Both close an entry
     under D1, but D4 requires the count of unrecognised models to be reportable, which is
     impossible once the two collapse into one verdict.
-
-    WHY this resolution order: a specific model rule must beat its owner rule. `gpt-oss` is
-    OpenAI's and `gemma` is Google's, so checking `_CLOSED_PROVIDER_MARKERS` first would file
-    both as closed on the owner's name while their weights are downloadable.
     """
-    identity = _strip_routing_prefix(route)
-    for markers, verdict in _MODEL_RULES:
-        if _matches_any(identity, markers):
-            return verdict
-    _log_unrecognized("model route", route)
-    return "unknown"
+    verdict = _owner_verdict(_split_route(route))
+    if verdict == "unknown":
+        _log_unrecognized("model route", route)
+    return verdict
+
+
+def _owner_verdict(parsed: tuple[str, str] | None) -> ModelOpenness:
+    """The rules themselves, so `classify_model` stays one decision and one log.
+
+    INVARIANT: the family exception is consulted FIRST and is scoped to its owner. Reversing
+    these two lines files `openai/gpt-oss-120b` as closed on its owner's name; widening the
+    family check beyond `_OPEN_FAMILIES_BY_OWNER[owner]` re-opens the crafted-name hole.
+    """
+    if parsed is None:
+        return "unknown"
+    owner, model = parsed
+    families = _OPEN_FAMILIES_BY_OWNER.get(owner, ())
+    if any(model.startswith(family) for family in families) or owner in _OPEN_OWNERS:
+        return "open"
+    return "closed" if owner in _CLOSED_OWNERS else "unknown"
 
 
 def classify_baseline_name(model_name: str) -> Openness:

--- a/apps/scoreboard/src/scoreboard/classification/openness.py
+++ b/apps/scoreboard/src/scoreboard/classification/openness.py
@@ -64,14 +64,30 @@ _OPEN_OWNERS: frozenset[str] = frozenset(
         "ollama",
     }
 )
+# INVARIANT: every `custom_llm_provider` the Gateway registers belongs in one of these two sets,
+# or an ordinary supported provider reports as a registry gap. `unknown` and `closed` both close
+# an entry under OME-1179 D1, so a miss here changes no percentage — it corrupts D4's staleness
+# count, which is only meaningful if it means "models the registry has not been taught about".
+#
+# Verified against `apps/aigateway/src/aigateway/plugins/*_provider/plugin.py`: the registered
+# ids are openai, anthropic, gemini-cli, codex, antigravity, huggingface, ollama, openrouter.
+# `gemini-cli`, `codex` and `antigravity` were missing (review of PR #922).
+#
+# AIDEV-NOTE: an owner segment is a Gateway provider id on a direct route, and a model owner on
+# an OpenRouter-carried one (`openrouter/google/...`), so both kinds live here. Entries are only
+# added once observed in one of those two places — an earlier version carried `cohere` and `xai`,
+# neither registered by the Gateway nor OpenRouter's actual namespace, which is `x-ai`.
 _CLOSED_OWNERS: frozenset[str] = frozenset(
     {
+        # Gateway provider ids
         "openai",
         "anthropic",
+        "gemini-cli",
+        "codex",
+        "antigravity",
+        # Model owners as they appear on OpenRouter routes
         "google",
         "gemini",
-        "cohere",
-        "xai",
     }
 )
 

--- a/apps/scoreboard/src/scoreboard/classification/openness.py
+++ b/apps/scoreboard/src/scoreboard/classification/openness.py
@@ -42,6 +42,42 @@ _OPEN_PROVIDER_MARKERS: tuple[str, ...] = (
 _CLOSED_BASELINE_MARKERS: tuple[str, ...] = ("gpt-", "claude-", "gemini-")
 _OPEN_BASELINE_MARKERS: tuple[str, ...] = ("llama", "mistral", "qwen", "deepseek")
 
+# FEATURE: OME-1181 — per-model classification, for `classify_model` only. The lists above
+# describe PROVIDERS and keep serving `classify_providers` unchanged.
+ModelOpenness = Literal["open", "closed", "unknown"]
+
+# WHY a separate list rather than more entries in _OPEN_PROVIDER_MARKERS: these are the
+# vendors that ship BOTH. Every marker here names a model family whose OWNER is on the closed
+# list, so it must be consulted before the owner rule or the owner wins and an open-weights
+# model is published as closed. That is the OME-1145 defect, and on the live draco-3pass board
+# `moonshotai`/`kimi` alone is the difference between 0% and 29%.
+#
+# INVARIANT (OME-1179 Q1): membership here means "weights are downloadable and locally
+# runnable", NOT "permissively licensed". Gemma carries use restrictions and gpt-oss a usage
+# policy; both are still open under the chosen definition, because the board's claim is
+# reproducibility — can someone else run this and get your number.
+_OPEN_MODEL_MARKERS: tuple[str, ...] = (
+    "gpt-oss",
+    "gemma",
+    "moonshotai",
+    "kimi",
+)
+
+# WHY: a routing prefix says who carried the request, not what ran. Every live draco-3pass
+# route is `openrouter/`-prefixed and `openrouter` is a closed PROVIDER marker, so without
+# stripping this every model on the board classifies closed however open its weights are.
+_ROUTING_PREFIXES: tuple[str, ...] = ("openrouter",)
+
+# INVARIANT: ORDER IS THE RULE. `classify_model` returns on the first match, so the specific
+# model markers must sit above the owner markers — `gpt-oss` before `openai`, `gemma` before
+# `google`. Reordering these three entries silently reintroduces OME-1145. Expressed as data
+# rather than an if-chain so the precedence is visible in one place and testable.
+_MODEL_RULES: tuple[tuple[tuple[str, ...], ModelOpenness], ...] = (
+    (_OPEN_MODEL_MARKERS, "open"),
+    (_OPEN_PROVIDER_MARKERS, "open"),
+    (_CLOSED_PROVIDER_MARKERS, "closed"),
+)
+
 
 def _matches_any(name: str, markers: tuple[str, ...]) -> bool:
     lowered = name.lower()
@@ -75,6 +111,36 @@ def classify_providers(providers: Sequence[str]) -> Openness:
             _log_unrecognized("provider", provider)
             saw_closed = True
     return "closed" if saw_closed else "open"
+
+
+def _strip_routing_prefix(route: str) -> str:
+    head, separator, tail = route.partition("/")
+    if separator and head.lower() in _ROUTING_PREFIXES:
+        return tail
+    return route
+
+
+def classify_model(route: str) -> ModelOpenness:
+    """Openness of ONE declared model route (OME-1181).
+
+    Distinct from `classify_providers`, which returns one verdict for a whole submission from
+    its provider prefixes. OME-1179 D1 keeps that any-closed-wins aggregation; this only
+    changes what gets fed to it.
+
+    INVARIANT: `unknown` is a THIRD value, not a synonym for `closed`. Both close an entry
+    under D1, but D4 requires the count of unrecognised models to be reportable, which is
+    impossible once the two collapse into one verdict.
+
+    WHY this resolution order: a specific model rule must beat its owner rule. `gpt-oss` is
+    OpenAI's and `gemma` is Google's, so checking `_CLOSED_PROVIDER_MARKERS` first would file
+    both as closed on the owner's name while their weights are downloadable.
+    """
+    identity = _strip_routing_prefix(route)
+    for markers, verdict in _MODEL_RULES:
+        if _matches_any(identity, markers):
+            return verdict
+    _log_unrecognized("model route", route)
+    return "unknown"
 
 
 def classify_baseline_name(model_name: str) -> Openness:

--- a/apps/scoreboard/src/scoreboard/scores/migrations/0013_score_models.py
+++ b/apps/scoreboard/src/scoreboard/scores/migrations/0013_score_models.py
@@ -1,0 +1,29 @@
+from tortoise import fields, migrations
+from tortoise.migrations import operations as ops
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("models", "0012_score_authors"),
+    ]
+
+    initial = False
+
+    # FEATURE: OME-1181 — the candidate's declared model routes.
+    #
+    # WHY nullable and deliberately NOT backfilled: the routes cannot be reconstructed from
+    # `ran_with_providers`, because the Client's truncation to a provider prefix is lossy —
+    # ["openrouter"] could have been any models at all. NULL therefore means "not declared",
+    # and the openness statistic excludes such a row from its numerator AND denominator rather
+    # than counting it closed (OME-1179 contract).
+    #
+    # Rows fill in as submitters re-run once OME-1180 ships: a same-owner replay may enrich a
+    # null value (OME-1179 Q3, owner 2026-09-11). Backfilling the existing rows from
+    # `url4_expression` was considered and left out of scope.
+    operations = [
+        ops.AddField(
+            model_name="Score",
+            name="models",
+            field=fields.JSONField(null=True),
+        ),
+    ]

--- a/apps/scoreboard/src/scoreboard/scores/models/score.py
+++ b/apps/scoreboard/src/scoreboard/scores/models/score.py
@@ -20,6 +20,24 @@ class BaseScore(BaseScoreboardModel):
     # specify authors, so read DTOs derive [submitted_by] for backwards compatibility; an
     # explicit JSON list is the exact credit line and is never auto-expanded.
     authors = fields.JSONField(null=True)
+    # FEATURE: OME-1181 — the candidate's DECLARED model routes, e.g.
+    # ["openrouter/deepseek/deepseek-v4-pro", "openrouter/qwen/qwen3.6-plus"].
+    #
+    # WHY this exists when `ran_with_providers` already does: the Client truncates each route
+    # to its first path segment, so a fusion of deepseek, kimi and qwen arrives as
+    # ["openrouter"] and classifies closed. The provider says who carried the request; this
+    # says what ran (OME-1145).
+    #
+    # WHY nullable and not backfilled: every existing row predates the Client that sends these
+    # (OME-1180), and the routes cannot be recovered from `ran_with_providers` — the truncation
+    # is lossy. NULL means "not declared", and such a row is excluded from the openness
+    # statistic's numerator AND denominator rather than counted as closed.
+    #
+    # AIDEV-NOTE: declared, not observed. These are the routes the recipe composes
+    # (`CandidateResult.models`), not the provider responses the run actually selected. A
+    # fallback model that never fired still appears here, which is correct for a statistic
+    # about what a system is made of.
+    models = fields.JSONField(null=True)
     submitted_at = fields.DatetimeField(auto_now_add=True)
     score = fields.FloatField()  # the exact primary score the Engine Benchmark produced
     total_questions = fields.IntField()

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -228,6 +228,26 @@ SubmittedBy = Annotated[
 _AUTHORS_MAX_BYTES = 4096
 _AUTHORS_MAX_DISTINCT = 10
 
+# FEATURE: OME-1181 — the declared candidate model routes.
+#
+# WHY a count cap AND a byte cap: 32 routes of 255 characters is still 8 KiB of
+# client-controlled text arriving on a public write path. Same reasoning and the
+# same envelope as `authors` above and `metadata`.
+#
+# WHY 32: the live maximum on any board is 4 (a three-member fusion plus its
+# synthesizer). A recipe naming 32 distinct models is already implausible, so the
+# cap bounds the payload without constraining any real submission.
+_MODELS_MAX_ROUTES = 32
+_MODELS_MAX_BYTES = 4096
+
+# INVARIANT: this mirrors the Client's own route grammar (`_MODEL_ROUTE_RE` in
+# `packages/screamingface/.../_evaluation/candidate.py:429`), anchored. The two ends must agree
+# on what a route is, or the Client compiles an expression the board then rejects at submit —
+# a failure that would only appear in the field, after a release.
+_MODEL_ROUTE_PATTERN = r"^[A-Za-z0-9\-_.~]+(?:/[A-Za-z0-9\-_.~]+)*$"
+
+ModelRoute = Annotated[str, Field(max_length=255, pattern=_MODEL_ROUTE_PATTERN)]
+
 
 def _author_identity(author: str) -> str:
     """The one comparison identity for author validation and publication."""
@@ -341,6 +361,22 @@ class ScoreSubmission(BaseModel):
     # None means the client did not specify a credit line; reads then derive [submitted_by].
     # An explicit list is exact — the submitter is not auto-added (OME-1051 D1).
     authors: Annotated[list[AuthorEmail], Field(min_length=1)] | None = None
+    # FEATURE: OME-1181 — the candidate's DECLARED model routes, as composed in the recipe.
+    #
+    # WHY optional: this field deploys BEFORE the Client that populates it (OME-1179
+    # constraint 1). `extra="forbid"` above means the rollout is one-directional — a Client
+    # sending an unknown field to an older board gets a 422 — so the board must tolerate its
+    # absence or the deploy order reverses and every in-field submission breaks.
+    #
+    # INVARIANT: `None` and `[]` are different. None is "the client did not send them"; an
+    # empty list would claim the run used no models at all, which no real submission can mean
+    # (`CandidateResult.models` is required and non-empty at the Client) and which would store
+    # an unclassifiable row that looks populated.
+    #
+    # AIDEV-NOTE: deliberately absent from `_content_hash`. These routes are a richer
+    # projection of what `url4_expression` already carries, and that IS hashed — see the
+    # invariant on `_content_hash` in store.py before changing this.
+    models: Annotated[list[ModelRoute], Field(min_length=1)] | None = None
     # the exact primary score the Engine Benchmark produced — any
     # finite number, higher is better
     score: Annotated[float, Field(strict=True, allow_inf_nan=False)]
@@ -392,6 +428,20 @@ class ScoreSubmission(BaseModel):
         encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode()
         if len(encoded) > _AUTHORS_MAX_BYTES:
             raise ValueError(f"authors must serialize to at most {_AUTHORS_MAX_BYTES} bytes")
+        return value
+
+    @field_validator("models")
+    @classmethod
+    def validate_bounded_models(cls, value: list[str] | None) -> list[str] | None:
+        # INVARIANT: both caps are needed. The route count alone still admits 32 maximum-length
+        # routes, and the byte cap alone still admits thousands of short ones.
+        if value is None:
+            return value
+        if len(value) > _MODELS_MAX_ROUTES:
+            raise ValueError(f"models must name at most {_MODELS_MAX_ROUTES} routes")
+        encoded = json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode()
+        if len(encoded) > _MODELS_MAX_BYTES:
+            raise ValueError(f"models must serialize to at most {_MODELS_MAX_BYTES} bytes")
         return value
 
     @field_validator("run_cost_usd")
@@ -488,6 +538,15 @@ class ScoreSchema(BaseModel):
     url4_expression: str
     submitted_by: SubmittedBy
     authors: Authors = None
+    # FEATURE: OME-1181 — the declared candidate model routes, for classification.
+    #
+    # INVARIANT (OME-1179 Q2, owner 2026-09-11): this is the INTERNAL read DTO. `models` is
+    # deliberately NOT on `LeaderboardEntry`, the public payload. The identities are already
+    # public inside `url4_expression`, so this is not a disclosure decision — it is an API
+    # commitment, and a typed field that returns null on every row until OME-1180 ships and
+    # submitters re-run is worse than no field. Widen the public payload when there is a
+    # consumer and real data behind it.
+    models: list[str] | None = None
     submitted_at: datetime
     score: float
     total_questions: int

--- a/apps/scoreboard/src/scoreboard/scores/schemas.py
+++ b/apps/scoreboard/src/scoreboard/scores/schemas.py
@@ -540,13 +540,18 @@ class ScoreSchema(BaseModel):
     authors: Authors = None
     # FEATURE: OME-1181 — the declared candidate model routes, for classification.
     #
-    # INVARIANT (OME-1179 Q2, owner 2026-09-11): this is the INTERNAL read DTO. `models` is
-    # deliberately NOT on `LeaderboardEntry`, the public payload. The identities are already
-    # public inside `url4_expression`, so this is not a disclosure decision — it is an API
-    # commitment, and a typed field that returns null on every row until OME-1180 ships and
-    # submitters re-run is worse than no field. Widen the public payload when there is a
-    # consumer and real data behind it.
-    models: list[str] | None = None
+    # INVARIANT: EXCLUDED WHEN ABSENT, like `ranking_notice` below and for the same reason.
+    # This schema is NOT internal — it is the response model for `POST /scores` and
+    # `GET /scores/{id}`, and it also feeds the private JSONL export, whose exact bytes
+    # `purge_private_benchmark.export_sha256` hashes to authorize a destructive purge against
+    # an operator-supplied digest. Emitting `"models": null` would change every export saved
+    # before this field existed, with no underlying row having changed, so a previously
+    # certified export could no longer authorize its own purge (review of PR #922).
+    #
+    # `models` stays off `LeaderboardEntry`, the ranked-board payload (OME-1179 Q2). That
+    # decision recorded this schema as internal, which was wrong; the exclusion below is what
+    # actually keeps the absent case off the wire.
+    models: list[str] | None = Field(default=None, exclude_if=lambda value: value is None)
     submitted_at: datetime
     score: float
     total_questions: int

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import Any, NamedTuple, cast
@@ -41,6 +42,12 @@ _NULLABLE_RAW_FIELDS = frozenset({"authors", "run_cost_usd"})
 logger = logging.getLogger(__name__)
 
 IDEMPOTENCY_TTL = timedelta(hours=24)
+
+# INVARIANT: the id set handed to `models_for_score_ids` is as large as the board, because the
+# Pareto frontier is neither small nor bounded — every best-per-spec point can be non-dominated
+# and spec ids are client-controlled. A single `WHERE id IN (...)` would eventually exceed the
+# driver's bind-parameter limit (SQLite's default is 999), at a board size no test reproduces.
+_MODELS_READ_CHUNK = 500
 
 
 class _Unset:
@@ -147,6 +154,46 @@ def _derived_providers(submission: ScoreSubmission) -> list[str]:
     # Order is part of what happened rather than incidental serialization (OME-391), so first
     # appearance wins and repeats collapse — the same rule the Client's own `_providers` uses.
     return list(dict.fromkeys(route.split("/", 1)[0] for route in submission.models))
+
+
+def _replay_updates(submission: ScoreSubmission) -> dict[str, object]:
+    """The ONLY fields a replay of an existing recipe may correct on the stored row.
+
+    FEATURE: OME-1054 — recipe identity deliberately excludes mutable provenance, so a
+    corrected credit line or metadata object updates the deduped row rather than pretending
+    success while discarding the correction.
+
+    INVARIANT: this is an allowlist, and its caller has already established that the replay
+    comes from the ORIGINAL submitter of the same recipe on the same benchmark. Nothing outside
+    this function may be written on the replay path, and nothing here may be written without
+    that guard — a public content hash is global across submitters, so anyone who copied a
+    team's candidate could otherwise rewrite that team's row.
+
+    INVARIANT: `None` means "not specified", so an older client replaying cannot erase newer
+    provenance. Empty containers stay meaningful explicit replacements where the wire contract
+    permits them (`metadata` may be `{}`; `authors=[]` and `models=[]` are rejected at
+    validation).
+    """
+    updates: dict[str, object] = {}
+    if submission.authors is not None:
+        updates["authors"] = submission.authors
+    if submission.metadata is not None:
+        updates["metadata"] = submission.metadata
+    # FEATURE: OME-1181 — how a row submitted before OME-1180 ever becomes classifiable.
+    # Without this a submitter who re-runs is deduplicated to their old row and the routes are
+    # discarded, leaving the board a permanent population the openness statistic cannot read.
+    #
+    # WHY accepting a changed value is safe rather than needing fill-if-null: `models` is
+    # deterministic for a given `content_hash`, which covers `url4_expression`, and the routes
+    # are a projection of that same recipe. A replay carrying different routes under the same
+    # hash is an inconsistent client, not a legitimate correction — and the same-owner guard
+    # means it can only ever be inconsistent with itself.
+    if submission.models is not None:
+        updates["models"] = submission.models
+        # The stored providers are derived from the routes (`_derived_providers`), so a replay
+        # that corrects one must correct the other or the two drift apart on this path alone.
+        updates["ran_with_providers"] = _derived_providers(submission)
+    return updates
 
 
 def _resolved_authors(authors: list[str] | None, submitted_by: str | None) -> list[str] | None:
@@ -864,29 +911,20 @@ class ScoreStore:
         if readable is None:
             raise BenchmarkVisibilityChanged(cast(str, getattr(existing, "benchmark_id")))
 
-        # FEATURE: OME-1054 — recipe identity deliberately excludes mutable provenance. A
-        # corrected explicit author list or metadata object therefore updates the deduped row,
-        # rather than pretending success while discarding the correction.
-        #
         # INVARIANT: a public content hash is global across submitters. Requiring the SAME stored
         # hash, benchmark and submitter prevents someone who copied another team's candidate (or
         # merely reused its idempotency key) from rewriting that team's credit. In production the
         # submitter is mesh-verified; disabled mode explicitly trusts this field for development.
-        updates: dict[str, object] = {}
+        #
+        # This guard is the ONLY thing standing between a replay and `_replay_updates`' field
+        # allowlist — read that function before widening either.
         same_candidate_owner = (
             existing.content_hash == content_hash
             and cast(str, getattr(existing, "benchmark_id")) == submission.benchmark_id
             and submission.submitted_by is not None
             and existing.submitted_by == submission.submitted_by
         )
-        if same_candidate_owner:
-            # None means "not specified", so an old client replay cannot erase newer provenance.
-            # Empty containers remain meaningful explicit replacements where the wire contract
-            # permits them (metadata may be {}, while authors=[] is rejected at validation).
-            if submission.authors is not None:
-                updates["authors"] = submission.authors
-            if submission.metadata is not None:
-                updates["metadata"] = submission.metadata
+        updates = _replay_updates(submission) if same_candidate_owner else {}
 
         if not updates:
             return readable
@@ -1269,6 +1307,31 @@ class ScoreStore:
             Score.filter(benchmark_id=benchmark_id).using_db(using_db).order_by("submitted_at")
         )
         return [_score_to_schema(score) for score in rows]
+
+    async def models_for_score_ids(self, score_ids: Sequence[str]) -> dict[str, list[str] | None]:
+        """Declared model routes for a given set of score ids, read in chunks.
+
+        FEATURE: OME-1181 — the second query behind the openness statistic. Membership comes
+        from `leaderboard_pareto_inputs` + `compute_pareto_frontier_ids`, which stay minimal;
+        this fills in only what those deliberately omit.
+
+        INVARIANT: selects `id` and `models` and nothing else. `leaderboard.py:270-275` records
+        why the whole-board read is minimal — client-controlled recipes and display metadata
+        must never be materialised en masse. This read is scoped to the frontier rather than the
+        board, but the frontier is still unbounded, so the same rule applies. Do NOT widen it
+        into a general row fetch.
+
+        An id with no row is simply absent from the result; a row with no declared routes maps
+        to `None`, which is not the same as absent and must stay distinguishable — the contract
+        excludes undeclared rows from the statistic rather than counting them closed.
+        """
+        found: dict[str, list[str] | None] = {}
+        for start in range(0, len(score_ids), _MODELS_READ_CHUNK):
+            chunk = score_ids[start : start + _MODELS_READ_CHUNK]
+            rows = await Score.filter(id__in=chunk).values("id", "models")
+            for row in rows:
+                found[str(row["id"])] = cast("list[str] | None", row["models"])
+        return found
 
     async def mark_verified(self, score_id: UUID | str) -> None:
         await Score.filter(id=score_id).update(verified_by_screamingface=True)

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -156,7 +156,7 @@ def _derived_providers(submission: ScoreSubmission) -> list[str]:
     return list(dict.fromkeys(route.split("/", 1)[0] for route in submission.models))
 
 
-def _replay_updates(submission: ScoreSubmission) -> dict[str, object]:
+def _replay_updates(submission: ScoreSubmission, existing: Score) -> dict[str, object]:
     """The ONLY fields a replay of an existing recipe may correct on the stored row.
 
     FEATURE: OME-1054 — recipe identity deliberately excludes mutable provenance, so a
@@ -183,15 +183,20 @@ def _replay_updates(submission: ScoreSubmission) -> dict[str, object]:
     # Without this a submitter who re-runs is deduplicated to their old row and the routes are
     # discarded, leaving the board a permanent population the openness statistic cannot read.
     #
-    # WHY accepting a changed value is safe rather than needing fill-if-null: `models` is
-    # deterministic for a given `content_hash`, which covers `url4_expression`, and the routes
-    # are a projection of that same recipe. A replay carrying different routes under the same
-    # hash is an inconsistent client, not a legitimate correction — and the same-owner guard
-    # means it can only ever be inconsistent with itself.
-    if submission.models is not None:
+    # INVARIANT: FILL ONLY, never replace. `_content_hash` excludes `models`, so two
+    # submissions differing only in their routes share one identity — an earlier version
+    # updated unconditionally, which let a replay swap what an entry is made of, and so flip
+    # its published openness, without changing its identity or its url4 expression (review of
+    # PR #922). A conflicting populated value is retained, not overwritten: enrichment fills a
+    # gap, it does not arbitrate between two claims.
+    #
+    # WHY this is not merely defence against a hostile client: the same-owner guard already
+    # limits it to the original submitter. It is defence against the field becoming a way to
+    # rewrite a published verdict at all, by anyone, including by accident.
+    if submission.models is not None and existing.models is None:
         updates["models"] = submission.models
         # The stored providers are derived from the routes (`_derived_providers`), so a replay
-        # that corrects one must correct the other or the two drift apart on this path alone.
+        # that fills one must fill the other or the two drift apart on this path alone.
         updates["ran_with_providers"] = _derived_providers(submission)
     return updates
 
@@ -924,7 +929,7 @@ class ScoreStore:
             and submission.submitted_by is not None
             and existing.submitted_by == submission.submitted_by
         )
-        updates = _replay_updates(submission) if same_candidate_owner else {}
+        updates = _replay_updates(submission, existing) if same_candidate_owner else {}
 
         if not updates:
             return readable

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -82,6 +82,11 @@ def _score_to_schema(model: Score) -> ScoreSchema:
         url4_expression=model.url4_expression,
         submitted_by=model.submitted_by,
         authors=_resolved_authors(model.authors, model.submitted_by),
+        # INVARIANT: no fallback, unlike `authors` above. A NULL here means the routes were
+        # never declared, and deriving them from `ran_with_providers` is impossible — the
+        # Client's truncation is lossy. Inventing a value would turn "we do not know" into a
+        # confident claim about what a submission is made of.
+        models=model.models,
         submitted_at=model.submitted_at,
         score=model.score,
         total_questions=model.total_questions,
@@ -140,6 +145,7 @@ def _submission_to_kwargs(submission: ScoreSubmission, content_hash: str) -> dic
         "url4_expression": submission.url4_expression,
         "submitted_by": submission.submitted_by,
         "authors": submission.authors,
+        "models": submission.models,
         "score": submission.score,
         "total_questions": submission.total_questions,
         "correct_questions": submission.correct_questions,

--- a/apps/scoreboard/src/scoreboard/scores/store.py
+++ b/apps/scoreboard/src/scoreboard/scores/store.py
@@ -123,6 +123,32 @@ def _resolve_benchmark_revision(submission: ScoreSubmission) -> str | None:
     return candidate if isinstance(candidate, str) and candidate else None
 
 
+def _derived_providers(submission: ScoreSubmission) -> list[str]:
+    """The providers to STORE, preferring the ones the declared routes imply.
+
+    `ran_with_providers` and `models` describe the same thing at different resolutions, and the
+    Client already computes the former from the latter. Recomputing it here means a submission
+    cannot assert a provider its own routes contradict, and the board never publishes a
+    Backends column its stored routes disagree with.
+
+    INVARIANT: this is the STORED value only. `_content_hash` keeps reading
+    `submission.ran_with_providers`, the wire value — see the note there. Correcting what is
+    stored is fine; rewriting recipe identity underneath existing rows is not.
+
+    WHY not reject a contradiction instead: a 422 would be the louder choice, but it turns a
+    field the board can compute for itself into a way for a client to fail. Nothing is lost by
+    correcting it, because the wire value survives in the hash.
+
+    No routes means nothing to derive from — the Client's truncation is lossy, so there is no
+    way back from ["openrouter"] to the models it stood for.
+    """
+    if not submission.models:
+        return submission.ran_with_providers
+    # Order is part of what happened rather than incidental serialization (OME-391), so first
+    # appearance wins and repeats collapse — the same rule the Client's own `_providers` uses.
+    return list(dict.fromkeys(route.split("/", 1)[0] for route in submission.models))
+
+
 def _resolved_authors(authors: list[str] | None, submitted_by: str | None) -> list[str] | None:
     """The backwards-compatible author credit shown for one stored submission."""
     if authors is not None:
@@ -149,7 +175,9 @@ def _submission_to_kwargs(submission: ScoreSubmission, content_hash: str) -> dic
         "score": submission.score,
         "total_questions": submission.total_questions,
         "correct_questions": submission.correct_questions,
-        "ran_with_providers": submission.ran_with_providers,
+        # INVARIANT: derived from `models` when present, so the two stored fields cannot
+        # contradict each other. `_content_hash` below still reads the WIRE value.
+        "ran_with_providers": _derived_providers(submission),
         "ran_at_local": submission.ran_at_local,
         "client_name": submission.client.name if submission.client else None,
         "client_version": submission.client.version if submission.client else None,
@@ -191,6 +219,12 @@ def _content_hash(submission: ScoreSubmission, *, per_submitter: bool = False) -
         "url4_expression": submission.url4_expression,
         "score": submission.score,
         "total_questions": submission.total_questions,
+        # INVARIANT: the WIRE value, deliberately NOT `_derived_providers(submission)`.
+        # OME-1181: the stored column is corrected from `models`, but identity must stay what
+        # the submitter actually sent. Hashing the derived value would recompute identity for
+        # every row whose client-sent providers differ from its routes — including every row
+        # predating OME-1180 — so each would stop deduplicating to its stored twin and create a
+        # duplicate instead.
         "ran_with_providers": submission.ran_with_providers,
     }
     if per_submitter:

--- a/apps/scoreboard/tests/unit/classification/test_classify_model.py
+++ b/apps/scoreboard/tests/unit/classification/test_classify_model.py
@@ -111,6 +111,47 @@ def test_an_unrecognised_model_stays_unknown_even_when_openrouter_carried_it() -
     assert classify_model("openrouter/acme/never-heard-of-this-one") == "unknown"
 
 
+@pytest.mark.parametrize(
+    "route",
+    [
+        "openrouter/openai/not-gemma-proprietary",
+        "openrouter/anthropic/kimi-wrapper",
+        "openrouter/google/not-qwen-api",
+        "openrouter/openai/gpt-5.5-llama-killer",
+        "openrouter/anthropic/claude-with-mistral-flavour",
+    ],
+)
+def test_a_crafted_model_name_cannot_buy_an_open_verdict(route: str) -> None:
+    """INVARIANT: routes are CLIENT-SUBMITTED, so the classifier is an adversarial surface.
+
+    Matching an open marker anywhere in the whole route lets a submitter name a proprietary
+    model `not-gemma-proprietary` and be published as open — the fail-closed contract inverted
+    by choosing a string. Found in review of PR #922; every route here returned `open`.
+
+    The rule is therefore structural, not textual: the OWNER segment decides, and a family
+    exception must belong to that owner. `google/gemma-*` is open because Google ships Gemma's
+    weights; `openai/not-gemma-anything` is not, because OpenAI does not.
+    """
+    assert classify_model(route) == "closed"
+
+
+def test_an_owner_family_exception_is_scoped_to_that_owner() -> None:
+    """`gpt-oss` is OpenAI's and `gemma` is Google's. Neither name may travel."""
+    assert classify_model("openrouter/openai/gpt-oss-120b") == "open"
+    assert classify_model("openrouter/google/gemma-2-27b-it") == "open"
+
+    assert classify_model("openrouter/google/gpt-oss-120b") == "closed"
+    assert classify_model("openrouter/anthropic/gemma-2-27b-it") == "closed"
+
+
+def test_a_route_with_no_owner_segment_is_unknown() -> None:
+    """Fail closed on a shape the registry cannot reason about, rather than guessing from the
+    bare string — which is how the crafted-name hole above was opened in the first place.
+    """
+    assert classify_model("claude-opus-4.8") == "unknown"
+    assert classify_model("openrouter/claude-opus-4.8") == "unknown"
+
+
 def test_the_existing_row_level_classifier_is_untouched() -> None:
     """GUARD: `classify_providers` still serves `_current_split` and `_compute_trend` until
     OME-1145 replaces them. Its provider-prefix behaviour must not shift under this change —

--- a/apps/scoreboard/tests/unit/classification/test_classify_model.py
+++ b/apps/scoreboard/tests/unit/classification/test_classify_model.py
@@ -84,13 +84,31 @@ def test_the_routing_prefix_does_not_change_the_verdict(route: str) -> None:
     """INVARIANT: routing is not openness.
 
     Every live draco-3pass route is `openrouter/`-prefixed, and `openrouter` is on the closed
-    marker list, so without stripping it every model on the board classifies closed however
-    open its weights are.
+    provider marker list.
     """
     bare = route.removeprefix("openrouter/")
 
     assert bare != route
     assert classify_model(bare) == classify_model(route)
+
+
+def test_an_unrecognised_model_stays_unknown_even_when_openrouter_carried_it() -> None:
+    """INVARIANT: the routing prefix must be stripped BEFORE the closed markers are consulted.
+
+    WHY this exists next to the parametrised prefix test above rather than instead of it: that
+    test cannot fail for a recognised model. `_MODEL_RULES` checks the open markers first, so
+    an open model wins on its own name and `openrouter` is never reached — the strip is
+    redundant for every route in OPEN_ROUTES, and CLOSED_ROUTES are closed either way. Removing
+    `_strip_routing_prefix` entirely leaves that whole parametrisation green (found by mutation
+    testing, 2026-09-11).
+
+    The unknown case is the one that needs it. Without the strip, `openrouter` matches
+    `_CLOSED_PROVIDER_MARKERS` and an unrecognised model is published as a confident `closed`
+    instead of an honest `unknown` — which destroys the count OME-1179 D4 requires, and does it
+    silently, since a stale registry then looks like a real closed verdict.
+    """
+    assert classify_model("acme/never-heard-of-this-one") == "unknown"
+    assert classify_model("openrouter/acme/never-heard-of-this-one") == "unknown"
 
 
 def test_the_existing_row_level_classifier_is_untouched() -> None:

--- a/apps/scoreboard/tests/unit/classification/test_classify_model.py
+++ b/apps/scoreboard/tests/unit/classification/test_classify_model.py
@@ -144,6 +144,37 @@ def test_an_owner_family_exception_is_scoped_to_that_owner() -> None:
     assert classify_model("openrouter/anthropic/gemma-2-27b-it") == "closed"
 
 
+# Every `custom_llm_provider` the Gateway registers, read off
+# `apps/aigateway/src/aigateway/plugins/*_provider/plugin.py`. Hardcoded because apps never
+# import another app's internals; this list is the contract between them, and it drifts only
+# when a provider is added there without being taught here — which is exactly what this catches.
+REGISTERED_GATEWAY_PROVIDERS = [
+    ("openai/gpt-5.5", "closed"),
+    ("anthropic/claude-opus-4.8", "closed"),
+    ("gemini-cli/gemini-2.5-flash", "closed"),
+    ("codex/gpt-5.4-mini", "closed"),
+    ("antigravity/gemini-3-pro", "closed"),
+    ("huggingface/meta-llama/Llama-3.1-70B", "open"),
+    ("ollama/llama3.1:70b", "open"),
+]
+
+
+@pytest.mark.parametrize(("route", "expected"), REGISTERED_GATEWAY_PROVIDERS)
+def test_every_registered_gateway_provider_is_classified(route: str, expected: str) -> None:
+    """INVARIANT: an owner the Gateway actually supports must never read as a registry gap.
+
+    `unknown` and `closed` both close the entry under OME-1179 D1, so a miss here changes no
+    percentage. It corrupts the D4 count: an ordinary supported API-only provider reported as
+    unrecognised makes the staleness signal meaningless, because the number stops meaning
+    "models the registry has not been taught about".
+
+    `gemini-cli`, `codex` and `antigravity` were all missing — found in review of PR #922. The
+    eighth registered provider, `openrouter`, is a routing prefix rather than an owner and is
+    covered by the prefix tests above.
+    """
+    assert classify_model(route) == expected
+
+
 def test_a_route_with_no_owner_segment_is_unknown() -> None:
     """Fail closed on a shape the registry cannot reason about, rather than guessing from the
     bare string — which is how the crafted-name hole above was opened in the first place.

--- a/apps/scoreboard/tests/unit/classification/test_classify_model.py
+++ b/apps/scoreboard/tests/unit/classification/test_classify_model.py
@@ -1,0 +1,104 @@
+"""Per-model openness classification (OME-1181, spec §2.4).
+
+Pure logic, no DB. `classify_model` answers about ONE declared model route, which is a
+different question from `classify_providers`' one verdict per submission — see OME-1179 D1:
+the aggregation stays any-closed-wins, only its input changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scoreboard.classification.openness import classify_model, classify_providers
+
+# FEATURE: OME-1179 Q1 — "open" means weights you can download and run, whatever the licence
+# says about commercial use. That is why mistral-large (research licence) is open here and
+# gemini (API only) is not.
+OPEN_ROUTES = [
+    "openrouter/meta-llama/Llama-3.1-70B-Instruct",
+    "openrouter/qwen/Qwen2.5-72B-Instruct",
+    "openrouter/deepseek/deepseek-v4-pro",
+    "openrouter/mistralai/mistral-large-2411",
+    "openrouter/mistralai/Mistral-7B-Instruct-v0.3",
+]
+
+CLOSED_ROUTES = [
+    "openrouter/openai/gpt-5.5",
+    "openrouter/anthropic/claude-opus-4.8",
+    "openrouter/google/gemini-3-pro",
+    "openrouter/google/gemini-3-flash-preview",
+]
+
+# INVARIANT: these three are why a specific model rule must beat its owner rule. Each ships
+# downloadable weights under a name whose OWNER is on the closed list, so a plain
+# owner-substring match files them closed — which is exactly the OME-1145 complaint.
+OWNER_CONTRADICTS_MODEL = [
+    ("openrouter/openai/gpt-oss-120b", "openai"),
+    ("openrouter/google/gemma-2-27b-it", "google"),
+]
+
+
+@pytest.mark.parametrize("route", OPEN_ROUTES)
+def test_downloadable_weights_classify_open(route: str) -> None:
+    assert classify_model(route) == "open"
+
+
+@pytest.mark.parametrize("route", CLOSED_ROUTES)
+def test_api_only_models_classify_closed(route: str) -> None:
+    assert classify_model(route) == "closed"
+
+
+@pytest.mark.parametrize(("route", "owner"), OWNER_CONTRADICTS_MODEL)
+def test_a_specific_model_rule_beats_its_owner_rule(route: str, owner: str) -> None:
+    """WHY both assertions: the first fails if the carve-out is missing, the second fails if
+    the carve-out was written so broadly that it swallowed the owner rule with it."""
+    assert classify_model(route) == "open"
+    assert owner in route
+    assert classify_model(f"openrouter/{owner}/something-proprietary") == "closed"
+
+
+def test_kimi_is_recognised_at_all() -> None:
+    """moonshotai matches nothing in the registry today, so it falls to the unknown default.
+
+    On the live draco-3pass board this single omission is the difference between 0% and 29%:
+    it closes `best_open_source` and `pareto_lean`, both all-open-weights fusions.
+    """
+    assert classify_model("openrouter/moonshotai/kimi-k2.6") == "open"
+
+
+def test_an_unrecognised_model_is_unknown_and_not_closed() -> None:
+    """INVARIANT: `unknown` must not collapse into `closed`.
+
+    Both close an entry under OME-1179 D1, so a test asserting only "it is not open" would
+    pass against a classifier that lost the distinction. D4 requires the count of unrecognised
+    models to be reportable, which is impossible once the two verdicts are the same value.
+    """
+    verdict = classify_model("acme/never-heard-of-this-one")
+
+    assert verdict == "unknown"
+    assert verdict != "closed"
+
+
+@pytest.mark.parametrize("route", OPEN_ROUTES + CLOSED_ROUTES)
+def test_the_routing_prefix_does_not_change_the_verdict(route: str) -> None:
+    """INVARIANT: routing is not openness.
+
+    Every live draco-3pass route is `openrouter/`-prefixed, and `openrouter` is on the closed
+    marker list, so without stripping it every model on the board classifies closed however
+    open its weights are.
+    """
+    bare = route.removeprefix("openrouter/")
+
+    assert bare != route
+    assert classify_model(bare) == classify_model(route)
+
+
+def test_the_existing_row_level_classifier_is_untouched() -> None:
+    """GUARD: `classify_providers` still serves `_current_split` and `_compute_trend` until
+    OME-1145 replaces them. Its provider-prefix behaviour must not shift under this change —
+    including the `openrouter` verdict, which is correct for a PROVIDER and wrong only when
+    a model route is fed to it.
+    """
+    assert classify_providers(["openrouter"]) == "closed"
+    assert classify_providers(["huggingface"]) == "open"
+    assert classify_providers([]) == "closed"

--- a/apps/scoreboard/tests/unit/scores/test_model_identities.py
+++ b/apps/scoreboard/tests/unit/scores/test_model_identities.py
@@ -205,6 +205,75 @@ def test_deriving_providers_does_not_change_recipe_identity() -> None:
     assert _content_hash(honest) != _content_hash(contradictory)
 
 
+@pytest.mark.asyncio
+async def test_a_replay_by_the_same_submitter_fills_in_missing_routes(
+    tortoise_db: None,
+) -> None:
+    """FEATURE: OME-1179 Q3 — the whole reason rows can ever become classifiable.
+
+    Every row predates the Client that sends routes. Without this, a submitter who re-runs
+    after OME-1180 ships gets deduplicated to their old row and the routes are silently
+    discarded, so the board keeps a permanent population it cannot classify.
+
+    `models` is deterministic for a given `content_hash`: the hash covers `url4_expression`,
+    and the routes are a projection of that same recipe. So a replay carrying different routes
+    for the same hash means an inconsistent client, not a legitimate correction.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+    first, first_created = await store.submit(_submission())
+
+    replay, replay_created = await store.submit(_submission(models=ROUTES))
+    stored = await Score.get(id=first.id)
+
+    assert first_created is True
+    assert replay_created is False
+    assert replay.id == first.id
+    assert stored.models == ROUTES
+    assert await Score.all().count() == 1
+
+
+@pytest.mark.asyncio
+async def test_another_submitter_cannot_write_routes_onto_someone_elses_row(
+    tortoise_db: None,
+) -> None:
+    """INVARIANT: the anti-hijack guard covers this field too, for free.
+
+    A public content hash is global across submitters, so without the same-owner requirement
+    anyone who copied a team's candidate could rewrite what that team's entry is made of — and
+    under OME-1179 D1 a single fabricated closed route flips the entry's published verdict.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+    original, _ = await store.submit(_submission(models=ROUTES))
+
+    attacker = _submission(models=["anthropic/claude-opus-4.8"])
+    attacker = attacker.model_copy(update={"submitted_by": "mallory@example.test"})
+    replay, created = await store.submit(attacker)
+    stored = await Score.get(id=original.id)
+
+    assert created is False
+    assert replay.id == original.id
+    assert stored.models == ROUTES
+
+
+@pytest.mark.asyncio
+async def test_a_replay_without_routes_does_not_erase_stored_ones(tortoise_db: None) -> None:
+    """None means "not specified", so an older Client replaying cannot wipe newer provenance —
+    the same rule `authors` and `metadata` already follow.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+    first, _ = await store.submit(_submission(models=ROUTES))
+
+    replay, created = await store.submit(_submission())
+    stored = await Score.get(id=first.id)
+
+    assert created is False
+    assert stored.models == ROUTES
+    assert replay.models == ROUTES
+
+
 def test_models_do_not_change_recipe_identity() -> None:
     """INVARIANT: `models` must NOT enter `_content_hash` (OME-1179 Q3).
 

--- a/apps/scoreboard/tests/unit/scores/test_model_identities.py
+++ b/apps/scoreboard/tests/unit/scores/test_model_identities.py
@@ -7,6 +7,8 @@ survive the wire. `OME-1180` makes the Client send them; this is the half that a
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -14,9 +16,10 @@ import pytest
 from pydantic import ValidationError
 from tortoise.queryset import QuerySet
 
+from scoreboard.export_private_submissions import format_jsonl_bytes
 from scoreboard.scores import store as store_module
 from scoreboard.scores.models import Score
-from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.schemas import ScoreSchema, ScoreSubmission
 from scoreboard.scores.store import ScoreStore, _content_hash
 
 ROUTES = [
@@ -24,6 +27,33 @@ ROUTES = [
     "openrouter/moonshotai/kimi-k2.6",
     "openrouter/qwen/qwen3.6-plus",
 ]
+
+
+def _schema_row(*, models: list[str] | None) -> ScoreSchema:
+    """A stored row as the export and the public GET see it."""
+    return ScoreSchema(
+        id=uuid4(),
+        version=1,
+        benchmark_id="hle",
+        benchmark_revision="rev-1",
+        spec_id="spec-1",
+        url4_expression="url4://benchmark/hle/spec-1",
+        submitted_by="alice@example.test",
+        models=models,
+        submitted_at=datetime(2026, 1, 1, tzinfo=UTC),
+        score=0.75,
+        total_questions=100,
+        correct_questions=75,
+        ran_with_providers=["openrouter"],
+        ran_at_local=None,
+        client_name=None,
+        client_version=None,
+        client_platform=None,
+        verified_by_screamingface=True,
+        metadata=None,
+        openness_override=None,
+        run_cost_usd=None,
+    )
 
 
 def _submission(
@@ -364,6 +394,70 @@ async def test_the_read_projects_only_the_two_columns_it_needs(tortoise_db: None
         monkeypatch.undo()
 
     assert captured == [("id", "models")]
+
+
+def test_a_legacy_row_serializes_byte_identically_to_before_this_field() -> None:
+    """INVARIANT: adding a field must not change what an EXISTING row exports.
+
+    `ScoreSchema` feeds the private JSONL export, and `purge_private_benchmark.export_sha256`
+    hashes those exact bytes to authorize a destructive purge against an operator-supplied
+    digest. A `"models": null` on every line silently invalidates every export saved before this
+    change, so a previously-certified export can no longer authorize its own purge — with no
+    underlying row having changed at all.
+
+    `ranking_notice` carries `exclude_if` for precisely this reason (schemas.py:567-573). Found
+    in review of PR #922.
+    """
+    row = _schema_row(models=None)
+
+    exported = format_jsonl_bytes([row])
+
+    assert b'"models"' not in exported
+    assert "models" not in json.loads(exported.decode().strip())
+
+
+def test_a_row_that_declares_routes_does_export_them() -> None:
+    """The exclusion is for ABSENCE, not for the field. A row whose routes are known has
+    genuinely changed, and staff reading an export must see what it was made of.
+    """
+    exported = format_jsonl_bytes([_schema_row(models=ROUTES)])
+
+    assert json.loads(exported.decode().strip())["models"] == ROUTES
+
+
+def test_the_public_score_response_omits_an_absent_models_field() -> None:
+    """`ScoreSchema` is the response model for POST /scores and GET /scores/{id}, so this is a
+    public payload, not an internal DTO — the Q2 decision recorded it as internal, which was
+    wrong. Absent stays absent on the wire rather than becoming an explicit null.
+    """
+    assert "models" not in json.loads(_schema_row(models=None).model_dump_json())
+    assert json.loads(_schema_row(models=ROUTES).model_dump_json())["models"] == ROUTES
+
+
+@pytest.mark.asyncio
+async def test_a_replay_cannot_replace_routes_that_are_already_declared(
+    tortoise_db: None,
+) -> None:
+    """INVARIANT: enrichment FILLS a missing value; it never replaces a present one.
+
+    `_content_hash` excludes `models`, so two submissions differing only in their routes share
+    an identity — verified in `test_models_do_not_change_recipe_identity`. Without this rule a
+    replay could therefore swap what an entry is made of, and so flip its published openness,
+    without changing its identity or its url4 expression. The Q3 decision was to enrich a
+    missing value, not to accept a conflicting one. Found in review of PR #922.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+    first, _ = await store.submit(_submission(models=ROUTES))
+
+    replay, created = await store.submit(
+        _submission(models=["openrouter/anthropic/claude-opus-4.8"])
+    )
+    stored = await Score.get(id=first.id)
+
+    assert created is False
+    assert stored.models == ROUTES
+    assert stored.ran_with_providers == ["openrouter"]
 
 
 def test_models_do_not_change_recipe_identity() -> None:

--- a/apps/scoreboard/tests/unit/scores/test_model_identities.py
+++ b/apps/scoreboard/tests/unit/scores/test_model_identities.py
@@ -7,9 +7,14 @@ survive the wire. `OME-1180` makes the Client send them; this is the half that a
 
 from __future__ import annotations
 
+from typing import Any
+from uuid import uuid4
+
 import pytest
 from pydantic import ValidationError
+from tortoise.queryset import QuerySet
 
+from scoreboard.scores import store as store_module
 from scoreboard.scores.models import Score
 from scoreboard.scores.schemas import ScoreSubmission
 from scoreboard.scores.store import ScoreStore, _content_hash
@@ -25,11 +30,13 @@ def _submission(
     *,
     models: list[str] | None = None,
     ran_with_providers: list[str] | None = None,
+    spec_id: str = "spec-1",
+    url4: str = "url4://benchmark/hle/spec-1",
 ) -> ScoreSubmission:
     return ScoreSubmission(
         benchmark_id="hle",
-        spec_id="spec-1",
-        url4_expression="url4://benchmark/hle/spec-1",
+        spec_id=spec_id,
+        url4_expression=url4,
         submitted_by="alice@example.test",
         models=models,
         score=0.75,
@@ -272,6 +279,91 @@ async def test_a_replay_without_routes_does_not_erase_stored_ones(tortoise_db: N
     assert created is False
     assert stored.models == ROUTES
     assert replay.models == ROUTES
+
+
+@pytest.mark.asyncio
+async def test_routes_are_read_back_for_a_set_of_score_ids(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+    with_routes, _ = await store.submit(_submission(models=ROUTES))
+    without, _ = await store.submit(
+        _submission(spec_id="spec-2", models=None, url4="url4://benchmark/hle/spec-2")
+    )
+
+    found = await store.models_for_score_ids([str(with_routes.id), str(without.id)])
+
+    assert found == {str(with_routes.id): ROUTES, str(without.id): None}
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_id_is_simply_absent(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    assert await store.models_for_score_ids([]) == {}
+    assert await store.models_for_score_ids([str(uuid4())]) == {}
+
+
+@pytest.mark.asyncio
+async def test_the_read_is_chunked_and_loses_nothing_across_the_boundary(
+    tortoise_db: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """INVARIANT: the frontier is neither small nor bounded.
+
+    Every best-per-spec point can be non-dominated, and spec ids are client-controlled, so the
+    id set handed to this read is as large as the board. A single `WHERE id IN (...)` can
+    exceed the database's bind-parameter limit — SQLite's default is 999 — which fails at a
+    board size nobody will reproduce in a test. Chunking is therefore exercised by shrinking
+    the chunk rather than by growing the board.
+    """
+    monkeypatch.setattr(store_module, "_MODELS_READ_CHUNK", 2)
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    expected: dict[str, list[str]] = {}
+    for index in range(5):
+        routes = [f"openrouter/vendor-{index}/model-{index}"]
+        score, _ = await store.submit(
+            _submission(
+                spec_id=f"spec-{index}",
+                models=routes,
+                url4=f"url4://benchmark/hle/spec-{index}",
+            )
+        )
+        expected[str(score.id)] = routes
+
+    found = await store.models_for_score_ids(list(expected))
+
+    assert found == expected
+
+
+@pytest.mark.asyncio
+async def test_the_read_projects_only_the_two_columns_it_needs(tortoise_db: None) -> None:
+    """GUARD: `leaderboard.py:270-275` records why the whole-board read stays minimal —
+    client-controlled recipes and display metadata must never be materialised en masse. This
+    read is scoped to the frontier rather than the board, but it is still unbounded, so the
+    same rule applies. A widened projection fails here.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+    score, _ = await store.submit(_submission(models=ROUTES))
+
+    captured: list[tuple[str, ...]] = []
+    original = QuerySet.values
+
+    def _spy(self: QuerySet[Any], *fields: str, **kwargs: Any) -> Any:
+        captured.append(fields)
+        return original(self, *fields, **kwargs)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(QuerySet, "values", _spy)
+    try:
+        await store.models_for_score_ids([str(score.id)])
+    finally:
+        monkeypatch.undo()
+
+    assert captured == [("id", "models")]
 
 
 def test_models_do_not_change_recipe_identity() -> None:

--- a/apps/scoreboard/tests/unit/scores/test_model_identities.py
+++ b/apps/scoreboard/tests/unit/scores/test_model_identities.py
@@ -126,6 +126,85 @@ async def test_a_submission_without_routes_still_succeeds(tortoise_db: None) -> 
     assert score.models is None
 
 
+@pytest.mark.asyncio
+async def test_providers_are_derived_from_the_routes_when_they_are_present(
+    tortoise_db: None,
+) -> None:
+    """The two fields describe the same thing, so only one of them should be authoritative.
+
+    The Client already derives `ran_with_providers` from these routes; recomputing it here
+    means a submission cannot assert a provider its own routes contradict.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    score, _ = await store.submit(
+        _submission(
+            models=["anthropic/claude-opus-4.8", "openrouter/qwen/qwen3.6-plus"],
+            ran_with_providers=["openrouter"],
+        )
+    )
+    stored = await Score.get(id=score.id)
+
+    assert stored.ran_with_providers == ["anthropic", "openrouter"]
+
+
+@pytest.mark.asyncio
+async def test_the_clients_providers_are_kept_when_no_routes_are_declared(
+    tortoise_db: None,
+) -> None:
+    """INVARIANT: no routes means nothing to derive from. The truncation is lossy, so there is
+    no way back from ["openrouter"] to the models — the client's value is all there is.
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    score, _ = await store.submit(_submission(ran_with_providers=["huggingface", "ollama"]))
+    stored = await Score.get(id=score.id)
+
+    assert stored.ran_with_providers == ["huggingface", "ollama"]
+
+
+@pytest.mark.asyncio
+async def test_derived_providers_preserve_order_and_collapse_repeats(
+    tortoise_db: None,
+) -> None:
+    """Order is part of what happened, not incidental serialization — `_content_hash` hashes
+    `ran_with_providers` as sent, unsorted, for exactly that reason (OME-391).
+    """
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    score, _ = await store.submit(
+        _submission(
+            models=[
+                "openrouter/qwen/qwen3.6-plus",
+                "anthropic/claude-opus-4.8",
+                "openrouter/deepseek/deepseek-v4-pro",
+            ]
+        )
+    )
+    stored = await Score.get(id=score.id)
+
+    assert stored.ran_with_providers == ["openrouter", "anthropic"]
+
+
+def test_deriving_providers_does_not_change_recipe_identity() -> None:
+    """INVARIANT: `_content_hash` reads the WIRE `ran_with_providers`, never the derived value.
+
+    Hashing the derived value would recompute identity for every recipe whose client-sent
+    providers differ from its routes — and, once OME-1180 ships, for every row submitted before
+    it. Each of those would stop deduplicating to its stored twin and create a second row
+    instead. Storage may be corrected; identity may not be rewritten underneath it.
+    """
+    honest = _submission(models=["anthropic/claude-opus-4.8"], ran_with_providers=["anthropic"])
+    contradictory = _submission(
+        models=["anthropic/claude-opus-4.8"], ran_with_providers=["openrouter"]
+    )
+
+    assert _content_hash(honest) != _content_hash(contradictory)
+
+
 def test_models_do_not_change_recipe_identity() -> None:
     """INVARIANT: `models` must NOT enter `_content_hash` (OME-1179 Q3).
 

--- a/apps/scoreboard/tests/unit/scores/test_model_identities.py
+++ b/apps/scoreboard/tests/unit/scores/test_model_identities.py
@@ -1,0 +1,140 @@
+"""Accepting and storing declared model routes (OME-1181, spec §2.1-§2.2).
+
+The Client truncates every route to its provider prefix before submission, so the board stores
+`["openrouter"]` for a fusion of deepseek, kimi and qwen. This field is how the identities
+survive the wire. `OME-1180` makes the Client send them; this is the half that accepts them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from scoreboard.scores.models import Score
+from scoreboard.scores.schemas import ScoreSubmission
+from scoreboard.scores.store import ScoreStore, _content_hash
+
+ROUTES = [
+    "openrouter/deepseek/deepseek-v4-pro",
+    "openrouter/moonshotai/kimi-k2.6",
+    "openrouter/qwen/qwen3.6-plus",
+]
+
+
+def _submission(
+    *,
+    models: list[str] | None = None,
+    ran_with_providers: list[str] | None = None,
+) -> ScoreSubmission:
+    return ScoreSubmission(
+        benchmark_id="hle",
+        spec_id="spec-1",
+        url4_expression="url4://benchmark/hle/spec-1",
+        submitted_by="alice@example.test",
+        models=models,
+        score=0.75,
+        total_questions=100,
+        correct_questions=75,
+        ran_with_providers=ran_with_providers or ["openrouter"],
+    )
+
+
+def test_declared_routes_are_accepted_verbatim() -> None:
+    submission = _submission(models=ROUTES)
+
+    assert submission.models == ROUTES
+
+
+def test_models_is_optional_so_older_clients_keep_working() -> None:
+    """INVARIANT: this unit DEPLOYS before the Client that populates it (OME-1179 constraint 1).
+
+    `ScoreSubmission` is `extra="forbid"`, so the rollout is one-directional: a Client sending
+    an unknown field to an older board gets a 422. The field must therefore be optional here,
+    or the deploy order reverses and every in-field submission breaks.
+    """
+    assert _submission().models is None
+
+
+def test_an_empty_model_list_is_rejected() -> None:
+    """None means "the client did not send them". `[]` would mean "this ran on no models",
+    which is not a state any real submission can be in — `CandidateResult.models` is required
+    and non-empty at the Client. Silently accepting it would store an unclassifiable row that
+    looks populated.
+    """
+    with pytest.raises(ValidationError):
+        _submission(models=[])
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "has spaces/in-it",
+        "trailing/",
+        "/leading",
+        "double//segment",
+        "a" * 256,
+    ],
+)
+def test_malformed_routes_are_rejected(route: str) -> None:
+    with pytest.raises(ValidationError):
+        _submission(models=[route])
+
+
+def test_too_many_routes_are_rejected_at_the_boundary() -> None:
+    at_cap = [f"provider/model-{index}" for index in range(32)]
+    over_cap = [*at_cap, "provider/model-32"]
+
+    assert _submission(models=at_cap).models == at_cap
+    with pytest.raises(ValidationError, match="at most 32"):
+        _submission(models=over_cap)
+
+
+def test_an_oversized_model_payload_is_rejected() -> None:
+    """WHY a byte cap on top of the route count: 32 routes of 255 characters is still 8 KiB of
+    client-controlled text on a public write path. The same reasoning and the same 4096-byte
+    limit as `authors` (OME-1109) and `metadata`.
+    """
+    fat = [f"provider/{'m' * 240}-{index}" for index in range(20)]
+
+    with pytest.raises(ValidationError, match="serialize to at most"):
+        _submission(models=fat)
+
+
+@pytest.mark.asyncio
+async def test_declared_routes_survive_storage(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    score, created = await store.submit(_submission(models=ROUTES))
+    stored = await Score.get(id=score.id)
+
+    assert created is True
+    assert stored.models == ROUTES
+    assert score.models == ROUTES
+
+
+@pytest.mark.asyncio
+async def test_a_submission_without_routes_still_succeeds(tortoise_db: None) -> None:
+    store = ScoreStore()
+    await store.register_benchmark(benchmark_id="hle", display_name="HLE")
+
+    score, created = await store.submit(_submission())
+    stored = await Score.get(id=score.id)
+
+    assert created is True
+    assert stored.models is None
+    assert score.models is None
+
+
+def test_models_do_not_change_recipe_identity() -> None:
+    """INVARIANT: `models` must NOT enter `_content_hash` (OME-1179 Q3).
+
+    The routes are a richer projection of data already inside `url4_expression`, which IS
+    hashed. Adding them would give one recipe two identities purely because a newer Client sent
+    more detail about the same run, so the first resubmission after `OME-1180` ships would
+    duplicate every row on the board instead of deduplicating to it.
+    """
+    without = _submission()
+    with_routes = _submission(models=ROUTES)
+
+    assert _content_hash(without) == _content_hash(with_routes)

--- a/docs/plan/2026-09-11-OME-1181-model-identities.md
+++ b/docs/plan/2026-09-11-OME-1181-model-identities.md
@@ -1,0 +1,156 @@
+---
+title: Accept and store model identities — plan
+ticket: OME-1181
+spec: docs/spec/2026-09-11-OME-1181-model-identities.md
+status: approved
+date: 2026-09-11
+---
+
+# OME-1181 — implementation plan
+
+Five phases, each RED → GREEN → gates → commit. Ordered so the pure, DB-free work lands first
+and the schema change lands as late as it can while still preceding its consumers.
+
+Tests are **append-only**. Nothing under `tests/` is edited or deleted; every phase adds.
+
+---
+
+## Phase 1 — `classify_model()` (pure, no DB, no migration)
+
+`apps/scoreboard/src/scoreboard/classification/openness.py`
+
+Add, without touching `classify_providers` / `classify_score` / `classify_baseline`:
+
+```python
+_ROUTING_PREFIXES: tuple[str, ...] = ("openrouter",)
+_OPEN_MODEL_MARKERS: tuple[str, ...]   # gpt-oss, gemma, moonshotai, kimi
+def _strip_routing_prefix(route: str) -> str
+def classify_model(route: str) -> Literal["open", "closed", "unknown"]
+```
+
+Order of resolution inside `classify_model`, and it matters:
+
+1. strip a leading routing prefix
+2. **specific open-model markers first** — `gpt-oss`, `gemma`, `moonshotai`, `kimi`
+3. then the existing `_OPEN_PROVIDER_MARKERS`
+4. then `_CLOSED_PROVIDER_MARKERS`
+5. otherwise `unknown`, logged via the existing `_log_unrecognized`
+
+Step 2 before 4 is the whole point: `openai/gpt-oss-120b` must not be caught by `openai`.
+
+**RED:** `tests/unit/classification/test_classify_model.py`
+
+- `openrouter/openai/gpt-oss-120b` → open (fails without the carve-out AND without the strip)
+- `openrouter/google/gemma-2-27b-it` → open
+- `openrouter/moonshotai/kimi-k2.6` → open
+- `openrouter/openai/gpt-5.5` → closed — the carve-out must not swallow the owner rule
+- `openrouter/google/gemini-3-pro` → closed
+- `openrouter/mistralai/mistral-large-2411` → open (Q1: downloadable)
+- `anthropic/claude-opus-4.8` → closed with no prefix to strip
+- `acme/never-heard-of-it` → unknown, and `unknown != "closed"`
+- parametrised: every route classifies identically with and without `openrouter/`
+- **guard:** `classify_providers(["openrouter"])` still returns `closed` — the existing
+  row-level surfaces are untouched
+
+## Phase 2 — wire, bounds, column, migration
+
+`schemas.py`:
+
+```python
+_MODELS_MAX_ROUTES = 32
+_MODELS_MAX_BYTES = 4096
+ModelRoute = Annotated[str, Field(max_length=255, pattern=_MODEL_ROUTE_PATTERN)]
+```
+
+`_MODEL_ROUTE_PATTERN` mirrors the Client's `_MODEL_ROUTE_RE`
+(`_evaluation/candidate.py:429`), anchored.
+
+- `ScoreSubmission.models: Annotated[list[ModelRoute], Field(min_length=1)] | None = None`
+- `@field_validator("models")` → route count and serialized-size caps, same shape as
+  `validate_distinct_authors`
+- `ScoreSchema.models: list[str] | None = None`
+- **`LeaderboardEntry` is NOT touched** (spec §3, Q2 option A)
+
+`models/score.py`: `models = fields.JSONField(null=True)` with a FEATURE anchor.
+
+`migrations/0013_score_models.py`: `ops.AddField`, depending on `0012_score_authors`.
+
+`store.py`: `_submission_to_kwargs` carries `models`; `_score_to_schema` projects it.
+
+**RED:** additive cases in `tests/unit/scores/test_schemas.py` and a new
+`tests/unit/scores/test_model_identities.py`
+
+- a valid `models` round-trips through submit → store → `ScoreSchema`
+- absent `models` still succeeds and stores `null`
+- `models: []` is rejected
+- 33 routes rejected; 32 accepted
+- a 256-char route rejected
+- a payload over 4096 serialized bytes rejected with a field error
+- a malformed route (spaces, empty segment) rejected
+- **guard:** `_content_hash` is byte-identical with and without `models`, so a resubmission
+  carrying it dedups to the same row rather than creating a second
+
+## Phase 3 — derive `ran_with_providers`
+
+`store.py`: when `submission.models` is present, `_submission_to_kwargs` stores providers
+derived from the routes rather than the client's copy.
+
+**INVARIANT to encode as a comment and a test:** `_content_hash` keeps reading
+`submission.ran_with_providers`, the wire value. Deriving into the hash would change every
+existing recipe's identity and split dedup history.
+
+**RED:**
+
+- routes present → stored providers derived from them
+- routes absent → the client's `ran_with_providers` stored unchanged
+- a client sending *inconsistent* providers and models → storage reflects the models, the
+  content hash reflects the wire value
+
+## Phase 4 — republish enrichment
+
+`store.py` `_confirm_replayable` (~L835-849): add `models` to the `updates` allowlist inside
+the existing `same_candidate_owner` branch. No new guard, no new lock.
+
+**RED:**
+
+- same submitter republishes with `models` → the existing row gains them, no new row
+- a **different** submitter republishing cannot set them — the anti-hijack guard holds
+- a republish omitting `models` does not erase existing ones (None means "not specified")
+- a row that already has `models` is not overwritten by a worse value
+
+## Phase 5 — chunked frontier-scoped read
+
+`store.py`: `models_for_score_ids(ids) -> dict[str, list[str] | None]`, selecting `id, models`
+only, issued in chunks.
+
+**RED:**
+
+- returns the right mapping for a small set
+- exercised above one chunk boundary, asserting more than one query was issued
+- **guard:** it selects only `id, models` — a widened projection fails
+
+---
+
+## Gates, every phase
+
+```
+uv run .claude/scripts/run_gates.py scoreboard --base origin/main
+```
+
+Append-only, ruff check, ruff format, pyright, pytest with `--cov-fail-under=80`, and all
+three portal suites. No `--skip-append-only` should be needed — this unit adds tests only.
+
+## Companion skills
+
+`tortoise-dev` is mandatory and applies to phase 2: model-per-file is already the layout, the
+abstract `BaseScore` already exists, `class Meta` stays first, and the migration uses the
+built-in Tortoise CLI — never Aerich.
+
+## Stop conditions
+
+Return to the owner rather than working around, if:
+
+- the migration cannot depend cleanly on `0012_score_authors` (a second head appeared on main)
+- deriving providers turns out to change `_content_hash` for any existing row
+- phase 4 cannot reuse the existing guard and would need a new write path
+- any existing test has to change

--- a/docs/spec/2026-09-11-OME-1181-model-identities.md
+++ b/docs/spec/2026-09-11-OME-1181-model-identities.md
@@ -1,7 +1,7 @@
 ---
 title: Accept and store model identities, and classify openness per model — spec
 ticket: OME-1181
-status: approved — Q2 and Q3 decided by the owner 2026-09-11
+status: approved — Q2 and Q3 decided 2026-09-11, both CORRECTED after review of PR #922
 date: 2026-09-11
 parent: OME-1179
 related:
@@ -213,3 +213,63 @@ unknown top-level field 422s against an un-upgraded Scoreboard.
 is knowable per model but not derivable from any field the Gateway exposes — checked, there is
 no licence or `open_weights` signal in its discovery code. D4's visible-miss count is the
 mitigation, not a fix.
+
+
+---
+
+## 8. Corrections after review of PR #922 (2026-09-11)
+
+Three findings, all confirmed empirically. Two invalidate answers recorded above.
+
+### 8.1 §3 was wrong — `models` is not internal
+
+`ScoreSchema` is itself the response model for `POST /scores` (`routes/scores.py:179`) and
+`GET /scores/{id}` (`:287`). Checking only that the field stays off `LeaderboardEntry` was not
+enough.
+
+The consequence is worse than disclosure. `export_private_submissions.format_jsonl` dumps this
+schema in python mode with `sort_keys=True`, and `purge_private_benchmark.export_sha256` hashes
+those exact bytes to authorize a destructive purge against an operator-supplied digest. Adding
+`"models": null` changed every export saved before the field existed, **with no underlying row
+having changed**, so a previously certified export could no longer authorize its own purge.
+
+`ranking_notice` carries `exclude_if` for exactly this reason, documented three lines above
+where `models` was added. `models` now carries it too. Verified: a legacy row exports byte
+identically to `origin/main` — sha256 `ac966efd…b8a3`, 582 bytes on both sides.
+
+### 8.2 §2.4 was exploitable — substring matching on a client-controlled string
+
+Routes are submitted by clients. Matching an open marker anywhere in the route let a submitter
+choose a verdict by choosing a name. All of these returned **open**:
+
+* `openrouter/openai/not-gemma-proprietary`
+* `openrouter/anthropic/kimi-wrapper`
+* `openrouter/google/not-qwen-api`
+* `openrouter/openai/gpt-5.5-llama-killer`
+
+Matching is now structural. The route parses as `owner/model`; the owner is matched exactly
+against open and closed sets, and a family exception is prefix-matched on the model segment and
+**scoped to its owner** — `google/gemma-*` is open, `openai/gemma-*` is not. A route with no
+owner segment is `unknown` rather than guessed at.
+
+Mutation testing had confirmed that `gpt-oss` beat `openai`. It never tested that a *crafted*
+name beat it too, which is the difference between checking a feature works and checking it
+cannot be abused.
+
+### 8.3 §4a was too permissive — enrichment must fill, not replace
+
+`_content_hash` excludes `models`, so two submissions differing only in their routes share one
+identity. The replay update was unconditional, so a same-owner replay could swap what an entry
+is made of — and thus flip its published openness — without changing its identity or its url4
+expression.
+
+The code comment justifying this claimed `models` is deterministic per `content_hash` because
+the hash covers `url4_expression`. True of an honest client, irrelevant to a careless or hostile
+one, since `url4_expression` is free text. It now writes only when the stored value is null,
+which is what the Q3 decision said in the first place.
+
+### 8.4 Bookkeeping
+
+The acceptance criterion requiring the unrecognised-model count to be **exposed** contradicted
+this unit's own scope boundary, which assigns response-shape changes to `OME-1145`. Moved there;
+this unit only guarantees `unknown` is a distinct verdict so the count is computable.

--- a/docs/spec/2026-09-11-OME-1181-model-identities.md
+++ b/docs/spec/2026-09-11-OME-1181-model-identities.md
@@ -1,7 +1,7 @@
 ---
 title: Accept and store model identities, and classify openness per model — spec
 ticket: OME-1181
-status: proposed — needs owner approval on §3 (Q2) and §4 (Q3)
+status: approved — Q2 and Q3 decided by the owner 2026-09-11
 date: 2026-09-11
 parent: OME-1179
 related:
@@ -123,7 +123,7 @@ metadata are never materialised en masse.
 
 ---
 
-## 3. DECISION NEEDED — Q2: is `models` public?
+## 3. DECIDED — Q2: `models` stays internal
 
 `ScoreSchema` is the internal read DTO; `LeaderboardEntry` is the public payload.
 
@@ -137,10 +137,13 @@ creates a new wire contract to support.
 | **A — internal only** (recommended) | `models` on `ScoreSchema`, absent from `LeaderboardEntry`. Classification works; nothing new is promised publicly. The portal's Backends column keeps reading `ran_with_providers` and keeps its honest label. `OME-1145` or a portal ticket can widen it later, when there is a consumer. |
 | B — public now | `models` on `LeaderboardEntry` too. Lets the portal render real model names, which is the visible fix people will ask for. But it commits to the field before the Client populates it, so every row returns `null` until `OME-1180` ships and people resubmit. |
 
-**Recommended: A.** It keeps this unit's blast radius inside the Scoreboard, and a public
-field whose value is `null` on every row is worse than no field.
+**Decided 2026-09-11: option A — internal only.** `models` lands on `ScoreSchema` and is
+absent from `LeaderboardEntry`. It keeps this unit's blast radius inside the Scoreboard, and a
+public field whose value is `null` on every row is worse than no field. The portal's Backends
+column is untouched and keeps its honest label. Widening the public payload is a later change,
+made when there is a consumer and real data behind it.
 
-## 4. DECISION NEEDED — Q3: legacy and deduplicated rows
+## 4. DECIDED — Q3: a same-owner republish may fill in `models`
 
 Every existing row will have `models = null`. Two sub-questions.
 
@@ -153,7 +156,17 @@ existing row is silently discarded today.
 | **A — enrich on same-owner replay** (recommended) | Add `models` to `updates` under the existing `same_candidate_owner` guard, reusing its anti-hijack check and visibility locking unchanged. Rows fill in naturally as people resubmit. |
 | B — leave null | Simplest. A row submitted before `OME-1180` can never gain identities, so the board carries permanently unclassifiable rows. |
 
-**4b. Do we backfill the seven live rows?** Not in this unit either way, but the answer shapes
+**Decided 2026-09-11: option A — enrich on same-owner replay.** `models` joins `authors` and
+`metadata` in the `updates` allowlist, under the existing `same_candidate_owner` guard. That
+guard already requires a matching benchmark, stored content hash and submitter, and the write
+already takes the visibility lock — both are reused verbatim, so this adds a field to an
+existing allowlist rather than a new write path.
+
+INVARIANT: enrichment fills a field, it does not overwrite a correct one with a worse one. The
+same anti-hijack rule that protects `authors` protects this.
+
+**4b. Do we backfill the seven live rows?** **Out of scope for this unit** (owner, 2026-09-11).
+Not in this unit either way, but the answer shapes
 what `OME-1145` can show. `url4_expression` does contain the routes; the grader-ambiguity
 problem that ruled out runtime parsing is manageable in a one-off operator script where the
 output can be inspected before it is committed. Proposed: **out of scope here, note it on

--- a/docs/spec/2026-09-11-OME-1181-model-identities.md
+++ b/docs/spec/2026-09-11-OME-1181-model-identities.md
@@ -1,0 +1,202 @@
+---
+title: Accept and store model identities, and classify openness per model — spec
+ticket: OME-1181
+status: proposed — needs owner approval on §3 (Q2) and §4 (Q3)
+date: 2026-09-11
+parent: OME-1179
+related:
+  - https://linear.app/openmined/issue/OME-1181
+  - docs/work/2026-09-10-OME-1145-openness-metric-review.md
+---
+
+# OME-1181 — Accept and store model identities
+
+## 1. Problem
+
+`packages/screamingface/.../leaderboards.py:502` reduces each declared model route to its
+first path segment before submission, so `openrouter/deepseek/deepseek-v4-pro` arrives as
+`"openrouter"`. Every live `draco-3pass` entry stores `ran_with_providers = ["openrouter"]`,
+which `_CLOSED_PROVIDER_MARKERS` matches, so an entry whose declared models are deepseek,
+kimi and qwen is published as closed.
+
+This unit gives the Scoreboard the inputs to classify correctly. It publishes no new number.
+
+## 2. Scope
+
+| | here | elsewhere |
+| -- | -- | -- |
+| accept, bound and store `models` | ✅ | |
+| derive `ran_with_providers` from it | ✅ | |
+| `classify_model()` + registry fixes | ✅ | |
+| bounded read of `models` for frontier ids | ✅ | |
+| the Client sending `models` | | `OME-1180` |
+| the metric and `/frontier` response | | `OME-1145` |
+
+### 2.1 Wire and storage
+
+`ScoreSubmission` gains:
+
+```python
+models: Annotated[list[ModelRoute], Field(min_length=1)] | None = None
+```
+
+`None` means the client did not send them. It is **not** the same as an empty list, which is
+rejected — a submission that declares no models at all is a client bug, not a legitimate
+state, and `CandidateResult.models` is a required non-empty field on the Client side.
+
+`ModelRoute` mirrors `AuthorEmail`: an annotated `str` with a length cap and a pattern. The
+pattern is the Client's own route grammar (`_MODEL_ROUTE_RE` in
+`_evaluation/candidate.py:429`), so the two ends cannot disagree about what a route is.
+
+`Score` gains a nullable `models` JSONField, and migration `0013_score_models` adds it —
+the same shape as `0012_score_authors`, nullable and not backfilled.
+
+### 2.2 Bounds
+
+Three, mirroring the `authors` precedent (`_AUTHORS_MAX_DISTINCT`, `_AUTHORS_MAX_BYTES`):
+
+| bound | proposed | why |
+| -- | -- | -- |
+| routes per submission | 32 | a fusion of 32 models is already implausible; the live maximum is 4 |
+| length per route | 255 | matches `AuthorEmail`'s cap and the `spec_id` column |
+| serialized size | 4096 bytes | identical to `_AUTHORS_MAX_BYTES` and `_METADATA_MAX_BYTES` |
+
+All three raise a field error, so an oversized payload is a 422 and never a 500.
+
+### 2.3 Deriving providers
+
+When `models` is present, `ran_with_providers` is computed server-side from it rather than
+stored from the client's copy, so the two fields cannot contradict each other.
+
+**INVARIANT: `_content_hash` keeps reading `submission.ran_with_providers`, the wire value,
+not the derived one.** The hash is recipe identity (`OME-391`); recomputing it from a
+server-derived value would change every existing recipe's hash and split the board's dedup
+history. In the normal case the two are identical, because the Client derives its providers
+from the same routes. They diverge only when a client sends inconsistent fields, and in that
+case storage should be honest while identity stays stable.
+
+This derivation does **not** establish which models ran. Both values originate with the
+submitter (`OME-1179`, Note on trust).
+
+### 2.4 Classification
+
+`OME-1179` D1 keeps the existing any-closed-wins aggregation, so there is no new algorithm.
+What changes is the input and one extra verdict:
+
+```python
+def classify_model(route: str) -> Literal["open", "closed", "unknown"]: ...
+```
+
+**Route normalisation.** Strip a leading routing prefix before matching, or every
+OpenRouter-carried route matches `openrouter` on the closed list regardless of the model it
+names. Verified: feeding the full route to today's `classify_providers` still returns closed.
+
+**Precedence.** A specific model rule beats its owner rule. Three carve-outs, all in the same
+direction, all verified wrong today:
+
+| route | today | required |
+| -- | -- | -- |
+| `google/gemma-*` | closed, via `google` | open |
+| `openai/gpt-oss-*` | closed, via `openai` | open |
+| `moonshotai/kimi-*` | closed, unmatched | open |
+
+`mistral` stays a bare substring. Under `OME-1179` Q1 — open means weights you can download
+and run — Mistral Large 2411 is already correct. The earlier "tighten mistral" instruction is
+withdrawn.
+
+**`unknown` must not collapse into `closed`.** Both close an entry under D1, but D4 requires
+the count of unrecognised models to be reportable, so they are distinct return values. The
+existing fail-closed `logger.warning` stays.
+
+`classify_score` and `classify_providers` are untouched. They keep serving the existing
+row-level surfaces until `OME-1145` replaces them.
+
+### 2.5 Reading models for a frontier
+
+A projection of `id, models` scoped to a set of score ids, **chunked**. The frontier is not
+small or bounded — every best-per-spec point can be non-dominated and spec ids are
+client-controlled — so a single `WHERE id IN (…)` can exceed database parameter limits.
+
+It reads `id, models` and nothing else. `ParetoEntry` is not widened: `leaderboard.py:270-275`
+records that the whole-board read stays minimal so client-controlled recipes and display
+metadata are never materialised en masse.
+
+---
+
+## 3. DECISION NEEDED — Q2: is `models` public?
+
+`ScoreSchema` is the internal read DTO; `LeaderboardEntry` is the public payload.
+
+Model identities are **already public** — `url4_expression` carries every declared route
+literally and is returned on `LeaderboardEntry` today. So this is not a disclosure question.
+It is an API-surface question: a typed `models` array makes that data directly enumerable and
+creates a new wire contract to support.
+
+| option | consequence |
+| -- | -- |
+| **A — internal only** (recommended) | `models` on `ScoreSchema`, absent from `LeaderboardEntry`. Classification works; nothing new is promised publicly. The portal's Backends column keeps reading `ran_with_providers` and keeps its honest label. `OME-1145` or a portal ticket can widen it later, when there is a consumer. |
+| B — public now | `models` on `LeaderboardEntry` too. Lets the portal render real model names, which is the visible fix people will ask for. But it commits to the field before the Client populates it, so every row returns `null` until `OME-1180` ships and people resubmit. |
+
+**Recommended: A.** It keeps this unit's blast radius inside the Scoreboard, and a public
+field whose value is `null` on every row is worse than no field.
+
+## 4. DECISION NEEDED — Q3: legacy and deduplicated rows
+
+Every existing row will have `models = null`. Two sub-questions.
+
+**4a. Does a replay enrich a null `models`?** `store.py:835-849` builds the dedup `updates`
+dict from exactly `authors` and `metadata`, so a resubmission carrying `models` against an
+existing row is silently discarded today.
+
+| option | consequence |
+| -- | -- |
+| **A — enrich on same-owner replay** (recommended) | Add `models` to `updates` under the existing `same_candidate_owner` guard, reusing its anti-hijack check and visibility locking unchanged. Rows fill in naturally as people resubmit. |
+| B — leave null | Simplest. A row submitted before `OME-1180` can never gain identities, so the board carries permanently unclassifiable rows. |
+
+**4b. Do we backfill the seven live rows?** Not in this unit either way, but the answer shapes
+what `OME-1145` can show. `url4_expression` does contain the routes; the grader-ambiguity
+problem that ruled out runtime parsing is manageable in a one-off operator script where the
+output can be inspected before it is committed. Proposed: **out of scope here, note it on
+`OME-1145`** so the "metric is empty at launch" risk is visible where it matters.
+
+**Not negotiable either way:** `models` must **not** enter `_content_hash`. It is a richer
+projection of data already in `url4_expression`, which is hashed. Adding it would split one
+recipe's identity merely because a newer client sent more detail about the same recipe.
+
+---
+
+## 5. Acceptance
+
+* an optional `models` is accepted, stored, and survives round-trip
+* `models: []` is rejected with a field error
+* a submission without `models` still succeeds and stores `null`
+* when `models` is present, stored `ran_with_providers` is derived from it
+* `_content_hash` is unchanged by the presence of `models` — a resubmission carrying it dedups
+  to the same row
+* each of the three bounds rejects with a field error, not a 500
+* `classify_model()` returns `unknown` for an unrecognised route, distinguishably from
+  `closed`, and still logs it
+* `classify_model()` classifies `gemma`, `gpt-oss` and `kimi` open — each pinned separately, so
+  removing one carve-out fails one test
+* a route classifies identically with and without its routing prefix
+* `classify_score` / `classify_providers` behaviour is unchanged — pinned, since the existing
+  frontier surfaces still call them
+* the frontier-scoped read is chunked, exercised above one chunk boundary
+* the migration ships in this iteration (stack rule S1)
+* full Scoreboard gates green
+
+## 6. Not in scope
+
+`_current_split()`, the `/frontier` response shape, the portal's Backends column, anything
+touching cost, and the Client change (`OME-1180`).
+
+## 7. Risks
+
+**Rollout.** This must be **deployed**, not merely merged, before `OME-1180` is released.
+Merging `OME-1180` starts a release-please train to PyPI, and a released Client sending an
+unknown top-level field 422s against an un-upgraded Scoreboard.
+
+**The registry stays hand-maintained.** Q1 chose downloadable-weights as the definition, which
+is knowable per model but not derivable from any field the Gateway exposes — checked, there is
+no licence or `open_weights` signal in its discovery code. D4's visible-miss count is the
+mitigation, not a fix.

--- a/docs/tasks/2026-09-10-OME-1179-pareto-frontier-openness.md
+++ b/docs/tasks/2026-09-10-OME-1179-pareto-frontier-openness.md
@@ -1,0 +1,52 @@
+---
+id: OME-1179
+linear_url: https://linear.app/openmined/issue/OME-1179/epic-compute-pareto-frontier-openness-from-submitted-model-identities
+status: Backlog
+type: decision
+priority: 2
+labels: [scoreboard, human, design-session]
+created: 2026-09-10
+closed:
+---
+
+# EPIC: Compute Pareto-frontier openness from submitted model identities
+
+Cross-landing epic. The Scoreboard has no structured candidate-model field, so it cannot tell
+an open-weights model from the reseller that carried it. Blocks `OME-1145`.
+
+One sub-issue per landing, per the cross-cutting rule:
+
+| sub-issue | landing | state |
+| -- | -- | -- |
+| `OME-1181` | `scoreboard` | built, PR #922, ships and **deploys** first |
+| `OME-1180` | `py-screamingface` | built, PR #923 held in draft, ships second |
+
+## Contract
+
+> Of the entries on the full-board cost/score Pareto frontier, report how many are open. An
+> entry is open when every declared model route it names has downloadable, locally runnable
+> weights. Any closed model — or any model the registry does not recognise — makes the whole
+> entry closed.
+
+## Decisions taken
+
+| # | outcome |
+| -- | -- |
+| D1 | Any-closed-wins, per **entry**. The unit is the submission, not the model. |
+| D2, D3 | Moot under D1 — neither counts models. |
+| D4 | Unrecognised fails closed, and the miss must be made visible. Exposure belongs to `OME-1145`. |
+| D5 | Superseded. `openness_override` has no application write path and loses its consumers. |
+| Q1 | "Open" means weights you can download and run, whatever the licence says about commercial use. |
+| Q2 | `models` stays off `LeaderboardEntry`. **Corrected**: `ScoreSchema` is itself public, so the field carries `exclude_if`. |
+| Q3 | A same-owner replay may **fill** a null value. **Corrected**: never replace a populated one. |
+
+Q2 and Q3 were both corrected after review of PR #922 — see the ledger for the evidence.
+
+## Artifacts
+
+- Review that drove this epic: `docs/work/2026-09-10-OME-1145-openness-metric-review.md`
+  and its companion feedback document
+- Sub-issue artifacts live with their own mirrors
+
+Related: `OME-1145` (the bug), `OME-772` (recorded the gap on 2026-08-11), `OME-323` (built the
+statistic).

--- a/docs/tasks/2026-09-10-OME-1181-model-identities.md
+++ b/docs/tasks/2026-09-10-OME-1181-model-identities.md
@@ -1,0 +1,55 @@
+---
+id: OME-1181
+linear_url: https://linear.app/openmined/issue/OME-1181/accept-and-store-model-identities-and-classify-openness-per-model
+status: In Progress
+type: task
+priority: 2
+labels: [scoreboard, agentic, autonomous]
+parent: OME-1179
+created: 2026-09-10
+closed:
+---
+
+# Accept and store model identities, and classify openness per model
+
+Scoreboard half of `OME-1179`. Provides the **inputs** to classify openness by model rather
+than by the reseller that carried the request. Publishes no new number — `OME-1145` owns the
+metric and the response shape.
+
+| | |
+| -- | -- |
+| Accept | optional `models` on `ScoreSubmission`, capped at 32 routes / 255 chars / 4096 bytes |
+| Store | nullable `models` JSON column + migration `0013_score_models` |
+| Derive | stored `ran_with_providers` computed from the routes |
+| Classify | `classify_model(route) -> open \| closed \| unknown`, structural owner matching |
+| Replay | a same-owner republish may **fill** a null value, never replace one |
+| Read | `models_for_score_ids()`, chunked, two columns |
+
+## Ships and DEPLOYS first
+
+`ScoreSubmission` is `extra="forbid"`, so a Client sending `models` to a Scoreboard that does
+not know the field gets a **422**. Merging is not sufficient — this must be deployed and
+confirmed live before `OME-1180` is released.
+
+## Review corrections (PR #922, 2026-09-11)
+
+Four findings, all confirmed empirically, two of which invalidated claims made without checking:
+
+1. `models` is **not** internal. `ScoreSchema` is the response model for `POST /scores` and
+   `GET /scores/{id}`, and feeds the private JSONL export whose bytes authorize a purge. Now
+   carries `exclude_if`; legacy export digests verified byte-identical to `origin/main`.
+2. Substring matching on a client-submitted route let a crafted name buy an open verdict.
+   Matching is now structural — owner matched exactly, family exceptions scoped to their owner.
+3. A replay could replace an existing declaration. Now fills only a null value.
+4. `gemini-cli`, `codex` and `antigravity` are registered Gateway providers and were missing
+   from the closed-owner set, corrupting the unrecognised-model count.
+
+## Artifacts
+
+- Spec: `docs/spec/2026-09-11-OME-1181-model-identities.md`
+- Plan: `docs/plan/2026-09-11-OME-1181-model-identities.md`
+- Ledger: `docs/work/2026-09-11-OME-1181-model-identities.md`
+- PR: #922
+
+Related: `OME-1180` (the Client half, PR #923), `OME-1145` (the bug this chain serves),
+`OME-1056` (the case-count rule this leaves alone).

--- a/docs/work/2026-09-11-OME-1181-model-identities.md
+++ b/docs/work/2026-09-11-OME-1181-model-identities.md
@@ -1,7 +1,7 @@
 ---
 ticket: OME-1181
 stack: scoreboard
-status: planned
+status: in_progress
 started: 2026-09-11
 finished:
 ---

--- a/docs/work/2026-09-11-OME-1181-model-identities.md
+++ b/docs/work/2026-09-11-OME-1181-model-identities.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1181
 stack: scoreboard
-status: in_progress
+status: done
 started: 2026-09-11
-finished:
+finished: 2026-09-11
 ---
 
 # OME-1181 — Accept and store model identities, and classify openness per model
@@ -53,9 +53,62 @@ See `docs/spec/2026-09-11-OME-1181-model-identities.md`. Summary: an optional `m
 accepted, bounded, stored, projected and classifiable; a submission without it still succeeds;
 the migration ships in this iteration; full Scoreboard gates green.
 
-## Outcome (fill at the end — required before COMMIT)
+## Outcome
 
-- **Actual files:** <vs planned>
-- **Commits:** <sha — message>
-- **Gates:** <run_gates.py result line / counts>
-- **Deviations:** <anything that differed from the plan, or "none">
+- **Actual files:** as planned. `classification/openness.py`, `scores/schemas.py`,
+  `scores/models/score.py`, `scores/migrations/0013_score_models.py`, `scores/store.py`, and two
+  new test modules. Nothing under `portal/` or `routes/` was touched — this unit publishes no
+  new number, per the scope boundary with OME-1145.
+
+- **Commits:**
+  - `4e5096a6` — `feat(scoreboard): classify openness per model route`
+  - `a84383a6` — `test(scoreboard): pin the routing-strip guard on the unknown case`
+  - `38edbc7a` — `feat(scoreboard): accept and store declared model routes`
+  - `1efe798b` — `feat(scoreboard): derive stored providers from the declared routes`
+  - `5b10f5f6` — `feat(scoreboard): let a same-owner replay fill in declared routes` (tests only, see Deviations)
+  - `77a426ce` — `feat(scoreboard): restore the replay allowlist and add the chunked route read`
+
+- **Gates:** `run_gates.py scoreboard --base origin/main` ALL GREEN — append-only, ruff check,
+  ruff format, pyright, pytest at 88% coverage, and all three portal suites. 63 tests across the
+  two new modules; no existing test was edited, so no append-only exception was needed.
+
+- **Migration verified by hand.** Nothing in this repo applies migrations — the test fixture
+  builds the schema from the models via `tortoise_test_context`, and neither the gate runner nor
+  `scoreboard-tests.yml` runs one. So `0013` was applied to a fresh SQLite database directly:
+  the whole chain through `0013_score_models` applied OK and the `models` JSON column landed
+  (23 columns). Owner declined filing a ticket for the gate gap.
+
+## Deviations
+
+1. **`5b10f5f6` committed its tests without their implementation, and was red.** The mutation
+   harness restores files with `git checkout`, and phase 4's implementation was still
+   uncommitted when I ran it, so the trap reverted `store.py` and I staged the result without
+   re-running the suite. Restored unchanged in `77a426ce`. Intermediate history is not a
+   correctness problem here because the repo squash-merges, but the lesson is: never run a
+   git-restoring harness against uncommitted work, and always re-run the suite between a
+   mutation run and a commit.
+
+2. **A mutation survived its own restore.** Inverting `_MODEL_RULES` is a same-size edit, and
+   `git checkout` landed inside the same mtime second, so Python's bytecode staleness check
+   (mtime + size) passed and pytest kept using the mutated `.pyc` while the source on disk was
+   correct. Two gate runs failed against code that was already right. The harness now clears
+   `__pycache__` before every run and inside the restore trap.
+
+3. **Mutation testing found a real gap in phase 1.** Deleting `_strip_routing_prefix` entirely
+   left every prefix-invariance assertion green — the open markers are consulted first, so a
+   recognised open model never reaches the `openrouter` marker. The strip is load-bearing for
+   the *unknown* case instead, where its absence turns an honest `unknown` into a confident
+   `closed`. Guard added in `a84383a6`.
+
+4. **`_confirm_replayable` exceeded its complexity budget** once `models` joined the replay
+   allowlist. The allowlist moved into `_replay_updates`, which also gives the three correctable
+   fields one place to be read. No behaviour change for `authors` or `metadata`.
+
+5. **Bounds are 32 routes / 255 chars / 4096 bytes** as specced. The route pattern is the
+   Client's own grammar, anchored, so the two ends cannot disagree about what a route is.
+
+## Follow-on
+
+`OME-1180` may now be built, but must not be **released** until this is deployed and confirmed
+live — `ScoreSubmission` is `extra="forbid"`, so a released Client sending `models` to an
+un-upgraded board 422s every submission.

--- a/docs/work/2026-09-11-OME-1181-model-identities.md
+++ b/docs/work/2026-09-11-OME-1181-model-identities.md
@@ -1,0 +1,61 @@
+---
+ticket: OME-1181
+stack: scoreboard
+status: planned
+started: 2026-09-11
+finished:
+---
+
+# OME-1181 — Accept and store model identities, and classify openness per model
+
+## Intent
+
+The Scoreboard cannot tell an open-weights model from the router that carried it. The Client
+truncates every declared model route to its first path segment, so all seven live
+`draco-3pass` entries store `ran_with_providers = ["openrouter"]` and an entry named
+`best_open_source` is classified closed.
+
+This unit gives the Scoreboard the **inputs** to do better: accept and store the declared
+model routes, derive providers from them, and classify a route rather than a provider prefix.
+It does not change any published number — `OME-1145` owns the metric and the response shape.
+
+It ships and **deploys** before `OME-1180`, because `ScoreSubmission` is `extra="forbid"` and
+an older Scoreboard 422s an unknown top-level field.
+
+## Planned changes
+
+- `apps/scoreboard/src/scoreboard/scores/schemas.py` — `models` on `ScoreSubmission` with its
+  bounds validator; `models` on `ScoreSchema`; `ModelRoute` annotated type.
+- `apps/scoreboard/src/scoreboard/scores/models/score.py` — nullable `models` JSONField.
+- `apps/scoreboard/src/scoreboard/scores/migrations/0013_score_models.py` — the AddField,
+  mirroring `0012_score_authors.py`.
+- `apps/scoreboard/src/scoreboard/scores/store.py` — `_submission_to_kwargs` carries `models`;
+  `_score_to_schema` projects it; `_derived_providers()`; the chunked frontier-scoped read.
+- `apps/scoreboard/src/scoreboard/classification/openness.py` — `classify_model()`, route
+  normalisation, the three registry carve-outs.
+- `apps/scoreboard/tests/unit/...` — additive tests only.
+
+## Test plan
+
+RED first. Full list in the spec's acceptance section; the invariants that need a guard rather
+than a restatement of the diff:
+
+- a route with and without the `openrouter/` prefix classify identically
+- `gemma`, `gpt-oss` and `kimi` each classify open, and each fails if its carve-out is removed
+- `unknown` is distinguishable from `closed` in the return value, not merely in the log
+- an oversized `models` payload returns a field error, not a 500
+- `models` is absent from `_content_hash`, so a resubmission carrying it dedups to the same row
+- the chunked read is exercised above one chunk boundary
+
+## Acceptance
+
+See `docs/spec/2026-09-11-OME-1181-model-identities.md`. Summary: an optional `models` is
+accepted, bounded, stored, projected and classifiable; a submission without it still succeeds;
+the migration ships in this iteration; full Scoreboard gates green.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:** <vs planned>
+- **Commits:** <sha — message>
+- **Gates:** <run_gates.py result line / counts>
+- **Deviations:** <anything that differed from the plan, or "none">


### PR DESCRIPTION
Scoreboard half of `OME-1179`. Gives the board the inputs to classify openness by **model** rather than by the reseller that carried the request. Publishes no new number — `OME-1145` owns the metric and the response.

## The problem

The Client truncates every declared route to its first path segment, so `openrouter/deepseek/deepseek-v4-pro` arrives as `"openrouter"` — which is on the closed marker list. All seven live `draco-3pass` entries store `ran_with_providers = ["openrouter"]`, and an entry named `best_open_source` (deepseek, kimi, qwen) is published as **closed**.

## What lands

| | |
|---|---|
| **Accept** | optional `models` on `ScoreSubmission`, capped at 32 routes / 255 chars / 4096 bytes |
| **Store** | nullable `models` JSON column + migration `0013_score_models` |
| **Derive** | stored `ran_with_providers` computed from the routes, so the two fields cannot contradict each other |
| **Classify** | `classify_model(route) -> open \| closed \| unknown` — **structural**: the owner segment is matched exactly, family exceptions are scoped to their owner |
| **Replay** | a same-owner republish may fill in routes on a row that lacks them |
| **Read** | `models_for_score_ids()`, chunked, projecting two columns |

## Decisions this encodes

* **OME-1179 D1** — any-closed-wins stays; the unit of the statistic is the entry, not the model. So there is no new aggregation, only better input.
* **Q1** — "open" means weights you can download and run, whatever the licence says about commercial use. `mistralai` is therefore an open **owner**, so Mistral Large 2411 classifies correctly and the earlier "tighten mistral" instruction is withdrawn. (An earlier revision of this description said `mistral` stays a bare substring; matching is now structural, not substring — see below.)
* **Q2** — `models` lands on `ScoreSchema` and stays off `LeaderboardEntry`, the ranked-board payload. It is **not** internal, though: `ScoreSchema` is itself a response model, so the field carries `exclude_if` and an absent value never reaches the wire. (This bullet originally called the schema internal. It is not — see round 2 below.)
* **Q3** — a same-owner replay may fill in routes, reusing the existing anti-hijack guard and visibility lock. `models` stays out of `_content_hash`.

## Two invariants worth review attention

**`_content_hash` reads the wire `ran_with_providers`, never the derived value.** Storage may be corrected; identity may not be rewritten underneath existing rows. Hashing the derived value would recompute identity for every row whose client-sent providers differ from its routes, and each would stop deduplicating to its stored twin.

**`unknown` is a third verdict, not a synonym for `closed`.** Both close an entry under D1, but D4 needs the count of unrecognised models reportable — a stale registry must be observable rather than looking like a genuinely closed board. On the live board `moonshotai/kimi-k2.6` alone is the difference between 0% and 29%.

## Test plan

`run_gates.py scoreboard --base origin/main` — **ALL GREEN**: append-only, ruff check, ruff format, pyright, pytest at 88% coverage, three portal suites. 688 passing overall, of which **66** are the two new modules here; no existing test edited, so no append-only exception.

Mutation-checked — dropping the same-owner guard, wiping routes on an omitted replay, deleting the routing-prefix strip, and skipping the provider derivation on either path are each caught. The classifier's own precedence is now pinned directly rather than by mutation, since the rules are structural: a family exception only fires for its own owner, and crafted names are covered by explicit cases.

**Migration verified by hand**, because nothing in this repo applies migrations: the fixture builds the schema from the models, and neither the gate runner nor CI runs one. The full chain through `0013` was applied to a fresh SQLite database and the column lands.

## ⚠️ Deploy before releasing OME-1180

`ScoreSubmission` is `extra="forbid"`, so a released Client sending `models` to an un-upgraded board **422s every submission**. Merging this is not sufficient — it must be deployed and confirmed live first.

## One thing in the history

`5b10f5f6` committed its tests without their implementation and was red. The mutation harness restores with a checkout and ran against uncommitted work, so its trap reverted `store.py` before I staged. Restored unchanged in `77a426ce`, and recorded in the ledger's deviations. Harmless on `main` since this squash-merges, but worth knowing if you read the commits individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round 2 — four findings, all fixed

Three P1s and one P2, all confirmed empirically before fixing. Two invalidated claims I had made without checking.

**`models` was not internal.** `ScoreSchema` is the response model for `POST /scores` and `GET /scores/{id}`, and it feeds the private JSONL export whose bytes `purge_private_benchmark.export_sha256` hashes to authorize a purge. `"models": null` changed every previously saved export, so a certified export could no longer authorize its own purge. Now carries `exclude_if`, like `ranking_notice` beside it. Verified byte-identical to `origin/main` for a legacy row: `ac966efd…b8a3`, 582 bytes both sides.

**Substring matching was exploitable.** Routes are client-submitted, so `openai/not-gemma-proprietary` classified **open** — along with `anthropic/kimi-wrapper` and `google/not-qwen-api`. Matching is now structural: owner matched exactly, family exceptions prefix-matched and scoped to their owner. No owner segment fails closed as `unknown`.

**Replay could replace a declaration.** `_content_hash` excludes `models`, so two submissions differing only in their routes share one identity, and the update was unconditional — a replay could swap what an entry is made of and flip its openness without changing its identity. Now fills only a null value.

**Three registered providers read as unknown.** `gemini-cli`, `codex` and `antigravity` were missing from the closed-owner set. No percentage changes, but it corrupts the D4 staleness count. Added, along with a test covering all seven owner-shaped registered providers. Also dropped `cohere` and `xai`, both of which I had added speculatively — neither is registered, and `xai` is not OpenRouter's namespace either.

One bookkeeping fix went to Linear rather than here: OME-1181's acceptance demanded the unrecognised-model count be *exposed*, contradicting its own scope table. Moved to OME-1145.
