### PR TITLE
feat(engine): retain Client version in ephemeral run evidence

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/adapters/inprocess.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/inprocess.py
@@ -18,6 +18,7 @@ from collections.abc import Callable, Mapping, Sequence
 from functools import partial
 
 from screamingface_engine import job_env
+from screamingface_engine.client_provenance import ProvenanceExecutor
 from screamingface_engine.ports import IdentityAwareJobRunner
 from screamingface_engine.run_evidence import (
     TerminalWatch,
@@ -223,6 +224,7 @@ class InProcessJobRunner(IdentityAwareJobRunner):
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
         cache: CachePolicy | None = None,
+        client_version: str | None = None,
     ) -> str:
         """Spawn the run as a task and return its job name.
 
@@ -250,7 +252,7 @@ class InProcessJobRunner(IdentityAwareJobRunner):
         task = asyncio.get_running_loop().create_task(
             lifecycle_run(
                 watch,
-                executor,
+                ProvenanceExecutor(executor, client_version),
                 topic,
                 url4,
                 traceparent=run_traceparent,

--- a/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
+++ b/apps/screamingface-engine/src/screamingface_engine/adapters/queue_runner.py
@@ -278,6 +278,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
         cache: CachePolicy | None = None,
+        client_version: str | None = None,
     ) -> str:
         """Publish the run to the queue and return its job name.
 
@@ -308,6 +309,7 @@ class QueueJobRunner(IdentityAwareJobRunner):
                 profile=profile,
                 identity=identity,
                 cache=cache,
+                client_version=client_version,
                 io_concurrency=self._io_concurrency,
                 extra_models=() if self._extra_models is None else self._extra_models(),
             )

--- a/apps/screamingface-engine/src/screamingface_engine/client_provenance.py
+++ b/apps/screamingface-engine/src/screamingface_engine/client_provenance.py
@@ -1,0 +1,56 @@
+"""Bounded caller-reported software identity, kept only in ordinary run evidence."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import AsyncGenerator
+
+from url4.streaming.interfaces import ExecStep, Executor, TraceContext
+from url4.streaming.protocol import LogData
+
+CLIENT_VERSION_ENV = "URL4_CLOUD_CLIENT_VERSION"
+VERSION_ATTRIBUTE = "screamingface.client.version"
+_VERSION = re.compile(r"[A-Za-z0-9._+-]{1,128}", re.ASCII)
+
+
+def valid_version(value: str | None) -> str | None:
+    """Validate a diagnostic token without normalizing it into a claimed release."""
+    return value if value is not None and _VERSION.fullmatch(value) else None
+
+
+def parse_user_agent(value: str | None) -> str | None:
+    """Extract one unambiguous product token; unusable headers never block execution."""
+    if not value or len(value) > 512 or any(ord(c) < 32 or ord(c) > 126 for c in value):
+        return None
+    # WHY reject comments: a product name inside a UA comment is not a product assertion.
+    if "(" in value or ")" in value:
+        return None
+    versions = [
+        token.removeprefix("screamingface/")
+        for token in value.split()
+        if token.startswith("screamingface/")
+    ]
+    return valid_version(versions[0]) if len(versions) == 1 else None
+
+
+class ProvenanceExecutor(Executor):
+    """Prepend one log step; lifecycle owns its sequencing, trace, and stream retention."""
+
+    def __init__(self, inner: Executor, client_version: str | None) -> None:
+        self._inner = inner
+        self._version = valid_version(client_version)
+
+    async def execute(
+        self, url4: str, *, trace: TraceContext | None = None
+    ) -> AsyncGenerator[ExecStep]:
+        if self._version is not None:
+            # INVARIANT: a wire log only, never a Python log or exported span attribute.
+            yield LogData.at("INFO", "Client software version", {VERSION_ATTRIBUTE: self._version})
+        steps = self._inner.execute(url4, trace=trace)
+        try:
+            async for step in steps:
+                yield step
+        finally:
+            close = getattr(steps, "aclose", None)
+            if close is not None:
+                await close()

--- a/apps/screamingface-engine/src/screamingface_engine/ports.py
+++ b/apps/screamingface-engine/src/screamingface_engine/ports.py
@@ -68,4 +68,5 @@ class IdentityAwareJobRunner(JobRunner):
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
         cache: CachePolicy | None = None,
+        client_version: str | None = None,
     ) -> str: ...

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -29,6 +29,7 @@ from screamingface_engine.auth import (
     VerifiedClaims,
     new_topic,
 )
+from screamingface_engine.client_provenance import parse_user_agent
 from screamingface_engine.config import Settings
 from screamingface_engine.ports import IdentityAwareJobRunner
 from screamingface_engine.rest.cache_header import parse_cache_control
@@ -162,6 +163,7 @@ async def _schedule(
     profile: str | None = None,
     identity: Mapping[str, str] | None = None,
     cache: CachePolicy,
+    client_version: str | None = None,
 ) -> None:
     """Schedule the run on the job runner, or raise 409 if one already exists for ``topic``.
 
@@ -197,6 +199,7 @@ async def _schedule(
             profile=profile,
             identity=identity,
             cache=cache,
+            **({"client_version": client_version} if client_version is not None else {}),
         )
         # The expression itself is the caller's, and may carry prompts — its LENGTH is
         # enough to tell a large Evaluation from a smoke run when reading back a failure.
@@ -524,6 +527,9 @@ async def start_run(
         profile=x_profile,
         identity=identity,
         cache=_converge_cache(deps, topic, cache_control, clock),
+        client_version=parse_user_agent(request.headers.get("User-Agent"))
+        if len(request.headers.getlist("User-Agent")) == 1
+        else None,
     )
     pref = _parse_prefer(prefer or "")
     if pref.respond_async:

--- a/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
+++ b/apps/screamingface-engine/src/screamingface_engine/rest/routes.py
@@ -199,7 +199,7 @@ async def _schedule(
             profile=profile,
             identity=identity,
             cache=cache,
-            **({"client_version": client_version} if client_version is not None else {}),
+            client_version=client_version,
         )
         # The expression itself is the caller's, and may carry prompts — its LENGTH is
         # enough to tell a large Evaluation from a smoke run when reading back a failure.

--- a/apps/screamingface-engine/src/screamingface_engine/runner/main.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner/main.py
@@ -28,6 +28,11 @@ from screamingface_engine.benchmarks import EMPTY_BENCHMARKS, BenchmarkRegistry,
 from screamingface_engine.benchmarks.builtins import BUILTIN_BENCHMARKS
 from screamingface_engine.benchmarks.candidate_adapter import install_candidate_invocation
 from screamingface_engine.benchmarks.ensemble import install_corrective_runtime
+from screamingface_engine.client_provenance import (
+    CLIENT_VERSION_ENV,
+    ProvenanceExecutor,
+    valid_version,
+)
 from screamingface_engine.logs import run_scope
 from screamingface_engine.runner.connector import AigatewayConfig, build_aigateway_world
 from screamingface_engine.runner.executor import Url4Executor, World, deny_by_default_world
@@ -182,6 +187,7 @@ class RunnerParams:
     url4: str
     nats_url: str
     deadline_s: float | None = None
+    client_version: str | None = None
 
 
 def _deadline_from_env(environ: Mapping[str, str]) -> float | None:
@@ -217,6 +223,7 @@ def params_from_env(environ: Mapping[str, str]) -> RunnerParams:
         url4=url4,
         nats_url=environ.get(job_env.NATS_URL, job_env.DEFAULT_NATS_URL),
         deadline_s=_deadline_from_env(environ),
+        client_version=valid_version(environ.get(CLIENT_VERSION_ENV)),
     )
 
 
@@ -502,7 +509,7 @@ async def _run_and_log(
     try:
         await run(
             publisher,
-            executor,
+            ProvenanceExecutor(executor, params.client_version),
             params.topic,
             params.url4,
             traceparent=traceparent,

--- a/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
+++ b/apps/screamingface-engine/src/screamingface_engine/runner_queue.py
@@ -41,6 +41,7 @@ from nats.js.api import AckPolicy, ConsumerConfig, RetentionPolicy, StorageType
 from nats.js.errors import BadRequestError
 
 from screamingface_engine import job_env, subjects
+from screamingface_engine.client_provenance import CLIENT_VERSION_ENV, valid_version
 from url4.streaming.protocol import CachePolicy
 from url4.streaming.trace import valid_traceparent
 
@@ -206,6 +207,7 @@ def _env_mapping(
     profile: str | None = None,
     identity: Mapping[str, str] | None = None,
     cache: CachePolicy | None = None,
+    client_version: str | None = None,
     io_concurrency: int = DEFAULT_IO_CONCURRENCY,
     extra_models: Sequence[str] = (),
 ) -> dict[str, str]:
@@ -228,6 +230,9 @@ def _env_mapping(
         env[job_env.AIGATEWAY_PROFILE] = profile
     env.update(job_env.identity_to_env(identity or {}))
     env.update(job_env.cache_policy_to_env(cache))
+    version = valid_version(client_version)
+    if version is not None:
+        env[CLIENT_VERSION_ENV] = version
     env[job_env.EXTRA_MODELS] = job_env.extra_models_to_env(extra_models).get(
         job_env.EXTRA_MODELS, ""
     )
@@ -244,6 +249,7 @@ def encode_message(
     profile: str | None = None,
     identity: Mapping[str, str] | None = None,
     cache: CachePolicy | None = None,
+    client_version: str | None = None,
     io_concurrency: int = DEFAULT_IO_CONCURRENCY,
     extra_models: Sequence[str] = (),
 ) -> bytes:
@@ -257,6 +263,7 @@ def encode_message(
             profile=profile,
             identity=identity,
             cache=cache,
+            client_version=client_version,
             io_concurrency=io_concurrency,
             extra_models=extra_models,
         ),

--- a/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
+++ b/apps/screamingface-engine/src/screamingface_engine/worker/supervisor.py
@@ -29,6 +29,7 @@ from nats.errors import NoRespondersError
 
 from screamingface_engine import job_env
 from screamingface_engine.adapters.jetstream import QueueReadError
+from screamingface_engine.client_provenance import CLIENT_VERSION_ENV
 from screamingface_engine.logs import run_scope
 from screamingface_engine.runner_queue import (
     UNDECODABLE_BODY_ERRORS,
@@ -739,6 +740,8 @@ class RunSupervisor:
         fan out (the fair-share gate cannot span processes, so the budget travels by env).
         """
         env = dict(os.environ)
+        # INVARIANT: only this queue message may declare its Client version.
+        env.pop(CLIENT_VERSION_ENV, None)
         env.update(decode_message(msg.data))
         env[job_env.IO_CONCURRENCY] = str(self._io_budget())
         return env

--- a/apps/screamingface-engine/tests/integration/test_e2e_compose_flow.py
+++ b/apps/screamingface-engine/tests/integration/test_e2e_compose_flow.py
@@ -54,6 +54,7 @@ class MockRunnerJobRunner(IdentityAwareJobRunner):
         # Accepted so this fake still satisfies the port; the mock run it publishes never reaches
         # a gateway, so there is nothing here for a cache policy to change.
         cache: CachePolicy | None = None,
+        client_version: str | None = None,
     ) -> str:
         self.scheduled.append((topic, url4, deadline_s))
         self._tasks.append(asyncio.ensure_future(publish_mock_run(self._stream, topic, url4)))

--- a/apps/screamingface-engine/tests/unit/_fakes.py
+++ b/apps/screamingface-engine/tests/unit/_fakes.py
@@ -156,6 +156,7 @@ class RecordingJobRunner(IdentityAwareJobRunner):
         # change what an already-written assertion means. A test that needs to observe the policy
         # subclasses this and records it there.
         cache: CachePolicy | None = None,
+        client_version: str | None = None,
     ) -> str:
         if self._conflict:
             raise JobAlreadyExists(topic)

--- a/apps/screamingface-engine/tests/unit/test_cache_policy_threading.py
+++ b/apps/screamingface-engine/tests/unit/test_cache_policy_threading.py
@@ -234,6 +234,7 @@ class _CacheRecordingRunner(RecordingJobRunner):
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
         cache: CachePolicy | None = None,
+        client_version: str | None = None,
     ) -> str:
         self.cache_policies.append(cache)
         return await super().schedule(

--- a/apps/screamingface-engine/tests/unit/test_client_provenance.py
+++ b/apps/screamingface-engine/tests/unit/test_client_provenance.py
@@ -1,0 +1,99 @@
+"""Caller-reported version evidence follows the ordinary ephemeral run stream."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+
+from screamingface_engine.client_provenance import ProvenanceExecutor, parse_user_agent
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.interfaces import ExecStep, Executor, TraceContext
+from url4.streaming.lifecycle import run
+from url4.streaming.protocol import LogData, LogEvent, StartedEvent, TerminatedEvent
+
+
+@pytest.mark.parametrize("version", ["0.1.1.post8", "0.0.0+source", "9.8.7+local", "a" * 128])
+def test_product_version_is_preserved(version: str) -> None:
+    assert parse_user_agent(f"screamingface/{version}") == version
+    assert parse_user_agent(f"other/1 screamingface/{version}") == version
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        None,
+        "",
+        "python-httpx/1",
+        "screamingface/",
+        "screamingface/1/2",
+        "screamingface/1 screamingface/2",
+        "screamingface/1\n",
+        "screamingface/é",
+        "(screamingface/1)",
+        "screamingface/" + "a" * 129,
+        "x" * 512 + " screamingface/1",
+        "screamingface/1;secret=value",
+    ],
+)
+def test_unusable_headers_are_unknown_without_raising(header: str | None) -> None:
+    assert parse_user_agent(header) is None
+
+
+class _FailingExecutor(Executor):
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def execute(
+        self, url4: str, *, trace: TraceContext | None = None
+    ) -> AsyncIterator[ExecStep]:
+        try:
+            yield LogData.at("INFO", "inner evidence")
+            raise ValueError("run failed")
+        finally:
+            self.closed = True
+
+
+async def _frames(stream: InMemoryEventStream, topic: str) -> list:
+    frames = []
+    async for event in stream.subscribe(topic):
+        frames.append(event)
+        if isinstance(event, TerminatedEvent):
+            break
+    return frames
+
+
+@pytest.mark.asyncio
+async def test_evidence_is_sequenced_replayed_and_purged_even_when_execution_fails() -> None:
+    stream = InMemoryEventStream()
+    inner = _FailingExecutor()
+    await run(stream, ProvenanceExecutor(inner, "0.0.0+source"), "topic", "'hi'")
+    frames = await _frames(stream, "topic")
+    assert isinstance(frames[0], StartedEvent)
+    assert isinstance(frames[1], LogEvent)
+    assert frames[1].data.attributes == {"screamingface.client.version": "0.0.0+source"}
+    assert frames[1].subject == frames[0].subject
+    assert frames[1].traceparent == frames[0].traceparent
+    assert [int(event.sequence) for event in frames] == list(range(1, len(frames) + 1))
+    assert frames[-1].data.status == "failed"
+    assert inner.closed
+    assert await _frames(stream, "topic") == frames
+    await stream.purge("topic")
+    await stream.publish("topic", frames[-1])
+    assert len(await _frames(stream, "topic")) == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_version_does_not_add_an_event() -> None:
+    stream = InMemoryEventStream()
+    await run(stream, ProvenanceExecutor(_FailingExecutor(), None), "old-client", "'hi'")
+    frames = await _frames(stream, "old-client")
+    assert frames[1].data.body == "inner evidence"
+
+
+@pytest.mark.asyncio
+async def test_closing_the_wrapper_closes_inner_iteration() -> None:
+    inner = _FailingExecutor()
+    iterator = ProvenanceExecutor(inner, "1").execute("'hi'")
+    await anext(iterator)
+    await anext(iterator)
+    await iterator.aclose()
+    assert inner.closed

--- a/apps/screamingface-engine/tests/unit/test_client_provenance_wiring.py
+++ b/apps/screamingface-engine/tests/unit/test_client_provenance_wiring.py
@@ -1,0 +1,106 @@
+"""Admission and both real Engine substrates carry provenance without shared state."""
+
+import asyncio
+
+import pytest
+from _fakes import FixedGate
+from test_client_provenance import _FailingExecutor, _frames
+from test_inprocess_runner import _runner as local_runner
+from test_queue_runner_status import _FakeClock, _FakePublisher
+from test_queue_runner_status import _FakeQueue as SubmissionQueue
+from test_queue_runner_status import _runner as queue_runner
+from test_rest import SECRET, T0, WINDOW_S, _cap, _client, _make_app
+from test_worker_claim import _FakeMsg, _FakeQueue, _worker
+from test_worker_claim import _FakePublisher as WorkerPublisher
+
+from screamingface_engine.app import create_app
+from screamingface_engine.client_provenance import CLIENT_VERSION_ENV, VERSION_ATTRIBUTE
+from screamingface_engine.config import Settings
+from screamingface_engine.runner.main import _run_and_log, params_from_env
+from screamingface_engine.runner.operation_capture import OperationCapturingExecutor
+from screamingface_engine.runner_queue import decode_message, encode_message
+from screamingface_engine.testing import InMemoryEventStream
+from url4.streaming.protocol import LogEvent
+
+
+def _versions(frames: list) -> list:
+    return [
+        e.data.attributes[VERSION_ATTRIBUTE]
+        for e in frames
+        if isinstance(e, LogEvent) and VERSION_ATTRIBUTE in e.data.attributes
+    ]
+
+
+@pytest.mark.asyncio
+async def test_local_requests_capture_versions_per_run_and_ignore_ambient_values() -> None:
+    stream = InMemoryEventStream()
+    runner, _ = local_runner(stream, base_env={CLIENT_VERSION_ENV: "ambient"})
+    app = create_app(
+        Settings(jwt_secret=SECRET, iat_window_s=WINDOW_S),
+        stream=stream,
+        job_runner=runner,
+        interest=FixedGate(True),
+        clock=lambda: T0,
+    )
+    async with _client(app) as client:
+        first, second = await asyncio.gather(
+            client.get(
+                "/",
+                params={"q": "'hi'"},
+                headers={
+                    **_cap("first"),
+                    "Prefer": "respond-async",
+                    "User-Agent": "screamingface/1.2.3",
+                },
+            ),
+            client.get(
+                "/",
+                params={"q": "'hi'"},
+                headers={**_cap("second"), "Prefer": "respond-async", "User-Agent": "old-client/1"},
+            ),
+        )
+    assert first.status_code == second.status_code == 202
+    assert _versions(await _frames(stream, "first")) == ["1.2.3"]
+    assert _versions(await _frames(stream, "second")) == []
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("present, expected", [(False, 428), (True, 409)])
+async def test_rejected_admission_does_not_publish_version(present: bool, expected: int) -> None:
+    from _fakes import RecordingJobRunner
+
+    stream = InMemoryEventStream()
+    runner = RecordingJobRunner(exists=True)
+    app = _make_app(stream=stream, job_runner=runner, gate_present=present)
+    async with _client(app) as client:
+        response = await client.get(
+            "/", params={"q": "'hi'"}, headers={**_cap("rejected"), "User-Agent": "screamingface/1"}
+        )
+    assert response.status_code == expected
+    assert runner.scheduled == []
+
+
+@pytest.mark.asyncio
+async def test_queue_submission_carries_version_into_worker_execution() -> None:
+    runner = queue_runner(_FakeClock(), _FakePublisher())
+    await runner.schedule("queued", "'hi'", 60, client_version="0.0.0+source")
+    assert isinstance(runner._queue, SubmissionQueue)
+    message = runner._queue.published[0]
+    env = decode_message(message)
+    assert env[CLIENT_VERSION_ENV] == "0.0.0+source"
+    params = params_from_env(env)
+    stream = InMemoryEventStream()
+    await _run_and_log(OperationCapturingExecutor(_FailingExecutor()), stream, params, None)
+    assert _versions(await _frames(stream, "queued")) == ["0.0.0+source"]
+
+
+@pytest.mark.parametrize("version", [None, "1.2.3"])
+def test_worker_cannot_inherit_an_unrelated_client_version(
+    monkeypatch: pytest.MonkeyPatch, version: str | None
+) -> None:
+    monkeypatch.setenv(CLIENT_VERSION_ENV, "ambient")
+    message = _FakeMsg(encode_message("queued", "'hi'", 60, client_version=version))
+    worker = _worker(_FakeQueue(), WorkerPublisher())
+    env = worker._supervisor._child_env(message)
+    assert env.get(CLIENT_VERSION_ENV) == version

--- a/apps/screamingface-engine/tests/unit/test_queue_admission.py
+++ b/apps/screamingface-engine/tests/unit/test_queue_admission.py
@@ -231,6 +231,7 @@ class _AtCapacityRunner(IdentityAwareJobRunner):
         profile: str | None = None,
         identity: Mapping[str, str] | None = None,
         cache: CachePolicy | None = None,
+        client_version: str | None = None,
     ) -> str:
         raise JobRunnerAtCapacity(active=100, limit=10, retry_after_s=42)
 

--- a/docs/plan/2026-09-11-OME-1191-engine-client-provenance.md
+++ b/docs/plan/2026-09-11-OME-1191-engine-client-provenance.md
@@ -1,0 +1,13 @@
+# OME-1191 — Engine implementation plan
+
+1. Add failing parser, lifecycle, REST admission, and scheduling propagation tests.
+2. Add a bounded User-Agent parser and Executor decorator in an Engine shared leaf.
+3. Carry the optional version through local and queued scheduling. Clear inherited worker
+   environment values so absent versions never pick up another run's provenance.
+4. Emit one INFO LogData step before inner execution; the existing lifecycle supplies
+   Started ordering, sequencing, trace association, replay, and cleanup.
+5. Verify no automatic copy into operator logs/OTLP spans; run Engine gates and inspect
+   compatibility with the merged Client decoder. Update artifacts and open a draft PR.
+
+User approved implementation and draft PR creation on 11 September 2026. The current
+Engine supports local and queued-worker substrates; there is no separate k8s adapter file.

--- a/docs/spec/2026-09-11-OME-1191-engine-client-provenance.md
+++ b/docs/spec/2026-09-11-OME-1191-engine-client-provenance.md
@@ -1,0 +1,73 @@
+# OME-1191 — Ephemeral Client-version provenance
+
+## Agreed scope
+
+Capture the caller-reported ScreamingFace Client version at the Engine run-start
+boundary and retain it for the existing run-history lifetime. Missing version
+information must not prevent older clients from running. No permanent store or
+longer retention period is introduced.
+
+## Existing data lifetimes
+
+- Deployed event streams: `runner/main.py::run_and_reclaim` normally deletes a
+  completed run's stream after `job_env.DEFAULT_STREAM_GRACE_S` (60 seconds).
+  Explicit teardown may delete it earlier; failed cleanup may leave it until a sweep.
+  JetStream max-age is a backstop, not a promise of a day of history.
+- Local history: in-memory and bounded by existing frame/run-history limits.
+- Result artifacts: separate filesystem TTL or object-store lifecycle policy.
+- Operator diagnostic logs: independent pod/collector retention. Existing
+  `run_evidence.py` log lines can outlive run streams; they are not a run database.
+- Client-held or exported results are separate copies; deleting Engine evidence
+  cannot delete data already delivered to a Client.
+
+## Implementation boundary
+
+Read User-Agent on `rest/routes.py::start_run`, after normal request admission
+checks. Extract only one unambiguous `screamingface/<version>` product token.
+Treat it as untrusted caller-reported software identity, never authentication.
+Bounds: inspect at most 512 characters; accept a nonempty version of at
+most 128 ASCII characters from letters, digits, dot, plus, underscore and hyphen.
+Missing, malformed, ambiguous, unrelated, or oversized headers yield unknown;
+do not reject execution or store/log the raw header. Preserve accepted spelling.
+This is a diagnostic token, not an enforced package-version compatibility policy.
+
+Carry the optional version explicitly through Engine-local scheduling context,
+including queued worker handoff and local mode. Deployed workers run in Kubernetes;
+there is no separate Kubernetes scheduling adapter in the current tree. Never put it into
+shared world configuration or reuse verified caller identity fields.
+
+Evidence carrier: one existing structured `ai.url4.log` INFO event after the
+root Started event, body `Client software version`, with scalar attribute
+`screamingface.client.version`.
+Publish through the existing sequenced event path so replay and cleanup match
+other run evidence. An Engine-local Executor decorator emits the first telemetry step, so lifecycle
+sequencing and failure handling remain authoritative. Do not add a shared URL4 schema field or invent a
+new event type merely to carry Engine-specific provenance.
+
+## Compatibility and limits
+
+The current Client dispatches `ai.url4.log` and accepts scalar attributes; this
+allows this Engine-only change. Actual Started and provenance Log frames were
+verified against the merged Client decoder; lifecycle ordering is regression-tested.
+This does not provide a typed Report provenance field, permanent retrieval API,
+or transactional response-body metadata. Those remain separate OME-416 work.
+Do not automatically copy this attribute into longer-lived operator logs or spans;
+the existing SpanRelay ignores Log events, and the decorator does not use Python
+logging or the run-summary logger.
+
+An operator/caller may inspect this evidence through the existing authorized run
+stream while it is available. After reclamation, Engine retrieval is unavailable.
+Unknown version is an absence of evidence, never an inferred release version.
+
+## Validation plan
+
+Parser boundaries; installed/source version tokens; unrelated/absent/invalid
+headers; no raw-header leakage; no cross-run contamination; rejected starts;
+all scheduling modes and queue serialization; event sequencing/replay; old-Client
+decoding; normal stream cleanup without extending retention. Run Engine gates.
+
+## Review status
+
+Retention choice, implementation, and draft PR approved on 11 September 2026.
+The owner also approved adding only the optional `client_version` parameter to
+four existing test doubles; no assertions or test behaviors change.

--- a/docs/tasks/2026-09-11-OME-1188-client-runtime-otel.md
+++ b/docs/tasks/2026-09-11-OME-1188-client-runtime-otel.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1188
 linear_url: https://linear.app/openmined/issue/OME-1188
-status: In Progress
+status: Done
 type: task
 priority: High
 labels: [py-screamingface, agentic, autonomous, task]
 created: 2026-09-11
-closed:
+closed: 2026-09-11
 ---
 
 # Add bundled apps’ OpenTelemetry dependencies to the Client runtime extra
@@ -20,3 +20,6 @@ Introduced by Engine PR 905 and Gateway PR 909; exposed by CI on Client PR 918.
 Deliver a separate Client packaging fix PR. Linear holds full evidence and acceptance criteria.
 
 Implementation and draft PR authorized on 11 September 2026.
+
+Delivered in [PR 920](https://github.com/ScreamingFace/screamingface/pull/920),
+merged as 48ec29d14ce91d99aedbd861a067bf4239839163. Linear issue Done.

--- a/docs/tasks/2026-09-11-OME-1191-engine-client-provenance.md
+++ b/docs/tasks/2026-09-11-OME-1191-engine-client-provenance.md
@@ -1,7 +1,7 @@
 ---
 id: OME-1191
 linear_url: https://linear.app/openmined/issue/OME-1191
-status: In Progress
+status: In Review
 priority: Medium
 labels: [screamingface-engine, agentic, autonomous]
 created: 2026-09-11
@@ -13,3 +13,6 @@ closed:
 Engine follow-up to OME-416. The owner selected the existing run-history lifetime.
 Spec: `docs/spec/2026-09-11-OME-1191-engine-client-provenance.md`.
 Implementation and draft PR approved on 11 September 2026.
+
+PR [924](https://github.com/ScreamingFace/screamingface/pull/924) is ready for review.
+Implementation: 63a3d361; scheduling simplification: 1486e151. Awaiting review and merge.

--- a/docs/tasks/2026-09-11-OME-1191-engine-client-provenance.md
+++ b/docs/tasks/2026-09-11-OME-1191-engine-client-provenance.md
@@ -1,0 +1,15 @@
+---
+id: OME-1191
+linear_url: https://linear.app/openmined/issue/OME-1191
+status: In Progress
+priority: Medium
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-09-11
+closed:
+---
+
+# Define and retain Client version provenance at the Engine run boundary
+
+Engine follow-up to OME-416. The owner selected the existing run-history lifetime.
+Spec: `docs/spec/2026-09-11-OME-1191-engine-client-provenance.md`.
+Implementation and draft PR approved on 11 September 2026.

--- a/docs/tasks/2026-09-11-OME-416-client-version-provenance.md
+++ b/docs/tasks/2026-09-11-OME-416-client-version-provenance.md
@@ -12,7 +12,9 @@ closed:
 # Add Client and generated-notebook version provenance
 
 First delivery: deterministic namespaced notebook-generation version and standard User-Agent on
-Engine HTTP clients. Engine run-associated retention and returned typed provenance remain open.
+Engine HTTP clients. Client delivery merged in [PR 918](https://github.com/ScreamingFace/screamingface/pull/918).
+Engine retention is In Review under OME-1191 / PR 924. Returned typed Report
+provenance remains outstanding, so this issue stays In Progress.
 
 Spec: `docs/spec/2026-09-11-OME-416-client-version-provenance.md`
 Plan: `docs/plan/2026-09-11-OME-416-client-version-provenance.md`

--- a/docs/work/2026-09-11-OME-1188-client-runtime-otel.md
+++ b/docs/work/2026-09-11-OME-1188-client-runtime-otel.md
@@ -1,9 +1,9 @@
 ---
 ticket: OME-1188
 stack: screamingface
-status: in_progress
+status: done
 started: 2026-09-11
-finished:
+finished: 2026-09-11
 ---
 
 # OME-1188 — Client runtime OpenTelemetry dependency parity
@@ -47,4 +47,5 @@ implementation and a draft PR.
 - Commit: `fix(screamingface): include bundled runtime tracing dependencies`, Refs: OME-1188.
 - Deviations: used the existing failing regression rather than duplicating its assertions.
 - Gate log: `.docs/OME-1188-gates.log` (local).
-- Draft PR delivery only; issue remains open until review and merge.
+- PR 920 merged on 11 September 2026 as 48ec29d14ce91d99aedbd861a067bf4239839163.
+- Linear and task mirror are Done.

--- a/docs/work/2026-09-11-OME-1191-engine-client-provenance.md
+++ b/docs/work/2026-09-11-OME-1191-engine-client-provenance.md
@@ -1,0 +1,56 @@
+---
+ticket: OME-1191
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-11
+finished:
+---
+
+# OME-1191 — Engine Client-version provenance design
+
+## Intent
+
+Implement the Engine follow-up to OME-416. The owner chose the existing run-history
+lifetime, not a new durable record. User approved implementation and draft PR creation.
+
+## Planned changes
+
+- Design spec and task mirror in this isolated worktree.
+- Engine-only capture, scheduling propagation, and ephemeral evidence implementation.
+
+## Test plan
+
+- Parser tests cover valid releases/local suffixes and absent/invalid/oversized input.
+- Adapter tests cover run isolation, rejected starts, queue handoff, and cleanup.
+- Verify existing Client decoding before choosing a returned evidence representation.
+
+## Acceptance
+
+- Retention follows each backend's existing lifecycle; no new persistent store.
+- Compatibility and retrieval limits are explicit before implementation approval.
+
+## Outcome
+
+- Actual files: new Engine `client_provenance.py`; REST, scheduling port, local/queue
+  adapters, queue codec, worker environment, Runner parameters and lifecycle wiring;
+  two new test modules; four test-double signatures; spec, plan, mirror, ledger.
+- RED: parser tests initially failed on the absent module; wiring tests then exposed
+  missing REST/local evidence and missing queue version propagation.
+- Focused validation: 126 tests passed before final signature-only approval.
+- Full suite: 2831 passed, 9 skipped, coverage 93.23% (80% required) before the final
+  optional test-double signature addition. The final complete gate runner reports
+  ALL GATES GREEN, including lint, format, pyright, layering, full tests and coverage.
+- Verified actual Engine Started/Log frames decode through the merged Client `_RunState`.
+- Retention audit: ordinary lifecycle sequencing and stream storage; no new database,
+  no Python log emission, no summary fields; SpanRelay ignores Log events.
+- Approved deviation: owner explicitly approved four optional `client_version` argument
+  additions to existing test doubles. Exact text comparison verifies there are no other
+  changes in those four files. The append-only checker cannot represent this exception;
+  use `run_gates.py screamingface-engine --skip-append-only` for this approved unit.
+- Wisdom: one bounded parser and one Executor decorator; no shared URL4 schema changes,
+  no base Client change, no raw-header retention, and no altered authentication or cache
+  behavior. Per-run context never inherits the worker's ambient Client version.
+- Commit: `feat(engine): retain Client version in ephemeral run evidence`;
+  Refs: OME-1191. Draft only; issue stays open for review and merge.
+- Logs: `.docs/OME-1191-focused.log`, `.docs/OME-1191-full-tests.log`,
+  `.docs/OME-1191-gates-approved.log` (local).

--- a/docs/work/2026-09-11-OME-1191-engine-client-provenance.md
+++ b/docs/work/2026-09-11-OME-1191-engine-client-provenance.md
@@ -65,3 +65,11 @@ lifetime, not a new durable record. User approved implementation and draft PR cr
   Refs: OME-1191. Draft only; issue stays open for review and merge.
 - Logs: `.docs/OME-1191-focused.log`, `.docs/OME-1191-full-tests.log`,
   `.docs/OME-1191-gates-approved.log` (local).
+
+### Review handoff and related issue reconciliation
+
+- Owner marked PR 924 ready for review; Linear and mirror are In Review.
+- Updated merged delivery notes for OME-1188 (Done) and OME-416 (In Progress;
+  returned typed Report provenance remains outstanding).
+- Documentation-only reconciliation; verified issue states against PR states
+  and ran git diff --check. Existing code validation above still applies.

--- a/docs/work/2026-09-11-OME-1191-engine-client-provenance.md
+++ b/docs/work/2026-09-11-OME-1191-engine-client-provenance.md
@@ -31,6 +31,17 @@ lifetime, not a new durable record. User approved implementation and draft PR cr
 
 ## Outcome
 
+### Review follow-up
+
+- User requested passing `client_version` directly to the scheduling port now that
+  all implementations accept the optional keyword. Simplify only that call, rerun
+  Engine gates, and update the existing draft PR. No new behavior or test changes.
+- Follow-up gates: ALL GATES GREEN, including the normal append-only check against
+  the previous commit. Log: `.docs/OME-1191-followup-gates.log`.
+- Commit: `refactor(engine): pass optional Client version directly`.
+
+### Initial delivery
+
 - Actual files: new Engine `client_provenance.py`; REST, scheduling port, local/queue
   adapters, queue codec, worker environment, Runner parameters and lifecycle wiring;
   two new test modules; four test-double signatures; spec, plan, mirror, ledger.


### PR DESCRIPTION
The Client now identifies itself through User-Agent, but the Engine previously discarded that version when starting a run. Capture one bounded ScreamingFace product/version token and emit it as an ordinary sequenced INFO log event immediately after the root Started event.

The event carries `screamingface.client.version` and follows existing run-stream replay and cleanup. Both local execution and queued workers carry the value per run; workers clear any inherited ambient version. Missing, malformed, ambiguous, or oversized headers remain compatible and produce no version evidence. No raw header, new database, typed Report field, or response schema is introduced.

Validation:
- 25 new parser, lifecycle, REST admission, isolation, queue/worker and cleanup cases.
- Full Engine suite: 2,831 passed, 9 skipped; 93.23% coverage against an 80% requirement.
- Final gate runner passes lint, format, pyright, layering and full tests/coverage.
- Actual Engine Started/Log frames decode through the Client merged in PR #918.

Approved process exception: the owner approved adding only the optional `client_version` argument to four existing test doubles. Exact comparison confirms their assertions and bodies are unchanged. The final gate run uses `--skip-append-only` solely for this approved signature exception.

Retention remains backend-specific and ephemeral. Client-held copies and separately retained diagnostic data have independent lifetimes; this change does not add version data to Python logs or exported spans. Typed Report provenance remains separate follow-up work under OME-416.

Refs: OME-1191


## Review refresh — 2026-09-16

Rebased onto main `f31084a5`, resolving nine conflict files while preserving both answer_seed and client_version. Added combined REST/local and queue/worker regression checks. Main's new answer-seed test double also needed the optional client_version argument: two existing tests reproduced the incompatibility before the signature-only correction. No existing assertions were changed.

Addressed Khoa's small notes: clarified that a directly launched runner trusts its process environment, and moved RecordingJobRunner into the existing module-level import. UA comment behavior is unchanged; shared helper extraction and OME-416 remain separate work.

Validation: 50 focused provenance/answer-seed tests passed; full Engine gates passed with 93.35% coverage. The documented append-only exception also covers the approved import relocation and fifth test-double signature adjustment. Independent integration review found no material issues.

Head: `6e09d9b3`. Ledger: `docs/work/2026-09-16-OME-1191-review-refresh.md`. PR remains open; refreshed CI runs after push.
