### PR TITLE
fix(engine): correct IFEval provider failure attribution (OME-981)

### DIFF
--- a/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/grade.py
+++ b/apps/screamingface-engine/src/screamingface_engine/benchmarks/ifeval/grade.py
@@ -10,11 +10,9 @@ FEATURE: one grading spine per benchmark (OME-1024); this fold (OME-1101) is the
 STORY: as a researcher, the number I publish is the IFEval paper's prompt-level strict
 accuracy (arXiv:2311.07911).
 
-INVARIANT: failure output is byte-identical to the pre-fold ``ifeval/aggregate.py`` —
-the recorded golden pins a collected-row failure as stage "grading" with the
-diagnostic's own code, so the board supplies the whole missing-row result
-(``_missing_row_result``) instead of the spine default. The candidate-vs-grading
-attribution question stays open for `OME-981`.
+INVARIANT: only connector-owned diagnostics establish Candidate provenance for an
+anonymous collected row (OME-981). Ambiguous rows retain the grading fallback;
+protected checker failures retain the shared spine's explicit grading boundary.
 
 INVARIANT: malformed or mismatched verifier envelopes abort the run (the RowReader
 wraps this module's decode ``ValueError`` with the row position) — their identity
@@ -24,6 +22,7 @@ cannot be trusted, and scoring the wrong Case is worse than reporting a failed o
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
@@ -265,8 +264,8 @@ def _missing_row_result(
 ) -> CaseResult:
     """This board's shape for a selected Case with no usable row — wording pinned.
 
-    A collected error row keeps today's published failure (stage "grading", the
-    diagnostic's own code, ``row_index``) exactly as the golden recorded it; a Case
+    A collected error row retains the diagnostic and row index, attributing known
+    Gateway-call failures to Candidate execution (OME-981); a Case
     with no row at all keeps the pre-fold ``case_result_missing`` synthesis.
     """
 
@@ -318,13 +317,7 @@ def _collected_failure_result(
         selected_case=selected_case,
         failures=[
             {
-                # WHY the constant stage: a collected url4 error row carries only
-                # kind+message — never a code — so public_error always falls back to
-                # the aggregate defaults and the old provider_/aigateway_ prefix
-                # heuristic could not fire. One IFEval row spans invocation AND
-                # checking, so "grading" (the stage that failed to produce a valid
-                # evaluation record) is the honest constant.
-                "stage": "grading",
+                "stage": "candidate" if _is_gateway_call_failure(error) else "grading",
                 "code": diagnostic.code,
                 "message": diagnostic.message,
                 "retryable": diagnostic.retryable,
@@ -332,6 +325,18 @@ def _collected_failure_result(
                 "metadata": metadata,
             }
         ],
+    )
+
+
+def _is_gateway_call_failure(error: Mapping[str, Any]) -> bool:
+    # WHY: these codes are emitted by runner/connector.py at the model-call boundary.
+    # IFEval's checker is deterministic; its protected failures never take this path.
+    # Do not infer provenance from a message, a broad prefix, or a sanitized code:
+    # unknown and legacy kind/message-only rows remain the grading fallback.
+    code = error.get("code")
+    return isinstance(code, str) and (
+        code in {"aigateway_transport_error", "aigateway_empty_response", "aigateway_bad_response"}
+        or re.fullmatch(r"aigateway_http_[45][0-9]{2}", code) is not None
     )
 
 

--- a/apps/screamingface-engine/tests/unit/test_ifeval_provider_failure_stage.py
+++ b/apps/screamingface-engine/tests/unit/test_ifeval_provider_failure_stage.py
@@ -1,0 +1,104 @@
+"""OME-981: connector diagnostics retain Candidate provenance through collection."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from screamingface_engine.benchmarks.case_execution import case_execution_payload
+from screamingface_engine.benchmarks.contract import encode_candidate_invocation
+from screamingface_engine.benchmarks.ifeval.grade import AggregateError, aggregate
+from screamingface_engine.runner.connector import _raise_for_status
+from url4.core.errors import ResolutionError
+from url4.dag.nodes import _error_payload
+
+_SPEC = {
+    153: {
+        "prompt": "Answer without commas.",
+        "instruction_id_list": ["punctuation:no_comma"],
+        "kwargs": [{}],
+    }
+}
+
+
+def _aggregate(row: dict):
+    return aggregate(json.dumps([row]), _SPEC, "ifeval", [153], selected_case_count=1)
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 429, 500, 503, 599])
+def test_connector_http_error_survives_collection_as_candidate_failure(status: int) -> None:
+    with pytest.raises(ResolutionError) as caught:
+        _raise_for_status(httpx.Response(status))
+    result = _aggregate(_error_payload(caught.value))
+    case = result["cases"][0]
+    failure = case["failures"][0]
+    assert failure == {
+        "stage": "candidate",
+        "code": f"aigateway_http_{status}",
+        "message": f"aigateway request failed with status {status}",
+        "retryable": status == 429 or status >= 500,
+        "case_id": 153,
+        "metadata": {"row_index": 0, "error_kind": "ResolutionError"},
+    }
+    assert case["status"] == "failed"
+    assert case["grade"] is None
+    assert result["score"] is None
+    assert result["coverage"] == 0.0
+    assert result["case_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "code", ["aigateway_transport_error", "aigateway_empty_response", "aigateway_bad_response"]
+)
+def test_known_connector_failures_are_candidate_stage(code: str) -> None:
+    result = _aggregate(
+        _error_payload(ResolutionError("Model call failed", code=code, permanent=False))
+    )
+    failure = result["cases"][0]["failures"][0]
+    assert (failure["stage"], failure["code"], failure["retryable"]) == ("candidate", code, True)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        None,
+        "provider_error",
+        "aigateway_unknown",
+        "aigateway_http_200",
+        "aigateway_http_600",
+        "aigateway_http_503_suffix",
+        " aigateway_http_503",
+        503,
+    ],
+)
+def test_ambiguous_errors_do_not_gain_candidate_provenance(code: object) -> None:
+    # INVARIANT: messages and a broad provider prefix are not attribution evidence.
+    result = _aggregate(
+        {
+            "error": {
+                "kind": "ResolutionError",
+                "code": code,
+                "message": "aigateway request failed with status 503",
+            }
+        }
+    )
+    assert result["cases"][0]["failures"][0]["stage"] == "grading"
+
+
+@pytest.mark.parametrize("code", ["ifeval_checker_failed", "aigateway_http_503"])
+def test_protected_checker_failure_keeps_its_grading_boundary(code: str) -> None:
+    row = case_execution_payload(
+        153,
+        encode_candidate_invocation("Answer", "stop", None),
+        [_error_payload(ResolutionError("Checker failed", code=code, permanent=False))],
+    )
+    case = _aggregate(row)["cases"][0]
+    assert case["output"] == "Answer"
+    assert case["failures"][0]["stage"] == "grading"
+
+
+def test_malformed_evaluation_is_not_an_operational_failure() -> None:
+    with pytest.raises(AggregateError, match="position 0"):
+        _aggregate({"candidate_text": "aigateway_http_503"})

--- a/docs/plan/2026-09-13-OME-981-ifeval-failure-stage.md
+++ b/docs/plan/2026-09-13-OME-981-ifeval-failure-stage.md
@@ -1,0 +1,8 @@
+# OME-981 — implementation plan
+
+1. Add connector → URL4 error payload → IFEval aggregate regression tests; confirm RED.
+2. Add a small IFEval-local exact diagnostic classifier and use it for anonymous
+   collected failures. Update stale comments about URL4 diagnostic preservation.
+3. Prove checker and ambiguous errors stay grading-stage; malformed records still
+   abort. Keep all existing tests unchanged, including the generic provider_error fixture.
+4. Run screamingface-engine gates, review the diff, commit and open a code draft PR.

--- a/docs/spec/2026-09-13-OME-981-ifeval-failure-stage.md
+++ b/docs/spec/2026-09-13-OME-981-ifeval-failure-stage.md
@@ -1,0 +1,15 @@
+# OME-981 — collected IFEval provider failures
+
+Current main c1c92562 and merged PR #913 retain a constant grading fallback. No
+other OME-981 implementation PR exists. The older claim that URL4 collection loses
+codes is stale: OME-924 retains code and retryable alongside kind/message.
+
+Recognize only the connector-owned diagnostic vocabulary: aigateway_http_400–599,
+aigateway_transport_error, aigateway_empty_response, aigateway_bad_response.
+These identify failed model calls; IFEval grading is deterministic and its genuine
+checker failures are separately protected by the shared case-execution boundary.
+
+Unknown/upstream-defined codes, broad provider_* names, and message-only rows are
+not sufficient provenance and keep the existing grading fallback. Retain the
+original safe code/message/retryability and Case identity. Malformed evaluation
+records still fail validation. No scoring or protocol revision changes.

--- a/docs/tasks/2026-09-13-OME-981-ifeval-failure-stage.md
+++ b/docs/tasks/2026-09-13-OME-981-ifeval-failure-stage.md
@@ -1,0 +1,16 @@
+---
+id: OME-981
+linear_url: https://linear.app/openmined/issue/OME-981/attribute-collected-ifeval-provider-failures-to-candidate-execution
+status: In Progress
+type: bug
+priority: high
+labels: [screamingface-engine, agentic, autonomous]
+created: 2026-08-25
+closed:
+---
+
+# Attribute collected IFEval provider failures to Candidate execution
+
+Recognize connector-owned failure codes in anonymous collected rows, preserve
+unknown/checker failures and all scoring behavior. See the matching spec, plan
+and work ledger dated 2026-09-13. OME-1101 is already merged; build on its hooks.

--- a/docs/work/2026-09-13-OME-981-ifeval-failure-stage.md
+++ b/docs/work/2026-09-13-OME-981-ifeval-failure-stage.md
@@ -1,0 +1,45 @@
+---
+ticket: OME-981
+stack: screamingface-engine
+status: done
+started: 2026-09-13
+finished: 2026-09-13
+---
+
+# OME-981 — IFEval collected failure attribution
+
+## Intent
+
+Identify proven Gateway-call failures as Candidate failures in IFEval, retaining
+unknown collected failures at the existing grading fallback.
+
+## Planned changes
+
+- IFEval grade.py: narrowly recognize the Engine connector's diagnostic codes.
+- New regression tests exercising connector errors through URL4 collection and aggregation.
+- Specification, plan, and task mirror.
+
+## Test plan
+
+RED first: Gateway HTTP/transport/response failures become candidate-stage.
+Unknown codes, kind/message-only rows and genuine protected checker failures stay
+grading-stage. Preserve safe diagnostics and malformed-row rejection. Run Engine gates.
+
+## Acceptance
+
+No message matching or blanket provider-prefix rule. No changes to successful scores,
+denominators, benchmark identity, shared protocol, or other benchmarks.
+
+## Outcome
+
+- Actual files: IFEval grade.py, one new regression module, and the planned docs.
+- RED: 11 failures and 11 passes before the production change. GREEN: all 22 new
+  cases pass; combined focused run with existing unscored tests: 27 passed.
+- Gates: `uv run .claude/scripts/run_gates.py screamingface-engine` ALL GATES GREEN:
+  append-only tests, Ruff lint/format, Pyright, layering, full pytest and coverage ≥80%.
+- Commit: `fix(engine): attribute known IFEval Gateway failures to candidate`;
+  body `Refs: OME-981`.
+- Wisdom review: small board-local classifier; no dependency, secret, schema,
+  public interface or shared execution changes. Explicit unknown-code fallback;
+  existing checker attribution and successful results remain protected.
+- Deviations: none. Linear stays open pending draft review/merge.


### PR DESCRIPTION
## Summary

IFEval can report a failed model call as a grading failure. For example, a collected `aigateway_http_503` error currently says `grading`; this change labels it `candidate` and preserves its safe message, code, and retryability.

This is a narrow IFEval diagnostic improvement. It does not change execution, scores, denominators, or Benchmark identity.

## Covered failures and remaining limitation

The change recognizes only these Engine connector codes:

- `aigateway_http_400` through `aigateway_http_599`
- `aigateway_transport_error`
- `aigateway_empty_response`
- `aigateway_bad_response`

Gateway responses can replace the generic HTTP code with their own code, such as `profile_not_found` or `provider_error`. Those errors, unknown codes, and legacy errors without a code still use the existing `grading` fallback. This PR therefore partially addresses OME-981; it does not establish correct attribution for every provider failure.

Explicit checker failures remain `grading`, including when their error code overlaps the recognized list. Other benchmarks are not changed.

## Validation

- 22 new regression cases; 11 failed before the fix, all pass after it.
- Tests pass connector HTTP errors through URL4 collection into IFEval aggregation and cover ambiguous errors, protected checker errors, and malformed evaluation data.
- Existing tests unchanged.
- Full Engine gates passed: Ruff, Pyright, layering, full pytest and coverage gate.
- CI passed, including Python 3.12/3.13 and golden replay.

Refs: OME-981
