### PR TITLE
docs: plan provider access preflight (OME-1042)

### DIFF
--- a/docs/plan/2026-09-12-OME-1042-provider-preflight.md
+++ b/docs/plan/2026-09-12-OME-1042-provider-preflight.md
@@ -1,0 +1,20 @@
+# OME-1042 — proposed implementation sequence
+
+Status: awaiting owner decision on cross-service scope.
+
+1. Create a coordinating epic and separate Gateway and Engine units; retain
+   OME-1042 as the Client unit. Link dependencies.
+2. Gateway: design a no-inference access-check contract around existing execution
+   credential resolution, including local connections, hosted profiles, and
+   profileless providers. Return no secrets. Prove success/missing/error behavior.
+3. Engine: relay the contract with the same caller and profile as execution;
+   preserve typed upstream failures. Add contract tests.
+4. Client: call the check once per evaluation for all required providers/models,
+   after planning and before starting observers or dispatching Candidates.
+   Cover sync and async, partial access, hosted access, and discovery failures.
+5. Refresh mock Engine fixtures for the added request without weakening existing
+   behavioral assertions. Follow the test-preservation approval rule if required.
+6. Run each landing's full gates and open separate draft PRs with dependencies.
+
+No Client implementation should hardcode provider names or infer execution access
+from model datasheets or local credential absence.

--- a/docs/spec/2026-09-12-OME-1042-provider-preflight.md
+++ b/docs/spec/2026-09-12-OME-1042-provider-preflight.md
@@ -1,0 +1,35 @@
+# OME-1042 — provider access before evaluation
+
+## Required behavior
+
+Before dispatching any Recipe evaluation Candidate, reject authoritative missing
+access to a required provider with ProviderConnectionError and an actionable hint.
+Support both Clients. Preserve valid local BYOK, hosted profiles, and supported
+profileless access. Discovery failures retain their own diagnostics. This check
+does not validate credentials by making an inference request.
+
+## Current gap
+
+At c1c92562, the evaluation runner checks model admission and explicit parameters,
+but not provider access. Neither existing discovery surface is sufficient:
+
+- Gateway model_parameters.py publishes datasheets without stored credentials
+  after OME-1167; a successful details lookup does not prove access.
+- Engine connections/aigateway.py reports stored connection rows or hosted
+  profile states. Missing rows become not_connected.
+- Gateway gemini_provider/plugin.py permits profileless dispatch and selects
+  api_key when its environment key exists. The existing test
+  tests/unit/gemini/test_gemini_routes.py::test_gemini_chat_allows_no_profile_when_env_key_exists
+  protects that behavior. A Client check based on not_connected would reject it.
+
+## Proposed boundary
+
+Gateway owns credential-target resolution and should expose a secret-free,
+no-inference access check using that same policy. Engine forwards caller/profile
+context and the result. Client consumes the result before Candidate dispatch.
+Do not copy provider-specific environment or credential rules into the Client.
+
+## Decision pending
+
+Expand the implementation across the three landings with separate linked units,
+instead of implementing an incorrect Client-only connection-list check.

--- a/docs/tasks/2026-09-12-OME-1042-provider-preflight.md
+++ b/docs/tasks/2026-09-12-OME-1042-provider-preflight.md
@@ -1,0 +1,22 @@
+---
+id: OME-1042
+linear_url: https://linear.app/openmined/issue/OME-1042/raise-providerconnectionerror-before-evaluation-starts-when-no
+status: Needs Owner
+type: bug
+priority: medium
+labels: [py-screamingface, autonomous, agentic]
+created: 2026-08-31
+closed:
+---
+
+# Raise ProviderConnectionError before evaluation starts when no provider is connected
+
+Prevent dispatch when required provider access is authoritatively missing; preserve
+local BYOK, hosted profiles, and supported profileless use.
+
+Investigation found the existing connections API is insufficient for execution
+access (Gemini environment-key dispatch works without a stored connection).
+Awaiting decision on the proposed Gateway → Engine → Client implementation.
+
+See docs/spec/2026-09-12-OME-1042-provider-preflight.md and
+docs/plan/2026-09-12-OME-1042-provider-preflight.md.

--- a/docs/work/2026-09-12-OME-1042-provider-preflight.md
+++ b/docs/work/2026-09-12-OME-1042-provider-preflight.md
@@ -1,0 +1,47 @@
+---
+ticket: OME-1042
+stack: screamingface
+status: blocked
+started: 2026-09-12
+finished:
+---
+
+# OME-1042 — provider preflight
+
+## Intent
+
+Raise an actionable provider-access error before Recipe evaluation dispatches any
+Candidate, without rejecting valid hosted or profileless access.
+
+## Planned changes
+
+- Client evaluation preflight and sync/async regression tests, after resolving the
+  access-authority gap described in the specification and plan.
+- Task mirror, specification, implementation plan, and this ledger.
+
+## Test plan
+
+- Missing and partially available providers: zero dispatches and ProviderConnectionError.
+- Local BYOK, hosted profiles, and Gemini environment-key access: permitted.
+- Discovery authentication and transport errors: preserve their original types.
+- Full screamingface quality gates before an implementation commit.
+
+## Acceptance
+
+- Only authoritative absence of required access fails evaluation before dispatch.
+- No inference request is made by preflight; doctor remains independent.
+
+## Outcome
+
+- Investigation at origin/main c1c92562 found no OME-1042 PR or existing preflight.
+- No production or test files changed; no implementation gates run yet.
+- Existing connection discovery is not an execution-access authority: it projects
+  stored connection/profile rows and misses Gemini's supported environment-key path.
+- Model details intentionally allow credential-free lookup (OME-1167).
+- Awaiting owner direction on expanding into Gateway/Engine/Client units; see
+  docs/plan/2026-09-12-OME-1042-provider-preflight.md.
+- Commit: `docs: record provider preflight design` (Refs: OME-1042).
+- Validation: documentation diff reviewed and `git diff --cached --check`; no runtime
+  changes, so application tests are not applicable.
+- Owner requested a draft PR for these findings and the proposed plan. The draft
+  does not claim to implement or resolve OME-1042.


### PR DESCRIPTION
## Summary

Recipe evaluation can reach execution without provider access and return an unscored report instead of raising an actionable error before dispatch. This draft records the investigation and proposed implementation for OME-1042; it contains documentation only and does not implement the fix.

The existing connections API reports stored connection/profile state, which misses supported Gemini access through a Gateway environment key. Model details are deliberately available without credentials. The proposed solution puts a no-inference access check in Gateway, relays it through Engine, and calls it from the Client before evaluation dispatch.

## Components touched

`docs/spec`, `docs/plan`, `docs/tasks`, and `docs/work` only. Implementation across Gateway, Engine, and Client remains pending in separate linked units.

## Validation

- Reviewed current access and evaluation code, including the existing Gemini profileless-access regression test.
- `git diff --cached --check` and commit hooks passed.
- Application tests were not run: no runtime or test code changed.

Refs: OME-1042
