### PR TITLE
refactor(screamingface-engine): fold MedXpertQA's grading orchestration onto the shared scored path

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/medxpert/aggregate.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/medxpert/aggregate.py
@@ -1,26 +1,26 @@
-"""Reduce every selected MedXpertQA Case into one Candidate result.
+"""MedXpertQA's grading hooks — everything this board still writes to be graded.
 
-INVARIANT — an unparseable answer scores 0.0; it is NOT excluded. This is the official harness's
-empty-prediction verdict, and it is what keeps two systems comparable: the prior experimental run
-scored a model answering 77% of rows over that smaller, easier denominator, so its accuracy was
-not the same measurement as a model that answered all of them.
+The spine owns the marking room (``spine/scored.py``); this module is the board's
+contribution: its exact-match ``grade_case`` (committed letter vs the private key),
+its plain-accuracy scorer, its slice tags, and its own failure wording. The engine
+ships mechanisms; a benchmark ships semantics (folded in OME-1149 — this board was
+the "second non-rubric data point" its pre-fold docstring asked for).
 
-AIDEV-NOTE: that is deliberately NOT the board's `failure_policy`. That axis governs a Case which
-never got a valid grade — an infrastructure failure — and those go to the shared
-`finalize_candidate_result`, which scores the gradeable subset and publishes coverage. Hence the
-board declares `coverage_declare`. An empty answer DOES get a grade here, of 0.0.
+INVARIANT — an unparseable answer scores 0.0; it is NOT excluded. This is the official
+harness's empty-prediction verdict, and it is what keeps two systems comparable: the prior
+experimental run scored a model answering 77% of rows over that smaller, easier denominator,
+so its accuracy was not the same measurement as a model that answered all of them.
+
+AIDEV-NOTE: that is deliberately NOT the board's `failure_policy`. That axis governs a Case
+which never got a valid grade — an infrastructure failure — and those go through the spine's
+failure ladder into the shared `finalize_candidate_result`, which scores the gradeable subset
+and publishes coverage. Hence the board declares `coverage_declare`. An empty answer DOES get
+a grade here, of 0.0.
 
 INVARIANT — a failure to COMMIT and a failure to RUN are different facts. A model that replies
 without a valid letter has answered badly (score 0.0, `answered: false`). A Case whose invocation
 errored has not been measured at all (score `None`, a visible failed Case). Collapsing the two
 would let an outage look like weakness, or weakness look like an outage.
-
-AIDEV-NOTE: this board deliberately does NOT use `spine.CaseGrader`. That grader is rubric-shaped
-— it takes `points: list[int]` with verdicts-by-position, and emits hardcoded failure codes
-(`missing_rubric_asset`, `incomplete_verdicts`, `no_positive_points`) that a board can reword but
-not rename. An MCQ board publishing `code: "missing_rubric_asset"` would contradict its own
-message. `spine.RowReader` IS used — row indexing is genuinely board-independent. If a second
-non-rubric board arrives, generalising `CaseGrader` becomes a spine ticket with two data points.
 """
 
 from __future__ import annotations
@@ -30,21 +30,19 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from screamingface_engine.benchmarks.aggregation import (
-    CandidateScore,
-    SelectedCase,
-    failed_case_result,
-    finalize_candidate_result,
-    grading_failure_case_result,
-    public_error,
-    refusal_case_result,
-    scored_case_result,
-)
+from screamingface_engine.benchmarks.aggregation import CandidateScore, SelectedCase
 from screamingface_engine.benchmarks.contract import CaseResult
 from screamingface_engine.benchmarks.medxpert.case_evaluation import decode_case_evaluation
 from screamingface_engine.benchmarks.medxpert.prepare import METADATA_COLUMNS
-from screamingface_engine.benchmarks.spine.rows import RowReader
+from screamingface_engine.benchmarks.spine.rows import RowReader, read_selected_cases
+from screamingface_engine.benchmarks.spine.scored import (
+    CaseGradeOutcome,
+    GradeRequest,
+    ScoredPath,
+)
 
+# INVARIANT: failure wording is this board's published voice — no rubric-flavored
+# codes ("missing_rubric_asset") may leak into an MCQ result.
 _FAILURE_MESSAGES = {
     "missing_answer_asset": "the baked answer record for this Case is missing or invalid",
     "missing_case_row": "no evaluation row for this Case reached the aggregate",
@@ -54,13 +52,6 @@ _FAILURE_MESSAGES = {
 
 class AggregateError(ValueError):
     """The reducer's input is unusable — raised before any scoring."""
-
-
-_ROWS = RowReader(
-    benchmark_label="MedXpertQA",
-    error_type=AggregateError,
-    decode_case_evaluation=decode_case_evaluation,
-)
 
 
 def load_answer(root: Path, case_id: int) -> dict[str, Any] | None:
@@ -77,25 +68,11 @@ def load_answer(root: Path, case_id: int) -> dict[str, Any] | None:
 
 
 def selected_cases(root: Path, case_ids: tuple[int, ...]) -> list[SelectedCase]:
-    try:
-        decoded = json.loads((root / "cases.json").read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        raise AggregateError(f"MedXpertQA cases are unavailable: {exc}") from None
-    if not isinstance(decoded, list):
-        raise AggregateError("MedXpertQA cases must be a JSON array")
-    by_id = {
-        row.get("id"): row
-        for row in decoded
-        if isinstance(row, Mapping) and isinstance(row.get("id"), int)
-    }
-    chosen: list[SelectedCase] = []
-    for case_id in case_ids:
-        row = by_id.get(case_id)
-        value = row.get("input") if isinstance(row, Mapping) else None
-        if not isinstance(value, str) or not value.strip():
-            raise AggregateError(f"MedXpertQA Case {case_id} has no public input")
-        chosen.append(SelectedCase(case_id=case_id, input=value, metadata={}))
-    return chosen
+    """The roll call from the baked ``cases.json``, in selected order."""
+
+    return read_selected_cases(
+        root, case_ids, benchmark_label="MedXpertQA", error_type=AggregateError
+    )
 
 
 def aggregate(
@@ -106,62 +83,82 @@ def aggregate(
     benchmark_revision: str,
     case_ids: tuple[int, ...],
 ) -> dict[str, Any]:
-    """Score every selected Case, then the exam as plain accuracy."""
+    """Score every selected Case on the shared scored path, then plain accuracy."""
 
-    chosen = selected_cases(root, case_ids)
-    index = _ROWS.index(raw_rows, case_ids)
-    results: list[CaseResult] = []
-    for selected in chosen:
-        case_id = int(selected.case_id)
-        failure = index.grading_failures.get(case_id)
-        if failure is not None:
-            assert failure.error is not None
-            results.append(
-                grading_failure_case_result(
-                    selected_case=selected,
-                    candidate=failure.candidate,
-                    error=failure.error,
-                    method="exact_match",
-                    default_code="medxpert_grading_failed",
-                    default_message="the MedXpertQA checker could not grade this Case",
-                )
-            )
-            continue
-        results.append(
-            _case_result(
-                selected,
-                index.rows.get(case_id),
-                load_answer(root, case_id),
-                index.collected_errors.get(case_id),
-            )
-        )
-    return finalize_candidate_result(
+    # WHY one read per Case: the answer record is both the grading material (its
+    # label) and the source of the public slice tags — load once, use twice.
+    answers: dict[int, dict[str, Any] | None] = {
+        case_id: load_answer(root, case_id) for case_id in case_ids
+    }
+    return _PATH.aggregate(
+        raw_rows,
         benchmark_id=benchmark_id,
         benchmark_revision=benchmark_revision,
-        selected_cases=chosen,
-        cases=results,
+        selected_cases=selected_cases(root, case_ids),
+        grading_material=lambda case_id: answers.get(case_id),
         scorer=_accuracy,
-    ).as_payload()
+        case_metadata=lambda case_id: _slice_metadata(answers.get(case_id)),
+    )
 
 
-def _case_result(
-    selected: SelectedCase,
-    row: Mapping[str, Any] | None,
-    answer: Mapping[str, Any] | None,
-    orphan_errors: list[dict[str, Any]] | None,
-) -> CaseResult:
-    """Score one Case, or turn an unusable state into a visible failure.
+def _decode(grading: object, expected_case_id: int) -> dict[str, Any]:
+    """Validate the envelope, then hoist attempt 1 into the spine's candidate shape.
 
-    Most-broken first: no answer key, then no row, then an error row. Only after all three does
-    the Candidate's own reply decide the score.
+    The committed letter, reasoning, and refusal all live on the first (only)
+    attempt; the spine reads the candidate's half of the row under ``case``.
     """
 
-    slices = _slice_metadata(answer)
-    failure = _terminal_failure(selected, row, answer, orphan_errors)
-    if failure is not None:
-        return _failed(selected, None if row is None else row, failure, slices)
-    assert row is not None and answer is not None
-    return _scored(selected, row, str(answer["label"]), slices)
+    envelope = decode_case_evaluation(grading, expected_case_id)
+    attempt: Mapping[str, Any] = envelope["attempts"][0]
+    metadata: object = attempt.get("metadata")
+    fields: dict[str, Any] = dict(metadata) if isinstance(metadata, Mapping) else {}
+    # D8: turn 1's essay rides the check envelope into the report — a letter with no
+    # reasoning is unauditable, and the audit matters most on the cases that went wrong.
+    reasoning: object = attempt.get("reasoning")
+    if isinstance(reasoning, str) and reasoning:
+        fields["reasoning"] = reasoning
+    return {
+        "case": {
+            "status": attempt.get("status"),
+            "output": attempt.get("commit_output"),
+            "finish_reason": attempt.get("finish_reason"),
+            "refusal": attempt.get("refusal"),
+            "execution": attempt.get("execution"),
+            "operations": attempt.get("operations"),
+            "metadata": fields,
+        },
+        "attempt": dict(attempt),
+    }
+
+
+async def _grade_case(request: GradeRequest) -> CaseGradeOutcome:
+    """Exact-match one committed letter against the private key — the whole exam rule.
+
+    INVARIANT: an unanswered Case scores 0.0, not None — the official empty-prediction
+    verdict. It counts toward the denominator like any other answered Case.
+    """
+
+    attempt: Mapping[str, Any] = request.row["attempt"]
+    material = request.material
+    assert isinstance(material, Mapping)  # the ladder already rejected unusable assets
+    label: str = str(material["label"])
+    committed: str = str(attempt.get("answer") or "")
+    answered: bool = bool(committed)
+    correct: bool = answered and committed == label
+    return CaseGradeOutcome(
+        score=1.0 if correct else 0.0,
+        metrics={"answered": answered},
+        checks=[
+            {
+                "type": "choice",
+                "id": "1",
+                "label": "committed choice matches the published key",
+                "outcome": "MET" if correct else "UNMET",
+                "evidence": [_match_evidence(committed, label, correct)],
+                "metadata": {"committed": committed, "expected": label},
+            }
+        ],
+    )
 
 
 def _slice_metadata(answer: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -183,70 +180,6 @@ def _slice_metadata(answer: Mapping[str, Any] | None) -> dict[str, Any]:
     }
 
 
-def _terminal_failure(
-    selected: SelectedCase,
-    row: Mapping[str, Any] | None,
-    answer: Mapping[str, Any] | None,
-    orphan_errors: list[dict[str, Any]] | None,
-) -> dict[str, Any] | None:
-    """The first unusable state, most-broken first — or ``None`` when the Case can be scored."""
-
-    case_id = int(selected.case_id)
-    if answer is None:
-        return _failure(case_id, "grading", "missing_answer_asset")
-    if row is None:
-        # WHY attach collected errors: an on_error=collect row loses its Case identity, so a
-        # mid-chain error surfaces here as a missing row. Without them the report names the
-        # symptom and hides the cause.
-        extra = {"collected_errors": orphan_errors[:3]} if orphan_errors else {}
-        return _failure(case_id, "candidate", "missing_case_row", **extra)
-    return (
-        _failure(case_id, "candidate", "case_error", error=row["error"]) if "error" in row else None
-    )
-
-
-def _scored(
-    selected: SelectedCase, row: Mapping[str, Any], label: str, slices: Mapping[str, Any]
-) -> CaseResult:
-    attempt = _attempt(row)
-    committed = str(attempt.get("answer") or "")
-    answered = bool(committed)
-    correct = answered and committed == label
-    fields = _candidate_fields(attempt)
-    # INVARIANT: an unanswered Case scores 0.0, not None — the official empty-prediction
-    # verdict. It counts toward the denominator like any other answered Case.
-    grade = {
-        "method": "exact_match",
-        "score": 1.0 if correct else 0.0,
-        "metrics": {"answered": answered},
-        "checks": [
-            {
-                "type": "choice",
-                "id": "1",
-                "label": "committed choice matches the published key",
-                "outcome": "MET" if correct else "UNMET",
-                "evidence": [_match_evidence(committed, label, correct)],
-                "metadata": {"committed": committed, "expected": label},
-            }
-        ],
-    }
-    common = {
-        "selected_case": selected,
-        "finish_reason": fields["finish_reason"],
-        "grade": grade,
-        "metadata": {**fields["metadata"], **slices},
-        "execution": fields["execution"],
-        "operations": fields.get("operations"),
-    }
-    if fields["status"] == "refused":
-        # OME-1037: a refusal WITH text is graded — 0.0 here, no letter was committed — and
-        # stays a scored Case carrying the refusal. A TEXTLESS refusal is a content_filter
-        # provider decline: the classifier drops the score and fails the Case as
-        # `provider_refusal`, so infrastructure never publishes as a plausible grade.
-        return refusal_case_result(refusal=fields["refusal"], **common)
-    return scored_case_result(output=fields["output"], **common)
-
-
 def _match_evidence(committed: str, label: str, correct: bool) -> dict[str, Any]:
     """The exact-match verdict, as the report schema's Evidence record.
 
@@ -266,98 +199,13 @@ def _match_evidence(committed: str, label: str, correct: bool) -> dict[str, Any]
     }
 
 
-def _failed(
-    selected: SelectedCase,
-    row: Mapping[str, Any] | None,
-    failure: dict[str, Any],
-    slices: Mapping[str, Any],
-) -> CaseResult:
-    fields = _candidate_fields(_attempt(row) if row else {})
-    grade = {"method": "exact_match", "score": None, "metrics": {}, "checks": []}
-    common = {
-        "selected_case": selected,
-        "finish_reason": fields["finish_reason"],
-        "grade": grade,
-        "failures": [failure],
-        "metadata": {**fields["metadata"], **slices},
-        "execution": fields["execution"],
-        "operations": fields.get("operations"),
-    }
-    if fields["status"] == "refused":
-        return refusal_case_result(refusal=fields["refusal"], **common)
-    return failed_case_result(output=fields["output"], **common)
-
-
-def _attempt(row: Mapping[str, Any] | None) -> Mapping[str, Any]:
-    attempts = row.get("attempts") if isinstance(row, Mapping) else None
-    first = attempts[0] if isinstance(attempts, list) and attempts else None
-    return first if isinstance(first, Mapping) else {}
-
-
-def _candidate_fields(attempt: Mapping[str, Any]) -> dict[str, Any]:
-    output = attempt.get("commit_output")
-    finish_reason = attempt.get("finish_reason")
-    refusal = attempt.get("refusal")
-    metadata = attempt.get("metadata")
-    fields = dict(metadata) if isinstance(metadata, Mapping) else {}
-    # D8: turn 1's essay rides the check envelope into the report — a letter with no
-    # reasoning is unauditable, and the audit matters most on the cases that went wrong.
-    reasoning = attempt.get("reasoning")
-    if isinstance(reasoning, str) and reasoning:
-        fields["reasoning"] = reasoning
-    return {
-        "status": attempt.get("status"),
-        "output": output if isinstance(output, str) else None,
-        "finish_reason": finish_reason if isinstance(finish_reason, str) else None,
-        "refusal": refusal if isinstance(refusal, str) and refusal.strip() else None,
-        "execution": attempt.get("execution"),
-        "operations": attempt.get("operations"),
-        "metadata": fields,
-    }
-
-
-def _failure(case_id: int, stage: str, code: str, **metadata: Any) -> dict[str, Any]:
-    message = _FAILURE_MESSAGES[code]
-    retryable: bool | None = None
-    public: dict[str, Any] = {}
-    source = metadata.get("error")
-    if not isinstance(source, Mapping):
-        collected = metadata.get("collected_errors")
-        rows = collected[:3] if isinstance(collected, list) else []
-        source = next(
-            (
-                r.get("error")
-                for r in rows
-                if isinstance(r, Mapping) and isinstance(r.get("error"), Mapping)
-            ),
-            None,
-        )
-    if isinstance(source, Mapping):
-        diagnostic = public_error(source, default_code=code, default_message=message)
-        message = diagnostic.message
-        retryable = diagnostic.retryable
-        public["source_error"] = {
-            "kind": diagnostic.kind,
-            "code": diagnostic.code,
-            "message": diagnostic.message,
-            "retryable": diagnostic.retryable,
-        }
-    return {
-        "stage": stage,
-        "code": code,
-        "message": message,
-        "retryable": retryable,
-        "case_id": case_id,
-        "metadata": public,
-    }
-
-
 def _accuracy(cases: Sequence[CaseResult]) -> CandidateScore:
     """Plain accuracy, with the answered fraction reported beside it.
 
-    WHY report `answered` even though withhold already counts unanswered Cases as wrong: 40%
-    built from 40% correct reads very differently from 40% built from 90% correct and half the
-    rows unanswered, and only the second is a formatting failure rather than a knowledge failure.
+    WHY report `answered` even though the empty-prediction verdict already counts
+    unanswered Cases as wrong: 40% built from 40% correct reads very differently from
+    40% built from 90% correct and half the rows unanswered, and only the second is a
+    formatting failure rather than a knowledge failure.
     """
 
     grades = [case.grade for case in cases if case.grade is not None]
@@ -376,5 +224,22 @@ def _accuracy(cases: Sequence[CaseResult]) -> CandidateScore:
         },
     )
 
+
+# WHY bound at module bottom: the scored path lives in the spine; the hooks and the
+# failure-message wording stay board-owned so per-case output is byte-identical to the
+# pre-fold copy (the medxpert unit suite pins every rung — no golden exists yet).
+_PATH = ScoredPath(
+    reader=RowReader(
+        benchmark_label="MedXpertQA",
+        error_type=AggregateError,
+        decode_case_evaluation=_decode,
+    ),
+    grade_case=_grade_case,
+    failure_messages=_FAILURE_MESSAGES,
+    method="exact_match",
+    grading_failure_code="medxpert_grading_failed",
+    grading_failure_message="the MedXpertQA checker could not grade this Case",
+    missing_material_code="missing_answer_asset",
+)
 
 __all__ = ["AggregateError", "aggregate", "load_answer", "selected_cases"]

--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/scored.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/scored.py
@@ -197,6 +197,12 @@ class ScoredPath:
             of a hook-reported failure (``grade_case`` returned a ``failure_code``).
             ``None`` keeps the default assembly (empty metrics, judged/expected
             metadata).
+        missing_material_code: the published failure code when a Case's grading
+            material is unusable (the default missing-material rung only — a
+            ``missing_material_result`` hook owns its whole shape). WHY board-named
+            (OME-1149): the rubric boards say ``missing_rubric_asset``, but an MCQ
+            board's material is its answer key — publishing a rubric-flavored code
+            there would contradict its own message.
     """
 
     reader: RowReader
@@ -209,6 +215,7 @@ class ScoredPath:
     error_row_result: ErrorRowResult | None = None
     missing_material_result: MissingMaterialResult | None = None
     hook_failure_result: HookFailureResult | None = None
+    missing_material_code: str = "missing_rubric_asset"
 
     def aggregate(
         self,
@@ -219,6 +226,7 @@ class ScoredPath:
         selected_cases: Sequence[SelectedCase],
         grading_material: Callable[[int], object | None],
         scorer: Callable[[Sequence[CaseResult]], CandidateScore],
+        case_metadata: Callable[[int], Mapping[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Mark every selected Case, then score the exam with the board's own scorer.
 
@@ -228,11 +236,17 @@ class ScoredPath:
             benchmark_revision: that board's revision, stamped into the result.
             selected_cases: the authoritative roll call, in selected order.
             grading_material: per-Case loader for the board's grading material;
-                ``None`` marks the material unusable ("missing_rubric_asset").
+                ``None`` marks the material unusable (``missing_material_code``).
             scorer: the exam-level reduction, the board's whole ``CandidateScore``
                 builder. Rubric boards bind ``exam_scorer(mean)`` (fixed rubric
                 vocabulary, mean the only choice); a non-rubric board (ifeval)
                 supplies its published metric vocabulary here (OME-1101).
+            case_metadata: optional per-Case loader for PUBLIC report metadata that
+                does not ride the row (OME-1149: MedXpertQA's slice tags live in the
+                private answer asset). Merged into the spine-assembled scored and
+                failed results, so failure-mode analysis can group by the same axes;
+                row-level grading failures and board-owned result hooks keep their
+                own (pre-fold) shape.
 
         Returns:
             The Candidate result payload: every selected Case, its grade or its
@@ -245,7 +259,7 @@ class ScoredPath:
         # Stage 3-4 — the hook is async (an enclave call is a network hop); the
         # surrounding url4 handler is sync.
         case_results: list[CaseResult] = _run_sync(
-            self._case_results(selected_cases, indexed, grading_material)
+            self._case_results(selected_cases, indexed, grading_material, case_metadata)
         )
         # Stage 5 — fold the marks into the class results.
         return finalize_candidate_result(
@@ -261,11 +275,12 @@ class ScoredPath:
         selected_cases: Sequence[SelectedCase],
         indexed: RowIndex,
         grading_material: Callable[[int], object | None],
+        case_metadata: Callable[[int], Mapping[str, Any]] | None,
     ) -> list[CaseResult]:
         # WHY sequential, not gather: selected order is publication order, and no
         # current hook overlaps I/O; concurrency semantics are a later, separate call.
         results: list[CaseResult | None] = [
-            await self._case_result(selected, index, indexed, grading_material)
+            await self._case_result(selected, index, indexed, grading_material, case_metadata)
             for index, selected in enumerate(selected_cases)
         ]
         # An omitted Case (a missing-row hook returned None) files nothing; the
@@ -278,12 +293,14 @@ class ScoredPath:
         selected_index: int,
         indexed: RowIndex,
         grading_material: Callable[[int], object | None],
+        case_metadata: Callable[[int], Mapping[str, Any]] | None,
     ) -> CaseResult | None:
         case_id: int = int(selected_case.case_id)
         row: dict[str, Any] | None = indexed.rows.get(case_id)
         material: object | None = grading_material(case_id)
+        extra_metadata: Mapping[str, Any] = case_metadata(case_id) if case_metadata else {}
         ladder: CaseResult | _Omitted | None = self._ladder_result(
-            selected_case, selected_index, indexed, row, material
+            selected_case, selected_index, indexed, row, material, extra_metadata
         )
         if isinstance(ladder, _Omitted):
             return None
@@ -306,7 +323,9 @@ class ScoredPath:
                     material=material,
                 )
             )
-            result = self._graded_result(selected_case, selected_index, row, outcome)
+            result = self._graded_result(
+                selected_case, selected_index, row, outcome, extra_metadata
+            )
         return result
 
     def _ladder_result(
@@ -316,6 +335,7 @@ class ScoredPath:
         indexed: RowIndex,
         row: Mapping[str, Any] | None,
         material: object | None,
+        extra_metadata: Mapping[str, Any],
     ) -> CaseResult | _Omitted | None:
         """Stage 3 — the ladder, most-broken first; ``None`` means the Case is gradeable."""
 
@@ -337,12 +357,12 @@ class ScoredPath:
             # is reported before the board's own missing material (draco's order).
             result = self.error_row_result(selected, selected_index, row)
         elif material is None:
-            result = self._missing_material(selected, selected_index, row)
+            result = self._missing_material(selected, selected_index, row, extra_metadata)
         elif row is None:
-            result = self._missing_row(selected, selected_index, indexed, case_id)
+            result = self._missing_row(selected, selected_index, indexed, case_id, extra_metadata)
         elif "error" in row:
             failure = self._failure(case_id, "candidate", "case_error", error=row["error"])
-            result = self._failed_result(selected, row, [], failure)
+            result = self._failed_result(selected, row, [], failure, extra_metadata)
         else:
             result = None
         return result
@@ -352,15 +372,16 @@ class ScoredPath:
         selected: SelectedCase,
         selected_index: int,
         row: Mapping[str, Any] | None,
+        extra_metadata: Mapping[str, Any],
     ) -> CaseResult:
         """The missing-material rung: board-owned shape when the hook is set."""
 
         if self.missing_material_result is not None:
             return self.missing_material_result(selected, selected_index, row)
         failure: dict[str, Any] = self._failure(
-            int(selected.case_id), "grading", "missing_rubric_asset"
+            int(selected.case_id), "grading", self.missing_material_code
         )
-        return self._failed_result(selected, row, [], failure)
+        return self._failed_result(selected, row, [], failure, extra_metadata)
 
     def _missing_row(
         self,
@@ -368,12 +389,13 @@ class ScoredPath:
         selected_index: int,
         indexed: RowIndex,
         case_id: int,
+        extra_metadata: Mapping[str, Any],
     ) -> CaseResult | _Omitted:
         """The missing-row rung: board-owned shape — or omission — when the hook is set."""
 
         orphans: list[dict[str, Any]] | None = indexed.collected_errors.get(case_id)
         if self.missing_row_result is None:
-            return self._missing_row_result(selected, orphans)
+            return self._missing_row_result(selected, orphans, extra_metadata)
         board_result: CaseResult | None = self.missing_row_result(selected, selected_index, orphans)
         # None from the board hook means "file nothing" — the finalizer reports
         # the Case as case_result_missing (draco's pinned shape).
@@ -385,6 +407,7 @@ class ScoredPath:
         selected_index: int,
         row: Mapping[str, Any],
         outcome: CaseGradeOutcome,
+        extra_metadata: Mapping[str, Any],
     ) -> CaseResult:
         if outcome.failure_code is not None:
             if self.hook_failure_result is not None:
@@ -398,14 +421,15 @@ class ScoredPath:
                 judged=outcome.metrics.get("judged"),
                 expected=outcome.metrics.get("expected"),
             )
-            return self._failed_result(selected, row, outcome.checks, failure)
-        return self._scored_result(selected, row, outcome)
+            return self._failed_result(selected, row, outcome.checks, failure, extra_metadata)
+        return self._scored_result(selected, row, outcome, extra_metadata)
 
     def _scored_result(
         self,
         selected: SelectedCase,
         row: Mapping[str, Any],
         outcome: CaseGradeOutcome,
+        extra_metadata: Mapping[str, Any],
     ) -> CaseResult:
         assert outcome.score is not None
         fields: CandidateFields = _candidate_fields(row)
@@ -419,7 +443,7 @@ class ScoredPath:
             "selected_case": selected,
             "finish_reason": fields.finish_reason,
             "grade": grade,
-            "metadata": fields.metadata,
+            "metadata": {**fields.metadata, **extra_metadata},
             "execution": fields.execution,
             "operations": fields.operations,
         }
@@ -433,6 +457,7 @@ class ScoredPath:
         self,
         selected: SelectedCase,
         orphan_errors: list[dict[str, Any]] | None,
+        extra_metadata: Mapping[str, Any],
     ) -> CaseResult:
         # WHY the collected_errors attachment: an on_error=collect row loses its
         # Case identity, so a mid-chain error surfaces HERE as a missing row —
@@ -444,7 +469,7 @@ class ScoredPath:
             "missing_case_row",
             **({"collected_errors": orphan_errors[:3]} if orphan_errors else {}),
         )
-        return self._failed_result(selected, None, [], failure)
+        return self._failed_result(selected, None, [], failure, extra_metadata)
 
     def _failed_result(
         self,
@@ -452,6 +477,7 @@ class ScoredPath:
         row: Mapping[str, Any] | None,
         checks: Sequence[Mapping[str, Any]],
         failure: dict[str, Any],
+        extra_metadata: Mapping[str, Any],
     ) -> CaseResult:
         fields: CandidateFields = _candidate_fields(row)
         # WHY a grade with score None rather than no grade: the judge evidence for a
@@ -469,7 +495,7 @@ class ScoredPath:
             "finish_reason": fields.finish_reason,
             "grade": grade,
             "failures": [failure],
-            "metadata": fields.metadata,
+            "metadata": {**fields.metadata, **extra_metadata},
             "execution": fields.execution,
             "operations": fields.operations,
         }

--- a/apps/screamingface-engine/tests/unit/test_spine_scored.py
+++ b/apps/screamingface-engine/tests/unit/test_spine_scored.py
@@ -680,6 +680,64 @@ def test_a_scored_outcome_never_reaches_the_hook_failure_result() -> None:
     assert result["cases"][0]["status"] == "scored"
 
 
+# ── OME-1149: the two seams a fixed-answer board needs ──────────────────────
+
+
+def test_case_metadata_rides_scored_and_failed_results() -> None:
+    """OME-1149: MedXpertQA's slice tags come from the PRIVATE answer asset, not the
+    row — a per-case loader must reach scored, ladder-failed, and missing-row
+    results alike, so failure-mode analysis can group by the same axes."""
+
+    hook = _Hook()
+    result = _path(hook).aggregate(
+        json.dumps([_envelope(1, _grading(1))]),
+        benchmark_id="test-board",
+        benchmark_revision="rev",
+        selected_cases=_selected(1, 2),
+        grading_material=lambda case_id: (5,),
+        scorer=exam_scorer(_mean),
+        case_metadata=lambda case_id: {"body_system": f"slice-{case_id}"},
+    )
+
+    scored, failed = result["cases"]
+    assert scored["status"] == "scored"
+    assert scored["metadata"]["body_system"] == "slice-1"
+    assert failed["status"] == "failed"  # missing row — slice tag must survive
+    assert failed["metadata"]["body_system"] == "slice-2"
+
+
+def test_omitting_case_metadata_changes_nothing() -> None:
+    hook = _Hook()
+    result = _aggregate(_path(hook), [_envelope(1, _grading(1))], _selected(1))
+
+    assert result["cases"][0]["metadata"] == {}
+
+
+def test_the_material_missing_code_is_board_named() -> None:
+    """OME-1149: an MCQ board publishing `missing_rubric_asset` would contradict its
+    own message — the rung's published code is the board's, not spine vocabulary."""
+
+    hook = _Hook()
+    messages = dict(MESSAGES) | {"missing_answer_asset": "test: answer key gone"}
+    result = _path(
+        hook,
+        failure_messages=messages,
+        missing_material_code="missing_answer_asset",
+    ).aggregate(
+        json.dumps([_envelope(1, _grading(1))]),
+        benchmark_id="test-board",
+        benchmark_revision="rev",
+        selected_cases=_selected(1),
+        grading_material=lambda case_id: None,
+        scorer=exam_scorer(_mean),
+    )
+
+    assert hook.requests == []
+    failure = result["cases"][0]["failures"][0]
+    assert (failure["stage"], failure["code"]) == ("grading", "missing_answer_asset")
+    assert failure["message"] == "test: answer key gone"
+
+
 # ── the shared rubric hook factory: both boards' marking, written once ──────
 
 

--- a/docs/tasks/2026-09-12-OME-1149-medxpert-spine-fold.md
+++ b/docs/tasks/2026-09-12-OME-1149-medxpert-spine-fold.md
@@ -1,12 +1,12 @@
 ---
 id: OME-1149
 linear_url: https://linear.app/openmined/issue/OME-1149/adding-a-second-exact-match-benchmark-means-copying-medxpertqas
-status: in_progress
+status: done
 type: task
 priority: 4
 labels: [screamingface-engine, agentic, autonomous, task]
 created: 2026-09-12
-closed:
+closed: 2026-09-12
 ---
 
 # Adding a second exact-match benchmark means copying MedXpertQA's grading code

--- a/docs/tasks/2026-09-12-OME-1149-medxpert-spine-fold.md
+++ b/docs/tasks/2026-09-12-OME-1149-medxpert-spine-fold.md
@@ -1,0 +1,20 @@
+---
+id: OME-1149
+linear_url: https://linear.app/openmined/issue/OME-1149/adding-a-second-exact-match-benchmark-means-copying-medxpertqas
+status: in_progress
+type: task
+priority: 4
+labels: [screamingface-engine, agentic, autonomous, task]
+created: 2026-09-12
+closed:
+---
+
+# Adding a second exact-match benchmark means copying MedXpertQA's grading code
+
+Shrink `medxpert/aggregate.py` (~380 lines) onto the shared `ScoredPath`: only the
+letter match, the accuracy formula, and MedX's own failure wording remain. Two small
+spine seams ride along: a board-named material-missing code and a per-case metadata
+loader (slice tags on scored AND failed cases). The medxpert unit suite runs untouched
+as the byte-identity net (no medxpert golden exists yet).
+
+Ledger: `docs/work/2026-09-12-OME-1149-medxpert-spine-fold.md`

--- a/docs/work/2026-09-12-OME-1149-medxpert-spine-fold.md
+++ b/docs/work/2026-09-12-OME-1149-medxpert-spine-fold.md
@@ -1,8 +1,9 @@
 ---
 ticket: OME-1149
 stack: screamingface-engine
-status: in_progress
+status: done
 started: 2026-09-12
+finished: 2026-09-12
 ---
 
 # OME-1149 — Fold MedXpertQA's grading orchestration onto the shared scored path
@@ -67,7 +68,12 @@ fold a fixed-answer benchmark writes one check function plus its exam formula.
 
 ## Outcome (fill at the end — required before COMMIT)
 
-- **Actual files:**
-- **Commits:**
-- **Gates:**
-- **Deviations:**
+- **Actual files:** as planned, except gdpval/healthbench/ifeval `grade.py` were NOT
+  touched — `missing_material_code` defaults to `missing_rubric_asset`, so the rubric
+  boards and ifeval's unreachable rung keep their bytes with zero call-site churn.
+- **Commits:** `171f2938` (fold) + this docs flip, squash-merged via the feature PR.
+- **Gates:** `run_gates.py screamingface-engine` ALL GREEN (append-only included —
+  spine tests were pure additions; ruff, pyright, layering, 2716 unit tests, cov ≥80%).
+  e2e: 4 recorded golden replays green (ifeval, gdpval-text, healthbench-worst30,
+  draco-3pass). The medxpert suite (77 tests) passed byte-for-byte untouched.
+- **Deviations:** none.

--- a/docs/work/2026-09-12-OME-1149-medxpert-spine-fold.md
+++ b/docs/work/2026-09-12-OME-1149-medxpert-spine-fold.md
@@ -1,0 +1,73 @@
+---
+ticket: OME-1149
+stack: screamingface-engine
+status: in_progress
+started: 2026-09-12
+---
+
+# OME-1149 — Fold MedXpertQA's grading orchestration onto the shared scored path
+
+## Intent
+
+MedXpertQA predates the scored spine and hand-rolls ~380 lines of orchestration
+(per-case loop, failure ladder, result assembly) around `spine.RowReader`. Its own
+docstring named the trigger: "a second non-rubric board" — ifeval's fold (OME-1101)
+supplied it, plus the scorer parameter that removes MedX's stated objection. After this
+fold a fixed-answer benchmark writes one check function plus its exam formula.
+
+## Design
+
+- **`aggregate.py` shrinks in place** (the acceptance names the file): keeps the answer
+  match, accuracy formula, failure wording, and the OME-1037/official-harness
+  invariants; orchestration comes from `ScoredPath`. Public functions (`aggregate`,
+  `load_answer`, `selected_cases`) keep their signatures — the whole medxpert unit
+  suite runs UNTOUCHED.
+- **Two small spine seams** (each RED-tested first in `test_spine_scored.py`):
+  1. `missing_material_code` on `ScoredPath` — the material-missing rung's published
+     code becomes board-named (MedX: `missing_answer_asset`; rubric boards pass
+     `missing_rubric_asset`, byte-identical; ifeval names `missing_instruction_spec`
+     for its unreachable rung).
+  2. `case_metadata` parameter on `aggregate()` — per-case public metadata (MedX's
+     three slice tags from the private answer record) merged into scored AND failed
+     results, so failed cases keep their slice tags. Boards that omit it are
+     byte-identical.
+- Row decode hoists the attempt into the spine's candidate-field shape (reasoning
+  riding metadata); `selected_cases` delegates to `spine.read_selected_cases`
+  (messages already byte-identical).
+- Stale `spine.CaseGrader` docstring reference rewritten against the real seam.
+
+## Planned changes
+
+- `apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/scored.py` —
+  the two seams above.
+- `.../benchmarks/gdpval/grade.py`, `healthbench/grade.py`, `ifeval/grade.py` — pass
+  the explicit `missing_material_code` (no output change).
+- `.../benchmarks/medxpert/aggregate.py` — orchestration deleted; hook + scorer +
+  wording remain.
+- `tests/unit/test_spine_scored.py` — RED tests for both seams (append-only).
+
+## Test plan
+
+- RED: spine — `case_metadata` reaches scored, ladder-failed, and missing-row results;
+  `missing_material_code` publishes the board's code with its message.
+- Existing `test_medxpert_aggregate.py` (17 tests) passes byte-for-byte UNTOUCHED —
+  it pins: 0.0-unanswered-in-denominator, the two-refusal split (graded text refusal
+  vs `provider_refusal`), slices + reasoning on scored and failed cases, the
+  answer-key-never-leaks invariant, and every ladder rung.
+- No medxpert golden exists (only draco-3pass / healthbench-worst30 / ifeval /
+  gdpval-text are recorded), so the unit suite is the net; the existing four golden
+  replays guard the shared-path changes.
+
+## Acceptance
+
+- `medxpert/aggregate.py` keeps only benchmark-specific logic; no rubric-flavored code
+  in any MCQ result; no `CaseGrader` reference.
+- Full engine gates green; 4 existing golden replays green.
+- Diff well under ~500 lines.
+
+## Outcome (fill at the end — required before COMMIT)
+
+- **Actual files:**
+- **Commits:**
+- **Gates:**
+- **Deviations:**


### PR DESCRIPTION
Folds MedXpertQA — the exact-match board — onto the shared scored path, so a fixed-answer benchmark is one check function plus its exam formula.

## Problem / Solution

**Problem:** MedXpertQA landed before the shared marking room existed, so it still carries its own ~380-line copy of the grading orchestration — the per-case loop, the broken-paper triage, the result assembly. Anyone onboarding a second fixed-answer benchmark would copy that file, and the codebase has already lived through this movie once: gdpval and healthbench drifted apart before their copies were merged.

**Solution:** MedXpertQA now walks through the same shared marking room as every other board, contributing only what is genuinely its own: the letter-vs-key check, the plain-accuracy formula, its slice tags, and its own failure wording. Its module docstring asked for exactly this once "a second non-rubric board" existed — ifeval's fold (OME-1101) was that board.

## Before / After

### Before
- Trigger: a dev onboards a new fixed-answer benchmark (MCQ, clause extraction, …).
- Today: they copy `medxpert/aggregate.py` — ~380 lines of which only the letter match and the accuracy formula are benchmark-specific.
- Cost: a third hand-rolled grading pipeline; a fix in one copy silently misses the others.

### After
- Same trigger.
- Now: they write one `grade_case` plus a scorer; `spine/scored.py` supplies the loop, the failure ladder, and result assembly. `medxpert/aggregate.py` is 245 lines, almost all of it the exam rule and its documented invariants.
- Win: the exact-match family joins rubric and deterministic on one spine; MedXpertQA's published output is byte-identical.

### Don't regress (all pinned by the untouched 77-test medxpert suite)
- An unparseable answer still scores 0.0 and stays in the denominator (official-harness invariant) — never a spine-level failure.
- "Failed to commit" vs "failed to run" stay different facts: 0.0 with `answered: false` vs a visible failed Case with score `None`.
- The two-refusal split (OME-1037): a text refusal is a graded 0.0; a textless one fails as `provider_refusal`.
- No rubric-flavored code in any MCQ result; slice tags and turn-1 reasoning ride scored AND failed cases; the answer key never leaks into metadata.
- No medxpert golden exists yet, so the unit suite is the byte-identity net; the four recorded golden replays (ifeval, gdpval-text, healthbench-worst30, draco-3pass) guard the shared-path changes and are green.

## What is genuinely new at runtime

Two board-agnostic seams on the spine, each RED-tested first:
- `ScoredPath.missing_material_code` — the material-missing rung's published code is board-named (`missing_answer_asset` for MedX). Defaults to `missing_rubric_asset`, so the rubric boards and ifeval needed zero call-site changes and keep their bytes.
- `aggregate(case_metadata=…)` — an optional per-case loader for public report metadata that does not ride the row (MedX's three slice tags live in the private answer asset), merged into scored and failed results alike.

Everything else is code motion: the loop, ladder, and assembly deleted from medxpert were the spine's existing stages.

## Test plan

- `run_gates.py screamingface-engine` all green — including the append-only check (spine tests are pure additions; the medxpert suite is untouched).
- e2e: 4 recorded golden replays green locally (`SCREAMINGFACE_TEST_E2E=1`, snapshot-driven, no keys).

## Review order

1. **`apps/screamingface-engine/src/screamingface_engine/benchmarks/spine/scored.py`** — the marking room's two new seams: the board-named material-missing code and the per-case metadata loader threaded into scored and failed results. Verify: with both omitted, every path is byte-for-byte the old behavior (the default value and the empty-mapping merge).
2. **`.../benchmarks/medxpert/aggregate.py`** — the board's contribution after the fold: the decode hoist (attempt 1 → the spine's candidate shape, reasoning riding metadata), the exact-match `grade_case`, the accuracy scorer, the slice-tag loader. Verify: the grade dict and failure wording match the pre-fold file byte-for-byte (the deleted loop's `_scored`/`_failed` shapes).
3. **`.../tests/unit/test_spine_scored.py`** — the new seams' contract: slice tags reach a missing-row case, omitting the loader changes nothing, the MCQ code replaces the rubric one. These are the spec for step 1.
4. **The diff's deletions in `medxpert/aggregate.py`** — confirm everything removed (per-case loop, ladder, `_failure` plumbing, `_candidate_fields`) exists in the spine and nothing else died. The 77 untouched medxpert tests are the proof.

Refs: OME-1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
